### PR TITLE
A retry says which version it is retrying, and the check that asks cannot be skipped (Part of #558)

### DIFF
--- a/.claude/agents/release.md
+++ b/.claude/agents/release.md
@@ -91,7 +91,17 @@ write release notes by hand: the shipped entry is the single source for both the
 notes and the offline `charter news` suggestion, and hand-editing forks them. To change what
 a Release says, change the entry and the text follows. That job carries `contents: write`
 alone — the workflow's top-level grant stays `contents: read` — and it leaves an existing
-Release untouched, so a `workflow_dispatch` retry after a partial failure is safe to run.
+Release untouched, so a `workflow_dispatch` retry after a partial failure is safe to run —
+but it must now say which version it is retrying (#558):
+
+```
+gh workflow run release.yml --ref main -f version=<X.Y.Z>
+```
+
+Without `-f version=`, `guard` refuses. That check used to be gated on the ref being a tag,
+so on the retry path it was skipped — and a skipped step reports success, which is how a
+retry could publish with its version cross-check never having run. Passing the version is
+what gives the guard a claim it can refuse.
 
 ## Then upgrade this machine — CLI first, pinned
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,17 +26,32 @@ name: release
 # The tag must match the version in pyproject.toml — the `guard` job below
 # fails the release if they disagree, because PyPI will not let you re-upload
 # a version after a mistake.
+#
+# Retry: run this workflow by hand and name the version you are retrying.
+#   gh workflow run release.yml --ref main -f version=0.1.0
+#
+# That input is not paperwork (#558). The version check used to be gated on
+# `startsWith(github.ref, 'refs/tags/v')`, so a `workflow_dispatch` run — which has a
+# branch in `github.ref`, not a tag — SKIPPED it, and a skipped step is a green step.
+# The retry path therefore carried strictly weaker checks than the path it retries, and
+# the check it dropped was the one guarding the irreversible act. Both paths now state
+# the version independently of the file being published and are refused when the two
+# disagree: the tag on one, this input on the other. Neither is skippable.
 on:
   push:
     tags: ["v*"]
   workflow_dispatch:      # lets a failed release be retried without a new tag
+    inputs:
+      version:
+        description: "The version this run publishes — must equal pyproject.toml, e.g. 0.53.0"
+        required: true
 
 permissions:
   contents: read
 
 jobs:
   guard:
-    name: Verify the tag matches the packaged version, and that it has notes
+    name: Verify the run names the packaged version, and that it has notes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -45,21 +60,62 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
-      - name: Compare the git tag to pyproject.toml
-        if: startsWith(github.ref, 'refs/tags/v')
+      # NO `if:` ON THIS STEP, OR ON ANY STEP IN THIS JOB. A skipped step is a green step
+      # in GitHub Actions, so a condition here is a way for the one check standing between
+      # a run and an irreversible upload to report success without ever having run. That
+      # is #558 exactly, and `tests/test_workflows.py` fails if an `if:` reappears in this
+      # job. Whatever a new trigger needs, it is not a condition on the refusal.
+      - name: Compare the version this run names against pyproject.toml
+        id: version-check
+        env:
+          # Empty on the tag path, set on the dispatch path. Which one is authoritative is
+          # decided below from the event name, not from which one happens to be non-empty,
+          # so an input cannot displace the tag on a tag run.
+          #
+          # `github.event.inputs.version` rather than `inputs.version`: the `inputs`
+          # context is documented as available in a workflow triggered by
+          # `workflow_dispatch`, and this step also runs on a tag push. `github.event` is
+          # defined on every trigger and its missing members render empty, so the tag path
+          # cannot fail here on a context that is not there — which would be this workflow
+          # breaking at tag push, the failure mode #558 is about, introduced by the fix.
+          CLAIMED_VERSION: ${{ github.event.inputs.version }}
         run: |
-          tag="${GITHUB_REF_NAME#v}"
+          set -eu
           pkg=$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
-          echo "tag=$tag  pyproject=$pkg"
-          if [ "$tag" != "$pkg" ]; then
-            echo "::error::tag v$tag does not match pyproject.toml version $pkg — refusing to publish"
+          event="${GITHUB_EVENT_NAME:-}"
+          case "$event" in
+            push)
+              ref="${GITHUB_REF_NAME:-}"
+              claimed="${ref#v}"
+              said="the tag ${ref:-<none>}"
+              ;;
+            workflow_dispatch)
+              input="${CLAIMED_VERSION:-}"
+              claimed="${input#v}"
+              said="the version input ${input:-<none>}"
+              ;;
+            *)
+              # Fail closed on a trigger nobody taught this check. A third entry under
+              # `on:` must arrive here with a way to state its version, not walk past.
+              echo "::error::release.yml was triggered by '$event', and this check does not know what that run claims to publish — refusing to publish"
+              exit 1
+              ;;
+          esac
+          echo "claimed=$claimed  pyproject=$pkg  (from $said)"
+          if [ -z "$claimed" ]; then
+            echo "::error::this run did not say which version it publishes ($said) — a workflow_dispatch retry must pass -f version=$pkg — refusing to publish"
+            exit 1
+          fi
+          if [ "$claimed" != "$pkg" ]; then
+            echo "::error::this run names $claimed ($said) but pyproject.toml says $pkg — refusing to publish"
             exit 1
           fi
       - name: Refuse to publish a version whose news entries cannot be rendered
         run: |
           # The version comes from pyproject, not the tag: it is defined on BOTH trigger
           # paths (a workflow_dispatch retry has no tag to read), and the step above has
-          # already refused a tag that disagrees with it.
+          # already refused a run whose stated version disagrees with it — the tag on one
+          # path, the `version` input on the other, and on every path it actually ran.
           #
           # And charter is asked rather than the directory globbed, because this is the
           # same call that renders the Release body below. Globbing would be a second

--- a/docs/news/unreleased-a-retry-says-what-it-is-retrying.md
+++ b/docs/news/unreleased-a-retry-says-what-it-is-retrying.md
@@ -1,0 +1,70 @@
+---
+version: unreleased
+headline: A release retried by hand now has to say which version it is retrying, and the check that asks can no longer be skipped
+---
+
+`release.yml` publishes to PyPI, where an upload cannot be taken back. One check stood
+between a run and that upload: the git tag must match the version in `pyproject.toml`. It
+was written like this.
+
+```yaml
+- name: Compare the git tag to pyproject.toml
+  if: startsWith(github.ref, 'refs/tags/v')
+```
+
+The workflow has a second trigger. `workflow_dispatch` exists so a release that failed
+halfway can be retried without burning a new tag — and a dispatch run has a *branch* in
+`github.ref`, never a tag. So on that path the condition was false, the step was
+**skipped**, and a skipped step in GitHub Actions is a green step. The retry path carried
+strictly weaker checks than the path it retries, and the check it dropped was the only one
+guarding the irreversible act.
+
+What survived was the news-entry check, which reads the version from `pyproject.toml` —
+the same file the skipped step exists to cross-examine. One file, asked twice, agreeing
+with itself.
+
+The window is the ordinary release procedure, not a corner case. Bump the version, merge,
+then tag: between the merge and the tag, `main` carries a version that has never been
+published. A dispatch in that window skipped the tag check because there was no tag,
+passed the news check because the entry was already stamped, built, and published. Today
+it lands softly only because PyPI refuses a duplicate version. That is PyPI declining, not
+charter refusing.
+
+## Both paths now state the version independently of the file
+
+`workflow_dispatch` takes a required `version` input, and the check compares *that* to
+`pyproject.toml`:
+
+```
+gh workflow run release.yml --ref main -f version=0.53.0
+```
+
+The tag path is unchanged and compares the tag, as it always did. What changed is that
+neither path can reach `build` without the comparison having actually run — the step
+carries no `if:` at all, and it decides which value is authoritative from the event name
+rather than from whichever happens to be non-empty, so an input left over from an earlier
+dispatch cannot displace the tag on a tag run. A dispatch that names nothing is refused. A
+dispatch that names the wrong version is refused. A trigger nobody has taught the check —
+a third entry under `on:`, added later by someone solving a different problem — is refused
+too, rather than reaching the publish job on the strength of nobody having thought about
+it.
+
+## The test had to distinguish "passed" from "ran"
+
+That distinction is the whole defect, and it is invisible to a checker that reads a
+workflow as lines of text. `tests/test_workflows.py` already read these files as YAML to
+answer a different question — is every action pinned to a commit nobody else can move
+(#443) — so it grew a second reader, for the same subset and with the same fail-closed
+discipline, that reads a workflow as a tree: jobs, `needs:`, steps, and `run:` bodies kept
+as text.
+
+Two halves are asserted, because either alone is satisfiable by a lie. The **shape** says
+the check cannot be skipped: no `if:` on the guard job, none on any step in it, and
+`publish` transitively behind it. The **behaviour** says the check is worth running: the
+step's own script is pulled out of the YAML and executed against a synthetic tree, on both
+triggers, and each refusal is asserted by the reason it gives — no input, the wrong input,
+a trigger the check was never taught. Put the old `if:` back and the suite goes red.
+
+One half of this is deliberately not here. The `pypi` environment still has no protection
+rule, so nothing pauses between `build` and the upload on either path. That is a
+repository setting rather than a line in a file, and no test in this suite can hold it.

--- a/docs/superpowers/plans/2026-08-26-phase2-command-surface.md
+++ b/docs/superpowers/plans/2026-08-26-phase2-command-surface.md
@@ -63,6 +63,26 @@ turn, run the full suite, and report any that stayed green **before** submitting
 
 A guard nothing pins is a comment with a runtime cost.
 
+### Assert the reason, not just the refusal
+
+A sweep that only checks the exit code is itself a guard with nothing behind it. Measured on
+`release.yml`'s version check (#558): deleting the `-z "$claimed"` refusal — the one that
+catches a `workflow_dispatch` with no version input — leaves the run **still exiting 1**,
+because the mismatch check below it then catches the empty string instead:
+
+```
+shipped:  rc=1  this run did not say which version it publishes (the version input <none>)
+mutant:   rc=1  this run names  (the version input <none>) but pyproject.toml says 0.53.0
+```
+
+Same exit code, different reason, and the second one is a worse answer to a different
+question. **Two guards in sequence mask each other**, so an exit-code assertion cannot tell
+them apart and stays green over a real deletion.
+
+So a refusal test asserts **which** refusal fired. This is the same failure the sweep exists
+to catch, one level up: a test that matches a *symptom* rather than the *property*, which is
+the shape behind every bypass this repo has shipped.
+
 ---
 
 ### Task 1: Retire the slot vocabulary

--- a/personas/release/persona.md
+++ b/personas/release/persona.md
@@ -105,7 +105,17 @@ want a reader to see if they stopped after two screens.
 
 That job carries `contents: write`
 alone — the workflow's top-level grant stays `contents: read` — and it leaves an existing
-Release untouched, so a `workflow_dispatch` retry after a partial failure is safe to run.
+Release untouched, so a `workflow_dispatch` retry after a partial failure is safe to run —
+but it must now say which version it is retrying (#558):
+
+```
+gh workflow run release.yml --ref main -f version=<X.Y.Z>
+```
+
+Without `-f version=`, `guard` refuses. That check used to be gated on the ref being a tag,
+so on the retry path it was skipped — and a skipped step reports success, which is how a
+retry could publish with its version cross-check never having run. Passing the version is
+what gives the guard a claim it can refuse.
 
 ## Then upgrade this machine — CLI first, pinned
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,4 +1,5 @@
-"""Every action CI runs is named by something nobody else can move (#443).
+"""Every action CI runs is named by something nobody else can move (#443), and every
+trigger that can publish is cross-examined before it does (#558).
 
 `release.yml`'s `publish` job holds `id-token: write`, and PyPI's Trusted Publishing
 verifies the token minted there as charter's genuine publisher — the claim is real, so
@@ -78,6 +79,21 @@ and both run in the job holding `id-token: write`. So the property this file enf
 that runs in the publishing job is pinned", and the gap between those two sentences is
 where the next look goes.
 
+**A second question, and a second reader for it (#558).** Pinning asks *what code runs*.
+The other thing this file has to hold is *which trigger reaches the job that publishes,
+and under what checks* — and the answer was: not the same checks on both. `release.yml`'s
+version check was gated on `if: startsWith(github.ref, 'refs/tags/v')`, so a
+`workflow_dispatch` run — which has a branch in `github.ref` — **skipped** it, and a
+skipped step is a green step. The retry path published with strictly weaker checks than
+the path it retries, and the check it dropped was the one guarding the irreversible act.
+`load` reads a workflow as a tree for that question, and it exists because the shape of a
+job graph is invisible to a reference scanner and a grep for `if:` is the spelling mistake
+this whole file refuses to make. Two halves are asserted, since either alone can be
+satisfied by a lie: the **shape** — no `if:` on the guard job, none on any step in it, and
+`publish` transitively behind it — and the **behaviour**, by executing the check's own
+`run:` script against a synthetic tree on both triggers and asserting what it refuses and
+why. Not that it passed; that it ran.
+
 **The next place to look**, since that is the question this file exists to keep asking. The
 transitive hop above is the first. Then the two mismatches a reader like this always has
 with the real one: what counts as a line break — see
@@ -94,7 +110,9 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -394,6 +412,290 @@ def scan_text(text: str) -> list[Ref]:
             found.append(Ref(line, name, ref, IMAGE))
 
     return found
+
+
+# ------------------------------------------------------------------------ the structure
+
+class _Loader:
+    """The same subset, read as a tree rather than as a stream of references (#558).
+
+    `scan_text` answers one question — *which third-party code can run* — and answers it
+    without ever knowing which job a step is in. The second question this file has to
+    answer is about shape, not content: **which trigger reaches `publish`, and under what
+    checks**. A version check gated on `if: startsWith(github.ref, 'refs/tags/v')` is
+    *skipped* on a `workflow_dispatch` run, and a skipped step is a green step — so the
+    retry path published with the one check guarding an irreversible upload never having
+    run. Nothing about that is visible to a reference scanner, and grepping for `if:` is
+    the spelling mistake this file exists to refuse to make.
+
+    So: block mappings, block sequences, plain and quoted scalars through the very same
+    `_scalar` the scanner uses, and literal block scalars kept as text — because a `run:`
+    body is the check, and the tests below *execute* it. Fail-closed on everything else,
+    exactly as `scan_text` is: a construct outside the subset raises `Unparsed` and stops
+    the suite rather than being guessed at, since a mis-read structure would answer "which
+    trigger reaches publish" confidently and wrongly.
+
+    Two limits, stated rather than assumed. Scalars stay **strings** — no `true`/`123`
+    inference, so `required: true` reads as `"true"` and no test can quietly depend on this
+    reader's idea of a type. And a key is a key: `on:` is the string `"on"` here, where
+    YAML 1.1 would have made it the boolean `True` — which is GitHub's own behaviour, and
+    the reason the workflow schema is written the way it is.
+    """
+
+    def __init__(self, text: str) -> None:
+        # A private copy: `_sequence` blanks a `- ` it has consumed, so the item's first
+        # line then reads as the ordinary line it means.
+        self.lines = text.splitlines()
+        self.i = 0
+
+    # ---------------------------------------------------------------- lines
+
+    def _skip(self) -> None:
+        """Advance to the next line that carries a node — not blank, not a comment."""
+        while self.i < len(self.lines):
+            raw = self.lines[self.i]
+            if "\t" in raw:
+                raise Unparsed(self.i + 1, "a tab character")
+            stripped = raw.strip()
+            if stripped in ("---", "..."):
+                raise Unparsed(self.i + 1,
+                               "a document marker — this reader loads one document")
+            if not stripped or stripped.startswith("#"):
+                self.i += 1
+                continue
+            return
+
+    def _head(self) -> tuple[int, int | None, int]:
+        """(column of the content, column of a `- ` opening an item or None, line number)."""
+        raw = self.lines[self.i]
+        no = self.i + 1
+        col = len(raw) - len(raw.lstrip(" "))
+        dash = None
+        if raw[col] == "-" and (col + 1 >= len(raw) or raw[col + 1] == " "):
+            dash = col
+            col += 1
+            while col < len(raw) and raw[col] == " ":
+                col += 1
+            if col < len(raw) and raw[col] == "-" and (
+                    col + 1 >= len(raw) or raw[col + 1] == " "):
+                raise Unparsed(no, "a nested sequence opened on one line")
+        return col, dash, no
+
+    # ---------------------------------------------------------------- nodes
+
+    def load(self) -> object:
+        self._skip()
+        if self.i >= len(self.lines):
+            return {}
+        col, dash, _ = self._head()
+        node = self._node(dash if dash is not None else col)
+        self._skip()
+        if self.i < len(self.lines):
+            raise Unparsed(self.i + 1, "a line at a column no block above it opened")
+        return node
+
+    def _node(self, indent: int) -> object:
+        _, dash, _ = self._head()
+        return self._sequence(indent) if dash is not None else self._mapping(indent)
+
+    def _sequence(self, indent: int) -> list:
+        out: list = []
+        while True:
+            self._skip()
+            if self.i >= len(self.lines):
+                return out
+            col, dash, no = self._head()
+            if dash is None:
+                if col >= indent:
+                    raise Unparsed(no, "a mapping key where a sequence item was expected")
+                return out
+            if dash != indent:
+                if dash > indent:
+                    raise Unparsed(no, "a sequence item indented past its list")
+                return out
+            raw = self.lines[self.i]
+            rest = raw[col:] if col < len(raw) else ""
+            if not rest or rest.startswith("#"):
+                self.i += 1                    # the item's node is on a following line
+                self._skip()
+                if self.i >= len(self.lines):
+                    raise Unparsed(no, "a sequence item with nothing in it")
+                ccol, cdash, _ = self._head()
+                start = cdash if cdash is not None else ccol
+                if start <= indent:
+                    raise Unparsed(no, "a sequence item with nothing in it")
+                out.append(self._node(start) if cdash is not None
+                           else self._item(start))
+                continue
+            # Consume the dash by blanking it. `- uses: x` then reads as `uses: x` at the
+            # content column, which is what it means — and the item's later keys line up
+            # under it without this reader having to model "the first line was special".
+            self.lines[self.i] = " " * col + rest
+            out.append(self._item(col))
+
+    def _item(self, indent: int) -> object:
+        """A sequence item: a mapping (`- uses: x`) or a scalar (`- macOS`).
+
+        Only a *sequence* item may be a bare scalar. `a:\\n  b` stays refused, because a
+        scalar wrapped onto the line below its key is the one shape where guessing would
+        read a continued value as a value of its own.
+        """
+        raw = self.lines[self.i]
+        no = self.i + 1
+        if self._opens_entry(raw, indent, no):
+            return self._mapping(indent)
+        value, end = _scalar(raw, indent, no)
+        _trailing(raw, end, no)
+        self.i += 1
+        return value
+
+    def _opens_entry(self, raw: str, col: int, no: int) -> bool:
+        """Does this line begin `key:`? Indicators answer yes so `_mapping` names them."""
+        if raw[col] in _INDICATORS or raw[col] in "|>":
+            return True
+        _, k = _scalar(raw, col, no)
+        while k < len(raw) and raw[k] == " ":
+            k += 1
+        return k < len(raw) and raw[k] == ":" and (k + 1 >= len(raw) or raw[k + 1] == " ")
+
+    def _mapping(self, indent: int) -> dict:
+        out: dict = {}
+        while True:
+            self._skip()
+            if self.i >= len(self.lines):
+                return out
+            col, dash, no = self._head()
+            if (dash if dash is not None else col) < indent:
+                return out                     # a dedent: this block is finished
+            if dash is not None:
+                raise Unparsed(no, "a sequence item where a mapping key was expected")
+            if col > indent:
+                raise Unparsed(no, "a value continued on the next line")
+
+            raw = self.lines[self.i]
+            if raw[col] in _INDICATORS:
+                raise Unparsed(no, _INDICATORS[raw[col]])
+            if raw[col] in "|>":
+                raise Unparsed(no, "a block scalar in key position")
+            name, k = _scalar(raw, col, no)
+            while k < len(raw) and raw[k] == " ":
+                k += 1
+            if k >= len(raw) or raw[k] != ":" or (k + 1 < len(raw) and raw[k + 1] != " "):
+                raise Unparsed(no, "a line that is not a mapping entry")
+            if name == "<<":
+                raise Unparsed(no, "a merge key")
+            if name in out:
+                raise Unparsed(no, f"a duplicate key: {name}")
+            tail = raw[k + 1:]
+            self.i += 1
+            out[name] = self._value(tail, col, no)
+
+    def _value(self, tail: str, key_col: int, no: int) -> object:
+        tail = tail.lstrip(" ")
+        if not tail or tail.startswith("#"):
+            self._skip()
+            if self.i >= len(self.lines):
+                return None
+            col, dash, cno = self._head()
+            if dash is not None and dash == key_col:
+                raise Unparsed(cno, "a sequence indented level with its key")
+            start = dash if dash is not None else col
+            if start <= key_col:
+                return None                    # an empty value: `push:` with a key next
+            return self._node(start)
+        if _BLOCK_HEADER.match(tail):
+            return self._block(tail, key_col, no)
+        if tail[0] == "[":
+            return self._flow(tail, no)
+        if tail[0] in _INDICATORS:
+            raise Unparsed(no, _INDICATORS[tail[0]])
+        value, end = _scalar(tail, 0, no)
+        _trailing(tail, end, no)
+        return value
+
+    def _block(self, header: str, key_col: int, no: int) -> str:
+        """A literal block scalar, kept as text. This is where a `run:` script lives."""
+        style, indicators = header[0], header[1:].partition("#")[0].strip()
+        if style == ">":
+            raise Unparsed(no, "a folded block scalar — this reader does not fold")
+        if any(c.isdigit() for c in indicators):
+            raise Unparsed(no, "a block scalar with an explicit indentation indicator")
+        if "+" in indicators:
+            raise Unparsed(no, "a block scalar that keeps its trailing blank lines")
+        body: list[str] = []
+        first: int | None = None
+        while self.i < len(self.lines):
+            raw = self.lines[self.i]
+            if not raw.strip():
+                body.append("")
+                self.i += 1
+                continue
+            here = len(raw) - len(raw.lstrip(" "))
+            if here <= key_col:
+                break
+            if first is None:
+                first = here
+            elif here < first:
+                raise Unparsed(self.i + 1,
+                               "a block scalar line indented less than its first")
+            body.append(raw[first:])
+            self.i += 1
+        while body and not body[-1]:
+            body.pop()                         # trailing blanks belong to the document
+        text = "\n".join(body)
+        return text if "-" in indicators else text + "\n"
+
+    def _flow(self, tail: str, no: int) -> list:
+        """A flow sequence of scalars — `tags: ["v*"]`. A mapping in one is refused."""
+        close = tail.find("]")
+        if close < 0:
+            raise Unparsed(no, "a flow collection spanning lines")
+        if "{" in tail[:close] or ":" in tail[:close]:
+            raise Unparsed(no, "a mapping inside a flow sequence")
+        out: list[str] = []
+        i = 1
+        while True:
+            while i < len(tail) and tail[i] in " ,":
+                i += 1
+            if i >= len(tail):
+                raise Unparsed(no, "a flow collection spanning lines")
+            if tail[i] == "]":
+                _trailing(tail, i + 1, no)
+                return out
+            if tail[i] in "'\"":
+                item, i = _scalar(tail, i, no)
+            else:
+                end = i
+                while end < len(tail) and tail[end] not in ",]":
+                    end += 1
+                item, i = tail[i:end].rstrip(), end
+            out.append(item)
+
+
+def load(text: str) -> object:
+    """A workflow as a tree: mappings, sequences, scalars, and `run:` bodies as text."""
+    return _Loader(text).load()
+
+
+def needs(job: dict) -> set[str]:
+    """The jobs this one waits for, in both shapes `needs:` is written in."""
+    declared = job.get("needs")
+    if declared is None:
+        return set()
+    return {declared} if isinstance(declared, str) else set(declared)
+
+
+def reached_before(jobs: dict, name: str) -> set[str]:
+    """Every job that must have finished before `name` starts."""
+    seen: set[str] = set()
+    queue = list(needs(jobs[name]))
+    while queue:
+        job = queue.pop()
+        if job in seen:
+            continue
+        seen.add(job)
+        queue.extend(needs(jobs[job]))
+    return seen
 
 
 # --------------------------------------------------------------------------- the rule
@@ -1072,6 +1374,362 @@ class ALocalActionIsFollowedIntoTheFileItNames(unittest.TestCase):
             with self.assertRaises(Unparsed) as caught:
                 _no_symlink(tmp / "link/action.yml")
             self.assertIn("symlink", caught.exception.what)
+
+
+# ------------------------------------------------------------------ the second reader
+
+class TheStructureIsReadTheSameWayTheRefsAre(unittest.TestCase):
+    """`load` gets the corpus treatment `scan_text` gets, in both directions.
+
+    A tree reader that quietly dropped half a file would make every assertion about the
+    job graph below vacuously true — the failure mode this repository keeps re-learning —
+    so the shapes it must read assert the value it produces, the shapes outside the subset
+    assert *which* refusal they get, and the real workflows are read twice and compared.
+    """
+
+    READS = [
+        ("a nested mapping", 'on:\n  push:\n    tags: ["v*"]\n',
+         {"on": {"push": {"tags": ["v*"]}}}),
+        ("a key whose value is nothing at all", "on:\n  push:\n  pull_request:\n",
+         {"on": {"push": None, "pull_request": None}}),
+        ("a sequence of mappings",
+         'steps:\n  - uses: a\n    with:\n      x: "1"\n  - run: echo\n',
+         {"steps": [{"uses": "a", "with": {"x": "1"}}, {"run": "echo"}]}),
+        ("the dash on its own line", "steps:\n  -\n    uses: a\n",
+         {"steps": [{"uses": "a"}]}),
+        ("a sequence of scalars", "options:\n  - macOS\n  - Windows (WSL)\n",
+         {"options": ["macOS", "Windows (WSL)"]}),
+        ("a literal block scalar", "run: |\n  echo hi\n  echo there\n",
+         {"run": "echo hi\necho there\n"}),
+        ("a stripped block scalar", "run: |-\n  echo hi\n", {"run": "echo hi"}),
+        ("a block scalar keeps its blank lines and its hashes",
+         "run: |\n  a\n\n  # not a comment in here\n  b\n",
+         {"run": "a\n\n# not a comment in here\nb\n"}),
+        ("a block scalar keeps its own indentation",
+         "run: |\n  if x; then\n    y\n  fi\n", {"run": "if x; then\n  y\nfi\n"}),
+        ("a comment after a value", "id-token: write        # REQUIRED: mints it\n",
+         {"id-token": "write"}),
+        ("a whole-line comment at depth", "jobs:\n  # a note\n  p: 1\n",
+         {"jobs": {"p": "1"}}),
+        ("an expression value", "with:\n  python-version: ${{ matrix.python-version }}\n",
+         {"with": {"python-version": "${{ matrix.python-version }}"}}),
+        ("a url with a colon in it", "url: https://pypi.org/p/charter-cp\n",
+         {"url": "https://pypi.org/p/charter-cp"}),
+        ("an if expression", "if: github.event_name == 'push'\n",
+         {"if": "github.event_name == 'push'"}),
+        ("a quoted key", '"uses": a\n', {"uses": "a"}),
+        ("a flow sequence of plain scalars", "on: [push, pull_request]\n",
+         {"on": ["push", "pull_request"]}),
+        ("an empty flow sequence", "x: []\n", {"x": []}),
+        ("a document that is a sequence", "- a\n- b\n", ["a", "b"]),
+    ]
+
+    REFUSES = [
+        ("a flow mapping", "jobs: {a: b}\n", "a flow mapping"),
+        ("an anchor", "a: &x 1\n", "an anchor"),
+        ("an alias", "a: *x\n", "an alias"),
+        ("a tag", "a: !!str 1\n", "a tag"),
+        ("an explicit key", "? a\n: b\n", "an explicit key"),
+        ("a directive", "%YAML 1.2\n", "a directive"),
+        ("a merge key", "a:\n  <<: *x\n", "a merge key"),
+        ("a second document", "a: 1\n---\nb: 2\n",
+         "a document marker — this reader loads one document"),
+        ("a tab where a space belongs", "a:\tb\n", "a tab character"),
+        ("a duplicate key", "a: 1\na: 2\n", "a duplicate key: a"),
+        ("a folded block scalar", "a: >\n  x\n",
+         "a folded block scalar — this reader does not fold"),
+        ("a block scalar that keeps its trailing blanks", "a: |+\n  x\n\n",
+         "a block scalar that keeps its trailing blank lines"),
+        ("a block scalar with an indentation indicator", "a: |2\n   x\n",
+         "a block scalar with an explicit indentation indicator"),
+        ("a block scalar line indented less than its first", "a: |\n    x\n  y\n",
+         "a block scalar line indented less than its first"),
+        ("a sequence indented level with its key", "steps:\n- uses: a\n",
+         "a sequence indented level with its key"),
+        ("a value continued on the next line", "name: a job name that\n  wraps\n",
+         "a value continued on the next line"),
+        ("a mapping key where a sequence item belongs", "steps:\n  - a\n  b: 1\n",
+         "a mapping key where a sequence item was expected"),
+        ("a sequence item where a mapping key belongs", "a:\n  b: 1\n  - c\n",
+         "a sequence item where a mapping key was expected"),
+        ("a nested sequence on one line", "a:\n  - - b\n",
+         "a nested sequence opened on one line"),
+        ("a scalar where a key belongs", "a:\n  b\n",
+         "a line that is not a mapping entry"),
+        ("two values on one line", "a: b: c\n",
+         "two values on one line, or a scalar this reader misread"),
+        ("a flow collection spanning lines", "a: [\n  b]\n",
+         "a flow collection spanning lines"),
+        ("a mapping inside a flow sequence", "a: [{b: c}]\n",
+         "a mapping inside a flow sequence"),
+        ("an unterminated quote", 'a: "b\n', "an unterminated double-quoted scalar"),
+        ("a sequence item with nothing in it", "a:\n  -\n", "a sequence item with nothing in it"),
+    ]
+
+    def test_every_shape_the_real_files_use_is_read_into_the_value_it_means(self):
+        for name, text, expected in self.READS:
+            with self.subTest(shape=name):
+                self.assertEqual(load(text), expected, name)
+
+    def test_every_construct_outside_the_subset_stops_the_suite_by_name(self):
+        for name, text, expected in self.REFUSES:
+            with self.subTest(shape=name):
+                with self.assertRaises(Unparsed) as caught:
+                    load(text)
+                self.assertEqual(caught.exception.what, expected,
+                                 f"{name}: refused, but for a different reason than the "
+                                 f"one this case exists to exercise")
+
+    def test_every_workflow_in_this_repository_reads_as_a_tree(self):
+        """Fail-closed on the real files, exactly as the reference scan is. A workflow
+        written outside the subset stops the suite rather than being read as a shorter
+        workflow that happens to have no `if:` in it."""
+        for path in sorted((GITHUB / "workflows").glob("*.y*ml")):
+            with self.subTest(file=path.name):
+                try:
+                    load(path.read_text())
+                except Unparsed as exc:
+                    self.fail(f"{path.relative_to(REPO)}: {exc}. Rewrite it in the subset "
+                              f"tests/test_workflows.py reads, or teach the reader this "
+                              f"construct deliberately — do not delete the check.")
+
+    def test_the_two_readers_agree_about_what_is_in_the_file(self):
+        """The cross-check that keeps one reader from going quietly blind. Both read the
+        same files for the same key by two different routes — a line-oriented scan and a
+        tree — and a step either of them cannot see is a step neither can judge."""
+        for path in sorted((GITHUB / "workflows").glob("*.y*ml")):
+            with self.subTest(file=path.name):
+                text = path.read_text()
+                scanned = sorted(r.ref for r in scan_text(text) if r.key == "uses")
+                walked = sorted(_every(load(text), "uses"))
+                self.assertEqual(scanned, walked)
+                self.assertTrue(scanned, "neither reader found a step: both are broken")
+
+
+def _every(node: object, key: str) -> list:
+    """Every value under `key`, anywhere in a loaded tree."""
+    if isinstance(node, dict):
+        return ([node[key]] if key in node else []) + [
+            v for child in node.values() for v in _every(child, key)]
+    if isinstance(node, list):
+        return [v for child in node for v in _every(child, key)]
+    return []
+
+
+# ------------------------------------------------------- which trigger reaches publish
+
+def _release() -> dict:
+    return load((GITHUB / "workflows" / "release.yml").read_text())
+
+
+def _step(job: dict, step_id: str) -> dict:
+    """The step this job runs under a given `id:`, refused if it is not there."""
+    found = [s for s in job["steps"] if isinstance(s, dict) and s.get("id") == step_id]
+    if len(found) != 1:
+        raise AssertionError(
+            f"expected exactly one step with `id: {step_id}`, found {len(found)}. That "
+            f"step is the version cross-check #558 exists for; if it moved, move these "
+            f"tests with it rather than deleting them.")
+    return found[0]
+
+
+class _Run(NamedTuple):
+    """One run of the release workflow, as the version check would see it."""
+    name: str
+    event: str
+    ref: str | None = None        # GITHUB_REF_NAME, unset when None
+    claimed: str | None = None    # the `version` input, unset when None
+    says: str = ""                # what its refusal must name, when it refuses
+
+
+def _execute(script: str, run: _Run, packaged: str = "0.53.0") -> tuple[int, str]:
+    """Actually run the check's script, in a tree whose pyproject says `packaged`.
+
+    Reading the YAML proves the step has no `if:`; only running it proves the step
+    refuses. `python` is a shim onto this interpreter because the step's own comment says
+    why the workflow pins one: it needs `tomllib`, which is 3.11+, and the runner's
+    default `python` is a version nobody chose.
+    """
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(os.path.realpath(raw))
+        (tmp / "pyproject.toml").write_text(
+            f'[project]\nname = "charter-cp"\nversion = "{packaged}"\n')
+        (tmp / "bin").mkdir()
+        shim = tmp / "bin" / "python"
+        shim.write_text(f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n')
+        shim.chmod(0o755)
+        env = {"PATH": f"{tmp / 'bin'}:/usr/bin:/bin", "GITHUB_EVENT_NAME": run.event}
+        if run.ref is not None:
+            env["GITHUB_REF_NAME"] = run.ref
+        if run.claimed is not None:
+            env["CLAIMED_VERSION"] = run.claimed
+        done = subprocess.run(["bash", "-e", "-c", script], cwd=tmp, env=env,
+                              capture_output=True, text=True)
+        return done.returncode, done.stdout + done.stderr
+
+
+class TheVersionCheckRunsOnEveryTriggerThatCanPublish(unittest.TestCase):
+    """The assertion #558 says is missing: which trigger reaches `publish`, under what.
+
+    `publish` mints an OIDC token PyPI accepts, and an upload it makes cannot be undone —
+    so the question is not whether the version check *passed* but whether it *ran*. Those
+    are the same colour in GitHub Actions: a step whose `if:` is false reports success.
+    The check was gated on `startsWith(github.ref, 'refs/tags/v')`, which is true only of
+    a tag push, so `workflow_dispatch` — the retry path, the one a human reaches for when
+    a release has already half-happened — published with the guard green and unrun.
+
+    Two halves, and both are here because either alone is satisfiable by a lie. The shape
+    says the check cannot be skipped: no `if:` on the job, none on any step in it, and
+    `publish` transitively behind it. The behaviour says the check is worth running: its
+    script is executed, on both triggers, and refused when the run cannot name what it is
+    publishing — no input, the wrong input, a trigger the check was never taught.
+    """
+
+    #: Runs that must be refused, and what each refusal must say. The message is asserted
+    #: because it is what makes the sweep honest: delete any one of the three refusals in
+    #: the script and the surviving ones still exit non-zero, so an exit-code-only test
+    #: would stay green while the run stopped being told what it did wrong.
+    REFUSED = [
+        _Run("a dispatch that names no version", "workflow_dispatch", "main", "",
+             says="did not say which version it publishes"),
+        _Run("a dispatch with no input at all", "workflow_dispatch", "main", None,
+             says="did not say which version it publishes"),
+        _Run("a dispatch naming the wrong version", "workflow_dispatch", "main", "0.52.0",
+             says="but pyproject.toml says 0.53.0"),
+        _Run("a dispatch from a tag-shaped branch, still naming nothing",
+             "workflow_dispatch", "v0.53.0", None,
+             says="did not say which version it publishes"),
+        _Run("a tag that disagrees with the packaged version", "push", "v0.52.0", None,
+             says="but pyproject.toml says 0.53.0"),
+        _Run("a tag push with no ref name", "push", "", None,
+             says="did not say which version it publishes"),
+        _Run("a trigger nobody taught this check", "schedule", "main", "0.53.0",
+             says="does not know what that run claims to publish"),
+        _Run("a repository_dispatch", "repository_dispatch", "main", "0.53.0",
+             says="does not know what that run claims to publish"),
+        _Run("no event at all", "", "main", "0.53.0",
+             says="does not know what that run claims to publish"),
+    ]
+
+    #: Runs that must be allowed: exactly the two ways to state the packaged version.
+    ACCEPTED = [
+        _Run("a tag naming the packaged version", "push", "v0.53.0", None),
+        _Run("a dispatch naming the packaged version", "workflow_dispatch", "main",
+             "0.53.0"),
+        _Run("a dispatch naming it with the tag's leading v", "workflow_dispatch", "main",
+             "v0.53.0"),
+        _Run("a tag run carrying a stale input from an earlier dispatch", "push",
+             "v0.53.0", "9.9.9"),
+    ]
+
+    def setUp(self):
+        self.release = _release()
+        self.jobs = self.release["jobs"]
+        self.check = _step(self.jobs["guard"], "version-check")
+
+    # ----------------------------------------------------------------- the shape
+
+    def test_the_job_graph_from_the_trigger_to_the_release_is_intact(self):
+        """Every job before `publish`, and `announce` behind it. If this is rearranged the
+        tests below are asserting about a job that no longer gates anything."""
+        self.assertEqual(needs(self.jobs["guard"]), set(), "guard waits for nothing")
+        self.assertEqual(needs(self.jobs["test"]), {"guard"})
+        self.assertEqual(needs(self.jobs["build"]), {"test"})
+        self.assertEqual(needs(self.jobs["publish"]), {"build"})
+        self.assertEqual(needs(self.jobs["announce"]), {"publish"})
+        self.assertEqual(reached_before(self.jobs, "publish"),
+                         {"guard", "test", "build"},
+                         "publish no longer waits on the job that refuses a bad version")
+
+    def test_no_job_between_the_trigger_and_the_upload_can_be_skipped(self):
+        """A job-level `if:` is the same trick one level up: a skipped job is a green
+        job, and `needs:` on a green job is satisfied."""
+        for name in sorted(reached_before(self.jobs, "publish") | {"publish"}):
+            with self.subTest(job=name):
+                self.assertNotIn(
+                    "if", self.jobs[name],
+                    f"the `{name}` job is between a trigger and an irreversible upload, "
+                    f"and a condition on it is a way for it to report success unrun")
+
+    def test_no_step_in_the_guard_job_can_be_skipped(self):
+        """The regression, exactly. Restore `if: startsWith(github.ref, 'refs/tags/v')`
+        on the version check — or put a condition on any other step in the job whose only
+        purpose is to refuse — and this goes red."""
+        for i, step in enumerate(self.jobs["guard"]["steps"]):
+            with self.subTest(step=step.get("name") or step.get("uses") or i):
+                self.assertNotIn(
+                    "if", step,
+                    "a conditional step in `guard`. A skipped step reports success, so "
+                    "this is how the release published with its version check unrun "
+                    "(#558). Whatever the new trigger needs, it is not a condition here.")
+
+    def test_the_dispatch_path_has_to_say_what_it_is_retrying(self):
+        """The input exists, is required, and is wired into the script that reads it. A
+        script reading an environment variable the workflow never sets would pass every
+        behavioural test below against a value only the test provides."""
+        dispatch = self.release["on"]["workflow_dispatch"]
+        self.assertIsInstance(dispatch, dict,
+                              "`workflow_dispatch:` takes no input, so a retry states "
+                              "nothing and there is nothing to cross-examine")
+        self.assertEqual(dispatch["inputs"]["version"].get("required"), "true")
+        self.assertIn("inputs.version", self.check["env"]["CLAIMED_VERSION"],
+                      "the version the check reads does not come from the dispatch input "
+                      "— in either spelling, `inputs.version` or the one defined on every "
+                      "trigger, `github.event.inputs.version`")
+
+    def test_the_publish_job_still_names_the_environment_pypi(self):
+        """Trusted Publishing's OIDC claim carries this name, so it is load-bearing for
+        the upload — and it is also where the other half of #558 hangs: a required
+        reviewer on this environment is a repository setting, not a line in this file, so
+        no test here can assert it. What this can hold is that the name is still there for
+        the rule to attach to."""
+        self.assertEqual(self.jobs["publish"]["environment"]["name"], "pypi")
+
+    # ----------------------------------------------------------------- the behaviour
+
+    def test_every_trigger_this_workflow_declares_is_one_the_check_understands(self):
+        """The link between the two halves. The tables below name the triggers they
+        exercise; adding a third entry under `on:` without teaching the check what such a
+        run claims to publish fails here, and fails in the workflow, rather than reaching
+        `build` on the strength of nobody having thought about it."""
+        declared = set(self.release["on"])
+        self.assertEqual(declared, {"push", "workflow_dispatch"})
+        for table in (self.ACCEPTED, self.REFUSED):
+            for trigger in declared:
+                self.assertIn(trigger, {run.event for run in table},
+                              f"{trigger} has no case in one of the tables")
+
+    def test_the_check_refuses_a_run_that_cannot_name_what_it_publishes(self):
+        script = self.check["run"]
+        for run in self.REFUSED:
+            with self.subTest(run=run.name):
+                code, said = _execute(script, run)
+                self.assertNotEqual(code, 0, f"{run.name} was allowed to publish:\n{said}")
+                self.assertIn("::error::", said, "refused without annotating the log")
+                self.assertIn(run.says, said,
+                              f"{run.name} was refused, but for a different reason than "
+                              f"the one this case exists to exercise")
+
+    def test_the_check_allows_a_run_that_names_the_packaged_version(self):
+        """The other direction, and it is not decoration: a check that refused everything
+        would pass every case above and take the release path with it."""
+        script = self.check["run"]
+        for run in self.ACCEPTED:
+            with self.subTest(run=run.name):
+                code, said = _execute(script, run)
+                self.assertEqual(code, 0, f"{run.name} was refused:\n{said}")
+                self.assertIn("pyproject=0.53.0", said)
+
+    def test_the_check_reads_the_packaged_version_from_pyproject_and_not_from_a_guess(self):
+        """The comparison is against the file being published, whatever it says. Pinning
+        `0.53.0` in the tables above would otherwise be indistinguishable from a script
+        that had the answer written into it."""
+        script = self.check["run"]
+        code, said = _execute(script, _Run("a tag", "push", "v9.9.9"), packaged="9.9.9")
+        self.assertEqual(code, 0, said)
+        code, said = _execute(script, _Run("the same tag", "push", "v9.9.9"),
+                              packaged="0.53.0")
+        self.assertNotEqual(code, 0, said)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part of #558 — the workflow half. **The `pypi` environment-protection half is deliberately
out of scope and still needs the repository owner**; last section says why.

## What this changes

A `workflow_dispatch` retry has to say which version it is retrying, and the check that
asks it cannot be skipped:

```
gh workflow run release.yml --ref main -f version=0.53.0
```

- `workflow_dispatch` gains a **required** `version` input.
- One step in `guard` — **no `if:` on it, or on any other step in that job** — compares
  the version the run *states* against `pyproject.toml`. Which value is authoritative is
  decided from `GITHUB_EVENT_NAME`: the tag on `push`, the input on `workflow_dispatch`.
  Not from whichever is non-empty, so a stale input cannot displace the tag on a tag run.
- A trigger the check was never taught — a third entry under `on:`, added later by
  somebody solving a different problem — is **refused**, not walked past.
- The tag path compares what it always compared. No `uses:` pin or its trailing tag is
  touched.
- `${{ github.event.inputs.version }}` rather than `${{ inputs.version }}`: the `inputs`
  context is documented as available in a workflow triggered by `workflow_dispatch`, and
  this step also runs on a tag push. `github.event` is defined on every trigger, so the
  tag path cannot break here on a context that is not there — a fix that breaks the
  release at tag push would be #558 again, introduced by the fix.

## The failure it prevents

`release.yml`'s version check was gated:

```yaml
- name: Compare the git tag to pyproject.toml
  if: startsWith(github.ref, 'refs/tags/v')
```

`workflow_dispatch` puts a *branch* in `github.ref`, so on the retry path that step was
**skipped** — and a skipped step reports success. The retry path reached an irreversible
PyPI upload with strictly weaker checks than the path it retries, and the check it dropped
was the one guarding the irreversible act. The only survivor, the news-render check, reads
the version from `pyproject.toml` — the same file the skipped step exists to
cross-examine. One file, asked twice, agreeing with itself.

The window is the ordinary release procedure: between the bump merging to `main` and the
tag being pushed, `main` carries a version that has never been published. Today it lands
softly only because PyPI refuses a duplicate. That is PyPI declining, not charter
refusing.

## How the test holds it

`tests/test_workflows.py` read these files as YAML already — but only for *references*,
which is blind to the shape of a job graph, and a grep for `if:` is the spelling mistake
that file exists to refuse to make. So it grew a second reader, `load`, over the same
subset with the same fail-closed discipline (`Unparsed` on any construct it does not
model, never a skip), that reads a workflow as a tree: jobs, `needs:`, steps, and `run:`
bodies kept as text. Stdlib only; no new dependency; `unittest`.

Both readers now run over every workflow and their `uses:` findings are compared, so one
going quietly blind is a failure rather than a silence. The new reader gets the same
corpus treatment as the old: 18 shapes it must read into the value they mean, 25
constructs it must refuse **by name**.

The property is asserted in two halves, because either alone is satisfiable by a lie:

- **Shape** — no `if:` on the `guard` job, none on *any step in it*, no job-level `if:` on
  anything `publish` waits for, and `guard → test → build → publish → announce` intact.
  This is what distinguishes *ran* from *passed*.
- **Behaviour** — the check's own `run:` script is pulled out of the YAML and **executed**
  against a synthetic tree on both triggers. Nine runs must be refused, four allowed, and
  each refusal is asserted by *the reason it gives* — so deleting one refusal cannot hide
  behind another that also exits non-zero.

Reintroducing the gate turns it red:

```
FAIL: test_no_step_in_the_guard_job_can_be_skipped (…) (step='Compare the version this run names against pyproject.toml')
AssertionError: 'if' unexpectedly found in {'name': …, 'id': 'version-check',
  'if': "startsWith(github.ref, 'refs/tags/v')", …} : a conditional step in `guard`.
  A skipped step reports success, so this is how the release published with its version
  check unrun (#558).
```

<details>
<summary><b>Deletion sweep</b> — every guard deleted in turn, the FULL suite each time (5970 tests). No hole.</summary>

| guard deleted | full suite | what died |
|---|---|---|
| the `if [ -z "$claimed" ]` that refuses a run naming nothing | RED — FAILED (failures=4), 5970 tests | `test_the_check_refuses_a_run_that_cannot_name_what_it_publishes` |
| the version-check step deleted outright | RED — FAILED (failures=9), 5970 tests | `test_every_trigger_this_workflow_declares_is_one_the_check_understands` (+8 more) |
| the `if [ "$claimed" != "$pkg" ]` that refuses a disagreeing version | RED — FAILED (failures=3), 5970 tests | `test_the_check_reads_the_packaged_version_from_pyproject_and_not_from_a_guess` (+1 more) |
| the `if:` gate back on the version check (the #558 regression itself) | RED — FAILED (failures=1), 5970 tests | `test_no_step_in_the_guard_job_can_be_skipped` |
| the `*)` arm that refuses a trigger the check was never taught | RED — FAILED (failures=3), 5970 tests | `test_the_check_refuses_a_run_that_cannot_name_what_it_publishes` |
| `required: true` on the dispatch input | RED — FAILED (failures=1), 5970 tests | `test_the_dispatch_path_has_to_say_what_it_is_retrying` |
| the `env:` that wires the input into the script | RED — FAILED (errors=1), 5970 tests | `test_the_dispatch_path_has_to_say_what_it_is_retrying` |
| the whole `inputs:` block — a dispatch states nothing again | RED — FAILED (failures=1), 5970 tests | `test_the_dispatch_path_has_to_say_what_it_is_retrying` |
| a job-level `if:` on guard — the same trick one level up | RED — FAILED (failures=1), 5970 tests | `test_no_job_between_the_trigger_and_the_upload_can_be_skipped` |
| `needs: build` on publish — publish no longer waits on the guard | RED — FAILED (failures=2), 5970 tests | `test_the_guard_runs_before_anything_is_published` (+1 more) |

The message assertions are what make this honest rather than decorative. Delete the
`if [ -z "$claimed" ]` refusal and the run still exits non-zero — the mismatch check
catches it — so an exit-code-only test would have stayed green:

```
AssertionError: 'did not say which version it publishes' not found in
'claimed=  pyproject=0.53.0  (from the version input <none>)
::error::this run names  (the version input <none>) but pyproject.toml says 0.53.0 — refusing to publish'
```
</details>

<details>
<summary><b>Two environments, three parsers</b></summary>

```
########## ENV A: python3.14, these unset: CHARTER_HARNESS CHARTER_PERSONA CHARTER_ROOT CHARTER_SESSION_ID CHARTER_WORKSPACE CLAUDECODE CLAUDE_CODE_CHILD_SESSION CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_EXECPATH CLAUDE_CODE_MESSAGING_SOCKET CLAUDE_CODE_MESSAGING_TOKEN CLAUDE_CODE_SESSION_ID CLAUDE_EFFORT CLAUDE_PID TMUX TMUX_PANE ##########
exit=0
Ran 5970 tests in 243.804s
OK

########## ENV B: python3.12, this shell's environment as it stands ##########
exit=0
Ran 5970 tests in 237.248s
OK

########## python versions ##########
Python 3.14.4
Python 3.12.13
```

The YAML is not taken on this repository's own reader's word — that would be the reader
grading its own homework:

```
$ actionlint .github/workflows/release.yml   # real YAML parser + workflow schema + expression checker
exit=0

$ ruby -ryaml   # a third parser, reading the same file
triggers:        ["push", "workflow_dispatch"]
dispatch inputs: {"version"=>{"description"=>"The version this run publishes — must equal pyproject.toml, e.g. 0.53.0", "required"=>true}}
job guard     needs="-"         job-level if=nil
job test      needs="guard"     job-level if=nil
job build     needs="test"      job-level if=nil
job publish   needs="build"     job-level if=nil
job announce  needs="publish"   job-level if=nil
version-check step has an if?  false
version-check env:             {"CLAIMED_VERSION"=>"${{ github.event.inputs.version }}"}
```
</details>

## Still open: the `pypi` environment protection rule

#558 also asks for a required-reviewer rule on the `pypi` environment, so the irreversible
step has a human checkpoint on both paths. That is a repository *setting*, not a line in
any file here — no test in this suite can assert it, and this PR touches no repository
settings. **It needs the repository owner.** ADR 0003 is about `charter report` rather
than CI, but the shape of the missing half is the same one: publishing takes a human
"yes".

Until it exists nothing pauses between `build` and the upload on either path. What changes
here is that neither path reaches `build` without having stated, and had checked, the
version it publishes.

With the rule in place the rehearsal #558 describes becomes available: a dispatch run
declined at the gate exercises `checkout`, `setup-python` and `upload-artifact` — three of
the four dependabot bumps (#478–#481) — for free.

One follow-up noticed and not taken: `personas/release/persona.md` (and the generated
`.claude/agents/release.md`) says a `workflow_dispatch` retry "is safe to run" — still
true, no longer complete, since it now needs `-f version=<X.Y.Z>`. That is control-plane
configuration rather than workflow code, so it is left for its owner.

## Checks

- [x] `python3 -m unittest discover -s tests` passes — see the environments section
- [x] A test fails without this change — the mutation above, plus the full sweep
- [x] Nothing reports success for a state it did not read back ([ADR 0013](../docs/adr/0013-success-is-checked-divergence-is-named.md)): the point of the change is that a skipped step stops counting as a read
- [x] Docs updated — the retry command is in `release.yml`'s own header, where the tag procedure already lives
- [x] `docs/news/unreleased-a-retry-says-what-it-is-retrying.md`
- [x] No new runtime dependencies — stdlib only, in a test file
- [x] No ADR contradicted
