### PR TITLE
The sweep's trace map compares paths, so it is handed one spelling of them (#572)

### DIFF
--- a/docs/news/unreleased-the-deletion-sweep-can-sweep-on-macos.md
+++ b/docs/news/unreleased-the-deletion-sweep-can-sweep-on-macos.md
@@ -1,0 +1,60 @@
+---
+version: unreleased
+headline: The deletion sweep can sweep on macOS, where its default workdir made it match nothing at all
+---
+
+`python3 tools/sweep.py` — the plain invocation, the one in its own docstring — could not
+sweep on macOS. It traced all 329 test modules, took ten minutes doing it, and then said:
+
+```
+  ! the trace produced 0 file(s) and 0 broken module(s). The map is not usable:
+RuntimeError: the selection map is empty — refusing to sweep blind
+```
+
+`0 broken modules` was the whole diagnosis, and nothing said so. Every runner had loaded
+its suite, run it, and reported no error. The tracer simply matched nothing.
+
+**Because a path was compared in two spellings.** The selection map is built by matching
+each traced `co_filename` against a prefix taken from the sandbox root. The trace runner
+puts `os.getcwd()` on `sys.path`, and the kernel answers that with every symlink already
+resolved — so `co_filename` is always the resolved spelling. The default workdir is
+`$TMPDIR`; macOS spells that `/var/folders/…`, and `/var` is a symlink to `/private/var`.
+Every filename began `/private/var/…` and every prefix began `/var/…`. `startswith` was
+never once true.
+
+So the tool's default was the one spelling of that path guaranteed not to work, and it
+was usable only when corrected: `--workdir /private/tmp/somewhere` was the workaround.
+
+**One normalisation now, at every boundary.** The repository root, the workdir,
+`--workdir`, every sandbox and the root the map is measured against all come through the
+same call. A `resolve()` at one site and a raw path at another is the same bug in a
+different spelling — this one survived precisely because the map's *keys* were resolved
+on both sides while the prefix that chose them was not, so the map looked right in every
+respect except that it was empty.
+
+**The refusal stands, and now it says which empty it is.** A map that measured nothing is
+still a hard stop; the alternative is sending every mutation to the full suite and calling
+a hundredfold slowdown a success. What is new is that the tool distinguishes the two ways
+to get there — modules that would not load, which it names, from a tracer that matched
+nothing, which it diagnoses:
+
+```
+  !   every module loaded and ran, so the tracer matched none of what
+  !   they executed. These two are one directory or they are nothing:
+  !     matched against : /var/folders/wl/…/charter-sweep-855eddc2fb8a/ref/
+  !     the runners ran : /private/var/folders/wl/…/charter-sweep-855eddc2fb8a/ref
+```
+
+The second line is measured by the runners rather than assumed by the caller, which is
+what turns ten minutes and a stack trace into one glance.
+
+**And it is pinned by a test that fails on Linux too.** The case builds its own symlink
+rather than relying on `$TMPDIR` being one, so a `resolve()`-less trace map goes red on
+any platform. That is the part that was missing: this is not a bug CI could have caught,
+and a case that merely asserted the map came back non-empty would have passed on CI
+forever. The trace map went from 0 of its 9 guards pinned to 8 (#569), which matters more
+than it sounds — a silent narrowing there does not produce a wrong answer, it produces
+*confident* ones, since a mutation run against too few tests survives nothing and scores
+"pinned".
+
+Nothing to adopt — it is a tool in the repository, not a change to charter.

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1085,6 +1085,279 @@ class TheMapIsCachedAgainstTheTreeItMeasured(unittest.TestCase):
         self.assertNotEqual(before, sweep.tree_hash(self.tmp, ("charter",)))
 
 
+_TRACED_SOURCE = """\
+def work():
+    return 1
+
+
+def other():
+    return 2
+"""
+
+_TRACED_TEST = """\
+import unittest
+
+from pkg import thing
+
+
+class T(unittest.TestCase):
+    def test_it(self):
+        self.assertEqual(thing.work(), 1)
+        self.assertEqual(thing.other(), 2)
+"""
+
+
+#: A module the loader cannot turn into a suite. What it raises has to be something OTHER
+#: than an `ImportError`: `loadTestsFromName` catches those and hands back a suite holding
+#: one failing test, which is a red suite and not a broken module. Anything else comes
+#: straight back out of the import, which is what `build_map` counts.
+_WILL_NOT_LOAD = "raise RuntimeError('this module cannot be imported')\n"
+
+
+def _mini_tree(where: Path, good: int = 1, broken: int = 0) -> Path:
+    """A repository small enough to trace in a subprocess and real enough to trace.
+
+    `build_map` measures by *running* the tests, one module per process, so none of this
+    can be faked with a stub: the tree needs a package the tests import, a `tests/` the
+    loader can find by name, and functions the tracer can watch being called.
+    """
+    (where / "pkg").mkdir(parents=True)
+    (where / "tests").mkdir()
+    (where / "pkg" / "__init__.py").write_text("")
+    (where / "pkg" / "thing.py").write_text(_TRACED_SOURCE)
+    (where / "tests" / "__init__.py").write_text("")
+    for i in range(good):
+        (where / "tests" / f"test_good{i:02d}.py").write_text(_TRACED_TEST)
+    for i in range(broken):
+        (where / "tests" / f"test_broken{i:02d}.py").write_text(_WILL_NOT_LOAD)
+    return where
+
+
+class _Traced(unittest.TestCase):
+    """A miniature tree, plus a second name for it that goes through a symlink."""
+
+    good = 1
+    broken = 0
+
+    def setUp(self):
+        # Resolved, so that the fixture's own `$TMPDIR` cannot be what makes a case here
+        # pass or fail. The only symlink in play is the one this class makes on purpose.
+        self.tmp = Path(tempfile.mkdtemp(prefix="charter-sweep-trace-")).resolve()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.tree = _mini_tree(self.tmp / "tree", self.good, self.broken)
+        self.link = self.tmp / "reached-through-here"
+        self.link.symlink_to(self.tree, target_is_directory=True)
+        self.log: list[str] = []
+        self._scratches = 0
+
+    def build(self, root=None, jobs=1):
+        self._scratches += 1
+        return sweep.build_map(self.tree if root is None else root, ("pkg",), jobs,
+                               self.tmp / f"scratch{self._scratches}", log=self.log.append)
+
+    @property
+    def logged(self) -> str:
+        return "\n".join(self.log)
+
+
+class TheMapIsMeasuredThroughEverySpellingOfItsRoot(_Traced):
+    """The tracer COMPARES paths, so the root it is handed has to be one spelling.
+
+    The trace runner puts `os.getcwd()` on `sys.path` and the kernel answers that with
+    every symlink already resolved, so `co_filename` is always the resolved spelling. A
+    prefix built from a root that still carries a symlink matches nothing at all — and
+    that is not an exotic case, it is the DEFAULT: `tempfile.gettempdir()` on macOS is
+    `/var/folders/…` and `/var` is a symlink to `/private/var`. Measured (#572): 329
+    modules traced, 0 files, 0 broken modules, and the tool refused to sweep at all.
+
+    The symlink below is made explicitly rather than inherited from `$TMPDIR`, so these
+    cases go red on a `resolve()`-less `build_map` on Linux too. A case that only
+    asserted the map came back non-empty would have passed on CI forever.
+    """
+
+    def test_a_root_reached_through_a_symlink_still_measures_what_ran(self):
+        found = self.build(self.link)
+        self.assertIn("pkg/thing.py::work", found)
+        self.assertEqual(found["pkg/thing.py::work"], ["tests.test_good00"])
+
+    def test_the_spelling_of_the_root_cannot_change_the_map(self):
+        """The strong form: not merely non-empty, the SAME map either way. A prefix is an
+        implementation detail of the measurement and must not be visible in its answer."""
+        self.assertEqual(self.build(self.link), self.build(self.tree))
+
+    def test_the_map_is_keyed_by_file_and_by_function(self):
+        """File alone is far too coarse in a tree where everything imports `layout`, and
+        function alone loses the `<lambda>`s and comprehension frames `select_for` falls
+        back on. The map carries both keys or the selection narrows in silence."""
+        found = self.build()
+        self.assertIn("pkg/thing.py", found)
+        self.assertIn("pkg/thing.py::other", found)
+
+
+class AnUnusableMapSaysWhichKindOfUnusable(_Traced):
+    """`0 file(s) and 0 broken module(s)` was the entire diagnosis of #572 — the tool had
+    it, printed it, and left the operator with nowhere to go from it.
+
+    The refusal is not softened here. A map that measured nothing still stops the sweep,
+    because the alternative is sending every mutation to the full suite and calling a
+    hundredfold slowdown a success. What changes is that it now says which of the two
+    failures it hit, and the failure that hides — the tracer matching nothing at all —
+    prints the two paths that had to be one path.
+    """
+
+    def test_a_tracer_that_matched_nothing_prints_both_spellings(self):
+        (self.tree / "tests" / "test_good00.py").write_text("import unittest\n")
+        with self.assertRaisesRegex(RuntimeError, "refusing to sweep blind"):
+            self.build()
+        self.assertIn("every module loaded and ran", self.logged)
+        self.assertIn(f"matched against : {self.tree}{os.sep}", self.logged)
+        # Measured by the runner, not assumed by the caller: this line is the one that
+        # would have shown `/private/var/…` against a `/var/…` prefix in a single glance.
+        self.assertIn(f"the runners ran : {self.tree}", self.logged)
+
+    def test_modules_that_would_not_load_are_named_instead(self):
+        """The other way to an empty map, and it wants the opposite thing done about it.
+        Printing a prefix here would be a red herring; the traceback is the answer."""
+        (self.tmp / "tree" / "tests" / "test_broken00.py").write_text(_WILL_NOT_LOAD)
+        with self.assertRaisesRegex(RuntimeError, "refusing to sweep blind"):
+            self.build()
+        self.assertIn("tests.test_broken00", self.logged)
+        self.assertNotIn("matched against", self.logged)
+
+    def test_a_runner_that_writes_nothing_is_a_broken_module_and_not_a_crash(self):
+        """A trace runner that dies before writing its JSON leaves no file at all. That
+        is a module this sweep could not measure, which the map already knows how to
+        report — it is not an exception for the whole run to die on."""
+        self.addCleanup(setattr, sweep, "_TRACE_RUNNER", sweep._TRACE_RUNNER)
+        sweep._TRACE_RUNNER = "import sys\nsys.exit(0)\n"
+        with self.assertRaisesRegex(RuntimeError, "refusing to sweep blind"):
+            self.build()
+        self.assertIn("the trace runner wrote nothing", self.logged)
+
+
+class TheTraceReportsWhatItMeasuredAsItGoes(_Traced):
+    good = 40
+
+    def test_a_minority_of_modules_that_will_not_load_is_a_note_and_not_a_refusal(self):
+        """Under a quarter broken is a usable map with a hole in it, and the hole is
+        stated: those files fall back to the full suite, which is slower and correct."""
+        (self.tmp / "tree" / "tests" / "test_broken.py").write_text(_WILL_NOT_LOAD)
+        found = self.build(jobs=4)
+        self.assertIn("pkg/thing.py::work", found)
+        self.assertIn("1 module(s) would not load", self.logged)
+
+    def test_the_trace_says_how_far_it_has_got(self):
+        """Tracing the real tree is 329 processes and ten minutes. A tool that prints
+        nothing for ten minutes cannot be told from a hung one, and gets killed."""
+        self.build(jobs=4)
+        self.assertIn("traced 40/40 modules", self.logged)
+
+
+class TheMapIsRetracedOnlyWhenItHasTo(_Traced):
+    """`cached.exists() and not refresh` — both halves, because either one alone is a
+    different tool: without the first it reads a cache that is not there, and without the
+    second `--refresh-map` hands back the very map the operator asked it to throw away."""
+
+    def cache(self):
+        return self.tmp / "cache"
+
+    def load(self, refresh=False):
+        return sweep.load_map(self.tree, ("pkg",), self.cache(), 1, refresh,
+                              log=self.log.append)
+
+    def test_the_first_call_traces_and_the_second_reads_what_it_wrote(self):
+        first = self.load()
+        self.assertIn("pkg/thing.py::work", first)
+        self.log.clear()
+        self.assertEqual(self.load(), first)
+        self.assertIn("cached", self.logged)
+
+    def test_refreshing_re_traces_even_though_the_cache_is_sitting_there(self):
+        fresh = self.load()
+        stale = next(iter(self.cache().glob("selection-*.json")))
+        stale.write_text('{"pkg/stale.py": ["tests.test_gone"]}')
+        self.assertEqual(self.load(refresh=True), fresh)
+
+
+class TheWorkdirIsOutsideTheTreeAndHasNoSymlinkInIt(unittest.TestCase):
+    """#572 at the exact place it bit: the DEFAULT workdir, which nobody passes.
+
+    `--workdir /private/tmp/…` was the published workaround, and that is another way of
+    saying the default was the one spelling of this path that could not work — the tool
+    was unusable as invoked and usable only as corrected. `$TMPDIR` is not this tool's to
+    choose, so the resolving is.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="charter-sweep-workdir-")).resolve()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        (self.tmp / "real").mkdir()
+        self.link = self.tmp / "tmp-through-a-symlink"
+        self.link.symlink_to(self.tmp / "real", target_is_directory=True)
+
+    def _tmpdir_is_a_symlink(self):
+        """Exactly the shape macOS ships: `$TMPDIR` names a directory through a link."""
+        self.addCleanup(setattr, tempfile, "tempdir", tempfile.tempdir)
+        tempfile.tempdir = str(self.link)
+
+    def test_the_default_workdir_is_resolved_even_when_tmpdir_is_a_symlink(self):
+        self._tmpdir_is_a_symlink()
+        where = sweep.workdir_for(self.tmp / "checkout", None)
+        self.assertEqual(where.parent, self.tmp / "real")
+
+    def test_an_explicit_workdir_is_resolved_the_same_way(self):
+        """`--workdir` is the escape hatch, so it is the last place to leave unnormalised
+        — and resolving it also makes a relative one mean what the operator meant."""
+        where = sweep.workdir_for(self.tmp / "checkout", str(self.link / "here"))
+        self.assertEqual(where, self.tmp / "real" / "here")
+
+    def test_one_checkout_reached_by_two_names_gets_one_workdir(self):
+        """The digest is the cache key. Taken from an unresolved root, the same tree
+        traced from two spellings would pay for the map twice and share neither."""
+        checkout = self.tmp / "real"
+        self.assertEqual(sweep.workdir_for(checkout, None),
+                         sweep.workdir_for(self.link, None))
+
+
+class TheSandboxIsOneSpellingOfOnePath(unittest.TestCase):
+    """A sandbox's path becomes the trace runners' `cwd` and the root the map is measured
+    against, which makes it the last place a symlink can get in — `--workdir` under a
+    linked directory is #572 by another route and nothing downstream can tell them
+    apart."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="charter-sweep-box-")).resolve()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.repo = self.tmp / "repo"
+        (self.repo / "charter").mkdir(parents=True)
+        (self.repo / "charter" / "m.py").write_text("x = 1\n")
+        # Sealed off from the machine's git, for the reason `TheDiffIsReadWithNoContext`
+        # gives: a global hooksPath or signing key would run this fixture through whatever
+        # the developer happens to have installed.
+        env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_SYSTEM=os.devnull,
+                   GIT_CONFIG_NOSYSTEM="1", GIT_TERMINAL_PROMPT="0")
+
+        def run(*a):
+            subprocess.run(("git", "-c", "core.hooksPath=", "-c", "commit.gpgsign=false")
+                           + a, cwd=self.repo, check=True, env=env, timeout=60,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        run("init", "-q", "-b", "main")
+        run("config", "user.email", "sweep@example.invalid")
+        run("config", "user.name", "sweep")
+        run("add", "-A")
+        run("commit", "-qm", "base")
+        self.head = sweep.git("rev-parse", "HEAD", cwd=self.repo).strip()
+        (self.tmp / "boxes").mkdir()
+        self.link = self.tmp / "boxes-through-a-symlink"
+        self.link.symlink_to(self.tmp / "boxes", target_is_directory=True)
+
+    def test_a_sandbox_asked_for_under_a_symlink_reports_where_it_really_is(self):
+        box = sweep.Sandbox(self.repo, self.link / "w0", self.head, {})
+        self.assertEqual(box.path, self.tmp / "boxes" / "w0")
+        self.assertEqual((box.path / "charter" / "m.py").read_text(), "x = 1\n")
+
+
 class TheReportNamesTheMaskingRisk(unittest.TestCase):
     def _result(self, line, symbol):
         m = sweep.Mutation(path="charter/frame/layout.py", line=line, end_line=line,

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -112,6 +112,29 @@ def platform_caveat(mutation: "Mutation") -> str:
     return hit[0] if hit else ""
 
 
+def resolved(path: Path | str) -> Path:
+    """*path*, absolute and with every symlink taken out of it.
+
+    One spelling, applied at every boundary, because a path this tool merely *joins* is
+    harmless and a path it *compares* is not. The selection map is built by matching each
+    traced `co_filename` against a prefix, and `co_filename` is written by the import
+    system from whatever `sys.path` entry the module was found under — which, for the
+    trace runner, is `os.getcwd()`. The kernel's answer to that never contains a symlink.
+    So a prefix built from a path that still has one in it matches **nothing, ever**.
+
+    Measured (#572): the default workdir is `$TMPDIR`, macOS spells that
+    `/var/folders/…`, `/var` is a symlink to `/private/var`, and a sweep on macOS traced
+    all 329 test modules, matched not one file, and refused. The guard held; ten minutes
+    of tracing bought a hard stop and no diagnosis.
+
+    A `resolve()` at one site and a raw path at another is the same bug in a different
+    spelling, so this is the only normalisation there is: the repository root, the
+    workdir, every sandbox and the root the map is measured against all come through
+    here, and everything below them is repo-relative and joined rather than compared.
+    """
+    return Path(path).resolve()
+
+
 # --------------------------------------------------------------------------------------
 # 1. Scoping: which lines is this branch answerable for
 # --------------------------------------------------------------------------------------
@@ -572,6 +595,13 @@ module, out_path, prefix = sys.argv[1], sys.argv[2], sys.argv[3]
 # tree under test. Without this the import of every `tests.*` module fails, the tracer
 # sees nothing, and the map comes back empty — which still produces correct answers, by
 # sending every mutation to the full suite, and takes a hundred times as long to do it.
+#
+# This line also decides how every `co_filename` below is SPELLED. The import system
+# copies the `sys.path` entry a module was found under into its code objects, and
+# `os.getcwd()` is the kernel's answer, which has no symlinks left in it. `prefix` is
+# matched against those names raw — resolving one per call event would put a syscall on
+# the hottest path in this tool — so the caller resolves it once instead (`resolved`),
+# and #572 is what happens when it does not.
 sys.path.insert(0, os.getcwd())
 seen = set()
 error = ""
@@ -613,7 +643,10 @@ if suite is not None:
         threading.settrace(None)
 
 with open(out_path, "w") as fh:
-    json.dump({"files": sorted(seen), "error": error}, fh)
+    # `cwd` is reported because it is the ground truth for the spelling above — the
+    # directory the tracer's filenames are actually written against. The one moment
+    # anybody needs it is the moment the map refuses itself.
+    json.dump({"files": sorted(seen), "error": error, "cwd": os.getcwd()}, fh)
 '''
 
 
@@ -637,15 +670,22 @@ def test_modules(root: Path) -> list[str]:
 def build_map(root: Path, paths: tuple[str, ...], jobs: int, scratch: Path,
               log=print) -> dict[str, list[str]]:
     """``{source file: [test modules that execute it]}``, measured once."""
+    # Before anything is compared against it. `prefix` below is matched against filenames
+    # the interpreter spelled for itself, and it is the caller's spelling of this path
+    # that decides whether the two can ever meet — see :func:`resolved`.
+    root = resolved(root)
     modules = test_modules(root)
     scratch.mkdir(parents=True, exist_ok=True)
     runner = scratch / "_trace_runner.py"
     runner.write_text(_TRACE_RUNNER)
     prefix = str(root) + os.sep
     hits: dict[str, list[str]] = {}
+    #: Where the runners say they ran, as they measured it rather than as this side
+    #: assumed it. Only ever read when the map has already refused itself.
+    ran_in: set[str] = set()
     done = 0
 
-    def one(module: str) -> tuple[str, list[str], str]:
+    def one(module: str) -> tuple[str, list[str], str, str]:
         out = scratch / f"{module}.json"
         subprocess.run([sys.executable, str(runner), module, str(out), prefix],
                        cwd=str(root), check=False, timeout=SUBSET_TIMEOUT,
@@ -653,20 +693,26 @@ def build_map(root: Path, paths: tuple[str, ...], jobs: int, scratch: Path,
         try:
             payload = json.loads(out.read_text())
         except (OSError, ValueError):
-            return module, [], "the trace runner wrote nothing"
-        return module, payload["files"], payload["error"]
+            return module, [], "the trace runner wrote nothing", ""
+        return module, payload["files"], payload["error"], payload["cwd"]
 
     broken: list[str] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
-        for module, files, error in pool.map(one, modules):
+        for module, files, error, cwd in pool.map(one, modules):
             done += 1
             if done % 40 == 0:
                 log(f"    traced {done}/{len(modules)} modules")
             if error:
                 broken.append(f"{module}: {error.strip().splitlines()[-1]}")
+            ran_in.add(cwd)
             for f in files:
                 name, _, symbol = f.partition("::")
-                rel = Path(name).resolve().relative_to(root.resolve()).as_posix()
+                # Lexical, and it cannot fail: the runner only reported names that start
+                # with `prefix`, which is this `root` and a separator. Resolving either
+                # side again here is the move that made the bug survivable in the first
+                # place — it made the KEYS come out right while the prefix that chose
+                # them was wrong, so the map looked correct in every way except empty.
+                rel = Path(name).relative_to(root).as_posix()
                 hits.setdefault(f"{rel}::{symbol}" if symbol else rel, []).append(module)
 
     # An empty or near-empty map is a broken map, not a tree with no coverage, and it is
@@ -676,8 +722,19 @@ def build_map(root: Path, paths: tuple[str, ...], jobs: int, scratch: Path,
     if len(hits) < 2 or len(broken) > len(modules) // 4:
         log(f"  ! the trace produced {len(hits)} file(s) and {len(broken)} broken "
             f"module(s). The map is not usable:")
-        for line in broken[:3]:
-            log(f"  !   {line}")
+        # Which of the two it is decides what to do about it, and the counts alone leave
+        # the operator nowhere. `0 broken` is the tell: every runner loaded its suite,
+        # ran it, reported no error, and the tracer still matched nothing — that is a
+        # prefix that cannot match, not a tree without coverage. It is what #572 looked
+        # like from the outside, and comparing the two spellings below IS the diagnosis.
+        if broken:
+            for line in broken[:3]:
+                log(f"  !   {line}")
+        else:
+            log("  !   every module loaded and ran, so the tracer matched none of what")
+            log("  !   they executed. These two are one directory or they are nothing:")
+            log(f"  !     matched against : {prefix}")
+            log(f"  !     the runners ran : {'; '.join(sorted(ran_in))}")
         raise RuntimeError("the selection map is empty — refusing to sweep blind")
     if broken:
         log(f"  selection map: {len(broken)} module(s) would not load; "
@@ -790,7 +847,11 @@ class Sandbox:
     """A private clone of the tree. The operator's checkout is never written to."""
 
     def __init__(self, root: Path, where: Path, ref: str, dirty: dict[str, bytes]):
-        self.path = where
+        # Resolved on the way in, once. Everything downstream hangs off this path — the
+        # `cwd` the trace runners are given, the prefix the tracer matches against, the
+        # keys of the selection map — and a symlink surviving into any one of them is
+        # #572 again, in a different spelling.
+        self.path = where = resolved(where)
         if where.exists():
             shutil.rmtree(where)
         where.parent.mkdir(parents=True, exist_ok=True)
@@ -1358,7 +1419,28 @@ def as_json(results: list[Result]) -> str:
 # --------------------------------------------------------------------------------------
 
 def repo_root(start: Path) -> Path:
-    return Path(git("rev-parse", "--show-toplevel", cwd=start).strip())
+    return resolved(git("rev-parse", "--show-toplevel", cwd=start).strip())
+
+
+def workdir_for(root: Path, override: str | None) -> Path:
+    """Where the sandboxes and the trace cache live.
+
+    Outside the checkout, always. Sandboxes and a trace cache are not the working tree's
+    business, `.git` is a FILE and not a directory in a linked worktree, and a sweep run
+    from one worktree must not write into the repository another is using.
+
+    And resolved, which is the load-bearing half. `tempfile.gettempdir()` is `$TMPDIR`;
+    macOS spells that `/var/folders/…` and `/var` is a symlink to `/private/var`. So the
+    DEFAULT workdir was the one path in this tool guaranteed to carry a symlink down into
+    the selection map, and on macOS the tool could not sweep at all (#572). An explicit
+    `--workdir` gets the same treatment, which also makes a relative one mean what the
+    operator meant. The digest is taken from the resolved root, so one checkout reached
+    by two names gets one workdir and one cache instead of two.
+    """
+    if override:
+        return resolved(override)
+    digest = hashlib.sha256(str(resolved(root)).encode()).hexdigest()[:12]
+    return resolved(Path(tempfile.gettempdir()) / f"charter-sweep-{digest}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1399,12 +1481,7 @@ def main(argv: list[str] | None = None) -> int:
                                         cwd=root, check=False).strip() else "main"
         base = git("merge-base", ref, upstream, cwd=root).strip()
 
-    # Outside the checkout, always. Sandboxes and a trace cache are not the working
-    # tree's business, `.git` is a FILE and not a directory in a linked worktree, and a
-    # sweep run from one worktree must not write into the repository another is using.
-    workdir = Path(args.workdir) if args.workdir else (
-        Path(tempfile.gettempdir())
-        / f"charter-sweep-{hashlib.sha256(str(root).encode()).hexdigest()[:12]}")
+    workdir = workdir_for(root, args.workdir)
     workdir.mkdir(parents=True, exist_ok=True)
     cache_dir = workdir / "cache"
 


### PR DESCRIPTION
`python3 tools/sweep.py` — the plain invocation, the one in the tool's own docstring —
could not sweep on macOS. It traced all 329 test modules, spent ten minutes doing it, and
refused with `0 file(s) and 0 broken module(s)`.

The refusal is not weakened here. It was the harness working; what it could not do was
say what it had found.

## The cause, confirmed by measurement rather than by reading

Reproduced in a fixture rather than taken from the issue — a miniature tree, reached
through a symlink made on purpose, so the same construction fails on Linux too:

```
link      : /var/folders/wl/…/probe-oejhnusw/link
resolved  : /private/var/folders/wl/…/probe-oejhnusw/real

  ! the trace produced 0 file(s) and 0 broken module(s). The map is not usable:
RuntimeError: the selection map is empty — refusing to sweep blind
```

`build_map` took `prefix` from the sandbox path **as the caller spelled it**. The trace
runner puts `os.getcwd()` on `sys.path`, and the kernel answers that with every symlink
already gone — so the import system writes the resolved spelling into every
`co_filename`. The default workdir is `$TMPDIR`; macOS spells that `/var/folders/…` and
`/var` is a symlink to `/private/var`. Every filename began `/private/var/…`, every
prefix began `/var/…`, and `startswith` was never once true.

**Why it survived being written.** The map's keys were built with
`Path(name).resolve().relative_to(root.resolve())` — both sides resolved. Every part of
the map that a reader would check was correct; the only wrong part was the prefix that
decided which files got in. A map that is right about everything except which files it
contains looks exactly like a map.

## Every place a path is compared, not just the one that bit

The rule now is one call, `resolved()`, at every boundary a path *enters* by, and
repo-relative joins below that. The audit, in full:

| where | what it is | now |
|---|---|---|
| `repo_root` | the checkout | `resolved` on the way out of `git rev-parse` |
| `workdir_for` | `$TMPDIR` default **and** `--workdir` | `resolved`; also makes a relative `--workdir` mean what was meant |
| `Sandbox.path` | the runners' `cwd`, the map's root | `resolved` in `__init__` |
| `build_map(root)` | what `prefix` is built from | `resolved` first thing |
| map keys | `{rel: [modules]}` | repo-relative, `relative_to(root)`, lexical |
| `Mutation.path` | mutation targets | repo-relative already — `git diff` output, or `relative_to(root)` |
| report / `--json` | what a reviewer reads | `Mutation.path`, unchanged |
| everything else | `evidence_for`, `_blob_at`, `dirty_files`, `tree_hash`, sandbox writes | **joins**, never compares — safe either way, and left alone |

Two consequences worth stating rather than burying:

* **The map keys stopped resolving.** `resolved(name).relative_to(root)` is now
  `Path(name).relative_to(root)`. The runner only reports names that *start with*
  `prefix`, which is this root and a separator, so the split is lexical and cannot fail.
  Resolving there again is the move that hid the bug in the first place, and I measured
  it as an equivalent mutant before removing it rather than assuming.
* **`workdir_for` is extracted from `main`.** Not tidying: the default workdir is the
  actual subject of this issue and `main()` is not reachable from a test, so the rule was
  unpinnable where it lived. It now takes three lines and has three cases against it.

The workdir moves from `/var/folders/…/charter-sweep-<digest>` to
`/private/var/folders/…/charter-sweep-<digest>` — the same physical directory under its
real name, and the digest is unchanged, so an existing trace cache is picked up rather
than orphaned.

## The deliverable is the test, because the bug is that nothing noticed

`TheMapIsMeasuredThroughEverySpellingOfItsRoot` builds a real miniature repo — a package,
a `tests/` the loader can find, functions the tracer can watch being called — and a
symlink to it **that the case creates itself**. It does not rely on `$TMPDIR` being one.
So it goes red on a `resolve()`-less `build_map` on Linux, on CI, anywhere:

* `test_a_root_reached_through_a_symlink_still_measures_what_ran`
* `test_the_spelling_of_the_root_cannot_change_the_map` — the strong form: not "non-empty"
  but *the same map either way*. A prefix is an implementation detail of the measurement
  and must not be visible in its answer.

A case that merely asserted the map came back non-empty would have passed on CI forever
and never seen this. That is the whole point of the issue.

The same shape covers the other two roots: `TheWorkdirIsOutsideTheTreeAndHasNoSymlinkInIt`
points `tempfile.tempdir` at a symlink (exactly what macOS ships) and
`TheSandboxIsOneSpellingOfOnePath` asks for a sandbox under one.

## The refusal now says which empty it is

`0 broken modules` was the entire diagnosis and the tool had it. The two ways to an
unusable map want opposite things done about them, so they are told apart:

```
  ! the trace produced 0 file(s) and 0 broken module(s). The map is not usable:
  !   every module loaded and ran, so the tracer matched none of what
  !   they executed. These two are one directory or they are nothing:
  !     matched against : /private/var/folders/wl/…/T/diag-t7emorf4/tree/
  !     the runners ran : /private/var/folders/wl/…/T/diag-t7emorf4/tree

  ! the trace produced 0 file(s) and 1 broken module(s). The map is not usable:
  !   tests.test_nothing: RuntimeError: this module cannot be imported
```

The second line is **measured by the runners** — the trace payload now carries its
`os.getcwd()` — rather than inferred by the side that got the spelling wrong. On the
machine in the issue those two lines would have differed at a glance. When they agree, as
above, that is also an answer: the spelling is not the problem and the tests are importing
the package from somewhere other than this tree.

## #569's first row, while the file was open

The trace map was **0 of 9 pinned**, which #569 names as the thing to fix first — a
silent narrowing there does not produce wrong answers, it produces *confident* ones, since
a mutation run against too few tests survives nothing and scores "pinned". **It is 8 of 9
now**, each verified by applying the mutation and watching a named case go red:

| guard | pinned by |
|---|---|
| `f"{rel}::{symbol}" if symbol else rel` (both arms) | `test_the_map_is_keyed_by_file_and_by_function` |
| `if error: broken.append(…)` | three cases, incl. `test_modules_that_would_not_load_are_named_instead` |
| `if broken: log("… would not load …")` | `test_a_minority_of_modules_that_will_not_load_is_a_note_and_not_a_refusal` |
| `except (OSError, ValueError)` in `one()` | `test_a_runner_that_writes_nothing_is_a_broken_module_and_not_a_crash` |
| `if done % 40 == 0` | `test_the_trace_says_how_far_it_has_got` |
| `cached.exists() and not refresh` (both conjuncts) | `test_the_first_call_traces_…`, `test_refreshing_re_traces_…` |

**The ninth is an equivalent mutant and is left for #569 to delete.** `tree_hash`'s
`if not base.exists(): continue` guards a `base.rglob("*.py")` that yields nothing for a
missing directory anyway — measured on 3.12.13 and 3.14.4, and measured again by deleting
the two lines and running `tests.test_sweep`, which stays green. By this file's own rule
that is a finding, not a gap: "equivalent mutant" and "dead code" are one thing. It is not
in scope here.

## Running the tool on itself, both ways round

There is a bootstrapping order to this. **Before the fix the only invocation that works is
the corrected one**, `--workdir` under an already-resolved path — that is what #571 had to
use. So: the same sweep, twice, with the workaround and then without it.

```
$ python3 tools/sweep.py --path tools --jobs 5 --workdir /private/tmp/charter-sweep-572a
  workdir: /private/tmp/charter-sweep-572a
sweeping ed179cd7ba79 (paths: tools)
  diff against 2aa29f86ad2d: 1 file(s), 93 added line(s)
  selection map: 10359 source files in 134s
  baseline: full suite, unmutated…
    Ran 6336 tests — OK in 448s
  3 mutations across 1 file(s)
    [1/3] pinned    tools/sweep.py:730  [disable-branch] broken   (1 module(s))
    [2/3] pinned    tools/sweep.py:730  [disable-branch] broken   (1 module(s))
    [3/3] pinned    tools/sweep.py:1440 [drop-if] if override: return resolved(override)
  pinned: 3   SURVIVED: 0   UNRESOLVED: 0   (10.6 min)
```

```
$ python3 tools/sweep.py --path tools --jobs 5
  workdir: /private/var/folders/wl/hs3pdt2j0t9gyc_l73py38l80000gp/T/charter-sweep-f37675b0fc0e
sweeping ed179cd7ba79 (paths: tools)
  selection map: 10359 source files in 109s
  baseline: full suite, unmutated…
    Ran 6336 tests — OK in 326s
  3 mutations across 1 file(s)
    [1/3] pinned    tools/sweep.py:1440 [drop-if] if override: return resolved(override)
    [2/3] pinned    tools/sweep.py:730  [disable-branch] broken   (1 module(s))
    [3/3] pinned    tools/sweep.py:730  [disable-branch] broken   (1 module(s))
  pinned: 3   SURVIVED: 0   UNRESOLVED: 0   (8.2 min)
```

The second run is the one the issue says is impossible. Its `workdir:` line is the fix,
printed: `/private/var/folders/…` where the issue's transcript reads `/var/folders/…`, and
the same 10359-key map either way. **This diff offers three mutations and all three go
red.**

## Verification

* Full suite, python **3.14.4**, inherited environment: **Ran 6336 tests — OK** (317s) —
  and again from a clean sandbox clone as the sweep's own baseline, twice: 448s and 326s.
* Full suite, python **3.12.13**, with `CHARTER_*` / `CLAUDE_*` / `ANTHROPIC_*` / `TMUX*`
  unset (`leaked=0` asserted before the run): **Ran 6336 tests — OK**. Fourteen of those
  are new here — `tests.test_sweep` goes 88 → 102.
* **Every line of this patch measured against a mutation**, not merely written beside one:
  20 un-fixings applied one at a time — each `resolved()` call removed, each new branch
  forced both ways, each trace-map guard deleted — with the case that goes red recorded
  for each. **17 pinned.** All three survivors are equivalence findings and all three are
  acted on: two are the map's redundant key resolution, which is why that `.resolve()` is
  no longer there, and the third is `tree_hash`'s `exists()` guard, left for #569.
* **CI green at `ed179cd`**, read from
  `gh api repos/diazoxide/charter/commits/ed179cd7…/check-runs` rather than
  `gh pr checks` (#561): `test (3.11)`, `test (3.12)`, `test (3.13)`, `test (3.14)` all
  `success`.

**CI proves nothing about this fix and should not be read as if it did.** The runners are
Linux, where `/tmp` is a real directory and this bug does not reproduce — `origin/main` is
green on the same runners while being unusable on macOS. What CI shows is that the fix
breaks nothing. What shows the fix *works* is the second sweep above, and what stops it
regressing anywhere is the symlink the new cases build for themselves.

Stdlib only; the new cases are `unittest`, no pytest. News entry at `version: unreleased`.
No bump, no stamp, no tag.

## Coordination

Task 6 is live on `charter/frame/palette.py`, `builtin_actions.py` and `overlay.py`. This
branch touches none of them: `tools/sweep.py`, `tests/test_sweep.py` (new classes
appended, nothing existing edited) and one new file under `docs/news/`.

Closes #572
