### PR TITLE
Typing at the palette matches names, and the doorways stay (Phase 2, Task 8)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -3517,6 +3517,14 @@ def _draw_palette(args) -> int:
     and goes through `invoke`. They are told apart by `choose.noun_of`, on ids a provider's
     action cannot spell — see `frame/choose.py`.
 
+    **A third kind arrives only if the operator types**, and the catalogue is deliberately
+    not where it lives. `query_only` hands the surface :func:`_name_rows`, which is called
+    the first time the query is non-empty and never while it is empty — so `F2` on a plane
+    with forty workspaces still costs what it cost when the doorways were the only way to
+    a name, and `F2` then `beta` then Enter switches without the doorway's Enter in
+    between. The rows that come back are the picker's own, so `_chosen_name` maps one back
+    to a name without knowing which route drew it.
+
     **Every outcome is said on the operator's own screen, and there is exactly one call
     that says it.** Three things can need a sentence and none of them has anywhere else to
     go, because the pane they would have been drawn in is the one this is about to kill:
@@ -3540,6 +3548,7 @@ def _draw_palette(args) -> int:
         surface = palette.Palette(
             catalogue=(choose.open_rows(fid)
                        + palette.rows(reg.offers(fid=fid, snapshot=snapshot))),
+            query_only=lambda: _name_rows(fid, opened),
             mouse=True)
         chosen = palette.own_the_tty(
             surface, then=lambda row: _picker(row, fid, opened))
@@ -3579,17 +3588,71 @@ def _picker(row, fid: str, opened: list) -> "palette.Palette | None":
     cannot honour. ``None`` here sends the row back to :func:`_draw_palette`, which says
     the note on the operator's screen.
 
-    The roster is appended to *opened* rather than returned beside the surface, because
-    what comes back out of `own_the_tty` is a ROW and the caller has to map it to the name
-    it stood for. Matching that by title would mean matching on a string
-    `overlay.Surface.render` has already contained — see `choose.Roster`.
+    The roster is put in *opened* by :func:`_roster` rather than returned beside the
+    surface, because what comes back out of `own_the_tty` is a ROW and the caller has to
+    map it to the name it stood for. Matching that by title would mean matching on a string
+    `overlay.Surface.render` has already contained — see `choose.Roster`. It also comes
+    from there rather than from `choose.roster` directly, so a noun the operator already
+    typed against is not listed a second time — see that function.
     """
     noun = choose.noun_of(row)
     if noun is None or row.note:
         return None
+    return palette.Palette(catalogue=_roster(noun, fid, opened).rows,
+                           label=noun, mouse=True)
+
+
+def _name_rows(fid: str, opened: list) -> "tuple[overlay.Row, ...]":
+    """Every workspace and every persona as one row, each labelled with which it is.
+
+    **Handed to the palette as `query_only`, so this runs on the first keystroke and never
+    on a query of nothing.** That is the cost half of Task 8: a directory listing per noun
+    is what a name row is made of, and an operator who opened `F2` to press `detach` asked
+    no question that needs one. `frame/palette.Palette._reachable` is where the promise is
+    kept and `tests/test_frame_palette_names.py` is where it is measured.
+
+    Workspaces before personas — `choose.NOUNS`' own order, which the doorways are already
+    drawn in — because `narrow` never reorders and this is where the two groups' order is
+    decided rather than at the moment somebody types.
+
+    **A pinned noun's names are listed WITH THE PIN, not dropped.** The doorway refuses to
+    open a picker for one, because a pane of names none of which can be switched to is an
+    offer charter knows it cannot honour — but a name the operator has already typed is a
+    question they asked, and answering it with an empty pane is #512's "no repos" over a
+    plane that had them. So the reason goes in the note (`choose.labelled`), the row says
+    why before the keypress, and pressing it lands the same sentence on the screen —
+    `choose.pin_reason` and `switch.to_workspace` build it from one read of
+    `state.identity`, so the row and the refusal cannot describe one frame two ways.
+
+    The rosters go into *opened* exactly as a doorway's would, which is what makes
+    :func:`_chosen_name` indifferent to how a name row reached the screen.
+    """
+    out: list = []
+    for noun in choose.NOUNS:
+        out.extend(choose.labelled(_roster(noun, fid, opened),
+                                   choose.pin_reason(noun, fid)))
+    return tuple(out)
+
+
+def _roster(noun: str, fid: str, opened: list) -> "choose.Roster":
+    """This palette's roster for *noun*, read from the plane at most once.
+
+    **One roster per noun per palette, and that is correctness rather than thrift.** Row
+    ids are `<noun>:n<N>` — an index into the list that produced them — so two rosters for
+    one noun are two lists that agree only for as long as the plane does not change under
+    them, and `_chosen_name` would answer from whichever was appended first. A workspace
+    created between the operator typing and the operator pressing Enter on a doorway is
+    enough to make that the wrong name.
+
+    Reading once is the same answer read twice as often as it needs to be: typing `bet`
+    and then opening the workspace doorway is one glob of `workspaces/`, not two.
+    """
+    for roster in opened:
+        if roster.noun == noun:
+            return roster
     roster = choose.roster(noun, fid)
     opened.append(roster)
-    return palette.Palette(catalogue=roster.rows, label=noun, mouse=True)
+    return roster
 
 
 def _chosen_name(row, opened: list) -> "tuple[str, str] | None":

--- a/charter/frame/choose.py
+++ b/charter/frame/choose.py
@@ -12,6 +12,15 @@ function from a chosen row back to the name it stood for, and one call into
 `frame/switch.py`. Everything modal, every key, the scrolling window, the containment and
 the escape hatch are already decided one module down and are not restated.
 
+**The same rows are reached two ways, and only one of them costs a directory read.** A
+doorway row (:func:`open_rows`) opens a picker over :func:`roster`, which is browsing — you
+do not know the name. Typing at the top level reaches the very same rows through
+:func:`labelled`, which is switching — you do. The palette gathers them the first time
+something is typed and never while the query is empty (`frame/palette.Palette.query_only`),
+so an operator who opened `F2` to press `detach` does not pay to enumerate forty
+workspaces, and one who knows the name spends `F2`, the name, Enter — the doorway's Enter
+back.
+
 **The picker runs in the palette's OWN pane, and that is a property rather than a saving.**
 The alternative — a palette row that spawns a second `charter` which splits a second
 overlay pane — races the palette's own teardown: `commands_frame._close_palette` sends
@@ -28,6 +37,13 @@ that alphabet, a provider shipping an action called `pick.workspace` would take 
 keypress. The `:` in :data:`OPEN_ID` and :data:`NAME_ID` cannot appear in an action id, so
 the two namespaces cannot meet; `overlay.Row` imposes no alphabet of its own, and none of
 these ids is ever drawn or ever reaches tmux.
+
+That same fact is what keeps these ids out of the FILTER now that name rows sit in the
+top-level list. `frame/palette.matches` matches a row's id only when the id is one a
+provider's documentation could name — `component.usable_id`, the same question
+`frame/action.py` asks — because :data:`NAME_ID` is charter's own counter and nobody types
+`workspace:n7`. Matched blindly it would make `n` list every name on the plane and
+`persona` list every persona, which is a filter answering a question nobody asked.
 
 **Containment is `frame/overlay.py`'s, asked for once, where the width arithmetic is.**
 `Surface.render` runs `contain.one_line` over every title and note *before* `tui.width`
@@ -177,6 +193,37 @@ def roster(noun: str, fid: str) -> Roster:
                              title=f"{MARK[0] if n == now else MARK[1]}{n}")
                  for i, n in enumerate(names))
     return Roster(noun=noun, rows=rows, names=names)
+
+
+def labelled(roster: Roster, reason: str = "") -> tuple[overlay.Row, ...]:
+    """*roster*'s rows for the top-level list: noted with *reason*, or with the KIND.
+
+    **The kind is what tells `zeb` the persona from `zeb-api` the workspace** when both
+    are answers to one query. Inside a picker the heading already says which noun the pane
+    is showing and every row is that noun, so the label there would be forty copies of a
+    word the header carries once — which is why :func:`roster` leaves the note empty and
+    this is a second function rather than a field on the first.
+
+    **The kind is a LABEL and never a search term.** It goes in the note, which
+    `frame/palette.matches` deliberately does not match, so typing `persona` finds the
+    doorway row that says so and not every persona the plane has. That is the same
+    decision that keeps `lock` from listing every action whose reason mentions one.
+
+    **A *reason* displaces it, and that inverts :func:`roster`'s own objection rather than
+    contradicting it.** That function refuses to repeat the launch pin on every row because
+    a pinned frame's picker cannot be opened at all — the doorway stops one keypress
+    earlier — so the line would be one no test could go red without. Typing does not go
+    through the doorway, so on THIS path the pinned rows are reachable, the reason is live,
+    and `frame/palette.py`'s first rule applies unchanged: an unavailable row is listed
+    *with its reason*, because an operator cannot ask about an option they cannot see
+    (#512). The reason names `$CHARTER_WORKSPACE` or `$CHARTER_PERSONA`, so the kind is
+    still on the row; it is a sentence instead of a word.
+
+    ``_replace`` rather than a fresh `overlay.Row`, so the id is carried over untouched:
+    it is what :meth:`Roster.name_of` matches on, and a labelled row that minted its own
+    would be a row that stands for no name.
+    """
+    return tuple(r._replace(note=reason or roster.noun) for r in roster.rows)
 
 
 def open_rows(fid: str) -> tuple[overlay.Row, ...]:

--- a/charter/frame/palette.py
+++ b/charter/frame/palette.py
@@ -19,6 +19,14 @@ the whole of the seam, and it is deliberately a function from offers to
 the same :class:`Palette` over a different row source, and a picker that had to subclass
 something would be a second surface wearing this one's name.
 
+**A NAME is not an action either, and it reaches this list without becoming one.** Task 6
+removed forty workspace `Action`s and was right to — an action's contract is
+fire-and-report, and forty of them meant forty `run`s each starting a second charter
+process — but the doorway it left cost the operator a keypress on the thing they do most.
+:attr:`Palette.query_only` is the seam that gives it back: rows the FILTER reaches which
+browsing does not, gathered the first time something is typed and never while the query is
+empty. Still rows, still no `Action`, and still nothing spawned until Enter.
+
 **Three rules the plan states and a first implementation loses.**
 
 *An unavailable action is listed WITH ITS REASON.* `frame/actions.py` already refuses to
@@ -49,11 +57,11 @@ import select
 import sys
 import termios
 import tty
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable, Iterable
 
 from .. import contain
-from . import overlay
+from . import component, overlay
 
 #: What the header says the palette is, before the operator types anything.
 HEADING = "charter"
@@ -103,12 +111,23 @@ def matches(query: str, row: overlay.Row) -> bool:
     run, and matching it would make typing `lock` list every action that merely mentions
     one — a filter that answers a question nobody asked.
 
+    **And the id only when it is an ACTION id**, which is the same sentence read
+    carefully rather than a new rule: an id earns its place in the filter by being the
+    name a provider's documentation gives the thing. `frame/choose.py`'s row ids are not
+    that — they are charter's own counter, `workspace:n7`, never drawn and never typed —
+    and now that name rows sit in this list, matching them blindly would make `n` list
+    every name on the plane and `persona` list every persona. `component.usable_id` is
+    the question `frame/action.py` already asks of an action id, asked here rather than
+    re-spelled, so "can be an action id" and "is matched as one" cannot drift apart.
+
     `casefold` on both sides rather than `lower`, and applied to the query once per row
     rather than hoisted, because this is the whole of the case rule and a hoisted copy is
     a second place for it to be wrong.
     """
     q = contain.one_line(query).casefold()
-    return q in row.title.casefold() or q in row.id.casefold()
+    if q in row.title.casefold():
+        return True
+    return component.usable_id(row.id) and q in row.id.casefold()
 
 
 def narrow(catalogue: Iterable[overlay.Row], query: str) -> tuple[overlay.Row, ...]:
@@ -145,9 +164,53 @@ class Palette(overlay.Surface):
     #: `Surface.heading`, which this class rewrites on every keystroke.
     label: str = HEADING
 
+    #: Rows a QUERY reaches and browsing does not. Called with no arguments the first time
+    #: :attr:`query` is non-empty, and never while it is empty. ``None`` — the default,
+    #: and what every picker passes — is "there are none".
+    #:
+    #: **The laziness is the whole reason this is a callable and not a second tuple.**
+    #: `frame/choose.py`'s names are directory listings off the plane: `switch.workspaces`
+    #: globs `workspaces/` and `switch.personas` globs `personas/`, once each per read. An
+    #: operator who opens the palette to press `detach` has asked no question about names,
+    #: and a catalogue built eagerly would enumerate forty workspaces to answer it. Passing
+    #: rows here instead of a function would have done that work at the call site, which is
+    #: the same cost one line earlier.
+    query_only: Callable[[], tuple[overlay.Row, ...]] | None = None
+
+    #: What :attr:`query_only` answered, kept so it is asked ONCE per palette rather than
+    #: once per keystroke — see :meth:`_reachable`. ``None`` is "not asked yet", which is
+    #: what makes that distinguishable from a plane that genuinely has no names.
+    _found: tuple[overlay.Row, ...] | None = field(default=None, init=False)
 
     def __post_init__(self) -> None:
         self._refilter()
+
+    def _reachable(self) -> tuple[overlay.Row, ...]:
+        """Everything :func:`narrow` may keep right now: the catalogue, and — once
+        something has been typed — :attr:`query_only`'s rows after it.
+
+        **Empty query, catalogue only, and that is a cost promise rather than a display
+        one.** It is what makes `F2` on a plane with forty workspaces read the same three
+        state files it read before this attribute existed. A version that gathered eagerly
+        and merely hid the rows would draw identically and be the thing this refuses.
+
+        **Asked once, not once per keystroke.** The gather is memoised in :attr:`_found`,
+        so `beta` costs one directory read rather than four, and backspacing to nothing and
+        typing again costs none. The names are therefore resolved at the FIRST keystroke
+        rather than when the palette opened, which is the same freshness the doorway path
+        has — `commands_frame._roster` hands both paths the one roster — and a palette
+        lives for as long as somebody is looking at it.
+
+        **After the catalogue, never before.** `narrow` does not reorder, so this is the
+        only place the order of the two groups is decided: every action and both doorways
+        keep the position they had before names existed, and a plane with forty workspaces
+        cannot bury `detach` under the ones whose names happen to contain a `d`.
+        """
+        if not self.query or self.query_only is None:
+            return self.catalogue
+        if self._found is None:
+            self._found = tuple(self.query_only())
+        return self.catalogue + self._found
 
     def _refilter(self) -> None:
         """Recompute the visible rows, the header, and where the cursor sits.
@@ -158,7 +221,7 @@ class Palette(overlay.Surface):
         `_top` follows it because `Surface._window` recomputes from the selection, so
         there is no second scroll state to keep in step.
         """
-        self.rows = narrow(self.catalogue, self.query)
+        self.rows = narrow(self._reachable(), self.query)
         self._sel = 0
         self._top = 0
         self.heading = self.label + (PROMPT + self.query if self.query else "")

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -781,6 +781,39 @@ workspace · 4 to choose from
   up/down move   enter choose   esc cancel   F12 back to the harness
 ```
 
+**If you already know the name, do not go through the doorway — just type it.** Once
+anything is typed, the palette also matches workspace and persona names, each row labelled
+with which it is, so `F2` `b` `e` `t` `a` Enter switches without opening anything:
+
+```
+charter /zeb · 3 to choose from
+> zeb-api                     workspace
+    zebra-ui                  workspace
+    zeb                       persona
+
+  up/down move   enter choose   esc cancel   F12 back to the harness
+```
+
+The doorways are for browsing — when you do not know the name — and typing is for
+switching, when you do. Both reach the same rows, and the one you are on keeps its `*`
+either way.
+
+**With nothing typed, no names are listed and none are read.** Names come off directory
+listings on your plane, so opening the palette to press `detach` does not enumerate forty
+workspaces to answer a question you did not ask. They are gathered on the first keystroke,
+once, for as long as that palette is open.
+
+**Typing the name of a noun this frame is pinned to lists it with the reason.** The doorway
+refuses to open a picker for a pinned noun, because every name in it would be a move that
+could not happen — but a name you typed is a question you asked, so the row appears with
+`cannot switch: $CHARTER_WORKSPACE pins this frame to '<name>'` beside it rather than an
+empty pane you cannot tell from a typo.
+
+**The filter reads titles and action ids, never the right-hand column.** So `detach` finds
+the detach row and `acme.deploy` finds a provider's action by the name its documentation
+uses, while `persona` finds the persona *doorway* rather than every persona on the plane —
+the kind label is a label, not a search term.
+
 **There is no row cap.** The old menu was a tmux `display-menu`, drawn inside your terminal
 and unable to scroll, so it cut every list at twelve and lost the digit shortcut past nine.
 The picker is a pane charter draws: it scrolls, it filters, and a plane with forty

--- a/docs/news/unreleased-typing-at-the-palette-finds-a-name.md
+++ b/docs/news/unreleased-typing-at-the-palette-finds-a-name.md
@@ -1,0 +1,55 @@
+---
+version: unreleased
+headline: Typing at the palette finds a workspace or persona by name, and the doorways stay
+---
+
+Switching workspace was the most common thing you do with `F2` and, since the picker
+landed, the one that cost the most keystrokes: `F2`, Enter on `workspace:`, type the name,
+Enter. **Now the name matches at the top level, so it is `F2`, type the name, Enter.**
+
+```
+F2                              F2 then "zeb"
+┌───────────────────────────┐   ┌───────────────────────────┐
+│ > workspace: alpha …      │   │ > zeb-api      workspace  │
+│   persona: steward …      │   │   zebra-ui     workspace  │
+│   detach                  │   │   zeb          persona    │
+│   density: minimal        │   └───────────────────────────┘
+└───────────────────────────┘
+```
+
+**Both nouns at once, each row saying which it is.** `zeb` the persona and `zeb-api` the
+workspace are one keystroke apart, so the right-hand column names the kind — the same
+column that already carries charter's reason for a row it cannot run. Enter switches; the
+one you are on keeps its `*`.
+
+**With nothing typed, the list is exactly what it was.** The two doorways first, then the
+actions, and no names at all. That is not a display choice — it is a cost promise. Names
+come off directory listings on your plane, and opening the palette to press `detach` should
+not enumerate forty workspaces to answer a question you did not ask. The names are gathered
+on your **first keystroke**, once per palette, and browsing them with no name in mind is
+still what the `workspace:` and `persona:` rows are for.
+
+**A name is still not an action.** The thing this does *not* do is go back to registering
+one action per workspace, which is what `F2` used to do and what starting forty
+fire-and-report `run`s — each spawning a second charter process to write two files — cost.
+These are rows. Nothing is started until you press Enter, and then exactly one switch
+happens, in the pane you are already looking at.
+
+**Typing a name of a pinned frame lists it and says why.** A frame launched with
+`$CHARTER_WORKSPACE` set cannot switch, and the doorway has always refused to open a picker
+for one. But a name you have already typed is a question you asked, so the rows appear with
+`cannot switch: $CHARTER_WORKSPACE pins this frame to 'alpha'` beside them rather than an
+empty pane you cannot tell from a typo.
+
+**And a hostile name is still one row that runs nothing.** A workspace is a directory a
+commit can add, so a name can hold a newline, a U+2028 or an escape sequence. Every name is
+made one line before any column width is measured, on this route exactly as on the picker's
+— it is the same row object, re-labelled — and the switch checks it against the same
+alphabet `charter workspace use` does.
+
+One thing that changed underneath: the palette's filter matches a row's **id** only when
+that id is one a provider could have published (`acme.deploy`). It never matched anything
+else you could type, and now that names share the list, matching charter's own internal row
+counter would have made `n` list every name on your plane.
+
+Nothing to adopt.

--- a/tests/test_frame_palette_integration.py
+++ b/tests/test_frame_palette_integration.py
@@ -315,6 +315,47 @@ class ThePaletteOpensAndRuns(_ThePalette, unittest.TestCase):
                         f"the chosen name never switched the frame: workspace is still "
                         f"{state.frame_workspace(self.fid)!r}")
 
+    def test_typing_a_name_switches_the_frame_with_no_doorway_in_between(self):
+        """**Task 8, end to end, with real keys, and the keystroke claim is the point.**
+
+        The case above spends `F2`, Enter on the doorway, the name, Enter. This one spends
+        `F2`, the name, Enter — one keypress fewer, on the thing an operator does most —
+        and it is the same pane, the same surface and the same switch underneath.
+
+        The kind is asserted on the drawn row rather than on the `Row`: `workspace` beside
+        `zebra` is what tells it from a persona of the same name, and it is the note
+        column, which `overlay.Surface.render` lays out against the pane's real width.
+        """
+        fd, pane = self._open()
+        self._await_screen(pane, "workspace: alpha")
+        self.assertEqual(state.frame_workspace(self.fid), "alpha")
+        was = state.version(self.fid)
+        os.write(fd, b"zebra")
+        self._await_screen(pane, "detach", present=False)
+        screen = self._screen(pane)
+        # Past the header, which carries what was typed and would answer for the row.
+        row = next((ln for ln in screen.splitlines()[1:] if "zebra" in ln), "")
+        self.assertIn("workspace", row,
+                      f"the row does not say what kind of thing `zebra` is:\n{screen}")
+        self.assertEqual(self._palette_pane(), pane,
+                         "typing a name opened a second pane")
+        os.write(fd, b"\r")
+        self.assertTrue(_await(lambda: state.frame_workspace(self.fid) == "zebra"),
+                        f"the typed name never switched the frame: workspace is still "
+                        f"{state.frame_workspace(self.fid)!r}")
+        self.assertTrue(_await(lambda: state.version(self.fid) != was),
+                        "the frame was never bumped, so no panel repaints")
+
+    def test_nothing_typed_lists_no_names_at_all(self):
+        """The other half, and the one a display test cannot fake: the palette that just
+        opened is the doorways and the actions, with `zebra` nowhere on it. A palette that
+        listed every name up front would draw it here."""
+        _, pane = self._open()
+        self._await_screen(pane, "density: minimal")
+        screen = self._screen(pane)
+        self.assertNotIn("zebra", screen, screen)
+        self.assertIn("workspace: alpha", screen, screen)
+
     def test_the_picker_bumps_the_frame_so_every_panel_repaints(self):
         """#411/#412's half of step 1. A pointer some panels may read is the bug; the
         version moving is what makes a panel's poll loop redraw against the new plane."""

--- a/tests/test_frame_palette_names.py
+++ b/tests/test_frame_palette_names.py
@@ -1,0 +1,568 @@
+"""Typing at the top of the palette matches NAMES, and the doorways stay.
+
+Phase 2, Task 8. Task 6 (#571) was right to stop registering an `Action` per workspace —
+the contract is fire-and-report, and forty of them meant forty `run`s each starting a
+second charter process — but the doorway it left behind cost the operator a keypress on
+the thing they do most: switching workspace went from `F2` → type → Enter to `F2` → Enter
+→ type → Enter. This puts the keypress back **without putting the actions back**.
+
+Four properties get most of this file's length, because each is a rule the decision states
+and a first implementation loses:
+
+* **Names are rows, never `Action`s.** The registry does not grow with the plane, nothing
+  is spawned by listing a name, and no id a name row carries could be an action id.
+* **The top level stays cheap.** An operator who opened `F2` to press `detach` must not pay
+  to enumerate forty workspaces, so the roster is read on the FIRST KEYSTROKE and never on
+  an empty query — measured here by counting the listers `choose.names_of` asks, which is
+  what "the roster is read" means.
+* **The doorways still work.** Browsing without knowing the name is the case they exist
+  for, and they are asserted on the surface `_draw_palette` actually constructs — the
+  measurement Task 6 recorded is that deleting them reddened nothing outside a tmux-gated
+  module that skips on a machine with no tmux.
+* **A hostile name is one row and runs nothing on THIS path too.** `overlay.Surface.render`
+  contains before `tui.width` sees anything, and Task 6 deliberately added no second call
+  because a second one would be unpinnable. This asserts the existing one covers the new
+  route rather than asking for another.
+
+The name rows and the picker's rows are the same objects (`choose.labelled` only re-notes
+them), so everything `tests/test_frame_pickers.py` pins about a picker row — the id-not-
+title mapping, the raw name reaching `switch.py`, the refusals — holds here unrestated.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config, tui
+from charter.frame import (builtin_actions, choose, component, overlay, palette, state,
+                           switch)
+
+from tests._isolation import PersonaIso
+from tests.test_frame_pickers import HOSTILE, _plane_personas, _plane_workspaces
+
+#: Every character `str.splitlines` treats as ending a line, which is the bound #472
+#: settled on: the property is "renders as one line", not "holds no `\\n`". Spelled with
+#: escapes rather than the characters themselves, because a U+2028 in this file's own
+#: source is a line the next reader cannot see.
+_SEPARATORS = ("\n", "\r", "\u2028", "\u2029", "\u0085")
+#: What a name row's id has and no action id can: `frame/choose.NAME_ID`'s counter, behind
+#: the `:` that keeps the two namespaces apart. Used to say "the rows that stand for a
+#: name" without re-deriving the format string.
+_NAME_ROW = ":n"
+
+#: `HOSTILE` with a findable prefix on each name, and the prefix is load-bearing rather
+#: than a detail: these names have to be reached *by typing*, and the eight share no single
+#: character between them (`next<U+0085>line` holds no `a`; the quoting one holds no `e`).
+#: What is prefixed is a plain two-letter word, so the row still ends up holding the
+#: hostile name unaltered — which is what the containment cases measure.
+_FIND = "zq"
+_FINDABLE = tuple(_FIND + n for n in HOSTILE)
+
+
+
+class _Frame(PersonaIso):
+    """One frame on an isolated plane. The same fixture the picker tests use, plus the
+    names the decision's own worked example is written against."""
+
+    FID = "f-name"
+    PIN = {"CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""}
+    WORKSPACES = ("alpha", "zeb-api", "zebra-ui")
+    PERSONAS = ("forge", "zeb")
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(
+            os.environ, {"CHARTER_SESSION_ID": self.FID}, clear=True))
+        _plane_workspaces(*self.WORKSPACES)
+        _plane_personas(*self.PERSONAS)
+        state.frame_dir(self.FID, create=True)
+        state.record_server(self.FID, "charter")
+        state.record_harness_pane(self.FID, "%3")
+        state.record_identity(self.FID, {"CHARTER_SESSION_ID": self.FID, **self.PIN})
+        state.record_workspace(self.FID, "alpha")
+        self.said = self.enterContext(
+            mock.patch.object(commands_frame, "_say_on_screen"))
+        self.enterContext(mock.patch.object(commands_frame, "_close_palette"))
+
+    # -- the two ways a test drives the palette ----------------------------------- #
+
+    def _surface(self) -> palette.Palette:
+        """The surface `_draw_palette` builds, taken off it rather than rebuilt here.
+
+        Rebuilding it in the test would be a second answer to "what is in the catalogue",
+        and the mutation that empties the real one would leave this file green.
+        """
+        seen: list = []
+        with mock.patch.object(palette, "own_the_tty",
+                               lambda surface, **kw: seen.append(surface)):
+            commands_frame.cmd_palette(SimpleNamespace(client="", pane=True))
+        return seen[0]
+
+    def _typed(self, query: str) -> palette.Palette:
+        """That surface with *query* typed into it one keypress at a time.
+
+        Through `Palette.handle` and never by assigning `query`, because the whole of this
+        task lives in what a keystroke triggers — a test that set the attribute would pass
+        against a `_refilter` that never consults `query_only` at all.
+        """
+        surface = self._surface()
+        for ch in query:
+            surface.handle(overlay.Event(overlay.KEY, ch), 24)
+        return surface
+
+    def _titles(self, surface) -> list[str]:
+        return [r.title for r in surface.rows]
+
+    def _names(self, surface) -> list[overlay.Row]:
+        """Only the rows that stand for a name. The doorways match a query as readily as
+        a name does — `workspace: alpha — pick another` contains `alpha` — and that is
+        deliberate, so a test about names says which rows it means."""
+        return [r for r in surface.rows if _NAME_ROW in r.id]
+
+
+def _pick(query: str, *, index: int = 0, want: str | None = None):
+    """Stand in for the operator: type *query*, then press Enter on one of what is left.
+
+    A double for `palette.own_the_tty` in the shape `tests/test_frame_pickers._pane`
+    already uses, one input earlier — that one stands in for an operator who only ever
+    presses keys the test hands it, and this one has to actually type, because the rows it
+    is about do not exist until something has been typed.
+
+    *want* names a row by ID, which is how a test says "the hostile one" without depending
+    on how many doorways and actions happened to match the same query; *index* is the
+    positional form, and is what says "whatever is under the cursor", which is the claim
+    the keystroke count is about.
+
+    *then* is consulted exactly as the real loop consults it, so a row that turns out to
+    be a doorway opens its picker here too rather than being answered with.
+    """
+    def fake(surface, *, then=None, **kw):
+        for ch in query:
+            surface.handle(overlay.Event(overlay.KEY, ch), 24)
+        while True:
+            if want is not None:
+                row = next((r for r in surface.rows if r.id == want), None)
+            else:
+                row = surface.rows[index] if index < len(surface.rows) else None
+            if row is None:
+                return None
+            nxt = then(row) if then is not None else None
+            if nxt is None:
+                return row
+            surface = nxt
+    return fake
+
+
+class TypingAtTheTopLevelFindsANameDirectly(_Frame, unittest.TestCase):
+    """The headline, and the worked example from the decision itself."""
+
+    def test_a_query_matches_workspace_and_persona_names(self):
+        self.assertEqual(self._titles(self._typed("zeb")),
+                         ["  zeb-api", "  zebra-ui", "  zeb"])
+
+    def test_each_name_says_which_KIND_it_is_so_two_nouns_are_told_apart(self):
+        """`zeb` the persona and `zeb-api` the workspace are one keystroke apart and would
+        otherwise be two bare words in one list. The kind is the note — the right-hand
+        column — which is where `frame/palette.py` already puts what charter has to say
+        about a row rather than what the operator typed."""
+        rows = self._typed("zeb").rows
+        self.assertEqual([(r.title.strip(), r.note) for r in rows],
+                         [("zeb-api", "workspace"), ("zebra-ui", "workspace"),
+                          ("zeb", "persona")])
+
+    def test_the_name_in_use_keeps_its_mark_here_too(self):
+        """A name row is the picker's own row re-noted, so the `*` that answers "which one
+        am I on" travels with it. Losing it would make the top-level list the one surface
+        in the frame that cannot say where the frame is.
+
+        The doorway matches `alpha` too — it says `workspace: alpha — pick another`, which
+        is Task 6's own reason for putting the name in that title — so this asks the name
+        rows rather than the first row.
+        """
+        rows = self._names(self._typed("alpha"))
+        self.assertEqual([r.title for r in rows], [f"{choose.MARK[0]}alpha"])
+
+    def test_an_empty_query_is_the_doorways_and_the_actions_and_nothing_else(self):
+        """The other half of "the doorways stay": with nothing typed the list is exactly
+        what it was before this task, so `F2` Enter still opens a picker and `F2` `d`
+        Enter still reaches `detach`."""
+        surface = self._surface()
+        ids = [r.id for r in surface.rows]
+        self.assertEqual(ids[:2], ["pick:workspace", "pick:persona"], ids)
+        self.assertIn("frame.detach", ids)
+        self.assertEqual([i for i in ids if _NAME_ROW in i], [],
+                         "a name reached the list with nothing typed")
+
+    def test_a_query_that_matches_a_doorway_still_shows_the_doorway(self):
+        """Browsing and switching are not exclusive: `workspace` finds the doorway, and
+        the doorway is what an operator who does not know the name presses."""
+        ids = [r.id for r in self._typed("workspace").rows]
+        self.assertIn("pick:workspace", ids)
+
+    def test_names_come_after_the_actions_so_no_action_moves(self):
+        """`narrow` never reorders, so where the two groups sit is decided once, in
+        `Palette._reachable`. Names first would bury `detach` under every name holding a
+        `d` — the palette would have bought a keystroke for one job by charging one for
+        every other."""
+        rows = self._typed("a").rows
+        ids = [r.id for r in rows]
+        first_name = next(i for i, r in enumerate(rows) if _NAME_ROW in r.id)
+        self.assertTrue(all(_NAME_ROW not in r.id for r in rows[:first_name]), ids)
+        self.assertIn("frame.detach", ids[:first_name], ids)
+
+    def test_typing_a_name_and_pressing_enter_switches_the_frame_and_bumps_it(self):
+        """The whole point, end to end through `_draw_palette`: three keystrokes of name
+        and one Enter, with no Enter on a doorway in between."""
+        was = state.version(self.FID)
+        with mock.patch.object(palette, "own_the_tty", _pick("zebra")):
+            self.assertEqual(commands_frame.cmd_palette(
+                SimpleNamespace(client="/dev/ttys7", pane=True)), 0)
+        self.assertEqual(state.workspace_for(self.FID), "zebra-ui")
+        self.assertNotEqual(state.version(self.FID), was)
+        self.assertIn("workspace → zebra-ui", self.said.call_args[0][1])
+
+    def test_a_persona_typed_at_the_top_level_takes_the_same_route(self):
+        with mock.patch.object(palette, "own_the_tty", _pick("forge")):
+            self.assertEqual(commands_frame.cmd_palette(
+                SimpleNamespace(client="", pane=True)), 0)
+        self.assertEqual(switch.current_persona(self.FID), "forge")
+        self.assertIn("persona → forge", self.said.call_args[0][1])
+
+    def test_the_doorway_still_opens_a_picker_and_switching_from_it_still_works(self):
+        """**The constraint that is not negotiable, asserted after the change**: browsing
+        without knowing the name is the case the doorways exist for, and the route through
+        them is untouched.
+
+        Nothing is typed, and row 0 is pressed twice: with an empty query that is the
+        workspace doorway, and inside the picker it opens it is the first workspace. The
+        frame is moved off `alpha` first so that landing there is a real switch rather than
+        a no-op that a broken doorway would also produce.
+        """
+        state.record_workspace(self.FID, "zeb-api")
+        was = state.version(self.FID)
+        with mock.patch.object(palette, "own_the_tty", _pick("", index=0)):
+            self.assertEqual(commands_frame.cmd_palette(
+                SimpleNamespace(client="", pane=True)), 0)
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+        self.assertNotEqual(state.version(self.FID), was)
+        self.assertIn("workspace → alpha", self.said.call_args[0][1])
+
+
+class TheRosterIsNeverReadUntilSomethingIsTyped(_Frame, unittest.TestCase):
+    """**The cost promise, pinned.** Nothing else in this file would notice a palette that
+    enumerated the plane eagerly and merely hid the rows — it would draw identically.
+
+    Measured on `switch.workspaces` and `switch.personas`, which is what `choose.names_of`
+    asks and therefore what "the roster is read" means. Both are directory globs off the
+    plane, once per call.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.ws = self.enterContext(mock.patch.object(
+            switch, "workspaces", side_effect=lambda: list(self.WORKSPACES)))
+        self.pe = self.enterContext(mock.patch.object(
+            switch, "personas", side_effect=lambda: list(self.PERSONAS)))
+
+    def _reads(self) -> int:
+        return self.ws.call_count + self.pe.call_count
+
+    def test_opening_the_palette_reads_no_roster_at_all(self):
+        """`F2` on a plane with forty workspaces costs what it cost with none."""
+        self._surface()
+        self.assertEqual(self._reads(), 0)
+
+    def test_pressing_an_action_with_nothing_typed_reads_no_roster_either(self):
+        """**The whole of the case this protects**: the operator opened the palette to
+        detach, and never asked a question about names at all. The query stays empty
+        through the whole of `_draw_palette`."""
+        with mock.patch.object(palette, "own_the_tty",
+                               _pick("", want="frame.detach")), \
+             mock.patch.object(builtin_actions, "_spawn") as spawn:
+            commands_frame.cmd_palette(SimpleNamespace(client="", pane=True))
+        spawn.assert_called_once()
+        self.assertEqual(self._reads(), 0)
+
+    def test_the_first_keystroke_is_what_reads_it(self):
+        surface = self._surface()
+        self.assertEqual(self._reads(), 0)
+        surface.handle(overlay.Event(overlay.KEY, "z"), 24)
+        self.assertEqual((self.ws.call_count, self.pe.call_count), (1, 1))
+
+    def test_every_keystroke_after_the_first_reads_nothing_more(self):
+        """Once per palette, not once per keystroke: `zebra` is one glob of `workspaces/`,
+        not five. `Palette._found` is what makes that true and this is what would go red
+        if it were dropped."""
+        self._typed("zebra")
+        self.assertEqual((self.ws.call_count, self.pe.call_count), (1, 1))
+
+    def test_backspacing_to_an_empty_query_and_typing_again_reads_nothing_more(self):
+        surface = self._typed("z")
+        for _ in range(3):
+            surface.handle(overlay.Event(overlay.KEY, "backspace"), 24)
+            surface.handle(overlay.Event(overlay.KEY, "z"), 24)
+        self.assertEqual(surface.query, "z")
+        self.assertEqual((self.ws.call_count, self.pe.call_count), (1, 1))
+
+    def test_an_empty_query_hides_the_names_it_already_read_rather_than_re_reading(self):
+        """Backspacing back to nothing returns the list to the doorways and the actions.
+        A palette that kept showing what it had gathered would make the top level depend
+        on what had been typed a moment ago."""
+        surface = self._typed("z")
+        surface.handle(overlay.Event(overlay.KEY, "backspace"), 24)
+        self.assertEqual([r.id for r in surface.rows if _NAME_ROW in r.id], [])
+
+    def test_the_doorway_reuses_the_roster_typing_already_read(self):
+        """One roster per noun per palette — `commands_frame._roster`. Two reads of one
+        noun are two lists that agree only while the plane holds still, and `_chosen_name`
+        answers from whichever was appended first."""
+        opened: list = []
+        commands_frame._name_rows(self.FID, opened)
+        doorway = next(r for r in choose.open_rows(self.FID)
+                       if choose.noun_of(r) == choose.WORKSPACE)
+        commands_frame._picker(doorway, self.FID, opened)
+        self.assertEqual((self.ws.call_count, self.pe.call_count), (1, 1))
+        self.assertEqual([r.noun for r in opened], [choose.WORKSPACE, choose.PERSONA])
+
+
+class FindingNothingIsAnANSWERAndNotAMissingOne(unittest.TestCase):
+    """`Palette.query_only` answering with no rows is remembered, like any other answer.
+
+    **A survivor of this task's own hand sweep, and it is not equivalent.** The memo asks
+    `self._found is None` — "has it been asked yet" — and the obvious-looking `if not
+    self._found` reads the same on a plane that has names and differently on one that does
+    not: an empty tuple is falsy, so every further keystroke would ask again. Nothing above
+    would notice, because `switch.workspaces` folds `default` in and therefore never
+    answers with nothing.
+
+    Asserted on a constructed `Palette` rather than through `_draw_palette`, because that
+    is where the attribute's contract lives: this class is a general surface, and a caller
+    whose rows are gathered from somewhere with nothing in it is an ordinary one.
+    """
+
+    def test_a_query_only_that_finds_nothing_is_still_only_asked_once(self):
+        asked: list = []
+        p = palette.Palette(catalogue=(overlay.Row(id="a.b", title="ship it"),),
+                            query_only=lambda: asked.append(1) or ())
+        for ch in "beta":
+            p.handle(overlay.Event(overlay.KEY, ch), 24)
+        self.assertEqual(len(asked), 1, "an empty answer was re-asked on every keystroke")
+
+    def test_and_it_is_not_asked_at_all_until_something_is_typed(self):
+        asked: list = []
+        p = palette.Palette(catalogue=(overlay.Row(id="a.b", title="ship it"),),
+                            query_only=lambda: asked.append(1) or ())
+        self.assertEqual(asked, [])
+        p.handle(overlay.Event(overlay.KEY, "backspace"), 24)
+        self.assertEqual(asked, [], "backspace on an empty query gathered")
+
+
+class ANameIsStillNotAnAction(_Frame, unittest.TestCase):
+    """**The cost Task 6 removed, and it stays removed.** An `Action` promises
+    fire-and-report work; a row promises a string on a screen."""
+
+    def test_the_registry_does_not_grow_with_the_plane(self):
+        """Forty workspaces and forty personas are eighty rows and zero offers. This is
+        the mutation that would undo Task 6 while every display assertion above stayed
+        green."""
+        reg = builtin_actions.build(self.FID, current_density="full")
+        before = len(reg.offers(fid=self.FID, snapshot={}))
+        _plane_workspaces(*[f"ws{i:02d}" for i in range(40)])
+        _plane_personas(*[f"pe{i:02d}" for i in range(40)])
+        reg = builtin_actions.build(self.FID, current_density="full")
+        self.assertEqual(len(reg.offers(fid=self.FID, snapshot={})), before)
+        self.assertGreaterEqual(len(self._typed("0").rows), 8)
+
+    def test_listing_a_name_starts_no_process(self):
+        """`Action.run` is what spawns, and a name row has none. Asserted against
+        `builtin_actions._spawn`, which is the one place a palette row becomes a second
+        charter."""
+        with mock.patch.object(builtin_actions, "_spawn") as spawn:
+            self._typed("zeb")
+        spawn.assert_not_called()
+
+    def test_no_id_a_name_row_carries_could_ever_be_an_action_id(self):
+        """`_draw_palette` dispatches on the id of whatever the surface answered with, and
+        a name row now sits in the same list as the actions. If one of these ids were
+        spellable as an action id, a provider shipping it would take the keypress —
+        `frame/choose.py`'s `:` is what keeps the two namespaces apart."""
+        ids = [r.id for r in self._typed("zeb").rows if _NAME_ROW in r.id]
+        self.assertTrue(ids)
+        for rid in ids:
+            self.assertFalse(component.usable_id(rid), rid)
+
+    def test_the_filter_ignores_a_row_id_that_is_not_an_action_id(self):
+        """The other side of that: a name row's id is charter's own counter, so matching
+        it would make `n` list every name on the plane and `persona` list every persona.
+
+        Asserted at both ends — the rule in `palette.matches`, and the consequence in the
+        drawn list — because the rule alone would pass a `matches` that had been narrowed
+        to the title and lost `acme.deploy` with it.
+        """
+        self.assertTrue(palette.matches("acme", overlay.Row(id="acme.deploy", title="x")))
+        self.assertFalse(palette.matches("n0", overlay.Row(id="workspace:n0", title="x")))
+        self.assertEqual([r.id for r in self._typed("n1").rows], [])
+
+    def test_the_kind_label_is_a_label_and_never_a_search_term(self):
+        """Typing `persona` finds the doorway that says so, not every persona the plane
+        has. The kind is in the note, and the note is the one column `matches` refuses."""
+        ids = [r.id for r in self._typed("persona").rows]
+        self.assertEqual(ids, ["pick:persona"], ids)
+
+
+class APinnedNounListsItsNamesWithTheReason(_Frame, unittest.TestCase):
+    """#512, one surface along: an operator cannot ask about an option they cannot see.
+
+    The doorway refuses to OPEN a picker for a pinned noun — a pane of names none of which
+    can be switched to is an offer charter knows it cannot honour — but a name that has
+    already been typed is a question the operator asked, and an empty pane is the wrong
+    answer to it. So the row is listed and it carries the sentence.
+    """
+
+    PIN = {"CHARTER_WORKSPACE": "alpha", "CHARTER_PERSONA": ""}
+
+    def test_the_names_are_listed_and_every_one_says_why_it_cannot_run(self):
+        rows = [r for r in self._typed("zeb").rows if r.id.startswith("workspace:")]
+        self.assertTrue(rows)
+        for row in rows:
+            self.assertIn("$CHARTER_WORKSPACE pins this frame to 'alpha'", row.note)
+
+    def test_the_other_noun_keeps_its_kind_label(self):
+        """One pin, one noun. Reading either as "this frame cannot switch anything" would
+        take the persona names away for a reason that is not about personas."""
+        rows = [r for r in self._typed("zeb").rows if r.id.startswith("persona:")]
+        self.assertEqual([r.note for r in rows], ["persona"])
+
+    def test_pressing_one_says_the_same_sentence_and_moves_nothing(self):
+        """The row said why before the keypress; the keypress says it again where the
+        operator is looking, because the pane the row was drawn in is about to be killed.
+        Both come from one read of `state.identity`, so they cannot disagree."""
+        with mock.patch.object(palette, "own_the_tty", _pick("zebra")):
+            self.assertEqual(commands_frame.cmd_palette(
+                SimpleNamespace(client="", pane=True)), 0)
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+        self.said.assert_called_once()
+        self.assertIn("$CHARTER_WORKSPACE pins this frame", self.said.call_args[0][1])
+
+    def test_the_pin_is_contained_before_it_becomes_a_note_and_a_status_line(self):
+        """`$CHARTER_WORKSPACE` is whatever the launching environment held, so a newline in
+        it is a committed value on two surfaces: eighty row notes, and one
+        `display-message`. `choose.pin_reason` contains it once, for both."""
+        state.record_identity(self.FID, {"CHARTER_WORKSPACE": "al\npha\u2028x"})
+        for line in self._typed("zeb").render(60, 12):
+            for bad in _SEPARATORS:
+                self.assertNotIn(bad, line, repr(line))
+        with mock.patch.object(palette, "own_the_tty", _pick("zebra")):
+            commands_frame.cmd_palette(SimpleNamespace(client="", pane=True))
+        said = self.said.call_args[0][1]
+        self.assertEqual(said, "".join(said.splitlines()), repr(said))
+
+
+class AHostileNameFoundByTypingIsOneRowAndRunsNothing(_Frame, unittest.TestCase):
+    """**Containment, on the new route, without a second containment.**
+
+    `overlay.Surface.render` runs `contain.one_line` over every title and note *before*
+    `tui.width` sees them (#472). Task 6 deliberately added no second call on the way into
+    a row, because a second one would be masked by this one and no test could go red over
+    its deletion — the shape this repository has now been bitten by six times. So this
+    class asserts the property on the DRAWN PANE reached by typing, and asserts that the
+    one call is enough.
+
+    The names are injected through the listers rather than written to disk, because those
+    two already refuse a name outside `workspace.valid_name` — a real defence, asserted in
+    `tests/test_frame_pickers.py`, and also exactly what would make this class test nothing
+    if it were the only line.
+    """
+
+    #: Narrow enough that the two-column layout has to squeeze, so the width arithmetic is
+    #: exercised rather than trivially satisfied.
+    SIZE = (44, 20)
+
+    FIND, NAMES = _FIND, _FINDABLE
+
+    def _hostile(self) -> palette.Palette:
+        self.enterContext(mock.patch.object(
+            switch, "workspaces", return_value=["alpha", *self.NAMES]))
+        self.enterContext(mock.patch.object(
+            switch, "personas", return_value=list(self.NAMES)))
+        return self._typed(self.FIND)
+
+    def test_every_hostile_name_is_its_own_row_and_the_pane_is_the_pane(self):
+        surface = self._hostile()
+        self.assertEqual(len(self._names(surface)), 2 * len(HOSTILE))
+        drawn = surface.render(*self.SIZE)
+        self.assertEqual(len(drawn), self.SIZE[1])
+        for line in drawn:
+            self.assertEqual(line, "".join(line.splitlines()), repr(line))
+
+    def test_no_hostile_byte_reaches_the_pane(self):
+        """Per LINE rather than on a join of them, so the separator this is about cannot
+        be one the test itself put there."""
+        for line in self._hostile().render(*self.SIZE):
+            for bad in _SEPARATORS + ("\x1b[31m",):
+                self.assertNotIn(bad, line, repr(line))
+
+    def test_the_column_arithmetic_sees_the_contained_name_not_the_raw_one(self):
+        """#472 exactly, now with a note beside the title: the kind label shares the row
+        with a name whose raw form is two lines long, and `_title_width` sizes from what
+        `contain.one_line` already made one line of."""
+        long_hostile = self.FIND + "z" * 30 + "\u2028" + "y" * 30
+        self.enterContext(mock.patch.object(
+            switch, "workspaces", return_value=["alpha", long_hostile]))
+        self.enterContext(mock.patch.object(switch, "personas", return_value=[]))
+        for line in self._typed(self.FIND).render(*self.SIZE):
+            self.assertLessEqual(tui.width(tui.strip_ansi(line)), self.SIZE[0],
+                                 repr(line))
+
+    def test_the_raw_name_is_what_reaches_the_switch_and_the_switch_refuses_it(self):
+        """"Runs nothing" is the other half, and the RAW name is what must arrive:
+        repairing it on the way in would be switching to a name charter never looked at.
+        `switch.to_workspace` is the one place it is checked.
+
+        The row is named by ID rather than by position, because how many doorways and
+        actions a query happens to match is not what this is about.
+        """
+        for name in self.NAMES:
+            with self.subTest(name=name):
+                self.said.reset_mock()
+                row_id = choose.NAME_ID.format(choose.WORKSPACE, 1)
+                with mock.patch.object(switch, "workspaces",
+                                       return_value=["alpha", name]), \
+                     mock.patch.object(switch, "personas", return_value=[]), \
+                     mock.patch.object(palette, "own_the_tty",
+                                       _pick(self.FIND, want=row_id)):
+                    self.assertEqual(commands_frame.cmd_palette(
+                        SimpleNamespace(client="", pane=True)), 0)
+                self.said.assert_called_once()
+                said = self.said.call_args[0][1]
+                self.assertEqual(len(said.splitlines()), 1, repr(said))
+                self.assertEqual(said, "".join(said.splitlines()), repr(said))
+                self.assertEqual(state.workspace_for(self.FID), "alpha")
+        self.assertEqual(sorted(p.name for p in config.WORKSPACES_DIR.iterdir()),
+                         sorted(self.WORKSPACES), "a refused switch created something")
+
+    def test_the_one_containment_is_the_surfaces_own_and_a_second_would_be_dead(self):
+        """**The line this class refuses to ask for.** A `contain.one_line` on the way into
+        a name row would sit under `Surface.render`'s, which runs over every title and note
+        unconditionally — so deleting the inner one changes no pane, reddens no test, and
+        is a line the deletion sweep would find and nobody could defend.
+
+        Asserted as the fact that makes it dead: what a row HOLDS is raw, and what is drawn
+        is contained. A future edit that starts repairing rows on the way in breaks the
+        first half here rather than being noticed by nothing.
+        """
+        self.enterContext(mock.patch.object(
+            switch, "workspaces", return_value=[self.FIND + "a\nb"]))
+        self.enterContext(mock.patch.object(switch, "personas", return_value=[]))
+        surface = self._typed(self.FIND)
+        row, = self._names(surface)
+        self.assertIn("\n", row.title,
+                      "the row was repaired on the way in, which makes render's call dead")
+        self.assertNotIn("\n", "".join(surface.render(*self.SIZE)))
+
+
+if __name__ == "__main__":                          # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Task 6 (#571) was right to stop registering an `Action` per workspace — the action contract
is *fire-and-report*, and forty of them meant forty `run`s each starting a second charter
process. But the doorway it left behind cost the operator a keypress on the thing they do
most. **This puts the keypress back without putting the actions back.**

## The keystrokes, which is the whole point

Switching to workspace `beta`, counting every key pressed:

| | keys | count |
|---|---|---|
| Task 4 (#567) — an `Action` per workspace | `F2` `b` `e` `t` `a` `Enter` | **6** |
| Task 6 (#571) — the doorway, on `main` today | `F2` `Enter` `b` `e` `t` `a` `Enter` | **7** |
| this branch | `F2` `b` `e` `t` `a` `Enter` | **6** |

The extra key on `main` is the `Enter` that opens the `workspace:` doorway — it is under the
cursor when the palette opens, so it costs exactly one keypress and no arrow keys. This
branch restores Task 4's count with none of Task 4's forty `Action`s.

Checkable end to end against a real tmux client:
`tests/test_frame_palette_integration.py::ThePaletteOpensAndRuns
::test_typing_a_name_switches_the_frame_with_no_doorway_in_between` writes `zebra` then
`\r` to an attached pty and asserts the frame moved — one write fewer than the case above
it, which writes `workspace\r` first.

Browsing is unchanged: `F2`, `Enter` on the doorway, arrows, `Enter` — for when you do not
know the name, which is what the doorways exist for.

## What changed

```
F2                              F2 then "zeb"
┌───────────────────────────┐   ┌───────────────────────────┐
│ > workspace: alpha …      │   │ > zeb-api      workspace  │
│   persona: steward …      │   │   zebra-ui     workspace  │
│   detach                  │   │   zeb          persona    │
│   density: minimal        │   └───────────────────────────┘
└───────────────────────────┘
```

**`palette.Palette.query_only`** — a callable of rows the *filter* reaches and browsing does
not. Called with no arguments the first time the query is non-empty, memoised, and
concatenated **after** the catalogue, so every action and both doorways keep the position
they had.

**`commands_frame._name_rows`** is what it answers with: every workspace and every persona as
the picker's own rows, re-noted by **`choose.labelled`** with the kind each one is. The kind
goes in the note column, which `matches` deliberately does not search — so `zeb` the persona
and `zeb-api` the workspace are distinguishable, and typing `persona` still finds the
*doorway* rather than every persona on the plane.

**`commands_frame._roster`** hands both routes one roster per noun per palette. That is
correctness as well as thrift: row ids are `<noun>:n<N>`, an index into the list that
produced them, so two rosters for one noun agree only for as long as the plane holds still
and `_chosen_name` would answer from whichever was appended first.

## The four constraints

**No `Action` per name.** `ANameIsStillNotAnAction` puts 40 workspaces and 40 personas on the
plane and asserts `builtin_actions.build(...).offers(...)` is the same length as before, and
that listing names calls `builtin_actions._spawn` zero times.

**Nothing gathered on an empty query.** Measured, not asserted about — a palette that
enumerated eagerly and hid the rows would draw identically. `TheRosterIsNeverReadUntilSomething
IsTyped` counts calls to `switch.workspaces`/`switch.personas`, which is what "the roster is
read" means: **0** for opening the palette, **0** for opening it and pressing `detach`, **1
each** on the first keystroke, and **still 1 each** after four more keystrokes, after
backspacing to nothing and typing again, and after opening the doorway on top.

**The doorways still work.** Asserted on the surface `_draw_palette` actually constructs
(`_surface()` takes it off `own_the_tty` rather than rebuilding it), plus the end-to-end
route through a doorway to a switched frame, plus a tmux case that the just-opened palette
lists no names at all.

**Containment.** No second `contain.one_line` was added and none is asked for.
`overlay.Surface.render` already contains every title and note before `tui.width` sees them,
and `AHostileNameFoundByTypingIsOneRowAndRunsNothing` measures that on the drawn pane reached
*by typing*: one row per hostile name, no separator or escape byte on any line, every line
inside the pane's width, and the raw name reaching `switch.to_workspace` and being refused.
One case asserts the fact that would make an inner call dead — the `Row` still *holds* the
raw newline, and only the pane is clean — so an edit that starts repairing rows on the way
in goes red rather than being noticed by nothing.

Picker ids still cannot collide with action ids (`component.usable_id` is false for every
one, asserted on the rows the top level now draws).

## One thing that moved underneath

`palette.matches` now matches a row's **id** only when that id is one a provider could have
published. That is the existing sentence read carefully rather than a new rule — an id earns
its place in the filter by being the name a provider's documentation gives the thing
(`acme.deploy`) — and without it, now that name rows share the list, `n` would list every
name on the plane and `persona` every persona, because `choose.NAME_ID` is charter's own
counter. `component.usable_id` is *asked* rather than re-spelled, so "can be an action id"
and "is matched as one" cannot drift apart.

## A decision worth a second look

**A pinned noun's names are listed with the pin, not dropped.** The doorway refuses to open a
picker for a pinned noun — a pane of names none of which can be switched to is an offer
charter knows it cannot honour. But a name the operator has already *typed* is a question
they asked, and answering it with an empty pane is #512's "no repos" over a plane that had
them. So the pin reason displaces the kind label on those rows, which is `frame/palette.py`'s
own first rule ("an unavailable row is listed *with its reason*") applied unchanged.
`choose.pin_reason` and `switch.to_workspace` build the sentence from one read of
`state.identity`, so the row and the refusal cannot describe one frame two ways.

This inverts `choose.roster`'s objection rather than contradicting it: that function refuses
to repeat the pin on a picker's rows because a pinned frame's picker *cannot be opened*, so
the line would be one no test could go red without. On this route the rows are reachable, so
the line is live and pinned.

## Verification

* **Full suite, two environments.** CPython **3.14.4**: `Ran 6403 tests — OK`. CPython
  **3.12.13** with `CHARTER_*`, `CLAUDE_*`, `ANTHROPIC_*` and `TMUX*` unset (verified: zero
  such names in the child environment): `Ran 6403 tests — OK`.
* **`tools/sweep.py` at this head** (`--workdir` under `/private/tmp`): 4 mutations across
  the diff, **4 pinned, 0 survived, 0 unresolved**. Baseline `Ran 6403 tests — OK`.
* **Hand mutations for the tool's known gaps (#569 — no operator for string/regex constants
  or semantic swaps).** 31 applied by hand across `choose.labelled`, `palette.matches`,
  `Palette._reachable`, `_refilter`, `_name_rows`, `_roster` and `_picker` — the note
  constant swapped both ways and to the other noun, the id gate removed / inverted / moved
  onto the title, the two row groups' order swapped, the catalogue dropped, the laziness
  condition inverted and its `or` turned to `and`, `NOUNS` truncated and reversed, the pin
  read for the wrong noun, and the roster memo removed at each of its three call sites.
  **30 went red first time. 1 survived** and is reported below.
* **The survivor, and it was not equivalent.** `if self._found is None` weakened to `if not
  self._found` re-reads on every keystroke for a `query_only` that finds nothing — invisible
  to every case above, because `switch.workspaces` folds `default` in and so never answers
  with nothing. Checked for a second unpinned line hiding the consequence: there is none, and
  the consequence is real at the level the attribute is declared, since `Palette` is a
  general surface and a caller whose rows come from somewhere empty is an ordinary one. Now
  pinned by `FindingNothingIsAnANSWERAndNotAMissingOne`, on a constructed `Palette`.
* **Not left to a tmux-gated module.** Every property above is pinned on a constructed
  surface as well as (for the two that have one) in `test_frame_palette_integration.py`,
  which skips where there is no tmux. The tmux cases were run here against **tmux 3.7c**:
  `Ran 17 tests — OK`, and the server was killed *and* its socket unlinked — no
  `charter-palette-integ-*` socket or process survives the run (#564).
* **News entry** `docs/news/unreleased-typing-at-the-palette-finds-a-name.md`, `version:
  unreleased`. No bump, no stamp, no tag.

Rebased onto `1115d08` (#574) after it landed mid-flight; the sweep, both suite runs, the
tmux run above and CI are all at head `b51f035`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
