### PR TITLE
The sweep's first two finds on main: the alias resolution gets a test, the dead except goes (#568)

### DIFF
--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -191,6 +191,19 @@ def _component_text(reg, cid: str, fid: str) -> str:
     function can fail: a snapshot that cannot be read, a pane whose size cannot be
     measured. A panel that stops repainting has already lost the pane, whatever the
     traceback would have said.
+
+    **Never raises means never raises an `Exception`**, and `except Exception` is the
+    whole of what keeps the operator's own interrupt out of that promise —
+    `KeyboardInterrupt` and `SystemExit` are `BaseException`s, which this clause does not
+    reach. It used to carry an `except KeyboardInterrupt: raise` above it as well, and
+    that was dead code rather than defence in depth: the clause below could never have
+    caught one either way. `tools/sweep.py` proved it equivalent on `main` and #568
+    removed it, because a line that cannot change an outcome is not documentation of an
+    intent — it is a second, weaker answer to a question `except Exception` had already
+    answered. Do not read `Registry.draw`'s identical-looking guard as the same thing:
+    the clause below THAT one is `except BaseException`, so there the two lines are the
+    only reason an interrupt survives a stranger's renderer at all.
+    `TheOperatorsInterruptIsNotAComponentFailure` pins both halves.
     """
     from . import ctx as _ctx, gather
     try:
@@ -199,8 +212,6 @@ def _component_text(reg, cid: str, fid: str) -> str:
         drew = reg.draw(cid, _ctx.build(c.needs, width=slots._width(),
                                         height=_rows(), fid=fid, snapshot=snapshot))
         return "\n".join(drew)
-    except KeyboardInterrupt:
-        raise
     except Exception as e:
         # `contain.one_line` BEFORE the width arithmetic, the order the rest of charter
         # keeps: *cid* arrived on this process's own command line, an escape sequence in

--- a/docs/news/unreleased-the-sweep-deletes-its-first-line.md
+++ b/docs/news/unreleased-the-sweep-deletes-its-first-line.md
@@ -1,0 +1,39 @@
+---
+version: unreleased
+headline: The deletion sweep deletes its first line, and the frame keeps every behaviour it had
+---
+
+`tools/sweep.py` shipped with a rule and no scalp:
+
+> If deleting a line genuinely changes nothing observable, the line should be deleted.
+> "Equivalent mutant" and "dead code" are the same finding.
+
+Run on `main` with nothing to look for, it named two lines. Three rounds of hand-sweeping
+had gone past both.
+
+**`charter/frame/panel.py` had an `except KeyboardInterrupt: raise` that could never
+fire.** `KeyboardInterrupt` is a `BaseException`, so the `except Exception` below it was
+never going to catch one — the guard above was answering a question already answered.
+Measured shipped-against-mutant before removing it: identical on `KeyboardInterrupt`,
+`SystemExit`, `BaseException`, `GeneratorExit`, `OSError`, `ValueError`, `RuntimeError`, an
+unknown component id and a normal repaint, and identical whether the exception came from
+the renderer, from the plane scan or from measuring the pane. The line is gone; `^C`
+during a repaint still ends the panel, and a component that fails still costs its own pane
+and nothing else.
+
+Two lines that look exactly like it, in `Registry.draw`, are **not** dead and stay: the
+clause below those is `except BaseException`, which does catch an interrupt, so there they
+are the only reason your `^C` survives a stranger's renderer. Identical spellings, opposite
+verdicts, told apart by the clause underneath — which is why removing one needed a
+measurement rather than a reading.
+
+**And `layout._key`'s alias resolution turned out to be unpinned.** Collapsing it to
+`return name` left the whole suite green, on the branch whose title was *"a component id is
+the frame's currency, end to end"* — and the resolution is precisely what makes `identity`
+and `top` one entry in the frame's tables rather than two. Nothing had ever asserted the
+mapping. It is asserted now, on every alias the table declares and at the three geometry
+functions a missing resolution actually reaches: a sidebar that stops costing the repo
+table its columns, and a strip that stops being charged to the harness as a fixed row.
+
+Nothing to adopt. The frame does exactly what it did — that is the claim, and it now has
+tests that would go red if it stopped.

--- a/tests/test_component_id_is_the_currency.py
+++ b/tests/test_component_id_is_the_currency.py
@@ -777,6 +777,98 @@ class APanelPaintsInsideItsOwnRectangle(PersonaIso, unittest.TestCase):
         self.assertLessEqual(tui.width(line), 40)
 
 
+class TheOperatorsInterruptIsNotAComponentFailure(PersonaIso, unittest.TestCase):
+    """A `KeyboardInterrupt` raised while a pane repaints leaves the panel, and
+    `_component_text`'s `except Exception` is the whole of what makes it.
+
+    **That function carried an `except KeyboardInterrupt: raise` above the clause, and it
+    was dead code** — `tools/sweep.py`'s second find on `main` (#568). Measured against a
+    copy of the same function with the clause removed, before removing it: identical on
+    `KeyboardInterrupt`, `SystemExit`, `BaseException`, `GeneratorExit`, `OSError`,
+    `ValueError`, `RuntimeError`, a `reg.get` miss, and a normal return, whether the
+    exception came from the renderer, from `gather.read` or from `_rows`.
+    `KeyboardInterrupt` is a `BaseException` and not an `Exception`, so the clause below
+    could never have caught one and the clause above could never have been the reason.
+
+    Per the sweep spec's §4 — *"equivalent mutant" and "dead code" are the same finding*
+    — it is gone. This class is the property the removal must not change, pinned at the
+    step that carries it rather than left to be inferred, the way #566 handled
+    `cmd_toggle`'s `if not fid: return 0`.
+
+    **The identical two lines in `Registry.draw` are NOT dead, and that contrast is the
+    reason this needed measuring rather than reading.** The clause below THOSE is `except
+    BaseException`, which does catch a `KeyboardInterrupt` — so there the guard is the
+    only reason an interrupt survives a stranger's renderer at all, and
+    `test_component_providers.py::test_the_operators_own_interrupt_still_travels` is what
+    says so. Two identical spellings, one load-bearing and one dead, told apart entirely
+    by the clause underneath.
+
+    **One axis did differ, and it is reported rather than pinned.** A class inheriting
+    from BOTH `KeyboardInterrupt` and `Exception` is legal Python; it escapes
+    `Registry.draw` through that live guard and reached the deleted clause first, so
+    shipped let it kill the pane where the mutant paints the failure line. Nothing in
+    charter or the standard library is such a class — it inverts the split PEP 352 made
+    `KeyboardInterrupt` a `BaseException` for — and the behaviour the deleted line
+    selected on it was the one §4b exists to refuse: a provider's exception costing the
+    SESSION instead of its own pane. Pinning that would have pinned an accident.
+    """
+
+    def test_an_interrupt_is_not_an_Exception_which_is_why_the_catch_lets_it_by(self):
+        """The chain asserted rather than inferred. Every case below rests on this one
+        fact about the hierarchy, so if it ever stopped holding, this says so at the step
+        where it changed instead of leaving four cases failing for a reason none of them
+        names."""
+        self.assertFalse(issubclass(KeyboardInterrupt, Exception))
+        self.assertFalse(issubclass(SystemExit, Exception))
+        self.assertTrue(issubclass(KeyboardInterrupt, BaseException))
+        self.assertTrue(issubclass(SystemExit, BaseException))
+
+    def test_an_interrupt_while_the_snapshot_is_read_leaves_the_panel(self):
+        """`gather.read` is `_component_text`'s own failure mode rather than a
+        renderer's, so this is the interrupt arriving in the half of the function the
+        deleted clause sat over. `^C` during the plane scan must end the process, not
+        paint `unavailable` and repaint forever."""
+        _installed(self, needs=("repos",))
+        with mock.patch("charter.frame.gather.read",
+                        side_effect=KeyboardInterrupt("^C")):
+            with self.assertRaises(KeyboardInterrupt):
+                _painted(CID)
+
+    def test_a_process_exit_while_the_snapshot_is_read_leaves_the_panel_too(self):
+        """`run`'s own docstring names both: *"`KeyboardInterrupt` and `SystemExit` are
+        how this process is MEANT to end, and swallowing either would hold a pane open
+        against the operator killing it."* The deleted clause named only one of them,
+        which is a second reason it was not the thing carrying the property."""
+        _installed(self, needs=("repos",))
+        with mock.patch("charter.frame.gather.read", side_effect=SystemExit(3)):
+            with self.assertRaises(SystemExit):
+                _painted(CID)
+
+    def test_an_interrupt_inside_a_providers_renderer_leaves_the_panel(self):
+        """The whole chain, end to end, through the pane a provider actually draws:
+        `Registry.draw`'s live guard re-raises, `_component_text` does not catch it, and
+        `run`'s outer `except Exception` does not either. That is three functions
+        agreeing, and only the middle one had a line to lose."""
+        _installed(self,
+                   render="lambda ctx: (_ for _ in ()).throw(KeyboardInterrupt())")
+        with self.assertRaises(KeyboardInterrupt):
+            _painted(CID)
+
+    def test_an_ordinary_failure_in_the_same_place_is_still_a_painted_line(self):
+        """The control, and it is not optional: without it a `_component_text` that had
+        stopped catching anything at all would pass every case above. Same call, same
+        fixture, an `OSError` instead — contained, named in the pane, and the panel still
+        returns 0."""
+        _installed(self, needs=("repos",))
+        with mock.patch("charter.frame.gather.read",
+                        side_effect=OSError("volume went away")):
+            rc, painted, err = _painted(CID, cols=78)
+        self.assertEqual(rc, 0, painted)
+        self.assertIn(CID, painted)
+        self.assertIn("OSError", painted)
+        self.assertNotIn("panel stopped", err)
+
+
 class TheProviderNameThatReachesThePaneIsContained(PersonaIso, unittest.TestCase):
     """A component name a stranger's distribution chose, on `run`'s failure path.
 
@@ -1015,3 +1107,112 @@ class ASizePolicyBecomesCellsByOneRuleStatedOnce(unittest.TestCase):
         for size in (component.Content(), component.Content(cap=9), component.Fill()):
             with self.subTest(size=size):
                 self.assertEqual(layout._policy_cells(size), 1)
+
+
+class TheCommittedSpellingAndTheComponentIdReachOneEntry(unittest.TestCase):
+    """`layout._key`'s alias resolution — this file's own title, read in the direction
+    nothing was asking it in.
+
+    `_derive` keys all five tables by the COMMITTED spelling, so every per-slot fact
+    `layout` answers is reachable under a built-in's component id only because `_key`
+    resolves one to the other. **Collapsing `_key` to `return name` left the full suite
+    green.** `tools/sweep.py` found that on `main`, after three rounds of hand-sweeping
+    had walked past it (#568).
+
+    The one case that named `_key` asked it for a value it must hand back unchanged
+    (`ANameThatIsNotTextIsAnAnswerRatherThanACrash` above). That is the guard's OTHER
+    half, and it answers identically with the resolution or without it — a real test,
+    pointed at the function, blind to the thing the line is for, which is the shape this
+    file's docstring says the review rounds kept hitting.
+
+    So the resolution is asked here on every alias the table declares rather than on one
+    of them, and then at the three geometry functions a wrong answer actually reaches. A
+    sidebar that stops costing columns is #500; a strip that stops being a fixed row is
+    #515. Neither arrives as an error — `slot_sizes` and `_edge_of` both degrade by
+    filtering rather than refusing, which is exactly why nothing went red.
+    """
+
+    #: Every alias :data:`builtins.SLOT_OF` declares, written out rather than read back
+    #: from it: a test that reads the table it is checking moves with the table and pins
+    #: nothing. :meth:`test_the_pinned_table_is_the_whole_table` is what keeps the two in
+    #: step instead.
+    #:
+    #: **`repos` is here because it is its OWN alias.** It is the one entry a `_key` that
+    #: resolved nothing would still get right, so it is the reason the other three have to
+    #: be asked beside it — one example standing for four would have a one-in-four chance
+    #: of being the example that cannot fail.
+    ALIASES = (("identity", "top"), ("attention", "bottom"),
+               ("repos", "repos"), ("sidebar", "right"))
+
+    def test_the_pinned_table_is_the_whole_table(self):
+        """An alias added to `SLOT_OF` and not to :data:`ALIASES` would ship unpinned in
+        exactly the way `identity` did, so the coverage is asserted rather than
+        believed."""
+        self.assertEqual(dict(self.ALIASES), builtins.SLOT_OF)
+
+    def test_a_built_in_id_resolves_to_the_slot_name_the_tables_are_keyed_by(self):
+        """`_key`'s own contract, stated as the mapping and not as an example of it."""
+        for cid, slot in self.ALIASES:
+            with self.subTest(cid=cid):
+                self.assertEqual(layout._key(cid), slot)
+
+    def test_every_per_slot_fact_answers_the_same_under_either_spelling(self):
+        """The three lookups that read `_key`, asked in both vocabularies at once.
+
+        `assertIsNotNone` on the slot-name side first, because `_edge_of` and `_size_of`
+        answer `None` for a name nothing placed: without that control a resolution that
+        had stopped working would agree with itself at `None` and pass.
+        """
+        for cid, slot in self.ALIASES:
+            with self.subTest(cid=cid):
+                self.assertIsNotNone(layout._edge_of(slot), "the fixture placed nothing")
+                self.assertIsNotNone(layout._size_of(slot), "the fixture placed nothing")
+                self.assertEqual(layout._edge_of(cid), layout._edge_of(slot))
+                self.assertEqual(layout._size_of(cid), layout._size_of(slot))
+                self.assertIs(layout._is_fixed_row(cid), layout._is_fixed_row(slot))
+
+    def test_a_sidebar_under_its_component_id_still_costs_the_table_its_columns(self):
+        """`repos_cols`, against the measurement in its own docstring: on tmux 3.7c at
+        120x40 a side pane split BEFORE the table leaves that table 97 columns, not the
+        window's 120. The sidebar reaches that arithmetic through `_edge_of` and
+        `_size_of`, so an arrangement spelled in component ids would be sized for a pane
+        23 columns wider than the one it gets — #500 exactly, whose visible form was a
+        seven-row pane with one line in it.
+        """
+        wanted = 120 - layout.SLOT_SIZE["right"] - layout._BORDER_COLS
+        self.assertEqual(
+            layout.repos_cols(["right", "top", "bottom", "repos"], window_cols=120),
+            wanted)
+        self.assertEqual(
+            layout.repos_cols(["sidebar", "identity", "attention", "repos"],
+                              window_cols=120),
+            wanted)
+
+    def test_a_frame_spelled_in_component_ids_is_sized_as_the_slot_names_are(self):
+        """`slot_sizes` drops a name it cannot size rather than raising on it, matching
+        `visible_slots`' filter-don't-refuse discipline — so an unresolved id is not an
+        error here, it is an ABSENT entry, and `panel_argvs` then splits that pane at the
+        shipped floor or the frame loses it. Asked as "the two spellings agree" so the
+        numbers stay `_derive`'s rather than being copied into this file.
+        """
+        ids = [cid for cid, _ in self.ALIASES]
+        by_id = layout.slot_sizes(ids, window_rows=50, content_rows=6)
+        by_name = layout.slot_sizes([slot for _, slot in self.ALIASES],
+                                    window_rows=50, content_rows=6)
+        self.assertEqual(len(by_name), len(self.ALIASES), "the fixture sized nothing")
+        self.assertEqual({builtins.SLOT_OF[cid]: n for cid, n in by_id.items()}, by_name)
+
+    def test_a_sidebar_under_its_component_id_is_still_charged_no_rows(self):
+        """`harness_rows` charges a pane's height against the harness unless its edge
+        costs COLUMNS, and that edge comes from `_edge_of`. Unresolved, `sidebar`'s 22
+        columns are charged as 22 rows and the harness loses them — the same arithmetic
+        `test_the_harness_is_charged_no_rows_for_a_pane_that_costs_columns` pins for a
+        component this plane placed, asked here for charter's own sidebar under its own
+        id. The number that comes out of this is what `resize-pane -y` is given, so it is
+        wrong on screen and not only in a dict.
+        """
+        by_name = {"top": 1, "bottom": 1, "repos": 6, "right": 22}
+        by_id = {"identity": 1, "attention": 1, "repos": 6, "sidebar": 22}
+        rows = sum(by_name[s] + layout._BORDER_ROWS for s in ("top", "bottom", "repos"))
+        self.assertEqual(layout.harness_rows(by_name, window_rows=50), 50 - rows)
+        self.assertEqual(layout.harness_rows(by_id, window_rows=50), 50 - rows)


### PR DESCRIPTION
Both findings are `tools/sweep.py`'s (#565), made on `main` from the diff alone with no
list supplied, after three rounds of hand-sweeping had walked past both.

**The tool reproduces them on this branch's base and goes quiet after the fix.** Evidence
below, including the one place my own measurement went further than the issue did.

## 1. `layout._key`'s alias resolution is pinned now

`_derive` keys all five per-slot tables by the COMMITTED spelling, so every fact `layout`
answers under a built-in's component id is reachable only because `_key` resolves one to
the other. Collapsing it to `return name` left the full suite green — on the branch whose
title was *"A component id is the frame's currency, end to end"*.

The one case that named `_key` asserted `assertIs(_key(value), value)`. That is the
guard's OTHER half — the `isinstance` filter — and it answers identically with the
resolution or without it. A real test, pointed at the function, blind to the thing the
line is for.

`TheCommittedSpellingAndTheComponentIdReachOneEntry` asks the mapping on **every alias the
table declares**, not one of them:

| id | committed slot | survives a collapsed `_key`? |
|---|---|---|
| `identity` | `top` | no |
| `attention` | `bottom` | no |
| `repos` | `repos` | **yes** — it is its own alias |
| `sidebar` | `right` | no |

`repos` is in the table for that reason: it is the one entry a `_key` that resolved
nothing would still get right, so one example standing for four would have had a
one-in-four chance of being the example that cannot fail. A separate case asserts the
pinned table *equals* `builtins.SLOT_OF`, so an alias added later cannot ship unpinned the
way `identity` did.

Then the same question at the three geometry functions a missing resolution actually
reaches — because none of them raise, they all degrade by filtering, which is why nothing
went red:

* **`repos_cols`** — a sidebar spelled `sidebar` stops costing the repo table its columns,
  so the table is sized for a pane 23 columns wider than the one it gets. That is #500,
  whose visible form was a seven-row pane with one line in it. Asserted against the
  measurement in `repos_cols`' own docstring (tmux 3.7c, 120x40, the table reads back 97).
* **`slot_sizes`** — an unresolved id is not an error, it is an ABSENT entry: the pane is
  split at the shipped floor or lost.
* **`harness_rows`** — `sidebar`'s 22 COLUMNS get charged to the harness as 22 rows. Same
  arithmetic `test_the_harness_is_charged_no_rows_for_a_pane_that_costs_columns` already
  pins for a component a plane placed, asked here for charter's own sidebar under its own
  id. That number is what `resize-pane -y` is given, so it is wrong on screen and not only
  in a dict.

**Five of the six cases go red under the collapse** (measured — see below); the sixth is
the coverage guard, which correctly does not depend on `_key`.

Tests only. No production line moved.

## 2. `panel.py:202`'s `except KeyboardInterrupt: raise` is deleted

### The diligence, done the way #566 did it for `cmd_toggle`

**1. Verified rather than taken on trust.** I compiled a copy of `_component_text` with
the clause removed into `panel`'s own globals — so `mock.patch` reaches both — and ran
shipped against mutant over every exception class I could think of, from all three sources
inside the `try`: a provider's renderer, `gather.read`, and `_rows`.

| raised | shipped | mutant |
|---|---|---|
| `KeyboardInterrupt` | propagates | propagates |
| `SystemExit` | painted by `Registry.draw` | same |
| `BaseException`, `GeneratorExit` | painted by `Registry.draw` | same |
| `OSError`, `ValueError`, `RuntimeError` | painted | same |
| unknown cid (`reg.get` miss) | painted | same |
| normal return | same string | same string |
| `KeyboardInterrupt` from `gather.read` | propagates | propagates |
| `SystemExit` from `gather.read` | propagates | propagates |
| `KeyboardInterrupt` from `_rows` | propagates | propagates |

Also measured and found identical: the re-raised object's identity, `__context__`,
`__cause__`, `__suppress_context__`, and `sys.exc_info()` after the frame unwinds. The
traceback's line number for the `_component_text` frame does move (the `raise` line rather
than the line that raised) — nothing in charter reads it, and no path prints this
traceback.

**2. What makes it unreachable, and whether that is pinned.** It is `except Exception` not
catching a `BaseException` — and nothing asserted that. So the property is pinned first,
and it is pinned as a chain rather than inferred, the way #566's
`test_outside_a_frame_it_does_nothing` asserts `frame_dir("")` and `harness_pane("")` at
the step where they would change:

* `issubclass(KeyboardInterrupt, Exception)` is False, `issubclass(..., BaseException)` is
  True — asked directly, and of `SystemExit` too, since `run`'s docstring names both.
* An interrupt out of `gather.read` leaves the panel. A `SystemExit` there does too.
* An interrupt out of a **provider's renderer** leaves the panel — three functions
  agreeing end to end, and only the middle one had a line to lose.
* The control: an `OSError` in the same place is still a painted, contained line and
  `rc == 0`. Without it, a `_component_text` that had stopped catching *anything* would
  pass every case above.

**3. Then removed**, with the docstring taking over what the line was pretending to say.

### The contrast that made this worth measuring rather than reading

`Registry.draw` carries the **identical two lines** and they are **not** dead. The clause
below those is `except BaseException`, which does catch an interrupt — so there they are
the only reason your `^C` survives a stranger's renderer, and
`test_component_providers.py::test_the_operators_own_interrupt_still_travels` is what says
so. Two identical spellings, opposite verdicts, told apart entirely by the clause
underneath. `run`'s own outer handler is the third instance and follows the same rule: it
is `except Exception` and carries no interrupt guard, which is what `panel.py` is now
consistent with.

### Where my measurement went past the issue

The issue says shipped and mutant are identical on `KeyboardInterrupt`, `SystemExit`,
`OSError` and a normal return. True — but there is **one input on which they differ**, and
it is reachable:

```python
class BothKinds(KeyboardInterrupt, Exception): ...   # legal; MRO resolves fine
```

Raised by a provider's renderer it escapes `Registry.draw` through *that* module's live
guard, reaches `_component_text`, and hits the deleted clause before `except Exception`.
Shipped let it kill the pane; without the clause it paints the failure line.

I still deleted the line, and the reason is not "close enough". Such a class inverts the
split PEP 352 made `KeyboardInterrupt` a `BaseException` for; nothing in charter, and
nothing in the standard library, is one. And on the single input where the line did
anything at all, the behaviour it selected was the one §4b exists to refuse — **a
provider's exception costing the SESSION rather than its own pane**. Pinning that would
have pinned an accident. It is written down in the test class docstring rather than left
out of the record.

## Running the tool, and checking it

**Before the fix**, plain CLI, on this branch's base (`1ddd6b0` = `origin/main`), scoped to
`charter/frame` against `98f4ffc^` — the merge-base of #553, the branch that introduced
both lines:

```
$ python3 tools/sweep.py --path charter/frame --base 98f4ffc^ --jobs 6
sweeping 1ddd6b05f00b (paths: charter/frame)
  diff against 473137855505: 12 file(s), 1838 added line(s)
  selection map: 10322 source files in 80s
  baseline: full suite, unmutated…
    Ran 6311 tests — OK in 295s
  174 mutations across 12 file(s)
    [37/174] SURVIVED  charter/frame/layout.py:259 [collapse-ifexp] _builtins.SLOT_OF.get(name, name) if isinstance(name, str) else name   (10 module(s), then all 6311)
```

**Finding 1 reproduced**, and not on a subset: it survived the 10-module selection *and*
the full 6311-test suite the tool re-runs every survivor against.

I stopped that run at 41/174. `--path` takes a directory, so `charter/frame` is the
smallest CLI scope containing `layout.py` — and against #553's merge-base that scope is
dominated by Task 6's files (`overlay.py` alone is 91 of the 174 mutations), each of whose
survivors costs a 300-second full-suite re-run. Three other agents were running their own
sweeps on the same machine at the time, two of them wedged.

**So the before/after comparison is the same pipeline at a two-function scope.**
`Sandbox`, `load_map`, `mutations_for`, `select_for` and `decide` are the tool's own,
unmodified — the green-baseline assertion, `PYTHONDONTWRITEBYTECODE=1`, scoring on the set
of newly-failing test ids, the full-suite run that has the last word, and `UNRESOLVED` for
a timeout all come with them. The only thing narrowed is the scope: every mutation the
tool offers anywhere in `layout._key` and `panel._component_text`.

```
$ python3 audit.py 1ddd6b0 before          # origin/main, this branch's base
=== before: 1ddd6b05f00b (1ddd6b0) ===
  baseline: Ran 6311 tests — OK in 378s
  selection map: 10322 source files in 90s
  8 mutation(s) in `layout._key` and `panel._component_text`
    [1/8] PINNED     charter/frame/layout.py:259 [collapse-ifexp] '…if isinstance(name, str) …' -> '_builtins.SLOT_OF.get(name, name)'   (10 module(s))
    [2/8] SURVIVED   charter/frame/layout.py:259 [collapse-ifexp] '…if isinstance(name, str) …' -> 'name'   (10 module(s), then all 6311)
    [3/8] PINNED     charter/frame/layout.py:259 [no-fallback] '_builtins.SLOT_OF.get(name, name)' -> '_builtins.SLOT_OF[name]'   (10 module(s))
    [4/8] PINNED     charter/frame/panel.py:198 [collapse-ifexp] 'gather.read(fid) if c.needs else {}' -> 'gather.read(fid)'   (2 module(s))
    [5/8] PINNED     charter/frame/panel.py:198 [collapse-ifexp] 'gather.read(fid) if c.needs else {}' -> '{}'   (2 module(s))
    [6/8] SURVIVED   charter/frame/panel.py:202 [narrow-except] 'KeyboardInterrupt' -> 'ZeroDivisionError'   (2 module(s), then all 6311)
    [7/8] PINNED     charter/frame/panel.py:204 [narrow-except] 'Exception' -> 'ZeroDivisionError'   (2 module(s))
    [8/8] PINNED     charter/frame/panel.py:210 [uncontain] 'contain.one_line(cid)' -> 'cid'   (2 module(s))
  --- before: 2 survived, 6 pinned, 0 other

$ python3 audit.py HEAD after              # this branch
=== after: 7bdc1e63fa97 (HEAD) ===
  baseline: Ran 6322 tests — OK in 322s
  selection map: 10333 source files in 87s
  7 mutation(s) in `layout._key` and `panel._component_text`
    [1/7] PINNED     charter/frame/layout.py:259 [collapse-ifexp] '…if isinstance(name, str) …' -> '_builtins.SLOT_OF.get(name, name)'   (10 module(s))
    [2/7] PINNED     charter/frame/layout.py:259 [collapse-ifexp] '…if isinstance(name, str) …' -> 'name'   (10 module(s))
    [3/7] PINNED     charter/frame/layout.py:259 [no-fallback] '_builtins.SLOT_OF.get(name, name)' -> '_builtins.SLOT_OF[name]'   (10 module(s))
    [4/7] PINNED     charter/frame/panel.py:211 [collapse-ifexp] 'gather.read(fid) if c.needs else {}' -> 'gather.read(fid)'   (2 module(s))
    [5/7] PINNED     charter/frame/panel.py:211 [collapse-ifexp] 'gather.read(fid) if c.needs else {}' -> '{}'   (2 module(s))
    [6/7] PINNED     charter/frame/panel.py:215 [narrow-except] 'Exception' -> 'ZeroDivisionError'   (2 module(s))
    [7/7] PINNED     charter/frame/panel.py:221 [uncontain] 'contain.one_line(cid)' -> 'cid'   (2 module(s))
  --- after: 0 survived, 7 pinned, 0 other
```

**Both findings reproduced, and both go quiet.** `layout._key`'s collapse to `name` is the
survivor at :259 — the tool's own one-line report cannot say which of its two
`collapse-ifexp` mutants that is, so this is where that gets settled — and it is PINNED
after. `panel.py:202` survives its `narrow-except` before, and after the fix the tool has
nothing to say about that line at all: the mutation set for `_component_text` is one entry
shorter, and the missing entry is exactly that one.

Nothing else in either function moved: the other six were already pinned before and still
are. `panel.py`'s other three are the ones round two and round three found and #553 then
pinned (`if c.needs`, the broad `except`, `contain.one_line(cid)`) — they are green here
both times, which is the control that says this audit can tell a pin from a survivor.

**Finding 2 reproduced, and it goes quiet in the most literal way there is.** After the fix
the tool reports nothing about `panel.py:202` because there is no longer a line there to
mutate — the mutation set for `_component_text` shrinks by exactly one entry, the
`narrow-except` on `KeyboardInterrupt`, and nothing else in either function changes shape.

### Where I did not trust it, and hand-checked instead

Its self-sweep is 132/196 survived, its trace map is 0/9 pinned (#569), and it has no
operator for string/regex constants or semantic swaps.

* **Its one-line report cannot tell its own two `collapse-ifexp` mutants apart.**
  `layout.py:259` yields both `→ name` and `→ _builtins.SLOT_OF.get(name, name)`, and the
  row prints the `before` text, which is identical for both. "SURVIVED at :259" therefore
  does not say *which*. I applied `→ name` to the tree by hand and recorded exactly which
  of my new cases go red under it; the other two mutants at that line were already pinned
  (by the existing unhashable case, and by the provider cases).
* **Its operator on `panel.py:202` is not a deletion.** `narrow-except` rewrites `except
  KeyboardInterrupt` to `except ZeroDivisionError`. That is equivalent for the same reason
  the deletion is, but it is not the same edit — so the equivalence table above is mine,
  measured against a real removal of the clause, not the tool's.
* Neither line is a string or regex constant, so its blind spot there does not bear on
  these two.


## Verification

* `tools/sweep.py`'s own baseline in a clean sandbox at this branch's head:
  **Ran 6322 tests — OK**, against 6311 on `origin/main` — 6311 + the 11 new cases.
* Full suite, python **3.12.13**, with `CHARTER_*` / `CLAUDE_*` / `ANTHROPIC_*` / `TMUX*`
  all unset: **Ran 6322 tests — OK** (458s).
* Full suite, python **3.14.4**, inherited environment: **Ran 6322 tests — OK** (507s).
* The new cases measured against the mutation, not merely written beside it: with `_key`
  collapsed to `return name`, five of the six go red —
  `test_a_built_in_id_resolves_to_the_slot_name_the_tables_are_keyed_by`,
  `test_every_per_slot_fact_answers_the_same_under_either_spelling`,
  `test_a_sidebar_under_its_component_id_still_costs_the_table_its_columns`,
  `test_a_frame_spelled_in_component_ids_is_sized_as_the_slot_names_are`,
  `test_a_sidebar_under_its_component_id_is_still_charged_no_rows`.
  The sixth is the coverage guard, which correctly does not depend on `_key`.
* And the interrupt cases the same way — against the line that actually carries the
  property, not the one that was deleted. With `_component_text`'s `except Exception`
  widened to `except BaseException`, three go red:
  `test_an_interrupt_while_the_snapshot_is_read_leaves_the_panel`,
  `test_a_process_exit_while_the_snapshot_is_read_leaves_the_panel_too`,
  `test_an_interrupt_inside_a_providers_renderer_leaves_the_panel`. The hierarchy case and
  the `OSError` control stay green, which is what each is for.
* CI green at the head sha `7bdc1e6`, read from
  `gh api repos/diazoxide/charter/commits/7bdc1e6.../check-runs` rather than
  `gh pr checks` (#561): `test (3.11)`, `test (3.12)`, `test (3.13)`, `test (3.14)` all
  `success`.

News entry for the production line (`version: unreleased`). No version bump, no stamp, no
tag.

## Coordination

Task 6 is live on `palette.py`, `builtin_actions.py` and `overlay.py`. This branch touches
none of them: `charter/frame/panel.py` (two lines removed, docstring added),
`tests/test_component_id_is_the_currency.py` (two new classes appended, nothing existing
edited) and one new file under `docs/news/`.

Closes #568
