### PR TITLE
A workspace is a name, not an action — so it gets a picker (Phase 2, Task 6)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -3534,7 +3534,7 @@ def _draw_palette(args) -> int:
     harness = state.harness_pane(fid) or ""
     reg = builtin_actions.build(fid, current_density=_current_density(fid))
     snapshot = gather.cached(fid) or {}
-    client = getattr(args, "client", "") or ""
+    client = getattr(args, "client", "")
     opened: list[choose.Roster] = []
     try:
         surface = palette.Palette(
@@ -3633,11 +3633,17 @@ def _close_palette(socket: str, *, harness: str, overlay_pane: str) -> None:
 def cmd_switch(args) -> int:
     """`charter frame-switch --workspace <name>` / `--persona <name>` — move THIS frame.
 
-    Started by a palette row (`frame/builtin_actions.py`), and typeable by hand from
-    inside a frame. The frame is resolved from `$CHARTER_SESSION_ID` exactly as
-    `cmd_density`, `cmd_palette` and `cmd_respawn` resolve theirs, and for the same
-    reason: one bind is shared by every frame on `SOCKET`, so the frame a keypress acts on
-    is resolved at the moment it fires, never baked into anything.
+    **Typed by hand, or run by an agent inside the harness.** The picker no longer starts
+    it: a name chosen off `frame/choose.py` is switched in the palette's own process,
+    which is what lets the outcome reach the pane the operator is looking at rather than
+    a status line after that pane is gone. This is the same switch by another door — one
+    that takes a name nobody drew, which is why it still has refusals a picker's row
+    cannot produce.
+
+    The frame is resolved from `$CHARTER_SESSION_ID` exactly as `cmd_density`,
+    `cmd_palette` and `cmd_respawn` resolve theirs, and for the same reason: one bind is
+    shared by every frame on `SOCKET`, so the frame a command acts on is resolved at the
+    moment it runs, never baked into anything.
 
     The switch itself is `frame/switch.py`'s — this function is the tmux half and nothing
     else: which frame, and where the answer is shown.

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -133,7 +133,7 @@ import sys
 import time
 
 from . import config, contain, harness, instance, tui, util, workspace
-from .frame import (builtin_actions, component, gather, layout, overlay,
+from .frame import (builtin_actions, choose, component, gather, layout, overlay,
                     palette, picker, state, switch, tmuxctl)
 # Aliased: `cmd_launch` already has a local variable named `slots` (the VISIBLE slot
 # list `layout.visible_slots` returns) — importing the renderer registry under its own
@@ -3498,7 +3498,7 @@ def _open_palette(args) -> int:
 
 
 def _draw_palette(args) -> int:
-    """Be the palette: draw the actions, take a choice, start it, hand the pane back.
+    """Be the palette: draw the rows, take a choice, act on it, hand the pane back.
 
     **The close is a ``finally``**, for `overlay.Surface.run`'s reason one layer down: a
     palette that raised must still give the operator their harness back. Whatever went
@@ -3506,36 +3506,104 @@ def _draw_palette(args) -> int:
     place charter may print it.
 
     **The registry is built here, not carried.** `builtin_actions.build` resolves the
-    density mark, the workspace list, the persona list and every installed provider's
-    actions against the moment the palette opened — the menu's staleness (`_rerecord_menu`,
-    deleted with it) was a snapshot on disk that every other command had to remember to
-    rewrite.
+    density mark and every installed provider's actions against the moment the palette
+    opened — the menu's staleness (`_rerecord_menu`, deleted with it) was a snapshot on
+    disk that every other command had to remember to rewrite. `choose.open_rows` resolves
+    the workspace and persona the frame is on at the same moment, for the same reason.
 
-    **A refusal is said on the operator's own screen.** `invoke` re-asks availability, so a
-    row drawn while a plane was one way and pressed while it is another is refused with the
-    same sentence the row carried — and that sentence has nowhere else to go, because the
-    pane it would have been drawn in is the pane this is about to kill. A STARTED action
-    says nothing: what it started surfaces through `inflight`, which is the frame's
-    existing spinner and not a second clock.
+    **Two kinds of row, and one of them is a doorway.** A picker row replaces the surface
+    in this same pane (`palette.own_the_tty`'s *then*) rather than starting anything, and
+    :func:`_picker` is what turns one into the next surface; everything else is an action
+    and goes through `invoke`. They are told apart by `choose.noun_of`, on ids a provider's
+    action cannot spell — see `frame/choose.py`.
+
+    **Every outcome is said on the operator's own screen, and there is exactly one call
+    that says it.** Three things can need a sentence and none of them has anywhere else to
+    go, because the pane they would have been drawn in is the one this is about to kill:
+    a picker row refused before it opens (the launch pin), a switch refused after a name is
+    chosen (an unknown name, a name that stopped existing while the picker was up), and a
+    switch that took effect over a session lock and must name what it overrode (#517 —
+    "a menu that silently fails against a lock is worse than no menu"). One call rather
+    than a branch per case, because a branch per case is a case somebody adds without one.
+
+    A STARTED action still says nothing: what it started surfaces through `inflight`,
+    which is the frame's existing spinner and not a second clock.
     """
     fid = os.environ.get("CHARTER_SESSION_ID", "")
     socket = state.frame_server(fid) or SOCKET
     harness = state.harness_pane(fid) or ""
     reg = builtin_actions.build(fid, current_density=_current_density(fid))
     snapshot = gather.cached(fid) or {}
+    client = getattr(args, "client", "") or ""
+    opened: list[choose.Roster] = []
     try:
         surface = palette.Palette(
-            catalogue=palette.rows(reg.offers(fid=fid, snapshot=snapshot)), mouse=True)
-        chosen = palette.own_the_tty(surface)
-        if chosen is not None:
-            inv = reg.invoke(chosen.id, fid=fid, snapshot=snapshot)
-            inv.join(timeout=_ACTION_START_GRACE)
-            if not inv.started:
-                _say_on_screen(fid, inv.reason, getattr(args, "client", "") or "")
+            catalogue=(choose.open_rows(fid)
+                       + palette.rows(reg.offers(fid=fid, snapshot=snapshot))),
+            mouse=True)
+        chosen = palette.own_the_tty(
+            surface, then=lambda row: _picker(row, fid, opened))
+        if chosen is None:
+            return 0
+        picked = _chosen_name(chosen, opened)
+        if picked is not None:
+            noun, name = picked
+            out = choose.switch_to(noun, fid, name)
+            _say_on_screen(fid, out.message, client)
+            return 0
+        if choose.noun_of(chosen) is not None:
+            # A picker row that never opened its picker: `_picker` refused it, which it
+            # does for exactly one reason and always with that reason in the row's note.
+            _say_on_screen(fid, chosen.note, client)
+            return 0
+        inv = reg.invoke(chosen.id, fid=fid, snapshot=snapshot)
+        inv.join(timeout=_ACTION_START_GRACE)
+        if not inv.started:
+            _say_on_screen(fid, inv.reason, client)
     finally:
         _close_palette(socket, harness=harness,
                        overlay_pane=os.environ.get("TMUX_PANE", ""))
     return 0
+
+
+def _picker(row, fid: str, opened: list) -> "palette.Palette | None":
+    """The surface *row* opens, or ``None`` when it opens none.
+
+    Handed to `palette.own_the_tty` as its *then*, so a picker is drawn in the palette's
+    own pane with the tty never leaving raw mode — see that function for why a second pane
+    would race this one's teardown.
+
+    **A pinned frame does not get a picker**, and that is Task 4's rule kept rather than
+    a new one: the row is listed, it carries the sentence that says why, and opening a list
+    of names none of which can be switched to would be an offer charter already knows it
+    cannot honour. ``None`` here sends the row back to :func:`_draw_palette`, which says
+    the note on the operator's screen.
+
+    The roster is appended to *opened* rather than returned beside the surface, because
+    what comes back out of `own_the_tty` is a ROW and the caller has to map it to the name
+    it stood for. Matching that by title would mean matching on a string
+    `overlay.Surface.render` has already contained — see `choose.Roster`.
+    """
+    noun = choose.noun_of(row)
+    if noun is None or row.note:
+        return None
+    roster = choose.roster(noun, fid)
+    opened.append(roster)
+    return palette.Palette(catalogue=roster.rows, label=noun, mouse=True)
+
+
+def _chosen_name(row, opened: list) -> "tuple[str, str] | None":
+    """``(noun, name)`` when *row* came off a picker this palette opened, else ``None``.
+
+    Asked of every roster rather than only the last, so that the answer does not depend on
+    how many surfaces were drawn — and asked by row ID, which is charter's own
+    `<noun>:n<N>` and never the operator's name.
+    """
+    for roster in opened:
+        name = roster.name_of(row)
+        if name is not None:
+            return roster.noun, name
+    return None
 
 
 def _close_palette(socket: str, *, harness: str, overlay_pane: str) -> None:

--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -4,11 +4,18 @@
 component seam a provider gets, and charter's own commands go through the action seam a
 provider gets. There is no private table of rows beside the registry the palette lists.
 
-**Everything the menu offered is here, and nothing else was invented.** Detach, the three
-densities, every workspace and every persona — the same four groups `_menu_entries` and
-`_switch_entries` built, minus the two things that were tmux's problem rather than
-charter's: the twelve-name cap (the overlay scrolls) and the submenu (a filter reaches a
-name in fewer keystrokes than a nested list does).
+**Everything the menu offered is reachable, and nothing else was invented.** Detach and
+the three densities are here; the workspace and persona lists are one keypress further on,
+in `frame/choose.py`, and the palette carries one row per noun that opens each. That is
+Task 6, and it is a correction to what this module shipped in Task 4 rather than an
+addition to it: a workspace is a *name*, not a thing this contract can honestly describe.
+An `Action`'s promise is fire-and-report — ``run`` starts work and returns — and forty
+names registered as forty actions meant forty ``run``s that each started a whole second
+charter process to write two files. A picker chooses the name first and switches once, in
+the pane the operator is already looking at.
+
+The two things that were tmux's problem rather than charter's are still gone either way:
+the twelve-name cap (the overlay scrolls) and the digit shortcut that ran out at nine.
 
 **An action starts a DETACHED process, and that is not incidental.** §4g's fire-and-report
 says `run` returns having started work; here it must also OUTLIVE the pane it was started
@@ -27,11 +34,8 @@ are both files the launcher already wrote.
 
 **Ids are charter's, titles carry the operator's names.** `frame.action.Action` holds an
 id to the component alphabet because it reaches a `bind` line, and a workspace may be
-named `my-repo.v2`, which is not in that alphabet. So a workspace's row is
-`workspace.w<N>` with the NAME in the title, contained by `Action.__post_init__` before
-anything measures it. The id is never drawn and never committed — this registry is rebuilt
-every time the palette opens, and the invocation happens against the same object — so
-nothing depends on `w3` meaning the same workspace twice.
+named `my-repo.v2`, which is not in that alphabet. That is why the picker's own rows are
+not actions at all — see `frame/choose.py`.
 """
 
 from __future__ import annotations
@@ -39,22 +43,14 @@ from __future__ import annotations
 import os
 import subprocess
 
-from .. import contain, util
-from . import action, actions, state, switch, tmuxctl
+from .. import util
+from . import action, actions, choose, state, tmuxctl
 
-#: What marks the workspace, persona or density a frame is currently on.
-#:
-#: **ASCII, deliberately** — the same rule `statusline._persona_chips` records having
-#: been broken twice by an East-Asian *Ambiguous* glyph, and `overlay.Surface.render`
-#: restates for its own marker. `*` is what `git branch` already uses for "the one you
-#: are on" and is unambiguously narrow everywhere.
-MARK = ("* ", "  ")
-
-#: What a workspace row's id counts up, and what a persona row's does. Charter's own
-#: prefixes, in the action alphabet, with the position appended — see the module
-#: docstring for why the name cannot be the id.
-WORKSPACE_ID = "workspace.w{}"
-PERSONA_ID = "persona.p{}"
+#: What marks the density a frame is currently on. **One constant, not two**: it is
+#: `frame/choose.py`'s, which marks the workspace and the persona a frame is on for the
+#: identical reason, and a second copy here would be a second answer to what "the one you
+#: are on" looks like. See that module for why it is ASCII.
+MARK = choose.MARK
 
 
 def _spawn(argv: list[str], *, fid: str) -> None:
@@ -168,67 +164,6 @@ def _run_density(fid: str, level: str):
     return f"density → {level}"
 
 
-def _register_switches(reg: actions.ActionRegistry, fid: str) -> None:
-    """Every workspace and every persona this plane has, as rows.
-
-    **Every one of them.** The menu capped each list at twelve because a `display-menu` is
-    drawn inside the terminal and tmux does not scroll it; this surface scrolls and
-    filters, so the cap would only hide names an operator can already reach faster by
-    typing three letters of one.
-
-    Two registrations rather than one loop over a table of two, because the two differ in
-    every part that matters — which lister, which pin, which command flag — and a table
-    would be a shared shape hiding four differences.
-    """
-    _register_names(reg, WORKSPACE_ID, switch.workspaces(),
-                    current=switch.current_workspace(fid), noun="workspace",
-                    pin="CHARTER_WORKSPACE")
-    _register_names(reg, PERSONA_ID, switch.personas(),
-                    current=switch.current_persona(fid), noun="persona",
-                    pin="CHARTER_PERSONA")
-
-
-def _register_names(reg: actions.ActionRegistry, template: str, names: list[str], *,
-                    current, noun: str, pin: str) -> None:
-    """One row per *name*, each running `charter frame-switch --<noun> <name>`.
-
-    **The pin is the availability rule, and it is the one refusal `switch.py` states as
-    permanent.** `$CHARTER_WORKSPACE` was set at launch, so it sits in every panel pane's
-    environment and nothing charter writes can outrank it; a row that offered to switch
-    anyway would report "switched" and draw the old workspace, which is the failure #411
-    was filed for. The session LOCK is not an unavailability — `to_workspace` overrides it
-    deliberately and says so in its own message — so it is not reported as one here.
-
-    `contain.one_line` before the name is measured or padded (#472), and again by
-    `Action.__post_init__` on the title it lands in. Twice, because they are two different
-    joins: this one is where a name meets charter's own marker column, and that one is
-    where a title meets the contract.
-    """
-    for i, name in enumerate(names):
-        on = MARK[0] if name == current else MARK[1]
-        reg.register(action.Action(
-            id=template.format(i),
-            title=f"{on}{noun}: {contain.one_line(name)}",
-            run=(lambda ctx, n=name, v=noun: _run_switch(ctx.fid, v, n)),
-            available=(lambda ctx, p=pin: not switch._pin(ctx.fid, p)),
-            reason_unavailable=(lambda ctx, p=pin: _pinned_reason(ctx.fid, p))))
-
-
-def _pinned_reason(fid: str, pin: str) -> str:
-    """Why a pinned frame will not switch, naming the value that pins it.
-
-    The same sentence `switch.to_workspace` refuses with, built from the same read, so the
-    row and the keypress cannot describe one frame two ways.
-    """
-    return (f"cannot switch: ${pin} pins this frame to "
-            f"'{contain.one_line(switch._pin(fid, pin) or '')}'")
-
-
-def _run_switch(fid: str, noun: str, name: str):
-    _spawn(util.self_relaunch_argv("frame-switch", f"--{noun}", name), fid=fid)
-    return f"{noun} → {contain.one_line(name)}"
-
-
 def build(fid: str, *, current_density: str) -> actions.ActionRegistry:
     """Charter's own actions, plus every action an installed provider supplies.
 
@@ -245,11 +180,19 @@ def build(fid: str, *, current_density: str) -> actions.ActionRegistry:
     somewhere to speak. Nothing here catches anything: `add` turns a missing distribution,
     a bad import, a version charter does not speak and an id collision each into a row
     that says which.
+
+    **`fid` is no longer read while BUILDING, and it stays in the signature anyway.** The
+    workspace and persona lists left with `_register_names` (see the module docstring), and
+    what remains — detach, the densities, a provider's own — resolves the frame at the
+    moment it is *invoked*, off `ctx.fid`. Dropping the parameter would mean every caller
+    stopped saying which frame it was building for, and `frame/actions.py` takes `fid` on
+    both `offers` and `invoke` precisely because that answer must never be ambient: one
+    tmux server is shared by every frame on the machine, and this process's own
+    `$CHARTER_SESSION_ID` may be another frame's (`state.record_identity` measures it).
     """
     reg = actions.ActionRegistry()
     _register_detach(reg)
     _register_density(reg, current=current_density)
-    _register_switches(reg, fid)
     for aid in reg.providers.ids():
         reg.add(aid)
     return reg

--- a/charter/frame/choose.py
+++ b/charter/frame/choose.py
@@ -1,0 +1,232 @@
+"""The pickers: choosing a workspace or a persona from inside a running frame.
+
+**This is `frame/overlay.py` over a list of NAMES, and that is the whole of it** — the
+seam `frame/palette.py` named when it wrote `rows(offers)` beside `Palette(catalogue=…)`:
+
+    Task 6's workspace and persona pickers are the same :class:`Palette` over a
+    different row source, and a picker that had to subclass something would be a
+    second surface wearing this one's name.
+
+So there is no `Picker` class here. There is a function from names to `overlay.Row`s, a
+function from a chosen row back to the name it stood for, and one call into
+`frame/switch.py`. Everything modal, every key, the scrolling window, the containment and
+the escape hatch are already decided one module down and are not restated.
+
+**The picker runs in the palette's OWN pane, and that is a property rather than a saving.**
+The alternative — a palette row that spawns a second `charter` which splits a second
+overlay pane — races the palette's own teardown: `commands_frame._close_palette` sends
+`select-pane ; kill-pane ; set-option @charter_hatch` as one chained command the instant
+the row has been chosen, and a picker pane that had already selected and zoomed itself
+would be un-selected, un-zoomed and un-hatched by it. Reusing the pane has no interleaving
+to lose: `palette.own_the_tty` hands one surface to the next inside the same raw-mode
+window, and the pane is handed back exactly once, at the end.
+
+**A picker row's id is deliberately not an action id.** `frame/action.py` holds every
+action id to `component._ID_RE` — lower-case letters, digits, underscores and at most one
+dot — and the palette dispatches on the id of whatever was chosen. If a picker's rows used
+that alphabet, a provider shipping an action called `pick.workspace` would take the
+keypress. The `:` in :data:`OPEN_ID` and :data:`NAME_ID` cannot appear in an action id, so
+the two namespaces cannot meet; `overlay.Row` imposes no alphabet of its own, and none of
+these ids is ever drawn or ever reaches tmux.
+
+**Containment is `frame/overlay.py`'s, asked for once, where the width arithmetic is.**
+`Surface.render` runs `contain.one_line` over every title and note *before* `tui.width`
+sees them (#472) — so a workspace directory holding a newline, a U+2028 or an escape
+sequence becomes one row there, and a second `contain.one_line` on the way in here would
+be a line no test could go red without. That is not a claim, it is the shape this
+repository has now been bitten by four times, and `builtin_actions._register_names` — the
+code this module replaces — carried exactly such a line: its `contain.one_line(name)` was
+masked by `Action.__post_init__` containing the title it landed in, and its test stayed
+green over the deletion. `tests/test_frame_pickers.py` measures the property against
+hostile names instead of restating the call.
+
+**What is NOT display text goes to `frame/switch.py` raw**, which is the other half of the
+same rule. :meth:`Roster.name_of` answers the name a row stood for, un-contained, because
+`switch.to_workspace` is the one place a name is checked against `workspace.valid_name`
+and refused — a name repaired on the way in would be a name charter switched to having
+never looked at.
+
+**Nothing here creates anything and nothing here touches tmux.** `switch.py`'s reasons,
+both: an unknown name is a refusal with the existing names beside it, and the one
+`display-message` that puts an outcome on screen belongs to `commands_frame`.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from .. import contain
+from . import overlay, switch
+
+#: The two nouns a picker offers. Values rather than an enum for the reason the rest of
+#: this package uses strings — they appear in a test's failure message as themselves —
+#: and they are also what `charter frame-switch` already spells its flags with, so the one
+#: word travels from the row to the command without a table in between.
+WORKSPACE, PERSONA = "workspace", "persona"
+
+#: Both, in the order the palette offers them. Workspace first: it is the plane a frame is
+#: looking at, and a persona is who is looking.
+NOUNS = (WORKSPACE, PERSONA)
+
+#: Which launch pin outranks a switch of each noun — the rung nothing charter writes can
+#: reach, because it is already in every panel pane's environment (`switch.py`'s module
+#: docstring). Named here because the row that opens a picker is the surface that reports
+#: it, and the reporting and the refusal must read the same variable.
+PIN = {WORKSPACE: "CHARTER_WORKSPACE", PERSONA: "CHARTER_PERSONA"}
+
+#: What marks the name the frame is on right now.
+#:
+#: **ASCII, deliberately** — `overlay._MARK`'s own rule and `statusline._persona_chips`'
+#: measurement behind it: `●`, `◆` and the pointing triangles are East-Asian *Ambiguous*
+#: and have broken this layout twice. Both entries are the same width by construction, so
+#: the mark moving does not move the names beside it.
+MARK = ("* ", "  ")
+
+#: The id of the palette row that OPENS a picker, and of one name row inside one. See the
+#: module docstring for why both carry a `:` — it is what keeps them out of the action
+#: alphabet, and it is never drawn.
+OPEN_ID = "pick:{}"
+NAME_ID = "{}:n{}"
+
+
+class Roster(NamedTuple):
+    """One picker's rows, and the names they stand for.
+
+    The two are carried together and matched by ROW ID rather than by title, because the
+    title carries :data:`MARK` and a committed name that `overlay.Surface.render`
+    contains before drawing — so the string on screen is not the string to switch to, and
+    a surface that matched on what it drew would switch to a repaired name or to nothing.
+    """
+
+    #: :data:`WORKSPACE` or :data:`PERSONA`. Carried so a caller that opened a picker does
+    #: not have to remember which one it asked for.
+    noun: str
+    #: What the overlay draws, in the order `switch.workspaces`/`switch.personas` gave.
+    rows: tuple[overlay.Row, ...]
+    #: The raw names, index-aligned with :attr:`rows`. Never contained — see the module
+    #: docstring.
+    names: tuple[str, ...]
+
+    def name_of(self, row: overlay.Row) -> str | None:
+        """The name *row* stood for, or ``None`` for a row that is not this roster's.
+
+        ``None`` rather than a raise or an empty string: an id that is not here means the
+        surface answered with a row this roster did not build, and `switch.to_workspace`
+        would read `""` as a name to check rather than as an absence.
+        """
+        for r, name in zip(self.rows, self.names):
+            if r.id == row.id:
+                return name
+        return None
+
+
+def names_of(noun: str) -> list[str]:
+    """Every name *noun* offers, from `frame/switch.py`'s own listers.
+
+    Asked there rather than re-derived, so the list a picker draws and the list a refusal
+    names ("no workspace 'x' — have: …") cannot disagree. Both are already held to
+    `workspace.valid_name`/`persona.valid_name` on the way out, which is #442's rule
+    applied where a directory name becomes a row.
+    """
+    return switch.workspaces() if noun == WORKSPACE else switch.personas()
+
+
+def current(noun: str, fid: str) -> str:
+    """The name frame *fid* is on right now — the row that gets :data:`MARK`.
+
+    `switch.current_persona` answers ``None`` for a plane with no persona at all, which is
+    an ordinary answer rather than a missing one; it becomes `""`, which matches no name
+    and therefore marks no row.
+    """
+    if noun == WORKSPACE:
+        return switch.current_workspace(fid)
+    return switch.current_persona(fid) or ""
+
+
+def pin_reason(noun: str, fid: str) -> str:
+    """Why *fid* will not switch its *noun*, or `""` when it will.
+
+    The same sentence `switch.to_workspace` refuses with, built from the same read
+    (`switch._pin`), so the row and the keypress cannot describe one frame two ways. `""`
+    exactly when the frame is not pinned, which is what makes "available" and "has no
+    reason" one decision here rather than two that can contradict each other on screen.
+    """
+    pinned = switch._pin(fid, PIN[noun])
+    if not pinned:
+        return ""
+    return (f"cannot switch: ${PIN[noun]} pins this frame to "
+            f"'{contain.one_line(pinned)}'")
+
+
+def roster(noun: str, fid: str) -> Roster:
+    """Every name *noun* has, as rows, with the one *fid* is on marked.
+
+    No cap and no reordering: `frame/palette.py`'s `narrow` filters this list as the
+    operator types and never reorders it, so the row under the cursor stays under the
+    cursor between keystrokes.
+
+    The note column is left empty. The one refusal a picker could carry per row is the
+    launch pin, and that is reported by the row that OPENS the picker (:func:`open_rows`)
+    — where it stops the pane being drawn at all, one keypress earlier. A reason repeated
+    on every row of a picker that cannot be reached while it is true is a line nothing
+    could go red without.
+    """
+    names = tuple(names_of(noun))
+    now = current(noun, fid)
+    rows = tuple(overlay.Row(id=NAME_ID.format(noun, i),
+                             title=f"{MARK[0] if n == now else MARK[1]}{n}")
+                 for i, n in enumerate(names))
+    return Roster(noun=noun, rows=rows, names=names)
+
+
+def open_rows(fid: str) -> tuple[overlay.Row, ...]:
+    """The two rows the palette carries: one per noun, each opening its picker.
+
+    **They are rows and not actions, and the difference is honest rather than
+    bureaucratic.** `frame/action.py`'s contract is *fire-and-report* — ``run`` starts
+    work and returns, and `ActionRegistry.invoke` never waits for it — and opening a
+    picker starts nothing at all: it replaces the surface in the pane the operator is
+    already looking at. An `Action` whose ``run`` did nothing would pass every test in
+    that contract and describe nothing that happens.
+
+    The title names the name in use, so the palette still answers "which workspace am I
+    on" without opening anything, and so typing `alpha` still finds the row when `alpha`
+    is where the frame is. The note is the pin reason, which is what makes a pinned frame
+    say so **before** a keypress — Task 4's rule, unchanged, one row instead of forty.
+    """
+    out = []
+    for noun in NOUNS:
+        now = current(noun, fid)
+        out.append(overlay.Row(
+            id=OPEN_ID.format(noun),
+            title=(f"{noun}: {now} — pick another" if now else f"{noun} — pick one"),
+            note=pin_reason(noun, fid)))
+    return tuple(out)
+
+
+def noun_of(row: overlay.Row) -> str | None:
+    """Which picker *row* opens, or ``None`` when it opens none.
+
+    How `commands_frame._draw_palette` tells a navigation row from an action row. Matched
+    against the two ids this module mints rather than by splitting on `:`, so a row id
+    that merely contains a colon cannot be read as an instruction.
+    """
+    for noun in NOUNS:
+        if row.id == OPEN_ID.format(noun):
+            return noun
+    return None
+
+
+def switch_to(noun: str, fid: str, name: str) -> switch.Outcome:
+    """Move frame *fid* to *name*, and answer with what happened and what to say.
+
+    One call into `frame/switch.py` and nothing else, which is what makes "the switch
+    moves the frame's own identity and bumps it" (#411/#412) a property of one function
+    rather than of every surface that switches. The pointer under the frame's id, the
+    frame's recorded workspace, the gather cache and the bump are all that function's, in
+    that order, and a picker that wrote any of them itself would be the second answer #411
+    is about.
+    """
+    if noun == WORKSPACE:
+        return switch.to_workspace(fid, name)
+    return switch.to_persona(fid, name)

--- a/charter/frame/palette.py
+++ b/charter/frame/palette.py
@@ -191,8 +191,9 @@ class Palette(overlay.Surface):
         return super().handle(ev, height)
 
 
-def own_the_tty(surface: overlay.Surface, *, fd: int | None = None,
-                out=None) -> overlay.Row | None:
+def own_the_tty(surface: overlay.Surface, *, fd: int | None = None, out=None,
+                then: Callable[[overlay.Row], overlay.Surface | None] | None = None
+                ) -> overlay.Row | None:
     """Put this process's own tty in raw mode and let *surface* have it until it is done.
 
     **Raw mode is what makes the surface modal at all.** Without it the terminal line
@@ -215,14 +216,43 @@ def own_the_tty(surface: overlay.Surface, *, fd: int | None = None,
     default size here would be a rectangle charter invented for a pane it could not
     measure, which is `frame/slots.py`'s measured 22-column pane reporting 200 columns,
     one surface over.
+
+    ---
+
+    **`then` is how one pane holds more than one surface**, and it is Task 6's whole
+    mechanism: a chosen row is offered to it, and a `Surface` coming back is run next, in
+    this same pane, without the tty leaving raw mode in between. `None` — the default, and
+    what `then` answers for every row that is not a doorway — ends the loop and returns
+    the row, exactly as before.
+
+    That is what a picker is (`frame/choose.py`): the palette's own pane, redrawn from a
+    different row source. The alternative shape, a palette row that starts a second
+    charter to split a second overlay pane, races the palette's own teardown —
+    `commands_frame._close_palette` selects the harness, kills this pane and re-arms the
+    escape hatch as ONE chained tmux command the instant a row has been chosen, and a
+    second pane that had already selected and zoomed itself would be undone by it.
+
+    `then` is charter's own code and answers `None` for every row a picker offers, so the
+    loop is a two-level tree rather than an open one. It is deliberately not bounded by a
+    count: a number here would be a limit on how deep a surface may nest, invented to
+    guard against charter's own code being wrong, and the honest answer to a surface that
+    will not end is the one `frame/overlay.py` already gives — `HATCH_KEY`, matched by
+    tmux's own root key table before any byte reaches this process.
     """
     fd = sys.stdin.fileno() if fd is None else fd
     out = sys.stdout if out is None else out
     before = termios.tcgetattr(fd)
     tty.setraw(fd)
     try:
-        return surface.run(read=_reader(fd), write=_writer(out),
-                           size=lambda: tuple(os.get_terminal_size(out.fileno())))
+        read, write = _reader(fd), _writer(out)
+        def size() -> tuple[int, int]:
+            return tuple(os.get_terminal_size(out.fileno()))
+        while True:
+            chosen = surface.run(read=read, write=write, size=size)
+            nxt = then(chosen) if (then is not None and chosen is not None) else None
+            if nxt is None:
+                return chosen
+            surface = nxt
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, before)
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -751,14 +751,13 @@ how to get back in (`tmux -L charter attach -t <frame-id>`) rather than leaving 
 remember the flags.
 
 ```
-charter · 7 to choose from
-> detach — leave the harness running
+charter · 6 to choose from
+> workspace: alpha — pick another
+    persona: steward — pick another
+    detach — leave the harness running
     density: minimal
     density: normal
   * density: full
-  * workspace: alpha             cannot switch: $CHARTER_WORKSPACE pins this fr…
-    workspace: default           cannot switch: $CHARTER_WORKSPACE pins this fr…
-    workspace: zebra             cannot switch: $CHARTER_WORKSPACE pins this fr…
 
   up/down move   enter choose   esc cancel   F12 back to the harness
 ```
@@ -767,9 +766,24 @@ charter · 7 to choose from
 An option you cannot see is one you cannot ask about, so a row that is refused stays and
 says what would make it available. The reason is the right-hand column.
 
+**Two of those rows are doorways.** `workspace:` and `persona:` say which one this frame is
+on, and Enter opens the list of the others **in the same pane** — a picker, which is this
+same surface over a different set of rows. Type to narrow it exactly as you would the
+palette, Enter to switch, Escape to leave having changed nothing:
+
+```
+workspace · 4 to choose from
+  * alpha
+>   beta
+    default
+    zebra
+
+  up/down move   enter choose   esc cancel   F12 back to the harness
+```
+
 **There is no row cap.** The old menu was a tmux `display-menu`, drawn inside your terminal
 and unable to scroll, so it cut every list at twelve and lost the digit shortcut past nine.
-The palette is a pane charter draws: it scrolls, it filters, and a plane with forty
+The picker is a pane charter draws: it scrolls, it filters, and a plane with forty
 workspaces lists forty.
 
 **The menu is gone.** `charter frame-menu` and `charter frame-action` no longer exist, and
@@ -777,7 +791,7 @@ neither does the `display-menu` they opened. `F2` was always trying to be a pale
 keeping both would have left two answers to "how do I do a thing", which is how the single
 menu became weird in the first place.
 
-**Switching from the palette moves the frame, and says so.** Choosing a workspace writes
+**Switching from the picker moves the frame, and says so.** Choosing a workspace writes
 the choice under the frame's own id — the same pointer `charter workspace use` writes from
 inside the frame, which is what makes the panels follow — records it as the frame's
 workspace, re-gathers the repo table for it, and bumps the frame so every panel repaints
@@ -787,15 +801,26 @@ one-line message lands on your own screen saying what happened.
 **A pinned frame says so before you press anything.** A frame launched with
 `$CHARTER_WORKSPACE` (or `$CHARTER_PERSONA`) set is *pinned*: that variable is in every
 panel pane's environment for as long as the pane lives, and nothing charter can write
-outranks it — so every workspace row carries `cannot switch: $CHARTER_WORKSPACE pins this
-frame to '<name>'` rather than offering a move that would not happen. Nothing here creates
-a workspace either.
+outranks it — so that noun's row carries `cannot switch: $CHARTER_WORKSPACE pins this
+frame to '<name>'` and opens no picker, rather than offering a list of moves that would not
+happen. The other noun is unaffected: one pin, one noun. Nothing here creates a workspace
+either — an unknown name is a refusal with the existing names beside it, never an implicit
+create.
+
+**A name that is not a name is drawn and never run.** A workspace or persona is a directory
+somebody can add in a commit, and a filesystem forbids only `/` and NUL — so a name can hold
+a newline, a U+2028, an escape sequence, a quote or a `#`. Every name is made one line
+before any column is measured (#472), so it is exactly one row on screen; and the switch
+re-checks it against the same alphabet `charter workspace use` does, so a name charter would
+not accept is refused with a message rather than acted on.
 
 **The session lock moves with you.** `charter workspace use` locks the session to what it
 selected so a workspace cannot be swapped out from under a running task — but a keypress on
-the palette *is* you, and the switcher's own first write would otherwise take a lock that
+the picker *is* you, and the switcher's own first write would otherwise take a lock that
 its second write hit, leaving a switcher that worked exactly once. So the switch overrides
-the lock and names what it overrode: `workspace → beta  (lock moved from 'alpha')`.
+the lock and names what it overrode: `workspace → beta  (lock moved from 'alpha')`. Silence
+would be the wrong answer: an agent inside the frame took that lock, and its next command
+acts on a workspace it was never told had moved.
 
 **Pressing `F2` again while the palette is open opens a second one.** `bind -n` is tmux's
 root key table, so tmux matches the key before any byte reaches the palette's pane — the

--- a/docs/news/unreleased-a-picker-for-workspaces-and-personas.md
+++ b/docs/news/unreleased-a-picker-for-workspaces-and-personas.md
@@ -1,0 +1,74 @@
+---
+version: unreleased
+headline: The palette stops listing every workspace and starts opening a picker for them
+---
+
+`F2` used to hand you one flat list with everything in it — detach, three densities, and
+then every workspace and every persona the plane has, one row each. On a plane with thirty
+workspaces the four things a frame can *do* were four rows in thirty-seven.
+
+**Two rows now, and each opens a list of its own:**
+
+```
+charter · 6 to choose from
+> workspace: alpha — pick another
+    persona: steward — pick another
+    detach — leave the harness running
+    density: minimal
+    density: normal
+  * density: full
+```
+
+Enter on `workspace:` redraws the **same pane** with the names alone:
+
+```
+workspace · 4 to choose from
+  * alpha
+>   beta
+    default
+    zebra
+```
+
+Type to narrow, Enter to switch, Escape to leave having changed nothing — the same keys,
+the same scrolling, the same `F12` back to the harness. It is not a second surface: a
+picker *is* the palette, over a different set of rows.
+
+**The palette still answers "where am I" without opening anything.** That is why the row
+says `workspace: alpha` rather than just `workspace`, and it is why typing the name you are
+already on still finds it.
+
+**A workspace is a name, not an action, and that was the actual defect.** Charter's action
+contract promises *fire-and-report*: `run` starts work and returns. Forty workspaces
+registered as forty actions meant forty `run`s, each of which started a whole second
+charter process to write two files. The picker chooses the name first and switches once, in
+the pane you are already looking at — no second process, and nothing racing the palette's
+own teardown for the pane.
+
+**A refused switch says so, on your own screen.** Three things can need a sentence and all
+three get one:
+
+* a frame launched with `$CHARTER_WORKSPACE` set is *pinned* — that variable is in every
+  panel pane's environment for as long as the pane lives, and nothing charter writes
+  outranks it. The row carries `cannot switch: $CHARTER_WORKSPACE pins this frame to
+  'alpha'` and opens no picker at all, rather than showing you a list of moves that would
+  not happen. The persona row is unaffected: one pin, one noun.
+* a workspace that stopped existing between the list being drawn and Enter being pressed is
+  refused with the names that *do* exist beside it, never created.
+* a switch that overrode the session lock says what it overrode — `workspace → beta  (lock
+  moved from 'alpha')`. An agent inside the frame took that lock, and its next command
+  would otherwise act on a workspace nobody told it had moved.
+
+**A hostile name is one row and runs nothing.** A workspace or persona is a directory a
+commit can add, and a filesystem forbids only `/` and NUL — so a name can hold a newline, a
+U+2028, an escape sequence, a quote or a `#`. Every name is made one line *before* any
+column width is measured, so it draws as exactly one row with its escapes visible; and the
+switch checks the name against the same alphabet `charter workspace use` does, so a name
+charter would not accept is refused rather than acted on.
+
+**And the switch is still the frame's own identity, not a pointer.** Choosing a name writes
+the per-session pointer under the frame's id and the frame's recorded workspace, refreshes
+the repo table, and *then* bumps the frame — which is what makes every panel repaint against
+the new plane rather than one of them noticing eventually.
+
+Nothing to adopt. `charter frame-switch --workspace <name>` still works typed by hand, and
+still says what it did.

--- a/tests/test_frame_palette.py
+++ b/tests/test_frame_palette.py
@@ -27,7 +27,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, contain, tui
-from charter.frame import action, actions, builtin_actions, overlay, palette, state, switch
+from charter.frame import action, actions, builtin_actions, overlay, palette, state
 
 from tests._isolation import PersonaIso
 

--- a/tests/test_frame_palette.py
+++ b/tests/test_frame_palette.py
@@ -598,11 +598,10 @@ class ThePaletteCommand(PersonaIso, unittest.TestCase):
         """`invoke` re-asks availability, so a row drawn while a plane was one way and
         pressed while it is another is refused — and that sentence has nowhere else to go,
         because the pane it would have been drawn in is the one about to be killed."""
-        state.record_identity(self.FID, {"CHARTER_WORKSPACE": "pinned-ws"})
-        with mock.patch.object(switch, "workspaces", return_value=["pinned-ws", "other"]):
-            self.assertEqual(self._draw(overlay.Row(id="workspace.w1", title="w")), 0)
+        state.record_harness_pane(self.FID, "not-a-pane-id")
+        self.assertEqual(self._draw(overlay.Row(id="density.full", title="d")), 0)
         self.said.assert_called_once()
-        self.assertIn("$CHARTER_WORKSPACE pins this frame", self.said.call_args[0][1])
+        self.assertIn("no record of this frame's harness pane", self.said.call_args[0][1])
         self.assertEqual(self.said.call_args[0][2], "/dev/ttys7")
 
     def test_the_pane_is_not_killed_before_the_action_has_started(self):

--- a/tests/test_frame_palette.py
+++ b/tests/test_frame_palette.py
@@ -500,6 +500,33 @@ class TheActionsCharterOffersItself(PersonaIso, unittest.TestCase):
         self.assertFalse(offer.available)
         self.assertIn("no record of this frame's harness pane", offer.reason)
 
+    def test_a_frame_with_NO_harness_record_at_all_says_the_same_thing(self):
+        """**A different condition from the one above, and the only one that reaches
+        `_laid_out`'s fallback.** `state.harness_pane` answers `None` — not a bad string —
+        for a frame launched by a charter that predates `record_harness_pane`, for a state
+        directory that was truncated, and for a file that cannot be read. Its own docstring
+        names all three.
+
+        Without the `or ""`, `PANE_ID_RE.fullmatch(None)` raises `TypeError` — and
+        `ActionRegistry._check` catches `BaseException` and turns it into an unavailable
+        row, so the row is refused **either way** and only the REASON differs. Measured on
+        this exact fixture:
+
+            shipped : charter has no record of this frame's harness pane, so it cannot
+                      move the panels — relaunch the frame
+            mutant  : TypeError: expected string or bytes-like object, got 'NoneType'
+
+        That is `release.yml`'s `-z` (#558) and `panel.py`'s dead `except` (#570) one
+        surface over: a neighbour that answers the same question a worse way, so a test
+        asserting only "unavailable" stays green over a real deletion. This asserts which
+        refusal fired.
+        """
+        (state.frame_dir(self.FID) / "harness").unlink()
+        self.assertIsNone(state.harness_pane(self.FID))
+        offer = self._offers()["density.normal"]
+        self.assertFalse(offer.available)
+        self.assertEqual(offer.reason, builtin_actions.NO_LAYOUT)
+
     def test_a_frame_with_a_real_harness_pane_can_move_its_density(self):
         """The other direction, so the reason above cannot pass by never being available."""
         self.assertTrue(self._offers()["density.normal"].available)

--- a/tests/test_frame_palette_integration.py
+++ b/tests/test_frame_palette_integration.py
@@ -277,32 +277,55 @@ class ThePaletteOpensAndRuns(_ThePalette, unittest.TestCase):
 
     def test_the_hotkey_opens_a_palette_listing_the_frames_actions(self):
         _, pane = self._open()
-        for expected in ("detach", "density: minimal", "workspace: alpha",
-                         "workspace: zebra"):
+        for expected in ("detach", "density: minimal", "workspace: alpha — pick another",
+                         "persona — pick one"):
             self._await_screen(pane, expected)
 
     def test_typing_narrows_the_list_to_what_matches(self):
         fd, pane = self._open()
         self._await_screen(pane, "workspace: alpha")
-        os.write(fd, b"zebra")
-        self._await_screen(pane, "workspace: alpha", present=False)
+        os.write(fd, b"workspace")
+        self._await_screen(pane, "detach", present=False)
         screen = self._screen(pane)
-        self.assertIn("workspace: zebra", screen, screen)
-        self.assertNotIn("detach", screen, screen)
-        self.assertIn("zebra", screen.splitlines()[0],
+        self.assertIn("workspace: alpha", screen, screen)
+        self.assertIn("workspace", screen.splitlines()[0],
                       "what the operator typed is not on the header")
 
-    def test_enter_runs_the_action_the_filter_left_and_it_outlives_the_pane(self):
-        """The action is a workspace switch, so what is asserted is a file the switch
-        wrote — which is the only way to see that `run` was reached AND that the work
-        survived `kill-pane` on the pane it was started from."""
+    def test_enter_opens_the_picker_in_this_same_pane_and_choosing_moves_the_frame(self):
+        """**Task 6's step 1, end to end, with real keys.** The palette's workspace row is
+        a doorway: Enter replaces the surface in the pane the operator is already looking
+        at — no second pane, no second charter process, nothing to race
+        `_close_palette` — and the name chosen there switches the frame.
+
+        Asserted on the frame's own record rather than on anything drawn, because "the
+        frame moved" is `state.workspace_for`'s rungs (#411) and not a repaint.
+        """
         fd, pane = self._open()
-        self._await_screen(pane, "workspace: zebra")
+        self._await_screen(pane, "workspace: alpha")
         self.assertEqual(state.frame_workspace(self.fid), "alpha")
+        self.assertEqual(self._palette_pane(), pane)
+        os.write(fd, b"workspace\r")
+        # The picker: the names alone, no `workspace:` prefix and no `detach` beside them.
+        self._await_screen(pane, "detach", present=False)
+        self._await_screen(pane, "zebra")
+        self.assertEqual(self._palette_pane(), pane,
+                         "the picker opened a second pane instead of reusing this one")
         os.write(fd, b"zebra\r")
         self.assertTrue(_await(lambda: state.frame_workspace(self.fid) == "zebra"),
-                        f"the chosen action never ran: workspace is still "
+                        f"the chosen name never switched the frame: workspace is still "
                         f"{state.frame_workspace(self.fid)!r}")
+
+    def test_the_picker_bumps_the_frame_so_every_panel_repaints(self):
+        """#411/#412's half of step 1. A pointer some panels may read is the bug; the
+        version moving is what makes a panel's poll loop redraw against the new plane."""
+        fd, pane = self._open()
+        self._await_screen(pane, "workspace: alpha")
+        was = state.version(self.fid)
+        os.write(fd, b"workspace\r")
+        self._await_screen(pane, "zebra")
+        os.write(fd, b"zebra\r")
+        self.assertTrue(_await(lambda: state.version(self.fid) != was),
+                        "the frame was never bumped, so no panel repaints")
 
     def test_the_pane_comes_back_to_the_harness_when_the_palette_closes(self):
         fd, pane = self._open()
@@ -343,13 +366,16 @@ class AnUnavailableActionIsDrawnWithItsReason(_ThePalette, unittest.TestCase):
 
     def test_the_row_is_listed_and_says_why_it_cannot_run(self):
         _, pane = self._open()
-        self._await_screen(pane, "workspace: zebra")
+        self._await_screen(pane, "workspace: alpha")
         self._await_screen(pane, "cannot switch: $CHARTER_WORKSPACE")
 
-    def test_choosing_it_changes_nothing_and_the_frame_says_so(self):
+    def test_choosing_it_opens_no_picker_changes_nothing_and_the_frame_says_so(self):
+        """A pinned frame does not get a list of names it cannot switch to. The row is
+        still there, still says why, and Enter on it closes the palette having moved
+        nothing — the reason goes to the operator's own screen on the way out."""
         fd, pane = self._open()
-        self._await_screen(pane, "workspace: zebra")
-        os.write(fd, b"zebra\r")
+        self._await_screen(pane, "workspace: alpha")
+        os.write(fd, b"workspace\r")
         self.assertTrue(_await(lambda: self._palette_pane() is None),
                         "the palette never closed")
         time.sleep(0.5)

--- a/tests/test_frame_pickers.py
+++ b/tests/test_frame_pickers.py
@@ -228,6 +228,25 @@ class AHostileNameIsOneRowAndRunsNothing(_Frame, unittest.TestCase):
         self.assertEqual(sorted(p.name for p in config.WORKSPACES_DIR.iterdir()),
                          ["alpha", "beta"], "a refused switch created something")
 
+    def test_a_hostile_PERSONA_name_is_refused_the_same_way(self):
+        """**The twin, and it was not pinned before this case.** `switch.to_persona` has
+        the same `shown = contain.one_line(name)` as `to_workspace`, reaching the same
+        `_say_on_screen`; the workspace one is covered twice over and the persona one was
+        covered nowhere — deleting it left the whole suite green. Task 6 step 4 says
+        "workspace **and** persona", and a picker exists for both.
+        """
+        with mock.patch.object(switch, "personas", return_value=["forge", *HOSTILE]):
+            roster = choose.roster(choose.PERSONA, self.FID)
+            self.assertEqual(len(roster.rows), 1 + len(HOSTILE))
+            for row in roster.rows[1:]:
+                name = roster.name_of(row)
+                out = choose.switch_to(choose.PERSONA, self.FID, name)
+                self.assertFalse(out.ok, f"{name!r} was switched to")
+                self.assertEqual(len(out.message.splitlines()), 1, repr(out.message))
+                self.assertEqual(out.message, "".join(out.message.splitlines()),
+                                 repr(out.message))
+        self.assertIsNone(switch.current_persona(self.FID))
+
 
 def _pane(*rows):
     """Stand in for the palette's pane: hand each row to *then* in turn, answer the last.

--- a/tests/test_frame_pickers.py
+++ b/tests/test_frame_pickers.py
@@ -265,6 +265,30 @@ class ThePaletteOpensThePickerAndActsOnWhatComesBack(_Frame, unittest.TestCase):
         return next(r for r in choose.open_rows(self.FID)
                     if choose.noun_of(r) == noun)
 
+    def test_the_palette_is_built_with_a_doorway_for_each_noun_ahead_of_the_actions(self):
+        """**What the pane is actually given**, asserted on the surface `_draw_palette`
+        constructs rather than on rows a test handed back to it. Every other case in this
+        class feeds `own_the_tty` a row directly, so none of them would notice the
+        doorways never being put in the catalogue at all — measured: removing
+        `choose.open_rows` from the catalogue reddened nothing outside the tmux-gated
+        integration module, which skips on a machine with no tmux.
+
+        The order is asserted with them first, so an accidental `F2`-then-Enter opens a
+        list rather than detaching the harness.
+        """
+        seen = []
+
+        def fake(surface, *, then=None, **kw):
+            seen.append(surface)
+            return None
+
+        with mock.patch.object(palette, "own_the_tty", fake):
+            self.assertEqual(commands_frame.cmd_palette(
+                SimpleNamespace(client="", pane=True)), 0)
+        ids = [r.id for r in seen[0].catalogue]
+        self.assertEqual(ids[:2], ["pick:workspace", "pick:persona"], ids)
+        self.assertIn("frame.detach", ids)
+
     def test_choosing_a_name_moves_the_frame_and_says_what_it_did(self):
         was = state.version(self.FID)
         self.assertEqual(self._draw(self._doorway(choose.WORKSPACE),
@@ -387,6 +411,33 @@ class APinnedFrameIsToldBeforeItPressesAnything(_Frame, unittest.TestCase):
         row = next(r for r in choose.open_rows(self.FID)
                    if choose.noun_of(r) == choose.PERSONA)
         self.assertEqual(row.note, "")
+
+    def test_the_pin_is_contained_before_it_becomes_a_line_on_a_status_area(self):
+        """**The one containment in this branch that `overlay.Surface.render` does not
+        already do**, and the sweep found it unpinned.
+
+        `$CHARTER_WORKSPACE` is whatever the launching environment held, so
+        `CHARTER_WORKSPACE=$'a\\nb' charter claude` puts a newline in `state.identity`. The
+        reason built from it goes two places: a row's note, where `render` contains it —
+        and, when the row is pressed, straight into `_say_on_screen`, whose docstring
+        states the split in as many words: callers close the newline half with
+        `contain.one_line`, `tmuxctl.inert_format` closes the `#` half, "both, because they
+        are different properties: one line, and inert". `inert_format` does not touch a
+        separator, so nothing downstream would.
+
+        Asserted on what reaches `_say_on_screen`, not on the drawn pane — the pane would
+        pass either way, which is exactly how this line came to have no test.
+        """
+        state.record_identity(self.FID, {"CHARTER_WORKSPACE": "al\npha\u2028x"})
+        row = next(r for r in choose.open_rows(self.FID)
+                   if choose.noun_of(r) == choose.WORKSPACE)
+        with mock.patch.object(palette, "own_the_tty", _pane(row)):
+            commands_frame.cmd_palette(SimpleNamespace(client="", pane=True))
+        said = self.said.call_args[0][1]
+        self.assertEqual(said, "".join(said.splitlines()), repr(said))
+        for bad in ("\n", "\r", "\u2028", "\u2029", "\u0085"):
+            self.assertNotIn(bad, said, repr(said))
+        self.assertIn("\\x0a", said, repr(said))
 
     def test_pressing_it_opens_no_picker_and_the_reason_reaches_the_screen(self):
         row = next(r for r in choose.open_rows(self.FID)

--- a/tests/test_frame_pickers.py
+++ b/tests/test_frame_pickers.py
@@ -1,0 +1,459 @@
+"""The pickers: one overlay, a different row source, and the switch that repaints.
+
+Phase 2, Task 6. `frame/choose.py` is `frame/overlay.py` over a list of NAMES instead of
+a list of actions — the seam Task 4 named in as many words when it wrote
+`palette.rows(offers)` beside `Palette(catalogue=…)`.
+
+Four properties get most of this file's length, because each is a rule the plan states
+and a first implementation loses:
+
+* **A workspace picker lists workspaces, and switching repaints every panel against the
+  new plane.** That second half is the whole of #411: a switch that writes a pointer some
+  panels may read is the bug, and one that moves the frame's own identity and BUMPS it is
+  the fix. Every case that chooses a name here asserts the version moved.
+* **A hostile name renders as ONE row and runs nothing.** Measured against real hostile
+  names rather than reasoned about (#472), and measured on the drawn pane rather than on
+  the row, because "one row" is a property of what reaches the terminal.
+* **A refused switch says so on screen.** #517: "a menu that silently fails against a lock
+  is worse than no menu." Both refusals a picker can produce are asserted — the launch pin
+  before the picker opens, and a name that stopped existing after it did — and so is the
+  lock override, which succeeds and still has to name what it overrode.
+* **The picker is drawn in the palette's OWN pane.** `palette.own_the_tty`'s *then*, which
+  is what makes that true, is pinned against a real tty here; the whole chain from a real
+  `F2` to a moved frame is `tests/test_frame_palette_integration.py`.
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config, tui, workspace
+from charter.frame import choose, component, overlay, palette, state, switch
+
+from tests._isolation import PersonaIso
+
+#: Names a filesystem accepts and charter did not mint. Every one of them is a committed
+#: value in the sense `contain.py` means: a directory somebody can add in a commit.
+#:
+#: `\n` and `\r` forge a second row; U+2028 is the separator #472 was filed over and
+#: `str.splitlines` honours it where `split("\n")` does not; the CSI turns the rest of the
+#: row a colour and can move the cursor; `"` and `#` are what a tmux command line and a
+#: tmux FORMAT read as structure.
+HOSTILE = ("line\nbreak",
+           "car\rriage",
+           "sep\u2028arator",
+           "para\u2029graph",
+           "next\u0085line",
+           "esc\x1b[31mape",
+           'quo"te ; run-shell "touch /tmp/pwned',
+           "hash#{session_name}")
+
+
+def _plane_workspaces(*names: str) -> None:
+    for n in names:
+        (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
+
+
+def _plane_personas(*names: str) -> None:
+    for n in names:
+        d = config.PERSONAS_DIR / n
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "persona.md").write_text("# p\n")
+
+
+class _Frame(PersonaIso):
+    """One frame on an isolated plane, with nothing pinned and nothing on a screen."""
+
+    FID = "f-pick"
+    PIN = {"CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""}
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(
+            os.environ, {"CHARTER_SESSION_ID": self.FID}, clear=True))
+        _plane_workspaces("alpha", "beta")
+        _plane_personas("forge", "scribe")
+        state.frame_dir(self.FID, create=True)
+        state.record_server(self.FID, "charter")
+        state.record_harness_pane(self.FID, "%3")
+        state.record_identity(self.FID, {"CHARTER_SESSION_ID": self.FID, **self.PIN})
+        state.record_workspace(self.FID, "alpha")
+        self.said = self.enterContext(
+            mock.patch.object(commands_frame, "_say_on_screen"))
+        self.enterContext(mock.patch.object(commands_frame, "_close_palette"))
+
+
+class AWorkspacePickerListsWorkspaces(_Frame, unittest.TestCase):
+    """Step 1, whole: the list, and what choosing off it does to the frame."""
+
+    def test_the_picker_lists_every_workspace_with_the_one_in_use_marked(self):
+        roster = choose.roster(choose.WORKSPACE, self.FID)
+        self.assertEqual([r.title for r in roster.rows],
+                         ["* alpha", "  beta", "  default"])
+
+    def test_choosing_a_row_switches_the_frame_and_bumps_it_so_panels_repaint(self):
+        roster = choose.roster(choose.WORKSPACE, self.FID)
+        was = state.version(self.FID)
+        row = next(r for r in roster.rows if roster.name_of(r) == "beta")
+        out = choose.switch_to(roster.noun, self.FID, roster.name_of(row))
+        self.assertTrue(out.ok, out.message)
+        self.assertEqual(state.workspace_for(self.FID), "beta")
+        self.assertNotEqual(state.version(self.FID), was)
+
+    def test_a_persona_picker_is_the_same_thing_one_noun_over(self):
+        roster = choose.roster(choose.PERSONA, self.FID)
+        self.assertEqual([r.title for r in roster.rows], ["  forge", "  scribe"])
+        was = state.version(self.FID)
+        out = choose.switch_to(choose.PERSONA, self.FID, "scribe")
+        self.assertTrue(out.ok, out.message)
+        self.assertEqual(switch.current_persona(self.FID), "scribe")
+        self.assertNotEqual(state.version(self.FID), was)
+
+    def test_the_name_a_row_stands_for_is_matched_by_ID_and_never_by_TITLE(self):
+        """The title carries `choose.MARK` and a name `overlay.Surface.render` contains
+        before drawing, so the string on screen is not the string to switch to. A surface
+        that matched on what it drew would switch to a repaired name or to nothing."""
+        roster = choose.roster(choose.WORKSPACE, self.FID)
+        for row, name in zip(roster.rows, roster.names):
+            self.assertEqual(roster.name_of(row), name)
+            self.assertNotEqual(row.title, name)
+        self.assertIsNone(roster.name_of(overlay.Row(id="not:mine", title="alpha")))
+
+
+class APickerRowIsNotAnAction(_Frame, unittest.TestCase):
+    """The ids, and why they are spelled the way they are.
+
+    `frame/action.py` holds every action id to `component._ID_RE`, and `_draw_palette`
+    dispatches on the id of whatever the surface answered with. If a picker's ids used
+    that alphabet, a provider shipping `pick.workspace` would take the keypress.
+    """
+
+    def test_no_id_this_module_mints_could_ever_be_an_action_id(self):
+        ids = ([r.id for r in choose.open_rows(self.FID)]
+               + [r.id for r in choose.roster(choose.WORKSPACE, self.FID).rows]
+               + [r.id for r in choose.roster(choose.PERSONA, self.FID).rows])
+        self.assertTrue(ids)
+        for rid in ids:
+            self.assertFalse(component.usable_id(rid),
+                             f"{rid!r} is a usable action id, so a provider can collide "
+                             f"with it and take the keypress")
+
+    def test_the_doorway_is_recognised_and_nothing_else_is(self):
+        opens = {r.id: choose.noun_of(r) for r in choose.open_rows(self.FID)}
+        self.assertEqual(opens, {"pick:workspace": choose.WORKSPACE,
+                                 "pick:persona": choose.PERSONA})
+        for stranger in ("frame.detach", "density.full", "workspace:n0", "acme.deploy"):
+            self.assertIsNone(choose.noun_of(overlay.Row(id=stranger, title="x")))
+
+
+class AHostileNameIsOneRowAndRunsNothing(_Frame, unittest.TestCase):
+    """Step 4, measured rather than reasoned about.
+
+    The names are injected through `switch.workspaces`/`switch.personas` rather than
+    written to disk, because those two listers already refuse a name outside
+    `workspace.valid_name`/`persona.valid_name` — which is a real defence and is asserted
+    below, and is also exactly what would make this file test nothing if it were the only
+    one. A picker must hold the line for a lister that stops filtering.
+    """
+
+    #: A pane narrow enough that the two-column layout has to squeeze, so the width
+    #: arithmetic is actually exercised rather than trivially satisfied.
+    SIZE = (44, 12)
+
+    def _drawn(self, names) -> list[str]:
+        with mock.patch.object(switch, "workspaces", return_value=list(names)):
+            roster = choose.roster(choose.WORKSPACE, self.FID)
+        surface = palette.Palette(catalogue=roster.rows, label=choose.WORKSPACE)
+        return surface.render(*self.SIZE)
+
+    def test_the_lister_refuses_a_hostile_directory_name_outright(self):
+        """The first line, and the reason the rest of this class injects rather than
+        creates: a directory a commit added is not a workspace charter will offer."""
+        for name in HOSTILE:
+            (config.WORKSPACES_DIR / name.replace("/", "_")).mkdir(exist_ok=True)
+        self.assertEqual(sorted(switch.workspaces()), ["alpha", "beta", "default"])
+
+    def test_every_hostile_name_is_exactly_one_row(self):
+        with mock.patch.object(switch, "workspaces",
+                               return_value=["alpha", *HOSTILE]):
+            roster = choose.roster(choose.WORKSPACE, self.FID)
+        self.assertEqual(len(roster.rows), 1 + len(HOSTILE))
+        self.assertEqual(len(set(r.id for r in roster.rows)), 1 + len(HOSTILE),
+                         "two names sharing a row id is one name that cannot be chosen")
+
+    def test_the_drawn_pane_is_exactly_as_tall_as_the_pane(self):
+        """**The property is what reaches the terminal**, not what the row holds. A `Row`
+        carries display text raw — `overlay.Row`'s own contract — and `Surface.render` is
+        the one place it is contained, immediately before `tui.width` measures it (#472).
+        A separator that survived to here would push the footer off the bottom and write a
+        line of its own choosing where charter's rows go."""
+        drawn = self._drawn(["alpha", *HOSTILE])
+        self.assertEqual(len(drawn), self.SIZE[1])
+        for line in drawn:
+            self.assertNotIn("\n", line, repr(line))
+            self.assertEqual(line, "".join(line.splitlines()), repr(line))
+
+    def test_no_hostile_byte_reaches_the_pane(self):
+        """Asserted per LINE rather than on a join of them, so the separator this test is
+        about cannot be one the test itself put there."""
+        for line in self._drawn(["alpha", *HOSTILE]):
+            for bad in ("\n", "\r", "\u2028", "\u2029", "\u0085", "\x1b[31m"):
+                self.assertNotIn(bad, line, repr(line))
+
+    def test_the_column_arithmetic_sees_the_contained_name_not_the_raw_one(self):
+        """#472 exactly: a table that sized its columns from a raw name. `tui.width` —
+        never `len` — measures what `contain.one_line` already made one line of, so a name
+        holding a separator cannot make the row wider than the pane."""
+        long_hostile = "z" * 30 + "\u2028" + "y" * 30
+        for line in self._drawn(["alpha", long_hostile]):
+            self.assertLessEqual(tui.width(tui.strip_ansi(line)), self.SIZE[0], repr(line))
+
+    def test_a_hostile_name_chosen_off_a_picker_switches_to_nothing(self):
+        """"Runs nothing" is the other half. The RAW name is what reaches
+        `switch.to_workspace` — repairing it on the way in would be switching to a name
+        charter never looked at — and that is the one place it is checked and refused."""
+        with mock.patch.object(switch, "workspaces",
+                               return_value=["alpha", *HOSTILE]):
+            roster = choose.roster(choose.WORKSPACE, self.FID)
+            for row in roster.rows[1:]:
+                name = roster.name_of(row)
+                out = choose.switch_to(choose.WORKSPACE, self.FID, name)
+                self.assertFalse(out.ok, f"{name!r} was switched to")
+                self.assertEqual(len(out.message.splitlines()), 1, repr(out.message))
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+        self.assertEqual(sorted(p.name for p in config.WORKSPACES_DIR.iterdir()),
+                         ["alpha", "beta"], "a refused switch created something")
+
+
+def _pane(*rows):
+    """Stand in for the palette's pane: hand each row to *then* in turn, answer the last.
+
+    A test double for `palette.own_the_tty`, and deliberately not a copy of its loop —
+    that loop is pinned against a real tty by :class:`ThePickerIsDrawnInThePalettesOwnPane`
+    below. What this stands in for is the OPERATOR: one row chosen per surface, in order.
+    """
+    def fake(surface, *, then=None, **kw):
+        chosen = None
+        for row in rows:
+            chosen = row
+            # `None` is "the operator left" and never reaches *then* — the real
+            # `own_the_tty` guards it, and a double that did not would let a test pass
+            # against a contract production does not keep.
+            if row is None or then is None or then(row) is None:
+                break
+        return chosen
+    return fake
+
+
+class ThePaletteOpensThePickerAndActsOnWhatComesBack(_Frame, unittest.TestCase):
+    """`_draw_palette`, with the pane faked out: a doorway row, then a name."""
+
+    def _draw(self, *rows) -> int:
+        with mock.patch.object(palette, "own_the_tty", _pane(*rows)):
+            return commands_frame.cmd_palette(
+                SimpleNamespace(client="/dev/ttys7", pane=True))
+
+    def _row(self, noun: str, name: str) -> overlay.Row:
+        roster = choose.roster(noun, self.FID)
+        return next(r for r in roster.rows if roster.name_of(r) == name)
+
+    def _doorway(self, noun: str) -> overlay.Row:
+        return next(r for r in choose.open_rows(self.FID)
+                    if choose.noun_of(r) == noun)
+
+    def test_choosing_a_name_moves_the_frame_and_says_what_it_did(self):
+        was = state.version(self.FID)
+        self.assertEqual(self._draw(self._doorway(choose.WORKSPACE),
+                                    self._row(choose.WORKSPACE, "beta")), 0)
+        self.assertEqual(state.workspace_for(self.FID), "beta")
+        self.assertNotEqual(state.version(self.FID), was)
+        self.said.assert_called_once()
+        self.assertIn("workspace → beta", self.said.call_args[0][1])
+        self.assertEqual(self.said.call_args[0][2], "/dev/ttys7")
+
+    def test_a_persona_name_takes_the_same_route(self):
+        self.assertEqual(self._draw(self._doorway(choose.PERSONA),
+                                    self._row(choose.PERSONA, "scribe")), 0)
+        self.assertEqual(switch.current_persona(self.FID), "scribe")
+        self.assertIn("persona → scribe", self.said.call_args[0][1])
+
+    def test_leaving_the_picker_without_choosing_moves_nothing(self):
+        """Escape in the picker cancels the whole palette — `Surface.run` answers ``None``
+        and there is nothing above it to go back to. Nothing moves and nothing is said."""
+        self.assertEqual(self._draw(self._doorway(choose.WORKSPACE), None), 0)
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+        self.said.assert_not_called()
+
+    def test_an_action_row_still_goes_through_invoke(self):
+        """The other branch, so the dispatch above cannot pass by swallowing everything:
+        a row that is not a doorway and not a name is an action and is started."""
+        with mock.patch.object(commands_frame.builtin_actions, "_spawn") as spawn:
+            self.assertEqual(self._draw(overlay.Row(id="frame.detach", title="d")), 0)
+        spawn.assert_called_once()
+
+
+class ARefusedSwitchSaysSoOnScreen(_Frame, unittest.TestCase):
+    """Step 6. #517: "a menu that silently fails against a lock is worse than no menu."
+
+    Every one of these ends with the palette's pane killed, so the sentence has nowhere
+    else to go — `commands_frame._say_on_screen` is the whole of "on screen" here, and it
+    is asserted rather than the tmux call it makes (`test_frame_palette.py` owns that).
+    """
+
+    def _draw(self, *rows) -> int:
+        with mock.patch.object(palette, "own_the_tty", _pane(*rows)):
+            return commands_frame.cmd_palette(
+                SimpleNamespace(client="/dev/ttys7", pane=True))
+
+    def test_a_name_that_stopped_existing_is_refused_and_the_frame_says_so(self):
+        """The race a picker actually has, staged as the race: `beta` is on the plane when
+        the picker draws its rows and gone by the time `to_workspace` re-reads them.
+
+        The two answers are scripted on `switch.workspaces` in the order the two callers
+        ask — the roster first, the switch second — rather than by deleting a directory,
+        because the property is that the switch re-checks at all. `to_workspace` refuses an
+        unknown name rather than creating one, and the refusal is what lands on the screen.
+        """
+        doorway = next(r for r in choose.open_rows(self.FID)
+                       if choose.noun_of(r) == choose.WORKSPACE)
+        listed = ["alpha", "beta", "default"]
+        row = overlay.Row(id=choose.NAME_ID.format(choose.WORKSPACE, 1), title="  beta")
+        with mock.patch.object(switch, "workspaces",
+                               side_effect=[listed, ["alpha", "default"]]):
+            self.assertEqual(self._draw(doorway, row), 0)
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+        self.said.assert_called_once()
+        self.assertIn("no workspace 'beta'", self.said.call_args[0][1])
+
+    def test_overriding_the_session_lock_is_said_out_loud_rather_than_silently(self):
+        """`workspace.set_active` locks the session to what it selected, so an agent's
+        `charter workspace use` mid-task is exactly what the lock is for — and a keypress
+        on the picker overrides it, because the operator is at the keyboard. What must not
+        happen is the override being silent: the agent's next command would act on a
+        workspace nobody was told about."""
+        workspace.set_active("alpha", session_id=self.FID)
+        roster = choose.roster(choose.WORKSPACE, self.FID)
+        row = next(r for r in roster.rows if roster.name_of(r) == "beta")
+        doorway = next(r for r in choose.open_rows(self.FID)
+                       if choose.noun_of(r) == choose.WORKSPACE)
+        self.assertEqual(self._draw(doorway, row), 0)
+        self.assertEqual(state.workspace_for(self.FID), "beta")
+        said = self.said.call_args[0][1]
+        self.assertIn("lock moved from 'alpha'", said)
+
+
+class APinnedFrameIsToldBeforeItPressesAnything(_Frame, unittest.TestCase):
+    """Task 4's rule, kept: the row is listed, it says why, and it opens nothing.
+
+    `$CHARTER_WORKSPACE` was set at launch, so it is in every panel pane's environment for
+    as long as the pane lives and nothing charter writes outranks it. A picker full of
+    names none of which can be switched to would be an offer charter already knows it
+    cannot honour.
+    """
+
+    PIN = {"CHARTER_WORKSPACE": "alpha", "CHARTER_PERSONA": ""}
+
+    def test_the_doorway_carries_the_reason(self):
+        row = next(r for r in choose.open_rows(self.FID)
+                   if choose.noun_of(r) == choose.WORKSPACE)
+        self.assertIn("cannot switch: $CHARTER_WORKSPACE pins this frame", row.note)
+        self.assertIn("'alpha'", row.note)
+
+    def test_the_other_noun_is_not_pinned_by_the_first_ones_pin(self):
+        """One pin per noun. Reading either as "this frame cannot switch anything" would
+        take the persona picker away for a reason that is not about personas."""
+        row = next(r for r in choose.open_rows(self.FID)
+                   if choose.noun_of(r) == choose.PERSONA)
+        self.assertEqual(row.note, "")
+
+    def test_pressing_it_opens_no_picker_and_the_reason_reaches_the_screen(self):
+        row = next(r for r in choose.open_rows(self.FID)
+                   if choose.noun_of(r) == choose.WORKSPACE)
+        opened = []
+        self.assertIsNone(commands_frame._picker(row, self.FID, opened))
+        self.assertEqual(opened, [])
+        with mock.patch.object(palette, "own_the_tty", _pane(row)):
+            self.assertEqual(commands_frame.cmd_palette(
+                SimpleNamespace(client="/dev/ttys7", pane=True)), 0)
+        self.said.assert_called_once()
+        self.assertIn("$CHARTER_WORKSPACE pins this frame", self.said.call_args[0][1])
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+
+
+class ThePickerIsDrawnInThePalettesOwnPane(unittest.TestCase):
+    """`palette.own_the_tty`'s *then*, against a REAL tty.
+
+    **This is what stops the picker being a second pane.** A palette row that started a
+    second charter to split its own overlay pane would race `_close_palette`, which
+    selects the harness, kills this pane and re-arms the escape hatch as ONE chained tmux
+    command the instant a row has been chosen. Handing the next surface to the same loop
+    has no interleaving to lose.
+    """
+
+    def setUp(self) -> None:
+        self.master, self.slave = pty.openpty()
+        self.addCleanup(self._close)
+        self.out = open(os.devnull, "w")
+        self.addCleanup(self.out.close)
+        self.first = palette.Palette(catalogue=(overlay.Row(id="pick:workspace",
+                                                            title="workspace"),))
+        self.second = palette.Palette(catalogue=(overlay.Row(id="workspace:n1",
+                                                             title="  beta"),))
+
+    def _close(self) -> None:
+        for fd in (self.master, self.slave):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    def _own(self, then):
+        return palette.own_the_tty(self.first, fd=self.slave, out=self.out, then=then)
+
+    def test_the_next_surface_runs_in_the_same_raw_mode_window_and_its_row_comes_back(self):
+        import termios
+
+        modes = []
+        with mock.patch.object(self.first, "run",
+                               side_effect=lambda **kw: (
+                                   modes.append(termios.tcgetattr(self.slave)),
+                                   self.first.rows[0])[1]), \
+             mock.patch.object(self.second, "run",
+                               side_effect=lambda **kw: (
+                                   modes.append(termios.tcgetattr(self.slave)),
+                                   self.second.rows[0])[1]) as second_run:
+            got = self._own(lambda row: self.second if row.id == "pick:workspace"
+                            else None)
+        second_run.assert_called_once()
+        self.assertEqual(got, self.second.rows[0],
+                         "the row the PICKER answered with is what comes back")
+        self.assertEqual(len(modes), 2)
+        for mode in modes:
+            self.assertFalse(mode[3] & termios.ECHO,
+                             "the tty left raw mode between the two surfaces")
+
+    def test_no_then_is_the_surface_answering_for_itself(self):
+        """The default, and every caller that has one surface: the row comes straight
+        back and nothing else runs."""
+        with mock.patch.object(self.first, "run", return_value=self.first.rows[0]), \
+             mock.patch.object(self.second, "run") as second_run:
+            self.assertEqual(self._own(None), self.first.rows[0])
+        second_run.assert_not_called()
+
+    def test_a_cancel_never_reaches_then(self):
+        """``None`` is "the operator left". Asking a doorway what to open next for a row
+        that does not exist would be a `None` dereference on the one path that must not
+        raise — the palette's pane is handed back in a `finally` either way, but a
+        traceback there is charter printing into a pane it is about to kill."""
+        asked = []
+        with mock.patch.object(self.first, "run", return_value=None):
+            self.assertIsNone(self._own(lambda row: asked.append(row)))
+        self.assertEqual(asked, [])
+
+
+if __name__ == "__main__":                          # pragma: no cover
+    unittest.main()

--- a/tests/test_frame_pickers.py
+++ b/tests/test_frame_pickers.py
@@ -288,6 +288,24 @@ class ThePaletteOpensThePickerAndActsOnWhatComesBack(_Frame, unittest.TestCase):
         self.assertEqual(state.workspace_for(self.FID), "alpha")
         self.said.assert_not_called()
 
+    def test_the_picker_says_which_noun_it_is_and_still_takes_a_click(self):
+        """Two things the surface is built with, and neither is cosmetic.
+
+        The heading is the only thing on a picker's screen that says what the names ARE —
+        the rows are bare names, deliberately, and a list of unlabelled words one keypress
+        after a list of actions is a pane an operator has to guess at. And `mouse` is one
+        declaration in `overlay.Surface`: it both asks the terminal for pointer reports and
+        decides whether one is acted on, so a picker built without it would be the one
+        surface in this frame where a click does nothing.
+        """
+        opened = []
+        doorway = self._doorway(choose.WORKSPACE)
+        surface = commands_frame._picker(doorway, self.FID, opened)
+        self.assertTrue(surface.mouse, "a click in the picker would do nothing")
+        header = surface.render(60, 10)[0]
+        self.assertIn(choose.WORKSPACE, tui.strip_ansi(header), header)
+        self.assertEqual(opened[0].noun, choose.WORKSPACE)
+
     def test_an_action_row_still_goes_through_invoke(self):
         """The other branch, so the dispatch above cannot pass by swallowing everything:
         a row that is not a doorway and not a name is an action and is started."""

--- a/tests/test_frame_switch.py
+++ b/tests/test_frame_switch.py
@@ -298,6 +298,19 @@ class ThePaletteOffersAPickerForEach(PersonaIso, unittest.TestCase):
         self.assertEqual({r.id: r.title for r in _rows(self.FID)}["pick:persona"],
                          "persona — pick one")
 
+    def test_nothing_chosen_is_the_empty_string_and_never_none(self):
+        """charter's own convention for "there is none", one module over: `switch._pin`
+        records that "empty is what every charter reader already treats as absent", and
+        `choose.current` is declared to answer a name.
+
+        **Pinned on the function rather than on a row, because both callers that exist
+        today mask it**: `open_rows` tests `if now` and `roster` compares `n == now`, and
+        `None` and `""` behave identically in both. A third caller writing `f"on {now}"`
+        would print the word `None`. That masking is the shape this repo has been bitten
+        by four times, so the contract is asserted where it is stated.
+        """
+        self.assertEqual(choose.current(choose.PERSONA, self.FID), "")
+
     def test_a_long_list_is_not_capped(self):
         """Thirty workspaces are thirty rows in the picker. The menu answered twelve plus
         a row saying how many it had hidden; this surface has nowhere to hide them."""

--- a/tests/test_frame_switch.py
+++ b/tests/test_frame_switch.py
@@ -26,7 +26,7 @@ import unittest
 from unittest import mock
 
 from charter import cli, commands_frame, config, persona, tui, workspace
-from charter.frame import builtin_actions, palette, picker, state, switch
+from charter.frame import builtin_actions, choose, palette, picker, state, switch
 
 from tests._isolation import PersonaIso
 
@@ -231,14 +231,16 @@ class SwitchingPersona(PersonaIso, unittest.TestCase):
 
 
 def _rows(fid: str, *, density: str = "normal"):
-    """The palette's own rows for *fid*, built exactly the way `_draw_palette` builds
-    them — through `builtin_actions.build`, not from a hand-written list."""
+    """The palette's whole catalogue for *fid*, built exactly the way `_draw_palette`
+    builds it — the two picker rows, then the action rows, neither from a hand-written
+    list."""
     reg = builtin_actions.build(fid, current_density=density)
-    return palette.rows(reg.offers(fid=fid, snapshot={}))
+    return (choose.open_rows(fid)
+            + palette.rows(reg.offers(fid=fid, snapshot={})))
 
 
 def _titles(fid: str, kind: str, *, density: str = "normal") -> list[str]:
-    """Every row title whose ID belongs to *kind* (`workspace`, `persona`, `density`).
+    """Every row title whose ID belongs to *kind* (today: `density`).
 
     Selected by ID and never by what the title says, because the mark charter puts in
     front of the current one is part of the title — a prefix match on the title would
@@ -248,15 +250,22 @@ def _titles(fid: str, kind: str, *, density: str = "normal") -> list[str]:
             if r.id.startswith(kind + ".")]
 
 
-class ThePaletteOffersBothLists(PersonaIso, unittest.TestCase):
-    """#517's whole surface, moved off `display-menu`: every workspace and every persona
-    is a row, and neither list is capped any more.
+def _names(fid: str, noun: str) -> list[str]:
+    """Every row title inside *noun*'s picker — the list one keypress past the palette."""
+    return [r.title for r in choose.roster(noun, fid).rows]
 
-    The menu capped each at twelve because a `display-menu` is drawn inside the terminal
-    and tmux does not scroll it. The palette scrolls AND filters, so the cap would only
-    hide names an operator can already reach by typing three letters of one — §2's
-    "charter's nine-row cap was charter's, not tmux's", applied to the other list it
-    bounded.
+
+class ThePaletteOffersAPickerForEach(PersonaIso, unittest.TestCase):
+    """#517's whole surface, moved off `display-menu` and then off the action registry:
+    one row per noun, saying which name the frame is on, opening the list of the rest.
+
+    **Task 6's correction to Task 4.** The menu capped each list at twelve because a
+    `display-menu` is drawn inside the terminal and tmux does not scroll it; Task 4 lifted
+    the cap by registering every name as an ACTION, which is a contract that promises
+    fire-and-report work and describes a name badly — forty names meant forty ``run``s that
+    each started a whole second charter to write two files. The names now live in a picker
+    (`frame/choose.py`), which is this same overlay over a different row source, and the
+    palette carries the doorway.
     """
 
     FID = "f-entries"
@@ -267,50 +276,41 @@ class ThePaletteOffersBothLists(PersonaIso, unittest.TestCase):
         state.frame_dir(self.FID, create=True)
         state.record_identity(self.FID, {"CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
 
-    def test_charters_own_rows_come_first_and_in_a_fixed_order(self):
+    def test_the_palette_opens_with_the_two_pickers_then_charters_own_actions(self):
+        """The order is fixed and the pickers are first, so an operator who presses `F2`
+        and Enter without reading opens a list rather than detaching their harness."""
         _plane_workspaces("alpha")
-        titles = [r.title for r in _rows(self.FID)]
-        self.assertTrue(titles[0].startswith("detach"), titles)
-        self.assertTrue(any("density: " in t for t in titles[1:4]), titles)
+        ids = [r.id for r in _rows(self.FID)]
+        self.assertEqual(ids[:3], ["pick:workspace", "pick:persona", "frame.detach"])
+        self.assertTrue(any(i.startswith("density.") for i in ids[3:6]), ids)
+
+    def test_each_doorway_says_which_name_the_frame_is_on(self):
+        """So the palette still answers "which workspace am I on" without opening
+        anything, and typing the name still finds the row when it is the one in use."""
+        _plane_workspaces("alpha")
+        state.record_workspace(self.FID, "alpha")
+        titles = {r.id: r.title for r in _rows(self.FID)}
+        self.assertEqual(titles["pick:workspace"], "workspace: alpha — pick another")
+
+    def test_a_noun_with_nothing_chosen_says_so_rather_than_naming_nothing(self):
+        """A plane with no persona at all is an ordinary answer, not a missing one — and
+        `persona: ` with nothing after it is a row that reads as broken."""
+        self.assertEqual({r.id: r.title for r in _rows(self.FID)}["pick:persona"],
+                         "persona — pick one")
 
     def test_a_long_list_is_not_capped(self):
-        """Thirty workspaces are thirty rows. The menu answered twelve plus a row saying
-        how many it had hidden; this surface has nowhere to hide them."""
+        """Thirty workspaces are thirty rows in the picker. The menu answered twelve plus
+        a row saying how many it had hidden; this surface has nowhere to hide them."""
         _plane_workspaces(*[f"ws{i:02d}" for i in range(30)])
-        rows = _titles(self.FID, "workspace")
+        rows = _names(self.FID, choose.WORKSPACE)
         self.assertGreaterEqual(len(rows), 30, rows)
         self.assertTrue(any("ws29" in r for r in rows), rows)
 
     def test_an_empty_list_is_simply_no_rows(self):
-        """A plane with no personas gets no persona rows — and nothing pretends otherwise.
+        """A plane with no personas gets an empty picker — and nothing pretends otherwise.
         The menu needed a placeholder row because `display-menu` refuses a zero-row menu
-        outright (`not enough arguments`); a palette with fewer rows is just a shorter
-        palette, and `overlay.EMPTY` covers the case where it has none at all."""
-        self.assertEqual(_titles(self.FID, "persona"), [])
-
-    def test_a_name_is_contained_before_it_becomes_a_row(self):
-        """#472: a table sized its columns from a raw name first. `contain.one_line` runs
-        before any width arithmetic — twice, once where the name meets charter's marker
-        column and once where the title meets `Action`'s own contract — so a name that
-        could hold a newline cannot put one in a row."""
-        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True)
-        with mock.patch.object(switch, "workspaces",
-                               return_value=["alpha", "line\nbreak"]):
-            rows = _titles(self.FID, "workspace")
-        self.assertTrue(all("\n" not in r for r in rows), rows)
-
-    def test_a_hostile_name_reaches_the_title_and_never_an_id(self):
-        """The property `frame/menu.py` existed for, one surface over: the NAME is display
-        text and nothing else. A row's id is charter's own `workspace.w<N>`, held to the
-        action alphabet, and it is the id — never the title — that `invoke` dispatches on."""
-        hostile = 'x" ; run-shell "touch /tmp/pwned'
-        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True)
-        with mock.patch.object(switch, "workspaces", return_value=["alpha", hostile]):
-            rows = [r for r in _rows(self.FID) if r.id.startswith("workspace.")]
-        carrying = [r for r in rows if hostile in r.title]
-        self.assertEqual(len(carrying), 1, [r.title for r in rows])
-        self.assertNotIn(";", carrying[0].id)
-        self.assertTrue(carrying[0].id.startswith("workspace.w"), carrying[0].id)
+        outright (`not enough arguments`); `overlay.EMPTY` is what this surface draws."""
+        self.assertEqual(_names(self.FID, choose.PERSONA), [])
 
 
 class ThePaletteCannotGoStale(PersonaIso, unittest.TestCase):
@@ -320,8 +320,9 @@ class ThePaletteCannotGoStale(PersonaIso, unittest.TestCase):
     re-record left the F2 menu naming the workspace the frame had LEFT, and a workspace
     made after launch never appeared at all — `_rerecord_menu` existed only to paper over
     that, and had to be called from every command that could move the frame. Nothing calls
-    anything now: `builtin_actions.build` resolves the lists and the marks when the palette
-    opens, so there is no second copy to keep in step.
+    anything now: `builtin_actions.build` resolves the density mark and `frame/choose.py`
+    resolves the names and their marks when the palette opens, so there is no second copy
+    to keep in step.
     """
 
     FID = "f-palette-follows"
@@ -347,26 +348,29 @@ class ThePaletteCannotGoStale(PersonaIso, unittest.TestCase):
     def test_the_mark_moves_with_the_frame(self):
         # `default` is folded in whether or not its directory exists — `switch.workspaces`
         # matches `commands_workspace.cmd_workspace_use` there.
-        self.assertEqual(_titles(self.FID, "workspace"),
-                         ["* workspace: alpha", "  workspace: beta",
-                          "  workspace: default"])
+        self.assertEqual(_names(self.FID, choose.WORKSPACE),
+                         ["* alpha", "  beta", "  default"])
         self.assertEqual(self._switch(workspace="beta"), 0)
-        self.assertEqual(_titles(self.FID, "workspace"),
-                         ["  workspace: alpha", "* workspace: beta",
-                          "  workspace: default"])
+        self.assertEqual(_names(self.FID, choose.WORKSPACE),
+                         ["  alpha", "* beta", "  default"])
+
+    def test_the_doorway_names_the_workspace_the_frame_moved_to(self):
+        """The mark inside the picker and the name on the palette row are one read
+        (`choose.current`), so the two surfaces cannot disagree about where the frame is."""
+        self._switch(workspace="beta")
+        self.assertEqual({r.id: r.title for r in _rows(self.FID)}["pick:workspace"],
+                         "workspace: beta — pick another")
 
     def test_a_persona_switch_moves_its_own_mark_too(self):
-        self.assertEqual(_titles(self.FID, "persona"),
-                         ["  persona: forge", "  persona: scribe"])
+        self.assertEqual(_names(self.FID, choose.PERSONA), ["  forge", "  scribe"])
         self._switch(persona="scribe")
-        self.assertEqual(_titles(self.FID, "persona"),
-                         ["  persona: forge", "* persona: scribe"])
+        self.assertEqual(_names(self.FID, choose.PERSONA), ["  forge", "* scribe"])
 
     def test_a_workspace_made_after_launch_is_offered(self):
         """The same staleness seen from the other side: the menu's table was written at
         launch, so a plane that grew a workspace since had no row for it."""
         _plane_workspaces("gamma")
-        self.assertIn("  workspace: gamma", _titles(self.FID, "workspace"))
+        self.assertIn("  gamma", _names(self.FID, choose.WORKSPACE))
 
     def test_a_pinned_frame_is_offered_the_row_WITH_ITS_REASON(self):
         """Step 4 of the plan, on the exact example it names. `$CHARTER_WORKSPACE` was set
@@ -374,11 +378,16 @@ class ThePaletteCannotGoStale(PersonaIso, unittest.TestCase):
         outrank it — and a palette that silently dropped the row would leave the operator
         unable to ask why a thing they remember is missing."""
         state.record_identity(self.FID, {"CHARTER_WORKSPACE": "alpha"})
-        rows = [r for r in _rows(self.FID) if r.id.startswith("workspace.")]
-        self.assertTrue(rows, "the rows must still be offered")
-        self.assertTrue(all("$CHARTER_WORKSPACE pins this frame" in r.note for r in rows),
-                        [r.note for r in rows])
-        self.assertTrue(all("'alpha'" in r.note for r in rows), [r.note for r in rows])
+        row = {r.id: r for r in _rows(self.FID)}["pick:workspace"]
+        self.assertIn("$CHARTER_WORKSPACE pins this frame", row.note)
+        self.assertIn("'alpha'", row.note)
+
+    def test_an_unpinned_frames_doorway_carries_no_reason_at_all(self):
+        """The other direction, so the reason above cannot pass by always being there:
+        `available` and "has no reason" are one decision in `choose.pin_reason`, and a
+        non-empty note is what `_draw_palette` refuses the keypress on."""
+        self.assertEqual({r.id: r for r in _rows(self.FID)}["pick:workspace"].note, "")
+        self.assertEqual({r.id: r for r in _rows(self.FID)}["pick:persona"].note, "")
 
     def test_the_density_mark_is_read_from_the_frames_own_record(self):
         """A switch does not change the density, and nothing re-writes it: the mark is


### PR DESCRIPTION
Phase 2, Task 6 — **pickers, and the containment that matters**. Last task in the phase, so the exit criteria are checked at the bottom.

## What changed

The palette listed every workspace and every persona as an `Action`. `frame/action.py`'s contract is *fire-and-report* — `run` starts work and returns — so forty workspaces meant forty `run`s, each of which started **a whole second charter process** to write two files, and the outcome landed on a status line after the pane that asked for it was already dead.

A workspace is a **name**, not an action. `builtin_actions._register_names` is gone; `frame/choose.py` turns names into `overlay.Row`s, and the palette carries one doorway row per noun:

```
charter · 6 to choose from
> workspace: alpha — pick another
    persona: steward — pick another
    detach — leave the harness running
    density: minimal
    density: normal
  * density: full
```

Enter on a doorway redraws **the same pane** with the names alone (`workspace · 4 to choose from`, `* alpha` / `  beta` / …). Same keys, same filter, same scroll, same `F12`.

**It is the same overlay, and there is no second palette.** `frame/choose.py` has no class — a function from names to rows, a function from a chosen row back to the name it stood for, and one call into `frame/switch.py`. The surface is `palette.Palette`, which is `overlay.Surface`.

### Why the picker reuses the palette's pane

The obvious shape — a palette row that starts `charter frame-pick` to split a second overlay pane — **races the palette's own teardown**. `_close_palette` sends `select-pane ; kill-pane ; set-option @charter_hatch` as one chained tmux command the instant a row has been chosen; a second pane that had already selected and zoomed itself would be un-selected, un-zoomed and un-hatched by it. Which one wins depends on how long a Python interpreter takes to start.

So `palette.own_the_tty` gained one parameter, `then`: a chosen row is offered to it, and a `Surface` coming back is run next, in this same pane, without the tty leaving raw mode. `None` — the default — ends the loop and returns the row, exactly as before. There is no interleaving left to lose, and no second process.

### A picker row's id is deliberately not an action id

`_draw_palette` dispatches on the id of whatever the surface answered with. `frame/action.py` holds every action id to `component._ID_RE`, which forbids `:` — so `pick:workspace` and `workspace:n3` are ids a provider's action **cannot spell**, and a provider shipping `pick.workspace` cannot take the keypress. Neither id is ever drawn or ever reaches tmux.

## The plan's eight steps

| step | where |
|---|---|
| 1. failing test first — a workspace picker lists workspaces, switching repaints every panel | `tests/test_frame_pickers.py::AWorkspacePickerListsWorkspaces` |
| 2. run it, confirm it fails | `ImportError: cannot import name 'choose'`, then two assertion failures once the module existed |
| 3. implement over Task 2 — same overlay, different row source | `charter/frame/choose.py`, `palette.own_the_tty(then=…)` |
| 4. containment, before width arithmetic, tested with hostile names | `AHostileNameIsOneRowAndRunsNothing` — see below |
| 5. the switch moves the frame's own identity and bumps it | `choose.switch_to` → `frame/switch.py` unchanged; asserted on `state.workspace_for` **and** `state.version`, unit and against real tmux |
| 6. a refused switch says so on screen | `ARefusedSwitchSaysSoOnScreen`, `APinnedFrameIsToldBeforeItPressesAnything` |
| 7. mutations: skip containment / write the pointer without bumping / swallow the lock refusal — each RED | below |
| 8. commit | 4 commits |

### Step 4 — the containment, and where it actually lives

**No new `contain.one_line` call was added on the row-building path, on purpose, and that is a finding rather than an omission.** `overlay.Surface.render` already runs `contain.one_line` over every title and note immediately before `tui.width` measures them — which is exactly "before width arithmetic" (#472). A second call on the way into `choose.roster` would be a line **no test could go red without**, because `render` would make the mutant pass.

That is not hypothetical here. The code this branch deletes carried exactly such a line: `_register_names`' `contain.one_line(name)` was masked by `Action.__post_init__` containing the title it landed in, and `test_a_name_is_contained_before_it_becomes_a_row` stayed green over its deletion. (It is one of the five the coordinator routed — see below.)

So the property is **measured on the drawn pane** instead, against real hostile names — `\n`, `\r`, U+2028, U+2029, U+0085, `ESC [31m`, `"`, `; run-shell "…`, `#{session_name}` — in a 44×12 pane narrow enough that the two-column layout has to squeeze:

* every name is exactly one row, and the pane is exactly as tall as the pane;
* no separator and no CSI reaches any drawn line;
* every drawn line is inside `tui.width`, measured on the contained string;
* the **raw** name is what reaches `switch.to_workspace`/`to_persona`, which is the one place it is checked — so each one is refused, none is created, and the refusal is itself one line. **Both nouns**, because the persona twin turned out to be unpinned (below).

There is one place containment is genuinely needed and `render` does **not** cover it, and the sweep found it unpinned: `choose.pin_reason` builds a sentence from `$CHARTER_WORKSPACE` as the launch recorded it, and pressing a pinned row sends that sentence straight to `_say_on_screen` — whose docstring states the split in as many words ("callers close the newline half with `contain.one_line`, `inert_format` closes the `#` half"). `inert_format` does not touch a separator. Now pinned, on what reaches the status area rather than on the pane.

### Step 7 — the three mutations the plan names

| mutation | result |
|---|---|
| skip containment (`overlay.render`: `contain.one_line(r.title)` → `r.title`) | **RED**, 4 tests |
| write the pointer without bumping (`switch.to_workspace`: drop `state.bump(fid)`) | **RED**, 3 tests |
| swallow the lock refusal (`_draw_palette`: drop `_say_on_screen(fid, out.message, client)`) | **RED**, 4 tests |

## The deletion sweep

### A defect in `tools/sweep.py` — #572

**The tool cannot run at all on macOS with its default workdir.** It traced all 329 test modules, produced a map of **0 files and 0 broken modules**, and refused. `build_map` computes `prefix = str(root) + os.sep` from a `tempfile.gettempdir()` path, which on macOS is `/var/folders/…`; `/var` is a symlink to `/private/var`, and the trace runner's `sys.path.insert(0, os.getcwd())` yields the **resolved** form, so `co_filename.startswith(prefix)` is never true. `hits` a few lines down already resolves both sides — the prefix is the one place that does not. Measured, with the three-line reproduction, in **#572**.

The refusal is the harness working; the ten silent minutes before it are not. `--workdir` at an already-resolved path fixes it, and that is what these runs used.

### The final run

```
deletion sweep — 1821a18b14ce against 2aa29f86ad2d
measured on      : darwin, CPython 3.14.4
baseline          : Ran 6355 tests — OK
mutations applied : 20
pinned            : 20
SURVIVED          : 0
UNRESOLVED        : 0
wall clock        : 7.2 min
```

The first run of the branch (`c85792f` against `1ddd6b0`) came back **18 pinned / 3 survivors / 0 unresolved**, and all three were real:

1. **`choose.pin_reason`'s `contain.one_line(pinned)`** — a genuine guard with no test. Fixed with the case described above.
2. **`choose.current`'s `or ""`** — masked by *both* callers: `open_rows` tests `if now` and `roster` compares `n == now`, and `None` and `""` behave identically in both. That is the "a second unpinned line hides its consequence" shape again. Both masking lines are themselves pinned (mutations 9/10 and 12/16 of that run), so the answer is the missing test rather than a deletion: `choose.current` is declared to answer a name, and the contract — never `None` — is now pinned on the function.
3. **`_draw_palette`'s `getattr(args, "client", "") or ""`** — the `or ""` answered nothing: `_say_on_screen` treats `None` and `""` alike, and that branch is pinned by `test_a_named_client_is_told_and_an_unnamed_one_is_the_session`. **Deleted.**

### What the tool cannot do, hand-checked

The brief was specific: no operator for **string/regex constants** or **semantic swaps**, and those are most of what this branch adds. 22 further mutations were applied by hand with the same discipline — score on the set of newly-failing test ids, green baseline asserted first, `PYTHONDONTWRITEBYTECODE=1`, restore after each.

`OPEN_ID`/`NAME_ID` leaving the `:` alphabet · `MARK` stopping marking · `PIN` reading the other noun's variable · the doorway dropping "— pick another" · `switch_to`/`names_of`/`current` reading the noun the other way round · the mark landing on every row *but* the current one · `render` uncontaining · `_picker` opening for a pinned frame · both `_say_on_screen` calls swallowed · the bump dropped · `own_the_tty` running one surface and never the next · `own_the_tty` offering a cancel to `then` · `pin_reason` building a sentence for an unpinned frame · `noun_of` answering `workspace` for everything · `_chosen_name` never recognising a name · the doorway losing its note · **and the catalogue losing the doorways entirely**.

**20/22 pinned on the first pass.** Two survivors:

* `choose.current`'s `or ""` — the same one the tool found, independently.
* **the palette losing its doorway rows reddened nothing.** Every unit case feeds `own_the_tty` a row directly, so none of them looks at the catalogue `_draw_palette` builds; the only cover was the tmux-gated integration module, which **skips where there is no tmux** — so on a runner without it, deleting `choose.open_rows(fid)` from the catalogue would have been green. Fixed with a case that asserts the surface `_draw_palette` constructs, including the order.

Re-checked after the fixes: **22/22**, and the tool's three survivors at **3/3**.

### The five routed survivors in `builtin_actions.py`

Routed here because the file is this branch's. **Four of the five are in code this branch deletes**, which is the stronger answer — but only if the property survives, so the two with a successor were re-checked on the successor rather than assumed:

| routed (on `main`) | here |
|---|---|
| `:211` `[uncontain]` `contain.one_line(name)` in `_register_names` | **deleted.** The successor is `choose.roster`'s title, contained by `overlay.Surface.render` — mutating *that* is RED (4 tests) |
| `:229` `[uncontain]` `contain.one_line(name)` in `_run_switch` | **deleted.** The successor message is `switch.to_workspace`'s, whose containment is RED (2 tests) |
| `:224` `[no-fallback]` `switch._pin(fid, pin) or ''` | **deleted.** Successor `choose.pin_reason`'s explicit `if not pinned: return ""` — RED, 8 tests |
| `:224` `[uncontain]` on the same line | **deleted.** Successor `choose.pin_reason`'s `contain.one_line(pinned)` — RED, 1 test (the case added for the tool's survivor 1) |
| `:90` `[no-fallback]` `state.harness_pane(fid) or ""` | **survives verbatim — fixed here** |

That last one is **#570's shape again, and the caution about neighbours was right.** `state.harness_pane` answers `None` — not a bad string — for a frame launched by a charter predating `record_harness_pane`, for a truncated state directory, and for a file that cannot be read; its own docstring names all three. Without the fallback, `PANE_ID_RE.fullmatch(None)` raises `TypeError`, and `ActionRegistry._check` catches **`BaseException`** and turns it into an unavailable row. So the row is refused either way and only the *reason* differs. Measured on the fixture this adds:

```
shipped : charter has no record of this frame's harness pane, so it cannot move the
          panels — relaunch the frame
mutant  : TypeError: expected string or bytes-like object, got 'NoneType'
```

The existing case records an *invalid* pane id, which is a string, so it never reached the fallback at all. The new one records none.

**And a sixth, found by extending the same check to the twin.** `switch.to_persona`'s `shown = contain.one_line(name)` was unpinned where `to_workspace`'s is covered twice over — deleting it left the whole suite green. Step 4 says workspace *and* persona, so the hostile-name case now covers both nouns and that line is RED.

## Verification

**Full suite, two environments, same answer** (at `1821a18`):

| env | python | environment | result |
|---|---|---|---|
| 1 | 3.14.4 | as the shell has it — inside a live frame, with `CHARTER_*`, `CLAUDE_*`, `TMUX*` all set | **Ran 6355 tests — OK** |
| 2 | 3.12.13 | `CHARTER_*` / `CLAUDE_*` / `ANTHROPIC_*` / `TMUX*` unset (asserted empty at the interpreter) | **Ran 6355 tests — OK** |

**CI green at the head sha**, via `gh api repos/diazoxide/charter/commits/1821a18b14ce105fed0de27a2bb42264f0c5bf6f/check-runs` (not `gh pr checks`, per #561):

```
test (3.11)  completed  success
test (3.12)  completed  success
test (3.13)  completed  success
test (3.14)  completed  success
```

**No tmux servers and no socket files leaked.** `pgrep -af tmux | grep charter-` is empty after every run; the one socket these runs created was unlinked by its own teardown (`test_frame_overlay_escape_hatch.py::TheHatch._teardown_socket`, reused unchanged) and is gone. The 208 stale sockets dated today on this machine all predate this worktree by five hours — #564's existing debt, not added to.

## Phase 2 exit criteria

| criterion | verdict | how |
|---|---|---|
| **Every action reachable in ≤2 keystrokes; every unavailable one says why** | met for actions — **but a NAME now costs one keystroke more, deliberately** | see below |
| **A hostile workspace or persona name renders as one row and runs nothing** | **met** | `AHostileNameIsOneRowAndRunsNothing`, 7 cases, 8 hostile names, both nouns, measured on the drawn pane and on what reaches `switch.to_*` |
| **`display-menu` and `frame-menu` are gone** | **met, and it stayed done** | `build_parser()` has no `frame-menu` and no `frame-action`; `conf_text` emits no `display-menu` (`test_no_bind_anywhere_still_opens_a_menu`). The only remaining occurrences in `charter/` are three docstring references explaining what was replaced. |
| **The escape hatch works against a deliberately hung overlay** | **met**, unchanged by this branch | `test_frame_overlay_escape_hatch.py::TheHatch::test_one_key_returns_to_the_harness_from_an_overlay_that_never_answers` — a real tmux, a real attached client, the overlay's process in `time.sleep` with its tty in raw mode |
| **A provider's component can be placed by config and drawn** | **met**, unchanged by this branch | `test_component_id_is_the_currency.py::test_charter_panel_draws_an_installed_providers_component` and `::test_the_committed_rectangle_is_what_is_placed` |

### The one deviation, stated plainly

On `main`, `F2` then `zeb` then Enter switched to the workspace `zebra` — one flat list. Here it is `F2`, Enter (the workspace doorway is row 1 and is selected on open), then `zeb`, Enter.

**Every *action* is still one list away**, which is what the criterion says. What is one list deeper is a *name*, and the trade is deliberate:

* Task 4's own docstring argues a filter beats a submenu for **reaching a known name** — true, and this costs one Enter. What it does not weigh is that a plane with thirty workspaces made the four things a frame can *do* four rows in thirty-seven, and that every one of those thirty rows was an `Action` describing something an `Action` cannot describe.
* §4h's "one answer to how do I do a thing" is what rules out the other resolution — keeping the names in the palette *and* adding a picker.
* The plan says it directly ("`_register_names` is what a picker replaces", "same overlay, different row source").

If the extra Enter is the wrong trade, the cheapest reversal is to append `choose.roster(...).rows` for both nouns to the catalogue beside the doorways; nothing in `frame/choose.py` would change. Flagged rather than assumed.

## Not done, on purpose

No version bump, no stamp, no tag. News entry at `version: unreleased`. Not merged.
