### PR TITLE
The overlay is a pane charter draws, and one key always leaves it (Phase 2, Task 2)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -133,7 +133,7 @@ import sys
 import time
 
 from . import config, contain, harness, tui, util, workspace
-from .frame import gather, layout, menu, picker, state, switch, tmuxctl
+from .frame import gather, layout, menu, overlay, picker, state, switch, tmuxctl
 # Aliased: `cmd_launch` already has a local variable named `slots` (the VISIBLE slot
 # list `layout.visible_slots` returns) — importing the renderer registry under its own
 # name would be shadowed by that local the moment it's assigned, and a `slots.SLOTS`
@@ -413,6 +413,18 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
     default single-client guess this module was replacing. Carrying the presser by name
     removes the guess entirely rather than making it a better one.
 
+    The last line is `frame/overlay.hatch_bind()` — **the escape hatch**, and it is here
+    rather than beside the hotkey because it is the one bind that must keep working when
+    charter's own code does not. It carries no frame identity at all (the pane ids live
+    in a window option the presser's own window answers for, see that module), and it
+    runs `run-shell -C`, which is tmux executing tmux commands with no shell and no
+    second charter process. `run-shell -C` first exists in tmux 3.2 — `tmuxctl.FLOOR`
+    exactly — so below the floor this one line fails to parse where the rest of this text
+    still applies. That is the same band `below_floor_message` already warns about, and
+    it is why the line goes LAST: whatever a tmux too old to parse it does with the rest
+    of the file, everything charter needs has already been applied by the time it gets
+    there.
+
     This also satisfies correction 2's "only in charter's own server" rule by
     construction rather than by discipline at each call site: `conf_text`'s only caller
     (`cmd_launch`) sources this text against `SOCKET`, charter's own private server —
@@ -455,6 +467,7 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
         f"'\"${_CHARTER_PY_ENV}\" -m charter frame-menu \"#{{client_name}}\"'",
         "bind -n WheelUpPane if-shell -F -t = '#{mouse_any_flag}'"
         " 'send-keys -M' 'copy-mode -e; send-keys -M'",
+        overlay.hatch_bind(),
         "",
     ])
 
@@ -799,27 +812,11 @@ def _panel_died_hook_argv(*, socket: str, panel_pane: str, slot: str,
 #: asserts the whole set of `-y`s issued, not merely that each one present is right.
 _RESIZE_FLAG = {"top": "-y", "bottom": "-y", "right": "-x"}
 
-#: Every real pane id tmux's own `-P -F '#{pane_id}'` has ever reported (`%<digits>`,
-#: confirmed against tmux 3.7c and never observed otherwise). Checked before a value
-#: read off `split-window`'s stdout is trusted as a pane id, because `_resize_hook_argv`
-#: interpolates it directly into a hook ACTION STRING tmux later re-parses as a command
-#: line — the exact construction the module docstring's "constant string" section bans
-#: for `status_path`, for the same reason: something interpolated into an action must be
-#: safe BY CONSTRUCTION, not merely safe because the one program that currently produces
-#: it (tmux itself) happens to be well-behaved. A value that fails this check is treated
-#: the same as `split-window` reporting no id at all (see the empty-string check right
-#: below this) — that one panel simply gets no resize-hook entry, rather than gambling
-#: that whatever the string actually was cannot corrupt the action tmux re-parses.
-#:
-#: **`[0-9]`, not `\d`, and the difference is the property.** Python's `\d` is Unicode by
-#: default: `re.fullmatch(r"%\d+", "%١٢")` is a MATCH, and so is the fullwidth `"%１１"`.
-#: Neither is a pane id tmux ever minted, and neither is dangerous on its own — a
-#: Unicode digit carries no meaning to any of the three parsers a hook action passes
-#: through — but the check is here to say "this is tmux's own word for a pane", and a
-#: class that also admits Arabic-Indic digits is answering a different question. The
-#: same spelling-instead-of-the-property gap this module keeps paying for, caught before
-#: it cost anything rather than after.
-_PANE_ID_RE = re.compile(r"%[0-9]+")
+#: Every real pane id tmux ever reports, held in `tmuxctl` because a SECOND module
+#: now interpolates one into text tmux re-parses (`frame/overlay.py`'s escape
+#: hatch), and two copies of one guard is the drift this repo keeps paying for.
+#: The reasoning — including why the class is `[0-9]` and not `\d` — moved with it.
+_PANE_ID_RE = tmuxctl.PANE_ID_RE
 
 #: tmux's own answer, verbatim, for a `set-hook` call naming an event this binary does
 #: not recognise at all — confirmed by hand against a real tmux 3.7c with a fabricated
@@ -1541,6 +1538,16 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, ws: str,
     which an operator already inside tmux has their own prefix key for. A key taken from
     every window on their server to reach a redundant menu is a worse trade than no key
     — `frame/slots.py` drops the hotkey hint from the bottom panel to match.
+
+    **And `frame/overlay.py`'s escape hatch is bound here no more than the hotkey is**,
+    for the identical reason and at a higher cost worth stating rather than discovering.
+    A root key table is server-wide with no per-window form, so `bind -n F12` here would
+    take F12 from every window the operator has open — which is precisely the sentence
+    above, unchanged. The cost is that the hatch's promise ("one key back to the harness
+    from any state, even a wedged one") is a promise of charter's OWN server, and on this
+    path the way out of a pane that has stopped answering is the operator's own prefix
+    key, which charter has not taken and cannot take. `docs/frame.md`'s list of what this
+    path costs says it in the operator's words; this is the reason it is on that list.
 
     Four things that ARE written are charter's own and reach nothing of theirs, because
     every one of them is scoped to a pane charter created or to the window charter
@@ -2497,6 +2504,22 @@ def cmd_launch(args) -> int:
     if py_set.returncode != 0:
         util.warn("charter frame: continuing without it — the hotkey menu may not open "
                   "on this frame")
+
+    # The escape hatch's other half. `conf_text`'s bind carries no identity — it reads a
+    # WINDOW option, and this is what puts this frame's own answer in it, so a key table
+    # every frame on `SOCKET` shares still returns each presser to their OWN harness (see
+    # `frame/overlay.py`). Armed the moment the harness pane exists and before any panel
+    # is split, because a frame with panes and no way back to the harness is exactly the
+    # state the hatch is for.
+    hatch = overlay.arm_hatch_argv(SOCKET, harness=harness_pane)
+    if hatch is None:
+        util.warn("charter frame: tmux did not report this frame's harness as a pane id "
+                  f"— the {overlay.HATCH_KEY} escape hatch will not be armed for it")
+    else:
+        armed_hatch = tmuxctl.run("arming the frame's escape hatch", hatch, env=env)
+        if armed_hatch.returncode != 0:
+            util.warn(f"charter frame: continuing without it — {overlay.HATCH_KEY} may "
+                      "not return to the harness in this frame")
 
     # #390: the same "-m prepends the cwd to sys.path" hole `util.self_relaunch_argv`'s
     # `-P` closes for the panel argv below, closed here as `PYTHONSAFEPATH=1` because

--- a/charter/frame/overlay.py
+++ b/charter/frame/overlay.py
@@ -1,0 +1,689 @@
+"""The overlay: charter's own modal surface, and the one key that always leaves it.
+
+**Full-pane, charter-drawn, modal** (§4k). Not `display-popup`, and not `display-menu`.
+Both were measured before this module was written, and both lost:
+
+* On tmux **3.2** — a version `tmuxctl.below_floor_message` explicitly still launches on
+  — **any client resize kills a popup**: `rc 129` (128 + SIGHUP), the popup's own log
+  ending mid-stream, with whatever the operator was typing. 3.3 changed that ("Do not
+  close popups on resize, instead adjust them to fit"), so a popup-first palette is one
+  surface that works and one resize-shaped bug on exactly one version, plus two surfaces
+  to keep in step. A full pane always works.
+* `display-menu` draws a list and takes a keypress, and charter's own nine-row cap sits
+  on top of it (`frame/menu.py`) — charter's cap, not tmux's; tmux 3.1c drew 20 rows
+  fine. Neither filters, neither scrolls, and neither is charter's to draw in.
+
+The popup's one real advantage survives and is why §4k keeps it as a later enhancement: a
+popup **is** the active surface, so its own mouse request is what reaches the terminal.
+This module gets the same property a different way — by making its pane the active one
+and zooming it over the window (:func:`modal_argvs`).
+
+---
+
+**Input is bytes; output is text.** A pane's input is a byte protocol — SGR mouse reports
+are bytes, and an escape sequence can arrive split across two reads — while everything
+charter draws is text `tui` has already measured. :func:`decode` owns the first half and
+holds back a partial sequence rather than guessing at it; :class:`Surface` owns the
+second and never calls `len` on anything it is about to lay out.
+
+**A `click` release may arrive with no matching press, and this module keeps no press
+state.** Measured, with tmux's own `mouse` off: a drag that begins on a pane border and
+ends inside a pane delivers exactly one release (`b'\\x1b[<0;70;4m'`) — the press was
+dropped because a border is not a pane, and the motion was dropped because the pane asked
+for 1000 rather than 1002/1003. §4i states the consequence: the first component that
+keeps press state wedges on it. So a release is a click on its own terms here, and — for
+the same reason — a click only ever **selects**. `Enter` is what chooses. The irreversible
+half is never driven by an event that can arrive unpaired.
+
+**Pointer events at all only because this pane asked for them.** §4i's correction to §4c
+is that charter's panels receive pointer events only while the ACTIVE pane requests
+reporting, and charter does not control what the harness requests. The overlay is the one
+place charter can promise them, because while it is open it *is* the active surface. One
+declaration — :attr:`Surface.mouse` — both writes :data:`MOUSE_ON` to the tty and decides
+whether a report is acted on, so there is no state in which charter acts on a report it
+never asked the terminal for.
+
+---
+
+**The escape hatch is a tmux key table entry and runs no charter code.**
+
+§4e: focus has two levels. tmux owns pane focus; charter owns intra-pane focus; and *the
+escape hatch operates at the tmux level*, so it works when charter's own loop is wedged
+or a third-party component has captured input badly. A single-level hatch would live
+inside the thing it must escape.
+
+So :func:`hatch_bind` emits `bind -n <key> run-shell -C '#{@charter_hatch}'` — tmux
+matches the key in its own root table before any byte reaches the pane, and `run-shell
+-C` runs the expansion as **tmux commands**, with no shell, no `$PATH` and no second
+charter process. Measured against tmux 3.7c: the key returns the harness to the operator
+while the overlay's process is in `time.sleep` with its tty in raw mode, never having
+read a byte. `run-shell -C` first exists in tmux **3.2** (CHANGES FROM 3.1c TO 3.2: "Add
+a -C flag to run-shell to use a tmux command rather than a shell command"), which is
+`tmuxctl.FLOOR` exactly.
+
+**Why an option and not the pane ids themselves.** A key table is server-wide in tmux —
+there is no per-session keymap — so every frame on charter's shared private server ends
+up sharing this one bind. `commands_frame.conf_text`'s docstring records what a bind that
+embedded one frame's own identity costs: the second frame launched opens the *first*
+frame's menu. The ids therefore live in a **window** option, and the presser's own window
+answers for them. Measured with two windows on one server, each with its own value: F12
+pressed on window 1 selected window 1's harness and left window 0 untouched.
+
+**Order inside the command is the unconditional half of the promise.** The harness is
+selected *first* and the overlay killed second, so a kill that cannot happen — a stale
+pane id, an overlay already gone — costs nothing that has not already been delivered.
+Measured: a `kill-pane` naming a pane that no longer exists is silent (nothing on the
+client, nothing in any pane, no copy-mode) and the `select-pane` before it has already
+run.
+
+**The hatch exists on charter's own server and nowhere else, and that is a real limit.**
+`bind -n` writes a ROOT key table, and a key table is server-wide with no per-window form
+— so on the path where charter builds the frame as a window inside the operator's OWN
+tmux (`commands_frame._launch_in_operator_tmux`), binding this key would take F12 from
+every window they have open. Charter binds nothing there, exactly as it binds no hotkey
+there. The honest consequence: on that path the way out of a pane that has stopped
+answering is the operator's own prefix key, and `docs/frame.md` says so beside the other
+costs of being a guest. A promise made on both servers and kept on one would be worse
+than the limit.
+
+**And an empty target is not a no-op — it is the current pane.** Measured against tmux
+3.7c: with `@charter_hatch` expanding to `kill-pane -t ""`, tmux killed the pane the
+command was running against. That is why :func:`hatch_command` never emits a `kill-pane`
+at all when there is no overlay, and why ``None`` is the only spelling of "there is no
+overlay": an ``""`` slipping through as a falsy sentinel would be that measurement, live.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable, NamedTuple
+
+from .. import contain, tui
+from . import layout, tmuxctl
+
+#: The key that returns to the harness, from any state, at the tmux level.
+#:
+#: **A constant rather than a `[frame]` setting, deliberately, and this is the version to
+#: revisit if an operator's terminal eats it.** The hatch is the safety property of the
+#: whole command surface: a value an operator can set is a value an operator can set
+#: wrong, and the failure mode of a mis-set hatch is exactly the state the hatch exists
+#: for. `[frame] hotkey` is configurable because opening a palette has an alternative;
+#: this does not.
+#:
+#: F12 rather than a letter or a modifier combination, because `bind -n` is the ROOT key
+#: table: whatever this is, tmux takes it away from the harness pane too, everywhere,
+#: for as long as the frame is up. A function key is the one class of key an agent
+#: harness has no use for. Held to `instance._HOTKEY_RE` by a test for the reason that
+#: constant exists — this string reaches tmux CONFIG TEXT.
+HATCH_KEY = "F12"
+
+#: The window option carrying the tmux commands the hatch runs — see the module
+#: docstring for why the ids are here rather than in the bind.
+#:
+#: `@`-prefixed because that is tmux's own namespace for a user option; charter-prefixed
+#: because the operator's own tmux may be the server charter is a guest on.
+HATCH_OPTION = "@charter_hatch"
+
+#: What the overlay writes to its own tty to ask for SGR mouse reporting: 1006 (SGR
+#: encoding, so coordinates past column 223 survive) then 1000 (press/release only —
+#: deliberately NOT 1002/1003, which add motion, because §4f closed the event kinds
+#: without `drag`). Measured: tmux propagates this pane's exact request to the outer
+#: terminal when tmux's own `mouse` is off, and coordinates arrive pane-relative and
+#: 1-based, with any `pane-border-status` row already subtracted.
+MOUSE_ON = "\x1b[?1006h\x1b[?1000h"
+
+#: And the withdrawal, in the reverse order it was asked for. Written before
+#: :data:`LEAVE`, so the pane hands its terminal back in the state it found it.
+MOUSE_OFF = "\x1b[?1000l\x1b[?1006l"
+
+#: The alternate screen, plus a hidden cursor. This is what "restores what was there"
+#: means: the pane's own scrollback and last paint are untouched underneath, and come
+#: back whole when the overlay leaves. Per-pane — measured, each tmux pane keeps its own
+#: screen — so an overlay in charter's pane cannot disturb the harness's.
+ENTER = "\x1b[?1049h\x1b[?25l"
+
+#: The exit, and it runs in a ``finally``: an overlay that raised must not leave the
+#: operator on an alternate screen with no cursor, which is a terminal that looks broken
+#: and takes a `reset` to fix. `frame/panel.py`'s `_hold` is the same argument for a
+#: panel that cannot paint.
+LEAVE = "\x1b[?25h\x1b[?1049l"
+
+#: What an overlay with nothing to offer says. **#512's shape**: "no repos" drawn on a
+#: plane that had them is worse than a refusal, and an overlay drawing an empty box is
+#: the same defect — indistinguishable from one whose rows failed to load.
+EMPTY = "(nothing to choose)"
+
+#: How many of the pane's rows the overlay spends on itself rather than on rows: the
+#: header and the key hint. Named once because both :meth:`Surface.render` and the click
+#: coordinate arithmetic need it, and two answers to "where does row 0 start" is an
+#: off-by-one nobody sees until a click selects the wrong thing.
+_HEADER_ROWS = 1
+_FOOTER_ROWS = 1
+_CHROME_ROWS = _HEADER_ROWS + _FOOTER_ROWS
+
+#: The two cells between the title column and the note column.
+_GAP = 2
+
+#: The narrowest the title column is ever squeezed to. Below this a title is not
+#: shortened, it is erased, and a row identified by nothing is worse than a row with no
+#: note — so this is the floor the cap below stops at rather than a value it trades away.
+_MIN_TITLE = 8
+
+#: How tall the overlay's pane is split before it is zoomed. It is zoomed over the whole
+#: window on the very next command, so this is only the size the pane holds for the
+#: instant in between — small enough that tmux never refuses the split for want of room
+#: in a short frame, which is the one way this number could cost anything.
+_SPLIT_ROWS = 5
+
+#: The event kinds this surface produces. A subset of `component.EVENT_KINDS` — §4f
+#: closed that list at six, and `focus`/`blur` are not among these because they do not
+#: exist yet: `focus-events` is off by default in tmux and gates the whole path, and with
+#: it off `#{client_flags}` still reads `attached,focused`, so a guard written against
+#: that flag passes with the feature dead (§4i). Task 7 of the Phase 2 plan turns it on;
+#: until then a `focus` this module invented would fire never or wrongly.
+KEY, CLICK, SCROLL, RESIZE = "key", "click", "scroll", "resize"
+
+#: What :meth:`Surface.handle` answers with. Strings rather than an enum for the reason
+#: the rest of this package uses strings: they appear in a test's failure message as
+#: themselves.
+CHOOSE, CANCEL = "choose", "cancel"
+
+_R, _DIM, _BOLD, _REV = "\033[0m", "\033[2m", "\033[1m", "\033[7m"
+
+#: The selected/unselected marker. **ASCII, and `frame/picker.py` records why**: `●`,
+#: `◆` and the pointing triangles are East-Asian *Ambiguous*, which `statusline
+#: ._persona_chips` measured breaking this exact layout twice. Both entries are the same
+#: width by construction, so a selection moving does not move the text beside it.
+_MARK = ("> ", "  ")
+
+#: One SGR mouse report: `ESC [ < button ; col ; row (M|m)`, `M` a press and `m` a
+#: release. Anchored at the start because :func:`decode` matches it against the head of
+#: what is left, and bounded on the digits so a byte stream that is not a mouse report
+#: cannot make this scan without end.
+_SGR = re.compile(rb"^\x1b\[<(\d{1,5});(\d{1,5});(\d{1,5})([Mm])")
+
+#: The prefix of an SGR report that has not all arrived yet. Kept whole rather than
+#: decoded as `ESC`, `[`, `<`, `0`, `;` — five keypresses out of half a mouse click.
+_SGR_PARTIAL = re.compile(rb"^\x1b\[<[\d;]*$")
+
+#: CSI sequences that are keys, by their final byte and (for the `~` family) their
+#: number. tmux's own key table sends these forms; `\x1bO` is the application-cursor
+#: variant, which nothing here requests but a terminal may still send after a program in
+#: this pane switched modes and died without switching back.
+_CSI_KEYS = {b"A": "up", b"B": "down", b"C": "right", b"D": "left",
+             b"H": "home", b"F": "end"}
+_TILDE_KEYS = {b"1": "home", b"4": "end", b"5": "pgup", b"6": "pgdn", b"7": "home",
+               b"8": "end"}
+
+#: One WHOLE CSI: `ESC [`, its numeric parameters, and the final byte that ends it —
+#: ECMA-48's own shape, `0x40`–`0x7e`.
+#:
+#: **Matched before any name is looked up, because finding the end is a separate question
+#: from knowing the key.** A terminal sends far more sequences than the six names above:
+#: every modified arrow (`\x1b[1;5A` is Ctrl-Up), every function key, and the brackets
+#: around a paste (`\x1b[200~` … `\x1b[201~`). A decoder that recognises only what it
+#: wants and lets the rest fall through to its single-byte path does not drop those — it
+#: **replays them as the keys they are spelled with**, so Ctrl-Up types `1;5A` and F1
+#: types `P`. That is the very thing :func:`decode`'s docstring already refuses to do to
+#: a sequence that arrived half-way, and a whole one deserves it no less; Task 4's
+#: palette filters on exactly these keys, which is where it would have cost something.
+#:
+#: The parameters are captured but only consulted for the `~` family: for the others the
+#: FINAL BYTE names the key and the parameters name modifiers, and this surface has no
+#: use for a modifier. So Ctrl-Up moves the selection up, which is what an operator who
+#: pressed it meant.
+#:
+#: The parameter class carries `<` as well, which no key sequence uses — it is how an SGR
+#: mouse report opens. :data:`_SGR` is tried first and answers every well-formed one, so
+#: the only reports reaching here are the ones it REFUSED (more digits than its bound
+#: admits, say). Those are still whole sequences, and this is what makes them consumed
+#: whole instead of typed as `<99999999;1;1M`.
+_CSI = re.compile(rb"^\x1b\[([\d;<]*)([\x40-\x7e])")
+
+#: An unfinished CSI (or SS3) — an escape sequence still arriving. Held back by
+#: :func:`decode` until the rest lands or the caller says nothing more is coming. The
+#: parameter class is :data:`_CSI`'s plus the `<` an SGR mouse report opens with, so one
+#: expression covers both families' prefixes.
+_CSI_PARTIAL = re.compile(rb"^\x1b(\[[\d;<]*|O|)$")
+
+
+def _title_width(shown: list[tuple[str, str]], width: int) -> int:
+    """How wide the title column is in a pane *width* columns across.
+
+    The titles' own width, **capped at half the row**. Sizing a column from its contents
+    alone is what makes a two-column layout eat its second column in a narrow pane:
+    measured at 34 columns, the widest title took 28 of them and every note came out as
+    one glyph and an ellipsis. That is not a cosmetic loss — Task 4's rule is that an
+    unavailable action is listed *with its reason*, and the reason is the note. A reason
+    truncated to nothing still LOOKS like an answer, which is #512's shape one column
+    over.
+
+    Half rather than a fixed number of columns because both sides have to scale: a wide
+    pane should spend its extra width on whichever column needs it, and only a
+    proportional cap does that without a second rule for wide panes. `tui.width` on the
+    marker rather than `len`, because :data:`_MARK`'s two entries are only the same width
+    by construction and the day one of them stops being ASCII this must still be right.
+    """
+    longest = max([tui.width(t) for t, _ in shown] or [0])
+    room = width - tui.width(_MARK[0]) - _GAP
+    return min(longest, max(_MIN_TITLE, room // 2))
+
+
+class Row(NamedTuple):
+    """One line the overlay offers.
+
+    *id* is what a caller matches on and never what is drawn; *title* and *note* are
+    display text and are contained — not refused — before they are measured, the way
+    `component.Component` splits the same pair. Task 3's actions and Task 6's pickers
+    both become sequences of these, which is the whole of "one mechanism, three faces".
+    """
+
+    id: str
+    title: str
+    note: str = ""
+
+
+class Event(NamedTuple):
+    """One decoded input event.
+
+    *row* is the pane row a pointer event landed on, **0-based**, already converted from
+    the 1-based coordinate tmux hands over. tmux subtracts `pane_left` and any
+    `pane-border-status` row itself — measured — so this module never does that
+    arithmetic and must not start.
+    """
+
+    kind: str
+    name: str = ""
+    row: int = 0
+    col: int = 0
+    pressed: bool = False
+
+
+def decode(buf: bytes, *, final: bool = False) -> tuple[list[Event], bytes]:
+    """*buf* as events, plus whatever is left of a sequence that has not all arrived.
+
+    **The tail is the point.** A pane's `read` returns whatever the kernel had, which
+    splits an escape sequence as readily as not: `\\x1b[` in one read and `B` in the next
+    is an arrow key, and decoding the first half as an Escape keypress would cancel the
+    overlay on a slow terminal — the one input this surface treats as "leave now".
+
+    *final* is the caller saying nothing more is coming *right now* — a `read` that timed
+    out, or a `SIGWINCH` that interrupted one. That is what resolves a lone `\\x1b` into
+    an Escape keypress; there is no other way to tell it from the start of a sequence, and
+    a quiet period is exactly how every terminal program tells them apart. An incomplete
+    sequence that is not a lone `\\x1b` is dropped at that point rather than replayed as
+    the keys it is spelled with.
+
+    **And a sequence that arrived WHOLE gets the same treatment.** A terminal sends far
+    more sequences than the six names this surface has, and one it has no name for is
+    consumed to its end (:data:`_CSI`) rather than falling through to the single-byte
+    path — otherwise Ctrl-Up types `1;5A`, F1 types `P`, and a paste types the brackets
+    tmux wrapped it in. The rule is one rule; only where it is enforced was ever in
+    question.
+    """
+    evs: list[Event] = []
+    while buf:
+        m = _SGR.match(buf)
+        if m:
+            button, col, row_, kind = int(m[1]), int(m[2]), int(m[3]), m[4]
+            buf = buf[m.end():]
+            if button & 64:
+                # Wheel. 64 is up and 65 is down on every terminal measured, and the
+                # wheel is reported as a press with no release — which is the second
+                # reason this module keeps no press state.
+                evs.append(Event(SCROLL, "up" if button == 64 else "down",
+                                 row=row_ - 1, col=col - 1))
+            else:
+                # A release with no press is a click. See the module docstring: it is
+                # measured, not hypothetical.
+                evs.append(Event(CLICK, row=row_ - 1, col=col - 1,
+                                 pressed=(kind == b"M")))
+            continue
+        if not final and (_SGR_PARTIAL.match(buf) or _CSI_PARTIAL.match(buf)):
+            return evs, buf
+        if buf.startswith(b"\x1b["):
+            m = _CSI.match(buf)
+            if m is None:
+                # `ESC [` with no final byte in sight and not a prefix `_CSI_PARTIAL`
+                # would have held: a stream this module cannot find the end of. Drop the
+                # introducer and let the rest take its chances rather than announcing an
+                # Escape keypress, which is the one input that means "leave now".
+                buf = buf[2:]
+                continue
+            params, final_byte, buf = m[1], m[2], buf[m.end():]
+            # For the `~` family the FIRST parameter names the key and the rest are
+            # modifiers, exactly as the final byte names it for the others — so
+            # `\x1b[5;5~` (Ctrl-PgUp) is PgUp, and one rule covers both families rather
+            # than the arrows honouring a modifier and the page keys refusing one.
+            name = (_TILDE_KEYS.get(params.split(b";", 1)[0]) if final_byte == b"~"
+                    else _CSI_KEYS.get(final_byte))
+            if name:
+                evs.append(Event(KEY, name))
+            continue
+        if buf.startswith(b"\x1bO"):
+            # SS3, the application-cursor form. Exactly one byte follows, and the same
+            # rule applies to it: `\x1bOA` is Up, `\x1bOP` is F1 and is consumed whole
+            # rather than typing a `P`.
+            name = _CSI_KEYS.get(buf[2:3])
+            buf = buf[3:]
+            if name:
+                evs.append(Event(KEY, name))
+            continue
+        ch, buf = buf[:1], buf[1:]
+        if ch == b"\x1b":
+            if not final and not buf:
+                return evs, ch
+            evs.append(Event(KEY, "escape"))
+        elif ch in (b"\r", b"\n"):
+            evs.append(Event(KEY, "enter"))
+        elif ch in (b"\x7f", b"\x08"):
+            evs.append(Event(KEY, "backspace"))
+        elif ch == b"\x03":
+            # Ctrl-C reads as "leave", not as a signal: the surface has the tty in raw
+            # mode, so nothing else is going to turn this into one.
+            evs.append(Event(KEY, "escape"))
+        else:
+            try:
+                text = ch.decode()
+            except UnicodeDecodeError:
+                continue                       # a partial UTF-8 byte: not a keypress
+            if text.isprintable():
+                evs.append(Event(KEY, text))
+    return evs, b""
+
+
+@dataclass
+class Surface:
+    """The rows, the selection, and the loop that owns the pane until one is chosen.
+
+    **Modal**: :meth:`run` consumes every event it is given and returns only when the
+    operator chose a row or cancelled. Nothing falls through it — an unrecognised key is
+    swallowed rather than ending the overlay, because a surface that exits on a stray
+    keypress is a surface that loses the operator's place for a typo.
+
+    Rendering is whole every paint, for `frame/panel.py`'s reason: a pane is a few
+    hundred cells, so diffing would be optimising something already free, and there is no
+    partial-line state to reconcile between paints.
+    """
+
+    rows: tuple[Row, ...] = ()
+
+    #: What the header says this overlay is for. Contained before it is drawn: a picker's
+    #: title is a workspace or persona name in Task 6, which is a committed value.
+    heading: str = "charter"
+
+    #: Whether this pane asks its terminal for pointer reports — and, by the same
+    #: attribute, whether it acts on one. See the module docstring: one declaration, not
+    #: two, so the request and the handling cannot disagree.
+    mouse: bool = False
+
+    _sel: int = field(default=0, init=False)
+    _top: int = field(default=0, init=False)
+
+    @property
+    def selected(self) -> Row | None:
+        """The row under the cursor, or ``None`` when there are no rows at all."""
+        return self.rows[self._sel] if self.rows else None
+
+    def move(self, delta: int) -> None:
+        """Move the selection by *delta*, clamped to the ends. Never wraps: a list that
+        wraps loses the operator's sense of where they are in it, and this one has no
+        row cap to make wrapping worth it."""
+        if self.rows:
+            self._sel = max(0, min(len(self.rows) - 1, self._sel + delta))
+
+    def _window(self, height: int) -> tuple[int, int]:
+        """``(first row drawn, how many)`` for a pane *height* tall.
+
+        **This is what "keeps the selection" means across a resize.** The selection is an
+        index into `rows` and a resize cannot move it; what a resize *can* do is leave it
+        off the bottom of a shorter pane, drawn nowhere, so the next keypress appears to
+        come from nothing. Scrolling the window to contain it is the half that has to be
+        recomputed every paint rather than only when the selection moves.
+        """
+        n = max(1, height - _CHROME_ROWS)
+        top = self._top
+        if self._sel < top:
+            top = self._sel
+        if self._sel >= top + n:
+            top = self._sel - n + 1
+        self._top = max(0, min(top, max(0, len(self.rows) - n)))
+        return self._top, n
+
+    def render(self, width: int, height: int) -> list[str]:
+        """The whole pane, as lines, each already inside *width*.
+
+        Every title and note goes through `contain.one_line` **before** `tui.width` sees
+        it (#472): a committed value is what a picker's rows are made of, and a name
+        carrying a newline that reached width arithmetic first would size the column from
+        a string that is about to become two rows.
+        """
+        top, n = self._window(height)
+        shown = [(contain.one_line(r.title), contain.one_line(r.note))
+                 for r in self.rows[top:top + n]]
+        title_w = _title_width(shown, width)
+        out = [tui.truncate(f"{_BOLD}{contain.one_line(self.heading)}{_R}"
+                            f"{_DIM} · {len(self.rows)} to choose from{_R}", width)]
+        if not self.rows:
+            out.append(tui.truncate(f"  {_DIM}{EMPTY}{_R}", width))
+        for i, (title, note) in enumerate(shown, start=top):
+            on = i == self._sel
+            mark = _MARK[0] if on else _MARK[1]
+            body = (f"{mark}{tui.pad(title, title_w)}{' ' * _GAP}"
+                    f"{_DIM}{note}{_R}")
+            out.append(tui.truncate(f"{_REV}{body}{_R}" if on else body, width))
+        while len(out) < height - _FOOTER_ROWS:
+            out.append("")
+        # ASCII, for `_MARK`'s reason: the arrows and the return symbol an overlay wants
+        # here (`↑↓`, `⏎`) are all East-Asian *Ambiguous*, which `statusline
+        # ._persona_chips` records breaking a charter layout twice on a terminal that
+        # draws them two cells wide.
+        out.append(tui.truncate(
+            f"{_DIM}  up/down move   enter choose   esc cancel   "
+            f"{HATCH_KEY} back to the harness{_R}", width))
+        return out[:max(1, height)]
+
+    def handle(self, ev: Event, height: int) -> str | None:
+        """One event. :data:`CHOOSE`, :data:`CANCEL`, or ``None`` for "carry on".
+
+        A pointer event is acted on **only** when this surface asked its terminal for
+        one, and a click only ever selects — see the module docstring for both.
+        """
+        if ev.kind == KEY:
+            if ev.name == "enter":
+                return CHOOSE if self.rows else None
+            if ev.name == "escape":
+                return CANCEL
+            page = max(1, height - _CHROME_ROWS)
+            self.move({"up": -1, "down": 1, "pgup": -page, "pgdn": page,
+                       "home": -len(self.rows), "end": len(self.rows)}.get(ev.name, 0))
+            return None
+        if not self.mouse:
+            return None
+        if ev.kind == SCROLL:
+            self.move(-1 if ev.name == "up" else 1)
+        elif ev.kind == CLICK:
+            i = self._top + ev.row - _HEADER_ROWS
+            if 0 <= i < len(self.rows):
+                self._sel = i
+        return None
+
+    def run(self, *, read: Callable[[], bytes | None],
+            write: Callable[[str], None],
+            size: Callable[[], tuple[int, int]]) -> Row | None:
+        """Own the pane until a row is chosen or the operator leaves. Never a hang.
+
+        *read* answers the next bytes, ``b""`` for "nothing arrived" — a poll that timed
+        out, or a `read` a `SIGWINCH` interrupted, which is how a resize reaches this loop
+        — and ``None`` for end of input. End of input is a **cancel**: it is what a closed
+        stdin means, and it is the one answer that can never become a wedge (`picker.ask`
+        makes the same call for the same reason).
+
+        *size* is asked every iteration rather than once, because `window-resized` does
+        not bump the frame's version and nothing else would redraw for it —
+        `frame/panel.py`'s SIGWINCH section is the same fact one pane over.
+
+        Both halves of :data:`ENTER`/:data:`LEAVE` are this function's, and the exit is a
+        ``finally``: an overlay that raised must still hand the pane back.
+        """
+        write(ENTER + (MOUSE_ON if self.mouse else ""))
+        try:
+            w, h = size()
+            self._paint(write, w, h)
+            tail = b""
+            while True:
+                chunk = read()
+                if chunk is None:
+                    return None
+                evs, tail = decode(tail + chunk, final=(chunk == b""))
+                nw, nh = size()
+                repaint = (nw, nh) != (w, h)
+                w, h = nw, nh
+                for ev in evs:
+                    verdict = self.handle(ev, h)
+                    if verdict == CHOOSE:
+                        return self.selected
+                    if verdict == CANCEL:
+                        return None
+                    repaint = True
+                if repaint:
+                    self._paint(write, w, h)
+        finally:
+            write((MOUSE_OFF if self.mouse else "") + LEAVE)
+
+    def _paint(self, write: Callable[[str], None], width: int, height: int) -> None:
+        """One whole pane, in ONE write: home the cursor, clear, draw.
+
+        One call rather than a line at a time so a paint cannot be seen half-done, and so
+        a test can read the pane's whole state out of a single string.
+        """
+        write("\x1b[H\x1b[2J" + "\r\n".join(self.render(width, height)))
+
+
+# --------------------------------------------------------------------------- #
+# The tmux half: the pane the overlay owns, and the key that always leaves it.
+# --------------------------------------------------------------------------- #
+
+
+def hatch_bind(key: str = HATCH_KEY) -> str:
+    """The root-table bind, as one line of `commands_frame.conf_text`.
+
+    `-n` is the root table, so tmux matches the key before any byte reaches the pane —
+    which is the whole mechanism: a wedged overlay never gets a chance to swallow it.
+    `run-shell -C` runs the expansion as tmux commands, with no shell, no `$PATH` and no
+    second charter process; see the module docstring for what is deliberately *not* in
+    here.
+    """
+    return f"bind -n {key} run-shell -C '#{{{HATCH_OPTION}}}'"
+
+
+def hatch_command(*, harness: str, overlay_pane: str | None = None) -> str | None:
+    """What the hatch runs, as tmux command text. ``None`` when charter will not build it.
+
+    ``None`` for *overlay_pane* is "there is no overlay open", and it is the **only**
+    spelling of that: an `""` is refused rather than read as absence, because a falsy
+    sentinel resolving one way here and another way at the next call site is how two
+    paths come to disagree. The stakes are specific — see the module docstring's last
+    paragraph for the measurement that makes an empty kill target a killed panel.
+
+    Both ids are held to `tmuxctl.PANE_ID_RE` because this string is stored in a tmux
+    option that tmux later **re-parses as a command line**. That is `_PANE_ID_RE`'s exact
+    call site one option over, and a value that fails it arms nothing at all rather than
+    arming something charter cannot predict the parse of.
+    """
+    if not tmuxctl.PANE_ID_RE.fullmatch(harness):
+        return None
+    back = f"select-pane -t {harness}"
+    if overlay_pane is None:
+        return back
+    if not tmuxctl.PANE_ID_RE.fullmatch(overlay_pane):
+        return None
+    return f"{back} ; kill-pane -t {overlay_pane}"
+
+
+def arm_hatch_argv(server: str, *, harness: str,
+                   overlay_pane: str | None = None) -> list[str] | None:
+    """`set-option -w`: put :func:`hatch_command`'s text where the presser's own window
+    will answer for it. ``None`` when there is nothing safe to arm.
+
+    **Window-scoped, targeting the harness pane** — the idiom
+    `commands_frame._panel_remain_on_exit_argv` already uses, and for the same reason:
+    `-w -t <a pane id>` resolves to that pane's window, which is charter's own on either
+    server. Never `-g`: a global write would hand frame N's harness pane to frame N-1,
+    the "last launched wins" trap `conf_text`'s docstring names for `mouse` and
+    `history-limit`.
+
+    ``None`` rather than a raise, following `commands_frame._resize_hook_argv`: this is
+    called from inside a launch, and a launch is not a place to propagate an exception
+    from a value tmux itself produced.
+    """
+    cmd = hatch_command(harness=harness, overlay_pane=overlay_pane)
+    if cmd is None:
+        return None
+    return tmuxctl.server_argv(server, "set-option", "-w", "-t", harness,
+                               HATCH_OPTION, cmd)
+
+
+def open_argv(server: str, *, harness: str, command: list[str],
+              env: dict[str, str] | None = None) -> list[str] | None:
+    """`split-window`: carve the overlay's own pane off *harness*, and report its id.
+
+    Targeted at the harness pane's **id**, never a `session:0.0`-style index, for
+    `frame/layout.py`'s measured reason: tmux renumbers pane indices on every split and
+    ids it never reuses. `-P -F '#{pane_id}'` before `--`, so those are `split-window`'s
+    own options and never reach *command*.
+
+    The pane is split small and zoomed on the very next command (:func:`modal_argvs`), so
+    :data:`_SPLIT_ROWS` is the size it holds for an instant rather than the size the
+    operator sees.
+    """
+    if not tmuxctl.PANE_ID_RE.fullmatch(harness):
+        return None
+    return tmuxctl.server_argv(server, "split-window", "-t", harness,
+                               "-v", "-l", str(_SPLIT_ROWS),
+                               *layout._env_argv(env),
+                               "-P", "-F", "#{pane_id}", "--", *command)
+
+
+def modal_argvs(server: str, *, harness: str,
+                overlay_pane: str) -> list[list[str]]:
+    """Make the new pane THE surface: hatch first, then focus, then the whole window.
+
+    **The order is the property.** A surface that is selected before its escape hatch
+    exists is a surface that can wedge with no way out — the same argument
+    `commands_frame` already makes for installing the `pane-died` write hook before the
+    teardown hook, one mechanism over. Arming first costs nothing: with the overlay pane
+    not yet active, the hatch simply returns to a harness that already has focus.
+
+    `resize-pane -Z` is what makes it full-pane and modal at once — measured, a zoomed
+    pane occupies the entire window and its siblings are not drawn — and it is also what
+    makes the overlay's own `\\x1b[?1006h\\x1b[?1000h` the request that reaches the
+    terminal, since the outer terminal's mouse mode follows the ACTIVE pane (§4i).
+
+    An empty list when either id is not tmux's own word for a pane: charter would rather
+    open no overlay than open one it cannot promise a way out of.
+    """
+    arm = arm_hatch_argv(server, harness=harness, overlay_pane=overlay_pane)
+    if arm is None:
+        return []
+    return [arm,
+            tmuxctl.server_argv(server, "select-pane", "-t", overlay_pane),
+            tmuxctl.server_argv(server, "resize-pane", "-Z", "-t", overlay_pane)]
+
+
+def close_argvs(server: str, *, harness: str, overlay_pane: str) -> list[list[str]]:
+    """Hand the pane back: focus the harness, kill the overlay, disarm the hatch.
+
+    The same order the hatch itself runs in, and then one more command the hatch cannot
+    run because by then there is no charter process left to run it: the option is
+    re-armed with **no** overlay, so the next press names no pane at all rather than a
+    dead one. (A dead one is harmless — measured silent — but "names a pane that is gone"
+    is a state worth not being in.)
+    """
+    arm = arm_hatch_argv(server, harness=harness)
+    if arm is None or not tmuxctl.PANE_ID_RE.fullmatch(overlay_pane):
+        return []
+    return [tmuxctl.server_argv(server, "select-pane", "-t", harness),
+            tmuxctl.server_argv(server, "kill-pane", "-t", overlay_pane),
+            arm]

--- a/charter/frame/overlay.py
+++ b/charter/frame/overlay.py
@@ -329,10 +329,18 @@ def decode(buf: bytes, *, final: bool = False) -> tuple[list[Event], bytes]:
             button, col, row_, kind = int(m[1]), int(m[2]), int(m[3]), m[4]
             buf = buf[m.end():]
             if button & 64:
-                # Wheel. 64 is up and 65 is down on every terminal measured, and the
-                # wheel is reported as a press with no release — which is the second
-                # reason this module keeps no press state.
-                evs.append(Event(SCROLL, "up" if button == 64 else "down",
+                # Wheel, and it is reported as a press with no release — which is the
+                # second reason this module keeps no press state.
+                #
+                # **The direction is the low bit, never the whole number.** An SGR
+                # button number is a bitfield: bit 6 (64) says "wheel", the low two bits
+                # say which one (0 up, 1 down, 2 and 3 the horizontal wheel a trackpad
+                # swipe reports), and bits 2–4 are shift/meta/ctrl. So shift with the
+                # wheel is 68, not 64, and reading it as "not 64, therefore down"
+                # scrolls the list the way the operator did not.
+                if button & 2:
+                    continue           # the horizontal wheel; this list has one axis
+                evs.append(Event(SCROLL, "down" if button & 1 else "up",
                                  row=row_ - 1, col=col - 1))
             else:
                 # A release with no press is a click. See the module docstring: it is
@@ -636,7 +644,17 @@ def open_argv(server: str, *, harness: str, command: list[str],
 
     The pane is split small and zoomed on the very next command (:func:`modal_argvs`), so
     :data:`_SPLIT_ROWS` is the size it holds for an instant rather than the size the
-    operator sees.
+    operator sees. `-v`, so that `-l` is a count of ROWS: under `-h` the same number is
+    columns, and a five-column overlay is a pane nothing can be drawn in.
+
+    *env* rides on `-e` through `layout._env_argv`, the single funnel every `-e` charter
+    builds goes through — #411's measurement is why the overlay needs one at all: every
+    frame shares one tmux server, so a pane inherits the SERVER's environment, captured
+    from whichever launcher started it, possibly days ago. A name outside
+    `layout.CARRIABLE` **raises** there rather than returning ``None`` here, and that
+    asymmetry is deliberate: a pane id charter read back off tmux is a value a launch
+    must survive, while a `-e` name is something charter's own code chose, so it is a
+    defect at the first call that builds it rather than a launch to degrade.
     """
     if not tmuxctl.PANE_ID_RE.fullmatch(harness):
         return None

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -136,6 +136,32 @@ _TMUX_ENV = re.compile(r"^(/[^,]*),\d+,(\d+)$")
 #: cannot drift apart.
 _TMUX_ENV_NAME = "TMUX"
 
+#: Every real pane id tmux's own `-P -F '#{pane_id}'` has ever reported (`%<digits>`,
+#: confirmed against tmux 3.7c and never observed otherwise). Checked before a value read
+#: off `split-window`'s stdout is trusted as a pane id, because two callers interpolate
+#: one directly into text tmux later **re-parses as a command line**:
+#: `commands_frame._resize_hook_argv`'s hook ACTION, and `frame/overlay.hatch_command`'s
+#: escape-hatch option. That is the exact construction `commands_frame`'s module
+#: docstring bans for `status_path`, and for the same reason: something interpolated into
+#: a command tmux re-parses must be safe BY CONSTRUCTION, not merely safe because the one
+#: program that currently produces it (tmux itself) happens to be well-behaved. A value
+#: that fails this check arms nothing at all, rather than gambling that whatever the
+#: string actually was cannot corrupt the parse.
+#:
+#: **`[0-9]`, not `\d`, and the difference is the property.** Python's `\d` is Unicode by
+#: default: `re.fullmatch(r"%\d+", "%١٢")` is a MATCH, and so is the fullwidth `"%１１"`.
+#: Neither is a pane id tmux ever minted, and neither is dangerous on its own — a Unicode
+#: digit carries no meaning to any of the parsers a command string passes through — but
+#: the check is here to say "this is tmux's own word for a pane", and a class that also
+#: admits Arabic-Indic digits is answering a different question. The same
+#: spelling-instead-of-the-property gap this repo keeps paying for, caught before it cost
+#: anything rather than after.
+#:
+#: **Here rather than in `commands_frame`**, where it was first written, because it is a
+#: fact about tmux's own vocabulary and this is the module that owns those; a second copy
+#: beside the second caller is how one guard becomes two that disagree.
+PANE_ID_RE = re.compile(r"%[0-9]+")
+
 
 def operator_server(env: Mapping[str, str] | None = None) -> tuple[str, str] | None:
     """``(socket path, session target)`` for the tmux the operator is ALREADY inside.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -163,6 +163,12 @@ the sentence above:
   prefix-scoped bind here; charter takes the stricter option, because the menu's one
   entry is "Detach" and your own prefix key already does that better. The bottom panel
   drops its hotkey hint to match rather than advertising a key that does nothing.
+- **No `F12` escape hatch either, and this is the one that is worth knowing.** In charter's
+  own tmux, `F12` returns you to your agent session from anywhere in the frame, including
+  from a pane that has stopped answering its keyboard. It is a root key-table entry, which
+  is the same server-wide thing the hotkey is, so the same rule applies here and charter
+  binds nothing. Inside your tmux the way out of a stuck pane is your own prefix key,
+  which charter has not taken and cannot take.
 - **Your status bar stays.** The frame gets the window, not the screen.
 - **Your pane-border styling does not apply inside the frame's window.** Charter pins all
   five of the options tmux draws a border from — both border styles, plus

--- a/docs/news/unreleased-one-key-always-gets-you-back-to-your-session.md
+++ b/docs/news/unreleased-one-key-always-gets-you-back-to-your-session.md
@@ -1,0 +1,67 @@
+---
+version: unreleased
+headline: F12 always gets you back to your session, even from something that has stopped answering
+---
+
+Charter is growing a modal surface — the palette, the workspace and persona pickers, and
+whatever a third-party component draws in a pane of its own. Everything on that list can
+take the keyboard, and one of them will eventually take it and not give it back.
+
+So before any of it ships, the way out ships: **F12 returns you to your agent session,
+from anywhere in the frame.**
+
+```
+bind -n F12 run-shell -C '#{@charter_hatch}'
+```
+
+That is the whole of it, and every part is deliberate. `bind -n` is tmux's *root* key
+table, so tmux matches the key before a single byte reaches the pane — a program that has
+stopped reading its terminal never gets a chance to swallow it. `run-shell -C` runs tmux
+commands, in tmux, with no shell and no second charter process: nothing in that line can
+be as stuck as the thing it is rescuing you from.
+
+It is tested the only way this is worth testing — against a pane running a program that
+puts its terminal in raw mode, ignores every signal it can, and then sleeps. Ordinary keys
+go into it and nothing comes back; F12 puts you back in your session and takes the wedged
+pane with it.
+
+**With nothing open, F12 still selects your session's pane.** That is the same promise
+said plainly: if you have clicked into a panel, or a panel has died oddly, the key means
+"back to my session" rather than "close the thing that is open".
+
+**One limit, stated rather than left to be found.** If you start `charter frame` from
+inside your own tmux, charter builds the frame as a window on *your* server and binds no
+keys at all there — a tmux key table is server-wide, so any key charter took would be
+taken from every window you have open. That is the same rule that already means there is
+no `F2` hotkey on that path. Inside your own tmux, your own prefix key is the way out of
+a stuck pane, and charter has not taken it. `docs/frame.md` lists this beside the other
+costs of charter being a guest.
+
+## The overlay itself
+
+The surface the palette and the pickers will be drawn on is in this release, though
+nothing opens it yet. Three decisions in it are worth knowing about, because they are what
+you will feel when Task 4 lands:
+
+**It is a full pane, not a tmux popup.** A popup would have been prettier. On tmux 3.2 —
+which charter still launches on — any resize of your terminal kills a popup outright, with
+whatever you had typed in it. Measured, not assumed: SIGHUP, exit 129, the log ending
+mid-sentence. A pane survives a resize, redraws, and keeps your place in the list.
+
+**A click selects a row; Enter runs it.** Also measured: with tmux's mouse mode off, a
+drag that starts on a pane border and ends inside a pane delivers a mouse *release* with
+no matching press. Any surface that assumed presses and releases came in pairs would jam
+on the first one. So this one keeps no press state at all — which means a stray release
+can move the highlight, and can never start anything.
+
+**And the mouse only works because the overlay is the pane that asked for it.** Charter
+cannot promise clickable panels in general: your terminal only reports mouse events while
+the *active* pane has asked it to, and the active pane is usually your agent, whose
+choices are not charter's. The overlay is the exception, because while it is open it is
+the active pane.
+
+## What to do
+
+Nothing. If F12 already means something to you inside the frame, it does not any more —
+that is the one thing this takes away, and it is why the key is a function key rather than
+anything you might type.

--- a/docs/superpowers/plans/2026-08-26-phase2-command-surface.md
+++ b/docs/superpowers/plans/2026-08-26-phase2-command-surface.md
@@ -89,20 +89,20 @@ constants, `panel_command`'s `charter panel <slot>` argv, `cli.py`'s `panel` sub
 
 ### Task 2: The overlay surface
 
-- [ ] **Step 1:** write the failing test — an overlay renders rows into a pane charter owns,
+- [x] **Step 1:** write the failing test — an overlay renders rows into a pane charter owns,
       returns a selection, and restores what was there.
-- [ ] **Step 2:** run it, confirm it fails.
-- [ ] **Step 3:** implement a **full-pane** overlay: charter draws it, owns its input loop, and
+- [x] **Step 2:** run it, confirm it fails.
+- [x] **Step 3:** implement a **full-pane** overlay: charter draws it, owns its input loop, and
       is modal. Not `display-popup`. Not `display-menu`.
-- [ ] **Step 4:** input — keys always; mouse **only when the overlay's own pane requests
+- [x] **Step 4:** input — keys always; mouse **only when the overlay's own pane requests
       reporting**, per §4c. Handle a release with no press.
-- [ ] **Step 5:** **the escape hatch.** One key returns to the harness unconditionally, from any
+- [x] **Step 5:** **the escape hatch.** One key returns to the harness unconditionally, from any
       state, including a wedged renderer. Operate it at the **tmux level** (§4e) so it works
       when charter's own loop is stuck. Test it against a deliberately hung overlay.
-- [ ] **Step 6:** resize — the overlay must survive `window-resized`, redraw, and keep selection.
-- [ ] **Step 7:** mutations — remove the escape hatch; make the overlay non-modal; drop the
+- [x] **Step 6:** resize — the overlay must survive `window-resized`, redraw, and keep selection.
+- [x] **Step 7:** mutations — remove the escape hatch; make the overlay non-modal; drop the
       release-with-no-press tolerance. Each RED.
-- [ ] **Step 8:** commit.
+- [x] **Step 8:** commit.
 
 ---
 

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -40,7 +40,7 @@ from unittest import mock
 
 from tests._isolation import PersonaIso
 from charter import commands_frame, config, instance, statusline, util
-from charter.frame import gather, layout, menu, slots, state, tmuxctl
+from charter.frame import gather, layout, menu, overlay, slots, state, tmuxctl
 from tests import _envguard
 
 #: The plane this test PROCESS was started in, captured at IMPORT — before any `setUp`
@@ -1391,7 +1391,8 @@ class _FakeTmux:
                 panel_pane_ids=None, pane_capture="",
                 session_rc=0, source_rc=0, env_set_rc=0, write_hook_rc=0,
                 teardown_hook_rc=0, panel_rc=0, select_rc=0, attach_rc=0, dm_rc=0,
-                kill_rc=0, arm_rc=0, chrome_rc=0, resize_hook_rc=0, capture_rc=0,
+                kill_rc=0, arm_rc=0, hatch_rc=0, chrome_rc=0, resize_hook_rc=0,
+                capture_rc=0,
                 respawn_hook_rc=0,
                 resize_hook_stderr="bad resize hook target"):
         self.pane_id = pane_id
@@ -1417,6 +1418,7 @@ class _FakeTmux:
         self.dm_rc = dm_rc
         self.kill_rc = kill_rc
         self.arm_rc = arm_rc
+        self.hatch_rc = hatch_rc
         self.chrome_rc = chrome_rc
         self.resize_hook_rc = resize_hook_rc
         self.capture_rc = capture_rc
@@ -1450,6 +1452,14 @@ class _FakeTmux:
             # file, never as a bare tmux argv command).
             return subprocess.CompletedProcess(cmd, self.arm_rc, stdout="",
                                                stderr="" if self.arm_rc == 0 else "cannot set")
+        if overlay.HATCH_OPTION in cmd:
+            # The escape hatch's window option. Matched on the PRODUCTION constant, and
+            # BEFORE the `select-pane` branch below, because the option's VALUE is a
+            # `select-pane` command line and a value that ever arrived as its own argv
+            # element would otherwise be answered by the wrong fake.
+            return subprocess.CompletedProcess(cmd, self.hatch_rc, stdout="",
+                                               stderr="" if self.hatch_rc == 0
+                                               else "cannot set")
         if _is_chrome(cmd):
             return subprocess.CompletedProcess(cmd, self.chrome_rc, stdout="",
                                                stderr="" if self.chrome_rc == 0

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1763,6 +1763,117 @@ class Launch(PersonaIso, unittest.TestCase):
                          "one laptop can be two different charter installs")
         self.assertEqual(cmd[-1], "1")
 
+    def test_the_escape_hatch_is_armed_with_this_frames_own_harness_pane(self):
+        """Charter's HALF of the escape hatch, which nothing pinned.
+
+        `conf_text`'s `bind -n F12 run-shell -C '#{@charter_hatch}'` carries no identity
+        — it reads a WINDOW option — so the bind alone is inert. This call is what puts
+        a value in it. Deleting the whole arming block from `cmd_launch` left the entire
+        suite green (5933 tests, OK), and the shipped consequence was measured against a
+        real tmux 3.7c: with `@charter_hatch` unset the bind expands to nothing and F12
+        is a **silent no-op** — no pane killed, no focus moved, no error. The safety
+        property of the whole command surface, gone, with every test still passing.
+
+        Why `tests/test_frame_overlay_escape_hatch.py`'s real-tmux tests do not cover
+        this: each of them ARMS THE OPTION ITSELF (directly via `overlay.arm_hatch_argv`,
+        or through `overlay.modal_argvs`) before pressing the key. They prove tmux's half
+        of the mechanism — that a bind reading this option does the right thing once the
+        option holds the right text — and never charter's half, that anything ever writes
+        it. A test that arms the mechanism it is verifying proves the other party's half.
+
+        `%41` rather than the fake's default `%7`: the value asserted here is a command
+        line that has to NAME the harness pane, and a distinctive id is what tells "the
+        launcher passed the pane tmux reported" from "some pane id got in there".
+        """
+        fake = _FakeTmux(exit_code=0, pane_id="%41")
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        arm_calls = [c for c in fake.calls if overlay.HATCH_OPTION in c]
+        self.assertEqual(len(arm_calls), 1,
+                         f"the frame's escape hatch must be armed exactly once: "
+                         f"{fake.calls}")
+        cmd = arm_calls[0]
+        self.assertIn("set-option", cmd)
+        self.assertIn("-w", cmd)
+        self.assertNotIn("-g", cmd,
+                         "a global write would hand frame N's harness pane to frame "
+                         "N-1 — the `last launched wins` trap `conf_text` names")
+        self.assertEqual(cmd[cmd.index("-t") + 1], "%41",
+                         "the window is resolved through the harness pane's own id, so "
+                         "the value lands on the window whose presser it answers for")
+        self.assertEqual(cmd[-1], "select-pane -t %41",
+                         "the armed value must return the presser to THIS frame's "
+                         "harness, and with no overlay open must carry no `kill-pane` "
+                         "at all — an empty kill target kills the current pane")
+
+    def test_the_hatch_is_armed_before_the_first_panel_is_split(self):
+        """The ordering `frame/overlay.py`'s docstring calls load-bearing, at the one
+        call site that can get it wrong.
+
+        A frame with panes drawn and no way back to the harness is exactly the state the
+        hatch exists for, so the window between "the harness pane exists" and "the hatch
+        answers for it" must contain nothing that can wedge. `modal_argvs` makes the same
+        argument for its own three commands (arm, then focus, then zoom) and
+        `cmd_launch` makes it for the two `pane-died` hooks; this is the third instance
+        of it and the only one nothing asserted.
+
+        The assertion is the ORDER, not the presence — moving the block below
+        `_draw_panels` leaves the test above green.
+        """
+        fake = _FakeTmux(exit_code=0)
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        arm_idx = next((i for i, c in enumerate(fake.calls)
+                        if overlay.HATCH_OPTION in c), None)
+        self.assertIsNotNone(arm_idx, f"the hatch was never armed: {fake.calls}")
+        split_idxs = [i for i, c in enumerate(fake.calls) if "split-window" in c]
+        self.assertTrue(split_idxs,
+                        "no panel was drawn — this ordering test would be vacuous")
+        self.assertLess(arm_idx, split_idxs[0],
+                        "the escape hatch must answer for the harness before the first "
+                        "panel is split, not after")
+
+    def test_a_hatch_that_cannot_be_armed_is_said_out_loud_and_is_not_fatal(self):
+        """The degrade every other cosmetic-to-the-launch tmux failure here gets — with
+        one difference worth naming in the message, which is that this one is not
+        cosmetic. The harness pane is already live by now, so refusing to attach over it
+        would cost the operator the session they asked for; but a frame whose F12 does
+        nothing is a frame with no way out of a wedged pane, and an operator who is
+        never told is an operator who finds out by pressing it.
+        """
+        fake = _FakeTmux(exit_code=4, hatch_rc=1)
+        warned = []
+        with mock.patch("charter.util.warn", side_effect=lambda m: warned.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 4, "an unarmed hatch must not cost the harness's own code")
+        self.assertTrue(any(overlay.HATCH_KEY in m and "continuing without it" in m
+                            for m in warned),
+                        f"a hatch that failed to arm was never named: {warned}")
+        self.assertTrue(any("attach" in c for c in fake.calls))
+
+    def test_a_harness_tmux_will_not_name_as_a_pane_arms_nothing_and_says_so(self):
+        """The other refusal, and the one that must not be quiet.
+
+        `overlay.hatch_command` holds both ids to `tmuxctl.PANE_ID_RE` because the value
+        is stored in an option tmux later **re-parses as a command line**, so a harness
+        tmux reports as something other than `%N` arms nothing at all rather than arming
+        something charter cannot predict the parse of. What the launcher owes on top of
+        that is the sentence: the operator's frame comes up perfectly, and the one key
+        that always leaves it does nothing, and the only difference between finding that
+        out here and finding it out by pressing F12 on a wedged pane is this warning.
+        """
+        fake = _FakeTmux(exit_code=0, pane_id="not-a-pane-id")
+        warned = []
+        with mock.patch("charter.util.warn", side_effect=lambda m: warned.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertEqual([c for c in fake.calls if overlay.HATCH_OPTION in c], [],
+                         "a pane id tmux's own regex refuses must never reach the "
+                         "option tmux re-parses as a command line")
+        self.assertTrue(any(overlay.HATCH_KEY in m and "escape hatch" in m
+                            for m in warned),
+                        f"an unarmable hatch was never named: {warned}")
+
     def test_panels_are_launched_via_self_relaunch_argv(self):
         """#390's visible failure: the panel argv (built inside `layout.panel_command`)
         used to be a hand-built `[sys.executable, "-m", "charter"]` with no `-P`. Spawned

--- a/tests/test_frame_overlay.py
+++ b/tests/test_frame_overlay.py
@@ -1,0 +1,517 @@
+"""The overlay: charter's own modal surface, and the one key that always leaves it.
+
+Spec §4k — **full-pane, charter-drawn, modal**. Not `display-popup` (measured: on tmux
+3.2, a version `tmuxctl.below_floor_message` explicitly still launches on, any client
+resize kills a popup with SIGHUP), not `display-menu` (charter's own nine-row cap and no
+way to page).
+
+Three properties get most of this file's length, because the measurements in
+`docs/superpowers/specs/2026-08-26-tmux-input-findings.md` say each of them is where a
+first implementation goes wrong:
+
+* **A `click` release arrives with no matching press.** Measured: a drag beginning on a
+  pane border and ending inside a pane delivers exactly one release. So the surface keeps
+  no press state at all, and the tests below feed a lone release and assert it lands.
+* **Mouse only when this pane asked for reporting.** The overlay is the one surface
+  charter can promise pointer events on, because it is the active pane while it is open
+  and its own request is what reaches the terminal. When it did not ask, a pointer event
+  must do nothing rather than something arbitrary.
+* **The escape hatch is a tmux key table entry, not charter code.** The unit half is
+  here; the half that presses the key on a real client against a deliberately WEDGED
+  overlay is `tests/test_frame_overlay_escape_hatch.py`, which needs a real tmux.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import commands_frame, config, tui
+from charter.frame import overlay
+
+
+def _rows(n: int = 4) -> tuple[overlay.Row, ...]:
+    """*n* rows whose ids, titles and notes are all distinguishable from each other."""
+    return tuple(overlay.Row(id=f"act{i}", title=f"action {i}", note=f"note {i}")
+                 for i in range(n))
+
+
+class _Tty:
+    """A pane's tty, faked: a script of reads and everything that was written to it.
+
+    `read` answers the next scripted chunk and then ``None`` — end of input — so a test
+    that forgets to end its script cancels rather than spinning. ``b""`` is a TICK: what
+    a real `read` returns when a `SIGWINCH` interrupted it, which is how a resize reaches
+    the loop.
+    """
+
+    def __init__(self, script: list[bytes | None], size=(60, 12)) -> None:
+        self.script = list(script)
+        self.written: list[str] = []
+        self.size = size
+        self.reads = 0
+
+    def read(self) -> bytes | None:
+        self.reads += 1
+        return self.script.pop(0) if self.script else None
+
+    def write(self, s: str) -> None:
+        self.written.append(s)
+
+    def out(self) -> str:
+        return "".join(self.written)
+
+
+def _lines(tty: "_Tty") -> list[str]:
+    """The pane as the operator sees it: the LAST paint, one string per drawn row.
+
+    Split on the paint's own `\r\n` before `tui.strip_ansi` touches anything, because
+    `strip_ansi` turns a newline into a space (`tui.sanitize` — that is its whole job for
+    a committed value) and would erase the line structure this file is asserting about.
+    """
+    paint = tty.out().rsplit("\x1b[H\x1b[2J", 1)[-1]
+    for tail in (overlay.MOUSE_OFF, overlay.LEAVE):
+        paint = paint.split(tail)[0]
+    return [tui.strip_ansi(ln) for ln in paint.split("\r\n")]
+
+
+def _run(rows, script, size=(60, 12), **kw):
+    """Drive a surface to completion. Returns ``(chosen row, the tty)``."""
+    tty = _Tty(script, size)
+    surface = overlay.Surface(rows=rows, **kw)
+    chosen = surface.run(read=tty.read, write=tty.write, size=lambda: tty.size)
+    return chosen, tty
+
+
+class TheOverlayDraws(unittest.TestCase):
+    """Step 1's property: rows go onto a pane, a selection comes back, the pane is
+    restored."""
+
+    def test_every_row_reaches_the_pane(self):
+        _, tty = _run(_rows(3), [b"\r"])
+        drawn = tui.strip_ansi(tty.out())
+        for r in _rows(3):
+            self.assertIn(r.title, drawn, f"{r.title!r} was never drawn")
+            self.assertIn(r.note, drawn, f"{r.note!r} was never drawn")
+
+    def test_the_row_the_operator_moved_to_is_the_one_returned(self):
+        chosen, _ = _run(_rows(4), [b"\x1b[B", b"\x1b[B", b"\r"])
+        self.assertEqual(chosen, _rows(4)[2])
+
+    def test_escape_returns_nothing_at_all(self):
+        chosen, _ = _run(_rows(4), [b"\x1b", b""])
+        self.assertIsNone(chosen)
+
+    def test_end_of_input_is_a_cancel_and_never_a_hang(self):
+        """A closed stdin is the one answer that can never be a wedge — `picker.ask`
+        makes the same call for the same reason."""
+        chosen, tty = _run(_rows(4), [])
+        self.assertIsNone(chosen)
+        self.assertEqual(tty.reads, 1)
+
+    def test_what_was_on_the_pane_comes_back(self):
+        """The alternate screen is the restore, and it is asserted on the BYTES.
+
+        Asserting that some `restore()` helper was called would be a test one layer below
+        the code that prints; what the pane's terminal actually receives is the property.
+        """
+        _, tty = _run(_rows(3), [b"\r"])
+        out = tty.out()
+        self.assertTrue(out.startswith(overlay.ENTER), repr(out[:12]))
+        self.assertTrue(out.endswith(overlay.LEAVE), repr(out[-12:]))
+
+    def test_the_pane_is_restored_even_when_the_paint_raises(self):
+        """A pane whose tty has gone away must not leave the operator on the alternate
+        screen with no cursor — `frame/panel.py`'s `_hold` is the same argument one pane
+        over. `os.get_terminal_size` on a vanished fd is exactly this `OSError`."""
+        tty = _Tty([b"\r"])
+
+        def size():
+            raise OSError("the pane's tty went away")
+
+        with self.assertRaises(OSError):
+            overlay.Surface(rows=_rows(2)).run(read=tty.read, write=tty.write, size=size)
+        self.assertTrue(tty.out().endswith(overlay.LEAVE), repr(tty.out()))
+
+    def test_an_overlay_with_no_rows_says_so_rather_than_drawing_an_empty_box(self):
+        """#512's shape: a convincing empty is worse than a refusal."""
+        chosen, tty = _run((), [b"\r", b"\x1b", b""])
+        self.assertIsNone(chosen)
+        self.assertIn(overlay.EMPTY, tui.strip_ansi(tty.out()))
+
+    def test_enter_on_an_empty_overlay_chooses_nothing(self):
+        """And it does not end the overlay either — there is nothing to have chosen."""
+        tty = _Tty([b"\r", b"\r", b"\x1b", b""])
+        surface = overlay.Surface(rows=())
+        self.assertIsNone(surface.run(read=tty.read, write=tty.write,
+                                      size=lambda: tty.size))
+        self.assertEqual(tty.reads, 4)
+
+
+class TheOverlayIsModal(unittest.TestCase):
+    """It consumes what it is given; nothing falls through it to anyone else."""
+
+    def test_an_unrecognised_key_is_swallowed_rather_than_ending_the_overlay(self):
+        chosen, tty = _run(_rows(3), [b"zzz", b"\x1b[B", b"\r"])
+        self.assertEqual(chosen, _rows(3)[1])
+
+    def test_opening_makes_the_overlay_the_active_pane_and_covers_the_window(self):
+        """Modality at the tmux level: the surface is zoomed over the whole window and
+        selected, which is also what makes its own mouse request the one that reaches the
+        terminal (§4i)."""
+        cmds = overlay.modal_argvs("charter", harness="%0", overlay_pane="%7")
+        flat = [" ".join(c) for c in cmds]
+        self.assertTrue(any("select-pane" in c and "%7" in c for c in flat), flat)
+        self.assertTrue(any("resize-pane" in c and "-Z" in c for c in flat), flat)
+
+    def test_the_hatch_is_armed_before_the_surface_can_capture_anything(self):
+        """Order, not merely presence. A surface selected before its escape hatch exists
+        is a surface that can wedge with no way out — the same "install the write hook
+        before the teardown hook" argument `commands_frame` already makes for `pane-died`.
+        """
+        cmds = overlay.modal_argvs("charter", harness="%0", overlay_pane="%7")
+        # The tmux SUBCOMMAND, not a substring of the whole line: the armed value itself
+        # contains the text `select-pane`, and matching on that would make this pass on
+        # the arm command alone.
+        names = [c[3] for c in cmds]
+        self.assertLess(names.index("set-option"), names.index("select-pane"), names)
+
+
+class TheInputContract(unittest.TestCase):
+    """`decode` — bytes to the five event kinds §4f left open, and nothing else."""
+
+    def test_the_arrow_keys(self):
+        evs, tail = overlay.decode(b"\x1b[A\x1b[B")
+        self.assertEqual([(e.kind, e.name) for e in evs],
+                         [(overlay.KEY, "up"), (overlay.KEY, "down")])
+        self.assertEqual(tail, b"")
+
+    def test_a_partial_escape_sequence_is_kept_rather_than_misread(self):
+        """Half of `\\x1b[B` arriving is not an Escape keypress. Reading it as one would
+        cancel the overlay on a slow terminal."""
+        evs, tail = overlay.decode(b"\x1b[")
+        self.assertEqual(evs, [])
+        self.assertEqual(tail, b"\x1b[")
+        evs, tail = overlay.decode(tail + b"B")
+        self.assertEqual([(e.kind, e.name) for e in evs], [(overlay.KEY, "down")])
+
+    def test_a_lone_escape_resolves_only_when_nothing_more_is_coming(self):
+        evs, tail = overlay.decode(b"\x1b")
+        self.assertEqual(evs, [])
+        evs, tail = overlay.decode(tail, final=True)
+        self.assertEqual([(e.kind, e.name) for e in evs], [(overlay.KEY, "escape")])
+        self.assertEqual(tail, b"")
+
+    def test_a_sequence_is_never_replayed_as_the_keys_it_is_spelled_with(self):
+        """The rule `decode`'s docstring already states for a sequence that arrived
+        HALF-way, applied to one that arrived WHOLE.
+
+        A terminal sends far more escape sequences than the six names this surface has —
+        every modified arrow, every function key, and the brackets around a paste. Each
+        one is a `\\x1b[`, some digits and semicolons, and a final byte, and a decoder
+        that only knows the six it wants hands the other bytes to whoever is next: `Ctrl`
+        with an arrow types `1;5A`, `F1` types `P`, and pasting a word into a filter
+        types `200~` before it and `201~` after. **Task 4's palette filters on exactly
+        the keys this produces**, which is where the cost lands.
+
+        Every case here is a real terminal's real bytes, so the property is "the surface
+        consumes the whole sequence and answers only for the ones it knows", not "these
+        eight strings".
+        """
+        for raw, want in (
+                # A modified arrow is still that arrow: the final byte names the key and
+                # the parameters name modifiers this surface has no use for.
+                (b"\x1b[1;5A", [(overlay.KEY, "up")]),      # Ctrl-Up
+                (b"\x1b[1;2B", [(overlay.KEY, "down")]),    # Shift-Down
+                (b"\x1b[1;5H", [(overlay.KEY, "home")]),    # Ctrl-Home
+                (b"\x1b[5;5~", [(overlay.KEY, "pgup")]),    # Ctrl-PgUp — the `~` family
+                (b"\x1b[6~", [(overlay.KEY, "pgdn")]),      #             and plain PgDn
+                # And one this surface has no name for at all is consumed, not spelled.
+                (b"\x1bOP", []),                            # F1
+                (b"\x1b[Z", []),                            # Shift-Tab
+                (b"\x1b[24~", []),                          # F12 — the HATCH key itself
+                (b"\x1b[3~", []),                           # Delete
+                # Bracketed paste: the pasted text arrives, its brackets do not.
+                (b"\x1b[200~hi\x1b[201~", [(overlay.KEY, "h"), (overlay.KEY, "i")]),
+        ):
+            with self.subTest(raw=raw):
+                evs, tail = overlay.decode(raw, final=True)
+                self.assertEqual([(e.kind, e.name) for e in evs], want)
+                self.assertEqual(tail, b"")
+
+    def test_a_modified_arrow_still_arrives_split_across_two_reads(self):
+        """The longer sequence must not lose the hold-it-back half: `\\x1b[1;5` is a
+        prefix of Ctrl-Up and of nothing this surface would rather act on."""
+        evs, tail = overlay.decode(b"\x1b[1;5")
+        self.assertEqual(evs, [])
+        self.assertEqual(tail, b"\x1b[1;5")
+        evs, tail = overlay.decode(tail + b"A")
+        self.assertEqual([(e.kind, e.name) for e in evs], [(overlay.KEY, "up")])
+        self.assertEqual(tail, b"")
+
+    def test_printable_bytes_arrive_as_themselves(self):
+        evs, _ = overlay.decode(b"wq")
+        self.assertEqual([(e.kind, e.name) for e in evs],
+                         [(overlay.KEY, "w"), (overlay.KEY, "q")])
+
+    def test_an_sgr_press_and_release_are_both_clicks(self):
+        evs, tail = overlay.decode(b"\x1b[<0;5;3M\x1b[<0;5;3m")
+        self.assertEqual([(e.kind, e.pressed, e.row) for e in evs],
+                         [(overlay.CLICK, True, 2), (overlay.CLICK, False, 2)])
+        self.assertEqual(tail, b"")
+
+    def test_a_release_with_no_matching_press_is_still_a_click(self):
+        """MEASURED, not supposed: with tmux's own `mouse` off, a drag that begins on a
+        pane border and ends inside a pane delivers exactly one release
+        (`b'\\x1b[<0;70;4m'`). §4i: the first component keeping press state wedges on it.
+        """
+        evs, tail = overlay.decode(b"\x1b[<0;70;4m")
+        self.assertEqual([(e.kind, e.pressed) for e in evs], [(overlay.CLICK, False)])
+        self.assertEqual(tail, b"")
+
+    def test_the_wheel_is_a_scroll_and_not_a_click(self):
+        evs, _ = overlay.decode(b"\x1b[<64;10;5M\x1b[<65;10;5M")
+        self.assertEqual([(e.kind, e.name) for e in evs],
+                         [(overlay.SCROLL, "up"), (overlay.SCROLL, "down")])
+
+    def test_a_partial_mouse_report_is_kept_whole(self):
+        evs, tail = overlay.decode(b"\x1b[<0;5;")
+        self.assertEqual(evs, [])
+        self.assertEqual(tail, b"\x1b[<0;5;")
+        evs, _ = overlay.decode(tail + b"3M")
+        self.assertEqual([e.kind for e in evs], [overlay.CLICK])
+
+
+class TheMouseIsConditional(unittest.TestCase):
+    """§4c, as the measurement leaves it: pointer events belong to the overlay only
+    because the overlay is the pane that asked for them."""
+
+    def test_a_surface_that_asked_moves_its_selection_on_a_lone_release(self):
+        chosen, tty = _run(_rows(6), [b"\x1b[<0;3;4m", b"\r"], mouse=True)
+        self.assertIn(overlay.MOUSE_ON, tty.out())
+        self.assertEqual(chosen, _rows(6)[2])
+
+    def test_a_surface_that_did_not_ask_neither_requests_nor_acts(self):
+        """Not two flags — one. The request written to the tty and the events acted on
+        are the same declaration, so there is no state in which charter acts on a report
+        it never asked the terminal for."""
+        chosen, tty = _run(_rows(6), [b"\x1b[<0;3;4m", b"\r"], mouse=False)
+        self.assertNotIn(overlay.MOUSE_ON, tty.out())
+        self.assertEqual(chosen, _rows(6)[0])
+
+    def test_the_request_is_withdrawn_before_the_pane_is_handed_back(self):
+        _, tty = _run(_rows(3), [b"\r"], mouse=True)
+        out = tty.out()
+        self.assertIn(overlay.MOUSE_OFF, out)
+        self.assertLess(out.index(overlay.MOUSE_ON), out.index(overlay.MOUSE_OFF))
+
+    def test_a_click_never_activates_a_row(self):
+        """A pointer event that can arrive unpaired must not drive the irreversible half.
+        The release with no press is real, so a click SELECTS and `Enter` chooses."""
+        tty = _Tty([b"\x1b[<0;3;4m", b"\x1b", b""])
+        surface = overlay.Surface(rows=_rows(6), mouse=True)
+        self.assertIsNone(surface.run(read=tty.read, write=tty.write,
+                                      size=lambda: tty.size))
+
+    def test_a_click_off_the_end_of_the_list_changes_nothing(self):
+        chosen, _ = _run(_rows(3), [b"\x1b[<0;3;11m", b"\r"], mouse=True)
+        self.assertEqual(chosen, _rows(3)[0])
+
+    def test_the_wheel_moves_through_the_rows(self):
+        chosen, _ = _run(_rows(6), [b"\x1b[<65;3;4M", b"\x1b[<65;3;4M", b"\r"],
+                         mouse=True)
+        self.assertEqual(chosen, _rows(6)[2])
+
+
+class TheOverlaySurvivesAResize(unittest.TestCase):
+    """`window-resized` does not bump the frame's version and nothing else redraws for
+    it — `frame/panel.py`'s SIGWINCH section is the same fact one pane over."""
+
+    def test_the_selected_row_is_still_selected_and_still_drawn(self):
+        tty = _Tty([b"\x1b[B"] * 9 + [b"", b"\r"], size=(60, 14))
+        surface = overlay.Surface(rows=_rows(20))
+
+        def size():
+            # The resize happens on the tick — a `read` interrupted by SIGWINCH.
+            if tty.reads >= 10:
+                return (40, 6)
+            return (60, 14)
+
+        chosen = surface.run(read=tty.read, write=tty.write, size=size)
+        self.assertEqual(chosen, _rows(20)[9])
+        # The pane is six rows now and the selection is the tenth: it is only still on
+        # screen because the window scrolled to it.
+        shown = _lines(tty)
+        self.assertLessEqual(len(shown), 6, shown)
+        self.assertTrue(any(_rows(20)[9].title in ln for ln in shown), shown)
+
+    def test_a_narrow_pane_still_has_a_note_column(self):
+        """Fitting inside the width is not the same as being readable at it.
+
+        The title column is sized from the titles, so in a narrow pane a two-column
+        layout eats the second column whole: measured at 34 columns, the widest title
+        took 28 of them and every note came out as one glyph and an ellipsis. **Task 4's
+        "an unavailable action appears WITH ITS REASON" is a note**, and a reason no pane
+        narrower than a full-width laptop can show is that requirement unmet rather than
+        met — #512's shape one column over, since a truncated reason still LOOKS like an
+        answer.
+        """
+        rows = (overlay.Row(id="a", title="a fairly long action title here",
+                            note="held"),
+                overlay.Row(id="b", title="short", note="ready"))
+        drawn = [tui.strip_ansi(ln) for ln in overlay.Surface(rows=rows).render(34, 8)]
+        for note in ("held", "ready"):
+            with self.subTest(note=note):
+                self.assertTrue(any(note in ln for ln in drawn),
+                                f"{note!r} never survived the title column: {drawn}")
+
+    def test_a_narrower_pane_wraps_nothing(self):
+        rows = (overlay.Row(id="a", title="a title far wider than this pane is",
+                            note="and a note as well"),)
+        tty = _Tty([b"\r"], size=(20, 8))
+        overlay.Surface(rows=rows).run(read=tty.read, write=tty.write,
+                                       size=lambda: tty.size)
+        for line in _lines(tty):
+            self.assertLessEqual(tui.width(line), 20, repr(line))
+
+
+class RowsAreContainedBeforeTheyAreMeasured(unittest.TestCase):
+    """#472's rule, and #498's reason for stating it as a property rather than a list."""
+
+    def test_a_title_carrying_a_line_break_still_renders_as_one_row(self):
+        rows = (overlay.Row(id="a", title="one\nline two", note="n"),
+                overlay.Row(id="b", title="plain", note="n"))
+        tty = _Tty([b"\r"], size=(60, 10))
+        overlay.Surface(rows=rows).run(read=tty.read, write=tty.write,
+                                       size=lambda: tty.size)
+        body = "\n".join(_lines(tty))
+        # Both of them: `\n` is the one everybody handles, and U+2028 is the one #498 was
+        # filed about after `\n` already was. Each survives as its own escape — visible,
+        # and unable to end a line.
+        self.assertIn("\\x0a", body)
+        self.assertIn("\\u2028", body)
+        rendered = [ln for ln in _lines(tty) if "line" in ln or "plain" in ln]
+        self.assertEqual(len(rendered), 2, rendered)
+
+    def test_an_escape_sequence_in_a_title_never_reaches_the_pane(self):
+        rows = (overlay.Row(id="a", title="\x1b[31mred\x1b[0m\x1b]0;title\x07", note=""),)
+        tty = _Tty([b"\r"], size=(60, 10))
+        overlay.Surface(rows=rows).run(read=tty.read, write=tty.write,
+                                       size=lambda: tty.size)
+        body = tty.out()
+        self.assertNotIn("\x1b]0;", body)
+        self.assertNotIn("\x07", body)
+
+
+class TheEscapeHatch(unittest.TestCase):
+    """§4e: one key, at the TMUX level, that returns to the harness from any state.
+
+    The half that presses it on a real client against a deliberately wedged overlay is
+    `tests/test_frame_overlay_escape_hatch.py`. What is here is the shape of the thing
+    tmux is asked to install.
+    """
+
+    def test_the_key_is_bound_in_tmux_own_root_table(self):
+        bind = overlay.hatch_bind()
+        self.assertTrue(bind.startswith(f"bind -n {overlay.HATCH_KEY} "), bind)
+
+    def test_the_hatch_runs_no_charter_code_at_all(self):
+        """The whole point: it has to work while charter's own loop is stuck. A
+        `run-shell` spawning charter would put a second charter process in the path out
+        of the first one, and `-C` is what makes tmux run the commands itself."""
+        bind = overlay.hatch_bind()
+        self.assertIn("run-shell -C", bind)
+        self.assertNotIn("CHARTER_PY", bind)
+        self.assertNotIn("-m charter", bind)
+
+    def test_the_bind_carries_no_frame_identity_of_its_own(self):
+        """A key table is server-wide in tmux. `conf_text`'s docstring records what a
+        bind holding one frame's own id costs the second frame launched: it resolves the
+        WRONG frame. The pane ids live in a WINDOW option the presser's own window
+        answers."""
+        self.assertNotIn("%", overlay.hatch_bind())
+        self.assertIn(overlay.HATCH_OPTION, overlay.hatch_bind())
+
+    def test_returning_to_the_harness_comes_first(self):
+        """Order is the unconditional half of the promise. If the kill fails — a stale
+        pane id, an overlay already gone — focus has already moved."""
+        cmd = overlay.hatch_command(harness="%0", overlay_pane="%7")
+        self.assertLess(cmd.index("select-pane"), cmd.index("kill-pane"), cmd)
+
+    def test_with_no_overlay_open_the_hatch_still_returns_to_the_harness(self):
+        cmd = overlay.hatch_command(harness="%0")
+        self.assertEqual(cmd, "select-pane -t %0")
+
+    def test_no_overlay_never_becomes_an_empty_kill_target(self):
+        """MEASURED against tmux 3.7c: `kill-pane -t ""` does not fail — it kills the
+        CURRENT pane. A hatch that expanded an unset option into that target would take
+        a panel out on every stray press."""
+        self.assertNotIn("kill-pane", overlay.hatch_command(harness="%0"))
+
+    def test_the_empty_string_is_not_a_spelling_of_no_overlay(self):
+        """`None` is the only spelling of "the caller did not say". A falsy sentinel
+        resolving one way here and another way elsewhere is Phase 1's own lesson."""
+        self.assertIsNone(overlay.hatch_command(harness="%0", overlay_pane=""))
+
+    def test_only_tmux_own_word_for_a_pane_reaches_the_command(self):
+        """The value becomes tmux command text that tmux re-parses — `_PANE_ID_RE`'s
+        exact call site, one option over."""
+        for bad in ("%0; kill-server", "%0\nkill-server", "harness", "", "%١٢", "%１１",
+                    "#{q:x}", "-t"):
+            with self.subTest(bad=bad):
+                self.assertIsNone(overlay.hatch_command(harness=bad))
+                self.assertIsNone(overlay.hatch_command(harness="%0",
+                                                        overlay_pane=bad))
+
+    def test_a_refused_pane_id_arms_nothing_rather_than_arming_something_wrong(self):
+        self.assertIsNone(overlay.arm_hatch_argv("charter", harness="nope"))
+        argv = overlay.arm_hatch_argv("charter", harness="%0")
+        self.assertEqual(argv[:2], ["tmux", "-L"])
+        self.assertIn("set-option", argv)
+        self.assertIn("-w", argv)
+        self.assertIn(overlay.HATCH_OPTION, argv)
+
+    def test_the_option_is_window_scoped_and_never_global(self):
+        """`-g` here would hand frame N's harness pane to frame N-1 — the "last launched
+        wins" trap `conf_text` names for `mouse` and `history-limit`."""
+        argv = overlay.arm_hatch_argv("charter", harness="%0")
+        self.assertNotIn("-g", argv)
+        self.assertEqual(argv[argv.index("-t") + 1], "%0")
+
+    def test_the_frame_config_installs_it(self):
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=100,
+                                        session="s1")
+        self.assertIn(overlay.hatch_bind(), text.split("\n"))
+
+    def test_the_hatch_key_is_not_the_key_that_opens_things(self):
+        """Two answers to one keypress is one answer that never fires."""
+        self.assertNotEqual(overlay.HATCH_KEY, config.FRAME["hotkey"])
+
+    def test_the_hatch_key_is_a_key_tmux_config_can_hold(self):
+        """The same bound `[frame] hotkey` is held to — a newline in a key name once
+        achieved code execution at launch (`instance._HOTKEY_RE`)."""
+        from charter import instance
+        self.assertTrue(instance._HOTKEY_RE.fullmatch(overlay.HATCH_KEY))
+
+
+class TheOverlayPaneIsCharterOwn(unittest.TestCase):
+    def test_it_is_split_off_the_harness_pane_and_reports_its_own_id(self):
+        argv = overlay.open_argv("charter", harness="%0", command=["python3", "-m", "x"])
+        self.assertIsNotNone(argv)
+        self.assertIn("split-window", argv)
+        self.assertEqual(argv[argv.index("-t") + 1], "%0")
+        self.assertEqual(argv[argv.index("-F") + 1], "#{pane_id}")
+        self.assertEqual(argv[argv.index("--") + 1:], ["python3", "-m", "x"])
+
+    def test_a_target_that_is_not_a_pane_id_opens_nothing(self):
+        self.assertIsNone(overlay.open_argv("charter", harness="0", command=["true"]))
+
+    def test_closing_hands_the_pane_back_and_disarms_the_hatch(self):
+        cmds = [" ".join(c) for c in
+                overlay.close_argvs("charter", harness="%0", overlay_pane="%7")]
+        self.assertTrue(any("select-pane" in c and "%0" in c for c in cmds), cmds)
+        self.assertTrue(any("kill-pane" in c and "%7" in c for c in cmds), cmds)
+        self.assertTrue(cmds[-1].endswith("select-pane -t %0"), cmds)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_overlay.py
+++ b/tests/test_frame_overlay.py
@@ -44,6 +44,19 @@ def _rows(n: int = 4) -> tuple[overlay.Row, ...]:
                  for i in range(n))
 
 
+def _numbered(n: int = 20) -> tuple[overlay.Row, ...]:
+    """*n* rows whose titles are zero-padded, so no title is a prefix of another.
+
+    :func:`_rows`' `action 1` **is** a prefix of `action 10`, which is harmless for a
+    test asking whether one title reached the pane and wrong for one asking WHICH rows
+    the window is showing. Every scrolling test below asserts both halves — the row that
+    must be drawn and the row that must not be — and only distinguishable titles can
+    carry the second half.
+    """
+    return tuple(overlay.Row(id=f"r{i}", title=f"row-{i:02d}", note=f"why-{i:02d}")
+                 for i in range(n))
+
+
 class _Tty:
     """A pane's tty, faked: a script of reads and everything that was written to it.
 
@@ -451,6 +464,40 @@ class TheOverlaySurvivesAResize(unittest.TestCase):
         self.assertLessEqual(len(shown), 6, shown)
         self.assertTrue(any(_rows(20)[9].title in ln for ln in shown), shown)
 
+    def test_a_pane_that_grew_fills_with_rows_and_not_with_blank_lines(self):
+        """The resize the other way, and the clamp only this direction can reach.
+
+        `_top` is wherever the last paint left the window, and a pane that GROWS can make
+        it a top the list has too few rows to sit at: ten rows scrolled to `_top` 8 for a
+        window two rows tall, and then a window ten rows tall. `_window`'s last line is
+        what pulls the top back to 0 so the whole list fills the pane; without it the
+        pane draws the last two rows and eight blank lines, and eight of the operator's
+        ten choices are simply not on screen.
+
+        **The test above only ever SHRINKS**, which is the one direction where that clamp
+        cannot bind — a smaller window always has a top its list can sit at. So the
+        clamp went unpinned, and deleting it left the whole suite green.
+        """
+        rows = _numbered(10)
+        # Precondition, and not decoration: four rows really is too short for this list,
+        # so the window really is scrolled away from row 0 before the pane grows. Without
+        # this the assertion below would hold for a surface that never scrolled at all.
+        _, small = _run(rows, [b"\x1b[F", b"\r"], size=(60, 4))
+        self.assertNotIn(rows[0].title, "\n".join(_lines(small)))
+
+        tty = _Tty([b"\x1b[F", b"", b"\r"], size=(60, 4))
+        surface = overlay.Surface(rows=rows)
+
+        def size():
+            # The pane grows on the tick — a `read` a SIGWINCH interrupted — which is
+            # how the test above delivers its shrink, in the other direction.
+            return (60, 12) if tty.reads >= 2 else (60, 4)
+
+        self.assertEqual(surface.run(read=tty.read, write=tty.write, size=size), rows[9])
+        drawn = _lines(tty)
+        for row in rows:
+            self.assertIn(row.title, "\n".join(drawn), drawn)
+
     def test_a_narrow_pane_still_has_a_note_column(self):
         """Fitting inside the width is not the same as being readable at it.
 
@@ -479,6 +526,51 @@ class TheOverlaySurvivesAResize(unittest.TestCase):
                                        size=lambda: tty.size)
         for line in _lines(tty):
             self.assertLessEqual(tui.width(line), 20, repr(line))
+
+
+class TheWindowFollowsTheSelectionBothWays(unittest.TestCase):
+    """`_window`'s two scroll branches are a mirror pair, and only one of them had a test.
+
+    One moves the window DOWN when the selection goes off the bottom; the other moves it
+    back UP when the selection goes off the top. The downward one was pinned by
+    `TheOverlaySurvivesAResize`, which was also the only test in this file that scrolled
+    at all — and it moves the selection down and shrinks the pane, so the upward branch
+    was never asked for anything. Deleting it left the full suite green while `Home` drew
+    the operator's selection **nowhere at all**, which is the outcome `_window`'s own
+    docstring exists to rule out: "drawn nowhere, so the next keypress appears to come
+    from nothing".
+    """
+
+    def test_home_scrolls_the_window_back_up_to_the_row_it_selected(self):
+        rows = _numbered(20)
+        # Precondition: `End` really does scroll the window off the top of the list. If
+        # it did not, `Home` would have nothing to scroll back and everything below would
+        # hold for a surface that never scrolls in either direction.
+        _, down = _run(rows, [b"\x1b[F", b"\r"], size=(60, 8))
+        self.assertIn(rows[19].title, "\n".join(_lines(down)))
+        self.assertNotIn(rows[0].title, "\n".join(_lines(down)))
+
+        chosen, up = _run(rows, [b"\x1b[F", b"\x1b[H", b"\r"], size=(60, 8))
+        # The selection is an index and `move` clamps it, so it is on row 0 whether or
+        # not the window followed — which is exactly why this cannot be the assertion.
+        self.assertEqual(chosen, rows[0])
+        drawn = _lines(up)
+        self.assertTrue(any(rows[0].title in ln for ln in drawn),
+                        f"the selected row is drawn nowhere: {drawn}")
+        self.assertFalse(any(rows[19].title in ln for ln in drawn),
+                         f"the window never left the bottom of the list: {drawn}")
+
+    def test_arrowing_back_up_past_the_top_of_the_window_scrolls_too(self):
+        """The same branch reached one row at a time rather than in one jump, because
+        `home` is a `move` of the whole list length and a single `up` is not — a window
+        that only recovered from the extreme would still lose the operator one row above
+        the fold."""
+        rows = _numbered(20)
+        chosen, tty = _run(rows, [b"\x1b[F"] + [b"\x1b[A"] * 7 + [b"\r"], size=(60, 8))
+        self.assertEqual(chosen, rows[12])
+        drawn = _lines(tty)
+        self.assertTrue(any(rows[12].title in ln for ln in drawn),
+                        f"the selected row is drawn nowhere: {drawn}")
 
 
 class RowsAreContainedBeforeTheyAreMeasured(unittest.TestCase):
@@ -640,6 +732,29 @@ class ThePaneChromeIsCountedOnce(unittest.TestCase):
                          overlay.Surface(rows=_rows(20)).render(60, height)]
                 self.assertLessEqual(len(drawn), height, drawn)
                 self.assertIn("esc cancel", drawn[-1], drawn)
+
+    def test_a_pane_with_room_for_only_one_line_of_list_spends_it_on_a_ROW(self):
+        """The floor under the window's height, at the only height where it binds.
+
+        Chrome is two rows and a two-row pane has nothing left over, so the window's
+        height is a **floor** rather than the subtraction: one row, and the key hint is
+        what `out[:height]` drops. Take the floor away and the subtraction answers zero,
+        the slice of rows comes back empty, and a pane with room for exactly one row
+        draws the hint instead — an overlay offering nothing at all, which is the one
+        state the operator cannot act from. (One row shorter still, the subtraction
+        answers **-1**, and `_window` starts walking `_top` forward on every paint.)
+
+        `test_the_key_hint_survives_at_every_height` starts at three, which is why this
+        was never asked: two is the height where the two rows of chrome and one row of
+        list stop both fitting, and something has to give. What gives is the hint, and
+        that is the trade this pins — the hint is where `esc` is written down, but a
+        list with no rows in it has nothing for `esc` to cancel out of.
+        """
+        rows = _numbered(20)
+        drawn = [tui.strip_ansi(ln) for ln in overlay.Surface(rows=rows).render(60, 2)]
+        self.assertEqual(len(drawn), 2, drawn)
+        self.assertIn(rows[0].title, drawn[1],
+                      f"a two-row pane drew no rows at all: {drawn}")
 
     def test_a_click_selects_the_row_that_was_drawn_where_it_landed(self):
         """Agreement between the two halves, asserted against `render`'s own output

--- a/tests/test_frame_overlay.py
+++ b/tests/test_frame_overlay.py
@@ -23,10 +23,19 @@ first implementation goes wrong:
 
 from __future__ import annotations
 
+import re
 import unittest
 
 from charter import commands_frame, config, tui
-from charter.frame import overlay
+from charter.frame import layout, overlay
+
+#: The two DEC private modes the overlay turns on and has to turn back off, spelled out
+#: here rather than reached for through `overlay.ENTER`/`overlay.LEAVE`. A constant
+#: compared against itself agrees with itself: an `ENTER` that lost its `\x1b[?25l` and a
+#: `LEAVE` that lost its `\x1b[?25h` both still satisfy "starts with ENTER, ends with
+#: LEAVE", and the operator is left on their own screen with no cursor either way.
+_ALT_ON, _ALT_OFF = "\x1b[?1049h", "\x1b[?1049l"
+_CURSOR_OFF, _CURSOR_ON = "\x1b[?25l", "\x1b[?25h"
 
 
 def _rows(n: int = 4) -> tuple[overlay.Row, ...]:
@@ -72,6 +81,25 @@ def _lines(tty: "_Tty") -> list[str]:
     for tail in (overlay.MOUSE_OFF, overlay.LEAVE):
         paint = paint.split(tail)[0]
     return [tui.strip_ansi(ln) for ln in paint.split("\r\n")]
+
+
+def _paint(tty: "_Tty") -> str:
+    """The last whole-pane write, as the bytes the pane's terminal received.
+
+    :func:`_lines` is the same paint *as the operator sees it* and runs `tui.strip_ansi`
+    on the way — which turns a control character into something printable, and so cannot
+    be asked whether one reached the pane at all. This is the unstripped half, for the
+    tests that are about exactly that.
+    """
+    paint = tty.out().rsplit("\x1b[H\x1b[2J", 1)[-1]
+    for tail in (overlay.MOUSE_OFF, overlay.LEAVE):
+        paint = paint.split(tail)[0]
+    return paint
+
+
+def _modes(s: str) -> list[tuple[int, str]]:
+    """The DEC private modes in *s*, in order, as ``(number, "h" set / "l" reset)``."""
+    return [(int(n), sl) for n, sl in re.findall(r"\x1b\[\?(\d+)([hl])", s)]
 
 
 def _run(rows, script, size=(60, 12), **kw):
@@ -280,6 +308,85 @@ class TheInputContract(unittest.TestCase):
         evs, _ = overlay.decode(tail + b"3M")
         self.assertEqual([e.kind for e in evs], [overlay.CLICK])
 
+    def test_a_sequence_whose_end_never_arrives_is_not_an_escape_keypress(self):
+        """`\\x1b[12` and then nothing is a CSI whose final byte will never come — the
+        `final=True` path with a buffer `_CSI_PARTIAL` would have held a moment earlier.
+
+        The one thing it must not become is `escape`, which is the single input this
+        surface reads as "leave now": a terminal that stopped mid-sequence would then
+        close the overlay the operator was typing into. So the introducer is dropped and
+        what is left takes its chances as ordinary keys, which a modal surface swallows.
+        """
+        evs, tail = overlay.decode(b"\x1b[12", final=True)
+        self.assertNotIn("escape", [e.name for e in evs], evs)
+        self.assertEqual([(e.kind, e.name) for e in evs],
+                         [(overlay.KEY, "1"), (overlay.KEY, "2")])
+        self.assertEqual(tail, b"")
+
+    def test_an_unfinished_sequence_does_not_cancel_the_overlay(self):
+        """The same fact one layer up, which is the layer it costs something on: the
+        half-sequence arrives, the read after it times out (`b""` — a tick), and the
+        overlay is still there to take the next keypress."""
+        chosen, _ = _run(_rows(3), [b"\x1b[12", b"", b"\x1b[B", b"\r"])
+        self.assertEqual(chosen, _rows(3)[1])
+
+    def test_ctrl_c_is_a_key_that_means_leave(self):
+        """The surface has the tty in RAW mode, so nothing downstream is going to turn
+        `\\x03` into a signal — there is no "and then the interrupt fires" to fall back
+        on. Dropped by the printable filter instead, it is a modal surface that does not
+        answer the first key an operator tries."""
+        evs, _ = overlay.decode(b"\x03")
+        self.assertEqual([(e.kind, e.name) for e in evs], [(overlay.KEY, "escape")])
+        tty = _Tty([b"\x03"])
+        surface = overlay.Surface(rows=_rows(3))
+        self.assertIsNone(surface.run(read=tty.read, write=tty.write,
+                                      size=lambda: tty.size))
+        self.assertEqual(tty.reads, 1, "the overlay read on past a Ctrl-C")
+
+    def test_a_control_byte_this_surface_has_no_name_for_is_not_a_keypress(self):
+        """Everything `decode` answers for, it names by hand; the filter is what keeps
+        the rest from arriving as keys. Without it a stray `\\x01`, or the `\\x00`s a
+        closing pty can deliver, become keypresses that Task 4's palette types into its
+        filter box — and every one of them repaints the pane."""
+        evs, tail = overlay.decode(b"\x01\x02\x0b\x1f", final=True)
+        self.assertEqual(evs, [])
+        self.assertEqual(tail, b"")
+
+    def test_half_a_utf_8_character_is_not_a_keypress(self):
+        """`decode` walks BYTES and a multi-byte character arrives as several of them,
+        so an undecodable byte is a *fragment*, not input. Replaced rather than dropped
+        it becomes a U+FFFD keypress — a key the operator never pressed, out of half of
+        one they did."""
+        evs, _ = overlay.decode("é".encode()[:1], final=True)
+        self.assertEqual(evs, [])
+
+    def test_the_wheel_is_a_scroll_whatever_modifier_is_held(self):
+        """An SGR button number is a BITFIELD, and both halves of that matter here.
+
+        Bit 6 (64) is what makes a report a wheel; bits 2–4 are shift/meta/ctrl, so
+        shift with the wheel is 68 and ctrl with it is 80. A test written against the
+        bare `64`/`65` lets a modifier turn a scroll into a CLICK, and on this surface a
+        click SELECTS the row under the pointer — so a shift-wheel would jump the
+        selection to wherever the pointer happened to rest instead of moving the list.
+
+        The low two bits are which wheel: 0 up, 1 down, and 2/3 the horizontal one a
+        trackpad swipe reports. Direction therefore comes from the low bit and never
+        from the whole number, and a horizontal swipe moves nothing at all — this list
+        has one axis, and scrolling it sideways-means-down is worse than not answering.
+        """
+        for button, want in ((64, [(overlay.SCROLL, "up")]),
+                             (65, [(overlay.SCROLL, "down")]),
+                             (68, [(overlay.SCROLL, "up")]),     # shift + wheel up
+                             (69, [(overlay.SCROLL, "down")]),   # shift + wheel down
+                             (80, [(overlay.SCROLL, "up")]),     # ctrl + wheel up
+                             (81, [(overlay.SCROLL, "down")]),   # ctrl + wheel down
+                             (66, []),                           # wheel left
+                             (67, [])):                          # wheel right
+            with self.subTest(button=button):
+                evs, tail = overlay.decode(f"\x1b[<{button};10;5M".encode())
+                self.assertEqual([(e.kind, e.name) for e in evs], want)
+                self.assertEqual(tail, b"")
+
 
 class TheMouseIsConditional(unittest.TestCase):
     """§4c, as the measurement leaves it: pointer events belong to the overlay only
@@ -392,6 +499,22 @@ class RowsAreContainedBeforeTheyAreMeasured(unittest.TestCase):
         rendered = [ln for ln in _lines(tty) if "line" in ln or "plain" in ln]
         self.assertEqual(len(rendered), 2, rendered)
 
+    def test_a_heading_is_contained_the_way_a_row_is(self):
+        """The heading is a committed value too — a workspace or persona name in Task 6 —
+        and the pane's entire layout is ONE write split on `\\r\\n`.
+
+        U+2028 is the character #498 was filed about, and it is what tells the heading's
+        own `contain.one_line` apart from the `tui.sanitize` every `truncate` already
+        runs: sanitize folds a `\\n` into a space and leaves a LINE SEPARATOR alone, so
+        without the containing step this one reaches the pane, is counted as one cell,
+        and breaks the line on any terminal that honours it.
+        """
+        tty = _Tty([b"\r"], size=(60, 10))
+        overlay.Surface(rows=_rows(2), heading="repo\u2028two").run(
+            read=tty.read, write=tty.write, size=lambda: tty.size)
+        self.assertNotIn("\u2028", _paint(tty), repr(_paint(tty)))
+        self.assertIn("\\u2028", _lines(tty)[0], _lines(tty))
+
     def test_an_escape_sequence_in_a_title_never_reaches_the_pane(self):
         rows = (overlay.Row(id="a", title="\x1b[31mred\x1b[0m\x1b]0;title\x07", note=""),)
         tty = _Tty([b"\r"], size=(60, 10))
@@ -400,6 +523,198 @@ class RowsAreContainedBeforeTheyAreMeasured(unittest.TestCase):
         body = tty.out()
         self.assertNotIn("\x1b]0;", body)
         self.assertNotIn("\x07", body)
+
+
+class TheSelectionNeverWraps(unittest.TestCase):
+    """`move` clamps to the ends, and the clamp carries more than the docstring's own
+    reason for it.
+
+    `home` and `end` are *spelled* as a move the whole length of the list
+    (`move(-len(rows))`, `move(+len(rows))`), so a `move` that wrapped instead of
+    clamping would not merely lose the operator's sense of place — it would turn both
+    keys into exact no-ops, because a move of `len(rows)` modulo `len(rows)` is zero.
+    Home and End would stop working with nothing to see.
+    """
+
+    def test_home_and_end_reach_the_ends_of_the_list(self):
+        chosen, _ = _run(_rows(10), [b"\x1b[B"] * 5 + [b"\x1b[H", b"\r"])
+        self.assertEqual(chosen, _rows(10)[0])
+        chosen, _ = _run(_rows(10), [b"\x1b[B"] * 5 + [b"\x1b[F", b"\r"])
+        self.assertEqual(chosen, _rows(10)[9])
+
+    def test_up_at_the_top_stays_at_the_top(self):
+        chosen, _ = _run(_rows(10), [b"\x1b[A", b"\x1b[A", b"\r"])
+        self.assertEqual(chosen, _rows(10)[0])
+
+    def test_down_past_the_bottom_stays_at_the_bottom(self):
+        chosen, _ = _run(_rows(10), [b"\x1b[B"] * 25 + [b"\r"])
+        self.assertEqual(chosen, _rows(10)[9])
+
+
+class ThePaneIsHandedBackTheWayItWasFound(unittest.TestCase):
+    """Every mode the overlay turns on is turned back off before it lets go.
+
+    On the LITERAL bytes: `test_what_was_on_the_pane_comes_back` above asserts against
+    `overlay.ENTER`/`overlay.LEAVE`, which is the right assertion for "the alternate
+    screen is the restore" and no assertion at all about what those constants contain —
+    an `ENTER` that lost its `\\x1b[?25l` and a `LEAVE` that lost its `\\x1b[?25h` both
+    still start and end the output. What `LEAVE`'s docstring is about is the operator's
+    terminal afterwards: a hidden cursor on their own screen looks broken and takes a
+    `reset` to fix.
+    """
+
+    def test_the_cursor_and_the_screen_both_come_back(self):
+        _, tty = _run(_rows(3), [b"\r"])
+        out = tty.out()
+        for on, off in ((_ALT_ON, _ALT_OFF), (_CURSOR_OFF, _CURSOR_ON)):
+            with self.subTest(mode=repr(on)):
+                self.assertEqual(out.count(on), 1, repr(out))
+                self.assertEqual(out.count(off), 1, repr(out))
+                self.assertLess(out.index(on), out.index(off), repr(out))
+
+    def test_they_come_back_even_when_the_overlay_raises(self):
+        """`frame/panel.py`'s `_hold` argument, one pane over: the pane that could not
+        finish is exactly the pane nobody is left to restore."""
+        tty = _Tty([b"\r"])
+
+        def size():
+            raise OSError("the pane's tty went away")
+
+        with self.assertRaises(OSError):
+            overlay.Surface(rows=_rows(2)).run(read=tty.read, write=tty.write, size=size)
+        self.assertIn(_CURSOR_ON, tty.out(), repr(tty.out()))
+        self.assertIn(_ALT_OFF, tty.out(), repr(tty.out()))
+
+
+class TheMouseRequestIsTheOneThisSurfaceCanAnswer(unittest.TestCase):
+    """What the overlay asks its terminal for is bounded by what `decode` and `handle`
+    can do with the answers."""
+
+    def test_it_never_asks_for_motion(self):
+        """1002 and 1003 add MOTION reports — one per cell the pointer crosses, on a
+        pane that is zoomed over the whole window.
+
+        This module keeps no press state by design (§4i: the first component that keeps
+        it wedges on it) and §4f closed the event kinds without a `drag`, so a motion
+        report is an event with nowhere to go: `decode` would emit a click for every
+        one, and `handle` would move the selection under a pointer that is merely
+        passing over. The request and the handling are one declaration here, and this is
+        the half that says what the declaration may contain.
+        """
+        asked = _modes(overlay.MOUSE_ON)
+        self.assertTrue(all(sl == "h" for _, sl in asked), asked)
+        numbers = [n for n, _ in asked]
+        self.assertNotIn(1002, numbers, "motion on button-press")
+        self.assertNotIn(1003, numbers, "motion always")
+        self.assertIn(1000, numbers, "press/release, the two kinds `decode` names")
+        self.assertIn(1006, numbers, "SGR, so a column past 223 still arrives")
+
+    def test_every_mode_asked_for_is_withdrawn_in_the_reverse_order(self):
+        """The pane hands its terminal back in the state it found it, which is an
+        ordering claim as well as a membership one: modes are a stack, and 1006 is the
+        ENCODING the 1000 reports arrive in — dropped first, a report already in flight
+        arrives in the other encoding."""
+        asked = _modes(overlay.MOUSE_ON)
+        dropped = _modes(overlay.MOUSE_OFF)
+        self.assertTrue(all(sl == "l" for _, sl in dropped), dropped)
+        self.assertEqual([n for n, _ in dropped],
+                         list(reversed([n for n, _ in asked])))
+
+
+class ThePaneChromeIsCountedOnce(unittest.TestCase):
+    """`_CHROME_ROWS` is both what `render` spends on itself and what the click
+    arithmetic subtracts back off — two answers to "where does row 0 start" is the
+    off-by-one nobody sees until a click selects the wrong thing."""
+
+    def test_the_key_hint_survives_at_every_height(self):
+        """The footer is a row `render` has to LEAVE FOR, not one it appends and hopes
+        fits: `out[:height]` is the last thing that happens, so a chrome count that
+        forgot the footer fills the pane with rows and then drops the hint off the
+        bottom — at every height where there are more rows than fit. The hint is where
+        `esc` and the hatch key are written down, which makes it the one line an
+        operator who is stuck needs.
+        """
+        for height in range(3, 13):
+            with self.subTest(height=height):
+                drawn = [tui.strip_ansi(ln) for ln in
+                         overlay.Surface(rows=_rows(20)).render(60, height)]
+                self.assertLessEqual(len(drawn), height, drawn)
+                self.assertIn("esc cancel", drawn[-1], drawn)
+
+    def test_a_click_selects_the_row_that_was_drawn_where_it_landed(self):
+        """Agreement between the two halves, asserted against `render`'s own output
+        rather than against `_HEADER_ROWS` restated in the test: whatever row the
+        operator can see on pane row N is the row a click on pane row N selects. Once
+        with the list at the top and once with it scrolled, because the window offset is
+        the other half of the same arithmetic.
+        """
+        rows = tuple(overlay.Row(id=f"r{i}", title=f"row-{i:02d}", note=f"why-{i:02d}")
+                     for i in range(20))
+        for start in (0, 15):
+            with self.subTest(selection=start):
+                surface = overlay.Surface(rows=rows, mouse=True)
+                surface.move(start)
+                drawn = [tui.strip_ansi(ln) for ln in surface.render(60, 10)]
+                landed = 0
+                for pane_row, line in enumerate(drawn):
+                    here = [r for r in rows if r.title in line]
+                    if not here:
+                        continue
+                    landed += 1
+                    surface.handle(overlay.Event(overlay.CLICK, row=pane_row), 10)
+                    self.assertEqual(surface.selected, here[0], (pane_row, line))
+                self.assertGreaterEqual(landed, 4, drawn)
+
+    def test_a_note_never_abuts_the_title_it_belongs_to(self):
+        """Two columns are two columns because there is a gap between them. With none, a
+        title and its note read as one string — `frame/statusline.py`'s chips are where
+        charter measured what that costs a reader — and the row's own identity is the
+        half that stops being findable."""
+        line = tui.strip_ansi(overlay.Surface(
+            rows=(overlay.Row(id="a", title="abc", note="xyz"),)).render(40, 5)[1])
+        self.assertRegex(line, r"abc {2,}xyz")
+
+
+class TheColumnsAreSizedInCells(unittest.TestCase):
+    """`_title_width`, at the two widths where its two rules bind."""
+
+    def test_a_narrow_pane_shortens_a_title_rather_than_erasing_it(self):
+        """A floor can only be seen from below it. At 34 columns — the width
+        `test_a_narrow_pane_still_has_a_note_column` renders at — the cap answers 15 and
+        `_MIN_TITLE` is never consulted, so that test passes with the floor deleted. This
+        renders at twelve, where the cap alone would leave four columns for the title and
+        identify the row by nothing: a row that cannot be told from its neighbour is
+        worse than a row with no note, which is the trade the floor refuses to make.
+        """
+        rows = (overlay.Row(id="a", title="workspace-alpha", note="ready"),)
+        line = tui.strip_ansi(overlay.Surface(rows=rows).render(12, 6)[1])
+        # One cell of the column goes to the ellipsis marking the cut.
+        self.assertIn(rows[0].title[:overlay._MIN_TITLE - 1], line, line)
+
+    def test_a_title_is_measured_in_cells_and_not_in_characters(self):
+        """`_MARK`'s own comment makes this argument for the two-character marker; the
+        titles are the values that actually vary. A CJK title is half as many characters
+        as it is cells, so sizing the column with `len` gives it half the room it needs
+        and truncates every such title — a workspace or persona name in Task 6, which is
+        the name the operator is picking BY.
+        """
+        rows = (overlay.Row(id="a", title="日本語のタイトル", note="reason"),
+                overlay.Row(id="b", title="short", note="ready"))
+        drawn = [tui.strip_ansi(ln) for ln in overlay.Surface(rows=rows).render(60, 8)]
+        self.assertTrue(any(rows[0].title in ln for ln in drawn), drawn)
+        self.assertTrue(any("reason" in ln for ln in drawn), drawn)
+
+    def test_moving_the_selection_never_moves_the_text_beside_it(self):
+        """`_MARK`'s two entries are the same width by construction, and this is the
+        property that construction is for: an operator holding `down` watches the text
+        stand still and the highlight move, not every row shift a column each time."""
+        surface = overlay.Surface(rows=_rows(4))
+        before = [tui.strip_ansi(ln) for ln in surface.render(60, 8)]
+        surface.move(1)
+        after = [tui.strip_ansi(ln) for ln in surface.render(60, 8)]
+        for a, b in zip(before[1:5], after[1:5]):
+            with self.subTest(row=a):
+                self.assertEqual(a.index("action"), b.index("action"), (a, b))
 
 
 class TheEscapeHatch(unittest.TestCase):
@@ -482,6 +797,23 @@ class TheEscapeHatch(unittest.TestCase):
                                         session="s1")
         self.assertIn(overlay.hatch_bind(), text.split("\n"))
 
+    def test_the_hatch_bind_is_the_last_line_of_the_config(self):
+        """POSITION, and it is this branch's whole compatibility story below
+        `tmuxctl.FLOOR`.
+
+        `run-shell -C` first exists in tmux 3.2, which is the floor exactly, and
+        `below_floor_message` still launches beneath it — so on those versions this one
+        line does not parse where the rest of the file does. Last is what makes that
+        cost only the hatch: `status`, `mouse`, `history-limit`, the hotkey bind and the
+        wheel bind have all been applied by the time tmux reaches it, whatever it then
+        does with the remainder. First, the same failure takes the frame's own settings
+        with it.
+        """
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=100,
+                                        session="s1")
+        lines = [ln for ln in text.split("\n") if ln]
+        self.assertEqual(lines[-1], overlay.hatch_bind(), lines)
+
     def test_the_hatch_key_is_not_the_key_that_opens_things(self):
         """Two answers to one keypress is one answer that never fires."""
         self.assertNotEqual(overlay.HATCH_KEY, config.FRAME["hotkey"])
@@ -505,12 +837,110 @@ class TheOverlayPaneIsCharterOwn(unittest.TestCase):
     def test_a_target_that_is_not_a_pane_id_opens_nothing(self):
         self.assertIsNone(overlay.open_argv("charter", harness="0", command=["true"]))
 
+    def test_the_pane_is_split_off_in_rows_and_not_in_columns(self):
+        """`-l` is a count of ROWS under `-v` and of COLUMNS under `-h`, and
+        `_SPLIT_ROWS` is a row count. The same number under the other flag is a
+        five-column pane — one nothing can be drawn in, and one the zoom that follows
+        would inherit its aspect from."""
+        argv = overlay.open_argv("charter", harness="%0", command=["true"])
+        self.assertIn("-v", argv)
+        self.assertNotIn("-h", argv)
+        self.assertEqual(argv[argv.index("-l") + 1], str(overlay._SPLIT_ROWS))
+
+    def test_the_split_fits_the_shortest_harness_the_frame_will_lay_out(self):
+        """The one way this number can cost anything, in its own docstring's words: tmux
+        refuses a split it has no room for, and a refused split is a launch with no
+        overlay in it. `layout.HARNESS_MIN_ROWS` is the floor the frame's own layout
+        leaves the harness pane, the overlay is split off THAT pane, and the split takes
+        its own rows plus the border between them."""
+        self.assertLess(overlay._SPLIT_ROWS + 1, layout.HARNESS_MIN_ROWS)
+
+    def test_the_overlay_pane_carries_the_frame_identity_the_panels_carry(self):
+        """#411's measurement is why a pane charter opens needs `-e` at all: every frame
+        shares one tmux server, so a new pane's environment comes from the SERVER's —
+        captured from whichever launcher happened to start it, possibly days ago. The
+        overlay runs charter's own code and resolves the frame from
+        `$CHARTER_SESSION_ID`, so a pane opened without this reads another frame's."""
+        argv = overlay.open_argv("charter", harness="%0", command=["true"],
+                                 env={"CHARTER_SESSION_ID": "s-1", "CHARTER_ROOT": "/r"})
+        carried = [argv[i + 1] for i, x in enumerate(argv) if x == "-e"]
+        self.assertEqual(sorted(carried), ["CHARTER_ROOT=/r", "CHARTER_SESSION_ID=s-1"])
+        # tmux's own options, so before the `--`: after it they would be the program's
+        # argv, which is `_env_argv`'s own rule and this call site's to keep.
+        self.assertLess(max(i for i, x in enumerate(argv) if x == "-e"),
+                        argv.index("--"))
+
+    def test_a_name_the_frame_may_not_carry_is_refused_loudly_here_too(self):
+        """`layout._env_argv` is the single funnel every `-e` charter builds goes
+        through, and it RAISES — #446's lesson being that a rule enforced at each call
+        site is a rule the next call site skips. Loud is the point: a launch that
+        believed it handed the overlay a variable which never arrived is the failure a
+        silent drop produces. Only the NAME is in the message; a value that does not
+        belong on a command line does not belong in a traceback either."""
+        with self.assertRaises(ValueError) as caught:
+            overlay.open_argv("charter", harness="%0", command=["true"],
+                              env={"AWS_SESSION_TOKEN": "s3cr3t-value"})
+        self.assertIn("AWS_SESSION_TOKEN", str(caught.exception))
+        self.assertNotIn("s3cr3t-value", str(caught.exception))
+
     def test_closing_hands_the_pane_back_and_disarms_the_hatch(self):
         cmds = [" ".join(c) for c in
                 overlay.close_argvs("charter", harness="%0", overlay_pane="%7")]
         self.assertTrue(any("select-pane" in c and "%0" in c for c in cmds), cmds)
         self.assertTrue(any("kill-pane" in c and "%7" in c for c in cmds), cmds)
         self.assertTrue(cmds[-1].endswith("select-pane -t %0"), cmds)
+
+    def test_closing_returns_to_the_harness_before_it_kills_anything(self):
+        """The same order the hatch itself runs in, and the same reason: a kill that
+        cannot happen — a stale id, an overlay already gone — costs nothing that has not
+        already been delivered.
+
+        Measured on tmux 3.7c with harness `%0`, a panel `%1` and a zoomed overlay `%2`:
+        shipped, focus lands on the harness; with the kill first, tmux moves focus off
+        the dying pane by itself and it lands on the PANEL, and the `select-pane` that
+        follows is then correcting a jump the operator already saw.
+
+        On the tmux SUBCOMMAND rather than a substring of the line, for the reason
+        `test_the_hatch_is_armed_before_the_surface_can_capture_anything` gives: the
+        armed value itself contains the text `select-pane`.
+        """
+        cmds = overlay.close_argvs("charter", harness="%0", overlay_pane="%7")
+        names = [c[3] for c in cmds]
+        self.assertLess(names.index("select-pane"), names.index("kill-pane"), names)
+
+    def test_a_refused_overlay_id_kills_nothing_rather_than_naming_the_current_pane(self):
+        """MEASURED on tmux 3.7c, and it is the measurement this module's docstring
+        leads with: `kill-pane -t ""` does not fail and is not a no-op — it kills the
+        pane the command is running against. Re-measured for THIS call site, which is a
+        CLI invocation rather than the hatch's `run-shell`: `tmux -L … kill-pane -t ""`
+        returned 0 and killed the session's active pane.
+
+        `close_argvs` is the one call site that can produce one. `hatch_command` takes
+        `None` for "there is no overlay" and every test above feeds it a well-formed
+        `%7`; this function takes the id as a plain string, so an unset variable, a
+        `#{pane_id}` that came back empty from a pane that had already died, or a
+        capture that failed all arrive here spelled `""`.
+        """
+        for bad in ("", " ", "%", "%0; kill-server", "%0\nkill-server", "harness",
+                    "%１１", "#{q:x}", "-t"):
+            with self.subTest(overlay_pane=bad):
+                self.assertEqual(
+                    overlay.close_argvs("charter", harness="%0", overlay_pane=bad), [],
+                    "a close that cannot name the overlay must emit no command at all")
+        self.assertEqual(overlay.close_argvs("charter", harness="0", overlay_pane="%7"),
+                         [], "and a harness it cannot name is no better")
+
+    def test_a_refused_id_opens_no_modal_overlay_at_all(self):
+        """"Charter would rather open no overlay than open one it cannot promise a way
+        out of" — the ids that fail `PANE_ID_RE` are exactly the ids the hatch cannot be
+        armed with, so selecting and zooming on them is the wedge the hatch exists for,
+        entered deliberately."""
+        for bad in ("", "%0; kill-server", "harness", "#{q:x}"):
+            with self.subTest(bad=bad):
+                self.assertEqual(
+                    overlay.modal_argvs("charter", harness="%0", overlay_pane=bad), [])
+                self.assertEqual(
+                    overlay.modal_argvs("charter", harness=bad, overlay_pane="%7"), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_overlay_escape_hatch.py
+++ b/tests/test_frame_overlay_escape_hatch.py
@@ -1,0 +1,257 @@
+"""The escape hatch, pressed on a real client against a DELIBERATELY HUNG overlay.
+
+**This is the safety property of the whole command surface, and it cannot be tested
+against a cooperative overlay.** An overlay that reads its tty and exits politely proves
+nothing at all: the question is whether the key still works when charter's own loop is
+stuck, which is precisely when nothing charter wrote gets to run. So the pane here runs a
+program that puts its tty in **raw mode**, ignores `SIGWINCH`, and then sleeps — it never
+reads a byte and never will.
+
+**Why a real tmux and a real attached client.** `tmux send-keys` feeds a PANE's own input
+queue and never touches the key table, so it cannot exercise a `bind -n` at all — the
+same fact `tests/test_frame_tmux_integration.py` records for `display-menu`. The hatch's
+entire mechanism is that tmux matches the key in its ROOT table *before* the bytes reach
+the pane, so the only honest test is a client on a pty with the key written to it as a
+terminal would.
+
+**The negative half is not a control against a different mechanism — it is the proof the
+overlay is really wedged.** Ordinary keys are written first and asserted to change
+nothing: not the active pane, not the overlay's own screen. Without that, "F12 moved the
+focus" would be equally satisfied by an overlay that had simply exited on its own.
+
+Skipped, never failed, where the machine cannot supply what this needs: no tmux, a tmux
+too old for `run-shell -C` (3.2), or a tmux that will not attach a client (a headless CI
+step's `TERM=dumb`). Each skip names what was missing, and every test that DOES run
+asserts exactly what it always did.
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import shutil
+import subprocess
+import time
+import unittest
+
+from charter import commands_frame
+from charter.frame import overlay, tmuxctl
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: This module's own server, unique per test PROCESS so an interrupted earlier run's
+#: socket can never be mistaken for this one's.
+SOCKET = f"charter-overlay-hatch-{os.getpid()}"
+
+#: How long a tmux state change gets before this gives up on it. Generous, and spent only
+#: on the way to a failure: every wait below returns the instant the state is right.
+_DEADLINE = 20.0
+
+#: The overlay that will never answer. Raw mode so the tty is genuinely captured, a
+#: `SIGWINCH` handler that does nothing so a resize cannot shake it loose, one marker
+#: written so `capture-pane` has something to compare against, and then a sleep. The
+#: closest thing to a third-party component that "captured input badly" (§4c) that can be
+#: written on purpose.
+_WEDGED = (
+    "python3 -c \""
+    "import sys,tty,signal,time;"
+    "sys.stdout.write('WEDGED-OVERLAY');sys.stdout.flush();"
+    "tty.setraw(sys.stdin.fileno());"
+    "signal.signal(signal.SIGWINCH, signal.SIG_IGN);"
+    "time.sleep(9999)\"")
+
+#: What a terminal sends for :data:`overlay.HATCH_KEY`. `\\x1b[24~` is the standard CSI
+#: form for F12 and is in tmux's own built-in key table (`tty-keys.c`) rather than coming
+#: from terminfo, so it does not depend on which `TERM` the client attached with. Asserted
+#: against `HATCH_KEY` by :meth:`TheHatch.test_the_key_this_module_presses_is_the_key_charter_binds`
+#: so the two cannot drift into a test that presses something charter does not bind.
+_F12 = b"\x1b[24~"
+
+_TERM_CANDIDATES = tuple(dict.fromkeys(
+    ([os.environ["TERM"]] if os.environ.get("TERM", "dumb") != "dumb" else [])
+    + ["xterm-256color", "screen", "vt100"]))
+
+
+def _tmux(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["tmux", "-L", SOCKET, *args], capture_output=True, text=True,
+                          timeout=15)
+
+
+def _panes() -> dict[str, str]:
+    """``{pane id: "1"|"0"}`` — which pane this window's client is typing into."""
+    out = _tmux("list-panes", "-t", "s", "-F", "#{pane_id} #{pane_active}").stdout
+    return dict(line.split() for line in out.splitlines() if " " in line)
+
+
+def _await(predicate, timeout: float = _DEADLINE) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class TheHatch(unittest.TestCase):
+    """One frame, one wedged overlay, one keypress."""
+
+    def setUp(self) -> None:
+        v = tmuxctl.version()
+        if v is None or v < tmuxctl.FLOOR:
+            self.skipTest(f"`run-shell -C` first exists in tmux {tmuxctl.FLOOR[0]}."
+                          f"{tmuxctl.FLOOR[1]}; this machine has {v}")
+        self.addCleanup(lambda: _tmux("kill-server"))
+        started = _tmux("-f", "/dev/null", "new-session", "-d", "-s", "s",
+                        "-x", "100", "-y", "30", "-P", "-F", "#{pane_id}", "cat")
+        self.assertEqual(started.returncode, 0, started.stderr)
+        self.harness = started.stdout.strip()
+        # A panel, so "the hatch returned to the HARNESS" is a real claim rather than
+        # "the only other pane left". With one panel there are three panes and two wrong
+        # answers.
+        split = _tmux("split-window", "-t", self.harness, "-v", "-l", "3",
+                      "-P", "-F", "#{pane_id}", "cat")
+        self.assertEqual(split.returncode, 0, split.stderr)
+        self.panel = split.stdout.strip()
+        # Charter's OWN frame config, sourced the way a launch sources it — not a
+        # hand-written `bind` line standing in for it. A test that re-spelled the bind
+        # would be measuring its own copy of charter's answer (#547), and the quoting
+        # inside that line is exactly the part worth putting through tmux's real parser.
+        conf = os.path.join(
+            os.environ.get("TMPDIR", "/tmp"), f"charter-hatch-{os.getpid()}.conf")
+        with open(conf, "w") as fh:
+            fh.write(commands_frame.conf_text(hotkey="F2", mouse=False,
+                                              history_limit=100, session="s"))
+        self.addCleanup(lambda: os.path.exists(conf) and os.unlink(conf))
+        sourced = _tmux("source-file", conf)
+        self.assertEqual(sourced.returncode, 0, sourced.stderr)
+        # Read back off tmux's own key table, not off the string charter produced: this
+        # is the one assertion that the quoting in that line survived tmux's parser.
+        bound = [ln for ln in _tmux("list-keys", "-T", "root").stdout.splitlines()
+                 if f" {overlay.HATCH_KEY} " in ln]
+        self.assertEqual(len(bound), 1, bound)
+        self.assertIn(overlay.HATCH_OPTION, bound[0])
+        self.assertIn("run-shell -C", bound[0])
+
+    def _open_a_wedged_overlay(self) -> str:
+        """Charter's own open path, with a program that will never answer in the pane."""
+        argv = overlay.open_argv(SOCKET, harness=self.harness, command=["sh", "-c", _WEDGED])
+        self.assertIsNotNone(argv)
+        opened = subprocess.run(argv, capture_output=True, text=True, timeout=15)
+        self.assertEqual(opened.returncode, 0, opened.stderr)
+        pane = opened.stdout.strip()
+        for cmd in overlay.modal_argvs(SOCKET, harness=self.harness, overlay_pane=pane):
+            got = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+            self.assertEqual(got.returncode, 0, got.stderr)
+        self.assertTrue(_await(lambda: "WEDGED-OVERLAY" in
+                               _tmux("capture-pane", "-p", "-t", pane).stdout),
+                        "the overlay pane never drew anything")
+        return pane
+
+    def _attach(self) -> int:
+        """A real `tmux attach` on a pty. Returns the master fd; the client is this
+        process's own child to reap."""
+        refusals = []
+        for term in _TERM_CANDIDATES:
+            pid, fd = pty.fork()
+            if pid == 0:
+                try:
+                    os.environ["TERM"] = term
+                    os.execvp("tmux", ["tmux", "-L", SOCKET, "attach", "-t", "s"])
+                finally:
+                    os._exit(127)
+            if _await(lambda: bool(_tmux("list-clients", "-t", "s",
+                                         "-F", "#{client_name}").stdout.strip()),
+                      timeout=10.0):
+                self.addCleanup(self._reap, pid, fd)
+                return fd
+            refusals.append(term)
+            self._reap(pid, fd)
+        self.skipTest("no tmux client will attach on this machine, and a key table entry "
+                      "needs one — tried TERM=" + ", ".join(refusals))
+
+    @staticmethod
+    def _reap(pid: int, fd: int) -> None:
+        for call in (lambda: os.kill(pid, 9), lambda: os.waitpid(pid, 0),
+                     lambda: os.close(fd)):
+            try:
+                call()
+            except OSError:
+                pass
+
+    def test_the_key_this_module_presses_is_the_key_charter_binds(self):
+        """`\\x1b[24~` is F12. If `HATCH_KEY` ever moves, this test must move with it —
+        otherwise every assertion below would be pressing a key charter does not bind and
+        measuring an overlay that simply never closed."""
+        self.assertEqual(overlay.HATCH_KEY, "F12")
+
+    def test_one_key_returns_to_the_harness_from_an_overlay_that_never_answers(self):
+        pane = self._open_a_wedged_overlay()
+        fd = self._attach()
+        self.assertTrue(_await(lambda: _panes().get(pane) == "1"),
+                        "the overlay pane never became the active one")
+
+        # The overlay really is wedged: ordinary keys reach it and change nothing.
+        before = _tmux("capture-pane", "-p", "-t", pane).stdout
+        os.write(fd, b"qqq\r\x1b[A\x1b[B")
+        time.sleep(1.0)
+        self.assertEqual(_panes().get(pane), "1",
+                         "an ordinary key moved the focus — the overlay was not modal")
+        self.assertEqual(_tmux("capture-pane", "-p", "-t", pane).stdout, before,
+                         "the overlay answered a key — it is not the wedge this tests")
+
+        os.write(fd, _F12)
+        self.assertTrue(_await(lambda: _panes().get(self.harness) == "1"),
+                        f"{overlay.HATCH_KEY} did not return the operator to the harness")
+        self.assertTrue(_await(lambda: pane not in _panes()),
+                        "the wedged overlay pane is still in the window")
+        self.assertIn(self.panel, _panes(),
+                      "the hatch took the panel with it")
+
+    def test_the_window_the_overlay_covered_comes_back(self):
+        """Zoom is what makes it modal; killing the pane is what gives the frame back."""
+        pane = self._open_a_wedged_overlay()
+        fd = self._attach()
+        self.assertTrue(_await(lambda: _tmux(
+            "display-message", "-p", "-t", "s", "#{window_zoomed_flag}").stdout.strip()
+            == "1"), "the overlay never covered the window")
+        os.write(fd, _F12)
+        self.assertTrue(_await(lambda: _tmux(
+            "display-message", "-p", "-t", "s", "#{window_zoomed_flag}").stdout.strip()
+            == "0"), "the window is still zoomed after the hatch")
+
+    def test_with_no_overlay_open_the_key_still_returns_to_the_harness(self):
+        """"Unconditionally, from any state" includes the state with no overlay in it —
+        and the measured trap is here: an unset option expanding into `kill-pane -t ""`
+        kills the CURRENT pane, so this asserts the panel is still standing."""
+        armed = overlay.arm_hatch_argv(SOCKET, harness=self.harness)
+        self.assertIsNotNone(armed)
+        self.assertEqual(subprocess.run(armed, capture_output=True, timeout=15)
+                         .returncode, 0)
+        fd = self._attach()
+        got = _tmux("select-pane", "-t", self.panel)
+        self.assertEqual(got.returncode, 0, got.stderr)
+        self.assertTrue(_await(lambda: _panes().get(self.panel) == "1"))
+        os.write(fd, _F12)
+        self.assertTrue(_await(lambda: _panes().get(self.harness) == "1"),
+                        f"{overlay.HATCH_KEY} did not return to the harness")
+        self.assertIn(self.panel, _panes(),
+                      "the hatch killed a pane when there was no overlay to kill")
+
+    def test_charter_own_close_path_hands_the_pane_back_too(self):
+        """The ordinary exit, so the hatch is the exception rather than the mechanism."""
+        pane = self._open_a_wedged_overlay()
+        for cmd in overlay.close_argvs(SOCKET, harness=self.harness, overlay_pane=pane):
+            got = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+            self.assertEqual(got.returncode, 0, got.stderr)
+        self.assertTrue(_await(lambda: pane not in _panes()))
+        self.assertEqual(_panes().get(self.harness), "1")
+        self.assertEqual(
+            _tmux("show-options", "-w", "-t", self.harness, "-v",
+                  overlay.HATCH_OPTION).stdout.strip(),
+            overlay.hatch_command(harness=self.harness),
+            "the hatch is still armed to kill a pane that is gone")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_overlay_escape_hatch.py
+++ b/tests/test_frame_overlay_escape_hatch.py
@@ -238,6 +238,53 @@ class TheHatch(unittest.TestCase):
         self.assertIn(self.panel, _panes(),
                       "the hatch killed a pane when there was no overlay to kill")
 
+    def test_the_overlay_pane_is_split_in_rows_and_tmux_accepts_the_size(self):
+        """Both halves of `open_argv`'s split, measured rather than restated.
+
+        `-l` is rows under `-v` and columns under `-h`, so the flag and the number are
+        one decision: under the other flag this same `5` is a five-COLUMN pane. And
+        `_SPLIT_ROWS`' own docstring names the single way the number can cost anything —
+        tmux refusing the split for want of room — which is a non-zero return code from
+        the very command this runs, in a window deliberately shorter than a laptop's.
+        """
+        short = _tmux("new-window", "-t", "s", "-P", "-F", "#{pane_id}", "cat")
+        self.assertEqual(short.returncode, 0, short.stderr)
+        harness = short.stdout.strip()
+        self.assertEqual(_tmux("resize-window", "-t", "s", "-x", "80", "-y", "14")
+                         .returncode, 0)
+        argv = overlay.open_argv(SOCKET, harness=harness, command=["cat"])
+        self.assertIsNotNone(argv)
+        opened = subprocess.run(argv, capture_output=True, text=True, timeout=15)
+        self.assertEqual(opened.returncode, 0,
+                         f"tmux refused the split: {opened.stderr}")
+        pane = opened.stdout.strip()
+        size = _tmux("display-message", "-p", "-t", pane,
+                     "#{pane_height} #{pane_width}").stdout.split()
+        self.assertEqual(size[0], str(overlay._SPLIT_ROWS),
+                         f"the overlay pane came out {size} — `-l` counted columns")
+        self.assertEqual(size[1], "80", f"the overlay pane came out {size}")
+
+    def test_a_close_that_cannot_name_the_overlay_kills_nothing(self):
+        """The module's leading measurement, run rather than described.
+
+        `kill-pane -t ""` is not a no-op: measured again for this call site — a plain
+        CLI invocation, not the hatch's `run-shell` — `tmux -L … kill-pane -t ""`
+        returns 0 and kills the session's ACTIVE pane, silently. `close_argvs` takes the
+        overlay's id as a plain string with no `None` spelling, so an unset variable or
+        a `#{pane_id}` capture that came back empty arrives here as `""`; what this
+        asserts is that whatever it produces for one can be run against a real server
+        with the harness and a panel standing and leave both of them standing.
+        """
+        before = set(_panes())
+        self.assertGreaterEqual(len(before), 2, before)
+        for bad in ("", " ", "%", "$overlay"):
+            with self.subTest(overlay_pane=bad):
+                for cmd in overlay.close_argvs(SOCKET, harness=self.harness,
+                                               overlay_pane=bad):
+                    subprocess.run(cmd, capture_output=True, timeout=15)
+                self.assertEqual(set(_panes()), before,
+                                 f"a close naming {bad!r} took a pane with it")
+
     def test_charter_own_close_path_hands_the_pane_back_too(self):
         """The ordinary exit, so the hatch is the exception rather than the mechanism."""
         pane = self._open_a_wedged_overlay()

--- a/tests/test_frame_overlay_escape_hatch.py
+++ b/tests/test_frame_overlay_escape_hatch.py
@@ -43,6 +43,17 @@ _HAS_TMUX = shutil.which("tmux") is not None
 #: socket can never be mistaken for this one's.
 SOCKET = f"charter-overlay-hatch-{os.getpid()}"
 
+#: Where tmux puts :data:`SOCKET`'s FILE, computed the way tmux computes it — and only
+#: the FALLBACK for it. `TheHatch._teardown_socket` asks the live server for
+#: `#{socket_path}` first, because tmux is the authority on its own path and this
+#: expression is only a COPY of a rule that lives in tmux's source (`$TMUX_TMPDIR` or
+#: `/tmp`, then `tmux-<uid>/<name>`) — a copy that can silently drift out of date, which
+#: is why nothing is ever *asserted* about it. It is spent on the one teardown that has
+#: no server left to ask, and every teardown that does have one makes its claim against
+#: what tmux said instead.
+SOCKET_PATH = os.path.join(os.environ.get("TMUX_TMPDIR") or "/tmp",
+                           f"tmux-{os.getuid()}", SOCKET)
+
 #: How long a tmux state change gets before this gives up on it. Generous, and spent only
 #: on the way to a failure: every wait below returns the instant the state is right.
 _DEADLINE = 20.0
@@ -101,7 +112,9 @@ class TheHatch(unittest.TestCase):
         if v is None or v < tmuxctl.FLOOR:
             self.skipTest(f"`run-shell -C` first exists in tmux {tmuxctl.FLOOR[0]}."
                           f"{tmuxctl.FLOOR[1]}; this machine has {v}")
-        self.addCleanup(lambda: _tmux("kill-server"))
+        # Registered FIRST so it runs LAST — `addCleanup` is LIFO, and every client this
+        # test forks onto a pty must be reaped before the server it is attached to goes.
+        self.addCleanup(self._teardown_socket)
         started = _tmux("-f", "/dev/null", "new-session", "-d", "-s", "s",
                         "-x", "100", "-y", "30", "-P", "-F", "#{pane_id}", "cat")
         self.assertEqual(started.returncode, 0, started.stderr)
@@ -132,6 +145,79 @@ class TheHatch(unittest.TestCase):
         self.assertEqual(len(bound), 1, bound)
         self.assertIn(overlay.HATCH_OPTION, bound[0])
         self.assertIn("run-shell -C", bound[0])
+
+    def _teardown_socket(self) -> None:
+        """End the server and take its socket FILE with it, in that order and in ONE
+        cleanup — `tests/test_frame_tmux_integration.py::_TmuxServerFixture` verbatim,
+        because this module had the same shared socket and was missing the second half.
+
+        **`kill-server` is a signal, not a wait, and the socket keeps ANSWERING while
+        the server is on its way out.** tmux's `cmd_kill_server_exec` is two statements —
+        `kill(getpid(), SIGTERM)` and `return (CMD_RETURN_NORMAL)` — so the server
+        signals ITSELF and then answers this client normally: `kill-server` returns 0
+        with the listening socket still bound and still accepting. A client that connects
+        in that window reads EOF where a reply should be, which is `client_dispatch`'s
+        `imsg == NULL` branch setting `CLIENT_EXIT_LOST_SERVER`, whose message is the
+        string `server exited unexpectedly` and whose status is 1. That is the whole of
+        the CI failure at `c735efc`: every test here shares one socket, so the next
+        test's `new-session` was racing the previous test's teardown, and it lost two of
+        the five matrix jobs that got far enough to run.
+
+        Measured rather than reasoned: on tmux 3.7c, connecting to the socket kept
+        SUCCEEDING for a median of 0.4 ms and up to 1.3 ms after `kill-server` had
+        already returned (24 of 25 trials landed at least one connect), and the socket
+        file was still on disk in 25 of 25. That is why no local run sees this — a whole
+        `subprocess` round trip between two tests is 10-20 ms on an unloaded machine,
+        which steps clean over a sub-millisecond window — and why a loaded four-core
+        runner walks straight into it: the CI log has the previous test finishing at
+        `.0170` and this one failing at `.0221`, 5 ms later.
+
+        Unlinking closes the window rather than waiting it out. A client whose socket
+        path is not there does not connect to a dying server at all: it starts a fresh
+        one. There is nothing left to wait FOR, which is the discipline the news entry
+        slugged `a-green-tmux-run-now-means-something` states for this whole module
+        family — a `sleep` long enough to cover the window would be a guess at a number
+        that was measured right here, and a poll for the server's absence would still be
+        polling the one call that can fail.
+
+        ONE cleanup doing both, never two registered separately: `addCleanup` runs LIFO,
+        so `addCleanup(kill-server)` followed by `addCleanup(unlink)` unlinks FIRST and
+        kills SECOND — which points `kill-server` at a path with no server on it, leaves
+        the real one running, and hands the next test a socket file it did not make.
+
+        **And the path comes from tmux, which is the only reason the check below is
+        worth anything.** The first version of this asserted that the paths it had
+        already decided to unlink were gone — which a wrong :data:`SOCKET_PATH` satisfies
+        for free, because a path that was never the socket does not exist either before
+        or after. Measured: with tmux's answer suppressed and `SOCKET_PATH` pointed at a
+        path that is not the socket, the module went green and left the real socket file
+        standing, race and all. So the claim is made against tmux's OWN answer, and a
+        running server that will not give one is a failure rather than a fallback.
+        """
+        said = _tmux("display-message", "-p", "#{socket_path}")
+        # rc tells "no server to ask" apart from "a server that would not answer", and
+        # only the second one is a defect: a teardown with no server has nothing to
+        # claim, and a tmux whose `#{socket_path}` expands to nothing has hidden the one
+        # fact this depends on.
+        was_running = said.returncode == 0
+        path = said.stdout.strip()
+        _tmux("kill-server")
+        for candidate in {SOCKET_PATH, path if path.startswith("/") else SOCKET_PATH}:
+            try:
+                os.unlink(candidate)
+            except OSError:
+                pass
+        if not was_running:
+            return
+        self.assertTrue(
+            path.startswith("/"),
+            f"tmux would not say where its socket is — `#{{socket_path}}` gave {path!r}, "
+            f"so this teardown is unlinking a guess ({SOCKET_PATH}) and cannot tell "
+            f"whether it removed the socket the next test will race")
+        self.assertFalse(
+            os.path.exists(path),
+            f"{path} survived this test's teardown, so the next test's `new-session` "
+            f"can still reach a server that is exiting")
 
     def _open_a_wedged_overlay(self) -> str:
         """Charter's own open path, with a program that will never answer in the pane."""

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -748,6 +748,10 @@ class NoCharterEscapesThroughTheExecFamily(unittest.TestCase):
             "running — a test doing this by accident loses the runner, not a plane.",
         "tests/test_frame_tmux_integration.py:execvp":
             "`tmux attach` inside a `pty.fork` child, which `os._exit`s in its `finally`.",
+        "tests/test_frame_overlay_escape_hatch.py:execvp":
+            "The same `tmux attach` inside a `pty.fork` child, for the same reason: a "
+            "`bind -n` can only be exercised by a real client with a real terminal, and "
+            "`send-keys` never reaches the key table. `os._exit`s in its `finally`.",
     }
 
     _WATCHED = ("execl", "execle", "execlp", "execlpe", "execv", "execve", "execvp",


### PR DESCRIPTION
Phase 2, Task 2 of `docs/superpowers/plans/2026-08-26-phase2-command-surface.md`. The surface Tasks 3–6 draw on, plus the one safety property the rest of the phase leans on.

## The overlay

**Full-pane, charter-drawn, modal** (§4k), and neither of the two things it is not:

- **Not `display-popup`.** On tmux 3.2 — a version `tmuxctl.below_floor_message` explicitly still launches on — any client resize kills a popup: SIGHUP, `rc 129`, the popup's own log ending mid-stream with whatever the operator had typed. A popup-first palette is one surface that works and one resize-shaped bug on exactly one version, plus two surfaces to keep in step.
- **Not `display-menu`.** It draws a list and takes a keypress, with charter's own nine-row cap on top of it. No filter, no paging, and not charter's to draw in.

The popup's one real advantage — it *is* the active surface, so its own mouse request is what reaches the terminal — is recovered a different way: the overlay's pane is selected and zoomed over the window.

## The escape hatch

**This is the safety property of the whole phase, so it ships before anything that can take the keyboard.**

```
bind -n F12 run-shell -C '#{@charter_hatch}'
```

`bind -n` is tmux's *root* key table, so tmux matches the key before a single byte reaches the pane — a program that has stopped reading its terminal never gets a chance to swallow it. `run-shell -C` runs tmux commands, in tmux, with no shell, no `$PATH` and no second charter process. A single-level hatch would live inside the thing it must escape.

The pane ids live in a **window** option rather than in the bind, because a key table is server-wide: a bind carrying one frame's identity resolves the *wrong* frame for the second frame launched, the trap `conf_text`'s docstring already records for the hotkey. Measured with two windows on one server, each with its own value.

Order inside the command is the unconditional half of the promise — the harness is selected first, the overlay killed second, so a kill that cannot happen costs nothing already delivered. And with no overlay open the command emits no `kill-pane` **at all**, because `kill-pane -t ""` is not a no-op: measured against tmux 3.7c, it kills the current pane. `None` is the only spelling of "there is no overlay".

### Tested against a deliberately hung overlay, on a real client

`tests/test_frame_overlay_escape_hatch.py` opens charter's own overlay pane running a program that puts its tty in raw mode, ignores `SIGWINCH`, and sleeps — it never reads a byte and never will. A real `tmux attach` on a pty, because `send-keys` feeds a pane's input queue and never touches the key table, so it cannot exercise a `bind -n` at all.

**The negative half is the proof the overlay is really wedged**, not a control against a different mechanism: ordinary keys are written first and asserted to change nothing — not the active pane, not the overlay's own screen. Without that, "F12 moved the focus" would be equally satisfied by an overlay that had simply exited on its own. All five of those tests **ran** on this machine rather than skipping.

## The three measurements, not re-litigated

- **A `click` release arrives with no matching press** — a drag from a pane border into a pane delivers exactly one. So the surface keeps no press state, and a click only ever *selects*; `Enter` chooses. The irreversible half is never driven by an event that can arrive unpaired.
- **Pointer events reach a pane only while it is ACTIVE and asked for reporting**, and charter does not control what the harness asks for. The overlay is the one place charter can promise them. One declaration (`Surface.mouse`) both writes the request to the tty and gates whether a report is acted on, so there is no state in which charter acts on a report it never asked the terminal for.
- **`focus`/`blur` are absent, not implemented-and-broken.** `focus-events` is off by default and gates the whole path, and with it off `#{client_flags}` still reads `attached,focused` — a guard written against that flag passes with the feature dead. Task 7 turns it on.

## Three defects found reviewing the surface before it had callers

**A whole escape sequence was replayed as the keys it is spelled with.** The decoder held back a *half-arrived* sequence but let a *complete* one it had no name for fall through to its single-byte path:

```
b'\x1b[1;5A' -> [('key','1'), ('key',';'), ('key','5'), ('key','A')]   # Ctrl-Up
b'\x1bOP'    -> [('key','P')]                                          # F1
b'\x1b[200~hi\x1b[201~' -> 2,0,0,~,h,i,2,0,1,~                         # a paste
```

Task 4's palette filters on exactly these keys. Sequences are now consumed to their final byte, and a modifier names a modifier rather than typing itself — in both CSI families, so Ctrl-PgUp is PgUp the same way Ctrl-Up is Up.

**The note column vanished in a narrow pane.** Sized from the titles alone, at 34 columns the widest title took 28 of them and every note came out as one glyph and an ellipsis. Task 4's rule is that an unavailable action is listed *with its reason*, and the reason is the note — a reason truncated to nothing still *looks* like an answer, which is #512's shape one column over. The title column is capped at half the row.

**The hatch does not exist on the operator's own tmux, and nothing said so.** A root key table is server-wide, so the guest path binds no key there — exactly as it binds no hotkey, and for the identical reason. The news entry had claimed "from anywhere in the frame" without qualification. Now stated in `docs/frame.md` beside the other costs of charter being a guest, in `_launch_in_operator_tmux`'s docstring, in the module, and in the news.

## Rendered

```
--- 64x10, third row selected ----------------------------------
charter · command palette · 6 to choose from
  Switch workspace…             3 available
  Switch persona…               harness-wrapper
> Density: comfortable          cycles
  Sync every repo               unavailable — the session lock …
  Detach from this frame
  a name with a separator  and a \x1b[31mred\x1b[0m note


  up/down move   enter choose   esc cancel   F12 back to the ha…
--- the same pane after a resize to 34x8 -----------------------
charter · command palette · 6 to …
  Switch workspa…  3 available
  Switch persona…  harness-wrapper
> Density: comfo…  cycles
  Sync every repo  unavailable — …
  Detach from th…
  a name wi…  and a \x1b[31m…
  up/down move   enter choose   e…
--- nothing to choose ------------------------------------------
charter · command palette · 0 to choose from
  (nothing to choose)



  up/down move   enter choose   esc cancel   F12 back to the ha…
```

The last one is #512's rule: an overlay with nothing to offer says so, because an empty box is indistinguishable from one whose rows failed to load. The hostile row is `contain.one_line`'d **before** width arithmetic (#472) — ` ` and `\x1b[31m` survive as visible escapes, unable to end a line or reach the terminal.

## Suite

**5933, OK, in two environments** — ambient cleared, and again with `CHARTER_WORKSPACE` set. They agree. 5880 (Phase 1 pin) + 53.

## Mutations — applied, RED, restored, GREEN, `__pycache__` cleared each time

| mutation | result |
|---|---|
| remove `overlay.hatch_bind()` from `conf_text` | **6 RED**, including all five real-tmux tests — `setUp` cannot find the bind in tmux's own key table |
| an unrecognised key returns `CANCEL` (non-modal) | **1 RED** |
| drop `resize-pane -Z` from `modal_argvs` (non-modal at the tmux level) | **2 RED**, one of them on the real client |
| only a press is a click (drop the release tolerance) | **3 RED** |
| `_CSI`'s final byte narrowed to the six known ones | **1 RED** |
| the title column sized from its titles alone | **2 RED** |
| `PANE_ID_RE.fullmatch` → `match` on the hatch's ids | **2 RED** — `%0; kill-server` |
| `overlay_pane is None` → `not overlay_pane` | **2 RED** |

No version bump, no stamping, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
