### PR TITLE
Focus events exist, and the mouse trade is unavoidable rather than deferred (Phase 2, Task 7)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -376,6 +376,47 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
     identical binding anyway, so nothing is lost by sharing it the same way
     `remain-on-exit` is (see `_PLACEHOLDER_CONF`).
 
+    **`focus-events` is the THIRD genuine server option here, and it is written `-g` for
+    exactly `escape-time`'s reason.** Spec §4f closes the component event kinds at six,
+    two of which are `focus` and `blur`; tmux ships `focus-events` OFF, and with it off
+    tmux writes `\\x1b[?1004l` to the client and never delivers a pane focus transition,
+    so those two kinds do not exist at all until this line runs. The Phase 2 plan asked
+    for `set -t <session> focus-events on`; measured on this machine, that spelling is a
+    lie about scope and the `-g` above is the true one. tmux 3.7c AND tmux 3.2 —
+    charter's own `tmuxctl.FLOOR`, built from the release tarball and run — both answer::
+
+        $ tmux -L t7 show-options -s | grep focus-events
+        focus-events off                 # server table
+        $ tmux -L t7 show-options -g | grep focus-events
+        (absent from -g)                 # NOT a session option, on either version
+        $ tmux -L t7 set -t one focus-events on
+        $ tmux -L t7 show-options -t two focus-events
+        focus-events on                  # the SIBLING session, which nobody set
+
+    `mouse`, run through the identical probe, answers `''` for the sibling — that is what
+    a genuinely session-scoped option looks like, and `focus-events` is not one. So
+    `set -t <session>` here would not contain anything; it would only read as though it
+    did, sitting in a list whose first three lines are session-scoped precisely so frame
+    N cannot rewrite frame N-1's settings. Nothing is actually lost by writing it
+    globally — every frame wants the identical `on`, like `escape-time` and
+    `remain-on-exit` — and tmux's own source says the same thing outright: 3.2's
+    `options-table.c` carries `.name = "focus-events"` with `.scope =
+    OPTIONS_TABLE_SERVER` and `.default_num = 0`.
+
+    **Do not replace this with a runtime check against `#{client_flags}`.** That format
+    reports `focused` whether or not focus events are being delivered, so a guard written
+    against it passes with the feature dead. Measured on 3.7c and 3.2, one attached pty
+    client, flipping the option underneath it::
+
+        focus-events off (feature DEAD)  client_flags='attached,focused,UTF-8'
+        focus-events on  (feature LIVE)  client_flags='attached,focused,UTF-8'
+        focus-events off again           client_flags='attached,focused,UTF-8'
+
+    Identical in all three states. The only readable evidence is the OPTION
+    (`show-options -t <session> focus-events`), which is why this line — not a probe — is
+    what makes §4f's `focus`/`blur` exist. Pinned by
+    `tests/test_frame_tmux_integration.py`'s `FocusEventsIntegration`.
+
     Neither `pane-died` hook lives here — see `_pane_died_write_hook_argv` and
     `_pane_died_teardown_hook_argv` for why they are issued as their own tmux commands
     instead of text baked into this string.
@@ -451,6 +492,7 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
         f"set -t {session} history-limit {int(history_limit)}",
         "set -g escape-time 0",
         "set -g remain-on-exit on",
+        "set -g focus-events on",
         f"bind -n {hotkey} run-shell "
         f"'\"${_CHARTER_PY_ENV}\" -m charter frame-menu \"#{{client_name}}\"'",
         "bind -n WheelUpPane if-shell -F -t = '#{mouse_any_flag}'"

--- a/charter/frame/component.py
+++ b/charter/frame/component.py
@@ -62,6 +62,32 @@ EDGES = ("top", "bottom", "left", "right")
 #: to get right across terminals, and the most likely to fight tmux's own selection —
 #: and the asymmetry is the whole argument: adding it in a later API version costs
 #: nothing, while removing it after a provider has shipped against it costs everything.
+#:
+#: **Declaring one of these is a declaration of what you HANDLE, never a promise that it
+#: FIRES — and for three of the six, charter cannot make that promise.** Written here
+#: because this constant is where a provider author meets the question;
+#: `docs/frame.md`'s "Mouse is off by default" says the operator's half of the same fact.
+#:
+#: * ``click`` and ``scroll`` — **charter does not control whether pointer events reach
+#:   your pane** (§4i). tmux asks the outer terminal to report the mouse from the ACTIVE
+#:   pane's own request alone: with `[frame] mouse` off and the harness pane active,
+#:   nothing has asked the terminal to report, so a click on your panel produces no bytes
+#:   at all and there is nothing for tmux to route. It is not that charter drops the
+#:   event — the event never happens. The harness (Claude Code, or whatever the operator
+#:   ran) is the program that decides, and charter does not own it. `[frame] mouse = true`
+#:   is the only setting that makes reporting unconditional, and it costs the operator
+#:   their terminal's own text-selection (see `instance.FRAME_FIELDS`). **So a component
+#:   whose only route to a piece of state is a click has no route to it on most planes.**
+#:   Give every pointer affordance a ``key`` as well.
+#: * ``focus``/``blur`` — needs tmux's ``focus-events``, which ships OFF.
+#:   `commands_frame.conf_text` turns it on for every frame charter launches, so on
+#:   charter's own server these fire; inside an operator's existing tmux charter sources
+#:   no config at all, and they do not. They also require the operator's terminal
+#:   emulator to report focus in the first place, which not all do.
+#:
+#: The rule that follows, and the one thing this constant is asking of you: **degrade to
+#: "never fires", never to "fires wrongly".** A component that treats a missing ``blur``
+#: as "still focused" is correct; one that infers focus from elapsed time is not.
 EVENT_KINDS = ("key", "click", "scroll", "focus", "blur", "resize")
 
 #: The slices of the plane snapshot a component may declare in ``needs`` — and therefore

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -542,9 +542,33 @@ FRAME_FIELDS = {
     #: `normal` -> `full` when #386 raised the `slots` default above, and that test is
     #: what made the move happen at merge time instead of being noticed later.
     "density": ("full", "density"),
-    #: Off by default: tmux's `set -g mouse on` takes over drag-select, so turning this on
-    #: trades the operator's terminal text-selection for clickable panels. That trade
-    #: belongs to a later release that actually ships clickable panels, not this one.
+    #: Off by default, and the trade it makes is UNAVOIDABLE rather than conditional.
+    #:
+    #: An earlier version of this comment said the trade "belongs to a later release that
+    #: actually ships clickable panels, not this one". Both halves of that are now wrong.
+    #: This IS that release — Phase 2 ships a clickable surface — and measurement says
+    #: there was never a later release in which the trade could be avoided.
+    #: `docs/superpowers/specs/2026-08-26-tmux-input-findings.md` §5, on tmux 3.1c, 3.2
+    #: and 3.7c: tmux enables mouse reporting on the OUTER terminal from the active pane's
+    #: mode alone, so the instant any mouse-requesting pane is active the terminal is
+    #: reporting and its own drag-select is gone for the whole window. **There is no state
+    #: in which charter's panels are clickable and native selection survives.** Turning
+    #: tmux's own `mouse` off does not dodge the trade; it only makes it conditional on
+    #: which pane happens to be focused.
+    #:
+    #: Which is the second thing this flag really controls, and the reason it stays a
+    #: flag: with it OFF, whether a panel is clickable is decided by the ACTIVE pane's
+    #: request — that is the harness (Claude Code, or whatever the operator ran), a
+    #: program charter does not own. So "clickable panels" is not a property charter can
+    #: promise for its panes at all with this off (§4i); with it on, reporting is
+    #: unconditional from attach and the cost is unconditional too. Off is the default
+    #: because an operator who has not asked for it keeps their selection.
+    #:
+    #: A component declaring `click`/`scroll` therefore declares what it HANDLES, never
+    #: that the event fires — `frame/component.py`'s `EVENT_KINDS` says that to the
+    #: provider author, `docs/frame.md` says it to the operator, and both point back here.
+    #: The palette is the exception and does not need this flag: while it is open it is
+    #: the active surface, so its own request is the one that reaches the terminal.
     "mouse": (False, "mouse"),
     "hotkey": ("F2", "hotkey"),
     "history_limit": (50000, "history-limit"),

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -59,9 +59,28 @@ first.** The frame raises tmux's `history-limit` (50 000 lines, configurable) an
 mouse wheel to enter copy-mode, but it is tmux's buffer you are scrolling, not the
 terminal emulator's.
 
-**Mouse is off by default.** `set -g mouse on` takes over drag-select, so turning it on
-trades your terminal's own text-selection for clickable panels — a trade this release does
-not make for you. `[frame] mouse = true` opts in.
+**Mouse is off by default, and turning it on costs you your terminal's own text-selection.**
+That is not a trade charter can soften and not one a later release will remove — it is how
+tmux works. tmux asks your terminal to report the mouse, and from that moment your terminal
+stops doing its own drag-select over the whole window. Measured on tmux 3.1c, 3.2 and 3.7c:
+there is no state in which charter's panels are clickable and native selection survives.
+`[frame] mouse = true` opts in with your eyes open.
+
+**With mouse off, whether a panel is clickable is decided by the harness, not by charter.**
+tmux asks your terminal to report the mouse from the *active* pane's own request alone. With
+`[frame] mouse` off and the harness pane active, nothing has asked, so a click on a panel
+produces no bytes at all — there is nothing for charter to receive and nothing for tmux to
+route. If the harness you ran (Claude Code, say) does request mouse reporting, panels become
+clickable while it is active, and you lose drag-select for as long as it is. Charter does not
+control that program and cannot promise you either behaviour. Keys always work. A surface
+charter draws over a whole pane and drives itself is the exception — while it is open it
+*is* the active pane, so its own request is the one that reaches your terminal.
+
+**Focus events are on inside a frame charter launched, and off inside your own tmux.** tmux
+ships `focus-events` off, and it is a server-wide setting; charter turns it on for its own
+private server, which is what lets a panel know it stopped being the active pane. Inside a
+tmux you already have, charter writes no config at all (see below), so panels there never
+learn it. Your terminal emulator also has to report focus for any of it to work.
 
 **Panels repaint when charter's own hooks say something changed**, not by reaching out for
 anything themselves: every `posttooluse*` hook bumps a version marker charter already
@@ -158,6 +177,11 @@ the sentence above:
   and `mouse` are session options in tmux; setting them for the frame would set them for
   every other window in that session too. `[frame] history-limit` and `[frame] mouse` are
   ignored inside your tmux.
+- **Your `focus-events` setting applies, and panels get no focus events unless you have
+  turned it on.** `focus-events` is a tmux *server* option — measured on 3.2 and 3.7c, it
+  sits in `show-options -s` and setting it for one session sets it for every session on
+  that server. Charter turns it on for its own private server and will not touch yours.
+  `set -s focus-events on` in your own config is how you get it here.
 - **No hotkey.** tmux key tables are server-wide with no per-window form, so any key
   charter bound would be taken from every window you have open. The spec allowed a
   prefix-scoped bind here; charter takes the stricter option, because the menu's one

--- a/docs/news/unreleased-focus-events-are-on-and-the-mouse-trade-is-honest.md
+++ b/docs/news/unreleased-focus-events-are-on-and-the-mouse-trade-is-honest.md
@@ -1,0 +1,64 @@
+---
+version: unreleased
+headline: The frame turns focus events on, and stops promising you clickable panels it cannot deliver
+---
+
+Two small things, both of which were charter saying something that was not true.
+
+## Focus events exist now
+
+A panel could not tell that it had stopped being the active pane. The frame's component
+contract lists six event kinds, two of which are `focus` and `blur` — and they never fired,
+on any machine, for anyone. tmux ships `focus-events` **off**, and with it off tmux writes
+`\x1b[?1004l` to your terminal and never delivers a pane focus transition at all. The
+option was simply missing from the config charter writes for its own server.
+
+It is there now. `charter frame` turns `focus-events` on for the private tmux server it
+launches, so a component that declares `focus` or `blur` receives them.
+
+Two honest edges on that, both measured rather than assumed:
+
+* **Inside a tmux you already have, they still do not fire.** `focus-events` is a tmux
+  *server* option — it lives in `show-options -s`, and setting it for one session sets it
+  for every session on that server. Charter writes nothing at all into your own tmux (that
+  boundary has not moved), so it will not turn this on for you either. `set -s focus-events
+  on` in your own config is how you get it there.
+* **Your terminal emulator has to report focus for any of it to work.** Not all do.
+
+The rule the contract now states for a provider: a declared event kind degrades to *never
+fires*, never to *fires wrongly*.
+
+## "A trade a later release will avoid" — it will not
+
+`[frame] mouse` has been off by default since it shipped, with a note saying that turning it
+on trades your terminal's own drag-select for clickable panels, and that the trade "belongs
+to a later release that actually ships clickable panels". Both halves of that were wrong.
+
+This is that release. And measured against tmux 3.1c, 3.2 and 3.7c, the trade was never
+conditional and no later release could have removed it: tmux asks your terminal to report
+the mouse based on the **active pane's** request alone, so the instant any mouse-requesting
+pane is active your terminal is reporting and its own selection is gone for the whole
+window. **There is no state in which charter's panels are clickable and native selection
+survives.** Leaving tmux's own `mouse` off does not dodge the trade — it only makes it
+depend on which pane happens to be focused.
+
+Which is the second thing, and the one worth knowing before you write a component:
+
+**With `[frame] mouse` off, whether a panel is clickable is decided by the harness, not by
+charter.** With the harness pane active and nothing having asked the terminal to report,
+a click on a panel produces no bytes at all — there is nothing for charter to drop, because
+the event never happens. If the harness you ran does request mouse reporting, panels become
+clickable while it is active, and you lose drag-select for as long as it is. Charter does
+not own that program and will not claim otherwise.
+
+So `click` and `scroll` in the component contract declare what a component **handles**,
+never that the event fires. Give every pointer affordance a key as well. A surface charter
+draws over a whole pane and drives itself is the exception and needs no setting: while it is
+open it *is* the active pane, so its own request is the one that reaches your terminal.
+
+## What to do
+
+Nothing. `[frame] mouse` still defaults to off and still means what it meant; the frame
+gains one tmux option it should always have set. If you have been waiting for the release
+that makes panels clickable without costing you text selection, stop waiting — that release
+does not exist, and charter now says so where you would look for it.

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -273,6 +273,41 @@ class Conf(unittest.TestCase):
         self.assertIn("set -g escape-time 0", text)
         self.assertIn("set -g remain-on-exit on", text)
 
+    def test_focus_events_is_turned_on_or_focus_and_blur_never_fire(self):
+        """`focus-events` ships OFF in tmux, and it gates the whole path: with it off tmux
+        writes `\\x1b[?1004l` to the client and never delivers a pane focus transition, so
+        two of the six event kinds `frame/component.py` closes (`focus`, `blur`) do not
+        exist. This line is the only thing that makes them exist.
+
+        The behavioural half — that tmux itself reports the option ON once this text is
+        `source-file`'d, having reported it OFF before — is
+        `tests/test_frame_tmux_integration.py`'s `FocusEventsIntegration`. This one is the
+        text, so a machine with no tmux still fails if the line goes."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                        session="demo-42")
+        self.assertIn("set -g focus-events on", text)
+
+    def test_focus_events_is_global_because_tmux_has_no_session_form_for_it(self):
+        """`-g`, deliberately, and NOT the `set -t <session>` the Phase 2 plan asked for.
+
+        `focus-events` is a tmux SERVER option — measured on tmux 3.7c and on tmux 3.2
+        (`tmuxctl.FLOOR`, built from the release tarball and run): it appears in
+        `show-options -s`, is absent from `show-options -g`, and `set -t one focus-events
+        on` leaves the SIBLING session `two` reading `focus-events on` as well. Run
+        through the identical probe, `mouse` leaves the sibling reading `''` — that is
+        what a genuinely session-scoped option looks like, and this is not one.
+
+        So `set -t <session>` here would contain nothing while reading, in a list whose
+        first three lines are session-scoped exactly so frame N cannot rewrite frame
+        N-1's, as though it did. Nothing is lost by writing it globally: every frame wants
+        the identical `on`. Asserts the absence of the misleading spelling, not merely the
+        presence of the true one — a change that added `-t` beside `-g` would satisfy the
+        test above on its own."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                        session="demo-42")
+        self.assertNotIn("set -t demo-42 focus-events", text)
+        self.assertNotIn("set -s focus-events", text)
+
     def test_mouse_is_off_unless_asked_for(self):
         off = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
                                        session="x")

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -4756,5 +4756,157 @@ class EveryBorderOptionThisTmuxHasIsPinned(_TmuxServerFixture, PersonaIso,
             self.assertIn(name, theirs, f"{name} is not a window option on this tmux")
 
 
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class FocusEventsIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase):
+    """`conf_text`'s `set -g focus-events on`, and the reason it is a CONFIG LINE rather
+    than something charter could detect at runtime and decide about.
+
+    Spec §4f closes a component's event kinds at six, two of which are `focus` and `blur`.
+    tmux ships `focus-events` OFF; with it off tmux writes `\\x1b[?1004l` to the client and
+    never delivers a pane focus transition, so those two kinds do not exist until charter
+    turns the option on. `tests/test_frame_launcher.py`'s `Conf` pins the TEXT (and fails
+    on a machine with no tmux at all); this class pins what tmux does with it.
+
+    **The second test here is the interesting one, and it is a refutation.** The obvious
+    alternative to a config line is a runtime guard — ask tmux whether the client is
+    focused and behave accordingly — and `#{client_flags}` is the format that looks like
+    the answer. It is not: it reports `focused` whether or not focus events are being
+    delivered, so a guard written against it passes with the feature dead. Measured on
+    3.7c and on 3.2 (`tmuxctl.FLOOR`, built from the release tarball and run) with one
+    attached pty client and the option flipped underneath it, all three readings were
+    `attached,focused,UTF-8`. That test asserts the flags are IDENTICAL across the flip,
+    which is the property that makes them useless as a guard — an `assertIn("focused")`
+    alone would pass on a tmux where the flag had started telling the truth.
+
+    The third pins the SCOPE, and exists so nobody "corrects" `-g` back to the
+    `set -t <session>` the Phase 2 plan asked for. `focus-events` is a server option on
+    both versions; a session-scoped write of it lands on every session on the server, so
+    the `-t` spelling would read as containment while containing nothing. `mouse` is the
+    control: run through the same probe it leaves the sibling untouched, which is what a
+    genuinely session-scoped option looks like.
+
+    Its own server, its own socket, and no attached client except in the one test that
+    needs one (`_NeedsAttachedClient` skips where tmux will not attach one at all).
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # kill-server THEN unlink, registered so LIFO runs them in that order — see
+        # `PanelIntegration._teardown_socket`'s own docstring. `conf_text` emits
+        # `set -g remain-on-exit on`, which this class sources for real, so its panes
+        # outlive their commands exactly as `MenuClientIntegration`'s do.
+        self.addCleanup(self._teardown_socket)
+
+    def _teardown_socket(self) -> None:
+        _tmux("kill-server")
+        (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
+
+    def _new_session(self, fid: str) -> None:
+        """A `cat`-backed session with its pane's own pid registered for cleanup —
+        `kill-server` alone is documented in `_kill_pid` as unreliable at reaping one."""
+        r = _tmux("new-session", "-d", "-s", fid, "-x", "80", "-y", "24", "cat")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pid = _tmux("display-message", "-p", "-t", fid, "#{pane_pid}").stdout.strip()
+        self.addCleanup(_kill_pid, pid)
+
+    def _source_conf(self, fid: str) -> None:
+        """`commands_frame.conf_text`'s own output, `source-file`'d for real — byte for
+        byte, never a hand-retyped `set`. The point is that the PRODUCTION text is what
+        turns the option on."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                        session=fid)
+        conf = Path(tempfile.mkdtemp(prefix="charter-integ-focusconf-")) / "tmux.conf"
+        self.addCleanup(shutil.rmtree, conf.parent, True)
+        conf.write_text(text)
+        r = _tmux("source-file", str(conf))
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    @staticmethod
+    def _focus_events(target: str) -> str:
+        return _tmux("show-options", "-t", target, "focus-events").stdout.strip()
+
+    def test_charters_own_conf_text_turns_focus_events_on_for_real(self):
+        """The behavioural pin for `set -g focus-events on`: tmux reports the option OFF
+        before charter's config is sourced and ON after it, with nothing hand-retyped in
+        between.
+
+        The BEFORE half is read from tmux rather than assumed, per this module's rule
+        against asserting on a version string — a tmux that had changed its own default
+        would make this test say so instead of quietly passing on a coincidence.
+        """
+        fid = "focus-conf"
+        self._new_session(fid)
+        self.assertEqual(self._focus_events(fid), "focus-events off",
+                         "this tmux does not ship focus-events off, so what the line "
+                         "below proves is no longer what it was written to prove")
+        self._source_conf(fid)
+        self.assertEqual(self._focus_events(fid), "focus-events on",
+                         "charter's own frame config left focus-events off — §4f's "
+                         "`focus`/`blur` event kinds do not exist without it")
+
+    def test_client_flags_cannot_serve_as_the_guard_this_line_replaces(self):
+        """`#{client_flags}` LIES, so no runtime guard can stand in for the config line.
+
+        It reads `focused` with focus events being delivered and `focused` with them
+        dead. Asserted as an EQUALITY across the flip rather than as "the string contains
+        focused": the defect is that the flag cannot distinguish the two states, and only
+        comparing them can catch a tmux where it started to.
+        """
+        fid = "focus-flags"
+        self._new_session(fid)
+        self._attach_pty(fid)
+
+        def flags() -> str:
+            r = _tmux("list-clients", "-t", fid, "-F", "#{client_flags}")
+            self.assertEqual(r.returncode, 0, r.stderr)
+            return r.stdout.strip()
+
+        self.assertEqual(_tmux("set", "-g", "focus-events", "off").returncode, 0)
+        dead = flags()
+        self.assertEqual(_tmux("set", "-g", "focus-events", "on").returncode, 0)
+        live = flags()
+        self.assertEqual(_tmux("set", "-g", "focus-events", "off").returncode, 0)
+        dead_again = flags()
+
+        self.assertTrue(dead, "no client was attached, so nothing was measured")
+        self.assertIn("focused", dead,
+                      "this tmux stopped reporting `focused` while focus events were "
+                      "off — the flag may have become honest; re-measure before relying "
+                      "on it")
+        self.assertEqual(dead, live,
+                         "`#{client_flags}` now distinguishes focus-events on from off; "
+                         "the reason `conf_text` sets the option rather than probing a "
+                         "flag no longer holds and should be re-argued")
+        self.assertEqual(live, dead_again)
+
+    def test_focus_events_is_a_server_option_so_a_session_scoped_write_would_not_contain_it(self):
+        """Why the line is `-g` and not the `set -t <session>` the plan asked for.
+
+        Two sessions on one server. Setting `focus-events` for one sets it for BOTH,
+        because it lives in tmux's server table — so the `-t` spelling would read as
+        containment while containing nothing, in a config whose first three lines are
+        session-scoped precisely so one frame cannot rewrite another's. `mouse` is the
+        control that stops this test passing on a broken probe: run through exactly the
+        same two calls it leaves the sibling reading empty, which is what a genuinely
+        session-scoped option does.
+        """
+        self._new_session("focus-one")
+        self._new_session("focus-two")
+        self.assertIn("focus-events", _tmux("show-options", "-s").stdout,
+                      "focus-events is no longer a tmux SERVER option on this version — "
+                      "`conf_text`'s `-g` should be re-argued against a per-session form")
+
+        self.assertEqual(_tmux("set", "-t", "focus-one", "focus-events", "on").returncode, 0)
+        self.assertEqual(self._focus_events("focus-two"), "focus-events on",
+                         "a session-scoped focus-events write did NOT reach the sibling, "
+                         "so tmux grew a per-session form and `conf_text` can use it")
+
+        self.assertEqual(_tmux("set", "-t", "focus-one", "mouse", "on").returncode, 0)
+        self.assertEqual(
+            _tmux("show-options", "-t", "focus-two", "mouse").stdout.strip(), "",
+            "the control failed: even `mouse`, which conf_text relies on being "
+            "session-scoped, reached the sibling here — this probe measures nothing")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Phase 2, Task 7 of `docs/superpowers/plans/2026-08-26-phase2-command-surface.md`.

Two things charter was saying that were not true, and one tmux option it had never set.

## 1. `focus-events` is on now

`frame/component.py` closes a component's event kinds at six, two of which are `focus` and
`blur`. They never fired for anyone. tmux ships `focus-events` **off**, and with it off tmux
writes `\x1b[?1004l` to the client and never delivers a pane focus transition — so those two
kinds did not exist. `conf_text` sets the option.

### It is `set -g`, not the `set -t <session>` the plan asked for — and that is a measurement, not a preference

**Deviation from the plan's literal Step 1, stated up front.** `focus-events` is a tmux
**server** option, so `set -t <session>` would not contain anything; it would only read as
though it did, sitting in a list whose first three lines are session-scoped precisely so
frame N cannot rewrite frame N−1's settings. This is exactly `escape-time`'s situation, which
`conf_text` already writes `-g` with a docstring recording the same probe.

Measured on **tmux 3.7c** and on **tmux 3.2** — `tmuxctl.FLOOR`, downloaded as the release
tarball and built (`./configure && make`, rc 0) so it could be *run*, not reasoned about.
Byte-identical answers from both:

```
$ tmux -L t7-scope show-options -s | grep focus-events
focus-events off                       # it is in the SERVER table
$ tmux -L t7-scope show-options -g | grep focus-events
(absent from -g)                       # it is NOT a session option

$ tmux -L t7-scope set -t one focus-events on
$ tmux -L t7-scope show-options -t one focus-events
focus-events on
$ tmux -L t7-scope show-options -t two focus-events
focus-events on                        # the SIBLING session, which nobody set
$ tmux -L t7-scope show-options -g focus-events
focus-events on                        # and the global value

# the control — `mouse`, which conf_text DOES rely on being session-scoped:
$ tmux -L t7-scope set -t one mouse on
$ tmux -L t7-scope show-options -t one mouse
mouse on
$ tmux -L t7-scope show-options -t two mouse
                                       # empty: the sibling is untouched
```

tmux's own source agrees — `tmux-3.2/options-table.c`:

```c
{ .name = "focus-events",
  .type = OPTIONS_TABLE_FLAG,
  .scope = OPTIONS_TABLE_SERVER,
  .default_num = 0,
  .text = "Whether to send focus events to applications."
},
```

All three spellings (`set -t <s>`, `set -g`, `set -s`) turn it on identically on both
versions. Nothing is lost by writing it globally: every frame wants the identical `on`, like
`escape-time` and `remain-on-exit`. `charter frame` sources this text only against charter's
own private socket, never the operator's server, so it does not reach anyone's own tmux.

Pinned in both directions: the text pin refuses `set -t <session> focus-events`, and
`FocusEventsIntegration` fails with a message telling you to re-argue the `-g` if tmux ever
grows a per-session form.

### `#{client_flags}` lies — re-measured on this machine

The plan flagged this and it reproduces. One attached pty client, the option flipped
underneath it, on **3.7c** and on **3.2**:

```
focus-events OFF (tmux default, feature DEAD)  client_flags='attached,focused,UTF-8'
focus-events ON  (feature LIVE)                client_flags='attached,focused,UTF-8'
focus-events OFF again                         client_flags='attached,focused,UTF-8'

VERDICT: flags identical across on/off -> True
VERDICT: 'focused' present while feature dead -> True
```

So a guard written against that flag passes with the feature dead. The test asserts the
readings are **identical across the flip**, not merely that `focused` appears — the defect is
that the two states cannot be told apart, and an `assertIn("focused", …)` would keep passing
on a tmux where the flag had started telling the truth.

## 2. The limits charter cannot promise, in the two places they are read

* **Provider author** — `charter/frame/component.py`, `EVENT_KINDS`. Declaring `click`/
  `scroll` declares what you **handle**, never that the event fires: tmux asks the outer
  terminal to report the mouse from the **active pane's** own request alone, and with
  `[frame] mouse` off that pane is the harness, which charter does not own. The click
  produces no bytes at all — the event never happens. Rule stated: degrade to *never fires*,
  never to *fires wrongly*.
* **Operator** — `docs/frame.md`, "What changes inside the frame", plus a bullet in "Inside a
  tmux you already have" for the half their own tmux decides.

## 3. `[frame] mouse`'s docstring now says what is true

It said the trade "belongs to a later release that actually ships clickable panels, not this
one". Both halves were wrong. This is that release, and per the findings (§5, tmux 3.1c/3.2/
3.7c) there was never a release in which the trade could be avoided: **there is no state
where charter's panels are clickable and native selection survives.** Turning tmux's own
`mouse` off does not dodge it — it makes it conditional on which pane is focused.

## The deletion sweep

One production line was added, so there is one thing to sweep. Full suite each time,
`__pycache__` cleared between runs, file restored from a pristine copy after each:

| mutation | result |
|---|---|
| **delete** `"set -g focus-events on"` | `Ran 5962 tests` · `FAILED (failures=2)` |
| **`set -t {session} focus-events on`** (the plan's literal spelling) | `Ran 5962 tests` · `FAILED (failures=2)` |
| **`set -g focus-events off`** (line present, feature dead) | `Ran 5962 tests` · `FAILED (failures=2)` |

Which tests died, per mutation:

```
M1 (deleted):
  FAIL: test_focus_events_is_turned_on_or_focus_and_blur_never_fire
        (tests.test_frame_launcher.Conf)
  FAIL: test_charters_own_conf_text_turns_focus_events_on_for_real
        (tests.test_frame_tmux_integration.FocusEventsIntegration)

M2 (session-scoped):
  FAIL: test_focus_events_is_global_because_tmux_has_no_session_form_for_it
        (tests.test_frame_launcher.Conf)
  FAIL: test_focus_events_is_turned_on_or_focus_and_blur_never_fire
        (tests.test_frame_launcher.Conf)

M3 (set off):
  FAIL: test_focus_events_is_turned_on_or_focus_and_blur_never_fire
        (tests.test_frame_launcher.Conf)
  FAIL: test_charters_own_conf_text_turns_focus_events_on_for_real
        (tests.test_frame_tmux_integration.FocusEventsIntegration)
```

**Nothing stayed green.** M1 and M3 each kill a *behavioural* pin as well as a text pin —
`test_charters_own_conf_text_turns_focus_events_on_for_real` sources `conf_text`'s own output
against a real tmux and reads the option back, having first asserted tmux reported it OFF, so
it is not an assertion that the line exists.

## Two environments

| environment | result |
|---|---|
| python 3.14.4, ambient shell | `Ran 5962 tests` · `OK` |
| python 3.12, `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset | `Ran 5962 tests` · `OK` |

They agree. +5 tests over the branch point (2 in `Conf`, 3 in `FocusEventsIntegration`).
No version bump, no tag, news entry is `version: unreleased`.

## Collision risk with the open PRs

Deliberately minimal. **One production line added to `conf_text`'s returned list**, at
`charter/commands_frame.py` — inserted immediately after `"set -g remain-on-exit on"` and
**before** the `bind -n {hotkey}` line, i.e. in the middle of the list, not at either end.

* **#554** (overlay, `commands_frame`'s launcher half) appends `overlay.hatch_bind()` at the
  **end** of the same list and its ordering note says the hatch bind must stay LAST. This
  change touches neither end of the list and does not move any existing line, so a rebase is
  a one-line context match.
* **#553** touches `frame/layout.py`, `frame/panel.py`, `frame/slots.py`, `frame/builtins.py`
  and `instance.py`. The overlap is `instance.py`, and it is **comment-only**: the `#:` block
  above `"mouse": (False, "mouse")` in `FRAME_FIELDS`. No key, default, TOML name or
  validation changed.

Nothing was refactored. Files touched: `charter/commands_frame.py` (docstring + 1 line),
`charter/frame/component.py` (comment only), `charter/instance.py` (comment only),
`docs/frame.md`, `docs/news/…`, and the two test modules.
