### PR TITLE
A panel gets its own key, and density becomes a name for one arrangement (Phase 2, Task 5)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -721,7 +721,8 @@ def _add_frame_parsers(sub) -> None:
     # version (see `commands_frame.cmd_probe`'s own docstring).
     _core_commands = set(sub.choices) | {"frame", "panel", "frame-palette",
                                          "frame-probe", "frame-respawn", "frame-density",
-                                         "frame-resize", "frame-gather", "frame-switch"}
+                                         "frame-resize", "frame-gather", "frame-switch",
+                                         "frame-toggle"}
 
     # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
     # already claimed each word, so a SECOND harness wanting it is told who got there
@@ -877,6 +878,22 @@ def _add_frame_parsers(sub) -> None:
     dn = sub.add_parser("frame-density")
     dn.add_argument("level")
     dn.set_defaults(func=commands_frame.cmd_density)
+
+    # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
+    # ones above. Fired by ONE COMPONENT's own `bind -n` — the `key` its
+    # `[[frame.component]]` table declares, written into the frame's config by
+    # `commands_frame.conf_text` — and typeable by hand from inside a frame. It shows or
+    # hides that one component on the RUNNING frame; charter.toml is not touched, for
+    # `frame-density`'s reason.
+    #
+    # Deliberately NOT `choices=` on the component, and for a stronger version of
+    # `frame-density`'s argument: which names are togglable is a property of THIS PLANE's
+    # arrangement, resolved from a committed file at the moment the key fires, so there is
+    # no set for argparse to hold at parser-build time at all. `cmd_toggle` refuses a name
+    # its own frame's arrangement does not contain — one gate, where the arrangement is.
+    tg = sub.add_parser("frame-toggle")
+    tg.add_argument("component")
+    tg.set_defaults(func=commands_frame.cmd_toggle)
 
     # A TOP-LEVEL sibling of `frame` for a DIFFERENT reason than `frame-palette` above:
     # that one exists because `_split_frame_argv` eats everything

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -132,9 +132,9 @@ import subprocess
 import sys
 import time
 
-from . import config, contain, harness, tui, util, workspace
-from .frame import (builtin_actions, gather, layout, overlay, palette, picker, state,
-                    switch, tmuxctl)
+from . import config, contain, harness, instance, tui, util, workspace
+from .frame import (builtin_actions, component, gather, layout, overlay,
+                    palette, picker, state, switch, tmuxctl)
 # Aliased: `cmd_launch` already has a local variable named `slots` (the VISIBLE slot
 # list `layout.visible_slots` returns) — importing the renderer registry under its own
 # name would be shadowed by that local the moment it's assigned, and a `slots.SLOTS`
@@ -360,7 +360,8 @@ def cmd_probe(args=None) -> int:
     return _report_probe(*frame_ready())
 
 
-def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> str:
+def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
+              toggles: dict | None = None) -> str:
     """The private tmux config for one frame's own settings. Never `~/.tmux.conf`.
 
     `status`, `mouse` and `history-limit` are SESSION-scoped (`set -t <session>`, no
@@ -506,8 +507,64 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
     session-scoped `CHARTER_PY` reaches the shell this bind spawns and expands there,
     and that this exact bind text survives `source-file` intact (`list-keys` reads it
     back byte for byte).
+
+    *toggles* is ``{component name: key}`` (`instance.frame_toggles`) and each pair
+    becomes one more `bind -n`, running `charter frame-toggle <name>` — which shows or
+    hides that one component on the running frame. Empty for every plane spelled with
+    `slots` or `density`, because there is nowhere in those to write a key and charter
+    binds none by default: a `bind -n` is server-wide and intercepts the key BEFORE the
+    harness pane sees it, so a shipped default would quietly take keys away from Claude
+    Code (or codex, or whatever the operator ran) on every plane that has a charter.toml.
+
+    These are frame-agnostic for the same reason the hotkey bind above is, and they carry
+    no `#{client_name}`: a toggle changes the FRAME, not what one client is looking at, so
+    unlike the palette there is nothing here to draw on a particular presser's screen.
+    `cmd_toggle` resolves which frame from `$CHARTER_SESSION_ID` when the key fires.
+
+    **Both halves of a toggle line are refused rather than escaped, and each on its own
+    line below.** A component name and its key arrive from the same committed file as
+    `hotkey`, land in the same `source-file` text, and a newline in either ends the `bind`
+    line and starts a second tmux command with no keypress — the incident
+    `instance._HOTKEY_RE`'s docstring measures. The key is asked of `instance.toggle_key`,
+    which IS that constant; the name is asked of `frame/component.py`'s `usable_id`, which
+    is the alphabet a component id already travels to tmux under. Neither is a new
+    validator, and both are asked HERE as well as at the config boundary because
+    `instance.component_tables` accepts a provider's id on the strength of an installed
+    entry point NAME — a word charter did not choose and cannot un-install.
+
+    A refused pair costs its key and nothing else: the panel is still placed, still split
+    for and still drawn, and the rest of the frame's keys still bind. That is the one
+    degrade available, since the alternative is a `source-file` that fails and takes
+    `mouse`, `history-limit` and the palette's own hotkey down with it.
+
+    Verified against tmux 3.7c, sourcing exactly what this returns for a two-key
+    arrangement — `source-file` returns 0 and `list-keys -T root` reads all four binds
+    back, the palette's, both toggles' and the hatch's, byte for byte::
+
+        bind-key -T root F2  run-shell "\\"\\$CHARTER_PY\\" -m charter frame-palette \\"#{client_name}\\""
+        bind-key -T root F7  run-shell "\\"\\$CHARTER_PY\\" -m charter frame-toggle repos"
+        bind-key -T root F12 run-shell -C "#{@charter_hatch}"
+        bind-key -T root M-s run-shell "\\"\\$CHARTER_PY\\" -m charter frame-toggle right"
+
+    **They sit between the hotkey bind and the escape hatch, and both ends of that are
+    load-bearing.**
+
+    *After the palette's bind*, because that is the order that keeps the config boundary's own
+    collision refusal honest rather than masked. tmux has no notion of a key conflict — a
+    later `bind -n` replaces an earlier one — so a component that bound `F2` here would
+    take the palette away, and that is exactly the consequence `instance.component_tables`
+    refuses to allow and its test asserts. Emitting these first would have made the same
+    deletion harmless-looking and the guard unpinnable, which is how `layout.py`'s own
+    masked guard got there (#553).
+
+    *Before `overlay.hatch_bind()`*, because that line's own reason for going last (see
+    above) is that a tmux below `tmuxctl.FLOOR` cannot parse `run-shell -C` and everything
+    charter needs must already have been applied by the time `source-file` reaches it. A
+    toggle bind appended after it would be the first thing such a tmux dropped, and the
+    operator would lose their keys to a version skew that costs nothing else. Pinned by
+    `test_the_escape_hatch_is_still_the_last_line`.
     """
-    return "\n".join([
+    lines = [
         f"set -t {session} status off",
         f"set -t {session} mouse {'on' if mouse else 'off'}",
         f"set -t {session} history-limit {int(history_limit)}",
@@ -518,9 +575,24 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
         f"'\"${_CHARTER_PY_ENV}\" -m charter frame-palette \"#{{client_name}}\"'",
         "bind -n WheelUpPane if-shell -F -t = '#{mouse_any_flag}'"
         " 'send-keys -M' 'copy-mode -e; send-keys -M'",
-        overlay.hatch_bind(),
-        "",
-    ])
+    ]
+    for name, key in (toggles or {}).items():
+        if not component.usable_id(name):
+            continue
+        if instance.toggle_key(key) is None:
+            continue
+        lines.append(f"bind -n {key} run-shell "
+                     f"'\"${_CHARTER_PY_ENV}\" -m charter frame-toggle {name}'")
+    # The escape hatch stays the LAST line, which is this file's own invariant and not
+    # this loop's convenience: `frame/overlay.py`'s `hatch_bind` is the one bind that has
+    # to keep working when charter's code does not, and it uses `run-shell -C`, which
+    # first parses in tmux 3.2 (`tmuxctl.FLOOR`). Below the floor that single line fails
+    # to parse, and everything charter needs must already have been applied by the time
+    # `source-file` reaches it — a toggle bind appended after it would be the first thing
+    # such a tmux dropped. So the toggles are inserted BEFORE it, never appended after.
+    lines.append(overlay.hatch_bind())
+    lines.append("")
+    return "\n".join(lines)
 
 
 def _charter_py_env_argv(*, socket: str, session: str) -> list[str]:
@@ -2525,7 +2597,8 @@ def cmd_launch(args) -> int:
 
     frame = config.FRAME
     conf_path.write_text(conf_text(hotkey=frame["hotkey"], mouse=frame["mouse"],
-                                   history_limit=frame["history_limit"], session=fid))
+                                   history_limit=frame["history_limit"], session=fid,
+                                   toggles=instance.frame_toggles(frame)))
     src = tmuxctl.run("loading the frame's config",
                       tmuxctl.server_argv(SOCKET, "source-file", str(conf_path)),
                       env=env)
@@ -3125,51 +3198,214 @@ def cmd_density(args) -> int:
     says the refusal BEFORE the keypress instead: `builtin_actions._laid_out` asks the
     same question this function's third refusal asks, and the row carries the answer.
 
+    **A level is a NAME for one arrangement of visibility, not a mechanism of its own**
+    (Phase 2, Task 5; see `instance.FRAME_DENSITY`). This writes a hidden SET and then
+    hands it to `_apply_arrangement`, which is the identical path a single component's
+    toggle key takes — so pressing `minimal` and then a component's own key are two edits
+    to one thing rather than two things arguing. The one axis a level still owns by itself
+    is ``verbosity``, which is how much each panel SAYS: no per-component key can express
+    it, which is exactly why the level is still recorded.
+
     Refusals, in order:
 
     * no `$CHARTER_SESSION_ID` — not fired from inside a frame at all;
     * a *level* outside `instance.FRAME_DENSITY` — a closed set of three constants charter
       wrote itself, so this can only be a hand-typed argument;
-    * a harness pane that is not tmux's own `%<digits>` — a frame launched by a charter
-      that predates `state.record_harness_pane`, or a corrupted file. There is nothing to
-      split off, and guessing at a pane id is the one thing `frame/layout.py`'s module
-      docstring measures the cost of. (An empty PANEL map is not a refusal: a frame whose
-      panels all failed to draw can still be given some.)
+    * anything `_relayout_target` refuses — a harness pane that is not tmux's own
+      `%<digits>`, or a tmux whose version charter could not read. Shared with
+      `cmd_toggle` rather than spelled twice; see that function.
 
-    The density is recorded BEFORE the panes move, so a re-layout that fails halfway still
-    leaves the panels that survive drawing at the density the operator asked for. The
-    version is bumped afterwards: that is what makes every surviving panel repaint with the
-    new verbosity, and a bump before the layout settled would repaint into the old shape.
+    The density and the hidden set are recorded BEFORE the panes move, so a re-layout that
+    fails halfway still leaves the panels that survive drawing at the density the operator
+    asked for. The version is bumped afterwards (`_apply_arrangement`): that is what makes
+    every surviving panel repaint with the new verbosity, and a bump before the layout
+    settled would repaint into the old shape.
     """
-    from . import instance
     fid = os.environ.get("CHARTER_SESSION_ID", "")
     level = instance.density_level(getattr(args, "level", None))
     if not fid or level is None:
         return 0
-    # The harness pane comes from `state.harness_pane`, the record ADR 0019's own
-    # `is_live` reads — not from a second copy of its own. `_PANE_ID_RE` still guards it:
-    # it arrives off disk here rather than off `split-window`'s stdout, and it is about to
-    # be interpolated into a hook action and a split target.
-    harness_pane = state.harness_pane(fid) or ""
-    panels = state.panes(fid)
-    if not _PANE_ID_RE.fullmatch(harness_pane):
+    where = _relayout_target(fid)
+    if where is None:
         return 0
-    socket = state.frame_server(fid) or SOCKET
+    state.record_density(fid, level)
+    # The whole of "density is a named arrangement over visibility". A level is turned
+    # into a HIDDEN SET over this frame's own arrangement and then handed to the same
+    # `_apply_arrangement` a single component's toggle key uses — it does not drive a
+    # layout of its own. Two consequences, and both are the point:
+    #
+    # * a toggle afterwards composes with the level instead of fighting it, because they
+    #   are edits to one set rather than two ideas about what the frame is;
+    # * the SPLIT ORDER is the plane's own, not the level's. `instance.FRAME_DENSITY`'s
+    #   lists are in charter's shipped order because they had to name one; an operator's
+    #   `[frame] slots` order is a promise `instance.frame_of` keeps verbatim, and it is
+    #   the order this frame's panes are actually in. A level names a SET of components;
+    #   the arrangement is what says where they go.
+    arrangement = instance.frame_arrangement(config.FRAME)
+    want = instance.density_slots(level)
+    state.record_hidden(fid, [n for n in arrangement if n not in want])
+    _apply_arrangement(fid, where=where, want=[n for n in arrangement if n in want])
+    return 0
+
+
+def _relayout_target(fid: str):
+    """Where a live re-layout of *fid* would act — ``(socket, harness pane, version)`` —
+    or ``None`` if this frame cannot be re-laid-out at all.
+
+    The refusals :func:`cmd_density` and :func:`cmd_toggle` share, held here so the two
+    keypresses cannot come to disagree about what a frame has to have before its panes may
+    be moved. Each is a quiet no-op for `cmd_respawn`'s reason: both callers normally run
+    as a `run-shell` child, where the only screen left to report on is the agent's own —
+    the one rectangle ADR 0018 says charter never draws in.
+
+    * A harness pane that is not tmux's own `%<digits>`. It comes from
+      `state.harness_pane` — the record ADR 0019's own `is_live` reads, never a second
+      copy — which means it arrives off DISK rather than off `split-window`'s stdout, and
+      it is about to be interpolated into a hook action and used as a split target.
+      `_PANE_ID_RE` is #475's rule applied to it. A frame launched by a charter that
+      predates `state.record_harness_pane`, or a corrupted file, has nothing to split off,
+      and guessing at a pane id is the one thing `frame/layout.py`'s module docstring
+      measures the cost of. (An empty PANEL map is not a refusal: a frame whose panels all
+      failed to draw can still be given some.)
+    * A tmux whose version charter could not read. Every builder below takes it.
+    """
+    harness_pane = state.harness_pane(fid) or ""
+    if not _PANE_ID_RE.fullmatch(harness_pane):
+        return None
     v = tmuxctl.version()
     if v is None:
-        return 0
+        return None
+    return (state.frame_server(fid) or SOCKET), harness_pane, v
 
-    state.record_density(fid, level)
+
+def _apply_arrangement(fid: str, *, where, want: list[str]) -> None:
+    """Make *fid*'s panes match *want*, and let every surviving panel know.
+
+    **The one live re-layout path**, and having exactly one is Task 5's actual
+    requirement: a density level and a component's toggle key are two ways of deciding
+    which components are visible, and a second resize path for the second of them would be
+    two answers to "what does this frame look like now" — the shape #500 and #547 both
+    cost. So a caller decides visibility and this does the rest, which is measurement,
+    the same two filters a LAUNCH goes through (`_drawable_slots`), the same `_relayout`,
+    and the same record-and-bump.
+
+    The version is bumped LAST: that is what makes every surviving panel repaint, and a
+    bump before the layout settled would repaint into the old shape. The caller records
+    its decision BEFORE calling here for the mirror-image reason — a re-layout that fails
+    halfway still leaves the panels that survive drawing the arrangement that was asked
+    for.
+    """
+    socket, harness_pane, v = where
     cols, rows = _window_size(socket, harness_pane)
-    want = _drawable_slots(cols, rows, instance.density_slots(level))
-    panes = _relayout(socket, fid=fid, harness_pane=harness_pane, panels=panels,
-                      want=want, v=v, window_cols=cols, window_rows=rows)
+    panes = _relayout(socket, fid=fid, harness_pane=harness_pane,
+                      panels=state.panes(fid),
+                      want=_drawable_slots(cols, rows, want), v=v,
+                      window_cols=cols, window_rows=rows)
     state.record_panes(fid, panels=panes)
     # Nothing to re-record. The palette is built from live state every time it opens
     # (`frame/builtin_actions.build`), so the mark on the density row moves with the frame
     # by construction — where the menu was a SNAPSHOT on disk that a switch had to rewrite
     # or it went on naming the level the frame had left.
     state.bump(fid)
+
+
+def _hidden_now(fid: str, frame: dict) -> list[str]:
+    """Which components *fid* is not drawing right now.
+
+    Two sources, in the one order that makes "for the running frame only" true: the
+    frame's OWN recorded set (`state.hidden`, written by a toggle key or a density level
+    and by nothing else) first, and the config behind it. This is
+    `frame/slots.py:verbosity`'s shape, said about visibility instead of about how much a
+    panel says.
+
+    ``None`` and not "empty" is what separates the two, which is why `state.record_hidden`
+    goes to the trouble of telling those apart: a frame whose operator has toggled the
+    last hidden panel back ON has an empty recorded set, and falling back to the config
+    there would put the panel straight back and make the key look broken.
+
+    **The config's answer is the arrangement MINUS the visible list, and reading only
+    ``visible = false`` instead would be wrong on the commonest plane there is.**
+    `instance.frame_arrangement` is deliberately longer than what a frame draws: it
+    appends charter's own built-ins the plane never named, so that a density level can
+    still reach them, as levels always have. A plane whose `[frame] slots` is
+    ``["top", "bottom"]`` therefore has `repos` and `sidebar` in its universe and neither
+    on screen — and taken as "not hidden", the very first keypress would have conjured
+    both. `frame["slots"]` is the VISIBLE list in either spelling (`instance.frame_of`
+    resolves `visible = false` into it), so subtracting it answers for both at once.
+    """
+    recorded = state.hidden(fid)
+    if recorded is not None:
+        return list(recorded)
+    visible = set(frame.get("slots") or ())
+    return [n for n in instance.frame_arrangement(frame) if n not in visible]
+
+
+def cmd_toggle(args) -> int:
+    """`charter frame-toggle <component>` — show or hide ONE component, live.
+
+    Fired by that component's own `bind -n` (`conf_text`), and typeable by hand from
+    inside a frame. The frame is resolved from `$CHARTER_SESSION_ID` exactly as
+    `cmd_density`, `cmd_palette` and `cmd_respawn` resolve theirs, since one bind text is
+    shared by every frame on `SOCKET`.
+
+    **charter.toml is not touched**, and every word of `cmd_density`'s argument for that
+    applies unchanged: `[[frame.component]]`'s `visible` says what a frame STARTS at, this
+    changes what one running frame IS, and the override lives in the frame's own state
+    directory (`state.record_hidden`) which `state.reap` deletes entire when the frame
+    ends. Relaunch and the arrangement the operator committed is back.
+
+    **The name is refused unless this frame's own arrangement contains it**, and that is
+    the guard that matters here rather than a shape check on the string. A name reaching
+    this far is about to become a `split-window`'s `charter panel <name>` argv and a
+    respawn hook's tmux CONFIG TEXT (`_arm_panel_respawn`), which is the `[frame] hotkey`
+    class of surface — and "is it in the arrangement" is a stronger answer than any
+    alphabet, because it admits only names that were already resolved by
+    `instance.component_tables` and already drawn. It is also the honest answer to the
+    ordinary case: `charter frame-toggle repos` on a plane whose arrangement has no repo
+    table is not a security question, it is a name this frame has nothing to toggle.
+
+    **Always 0, and every refusal is a quiet no-op**, for `cmd_density`'s reason: this
+    normally runs as a `run-shell` child of a keypress, where the only screen left to
+    report on is the agent's own — the one rectangle ADR 0018 says charter never draws in.
+
+    **There is deliberately NO "not inside a frame" refusal here, and the deletion sweep is
+    why.** An `if not fid: return 0` stood at the top of this function and was found to be
+    exactly equivalent — deleted, the FULL suite stayed green (6092 tests), and every
+    observable was identical: same return code, no tmux command issued, no file written,
+    nothing readable back out of the state directory. `$CHARTER_SESSION_ID` unset means
+    ``fid == ""``; `contain.child` refuses ``""`` as a path segment, so `state.frame_dir`
+    answers ``None`` and `state.harness_pane` with it, and :func:`_relayout_target`'s
+    `_PANE_ID_RE` check — which IS pinned, and goes red when deleted — is what stops the
+    empty string ever reaching a `-t`. Two guards in sequence, one of them free.
+
+    It was deleted rather than left, and rather than papered over with a test that would
+    have had to assert an implementation detail to see it: this command emits nothing by
+    construction, so there is no *reason* for a refusal test to distinguish, only a
+    consequence — and the consequence is already another line's. A guard nothing can pin
+    is a comment with a runtime cost. `test_outside_a_frame_it_does_nothing` pins the
+    property that survives it, and names the line that carries it.
+    """
+    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    name = getattr(args, "component", None)
+    frame = config.FRAME
+    arrangement = instance.frame_arrangement(frame)
+    if name not in arrangement:
+        return 0
+    where = _relayout_target(fid)
+    if where is None:
+        return 0
+    hidden = set(_hidden_now(fid, frame))
+    # `symmetric_difference_update` and not two branches: a toggle is one bit flipped, and
+    # written as `if name in hidden: discard else: add` it is two statements that have to
+    # agree about which name they are talking about.
+    hidden.symmetric_difference_update({name})
+    # Written back in the arrangement's own order rather than the set's, so the file a
+    # human may end up reading reads like the frame does. Filtered by the arrangement too,
+    # which is what keeps a name that has since left the operator's config from living in
+    # this file for the rest of the frame's life.
+    state.record_hidden(fid, [n for n in arrangement if n in hidden])
+    _apply_arrangement(fid, where=where,
+                       want=[n for n in arrangement if n not in hidden])
     return 0
 
 

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -550,9 +550,72 @@ def density(fid: str) -> str | None:
         return None
 
 
+def record_hidden(fid: str, names) -> None:
+    """Write down which components THIS RUNNING FRAME is not drawing.
+
+    The mechanism a toggle key and a density level are both expressed in
+    (`commands_frame.cmd_toggle`, `commands_frame.cmd_density`): visibility is per
+    component, and a level is a name for one set of it.
+
+    Same place and same argument as :func:`record_density` — charter.toml is
+    hand-maintained and committed, this directory is machine-written and `reap` deletes it
+    whole when the frame ends, so a keypress lands here and the operator's own file is
+    left alone. Relaunch and the arrangement they configured is back.
+
+    One name per line, newline-terminated, so that "nothing is hidden" is an EMPTY FILE
+    and "nothing has been recorded" is NO FILE. Those are different answers — the first is
+    an operator who toggled the last panel back on, the second is a frame nobody has
+    touched, whose hidden set is whatever ``visible = false`` its config declared — and a
+    caller cannot tell them apart from any value that flattens both to "empty", which is
+    why this is a file per frame rather than a line in one. Same must-not-raise,
+    atomic-write shape as :func:`record_density`.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "hidden.tmp"
+    try:
+        tmp.write_text("".join(f"{n}\n" for n in names))
+        os.replace(tmp, d / "hidden")
+    except OSError:
+        return
+
+
+def hidden(fid: str) -> tuple[str, ...] | None:
+    """The components this frame has been told not to draw, or ``None`` for "never told".
+
+    ``None`` is the ordinary case and is not a failure: a frame comes up drawing the
+    arrangement its config describes, and only a keypress writes here. The caller falls
+    back to the ``visible = false`` names in that config — see
+    `commands_frame._hidden_now`.
+
+    **The text is NOT validated here, and unlike :func:`density` that is not a deferral —
+    there is nothing for a validator to protect.** A name in this set is only ever asked
+    ``is this name in it?`` about a name that is already in the frame's own arrangement
+    (`instance.frame_arrangement`), so a line that is not one of those names removes
+    nothing, reaches no tmux command and is not carried anywhere. A guard here would be a
+    guard with no consequence, which this repo's own sweep exists to find and delete.
+
+    Blank lines are dropped, which is what makes an empty recorded set read back as an
+    empty tuple rather than as one component named ``""``.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        text = (d / "hidden").read_text()
+    except (OSError, ValueError):
+        return None
+    return tuple(line for line in text.split("\n") if line)
+
+
 def clear_shape(fid: str) -> None:
-    """Forget the density, the pane map and the harness session recorded under *fid*,
+    """Forget the shape, the pane map and the harness session recorded under *fid*,
     because a NEW frame is claiming the id.
+
+    "The shape" is two files: the ``density`` a keypress chose and the ``hidden`` set a
+    component's own toggle key wrote (:func:`record_hidden`). Both are one operator's
+    decision about one frame, and that frame is over.
 
     The fourth and fifth lines on :func:`clear_exit`'s bill, and the same recycled pid
     underneath them (#383). A frame id is ``<workspace>-<launcher pid>``; :func:`reap`
@@ -567,6 +630,13 @@ def clear_shape(fid: str) -> None:
       says otherwise and nothing anywhere explains it — the config silently overridden by
       a keypress from another session, which is the one thing "for the running frame only"
       promises cannot happen.
+    * ``hidden`` is the same keypress said one component at a time (:func:`record_hidden`)
+      and inherits for the same reason, one level sharper: a level at least names a frame
+      charter ships, while a stale hidden set can leave a brand-new frame missing exactly
+      the panel a previous operator dismissed, with `[frame] slots` naming it and nothing
+      on screen to say why. The file's whole contract is that "never recorded" and
+      "recorded empty" are different answers, so a file inherited from a dead frame is
+      read as a live decision this frame's operator never made.
     * ``panes`` names tmux panes of a frame that no longer exists. `cmd_launch` rewrites
       it as it draws, so this only matters when a launch dies before that — but then the
       map survives pointing at nothing, and the next density change on the next frame to
@@ -584,7 +654,7 @@ def clear_shape(fid: str) -> None:
     d = frame_dir(fid)
     if d is None:
         return
-    for name in ("density", "panes", "session"):
+    for name in ("density", "hidden", "panes", "session"):
         try:
             (d / name).unlink(missing_ok=True)
         except OSError:

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -970,11 +970,21 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
         #   so this one takes the palette away from every frame on the socket, and with it
         #   every action §4h moved out of the deleted menu, leaving nothing to get them
         #   back with;
-        # * `frame/overlay.py`'s `HATCH_KEY` — the escape hatch, which `conf_text` writes
-        #   AFTER these, so tmux's last-wins leaves the hatch alive and the component's
-        #   key silently dead. Refused here anyway, and deliberately not left to that
-        #   ordering: a guard whose consequence depends on the order two other lines are
-        #   emitted in is a guard nothing can pin (#553).
+        # * `frame/overlay.py`'s `HATCH_KEY` — the escape hatch. `conf_text` writes that
+        #   bind AFTER these, so tmux's last-wins leaves the hatch alive and the
+        #   component's key silently dead. Measured on tmux 3.7c, sourcing both binds in
+        #   the order `conf_text` emits them::
+        #
+        #       $ tmux -L t source-file both.tmux ; echo $?
+        #       0
+        #       $ tmux -L t list-keys -T root | grep F12
+        #       bind-key -T root F12  run-shell -C "#{@charter_hatch}"
+        #
+        #   One line back, not two: the operator's key is simply gone, and `source-file`
+        #   said nothing. Refused here anyway, and deliberately not left to that emission
+        #   order — a guard whose consequence depends on where two other lines are
+        #   emitted is a guard nothing can pin (#553), which is the same trap one level
+        #   up from the one this sweep exists to catch.
         if key is not None and key in bound:
             return None
         if key is not None:

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -385,6 +385,16 @@ FRAME_SLOTS = ("top", "bottom", "repos", "right")
 #: How much frame there is, as a PRESET over :data:`FRAME_SLOTS` — never a second
 #: configuration system sitting beside `slots`.
 #:
+#: **And, since Phase 2's Task 5, a NAMED ARRANGEMENT OVER VISIBILITY rather than a
+#: mechanism of its own** (spec §4). The operator's own words for what was wrong with it:
+#: *"instead of having density - we need to have hotkeys to hide and show separately
+#: components"*. A level is now three panels' worth of "visible", written down under one
+#: word: `commands_frame.cmd_density` turns the list below into a HIDDEN SET over
+#: :func:`frame_arrangement`, and then goes through the very same re-layout a single
+#: component's toggle key does. Nothing about a level is a second path, and the mark it
+#: still leaves on the frame — its ``verbosity`` — is the one axis a per-component
+#: toggle genuinely cannot express, which is why the table below still carries it.
+#:
 #: Each level expands to two things: the ``slots`` an operator could have written by hand,
 #: and a ``verbosity`` naming how much each panel on them says (`frame/slots.py` owns what
 #: the two verbosities actually draw). `slots` stays the primitive, and an EXPLICIT
@@ -630,6 +640,41 @@ FRAME_DEFAULTS = {key: default for key, (default, _toml_key) in FRAME_FIELDS.ite
 _HOTKEY_RE = re.compile(r"^(?:[CMS]-){0,3}(?:[A-Za-z0-9]{1,20}|[!%&()*+,./:<=>?@\[\]^_|~-])$")
 
 
+def toggle_key(value):
+    """*value* if it is a tmux key charter will let reach a ``bind`` line, else ``None``.
+
+    **:data:`_HOTKEY_RE` asked, never a second pattern**, and that is the whole of this
+    function. A component's toggle key (``[[frame.component]]``'s ``key``) is interpolated
+    into tmux CONFIG TEXT by `commands_frame.conf_text` — the same ``bind -n {key}
+    run-shell '…'`` line, in the same file, sourced by the same ``source-file`` — as
+    ``[frame] hotkey``. The injection that constant's docstring measures is therefore the
+    identical injection, reached through a second committed key rather than a second
+    mechanism — re-measured on tmux 3.7c against a config in exactly the shape
+    `conf_text` writes, with ``key = "F9\\nrun-shell -b 'touch /tmp/PWNED'"``::
+
+        $ tmux -L t source-file evil.tmux ; echo $?
+        0                                   # silently
+        $ ls -l /tmp/PWNED
+        -rw-r--r--  1 …  /tmp/PWNED         # at source-file time, no keypress
+
+    The newline simply ends the ``bind`` line and starts a second tmux command.
+
+    A second regex spelled here would be a second answer to "what may reach a ``bind``
+    line", and the two would drift — which is exactly what `frame/component.py`'s own
+    ``match``/``fullmatch`` slip cost inside one module, and what `contain.py`'s docstring
+    argues against in general. So the two keys are one alphabet by construction.
+
+    ``isinstance`` first, for :func:`density_level`'s reason: ``tomllib`` can hand this a
+    list or a table, and ``_HOTKEY_RE.fullmatch`` raises ``TypeError`` for either — in a
+    module every command imports, ``charter --version`` included.
+
+    ``None`` rather than ``False``, so a caller can write the matched value back the way
+    :func:`density_level` does: what reaches tmux is then this function's answer, not the
+    object a committed file supplied.
+    """
+    return value if isinstance(value, str) and _HOTKEY_RE.fullmatch(value) else None
+
+
 def frame_of(cfg: dict) -> dict:
     """The ``[frame]`` section merged over :data:`FRAME_DEFAULTS`.
 
@@ -709,7 +754,11 @@ def frame_of(cfg: dict) -> dict:
             out[key] = value
     if "density" in section and not took_slots:
         out["slots"] = density_slots(out["density"])
-    placed = component_tables(section)
+    # *After* the loop, so ``hotkey`` is already resolved: a component's own ``key`` is
+    # refused when it would steal the frame's palette key, and the value it is compared
+    # against has to be the one `conf_text` will actually bind — the operator's, if they
+    # wrote a usable one, and the shipped ``F2`` if they did not.
+    placed = component_tables(section, hotkey=out["hotkey"])
     if placed is not None:
         out["slots"] = [p["slot"] for p in placed if p["visible"]]
     # The arrangement itself, and not only the names it comes down to. `slots` carries
@@ -742,10 +791,18 @@ FRAME_COMPONENT_KEY = "component"
 #: * ``size`` — how many cells it is given, for a component whose size is `Fixed`.
 #: * ``visible`` — whether it is drawn at all. The one key `slots` could only express by
 #:   deleting a name, which loses the position with it.
-FRAME_COMPONENT_FIELDS = ("use", "edge", "size", "visible")
+#: * ``key`` — the tmux key that TOGGLES ``visible`` on the running frame, live. Optional,
+#:   and there is no default: a `bind -n` is server-wide and intercepts the key before the
+#:   harness pane ever sees it, so charter shipping four of them would silently take four
+#:   keys away from Claude Code (or codex, or whatever the operator ran) on every plane.
+#:   A key is bound because an operator asked for it by name. Held to
+#:   :func:`toggle_key` — which is :data:`_HOTKEY_RE` — because it reaches the same
+#:   ``bind`` line ``[frame] hotkey`` does.
+FRAME_COMPONENT_FIELDS = ("use", "edge", "size", "visible", "key")
 
 
-def _placement(cid: str, *, edge: str, size, visible: bool = True) -> dict:
+def _placement(cid: str, *, edge: str, size, visible: bool = True,
+               key: str | None = None) -> dict:
     """One resolved placement: the component, where it sits, how big, and whether drawn.
 
     **The one place a placement is spelled**, which is why the rectangle is passed in
@@ -764,19 +821,26 @@ def _placement(cid: str, *, edge: str, size, visible: bool = True) -> dict:
     every plane that has a charter.toml; a component charter did not write has no
     committed spelling and travels under its id, which is the whole of "a component id is
     the frame's currency".
+
+    ``key`` travels beside ``visible`` because it is the one thing that CHANGES it: the
+    frame binds it to `commands_frame.cmd_toggle`, which flips this component's visibility
+    and hands the result to the same re-layout a density change goes through. ``None`` is
+    the ordinary answer — a plane spelled with `slots` has no place to write one, and a
+    component nobody asked to bind does not get a key.
     """
     from .frame import builtins as _builtins
     return {"use": cid, "slot": _builtins.SLOT_OF.get(cid, cid), "edge": edge,
-            "size": size, "visible": visible}
+            "size": size, "visible": visible, "key": key}
 
 
-def _built_in_placement(reg, cid: str, *, visible: bool = True) -> dict:
+def _built_in_placement(reg, cid: str, *, visible: bool = True,
+                        key: str | None = None) -> dict:
     """:func:`_placement` for one of charter's own, in the rectangle it declares."""
     c = reg.get(cid)
-    return _placement(cid, edge=c.edge, size=c.size, visible=visible)
+    return _placement(cid, edge=c.edge, size=c.size, visible=visible, key=key)
 
 
-def component_tables(section) -> list[dict] | None:
+def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None:
     """The ``[[frame.component]]`` arrangement *section* declares, or ``None``.
 
     ``None`` means "nothing usable was declared here" — no tables at all, or an
@@ -844,15 +908,37 @@ def component_tables(section) -> list[dict] | None:
     meanwhile is writing the arrangement out in full: `frame_components` answers every
     `slots` list as tables that resolve back to the same frame, which is what makes the
     mapping lossless in both directions.
+
+    **A ``key`` is the one value here that reaches tmux CONFIG TEXT**, which is why
+    *hotkey* is a parameter rather than something read back later. `commands_frame
+    .conf_text` writes ``bind -n {key} run-shell '…frame-toggle {name}'`` into the file
+    ``source-file`` parses, so a component's key is in exactly the position ``[frame]
+    hotkey`` was in when a newline in it ran a second tmux command at launch with no
+    keypress (:data:`_HOTKEY_RE`). :func:`toggle_key` is that same constant, asked here.
+
+    *hotkey* is the key the frame's own palette is bound to — resolved by :func:`frame_of`
+    before it calls this, because the comparison has to be against what will actually be
+    bound, not against the shipped constant a plane may have moved off. It joins
+    `frame/overlay.py`'s ``HATCH_KEY`` in the set of keys charter has already taken, and a
+    component may have neither. ``None`` means the caller has no palette key to reserve,
+    which is what resolving an arrangement outside a `[frame]` section has; the hatch is
+    reserved regardless, because charter binds it for every frame on its own server.
     """
     tables = section.get(FRAME_COMPONENT_KEY) if isinstance(section, dict) else None
     if not isinstance(tables, list) or not tables:
         return None
     from .frame import builtins as _builtins
+    from .frame import overlay as _overlay
     from .frame.component import EDGES, Fixed
     reg = _builtins.build()
     out: list[dict] = []
     seen: set[str] = set()
+    # Every key charter has already bound for this frame, which a component may not take.
+    # Built HERE rather than in :func:`frame_of` because reaching `frame/overlay.py` for
+    # the hatch key is an import, and this line runs only once a plane has actually
+    # written `[[frame.component]]` tables — `frame_of` itself is on the path of every
+    # command, `charter --version` included, and must stay as cheap as it was.
+    bound: set[str] = {k for k in (hotkey, _overlay.HATCH_KEY) if k}
     for table in tables:
         if not isinstance(table, dict):
             return None
@@ -865,6 +951,34 @@ def component_tables(section) -> list[dict] | None:
         visible = table.get("visible", True)
         if not isinstance(visible, bool):
             return None
+        # The two refusals a toggle key gets, each its own line because each is a
+        # different thing going wrong and the sweep has to be able to tell them apart.
+        key = table.get("key")
+        # One: it is not a key charter will let reach a `bind` line at all. `[frame]
+        # hotkey`'s own injection, arriving through a second committed key — see
+        # :func:`toggle_key`, which is the SAME pattern and not a second one.
+        if key is not None and toggle_key(key) is None:
+            return None
+        # Two: something has already bound it. tmux key tables have no notion of a
+        # conflict — the later `bind -n` simply replaces the earlier — so unrefused this
+        # is one dead key and nothing anywhere saying which. `bound` starts holding the
+        # keys charter binds for its own frame and grows by each component's, so one line
+        # answers for all three collisions rather than three lines answering separately:
+        #
+        # * another component's key — a panel that cannot be toggled at all;
+        # * the frame's own `hotkey` — `conf_text` writes the palette's bind BEFORE these,
+        #   so this one takes the palette away from every frame on the socket, and with it
+        #   every action §4h moved out of the deleted menu, leaving nothing to get them
+        #   back with;
+        # * `frame/overlay.py`'s `HATCH_KEY` — the escape hatch, which `conf_text` writes
+        #   AFTER these, so tmux's last-wins leaves the hatch alive and the component's
+        #   key silently dead. Refused here anyway, and deliberately not left to that
+        #   ordering: a guard whose consequence depends on the order two other lines are
+        #   emitted in is a guard nothing can pin (#553).
+        if key is not None and key in bound:
+            return None
+        if key is not None:
+            bound.add(key)
         if cid in _builtins.SLOT_OF:
             c = reg.get(cid)
             if "edge" in table and table["edge"] != c.edge:
@@ -873,7 +987,7 @@ def component_tables(section) -> list[dict] | None:
                                         and table["size"] == c.size.n
                                         and not isinstance(table["size"], bool)):
                 return None
-            out.append(_built_in_placement(reg, cid, visible=visible))
+            out.append(_built_in_placement(reg, cid, visible=visible, key=key))
             continue
         # Not one of charter's own: a component id, which is placeable exactly when an
         # installed distribution declares it. Asked of entry point METADATA — nothing is
@@ -883,7 +997,7 @@ def component_tables(section) -> list[dict] | None:
         if (not reg.providers.supplies(cid) or edge not in EDGES
                 or not isinstance(size, int) or isinstance(size, bool) or size < 1):
             return None
-        out.append(_placement(cid, edge=edge, size=Fixed(size), visible=visible))
+        out.append(_placement(cid, edge=edge, size=Fixed(size), visible=visible, key=key))
     return out
 
 
@@ -907,19 +1021,80 @@ def frame_components(cfg: dict) -> list[dict]:
     happen once, where they always did.
 
     **Lossless in both directions.** Every list this answers can be written back out as
-    ``[[frame.component]]`` tables — one per placement, carrying its ``use``, ``edge`` and
-    ``size`` — and :func:`component_tables` resolves those to the same placements again.
+    ``[[frame.component]]`` tables — one per placement, carrying its ``use``, ``edge``,
+    ``size``, ``visible`` and ``key`` — and :func:`component_tables` resolves those to the
+    same placements again.
     That round trip is what "the config maps onto the registry" has to mean if `slots` is
     to be retired later without an operator's committed frame changing under them.
+
+    **:func:`frame_of` is asked for the arrangement too, and not only for the slot list.**
+    This used to call :func:`component_tables` a second time, directly — which was one
+    reading of a committed value while that comment above said it was not. It became a
+    real disagreement the moment a table grew a ``key``: `frame_of` resolves ``hotkey``
+    and passes it down, so it refuses a component key that would steal the frame's palette,
+    and a second call without it would have accepted the very arrangement `config.FRAME`
+    had already thrown away. Two answers to one question, which is the shape #547 cost.
     """
-    section = cfg.get("frame")
-    placed = component_tables(section)
-    if placed is not None:
-        return placed
+    frame = frame_of(cfg)
+    if frame["components"]:
+        return frame["components"]
     from .frame import builtins as _builtins
     reg = _builtins.build()
     return [_built_in_placement(reg, _builtins.COMPONENT_OF[slot])
-            for slot in frame_of(cfg)["slots"]]
+            for slot in frame["slots"]]
+
+
+def frame_arrangement(frame: dict) -> list[str]:
+    """Every component name *frame* can show, in split order — visible or not.
+
+    **The universe a toggle and a density level both move within**, and the reason
+    visibility can be the one mechanism. `slots` says which panels are ON; it cannot say
+    which panels EXIST but are off, because deleting a name from a list loses the position
+    with it. This answers the longer list, so a hidden component keeps its place in the
+    split order — and that order is what a re-layout is asked with, so a level or a key
+    never has to invent a position for a panel it brings back.
+
+    *frame* is a RESOLVED ``[frame]`` mapping — :func:`frame_of`'s answer, which is
+    exactly what `config.FRAME` holds. It is read rather than re-derived from a cfg on
+    purpose: this is asked from inside a running frame (`commands_frame.cmd_toggle`,
+    `commands_frame.cmd_density`), and re-resolving there would be a second reading of the
+    committed file, taken at a different moment, free to disagree with the one the frame
+    was launched from.
+
+    Two sources, in the order the config boundary already ranks them:
+
+    * an arrangement written out (``components``) names its own components, invisible ones
+      included, and its file order is the split order;
+    * otherwise ``slots``, which is the same list with nothing hidden in it.
+
+    Then **charter's own built-ins that neither named, appended in shipped split order**.
+    That tail is what keeps `[frame] slots = ["top", "bottom"]` able to answer the
+    ``full`` density at all — a level names built-ins the plane never listed, and it has
+    done so since presets existed. Appended rather than merged, because a name the plane
+    did not write has no position of its own to be inserted at, and :data:`FRAME_SLOTS`'
+    order is the only other one charter knows: for a plane whose list is a prefix of the
+    shipped one — which is every plane that took a `slots` default and trimmed it — the
+    result IS the shipped order.
+    """
+    placed = frame.get("components") or ()
+    names = [p["slot"] for p in placed] or list(frame.get("slots") or ())
+    return names + [s for s in FRAME_SLOTS if s not in names]
+
+
+def frame_toggles(frame: dict) -> dict[str, str]:
+    """name → the tmux key that shows or hides it, for every component *frame* binds one
+    to, in split order.
+
+    What `commands_frame.conf_text` turns into ``bind -n`` lines. Empty for every plane
+    spelled with `slots` or `density`, and empty for an arrangement that declared no
+    ``key`` — there is no default key and :data:`FRAME_COMPONENT_FIELDS` says why.
+
+    Split order because a mapping keeps its insertion order and *frame*'s own placements
+    are in it. Nothing downstream depends on that, but a `list-keys` an operator reads
+    back should be in the order their file is written in rather than in whatever order a
+    set happened to iterate.
+    """
+    return {p["slot"]: p["key"] for p in (frame.get("components") or ()) if p.get("key")}
 
 
 #: The channels ``[update] channel`` may name, and a CLOSED set — the single most

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -587,6 +587,67 @@ That is the one thing `slots` cannot express. Deleting a name from `slots` loses
 *position* along with it, so turning the panel back on later means remembering where in the
 order it went; `visible = false` keeps the order and turns off the panel.
 
+### A key that shows and hides one panel
+
+Give a component a `key` and that key turns it off and on while the frame is running:
+
+```toml
+[[frame.component]]
+use = "identity"
+
+[[frame.component]]
+use = "attention"
+
+[[frame.component]]
+use = "repos"
+key = "F7"
+
+[[frame.component]]
+use = "sidebar"
+key = "F8"
+```
+
+`F7` now hides the repo table and gives its rows back to your agent session; press it
+again and the table is back. **Hiding a panel does not delete it from your arrangement**,
+which is the whole difference from taking a name out of `slots`: charter still knows the
+panel's edge, its size and where it sits in the order, so you never have to remember any
+of it. Charter does not move panes that did not change, so a panel toggled back on is
+split beside the ones that stayed; relaunch and you get your file's order exactly.
+
+**Charter binds no key of its own for this, and it never will.** A tmux `bind -n`
+intercepts the key before the pane underneath ever sees it, so a default would silently
+take that key away from Claude Code — or codex, or whatever you ran — on every plane with
+a `charter.toml`. Keys are bound because you named them. Pick ones your harness does not
+use; function keys and `M-`/`C-` combinations are the usual safe ground.
+
+**The key is held to the same alphabet as `hotkey`**, and for the same reason: it is
+written into the tmux config your frame loads. Optional modifiers (`C-`, `M-`, `S-`) and
+then a key name or one punctuation character — `F7`, `M-r`, `C-M-t`, `\`. Anything else
+takes the whole arrangement out of play, like every other value charter cannot honour.
+
+**And you cannot take a key charter has already bound.** Two components asking for the
+same key, your frame's own `hotkey` (`F2` unless you moved it), and `F12` — the escape
+hatch, the key that always returns you to your session even from a wedged overlay — are
+all refused the same way. tmux has no notion of a key conflict: the last `bind` simply
+replaces the earlier one, so one of the two would silently stop working and nothing would
+say which.
+
+**Density is now a name for one of these arrangements.** The three levels have not
+changed and the `F2` palette still offers them — `minimal` still means the two one-row
+strips, `full` still means every edge charter draws — but a level is applied by hiding
+and showing the same components a key does, so the two compose. Press `minimal`, then
+press the sidebar's own key, and you have the strips and the sidebar; pick a level again
+and you are back to exactly what that level names. What a level still does that a key
+cannot is set the *verbosity* — how much each panel says — which is why the levels are
+worth keeping.
+
+Nothing about this touches `charter.toml`. A key changes the frame you are in, for as
+long as it runs; relaunch and you have the arrangement you committed.
+
+If your plane is spelled with `slots`, write the arrangement out first — the long form
+above says exactly the same thing, and the `[[frame.component]]` tables for any `slots`
+list are one per name, in the same order.
+
 For one of charter's own four, `edge` and `size` may be written down and may only say what
 the component already declares — `edge = "right"` and `size = 22` on the sidebar, `edge =
 "top"` on identity. Charter derives the built-in geometry from those declarations, and
@@ -659,7 +720,8 @@ one of the four, a provider placed without an `edge` and a `size`, or a `visible
 not `true`/`false` all mean the same thing: the arrangement is ignored and you get the
 frame your `slots` (or `density`, or the default) describes. You see your whole arrangement
 not take effect, which is something you can act on, rather than one pane's worth of quiet
-fiction.
+fiction. A `key` charter will not bind, a key two components both claim, and a key equal to
+your frame's own `hotkey` are on that list too.
 
 Precedence, most explicit first: `[[frame.component]]`, then an explicit `slots`, then
 `density`, then the shipped default.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -14,11 +14,12 @@ for a command charter has no launcher for at all. That is not just naming: once 
 frame` is on the command line, everything after it is grafted onto the harness's own argv
 verbatim, before charter's own argument parser ever sees it, so `frame claude -p hi` would
 hand `claude -p hi` to the `frame --` mechanism rather than route anywhere. The same reason
-keeps `frame-palette`, `frame-density`, `frame-switch`, `frame-resize` and
-`frame-probe` — the command tmux's hotkey calls back into (and the program the palette's
-own pane runs), the one the density rows start, the one the workspace and persona rows
-start, the one the `window-resized` hook calls back into, and the read-only probe — as
-top-level names rather than nested under `frame` too.
+keeps `frame-palette`, `frame-density`, `frame-toggle`, `frame-switch`, `frame-resize`
+and `frame-probe` — the command tmux's hotkey calls back into (and the program the
+palette's own pane runs), the one the density rows start, the one a component's own key
+runs, the one the workspace and persona rows start, the one the `window-resized` hook
+calls back into, and the read-only probe — as top-level names rather than nested under
+`frame` too.
 
 ## What it needs
 
@@ -492,9 +493,17 @@ directory and goes with the frame; relaunch and you are back to what the file sa
 same applies to `charter frame-density <level>` typed by hand from inside a frame, which
 is what the palette row starts.
 
+A level is a *name for one arrangement*, applied by hiding and showing the same components
+a component's own key does — see "A key that shows and hides one panel" below. The two
+compose, and re-picking a level always puts the arrangement back to exactly what that level
+names.
+
 Inside a tmux you already have, charter binds no key at all (see above), so there is no
 palette and no keypress route to density there — `[frame] density` is what sets it, and the
-command still works if you run it inside the frame's own window.
+command still works if you run it inside the frame's own window. The same is true of a
+component's `key`: the binds live in the config charter sources onto its own server, which
+it never does inside your tmux, so `charter frame-toggle <name>` typed in the frame's own
+window is the route there.
 
 `hotkey` is checked against the shape of a tmux key name — optional `C-`/`M-`/`S-`
 modifiers and then a key (`F2`, `Up`, `PPage`, `a`, `/`). Anything else falls back to

--- a/docs/news/unreleased-a-key-per-panel-instead-of-a-density-preset.md
+++ b/docs/news/unreleased-a-key-per-panel-instead-of-a-density-preset.md
@@ -1,0 +1,71 @@
+---
+version: unreleased
+headline: Every panel can have its own key, and density becomes a name for one arrangement
+---
+
+*"instead of having density - we need to have hotkeys to hide and show separately
+components"*
+
+Density was three names and nothing in between. `minimal` gave the two one-row strips,
+`full` gave every edge charter draws, and if what you actually wanted was "everything
+except the repo table, right now, for the next ten minutes" there was no way to say it.
+
+**Give a component a key and that key is the panel's own switch:**
+
+```toml
+[[frame.component]]
+use = "identity"
+
+[[frame.component]]
+use = "attention"
+
+[[frame.component]]
+use = "repos"
+key = "F7"
+
+[[frame.component]]
+use = "sidebar"
+key = "F8"
+```
+
+`F7` hides the repo table and hands its rows back to the agent session. `F7` again and the
+table is back. **Hiding a panel does not delete it from your arrangement** — charter still
+holds its edge, its size and its place in the order — which is exactly what taking a name
+out of `slots` costs you: the position goes with the panel, and turning it back on later
+means remembering where in the list it went.
+
+**Density did not go away; it stopped being a separate thing.** A level is now a name for
+one set of visible components, applied by the same mechanism a key uses. So the two
+compose instead of overwriting each other:
+
+```
+F2 → density: minimal        the two strips, harness gets everything else
+F8                           …and the sidebar back, and only the sidebar
+F2 → density: full           every edge again — a level means what it names
+```
+
+What a level still does that no key can is set the *verbosity* — how much each panel says
+— which is why the three levels are worth keeping and why the palette still offers them.
+
+**Charter binds no key for this by default, and it will not start.** A tmux `bind -n`
+intercepts the key before the pane underneath ever sees it, so four shipped defaults would
+be four keys quietly taken away from Claude Code — or codex, or whatever you ran — on
+every plane with a `charter.toml`. Keys are bound because you named them. Pick ones your
+harness does not use.
+
+The key is held to exactly the alphabet `[frame] hotkey` is held to, and that is one
+function rather than two that look alike: a committed key is written into the tmux config
+your frame loads, and a newline in one of those once ran a second tmux command at launch
+with no keypress. A key charter will not bind — or one it has already bound: another
+component's, your frame's own `hotkey`, or `F12`, the escape hatch that always gets you
+back to your session — takes the whole arrangement out of play. That is the same
+whole-arrangement refusal every other value charter cannot honour already gets, so you see
+your arrangement ignored rather than one panel quietly missing a switch, or worse, an
+escape hatch quietly missing.
+
+Nothing here touches `charter.toml`. A key changes the frame you are in, for as long as it
+runs; relaunch and you have the arrangement you committed.
+
+To adopt it: write your arrangement out as `[[frame.component]]` tables if it is still
+spelled `slots` — one table per name, same order, same frame — and add a `key` to the
+panels you want a switch for.

--- a/tests/test_component_config.py
+++ b/tests/test_component_config.py
@@ -197,9 +197,14 @@ class AnArrangementCharterCannotDrawIsRefusedWhole(unittest.TestCase):
                 self.assertEqual(got, list(instance.FRAME_DEFAULTS["slots"]))
 
     def test_the_component_keys_a_declared_arrangement_may_carry(self):
-        """Named as a closed set, so a key added to the form has to be added here too."""
+        """Named as a closed set, so a key added to the form has to be added here too.
+
+        `key` joined it in Phase 2's Task 5 — the tmux key that toggles this component's
+        `visible` on the running frame. It is what made density a NAME for an arrangement
+        of visibility rather than a mechanism of its own, and its refusals live in
+        `tests/test_component_toggle_keys.py`."""
         self.assertEqual(instance.FRAME_COMPONENT_FIELDS,
-                         ("use", "edge", "size", "visible"))
+                         ("use", "edge", "size", "visible", "key"))
 
 
 class OrderIsGeometry(unittest.TestCase):

--- a/tests/test_component_toggle_keys.py
+++ b/tests/test_component_toggle_keys.py
@@ -1,0 +1,765 @@
+"""A component has its own key, and pressing it hides or shows that component alone.
+
+Density was all-or-nothing: three level names, each expanding to a whole frame. The
+operator's own words for what was missing — *"instead of having density - we need to have
+hotkeys to hide and show separately components"*.
+
+So **visibility is the mechanism and density is a name for one arrangement of it**
+(spec §4). One key per component, declared beside the component in `[[frame.component]]`,
+bound by `commands_frame.conf_text` at launch, and firing `charter frame-toggle <name>`
+— which flips that one name in the frame's own hidden set and hands the result to the
+SAME re-layout a density change goes through. There is no second resize path, and
+`cmd_density` is now a caller of the same one rather than the owner of it.
+
+Four properties, one class each:
+
+**A key is validated at the config boundary, by `instance._HOTKEY_RE`.** Not a second
+regex. `[frame] hotkey` reached tmux CONFIG TEXT and a newline in it ran a second command
+at launch with no keypress (`instance._HOTKEY_RE`'s own docstring measures it); a
+component's key reaches the identical `bind -n` line from the identical committed file,
+so it is held to the identical alphabet. `TheKeyIsValidatedWhereTheHotkeyIs` asks that as
+a property of the two functions, not of a spelling.
+
+**A key toggles ONE component, live, and the layout recomputes.**
+`AKeyTogglesOneComponentLive` is Task 5's headline: the pane that goes is the toggled
+component's, every other pane survives with its size re-asserted, and the panels repaint
+because the frame's version bumped.
+
+**Density is a named arrangement over that same visibility.**
+`DensityIsANamedArrangementOverVisibility` pins that a level writes a hidden SET rather
+than driving a layout of its own, so a toggle after a density change composes with it
+instead of fighting it.
+
+**Nothing off disk reaches tmux unchecked.** The hidden set is a file under the frame's
+own state directory, which is to say a file whoever can write there decides the contents
+of (#475's whole shape) — so a name read back out of it is held to the component
+alphabet, and a name that is not in this frame's arrangement toggles nothing.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config, instance
+from charter.frame import component, overlay, state
+
+from tests._isolation import PersonaIso
+
+
+def _a_dead_pid() -> int:
+    """A real pid that has exited and been reaped — `tests/test_frame_density.py`'s own
+    helper, repeated rather than imported for the reason that copy states: a test module
+    importing another test module's private helper couples two files that are otherwise
+    independent."""
+    p = subprocess.Popen([sys.executable, "-c", "pass"])
+    p.wait()
+    return p.pid
+
+
+class _Tmux:
+    """A recording stand-in for `tmuxctl.run` — `tests/test_frame_density.py`'s fake,
+    repeated for the same reason `_a_dead_pid` is. It answers the two queries a re-layout
+    actually reads a value out of (the window size, and a pane id per split) and reports
+    success for everything else."""
+
+    def __init__(self, *, size="200:50", new_panes=("%7", "%8", "%9")):
+        self.size = size
+        self.new_panes = list(new_panes)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, action, argv, *, env=None, timeout=None, report=True):
+        self.calls.append(list(argv))
+        out = ""
+        if "display-message" in argv:
+            out = self.size
+        elif "split-window" in argv:
+            out = self.new_panes.pop(0) if self.new_panes else ""
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+    def killed(self) -> set[str]:
+        return {c[c.index("kill-pane") + 2] for c in self.calls if "kill-pane" in c}
+
+    def split(self) -> list[str]:
+        return [c[c.index("panel") + 1] for c in self.calls
+                if "split-window" in c and "panel" in c]
+
+
+#: The arrangement every live test below runs against: charter's own four panels, written
+#: out the long way so each can carry a key. Spelled as committed TOML tables rather than
+#: as resolved placements, because the thing under test is what a COMMITTED file does —
+#: an arrangement assembled by hand into the shape `layout` wants would pass with
+#: `instance.frame_of` dropping the key on the floor.
+_TABLES = [
+    {"use": "identity", "key": "F5"},
+    {"use": "attention", "key": "F6"},
+    {"use": "repos", "key": "F7"},
+    {"use": "sidebar", "key": "F8"},
+]
+
+
+class AKeyTogglesOneComponentLive(PersonaIso, unittest.TestCase):
+    """Task 5's headline: a component's key toggles only it, live, and the layout
+    recomputes — through the Phase 1 registry's own path, not a second one."""
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"tg-{_a_dead_pid()}"
+        self.enterContext(mock.patch.dict(os.environ,
+                                          {"CHARTER_SESSION_ID": self.fid}))
+        self.enterContext(mock.patch("charter.frame.tmuxctl.version",
+                                     return_value=(3, 7)))
+        self.frame = instance.frame_of({"frame": {"component": list(_TABLES)}})
+        self.enterContext(mock.patch.dict(config.FRAME, self.frame))
+        state.record_harness_pane(self.fid, "%0")
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2",
+                                             "repos": "%5", "right": "%4"})
+
+    def _toggle(self, name, fake=None):
+        fake = fake or _Tmux()
+        with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            rc = commands_frame.cmd_toggle(SimpleNamespace(component=name))
+        return rc, fake
+
+    def test_the_arrangement_carries_every_declared_key(self):
+        """The control for everything below: the committed key survives `frame_of`. A
+        run where it did not would pass the no-op assertions for the wrong reason."""
+        self.assertEqual({p["slot"]: p["key"] for p in self.frame["components"]},
+                         {"top": "F5", "bottom": "F6", "repos": "F7", "right": "F8"})
+
+    def test_pressing_a_key_kills_that_components_pane_and_no_other(self):
+        before = state.version(self.fid)
+        rc, fake = self._toggle("repos")
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.killed(), {"%5"}, fake.calls)
+        self.assertEqual(state.panes(self.fid),
+                         {"top": "%1", "bottom": "%2", "right": "%4"})
+        self.assertGreater(state.version(self.fid), before)
+
+    def test_pressing_it_again_brings_that_component_back_and_only_it(self):
+        """A toggle is not a delete: the arrangement still holds `repos`, so the second
+        press has something to bring back and knows its edge and its size without the
+        operator naming any of it again. That is the whole difference from deleting a name
+        from `slots`, which loses the position along with the panel.
+
+        The recorded map is survivors-then-new, and that is `_relayout`'s own documented
+        behaviour rather than anything this changes: a pane that did not change is not
+        re-split (#500 round 3 measures why the surviving order is what `repos_cols` must
+        be asked with). Where the ARRANGEMENT's order shows up is in `want`, which is what
+        a re-layout from nothing splits in — `DensityIsANamedArrangementOverVisibility`
+        asserts that half."""
+        self._toggle("repos")
+        rc, fake = self._toggle("repos")
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.split(), ["repos"], fake.calls)
+        self.assertEqual(fake.killed(), set(), fake.calls)
+        self.assertEqual(list(state.panes(self.fid)),
+                         ["top", "bottom", "right", "repos"])
+        # Recorded EMPTY, not forgotten: "the operator turned the last one back on" and
+        # "nobody has touched this frame" are different answers, and only the second one
+        # falls back to what the config declared.
+        self.assertEqual(state.hidden(self.fid), ())
+
+    def test_a_first_press_never_conjures_a_panel_the_frame_was_not_showing(self):
+        """A plane whose `[frame] slots` was trimmed to two panels shows two panels, and a
+        keypress may only ever change the ONE component it names. The universe a level can
+        reach is longer than the frame — that is what lets `full` still mean four panels —
+        and reading that longer list as "everything is visible" would make the first press
+        of any key add the two the operator had removed."""
+        frame = instance.frame_of({"frame": {"slots": ["top", "bottom"]}})
+        with mock.patch.dict(config.FRAME, frame):
+            state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+            rc, fake = self._toggle("top")
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.split(), [], fake.calls)
+        self.assertEqual(fake.killed(), {"%1"}, fake.calls)
+        self.assertEqual(state.panes(self.fid), {"bottom": "%2"})
+
+    def test_the_survivors_keep_their_sizes(self):
+        """tmux redistributes every remaining pane proportionally on a `kill-pane`, so a
+        toggle that only killed a pane would leave the others stretched. This is the same
+        `_reassert_sizes` a density change goes through — which is the point: one path."""
+        _, fake = self._toggle("repos")
+        resized = {c[c.index("-t") + 1] for c in fake.calls if "resize-pane" in c}
+        self.assertIn("%1", resized)
+        self.assertIn("%2", resized)
+        self.assertIn("%4", resized)
+
+
+class ARefusedToggleChangesNothingAtAll(PersonaIso, unittest.TestCase):
+    """The refusals `cmd_toggle` makes, each asserted by what did NOT happen.
+
+    A return code cannot tell these apart — `cmd_toggle` answers 0 for everything, on
+    purpose, because it runs as a `run-shell` child where the only screen left to report
+    on is the agent's own. So each test below asserts the CONSEQUENCE the guard exists to
+    prevent: no tmux command ran, and the frame's hidden set is untouched. A guard deleted
+    is then a tmux call that appears, not an exit code that stays the same.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"tg-{_a_dead_pid()}"
+        self.enterContext(mock.patch("charter.frame.tmuxctl.version",
+                                     return_value=(3, 7)))
+        self.enterContext(mock.patch.dict(
+            config.FRAME, instance.frame_of({"frame": {"component": list(_TABLES)}})))
+        state.record_harness_pane(self.fid, "%0")
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2",
+                                             "repos": "%5", "right": "%4"})
+
+    def _toggle(self, name, *, fid=None):
+        env = {} if fid is None else {"CHARTER_SESSION_ID": fid}
+        fake = _Tmux()
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            rc = commands_frame.cmd_toggle(SimpleNamespace(component=name))
+        return rc, fake
+
+    def test_a_name_this_frames_arrangement_does_not_hold_moves_no_pane(self):
+        """`made_up` is a perfectly usable component id and is not in this arrangement,
+        so the ONLY guard that can refuse it is the arrangement check. Without it the name
+        goes on to `_relayout` and becomes a `split-window ... charter panel made_up` and
+        a respawn hook naming it in tmux config text."""
+        rc, fake = self._toggle("made_up", fid=self.fid)
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.calls, [])
+        self.assertIsNone(state.hidden(self.fid))
+
+    def test_a_hostile_name_is_refused_by_the_same_one_guard(self):
+        """The `[frame] hotkey` class, arriving on an argv instead of in a config file.
+        Not reasoned about — each of these is run.
+
+        The consequence a survivor would have: `_arm_panel_respawn` writes the name into
+        a tmux hook's ACTION TEXT, which tmux re-parses, and `layout.panel_command` puts
+        it on a `split-window` argv. A newline there is `instance._HOTKEY_RE`'s own
+        incident one surface over."""
+        for name in ("repos\nkill-server", "repos kill-server", "repos\x1b[31m",
+                     "repos'", 'repos"', "repos#{q:x}", "repos;kill-server",
+                     "repos $(id)", "../../etc/passwd", "REPOS", ""):
+            with self.subTest(name=name):
+                rc, fake = self._toggle(name, fid=self.fid)
+                self.assertEqual(rc, 0)
+                self.assertEqual(fake.calls, [], name)
+                self.assertIsNone(state.hidden(self.fid))
+
+    def test_a_real_name_is_the_control_and_does_move_a_pane(self):
+        """Without this, a `cmd_toggle` that refused everything would pass every
+        assertion above."""
+        rc, fake = self._toggle("repos", fid=self.fid)
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.killed(), {"%5"}, fake.calls)
+        self.assertEqual(state.hidden(self.fid), ("repos",))
+
+    def test_outside_a_frame_it_does_nothing(self):
+        """No `$CHARTER_SESSION_ID` — typed in an ordinary shell rather than fired by a
+        bind. Nothing runs and nothing is written.
+
+        **`cmd_toggle` has no refusal of its own for this, and that is a finding rather
+        than an omission.** The deletion sweep proved an `if not fid: return 0` at the top
+        of that function exactly equivalent: with it gone the full suite stayed green and
+        every observable was identical — same return code, no tmux command, no file
+        created, nothing readable back. The line that actually carries the property is
+        `_relayout_target`'s `_PANE_ID_RE` check, because `contain.child` refuses `""` as a
+        path segment, so `state.frame_dir` and `state.harness_pane` both answer `None` and
+        the pane id is the empty string. That line IS pinned
+        (`test_a_harness_pane_that_is_not_tmuxs_own_shape_moves_nothing`), so the guarantee
+        rests on something a mutation can reach — which is the whole test the sweep applies.
+
+        The chain is asserted here, not inferred: if `frame_dir` ever started answering for
+        an empty id, this test says so at the step where it changed."""
+        self.assertIsNone(state.frame_dir(""))
+        self.assertIsNone(state.harness_pane(""))
+        rc, fake = self._toggle("repos")
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.calls, [])
+        self.assertIsNone(state.hidden(self.fid))
+
+    def test_a_harness_pane_that_is_not_tmuxs_own_shape_moves_nothing(self):
+        """#475's rule, on the value `_relayout_target` reads off disk. Unrefused, `%1;
+        kill-server` becomes a split target and a hook action — which is the file-in-the-
+        state-directory attack that guard was added for.
+
+        The control is the test above: the same call with a real `%0` recorded does move a
+        pane, so a `cmd_toggle` that had simply stopped working is red."""
+        for pane in ("%1;kill-server", "", "1", "%", "@1"):
+            with self.subTest(pane=pane):
+                state.record_harness_pane(self.fid, pane)
+                rc, fake = self._toggle("repos", fid=self.fid)
+                self.assertEqual(rc, 0)
+                self.assertEqual(fake.calls, [], pane)
+                self.assertIsNone(state.hidden(self.fid))
+
+    def test_a_tmux_whose_version_charter_could_not_read_moves_nothing(self):
+        """Every builder a re-layout reaches for takes the version — `_relayout` decides
+        `split-window`'s flags from it. Without a version there is nothing to build the
+        commands from, so the frame is left exactly as it is."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=None):
+            rc, fake = self._toggle("repos", fid=self.fid)
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.calls, [])
+        self.assertIsNone(state.hidden(self.fid))
+
+    def test_the_hidden_set_is_written_only_after_the_frame_can_be_relaid_out(self):
+        """Ordering, asserted rather than assumed. A refusal that had already written the
+        hidden set would leave the frame's recorded shape disagreeing with its panes for
+        the rest of its life — and the next thing that DID re-lay it out would silently
+        apply a decision this keypress was refused."""
+        state.record_harness_pane(self.fid, "%1;kill-server")
+        self._toggle("repos", fid=self.fid)
+        self.assertIsNone(state.hidden(self.fid))
+
+
+class TheKeyIsValidatedWhereTheHotkeyIs(unittest.TestCase):
+    """`[[frame.component]]`'s `key` is `[frame] hotkey`'s alphabet, asked once.
+
+    Not "a similar check". `instance.toggle_key` IS `instance._HOTKEY_RE`, and the first
+    test below asks that as a property of the two functions rather than by reading the
+    pattern — a second regex spelled beside the first would pass an eyeball review and
+    drift on the first change to either.
+    """
+
+    def test_a_toggle_key_and_a_frame_hotkey_accept_exactly_the_same_words(self):
+        """The two answer identically for every word, accepted and refused alike. A
+        second pattern — even a correct copy of today's — is red the day either moves."""
+        for word in ("F2", "F12", "M-m", "C-M-S-x", "a", "7", "Up", "PPage", "BSpace",
+                     "Escape", "|", "_", "-",
+                     "F2\nrun-shell 'touch /tmp/PWNED'", "F2 ", " F2", "F2;kill-server",
+                     "F2#{q:x}", "F2$(id)", 'F2"', "F2'", "", "F2 x", "M-",
+                     "C-C-C-C-x", "toolongforakeynametobeatallplausible"):
+            with self.subTest(word=word):
+                self.assertEqual(instance.toggle_key(word) is not None,
+                                 instance._HOTKEY_RE.fullmatch(word) is not None)
+
+    def test_a_key_that_is_not_text_is_refused_rather_than_raising(self):
+        """`tomllib` hands a table or an array straight through, and
+        `_HOTKEY_RE.fullmatch` raises `TypeError` for either — in a module every command
+        imports, `charter --version` included. `density_level`'s own guard, one key over.
+        """
+        for value in ([], {}, ["F2"], 2, True, None, 1.5):
+            with self.subTest(value=value):
+                self.assertIsNone(instance.toggle_key(value))
+
+    def test_a_usable_key_reaches_the_placement(self):
+        """The control: without it every refusal below passes against a `key` nothing
+        ever reads."""
+        got = instance.frame_of(
+            {"frame": {"component": [{"use": "identity", "key": "M-i"}]}})
+        self.assertEqual([(p["slot"], p["key"]) for p in got["components"]],
+                         [("top", "M-i")])
+
+    def test_a_key_charter_will_not_bind_refuses_the_whole_arrangement(self):
+        """#535's rule, applied to the new field: refused whole, so the operator sees
+        their arrangement not take effect rather than one panel quietly un-toggleable.
+
+        The fixture reaches exactly ONE guard — a single table, a key no other component
+        claims and no `[frame] hotkey` equals — so a survivor here cannot be a neighbour
+        catching it for a different reason."""
+        for key in ("F2\nbind -n F3 kill-server", "F2 ", "F2;kill-server", "F2#{q:x}",
+                    "F2'", 'F2"', "F2 x", "", ["F2"], {"k": "F2"}, 7, True):
+            with self.subTest(key=key):
+                frame = instance.frame_of(
+                    {"frame": {"hotkey": "M-x",
+                               "component": [{"use": "identity", "key": key}]}})
+                self.assertEqual(frame["components"], [])
+                self.assertEqual(frame["slots"], instance.FRAME_DEFAULTS["slots"])
+
+    def test_two_components_may_not_claim_one_key(self):
+        """Only the duplicate guard can fire here: `F5` is a key `_HOTKEY_RE` accepts and
+        is not the frame's hotkey. tmux has no notion of a conflict — the later `bind -n`
+        replaces the earlier — so unrefused this is one panel that cannot be toggled at
+        all and nothing anywhere saying which."""
+        frame = instance.frame_of({"frame": {"hotkey": "M-x", "component": [
+            {"use": "identity", "key": "F5"}, {"use": "attention", "key": "F5"}]}})
+        self.assertEqual(frame["components"], [])
+
+    def test_two_components_with_different_keys_are_the_control(self):
+        frame = instance.frame_of({"frame": {"hotkey": "M-x", "component": [
+            {"use": "identity", "key": "F5"}, {"use": "attention", "key": "F6"}]}})
+        self.assertEqual([p["key"] for p in frame["components"]], ["F5", "F6"])
+
+    def test_a_component_may_not_take_the_frames_own_palette_key(self):
+        """Only the collision guard can fire: `F2` is usable and no other component
+        claims it. `conf_text` writes the palette's bind FIRST, so a later `bind -n F2`
+        here replaces it — and since Task 4 deleted the menu (§4h), that is every action
+        charter has: the density levels, both pickers, detach, all of it, gone from every
+        frame on the socket with nothing left to open them with."""
+        frame = instance.frame_of(
+            {"frame": {"component": [{"use": "identity", "key": "F2"}]}})
+        self.assertEqual(frame["components"], [])
+        self.assertEqual(frame["slots"], instance.FRAME_DEFAULTS["slots"])
+
+    def test_a_component_may_not_take_the_escape_hatchs_key(self):
+        """Task 2 (#554) bound `F12` as the escape hatch — the one key that must keep
+        working when charter's own code does not. A committed `key = "F12"` would be a
+        second `bind -n` for it.
+
+        **Refused here rather than left to the emission order, which happens to be
+        harmless.** `conf_text` writes toggle binds BEFORE `overlay.hatch_bind()`, so
+        tmux's last-wins would leave the hatch alive and the component's key silently
+        dead — an operator's key doing nothing, with nothing saying why. Relying on that
+        would also make this refusal unpinnable, since deleting it would change nothing
+        observable: a guard whose consequence depends on where two other lines are emitted
+        is the masked guard #553 was.
+
+        Only this refusal can fire: `F12` is a key `_HOTKEY_RE` accepts, no other component
+        claims it, and the frame's palette is on `M-x`."""
+        frame = instance.frame_of({"frame": {"hotkey": "M-x", "component": [
+            {"use": "identity", "key": overlay.HATCH_KEY}]}})
+        self.assertEqual(frame["components"], [])
+        self.assertEqual(frame["slots"], instance.FRAME_DEFAULTS["slots"])
+
+    def test_a_key_charter_has_not_taken_is_the_control(self):
+        """Without this, a `component_tables` that refused every key would pass the test
+        above. `F11` is next to the hatch and is nobody's."""
+        frame = instance.frame_of({"frame": {"hotkey": "M-x", "component": [
+            {"use": "identity", "key": "F11"}]}})
+        self.assertEqual([p["key"] for p in frame["components"]], ["F11"])
+
+    def test_the_collision_is_with_the_key_actually_bound_not_the_shipped_one(self):
+        """The operator moved their palette to `M-x`, so `F2` is theirs to bind and `M-x` is
+        not. Asserted in both directions, because a guard comparing against the shipped
+        `F2` constant instead of the RESOLVED hotkey passes the test above and is wrong
+        on every plane that set the key."""
+        frame = {"hotkey": "M-x", "component": [{"use": "identity", "key": "F2"}]}
+        self.assertEqual([p["key"] for p in instance.frame_of({"frame": frame})
+                          ["components"]], ["F2"])
+        frame["component"] = [{"use": "identity", "key": "M-x"}]
+        self.assertEqual(instance.frame_of({"frame": frame})["components"], [])
+
+    def test_an_unusable_hotkey_collides_at_the_key_that_replaces_it(self):
+        """A refused `[frame] hotkey` degrades to the shipped `F2` (`_HOTKEY_RE`), and
+        `F2` is then what the palette is bound to — so `F2` is what a component may not take.
+        The comparison is against `frame_of`'s resolved answer for that reason, not
+        against what the file said."""
+        frame = instance.frame_of(
+            {"frame": {"hotkey": "not a key at all",
+                       "component": [{"use": "identity", "key": "F2"}]}})
+        self.assertEqual(frame["hotkey"], "F2")
+        self.assertEqual(frame["components"], [])
+
+    def test_the_arrangement_is_one_answer_however_it_is_asked(self):
+        """`frame_components` used to resolve the committed tables a SECOND time, without
+        the hotkey — so it would have accepted the very arrangement `config.FRAME` had
+        already thrown away. Two answers to one question is what #547 cost."""
+        cfg = {"frame": {"component": [{"use": "identity", "key": "F2"}]}}
+        self.assertEqual(instance.frame_of(cfg)["components"], [])
+        self.assertEqual([p["use"] for p in instance.frame_components(cfg)],
+                         ["identity", "attention", "repos", "sidebar"])
+
+    def test_an_arrangement_with_no_keys_at_all_still_resolves(self):
+        """The overwhelmingly common case, and the control for every refusal above: a
+        table with no `key` is not a table with a bad one."""
+        frame = instance.frame_of(
+            {"frame": {"component": [{"use": "identity"}, {"use": "attention"}]}})
+        self.assertEqual([(p["slot"], p["key"]) for p in frame["components"]],
+                         [("top", None), ("bottom", None)])
+        self.assertEqual(instance.frame_toggles(frame), {})
+
+
+class TheBindReachesTmuxConfigText(unittest.TestCase):
+    """`conf_text` writes one `bind -n` per toggle — and refuses both halves of a line it
+    cannot write safely.
+
+    This is the `source-file` boundary: `instance._HOTKEY_RE`'s docstring records
+    measuring, on tmux 3.7c, that a newline in a value interpolated here makes
+    `source-file` return **0**, silently, and runs a second tmux command at launch with no
+    keypress. So the assertions are about the TEXT, and the hostile values are run rather
+    than reasoned about.
+    """
+
+    def _text(self, toggles):
+        return commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                        session="fr-1", toggles=toggles)
+
+    def test_a_key_binds_the_toggle_for_its_own_component(self):
+        text = self._text({"repos": "F7"})
+        self.assertIn("bind -n F7 run-shell "
+                      "'\"$CHARTER_PY\" -m charter frame-toggle repos'", text)
+
+    def test_every_declared_toggle_gets_its_own_line_in_split_order(self):
+        text = self._text({"top": "F5", "bottom": "F6", "repos": "F7"})
+        bound = [ln.split()[2] for ln in text.split("\n") if "frame-toggle" in ln]
+        self.assertEqual(bound, ["F5", "F6", "F7"])
+
+    def test_a_plane_that_declared_none_gets_the_config_it_always_got(self):
+        """The default is not a hidden feature: a `slots`-spelled plane has nowhere to
+        write a key, so its frame's config must be byte-identical to the one it had."""
+        self.assertEqual(self._text({}), self._text(None))
+        self.assertNotIn("frame-toggle", self._text({}))
+
+    def test_a_hostile_component_name_never_reaches_the_bind_line(self):
+        """Only the name guard is in play — every key here is a plain `F7`. A survivor is
+        a `bind` line ending early and a second tmux command starting."""
+        for name in ("repos\nbind -n F3 kill-server", "repos'", 'repos"', "repos;x",
+                     "repos #{q:x}", "repos x", "repos\x1b[31m", "../etc", "REPOS",
+                     "", "repos bottom"):
+            with self.subTest(name=name):
+                text = self._text({name: "F7"})
+                self.assertNotIn("frame-toggle", text, name)
+                self.assertEqual(len(text.split("\n")), len(self._text({}).split("\n")))
+
+    def test_a_hostile_key_never_reaches_the_bind_line(self):
+        """Only the key guard is in play — every name here is a plain `repos`. The
+        newline payload is `instance._HOTKEY_RE`'s own measured exploit, moved one key
+        over."""
+        for key in ("F7\nrun-shell 'touch /tmp/PWNED'", "F7 ", "F7;kill-server",
+                    "F7#{q:x}", "F7'", 'F7"', "F7 x", "", None, ["F7"], 7, True):
+            with self.subTest(key=key):
+                text = self._text({"repos": key})
+                self.assertNotIn("frame-toggle", text, repr(key))
+                self.assertEqual(len(text.split("\n")), len(self._text({}).split("\n")))
+
+    def test_a_refused_pair_costs_its_key_and_nothing_else(self):
+        """The degrade, stated: the other keys still bind and the settings above them are
+        untouched, because the alternative is a `source-file` that fails and takes
+        `mouse`, `history-limit` and the palette's own hotkey down with it."""
+        text = self._text({"top": "F5", "repos": "F7\nkill-server", "bottom": "F6"})
+        bound = [ln.split()[2] for ln in text.split("\n") if "frame-toggle" in ln]
+        self.assertEqual(bound, ["F5", "F6"])
+        self.assertIn("set -t fr-1 status off", text)
+        self.assertIn("bind -n F2 run-shell", text)
+
+    def test_the_toggle_binds_are_written_after_the_palettes_own(self):
+        """Order is what keeps `instance.component_tables`' collision refusal honest. tmux
+        replaces a bind rather than reporting a conflict, so a component that reached this
+        function with the palette's key would take the palette away — a real, observable
+        consequence, which is what makes that refusal pinnable. Emitting these first would
+        make the same deletion look harmless."""
+        lines = self._text({"repos": "F7"}).split("\n")
+        self.assertLess(next(i for i, ln in enumerate(lines) if "frame-palette" in ln),
+                        next(i for i, ln in enumerate(lines) if "frame-toggle" in ln))
+
+    def test_the_escape_hatch_is_still_the_last_line(self):
+        """Task 2's invariant, which this change had to be inserted underneath rather than
+        appended after. `frame/overlay.py`'s `hatch_bind` uses `run-shell -C`, which first
+        parses in tmux 3.2 (`tmuxctl.FLOOR`), so it goes last precisely so that a tmux too
+        old to parse it has already applied everything else in the file. A toggle bind
+        appended after it would be the first thing such a tmux dropped — the operator's
+        keys lost to a version skew that costs nothing else.
+
+        Asserted with toggles present AND absent, because the interesting case is the one
+        this task introduced and the other is the control."""
+        for toggles in ({"repos": "F7", "right": "M-s"}, {}, None):
+            with self.subTest(toggles=toggles):
+                lines = [ln for ln in self._text(toggles).split("\n") if ln]
+                self.assertEqual(lines[-1], overlay.hatch_bind())
+
+    def test_a_toggle_bind_sits_between_the_palette_and_the_hatch(self):
+        """The whole ordering, in one assertion, because the two ends are load-bearing for
+        opposite reasons: after the palette so a colliding key would visibly steal it (which
+        is what makes `component_tables`' refusal pinnable), before the hatch so a tmux
+        below the floor never drops it."""
+        lines = self._text({"repos": "F7"}).split("\n")
+        palette = next(i for i, ln in enumerate(lines) if "frame-palette" in ln)
+        toggle = next(i for i, ln in enumerate(lines) if "frame-toggle" in ln)
+        hatch = next(i for i, ln in enumerate(lines) if ln == overlay.hatch_bind())
+        self.assertLess(palette, toggle)
+        self.assertLess(toggle, hatch)
+
+    def test_the_interpreter_is_carried_out_of_band_like_every_other_bind(self):
+        """`"$CHARTER_PY" -m charter`, never a bare `charter` — #390 and `conf_text`'s own
+        docstring. A bare name resolves to whatever the tmux server's PATH has, and
+        `run-shell` reports the 127 by printing it INTO THE HARNESS PANE."""
+        line = next(ln for ln in self._text({"repos": "F7"}).split("\n")
+                    if "frame-toggle" in ln)
+        self.assertIn('"$CHARTER_PY" -m charter', line)
+        self.assertNotIn("'charter ", line)
+
+
+class DensityIsANamedArrangementOverVisibility(PersonaIso, unittest.TestCase):
+    """A level names a set of visible components; it does not drive a layout of its own.
+
+    The operator's own words for why this had to change: *"instead of having density - we
+    need to have hotkeys to hide and show separately components"*. If a level kept its own
+    path, a toggle afterwards would be a second idea about what the frame is, and the two
+    would take turns overwriting each other.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"dn-{_a_dead_pid()}"
+        self.enterContext(mock.patch.dict(os.environ,
+                                          {"CHARTER_SESSION_ID": self.fid}))
+        self.enterContext(mock.patch("charter.frame.tmuxctl.version",
+                                     return_value=(3, 7)))
+        state.record_harness_pane(self.fid, "%0")
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2",
+                                             "repos": "%5", "right": "%4"})
+
+    def _density(self, level, fake=None):
+        fake = fake or _Tmux()
+        with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            rc = commands_frame.cmd_density(SimpleNamespace(level=level))
+        return rc, fake
+
+    def _toggle(self, name):
+        fake = _Tmux()
+        with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            rc = commands_frame.cmd_toggle(SimpleNamespace(component=name))
+        return rc, fake
+
+    def test_a_level_is_recorded_as_the_components_it_hides(self):
+        rc, _ = self._density("minimal")
+        self.assertEqual(rc, 0)
+        self.assertEqual(state.hidden(self.fid), ("repos", "right"))
+
+    def test_the_level_itself_is_still_recorded_for_the_verbosity(self):
+        """The one axis a per-component key cannot express: how much each panel SAYS. A
+        level that only wrote a hidden set would silently drop `terse`."""
+        self._density("minimal")
+        self.assertEqual(state.density(self.fid), "minimal")
+
+    def test_a_key_after_a_level_composes_with_it_instead_of_undoing_it(self):
+        """The property the whole design turns on. `minimal` hides the table and the
+        sidebar; the sidebar's own key then brings back the sidebar AND NOTHING ELSE."""
+        self._density("minimal")
+        rc, fake = self._toggle("right")
+        self.assertEqual(rc, 0)
+        self.assertEqual(state.hidden(self.fid), ("repos",))
+        self.assertEqual(fake.split(), ["right"], fake.calls)
+
+    def test_a_level_after_a_key_replaces_the_whole_set(self):
+        """The other direction, and why a level is a NAME for an arrangement rather than
+        one more edit to it: picking `full` means "everything", including whatever was
+        toggled off before it."""
+        self._toggle("repos")
+        self.assertEqual(state.hidden(self.fid), ("repos",))
+        self._density("full")
+        self.assertEqual(state.hidden(self.fid), ())
+
+    def test_the_level_names_a_set_and_the_arrangement_says_where_they_go(self):
+        """Split order is the plane's, not the level's. `instance.FRAME_DENSITY`'s lists
+        are in charter's shipped order because they had to name one; an operator's own
+        `[frame] slots` order is a promise `instance.frame_of` keeps verbatim, and
+        `layout.repos_cols`' whole docstring is about that order being the geometry.
+
+        Asserted with NO panes recorded, which is the only shape that tells the two
+        orders apart: with a pane already there it survives in place and everything else
+        is split after it in the same relative order either way. From nothing, every pane
+        is split in *want*'s order and the recorded map is that order."""
+        frame = instance.frame_of({"frame": {"slots": ["right", "top", "bottom"]}})
+        with mock.patch.dict(config.FRAME, frame):
+            state.record_panes(self.fid, panels={})
+            self._density("full", _Tmux(new_panes=("%7", "%8", "%9", "%10")))
+        self.assertEqual(list(state.panes(self.fid)),
+                         ["right", "top", "bottom", "repos"])
+
+    def test_the_universe_is_the_planes_own_order_and_then_charters(self):
+        """Asserted on a `slots` list that is NOT a prefix of the shipped one, which is
+        the only shape that tells the two halves apart: reading the plane's own order
+        first, and appending the built-ins it never named. `["right", "top"]` is the
+        shortest list with that property — `tests/test_frame_config.py` uses it for the
+        same reason."""
+        frame = instance.frame_of({"frame": {"slots": ["right", "top"]}})
+        self.assertEqual(instance.frame_arrangement(frame),
+                         ["right", "top", "bottom", "repos"])
+
+    def test_a_written_out_arrangement_keeps_its_hidden_panels_in_the_universe(self):
+        """`visible = false` is a component that EXISTS and is off, which `slots` cannot
+        say at all — so the universe has to come from the placements rather than from the
+        visible list they resolve down to. Read the other way, `repos` would lose the
+        position its own file gives it and come back at charter's."""
+        frame = instance.frame_of({"frame": {"component": [
+            {"use": "repos", "visible": False}, {"use": "identity"}]}})
+        self.assertEqual(frame["slots"], ["top"])
+        self.assertEqual(instance.frame_arrangement(frame),
+                         ["repos", "top", "bottom", "right"])
+
+    def test_a_level_can_still_name_a_panel_the_plane_never_listed(self):
+        """`slots = ["top", "bottom"]` and `full` — behaviour every plane has had since
+        presets existed, and the reason `frame_arrangement` appends charter's own
+        built-ins to the universe rather than stopping at what the file wrote."""
+        frame = instance.frame_of({"frame": {"slots": ["top", "bottom"]}})
+        self.assertEqual(instance.frame_arrangement(frame),
+                         ["top", "bottom", "repos", "right"])
+        with mock.patch.dict(config.FRAME, frame):
+            self._density("full")
+        self.assertEqual(state.hidden(self.fid), ())
+        self.assertEqual(sorted(state.panes(self.fid)),
+                         ["bottom", "repos", "right", "top"])
+
+
+class WhatTheFrameIsNotDrawingRightNow(PersonaIso, unittest.TestCase):
+    """`state.hidden` and `commands_frame._hidden_now` — the two-source read that makes
+    "for the running frame only" true."""
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"hd-{_a_dead_pid()}"
+
+    def test_a_frame_nobody_has_touched_has_recorded_nothing(self):
+        self.assertIsNone(state.hidden(self.fid))
+
+    def test_recorded_empty_and_never_recorded_are_different_answers(self):
+        """The distinction `record_hidden` writes a newline-per-name file to keep. Without
+        it, an operator who toggles the last hidden panel back on has that panel put
+        straight back by the config on the next repaint, and the key looks broken."""
+        state.record_hidden(self.fid, [])
+        self.assertEqual(state.hidden(self.fid), ())
+        self.assertIsNotNone(state.hidden(self.fid))
+
+    def test_the_config_answers_with_everything_it_is_not_showing(self):
+        """The arrangement minus the visible list, in arrangement order. `repos` is
+        hidden because the file says `visible = false`; `attention` and `sidebar` are
+        hidden because this plane never placed them at all, and they are only in the
+        universe so a density level can still reach them."""
+        frame = instance.frame_of({"frame": {"component": [
+            {"use": "identity"}, {"use": "repos", "visible": False}]}})
+        self.assertEqual(frame["slots"], ["top"])
+        self.assertEqual(commands_frame._hidden_now(self.fid, frame),
+                         ["repos", "bottom", "right"])
+
+    def test_a_trimmed_slot_list_is_read_the_same_way(self):
+        """The commonest plane there is, and the one a `visible = false`-only reading got
+        wrong: `slots = ["top", "bottom"]` shows two panels, so the other two are hidden.
+        Read as "nothing is hidden", the very first keypress on such a plane would have
+        conjured the repo table and the sidebar out of nowhere."""
+        frame = instance.frame_of({"frame": {"slots": ["top", "bottom"]}})
+        self.assertEqual(commands_frame._hidden_now(self.fid, frame),
+                         ["repos", "right"])
+
+    def test_a_recorded_set_beats_the_configured_one(self):
+        frame = instance.frame_of({"frame": {"component": [
+            {"use": "identity"}, {"use": "repos", "visible": False}]}})
+        state.record_hidden(self.fid, [])
+        self.assertEqual(commands_frame._hidden_now(self.fid, frame), [])
+
+    def test_it_round_trips_in_order(self):
+        state.record_hidden(self.fid, ["repos", "right"])
+        self.assertEqual(state.hidden(self.fid), ("repos", "right"))
+
+    def test_a_frame_id_that_cannot_name_a_directory_writes_nothing_and_raises_nothing(self):
+        """`$CHARTER_SESSION_ID` reaches both halves without ever going through
+        `state.frame_id`'s minting, so a hostile or oversized id is a real input and
+        `contain.child` answers ``None`` for it. Both run inside a `run-shell` child,
+        where an exception is a traceback printed INTO THE HARNESS PANE — the one
+        rectangle ADR 0018 says charter never draws in."""
+        for fid in ("../evil", "a/b", "", ".", "x" * 5000):
+            with self.subTest(fid=fid):
+                state.record_hidden(fid, ["repos"])          # must not raise
+                self.assertIsNone(state.hidden(fid))
+
+    def test_a_state_directory_that_cannot_be_written_is_not_an_exception(self):
+        """The other half of the same promise, one layer down: a full disk, a read-only
+        state directory, an `os.replace` across a boundary. The keypress does nothing,
+        which is what every other writer in `frame/state.py` already does."""
+        with mock.patch("pathlib.Path.write_text", side_effect=OSError("no space")):
+            state.record_hidden(self.fid, ["repos"])         # must not raise
+        self.assertIsNone(state.hidden(self.fid))
+
+    def test_a_new_frame_never_inherits_a_dead_ones_hidden_set(self):
+        """#383's recycled pid, one file over. A frame id is `<workspace>-<launcher pid>`,
+        and a launcher landing on a pid an earlier launcher used adopts that directory —
+        so a panel the previous operator dismissed would be missing from a brand-new
+        frame, with `[frame] slots` naming it and nothing on screen to say why."""
+        state.record_hidden(self.fid, ["repos"])
+        state.clear_shape(self.fid)
+        self.assertIsNone(state.hidden(self.fid))
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1706,6 +1706,35 @@ class Launch(PersonaIso, unittest.TestCase):
                         "the real config was never loaded via `source-file`")
         self.assertIn("mouse", fake.sourced_conf_text)
 
+    def test_a_components_toggle_key_is_bound_by_the_config_the_launch_sources(self):
+        """Phase 2, Task 5, wired end to end: a `key` in the plane's committed
+        arrangement becomes a `bind -n` in the file this launch actually loads.
+
+        Asserted HERE rather than on `conf_text` alone, because `conf_text` takes the
+        toggles as a parameter and a launch that simply never passed them would leave
+        every one of that function's own tests green while no key on any plane did
+        anything. The frame is `instance.frame_of`'s answer, so this fails if the config
+        boundary drops the key too.
+        """
+        frame = instance.frame_of({"frame": {"component": [
+            {"use": "identity"}, {"use": "attention"},
+            {"use": "repos", "key": "F7"}]}})
+        self.assertEqual(instance.frame_toggles(frame), {"repos": "F7"})
+        fake = _FakeTmux(exit_code=0)
+        with mock.patch.dict(config.FRAME, frame):
+            _launch(fake)
+        self.assertIn("bind -n F7 run-shell "
+                      "'\"$CHARTER_PY\" -m charter frame-toggle repos'",
+                      fake.sourced_conf_text)
+
+    def test_a_plane_that_binds_no_component_keys_sources_no_toggle_binds(self):
+        """The control, and the shipped default: `[frame] slots` has nowhere to write a
+        key, so charter binds none — a `bind -n` is server-wide and intercepts the key
+        before the harness pane ever sees it."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        self.assertNotIn("frame-toggle", fake.sourced_conf_text)
+
     def test_both_hooks_are_installed_as_their_own_commands(self):
         """Companion to the `source-file` test: neither hook is missing from BOTH
         places (baked into the sourced config nor issued separately)."""


### PR DESCRIPTION
Phase 2, Task 5 of the command surface (part of #538), on top of Task 1 (#553).

> *"instead of having density - we need to have hotkeys to hide and show separately components"*

Density was three level names and nothing in between. "Everything except the repo table,
right now, for the next ten minutes" could not be said at all.

## What this is

**Visibility is the mechanism. A density level is a name for one arrangement of it.**

```toml
[[frame.component]]
use = "repos"
key = "F7"

[[frame.component]]
use = "sidebar"
key = "F8"
```

`F7` hides the repo table and gives its rows back to the agent session; `F7` again brings
it back. Hiding a panel does not delete it from the arrangement, so charter still holds
its edge, its size and its place in the order — which is exactly what deleting a name from
`slots` costs you.

## The shape

* `commands_frame.conf_text` turns each `key` into one more `bind -n` running
  `charter frame-toggle <name>`, which flips that one component in the frame's own hidden
  set (`state.record_hidden`) and hands the result to `_apply_arrangement`.
* **`_apply_arrangement` is the one live re-layout path.** `cmd_density` is a caller of it
  now rather than the owner of one: a level is turned into a hidden SET over
  `instance.frame_arrangement` and goes through the same measurement, the same
  `_drawable_slots` filters a launch goes through, the same `_relayout`, the same
  record-and-bump. No second resize path — that would be two answers to "what does this
  frame look like now", the shape #500 and #547 both cost.
* So the two compose: `minimal`, then the sidebar's key, gives the strips and the sidebar;
  picking a level again puts the arrangement back to exactly what the level names. The one
  axis a level still owns alone is `verbosity`, which no per-component key can express,
  and that is what it still records.
* `instance.frame_arrangement` is the universe both move within — the plane's own
  placements in split order, invisible ones included, then charter's built-ins the plane
  never named. That tail is what keeps `slots = ["top", "bottom"]` able to answer `full`,
  as it always could.

## Containment

`instance.toggle_key` **is** `_HOTKEY_RE`, not a second pattern. A component's key is
interpolated into the same `bind -n` line, in the same file, sourced by the same
`source-file`, as `[frame] hotkey`. Re-measured on tmux 3.7c against a config in exactly
the shape `conf_text` writes, with `key = "F9\nrun-shell -b 'touch /tmp/PWNED'"`:

```
$ tmux -L t source-file evil.tmux ; echo $?
0                                     # silently
$ ls -l /tmp/PWNED
-rw-r--r--  1 …  /tmp/PWNED           # at source-file time, no keypress
```

Three refusals at the config boundary, each on its own line so the sweep can tell them
apart, and each taking the whole arrangement out of play (#535): a key charter will not
bind; a key two components both claim (tmux has no notion of a conflict — the later
`bind -n` simply replaces the earlier); and a key equal to the frame's own `hotkey`
(`conf_text` writes the menu's bind first, so that one takes the menu away from every
frame on the socket). The comparison is against `frame_of`'s **resolved** hotkey, never
the shipped constant.

`conf_text` refuses both halves of a toggle line as well, because `component_tables`
accepts a provider's id on the strength of an installed entry-point NAME — a word charter
did not choose. Name through `component.usable_id`, key through `instance.toggle_key`;
neither is a new validator. The binds are written **after** the menu's on purpose: tmux
replaces a bind rather than reporting a conflict, so that order is what keeps the
collision refusal's consequence observable and therefore pinnable, rather than masked by
an emission order two functions away (#553).

Verified against real tmux 3.7c that what `conf_text` returns sources cleanly and reads
back byte for byte:

```
$ tmux -L t5probe source-file conf.tmux ; echo $?
0
$ tmux -L t5probe list-keys -T root | grep -E 'F2|F7|M-s'
bind-key -T root F2  run-shell "\"\$CHARTER_PY\" -m charter frame-menu \"#{client_name}\""
bind-key -T root F7  run-shell "\"\$CHARTER_PY\" -m charter frame-toggle repos"
bind-key -T root M-s run-shell "\"\$CHARTER_PY\" -m charter frame-toggle right"
```

**Charter binds no key by default and must not start.** A `bind -n` is server-wide and
intercepts the key before the pane underneath ever sees it, so four shipped defaults would
be four keys quietly taken from Claude Code — or codex, or whatever the operator ran — on
every plane with a `charter.toml`.

## Two defects found while reviewing, before they shipped

**1. `_hidden_now` read the config wrongly for a trimmed `slots` list.** It first read only
`visible = false`. `frame_arrangement` is deliberately longer than what a frame draws, so a
plane whose `[frame] slots` is `["top", "bottom"]` has `repos` and `sidebar` in its universe
and neither on screen — read as "not hidden", the very first keypress would have conjured
both. It reads **arrangement minus visible** now, which answers for both spellings at once.
Pinned by `test_a_first_press_never_conjures_a_panel_the_frame_was_not_showing` and
`test_a_trimmed_slot_list_is_read_the_same_way`.

**2. A component could take the escape hatch's key.** This surfaced on the rebase onto
`6227ce3`: Task 2 binds `F12` as the hatch — the one key that must keep working when
charter's own code does not. A committed `key = "F12"` is a second `bind -n` for it.
`conf_text` happens to write toggles *before* the hatch, so tmux's last-wins would have left
the hatch alive and the operator's key silently dead — but relying on that would make the
refusal unpinnable, which is the masked guard `#553` was. It is refused at the config
boundary instead, folded into the one `key in bound` line that now answers all three
collisions (another component's key, the frame's `hotkey`, the hatch's key). Pinned by
`test_a_component_may_not_take_the_escape_hatchs_key`, with `F11` as the control.

## Coordination with Task 4 (the palette, #567 — now landed)

Rebased onto `bd90de3`. Task 4 deleted the menu, so two things merged rather than
conflicted:

* **`_apply_arrangement` no longer re-records anything.** It used to call
  `menu.record(... _menu_entries(...))` so the density mark moved with the frame; the
  palette is built from live state each time it opens, so that block is simply gone.
* **The toggle binds sit between the palette's bind and the escape hatch.** Both ends are
  load-bearing and now both are pinned.

The only shared key-binding code is `commands_frame.conf_text`. Exactly what this branch
changes in it:

* the signature — one added keyword, `toggles: dict | None = None`;
* `return "\n".join([...])` became `lines = [...]`, so the list can be appended to;
* a seven-line loop appending one `bind -n <key> run-shell '"$CHARTER_PY" -m charter
  frame-toggle <name>'` per pair, with two containment `continue`s;
* `lines.append(overlay.hatch_bind())` and `lines.append("")` moved out of the literal to
  after the loop — **the hatch is still the last line** (Task 2's invariant, pinned by
  `test_the_escape_hatch_is_still_the_last_line`).

Nothing else in the bind text moved. Verified on real tmux 3.7c that all four binds land:

```
$ tmux -L t source-file conf.tmux ; echo $?
0
$ tmux -L t list-keys -T root | grep -E 'F2|F7|M-s|F12'
bind-key -T root F2  run-shell "\"\$CHARTER_PY\" -m charter frame-palette \"#{client_name}\""
bind-key -T root F7  run-shell "\"\$CHARTER_PY\" -m charter frame-toggle repos"
bind-key -T root F12 run-shell -C "#{@charter_hatch}"
bind-key -T root M-s run-shell "\"\$CHARTER_PY\" -m charter frame-toggle right"
```

**A component may not take a key charter already bound** — another component's, the
palette's own `hotkey`, or the hatch's `F12`. One `key in bound` line answers all three,
and `bound` starts from `{hotkey, overlay.HATCH_KEY}`. If the palette ever binds a second
key, adding it to that set is the whole change.

## Verification

**Full suite, two environments, both at `ea1a0fa` (rebased onto `bd90de3`):**

| environment | result |
| --- | --- |
| CPython 3.14.4, inherited shell | `Ran 6223 tests` — OK |
| CPython 3.12.13, `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset (32 variables) | `Ran 6223 tests` — OK |

**CI green at the head sha**, asked of `check-runs` rather than `gh pr checks` (#561):

```
$ gh api repos/diazoxide/charter/commits/ea1a0fa7f29d50e36d85e37a6f8876f39ffdee23/check-runs
test (3.11): completed/success
test (3.12): completed/success
test (3.13): completed/success
test (3.14): completed/success
A dev-channel install from main actually installs: completed/skipped
```

### The deletion sweep, and the harness it took to trust it

**34 mutations, each applied alone, re-run on this base: 34 RED, 0 survivors.**

The harness was rebuilt to answer the three measured ways a sweep on this project lies —
all of which produce *false pins*, the direction nobody re-checks:

1. **Exit-code scoring.** Verdicts are the **set of test ids that newly fail**, diffed
   against a baseline set, never a return code. A mutation that changes only *which*
   refusal fires is caught; a run that exits non-zero for an unrelated reason is not
   counted as a pin.
2. **A broken baseline.** Mutants are copies of a real `git clone` of this branch, and the
   run asserts the baseline is green before trusting any verdict from it. My *first*
   harness copied the tree without `.git`, which errored `test_workflows`,
   `test_plugin_freshness` and `test_doctor_shadowed` in **every** mutant — 4/4 "RED" that
   meant nothing. Those results were thrown away.
3. **Stale bytecode.** No `__pycache__` is ever copied — asserted per mutant, `0` `.pyc`
   against `418` in the source clone — and every run is `python -B` with
   `PYTHONDONTWRITEBYTECODE=1`. Proved rather than assumed: a canary comment inserted into
   `charter/instance.py` was read back through `inspect.getsource` in the child process.

A red *subset* proves a red full suite, so the subset decides REDs; a green subset
escalates to the full suite, because only a survivor needs one.

| # | mutation | verdict | first test that goes red |
| --- | --- | --- | --- |
| 1 | `instance.toggle_key: drop the type check` | **RED** | `TheBindReachesTmuxConfigText.test_a_hostile_key_never_reaches_the_bind_line` |
| 2 | `instance.toggle_key: drop the pattern check` | **RED** | `TheBindReachesTmuxConfigText.test_a_hostile_key_never_reaches_the_bind_line` |
| 3 | `component_tables: let a toggle key skip validation` | **RED** | `TheKeyIsValidatedWhereTheHotkeyIs.test_a_key_charter_will_not_bind_refuses_the_whole_arrangement` |
| 4 | `component_tables: let a component take a key already bound` | **RED** | `TheKeyIsValidatedWhereTheHotkeyIs.test_a_component_may_not_take_the_escape_hatchs_key` |
| 5 | `component_tables: stop reserving the frame's own menu key` | **RED** | `TheKeyIsValidatedWhereTheHotkeyIs.test_a_component_may_not_take_the_frames_own_palette_key` |
| 6 | `component_tables: stop reserving the escape hatch's key` | **RED** | `TheKeyIsValidatedWhereTheHotkeyIs.test_a_component_may_not_take_the_escape_hatchs_key` |
| 7 | `component_tables: reserve nothing charter already bound` | **RED** | `TheKeyIsValidatedWhereTheHotkeyIs.test_a_component_may_not_take_the_escape_hatchs_key` |
| 8 | `component_tables: stop remembering a key a component took` | **RED** | `TheKeyIsValidatedWhereTheHotkeyIs.test_two_components_may_not_claim_one_key` |
| 9 | `frame_of: stop telling component_tables what the menu key is` | **RED** | `TheKeyIsValidatedWhereTheHotkeyIs.test_a_component_may_not_take_the_frames_own_palette_key` |
| 10 | `frame_of: compare against the SHIPPED hotkey, not the resolved one` | **RED** | `TheKeyIsValidatedWhereTheHotkeyIs.test_the_collision_is_with_the_key_actually_bound_not_the_shipped_one` |
| 11 | `frame_arrangement: drop the slots fallback` | **RED** | `DensityIsANamedArrangementOverVisibility.test_the_level_names_a_set_and_the_arrangement_says_where_they_go` |
| 12 | `frame_arrangement: drop the built-in tail` | **RED** | `DensityIsANamedArrangementOverVisibility.test_a_level_can_still_name_a_panel_the_plane_never_listed` |
| 13 | `frame_arrangement: read the visible slot list before the placements` | **RED** | `DensityIsANamedArrangementOverVisibility.test_a_written_out_arrangement_keeps_its_hidden_panels_in_the_universe` |
| 14 | `frame_toggles: drop the has-a-key filter` | **RED** | `TheKeyIsValidatedWhereTheHotkeyIs.test_an_arrangement_with_no_keys_at_all_still_resolves` |
| 15 | `frame_components: resolve the committed tables a second time` | **RED** | `TheKeyIsValidatedWhereTheHotkeyIs.test_the_arrangement_is_one_answer_however_it_is_asked` |
| 16 | `state.record_hidden: drop the no-directory refusal` | **RED** | `WhatTheFrameIsNotDrawingRightNow.test_a_frame_id_that_cannot_name_a_directory_writes_nothing_and_raises_nothing` |
| 17 | `state.record_hidden: let an unwritable directory raise` | **RED** | `WhatTheFrameIsNotDrawingRightNow.test_a_state_directory_that_cannot_be_written_is_not_an_exception` |
| 18 | `state.hidden: drop the no-directory refusal` | **RED** | `WhatTheFrameIsNotDrawingRightNow.test_a_frame_id_that_cannot_name_a_directory_writes_nothing_and_raises_nothing` |
| 19 | `state.hidden: let a missing file raise` | **RED** | `AKeyTogglesOneComponentLive.test_a_first_press_never_conjures_a_panel_the_frame_was_not_showing` |
| 20 | `state.hidden: drop the blank-line filter` | **RED** | `AKeyTogglesOneComponentLive.test_pressing_it_again_brings_that_component_back_and_only_it` |
| 21 | `state.clear_shape: let a new frame inherit the hidden set` | **RED** | `WhatTheFrameIsNotDrawingRightNow.test_a_new_frame_never_inherits_a_dead_ones_hidden_set` |
| 22 | `conf_text: let a component name skip containment` | **RED** | `TheBindReachesTmuxConfigText.test_a_hostile_component_name_never_reaches_the_bind_line` |
| 23 | `conf_text: let a toggle key skip validation` | **RED** | `TheBindReachesTmuxConfigText.test_a_hostile_key_never_reaches_the_bind_line` |
| 24 | `cmd_launch: stop binding the arrangement's toggle keys` | **RED** | `test_frame_launcher: Launch.test_a_components_toggle_key_is_bound_by_the_config_the_launch_sources` |
| 25 | `_relayout_target: drop the harness-pane shape refusal` | **RED** | `ARefusedToggleChangesNothingAtAll.test_a_harness_pane_that_is_not_tmuxs_own_shape_moves_nothing` |
| 26 | `_relayout_target: drop the tmux-version refusal` | **RED** | `ARefusedToggleChangesNothingAtAll.test_a_tmux_whose_version_charter_could_not_read_moves_nothing` |
| 27 | `_hidden_now: let the config outrank what the frame recorded` | **RED** | `AKeyTogglesOneComponentLive.test_pressing_it_again_brings_that_component_back_and_only_it` |
| 28 | `cmd_toggle: accept a name this frame's arrangement does not hold` | **RED** | `ARefusedToggleChangesNothingAtAll.test_a_hostile_name_is_refused_by_the_same_one_guard` |
| 29 | `cmd_toggle: act on a frame that cannot be re-laid-out` | **RED** | `ARefusedToggleChangesNothingAtAll.test_a_harness_pane_that_is_not_tmuxs_own_shape_moves_nothing` |
| 30 | `cmd_toggle: record the decision before the frame is checked` | **RED** | `ARefusedToggleChangesNothingAtAll.test_a_harness_pane_that_is_not_tmuxs_own_shape_moves_nothing` |
| 31 | `cmd_density: stop expressing a level as visibility` | **RED** | `DensityIsANamedArrangementOverVisibility.test_a_key_after_a_level_composes_with_it_instead_of_undoing_it` |
| 32 | `cmd_density: split in the level's order rather than the plane's` | **RED** | `DensityIsANamedArrangementOverVisibility.test_the_level_names_a_set_and_the_arrangement_says_where_they_go` |
| 33 | `conf_text: append the toggle binds after the escape hatch` | **RED** | `TheBindReachesTmuxConfigText.test_a_toggle_bind_sits_between_the_palette_and_the_hatch` |
| 34 | `conf_text: write the toggle binds before the palette's own` | **RED** | `TheBindReachesTmuxConfigText.test_a_refused_pair_costs_its_key_and_nothing_else` |

### The one survivor, and why the line is gone rather than pinned

An earlier round found exactly one: **`cmd_toggle`'s `if not fid: return 0`**. Measured
side by side, shipped versus mutant, with `$CHARTER_SESSION_ID` unset:

```
                   rc   tmux calls   files created   state read back
shipped            0    []           []              None
guard deleted      0    []           []              None
```

Identical on every observable axis. The reason is a second guard downstream:
`$CHARTER_SESSION_ID` unset means `fid == ""`, `contain.child` refuses `""` as a path
segment, so `state.frame_dir` and `state.harness_pane` both answer `None`, and
`_relayout_target`'s `_PANE_ID_RE` check is what stops the empty string reaching a `-t`.

Before calling it equivalent I checked whether that second line was itself unpinned — the
`layout.py:291` failure mode. **It is pinned**: the mutation that deletes it goes red. So
the property rests on a line a mutation can reach, and the fid check was pure cost. This
command emits nothing by construction (ADR 0018), so there is no *reason* for a refusal
test to distinguish — only a consequence, and the consequence is already another line's.
**The line was deleted.** `test_outside_a_frame_it_does_nothing` pins the property that
survives it and asserts the chain step by step, so if `frame_dir` ever starts answering for
an empty id the test says so at the step that changed.

No version bump, no stamping, no tag. News entry at `version: unreleased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
