### PR TITLE
A value glued to a short flag is one value, not two (#547)

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -1786,6 +1786,39 @@ _SPLIT_STRING_FLAGS = ("-S", "--split-string")
 _DURATION_RE = re.compile(r"^\d+(?:\.\d+)?[smhd]?$")
 
 
+def _flag_name_value(tok: str, spellings: tuple[str, ...]) -> tuple[str, str]:
+    """``(flag name, the value ATTACHED to it)`` for one option token, given every spelling
+    of the flags whose value can be attached. An empty value means "not attached here" —
+    the caller decides whether the NEXT token is it.
+
+    **The glued SHORT form is read before the long form's `=`, and #547 is what happens
+    when it is not.** getopt gives a short option everything glued after it, `=` included,
+    so `-Sfoo=1` packs `foo=1` — while `--split-string=foo=1` splits at its FIRST `=` and
+    packs the same thing. Reading the `=` rule first splits the glued form at the packed
+    value's OWN `=`: `env -Sfoo=1 cat .charter/vaults/x.json` came back with `1` as the
+    program, the `cat` never named, and the vault printed on a plane where the same command
+    unwrapped was denied. Its four neighbours — `-S <string>`, `--split-string=…`,
+    `env NAME=value`, and a glued value with no `=` in it — all denied, which is why the
+    one that did not survived a hand probe (#547 has the six-row measurement, and
+    `tests/test_guard_attached_option_values.py` pins all six).
+
+    The two rules are now DISJOINT rather than merely ordered — a glued short form never
+    starts with `--`, and the `=` rule now requires it — so the ordering cannot silently
+    come back. Same repair, same reason, for every other attached value in
+    :data:`_WRAPPER_VALUE_FLAGS`: `env -C<dir>` has exactly this shape, and
+    `env -Cx=y/../.charter/vaults cat x.json` was allowed and printed the vault — verified
+    live, the same way, with the same `mkdir x=y` a shell will do without being asked twice.
+    """
+    glued = next((f for f in spellings if not f.startswith("--")
+                  and tok.startswith(f) and len(tok) > len(f)), None)
+    if glued is not None:                   # `env -Sfoo=1`, `env -C<dir>`, `stdbuf -o0`
+        return glued, tok[len(glued):]
+    if tok.startswith("--") and "=" in tok:  # `env --split-string=…`, `sudo --chdir=<dir>`
+        name, value = tok.split("=", 1)
+        return name, value
+    return tok, ""
+
+
 def _split_env(toks: list[str]) -> tuple[str, list[str], list[str]]:
     """``(program, env-assignment prefixes, argv)`` — :func:`_split_env_chdir` without the
     directory or the files this command opens, for the guards that only name a program."""
@@ -1850,8 +1883,7 @@ def _split_env_chdir(
             nxt = toks[0]
             if base == "env" and nxt.startswith(_SPLIT_STRING_FLAGS):
                 toks.pop(0)
-                rest = nxt.split("=", 1)[1] if "=" in nxt else (
-                    nxt[2:] if nxt.startswith("-S") and len(nxt) > 2 else "")
+                rest = _flag_name_value(nxt, _SPLIT_STRING_FLAGS)[1]
                 if not rest and toks:
                     rest = toks.pop(0)
                 try:
@@ -1866,16 +1898,9 @@ def _split_env_chdir(
                 # what decides whether the next token is the program, the value is where a
                 # chdir flag relocates to. Two readings is how the value came to be lost.
                 takes = _WRAPPER_VALUE_FLAGS.get(base, ())
-                name, value = nxt, ""
-                if "=" in nxt:
-                    name, value = nxt.split("=", 1)
-                else:
-                    glued = next((f for f in takes if not f.startswith("--")
-                                  and nxt.startswith(f) and len(nxt) > len(f)), None)
-                    if glued is not None:           # `env -C<dir>`, `stdbuf -o0`
-                        name, value = glued, nxt[len(glued):]
-                    elif nxt in takes and toks:
-                        value = toks.pop(0)         # the value is the NEXT token
+                name, value = _flag_name_value(nxt, takes)
+                if not value and nxt in takes and toks:
+                    value = toks.pop(0)             # the value is the NEXT token
                 if value and name in _WRAPPER_CHDIR_FLAGS.get(base, ()):
                     chdir = value
                 if value and name in _WRAPPER_READ_FLAGS.get(base, ()):

--- a/docs/news/unreleased-a-value-glued-to-a-short-flag-is-read-as-one.md
+++ b/docs/news/unreleased-a-value-glued-to-a-short-flag-is-read-as-one.md
@@ -1,0 +1,69 @@
+---
+version: unreleased
+headline: A value glued to a short flag is read as one value again — `env -Sfoo=1 cat <vault>` printed a vault and is denied
+security: true
+---
+
+`env -Sfoo=1 cat .charter/vaults/x.json` printed a fabricated vault on a real plane while
+`cat .charter/vaults/x.json` on the same plane was denied. One wrapper word, one flag, and
+the guard that exists to keep a credential out of a transcript had nothing to say.
+
+The parse is the whole of it. `env` packs a command into one token two ways —
+`--split-string=<command>` and the glued short `-S<command>` — and `hooks._split_env_chdir`
+read the long form's rule first. So a packed command carrying its **own** `=` was split at
+the wrong one: `-Sfoo=1 cat …` yielded `1` as the program, the `cat` was never named, and no
+guard downstream had a reader to object to. getopt hands a short option everything glued
+after it, `=` included; the rule for the long form was answering about a token that was
+never a long form.
+
+**Four of its five neighbours were denied the whole time, and that is the part worth
+recording.** Measured against the shipped hook, one row at a time:
+
+```
+cat .charter/vaults/x.json                           -> DENY   (control)
+env -Sfoo=1 cat .charter/vaults/x.json               -> ALLOW  <-- the bypass
+env -S "cat .charter/vaults/x.json"                  -> DENY
+env --split-string=foo=1 cat .charter/vaults/x.json  -> DENY
+env -S "foo=1 cat .charter/vaults/x.json"            -> DENY
+env FOO=1 cat .charter/vaults/x.json                 -> DENY
+```
+
+Anyone probing this by hand would very likely have stopped at the third row and concluded
+the guard held. It took the one form combining a glued short flag with a value that itself
+contains an `=` — which is exactly the form a real `env -S` setting a variable takes. All
+six rows are now one table in `tests/test_guard_attached_option_values.py`, driven by one
+loop, because the five that already denied are what make the sixth's regression visible: a
+later refactor that trades one spelling for another has to redden something.
+
+**And its siblings, because a bug with a shape has them.** Every flag whose value may be
+attached went through the same two rules in the same wrong order, and `env -C` — the chdir
+whose value is what makes a later relative operand resolve — was live in the same way:
+`env -Cx=y/../.charter/vaults cat x.json` was allowed and printed the vault, after the
+`mkdir x=y` a shell does without being asked twice. `sudo -D` and `xargs -a` are the same
+parse. The two rules are now disjoint rather than merely ordered — a glued short form never
+starts with `--`, and the `=` rule now requires it — so the ordering cannot quietly come
+back, and all three wrappers are walked across all four spellings in the tests.
+
+The same parser is what charter's own test harness uses to decide whether a test is about to
+spawn charter against your live plane. It had been repairing this ordering on its way in
+since the defect was filed; that repair is deleted with this fix, which makes its removal a
+second regression test — the suite stays green on production's parse alone.
+
+Two neighbours found while measuring this one are **not** fixed here, and are filed rather
+than quietly absorbed: [#556](https://github.com/diazoxide/charter/issues/556), a value
+attached to a *bundled* short option (`env -iC<dir> cat x.json`, which relocates into the
+vault directory and is allowed), and
+[#555](https://github.com/diazoxide/charter/issues/555), `env` accepting assignments to
+names that are not shell identifiers while the parser stops at the first token it cannot
+read as one (`env a-b=1 cat <vault>`). Both are live, both are unchanged in either direction
+by this fix, and both are a different question from the one #547 asked — a fix that widens
+its own scope until it is answering three questions is how a guard change stops being
+reviewable. `SECURITY.md`'s position is unmoved: guard rails, not guarantees — four
+rounds of adversarial review established that deciding what a shell will execute, without
+executing it, is not winnable in a Python tokeniser. This was a mis-ordering with a correct
+answer, and it has one now.
+
+Nothing to adopt: upgrading is the whole of it.
+
+[#547](https://github.com/diazoxide/charter/issues/547), found by external review and
+confirmed on a plane built by `charter init`.

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -104,9 +104,12 @@ was weaker than the one production already had.
 So `_launcher_argv` calls `hooks._split_env_chdir`, `_COMMAND_WRAPPERS` derives from
 `hooks._WRAPPERS`, and `_CHARTER_WORD` from `hooks._CHARTER_PROGS`. What is left here is
 what production deliberately does not ask — a shell's ``-c`` string, Python source, a script
-file — plus one repair, `_unpack_split_strings`, for a defect in production's `-S` parse
-that reuse would otherwise inherit (#547). `TheHarnessGuardIsNotASecondCopyOfProductions`
-in `test_plane_spawn_guard.py` fails if the two drift apart again.
+file. There was one repair on the way in as well, `_unpack_split_strings`, for the defect in
+production's `-S` parse that reuse would otherwise inherit; #547 fixed that parse and the
+repair is gone, which is a regression test in its own right — nothing here re-orders
+anything any more, so the harness's answer to ``env -Sfoo=1 charter docs`` is production's.
+`TheHarnessGuardIsNotASecondCopyOfProductions` in `test_plane_spawn_guard.py` fails if the
+two drift apart again.
 
 **Charter's own spawners now hand the plane over** (`util.child_env`), so an isolated case
 satisfies this without knowing it exists. What is left for the tripwire is the case that
@@ -629,56 +632,6 @@ def _script_imports_charter(path: str) -> bool:
         return True
 
 
-def _unpack_split_strings(parts: list[str]) -> list[str]:
-    """``env -S '<command>'`` with its packed command put back as ordinary tokens.
-
-    Production unpacks this too, and for the reason its own comment gives
-    (:data:`charter.hooks._SPLIT_STRING_FLAGS`): the value IS the command word, so skipping
-    it leaves an empty argv. It reads the ``--split-string=`` spelling BEFORE the glued
-    ``-S…`` one, though, so a packed command that itself contains an ``=`` is split at the
-    wrong one — ``env -Sfoo=1 charter docs`` yields ``1`` as the program and the charter is
-    never seen at all.
-
-    That is not only this guard's problem: measured against `main`'s Bash tool-gate, both
-    ``env -Sfoo=1 charter secret get v k --reveal --force`` and ``env -Sfoo=1 cat
-    .charter/vaults/x.json`` are ALLOWED while the same commands unwrapped are denied.
-    Filed as #547 — this is not the place to change a production guard's decisions. What is
-    repaired here is only the ordering, on the way IN: the flag names are still production's
-    constant, and the result goes straight back to production's splitter, so there is still
-    one reader of what a wrapper run means.
-
-    Only a ``-S`` that an `env` could be taking is unpacked. `ssh -S <control-socket>` is a
-    different flag on a different program, and a guard that unpacked it would be inventing
-    an arity for a program it has not identified — the mistake this function's neighbour
-    was sent back over.
-    """
-    out: list[str] = []
-    env_seen = False
-    i, n = 0, len(parts)
-    while i < n:
-        tok = parts[i]
-        if env_seen and tok.startswith(_hooks._SPLIT_STRING_FLAGS):
-            if tok.startswith("--") and "=" in tok:
-                packed = tok.split("=", 1)[1]
-            elif not tok.startswith("--") and len(tok) > 2:
-                packed = tok[2:]
-            elif i + 1 < n:
-                packed, i = parts[i + 1], i + 1
-            else:
-                packed = ""
-            try:
-                out.extend(shlex.split(packed))
-            except ValueError:            # will not lex; the words are still the words
-                out.extend(packed.split())
-            i += 1
-            continue
-        if os.path.basename(tok).lower() == "env":
-            env_seen = True
-        out.append(tok)
-        i += 1
-    return out
-
-
 def _launcher_argv(parts: list[str]) -> tuple[list[str], list[str]]:
     """``(the argv the launcher run really reaches, the words consumed getting there)``.
 
@@ -698,6 +651,13 @@ def _launcher_argv(parts: list[str]) -> tuple[list[str], list[str]]:
       leave an empty argv and the guard would see no program at all — fail-open on the exact
       input the rest of this table exists to catch."*
 
+    Delegation used to come with ONE repair on the way in, `_unpack_split_strings`, because
+    production read the ``--split-string=`` spelling before the glued ``-S…`` one and split
+    ``-Sfoo=1`` at the packed value's own ``=``. That was #547, it is fixed in
+    :func:`~charter.hooks._flag_name_value`, and the repair is deleted rather than left
+    standing: a second implementation of one question is what #543 collapsed, and a repair
+    that outlives its defect quietly becomes the thing hiding the next one.
+
     *consumed* is what was dropped on the way, and it is asked separately because the name
     can be IN it: ``c=charter; eval $c`` puts charter in an assignment and nothing else,
     and ``env -S`` packs a whole command into one token. Computed as "in *parts* and not in
@@ -709,8 +669,7 @@ def _launcher_argv(parts: list[str]) -> tuple[list[str], list[str]]:
     direction it is safe to be wrong in.
     """
     try:
-        unpacked = _unpack_split_strings(list(parts))
-        _prog, _env, argv, _chdir, _reads = _hooks._split_env_chdir(unpacked)
+        _prog, _env, argv, _chdir, _reads = _hooks._split_env_chdir(list(parts))
     except Exception:
         return list(parts), list(parts)
     return list(argv), [tok for tok in parts if tok not in argv]

--- a/tests/test_guard_attached_option_values.py
+++ b/tests/test_guard_attached_option_values.py
@@ -1,0 +1,245 @@
+"""A value ATTACHED to a short flag, read by a rule written for the long one (#547).
+
+`env -Sfoo=1 cat .charter/vaults/x.json` printed a vault on a real plane while the same
+command unwrapped was denied. `hooks._split_env_chdir` read the `--split-string=` spelling
+BEFORE the glued `-S…` one, so a packed command carrying its own `=` was split at the wrong
+one: the program came back `1`, the `cat` was never named, and nothing downstream had a
+reader to object to.
+
+**The six-row table below is the point of this file, not the one row that failed.** Measured
+on a plane built by `charter init`, a fabricated value in `.charter/vaults/x.json`, every
+command fed to the real `charter hook pretooluse`:
+
+    cat .charter/vaults/x.json                           -> DENY   (control)
+    env -Sfoo=1 cat .charter/vaults/x.json               -> ALLOW  <-- the bypass
+    env -S "cat .charter/vaults/x.json"                  -> DENY
+    env --split-string=foo=1 cat .charter/vaults/x.json  -> DENY
+    env -S "foo=1 cat .charter/vaults/x.json"            -> DENY
+    env FOO=1 cat .charter/vaults/x.json                 -> DENY
+
+Four of the five neighbours denied, which is why a hand probe concluded the guard held: it
+took the one form combining a GLUED SHORT FLAG with a value that itself contains `=` — and
+that is the form a real `env -S` setting a variable naturally takes. So all six rows are
+pinned in one table, driven by one loop. The five that already denied are what make the
+sixth's regression visible; without them a later refactor can trade one spelling for another
+and stay green, which is the shape this guard keeps getting caught by.
+
+**And its siblings, because the bug is a SHAPE and `-S` is not the only flag with it.**
+Every flag in `hooks._WRAPPER_VALUE_FLAGS` whose value may be attached had the same two
+rules in the same wrong order, and `env -C` — the chdir whose value is what makes a later
+relative operand resolve — was a live bypass of exactly the same kind:
+
+    env -Cx=y/../.charter/vaults cat x.json  -> ALLOW, and it printed the vault
+
+verified on the same plane, after the `mkdir x=y` a shell does without being asked twice.
+`sudo -D` and `xargs -a` are the same parse and are here for the same reason.
+`TestEveryFlagWhoseValueCanBeAttached` walks all three wrappers across all four spellings,
+so the answer cannot depend on which one a reviewer happened to try.
+
+**What this file does NOT claim.** `SECURITY.md` says guard rails, not guarantees, and
+deciding what a shell will execute without executing it is not winnable in a Python
+tokeniser. This is one mis-ordering with a correct answer — getopt gives a short option
+everything glued after it, `=` included — not an attempt to close the class. Two neighbours
+found while measuring this one are NOT fixed here and are filed rather than pinned as
+limits, because they are defects and not decisions: #556, a value attached to a BUNDLED
+short option (`env -iC<dir> cat x.json`), and #555, `env` accepting assignments to names
+that are not shell identifiers while this parser stops at the first token it cannot read as
+one (`env a-b=1 cat <vault>`). Both are live on `main` and both are unchanged by this fix,
+in either direction. They are deliberately absent from the tables below: a row asserting
+today's ALLOW would have to be deleted by whoever closes them, and a test that has to be
+deleted to make a fix pass teaches the wrong reflex.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import hooks
+from tests._isolation import PersonaIso, run_hook
+
+VAULT = ".charter/vaults/x.json"
+
+#: The measurement in #547, verbatim, as ``(command, must be denied)``. The `False` rows
+#: are not padding: they are the control and the four neighbours whose denial made the
+#: fifth look like a working guard. Written as one table so that no row can be dropped
+#: without the count below noticing.
+SIX_ROWS = (
+    (f"cat {VAULT}", True),                          # the control
+    (f"env -Sfoo=1 cat {VAULT}", True),              # #547 — allowed before the fix
+    (f'env -S "cat {VAULT}"', True),
+    (f"env --split-string=foo=1 cat {VAULT}", True),
+    (f'env -S "foo=1 cat {VAULT}"', True),
+    (f"env FOO=1 cat {VAULT}", True),
+)
+
+
+def _decision(r) -> str | None:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+class TestTheSixSpellingsOfOneVaultRead(unittest.TestCase):
+    """`_leak_reason`, the guard's own answer, over the whole table."""
+
+    def test_the_table_is_the_size_it_claims(self):
+        """Six rows, one of them #547's. A table that quietly loses its neighbours stops
+        being able to show that a fix traded one spelling for another."""
+        self.assertEqual(len(SIX_ROWS), 6)
+        self.assertIn(f"env -Sfoo=1 cat {VAULT}", [c for c, _ in SIX_ROWS])
+
+    def test_every_row_is_denied(self):
+        for cmd, denied in SIX_ROWS:
+            with self.subTest(cmd=cmd):
+                reason = hooks._leak_reason(cmd)
+                self.assertEqual(reason is not None, denied, cmd)
+                self.assertIn("reads a vault/secret file directly", reason or "")
+
+    def test_the_glued_short_form_names_the_reader(self):
+        """The row that failed, stated as the parse rather than as the verdict — so a
+        denial arriving from somewhere else (the raw-string arm, say) cannot stand in for
+        the ordering being right.
+
+        `-Sfoo=1` packs `foo=1`; the packed word is an env ASSIGNMENT and the program after
+        it is `cat`. Before the fix this came back `("1", …)`.
+        """
+        prog, env, argv, _chdir, _reads = hooks._split_env_chdir(
+            ["env", "-Sfoo=1", "cat", VAULT])
+        self.assertEqual(prog, "cat")
+        self.assertEqual(env, ["foo=1"])
+        self.assertEqual(argv, ["cat", VAULT])
+
+    def test_the_long_form_still_splits_at_its_own_equals(self):
+        """The rule that was being reached first is still right about its own spelling:
+        `--split-string=foo=1` splits at the FIRST `=`, packed value `foo=1`. Fixing an
+        ordering may not be a way of losing the other branch."""
+        prog, env, _argv, _c, _r = hooks._split_env_chdir(
+            ["env", "--split-string=foo=1", "cat", VAULT])
+        self.assertEqual((prog, env), ("cat", ["foo=1"]))
+
+    def test_a_separate_value_is_still_taken_from_the_next_token(self):
+        """`-S` and `--split-string` with nothing attached: the value is the NEXT token,
+        and skipping it instead of unpacking it leaves an empty argv — the fail-open
+        `_SPLIT_STRING_FLAGS` was written against."""
+        for flag in ("-S", "--split-string"):
+            with self.subTest(flag=flag):
+                prog, _e, _a, _c, _r = hooks._split_env_chdir(
+                    ["env", flag, f"foo=1 cat {VAULT}"])
+                self.assertEqual(prog, "cat")
+
+    def test_a_glued_value_with_no_equals_in_it_still_works(self):
+        """The neighbour that always denied. `-Scat <vault>` packs a whole command with no
+        `=` anywhere, so it never depended on which rule ran first."""
+        prog, _e, _a, _c, _r = hooks._split_env_chdir(["env", f"-Scat {VAULT}"])
+        self.assertEqual(prog, "cat")
+
+
+class TestTheSixSpellingsThroughTheRealHook(PersonaIso):
+    """The same six rows through `hooks.pretooluse`, which is where they were measured.
+
+    `_leak_reason` above is the guard; this is the DECISION — the JSON a harness acts on,
+    nested under `hookSpecificOutput` (reading `permissionDecision` from the root answers
+    `None` for every input and looks exactly like a guard that has stopped working, which
+    cost the reporter of #547 a round).
+    """
+
+    def test_every_row_is_denied_end_to_end(self):
+        for cmd, denied in SIX_ROWS:
+            with self.subTest(cmd=cmd):
+                r = run_hook(hooks.pretooluse,
+                             {"tool_name": "Bash", "tool_input": {"command": cmd},
+                              "session_id": "s"})
+                self.assertEqual(_decision(r), "deny" if denied else None, cmd)
+
+
+#: `(wrapper, flag whose value may be attached, what the value has to reach)`. One row per
+#: flag in `_WRAPPER_CHDIR_FLAGS`/`_WRAPPER_READ_FLAGS` — the two tables where a LOST value
+#: is a lost denial rather than a cosmetic misparse.
+ATTACHED_VALUE_FLAGS = (
+    ("env", "-C", "--chdir", "cat x.json"),
+    ("sudo", "-D", "--chdir", "cat x.json"),
+    ("xargs", "-a", "--arg-file", "echo"),
+)
+
+
+class TestEveryFlagWhoseValueCanBeAttached(unittest.TestCase):
+    """The sibling search, run as a test rather than reported in a commit message.
+
+    Four spellings per flag: separated, glued, long-with-`=`, and glued-with-an-`=`-in-the
+    -value — the last being #547's shape, and the one that was allowed for `env -C`,
+    `sudo -D` and `xargs -a` alike. The `x=y/../` prefix resolves away lexically, so all
+    four name the same file; the `=` in it is the whole point.
+    """
+
+    def _cmds(self, wrapper: str, short: str, long: str, tail: str):
+        target = ".charter/vaults" if wrapper != "xargs" else VAULT
+        return {
+            "separated": f"{wrapper} {short} {target} {tail}",
+            "glued": f"{wrapper} {short}{target} {tail}",
+            "long with =": f"{wrapper} {long}={target} {tail}",
+            "glued, = in the value": f"{wrapper} {short}x=y/../{target} {tail}",
+        }
+
+    def test_every_spelling_is_denied(self):
+        for wrapper, short, long, tail in ATTACHED_VALUE_FLAGS:
+            for spelling, cmd in self._cmds(wrapper, short, long, tail).items():
+                with self.subTest(wrapper=wrapper, spelling=spelling):
+                    self.assertIsNotNone(hooks._leak_reason(cmd), cmd)
+
+    def test_the_value_itself_comes_back_whole(self):
+        """Stated as the parse, because "denied" can be true for the wrong reason. A short
+        option takes everything glued after it — getopt included the `=` — so the chdir is
+        the whole `x=y/../.charter/vaults`, not the `y/../…` after its first `=`."""
+        _p, _e, _a, chdir, _r = hooks._split_env_chdir(
+            ["env", "-Cx=y/../.charter/vaults", "cat", "x.json"])
+        self.assertEqual(chdir, "x=y/../.charter/vaults")
+
+        _p, _e, _a, _c, reads = hooks._split_env_chdir(
+            ["xargs", f"-ax=y/../{VAULT}", "echo"])
+        self.assertEqual(reads, [f"x=y/../{VAULT}"])
+
+    def test_the_long_form_is_still_read_as_a_long_form(self):
+        """`--chdir=<dir>` splits at its `=` exactly as before — the glued rule must not
+        start eating long options because they happen to contain a short flag's letters."""
+        _p, _e, _a, chdir, _r = hooks._split_env_chdir(
+            ["env", "--chdir=.charter/vaults", "cat", "x.json"])
+        self.assertEqual(chdir, ".charter/vaults")
+
+    def test_a_flag_that_takes_no_value_still_takes_none(self):
+        """`env -i` ignores the environment and takes nothing. A glued rule that matched it
+        would swallow the program — the fail-open `_WRAPPER_VALUE_FLAGS` is per-wrapper to
+        avoid, since `xargs -i` and `stdbuf -i` DO take one."""
+        prog, _e, _a, _c, _r = hooks._split_env_chdir(["env", "-i", "cat", VAULT])
+        self.assertEqual(prog, "cat")
+
+
+class TestTheParserIsShared(unittest.TestCase):
+    """`tests/_planeguard.py` reads this parser rather than keeping its own (#543), so a
+    change here moves the production guard AND the harness's spawn tripwire together.
+
+    It used to repair this very ordering on the way in (`_unpack_split_strings`), with a
+    comment saying to delete the repair when #547 landed. It is deleted; this asserts the
+    reason it could be — the ordering is right in the one parser both callers read.
+    """
+
+    def test_the_harness_reads_production_and_gets_the_same_answer(self):
+        """`env -Sfoo=1 charter docs` reaches `charter docs` — the harness's answer with
+        no repair of its own, which is what the deleted one was standing in for.
+
+        *consumed* is "in the input and not in the argv", so it holds the `-Sfoo=1` TOKEN
+        rather than the `foo=1` word production unpacked out of it; the packed word is
+        checked in the argv, where it is checked properly.
+        """
+        from tests import _planeguard
+        argv, consumed = _planeguard._launcher_argv(["env", "-Sfoo=1", "charter", "docs"])
+        self.assertEqual(argv, ["charter", "docs"])
+        self.assertEqual(consumed, ["env", "-Sfoo=1"])
+
+    def test_no_ordering_repair_is_left_in_the_harness(self):
+        """Named directly, so re-adding a private repair is a test failure and not a
+        judgement call. Two implementations of one question hide each other's defects —
+        which is why #543 collapsed them, and why this one may not come back."""
+        from tests import _planeguard
+        self.assertFalse(hasattr(_planeguard, "_unpack_split_strings"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -376,17 +376,18 @@ class EverySpellingThatReachesCharter(_FakePlane):
     def test_a_packed_command_that_itself_contains_an_equals_sign(self):
         """``env -Sfoo=1 charter docs``, which reusing production's reader let through.
 
-        `hooks._split_env_chdir` reads the ``--split-string=`` spelling before the glued
-        ``-S…`` one, so it splits this at the FIRST ``=`` — the program becomes ``1`` and
-        the charter after it is never looked at. Reuse means inheriting that, so the
-        ORDERING is repaired on the way in (`_unpack_split_strings`) using production's own
-        flag names, and the repaired tokens go back to production's splitter.
+        `hooks._split_env_chdir` used to read the ``--split-string=`` spelling before the
+        glued ``-S…`` one, so it split this at the FIRST ``=`` — the program came back ``1``
+        and the charter after it was never looked at. Reuse means inheriting that, so the
+        ordering was repaired here on the way in while #547 was open.
 
-        The same input is a live bypass of charter's Bash tool-gate on `main` — measured:
+        The same input was a live bypass of charter's Bash tool-gate — measured:
         ``env -Sfoo=1 cat .charter/vaults/x.json`` and ``env -Sfoo=1 charter secret get v k
-        --reveal --force`` are both ALLOWED there while the unwrapped commands are denied.
-        That is production's to fix (#547); this case is only about the harness not
-        shipping the same hole.
+        --reveal --force`` were both ALLOWED while the unwrapped commands were denied. #547
+        fixed the ordering in production (`hooks._flag_name_value`), the repair here is
+        deleted, and this case now passes on production's parse alone — which is the second,
+        free regression test that fix came with. `tests/test_guard_attached_option_values.py`
+        holds the six-row table on the production side.
         """
         for argv in ([str(self.fake), "docs"],
                      ["env", f"-Sfoo=1 {self.fake} docs"],


### PR DESCRIPTION
Closes #547.

`env -Sfoo=1 cat .charter/vaults/x.json` printed a fabricated vault on a plane built by
`charter init` while the same `cat` unwrapped was denied. `hooks._split_env_chdir` read the
`--split-string=` rule before the glued `-S…` one, so a packed command carrying its own `=`
was split at the wrong one: the program came back `1`, the `cat` was never named, and no
guard downstream had a reader to object to.

getopt hands a short option everything glued after it, `=` included. `_flag_name_value` now
says that once, for every flag whose value can be attached, and the two rules are **disjoint**
rather than merely ordered — a glued short form never starts with `--`, and the `=` rule now
requires it — so the ordering cannot come back by accident.

## The six rows, before and after

Measured on a plane built by `charter init`, a fabricated value in `.charter/vaults/x.json`,
every command fed to the real `charter hook pretooluse` (decision read from
`hookSpecificOutput`; empty stdout is an allow).

| command | before | after |
| --- | --- | --- |
| `cat .charter/vaults/x.json` | DENY (control) | DENY |
| `env -Sfoo=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `env -S "cat .charter/vaults/x.json"` | DENY | DENY |
| `env --split-string=foo=1 cat .charter/vaults/x.json` | DENY | DENY |
| `env -S "foo=1 cat .charter/vaults/x.json"` | DENY | DENY |
| `env FOO=1 cat .charter/vaults/x.json` | DENY | DENY |

All six are pinned in `tests/test_guard_attached_option_values.py`, driven by one loop, both
through `_leak_reason` and end to end through `hooks.pretooluse`. The five that already denied
are the point of the table: without them a later refactor can trade one spelling for another
and stay green.

## The sibling search

The question asked: does any other option in that parser have both a glued short spelling and
an `=`-bearing long spelling, and the same mis-ordering?

**Yes — the generic value-flag branch had exactly the same two rules in the same wrong order,
and one of them was live.** `env -C` is the chdir whose value is what makes a later relative
operand resolve, and:

```
$ env -Cx=y/../.charter/vaults cat x.json     # guard: ALLOW (before)
{"k":"FABRICATED-NOT-A-REAL-SECRET-9271"}
```

The chdir was lost at the path's own `=` (`name="-Cx"`, `value="y/../…"`, which is in no chdir
table), so `x.json` resolved against the plane root and named nothing guarded. It needs a
`mkdir x=y` first, which a shell does without being asked twice. `sudo -D` and `xargs -a` are
the same parse and were allowed the same way at the guard level (`xargs -a` is GNU-only, so
its execution could not be run down on this macOS box; its *decision* was measured and is
fixed with the others). All three wrappers are now walked across all four spellings —
separated, glued, long-with-`=`, and glued-with-an-`=`-in-the-value.

**Checked and clear:** every other `=` split in `hooks.py` already requires `--` first
(`--config-env=`, `_checkout_operand_kind`, `_created_branch`, `_git_config_pairs`), and
`toolgate._path_candidates` takes the *union* of both readings rather than choosing between
them, so neither has this shape.

## `_unpack_split_strings` deleted cleanly

`tests/_planeguard.py`'s workaround (added in #543 to repair this ordering on the way in while
reusing production's parser, with a note to delete it when #547 landed) is gone, and the suite
stays green on production's parse alone — so the fix is genuinely in production, not in the
harness. It is also a live regression test: with the ordering reverted,
`test_plane_spawn_guard.EverySpellingThatReachesCharter::test_a_packed_command_that_itself_contains_an_equals_sign`
reddens alongside the new table, which it could not do while the repair stood.

## Verification

**Two environments, agreeing.** (1) zsh runner, default `python3` 3.14.4, every `CHARTER_*`
cleared with `unset`: `Ran 5893 tests … OK`. (2) scrubbed shell (all `CHARTER_*`, `CLAUDE_*`,
`ANTHROPIC_*`, `TMUX*` unset) on a different interpreter, `python3.12` 3.12.13:
`Ran 5893 tests … OK`.

**Mutation.** Reverted `_flag_name_value` to the pre-#547 ordering (`if "=" in tok:` first,
glued second) and ran the new module plus `test_plane_spawn_guard`: **10 failures**, naming the
spelling in the subTest label —

```
FAIL: test_every_row_is_denied (cmd='env -Sfoo=1 cat .charter/vaults/x.json')
FAIL: test_every_row_is_denied_end_to_end (cmd='env -Sfoo=1 cat .charter/vaults/x.json')
FAIL: test_the_glued_short_form_names_the_reader          AssertionError: '1' != 'cat'
FAIL: test_every_spelling_is_denied (wrapper='env'|'sudo'|'xargs', spelling='glued, = in the value')
FAIL: test_the_value_itself_comes_back_whole
FAIL: test_the_harness_reads_production_and_gets_the_same_answer
FAIL: test_a_packed_command_that_itself_contains_an_equals_sign (× 2 spellings)
```

Restored: `Ran 73 tests … OK`.

## Filed, not folded in

Two neighbours found while measuring this one, both live and both **unchanged in either
direction** by this fix:

* **#556** — a value attached to a *bundled* short option is never read. `env -iC.charter/vaults
  cat x.json` relocates into the vault directory, prints it, and is allowed. Reading a bundle
  needs a new per-wrapper table of letters that take *no* value, which is the opposite of the
  one that exists and is a different change.
* **#555** — `env` accepts assignments to names that are not shell identifiers, and
  `_split_env_chdir` stops at the first token it cannot read as one and calls it the program.
  `env a-b=1 cat .charter/vaults/x.json` prints the vault; so does
  `env -Sfoo=1 -Sbar=2 cat .charter/vaults/x.json`, which is the same root cause wearing this
  issue's clothes.

They are deliberately absent from the new tables: a row asserting today's ALLOW would have to
be deleted by whoever closes them.

`SECURITY.md`'s position is unmoved — guard rails, not guarantees; four rounds of adversarial
review established that deciding what a shell will execute, without executing it, is not
winnable in a Python tokeniser. This was a mis-ordering with a correct answer, and it has one.

**No overlap with the Phase 2 branches in flight** (#552, #553, #554): nothing here touches
`instance.py`, `commands_frame.py`, `ctx.py` or the overlay module. Files changed are
`charter/hooks.py`, `tests/_planeguard.py`, `tests/test_plane_spawn_guard.py`, one new test
module and one news entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
