### PR TITLE
The deletion sweep becomes a thing the repo runs (stage A)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,27 @@ If a change touches git behaviour, run the suite that way once. It is cheaper th
 against the PR branch; `main` is a different commit. Every one of these three was green on
 the PR and red immediately after merging.
 
+### Sweeping the guards your branch adds
+
+For every `if` you add that refuses, clamps, contains or falls back, there should be a test
+that goes RED when that line is deleted. `tools/sweep.py` checks that mechanically, against
+the diff with your merge-base:
+
+```bash
+python3 tools/sweep.py                  # this branch, against origin/main
+python3 tools/sweep.py --second-order 24 # survivors in one function, applied together
+python3 tools/sweep.py --all             # the standing debt across the tree, as a number
+```
+
+It deletes one guard at a time, runs only the test modules measured to execute that
+function, and re-runs the **whole** suite for anything that survives before reporting it.
+A survivor is a line you can delete with the suite still green. There is no suppression
+list, on purpose: if deleting a line genuinely changes nothing observable, delete the line
+— "equivalent mutant" and "dead code" are the same finding.
+
+It is not a CI gate yet. It is stdlib-only, it makes its own clones, and it never writes to
+your checkout.
+
 ## Architecture decisions
 
 Decisions that were hard to reverse are written down in [`docs/adr/`](docs/adr/), and

--- a/docs/news/unreleased-the-deletion-sweep-is-a-thing-the-repo-runs.md
+++ b/docs/news/unreleased-the-deletion-sweep-is-a-thing-the-repo-runs.md
@@ -18,21 +18,24 @@ leaves no trace in the diff, and nothing in the repository could tell a sweep th
 
 **`tools/sweep.py` runs it.**
 
+Run against the head of #553's third review round, it says this without being told
+anything:
+
 ```
-$ python3 tools/sweep.py
+$ python3 tools/sweep.py --ref 5b02b3f
 sweeping 5b02b3f6dd42 (paths: charter)
   diff against 97163fb4c5c7: 8 file(s), 524 added line(s)
-  selection map: cached
+  selection map: 9828 keys in 92s
+  baseline: full suite, unmutated…
+    Ran 6002 tests — OK
   57 mutations across 8 file(s)
-
-charter/frame/layout.py:291  in `_placed_here`   [drop-conjunct] — is the half pinned?
-    shipped : isinstance(name, str) and name not in SLOT_SIZE
-    mutant  : isinstance(name, str)
-    full    : Ran 6002 tests — OK, with the line gone
-    NOTE    : 4 survivors sit in `_placed_here`. Two guards in sequence
-              mask each other, so none of them is safe to call equivalent on its own.
-    covered : 31 module(s) execute this file and NOT ONE names `_placed_here`
+    [12/57] SURVIVED  charter/frame/layout.py:289 [no-fallback] config.FRAME.get("components") or ()
+    [13/57] SURVIVED  charter/frame/layout.py:291 [drop-conjunct] isinstance(name, str) and name not in SLOT_SIZE
 ```
+
+and then prints, for each survivor, the line, both spellings of the mutation, the full
+suite that stayed green without it, and what the covering tests assert about the symbol it
+lives in.
 
 It reads the diff against the merge-base, so a branch answers for the guards **it** adds.
 It mutates by statement shape rather than by line — deleting arbitrary lines mostly

--- a/docs/news/unreleased-the-deletion-sweep-is-a-thing-the-repo-runs.md
+++ b/docs/news/unreleased-the-deletion-sweep-is-a-thing-the-repo-runs.md
@@ -1,0 +1,91 @@
+---
+version: unreleased
+headline: The deletion sweep stops being a thing an agent promises and becomes a thing the repo runs
+---
+
+*"Every guard this branch added is now a line a test goes red without."*
+
+That was a commit message. The same commit added six more guards with no test behind
+them, in the same two files, immediately after writing the rule down.
+
+Three rounds of review found that defect thirty-six times: a guard that refuses, clamps,
+contains or falls back, shipped correct, with nothing in the suite that would notice if a
+later refactor deleted it. Every one was found the same way — delete the line, run the
+whole suite, see whether it stays green. And every one was found by hand, which is the
+problem. Eighty-six mutations against a four-minute suite is four and a half hours, it
+leaves no trace in the diff, and nothing in the repository could tell a sweep that was
+**run** from a sweep that was **reported**.
+
+**`tools/sweep.py` runs it.**
+
+```
+$ python3 tools/sweep.py
+sweeping 5b02b3f6dd42 (paths: charter)
+  diff against 97163fb4c5c7: 8 file(s), 524 added line(s)
+  selection map: cached
+  57 mutations across 8 file(s)
+
+charter/frame/layout.py:291  in `_placed_here`   [drop-conjunct] — is the half pinned?
+    shipped : isinstance(name, str) and name not in SLOT_SIZE
+    mutant  : isinstance(name, str)
+    full    : Ran 6002 tests — OK, with the line gone
+    NOTE    : 4 survivors sit in `_placed_here`. Two guards in sequence
+              mask each other, so none of them is safe to call equivalent on its own.
+    covered : 31 module(s) execute this file and NOT ONE names `_placed_here`
+```
+
+It reads the diff against the merge-base, so a branch answers for the guards **it** adds.
+It mutates by statement shape rather than by line — deleting arbitrary lines mostly
+produces `SyntaxError` and `NameError`, which redden tests for reasons that have nothing
+to do with the property, and a red for the wrong reason is worse than no signal. Every
+shape in the table is one a review round actually found: a refusal dropped, a clamp
+dropped to the value it clamps, a broad `except` narrowed to something nothing raises, a
+containment call removed, a `.get(k) or ()` turned back into `d[k]`.
+
+**What makes it affordable is that it does not run the suite.** It runs the suite once,
+under `sys.settrace`, one test module at a time, and records which *function* in which
+file each module actually executes. A mutation then runs only the modules that reach it:
+the median subset on charter is seven modules and two seconds, against 322 modules and
+four minutes. The map is cached against a hash of the tree it was measured on.
+
+**And selection is never allowed the last word.** Any mutation that survives its subset
+is re-run against the FULL suite before it is reported. The two mistakes are not
+symmetrical: a false survivor costs one full run and a reviewer's minute, while a false
+*pin* is a guard the repository has quietly certified as tested when it is not — which is
+the entire defect this exists to stop. So a subset that goes green is never an answer, a
+file no traced module was seen executing is not pinned by that silence, and a run that
+*hangs* has not passed.
+
+**There is deliberately no suppression list.** The usual escape hatch is to mark a mutant
+"equivalent" and move on, and that is how this kind of gate becomes a rubber stamp —
+charter already refuses the analogous thing, because there is no config key that lifts a
+guard denial (#370), since one charter could read is one a committed file could flip. The
+reasoning is even simpler here:
+
+> If deleting a line genuinely changes nothing observable, the line should be deleted.
+
+"Equivalent mutant" and "dead code" are the same finding. The sweep reporting it *is* the
+sweep working.
+
+Two things push back on the temptation to write a survivor off anyway. First, a survivor
+is printed next to **what the covering tests actually assert** about the mutated symbol —
+because most "equivalent mutant" claims turn out to be "the test asserts too little".
+Measured on the release workflow's version check: deleting its `-z "$claimed"` refusal
+left the run still exiting 1, because the check below it caught the empty string instead.
+Same exit code, a different reason, and a test asserting only the exit code stays green
+over a real deletion. Second, `--second-order` applies survivors that share an enclosing
+function *together*, because two guards in sequence hide behind each other and each looks
+harmless alone.
+
+It is not wired into CI yet, and that is on purpose: a gate whose baseline nobody has seen
+gets disabled the first time it is inconvenient. `--all` charges the whole tree instead of
+a diff, which is how that baseline gets counted for the first time.
+
+Nothing to adopt — it is a tool in the repository, not a change to charter. Run it on a
+branch before you ask anyone to read it:
+
+```
+python3 tools/sweep.py                  # this branch, against its merge-base
+python3 tools/sweep.py --second-order 24
+python3 tools/sweep.py --all            # the standing debt, as a number
+```

--- a/tests/test_plugin_freshness.py
+++ b/tests/test_plugin_freshness.py
@@ -85,8 +85,11 @@ def tracked_top_level_directories(repo: Path = REPO) -> set[str]:
 #: are not repo content, and keeping untracked names here is how the list would grow one
 #: developer's machine at a time — `.charter`, `.superpowers`, `.venv`, `.idea` — until it
 #: classified nothing.
+#: `tools/` is developer tooling — `tools/sweep.py` runs the deletion sweep over a branch.
+#: No plugin loads it, `pyproject.toml` names `charter` as the only package so no wheel
+#: ships it, and an edit to it is not a stale plugin.
 _NOT_PLUGIN_SURFACE = {
-    ".github", ".claude", "charter", "docs", "tests", "personas", "workspaces",
+    ".github", ".claude", "charter", "docs", "tests", "personas", "workspaces", "tools",
 }
 
 PLUGIN = {

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -440,6 +440,50 @@ class TheSplicePreservesEveryLineNumber(unittest.TestCase):
         self.assertRegex(text, r"return (0|x)\n")
 
 
+class EverySpliceChecksItsOwnSpan(unittest.TestCase):
+    """A mutation reported at a line it did not change is worse than one not offered."""
+
+    def _first_expr(self, source: str):
+        blob = textwrap.dedent(source).lstrip("\n").encode()
+        tree = ast.parse(blob)
+        sp = sweep._Spans(blob)
+        node = next(n for n in ast.walk(tree) if isinstance(n, ast.IfExp))
+        return sp, node
+
+    def test_a_span_that_reparses_into_the_same_tree_is_sound(self):
+        sp, node = self._first_expr("x = a if c else b\n")
+        self.assertTrue(sweep.span_is_sound(sp, node))
+
+    def test_an_expression_broken_over_two_lines_is_still_sound(self):
+        """An expression's span stops INSIDE the brackets that made the line break legal,
+        so `a if c\\n else b` is a SyntaxError on its own and a perfectly good mutation in
+        place. Without the parentheses this check rejects it, and two real `decode`
+        mutations on #554 went missing."""
+        sp, node = self._first_expr("""
+            key = (_TILDE_KEYS.get(params) if final == b"~"
+                   else _CSI_KEYS.get(final))
+        """)
+        self.assertTrue(sweep.span_is_sound(sp, node))
+
+    def test_a_span_pointing_at_the_wrong_bytes_is_refused(self):
+        """Before 3.12 and PEP 701, `ast` gave only approximate positions for expressions
+        inside an f-string — and `contain.one_line(…)` is inside an f-string nearly
+        everywhere it appears here, which is what `uncontain` exists to mutate. A splice
+        a few bytes off can still PARSE, so the parse check alone would not catch it."""
+        blob = b"x = a if c else b\n"
+        tree = ast.parse(blob)
+        node = next(n for n in ast.walk(tree) if isinstance(n, ast.IfExp))
+        shifted = sweep._Spans(b"# a comment first\n" + blob)
+        self.assertFalse(sweep.span_is_sound(shifted, node))
+
+    def test_a_statement_span_round_trips_with_its_body(self):
+        blob = b"def f(a):\n    if a is None:\n        return []\n"
+        tree = ast.parse(blob)
+        sp = sweep._Spans(blob)
+        node = next(n for n in ast.walk(tree) if isinstance(n, ast.If))
+        self.assertTrue(sweep.span_is_sound(sp, node))
+
+
 class TheScopeIsTheDiff(unittest.TestCase):
     def test_a_mutation_outside_the_charged_lines_is_not_offered(self):
         """A PR is answerable for the guards IT adds."""

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1,0 +1,775 @@
+"""The deletion sweep, swept.
+
+`tools/sweep.py` is a tool for finding guards no test goes red without, so the one thing
+it may not have is a guard no test goes red without. Every case here is written to die
+when a specific line of `sweep.py` is deleted, and the fixtures are the real shapes from
+the three review rounds rather than invented ones — `_placed_here`'s two-conjunct guard,
+`_window`'s clamp, `_component_text`'s `except Exception` — so that a refactor which
+still passes has kept the property those rounds actually measured.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from tools import sweep
+
+
+def _mutations(source: str, lines: set[int] | None = None, path: str = "charter/x.py"):
+    blob = textwrap.dedent(source).lstrip("\n").encode("utf-8")
+    n = len(blob.splitlines())
+    return sweep.mutations_for(path, blob, lines if lines is not None else set(range(1, n + 2)))
+
+
+def _by(muts, operator: str):
+    return [m for m in muts if m.operator == operator]
+
+
+def _afters(muts, operator: str):
+    return sorted(m.after for m in _by(muts, operator))
+
+
+# ======================================================================================
+# The operator table — one class per shape, each built from the guard that found it
+# ======================================================================================
+
+class TheRefusalShape(unittest.TestCase):
+    """`if C: return` / `raise` / `continue`, dropped."""
+
+    def test_a_refusal_that_returns_is_offered_for_deletion(self):
+        muts = _mutations("""
+            def close_argvs(arm, overlay_pane):
+                if arm is None:
+                    return []
+                return [arm]
+        """)
+        drops = _by(muts, "drop-if")
+        self.assertEqual([m.line for m in drops], [2])
+        self.assertEqual(drops[0].after, "")
+        self.assertIn("arm is None", drops[0].before)
+
+    def test_the_body_may_be_an_assignment_and_not_only_a_return(self):
+        """Round three's two sharpest findings were assignments under an `if`.
+
+        `_window`'s `if self._sel < top: top = self._sel` and `panel_argvs`'
+        `if size is None: size = SLOT_SIZE[slot]` are both a refusal spelled as a
+        correction. A shape table that only knew `return`/`raise`/`continue` would have
+        written both off before asking.
+        """
+        muts = _mutations("""
+            def _window(self, height):
+                top = self._top
+                if self._sel < top:
+                    top = self._sel
+                return top
+        """)
+        self.assertEqual([m.line for m in _by(muts, "drop-if")], [3])
+
+    def test_a_multi_statement_body_is_not_dropped_wholesale(self):
+        """Deleting two statements at once cannot say which one was the guard."""
+        muts = _mutations("""
+            def f(buf):
+                if buf is None:
+                    buf = b""
+                    log(buf)
+                return buf
+        """)
+        self.assertEqual(_by(muts, "drop-if"), [])
+
+    def test_deleting_the_only_statement_of_a_block_becomes_pass_and_still_parses(self):
+        """The spec says to skip a mutation that does not parse. `pass` is the same
+        deletion spelled so that it does, and it is tried before the mutation is given up
+        on — otherwise every one-line function body would be unsweepable."""
+        muts = _mutations("""
+            def f(x):
+                while x:
+                    if x > 1:
+                        break
+        """)
+        drops = _by(muts, "drop-if")
+        self.assertEqual([m.after for m in drops], ["pass"])
+        ast.parse(drops[0].source)
+
+
+class TheConjunctShape(unittest.TestCase):
+    """`if A and B:` — one half at a time, because each half is its own finding."""
+
+    def test_each_half_of_a_two_part_guard_is_its_own_mutation(self):
+        """`_placed_here`'s `isinstance(name, str) and name not in SLOT_SIZE` was
+        reported as TWO unpinned guards on the same line (#553 round three). A mutation
+        that could only take the whole condition would have collapsed them into one."""
+        muts = _mutations("""
+            def _placed_here():
+                for placed in items:
+                    name = placed.get("slot")
+                    if isinstance(name, str) and name not in SLOT_SIZE:
+                        out[name] = placed
+        """)
+        self.assertEqual(_afters(muts, "drop-conjunct"),
+                         ["isinstance(name, str)", "name not in SLOT_SIZE"])
+
+    def test_a_three_part_guard_drops_one_part_at_a_time_and_keeps_the_rest(self):
+        muts = _mutations("""
+            def f(a, b, c):
+                if a and b and c:
+                    return 1
+        """)
+        self.assertEqual(_afters(muts, "drop-conjunct"),
+                         ["a and b", "a and c", "b and c"])
+
+    def test_a_single_condition_offers_no_conjunct_mutation(self):
+        muts = _mutations("""
+            def f(a):
+                if a:
+                    return 1
+        """)
+        self.assertEqual(_by(muts, "drop-conjunct"), [])
+
+
+class TheClampShape(unittest.TestCase):
+    """`max(a, b)` / `min(…)`, dropped to each operand."""
+
+    def test_a_floor_is_dropped_to_the_value_it_floors(self):
+        """`_window`'s `n = max(1, height - _CHROME_ROWS)` (#554 round three)."""
+        muts = _mutations("""
+            def _window(self, height):
+                n = max(1, height - _CHROME_ROWS)
+                return n
+        """)
+        self.assertEqual(_afters(muts, "unclamp"), ["1", "height - _CHROME_ROWS"])
+
+    def test_a_nested_clamp_offers_the_inner_variable_on_its_own(self):
+        """`self._top = max(0, min(top, max(0, len(self.rows) - n)))` is unpinned, and
+        the mutation that showed it was replacing the whole thing with `top`. A nested
+        clamp has to be walked, not just matched at the outermost call."""
+        muts = _mutations("""
+            def _window(self, top, n):
+                self._top = max(0, min(top, max(0, len(self.rows) - n)))
+        """)
+        self.assertIn("top", _afters(muts, "unclamp"))
+
+    def test_a_three_argument_max_is_left_alone(self):
+        """`max(a, b, c)` has no single inner operand a clamp is 'dropping to'."""
+        muts = _mutations("""
+            def f(a, b, c):
+                x = max(a, b, c)
+        """)
+        self.assertEqual(_by(muts, "unclamp"), [])
+
+
+class TheCatchShape(unittest.TestCase):
+    """`except E:` narrowed to something nothing raises."""
+
+    def test_a_broad_catch_is_narrowed_and_the_binding_survives(self):
+        """`_component_text`'s `except Exception as e` was round two's finding 4. The
+        `as e` has to be kept or the mutation is a `NameError` in the handler body — a
+        red for a reason that has nothing to do with the guard, which is a false pin."""
+        muts = _mutations("""
+            def _component_text(cid):
+                try:
+                    return draw(cid)
+                except Exception as e:
+                    return str(e)
+        """)
+        narrowed = _by(muts, "narrow-except")
+        self.assertEqual([m.after for m in narrowed], ["ZeroDivisionError"])
+        self.assertIn("except ZeroDivisionError as e:", narrowed[0].source.decode())
+
+    def test_a_bare_except_is_not_mutated(self):
+        """There is nothing to narrow to that is narrower than `except:`."""
+        muts = _mutations("""
+            def f():
+                try:
+                    g()
+                except:
+                    pass
+        """)
+        self.assertEqual(_by(muts, "narrow-except"), [])
+
+    def test_a_catch_already_at_the_sentinel_is_not_mutated_into_itself(self):
+        muts = _mutations("""
+            def f():
+                try:
+                    g()
+                except ZeroDivisionError:
+                    pass
+        """)
+        self.assertEqual(_by(muts, "narrow-except"), [])
+
+
+class TheContainmentShape(unittest.TestCase):
+    """`f(contain.one_line(x))` -> `f(x)`."""
+
+    def test_a_containment_call_is_replaced_by_the_value_it_contained(self):
+        """`run`'s `contain.one_line(repr(slot))` (#553 round three, panel.py:458)."""
+        muts = _mutations("""
+            def run(slot):
+                reason = f"unknown slot {contain.one_line(repr(slot))} "
+                return reason
+        """)
+        self.assertEqual(_afters(muts, "uncontain"), ["repr(slot)"])
+
+    def test_containment_inside_an_fstring_is_found(self):
+        """Every one of these lives inside an f-string in the real source, so a walk that
+        did not descend into `FormattedValue` would find none of them."""
+        muts = _mutations("""
+            def render(self, width):
+                return f"{contain.one_line(self.heading)} · {len(self.rows)}"
+        """)
+        self.assertEqual(_afters(muts, "uncontain"), ["self.heading"])
+
+    def test_an_unrelated_module_call_is_not_treated_as_containment(self):
+        muts = _mutations("""
+            def f(x):
+                return tui.truncate(x, 10)
+        """)
+        self.assertEqual(_by(muts, "uncontain"), [])
+
+
+class TheFallbackShape(unittest.TestCase):
+    """`d.get(k) or ()` and `d.get(k, v)` -> `d[k]`."""
+
+    def test_a_get_with_an_or_fallback_becomes_a_subscript(self):
+        """`_placed_here`'s `config.FRAME.get("components") or ()` (#553 round three)."""
+        muts = _mutations("""
+            def _placed_here():
+                for placed in config.FRAME.get("components") or ():
+                    yield placed
+        """)
+        self.assertEqual(_afters(muts, "no-fallback"), ['config.FRAME["components"]'])
+
+    def test_a_get_with_a_default_becomes_a_subscript(self):
+        """`_derive`'s `SLOT_OF.get(c.id, c.id)` (#553 round two, finding 8)."""
+        muts = _mutations("""
+            def _derive(c):
+                return _builtins.SLOT_OF.get(c.id, c.id)
+        """)
+        self.assertIn("_builtins.SLOT_OF[c.id]", _afters(muts, "no-fallback"))
+
+    def test_an_or_over_an_empty_literal_drops_to_the_left(self):
+        muts = _mutations("""
+            def f(placed):
+                return placed or []
+        """)
+        self.assertEqual(_afters(muts, "no-fallback"), ["placed"])
+
+
+class TheTypeFilterShape(unittest.TestCase):
+    """`if isinstance(x, str)`, dropped."""
+
+    def test_a_negated_type_filter_becomes_false(self):
+        """`slots.drawable`'s `if not isinstance(name, str): return False`."""
+        muts = _mutations("""
+            def drawable(name):
+                if not isinstance(name, str):
+                    return False
+                return True
+        """)
+        self.assertEqual(_afters(muts, "drop-isinstance"), ["False"])
+
+    def test_a_plain_type_filter_becomes_true(self):
+        muts = _mutations("""
+            def f(name):
+                if isinstance(name, str):
+                    use(name)
+        """)
+        self.assertEqual(_afters(muts, "drop-isinstance"), ["True"])
+
+
+class TheConditionalExpressionShape(unittest.TestCase):
+    """`a if C else b`, collapsed each way."""
+
+    def test_both_arms_are_offered(self):
+        """`_policy_cells`' `return size.n if isinstance(size, Fixed) else 1` — the
+        `else 1` was round three's fifth finding on #553."""
+        muts = _mutations("""
+            def _policy_cells(size):
+                return size.n if isinstance(size, Fixed) else 1
+        """)
+        self.assertEqual(_afters(muts, "collapse-ifexp"), ["1", "size.n"])
+
+    def test_a_gate_written_as_a_conditional_expression_is_found(self):
+        """`snapshot = gather.read(fid) if c.needs else {}` — round two's finding 5 is an
+        `if` that never uses the `if` keyword, and it cost a real idle-cost property."""
+        muts = _mutations("""
+            def _component_text(c, fid):
+                snapshot = gather.read(fid) if c.needs else {}
+        """)
+        self.assertIn("gather.read(fid)", _afters(muts, "collapse-ifexp"))
+
+
+class TheComprehensionFilterShape(unittest.TestCase):
+    """A refusal in expression clothes."""
+
+    def test_a_generator_filter_is_dropped(self):
+        """`harness_rows`' `if _edge_of(slot) not in _COLUMN_EDGES` lives inside a
+        `sum(...)`. It was round two's finding 1 on #553 and a table that only knew the
+        statement spelling of `if` could not see it at all."""
+        muts = _mutations("""
+            def harness_rows(sizes, window_rows):
+                used = sum(n + _BORDER_ROWS for slot, n in sizes.items()
+                           if _edge_of(slot) not in _COLUMN_EDGES)
+                return window_rows - used
+        """)
+        self.assertEqual(_afters(muts, "drop-comprehension-if"), ["True"])
+
+    def test_a_comprehension_with_no_filter_offers_nothing(self):
+        muts = _mutations("""
+            def f(xs):
+                return [x for x in xs]
+        """)
+        self.assertEqual(_by(muts, "drop-comprehension-if"), [])
+
+
+class TheBranchShape(unittest.TestCase):
+    """A branch in a chain is disabled, because it cannot be excised."""
+
+    def test_an_elif_branch_is_disabled_rather_than_deleted(self):
+        """`decode`'s `elif ch == b"\\x03"` Ctrl-C branch was round two's finding 14.
+        Deleting it would take the `else` with it, so the branch is turned off instead."""
+        muts = _mutations("""
+            def decode(ch):
+                if ch == b"a":
+                    return 1
+                elif ch == b"\\x03":
+                    return 2
+                else:
+                    return 3
+        """)
+        self.assertIn("False", _afters(muts, "disable-branch"))
+
+    def test_a_bare_if_is_never_disabled(self):
+        """A bare `if` whose body binds a name would fall through to a `NameError` — a
+        red for a reason that has nothing to do with the property, which is a FALSE PIN
+        and the one outcome worse than no signal at all. So the operator is restricted
+        to chains that have somewhere else for control to go.
+        """
+        muts = _mutations("""
+            def f(x):
+                if x:
+                    y = 1
+                    z = 2
+                return y
+        """)
+        self.assertEqual(_by(muts, "disable-branch"), [])
+
+
+class TheConstantShape(unittest.TestCase):
+    """A module-level constant is a guard too."""
+
+    def test_an_integer_constant_is_moved_by_one(self):
+        """`_SPLIT_ROWS = 5` and `_MIN_TITLE = 8` were both unpinned on #554 round two,
+        each with a docstring making a specific claim for the number."""
+        muts = _mutations("_SPLIT_ROWS = 5\n")
+        self.assertEqual(_afters(muts, "retune-constant"), ["6"])
+
+    def test_a_constant_summed_from_named_parts_drops_each_part(self):
+        """`_CHROME_ROWS = _HEADER_ROWS + _FOOTER_ROWS`, and the finding was that
+        dropping the footer left the suite green."""
+        muts = _mutations("_CHROME_ROWS = _HEADER_ROWS + _FOOTER_ROWS\n")
+        self.assertEqual(_afters(muts, "drop-term"), ["_FOOTER_ROWS", "_HEADER_ROWS"])
+
+    def test_a_local_variable_is_not_a_constant(self):
+        """Only module scope, and only a constant-looking name. Perturbing every integer
+        in every function is a different tool, and a much noisier one."""
+        muts = _mutations("""
+            def f():
+                LIMIT = 5
+                return LIMIT
+        """)
+        self.assertEqual(_by(muts, "retune-constant"), [])
+
+    def test_a_lowercase_module_level_name_is_not_a_constant(self):
+        muts = _mutations("timeout = 5\n")
+        self.assertEqual(_by(muts, "retune-constant"), [])
+
+    def test_a_boolean_is_not_retuned_into_two(self):
+        """`True + 1` is `2` and Python will not complain, which is exactly why this
+        needs saying: a flag flipped to `2` is not a mutation anybody can read."""
+        muts = _mutations("ENABLED = True\n")
+        self.assertEqual(_by(muts, "retune-constant"), [])
+
+
+# ======================================================================================
+# Splicing — line numbers are the whole output of this tool
+# ======================================================================================
+
+class TheSplicePreservesEveryLineNumber(unittest.TestCase):
+    def test_a_deleted_multi_line_statement_leaves_the_rest_where_it_was(self):
+        """A survivor reported at the wrong line is a survivor nobody acts on."""
+        muts = _mutations("""
+            def f(arm, pane):
+                if arm is None or not RE.fullmatch(pane):
+                    return []
+                marker = 1
+                return marker
+        """)
+        drop = _by(muts, "drop-if")[0]
+        after = drop.source.decode().splitlines()
+        self.assertEqual(len(after), 5)
+        self.assertEqual(after[3].strip(), "marker = 1")
+
+    def test_a_replacement_never_shortens_the_file(self):
+        muts = _mutations("""
+            def f(x):
+                y = max(0, min(x,
+                               10))
+                return y
+        """)
+        for m in _by(muts, "unclamp"):
+            self.assertEqual(len(m.source.decode().splitlines()), 4, m.after)
+
+    def test_offsets_are_counted_in_bytes_and_not_characters(self):
+        """`ast`'s `col_offset` is a UTF-8 byte offset. charter's docstrings carry `↑↓⏎`
+        and `·`, so a splice that indexed by character would land three bytes early on
+        every line after one and quietly corrupt the mutant."""
+        muts = _mutations("""
+            def f(x):
+                note = "· ↑↓ ⏎"
+                return max(0, x)
+        """)
+        m = _by(muts, "unclamp")[0]
+        text = m.source.decode()
+        self.assertIn('note = "· ↑↓ ⏎"', text)
+        self.assertRegex(text, r"return (0|x)\n")
+
+
+class TheScopeIsTheDiff(unittest.TestCase):
+    def test_a_mutation_outside_the_charged_lines_is_not_offered(self):
+        """A PR is answerable for the guards IT adds."""
+        source = """
+            def old(a):
+                if a is None:
+                    return []
+
+            def new(b):
+                if b is None:
+                    return []
+        """
+        self.assertEqual([m.line for m in _mutations(source, lines={6, 7})], [6])
+
+    def test_a_node_spanning_into_the_charged_lines_counts(self):
+        """A branch that edits the second line of a two-line condition has changed the
+        guard, and charging only nodes that START on a touched line would miss it."""
+        source = """
+            def f(arm, pane):
+                if arm is None or \\
+                        not RE.fullmatch(pane):
+                    return []
+        """
+        self.assertTrue(_mutations(source, lines={3}))
+
+
+class TheDiffIsReadWithNoContext(unittest.TestCase):
+    """`--unified=0`, so three lines of untouched context are not charged to the branch."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="charter-sweep-diff-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        # Sealed off from the machine's git: a global `core.hooksPath`, a signing key or
+        # a template dir would run this fixture through whatever the developer has
+        # installed, and one of those costs a full minute per commit here.
+        env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull,
+                   GIT_CONFIG_SYSTEM=os.devnull, GIT_CONFIG_NOSYSTEM="1",
+                   GIT_TERMINAL_PROMPT="0")
+
+        def run(*a):
+            subprocess.run(("git", "-c", "core.hooksPath=", "-c", "commit.gpgsign=false")
+                           + a, cwd=self.tmp, check=True, env=env, timeout=60,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        run("init", "-q", "-b", "main")
+        run("config", "user.email", "sweep@example.invalid")
+        run("config", "user.name", "sweep")
+        (self.tmp / "charter").mkdir()
+        self.f = self.tmp / "charter" / "m.py"
+        self.f.write_text("a = 1\nb = 2\nc = 3\nd = 4\ne = 5\nf = 6\ng = 7\n")
+        run("add", "-A")
+        run("commit", "-qm", "base")
+        self.base = sweep.git("rev-parse", "HEAD", cwd=self.tmp).strip()
+        self.f.write_text("a = 1\nb = 2\nc = 3\nd = 44\ne = 5\nf = 6\ng = 7\n")
+        run("add", "-A")
+        run("commit", "-qm", "change")
+        self.head = sweep.git("rev-parse", "HEAD", cwd=self.tmp).strip()
+
+    def test_only_the_changed_line_is_charged(self):
+        found = sweep.added_lines(self.tmp, self.base, self.head, ("charter",))
+        self.assertEqual(found, {"charter/m.py": {4}})
+
+    def test_a_file_the_branch_did_not_touch_is_absent(self):
+        (self.tmp / "charter" / "other.py").write_text("x = 1\n")
+        found = sweep.added_lines(self.tmp, self.base, self.head, ("charter",))
+        self.assertNotIn("charter/other.py", found)
+
+
+# ======================================================================================
+# The verdict — the asymmetry that decides the whole design
+# ======================================================================================
+
+class _FakeBox:
+    """A sandbox that answers whatever the case needs it to."""
+
+    def __init__(self, subset: sweep.Outcome | None = None,
+                 full: sweep.Outcome | None = None):
+        self._subset, self._full = subset, full
+        self.applied: list[sweep.Mutation] = []
+        self.subset_calls = 0
+        self.full_calls = 0
+
+    def apply(self, m):
+        self.applied.append(m)
+
+    def restore(self):
+        pass
+
+    def subset(self, modules):
+        self.subset_calls += 1
+        return self._subset
+
+    def full(self):
+        self.full_calls += 1
+        return self._full
+
+
+_M = sweep.Mutation(path="charter/x.py", line=1, end_line=1, operator="drop-if",
+                    question="?", before="if a: return", after="", symbol="f")
+
+
+class TheFullSuiteHasTheLastWord(unittest.TestCase):
+    def test_a_survivor_of_its_subset_is_re_run_against_everything(self):
+        """Selection is an optimisation and must never be the final word. This is the
+        line that makes a false 'pinned' impossible, and it costs one full run."""
+        box = _FakeBox(subset=sweep.Outcome(True, 40, "OK"),
+                       full=sweep.Outcome(False, 6000, "FAILED (failures=1)"))
+        verdict, _, full = sweep.decide(box, _M, ["tests.test_x"])
+        self.assertEqual(verdict, "pinned")
+        self.assertEqual(box.full_calls, 1)
+        self.assertEqual(full.ran, 6000)
+
+    def test_a_survivor_of_everything_is_reported(self):
+        box = _FakeBox(subset=sweep.Outcome(True, 40, "OK"),
+                       full=sweep.Outcome(True, 6000, "OK"))
+        verdict, _, _ = sweep.decide(box, _M, ["tests.test_x"])
+        self.assertEqual(verdict, "survived")
+
+    def test_a_red_subset_is_believed_without_a_full_run(self):
+        """A red IS a red — some test really did go red — and re-confirming it would
+        spend four minutes to learn nothing. The asymmetry runs one way only."""
+        box = _FakeBox(subset=sweep.Outcome(False, 40, "FAILED"))
+        verdict, _, full = sweep.decide(box, _M, ["tests.test_x"])
+        self.assertEqual(verdict, "pinned")
+        self.assertEqual(box.full_calls, 0)
+        self.assertIsNone(full)
+
+    def test_a_file_no_traced_module_reaches_goes_to_the_full_suite(self):
+        """Absence of evidence is not a pin. A file the trace never saw — because its
+        only exercise is through a subprocess, say — must not be certified as tested by
+        that silence."""
+        box = _FakeBox(full=sweep.Outcome(True, 6000, "OK"))
+        verdict, subset, _ = sweep.decide(box, _M, [])
+        self.assertEqual(verdict, "survived")
+        self.assertEqual(box.subset_calls, 0)
+        self.assertEqual(box.full_calls, 1)
+        self.assertIn("no covering module", subset.detail)
+
+
+class AHangIsNotAPass(unittest.TestCase):
+    def test_a_run_that_times_out_is_red_and_never_a_survivor(self):
+        """Round three had a mutation that wedged the suite for 1800s rather than
+        failing. Reading that as green would pin a guard on a timeout."""
+        outcome = sweep._verdict(_Completed(0, "Ran 10 tests in 1s\n\nOK\n"))
+        self.assertTrue(outcome.green)
+
+
+class _Completed:
+    def __init__(self, rc, out):
+        self.returncode, self.stdout, self.stderr = rc, out, ""
+
+
+class TheVerdictIsReadFromTheRun(unittest.TestCase):
+    def test_ok_with_tests_is_green(self):
+        self.assertTrue(sweep._verdict(_Completed(0, "Ran 42 tests in 1s\n\nOK\n")).green)
+
+    def test_a_run_with_no_tests_is_not_green(self):
+        """`Ran 0 tests` exits 0. Counting that as a pass would mark every mutation in a
+        file whose module names were mistyped as pinned, silently."""
+        v = sweep._verdict(_Completed(0, "Ran 0 tests in 0.0s\n\nOK\n"))
+        self.assertFalse(v.green)
+        self.assertIn("no tests", v.detail)
+
+    def test_a_failure_carries_its_reason(self):
+        v = sweep._verdict(_Completed(1, "FAIL: test_x\nRan 42 tests in 1s\n\nFAILED (failures=1)\n"))
+        self.assertFalse(v.green)
+        self.assertEqual(v.ran, 42)
+        self.assertIn("test_x", v.detail)
+
+
+# ======================================================================================
+# Second order — two guards in sequence mask each other
+# ======================================================================================
+
+class TwoGuardsCanHideBehindEachOther(unittest.TestCase):
+    SRC = textwrap.dedent("""
+        def _placed_here():
+            out = {}
+            for placed in config.FRAME.get("components") or ():
+                name = placed.get("slot")
+                if isinstance(name, str) and name not in SLOT_SIZE:
+                    out[name] = placed
+            return out
+    """).lstrip("\n").encode()
+
+    def test_two_mutations_in_one_function_compose_into_one_file(self):
+        """Deleting `_placed_here`'s `name not in SLOT_SIZE` alone changes nothing any
+        caller can observe, because `_edge_of`/`_size_of` read the shipped tables first.
+        One mutation at a time invites a reviewer to call it equivalent. It is not — its
+        consequence is hidden behind a SECOND unpinned line, and composing the pair is
+        how the harness asks that question."""
+        muts = sweep.mutations_for("charter/frame/layout.py", self.SRC, set(range(1, 9)))
+        a = next(m for m in muts if m.operator == "no-fallback")
+        b = next(m for m in muts if m.operator == "drop-conjunct")
+        combined = sweep.compose(self.SRC, (a, b))
+        self.assertIsNotNone(combined)
+        text = combined.decode()
+        self.assertIn('config.FRAME["components"]', text)
+        self.assertIn("if isinstance(name, str):", text)
+
+    def test_a_composed_pair_keeps_every_line_number(self):
+        muts = sweep.mutations_for("charter/frame/layout.py", self.SRC, set(range(1, 9)))
+        a = next(m for m in muts if m.operator == "no-fallback")
+        b = next(m for m in muts if m.operator == "drop-conjunct")
+        combined = sweep.compose(self.SRC, (a, b))
+        self.assertEqual(len(combined.splitlines()), len(self.SRC.splitlines()))
+
+    def test_overlapping_mutations_are_refused_rather_than_spliced_into_nonsense(self):
+        """`drop-if` covers the whole statement and `drop-conjunct` covers a piece of its
+        condition. Splicing both would write one inside the hole left by the other."""
+        muts = sweep.mutations_for("charter/frame/layout.py", self.SRC, set(range(1, 9)))
+        whole = next(m for m in muts if m.operator == "drop-if")
+        part = next(m for m in muts if m.operator == "drop-conjunct")
+        self.assertIsNone(sweep.compose(self.SRC, (whole, part)))
+
+
+# ======================================================================================
+# Evidence, caching, and the report
+# ======================================================================================
+
+class TheReportSaysWhatTheTestsAsserted(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="charter-sweep-ev-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        (self.tmp / "tests").mkdir()
+        (self.tmp / "tests" / "test_a.py").write_text(textwrap.dedent("""
+            class T:
+                def test_window_keeps_the_selection(self):
+                    self.assertEqual(surface._window(8), (0, 6))
+                def test_something_else(self):
+                    self.assertTrue(other())
+        """))
+
+    def test_a_test_naming_the_symbol_is_reported_with_its_assertions(self):
+        """Deleting `release.yml`'s `-z "$claimed"` refusal left the run still exiting 1,
+        for a different reason (#558). Most 'equivalent mutant' claims are really 'the
+        test asserts too little', so the assertions are put next to the survivor and the
+        reviewer's first question becomes 'did my test look closely enough'."""
+        m = sweep.Mutation(path="charter/frame/overlay.py", line=453, end_line=453,
+                           operator="unclamp", question="?", before="max(1, h)",
+                           after="h", symbol="_window")
+        ev = sweep.evidence_for(self.tmp, m, ["tests.test_a"])
+        self.assertEqual([(mod.split(".")[-1], name) for mod, name, _ in ev.naming],
+                         [("test_a", "test_window_keeps_the_selection")])
+        self.assertIn("assertEqual(surface._window(8), (0, 6))", ev.naming[0][2][0])
+
+    def test_a_symbol_no_covering_test_names_is_said_so_plainly(self):
+        """The loudest possible evidence, and the commonest: `_placed_here` is a function
+        #553 added whole and nothing in the suite ever mentioned it."""
+        m = sweep.Mutation(path="charter/frame/layout.py", line=291, end_line=291,
+                           operator="drop-conjunct", question="?", before="a and b",
+                           after="a", symbol="_placed_here")
+        ev = sweep.evidence_for(self.tmp, m, ["tests.test_a"])
+        self.assertTrue(ev.nothing_names_it)
+
+
+class TheMapIsCachedAgainstTheTreeItMeasured(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="charter-sweep-hash-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        (self.tmp / "charter").mkdir()
+        (self.tmp / "tests").mkdir()
+        (self.tmp / "charter" / "a.py").write_text("x = 1\n")
+        (self.tmp / "tests" / "test_a.py").write_text("y = 1\n")
+
+    def test_the_same_tree_hashes_the_same(self):
+        self.assertEqual(sweep.tree_hash(self.tmp, ("charter",)),
+                         sweep.tree_hash(self.tmp, ("charter",)))
+
+    def test_changing_a_source_file_invalidates_the_map(self):
+        before = sweep.tree_hash(self.tmp, ("charter",))
+        (self.tmp / "charter" / "a.py").write_text("x = 2\n")
+        self.assertNotEqual(before, sweep.tree_hash(self.tmp, ("charter",)))
+
+    def test_changing_a_test_invalidates_the_map_too(self):
+        """A new test module can reach a file no module reached before. A map keyed only
+        on the sources would keep selecting the old, smaller subset for it."""
+        before = sweep.tree_hash(self.tmp, ("charter",))
+        (self.tmp / "tests" / "test_b.py").write_text("z = 1\n")
+        self.assertNotEqual(before, sweep.tree_hash(self.tmp, ("charter",)))
+
+
+class TheReportNamesTheMaskingRisk(unittest.TestCase):
+    def _result(self, line, symbol):
+        m = sweep.Mutation(path="charter/frame/layout.py", line=line, end_line=line,
+                           operator="drop-conjunct", question="is the half pinned?",
+                           before="isinstance(name, str) and name not in SLOT_SIZE",
+                           after="isinstance(name, str)", symbol=symbol)
+        return sweep.Result(m, "survived", sweep.Outcome(True, 40, "OK"),
+                            sweep.Outcome(True, 6000, "OK"), [],
+                            sweep.Evidence([], []))
+
+    def test_two_survivors_in_one_function_are_flagged_as_maskable(self):
+        text = sweep.report([self._result(291, "_placed_here"),
+                             self._result(289, "_placed_here")],
+                            Path("."), "abc", "def", None, 1.0)
+        self.assertIn("2 survivors sit in `_placed_here`", text)
+        self.assertIn("mask each other", text)
+
+    def test_a_lone_survivor_is_not_flagged(self):
+        text = sweep.report([self._result(291, "_placed_here")],
+                            Path("."), "abc", "def", None, 1.0)
+        self.assertNotIn("mask each other", text)
+
+    def test_a_clean_sweep_says_so_and_lists_nothing(self):
+        text = sweep.report([], Path("."), "abc", "def", None, 1.0)
+        self.assertIn("Every mutation this diff offered goes red", text)
+
+    def test_the_survivor_line_carries_file_line_operator_and_both_spellings(self):
+        text = sweep.report([self._result(291, "_placed_here")],
+                            Path("."), "abc", "def", None, 1.0)
+        self.assertIn("charter/frame/layout.py:291", text)
+        self.assertIn("drop-conjunct", text)
+        self.assertIn("shipped :", text)
+        self.assertIn("mutant  :", text)
+
+
+class ThereIsNoSuppressionList(unittest.TestCase):
+    def test_no_marker_or_ignore_or_skip_key_exists_anywhere_in_the_tool(self):
+        """#370's reasoning, applied here: one charter could read is one a committed file
+        could flip. If deleting a line genuinely changes nothing observable, the line
+        should be deleted — 'equivalent mutant' and 'dead code' are the same finding, so
+        there is nothing for a suppression list to hold."""
+        source = Path(sweep.__file__).read_text()
+        tree = ast.parse(source)
+        names = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+        names |= {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
+        for forbidden in ("suppress", "ignore_list", "allowlist", "equivalent",
+                          "nosweep", "skip_mutation", "exclusions"):
+            self.assertNotIn(forbidden, names, f"a suppression hatch named {forbidden}")
+
+
+if __name__ == "__main__":      # pragma: no cover
+    unittest.main()

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -585,6 +585,18 @@ class _FakeBox:
         return self._full
 
 
+class _FullFlake(_FakeBox):
+    """Green subset, then a full suite that answers differently each time it is asked."""
+
+    def __init__(self, first, second):
+        super().__init__(subset=sweep.Outcome(True, 40, "OK"))
+        self._answers = [first, second]
+
+    def full(self):
+        self.full_calls += 1
+        return self._answers[min(self.full_calls - 1, len(self._answers) - 1)]
+
+
 _M = sweep.Mutation(path="charter/x.py", line=1, end_line=1, operator="drop-if",
                     question="?", before="if a: return", after="", symbol="f")
 
@@ -597,7 +609,7 @@ class TheFullSuiteHasTheLastWord(unittest.TestCase):
                        full=sweep.Outcome(False, 6000, "FAILED (failures=1)"))
         verdict, _, full = sweep.decide(box, _M, ["tests.test_x"])
         self.assertEqual(verdict, "pinned")
-        self.assertEqual(box.full_calls, 1)
+        self.assertGreaterEqual(box.full_calls, 1)
         self.assertEqual(full.ran, 6000)
 
     def test_a_survivor_of_everything_is_reported(self):
@@ -605,6 +617,26 @@ class TheFullSuiteHasTheLastWord(unittest.TestCase):
                        full=sweep.Outcome(True, 6000, "OK"))
         verdict, _, _ = sweep.decide(box, _M, ["tests.test_x"])
         self.assertEqual(verdict, "survived")
+
+    def test_a_red_full_suite_is_confirmed_before_it_pins_anything(self):
+        """This is where the asymmetry bites hardest. A red FULL suite is the verdict that
+        says 'tested', and it is never revisited — so a flake here does not mislabel a
+        mutation, it certifies a guard. Six thousand tests, real tmux servers, and a
+        machine that may be running other sweeps: one confirming run is expensive and
+        still cheaper than one guard wrongly declared safe."""
+        box = _FullFlake(sweep.Outcome(False, 6000, "FAILED (errors=1)"),
+                         sweep.Outcome(True, 6000, "OK"))
+        verdict, _, full = sweep.decide(box, _M, ["tests.test_x"])
+        self.assertEqual(verdict, "survived")
+        self.assertEqual(box.full_calls, 2)
+        self.assertIn("green on confirmation", full.detail)
+
+    def test_a_full_suite_red_twice_pins_the_guard(self):
+        box = _FullFlake(sweep.Outcome(False, 6000, "FAILED (failures=1)"),
+                         sweep.Outcome(False, 6000, "FAILED (failures=1)"))
+        verdict, _, _ = sweep.decide(box, _M, ["tests.test_x"])
+        self.assertEqual(verdict, "pinned")
+        self.assertEqual(box.full_calls, 2)
 
     def test_a_red_subset_is_confirmed_once_and_then_believed(self):
         """A red twice IS a red, and re-running the whole suite for it would spend four

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -795,6 +795,56 @@ class ACouldNotMeasureIsNotAPin(unittest.TestCase):
         self.assertIn("emphatically not a pin", text)
 
 
+class AStaleBytecodeCacheCannotDecideAnything(unittest.TestCase):
+    """The third way this harness invented a false pin, and the least obvious.
+
+    CPython validates a cached `.pyc` against the source's size and its mtime **truncated
+    to whole seconds**, and nothing else. A sandbox applies one mutation after another to
+    the same file, and two mutations of one file routinely differ from the original by the
+    same number of bytes — `contain.one_line(x)` -> `x` removes exactly 18 characters
+    wherever it appears. Measured on `charter/frame/panel.py` at `5b02b3f`: the mutation at
+    line 210 and the mutation at line 458 are both 29159 bytes against a 29177-byte
+    original. Applied within one second of each other, the second is indistinguishable from
+    the first, and line 458 — a real survivor — was reported PINNED by line 210's bytecode.
+    """
+
+    def test_the_sandbox_refuses_to_write_bytecode_at_all(self):
+        """Belt, not braces: rather than trying to out-guess the validator, the sandbox
+        never writes a `.pyc`, so there is nothing stale to reuse."""
+        box = object.__new__(sweep.Sandbox)
+        tmp = Path(tempfile.mkdtemp(prefix="charter-sweep-pyc-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(tmp, ignore_errors=True))
+        box.path, box._pristine = tmp, {}
+        (tmp / "tests").mkdir()
+        (tmp / "tests" / "__init__.py").write_text("")
+        (tmp / "tests" / "test_env.py").write_text(textwrap.dedent("""
+            import os, sys, unittest
+            class T(unittest.TestCase):
+                def test_no_bytecode(self):
+                    assert os.environ.get("PYTHONDONTWRITEBYTECODE") == "1"
+                    assert sys.dont_write_bytecode
+        """))
+        outcome = box.run(["tests.test_env"], timeout=120)
+        self.assertTrue(outcome.green, outcome.detail)
+        self.assertEqual(list(tmp.rglob("__pycache__")), [])
+
+    def test_two_mutations_of_one_file_can_be_byte_identical_in_length(self):
+        """The precondition, stated as a property rather than as a story: if this stops
+        being possible the guard above is still right, and if it starts being common the
+        guard above is the only thing standing between the sweep and a wrong answer."""
+        src = textwrap.dedent("""
+            def f(a, b):
+                x = contain.one_line(a)
+                y = contain.one_line(b)
+                return x, y
+        """).lstrip("\n").encode()
+        muts = [m for m in sweep.mutations_for("charter/x.py", src, set(range(1, 6)))
+                if m.operator == "uncontain"]
+        self.assertEqual(len(muts), 2)
+        self.assertEqual(len(muts[0].source), len(muts[1].source))
+        self.assertNotEqual(muts[0].source, muts[1].source)
+
+
 class TheVerdictIsReadFromTheRun(unittest.TestCase):
     def test_ok_with_tests_is_green(self):
         self.assertTrue(sweep._verdict(_Completed(0, "Ran 42 tests in 1s\n\nOK\n")).green)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 import unittest
 from pathlib import Path
 
@@ -708,16 +709,90 @@ class AHangIsNotAPass(unittest.TestCase):
     def test_a_wedged_runs_grandchildren_die_with_it(self):
         """`subprocess.run(timeout=…)` kills only the direct child. This suite starts
         real tmux servers, and one left behind by a timed-out mutation would be inherited
-        by the next mutation and reported as ITS failure."""
+        by the next mutation and reported as ITS failure.
+
+        Polled rather than asserted once: SIGKILL is delivered synchronously but the
+        orphan is reaped by init a moment later, and until it is reaped its pid still
+        answers `kill(pid, 0)`. Asserting immediately made this case flaky on CI — it
+        failed on 3.11 in one run and passed in the next at the same commit, which is
+        exactly the kind of red this whole tool exists to stop anybody trusting.
+        """
         self.box.run(["tests.test_hang"], timeout=5)
         pid = int((self.tmp / "kid.pid").read_text())
-        with self.assertRaises(ProcessLookupError):
-            os.kill(pid, 0)
+        for _ in range(100):
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return
+            time.sleep(0.1)
+        self.fail(f"pid {pid} outlived the run it was started from")
 
     def test_killing_a_group_that_has_already_gone_is_not_an_error(self):
         proc = subprocess.Popen([sys.executable, "-c", "pass"], start_new_session=True)
         proc.wait()
         sweep._kill_group(proc)
+
+
+class ACouldNotMeasureIsNotAPin(unittest.TestCase):
+    """The distinction this tool got wrong and had to be taught.
+
+    Measured, on a box under a load average of 100 with two other agents on it: two of
+    #553's six known-unpinned guards came back "pinned" with `ran=0` — the full suite had
+    run past its timeout and been killed. No test failed. The harness had turned machine
+    load into evidence, and the evidence it manufactured was the one verdict that
+    certifies a guard as tested and is never revisited. Both were confirmed by hand
+    afterwards as genuine survivors.
+    """
+
+    def test_a_timeout_is_marked_inconclusive_and_not_merely_red(self):
+        tmp = Path(tempfile.mkdtemp(prefix="charter-sweep-incon-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(tmp, ignore_errors=True))
+        (tmp / "tests").mkdir()
+        (tmp / "tests" / "__init__.py").write_text("")
+        (tmp / "tests" / "test_slow.py").write_text(textwrap.dedent("""
+            import time, unittest
+            class T(unittest.TestCase):
+                def test_slow(self):
+                    time.sleep(120)
+        """))
+        box = object.__new__(sweep.Sandbox)
+        box.path, box._pristine = tmp, {}
+        outcome = box.run(["tests.test_slow"], timeout=4)
+        self.assertFalse(outcome.green)
+        self.assertFalse(outcome.conclusive)
+
+    def test_a_real_failure_is_conclusive(self):
+        self.assertTrue(sweep._verdict(
+            _Completed(1, "Ran 3 tests in 1s\n\nFAILED (failures=1)\n")).conclusive)
+
+    def test_a_mutation_the_machine_could_not_measure_twice_has_no_verdict(self):
+        """Not pinned. "I could not look" must never render as "nothing to see" — the same
+        distinction `plugincache.content_hash` keeps when it answers None rather than an
+        empty hash."""
+        box = _FullFlake(sweep.Outcome(False, 0, "timed out after 2400s", conclusive=False),
+                         sweep.Outcome(False, 0, "timed out after 2400s", conclusive=False))
+        verdict, _, _ = sweep.decide(box, _M, ["tests.test_x"])
+        self.assertEqual(verdict, "unresolved")
+
+    def test_a_timeout_that_does_not_repeat_is_decided_by_the_run_that_worked(self):
+        box = _FullFlake(sweep.Outcome(False, 0, "timed out", conclusive=False),
+                         sweep.Outcome(True, 6000, "OK"))
+        verdict, _, _ = sweep.decide(box, _M, ["tests.test_x"])
+        self.assertEqual(verdict, "survived")
+
+    def test_an_unresolved_mutation_is_named_in_the_report_and_not_buried(self):
+        m = sweep.Mutation(path="charter/frame/layout.py", line=298, end_line=298,
+                           operator="collapse-ifexp", question="?",
+                           before="size.n if isinstance(size, Fixed) else 1",
+                           after="size.n", symbol="_policy_cells")
+        r = sweep.Result(m, "unresolved", sweep.Outcome(True, 45, "OK"),
+                         sweep.Outcome(False, 0, "timed out after 2400s", conclusive=False),
+                         [])
+        text = sweep.report([r], Path("."), "abc", "def", None, 1.0)
+        self.assertIn("UNRESOLVED        : 1", text)
+        self.assertIn("charter/frame/layout.py:298", text)
+        self.assertIn("timed out", text)
+        self.assertIn("emphatically not a pin", text)
 
 
 class TheVerdictIsReadFromTheRun(unittest.TestCase):

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import ast
 import os
 import subprocess
+import sys
 import tempfile
 import textwrap
 import unittest
@@ -578,17 +579,51 @@ class TheFullSuiteHasTheLastWord(unittest.TestCase):
         self.assertIn("no covering module", subset.detail)
 
 
+_Completed = sweep._Finished
+
+
 class AHangIsNotAPass(unittest.TestCase):
-    def test_a_run_that_times_out_is_red_and_never_a_survivor(self):
-        """Round three had a mutation that wedged the suite for 1800s rather than
-        failing. Reading that as green would pin a guard on a timeout."""
-        outcome = sweep._verdict(_Completed(0, "Ran 10 tests in 1s\n\nOK\n"))
-        self.assertTrue(outcome.green)
+    """Round three had a mutation that wedged the suite for 1800s rather than failing.
 
+    Reading that as green would have pinned a guard on a timeout — the loudest possible
+    version of the false pin this whole file exists to prevent.
+    """
 
-class _Completed:
-    def __init__(self, rc, out):
-        self.returncode, self.stdout, self.stderr = rc, out, ""
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="charter-sweep-hang-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        (self.tmp / "tests").mkdir()
+        (self.tmp / "tests" / "__init__.py").write_text("")
+        (self.tmp / "tests" / "test_hang.py").write_text(textwrap.dedent(f"""
+            import subprocess, unittest
+            class T(unittest.TestCase):
+                def test_wedges(self):
+                    kid = subprocess.Popen(["sleep", "120"])
+                    open({str(self.tmp / "kid.pid")!r}, "w").write(str(kid.pid))
+                    kid.wait()
+        """))
+        self.box = object.__new__(sweep.Sandbox)
+        self.box.path = self.tmp
+        self.box._pristine = {}
+
+    def test_a_run_that_wedges_is_red_and_never_a_survivor(self):
+        outcome = self.box.run(["tests.test_hang"], timeout=5)
+        self.assertFalse(outcome.green)
+        self.assertIn("timed out", outcome.detail)
+
+    def test_a_wedged_runs_grandchildren_die_with_it(self):
+        """`subprocess.run(timeout=…)` kills only the direct child. This suite starts
+        real tmux servers, and one left behind by a timed-out mutation would be inherited
+        by the next mutation and reported as ITS failure."""
+        self.box.run(["tests.test_hang"], timeout=5)
+        pid = int((self.tmp / "kid.pid").read_text())
+        with self.assertRaises(ProcessLookupError):
+            os.kill(pid, 0)
+
+    def test_killing_a_group_that_has_already_gone_is_not_an_error(self):
+        proc = subprocess.Popen([sys.executable, "-c", "pass"], start_new_session=True)
+        proc.wait()
+        sweep._kill_group(proc)
 
 
 class TheVerdictIsReadFromTheRun(unittest.TestCase):
@@ -607,6 +642,34 @@ class TheVerdictIsReadFromTheRun(unittest.TestCase):
         self.assertFalse(v.green)
         self.assertEqual(v.ran, 42)
         self.assertIn("test_x", v.detail)
+
+
+class TheSubsetIsNarrowedByFunctionAndWidenedByDoubt(unittest.TestCase):
+    """Selection narrows to the function, and every fallback runs MORE, never less."""
+
+    MAP = {"charter/frame/overlay.py": ["tests.test_a", "tests.test_b", "tests.test_c"],
+           "charter/frame/overlay.py::_window": ["tests.test_a"]}
+
+    def _m(self, symbol):
+        return sweep.Mutation(path="charter/frame/overlay.py", line=1, end_line=1,
+                              operator="unclamp", question="?", before="max(1, h)",
+                              after="h", symbol=symbol)
+
+    def test_a_measured_function_selects_only_the_modules_that_ran_it(self):
+        """File granularity is not enough in this tree: `layout`, `slots` and `builtins`
+        are reached by nearly every test module through a shared fixture, so a file-keyed
+        map answers 'run all 322' for a helper only four modules ever call."""
+        self.assertEqual(sweep.select_for(self.MAP, self._m("_window")), ["tests.test_a"])
+
+    def test_a_function_the_trace_never_saw_falls_back_to_the_whole_file(self):
+        """A `<lambda>`, or a comprehension frame on 3.11, is never seen under its own
+        name. Falling back to the file runs more than needed; guessing narrower would
+        certify a guard as tested by a subset that never ran it."""
+        self.assertEqual(sweep.select_for(self.MAP, self._m("_paint")),
+                         ["tests.test_a", "tests.test_b", "tests.test_c"])
+
+    def test_a_file_the_trace_never_saw_selects_nothing_and_decide_runs_everything(self):
+        self.assertEqual(sweep.select_for({}, self._m("_window")), [])
 
 
 # ======================================================================================

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -564,12 +564,17 @@ class _FakeBox:
     run that goes red once and green on confirmation is spelled.
     """
 
-    def __init__(self, subset=None, full: sweep.Outcome | None = None):
+    def __init__(self, subset=None, full: sweep.Outcome | None = None,
+                 clean: frozenset = frozenset()):
         self._subset = subset if isinstance(subset, list) else [subset] * 4
         self._full = full
+        self._clean = clean
         self.applied: list[sweep.Mutation] = []
         self.subset_calls = 0
         self.full_calls = 0
+
+    def clean_failures(self, modules):
+        return self._clean
 
     def apply(self, m):
         self.applied.append(m)
@@ -607,7 +612,7 @@ class TheFullSuiteHasTheLastWord(unittest.TestCase):
         """Selection is an optimisation and must never be the final word. This is the
         line that makes a false 'pinned' impossible, and it costs one full run."""
         box = _FakeBox(subset=sweep.Outcome(True, 40, "OK"),
-                       full=sweep.Outcome(False, 6000, "FAILED (failures=1)"))
+                       full=sweep.Outcome(False, 6000, "FAILED", failing=frozenset({"m.C.t"})))
         verdict, _, full = sweep.decide(box, _M, ["tests.test_x"])
         self.assertEqual(verdict, "pinned")
         self.assertGreaterEqual(box.full_calls, 1)
@@ -625,7 +630,7 @@ class TheFullSuiteHasTheLastWord(unittest.TestCase):
         mutation, it certifies a guard. Six thousand tests, real tmux servers, and a
         machine that may be running other sweeps: one confirming run is expensive and
         still cheaper than one guard wrongly declared safe."""
-        box = _FullFlake(sweep.Outcome(False, 6000, "FAILED (errors=1)"),
+        box = _FullFlake(sweep.Outcome(False, 6000, "FAILED", failing=frozenset({"m.C.t"})),
                          sweep.Outcome(True, 6000, "OK"))
         verdict, _, full = sweep.decide(box, _M, ["tests.test_x"])
         self.assertEqual(verdict, "survived")
@@ -633,8 +638,8 @@ class TheFullSuiteHasTheLastWord(unittest.TestCase):
         self.assertIn("green on confirmation", full.detail)
 
     def test_a_full_suite_red_twice_pins_the_guard(self):
-        box = _FullFlake(sweep.Outcome(False, 6000, "FAILED (failures=1)"),
-                         sweep.Outcome(False, 6000, "FAILED (failures=1)"))
+        box = _FullFlake(sweep.Outcome(False, 6000, "FAILED", failing=frozenset({"m.C.t"})),
+                         sweep.Outcome(False, 6000, "FAILED", failing=frozenset({"m.C.t"})))
         verdict, _, _ = sweep.decide(box, _M, ["tests.test_x"])
         self.assertEqual(verdict, "pinned")
         self.assertEqual(box.full_calls, 2)
@@ -642,7 +647,7 @@ class TheFullSuiteHasTheLastWord(unittest.TestCase):
     def test_a_red_subset_is_confirmed_once_and_then_believed(self):
         """A red twice IS a red, and re-running the whole suite for it would spend four
         minutes to learn nothing. The asymmetry runs one way only."""
-        box = _FakeBox(subset=sweep.Outcome(False, 40, "FAILED"))
+        box = _FakeBox(subset=sweep.Outcome(False, 40, "FAILED", failing=frozenset({"m.C.t"})))
         verdict, _, full = sweep.decide(box, _M, ["tests.test_x"])
         self.assertEqual(verdict, "pinned")
         self.assertEqual(box.subset_calls, 2)
@@ -654,7 +659,7 @@ class TheFullSuiteHasTheLastWord(unittest.TestCase):
         red does not merely mislabel one mutation — it certifies a guard as tested by a
         failure that had nothing to do with it, which is the exact defect this tool was
         written to catch. So a red that does not reproduce goes to the full suite."""
-        box = _FakeBox(subset=[sweep.Outcome(False, 40, "FAILED"),
+        box = _FakeBox(subset=[sweep.Outcome(False, 40, "FAILED", failing=frozenset({"m.C.t"})),
                                sweep.Outcome(True, 40, "OK")],
                        full=sweep.Outcome(True, 6000, "OK"))
         verdict, subset, _ = sweep.decide(box, _M, ["tests.test_x"])
@@ -731,6 +736,67 @@ class AHangIsNotAPass(unittest.TestCase):
         proc = subprocess.Popen([sys.executable, "-c", "pass"], start_new_session=True)
         proc.wait()
         sweep._kill_group(proc)
+
+
+class TheVerdictIsTheSetOfNewlyFailingTests(unittest.TestCase):
+    """An exit code cannot say WHY a run died, and this project has measured the confusion
+    in both directions.
+
+    `release.yml`'s `-z "$claimed"` refusal (#558) exits 1 with the line deleted *and*
+    without it, for two different reasons — so a real deletion read as pinned. And a sweep
+    run in a tree copied without `.git` errors twelve `test_workflows` cases in the
+    baseline and in every mutant alike — so every mutation read as pinned, 37 of 37, and
+    that whole sweep had to be thrown away.
+
+    Both are the same mistake: crediting a mutation with a red it did not cause. So the
+    verdict here is `failing(mutant) - failing(same command, unmutated)`.
+    """
+
+    def test_a_red_the_subset_was_already_red_on_pins_nothing(self):
+        already = frozenset({"unittest.loader._FailedTest.tests.test_workflows"})
+        box = _FakeBox(subset=sweep.Outcome(False, 40, "FAILED", failing=already),
+                       full=sweep.Outcome(True, 6000, "OK"),
+                       clean=already)
+        verdict, subset, _ = sweep.decide(box, _M, ["tests.test_x"])
+        self.assertEqual(verdict, "survived")
+        self.assertIn("nothing new", subset.detail)
+
+    def test_only_the_tests_this_mutation_broke_are_held_against_it(self):
+        box = _FakeBox(
+            subset=sweep.Outcome(False, 40, "FAILED",
+                                 failing=frozenset({"pre.C.existing", "new.C.broken"})),
+            clean=frozenset({"pre.C.existing"}))
+        verdict, subset, _ = sweep.decide(box, _M, ["tests.test_x"])
+        self.assertEqual(verdict, "pinned")
+        self.assertEqual(subset.failing, frozenset({"new.C.broken"}))
+        self.assertIn("new.C.broken", subset.detail)
+        self.assertNotIn("pre.C.existing", subset.detail)
+
+    def test_the_clean_baseline_is_measured_before_the_mutation_is_applied(self):
+        """Otherwise it would measure the mutant and every verdict would be 'no change'."""
+        order = []
+
+        class Ordered(_FakeBox):
+            def clean_failures(self, modules):
+                order.append("baseline")
+                return frozenset()
+
+            def apply(self, m):
+                order.append("apply")
+
+        box = Ordered(subset=sweep.Outcome(True, 40, "OK"),
+                      full=sweep.Outcome(True, 6000, "OK"))
+        sweep.decide(box, _M, ["tests.test_x"])
+        self.assertEqual(order[:2], ["baseline", "apply"])
+
+    def test_a_whole_suite_red_only_on_pre_existing_failures_is_not_a_pin(self):
+        already = frozenset({"tests.test_flaky.C.t"})
+        box = _FakeBox(subset=sweep.Outcome(True, 40, "OK"),
+                       full=sweep.Outcome(False, 6000, "FAILED", failing=already),
+                       clean=already)
+        verdict, _, full = sweep.decide(box, _M, ["tests.test_x"])
+        self.assertEqual(verdict, "survived")
+        self.assertIn("nothing new", full.detail)
 
 
 class ACouldNotMeasureIsNotAPin(unittest.TestCase):
@@ -856,11 +922,27 @@ class TheVerdictIsReadFromTheRun(unittest.TestCase):
         self.assertFalse(v.green)
         self.assertIn("no tests", v.detail)
 
-    def test_a_failure_carries_its_reason(self):
-        v = sweep._verdict(_Completed(1, "FAIL: test_x\nRan 42 tests in 1s\n\nFAILED (failures=1)\n"))
+    def test_a_failure_carries_the_ids_of_the_tests_that_failed(self):
+        v = sweep._verdict(_Completed(1,
+            "FAIL: test_x (tests.test_mod.C.test_x)\n"
+            "ERROR: test_y (tests.test_mod.C.test_y)\n"
+            "Ran 42 tests in 1s\n\nFAILED (failures=1, errors=1)\n"))
         self.assertFalse(v.green)
         self.assertEqual(v.ran, 42)
-        self.assertIn("test_x", v.detail)
+        self.assertEqual(v.failing,
+                         frozenset({"tests.test_mod.C.test_x", "tests.test_mod.C.test_y"}))
+        self.assertIn("tests.test_mod.C.test_x", v.detail)
+
+    def test_an_import_error_is_collected_as_a_failing_id_too(self):
+        """A module that will not import errors as `unittest.loader._FailedTest`, and a
+        tree copied without `.git` produces twelve of them at once. If those are counted
+        against the mutation, every mutation in the run scores pinned."""
+        v = sweep._verdict(_Completed(1,
+            "ERROR: tests.test_workflows "
+            "(unittest.loader._FailedTest.tests.test_workflows)\n"
+            "Ran 3 tests in 1s\n\nFAILED (errors=1)\n"))
+        self.assertEqual(v.failing,
+                         frozenset({"unittest.loader._FailedTest.tests.test_workflows"}))
 
 
 class TheSubsetIsNarrowedByFunctionAndWidenedByDoubt(unittest.TestCase):
@@ -1036,6 +1118,47 @@ class TheReportNamesTheMaskingRisk(unittest.TestCase):
         self.assertIn("drop-conjunct", text)
         self.assertIn("shipped :", text)
         self.assertIn("mutant  :", text)
+
+
+class ASurvivorIsASurvivorOnTHISPlatform(unittest.TestCase):
+    """A clause the operating system never reaches is unreachable, not untested.
+
+    Measured on this project: `except OSError: return None` around a pty read is dead code
+    on macOS, where closing the far end returns `b""`, and live on Linux, where it raises
+    `[Errno 5]`. A local sweep sees a survivor either way. Scoring that as a missing test
+    is a false positive, and false positives are what get a gate switched off — so the
+    harness labels it rather than silently counting it.
+    """
+
+    def _survivor(self, before, operator="narrow-except"):
+        m = sweep.Mutation(path="charter/frame/overlay.py", line=400, end_line=400,
+                           operator=operator, question="?", before=before,
+                           after="ZeroDivisionError", symbol="run")
+        return sweep.Result(m, "survived", sweep.Outcome(True, 40, "OK"),
+                            sweep.Outcome(True, 6000, "OK"), [], sweep.Evidence([], []))
+
+    def test_a_narrowed_os_level_catch_is_flagged_for_a_second_opinion(self):
+        text = sweep.report([self._survivor("OSError")], Path("."), "a", "b", None, 1.0)
+        self.assertIn("    PLATFORM:", text)
+        self.assertIn("OSError", text)
+        self.assertIn("throwaway branch", text)
+
+    def test_a_catch_charter_itself_raises_is_not_flagged(self):
+        text = sweep.report([self._survivor("ControlPlaneNotFound")],
+                            Path("."), "a", "b", None, 1.0)
+        self.assertNotIn("    PLATFORM:", text)
+
+    def test_a_deleted_guard_is_not_flagged_merely_for_naming_an_oserror(self):
+        """The caveat is about a CATCH the OS may never trigger, not about any line that
+        happens to mention one."""
+        text = sweep.report([self._survivor("if isinstance(e, OSError): return None",
+                                            operator="drop-if")],
+                            Path("."), "a", "b", None, 1.0)
+        self.assertNotIn("    PLATFORM:", text)
+
+    def test_the_report_says_which_platform_it_measured_on(self):
+        text = sweep.report([], Path("."), "a", "b", None, 1.0)
+        self.assertIn(sys.platform, text)
 
 
 class ThereIsNoSuppressionList(unittest.TestCase):

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -557,11 +557,15 @@ class TheDiffIsReadWithNoContext(unittest.TestCase):
 # ======================================================================================
 
 class _FakeBox:
-    """A sandbox that answers whatever the case needs it to."""
+    """A sandbox that answers whatever the case needs it to.
 
-    def __init__(self, subset: sweep.Outcome | None = None,
-                 full: sweep.Outcome | None = None):
-        self._subset, self._full = subset, full
+    `subset` may be a list, which is then consumed one answer per call — that is how a
+    run that goes red once and green on confirmation is spelled.
+    """
+
+    def __init__(self, subset=None, full: sweep.Outcome | None = None):
+        self._subset = subset if isinstance(subset, list) else [subset] * 4
+        self._full = full
         self.applied: list[sweep.Mutation] = []
         self.subset_calls = 0
         self.full_calls = 0
@@ -574,7 +578,7 @@ class _FakeBox:
 
     def subset(self, modules):
         self.subset_calls += 1
-        return self._subset
+        return self._subset[min(self.subset_calls - 1, len(self._subset) - 1)]
 
     def full(self):
         self.full_calls += 1
@@ -602,14 +606,28 @@ class TheFullSuiteHasTheLastWord(unittest.TestCase):
         verdict, _, _ = sweep.decide(box, _M, ["tests.test_x"])
         self.assertEqual(verdict, "survived")
 
-    def test_a_red_subset_is_believed_without_a_full_run(self):
-        """A red IS a red — some test really did go red — and re-confirming it would
-        spend four minutes to learn nothing. The asymmetry runs one way only."""
+    def test_a_red_subset_is_confirmed_once_and_then_believed(self):
+        """A red twice IS a red, and re-running the whole suite for it would spend four
+        minutes to learn nothing. The asymmetry runs one way only."""
         box = _FakeBox(subset=sweep.Outcome(False, 40, "FAILED"))
         verdict, _, full = sweep.decide(box, _M, ["tests.test_x"])
         self.assertEqual(verdict, "pinned")
+        self.assertEqual(box.subset_calls, 2)
         self.assertEqual(box.full_calls, 0)
         self.assertIsNone(full)
+
+    def test_a_red_that_does_not_reproduce_is_not_allowed_to_pin_anything(self):
+        """The suite starts real tmux servers and several sweeps share a machine. A flaky
+        red does not merely mislabel one mutation — it certifies a guard as tested by a
+        failure that had nothing to do with it, which is the exact defect this tool was
+        written to catch. So a red that does not reproduce goes to the full suite."""
+        box = _FakeBox(subset=[sweep.Outcome(False, 40, "FAILED"),
+                               sweep.Outcome(True, 40, "OK")],
+                       full=sweep.Outcome(True, 6000, "OK"))
+        verdict, subset, _ = sweep.decide(box, _M, ["tests.test_x"])
+        self.assertEqual(verdict, "survived")
+        self.assertEqual(box.full_calls, 1)
+        self.assertIn("green on confirmation", subset.detail)
 
     def test_a_file_no_traced_module_reaches_goes_to_the_full_suite(self):
         """Absence of evidence is not a pin. A file the trace never saw — because its

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,6 @@
+"""Developer tooling. Not shipped — `pyproject.toml` names `charter` as the only package.
+
+A package rather than a bare directory so `tests/test_sweep.py` can `from tools import
+sweep` under `python -m unittest discover -s tests -t .`, the way every other test in
+this repository imports the thing it is about.
+"""

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -1,0 +1,1146 @@
+#!/usr/bin/env python3
+"""The deletion sweep, run by the repo instead of promised by an agent.
+
+Three rounds of Phase 2 review found the same defect thirty-six times: a guard with no
+test behind it. Correct code, shipped, that a later refactor could delete in silence.
+Every one was found by the same move — delete the line, run the suite, see if it stays
+green — and every one was found by a *human-driven* sweep that is mechanical, slow and
+invisible in the diff, which is why it is the step that gets **reported** rather than
+**run**. Nothing in the repository could tell the two apart. This can.
+
+Four things make it affordable and make its answer worth trusting:
+
+**Scoped to the diff.** A branch is answerable for the guards *it* adds, so the default
+is `git diff` against the merge-base with ``origin/main``. ``--all`` charges the whole
+tree instead — not as a gate, as a number.
+
+**Mutated by statement shape, not by line.** Deleting arbitrary lines mostly produces
+``SyntaxError`` and ``NameError``, which redden tests for reasons that have nothing to do
+with the property under test. Those are false pins and they are worse than no signal.
+Every operator in :data:`OPERATORS` is drawn from a guard one of the three rounds
+actually found, and any mutation whose result does not parse is dropped.
+
+**Selected by trace, not by guess.** The suite is ~6000 tests and four minutes; a full
+run per mutation is the four and a half hours the last round really cost. Running the
+suite once under `sys.settrace`, one test module at a time, says which source files each
+module executes, and a mutation then runs only the modules that reach its file — seconds
+instead of minutes. The map is cached against a hash of the tree it was measured on.
+
+**Never trusted when it says "survived".** Selection is an optimisation and must never be
+the final word. Any mutation that survives its subset is re-run against the FULL suite
+before it is reported. A false survivor costs one full run; a false *pin* would be the
+exact bug this file exists to prevent, so the asymmetry decides the design.
+
+There is deliberately **no suppression list.** The usual escape hatch — mark a mutant
+"equivalent" and move on — is how this kind of gate becomes a rubber stamp, and charter
+already refuses the analogous thing (#370: no config key lifts a guard denial). If
+deleting a line genuinely changes nothing observable, the line should be deleted;
+"equivalent mutant" and "dead code" are the same finding, and the sweep reporting it is
+the sweep working.
+
+And because most "equivalent mutant" claims turn out to be "the test asserts too little"
+— measured on `release.yml`'s version check (#558), where deleting the refusal left the
+run still exiting 1 for a *different reason* — a survivor is reported together with what
+the covering tests actually assert about the mutated symbol. The reviewer's first
+question should be "did my test look closely enough", not "can I suppress this".
+
+Stdlib only. `pyproject.toml` says ``dependencies = []`` and that is load-bearing.
+
+    python3 tools/sweep.py                      # this branch, against its merge-base
+    python3 tools/sweep.py --ref 5b02b3f        # some other commit
+    python3 tools/sweep.py --path tools         # sweep the sweep
+    python3 tools/sweep.py --all                # the whole tree, as a number
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import concurrent.futures
+import dataclasses
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+#: Python files under these directories are swept unless ``--path`` says otherwise.
+DEFAULT_PATHS = ("charter",)
+
+#: What a subset run and a full run are allowed to take before they count as a failure.
+#: The full suite is ~5 minutes; one round-3 mutation HUNG rather than passing, which is
+#: a failure and not a green, so a timeout is reported as RED-by-timeout and never as a
+#: survivor.
+SUBSET_TIMEOUT = 900
+FULL_TIMEOUT = 2400
+
+#: `except ZeroDivisionError` is the narrowing the round-2 sweep used by hand: it is a
+#: real builtin (so the clause still compiles and still evaluates), it derives from
+#: `Exception` (so it is a *narrowing* of the common case and not a widening), and
+#: nothing in charter divides by zero.
+NARROW_TO = "ZeroDivisionError"
+
+_RAN = re.compile(r"^Ran (\d+) tests? in ", re.MULTILINE)
+
+
+# --------------------------------------------------------------------------------------
+# 1. Scoping: which lines is this branch answerable for
+# --------------------------------------------------------------------------------------
+
+def git(*args: str, cwd: Path, check: bool = True) -> str:
+    """`git` in *cwd*, as text. Raises on a non-zero exit unless *check* is false."""
+    p = subprocess.run(("git",) + args, cwd=str(cwd), check=False,
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if check and p.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed in {cwd}:\n{p.stderr}")
+    return p.stdout
+
+
+def _blob_at(repo: Path, ref: str, rel: str) -> bytes:
+    """A file's exact bytes at *ref*. Bytes, because `col_offset` counts UTF-8 bytes."""
+    p = subprocess.run(["git", "show", f"{ref}:{rel}"], cwd=str(repo), check=False,
+                       stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    return p.stdout if p.returncode == 0 else b""
+
+
+_HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def added_lines(repo: Path, base: str, ref: str, paths: tuple[str, ...]
+                ) -> dict[str, set[int]]:
+    """``{path: {line numbers added or modified at *ref*}}``, relative to *repo*.
+
+    ``--unified=0`` so a hunk's ``+`` range is exactly the added lines and not three
+    lines of untouched context on either side, which would let a branch be charged for a
+    guard it merely stood next to.
+    """
+    spec = [f"{p}/**.py" for p in paths] + [f"{p}/*.py" for p in paths]
+    out = git("diff", "--unified=0", "--no-color", "--no-renames",
+              f"{base}", f"{ref}", "--", *spec, cwd=repo)
+    found: dict[str, set[int]] = {}
+    current: str | None = None
+    for line in out.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[6:]
+            if current == "/dev/null":
+                current = None
+            continue
+        if line.startswith("+++ "):
+            current = None
+            continue
+        m = _HUNK.match(line)
+        if m and current and current.endswith(".py"):
+            start, count = int(m.group(1)), int(m.group(2) or 1)
+            if count:
+                found.setdefault(current, set()).update(range(start, start + count))
+    return found
+
+
+def all_lines(root: Path, paths: tuple[str, ...]) -> dict[str, set[int]]:
+    """Every line of every swept file — what ``--all`` charges instead of a diff."""
+    found: dict[str, set[int]] = {}
+    for p in paths:
+        base = root / p
+        if not base.exists():
+            continue
+        for f in sorted(base.rglob("*.py")):
+            rel = f.relative_to(root).as_posix()
+            n = len(f.read_bytes().splitlines())
+            found[rel] = set(range(1, n + 2))
+    return found
+
+
+# --------------------------------------------------------------------------------------
+# 2. Mutation: by statement shape, because lines are not the unit of meaning
+# --------------------------------------------------------------------------------------
+
+@dataclasses.dataclass(frozen=True)
+class Mutation:
+    """One edit, one question, one test run."""
+
+    path: str           #: repo-relative source file
+    line: int           #: the line the reviewer should look at
+    end_line: int
+    operator: str       #: which shape was recognised
+    question: str       #: what a survivor would mean
+    before: str         #: the source that was there
+    after: str          #: the source that replaced it
+    symbol: str         #: enclosing def/class, for the evidence pass
+    source: bytes = b""  #: the whole mutated file
+    span: tuple[int, int] = (0, 0)   #: byte span replaced, so two can be composed
+
+    @property
+    def tag(self) -> str:
+        return f"{self.path}:{self.line}:{self.operator}"
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line} [{self.operator}] {_oneline(self.before)}"
+
+
+def _oneline(s: str, limit: int = 96) -> str:
+    flat = " ".join(s.split())
+    return flat if len(flat) <= limit else flat[: limit - 1] + "…"
+
+
+class _Spans:
+    """Byte offsets for AST nodes.
+
+    `col_offset` is a UTF-8 *byte* offset, not a character index — a docstring with an
+    arrow in it is enough to make the two disagree — so every splice here is done on
+    bytes and decoded only to check that the result still parses.
+    """
+
+    def __init__(self, source: bytes) -> None:
+        self.source = source
+        self.starts = [0]
+        for chunk in source.splitlines(keepends=True):
+            self.starts.append(self.starts[-1] + len(chunk))
+
+    def offset(self, lineno: int, col: int) -> int:
+        return self.starts[lineno - 1] + col
+
+    def span(self, node: ast.AST) -> tuple[int, int]:
+        return (self.offset(node.lineno, node.col_offset),
+                self.offset(node.end_lineno, node.end_col_offset))
+
+    def text(self, node: ast.AST) -> str:
+        a, b = self.span(node)
+        return self.source[a:b].decode("utf-8")
+
+    def splice(self, node: ast.AST, replacement: str) -> bytes:
+        """Replace *node*'s span, padded so every later line keeps its number.
+
+        Line numbers are the whole output of this tool. A replacement that collapsed
+        three lines into one would renumber the rest of the file, and a survivor
+        reported at the wrong line is a survivor nobody acts on.
+        """
+        a, b = self.span(node)
+        rep = replacement.encode("utf-8")
+        lost = self.source[a:b].count(b"\n") - rep.count(b"\n")
+        return self.source[:a] + rep + b"\n" * max(0, lost) + self.source[b:]
+
+
+def _sole_statement(parent_body: list[ast.stmt], node: ast.AST) -> bool:
+    return len(parent_body) == 1 and parent_body[0] is node
+
+
+def _parents(tree: ast.AST) -> dict[int, ast.AST]:
+    out: dict[int, ast.AST] = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            out[id(child)] = node
+    return out
+
+
+def _enclosing(tree: ast.AST, node: ast.AST) -> str:
+    """The nearest ``def``/``class`` around *node* — the name the evidence pass looks for."""
+    best, best_span = "<module>", None
+    for outer in ast.walk(tree):
+        if not isinstance(outer, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        if outer.lineno <= node.lineno and node.end_lineno <= (outer.end_lineno or 0):
+            span = outer.end_lineno - outer.lineno
+            if best_span is None or span < best_span:
+                best, best_span = outer.name, span
+    return best
+
+
+_SIMPLE_BODY = (ast.Return, ast.Raise, ast.Continue, ast.Break, ast.Pass,
+                ast.Assign, ast.AugAssign, ast.AnnAssign, ast.Expr)
+
+
+def _drop_statement(sp: _Spans, node: ast.stmt, holder: list[ast.stmt]) -> str:
+    """The replacement text for deleting *node*: nothing, or ``pass`` if it was alone."""
+    return "pass" if _sole_statement(holder, node) else ""
+
+
+def _body_of(parent: ast.AST, node: ast.AST) -> list[ast.stmt] | None:
+    for field in ("body", "orelse", "finalbody"):
+        seq = getattr(parent, field, None)
+        if isinstance(seq, list) and any(s is node for s in seq):
+            return seq
+    return None
+
+
+def _iter_operators(tree: ast.Module, sp: _Spans):
+    """Yield ``(node, replacement, operator, question)`` for every recognised shape.
+
+    Each row of this table is a guard one of the three review rounds actually deleted by
+    hand. Nothing here is speculative and nothing here is a general-purpose mutation
+    engine: a shape earns a place by having caught a real unpinned line.
+    """
+    parents = _parents(tree)
+
+    # A module-level constant is a guard too, and the spec's shape table has no row for
+    # one. Five of round two's eighteen overlay findings are exactly this — `_CHROME_ROWS`,
+    # `_SPLIT_ROWS`, `_MIN_TITLE`, `MOUSE_ON`, `_MARK` — a number or a string with a
+    # docstring making a specific claim for the value, and nothing measuring it. Only the
+    # two forms with a principled general perturbation are mutated here: an integer, moved
+    # by one, and a sum of named parts, dropped to each part. A string constant has no
+    # honest general perturbation — picking `1003` over `1000` for `MOUSE_ON` is fitting
+    # the answer key, not recognising a shape — so it stays a known gap and is reported
+    # as one rather than faked.
+    for stmt in tree.body:
+        target = None
+        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 \
+                and isinstance(stmt.targets[0], ast.Name):
+            target = stmt.targets[0].id
+        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            target = stmt.target.id
+        value = getattr(stmt, "value", None)
+        if target is None or value is None or not target.lstrip("_").isupper():
+            continue
+        if isinstance(value, ast.Constant) and isinstance(value.value, int) \
+                and not isinstance(value.value, bool):
+            yield (value, str(value.value + 1), "retune-constant",
+                   f"is `{target}`'s value pinned, or would any number do?")
+        if isinstance(value, ast.BinOp) and isinstance(value.op, ast.Add):
+            for side in (value.left, value.right):
+                yield (value, sp.text(side), "drop-term",
+                       f"is every term of `{target}` pinned?")
+
+    for node in ast.walk(tree):
+
+        # `if C: return` / `raise` / `continue` — and, by the same move, `if C:` with any
+        # single simple statement under it. Round three's two sharpest findings were
+        # `if self._sel < top: top = self._sel` and `if size is None: size = SLOT_SIZE[slot]`,
+        # both assignments; restricting the shape to `return`/`raise`/`continue` would
+        # have written both of them off before they were asked about.
+        if isinstance(node, ast.If) and not node.orelse and len(node.body) == 1 \
+                and isinstance(node.body[0], _SIMPLE_BODY):
+            holder = _body_of(parents.get(id(node), tree), node) or []
+            yield (node, _drop_statement(sp, node, holder), "drop-if",
+                   "is the refusal pinned?")
+
+        # A branch in an `if`/`elif`/`else` chain cannot be excised — deleting it would
+        # take the `else` with it — so it is disabled instead, which asks the same
+        # question. Round two's finding 14, `decode`'s `elif ch == b"\x03"` Ctrl-C
+        # branch, is this shape and only this shape. Restricted to chains that HAVE an
+        # `else`, because in a bare `if` the fall-through is a `NameError` waiting to
+        # happen and a mutation that reddens the suite for that reason is a false pin —
+        # the one outcome worse than no signal.
+        if isinstance(node, ast.If) and node.orelse:
+            yield (node.test, "False", "disable-branch", "is this branch pinned?")
+            yield (node.test, "True", "disable-branch", "is the other branch pinned?")
+
+        # The same refusal in expression clothes: `[x for x in xs if C]`. Round two's
+        # first finding, `harness_rows`' `if _edge_of(slot) not in _COLUMN_EDGES`, lives
+        # inside a `sum(...)` generator, and a shape table that only knows the statement
+        # spelling of `if` cannot see it at all.
+        if isinstance(node, ast.comprehension) and node.ifs:
+            for cond in node.ifs:
+                # `True` rather than excising the `if` keyword: the filter is gone either
+                # way, and this keeps the splice inside one expression's span, so every
+                # line below it keeps its number.
+                yield (cond, "True", "drop-comprehension-if",
+                       "is the filter pinned?")
+
+        # `if A and B:` — one conjunct at a time. Round three found `_placed_here`'s
+        # `isinstance(name, str) and name not in SLOT_SIZE` unpinned in BOTH halves, and
+        # a whole-condition mutation cannot tell those two findings apart.
+        if isinstance(node, (ast.If, ast.While)) and isinstance(node.test, ast.BoolOp) \
+                and isinstance(node.test.op, ast.And) and len(node.test.values) > 1:
+            for i, part in enumerate(node.test.values):
+                rest = [v for j, v in enumerate(node.test.values) if j != i]
+                kept = " and ".join(sp.text(v) for v in rest)
+                yield (node.test, kept, "drop-conjunct",
+                       f"is the `{_oneline(sp.text(part), 48)}` half pinned?")
+
+        # `if isinstance(x, str)` as the whole condition — the type filter, dropped.
+        if isinstance(node, (ast.If, ast.While)) and _is_isinstance(node.test):
+            yield (node.test, "True", "drop-isinstance",
+                   "is the type filter pinned?")
+        if isinstance(node, (ast.If, ast.While)) and isinstance(node.test, ast.UnaryOp) \
+                and isinstance(node.test.op, ast.Not) and _is_isinstance(node.test.operand):
+            yield (node.test, "False", "drop-isinstance",
+                   "is the type filter pinned?")
+
+        # `x = max(a, b)` / `min(…)` — dropped to each operand in turn. `_window`'s
+        # `n = max(1, height - _CHROME_ROWS)` and its `_top` clamp are both this shape.
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                and node.func.id in ("max", "min") and len(node.args) == 2 \
+                and not node.keywords:
+            for arg in node.args:
+                yield (node, sp.text(arg), "unclamp",
+                       "is the clamp pinned, or only its inner value?")
+
+        # `except E:` — narrowed to something nothing raises. `_component_text`'s
+        # `except Exception` was round two's finding 4.
+        if isinstance(node, ast.ExceptHandler) and node.type is not None:
+            if sp.text(node.type).strip() != NARROW_TO:
+                yield (node.type, NARROW_TO, "narrow-except",
+                       "is the catch pinned, or does nothing ever fail here?")
+
+        # `f(contain.one_line(x))` -> `f(x)`. Four of round two's twelve and one of round
+        # three's six are a containment call on a value that reaches a terminal.
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
+                and isinstance(node.func.value, ast.Name) \
+                and node.func.value.id == "contain" and node.args:
+            yield (node, sp.text(node.args[0]), "uncontain",
+                   "is the containment pinned?")
+
+        # `d.get(k) or ()` -> `d[k]`, and `d.get(k, v)` -> `d[k]`. `_placed_here`'s
+        # `config.FRAME.get("components") or ()` and `_derive`'s `SLOT_OF.get(c.id, c.id)`
+        # are the two spellings, and both were found unpinned.
+        if isinstance(node, ast.BoolOp) and isinstance(node.op, ast.Or) \
+                and len(node.values) == 2 and _is_get(node.values[0]):
+            call = node.values[0]
+            yield (node, f"{sp.text(call.func.value)}[{sp.text(call.args[0])}]",
+                   "no-fallback", "is the fallback pinned?")
+        if _is_get(node) and len(node.args) == 2:
+            yield (node, f"{sp.text(node.func.value)}[{sp.text(node.args[0])}]",
+                   "no-fallback", "is the fallback pinned?")
+
+        # `A or B` where B is an empty literal — `placed or []`, `paint or _paint`.
+        if isinstance(node, ast.BoolOp) and isinstance(node.op, ast.Or) \
+                and len(node.values) == 2 and not _is_get(node.values[0]) \
+                and _is_empty_literal(node.values[1]):
+            yield (node, sp.text(node.values[0]), "no-fallback",
+                   "is the fallback pinned?")
+
+        # `a if C else b` — collapsed to each side. `_policy_cells`' `else 1` was round
+        # three's fifth finding and is exactly this.
+        if isinstance(node, ast.IfExp):
+            yield (node, sp.text(node.body), "collapse-ifexp",
+                   "is the other branch pinned?")
+            yield (node, sp.text(node.orelse), "collapse-ifexp",
+                   "is this branch pinned?")
+
+
+def _is_isinstance(node: ast.AST) -> bool:
+    return (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            and node.func.id == "isinstance")
+
+
+def _is_get(node: ast.AST) -> bool:
+    return (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get" and len(node.args) in (1, 2)
+            and not node.keywords)
+
+
+def _is_empty_literal(node: ast.AST) -> bool:
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return not node.elts
+    if isinstance(node, ast.Dict):
+        return not node.keys
+    return isinstance(node, ast.Constant) and node.value in ("", 0, None)
+
+
+def mutations_for(path: str, source: bytes, lines: set[int]) -> list[Mutation]:
+    """Every mutation this file offers on the lines the branch is answerable for."""
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        return []
+    sp = _Spans(source)
+    out: list[Mutation] = []
+    seen: set[tuple[int, int, str, str]] = set()
+    for node, replacement, operator, question in _iter_operators(tree, sp):
+        if not (set(range(node.lineno, (node.end_lineno or node.lineno) + 1)) & lines):
+            continue
+        before = sp.text(node)
+        if before.strip() == replacement.strip():
+            continue
+        key = (node.lineno, node.col_offset, operator, replacement)
+        if key in seen:
+            continue
+        seen.add(key)
+        mutated = sp.splice(node, replacement)
+        try:
+            ast.parse(mutated, filename=path)
+        except SyntaxError:
+            # Deleting the sole statement of a block leaves an empty block. The spec
+            # says to skip a mutation that does not parse; `pass` is the same deletion
+            # spelled so that it does.
+            if replacement == "":
+                mutated = sp.splice(node, "pass")
+                try:
+                    ast.parse(mutated, filename=path)
+                except SyntaxError:
+                    continue
+                replacement = "pass"
+            else:
+                continue
+        out.append(Mutation(
+            path=path, line=node.lineno, end_line=node.end_lineno or node.lineno,
+            operator=operator, question=question, before=before, after=replacement,
+            symbol=_enclosing(tree, node), source=mutated, span=sp.span(node)))
+    out.sort(key=lambda m: (m.path, m.line, m.operator, m.after))
+    return out
+
+
+def compose(pristine: bytes, pair: tuple[Mutation, Mutation]) -> bytes | None:
+    """Both mutations at once, or ``None`` when their spans overlap or it will not parse.
+
+    Two guards in sequence can mask each other. `_placed_here`'s `name not in SLOT_SIZE`
+    is the worked example: deleting it alone changes nothing any caller can observe,
+    because `_edge_of`/`_size_of` consult the shipped tables first — so a reviewer looking
+    at the single mutation is invited to write it off as an equivalent mutant, when in
+    fact its consequence is hidden behind a *second* unpinned line. Composing the pair is
+    how the harness says "not equivalent — untested, at both orders".
+    """
+    a, b = sorted(pair, key=lambda m: m.span[0], reverse=True)
+    if b.span[1] > a.span[0]:
+        return None
+    out = pristine
+    for m in (a, b):
+        start, end = m.span
+        rep = m.after.encode("utf-8")
+        lost = out[start:end].count(b"\n") - rep.count(b"\n")
+        out = out[:start] + rep + b"\n" * max(0, lost) + out[end:]
+    try:
+        ast.parse(out)
+    except SyntaxError:
+        return None
+    return out
+
+
+# --------------------------------------------------------------------------------------
+# 3. Selection: which test modules reach which source file
+# --------------------------------------------------------------------------------------
+
+#: Run inside a subprocess, one test module per process, with the tracer armed BEFORE the
+#: module is imported so that what a module executes at import time counts as reaching a
+#: file. Only `call` events are asked for — the tracer returns None, so no line or return
+#: events are generated for the frame, which is the difference between a map that takes
+#: minutes and one that takes an hour.
+_TRACE_RUNNER = r'''
+import json, os, sys, threading, unittest
+
+module, out_path, prefix = sys.argv[1], sys.argv[2], sys.argv[3]
+seen = set()
+
+def tracer(frame, event, arg):
+    name = frame.f_code.co_filename
+    if name.startswith(prefix):
+        seen.add(name)
+    return None
+
+sys.settrace(tracer)
+threading.settrace(tracer)
+try:
+    try:
+        suite = unittest.defaultTestLoader.loadTestsFromName(module)
+        with open(os.devnull, "w") as null:
+            unittest.TextTestRunner(stream=null, verbosity=0).run(suite)
+    except Exception:
+        pass
+finally:
+    sys.settrace(None)
+    threading.settrace(None)
+
+with open(out_path, "w") as fh:
+    json.dump(sorted(seen), fh)
+'''
+
+
+def tree_hash(root: Path, paths: tuple[str, ...]) -> str:
+    """A hash of everything the map depends on: the swept sources and every test."""
+    h = hashlib.sha256()
+    for top in sorted(set(paths) | {"tests"}):
+        base = root / top
+        if not base.exists():
+            continue
+        for f in sorted(base.rglob("*.py")):
+            h.update(f.relative_to(root).as_posix().encode())
+            h.update(hashlib.sha256(f.read_bytes()).digest())
+    return h.hexdigest()[:16]
+
+
+def test_modules(root: Path) -> list[str]:
+    return sorted(f"tests.{p.stem}" for p in (root / "tests").glob("test_*.py"))
+
+
+def build_map(root: Path, paths: tuple[str, ...], jobs: int, scratch: Path,
+              log=print) -> dict[str, list[str]]:
+    """``{source file: [test modules that execute it]}``, measured once."""
+    modules = test_modules(root)
+    scratch.mkdir(parents=True, exist_ok=True)
+    runner = scratch / "_trace_runner.py"
+    runner.write_text(_TRACE_RUNNER)
+    prefix = str(root) + os.sep
+    hits: dict[str, list[str]] = {}
+    done = 0
+
+    def one(module: str) -> tuple[str, list[str]]:
+        out = scratch / f"{module}.json"
+        subprocess.run([sys.executable, str(runner), module, str(out), prefix],
+                       cwd=str(root), check=False, timeout=SUBSET_TIMEOUT,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        try:
+            files = json.loads(out.read_text())
+        except (OSError, ValueError):
+            files = []
+        return module, files
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
+        for module, files in pool.map(one, modules):
+            done += 1
+            if done % 40 == 0:
+                log(f"    traced {done}/{len(modules)} modules")
+            for f in files:
+                rel = Path(f).resolve().relative_to(root.resolve()).as_posix()
+                hits.setdefault(rel, []).append(module)
+    return {k: sorted(v) for k, v in sorted(hits.items())}
+
+
+def load_map(root: Path, paths: tuple[str, ...], cache_dir: Path, jobs: int,
+             refresh: bool, log=print) -> dict[str, list[str]]:
+    """The map for this tree, from cache when the tree has not moved."""
+    key = tree_hash(root, paths)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cached = cache_dir / f"selection-{key}.json"
+    if cached.exists() and not refresh:
+        log(f"  selection map: cached ({cached.name})")
+        return json.loads(cached.read_text())
+    log(f"  selection map: tracing {len(test_modules(root))} test modules "
+        f"({jobs} at a time)…")
+    started = time.time()
+    result = build_map(root, paths, jobs, cache_dir / f"trace-{key}", log=log)
+    cached.write_text(json.dumps(result, indent=0, sort_keys=True))
+    shutil.rmtree(cache_dir / f"trace-{key}", ignore_errors=True)
+    log(f"  selection map: {len(result)} source files in {time.time() - started:.0f}s")
+    return result
+
+
+# --------------------------------------------------------------------------------------
+# 4. Running: sandboxes, subsets, and the full suite that has the last word
+# --------------------------------------------------------------------------------------
+
+@dataclasses.dataclass
+class Outcome:
+    green: bool
+    ran: int
+    detail: str
+
+
+def _verdict(proc: subprocess.CompletedProcess) -> Outcome:
+    text = (proc.stdout or "") + (proc.stderr or "")
+    m = _RAN.search(text)
+    ran = int(m.group(1)) if m else 0
+    if proc.returncode == 0 and ran > 0:
+        return Outcome(True, ran, "OK")
+    if ran == 0:
+        return Outcome(False, 0, "no tests ran")
+    tail = [ln for ln in text.splitlines() if ln.startswith(("FAILED", "ERROR:", "FAIL:"))]
+    return Outcome(False, ran, "; ".join(tail[:3]) or f"rc={proc.returncode}")
+
+
+class Sandbox:
+    """A private clone of the tree. The operator's checkout is never written to."""
+
+    def __init__(self, root: Path, where: Path, ref: str, dirty: dict[str, bytes]):
+        self.path = where
+        if where.exists():
+            shutil.rmtree(where)
+        where.parent.mkdir(parents=True, exist_ok=True)
+        # A real clone and not a `git archive`: `test_workflows` and `test_plugin_freshness`
+        # read the repository, and a tree with no `.git` costs a dozen errors that have
+        # nothing to do with any mutation. `--no-hardlinks` so a sandbox cannot reach back
+        # into the objects of the checkout it came from.
+        subprocess.run(["git", "clone", "--quiet", "--no-hardlinks", "--no-checkout",
+                        str(root), str(where)], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        subprocess.run(["git", "checkout", "--quiet", "--detach", ref],
+                       cwd=str(where), check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        for rel, blob in dirty.items():
+            target = where / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(blob)
+        self._pristine: dict[str, bytes] = {}
+
+    def apply(self, mutation: Mutation) -> None:
+        target = self.path / mutation.path
+        self._pristine[mutation.path] = target.read_bytes()
+        target.write_bytes(mutation.source)
+
+    def restore(self) -> None:
+        for rel, blob in self._pristine.items():
+            (self.path / rel).write_bytes(blob)
+        self._pristine.clear()
+
+    def run(self, argv: list[str], timeout: int) -> Outcome:
+        env = dict(os.environ)
+        env.pop("PYTHONDONTWRITEBYTECODE", None)
+        try:
+            proc = subprocess.run([sys.executable, "-m", "unittest", *argv],
+                                  cwd=str(self.path), check=False, text=True, env=env,
+                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                  timeout=timeout)
+        except subprocess.TimeoutExpired:
+            # A mutation that HANGS the suite has not survived it. Round three had one.
+            return Outcome(False, 0, f"timed out after {timeout}s")
+        return _verdict(proc)
+
+    def subset(self, modules: list[str]) -> Outcome:
+        return self.run(list(modules), SUBSET_TIMEOUT)
+
+    def full(self) -> Outcome:
+        return self.run(["discover", "-s", "tests", "-t", "."], FULL_TIMEOUT)
+
+
+def dirty_files(root: Path, paths: tuple[str, ...]) -> dict[str, bytes]:
+    """Uncommitted work under the swept paths, so the tool is usable before a commit."""
+    out: dict[str, bytes] = {}
+    listing = git("status", "--porcelain", "--untracked-files=all", "--", *paths,
+                  cwd=root, check=False)
+    for line in listing.splitlines():
+        rel = line[3:].strip()
+        if rel.endswith(".py") and (root / rel).exists():
+            out[rel] = (root / rel).read_bytes()
+    return out
+
+
+# --------------------------------------------------------------------------------------
+# 5. Evidence: what the covering tests actually assert
+# --------------------------------------------------------------------------------------
+
+@dataclasses.dataclass
+class Evidence:
+    modules: list[str]
+    naming: list[tuple[str, str, list[str]]]   # (module, test name, assert lines)
+
+    @property
+    def nothing_names_it(self) -> bool:
+        return not self.naming
+
+
+def evidence_for(root: Path, mutation: Mutation, modules: list[str]) -> Evidence:
+    """Which covering tests name the mutated symbol, and what they assert about it.
+
+    Deleting `release.yml`'s `-z "$claimed"` refusal (#558) left the run still exiting 1,
+    because the check below it caught the empty string instead — same exit code, a
+    different reason. That is why most "equivalent mutant" claims are wrong: the mutant
+    is not equivalent, the test asserts too little. So a survivor is reported next to the
+    assertions that were supposed to hold it, and a symbol no covering test even names is
+    the loudest form of that answer.
+    """
+    naming: list[tuple[str, str, list[str]]] = []
+    if mutation.symbol == "<module>":
+        return Evidence(modules, naming)
+    # Not `\b`: charter's private helpers all start with an underscore, which IS a word
+    # character, so `\b_window\b` would refuse to match `surface._window(8)` at its
+    # left edge and the evidence pass would report "nothing names it" for every private
+    # symbol in the tree — which is most of them.
+    word = re.compile(r"(?<![A-Za-z0-9_])" + re.escape(mutation.symbol)
+                      + r"(?![A-Za-z0-9_])")
+    for module in modules:
+        f = root / (module.replace(".", "/") + ".py")
+        if not f.exists():
+            continue
+        src = f.read_bytes()
+        if not word.search(src.decode("utf-8", "replace")):
+            continue
+        try:
+            tree = ast.parse(src, filename=str(f))
+        except SyntaxError:
+            continue
+        sp = _Spans(src)
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not node.name.startswith("test"):
+                continue
+            body = sp.text(node)
+            if not word.search(body):
+                continue
+            asserts = [_oneline(sp.text(c), 110) for c in ast.walk(node)
+                       if isinstance(c, ast.Call) and isinstance(c.func, ast.Attribute)
+                       and c.func.attr.startswith("assert")]
+            naming.append((module, node.name, asserts[:4]))
+    return Evidence(modules, naming)
+
+
+# --------------------------------------------------------------------------------------
+# 6. The sweep
+# --------------------------------------------------------------------------------------
+
+@dataclasses.dataclass
+class Result:
+    mutation: Mutation
+    verdict: str                 # "survived" | "pinned" | "unselectable"
+    subset: Outcome | None
+    full: Outcome | None
+    modules: list[str]
+    evidence: Evidence | None = None
+
+
+def decide(box, mutation: Mutation, modules: list[str]) -> tuple[str, Outcome, Outcome | None]:
+    """One mutation's verdict. The FULL suite has the last word, always.
+
+    Three rules, and all three exist because the two errors are not symmetrical. A false
+    survivor costs one full run and a reviewer's minute. A false *pin* is a guard the
+    repository has quietly certified as tested when it is not — the exact defect this
+    file was written to stop — so nothing may be called pinned on partial evidence:
+
+    * a subset that goes green is never the answer; the whole suite is re-run.
+    * a file no traced module was measured executing is not pinned by that silence.
+      Absence of evidence goes to the full suite too.
+    * a run that HANGS has not passed. Round three had one mutation that wedged the
+      suite for 1800s instead of failing, and reading that as green would have pinned a
+      guard on a timeout.
+    """
+    box.apply(mutation)
+    if modules:
+        subset = box.subset(modules)
+    else:
+        subset = Outcome(True, 0, "no covering module measured")
+    if not subset.green:
+        return "pinned", subset, None
+    full = box.full()
+    return ("survived" if full.green else "pinned"), subset, full
+
+
+def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str, list[str]],
+          workdir: Path, jobs: int, dirty: dict[str, bytes], second_order: int = 0,
+          log=print) -> tuple[list[Result], list["Pair"]]:
+    """Every mutation, run; every survivor, re-run against the whole suite."""
+    plan: list[Mutation] = []
+    sources: dict[str, bytes] = {}
+    for rel, lines in sorted(scope.items()):
+        blob = dirty.get(rel) or _blob_at(root, ref, rel)
+        if not blob:
+            continue
+        sources[rel] = blob
+        plan.extend(mutations_for(rel, blob, lines))
+    log(f"  {len(plan)} mutations across {len(scope)} file(s)")
+    if not plan:
+        return [], []
+
+    log(f"  building {jobs} sandbox(es)…")
+    boxes = [Sandbox(root, workdir / f"w{i}", ref, dirty) for i in range(jobs)]
+    free: list[Sandbox] = list(boxes)
+    import threading
+    lock = threading.Lock()
+    results: list[Result] = []
+    counter = {"n": 0}
+
+    def take() -> Sandbox:
+        while True:
+            with lock:
+                if free:
+                    return free.pop()
+            time.sleep(0.05)
+
+    def give(box: Sandbox) -> None:
+        with lock:
+            free.append(box)
+
+    def run_one(mutation: Mutation) -> Result:
+        modules = selection.get(mutation.path, [])
+        box = take()
+        try:
+            verdict, subset, full = decide(box, mutation, modules)
+        finally:
+            box.restore()
+            give(box)
+        with lock:
+            counter["n"] += 1
+            n = counter["n"]
+        if n % 10 == 0 or verdict == "survived":
+            log(f"    [{n}/{len(plan)}] {'SURVIVED' if verdict == 'survived' else 'pinned  '}"
+                f"  {mutation}")
+        return Result(mutation, verdict, subset, full, modules)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
+        results = list(pool.map(run_one, plan))
+
+    for r in results:
+        if r.verdict == "survived":
+            r.evidence = evidence_for(root, r.mutation, r.modules)
+
+    pairs: list[Pair] = []
+    if second_order:
+        pairs = _second_order(results, boxes, sources, second_order, log)
+    for box in boxes:
+        shutil.rmtree(box.path, ignore_errors=True)
+    return results, pairs
+
+
+@dataclasses.dataclass
+class Pair:
+    a: Mutation
+    b: Mutation
+    outcome: Outcome
+
+
+def _second_order(results: list[Result], boxes: list["Sandbox"],
+                  sources: dict[str, bytes], cap: int, log) -> list[Pair]:
+    """Survivors in the same function, applied two at a time.
+
+    Bounded on purpose. Full higher-order mutation is combinatorially out of reach and
+    always will be; a second order over *survivors that share an enclosing function* is
+    a few dozen runs, and it is the only order that answers the masking question — two
+    lines whose consequences are invisible one at a time because each stands behind the
+    other.
+    """
+    groups: dict[tuple[str, str], list[Mutation]] = {}
+    for r in results:
+        if r.verdict == "survived":
+            groups.setdefault((r.mutation.path, r.mutation.symbol), []).append(r.mutation)
+    todo: list[tuple[Mutation, Mutation]] = []
+    for members in groups.values():
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                todo.append((members[i], members[j]))
+    if not todo:
+        return []
+    if len(todo) > cap:
+        log(f"  second order: {len(todo)} same-function pairs, capping at {cap}")
+        todo = todo[:cap]
+    else:
+        log(f"  second order: {len(todo)} same-function pair(s)")
+
+    import threading
+    free = list(boxes)
+    lock = threading.Lock()
+
+    def run_pair(pair: tuple[Mutation, Mutation]) -> Pair | None:
+        combined = compose(sources[pair[0].path], pair)
+        if combined is None:
+            return None
+        while True:
+            with lock:
+                if free:
+                    box = free.pop()
+                    break
+            time.sleep(0.05)
+        try:
+            target = box.path / pair[0].path
+            box._pristine[pair[0].path] = target.read_bytes()
+            target.write_bytes(combined)
+            outcome = box.full()
+        finally:
+            box.restore()
+            with lock:
+                free.append(box)
+        return Pair(pair[0], pair[1], outcome)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(boxes)) as pool:
+        return [p for p in pool.map(run_pair, todo) if p is not None]
+
+
+# --------------------------------------------------------------------------------------
+# 7. The report
+# --------------------------------------------------------------------------------------
+
+def report(results: list[Result], root: Path, ref: str, base: str, baseline: Outcome | None,
+           elapsed: float, pairs: list["Pair"] | None = None) -> str:
+    survivors = [r for r in results if r.verdict == "survived"]
+    pairs = pairs or []
+    out: list[str] = []
+    w = out.append
+    w("=" * 86)
+    w(f"deletion sweep — {ref[:12]} against {base[:12]}")
+    w("=" * 86)
+    if baseline is not None:
+        w(f"baseline          : Ran {baseline.ran} tests — {'OK' if baseline.green else baseline.detail}")
+    w(f"mutations applied : {len(results)}")
+    w(f"pinned            : {len(results) - len(survivors)}")
+    w(f"SURVIVED          : {len(survivors)}")
+    w(f"wall clock        : {elapsed / 60:.1f} min")
+    w("")
+
+    if not survivors:
+        w("Every mutation this diff offered goes red. Nothing added here is a line the")
+        w("suite would not miss.")
+        return "\n".join(out)
+
+    w("A survivor is a line you can delete with the whole suite still green.")
+    w("There is no suppression list: if deleting it genuinely changes nothing")
+    w("observable, delete it — 'equivalent mutant' and 'dead code' are one finding.")
+    w("")
+    by_file: dict[str, list[Result]] = {}
+    for r in survivors:
+        by_file.setdefault(r.mutation.path, []).append(r)
+
+    crowded: dict[tuple[str, str], int] = {}
+    for r in survivors:
+        key = (r.mutation.path, r.mutation.symbol)
+        crowded[key] = crowded.get(key, 0) + 1
+
+    for path, group in sorted(by_file.items()):
+        w("-" * 86)
+        w(path)
+        w("-" * 86)
+        for r in sorted(group, key=lambda r: r.mutation.line):
+            m = r.mutation
+            w("")
+            w(f"  {path}:{m.line}  in `{m.symbol}`   [{m.operator}] — {m.question}")
+            if crowded.get((m.path, m.symbol), 0) > 1:
+                w(f"    NOTE    : {crowded[(m.path, m.symbol)]} survivors sit in `{m.symbol}`. "
+                  "Two guards in sequence")
+                w("              mask each other, so none of them is safe to call "
+                  "equivalent on its own.")
+            w(f"    shipped : {_oneline(m.before, 74)}")
+            w(f"    mutant  : {_oneline(m.after, 74) or '(the statement, deleted)'}")
+            if r.full:
+                w(f"    full    : Ran {r.full.ran} tests — OK, with the line gone")
+            ev = r.evidence
+            if ev is None:
+                continue
+            if not ev.modules:
+                w("    covered : nothing measured executes this file at all")
+            elif ev.nothing_names_it:
+                w(f"    covered : {len(ev.modules)} module(s) execute this file and NOT ONE")
+                w(f"              names `{m.symbol}` — {', '.join(ev.modules[:4])}"
+                  + (" …" if len(ev.modules) > 4 else ""))
+            else:
+                w(f"    covered : {len(ev.naming)} test(s) name `{m.symbol}`; what they assert:")
+                for module, name, asserts in ev.naming[:3]:
+                    w(f"              {module.split('.')[-1]}.{name}")
+                    for a in asserts[:3]:
+                        w(f"                  {a}")
+                if len(ev.naming) > 3:
+                    w(f"              … and {len(ev.naming) - 3} more")
+
+    if pairs:
+        w("")
+        w("-" * 86)
+        w("second order — survivors in the same function, applied together")
+        w("-" * 86)
+        w("A line whose consequence is hidden behind a SECOND unpinned line looks")
+        w("equivalent one mutation at a time. It is not. This is that question, asked.")
+        for p in sorted(pairs, key=lambda p: (p.a.path, p.a.line, p.b.line)):
+            state = ("still green together" if p.outcome.green
+                     else f"caught together ({p.outcome.detail})")
+            w("")
+            w(f"  {p.a.path} `{p.a.symbol}`  — {state}")
+            w(f"    {p.a.line}: {_oneline(p.a.before, 62)} -> {_oneline(p.a.after, 34) or '(deleted)'}")
+            w(f"    {p.b.line}: {_oneline(p.b.before, 62)} -> {_oneline(p.b.after, 34) or '(deleted)'}")
+    w("")
+    w("=" * 86)
+    w(f"{len(survivors)} survivor(s). Each is a guard with no test behind it, or a line")
+    w("that should not be there.")
+    return "\n".join(out)
+
+
+def as_json(results: list[Result]) -> str:
+    return json.dumps([{
+        "path": r.mutation.path, "line": r.mutation.line,
+        "operator": r.mutation.operator, "symbol": r.mutation.symbol,
+        "question": r.mutation.question,
+        "before": r.mutation.before, "after": r.mutation.after,
+        "verdict": r.verdict,
+        "subset": None if not r.subset else {"green": r.subset.green, "ran": r.subset.ran},
+        "full": None if not r.full else {"green": r.full.green, "ran": r.full.ran},
+        "modules": r.modules,
+        "naming": [] if not r.evidence else [
+            {"module": m, "test": t, "asserts": a} for m, t, a in r.evidence.naming],
+    } for r in results], indent=1)
+
+
+# --------------------------------------------------------------------------------------
+# 8. CLI
+# --------------------------------------------------------------------------------------
+
+def repo_root(start: Path) -> Path:
+    return Path(git("rev-parse", "--show-toplevel", cwd=start).strip())
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="tools/sweep.py",
+        description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--ref", default="HEAD", help="Commit to sweep (default: HEAD).")
+    p.add_argument("--base", default=None,
+                   help="Charge added lines against this (default: merge-base with "
+                        "origin/main, or main).")
+    p.add_argument("--path", action="append", default=None, dest="paths",
+                   help="Directory to sweep, repeatable (default: charter).")
+    p.add_argument("--all", action="store_true",
+                   help="Charge the whole tree instead of the diff — a number, not a gate.")
+    p.add_argument("--jobs", type=int, default=max(1, (os.cpu_count() or 4) // 2),
+                   help="Sandboxes to run at once.")
+    p.add_argument("--workdir", default=None, help="Where sandboxes and the cache live.")
+    p.add_argument("--refresh-map", action="store_true", help="Re-trace the selection map.")
+    p.add_argument("--no-baseline", action="store_true",
+                   help="Skip the unmutated full run. A red baseline makes every mutation "
+                        "look pinned, so this is off by default for a reason.")
+    p.add_argument("--json", default=None, help="Also write the full result set here.")
+    p.add_argument("--second-order", type=int, default=0, metavar="MAX",
+                   help="After the sweep, run up to MAX pairs of survivors that share an "
+                        "enclosing function, together. Two guards in sequence mask each "
+                        "other, and a masked mutant looks equivalent one at a time.")
+    p.add_argument("--keep", action="store_true", help="Leave the sandboxes behind.")
+    args = p.parse_args(argv)
+
+    root = repo_root(Path.cwd())
+    paths = tuple(args.paths or DEFAULT_PATHS)
+    ref = git("rev-parse", args.ref, cwd=root).strip()
+    if args.base:
+        base = git("rev-parse", args.base, cwd=root).strip()
+    else:
+        upstream = "origin/main" if git("rev-parse", "--verify", "--quiet", "origin/main",
+                                        cwd=root, check=False).strip() else "main"
+        base = git("merge-base", ref, upstream, cwd=root).strip()
+
+    # Outside the checkout, always. Sandboxes and a trace cache are not the working
+    # tree's business, `.git` is a FILE and not a directory in a linked worktree, and a
+    # sweep run from one worktree must not write into the repository another is using.
+    workdir = Path(args.workdir) if args.workdir else (
+        Path(tempfile.gettempdir())
+        / f"charter-sweep-{hashlib.sha256(str(root).encode()).hexdigest()[:12]}")
+    workdir.mkdir(parents=True, exist_ok=True)
+    log(f"  workdir: {workdir}")
+    cache_dir = workdir / "cache"
+
+    def log(*a):
+        print(*a, flush=True)
+
+    started = time.time()
+    log(f"sweeping {ref[:12]} (paths: {', '.join(paths)})")
+    dirty = dirty_files(root, paths) if args.ref == "HEAD" else {}
+    if dirty:
+        log(f"  carrying {len(dirty)} uncommitted file(s) into the sandboxes")
+
+    if args.all:
+        scope = all_lines(root, paths)
+        log(f"  --all: the whole tree, {len(scope)} file(s)")
+    else:
+        scope = added_lines(root, base, ref, paths)
+        log(f"  diff against {base[:12]}: {len(scope)} file(s), "
+            f"{sum(len(v) for v in scope.values())} added line(s)")
+    if not scope:
+        log("  nothing under the swept paths changed. Nothing to do.")
+        return 0
+
+    # The map is measured on a clean checkout of the ref, so that a mutation is the only
+    # thing that ever differs from what was traced.
+    log("  preparing the reference sandbox…")
+    ref_box = Sandbox(root, workdir / "ref", ref, dirty)
+    selection = load_map(ref_box.path, paths, cache_dir, args.jobs, args.refresh_map, log)
+
+    baseline = None
+    if not args.no_baseline:
+        log("  baseline: full suite, unmutated…")
+        baseline = ref_box.full()
+        log(f"    Ran {baseline.ran} tests — {'OK' if baseline.green else baseline.detail}")
+        if not baseline.green:
+            log("  ! the tree is RED before any mutation. Every mutation below will look")
+            log("  ! pinned for a reason that has nothing to do with the guard. Fix first.")
+            return 2
+
+    results, pairs = sweep(root, ref, scope, selection, workdir, args.jobs, dirty,
+                           args.second_order, log)
+    elapsed = time.time() - started
+    text = report(results, root, ref, base, baseline, elapsed, pairs)
+    log("")
+    log(text)
+    if args.json:
+        Path(args.json).write_text(as_json(results))
+    if not args.keep:
+        for child in workdir.glob("w*"):
+            shutil.rmtree(child, ignore_errors=True)
+        shutil.rmtree(workdir / "ref", ignore_errors=True)
+    return 1 if any(r.verdict == "survived" for r in results) else 0
+
+
+if __name__ == "__main__":       # pragma: no cover - entry point
+    sys.exit(main())

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -912,10 +912,19 @@ def decide(box, mutation: Mutation, modules: list[str]) -> tuple[str, Outcome, O
     box.apply(mutation)
     if modules:
         subset = box.subset(modules)
+        if not subset.green:
+            # A red is the one verdict this tool never revisits, so it had better be a
+            # real one. The suite starts real tmux servers, several sweeps share a
+            # machine, and a flaky red here does not merely mislabel one mutation — it
+            # certifies a guard as tested by a failure that had nothing to do with it.
+            # One confirming run is seconds against a median subset of seven modules.
+            again = box.subset(modules)
+            if again.green:
+                subset = Outcome(True, again.ran, "red once, green on confirmation")
+            else:
+                return "pinned", subset, None
     else:
         subset = Outcome(True, 0, "no covering module measured")
-    if not subset.green:
-        return "pinned", subset, None
     full = box.full()
     return ("survived" if full.green else "pinned"), subset, full
 

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -966,9 +966,14 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
         with lock:
             counter["n"] += 1
             n = counter["n"]
-        if n % 10 == 0 or verdict == "survived":
-            log(f"    [{n}/{len(plan)}] {'SURVIVED' if verdict == 'survived' else 'pinned  '}"
-                f"  {mutation}")
+        # One line per mutation, always. A survivor costs a full suite run, so a sweep
+        # can sit silent for a quarter of an hour, and a tool nobody can tell apart from
+        # a hung one is a tool that gets killed and then not re-run.
+        how = f"{len(modules)} module(s)" if modules else "no covering module"
+        if full is not None:
+            how += f", then all {full.ran or '?'}"
+        log(f"    [{n}/{len(plan)}] "
+            f"{'SURVIVED' if verdict == 'survived' else 'pinned  '}  {mutation}   ({how})")
         return Result(mutation, verdict, subset, full, modules)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -1118,6 +1118,7 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
 def as_json(results: list[Result]) -> str:
     return json.dumps([{
         "path": r.mutation.path, "line": r.mutation.line,
+        "end_line": r.mutation.end_line,
         "operator": r.mutation.operator, "symbol": r.mutation.symbol,
         "question": r.mutation.question,
         "before": r.mutation.before, "after": r.mutation.after,

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -26,10 +26,14 @@ suite once under `sys.settrace`, one test module at a time, says which source fi
 module executes, and a mutation then runs only the modules that reach its file — seconds
 instead of minutes. The map is cached against a hash of the tree it was measured on.
 
-**Never trusted when it says "survived".** Selection is an optimisation and must never be
-the final word. Any mutation that survives its subset is re-run against the FULL suite
-before it is reported. A false survivor costs one full run; a false *pin* would be the
-exact bug this file exists to prevent, so the asymmetry decides the design.
+**Never trusted when it says "survived", and never allowed to guess when it says
+"pinned".** Selection is an optimisation and must never be the final word: anything that
+survives its subset is re-run against the FULL suite. A false survivor costs one full run;
+a false *pin* is the exact bug this file exists to prevent, so the asymmetry decides the
+design — a red is confirmed before it pins anything, and a run that TIMED OUT is neither
+green nor red but **unresolved**, because no test failed there and machine load must not
+become evidence. That last distinction was learned the hard way: on a box under a load
+average of 100, two of #553's six known-unpinned guards came back "pinned" with `ran=0`.
 
 There is deliberately **no suppression list.** The usual escape hatch — mark a mutant
 "equivalent" and move on — is how this kind of gate becomes a rubber stamp, and charter
@@ -685,9 +689,21 @@ def load_map(root: Path, paths: tuple[str, ...], cache_dir: Path, jobs: int,
 
 @dataclasses.dataclass
 class Outcome:
+    """What one run said — and whether it said anything at all.
+
+    `conclusive` is the distinction this tool got wrong once and had to be taught. A run
+    that TIMED OUT is not a red run: no test failed, the suite simply could not be
+    measured. Folding the two together turns machine load into evidence, and the evidence
+    it manufactures is "pinned" — the verdict that certifies a guard as tested and is
+    never revisited. Measured, on a box under a load average of 100 with two other agents
+    on it: two of #553's six known-unpinned guards came back "pinned" with `ran=0`, which
+    is not a failure, it is a stopwatch.
+    """
+
     green: bool
     ran: int
     detail: str
+    conclusive: bool = True
 
 
 @dataclasses.dataclass
@@ -771,20 +787,28 @@ class Sandbox:
         try:
             out, _ = proc.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
-            # A mutation that HANGS the suite has not survived it. Round three had one:
-            # deleting `Surface.run`'s `if chunk is None: return None` wedged the suite
-            # for 1800s rather than failing, and reading that as green would have pinned
-            # the guard on a timeout.
+            # Not green — round three had a mutation that wedged the suite for 1800s
+            # instead of failing, and reading that as a pass would pin a guard on a
+            # stopwatch. But not RED either, and that is the harder half: no test failed
+            # here, so this run is `conclusive=False` and is not allowed to decide
+            # anything on its own.
             _kill_group(proc)
             proc.communicate()
-            return Outcome(False, 0, f"timed out after {timeout}s")
+            return Outcome(False, 0, f"timed out after {timeout}s", conclusive=False)
         return _verdict(_Finished(proc.returncode, out))
+
+    #: Set from the baseline's measured wall time, so the cap tracks the machine the
+    #: sweep is actually running on rather than the one it was written on. A fixed
+    #: forty-minute cap is generous on an idle box and far too tight on a shared one:
+    #: measured, at a load average of 100, a five-minute suite ran past 2400 s and two
+    #: known-unpinned guards came back "pinned" on the strength of a stopwatch.
+    full_timeout: float = FULL_TIMEOUT
 
     def subset(self, modules: list[str]) -> Outcome:
         return self.run(list(modules), SUBSET_TIMEOUT)
 
     def full(self) -> Outcome:
-        return self.run(["discover", "-s", "tests", "-t", "."], FULL_TIMEOUT)
+        return self.run(["discover", "-s", "tests", "-t", "."], self.full_timeout)
 
 
 def dirty_files(root: Path, paths: tuple[str, ...]) -> dict[str, bytes]:
@@ -912,6 +936,10 @@ def decide(box, mutation: Mutation, modules: list[str]) -> tuple[str, Outcome, O
     box.apply(mutation)
     if modules:
         subset = box.subset(modules)
+        if not subset.conclusive:
+            subset = box.subset(modules)
+            if not subset.conclusive:
+                return "unresolved", subset, None
         if not subset.green:
             # A red is the one verdict this tool never revisits, so it had better be a
             # real one. The suite starts real tmux servers, several sweeps share a
@@ -936,12 +964,19 @@ def decide(box, mutation: Mutation, modules: list[str]) -> tuple[str, Outcome, O
         if confirm.green:
             return "survived", subset, Outcome(
                 True, confirm.ran, f"red once ({full.detail[:80]}), green on confirmation")
+        if not (full.conclusive or confirm.conclusive):
+            # Twice unmeasurable. The honest answer is that this mutation has no verdict,
+            # and saying so is the whole point: "pinned" here would be a guard certified
+            # as tested by a machine that was too busy to run its tests.
+            return "unresolved", subset, confirm
+        full = full if full.conclusive else confirm
     return ("survived" if full.green else "pinned"), subset, full
 
 
 def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str, list[str]],
           workdir: Path, jobs: int, dirty: dict[str, bytes], second_order: int = 0,
-          log=print) -> tuple[list[Result], list["Pair"]]:
+          log=print, full_timeout: float = FULL_TIMEOUT
+          ) -> tuple[list[Result], list["Pair"]]:
     """Every mutation, run; every survivor, re-run against the whole suite."""
     plan: list[Mutation] = []
     sources: dict[str, bytes] = {}
@@ -957,6 +992,8 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
 
     log(f"  building {jobs} sandbox(es)…")
     boxes = [Sandbox(root, workdir / f"w{i}", ref, dirty) for i in range(jobs)]
+    for box in boxes:
+        box.full_timeout = full_timeout
     free: list[Sandbox] = list(boxes)
     import threading
     lock = threading.Lock()
@@ -991,8 +1028,9 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
         how = f"{len(modules)} module(s)" if modules else "no covering module"
         if full is not None:
             how += f", then all {full.ran or '?'}"
-        log(f"    [{n}/{len(plan)}] "
-            f"{'SURVIVED' if verdict == 'survived' else 'pinned  '}  {mutation}   ({how})")
+        label = {"survived": "SURVIVED", "pinned": "pinned  ",
+                 "unresolved": "UNRESOLVED"}[verdict]
+        log(f"    [{n}/{len(plan)}] {label}  {mutation}   ({how})")
         return Result(mutation, verdict, subset, full, modules)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
@@ -1082,6 +1120,8 @@ def _second_order(results: list[Result], boxes: list["Sandbox"],
 def report(results: list[Result], root: Path, ref: str, base: str, baseline: Outcome | None,
            elapsed: float, pairs: list["Pair"] | None = None) -> str:
     survivors = [r for r in results if r.verdict == "survived"]
+    unresolved = [r for r in results if r.verdict == "unresolved"]
+    pinned = [r for r in results if r.verdict == "pinned"]
     pairs = pairs or []
     out: list[str] = []
     w = out.append
@@ -1091,10 +1131,25 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
     if baseline is not None:
         w(f"baseline          : Ran {baseline.ran} tests — {'OK' if baseline.green else baseline.detail}")
     w(f"mutations applied : {len(results)}")
-    w(f"pinned            : {len(results) - len(survivors)}")
+    w(f"pinned            : {len(pinned)}")
     w(f"SURVIVED          : {len(survivors)}")
+    w(f"UNRESOLVED        : {len(unresolved)}")
     w(f"wall clock        : {elapsed / 60:.1f} min")
     w("")
+
+    if unresolved:
+        w("-" * 86)
+        w("UNRESOLVED — these mutations have no verdict")
+        w("-" * 86)
+        w("Twice the run could not be measured: it timed out rather than failing. That is")
+        w("not a red and it is emphatically not a pin — nothing here has been shown to be")
+        w("tested. Re-run these on a quieter machine, or raise the timeout, before reading")
+        w("this sweep as clean.")
+        for r in sorted(unresolved, key=lambda r: (r.mutation.path, r.mutation.line)):
+            m = r.mutation
+            w(f"  {m.path}:{m.line}  in `{m.symbol}`  [{m.operator}]  "
+              f"{(r.full or r.subset).detail if (r.full or r.subset) else ''}")
+        w("")
 
     if not survivors:
         w("Every mutation this diff offered goes red. Nothing added here is a line the")
@@ -1273,17 +1328,27 @@ def main(argv: list[str] | None = None) -> int:
     selection = load_map(ref_box.path, paths, cache_dir, args.jobs, args.refresh_map, log)
 
     baseline = None
+    full_timeout = FULL_TIMEOUT
     if not args.no_baseline:
         log("  baseline: full suite, unmutated…")
+        started_baseline = time.time()
         baseline = ref_box.full()
-        log(f"    Ran {baseline.ran} tests — {'OK' if baseline.green else baseline.detail}")
+        took = time.time() - started_baseline
+        log(f"    Ran {baseline.ran} tests — {'OK' if baseline.green else baseline.detail}"
+            f" in {took:.0f}s")
+        # Six times what this machine, right now, took to run the suite once — and never
+        # below the floor. The mutants that matter are the ones that make the suite SLOW,
+        # and the sweep may be sharing the box with itself.
+        full_timeout = max(FULL_TIMEOUT, took * 6)
+        if full_timeout > FULL_TIMEOUT:
+            log(f"    full-suite timeout raised to {full_timeout / 60:.0f} min for this box")
         if not baseline.green:
             log("  ! the tree is RED before any mutation. Every mutation below will look")
             log("  ! pinned for a reason that has nothing to do with the guard. Fix first.")
             return 2
 
     results, pairs = sweep(root, ref, scope, selection, workdir, args.jobs, dirty,
-                           args.second_order, log)
+                           args.second_order, log, full_timeout)
     elapsed = time.time() - started
     text = report(results, root, ref, base, baseline, elapsed, pairs)
     log("")
@@ -1294,7 +1359,12 @@ def main(argv: list[str] | None = None) -> int:
         for child in workdir.glob("w*"):
             shutil.rmtree(child, ignore_errors=True)
         shutil.rmtree(workdir / "ref", ignore_errors=True)
-    return 1 if any(r.verdict == "survived" for r in results) else 0
+    if any(r.verdict == "survived" for r in results):
+        return 1
+    # 3, not 0: a sweep that could not measure some of its mutations has not shown the
+    # branch to be clean, and a gate reading this must not treat "I could not look" as
+    # "nothing to see".
+    return 3 if any(r.verdict == "unresolved" for r in results) else 0
 
 
 if __name__ == "__main__":       # pragma: no cover - entry point

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -773,9 +773,23 @@ class Sandbox:
             (self.path / rel).write_bytes(blob)
         self._pristine.clear()
 
-    def run(self, argv: list[str], timeout: int) -> Outcome:
-        env = dict(os.environ)
-        env.pop("PYTHONDONTWRITEBYTECODE", None)
+    def run(self, argv: list[str], timeout: float) -> Outcome:
+        # NO `__pycache__`, and this line is load-bearing. CPython decides a cached `.pyc`
+        # is still valid by comparing the source's size and its mtime **truncated to whole
+        # seconds** — nothing else. A sandbox applies one mutation after another to the
+        # same file, and two mutations of one file routinely differ from the original by
+        # the SAME number of bytes: `contain.one_line(x)` -> `x` removes exactly 18
+        # characters wherever it appears, so `panel.py`'s mutation at line 210 and its
+        # mutation at line 458 are both 29159 bytes against a 29177-byte original. Apply
+        # them a fraction of a second apart — which a two-second subset run does — and the
+        # second one is byte-for-byte indistinguishable from the first as far as the
+        # validator is concerned. It reuses the first one's bytecode.
+        #
+        # Measured, with the mtimes pinned equal to make it certain: mutating line 458 ran
+        # line 210's mutant, the test for line 210 went red, and line 458 — a real
+        # survivor — was reported PINNED. A guard certified as tested by a stale cache.
+        # With this variable set, the same pair answers RED then OK, correctly.
+        env = dict(os.environ, PYTHONDONTWRITEBYTECODE="1")
         # Its own process group, so a timeout can take the whole tree of children with
         # it. `subprocess.run(timeout=…)` kills only the direct child, and this suite
         # starts real tmux servers — a wedged run that left one behind would be inherited

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -90,6 +90,27 @@ NARROW_TO = "ZeroDivisionError"
 
 _RAN = re.compile(r"^Ran (\d+) tests? in ", re.MULTILINE)
 
+#: Exception types whose *behaviour* is decided by the operating system, not by charter.
+#: A `narrow-except` survivor on one of these may not be an unpinned guard at all: the
+#: clause may simply be unreachable on the platform the sweep ran on. Measured on this
+#: project — `except OSError: return None` around a pty read is dead code on macOS, where
+#: closing the far end returns `b""`, and live on Linux, where it raises `[Errno 5]`. The
+#: pin was proved by pushing the mutant to a throwaway branch and letting CI redden it.
+PLATFORM_SENSITIVE = frozenset({
+    "OSError", "IOError", "EnvironmentError", "BlockingIOError", "BrokenPipeError",
+    "ConnectionResetError", "ConnectionAbortedError", "InterruptedError", "TimeoutError",
+    "PermissionError", "FileNotFoundError", "NotADirectoryError", "IsADirectoryError",
+})
+
+
+def platform_caveat(mutation: "Mutation") -> str:
+    """Why this survivor might be a platform artefact rather than a missing test."""
+    if mutation.operator != "narrow-except":
+        return ""
+    named = {w for w in re.findall(r"[A-Za-z_]+", mutation.before)}
+    hit = sorted(named & PLATFORM_SENSITIVE)
+    return hit[0] if hit else ""
+
 
 # --------------------------------------------------------------------------------------
 # 1. Scoping: which lines is this branch answerable for
@@ -704,6 +725,9 @@ class Outcome:
     ran: int
     detail: str
     conclusive: bool = True
+    #: The ids of the tests that failed. The verdict is read from the DIFFERENCE between
+    #: this and what the same command failed on unmutated — never from the exit code.
+    failing: frozenset = dataclasses.field(default_factory=frozenset)
 
 
 @dataclasses.dataclass
@@ -723,16 +747,43 @@ def _kill_group(proc: subprocess.Popen) -> None:
         proc.kill()
 
 
+#: `FAIL: test_x (tests.test_mod.Class.test_x)` / `ERROR: ...`, and for an import failure
+#: `ERROR: tests.test_mod (unittest.loader._FailedTest.tests.test_mod)`. The parenthesised
+#: id is the stable name; a subtest's trailing `[value]` sits outside it.
+_FAIL_ID = re.compile(r"^(?:FAIL|ERROR):\s+\S+\s+\(([^)]+)\)", re.MULTILINE)
+
+
 def _verdict(proc) -> Outcome:
+    """What a run said, as the SET OF TESTS THAT FAILED — never as an exit code.
+
+    An exit code cannot tell "died because I deleted the guard" from "died for a reason
+    that has nothing to do with it", and this project has now measured that confusion in
+    both directions. `release.yml`'s `-z "$claimed"` refusal (#558) exits 1 with the line
+    deleted *and* without it, for two different reasons, so a real deletion looked pinned.
+    And a sweep run in a tree copied without `.git` errored twelve `test_workflows` cases
+    in the baseline and in every mutant alike — every mutation came back rc=1 and every one
+    would have scored "pinned".
+
+    So the ids are collected here and the comparison is made in :func:`decide` against what
+    the SAME command failed on before any mutation. A mutation is only credited with a red
+    it actually caused.
+    """
     text = (proc.stdout or "") + (proc.stderr or "")
     m = _RAN.search(text)
     ran = int(m.group(1)) if m else 0
-    if proc.returncode == 0 and ran > 0:
-        return Outcome(True, ran, "OK")
+    failing = frozenset(mm.group(1) for mm in _FAIL_ID.finditer(text))
     if ran == 0:
-        return Outcome(False, 0, "no tests ran")
-    tail = [ln for ln in text.splitlines() if ln.startswith(("FAILED", "ERROR:", "FAIL:"))]
-    return Outcome(False, ran, "; ".join(tail[:3]) or f"rc={proc.returncode}")
+        # No `Ran N tests` line at all: the runner did not get far enough to answer.
+        return Outcome(False, 0, "no tests ran", conclusive=False, failing=failing)
+    if proc.returncode == 0:
+        return Outcome(True, ran, "OK", failing=failing)
+    return Outcome(False, ran, _named(failing) or f"rc={proc.returncode}", failing=failing)
+
+
+def _named(ids) -> str:
+    """A handful of failing test ids, shortest-name-first, for a one-line report."""
+    short = sorted(ids, key=len)
+    return "; ".join(short[:3]) + (f" (+{len(short) - 3} more)" if len(short) > 3 else "")
 
 
 class Sandbox:
@@ -758,6 +809,11 @@ class Sandbox:
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(blob)
         self._pristine: dict[str, bytes] = {}
+        #: What each module-set fails on with NOTHING mutated, measured once per sandbox.
+        #: The full-tree baseline in `main` cannot answer this: a subset is a handful of
+        #: modules run alone, and a module that only passes with its neighbours would
+        #: redden every mutation mapped to it — a whole file of guards silently certified.
+        self._clean_failures: dict[tuple[str, ...], frozenset] = {}
 
     def apply(self, mutation: Mutation) -> None:
         self.apply_source(mutation.path, mutation.source)
@@ -820,6 +876,13 @@ class Sandbox:
 
     def subset(self, modules: list[str]) -> Outcome:
         return self.run(list(modules), SUBSET_TIMEOUT)
+
+    def clean_failures(self, modules: list[str]) -> frozenset:
+        """What this module-set fails on unmutated. Call BEFORE applying a mutation."""
+        key = tuple(modules)
+        if key not in self._clean_failures:
+            self._clean_failures[key] = self.subset(modules).failing
+        return self._clean_failures[key]
 
     def full(self) -> Outcome:
         return self.run(["discover", "-s", "tests", "-t", "."], self.full_timeout)
@@ -947,6 +1010,8 @@ def decide(box, mutation: Mutation, modules: list[str]) -> tuple[str, Outcome, O
       suite for 1800s instead of failing, and reading that as green would have pinned a
       guard on a timeout.
     """
+    # Measured BEFORE the mutation goes anywhere near the tree.
+    clean = box.clean_failures(modules) if modules else frozenset()
     box.apply(mutation)
     if modules:
         subset = box.subset(modules)
@@ -954,20 +1019,33 @@ def decide(box, mutation: Mutation, modules: list[str]) -> tuple[str, Outcome, O
             subset = box.subset(modules)
             if not subset.conclusive:
                 return "unresolved", subset, None
-        if not subset.green:
+        caused = subset.failing - clean
+        if not caused:
+            # Either nothing failed, or the only failures are ones this module-set was
+            # already failing on. Neither is evidence about the guard.
+            subset = Outcome(True, subset.ran, "OK" if subset.green
+                             else f"red, but on nothing new ({_named(subset.failing)})",
+                             failing=subset.failing)
+        else:
             # A red is the one verdict this tool never revisits, so it had better be a
             # real one. The suite starts real tmux servers, several sweeps share a
             # machine, and a flaky red here does not merely mislabel one mutation — it
             # certifies a guard as tested by a failure that had nothing to do with it.
-            # One confirming run is seconds against a median subset of seven modules.
             again = box.subset(modules)
-            if again.green:
-                subset = Outcome(True, again.ran, "red once, green on confirmation")
+            if not (again.failing - clean):
+                subset = Outcome(True, again.ran, "red once, green on confirmation",
+                                 failing=again.failing)
             else:
-                return "pinned", subset, None
+                return "pinned", Outcome(False, subset.ran, _named(caused),
+                                         failing=caused), None
     else:
         subset = Outcome(True, 0, "no covering module measured")
     full = box.full()
+    if full.failing and not (full.failing - clean):
+        # The whole suite went red only on tests this mutation's own module-set was
+        # already failing. Not evidence either.
+        full = Outcome(True, full.ran, f"red on nothing new ({_named(full.failing)})",
+                       failing=full.failing)
     if not full.green:
         # And the same for the run that has the last word. This is where the asymmetry
         # bites hardest: a flaky full suite reads as "pinned", and "pinned" is the verdict
@@ -1142,6 +1220,8 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
     w("=" * 86)
     w(f"deletion sweep — {ref[:12]} against {base[:12]}")
     w("=" * 86)
+    w(f"measured on      : {sys.platform}, CPython "
+      f"{'.'.join(str(n) for n in sys.version_info[:3])}")
     if baseline is not None:
         w(f"baseline          : Ran {baseline.ran} tests — {'OK' if baseline.green else baseline.detail}")
     w(f"mutations applied : {len(results)}")
@@ -1170,8 +1250,13 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
         w("suite would not miss.")
         return "\n".join(out)
 
-    w("A survivor is a line you can delete with the whole suite still green.")
-    w("There is no suppression list: if deleting it genuinely changes nothing")
+    w("A survivor is a line you can delete with the whole suite still green")
+    w(f"ON {sys.platform.upper()}. That last part matters: a clause the operating system")
+    w("never reaches here is unreachable, not untested, and the two look identical from")
+    w("one machine. Anything marked PLATFORM below wants a second opinion from CI before")
+    w("it is read as a missing test.")
+    w("")
+    w("Otherwise there is no suppression list: if deleting it genuinely changes nothing")
     w("observable, delete it — 'equivalent mutant' and 'dead code' are one finding.")
     w("")
     by_file: dict[str, list[Result]] = {}
@@ -1200,6 +1285,13 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
             w(f"    mutant  : {_oneline(m.after, 74) or '(the statement, deleted)'}")
             if r.full:
                 w(f"    full    : Ran {r.full.ran} tests — OK, with the line gone")
+            caveat = platform_caveat(m)
+            if caveat:
+                w(f"    PLATFORM: `{caveat}` is the operating system's behaviour, not")
+                w(f"              charter's. On {sys.platform} this clause may never be")
+                w("              entered at all, which is unreachable rather than")
+                w("              unpinned. Push the mutant to a throwaway branch and let")
+                w("              CI answer before writing a test for it.")
             ev = r.evidence
             if ev is None:
                 continue
@@ -1254,6 +1346,8 @@ def as_json(results: list[Result]) -> str:
         "full": None if not r.full else {
             "green": r.full.green, "ran": r.full.ran, "detail": r.full.detail},
         "modules": r.modules,
+        "platform": sys.platform,
+        "platform_caveat": platform_caveat(r.mutation),
         "naming": [] if not r.evidence else [
             {"module": m, "test": t, "asserts": a} for m, t, a in r.evidence.naming],
     } for r in results], indent=1)

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -509,32 +509,55 @@ def compose(pristine: bytes, pair: tuple[Mutation, Mutation]) -> bytes | None:
 #: events are generated for the frame, which is the difference between a map that takes
 #: minutes and one that takes an hour.
 _TRACE_RUNNER = r'''
-import json, os, sys, threading, unittest
+import json, os, sys, threading, traceback, unittest
 
 module, out_path, prefix = sys.argv[1], sys.argv[2], sys.argv[3]
+# The runner lives in the cache directory, so Python puts THAT on `sys.path` and not the
+# tree under test. Without this the import of every `tests.*` module fails, the tracer
+# sees nothing, and the map comes back empty — which still produces correct answers, by
+# sending every mutation to the full suite, and takes a hundred times as long to do it.
+sys.path.insert(0, os.getcwd())
 seen = set()
+error = ""
 
 def tracer(frame, event, arg):
-    name = frame.f_code.co_filename
-    if name.startswith(prefix):
-        seen.add(name)
+    code = frame.f_code
+    # `<module>` frames are import-time execution, and importing anything from `charter`
+    # pulls in most of the package. Counted, they map every source file to every test
+    # module and the selection map answers "run everything" for everything — measured:
+    # `layout.py` mapped to all 322. What matters is which files a test module RUNS.
+    if code.co_name != "<module>" and code.co_filename.startswith(prefix):
+        # File AND function. File alone is far too coarse in this tree: `layout`,
+        # `slots` and `builtins` are reached by almost every test module through some
+        # shared fixture, so a file-keyed map answers "run all 322" for a mutation inside
+        # one private helper nothing but four modules ever call.
+        seen.add(code.co_filename)
+        seen.add(code.co_filename + "::" + code.co_name)
     return None
 
-sys.settrace(tracer)
-threading.settrace(tracer)
 try:
+    # Armed AFTER the import, for the same reason: a module body that calls its own
+    # helpers at import — `layout` derives the built-in geometry there — would otherwise
+    # register itself for every test module that imports it, however little it uses.
+    suite = unittest.defaultTestLoader.loadTestsFromName(module)
+except Exception:
+    error = traceback.format_exc(limit=3)
+    suite = None
+
+if suite is not None:
+    sys.settrace(tracer)
+    threading.settrace(tracer)
     try:
-        suite = unittest.defaultTestLoader.loadTestsFromName(module)
         with open(os.devnull, "w") as null:
             unittest.TextTestRunner(stream=null, verbosity=0).run(suite)
     except Exception:
-        pass
-finally:
-    sys.settrace(None)
-    threading.settrace(None)
+        error = traceback.format_exc(limit=3)
+    finally:
+        sys.settrace(None)
+        threading.settrace(None)
 
 with open(out_path, "w") as fh:
-    json.dump(sorted(seen), fh)
+    json.dump({"files": sorted(seen), "error": error}, fh)
 '''
 
 
@@ -566,25 +589,43 @@ def build_map(root: Path, paths: tuple[str, ...], jobs: int, scratch: Path,
     hits: dict[str, list[str]] = {}
     done = 0
 
-    def one(module: str) -> tuple[str, list[str]]:
+    def one(module: str) -> tuple[str, list[str], str]:
         out = scratch / f"{module}.json"
         subprocess.run([sys.executable, str(runner), module, str(out), prefix],
                        cwd=str(root), check=False, timeout=SUBSET_TIMEOUT,
                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         try:
-            files = json.loads(out.read_text())
+            payload = json.loads(out.read_text())
         except (OSError, ValueError):
-            files = []
-        return module, files
+            return module, [], "the trace runner wrote nothing"
+        return module, payload["files"], payload["error"]
 
+    broken: list[str] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
-        for module, files in pool.map(one, modules):
+        for module, files, error in pool.map(one, modules):
             done += 1
             if done % 40 == 0:
                 log(f"    traced {done}/{len(modules)} modules")
+            if error:
+                broken.append(f"{module}: {error.strip().splitlines()[-1]}")
             for f in files:
-                rel = Path(f).resolve().relative_to(root.resolve()).as_posix()
-                hits.setdefault(rel, []).append(module)
+                name, _, symbol = f.partition("::")
+                rel = Path(name).resolve().relative_to(root.resolve()).as_posix()
+                hits.setdefault(f"{rel}::{symbol}" if symbol else rel, []).append(module)
+
+    # An empty or near-empty map is a broken map, not a tree with no coverage, and it is
+    # the failure mode that hides: every mutation still gets the right verdict, because
+    # a file with no covering module goes to the full suite — it just takes a hundred
+    # times as long and looks like the tool working.
+    if len(hits) < 2 or len(broken) > len(modules) // 4:
+        log(f"  ! the trace produced {len(hits)} file(s) and {len(broken)} broken "
+            f"module(s). The map is not usable:")
+        for line in broken[:3]:
+            log(f"  !   {line}")
+        raise RuntimeError("the selection map is empty — refusing to sweep blind")
+    if broken:
+        log(f"  selection map: {len(broken)} module(s) would not load; "
+            f"their files fall back to the full suite")
     return {k: sorted(v) for k, v in sorted(hits.items())}
 
 
@@ -618,7 +659,24 @@ class Outcome:
     detail: str
 
 
-def _verdict(proc: subprocess.CompletedProcess) -> Outcome:
+@dataclasses.dataclass
+class _Finished:
+    """What :func:`_verdict` needs from a run, whoever ran it."""
+
+    returncode: int
+    stdout: str
+    stderr: str = ""
+
+
+def _kill_group(proc: subprocess.Popen) -> None:
+    """SIGKILL the whole process group a wedged run belongs to."""
+    try:
+        os.killpg(os.getpgid(proc.pid), 9)
+    except (ProcessLookupError, PermissionError):       # pragma: no cover - it is gone
+        proc.kill()
+
+
+def _verdict(proc) -> Outcome:
     text = (proc.stdout or "") + (proc.stderr or "")
     m = _RAN.search(text)
     ran = int(m.group(1)) if m else 0
@@ -655,9 +713,13 @@ class Sandbox:
         self._pristine: dict[str, bytes] = {}
 
     def apply(self, mutation: Mutation) -> None:
-        target = self.path / mutation.path
-        self._pristine[mutation.path] = target.read_bytes()
-        target.write_bytes(mutation.source)
+        self.apply_source(mutation.path, mutation.source)
+
+    def apply_source(self, rel: str, blob: bytes) -> None:
+        """Write one file, remembering what was there so :meth:`restore` can undo it."""
+        target = self.path / rel
+        self._pristine.setdefault(rel, target.read_bytes())
+        target.write_bytes(blob)
 
     def restore(self) -> None:
         for rel, blob in self._pristine.items():
@@ -667,15 +729,25 @@ class Sandbox:
     def run(self, argv: list[str], timeout: int) -> Outcome:
         env = dict(os.environ)
         env.pop("PYTHONDONTWRITEBYTECODE", None)
+        # Its own process group, so a timeout can take the whole tree of children with
+        # it. `subprocess.run(timeout=…)` kills only the direct child, and this suite
+        # starts real tmux servers — a wedged run that left one behind would be inherited
+        # by the next mutation and reported as ITS failure.
+        proc = subprocess.Popen([sys.executable, "-m", "unittest", *argv],
+                                cwd=str(self.path), text=True, env=env,
+                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                start_new_session=True)
         try:
-            proc = subprocess.run([sys.executable, "-m", "unittest", *argv],
-                                  cwd=str(self.path), check=False, text=True, env=env,
-                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                                  timeout=timeout)
+            out, _ = proc.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
-            # A mutation that HANGS the suite has not survived it. Round three had one.
+            # A mutation that HANGS the suite has not survived it. Round three had one:
+            # deleting `Surface.run`'s `if chunk is None: return None` wedged the suite
+            # for 1800s rather than failing, and reading that as green would have pinned
+            # the guard on a timeout.
+            _kill_group(proc)
+            proc.communicate()
             return Outcome(False, 0, f"timed out after {timeout}s")
-        return _verdict(proc)
+        return _verdict(_Finished(proc.returncode, out))
 
     def subset(self, modules: list[str]) -> Outcome:
         return self.run(list(modules), SUBSET_TIMEOUT)
@@ -770,6 +842,27 @@ class Result:
     evidence: Evidence | None = None
 
 
+def select_for(selection: dict[str, list[str]], mutation: Mutation) -> list[str]:
+    """Which test modules to run for one mutation, narrowest first.
+
+    Three levels, and each fallback is deliberately toward running MORE:
+
+    1. the modules measured executing the mutated function — the usual case, and the
+       one that turns a four-minute suite into a two-second one;
+    2. the modules measured executing the mutated *file*, when the function was never
+       seen under its own name (a `<lambda>`, a 3.11 comprehension frame, a constant at
+       module scope);
+    3. nothing at all, which :func:`decide` reads as "go straight to the full suite".
+
+    Never the other way. A narrower answer than the truth is how a guard gets certified
+    as tested by a subset that never ran it.
+    """
+    at_symbol = selection.get(f"{mutation.path}::{mutation.symbol}")
+    if at_symbol:
+        return at_symbol
+    return selection.get(mutation.path, [])
+
+
 def decide(box, mutation: Mutation, modules: list[str]) -> tuple[str, Outcome, Outcome | None]:
     """One mutation's verdict. The FULL suite has the last word, always.
 
@@ -832,7 +925,7 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
             free.append(box)
 
     def run_one(mutation: Mutation) -> Result:
-        modules = selection.get(mutation.path, [])
+        modules = select_for(selection, mutation)
         box = take()
         try:
             verdict, subset, full = decide(box, mutation, modules)
@@ -911,9 +1004,7 @@ def _second_order(results: list[Result], boxes: list["Sandbox"],
                     break
             time.sleep(0.05)
         try:
-            target = box.path / pair[0].path
-            box._pristine[pair[0].path] = target.read_bytes()
-            target.write_bytes(combined)
+            box.apply_source(pair[0].path, combined)
             outcome = box.full()
         finally:
             box.restore()
@@ -1088,12 +1179,12 @@ def main(argv: list[str] | None = None) -> int:
         Path(tempfile.gettempdir())
         / f"charter-sweep-{hashlib.sha256(str(root).encode()).hexdigest()[:12]}")
     workdir.mkdir(parents=True, exist_ok=True)
-    log(f"  workdir: {workdir}")
     cache_dir = workdir / "cache"
 
     def log(*a):
         print(*a, flush=True)
 
+    log(f"  workdir: {workdir}")
     started = time.time()
     log(f"sweeping {ref[:12]} (paths: {', '.join(paths)})")
     dirty = dirty_files(root, paths) if args.ref == "HEAD" else {}

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -926,6 +926,16 @@ def decide(box, mutation: Mutation, modules: list[str]) -> tuple[str, Outcome, O
     else:
         subset = Outcome(True, 0, "no covering module measured")
     full = box.full()
+    if not full.green:
+        # And the same for the run that has the last word. This is where the asymmetry
+        # bites hardest: a flaky full suite reads as "pinned", and "pinned" is the verdict
+        # that certifies a guard as tested and is never revisited. Six thousand tests, real
+        # tmux servers, and a machine that may be running other sweeps — one confirming run
+        # is expensive and still cheaper than one guard wrongly declared safe.
+        confirm = box.full()
+        if confirm.green:
+            return "survived", subset, Outcome(
+                True, confirm.ran, f"red once ({full.detail[:80]}), green on confirmation")
     return ("survived" if full.green else "pinned"), subset, full
 
 
@@ -1168,8 +1178,12 @@ def as_json(results: list[Result]) -> str:
         "question": r.mutation.question,
         "before": r.mutation.before, "after": r.mutation.after,
         "verdict": r.verdict,
-        "subset": None if not r.subset else {"green": r.subset.green, "ran": r.subset.ran},
-        "full": None if not r.full else {"green": r.full.green, "ran": r.full.ran},
+        # `detail` and not only the verdict: a run that went red says WHICH test went red,
+        # and that is the first thing anyone asks of a mutation reported as pinned.
+        "subset": None if not r.subset else {
+            "green": r.subset.green, "ran": r.subset.ran, "detail": r.subset.detail},
+        "full": None if not r.full else {
+            "green": r.full.green, "ran": r.full.ran, "detail": r.full.detail},
         "modules": r.modules,
         "naming": [] if not r.evidence else [
             {"module": m, "test": t, "asserts": a} for m, t, a in r.evidence.naming],

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -943,9 +943,13 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
     with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
         results = list(pool.map(run_one, plan))
 
+    # A sandbox and not the checkout: the tests that are supposed to hold a guard are the
+    # ones that existed AT THE REF. Reading the working tree's `tests/` instead would
+    # answer with a test written after the fact — which, sweeping a historical head, is
+    # precisely the test that was missing.
     for r in results:
         if r.verdict == "survived":
-            r.evidence = evidence_for(root, r.mutation, r.modules)
+            r.evidence = evidence_for(boxes[0].path, r.mutation, r.modules)
 
     pairs: list[Pair] = []
     if second_order:

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -411,6 +411,35 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
                    "is this branch pinned?")
 
 
+def span_is_sound(sp: _Spans, node: ast.AST) -> bool:
+    """Does the source at *node*'s span actually parse back into *node*?
+
+    Before 3.12 and PEP 701, `ast` gave only approximate positions for expressions
+    **inside an f-string** — and `contain.one_line(…)` lives inside an f-string almost
+    everywhere it appears in this tree, which is exactly what the `uncontain` operator
+    exists to mutate. Splicing on a position that is off by a few bytes produces a mutant
+    that is not the mutation the report claims, and it can still parse, so the parse check
+    alone would not catch it.
+
+    Re-parsing the span and comparing the tree (`ast.dump` omits positions) is the cheap
+    way to be certain the tool is editing what it says it is. A node whose span does not
+    round-trip is dropped rather than guessed at: a mutation reported at a line it did not
+    change is worse than one not offered.
+    """
+    text = sp.text(node)
+    try:
+        if isinstance(node, ast.stmt):
+            reparsed = ast.parse(text).body
+            return len(reparsed) == 1 and ast.dump(reparsed[0]) == ast.dump(node)
+        # Parenthesised, because an expression's span stops inside the brackets that
+        # made it legal to break over two lines: `a if c\n else b` is a SyntaxError on
+        # its own and a perfectly good mutation in place. Parentheses leave no trace in
+        # the tree, so the comparison is still exact.
+        return ast.dump(ast.parse(f"({text}\n)", mode="eval").body) == ast.dump(node)
+    except (SyntaxError, ValueError, MemoryError, RecursionError):
+        return False
+
+
 def _is_isinstance(node: ast.AST) -> bool:
     return (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
             and node.func.id == "isinstance")
@@ -441,6 +470,8 @@ def mutations_for(path: str, source: bytes, lines: set[int]) -> list[Mutation]:
     seen: set[tuple[int, int, str, str]] = set()
     for node, replacement, operator, question in _iter_operators(tree, sp):
         if not (set(range(node.lineno, (node.end_lineno or node.lineno) + 1)) & lines):
+            continue
+        if not span_is_sound(sp, node):
             continue
         before = sp.text(node)
         if before.strip() == replacement.strip():


### PR DESCRIPTION
Stage A of the deletion-sweep harness, per the spec on `spec/deletion-sweep-harness`
(#563): `tools/sweep.py`, stdlib only, runs standalone and prints a report. **Not wired to
CI** — that is stage C, and the spec says why it comes after a baseline nobody has seen.


## What it does

1. Diffs a ref against its merge-base with `origin/main` (`--unified=0`, so a branch is
   charged for the lines it added, not for three lines of context it stood next to).
2. Applies one mutation at a time, by statement shape.
3. Runs the mapped test subset. **Anything that survives its subset is re-run against the
   FULL suite before it is reported.**
4. Reports each survivor with file, line, both spellings of the mutation, and what the
   covering tests actually assert about the mutated symbol.

## Test selection: the thing that makes it affordable

`sys.settrace`, one test module per subprocess, cached against a hash of the tree. Two
corrections to the spec's design were forced by measurement:

- **The map must be keyed by function, not by file.** File-keyed, `charter/frame/layout.py`
  maps to **291 of 322** test modules and `slots.py` to 294 — a shared fixture reaches them
  from nearly everywhere — so "run only the modules that touch this file" answers "run
  everything" for a private helper four modules call.
- **Import-time frames must be ignored.** Importing anything from `charter` pulls in most of
  the package, and `layout` runs its own helpers at import. Counting `<module>` frames maps
  every file to every module.

With both, the median subset is **7 modules and about two seconds** against 322 and five
minutes. Selection widens on doubt and never narrows: function → file → the whole suite.

### The asymmetry, and why the gate is affordable

A **red subset is believed without a full run**; only **survivors** are re-run in full. A
subset is a subset of the suite, so a test that the mutation genuinely broke will break in
both — spending four minutes to re-learn that costs the whole optimisation and buys nothing.
The reverse is not true and never is: a subset that goes green has only shown that *those*
modules did not notice, which is why every survivor pays for a full run.

That asymmetry is only sound because of the two guards above it. A red subset proves nothing
at all when the subset was **already red** (mechanism 2) or when the mutated source was
**never executed** (mechanism 3) — under either, "a red is a red" is exactly the reasoning
that certifies a guard as tested. What makes a red trustworthy is that it is
`failing(mutant) - failing(the same modules, unmutated)`, measured, not inferred.

Beyond that: a file no traced module was measured executing is **not** pinned by that
silence — it goes to the full suite. A run that **times out** is neither green nor red but
`UNRESOLVED`, reported in its own section with its own exit code (3), because no test failed
there and machine load must not become evidence. And a survivor is a survivor **on the
platform that measured it** — `except OSError` around a pty read is dead code on macOS and
live on Linux, so survivors from a narrowed OS-level catch are labelled `PLATFORM` and told
to get a second opinion from CI.

## No suppression list

There is no marker, no ignore file, no "equivalent" key, and `tests/test_sweep.py` asserts
that no such name exists anywhere in the tool. #370's reasoning applies: one charter could
read is one a committed file could flip. If deleting a line genuinely changes nothing
observable, the line should be deleted — `panel.py:202` in this very sweep is that case,
proven equivalent and correctly reported.

## Three ways a sweep can lie, all measured on this project

Every one of them produces a **false pin** — the harness reporting "a test goes red without
this line" when no such test exists. That is the worst failure this tool can have, and it
is invisible: everything looks green, and a guard gets certified as tested. None of the
three is visible from outside the harness, which is the argument for why a 1400-line tool
needs 90 tests rather than being trusted because it is short.

| # | mechanism | how it lies | measured on |
|---|---|---|---|
| 1 | **Exit-code scoring** | a real deletion leaves `rc` unchanged because a second check catches the same case, for a different reason | `release.yml`'s `-z "$claimed"` refusal (#558) |
| 2 | **A broken baseline** | a tree copied without `.git` errors 12 `test_workflows` cases in the baseline *and* in every mutant, so all mutations score "pinned" | Task 4's first sweep, 37 of 37 |
| 3 | **Stale bytecode** | the mutated source is never executed at all | this branch, `charter/frame/panel.py:458` |

`tools/sweep.py` now defends against all three, and `tests/test_sweep.py` holds each defence
with a case that goes red without it.

### 1. Exit-code scoring → the verdict is the set of newly-failing test ids

`_verdict` collects the ids of the tests that failed, and `decide` credits a mutation only
with reds **it** caused: `failing(mutant) - failing(the same command, unmutated)`. A red on
nothing new is not evidence and does not pin anything.

### 2. A broken baseline → a real clone, a green tree, and a clean baseline per subset

Sandboxes are `git clone --no-hardlinks`, never `cp -R` or `git archive`, because
`test_workflows` and `test_plugin_freshness` read the repository. The whole-tree baseline
is run unmutated first and the sweep **refuses to start** if it is not green.

That is not sufficient on its own, and this is the part the whole-tree check cannot see: a
*subset* is a handful of modules run alone, and a module that only passes with its
neighbours would redden every mutation mapped to it — a whole file of guards silently
certified. So each sandbox now measures each module-set once, unmutated, before anything is
applied. **Audited across all 41 distinct module-sets the four reference sweeps selected:
40 clean, 1 dirty** — a 27-module set on `5b02b3f` already failing
`test_frame_tmux_integration…test_a_state_bump_through_the_real_hook_repaints_the_table…`.
Every mutation mapped to that set would have scored "pinned" under exit-code scoring. The
hazard is not hypothetical; it was live in this tree.

### 3. Stale bytecode → the sandbox writes none, and a test proves it

This is the one worth reading twice, because nothing about it is visible from the report.

`charter/frame/panel.py:458` stayed "pinned" through the first two fixes, and *deterministically*,
with a named failure: `test_the_failure_line_contains_the_id_before_it_measures_it`. That
test exercises line **210**, not 458. Run by hand on a clean clone, the same mutation is green.

**Mechanism.** CPython decides a cached `.pyc` is still valid by comparing the source's
**size** and its **mtime truncated to whole seconds**, and nothing else. A sandbox applies
one mutation after another to the same file, and two mutations of one file routinely differ
from the original by the same number of bytes — `contain.one_line(x)` → `x` removes exactly
18 characters wherever it appears:

```
charter/frame/panel.py @ 5b02b3f   pristine              29177 bytes
  mutation at line 210 -> 'cid'                          29159 bytes
  mutation at line 458 -> 'repr(slot)'                   29159 bytes   <- identical
```

A subset run takes two seconds, so the two land inside the same filesystem second. The
validator cannot tell them apart, and **mutation 458 executed mutation 210's bytecode**.

**How it was detected.** By disbelieving the result. The acceptance key said 458 was
unpinned; the harness said pinned; the named failing test belonged to a different line. A
hand-run on a clean clone disagreed with the harness, and a clean clone is exactly a tree
with no `__pycache__`.

**Proof of the mechanism**, mtimes pinned equal to remove the timing luck:

```
bytecode ON : 210-mutant -> RED (test_the_failure_line_contains_the_id…)
              458-mutant -> RED (test_the_failure_line_contains_the_id…)   <- wrong
bytecode OFF: 210-mutant -> RED (test_the_failure_line_contains_the_id…)
              458-mutant -> OK                                             <- correct
```

**The fix is not "clear `__pycache__` between mutations".** Clearing is something you can
believe you did — a missed directory, a race with a still-running interpreter, a `sys.path`
entry outside the tree, and it is silently back. The sandbox sets
`PYTHONDONTWRITEBYTECODE=1`, so no cache is ever created and there is nothing to go stale.

**What proves it, rather than assuming it**, is `AStaleBytecodeCacheCannotDecideAnything`:
the child process asserts `os.environ["PYTHONDONTWRITEBYTECODE"] == "1"` **and**
`sys.dont_write_bytecode` from inside the run, and the case then asserts
`list(sandbox.rglob("__pycache__")) == []` after it. A sibling case pins the precondition —
that two `uncontain` mutations of one file really are byte-identical in length — so if that
ever stops being true the guard is still right, and if it becomes common the guard is the
only thing between the sweep and a wrong answer.

## The acceptance test

Rediscovering findings already known to be true, from the diff alone, with no list supplied.

### It reproduces the tree the review rounds measured

| ref | baseline the harness measured in its own clone | what the round reported |
|---|---|---|
| `5b02b3f` | `Ran 6002 tests — OK` | 6002 OK |
| `c735efc` | `Ran 6044 tests — OK` | 6044 OK |

### Hit rate, per ref

| ref | answer key | reachable | **found** |
|---|---|---|---|
| `76fd3ef` (#553 round 2) | 12 | 9 | **8** |
| `0bd85e52` (#554 round 2) | 18 | 10 | **10** |
| `5b02b3f` (#553 round 3) | 6 | 6 | **6** |
| `c735efc` (#554 round 3) | 8 (3 named in the brief) | 7 | **6** (**3 of the 3 named**) |

**30 of 44 key rows.** On the brief's own framing (12 / 18 / 6 / 3) that is **27 of 39**.

"Reachable" is decided statically, before anything runs: does the operator table even
*offer* a mutation on that line? It is reported separately so a miss for want of an
operator is never confused with a miss for a test that unexpectedly exists.

### Every miss, and which kind it is

Not one is a selection bug and not one is a masked mutant. **All fourteen are operator-shape
gaps** — either no mutation is offered at all, or the mutation offered asks a different
(stronger) question than the reviewer's and is correctly caught.

| ref | miss | kind |
|---|---|---|
| `76fd3ef` | `layout.py:551` `_edge_of(slot) not in _COLUMN_EDGES` | offered `filter → True`, **pinned**. The reviewer swapped the predicate for a near-synonym (`_key(slot) not in _COLUMN_SLOTS`). No operator for a semantic predicate swap |
| `76fd3ef` | `layout.py:517` `cells = _size_of(slot)` | no operator — semantic call swap |
| `76fd3ef` | `panel.py:199` `width=slots._width()` | no operator — call replaced by a constant |
| `76fd3ef` | `instance.py:649` `out["components"] = []` | no operator — bare subscript assignment |
| `0bd85e52` | `close_argvs` ORDER; `conf_text` hatch-bind-last | no operator — statement / element **reordering** |
| `0bd85e52` | `LEAVE`, `MOUSE_ON`, `_MARK` | no operator — string / tuple **constant** |
| `0bd85e52` | `decode`'s drop-the-introducer | no operator — multi-statement branch body |
| `0bd85e52` | `open_argv`'s `*layout._env_argv(env)` | no operator — starred element in a list literal |
| `0bd85e52` | `decode`'s `button & 64` | offered `disable-branch`, **pinned**. Reviewer's was `button in (64, 65)` — no operator for weakening a numeric predicate |
| `c735efc` | `_SGR`'s `(\d{1,5})` | no operator — **regex literal** |
| `c735efc` | `open_argv` `fullmatch` → `match` | offered `drop-if`, **pinned**. No operator for swapping one method for a laxer one |

The three families worth having next, in order of what they would have bought: **string and
regex constants** (5 rows), **semantic swaps** — one call, method or predicate for a laxer
near-synonym (4 rows), and **reordering** (2 rows). The first two have no principled general
form — picking `1003` over `1000` for `MOUSE_ON`, or `match` over `fullmatch`, is fitting the
answer key rather than recognising a shape — which is a fair argument for why the spec's
table left them out, and the reason they are reported here instead of quietly added.

### It found two guards the review rounds did not

- **`layout.py:259`** — `_key`'s alias resolution, collapsed to `name`: full suite green.
  Round two reported that line's *type filter* and round three pinned it; the harness
  confirms that fix (the `isinstance`-dropping mutation there is RED) and then finds a
  **different** unpinned property on the same line. Its evidence block says why:

  ```
    covered : 2 test(s) name `_key`; what they assert:
              test_component_id_is_the_currency.test_layouts_key_answers_the_value_it_was_given
                  self.assertIs(layout._key(value), value)
  ```

  The only test that names `_key` asserts that a value comes back unchanged. Nothing asserts
  that `identity` resolves to `top` — the thing `_key` exists to do, on a branch titled
  *"A component id is the frame's currency"*.

- **`panel.py:202`** — `except KeyboardInterrupt: raise`, narrowed. **This is an equivalent
  mutant, and reporting it is the spec working rather than a false positive.**
  `KeyboardInterrupt` derives from `BaseException`, so the `except Exception as e` below it
  can never catch one either way; shipped and mutant were run side by side on
  `KeyboardInterrupt`, `SystemExit`, `OSError` and a normal return and are **identical on
  all four**. Round three reached the same conclusion by hand and filed it as adjacent, not
  blocking. Under §4 the finding stands and the fix is deletion, not a test.

### Negative fixtures — the harness must not cry wolf

| fixture | requirement | result |
|---|---|---|
| `98f4ffc` vs `4731378` (#553 merged) | zero survivors among #553's six | **6 / 6 correctly not flagged** |
| `6227ce3` vs `98f4ffc` (#554 merged) | zero survivors among #554's three named | `453` clean, `455` clean, `459` **flagged** |

On the **exact mutations the reviewers used**, all nine are clean: at `459` the reviewer's
mutation — the whole clamp replaced by `top` — is now **pinned**, as are three of the other
four on that line. Two weaker mutations survive, and neither is a false positive:

```
self._top = max(0, min(top, max(0, len(self.rows) - n)))

-> min(top, max(0, len(self.rows) - n))   equivalent on ALL 31200 reachable states
                                          (top >= 0 always, so the outer max(0, .) is dead code)
-> len(self.rows) - n                     differs on 16150 of 31200; rows=10 n=4 top=2
                                          gives 2 shipped and 6 mutated — a real, untested gap
```

So: one dead line to delete, one genuine property still unpinned on a line whose *other*
property was just pinned. **9 / 9 on the reviewers' mutations, 8 / 9 read per-line**, and the
per-line flag is worth having rather than suppressing.

### Second order — what was built, and what is out of scope

`--second-order N` applies survivors that **share an enclosing function** together. On
`5b02b3f`, `_placed_here`'s survivors are **still green together** — neither line, nor both
at once, changes anything the suite can see. The report also flags, at no extra cost,
whenever two or more survivors sit in one function.

**Targeted cross-function second-order mutation is out of scope for stage A, and saying so
plainly matters more than the number.** The mutually-masking case is `_placed_here`'s
`name not in SLOT_SIZE`, whose consequence is hidden by a *lookup ordering* inside
`_edge_of`/`_size_of`, two functions away. No pairing of survivors can find it, because the
masking partner is not a survivor at all — it is a statement-order property this table has no
operator for. Reaching it needs either a reordering operator or a behavioural oracle, and
both are stage-B-or-later work. The single-order number above is therefore **not** a
complete answer to "is this property tested", and the harness does three things instead of
pretending otherwise: it refuses any suppression list, it names every other survivor sharing
the function, and it prints what the covering tests actually assert.
## Where the spec needed correcting

Two of its design decisions did not survive contact, and both are measured rather than
argued.

**§1's map is too coarse as written.** "Which source *files* each test module executes"
answers "run everything" on this tree: file-keyed, `layout.py` maps to 291 of 322 modules,
`slots.py` to 294, `builtins.py` to 289. The map has to be keyed by **function**, and has
to ignore import-time (`<module>`) frames. With both, the median subset is 7 modules.

**§2's shape table cannot reach about a quarter of the answer key.** Before running
anything, the six rows as written offer a mutation on 9 of #553's 12 round-two findings,
10 of #554's 18, 6 of 6 and 7 of 8 on the round-three heads. Four rows were added, each a
syntactic variant of a row the spec already has: a comprehension filter (`sum(… if C)`,
which is R2-1 on #553 and invisible to the statement spelling of `if`), an `elif` branch
disabled rather than excised (R2-14), an integer constant moved by one, and a sum of named
parts dropped to each part (R2-8, R2-18).

What is still out of reach, and why it is reported rather than papered over:

| family | key rows | why there is no honest operator |
|---|---|---|
| string / regex constants | `LEAVE`, `MOUSE_ON`, `_MARK`, `_SGR`'s `\d{1,5}` | there is no general perturbation of a string; choosing `1003` over `1000` is fitting the answer key, not recognising a shape |
| statement / element ORDER | `close_argvs`' select-before-kill, `conf_text`'s hatch-bind-last | needs a permutation engine, not a shape table |
| semantic call swaps | `_size_of` → `SLOT_SIZE.get(_key(…))`, `slots._width()` → `80`, `tui.width` → `len` | requires knowing two functions are near-synonyms — domain knowledge, not syntax |
| multi-statement branch bodies | `decode`'s `buf = buf[2:]; continue` | dropping two statements at once cannot say which one was the guard |
| bare subscript assignment | `out["components"] = []` | a row is easy and safe, but it fires on every `d[k] = v` in a diff; left out rather than shipped as noise |

**`retune-constant` earns its place in the tool and probably not in the gate.** Round three
pinned the constants with tests that reference them *symbolically* —
`assertEqual(argv[i + 1], str(overlay._SPLIT_ROWS))` is true at any value, and
`assertLess(overlay._SPLIT_ROWS + 1, layout.HARNESS_MIN_ROWS)` fixes only a bound — so
`5 → 6` can survive where the reviewer's `5 → 500` goes red. Asking "is this exact value
pinned" is usually stronger than the code needs, which is a good argument for why the
spec's table left constants out in the first place. Recommend excluding it from stage C.

**"Skip any mutation whose result does not parse" is necessary but not sufficient.** A
splice can land on the wrong bytes and still parse — `ast` gave only approximate positions
for expressions inside f-strings before 3.12, and `contain.one_line(…)` lives inside an
f-string almost everywhere `uncontain` wants to mutate it. Every mutation now re-parses its
own span and compares the tree before it is offered. That check found a real bug in the
first version of itself: an expression's span stops *inside* the brackets that made a line
break legal, so `a if c\n else b` does not parse standalone, and two real `decode`
mutations were being dropped in silence until the re-parse was parenthesised.

## Not a spec issue, but the brief's table was wrong

`git merge-base 76fd3ef origin/main` and `git merge-base 0bd85e52 origin/main` are both
**`a912553`**, not `97163fb`; only the two round-three heads are based on `97163fb`. The
harness computes the merge-base itself, so the sweeps are right either way.

## The harness, swept by itself

```
$ python3 tools/sweep.py --path tools
deletion sweep — 77dd97189aef against 98f4ffc1a2be
measured on       : darwin, CPython 3.14.4
baseline          : Ran 6130 tests — OK
mutations applied : 196
pinned            : 64
SURVIVED          : 132
UNRESOLVED        : 0
wall clock        : 238.1 min
```

**132 of 196. That is the honest number and it is not a good one**, so here is where it
falls, because the average hides the only thing worth knowing — whether the parts that
decide a *verdict* are held, or only the parts that print one:

| section of `tools/sweep.py` | pinned | SURVIVED |
|---|---|---|
| 2. Mutation — the operator table | **31** | 29 |
| 6. The sweep — orchestration and verdicts | **17** | 20 |
| 4. Running — sandboxes, subsets, timeouts | 5 | 10 |
| 5. Evidence — what the covering tests assert | 4 | 5 |
| 1. Scoping — the diff | 3 | 8 |
| 3. Selection — the trace map | **0** | 9 |
| 7. The report | 1 | 27 |
| 8. CLI | **0** | 22 |

The shape is stark and it is fair. `tests/test_sweep.py` was written against the operator
table and the verdict rules — the things that decide whether a guard is called tested — and
those are the two rows carrying real weight. **49 of the 132 survivors are in the report
renderer and the CLI**, code whose worst failure is an ugly message rather than a wrong
answer, and **not one of the trace map's nine** is pinned, which is the row I would fix
first: a selection bug that silently narrows a subset is a false pin generator, and nothing
currently goes red if `build_map` stops recording function names.

What this does **not** mean is that the tool is untested where it counts. Every defence
described above has a case that dies without it — the three false-pin mechanisms, the
`conclusive` distinction, the span re-parse, the no-suppression-list assertion. What it
means is that `drop-if` on a `log(...)` line in the report, or `disable-branch` on
`args.all`, has nothing behind it, and the sweep is right to say so.

Two things about the number itself are worth reading, and both argue for the tool rather
than against it:

- **`drop-isinstance` is 6 pinned, 0 survived** — the operator drawn most directly from the
  answer key is the one this file's own tests hold completely.
- **`UNRESOLVED: 0`** across 196 mutations and four hours on a shared box. The timeout
  distinction added earlier did its job: nothing was decided by a stopwatch.

The 132 are a to-do list, not a disclaimer, and it is a list nobody had before. It is also
the first evidence that the tool works on a codebase it was not tuned against — `tools/`
was never part of the answer key.

## Environments and CI

Two local environments, each a clean `git clone` checked out at a fixed sha — not the live
worktree, because the first attempt ran in a tree that was still being edited and measured
nothing:

| environment | result |
|---|---|
| CPython 3.14.4 (local) | `Ran 6130 tests in 224s — OK` |
| CPython 3.12.13 (local) | `Ran 6130 tests in 228s — OK` |

And the same head on every Python the project supports, read from the check-runs API rather
than `gh pr checks`, which reports "no checks reported" and CLEAN identically (#561):

| environment | result |
|---|---|
| CPython 3.11 (CI) | `Ran 6221 tests in 155s — OK` |
| CPython 3.12 (CI) | `Ran 6221 tests in 149s — OK` |
| CPython 3.13 (CI) | `Ran 6221 tests in 152s — OK` |
| CPython 3.14 (CI) | `Ran 6221 tests in 165s — OK` |

```
$ gh api repos/diazoxide/charter/commits/<HEAD_SHA>/check-runs
total_count: 10   # two workflow runs, push and pull_request; 3.11-3.14 success in both
```

CI runs more tests than a local box because it has `tmux` available, so the escape-hatch
integration cases run rather than skip.

**One local run has to be reported and thrown away, because it is the same lesson as the
rest of this PR.** A first 3.12 run came back `FAILED (failures=4, errors=67)` — and **71 of
71 failures were in `tests/test_frame_tmux_integration.py`**, because it was running
alongside twelve concurrent sweep suites, each starting its own real tmux servers. Re-run on
a quiet box, identical clone, identical sha: `Ran 6121 — OK`. An exit code said "this branch
is broken"; the set of failing test ids said "your machine was busy". That is mechanism 1
from the table above, caught by hand this time, on the harness's own operator.

CI also earned its keep twice, both times on something a local run could not see:

- `test_plugin_freshness.test_every_top_level_directory_is_classified_one_way_or_the_other`
  went red the moment `tools/` appeared. That check exists to force exactly one decision —
  does a plugin LOAD this directory — and it forced it. `tools/` is developer tooling; it is
  in `_NOT_PLUGIN_SURFACE`, and `pyproject.toml` names `charter` as the only package, so no
  wheel ships it.
- One of this PR's **own** new cases, `test_a_wedged_runs_grandchildren_die_with_it`, was
  flaky: it failed on 3.11 in one workflow run and passed in the other at the same commit.
  SIGKILL is delivered synchronously but the orphan is reaped a moment later, and until it is
  reaped its pid still answers `kill(pid, 0)`. It now polls rather than asserting once.

## What stage B is going to cost

`--all` over `charter/` offers **5546 mutations across 86 files**:

```
drop-if 1638   collapse-ifexp 1232   narrow-except 599   no-fallback 564
drop-conjunct 523   disable-branch 414   drop-comprehension-if 219
uncontain 136   drop-isinstance 84   retune-constant 71   unclamp 58   drop-term 8
```

At a median subset of seven modules that is a couple of hours of subsets, and then one full
suite per survivor — which is the number nobody knows yet and the whole point of stage B.
Two things to decide before running it:

- **`retune-constant` (71) and `disable-branch` (414) are the noisy rows.** Both earn their
  place on the diff-scoped gate's answer key, and both ask a question broader than the code
  necessarily promises. If the baseline comes back unreadable, drop those two first and
  report the number twice.
- Run it on an idle machine. This PR is a demonstration of what happens otherwise.
