### PR TITLE
A news key is honoured or reported, and a filename cannot forge a line of the report (#502, #503)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,14 +122,18 @@ jobs:
           # answer to one question, free to say yes on a release whose notes come out
           # empty. `charter news --for` exits non-zero when there is nothing to render.
           #
-          # It exits non-zero for MORE than that now (#486): an ordering field charter
-          # cannot read, or two entries both claiming `lead: true`. So the annotation
-          # names both causes and defers to the command's own stderr — which `>/dev/null`
-          # keeps, since it drops only stdout — rather than prescribing `news stamp` for
-          # a failure stamping cannot fix.
+          # It exits non-zero for MORE than that now: an ordering field charter cannot
+          # read, or two entries both claiming `lead: true` (#486); a frontmatter key
+          # charter does not know, which is where `Security: true` lands (#503); or a file
+          # in docs/news that is not an entry at all. So the annotation names the two
+          # SHAPES — no entry, or something the entries declare that charter cannot honour
+          # — and defers to the command's own stderr for which, since that stderr is
+          # already one sentence per finding. `>/dev/null` keeps it, dropping only stdout.
+          # Prescribing `news stamp` for any of the second shape would be prescribing a
+          # no-op for a failure stamping cannot fix.
           version=$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
           if ! python -m charter news --for "$version" >/dev/null; then
-            echo "::error::cannot render the release notes for $version: either no docs/news/$version-<slug>.md (every published version ships an entry, including a patch — run: charter news stamp $version), or an ordering those entries declare that charter cannot honour. See the error above for which."
+            echo "::error::cannot render the release notes for $version: either no docs/news/$version-<slug>.md (every published version ships an entry, including a patch — run: charter news stamp $version), or something those entries declare that charter cannot honour — an ordering, a frontmatter key, or a file in docs/news that is not an entry. See the error above for which."
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,15 @@ command.
   to the release, which is the only vantage point from which "first" means anything.
   Without either, entries sort by filename as they always have.
 
+  **Those six keys are the whole set, and they are matched exactly.** `version`,
+  `headline`, `check`, `adopt`, `lead`, `security` — anything else in an entry's
+  frontmatter is reported at the release gate rather than ignored, `Security:` and
+  `securiy:` included. Charter does not guess which one you meant: a key it does not read
+  reads as nothing at all, and an entry that renders as nothing is indistinguishable from
+  an entry nobody wrote (#503). The same goes for the file itself — every `.md` in
+  `docs/news/` is an entry, and one that declares no `version:` charter can read stops the
+  release rather than quietly sitting the release out.
+
   Write it in the PR that builds the thing: you are the only person who knows why it
   matters and what would prove somebody has taken it up, and reconstructing that from
   commit titles at release time is how notes become a changelog nobody reads. Nothing in CI

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2461,11 +2461,22 @@ def _news_line(e, status: str) -> str:
     Deliberately not JSON. The skill is a Claude Code artifact and opencode gets none, so
     this text is the only thing an agent on another harness has — a machine surface would
     become the parsed one, and this the unchecked one.
+
+    Every span an entry owns goes through `contain.one_line`. The slug, the headline and
+    the `adopt:` command are all frontmatter or a filename, this is two lines of charter's
+    own report with a structure a reader parses by eye, and #502 is the same value crossing
+    into the same kind of line one function over. The `·` and the indent are charter's; a
+    third of each would be the entry's.
     """
     from . import news
 
-    how = f"adopt: charter {e.adopt}" if e.adopt else "adopt: manual (see the entry)"
-    return f"  {e.slug} · {news.marker(e)}{e.headline}\n      {how}"
+    adopt = contain.one_line(e.adopt)
+    # Asked of the CONTAINED value, not the raw one. They agree today; the question this
+    # line needs answered is "is there a command to show the reader", and a value that
+    # renders as nothing is not one.
+    how = f"adopt: charter {adopt}" if adopt else "adopt: manual (see the entry)"
+    return (f"  {contain.one_line(e.slug)} · {news.marker(e)}"
+            f"{contain.one_line(e.headline)}\n      {how}")
 
 
 #: Said once, where a probe would otherwise be run against nothing.
@@ -2491,10 +2502,19 @@ def cmd_news(args) -> int:
         # `gh release create --notes-file`. So an ordering charter cannot honour is caught
         # before a Release exists to be wrong, rather than after — which is the position
         # #486 was filed from, with the notes already published.
-        problems = news.ordering_errors(news.for_version(version))
+        # Both halves, behind one gate. `entry_errors` speaks for files that BECAME
+        # entries; `unreadable` speaks for files in the news directory that did not, which
+        # is where a miscased `Version:` lands — dropped by `_read` before any per-entry
+        # check exists to be asked, and waved through by a release guard that answers from
+        # filenames (#503). Asked over the whole directory rather than for this version,
+        # because a file with no readable version has no version to be filtered by and the
+        # release being cut is when somebody wants to hear about it.
+        problems = news.entry_errors(news.for_version(version)) + news.unreadable()
         if problems:
-            util.err(f"the news entries for {version} declare an ordering charter cannot "
-                     f"honour:")
+            # "the news for", not "the news entries for": half of what this gate now
+            # catches is a file that never became an entry, and a sentence naming only
+            # entries would send the reader looking for one that does not exist.
+            util.err(f"the news for {version} declares something charter cannot honour:")
             for why in problems:
                 util.info(f"  {why}")
             return 1
@@ -2519,7 +2539,9 @@ def cmd_news(args) -> int:
                 # Said, not swallowed. A probe that could not run is the one case where
                 # silence would be read as "nothing to adopt" — the shape ADR 0013 and
                 # `doctor`'s not-checked hint both exist to refuse.
-                util.warn(f"{e.slug}: {why}")
+                # The slug is the committed filename with its version prefix cut off, and
+                # `why` already carries the entry's `check:` contained (`news._report`).
+                util.warn(f"{contain.one_line(e.slug)}: {why}")
                 unchecked += 1
         if not shown:
             if unchecked:
@@ -2552,11 +2574,14 @@ def cmd_news(args) -> int:
     # over a malformed `security:` line would lose them the other nineteen entries to
     # protect them from one being in the wrong place. `--for` is where refusing belongs,
     # because that is the call that becomes a published Release.
-    for why in news.ordering_errors(entries):
+    for why in news.entry_errors(entries) + news.unreadable():
         util.warn(why)
     for e in entries:
         status, _ = (news.INFORMATIONAL, "") if planeless else news.probe(e)
-        print(f"{e.version}  {news.marker(e)}{e.headline}")
+        # Version and headline are both frontmatter, and this is a report line whose
+        # two-space column a reader parses by eye (#502).
+        print(f"{contain.one_line(e.version)}  {news.marker(e)}"
+              f"{contain.one_line(e.headline)}")
         # Only an entry with something to DO gets the action line. An informational entry
         # — a patch note, usually — exists to say there is nothing to take up, so printing
         # "adopt: manual" beneath it invents a chore out of the line that denies one.
@@ -2581,7 +2606,11 @@ def cmd_news_stamp(args) -> int:
     if blocked:
         return 1
     for src, dst in renamed:
-        util.ok(f"{src.name} → {dst.name}")
+        # The same pair of committed filenames `news.stamp`'s refusals carry, on the path
+        # that always runs. Containing the refusal and not the success would be #502 in
+        # miniature: one spelling of the message guarded, its neighbour three lines away
+        # not — and this is the one a release prints.
+        util.ok(f"{contain.one_line(src.name)} → {contain.one_line(dst.name)}")
     if not renamed:
         util.info(f"no staged entries — nothing to move onto {version}.")
 

--- a/charter/news.py
+++ b/charter/news.py
@@ -4,7 +4,7 @@ A *news entry* is a shipped, per-item note that a version introduced something, 
 an optional probe for whether this plane has adopted it. Not a changelog: an entry exists
 to be **acted on**, and one with nothing to adopt is one line.
 
-Five properties are load-bearing.
+Six properties are load-bearing.
 
 **One entry, two consumers, one answer.** The GitHub Release body and the offline `charter
 news` suggestion are the same entries rendered twice — `release.yml`'s announce job pipes
@@ -14,6 +14,21 @@ never at a call site. It was not, and #486 is what that cost: ORDER was left to
 `sorted(glob("*.md"))`, which for a stamped release is alphabetical by slug, so 0.52.0's
 vault-spending fix rendered eighth, under a docs correction. :func:`all` now applies the
 declared order and :func:`marker` the label, and both views come through them.
+
+**What an entry declares is honoured or reported, never neither.** An entry is a committed
+file and the release notes are the one document nobody re-derives, so an entry that does
+not render is indistinguishable from an entry nobody wrote. :func:`_flag` holds that line
+for a VALUE charter cannot read. It was held for nothing else: `Security: true` is a
+different dict key from `security:`, so `meta.get("security")` found nothing, the entry
+sorted as though it had declared nothing, and `charter news --for` — the release gate —
+exited 0 with an empty stderr (#503). :data:`_KNOWN_FIELDS` closes the key half, and
+:func:`unreadable` closes the half below it, where a miscased ``Version:`` costs the file
+its `Entry` altogether and no per-entry check can be asked about it.
+
+And the report saying so is charter's own output, so every span in it is contained as the
+sentence is assembled (:func:`_report`) rather than at the spans somebody was thinking
+about: the ordering VALUE was contained and the committed FILENAME beside it was not, so a
+filename holding a newline forged an extra line of charter's report (#502).
 
 **It ships in the wheel.** Entries travel with the code that implements them, resolved the
 way :mod:`charter.docsrc` resolves documentation — packaged copy first, the repo's
@@ -143,7 +158,7 @@ _ENV = "CHARTER_NEWS_PROBE"
 #: The two opt-in ordering fields, and the only two. `security:` is a CLASS — a version
 #: may ship any number of security entries, and they sort above everything else. `lead:`
 #: is a POSITION, so at most one entry per version may claim it; a second is a
-#: contradiction :func:`ordering_errors` reports rather than resolving.
+#: contradiction :func:`entry_errors` reports rather than resolving.
 #:
 #: Split rather than collapsed into one `rank: <int>`, because the two answer different
 #: questions and only one of them can be answered by an author working alone. "Is this a
@@ -154,6 +169,36 @@ _ENV = "CHARTER_NEWS_PROBE"
 #: let an author state only what they actually know.
 LEAD, SECURITY = "lead", "security"
 _ORDERING_FIELDS = (LEAD, SECURITY)
+
+#: Every frontmatter key a news entry may declare, and a CLOSED set: a key outside it is
+#: reported by :func:`entry_errors` rather than read past.
+#:
+#: Closed because the alternative failure is silent. `persona.parse` keeps a key exactly as
+#: written, so ``Security: true`` is the key ``Security``, ``meta.get("security")`` finds
+#: nothing, and the entry declares a security fix, sorts as though it declared nothing, and
+#: leaves `charter news --for` exiting 0 with an empty stderr (#503). That is #486's own
+#: defect reached through the KEY instead of the value, and the key half fails the more
+#: quietly of the two, because an unfound key leaves no value to report.
+#:
+#: **Loud rather than liberal, and the case is why.** Folding the lookup to lower case
+#: answers ``Security:`` and nothing else: ``securiy:``, ``leads:``, ``security-fix:`` and
+#: ``sec urity:`` all parse cleanly, are never looked up, and sink the entry in exactly the
+#: same silence. Accepting more spellings is a guard against a spelling — the shape this
+#: module's docstring names six times over — where the property is "a key the author
+#: declared is honoured or reported, never neither". With no unspoken key left, case stops
+#: being a special case of anything.
+#:
+#: There is a second reason not to fold. `persona.parse` keeps the LAST of two lines with
+#: the same key, so a case-folding parser would owe an answer to
+#: ``{"Security": "true", "security": "false"}`` — which wins, or does it refuse (#509).
+#: Reporting needs no such rule, and needs no change to a parser whose dict is also read
+#: for ``vault:`` and ``extends:``.
+#:
+#: Every name here is also an :class:`Entry` field, asserted rather than assumed by
+#: `tests/test_a_news_key_is_honoured_or_reported.py`: a name added here that `_read` does
+#: not actually read would be a key charter accepts and then ignores — the silence this set
+#: exists to remove, wearing a commit.
+_KNOWN_FIELDS = ("version", "headline", "check", "adopt") + _ORDERING_FIELDS
 
 
 class Entry(NamedTuple):
@@ -172,9 +217,16 @@ class Entry(NamedTuple):
     #: rather than raised, and rather than silently read as false, because false is the
     #: answer that SINKS the entry — an author who wrote `security: yes` and got the
     #: bottom of the release notes would have been failed by the field that was supposed
-    #: to help them. :func:`ordering_errors` turns these into sentences, and
+    #: to help them. :func:`entry_errors` turns these into sentences, and
     #: `charter news --for` — which is the release workflow's own gate — refuses on them.
     bad: tuple[tuple[str, str], ...] = ()
+    #: Frontmatter keys this entry declared that charter does not read, in the order the
+    #: file wrote them. Beside :attr:`bad` and for the same reason, one half of the
+    #: declaration each: `bad` is a value charter could not read, this is a key it never
+    #: looked up. Both are carried rather than raised, and neither is dropped, because
+    #: dropping is what makes an entry that declared something indistinguishable from one
+    #: that declared nothing (#503).
+    unknown: tuple[str, ...] = ()
 
 
 def _is_checkout(d: Path) -> bool:
@@ -232,12 +284,16 @@ def _read(p: Path) -> Entry | None:
         if value is None:
             bad.append((field, raw or ""))
         flags[field] = bool(value)
+    # In the file's own order, not sorted: an author reading the report is looking for the
+    # line they typed, and `persona.parse` hands its keys back in the order it read them.
+    unknown = tuple(k for k in meta if k not in _KNOWN_FIELDS)
     return Entry(version=version, slug=slug,
                  headline=(meta.get("headline") or "").strip(),
                  check=(meta.get("check") or "").strip(),
                  adopt=(meta.get("adopt") or "").strip(),
                  body=body, path=p,
-                 lead=flags[LEAD], security=flags[SECURITY], bad=tuple(bad))
+                 lead=flags[LEAD], security=flags[SECURITY], bad=tuple(bad),
+                 unknown=unknown)
 
 
 def _flag(raw: str | None) -> bool | None:
@@ -275,16 +331,22 @@ def _flag(raw: str | None) -> bool | None:
 
     So the property is not "which words mean yes" but **"was this value understood?"**.
     Two literals are recognised, case-folded; every other string an author typed is
-    reported by :func:`ordering_errors` naming the value it could not read. An author who
+    reported by :func:`entry_errors` naming the value it could not read. An author who
     writes something outside the pair is told so at the release gate rather than being
     quietly overruled by it.
 
-    **The next spelling** is not in this function: it is the KEY. `persona.parse` matches
+    **The next spelling was not in this function: it was the KEY.** `persona.parse` matches
     exactly and case-sensitively, so ``Security: true`` never arrives as ``security`` and
-    is genuinely absent here (#503); and it keeps the LAST of two lines with the same key,
-    so an entry declaring ``security:`` twice has one of them dropped without a word
-    (#509). Both are reached through the dict this function is handed, not through the
-    value it reads, and both change how every caller of `persona.parse` reads its result.
+    is genuinely absent here — this function is handed ``None`` and answers False, which is
+    the right answer to the question it was asked and the wrong outcome for the entry
+    (#503). The key half is answered where the key lives, by :data:`_KNOWN_FIELDS`: a key
+    outside that set is a sentence rather than a shrug, so ``Security:`` is reported and so
+    is ``securiy:``, which no amount of case-folding here would have caught.
+
+    What is still open is the same dict keeping the LAST of two lines with one key, so an
+    entry declaring ``security:`` twice has one of them dropped without a word (#509).
+    That one is reached through `persona.parse` itself, whose result is also read for
+    ``vault:`` and ``extends:``, and is filed rather than folded in here.
     """
     if raw is None:
         return False
@@ -314,57 +376,203 @@ def marker(e: Entry) -> str:
     return "security: " if e.security else ""
 
 
-def ordering_errors(entries: list[Entry]) -> list[str]:
-    """Why the declared ordering of *entries* cannot be honoured, as sentences.
+def _report(template: str, **fields) -> str:
+    """One line of charter's own report, with **every** field in it bounded to one line.
 
-    Empty is the ordinary answer. Two failures are reported, and neither is resolved
-    quietly, because a quiet resolution is what #486 was about:
+    *template* is a literal in this module — charter's own sentence, with ``{}`` slots.
+    Everything substituted into it comes out of a committed file and goes through
+    :func:`contain.one_line`; a sequence is contained element by element and then joined
+    with charter's own comma, so the separator cannot come from the data either.
+
+    **Why the containment is here and not at the slots.** A news entry is a committed file
+    and so is its NAME: whoever writes the commit chooses both, and both land in a line a
+    release engineer reads out of CI. `entry_errors` contained the ordering *value* and
+    interpolated the *filename* three inches away raw, so an entry named
+    ``0.60.0-a\\nEVIL: charter says nothing is wrong.md`` printed two lines where charter
+    emitted one, the second being the attacker's sentence in charter's own voice (#502).
+    The value was contained because the value was what that commit was about — not because
+    the filename half had been judged safe.
+
+    Wrapping each span individually would have fixed those four call sites and left the
+    door open at the fifth, which is a THIRD untrusted span appearing in one of these
+    sentences: the ``{version}`` in the duplicate-`lead:` message is frontmatter, the
+    ``{check}`` in a probe's reason is frontmatter, and a slug is a filename with its
+    prefix cut off. So the message is contained as it is ASSEMBLED. A field added to one of
+    these templates tomorrow is contained by having been passed here, which is the one
+    property a reviewer can check by reading the call site.
+
+    What this does not reach is a call site that builds its sentence with an f-string
+    instead of calling this. Nothing in the language stops that, so
+    `tests/test_a_news_entry_cannot_forge_a_report_line.py` plants a newline in every field
+    a news entry owns and asserts each of these reports is still the number of lines
+    charter meant to write.
+    """
+    shown = {}
+    for key, value in fields.items():
+        if isinstance(value, (list, tuple)):
+            shown[key] = ", ".join(contain.one_line(v) for v in value)
+        else:
+            shown[key] = contain.one_line(value)
+    return template.format(**shown)
+
+
+#: An ordering field whose value charter could not read, quoted back to its author.
+_BAD_VALUE = ("{name}: `{field}: {raw}` is not a value charter reads — a news ordering "
+              "field is `true` or `false`. Left unread, this entry sorts as though it "
+              "never declared anything.")
+
+#: The same field declared with nothing after the colon. Distinct from :data:`_BAD_VALUE`
+#: because the fix is different: there is no value to correct, and quoting one back
+#: ("`security: `") would read like a rendering bug. Name the shape that produces it
+#: instead — the value on the continuation line is the way this gets typed.
+_EMPTY_VALUE = ("{name}: `{field}:` is declared with no value on that line — a news "
+                "ordering field is `true` or `false`, written after the colon. charter's "
+                "frontmatter is flat `key: value` and drops a line without a colon, so a "
+                "value indented onto the NEXT line never reaches charter. Left unread, "
+                "this entry sorts as though it never declared anything.")
+
+#: Charter's own list of what an entry may declare, built from :data:`_KNOWN_FIELDS` so the
+#: sentence cannot drift from the set it describes.
+_FIELDS_SAID = ", ".join(f"`{f}:`" for f in _KNOWN_FIELDS)
+
+#: A key that is one of charter's fields in another case. Its own sentence, because the
+#: author has already written the right word and needs to be told only that the key is
+#: matched exactly — pointing them at the whole list would make them hunt for a difference
+#: that is not there.
+_MISCASED_KEY = ("{name}: `{key}:` differs from `{known}:` only in case, and charter "
+                 "matches a frontmatter key exactly — so this entry declared no "
+                 "`{known}:` at all and was read as though the line were not there. "
+                 "Spell the key `{known}:`.")
+
+#: Any other key charter does not read. Reported rather than ignored because ignoring is
+#: what makes `securiy: true` indistinguishable from a line nobody wrote (#503).
+_UNKNOWN_KEY = ("{name}: `{key}:` is not a field a news entry declares, so nothing read "
+                "it. A news entry declares " + _FIELDS_SAID + ", matched exactly — a near "
+                "miss parses like anything else, is looked up by nothing, and would "
+                "otherwise sink this entry without a word.")
+
+#: Two entries in one version both claiming the position only one of them can have.
+_TWO_LEADS = ("{version}: {count} entries declare `lead: true` ({names}) — only one entry "
+              "can be the one a reader sees first. Leave `lead:` off all but one; a "
+              "security fix that need not be first can say `security: true` instead, "
+              "which any number of entries may.")
+
+
+def entry_errors(entries: list[Entry]) -> list[str]:
+    """What *entries* declare that charter cannot honour, as sentences.
+
+    Empty is the ordinary answer. Three kinds of failure are reported, and none of them is
+    resolved quietly, because a quiet resolution is what #486 was about:
 
     * an ordering field whose value was not understood (see :func:`_flag`), named with the
       value, so an author who wrote ``security: yes`` learns which word charter reads —
       and, when the field was declared with nothing after the colon, naming the shape
       instead of the empty value, because the author who wrote it almost certainly put
       the value on the next line and needs to be told that line is not read;
+    * a key outside :data:`_KNOWN_FIELDS`, which is where ``Security: true`` lands and
+      where ``securiy: true`` lands with it (#503). This is the quietest of the four:
+      an unfound key leaves no value to report, so before it was reported the entry
+      declared a security fix, rendered below the ordinary ones, and let the release gate
+      pass with an empty stderr;
     * two entries in one version both declaring ``lead: true``. One of them is not going
       to be first, and picking silently would hand back the accident #486 already
       diagnosed — a position decided by something other than a person deciding it.
 
+    Named for the ENTRY rather than for the ordering it used to be named for, because an
+    unrecognised key is not an ordering claim and the narrower name is how the middle one
+    would have ended up somewhere else, reported by nobody. What they share is the
+    property: a thing the author declared is honoured or reported, never neither.
+
     Callers rather than this function decide the consequence: `charter news --for`, which
     IS the release workflow's publish gate, refuses; the range view warns and prints on.
+    Every sentence is assembled through :func:`_report`, so a committed filename in one
+    cannot write a second line into the report it appears in (#502).
     """
     out: list[str] = []
     for e in sorted(entries, key=lambda e: e.path.name):
         for field, raw in e.bad:
-            if raw == "":
-                # Distinct from the sentence below, because the fix is different: there
-                # is no value to correct, and quoting one back ("`security: `") would
-                # read like a rendering bug. Name the shape that produces it instead —
-                # the value on the continuation line is the way this gets typed.
-                out.append(
-                    f"{e.path.name}: `{field}:` is declared with no value on that line "
-                    f"— a news ordering field is `true` or `false`, written after the "
-                    f"colon. charter's frontmatter is flat `key: value` and drops a line "
-                    f"without a colon, so a value indented onto the NEXT line never "
-                    f"reaches charter. Left unread, this entry sorts as though it never "
-                    f"declared anything.")
-                continue
-            out.append(
-                f"{e.path.name}: `{field}: {contain.one_line(raw)}` is not a value "
-                f"charter reads — a news ordering field is `true` or `false`. Left "
-                f"unread, this entry sorts as though it never declared anything.")
+            template = _EMPTY_VALUE if raw == "" else _BAD_VALUE
+            out.append(_report(template, name=e.path.name, field=field, raw=raw))
+        for key in e.unknown:
+            known = next((f for f in _KNOWN_FIELDS if f == key.casefold()), None)
+            if known is not None:
+                out.append(_report(_MISCASED_KEY, name=e.path.name, key=key, known=known))
+            else:
+                out.append(_report(_UNKNOWN_KEY, name=e.path.name, key=key))
     leads: dict[str, list[Entry]] = {}
     for e in entries:
         if e.lead:
             leads.setdefault(e.version, []).append(e)
     for version, claimants in sorted(leads.items()):
         if len(claimants) > 1:
-            names = ", ".join(sorted(c.path.name for c in claimants))
-            out.append(
-                f"{version}: {len(claimants)} entries declare `lead: true` ({names}) — "
-                f"only one entry can be the one a reader sees first. Leave `lead:` off "
-                f"all but one; a security fix that need not be first can say "
-                f"`security: true` instead, which any number of entries may.")
+            out.append(_report(_TWO_LEADS, version=version, count=len(claimants),
+                               names=sorted(c.path.name for c in claimants)))
     return out
+
+
+#: A file in the news directory that :func:`_read` declined, and the four ways that
+#: happens. Each names the edit, because "not an entry" alone sends a release engineer to
+#: read a file and guess.
+_UNREADABLE_FILE = ("{name}: charter could not read this file ({error}), so it is a file "
+                    "in the news directory and an entry in no release.")
+_NO_FRONTMATTER = ("{name}: no `key: value` frontmatter, so charter reads it as no entry "
+                   "at all. Every file in the news directory is an entry — give it "
+                   "`version:` and `headline:`, or move it out of the directory.")
+_MISCASED_VERSION = ("{name}: `{key}:` differs from `version:` only in case, and charter "
+                     "matches a frontmatter key exactly — so this file names no version "
+                     "and is in no release, in the offline view or the published notes. "
+                     "Spell the key `version:`.")
+_NO_VERSION = ("{name}: no `version:` charter could read in its frontmatter, so this file "
+               "is in no release, in the offline view or the published notes. A staged "
+               "entry writes `version: " + UNRELEASED + "` until `charter news stamp` "
+               "moves it.")
+
+
+def _not_an_entry(p: Path) -> str:
+    """Why *p* produced no :class:`Entry`, as a sentence — best effort, always something.
+
+    The SET this explains comes from :func:`_read` returning ``None``; only the wording is
+    here. That split is deliberate: a fifth way for `_read` to decline would otherwise have
+    to be remembered in two places, and the one that gets forgotten is this one — where
+    being forgotten means a file reported with a reason that is no longer true. The
+    fallthrough sentence at the end is what a fifth reason gets until somebody writes it
+    one, and it is still a sentence naming the file.
+    """
+    try:
+        text = p.read_text()
+    except (OSError, UnicodeDecodeError) as exc:
+        return _report(_UNREADABLE_FILE, name=p.name, error=f"{type(exc).__name__}: {exc}")
+    meta, _body = persona.parse(text)
+    if not meta:
+        return _report(_NO_FRONTMATTER, name=p.name)
+    miscased = next((k for k in meta if k != "version" and k.casefold() == "version"), None)
+    if miscased is not None:
+        return _report(_MISCASED_VERSION, name=p.name, key=miscased)
+    return _report(_NO_VERSION, name=p.name)
+
+
+def unreadable() -> list[str]:
+    """Every file in the news directory that is not an entry, as sentences.
+
+    The sibling of :func:`entry_errors`, and it exists because the loudest version of
+    #503's defect is the one that never reaches that function. ``Security: true`` sinks an
+    entry; ``Version: 0.60.0`` **deletes** it — `_read` finds no ``version`` and returns
+    ``None``, so the file is dropped before any of `all`'s consumers see it, and there is
+    no `Entry` for `entry_errors` to have an opinion about. The release guard does not
+    catch it either: `stamped()` answers from FILENAMES, so a file named
+    ``0.60.0-fix.md`` satisfies "every published version ships an entry" while rendering
+    into neither the Release body nor `charter news`.
+
+    So the two questions are asked separately and answered the same way — reported, not
+    swallowed — and `cmd_news` puts both behind the same gate. Asked over the whole
+    directory rather than per version on purpose: a file with no readable version has no
+    version to be filtered by, and the release being cut is exactly when somebody wants to
+    know that the entry they wrote for it is not in it.
+    """
+    d = _dir()
+    if d is None:
+        return []
+    return [_not_an_entry(p) for p in sorted(d.glob("*.md")) if _read(p) is None]
 
 
 def all() -> list[Entry]:
@@ -842,7 +1050,13 @@ def probe(entry: Entry) -> tuple[str, str]:
     code = _dispatch(entry.check)
     if code is None:
         why = _IN_FLIGHT if in_flight else (_refused or _NOT_RUN)
-        return UNKNOWN, why.format(check=entry.check)
+        # Through `_report` rather than `.format` directly: `check:` is frontmatter, this
+        # sentence is printed as a line of `charter news --pending`'s own report, and the
+        # five templates above are the third untrusted span #502 predicted would turn up in
+        # one of these messages. `_tokens` refuses `\n` as shell syntax and never sees
+        # U+2028 or an ANSI escape, and in any case a guard that decides whether a probe
+        # RUNS is not a guard on what the report PRINTS.
+        return UNKNOWN, _report(why, check=entry.check)
     return (ADOPTED if code == 0 else PENDING), ""
 
 
@@ -915,6 +1129,18 @@ def _restamp(text: str, version: str) -> str | None:
     return "".join(out) if found else None
 
 
+#: Why a stamp was refused, one sentence each. Through :func:`_report` for the reason
+#: `entry_errors`' sentences are: these name FILES, a filename is chosen by whoever wrote
+#: the commit, and this text is read out of a release engineer's terminal at the one moment
+#: nobody re-derives it (#502). `{version}` is argv rather than a committed file and is
+#: bounded anyway — a value charter refused is by definition one nothing has vouched for.
+_NOT_A_VERSION = ("'{version}' is not a version — pass the number alone, as in 0.45.0, "
+                  "not the tag name")
+_NAME_TAKEN = ("{src} → {dst}: that name is already taken, and charter will not overwrite "
+               "an entry that already shipped")
+_NOTHING_TO_STAMP = "{src}: no `version:` line in its frontmatter to stamp"
+
+
 def stamp(version: str) -> tuple[list[tuple[Path, Path]], list[str]]:
     """Move every staged entry onto *version*: rename the file, rewrite the field.
 
@@ -928,8 +1154,7 @@ def stamp(version: str) -> tuple[list[tuple[Path, Path]], list[str]]:
     leaves every entry staged, which fails loudly at the next catch.
     """
     if not _is_version(version):
-        return [], [f"{version!r} is not a version — pass the number alone, as in 0.45.0, "
-                    f"not the tag name"]
+        return [], [_report(_NOT_A_VERSION, version=version)]
     d = checkout_dir()
     if d is None:
         return [], ["news entries are stamped in the repo, and this is not a charter "
@@ -941,12 +1166,11 @@ def stamp(version: str) -> tuple[list[tuple[Path, Path]], list[str]]:
         slug = src.stem.split("-", 1)[1]
         dst = d / f"{version}-{slug}.md"
         if dst.exists():
-            blocked.append(f"{src.name} → {dst.name}: that name is already taken, and "
-                           f"charter will not overwrite an entry that already shipped")
+            blocked.append(_report(_NAME_TAKEN, src=src.name, dst=dst.name))
             continue
         text = _restamp(src.read_text(), version)
         if text is None:
-            blocked.append(f"{src.name}: no `version:` line in its frontmatter to stamp")
+            blocked.append(_report(_NOTHING_TO_STAMP, src=src.name))
             continue
         plan.append((src, dst, text))
     if blocked:

--- a/charter/news.py
+++ b/charter/news.py
@@ -511,8 +511,8 @@ def entry_errors(entries: list[Entry]) -> list[str]:
 
 
 #: A file in the news directory that :func:`_read` declined, and the four ways that
-#: happens. Each names the edit, because "not an entry" alone sends a release engineer to
-#: read a file and guess.
+#: happens today — plus the one for a way it does not. Each names the edit, because "not an
+#: entry" alone sends a release engineer to read a file and guess.
 _UNREADABLE_FILE = ("{name}: charter could not read this file ({error}), so it is a file "
                     "in the news directory and an entry in no release.")
 _NO_FRONTMATTER = ("{name}: no `key: value` frontmatter, so charter reads it as no entry "
@@ -527,6 +527,14 @@ _NO_VERSION = ("{name}: no `version:` charter could read in its frontmatter, so 
                "entry writes `version: " + UNRELEASED + "` until `charter news stamp` "
                "moves it.")
 
+#: For a decline this version cannot explain. It says so rather than guessing at one of the
+#: four above, because a file reported with a reason that is not the reason is worse than a
+#: file reported with none: the reader makes the edit it names, nothing changes, and the
+#: sentence has spent its credibility.
+_NOT_AN_ENTRY = ("{name}: charter reads this file as no entry at all, for a reason this "
+                 "version has no sentence for. It is in the news directory and in no "
+                 "release.")
+
 
 def _not_an_entry(p: Path) -> str:
     """Why *p* produced no :class:`Entry`, as a sentence — best effort, always something.
@@ -534,9 +542,10 @@ def _not_an_entry(p: Path) -> str:
     The SET this explains comes from :func:`_read` returning ``None``; only the wording is
     here. That split is deliberate: a fifth way for `_read` to decline would otherwise have
     to be remembered in two places, and the one that gets forgotten is this one — where
-    being forgotten means a file reported with a reason that is no longer true. The
-    fallthrough sentence at the end is what a fifth reason gets until somebody writes it
-    one, and it is still a sentence naming the file.
+    being forgotten means a file reported with a reason that is not the reason. So the
+    fourth answer is asked as a question (*is there a readable version?*) rather than
+    assumed from having reached the end, and a decline this version cannot explain gets
+    :data:`_NOT_AN_ENTRY`: still a sentence, still naming the file, claiming nothing.
     """
     try:
         text = p.read_text()
@@ -548,7 +557,9 @@ def _not_an_entry(p: Path) -> str:
     miscased = next((k for k in meta if k != "version" and k.casefold() == "version"), None)
     if miscased is not None:
         return _report(_MISCASED_VERSION, name=p.name, key=miscased)
-    return _report(_NO_VERSION, name=p.name)
+    if not (meta.get("version") or "").strip():
+        return _report(_NO_VERSION, name=p.name)
+    return _report(_NOT_AN_ENTRY, name=p.name)
 
 
 def unreadable() -> list[str]:

--- a/charter/news.py
+++ b/charter/news.py
@@ -393,13 +393,15 @@ def _report(template: str, **fields) -> str:
     The value was contained because the value was what that commit was about — not because
     the filename half had been judged safe.
 
-    Wrapping each span individually would have fixed those four call sites and left the
-    door open at the fifth, which is a THIRD untrusted span appearing in one of these
-    sentences: the ``{version}`` in the duplicate-`lead:` message is frontmatter, the
-    ``{check}`` in a probe's reason is frontmatter, and a slug is a filename with its
-    prefix cut off. So the message is contained as it is ASSEMBLED. A field added to one of
-    these templates tomorrow is contained by having been passed here, which is the one
-    property a reviewer can check by reading the call site.
+    Wrapping each span individually would have fixed the four call sites #502 named and
+    left the door open at the shape it predicted: a THIRD untrusted span turning up in one
+    of these sentences. There were three of those already. The ``{version}`` in the
+    duplicate-`lead:` message is frontmatter; the ``{check}`` in a probe's reason is
+    frontmatter; the pair of filenames in `stamp`'s SUCCESS line is the same pair its
+    refusals carry, on the path that runs at every release. So the message is contained as
+    it is ASSEMBLED, and a field added to one of these templates tomorrow is contained by
+    having been passed here — which is a property a reviewer can check by reading the call
+    site, rather than one they have to remember.
 
     What this does not reach is a call site that builds its sentence with an f-string
     instead of calling this. Nothing in the language stops that, so

--- a/docs/news/unreleased-a-news-key-is-honoured-or-reported.md
+++ b/docs/news/unreleased-a-news-key-is-honoured-or-reported.md
@@ -1,0 +1,80 @@
+---
+version: unreleased
+headline: A news entry is read the way its author wrote it, or charter says so — and an entry's filename can no longer write a line of charter's own report
+security: true
+---
+
+Two defects in the same subsystem, and the same shape twice: **a value crossing from a
+committed file into something somebody reads, where the code handled one spelling and not
+its neighbours.**
+
+## A key charter does not read is a sentence now, not a shrug
+
+`Security: true` used to sink an entry in silence. charter's frontmatter parser keeps a key
+exactly as written, so that line put `Security` in the dict, the lookup for `security`
+found nothing, and the entry was **absent** — not wrong, not reported, absent. It rendered
+below the ordinary entries, `charter news --for` exited 0 with an empty stderr, and the
+release published notes that did not carry what the entry declared.
+
+That is the defect the ordering fields were added to prevent, restored through the *key*
+instead of the value. The value half was already careful: a `security: yes` charter cannot
+read is reported, never read as false. The key half had no such treatment, because an
+unfound key leaves no value to report — which makes it the quieter of the two failures, and
+the release notes are the one document nobody re-derives.
+
+**The fix is not case-insensitivity.** Folding the lookup answers `Security:` and nothing
+else: `securiy:`, `leads:`, `security-fix:` and `sec urity:` all parse cleanly, are looked
+up by nothing, and sink an entry in exactly the same silence. It would also have to be done
+in the shared frontmatter parser, whose dict is read by key for `role:`, `vault:`,
+`extends:` and `tools:` — one of which decides which credentials a persona reaches — and it
+would owe an answer to two keys that differ only in case.
+
+So the six keys a news entry may declare are a closed set — `version`, `headline`, `check`,
+`adopt`, `lead`, `security` — and anything else is **reported at the release gate**. Case
+stops being a special case of anything, because there is no unspoken key of any kind left.
+charter never guesses which field you meant; it tells you which one it does not have.
+
+The sibling with worse teeth came with it. A miscased `Version:` does not sink an entry, it
+**deletes** it: charter finds no version, drops the file before any view sees it, and the
+release guard — which answers "does this version have an entry?" from *filenames* — waves
+it through. Every `.md` in the news directory is now either an entry or a sentence naming
+what is wrong with it.
+
+Nothing that ships today changes: all 105 entries in the tree declare only keys charter
+reads.
+
+## And the report saying so is charter's own output
+
+The message that reports an unreadable ordering value was built out of two spans:
+
+```
+<filename>: `security: <value>` is not a value charter reads — …
+```
+
+The **value** was contained. The committed **filename** three inches to its left was
+interpolated raw — and a news entry's name is chosen by whoever writes the commit, exactly
+as its frontmatter is. An entry named with a newline in it printed *two* lines where charter
+emitted one, and the second was the author's sentence sitting in a CI log in charter's own
+voice, above the release a human was about to publish.
+
+The value was guarded because the value was what that commit was about. The filename was
+not judged safe; it was not judged.
+
+Four sites were named in the report and there were more, so the guard is no longer at the
+spans somebody enumerated — it is at the **assembly**. Every sentence `news` writes about an
+entry is built by handing a template and its fields to one function that bounds all of them,
+so a field added to one of those templates tomorrow is contained by having been passed
+there. That caught three spans nobody had listed: the version in the duplicate-`lead:`
+message, the `check:` echoed by a probe that could not run, and the pair of filenames in
+`charter news stamp`'s **success** line — the one that runs at every release. The slug,
+headline and `adopt:` command printed by `charter news` and `charter news --pending` are
+bounded too.
+
+Escaped, never dropped: the value is still shown, spelled so it cannot restructure the
+report it appears in.
+
+## What this is worth checking
+
+Nothing to adopt — upgrading is the whole of it. If you have written a news entry against
+this charter and it did not appear in the notes you expected, `charter news --for <version>`
+now says why instead of exiting 0.

--- a/tests/test_a_news_entry_cannot_forge_a_report_line.py
+++ b/tests/test_a_news_entry_cannot_forge_a_report_line.py
@@ -1,0 +1,436 @@
+"""#502: a news entry owns its text, not the structure of charter's report about it.
+
+`news.entry_errors` said this, in a message built out of two spans::
+
+    f"{e.path.name}: `{field}: {contain.one_line(raw)}` is not a value charter reads …"
+
+The ordering VALUE was contained. The committed FILENAME three inches to its left was
+interpolated raw — so an entry named ``0.60.0-a\\nEVIL: charter says nothing is wrong.md``
+printed **two** lines where charter emitted one, and the second was the author's sentence
+sitting in a CI log in charter's own voice, above the release a human is about to publish.
+
+**A filename is committed data.** Whoever writes the commit chooses it, exactly as whoever
+writes it chooses `security:`'s value, and #453 is the same mechanism one surface over: a
+value crossing into a format that has structure without being escaped for that structure.
+The value was guarded because the value was what that commit was about; the filename was
+not judged safe, it was not judged.
+
+**So the property is not "the filename is contained".** It is *every untrusted span in a
+report line is contained, including the ones nobody was thinking about* — and the way to
+have that is to contain the sentence as it is ASSEMBLED rather than at the spans somebody
+enumerated. `news._report` does that, and this module is what says so about spans that
+were not enumerated: the `{version}` in the duplicate-`lead:` message is frontmatter, the
+`{check}` in a probe's reason is frontmatter, a slug is a filename with its prefix cut off,
+and the two filenames in `news stamp`'s SUCCESS line are the same pair its refusal carries.
+
+Every fixture below plants the same payload in a different span and asserts the same two
+things: charter's report is the number of lines charter meant to write, and the payload is
+still *shown* rather than dropped. Escaped, never swallowed — a report that silently loses
+the value it is complaining about is a report about nothing.
+
+The line counts are never hard-coded. Each surface is run twice, once with an ordinary
+fixture and once with the hostile one, and the two are compared: a test that pinned "4
+lines" would go red on a wording change and green on a forged line inside a longer message.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, news
+
+_V = "0.60.0"
+
+#: A payload with one of every way to end a line, plus one that ends no line but repaints
+#: the terminal. Named by what each one DOES rather than by codepoint, because the reason
+#: they are all here is that "newline" is four different characters depending on who is
+#: reading: `str.splitlines` splits on all of the first four, a YAML 1.1 reader and a
+#: pre-ES2019 JavaScript parser split on U+2028, and `\\x1b` is what makes the forged line
+#: look like it came from a different program.
+_LF = "\n"
+_CR = "\r"
+_NEL = "\x85"                # NEXT LINE, a line break to `str.splitlines`
+_LINE_SEP = " "         # LINE SEPARATOR, a line break to YAML and to `splitlines`
+_ESC = "\x1b[31m"            # an ANSI sequence: no line break, a repainted terminal
+
+#: The word a forged line would carry, chosen so a test can tell "escaped and shown" from
+#: "dropped" — the two outcomes that look identical if you assert only the line count.
+_MARK = "EVIL"
+
+#: The payload as it appears in a span that can hold a line break: a FILENAME, which the
+#: filesystem is happy to let hold a ``\\n``, and any field of an `Entry` built directly.
+_HOSTILE = f"a{_LF}{_MARK}: charter says nothing is wrong{_CR}{_NEL}{_LINE_SEP}{_ESC}b"
+
+#: The payload as it can appear in a frontmatter VALUE, which is a narrower thing — see
+#: :class:`AFrontmatterValueCannotHoldALineBreakInTheFirstPlace`. No line break survives
+#: the parser, so what a value can actually carry into a report is the half of the payload
+#: that ends no line and still owns the terminal.
+_HOSTILE_VALUE = f"a{_ESC}{_MARK}: charter says nothing is wrong‍b"
+
+#: The same shape with nothing dangerous in it, for the run the hostile one is compared to.
+_BENIGN = f"a{_MARK} charter says nothing is wrong b"
+
+
+def _entry(version: str = _V, headline: str = "important", **fields) -> str:
+    lines = [f"version: {version}", f"headline: {headline}"]
+    lines += [f"{k}: {v}" for k, v in fields.items()]
+    return "---\n" + "\n".join(lines) + "\n---\n\nbody text\n"
+
+
+class OneLine(unittest.TestCase):
+    """The two assertions every case in this file makes."""
+
+    def assertOneLine(self, said: str, where: str = "") -> None:
+        """*said* occupies exactly one physical line, by every definition of one.
+
+        `splitlines` is the check rather than ``"\\n" not in said`` because the codepoints
+        that break a line are not the codepoint an author would think to look for: it
+        splits on ``\\r``, ``\\x0b``, ``\\x0c``, ``\\x1c``-``\\x1e``, ``\\x85``, ``\\u2028``
+        and ``\\u2029`` as well, and a guard written against ``\\n`` alone passes every one
+        of them straight through.
+        """
+        self.assertEqual(len(said.splitlines()), 1,
+                         f"{where or 'this report line'} is {len(said.splitlines())} "
+                         f"physical lines: {said!r}")
+        self.assertNotIn("\x1b", said,
+                         f"{where or 'this report line'} carries a raw escape sequence")
+
+    def assertShown(self, said: str, where: str = "") -> None:
+        """The payload is escaped INTO the line, not dropped out of it. A report that
+        quietly loses the value it is complaining about names a problem the reader then
+        cannot find."""
+        self.assertIn(_MARK, said,
+                      f"{where or 'this report line'} dropped the value it is about")
+
+
+class NewsDir(OneLine):
+    """Entries read from a throwaway directory. The hostile filenames below really are
+    created on disk — a POSIX filename may hold a newline, which is the whole point — so
+    they never go anywhere near the repository."""
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
+        patch = mock.patch.object(news, "_PACKAGED", self.dir)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def write(self, name: str, text: str) -> Path:
+        p = self.dir / name
+        p.write_text(text)
+        return p
+
+
+class AFrontmatterValueCannotHoldALineBreakInTheFirstPlace(NewsDir):
+    """The premise the fixtures above rest on, asserted rather than assumed.
+
+    `persona.parse` splits the block with `str.splitlines()` before it partitions a line on
+    its colon, so a line break inside a *value* is not a value that contains a line break —
+    it is a second frontmatter line, and usually a second KEY. That is why the file-borne
+    payload goes in the FILENAME, which the filesystem is glad to let hold a ``\\n``, and
+    the value-borne payload is the half that ends no line.
+
+    It is also why this is a class and not a comment. If `persona.parse` ever grew
+    multi-line values, every fixture in this file that plants a value payload would be
+    testing a shape that no longer exists — and would keep passing while doing it. This
+    goes red instead, and names the reason.
+
+    None of it makes the value guard optional: an `Entry` is also built by `_replace`, by a
+    caller in another module, and by whatever reads frontmatter after `persona.parse` is
+    changed. `contain` is not a second parser and the parser is not a second `contain`.
+    """
+
+    def test_a_line_break_in_a_value_becomes_another_frontmatter_line(self):
+        from charter import persona
+
+        meta, _body = persona.parse(f"---\nversion: {_V}\n"
+                                    f"headline: a{_LF}{_MARK}: forged\n---\n\nb\n")
+        self.assertEqual(meta.get("headline"), "a")
+        self.assertIn(_MARK, meta, "the payload did not become its own key after all")
+
+    def test_which_is_why_the_value_payload_ends_no_line(self):
+        self.assertEqual(len(_HOSTILE_VALUE.splitlines()), 1)
+        self.assertGreater(len(_HOSTILE.splitlines()), 1)
+
+    def test_and_the_filename_payload_really_reaches_the_disk_intact(self):
+        """A POSIX filename may contain anything but ``/`` and NUL. If a filesystem under
+        this suite ever refused one, every filename case here would be vacuous."""
+        p = self.write(f"{_V}-{_HOSTILE}.md", _entry())
+        self.assertIn(_LF, p.name)
+        entry, = news.all()
+        self.assertEqual(entry.path.name, p.name)
+
+
+class AFilenameCannotWriteASecondLine(NewsDir):
+    """#502's own reproduction, at the layer the issue reported it."""
+
+    def _named(self, payload: str) -> list[str]:
+        self.write(f"{_V}-{payload}.md", _entry(security="yes"))
+        return news.entry_errors(news.all())
+
+    def test_the_reproduction_from_the_issue_is_one_line(self):
+        why, = self._named(_HOSTILE)
+        self.assertOneLine(why, "the unreadable-value sentence")
+        self.assertShown(why)
+
+    def test_and_an_ordinary_filename_still_reads_as_it_did(self):
+        """The counterfactual. Containing everything is only a fix if the ordinary case
+        comes out unchanged — a guard that mangled every filename would pass the
+        assertion above and make every real message harder to act on."""
+        why, = self._named("z-important")
+        self.assertIn("z-important.md", why)
+        self.assertOneLine(why)
+
+    def test_the_hostile_and_ordinary_reports_are_the_same_number_of_lines(self):
+        """The property, stated without a hard-coded count: what an entry may not do is
+        change how many lines charter's report has."""
+        hostile = self._named(_HOSTILE)
+        self.setUp()
+        ordinary = self._named(_BENIGN)
+        self.assertEqual([len(w.splitlines()) for w in hostile],
+                         [len(w.splitlines()) for w in ordinary])
+
+
+class EverySpanInEverySentence(NewsDir):
+    """Not the filename alone. Each case below plants the payload in a DIFFERENT span of a
+    sentence `news` assembles, and three of them are spans #502 predicted would be missed
+    by a fix that wrapped the two it named: the version in the duplicate-`lead:` message,
+    the `check:` in a probe's reason, and the second filename in a stamp refusal."""
+
+    def test_the_ordering_value(self):
+        self.write(f"{_V}-z.md", _entry())
+        e = news.for_version(_V)[0]._replace(bad=(("security", _HOSTILE),))
+        why, = news.entry_errors([e])
+        self.assertOneLine(why, "the unreadable-value sentence")
+        self.assertShown(why)
+
+    def test_the_version_in_the_duplicate_lead_message(self):
+        """Frontmatter, and the span the issue named as "the next spelling". Two entries
+        have to claim the lead for this sentence to exist at all, and they have to agree
+        on the version — so the payload IS the key the claimants were grouped by.
+
+        Planted on the `Entry` rather than in the file, for the reason
+        `test_news_ordering.py` gives about the same manoeuvre: the guard has to hold on
+        the argument it is handed, not on a parser upstream that happens to filter the
+        input today. `version:` reaches this sentence through `for_version` and through
+        `all`, and neither of those is `persona.parse`.
+        """
+        self.write(f"{_V}-a.md", _entry(lead="true"))
+        self.write(f"{_V}-z.md", _entry(lead="true"))
+        entries = [e._replace(version=_HOSTILE) for e in news.all()]
+        self.assertEqual(len(entries), 2, "the fixture did not stage two leads")
+        why, = news.entry_errors(entries)
+        self.assertOneLine(why, "the duplicate-`lead:` sentence")
+        self.assertShown(why)
+
+    def test_the_joined_filenames_in_the_duplicate_lead_message(self):
+        """A list of spans, not one span. Each element is contained on its own and the
+        comma between them is charter's, so an entry cannot supply the separator either —
+        and a fix that contained the JOINED string would clip the third claimant out of a
+        sentence whose whole job is to name all of them."""
+        for slug in ("a", "z"):
+            self.write(f"{_V}-{slug}{_HOSTILE}.md", _entry(lead="true"))
+        why, = news.entry_errors(news.all())
+        self.assertOneLine(why, "the duplicate-`lead:` sentence")
+        self.assertShown(why)
+
+    def test_the_check_a_file_really_can_carry(self):
+        """`check:` is frontmatter and the reason is printed as a line of `charter news
+        --pending`'s report. `_tokens` refuses a `\\n` as shell syntax, which decides
+        whether the probe RUNS and decides nothing about what the report PRINTS — and it
+        has no opinion at all about an escape sequence, which is what a file can actually
+        deliver here."""
+        self.write(f"{_V}-z.md", _entry(check=f"frobnicate{_HOSTILE_VALUE}"))
+        entry, = news.released()
+        status, why = news.probe(entry)
+        self.assertEqual(status, news.UNKNOWN, "the fixture's probe was not refused")
+        self.assertOneLine(why, "the probe's reason")
+        self.assertShown(why)
+
+    def test_the_check_of_an_entry_handed_to_probe_directly(self):
+        """And the line-breaking half, at the layer the sentence is built from. `probe`
+        takes an `Entry`; whether one can be spelled in today's frontmatter is a fact
+        about `persona.parse`, not about this guard."""
+        self.write(f"{_V}-z.md", _entry(check="frobnicate"))
+        entry, = news.released()
+        _status, why = news.probe(entry._replace(check=f"frobnicate{_HOSTILE}"))
+        self.assertOneLine(why, "the probe's reason")
+        self.assertShown(why)
+
+    def test_the_unrecognised_key_of_a_frontmatter_line(self):
+        """#503's sentence is #502's problem too: the key it quotes back is written by
+        the same author, in the same file, and lands in the same report."""
+        self.write(f"{_V}-z.md", "---\n"
+                                 f"version: {_V}\nheadline: h\n"
+                                 f"{_ESC}{_MARK}: true\n---\n\nb\n")
+        why, = news.entry_errors(news.all())
+        self.assertOneLine(why, "the unrecognised-key sentence")
+        self.assertShown(why)
+
+    def test_the_reason_a_file_is_not_an_entry(self):
+        """`unreadable()` names files, and a file that is not an entry is the one whose
+        name nobody has ever looked at."""
+        self.write(f"{_V}-{_HOSTILE}.md", "---\nheadline: h\n---\n\nb\n")
+        why, = news.unreadable()
+        self.assertOneLine(why, "the not-an-entry sentence")
+        self.assertShown(why)
+
+
+class StampDir(OneLine):
+    """A throwaway checkout, so nothing here renames a file that really ships."""
+
+    def setUp(self):
+        self.repo = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.repo, ignore_errors=True)
+        (self.repo / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        self.dir = self.repo / "docs" / "news"
+        self.dir.mkdir(parents=True)
+        for attr, value in (("_CHECKOUT", self.dir), ("_PACKAGED", self.repo / "absent")):
+            patch = mock.patch.object(news, attr, value)
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def write(self, name: str, text: str) -> Path:
+        p = self.dir / name
+        p.write_text(text)
+        return p
+
+
+class AStampSaysWhichFilesInOneLineEach(StampDir):
+    """`stamp`'s two refusals are the half of #502 that predates the ordering fields
+    entirely — they have been interpolating `src.name` since news entries existed — and
+    the SUCCESS line is a third, on the path that runs at every release."""
+
+    def test_a_name_already_taken_is_reported_in_one_line(self):
+        self.write(f"{news.UNRELEASED}-{_HOSTILE}.md", _entry(version=news.UNRELEASED))
+        self.write(f"{_V}-{_HOSTILE}.md", _entry())
+        _renamed, blocked = news.stamp(_V)
+        why, = blocked
+        self.assertOneLine(why, "the name-already-taken refusal")
+        self.assertShown(why)
+
+    def test_an_entry_with_no_version_line_is_reported_in_one_line(self):
+        self.write(f"{news.UNRELEASED}-{_HOSTILE}.md", "no frontmatter here\n")
+        _renamed, blocked = news.stamp(_V)
+        why, = blocked
+        self.assertOneLine(why, "the nothing-to-stamp refusal")
+        self.assertShown(why)
+
+    def test_a_version_charter_refused_is_reported_in_one_line(self):
+        """The value came from argv rather than from a commit, and it is bounded anyway:
+        a string charter has just refused is by definition one nothing has vouched for."""
+        _renamed, blocked = news.stamp(f"not-a-version{_HOSTILE}")
+        why, = blocked
+        self.assertOneLine(why, "the not-a-version refusal")
+        self.assertShown(why)
+
+    def test_the_success_line_is_one_line_per_entry_renamed(self):
+        """The path that always runs. Containing the refusal and not the success would be
+        this whole issue in miniature — one spelling of a message guarded and its
+        neighbour, three lines away, not."""
+        self.write(f"{news.UNRELEASED}-{_HOSTILE}.md", _entry(version=news.UNRELEASED))
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = commands.cmd_news_stamp(SimpleNamespace(version=_V))
+        self.assertEqual(rc, 0, err.getvalue())
+        said = out.getvalue() + err.getvalue()
+        self.assertEqual(len(said.strip().splitlines()), 1,
+                         f"one entry was renamed and charter wrote: {said!r}")
+        self.assertShown(said, "the stamp's success line")
+
+
+class TheCommandsPrintWhatTheModuleAssembled(NewsDir):
+    """The report a person actually sees. Each view is rendered twice — once from an
+    ordinary fixture, once from a hostile one whose spans are otherwise identical — and
+    the two are required to have the same number of lines. That is the property stated
+    without a count in it: an entry may fill charter's lines, and may not add one.
+    """
+
+    def _stage(self, name_payload: str, value_payload: str) -> None:
+        """The filename takes the payload that can end a line; the frontmatter values take
+        the one that can survive `persona.parse`. Both fixtures declare the same KEYS, so
+        the two runs differ in the text of the report and in nothing else — a payload that
+        added a frontmatter key would add a finding, and a count that moved for that
+        reason would say nothing about forged lines."""
+        self.write(f"{_V}-a{name_payload}.md",
+                   _entry(headline=f"h{value_payload}", adopt=f"doctor{value_payload}",
+                          security="yes"))
+        self.write(f"{_V}-z-plain.md", _entry(headline="plain"))
+
+    def _lines(self, name_payload: str, value_payload: str,
+               args: SimpleNamespace) -> tuple[int, str]:
+        self.setUp()
+        self._stage(name_payload, value_payload)
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch.object(news, "probe", return_value=(news.PENDING, "")), \
+             redirect_stdout(out), redirect_stderr(err):
+            commands.cmd_news(args)
+        said = out.getvalue() + err.getvalue()
+        return len(said.splitlines()), said
+
+    def _both(self, args: SimpleNamespace) -> None:
+        hostile_lines, hostile = self._lines(_HOSTILE, _HOSTILE_VALUE, args)
+        benign_lines, _benign = self._lines(_BENIGN, _BENIGN, args)
+        self.assertEqual(hostile_lines, benign_lines,
+                         f"the hostile fixture changed the shape of the report: "
+                         f"{hostile!r}")
+        self.assertNotIn("\x1b", hostile)
+        self.assertIn(_MARK, hostile, "the report dropped the value it is about")
+
+    def test_the_release_gate_refusal(self):
+        self._both(SimpleNamespace(for_version=_V, pending=False, since=None, until=None))
+
+    def test_the_range_view(self):
+        self._both(SimpleNamespace(for_version=None, pending=False,
+                                   since="0.59.0", until=_V))
+
+    def test_the_pending_view(self):
+        with mock.patch.object(commands.config, "HAS_CONTROL_PLANE", True):
+            self._both(SimpleNamespace(for_version=None, pending=True,
+                                       since=None, until=None))
+
+
+class TheGuardIsAtTheAssemblyNotAtTheSpans(unittest.TestCase):
+    """What separates this fix from the one #502 argued against.
+
+    Wrapping each span individually fixes the spans somebody enumerated. `_report`
+    contains what it is HANDED, so the next field added to one of these templates is
+    contained by having been passed through it — which is a property a reviewer can check
+    by reading the call site, rather than one they have to remember.
+    """
+
+    def test_every_field_handed_to_report_is_contained(self):
+        said = news._report("{a} {b}", a=f"x{_LF}y", b=f"p{_LINE_SEP}q")
+        self.assertEqual(len(said.splitlines()), 1, said)
+
+    def test_a_sequence_is_contained_element_by_element(self):
+        """Not by containing the joined string: the comma is charter's structure, and
+        containing the join would clip a long list's last element out of a sentence whose
+        purpose is to name every one of them.
+
+        `assertEqual` on the whole result rather than "is it one line", because the
+        obvious wrong implementation — drop the branch and let `one_line` stringify the
+        list — also produces one line. It produces ``['a\\x0ab', 'c\\x0ad']``: Python's
+        repr, with the brackets and quotes of a data structure, in a sentence a person
+        reads.
+        """
+        said = news._report("{names}", names=[f"a{_LF}b", f"c{_LF}d"])
+        self.assertEqual(said, "a\\x0ab, c\\x0ad")
+
+    def test_a_sequence_is_joined_by_charter_and_not_by_python(self):
+        said = news._report("{names}", names=["one.md", "two.md"])
+        self.assertEqual(said, "one.md, two.md")
+
+    def test_the_templates_are_charters_own_text(self):
+        """`str.format` reads the TEMPLATE for `{}` slots and never the values, so a
+        committed value holding braces is data. Asserted rather than assumed, because it
+        is the reason this helper can take a template at all."""
+        said = news._report("{a}", a="{b} {0} {}")
+        self.assertEqual(said, "{b} {0} {}")

--- a/tests/test_a_news_entry_cannot_forge_a_report_line.py
+++ b/tests/test_a_news_entry_cannot_forge_a_report_line.py
@@ -396,6 +396,57 @@ class TheCommandsPrintWhatTheModuleAssembled(NewsDir):
             self._both(SimpleNamespace(for_version=None, pending=True,
                                        since=None, until=None))
 
+    def test_the_pending_view_when_a_probe_could_not_run(self):
+        """A DIFFERENT line of the same view, and the one the case above never reaches.
+        `--pending` prints an adopt line for a PENDING entry and warns for an UNKNOWN one,
+        and the warning is where the slug is interpolated. Mocking every probe to PENDING
+        leaves that branch untouched — which is exactly how its containment read as
+        covered while nothing executed it."""
+        args = SimpleNamespace(for_version=None, pending=True, since=None, until=None)
+        said = {}
+        for label, name_payload, value_payload in (("hostile", _HOSTILE, _HOSTILE_VALUE),
+                                                   ("benign", _BENIGN, _BENIGN)):
+            self.setUp()
+            # A `check:` no CLI resolves: refused before any command function runs, so
+            # `probe` answers UNKNOWN with a reason, and no real probe is dispatched.
+            self.write(f"{_V}-a{name_payload}.md",
+                       _entry(headline=f"h{value_payload}", check="frobnicate --hard"))
+            out, err = io.StringIO(), io.StringIO()
+            with mock.patch.object(commands.config, "HAS_CONTROL_PLANE", True), \
+                 redirect_stdout(out), redirect_stderr(err):
+                commands.cmd_news(args)
+            said[label] = out.getvalue() + err.getvalue()
+        self.assertIn("unchecked", said["hostile"], "the UNKNOWN branch was never reached")
+        self.assertEqual(len(said["hostile"].splitlines()),
+                         len(said["benign"].splitlines()),
+                         f"the hostile fixture changed the shape of the report: "
+                         f"{said['hostile']!r}")
+        self.assertNotIn("\x1b", said["hostile"])
+
+    def test_the_version_a_file_can_really_carry_into_the_range_view(self):
+        """`version:` is printed in that view's own left column, and it is frontmatter.
+
+        A line break cannot reach it — `persona.parse` would make a second key of it — but
+        an escape sequence can, and `update._parse` is deliberately lenient about junk
+        ("anything non-numeric sorts low rather than raising"), so the entry passes the
+        range filter and gets printed. That is the whole path, from a committed file to a
+        repainted terminal, with no step that had to be mocked.
+        """
+        self.write(f"{_V}-a-one.md", _entry(version=f"{_V}{_ESC}", headline="h"))
+        out, err = io.StringIO(), io.StringIO()
+        # `until` is above this version, because `_parse` reads the escape's own digits as
+        # part of the last component ("0\x1b[31m" → 31) and the entry sorts a little high.
+        # That is the leniency doing exactly what its docstring says, and the entry is
+        # still in a range a reader would ask for.
+        args = SimpleNamespace(for_version=None, pending=False,
+                               since="0.59.0", until="0.61.0")
+        with mock.patch.object(news, "probe", return_value=(news.INFORMATIONAL, "")), \
+             redirect_stdout(out), redirect_stderr(err):
+            commands.cmd_news(args)
+        said = out.getvalue()
+        self.assertIn("h", said, "the entry never reached the range view")
+        self.assertNotIn("\x1b", said)
+
 
 class TheGuardIsAtTheAssemblyNotAtTheSpans(unittest.TestCase):
     """What separates this fix from the one #502 argued against.

--- a/tests/test_a_news_key_is_honoured_or_reported.py
+++ b/tests/test_a_news_key_is_honoured_or_reported.py
@@ -297,9 +297,13 @@ class AMiscasedVersionDeletesTheEntryAndCharterSaysSo(NewsDir):
     """
 
     def _lost(self) -> None:
+        """`headline:` is written FIRST on purpose. A search for the miscased key that
+        forgot to filter — `next(k for k in meta)` — picks whichever key the file happens
+        to write first, and a fixture that put `Version:` there would let that pass and
+        report the right key by coincidence."""
         self.write(f"{_V}-a-ordinary.md", _entry(headline="ordinary"))
         self.write(f"{_V}-z-fix.md",
-                   f"---\nVersion: {_V}\nheadline: the one that vanished\n---\n\nb\n")
+                   f"---\nheadline: the one that vanished\nVersion: {_V}\n---\n\nb\n")
 
     def test_the_file_really_does_fall_out_of_every_view(self):
         """The premise. If `_read` ever started returning an entry for this, the class
@@ -323,6 +327,14 @@ class AMiscasedVersionDeletesTheEntryAndCharterSaysSo(NewsDir):
         self.assertIn("Version", why)
         self.assertIn("version:", why)
 
+    def test_and_names_the_key_that_is_wrong_rather_than_the_first_one(self):
+        """The assertion above is satisfied by a search that returns any key at all —
+        `Version` is a substring of the file's own frontmatter either way. This is the one
+        that says charter found the key it was looking for."""
+        self._lost()
+        why, = news.unreadable()
+        self.assertNotIn("headline", why)
+
     def test_and_the_release_gate_refuses(self):
         self._lost()
         rc, out, err = self.gate()
@@ -344,11 +356,14 @@ class AFileThatIsNotAnEntryIsAlsoSaid(NewsDir):
     alone sends a release engineer to open a file and guess."""
 
     def test_a_file_with_no_frontmatter(self):
+        """`key: value` rather than the word "frontmatter": the no-version sentence also
+        contains "frontmatter", so asserting that word alone is satisfied by the wrong
+        sentence — which is how a dropped `if not meta` reads as tested."""
         self.two()
         self.write(f"{_V}-z-notes.md", "just some prose, no frontmatter at all\n")
         why, = news.unreadable()
         self.assertIn("z-notes", why)
-        self.assertIn("frontmatter", why)
+        self.assertIn("`key: value` frontmatter", why)
 
     def test_a_file_whose_frontmatter_declares_no_version(self):
         self.two()
@@ -356,6 +371,16 @@ class AFileThatIsNotAnEntryIsAlsoSaid(NewsDir):
         why, = news.unreadable()
         self.assertIn("z-nover", why)
         self.assertIn("version:", why)
+        self.assertNotIn("`key: value` frontmatter", why)
+
+    def test_and_that_sentence_says_what_a_staged_entry_writes(self):
+        """The edit, not just the diagnosis. An author whose entry names no version is
+        usually one who has not staged it, and `unreleased` is the word they need — a
+        sentence that stops at "no version" leaves them to go and find it."""
+        self.two()
+        self.write(f"{_V}-z-nover.md", "---\nheadline: h\n---\n\nb\n")
+        why, = news.unreadable()
+        self.assertIn(news.UNRELEASED, why)
 
     def test_a_version_declared_with_nothing_after_the_colon(self):
         """The same shape `_flag` answers for an ordering field, one field up. The
@@ -364,6 +389,39 @@ class AFileThatIsNotAnEntryIsAlsoSaid(NewsDir):
         self.write(f"{_V}-z-empty.md", f"---\nversion:\n  {_V}\nheadline: h\n---\n\nb\n")
         why, = news.unreadable()
         self.assertIn("z-empty", why)
+
+    def test_a_file_charter_cannot_decode(self):
+        """Bytes that are not UTF-8. The `except` catching this is a guard like any
+        other: unpinned, it is a clause somebody narrows or widens with nothing to say
+        whether they were right — and here widening it would swallow a real bug while
+        reporting the file as merely undecodable."""
+        self.two()
+        (self.dir / f"{_V}-z-bytes.md").write_bytes(b"---\nversion: 0.60.0\n\xff\xfe\n---\n")
+        why, = news.unreadable()
+        self.assertIn("z-bytes", why)
+        self.assertIn("UnicodeDecodeError", why)
+
+    def test_a_directory_wearing_an_entrys_name(self):
+        """The OSError half, spelled portably. A directory named `<version>-<slug>.md`
+        is matched by the glob and raises `IsADirectoryError` on read — on darwin and on
+        Linux alike, with no permission bit involved, so this is not a case that only
+        fires on the runner or only on a laptop."""
+        self.two()
+        (self.dir / f"{_V}-z-dir.md").mkdir()
+        why, = news.unreadable()
+        self.assertIn("z-dir", why)
+        self.assertIn("Error", why)
+
+    def test_with_no_news_directory_at_all_there_is_nothing_to_report(self):
+        """The refusal at the top of `unreadable`. An installed charter whose wheel
+        carries no entries, and a checkout that is not one, both land here — and without
+        it the glob runs on `None` and the command raises instead of saying nothing."""
+        gone = self.dir / "not-here"
+        with mock.patch.object(news, "_PACKAGED", gone), \
+             mock.patch.object(news, "_CHECKOUT", gone):
+            self.assertIsNone(news._dir())
+            self.assertEqual(news.unreadable(), [])
+            self.assertEqual(news.all(), [])
 
     def test_a_decline_this_version_cannot_explain_still_gets_a_sentence(self):
         """The branch no fixture can reach today, and the reason it is not "whatever the

--- a/tests/test_a_news_key_is_honoured_or_reported.py
+++ b/tests/test_a_news_key_is_honoured_or_reported.py
@@ -374,13 +374,19 @@ class AFileThatIsNotAnEntryIsAlsoSaid(NewsDir):
         self.assertNotIn("`key: value` frontmatter", why)
 
     def test_and_that_sentence_says_what_a_staged_entry_writes(self):
-        """The edit, not just the diagnosis. An author whose entry names no version is
-        usually one who has not staged it, and `unreleased` is the word they need — a
-        sentence that stops at "no version" leaves them to go and find it."""
+        """The edit, not just the diagnosis, and BOTH halves of it.
+
+        An author whose entry names no version is usually one who has not staged it, so
+        the sentence owes them two things: the word to write (`unreleased`) and what takes
+        it off again (`charter news stamp`). A sentence that names only the first tells
+        somebody to write a placeholder and not what ever removes it — which is how a
+        staged entry becomes a permanent one.
+        """
         self.two()
         self.write(f"{_V}-z-nover.md", "---\nheadline: h\n---\n\nb\n")
         why, = news.unreadable()
         self.assertIn(news.UNRELEASED, why)
+        self.assertIn("news stamp", why)
 
     def test_a_version_declared_with_nothing_after_the_colon(self):
         """The same shape `_flag` answers for an ordering field, one field up. The

--- a/tests/test_a_news_key_is_honoured_or_reported.py
+++ b/tests/test_a_news_key_is_honoured_or_reported.py
@@ -1,0 +1,429 @@
+"""#503: a field an author declared is honoured or reported. Never neither.
+
+`news._read` looked its ordering fields up by an exact, case-sensitive key. `persona.parse`
+keeps a key exactly as written, so ``Security: true`` put ``"Security"`` in the dict,
+``meta.get("security")`` returned nothing, and the entry was **absent** — not wrong, not
+reported, absent. It sorted below the ordinary entries, `ordering_errors` returned ``[]``,
+and the release gate exited 0 with an empty stderr.
+
+That is #486's own defect restored by the field added to prevent it, reached through the
+KEY instead of the value. `_flag` was built so a value charter does not understand is
+reported and never read as false; a capitalised key got no such treatment, because there
+was no value to report — the lookup never found one. **The key half fails more quietly than
+the value half**, and the release notes are the one document nobody re-derives, so an entry
+that does not render is indistinguishable from an entry nobody wrote.
+
+**Two answers were defensible and they are not the same.** Accept any case, or refuse
+loudly. This is the second, and the reason is the first one's blast radius in both
+directions:
+
+* Case-folding answers ``Security:`` and nothing else. ``securiy:``, ``leads:``,
+  ``security-fix:`` and ``sec urity:`` parse cleanly, are looked up by nothing, and sink an
+  entry in exactly the same silence. Accepting more spellings is a guard written against a
+  spelling — which is the shape this project keeps filing (#547, #558, #537, #498) — where
+  the property is "was this declaration read by anything?".
+* The dict a fold would have to change is `persona.parse`'s, and it is read by key at every
+  caller: `persona.load`, `structural_errors`, `docsrc`, `news._read`, for ``role:``,
+  ``vault:``, ``delegate-when:``, ``extends:``, ``tools:``. One of those decides which
+  credentials a persona reaches. And a folding parser owes an answer to
+  ``{"Security": "true", "security": "false"}``, which is two keys today (#509).
+* Refusing loudly already has a caller ready to act on it: `charter news --for` exits
+  non-zero for more than "nothing to render" (#486), and `release.yml`'s guard job is built
+  on that exit code.
+
+So `news` declares a CLOSED set of keys and reports anything outside it. Case stops being a
+special case of anything, because there is no longer an unspoken key of any kind — and
+charter never guesses what the author meant, which is the one thing a fold has to do.
+
+The sibling with worse teeth is below: a miscased ``Version:`` does not sink an entry, it
+**deletes** it. `_read` finds no version and returns ``None``, so the file never becomes an
+`Entry` and no per-entry check exists to be asked about it — while `stamped()` answers the
+release guard from FILENAMES and says the version has its entry. `news.unreadable` is that
+half.
+
+Entries here are named by slug in the prose and written into a throwaway directory, never
+by the path of a staged entry: `charter news stamp` renames those during a release, and a
+test that opens one by its staged name goes red in the middle of one.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, news
+
+_V = "0.60.0"
+
+
+def _entry(version: str = _V, headline: str = "important", **fields) -> str:
+    lines = [f"version: {version}", f"headline: {headline}"]
+    lines += [f"{k}: {v}" for k, v in fields.items()]
+    return "---\n" + "\n".join(lines) + "\n---\n\nbody text\n"
+
+
+class NewsDir(unittest.TestCase):
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
+        patch = mock.patch.object(news, "_PACKAGED", self.dir)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def write(self, name: str, text: str) -> None:
+        (self.dir / name).write_text(text)
+
+    def two(self, **fields) -> None:
+        """The issue's own fixture: an ordinary entry named `a-…` and the one that
+        matters named `z-…`, so an entry that fails to be recognised as a security fix
+        stays where the filename put it. A fixture whose right answer is also the
+        alphabetical one cannot fail."""
+        self.write(f"{_V}-a-ordinary.md", _entry(headline="ordinary"))
+        self.write(f"{_V}-z-fix.md", _entry(headline="the security fix", **fields))
+
+    def gate(self, version: str = _V) -> tuple[int, str, str]:
+        """`charter news --for`, which IS `release.yml`'s pre-publish guard."""
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(for_version=version, pending=False, since=None, until=None)
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = commands.cmd_news(args)
+        return rc, out.getvalue(), err.getvalue()
+
+    def headlines(self) -> list[str]:
+        return [ln[4:] for ln in news.render_body(_V).splitlines()
+                if ln.startswith("### ")]
+
+
+class TheIssuesOwnReproduction(NewsDir):
+    """Verbatim from #503, and every assertion in it was true before this change."""
+
+    def test_the_declaration_is_reported_rather_than_returning_nothing(self):
+        self.two(Security="true")
+        why, = news.entry_errors(news.all())
+        self.assertIn("z-fix", why)
+        self.assertIn("Security", why)
+
+    def test_and_the_release_gate_refuses_instead_of_publishing_it_second(self):
+        """The whole point. Before this, `--for` exited 0, printed `### ordinary` first,
+        and the security fix rendered below it — with an empty stderr."""
+        self.two(Security="true")
+        rc, out, err = self.gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("z-fix", err)
+        self.assertEqual(out, "", "a refusal must publish no partial body")
+
+    def test_lead_in_another_case_is_the_same_answer(self):
+        """Both ordering fields, not the one the repro used. A fix applied to `security`
+        alone would be a fix nobody wrote, and a test that only ever names `security`
+        would not know."""
+        self.two(Lead="true")
+        why, = news.entry_errors(news.all())
+        self.assertIn("Lead", why)
+
+    def test_and_so_is_a_shouted_one(self):
+        self.two(SECURITY="true")
+        why, = news.entry_errors(news.all())
+        self.assertIn("SECURITY", why)
+
+    def test_a_leading_space_was_never_the_failure(self):
+        """`persona.parse` strips the key, so ` security:` really does arrive as
+        `security` — the issue says so and it is worth pinning, because a fix aimed at
+        whitespace instead of at the unrecognised key would pass every case above."""
+        self.write(f"{_V}-a-ordinary.md", _entry(headline="ordinary"))
+        self.write(f"{_V}-z-fix.md",
+                   f"---\nversion: {_V}\nheadline: the security fix\n"
+                   f" security: true\n---\n\nb\n")
+        self.assertEqual(news.entry_errors(news.all()), [])
+        self.assertEqual(self.headlines()[0], "security: the security fix")
+
+
+class CharterReportsRatherThanGuessing(NewsDir):
+    """The decision, asserted as behaviour rather than left in a docstring.
+
+    Accepting any case would make `Security: true` a security fix. Refusing makes it a
+    sentence. These are the assertions that tell the two apart, and they are the ones that
+    would go red if somebody "fixed" this later by folding the lookup — which is a thing
+    worth going red for, because the fold is not a superset of this: it decides for the
+    author, and it has to decide again the moment two keys differ only in case (#509).
+    """
+
+    def test_the_entry_is_not_quietly_promoted_to_a_security_fix(self):
+        self.two(Security="true")
+        entry = next(e for e in news.for_version(_V) if e.slug == "z-fix")
+        self.assertFalse(entry.security,
+                         "charter guessed what the author meant instead of saying so")
+        self.assertEqual(news.marker(entry), "")
+
+    def test_the_lookup_that_finds_the_key_is_not_the_one_that_reads_it(self):
+        """The subtler version of the same fold, and the one a later reader is most
+        likely to write: leave the value lookup exact and make only the *unknown-key*
+        check case-insensitive, so `Security:` is "recognised" and therefore not
+        reported. That is silence again, arrived at from the other side — the key is
+        accepted by the check and read by nothing.
+        """
+        self.two(Security="true")
+        got = next(e for e in news.all() if e.slug == "z-fix")
+        self.assertEqual(got.unknown, ("Security",),
+                         "the key was treated as recognised and then read by nothing")
+        self.assertFalse(got.security)
+
+    def test_the_entry_still_ships_rather_than_vanishing(self):
+        """Refusing to parse it would be worse than mis-sorting it: `stamped()` reads
+        filenames, so the release guard would still pass while the notes lost an entry.
+        The entry renders; the declaration is what gets reported."""
+        self.two(Security="true")
+        self.assertIn("the security fix", self.headlines())
+
+    def test_declaring_the_key_correctly_is_still_silent_and_still_works(self):
+        """The counterfactual, and it is not decorative: "every key is unrecognised"
+        passes every assertion above while refusing all 105 shipped entries."""
+        self.two(security="true")
+        self.assertEqual(news.entry_errors(news.all()), [])
+        self.assertEqual(self.headlines()[0], "security: the security fix")
+        self.assertEqual(self.gate()[0], 0)
+
+
+class ANearMissIsTheSameSilenceAndTheSameAnswer(NewsDir):
+    """Why case is not the property. Every key below parses cleanly, is looked up by
+    nothing, and sinks the entry exactly as `Security:` did — so a case-insensitive lookup
+    would have fixed the issue's title and left the issue."""
+
+    def test_each_unrecognised_key_is_reported(self):
+        for key in ("securiy", "leads", "security-fix", "sec urity", "Sécurity",
+                    "security_fix", "securitys"):
+            with self.subTest(key=key):
+                self.setUp()
+                self.two(**{key: "true"})
+                why, = news.entry_errors(news.all())
+                self.assertIn(key, why)
+                self.assertIn("z-fix", why)
+                self.assertEqual(self.gate()[0], 1)
+
+    def test_a_key_from_the_future_is_reported_rather_than_dropped(self):
+        """A field a newer charter reads, in an entry an older charter is rendering. It
+        is not a typo and it is still worth a sentence: this charter is about to publish
+        notes that do not carry what the entry declared."""
+        self.two(embargo="2030-01-01")
+        why, = news.entry_errors(news.all())
+        self.assertIn("embargo", why)
+
+    def test_the_sentence_lists_what_charter_does_read(self):
+        """A near miss is only actionable if the reader can see what they missed. The
+        list comes from `_KNOWN_FIELDS` rather than from prose, so it cannot drift from
+        the set that decides."""
+        self.two(securiy="true")
+        why, = news.entry_errors(news.all())
+        for field in news._KNOWN_FIELDS:
+            self.assertIn(f"`{field}:`", why)
+
+    def test_a_key_that_is_only_a_case_away_gets_the_shorter_sentence(self):
+        """The author has already written the right word. Handing them the whole list to
+        hunt through, for a difference that is not in the letters, is the message failing
+        at the one job it has."""
+        self.setUp()
+        self.two(Security="true")
+        miscased, = news.entry_errors(news.all())
+        self.setUp()
+        self.two(securiy="true")
+        typo, = news.entry_errors(news.all())
+        self.assertIn("only in case", miscased)
+        self.assertNotIn("only in case", typo)
+        self.assertLess(len(miscased), len(typo))
+
+
+class TheSetOfFieldsIsClosedAndEveryNameInItIsRead(NewsDir):
+    """`_KNOWN_FIELDS` is what makes an unknown key answerable, so the set itself has to
+    be honest in both directions.
+
+    A name IN it that `_read` does not actually read is a key charter accepts and then
+    ignores — which is the silence the set exists to remove, wearing a commit. A field
+    `_read` reads that is NOT in it is reported on every entry that declares it, which is
+    loud, wrong, and would stop a release; noisy is the safe direction of that drift, and
+    it is still worth catching here.
+    """
+
+    def test_every_known_field_is_a_field_of_an_entry(self):
+        self.assertTrue(set(news._KNOWN_FIELDS) <= set(news.Entry._fields),
+                        f"{set(news._KNOWN_FIELDS) - set(news.Entry._fields)} is accepted "
+                        f"in frontmatter and is not carried on an Entry")
+
+    def test_every_known_field_declared_alone_changes_the_entry_it_is_declared_on(self):
+        """Read, not merely tolerated. Each field is declared on its own and compared
+        against an entry that declared nothing — so a name added to the set without a
+        reader goes red here rather than being accepted in silence forever."""
+        self.write(f"{_V}-a-bare.md", _entry())
+        bare = news.for_version(_V)[0]
+        values = {"version": "0.61.0", "headline": "another", "check": "doctor",
+                  "adopt": "doctor", "lead": "true", "security": "true"}
+        self.assertEqual(set(values), set(news._KNOWN_FIELDS),
+                         "this test does not know a value for every declarable field")
+        for field in news._KNOWN_FIELDS:
+            with self.subTest(field=field):
+                self.setUp()
+                self.write(f"{_V}-a-bare.md", _entry(**{field: values[field]}))
+                got, = news.all()
+                self.assertNotEqual(getattr(got, field), getattr(bare, field),
+                                    f"`{field}:` is accepted and read by nothing")
+
+    def test_no_known_field_is_ever_reported_as_unknown(self):
+        self.write(f"{_V}-a-all.md",
+                   _entry(check="doctor", adopt="doctor", lead="true", security="false"))
+        got, = news.all()
+        self.assertEqual(got.unknown, ())
+        self.assertEqual(news.entry_errors([got]), [])
+
+    def test_an_entry_that_declares_nothing_extra_carries_no_unknown_keys(self):
+        self.two()
+        for e in news.all():
+            self.assertEqual(e.unknown, ())
+        self.assertEqual(news.entry_errors(news.all()), [])
+
+
+class AMiscasedVersionDeletesTheEntryAndCharterSaysSo(NewsDir):
+    """The sibling with worse teeth, and the reason `unreadable` exists.
+
+    `Security:` sinks an entry. `Version:` removes it: `_read` finds no version and returns
+    ``None``, so there is no `Entry` for `entry_errors` to have an opinion about and the
+    file is dropped before `all`'s consumers see it. The release guard does not notice
+    either — `stamped()` answers from filenames, so a file named `<version>-<slug>.md`
+    satisfies "every published version ships an entry" while rendering into neither the
+    Release body nor `charter news`.
+    """
+
+    def _lost(self) -> None:
+        self.write(f"{_V}-a-ordinary.md", _entry(headline="ordinary"))
+        self.write(f"{_V}-z-fix.md",
+                   f"---\nVersion: {_V}\nheadline: the one that vanished\n---\n\nb\n")
+
+    def test_the_file_really_does_fall_out_of_every_view(self):
+        """The premise. If `_read` ever started returning an entry for this, the class
+        would be testing a shape that no longer exists and should say so here."""
+        self._lost()
+        self.assertEqual([e.slug for e in news.all()], ["a-ordinary"])
+        self.assertNotIn("the one that vanished", news.render_body(_V))
+
+    def test_and_the_filename_still_satisfies_the_stamped_check(self):
+        """Which is why nothing else catches it: the guard that asks "does this version
+        have an entry?" is answered by a name on the disk."""
+        self._lost()
+        with mock.patch.object(news, "_CHECKOUT", self.dir), \
+             mock.patch.object(news, "_is_checkout", return_value=True):
+            self.assertEqual(len(news.stamped(_V)), 2)
+
+    def test_charter_names_the_file_and_the_key(self):
+        self._lost()
+        why, = news.unreadable()
+        self.assertIn("z-fix", why)
+        self.assertIn("Version", why)
+        self.assertIn("version:", why)
+
+    def test_and_the_release_gate_refuses(self):
+        self._lost()
+        rc, out, err = self.gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("z-fix", err)
+        self.assertEqual(out, "")
+
+    def test_a_directory_of_ordinary_entries_reports_nothing(self):
+        """The counterfactual. Without it every assertion above passes on an
+        `unreadable()` that refuses everything."""
+        self.two()
+        self.assertEqual(news.unreadable(), [])
+        self.assertEqual(self.gate()[0], 0)
+
+
+class AFileThatIsNotAnEntryIsAlsoSaid(NewsDir):
+    """`unreadable` is asked over the directory, so the other ways a file lands there and
+    renders as nothing get a sentence too. Each names the edit, because "not an entry"
+    alone sends a release engineer to open a file and guess."""
+
+    def test_a_file_with_no_frontmatter(self):
+        self.two()
+        self.write(f"{_V}-z-notes.md", "just some prose, no frontmatter at all\n")
+        why, = news.unreadable()
+        self.assertIn("z-notes", why)
+        self.assertIn("frontmatter", why)
+
+    def test_a_file_whose_frontmatter_declares_no_version(self):
+        self.two()
+        self.write(f"{_V}-z-nover.md", "---\nheadline: h\n---\n\nb\n")
+        why, = news.unreadable()
+        self.assertIn("z-nover", why)
+        self.assertIn("version:", why)
+
+    def test_a_version_declared_with_nothing_after_the_colon(self):
+        """The same shape `_flag` answers for an ordering field, one field up. The
+        author put the value on the continuation line; charter's frontmatter is flat."""
+        self.two()
+        self.write(f"{_V}-z-empty.md", f"---\nversion:\n  {_V}\nheadline: h\n---\n\nb\n")
+        why, = news.unreadable()
+        self.assertIn("z-empty", why)
+
+    def test_every_reason_is_one_sentence_that_names_the_file(self):
+        """The set of files reported comes from `_read` returning None; only the WORDING
+        is `_not_an_entry`'s. A sixth way for `_read` to decline gets the fallthrough
+        sentence rather than no sentence — which is the property, not the prose."""
+        for name, text in ((f"{_V}-z-a.md", "prose\n"),
+                           (f"{_V}-z-b.md", "---\nheadline: h\n---\n\nb\n"),
+                           (f"{_V}-z-c.md", f"---\nVersion: {_V}\n---\n\nb\n")):
+            with self.subTest(name=name):
+                self.setUp()
+                self.write(name, text)
+                why, = news.unreadable()
+                self.assertEqual(len(why.splitlines()), 1, why)
+                self.assertIn(name.split("-", 1)[1].removesuffix(".md"), why)
+
+
+class TheRangeViewWarnsRatherThanWithholding(NewsDir):
+    """A reader catching up is not a release. Losing them nineteen entries because a
+    twentieth spelled a key wrong would be the wrong trade — `--for` is the call that
+    becomes something permanent, and it is the one that refuses."""
+
+    def _range(self) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(for_version=None, pending=False, since="0.59.0", until=_V)
+        with mock.patch.object(news, "probe", return_value=(news.INFORMATIONAL, "")), \
+             redirect_stdout(out), redirect_stderr(err):
+            rc = commands.cmd_news(args)
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_a_miscased_key_is_warned_about_and_every_entry_still_prints(self):
+        self.two(Security="true")
+        rc, out, err = self._range()
+        self.assertEqual(rc, 0)
+        self.assertIn("Security", err)
+        self.assertEqual(len([ln for ln in out.splitlines() if ln.startswith(_V)]), 2)
+
+    def test_a_file_that_is_not_an_entry_is_warned_about_too(self):
+        self.two()
+        self.write(f"{_V}-z-notes.md", "prose\n")
+        rc, _out, err = self._range()
+        self.assertEqual(rc, 0)
+        self.assertIn("z-notes", err)
+
+
+class WhatShippedDeclaresNothingCharterDoesNotRead(unittest.TestCase):
+    """Over the real news directory, not a fixture. Every entry in the tree declares only
+    keys charter reads, and every file in the directory is an entry.
+
+    This is the assertion that makes the closed set a decision rather than a hope: it is
+    what would have gone red on the commit that added a seventh key without teaching
+    `_read` about it, and it is what says the change refuses nothing that already ships.
+    """
+
+    def test_no_shipped_entry_declares_a_key_charter_does_not_read(self):
+        entries = news.all()
+        self.assertTrue(entries, "no news entries found — this test proves nothing")
+        self.assertEqual([(e.slug, e.unknown) for e in entries if e.unknown], [])
+
+    def test_and_every_file_in_the_directory_is_an_entry(self):
+        self.assertEqual(news.unreadable(), [])
+
+    def test_which_together_is_what_the_release_gate_asks(self):
+        self.assertEqual(news.entry_errors(news.all()), [])

--- a/tests/test_a_news_key_is_honoured_or_reported.py
+++ b/tests/test_a_news_key_is_honoured_or_reported.py
@@ -365,6 +365,20 @@ class AFileThatIsNotAnEntryIsAlsoSaid(NewsDir):
         why, = news.unreadable()
         self.assertIn("z-empty", why)
 
+    def test_a_decline_this_version_cannot_explain_still_gets_a_sentence(self):
+        """The branch no fixture can reach today, and the reason it is not "whatever the
+        last `if` said". The set of reported files comes from `_read`; a fifth way for it
+        to decline would arrive here with none of the four reasons true, and reporting a
+        healthy-looking file as "no `version:`" sends the reader to make an edit that
+        changes nothing and spends the sentence's credibility.
+        """
+        self.write(f"{_V}-z-ok.md", _entry(headline="perfectly fine"))
+        with mock.patch.object(news, "_read", return_value=None):
+            why, = news.unreadable()
+        self.assertIn("z-ok", why)
+        self.assertNotIn("version:", why)
+        self.assertIn("no entry at all", why)
+
     def test_every_reason_is_one_sentence_that_names_the_file(self):
         """The set of files reported comes from `_read` returning None; only the WORDING
         is `_not_an_entry`'s. A sixth way for `_read` to decline gets the fallthrough

--- a/tests/test_news_ordering.py
+++ b/tests/test_news_ordering.py
@@ -115,7 +115,7 @@ class DeclaringNothingChangesNothing(NewsDir):
             self.assertFalse(e.lead)
             self.assertFalse(e.security)
             self.assertEqual(e.bad, ())
-        self.assertEqual(news.ordering_errors(news.for_version(_V)), [])
+        self.assertEqual(news.entry_errors(news.for_version(_V)), [])
 
 
 class ADeclaredOrderBeatsTheFilename(NewsDir):
@@ -193,13 +193,13 @@ class AValueCharterCannotReadIsSaid(NewsDir):
     def test_true_and_false_are_the_two_values(self):
         self.three(**{"z-important": {"security": "true"},
                       "m-middle": {"security": "false"}})
-        self.assertEqual(news.ordering_errors(news.for_version(_V)), [])
+        self.assertEqual(news.entry_errors(news.for_version(_V)), [])
         self.assertEqual(self.release_body_order(),
                          ["security: important", "ordinary", "middle"])
 
     def test_case_is_not_a_spelling_difference(self):
         self.three(**{"z-important": {"security": "TRUE"}})
-        self.assertEqual(news.ordering_errors(news.for_version(_V)), [])
+        self.assertEqual(news.entry_errors(news.for_version(_V)), [])
         self.assertEqual(self.release_body_order()[0], "security: important")
 
     def test_a_value_outside_the_pair_is_reported_rather_than_read_as_false(self):
@@ -207,7 +207,7 @@ class AValueCharterCannotReadIsSaid(NewsDir):
         would accept it and be walked past by the one after that; the property here is
         not which words mean yes but whether the value was UNDERSTOOD."""
         self.three(**{"z-important": {"security": "yes"}})
-        why, = news.ordering_errors(news.for_version(_V))
+        why, = news.entry_errors(news.for_version(_V))
         self.assertIn("z-important", why)
         self.assertIn("yes", why)
         self.assertIn("`true` or `false`", why)
@@ -217,7 +217,7 @@ class AValueCharterCannotReadIsSaid(NewsDir):
         so rather than deciding for the author. This is the codepoint that walks past
         every membership test written against a list of words."""
         self.three(**{"z-important": {"security": "ｔｒｕｅ"}})
-        self.assertTrue(news.ordering_errors(news.for_version(_V)))
+        self.assertTrue(news.entry_errors(news.for_version(_V)))
 
     def test_the_unreadable_value_cannot_forge_a_second_line_of_output(self):
         """A news entry is a committed file, so its frontmatter is untrusted input, and
@@ -228,7 +228,7 @@ class AValueCharterCannotReadIsSaid(NewsDir):
         # at the layer the message is built from — the guard has to hold on the argument
         # it is given, not on the parser upstream of it.
         e = news.for_version(_V)[0]._replace(bad=(("security", "yes\nEVIL: line"),))
-        why, = news.ordering_errors([e])
+        why, = news.entry_errors([e])
         self.assertNotIn("\n", why)
         self.assertIn("EVIL", why)  # shown, escaped — not dropped
 
@@ -292,7 +292,7 @@ class ADeclaredFieldWithNoValueIsUnreadRatherThanUnmade(NewsDir):
 
     def test_a_value_on_the_continuation_line_is_reported_not_read_as_false(self):
         self._important(self._CONTINUATION)
-        why, = news.ordering_errors(news.for_version(_V))
+        why, = news.entry_errors(news.for_version(_V))
         self.assertIn("z-important", why)
         self.assertIn("security", why)
 
@@ -317,7 +317,7 @@ class ADeclaredFieldWithNoValueIsUnreadRatherThanUnmade(NewsDir):
                      f"---\nversion: {_V}\nheadline: important\nsecurity: \n---\n\nb\n"):
             with self.subTest(text=text):
                 self._important(text)
-                self.assertTrue(news.ordering_errors(news.for_version(_V)))
+                self.assertTrue(news.entry_errors(news.for_version(_V)))
 
     def test_lead_declared_empty_is_reported_too(self):
         """Both ordering fields, not just the one the repro used. `_ORDERING_FIELDS` is
@@ -325,7 +325,7 @@ class ADeclaredFieldWithNoValueIsUnreadRatherThanUnmade(NewsDir):
         wrote — but a test that only ever names `security` would not know."""
         self._important(f"---\nversion: {_V}\nheadline: important\nlead:\n  true\n"
                         f"---\n\nb\n")
-        why, = news.ordering_errors(news.for_version(_V))
+        why, = news.entry_errors(news.for_version(_V))
         self.assertIn("lead", why)
 
     def test_the_message_names_the_shape_instead_of_quoting_an_empty_value(self):
@@ -333,7 +333,7 @@ class ADeclaredFieldWithNoValueIsUnreadRatherThanUnmade(NewsDir):
         nothing after it — reads as a rendering bug and tells the author nothing. The
         sentence has to name the line the value went onto, because that is the edit."""
         self._important(self._CONTINUATION)
-        why, = news.ordering_errors(news.for_version(_V))
+        why, = news.entry_errors(news.for_version(_V))
         self.assertNotIn("`security: `", why)
         self.assertIn("`true` or `false`", why)
         self.assertIn("next line", why.casefold())
@@ -347,7 +347,7 @@ class ADeclaredFieldWithNoValueIsUnreadRatherThanUnmade(NewsDir):
             self.assertFalse(e.security)
             self.assertFalse(e.lead)
             self.assertEqual(e.bad, ())
-        self.assertEqual(news.ordering_errors(news.for_version(_V)), [])
+        self.assertEqual(news.entry_errors(news.for_version(_V)), [])
         self.assertEqual(self.release_body_order(),
                          ["ordinary", "middle", "important"])
 
@@ -413,7 +413,7 @@ class TheReleaseGateRefusesAContradiction(NewsDir):
         version would refuse the second release that ever used the field."""
         self.write(f"{_V}-only.md", _entry(_V, "this one", lead="true"))
         self.write("0.61.0-only.md", _entry("0.61.0", "that one", lead="true"))
-        self.assertEqual(news.ordering_errors(news.all()), [])
+        self.assertEqual(news.entry_errors(news.all()), [])
         self.assertEqual(self._for(_V)[0], 0)
         self.assertEqual(self._for("0.61.0")[0], 0)
 
@@ -446,7 +446,7 @@ class WhatShippedStillParses(unittest.TestCase):
     def test_no_shipped_entry_declares_an_order_charter_cannot_honour(self):
         entries = news.all()
         self.assertTrue(entries, "no news entries found — this test proves nothing")
-        self.assertEqual(news.ordering_errors(entries), [])
+        self.assertEqual(news.entry_errors(entries), [])
 
     def test_the_0_52_0_release_leads_with_its_security_fix(self):
         """#486's own case, on real data. 0.52.0 shipped 24 entries and the vault-spending
@@ -546,11 +546,16 @@ class TheGateAnnotationNamesWhatTheGateNowCatches(NewsDir):
     `release.yml`'s pre-publish guard *is* `charter news --for $version`, and until #486
     that call had exactly one way to exit 1 — no entry — so its `::error::` could state
     that as fact and prescribe `charter news stamp $version`. #486 gave it two more: an
-    ordering value charter cannot read, and two entries both claiming `lead: true`.
-    Against either, an annotation naming only the missing entry names a cause that is not
-    the cause and prescribes a command that changes nothing — and stamping a version that
-    is already stamped is a no-op, so the operator's next move produces no new
-    information either.
+    ordering value charter cannot read, and two entries both claiming `lead: true`; #503
+    gave it two after that, a frontmatter key charter does not read (`Security:`,
+    `securiy:`) and a file in `docs/news` that is not an entry at all. Against any of
+    them, an annotation naming only the missing entry names a cause that is not the cause
+    and prescribes a command that changes nothing — and stamping a version that is already
+    stamped is a no-op, so the operator's next move produces no new information either.
+
+    Which is also why the vocabulary the two texts share is no longer the word "ordering".
+    Four of the five causes are not orderings, and a shared word that is true of one cause
+    is the same narrowing that put #486 back through the field added to prevent it.
 
     Three properties, in ascending order of teeth.
 
@@ -589,9 +594,9 @@ class TheGateAnnotationNamesWhatTheGateNowCatches(NewsDir):
                              f"--for {version} was expected to refuse")
         return err.getvalue()
 
-    def test_the_annotation_names_the_ordering_cause_as_well_as_the_missing_entry(self):
+    def test_the_annotation_names_the_declared_cause_as_well_as_the_missing_entry(self):
         self.assertIn("docs/news/", self.annotation)
-        self.assertIn("ordering", self.annotation)
+        self.assertIn("cannot honour", self.annotation)
 
     def test_and_defers_to_the_command_for_which_of_them_it_was(self):
         """Rather than diagnosing. Two causes named in one line is only an improvement if
@@ -601,15 +606,20 @@ class TheGateAnnotationNamesWhatTheGateNowCatches(NewsDir):
     def test_a_missing_entry_prints_the_words_the_annotation_sends_a_reader_to_find(self):
         self.assertIn("news entry", self._stderr_of("9.9.9"))
 
-    def test_an_unhonourable_ordering_prints_them_too(self):
+    def test_a_declaration_charter_cannot_honour_prints_them_too(self):
         """The coupling that makes property 1 more than a word in a YAML file: reword
-        `cmd_news`'s ordering refusal to drop "ordering" and this goes red, because the
+        `cmd_news`'s refusal to drop "cannot honour" and this goes red, because the
         annotation is still sending the reader to look for it.
 
-        Every ordering shape that refuses, not one of them. The sentence the annotation
-        sends the reader to find is `cmd_news`'s wrapper line, and a refusal added later
-        that printed only its own per-entry sentence would leave that reader grepping the
-        log for a word the run never says.
+        Every shape that refuses, not one of them. The sentence the annotation sends the
+        reader to find is `cmd_news`'s wrapper line, and a refusal added later that
+        printed only its own per-entry sentence would leave that reader grepping the log
+        for a word the run never says.
+
+        The last three shapes are #503's, and they are the reason the coupled word is no
+        longer "ordering": `securiy: true` is not an ordering claim, and a file whose key
+        reads `Version:` is not an entry at all — but each of them stops a release, and
+        each has to print the vocabulary the annotation promises.
         """
         shapes = {
             "two entries claim the lead":
@@ -622,11 +632,20 @@ class TheGateAnnotationNamesWhatTheGateNowCatches(NewsDir):
                          self.write(f"{_V}-z-important.md",
                                     f"---\nversion: {_V}\nheadline: important\n"
                                     f"security:\n  true\n---\n\nb\n")),
+            "an ordering field spelled in another case":
+                lambda: self.three(**{"z-important": {"Security": "true"}}),
+            "a key that is a near miss for one charter reads":
+                lambda: self.three(**{"z-important": {"securiy": "true"}}),
+            "a file in the directory that is not an entry":
+                lambda: (self.three(),
+                         self.write(f"{_V}-z-important.md",
+                                    f"---\nVersion: {_V}\nheadline: important\n"
+                                    f"---\n\nb\n")),
         }
         for name, stage in shapes.items():
             with self.subTest(shape=name):
                 stage()
-                self.assertIn("ordering", self._stderr_of(_V))
+                self.assertIn("cannot honour", self._stderr_of(_V))
 
     def test_the_gate_drops_only_the_stream_the_annotation_does_not_point_at(self):
         """stdout is discarded on purpose — it is the Release body, and the guard wants


### PR DESCRIPTION
Closes #502
Closes #503

**One PR, because they are one shape twice.** Both are a value crossing from a committed file into something a person reads, where the code handled one spelling and not its neighbours. They also touch the same four lines: #503's fix *adds* a report sentence that quotes a committed key, which is exactly a #502 span — fixing them apart would mean adding an uncontained sentence and then containing it.

---

## #503 — the key half of a declaration was unenforced

`persona.parse` keeps a key exactly as written. `Security: true` put `Security` in the dict, `meta.get("security")` found nothing, `_flag(None)` answered False, and the entry was **absent** — not wrong, not reported, absent. It rendered below the ordinary entries, `ordering_errors` returned `[]`, and `charter news --for` exited 0 with an empty stderr.

That is #486's own defect restored through the field added to prevent it. The value half was already careful; the key half had no such treatment, and it is the quieter of the two, because an unfound key leaves no value to report.

### The decision: refuse loudly, not accept any case

Both were defensible. This is the second, for three reasons:

1. **Case-folding fixes the title of the issue, not the issue.** It answers `Security:` and nothing else. `securiy:`, `leads:`, `security-fix:` and `sec urity:` all parse cleanly, are looked up by nothing, and sink an entry in exactly the same silence. Accepting more spellings is a guard written against a spelling — the shape this repo keeps filing (#547, #558, #537, #498) — where the property is *"was this declaration read by anything?"*
2. **The blast radius points the wrong way.** The dict a fold would change is `persona.parse`'s, read by key at every caller for `role:`, `vault:`, `delegate-when:`, `extends:`, `tools:`. One of those decides which credentials a persona reaches. #503 says this itself, and it is why the issue was filed rather than folded into #490.
3. **A fold owes an answer this does not.** `{"Security": "true", "security": "false"}` is two keys today (#509). Reporting needs no rule for which wins.

So `news._KNOWN_FIELDS` is a closed set — `version`, `headline`, `check`, `adopt`, `lead`, `security` — and anything outside it is a sentence at the release gate. **charter never guesses which field the author meant.** Case stops being a special case of anything, because no unspoken key of any kind is left.

The alternative design is pinned as a *failing* one: applying `{k.casefold(): v}` to the parsed dict turns 13 tests red, including `test_the_entry_is_not_quietly_promoted_to_a_security_fix`.

### The sibling nobody named, which is worse

`Security:` sinks an entry. **`Version:` deletes it.** `_read` finds no version and returns `None`, so the file is dropped before any consumer sees it and there is no `Entry` for a per-entry check to have an opinion about — while `stamped()` answers the release guard from **filenames**, so `0.60.0-fix.md` satisfies "every published version ships an entry" while rendering into neither the Release body nor `charter news`.

`news.unreadable()` reports every file in the news directory that is not an entry (undecodable bytes, a directory wearing an entry's name, no frontmatter, a miscased `Version:`, a `version:` with nothing after the colon, and a fallthrough for a reason this version cannot name). `--for` gates on it, asked over the whole directory rather than per version, because a file with no readable version has no version to be filtered by.

**Nothing that ships today changes**: all 105 entries in the tree declare only the six keys.

---

## #502 — a filename could write a line of charter's own report

`ordering_errors` contained the ordering **value** and interpolated the committed **filename** three inches away raw. An entry named `0.60.0-a\nEVIL: charter says nothing is wrong.md` printed *two* lines where charter emitted one, the second being the author's sentence in charter's own voice, in the CI log above a release somebody was about to publish.

The issue asked for the guard at the **assembly**, not at the spans somebody enumerated — and that is what caught three spans nobody had listed:

| span | where | committed? |
|---|---|---|
| `{version}` | duplicate-`lead:` message | frontmatter |
| `{check}` | a probe's "did not run" reason | frontmatter |
| `{src} → {dst}` | `news stamp`'s **success** line | filenames, and it runs at every release |

Every sentence `news` writes about an entry now goes through `news._report(template, **fields)`, which bounds every field it is handed and joins a sequence element-by-element with charter's own comma. `commands.py`'s news report lines — slug, headline, `adopt:`, version — are bounded too. Escaped, never dropped.

What no design closes is a call site that writes an f-string instead of calling the helper, so `tests/test_a_news_entry_cannot_forge_a_report_line.py` plants a payload in every span an entry owns and asserts each report is the number of lines charter meant to write — compared against a benign fixture rather than a hard-coded count.

It also pins a structural fact found while writing it: **a frontmatter *value* can never carry a line break**, because `persona.parse` splits the block into lines before partitioning on the colon. So the file-borne line break lives in the *filename*; the value-borne one is the half that ends no line (an escape sequence, a zero-width joiner) or has to be planted at the layer the sentence is built from. If that ever stops being true, the class saying so goes red instead of the fixtures silently testing nothing.

---

## Renames and couplings

- `news.ordering_errors` → `news.entry_errors`. Three of the things it reports are not orderings, and the narrower name is how the next finding ends up somewhere else, reported by nobody.
- `release.yml`'s `::error::` annotation and `cmd_news`'s wrapper line now share the phrase **"cannot honour"** rather than "ordering" — four of the five causes are not orderings. `TheGateAnnotationNamesWhatTheGateNowCatches` pins the two texts to each other and covers the new causes; `test_a_new_refusal_is_a_new_sentence`'s `return 1` count is unchanged (2), because these went behind the existing gate rather than adding one.
- `CONTRIBUTING.md` says the six keys are the whole set and are matched exactly.

## Verification

**Full suite, two environments.** Python 3.14.4 — 6418 tests, OK. Python 3.12.13 with `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset (asserted empty in the child, not merely passed `-u`) — 6418 tests, OK. Baseline on the merge-base was 6355; +63 new tests, none of which skips.

**`tools/sweep.py`, twice.** First run: 35 mutations, **8 survivors**, every one a line this branch added — including two containment call sites that read as covered while nothing executed them (the pending view's UNKNOWN branch was mocked away; every range-view fixture carried a benign `version:`). All eight are now killed, verified by re-applying the sweep's own exact mutant. The three that shared `_not_an_entry` were also checked in **every pair and all four together**, since guards in sequence mask each other. Second run at the fixed head: 37 mutations, **1 survivor** — a trailing term of the no-version sentence, pinned rather than deleted because it is the half that says what takes an entry off `unreleased`. It dies now too.

**Hand-checked**, since the tool has no operator for string constants or semantic swaps (#569): `_report` not containing → 16 red; `commands.py` spans raw → 3 red; `_read` never recording an unknown key → 15 red; `entry_errors` dropping the unknown-key loop → 15 red; `cmd_news` not asking `unreadable()` → 2 red; the two key sentences collapsed into one → 1 red; the sequence branch removed from `_report` → 2 red; the unknown-key check made case-insensitive → 7 red; **the whole alternative design (case-fold the parsed dict) → 13 red.**

Both issue reproductions run verbatim: #502's is one physical line with the payload escaped and shown; #503's reports the declaration and `--for` exits 1.

## Found and filed rather than folded in

- **#575** — the same key-half silence in `persona.parse`'s other callers, where `Borrows: none` **fails open**: `borrows_of` returns `None` for an absent key by design, `None` means "keep the legacy `uses:` grant", so a persona that wrote the word granting nothing gets both borrowed personas' tools auto-approved with `structural_errors` returning `[]`. Reproduced.
- **#576** — `contain._sentence` and `news._report` are two private copies of "contain the sentence as it is assembled", with two different budgets and two answers to "what about a list?". This repo's own argument about two copies applies to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)