### PR TITLE
A report that tells you to fix a persona names it (#498)

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -737,15 +737,29 @@ def _render_agent(name: str, meta: dict, charter: str) -> str:
     scripts = persona.bin_scripts(name)
     bin_note = ""
     if scripts:
-        # `contain.one_line`, because these are FILENAMES read off the disk, not names
-        # charter minted: `personas/<name>/bin/` is committed and a filesystem forbids only
-        # `/` and NUL. A script named with a U+2028 wrote a second bullet into the brief
-        # the sub-agent is given, formatted exactly like charter's own — #453's mechanism
-        # aimed at the model rather than at the YAML parser. Reproduced before it was
-        # bounded. A path is shown escaped rather than dropped: the agent still has to be
-        # able to run the ones that are fine.
+        # Contained, because these are FILENAMES read off the disk, not names charter
+        # minted: `personas/<name>/bin/` is committed and a filesystem forbids only `/` and
+        # NUL. A script named with a U+2028 wrote a second bullet into the brief the
+        # sub-agent is given, formatted exactly like charter's own — #453's mechanism aimed
+        # at the model rather than at the YAML parser. Reproduced before it was bounded. A
+        # path is shown escaped rather than dropped: the agent still has to be able to run
+        # the ones that are fine.
+        #
+        # `contain.readable` rather than `contain.one_line` (#498). The bullet says "run
+        # them by path", so the property this needs is not "the bullet is one bullet" but
+        # "the path names a file". `one_line` gives the first: it escapes five general
+        # categories, and U+3164 HANGUL FILLER is `Lo`, so a script named with three of them
+        # produced `` `personas/<name>/bin/` `` — a bullet ordering the model to run a
+        # directory, in the one document written for the model. `readable` keeps printable
+        # ASCII and escapes the rest, so the last segment is always there to be read.
+        #
+        # The trade, since it lands on this site hardest: a script whose filename is
+        # legitimately non-ASCII now shows as escapes, and an escaped path is not one the
+        # agent can paste. That is the same outcome as today for a name it cannot see at
+        # all, and better than a path that silently names nothing — but it is a real cost,
+        # unlike at the two lint sites where `valid_name` makes the input ASCII anyway.
         listed = "\n".join(
-            f"  - `{contain.one_line(_rel(path), contain.PATH_DISPLAY_LIMIT)}`"
+            f"  - `{contain.readable(_rel(path), contain.PATH_DISPLAY_LIMIT)}`"
             for _n, path in sorted(scripts.items()))
         bin_note = (
             f"\n- **You carry your own executables.** Run them by path, not by name:\n"
@@ -1138,7 +1152,18 @@ def cmd_persona_lint(args) -> int:
         # name a commit chose, and a filesystem forbids only `/` and NUL. `persona.lint`
         # bounds the message it returns; that left the `f"{n}: …"` around it as the
         # remaining way to write a second physical row wearing charter's own ✗ glyph.
-        shown = contain.one_line(n)
+        #
+        # `contain.readable`, not `contain.one_line`, and the difference is which question
+        # this row asks. Every row here ends in "go and fix this persona", so the row has to
+        # SAY WHICH — and `one_line` promises only that the name cannot forge a second row,
+        # by escaping five general categories. U+3164 HANGUL FILLER is `Lo` and on none of
+        # them, is not whitespace and survives `strip`, so a directory named with three of
+        # them linted as `✗ : no role`: a finding about a persona the row does not name, and
+        # a name the reader cannot search for (#498). `readable` decides on the complement —
+        # printable ASCII is what may reach the row, everything else prints as its escape —
+        # which is the same rule `mcpseen.label` already gives the `mcp: server name …` row
+        # printed a few lines further down this very report.
+        shown = contain.readable(n)
         issues = list(persona.lint(n)) + _agent_sync_issues(n)
         if only:
             issues = [(lvl, msg) for lvl, msg in issues if only in msg]

--- a/charter/contain.py
+++ b/charter/contain.py
@@ -183,6 +183,14 @@ def one_line(value, limit: int = DISPLAY_LIMIT) -> str:
     *bounded* rather than merely displayable — an MCP server name, which charter emits
     into YAML and into a tool-grant pattern — the bound belongs at the boundary that reads
     it, and this is what the refusal then uses to say which value it refused.
+
+    Nor does it make the value **visible**, and that is the boundary worth naming because
+    three callers crossed it (#498). :data:`_INVISIBLE` is a list of categories, so a
+    value that renders as nothing without being in one of them — U+3164 HANGUL FILLER is
+    ``Lo`` — comes back unchanged and correct: it forges no row. A caller whose sentence
+    has to NAME something wants :func:`readable` instead. This function is not widened to
+    cover it, because its other callers are printing content into a TUI and want their
+    glyphs.
     """
     s = value if isinstance(value, str) else str(value)
     out = []
@@ -193,6 +201,124 @@ def one_line(value, limit: int = DISPLAY_LIMIT) -> str:
             out.append(ch)
     rendered = "".join(out)
     return rendered if len(rendered) <= limit else rendered[:limit] + "…"
+
+
+#: Shown by :func:`readable` in place of a value whose whole rendering is ASCII spaces —
+#: the empty string, or a name made of nothing else. ``""`` rather than a word, so
+#: ``✗ "": no role`` reads as a persona whose name is blank rather than as a missing word,
+#: and so the marker cannot be confused with a name that spells "blank". The same marker
+#: `mcpseen._name` prints, because it is the same question one report over.
+BLANK = '""'
+
+
+def escape_char(ch: str) -> str:
+    """One codepoint as an escape no other codepoint can also spell.
+
+    Astral planes get the eight-digit ``\\U`` form rather than a long ``\\u``, because
+    ``\\u1f600`` is five hex digits: U+1F600 and the two characters U+1F60 + ``0`` would
+    render the same, and two values that read identically on a report line is the
+    homoglyph finding with a different alphabet.
+
+    Deliberately NOT the escape :func:`one_line` writes. That one spells a codepoint below
+    U+0100 as ``\\xNN`` and everything else with a ``:04x`` — which for an astral codepoint
+    produces the five hex digits above, and ``\\x`` and ``\\u`` forms of two different
+    widths besides. Harmless there: `one_line` escapes only the categories that carry no
+    glyph, and two *controls* that read alike are not a finding. Here the escape is what a
+    reader identifies the value BY, so every form has to be fixed-width and injective.
+
+    **Where the boundary sits is a choice and not a property.** ``<=`` could be ``<`` and
+    U+FFFF would come back as ``\\U0000ffff``: still fixed-width, still injective, still
+    printable ASCII, so no test reddens and none should — the claims above hold either way.
+    It is written as the shorter form for every codepoint that has one, which is the reason
+    to prefer this side rather than a rule anything depends on.
+    """
+    cp = ord(ch)
+    return f"\\u{cp:04x}" if cp <= 0xFFFF else f"\\U{cp:08x}"
+
+
+def escaped(text: str, *, quote: bool = False) -> str:
+    """*text* as printable ASCII — every other codepoint shown as its escape, reversibly.
+
+    **The rule is a complement, and that is the whole point.** Everything else in this
+    module's display layer names a class of *bad* characters: :data:`_INVISIBLE` is five
+    general categories, and a list of categories is a list of spellings that the next
+    codepoint is one step outside of. This says instead what a report line **may** hold —
+    U+0020..U+007E — and escapes the rest, whatever category, plane, script or combining
+    class it belongs to. Nothing has to be added to it when Unicode grows.
+
+    The argument for that complement was made in full one surface over, at
+    `mcpseen._safe`, after three rounds of narrower rules were each walked past: a control
+    character repaints the line, a bidi override reverses it, U+3164 HANGUL FILLER renders
+    as nothing while `str.isprintable` calls it printable, and a Cyrillic ``а`` spells a
+    different value that reads the same. This is that rule, extracted so `mcpseen` and
+    :func:`readable` share one implementation rather than two that drift.
+
+    **Reversible.** ``\\\\`` for a real backslash, ``\\"`` for a real quote when *quote*,
+    an escape for everything outside printable ASCII, and itself for the rest — so the
+    characters printed for a value determine that value. The backslash doubling is what
+    makes that true and is not decoration: without it a committed name holding the six
+    literal characters ``\\u3164`` reads exactly like one holding U+3164, which is one more
+    pair of different values a reader cannot tell apart.
+
+    *quote* escapes the ASCII double quote as well, which is what lets an unescaped ``"``
+    be a delimiter no committed byte can spell. Off by default: a surface that delimits
+    with something else does not need it, and escaping a quote nobody is using as a
+    delimiter only makes an ordinary value harder to read.
+    """
+    return "".join("\\\\" if c == "\\" else '\\"' if (quote and c == '"')
+                   else c if " " <= c <= "~" else escape_char(c) for c in text)
+
+
+def readable(value, limit: int = DISPLAY_LIMIT) -> str:
+    """*value* as one line a reader can **read the value back off**. Never blank.
+
+    A different question from :func:`one_line`, and a second function rather than a wider
+    one, because `one_line` has some ninety callers and the property most of them want is
+    the one it promises: a committed value cannot forge a second ROW. Those callers print
+    workspace names, persona roles, component titles and forge text into a TUI, and a
+    non-ASCII value there is ordinary content that should reach the screen as its glyphs.
+    Widening `one_line` would escape every one of them to make three call sites legible.
+
+    So this is for the three surfaces where the value is an **identifier** — a name a
+    sentence tells somebody to go and fix, a path a sub-agent is told to run. There, being
+    able to tell which one it is beats keeping the glyph, and `one_line` cannot deliver it:
+    it decides on :data:`_INVISIBLE`, a list of five categories, and U+3164 HANGUL FILLER
+    (``Lo``), U+2800 BRAILLE PATTERN BLANK (``So``), U+115F and U+1160 (``Lo``) are on none
+    of them, are not `isspace`, and survive `strip`. A persona directory named with three
+    of them linted as ``✗ : no role`` — a row naming no persona (#498).
+
+    **Blankness is decided, not enumerated.** After :func:`escaped`, the string holds only
+    U+0020..U+007E, and the ASCII space is the only member of that range that renders as
+    nothing. So "this renders as nothing" is exactly "this is spaces", which is a question
+    about the whole class rather than a sample of it, and :data:`BLANK` stands in when the
+    answer is yes. That is why the escape comes first and the emptiness test second; the
+    other order is the growing list this exists to avoid.
+
+    **What it costs, said out loud.** A legitimately non-ASCII value prints as its escapes
+    here. That is a real loss and it is bounded to these surfaces on purpose: charter mints
+    persona names itself (`persona.valid_name` — a lowercase letter or digit, then
+    ``[a-z0-9._-]``), so a name this is asked about is ASCII by construction and comes back
+    byte-identical, and the same holds for the ordinary `bin/` script name. Nowhere a person
+    writes prose — a `role:`, a memory, a workspace title — goes through this.
+
+    Clipped with ASCII dots rather than ``…``, so the promise "what comes back is printable
+    ASCII" holds for a clipped value too and a caller never has to special-case the marker.
+    """
+    # `str(value)` unconditionally, and not `value if isinstance(value, str) else …`: for a
+    # string `str` hands the same object straight back, so the type test in front of it was
+    # a branch that could not change an answer. `one_line` above carries the longer form;
+    # this one does not copy it. The coercion ITSELF is load-bearing and is pinned by a
+    # test — a report surface that raises on a `Path` tells its reader less than one that
+    # prints the path, and "nothing here raises" is this module's rule.
+    shown = escaped(str(value))
+    if len(shown) > limit:
+        shown = shown[:limit] + "..."
+    # `.strip(" ")` and not `.strip()`, and the two are EQUIVALENT here — deliberately, and
+    # checked: after `escaped` the string is U+0020..U+007E, so a bare `strip` has no other
+    # whitespace left to find and no test can tell them apart. Naming the space is what says
+    # WHY the question is decidable at all; a bare `strip` would read as "whatever Python
+    # calls whitespace", which is the category list this function exists to get away from.
+    return shown if shown.strip(" ") else BLANK
 
 
 #: How much of any ONE path a refusal sentence — or a generated brief — repeats back.

--- a/charter/mcpseen.py
+++ b/charter/mcpseen.py
@@ -83,7 +83,7 @@ import json
 import re
 from pathlib import Path
 
-from . import config
+from . import config, contain
 
 #: One file per plane, under the state dir. Never committed — see the module docstring.
 FILE_NAME = "mcp-approved.json"
@@ -248,9 +248,13 @@ def _escape(ch: str) -> str:
     ``\\u1f600`` is five hex digits: U+1F600 and the two characters U+1F60 + ``0`` would
     render the same, and two different commands that read the same on a consent line is
     the homoglyph finding with a different alphabet.
+
+    Lives in :mod:`charter.contain` now, because the same rule decides the same question on
+    a second report (#498) and two copies of an escape table is how the two reports come to
+    disagree about what a value is called. Kept as a name here so the reasoning above sits
+    beside the consent line it was written for.
     """
-    cp = ord(ch)
-    return f"\\u{cp:04x}" if cp <= 0xFFFF else f"\\U{cp:08x}"
+    return contain.escape_char(ch)
 
 
 def _safe(text: str) -> str:
@@ -305,10 +309,14 @@ def _safe(text: str) -> str:
     identifier rather than a destination and is clipped anyway, and the "does this entry
     name anything at all" test in :func:`describe`. The destination goes through
     :func:`_esc`, which loses nothing.
+
+    The escape itself is `contain.escaped` — one implementation, because `contain.readable`
+    decides the same question for the lint row and the "does not load" sentence (#498), and
+    a second copy of this table is how those two reports come to spell the same name two
+    ways. What stays here is the part that is about a CONSENT line and nothing else: the
+    collapsing and the stripping below.
     """
-    out = "".join("\\\\" if c == "\\" else c if " " <= c <= "~" else _escape(c)
-                  for c in text)
-    return _SPACE_RUN.sub(" ", out).strip()
+    return _SPACE_RUN.sub(" ", contain.escaped(text)).strip()
 
 
 def _esc(text: str) -> str:
@@ -333,9 +341,12 @@ def _esc(text: str) -> str:
     :func:`_tok` and :func:`_val` put around it, and — being neither collapsed nor cut — it
     counts its full width against :data:`MAX_LINE`, so padding is refused rather than
     silently tidied away into a line that no longer says what would run.
+
+    `contain.escaped(…, quote=True)` is the escape, shared with :func:`_safe` and with
+    `contain.readable` (#498). The quote flag is the whole of the difference between the
+    two calls, which is what the flag exists to make visible.
     """
-    return "".join("\\\\" if c == "\\" else '\\"' if c == '"'
-                   else c if " " <= c <= "~" else _escape(c) for c in text)
+    return contain.escaped(text, quote=True)
 
 
 def _tok(text: str) -> str:

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -1268,18 +1268,28 @@ def lint(name: str, deep: bool = True) -> list[tuple[str, str]]:
         # there sends the reader looking for a missing file; the refusal names the path
         # charter actually resolved to, which is the whole defect (#336).
         refused = definition_refusal(name)
-        # `contain.one_line`, because *name* here is a DIRECTORY name and a directory name
+        # `contain.readable`, because *name* here is a DIRECTORY name and a directory name
         # is not a name charter minted: `personas/` is committed, and a filesystem forbids
         # only `/` and NUL. A U+2028 in one made this single lint row two rows, the second
         # of them indistinguishable from charter's own — the #453 mechanism on the surface
         # that exists to REPORT #453. Reproduced before it was bounded.
+        #
+        # It was `contain.one_line`, which stops that and nothing else: it escapes five
+        # general categories, and U+3164 HANGUL FILLER is `Lo`, not whitespace, and survives
+        # `strip`, so this read `persona '' does not load` — the one sentence whose entire
+        # job is to tell somebody WHICH persona to go and fix, with the name left out
+        # (#498). `readable` decides on the complement instead: printable ASCII is what may
+        # reach the sentence and everything else prints as its escape, so the name is one
+        # the reader can find on disk. Charter mints persona names out of
+        # `[a-z0-9][a-z0-9._-]` (`valid_name`), so a name that resolves is ASCII already and
+        # comes back unchanged; the escapes only ever appear for a directory that is broken.
         #
         # This bounds the MESSAGE and only the message. `cmd_persona_lint` builds the row
         # around it out of the same directory name and bounds its own prefix; `persona
         # list` and `persona stats` still do not, which is #472. A bound here is not a
         # bound on every report that prints this name.
         return [("error", f"persona.md: {refused}" if refused
-                 else f"persona '{contain.one_line(name)}' does not load")]
+                 else f"persona '{contain.readable(name)}' does not load")]
     meta = d["meta"]
     issues: list[tuple[str, str]] = []
     if deep:

--- a/docs/news/unreleased-a-report-that-tells-you-to-fix-a-persona-names-it.md
+++ b/docs/news/unreleased-a-report-that-tells-you-to-fix-a-persona-names-it.md
@@ -1,0 +1,87 @@
+---
+version: unreleased
+headline: A report that tells you to fix a persona now names it — three rows read `✗ : no role` for a directory that renders as nothing
+security: true
+---
+
+`charter persona lint` printed `✗ : no role` for a persona whose directory name is three
+U+3164 HANGUL FILLERs. The sentence beside it read `persona '' does not load`. And the brief
+a dispatched sub-agent reads listed `` `personas/<name>/bin/` `` — a path with no filename
+on the end, under the words *run them by path, not by name*.
+
+All three are reports whose every row ends in *go and fix this*, and none of them said which
+thing.
+
+**The cause is a list of spellings, which is the fourth time this month.** `contain.one_line`
+escapes a character whose Unicode general category is in `{"Cc", "Cf", "Cs", "Zl", "Zp"}`,
+or that is whitespace other than the ASCII space. The class that renders as nothing is not
+in there:
+
+| codepoint | category | `isspace()` | survives `strip` | `one_line` |
+| --- | --- | --- | --- | --- |
+| U+3164 HANGUL FILLER | `Lo` | no | yes | unchanged |
+| U+2800 BRAILLE PATTERN BLANK | `So` | no | yes | unchanged |
+| U+115F HANGUL CHOSEONG FILLER | `Lo` | no | yes | unchanged |
+| U+1160 HANGUL JUNGSEONG FILLER | `Lo` | no | yes | unchanged |
+
+`personas/` is committed and a filesystem forbids only `/` and NUL, so the directory name is
+a name a commit chose. `list_personas()` globs `personas/*/` and asks only about a leading
+underscore.
+
+**`one_line` was not the defect and has not been changed.** Its docstring is explicit about
+scope: on the rows charter prints a committed value into, it escapes the categories with no
+glyph so the value does not end the row, and it says in the same breath that this does not
+make the value readable. It keeps that contract, and it keeps its ninety-odd callers — the
+frame's pickers, overlays and switch messages, the roster table, the component registry's
+diagnostics — which print workspace names, roles and titles into a TUI where a Cyrillic or
+Japanese value is *content* and should reach the screen as its glyphs. Widening it to make
+three reports legible would have escaped every one of them. The defect was three callers
+asking a line-safety function for readability.
+
+**What they ask instead.** `contain.readable`, which decides on the **complement**: printable
+ASCII is what a report line may hold, and everything outside it — any category, any plane,
+any combining mark, any lookalike — prints as its `\uXXXX` escape. That is not a longer list;
+it is the absence of one, and it covers the next codepoint without anybody adding an entry.
+
+The argument is not new here, and neither is the code. `mcpseen._safe` made it one surface
+over, after three rounds of narrower rules were each walked past, and the `Refused …` row in
+`sync-agents` and the `mcp: server name '<name>' is refused` lint error were moved onto it
+for exactly this reason — they sit in the same printed reports as these three rows. The
+escape now lives in `contain` and both modules share it, so the two halves of one report
+cannot come to spell the same name two different ways.
+
+Measured on a persona directory named with three U+3164, before and after. The "after"
+column is what the terminal shows, which is the whole point — the codepoint is spelled out
+rather than drawn, because drawing it is what drew nothing:
+
+```
+lint row      before:  ✗ : no role
+              after:   ✗ \u3164\u3164\u3164: no role
+
+sentence      before:  persona '' does not load
+              after:   persona '\u3164\u3164\u3164' does not load
+
+brief bullet  before:  - `personas/seo/bin/`
+              after:   - `personas/seo/bin/\u3164\u3164\u3164`
+```
+
+**A note for anyone whose names are not ASCII, because this has a real cost.** At these three
+sites a non-ASCII value now prints as escapes. It is bounded to them deliberately: charter
+mints persona names itself — `persona create` enforces a lowercase letter or digit followed
+by `[a-z0-9._-]` — so a name these reports are asked about is ASCII by construction and comes
+back byte for byte unchanged, and nowhere a person writes prose (a `role:`, a memory, a
+workspace title, anything in the frame) goes anywhere near this. The one place it can bite is
+a `personas/*/bin/` script with a non-ASCII filename, which will now appear in the brief
+escaped; the alternative was a bullet that names no file at all. The escape is reversible, so
+the value is re-spelled and never destroyed.
+
+`tests/test_a_name_that_renders_as_nothing_is_still_a_name.py` asks the question of all
+1,114,112 codepoints rather than of the four above, and asks it of the printed row rather
+than of the helper — because bounding a helper is not bounding a report, and that gap is this
+defect's own shape: `persona.lint` already bounded the message it returns while
+`cmd_persona_lint` built the row prefix around it out of the raw name.
+
+Nothing to adopt: upgrading is the whole of it.
+
+[#498](https://github.com/diazoxide/charter/issues/498), reproduced against the tree before
+it was fixed.

--- a/tests/test_a_name_that_renders_as_nothing_is_still_a_name.py
+++ b/tests/test_a_name_that_renders_as_nothing_is_still_a_name.py
@@ -1,0 +1,591 @@
+"""Three reports told somebody to go and fix a thing, without naming the thing (#498).
+
+`contain.one_line` escapes a character whose Unicode general category is in
+``{"Cc", "Cf", "Cs", "Zl", "Zp"}``, or that is whitespace other than ``" "``. That is a
+list of **spellings**, and the class that renders as nothing is not inside it: U+3164
+HANGUL FILLER and U+115F/U+1160 are ``Lo``, U+2800 BRAILLE PATTERN BLANK is ``So``, none of
+the four is `isspace`, and all four survive `strip`.
+
+`one_line`'s docstring is honest about that — it promises a value cannot forge a second
+ROW, and says in the same breath that it does not make the value readable. So the defect
+was never in that function. It was in three callers that need the second property and asked
+this one for it:
+
+* the `lint` row prefix, which read ``✗ : no role`` — a finding about a persona it does not
+  name, out of a report whose every row ends in *go and fix it*;
+* ``persona '' does not load``, the one sentence whose whole job is to say WHICH;
+* the `bin/` bullet in the brief a sub-agent reads, which read ``- `personas/<name>/bin/```
+  — an instruction to run a directory, in the one document written for the model.
+
+**What this file pins, and why it is three things and not one.**
+
+1. *The property, over the whole codespace.* `contain.readable` decides on the COMPLEMENT —
+   printable ASCII is what may reach a report line, everything else prints as its escape —
+   so "renders as nothing" is decidable rather than enumerable, and no codepoint has to be
+   added to anything. `TestReadableIsDecidedNotEnumerated` asks that of all 1,114,112
+   codepoints rather than of the four in the issue. The four are here too, by name, so a
+   failure says which one.
+2. *The three reports.* Asserted end to end, on the printed row, because a bound on a
+   helper is not a bound on a report — that gap is #498's own shape, and `persona.lint`
+   bounding its MESSAGE while `cmd_persona_lint` built the row prefix out of the raw name
+   is exactly how it survived a round.
+3. *That `one_line` was NOT widened.* It has some ninety callers printing workspace names,
+   roles, component titles and forge text into a TUI, where a non-ASCII value is content
+   that should reach the screen as its glyphs. `TestOneLineKeptItsContract` fails if a later
+   round "fixes" #498 by widening the shared function instead, which would escape every one
+   of them to make these three legible.
+
+The cost is stated rather than hidden: a legitimately non-ASCII value at one of these three
+sites prints as escapes. `TestOrdinaryNamesAreUntouched` holds the half that matters —
+charter mints persona names out of ``[a-z0-9][a-z0-9._-]`` (`persona.valid_name`), so a name
+these reports are asked about is ASCII by construction and comes back byte-identical — and
+`TestReadableLosesNothing` holds the other half: the escape is reversible, so a non-ASCII
+value is re-spelled and never destroyed.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import string
+import unicodedata
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands_persona, config, contain, mcpseen, persona, tui
+from tests._isolation import PersonaIso
+
+#: The four from the issue. Written as escapes, never as the literal character: a raw
+#: U+3164 in a fixture is invisible in the editor of whoever reads this next, which is the
+#: same property that let it through three report surfaces. NOT the bound — the bound is the
+#: codespace sweep below. This exists so a failure names which spelling failed.
+BLANK_RENDERING = {
+    "U+3164 HANGUL FILLER": "\u3164",
+    "U+2800 BRAILLE PATTERN BLANK": "\u2800",
+    "U+115F HANGUL CHOSEONG FILLER": "\u115f",
+    "U+1160 HANGUL JUNGSEONG FILLER": "\u1160",
+}
+
+#: Every spelling of "this line ends here" beyond the `\r`/`\n` pair everyone thinks of.
+#: Escapes, for the same reason as above. The BOUND is the codespace sweep; this exists so
+#: a failure names the separator.
+SEPARATORS = ("\n", "\r", "\u2028", "\u2029", "\x85", "\v", "\f", "\x1c")
+
+#: Values a person might legitimately carry that are not ASCII. The control group: this fix
+#: must not destroy them, and must not leak into the surfaces that print them as content.
+ORDINARY_NON_ASCII = ("Աարոն", "дизайн", "Ünal", "日本語", "José", "Χάρης")
+
+
+def printable_ascii(s: str) -> bool:
+    return all(" " <= c <= "~" for c in s)
+
+
+def could_be_a_filename(ch: str) -> bool:
+    """The two characters no POSIX filesystem can hold, which is all this can know up front.
+
+    Everything past that is the filesystem's own answer and is asked BY CREATING THE
+    DIRECTORY — see `ReportCase.sweep_categories`. APFS validates names against its own Unicode
+    version and refuses an unassigned codepoint or a lone surrogate outright (EILSEQ),
+    while ext4 takes any byte sequence, so a static predicate here would either drop
+    categories Linux covers fine or claim ones macOS cannot reach.
+    """
+    return ch not in ("/", "\x00")
+
+
+def one_per_category(usable=lambda ch: True) -> dict[str, str]:
+    """One codepoint per Unicode general category, taken by sweeping the codespace.
+
+    Generated rather than listed, so a category nobody here has thought about is covered
+    without this file being edited — which is #498's own complaint restated as a test: a
+    list of categories is a list of spellings.
+
+    Printable ASCII is skipped because it is the TARGET of the rule, not a threat to it.
+    """
+    out: dict[str, str] = {}
+    for cp in range(0x110000):
+        ch = chr(cp)
+        if " " <= ch <= "~":
+            continue
+        cat = unicodedata.category(ch)
+        if cat not in out and usable(ch):
+            out[cat] = ch
+    return out
+
+
+def unescape(shown: str) -> str:
+    """`contain.escaped` read backwards. A left inverse is what "reversible" MEANS, so this
+    is written out rather than asserted against a second copy of the forward table."""
+    out: list[str] = []
+    i = 0
+    while i < len(shown):
+        c = shown[i]
+        if c != "\\":
+            out.append(c)
+            i += 1
+        elif shown[i + 1] == "\\":
+            out.append("\\")
+            i += 2
+        elif shown[i + 1] == "u":
+            out.append(chr(int(shown[i + 2:i + 6], 16)))
+            i += 6
+        elif shown[i + 1] == "U":
+            out.append(chr(int(shown[i + 2:i + 10], 16)))
+            i += 10
+        else:
+            raise AssertionError(f"not an escape this function writes: {shown[i:i + 4]!r}")
+    return "".join(out)
+
+
+class TestReadableIsDecidedNotEnumerated(unittest.TestCase):
+    """The property, over the codespace — not over a list of four."""
+
+    def test_no_codepoint_renders_as_nothing(self):
+        """The whole class, one codepoint at a time.
+
+        The assertion is the PROPERTY — what comes back is printable ASCII and holds
+        something other than a space — rather than equality with whichever escape the code
+        currently writes, which would pass for any escape including none.
+        """
+        for cp in range(0x110000):
+            shown = contain.readable(chr(cp) * 3)
+            if not (printable_ascii(shown) and shown.strip(" ")):
+                self.fail(f"U+{cp:04X} ({unicodedata.category(chr(cp))}) → {shown!r}")
+
+    def test_the_four_from_the_issue_are_named_by_the_output(self):
+        """Redundant with the sweep, and kept: a failure that says U+2800 sends the reader
+        to the right paragraph, where "some codepoint in the sweep" sends them to none."""
+        for label, ch in BLANK_RENDERING.items():
+            with self.subTest(codepoint=label):
+                shown = contain.readable(ch * 3)
+                self.assertTrue(shown.strip(" "), f"{label} renders as nothing")
+                self.assertTrue(printable_ascii(shown), repr(shown))
+                self.assertIn(f"{ord(ch):04x}", shown.lower())
+
+    def test_only_a_run_of_spaces_is_shown_as_blank(self):
+        """After the escape the string is printable ASCII, where the space is the only
+        member that renders as nothing — so this is the ONE remaining input that names
+        nothing, and it is named rather than printed as a gap."""
+        self.assertEqual(contain.readable(""), contain.BLANK)
+        self.assertEqual(contain.readable("     "), contain.BLANK)
+        self.assertEqual(contain.readable("\t\n"), "\\u0009\\u000a")
+        # …and NOT for a value that merely begins with spaces: that one has a name.
+        self.assertNotEqual(contain.readable("   devops"), contain.BLANK)
+        self.assertTrue(contain.BLANK.strip(" "), "the blank marker is itself blank")
+
+    def test_a_clipped_value_is_still_printable_ascii(self):
+        """The clip marker is ASCII dots and not `…`, so the promise holds for a long value
+        too and no caller has to special-case the marker it appended itself."""
+        shown = contain.readable("\u3164" * 5000, limit=64)
+        self.assertTrue(printable_ascii(shown), repr(shown))
+        self.assertLessEqual(len(shown), 64 + 3)
+
+    def test_a_value_that_is_not_text_is_rendered_rather_than_raised(self):
+        """`contain`'s rule is that nothing on a report path raises, and these are report
+        paths: a row that crashes tells its reader less than a row that says `None`. The
+        coercion is what delivers that, so it is asserted rather than assumed — the sweep
+        found it unpinned, and deleting it turns `readable(Path(...))` into a TypeError
+        one caller away."""
+        self.assertEqual(contain.readable(None), "None")
+        self.assertEqual(contain.readable(7), "7")
+        self.assertEqual(contain.readable(Path("personas/seo/bin/x")),
+                         "personas/seo/bin/x")
+
+    def test_a_value_that_exactly_fits_is_not_clipped(self):
+        """The boundary. An off-by-one here takes the last character off every name of
+        exactly the limit's length, which is a quieter version of the finding this fixes:
+        a report that names something slightly other than the thing."""
+        self.assertEqual(contain.readable("a" * 64, limit=64), "a" * 64)
+        self.assertEqual(contain.readable("a" * 65, limit=64), "a" * 64 + "...")
+
+    def test_two_different_values_never_print_the_same(self):
+        """A five-hex-digit escape would make U+1F600 and U+1F60 followed by '0' read
+        identically, which is the blank-name finding wearing an alphabet. The astral form is
+        eight digits, and a literal backslash is doubled, so every escape printed is a
+        codepoint that was really there."""
+        self.assertNotEqual(contain.readable(chr(0x1F600)),
+                            contain.readable(chr(0x1F60) + "0"))
+        self.assertNotEqual(contain.readable("\\u3164"), contain.readable("\u3164"))
+
+
+class TestReadableLosesNothing(unittest.TestCase):
+    """Escaped, never dropped — so a non-ASCII value is re-spelled rather than destroyed."""
+
+    def test_an_ordinary_non_ascii_value_round_trips(self):
+        for raw in ORDINARY_NON_ASCII:
+            with self.subTest(raw=raw):
+                self.assertEqual(unescape(contain.readable(raw)), raw)
+
+    def test_every_codepoint_round_trips(self):
+        for cp in range(0x110000):
+            raw = "x" + chr(cp) + "y"
+            if unescape(contain.readable(raw)) != raw:
+                self.fail(f"U+{cp:04X} does not round-trip: {contain.readable(raw)!r}")
+
+
+class TestOneLineKeptItsContract(unittest.TestCase):
+    """#498 is a defect in three CALLERS, and this is what says so in code.
+
+    `one_line` promises line structure and states that it does not promise readability. Its
+    other callers — the frame's pickers, overlays, slots and switch messages, the roster
+    table, the registry's diagnostics — print content into a TUI, where a Cyrillic or
+    Japanese value should reach the screen as its glyphs. Widening `one_line` to fix these
+    three reports would escape every one of them, which is why this fix did not.
+    """
+
+    def test_an_invisible_codepoint_still_reaches_one_line_unchanged(self):
+        for label, ch in BLANK_RENDERING.items():
+            with self.subTest(codepoint=label):
+                self.assertEqual(contain.one_line(ch * 3), ch * 3)
+
+    def test_ordinary_non_ascii_still_reaches_one_line_unchanged(self):
+        for raw in ORDINARY_NON_ASCII:
+            with self.subTest(raw=raw):
+                self.assertEqual(contain.one_line(raw), raw)
+
+    def test_one_line_still_stops_a_second_row(self):
+        """The property it does promise, unchanged by this fix."""
+        for sep in SEPARATORS:
+            with self.subTest(sep=repr(sep)):
+                self.assertEqual(len(contain.one_line(f"a{sep}b").splitlines()), 1)
+
+    def test_readable_also_stops_a_second_row(self):
+        """A readable rendering has to be a one-line rendering too, or the fix trades one
+        finding for the other. It is, by construction: a separator is outside printable
+        ASCII, so the complement escapes it without having to know it is a separator."""
+        for sep in SEPARATORS:
+            with self.subTest(sep=repr(sep)):
+                self.assertEqual(len(contain.readable(f"a{sep}b").splitlines()), 1)
+
+    def test_no_codepoint_at_all_can_forge_a_row(self):
+        for cp in range(0x110000):
+            if len(contain.readable(f"a{chr(cp)}b").splitlines()) != 1:
+                self.fail(f"U+{cp:04X} ended the line")
+
+
+class TestTheSharedEscapeKeptItsTwoCallersApart(unittest.TestCase):
+    """`mcpseen._safe` and `_esc` now call the same `contain.escaped`, and the ONE thing
+    that separates them is the `quote` flag. A flag is a thing somebody flips, so both
+    settings are pinned here rather than left to the docstring that explains them.
+
+    Neither direction was caught before: hand-checking the swap turned up that adding
+    `quote=True` to `_safe` reddened nothing at all, which is a refactor that has quietly
+    changed a printed label with nothing to say so.
+    """
+
+    def test_a_label_shows_a_quote_as_itself(self):
+        """`_safe` renders an IDENTIFIER, and nothing delimits with a quote there — so
+        escaping one only makes an ordinary name harder to read."""
+        self.assertEqual(mcpseen.label('say "hi"'), 'say "hi"')
+        self.assertNotIn('\\"', mcpseen.label('a"b'))
+
+    def test_a_destination_shows_a_quote_as_an_escape(self):
+        """`_esc` renders a value that charter prints BETWEEN quotes, so the quote has to
+        be a delimiter no committed byte can spell."""
+        self.assertEqual(mcpseen._esc('a"b'), 'a\\"b')
+
+    def test_both_still_escape_everything_outside_printable_ascii(self):
+        for fn in (mcpseen._safe, mcpseen._esc):
+            with self.subTest(fn=fn.__name__):
+                for ch in BLANK_RENDERING.values():
+                    out = fn("x" + ch + "y")
+                    self.assertTrue(printable_ascii(out), repr(out))
+                    self.assertIn(f"{ord(ch):04x}", out.lower())
+
+
+class TestOrdinaryNamesAreUntouched(unittest.TestCase):
+    """The control. An over-eager fix mangles the names it was not about."""
+
+    def test_a_persona_name_comes_back_byte_identical(self):
+        """Charter mints these itself — `persona.valid_name` is a lowercase letter or digit
+        then `[a-z0-9._-]` — so every name these three reports are asked about in practice
+        is ASCII, and passes through unchanged."""
+        for name in ("devops", "seo", "front-door", "a.b_c-1", "steward2"):
+            with self.subTest(name=name):
+                self.assertTrue(persona.valid_name(name))
+                self.assertEqual(contain.readable(name), name)
+
+    def test_every_character_the_alphabet_admits_is_unchanged(self):
+        """Derived from `valid_name` itself rather than from a list of five, so the claim
+        survives that alphabet being widened, and fails loudly if it is ever widened outside
+        ASCII — which is the day this fix starts costing somebody their name."""
+        admitted = sorted({c for c in map(chr, range(0x110000))
+                           if persona.valid_name("a" + c)})
+        self.assertGreater(len(admitted), 35, "the alphabet sweep found almost nothing")
+        # `_NAME_RE` ends in `$`, and in Python `$` matches before a TRAILING newline — so
+        # `valid_name("a\n")` is true and a `personas/evil\n/` directory resolves, loads and
+        # is written into a generated agent's frontmatter. Found by this sweep, filed as
+        # #577, and NOT fixed here: changing the alphabet every persona and workspace name
+        # is validated against is a different question from three reports that do not name
+        # what they are about. Asserted rather than filtered out, so the day somebody
+        # switches to `fullmatch` this line tells them what it was holding.
+        self.assertEqual("".join(admitted),
+                         "\n-." + string.digits + "_" + string.ascii_lowercase)
+        joined = "a" + "".join(c for c in admitted if c != "\n")
+        self.assertEqual(contain.readable(joined), joined)
+
+    def test_an_ordinary_script_path_is_unchanged(self):
+        for p in ("personas/seo/bin/site-health.sh", "personas/a.b/bin/run_me",
+                  "/opt/plane/personas/x/bin/tool-2"):
+            with self.subTest(path=p):
+                self.assertEqual(contain.readable(p, contain.PATH_DISPLAY_LIMIT), p)
+
+    def test_the_backslash_is_the_only_ascii_that_changes(self):
+        """Doubled, so a literal `\\u3164` in a value cannot read as the codepoint. That is
+        the one place an ASCII value is re-spelled, and it is stated rather than found.
+
+        Probed inside ``x…y`` rather than alone, because a value that is only a space is
+        the one input :data:`contain.BLANK` is for and would otherwise read as a second
+        exception to a rule that has one.
+        """
+        changed = [c for c in map(chr, range(0x80))
+                   if " " <= c <= "~" and contain.readable(f"x{c}y") != f"x{c}y"]
+        self.assertEqual(changed, ["\\"])
+
+
+def named_in(row: str) -> str:
+    """The name a lint row is ABOUT, with charter's own decoration taken off.
+
+    A row is ``<glyph> <name>: <message>``; the glyph is charter's (`util.err` writes ``✗``,
+    `util.warn` writes ``!``). What this returns is the part a reader would copy in order to
+    go and find the persona.
+    """
+    prefix = tui.strip_ansi(row).split(":", 1)[0]
+    return prefix.split(" ", 1)[1].strip() if " " in prefix else ""
+
+
+class ReportCase(PersonaIso):
+    """A persona directory whose NAME a commit chose — which is what `personas/*/` is."""
+
+    def reset(self) -> None:
+        """Back to an empty roster, without tearing down the isolated plane. `tearDown` is
+        not what restores this fixture (`addCleanup` is), so calling it in a loop would
+        leave the sweeps running against a plane nobody had put back."""
+        shutil.rmtree(config.PERSONAS_DIR, ignore_errors=True)
+        config.PERSONAS_DIR.mkdir(parents=True, exist_ok=True)
+
+    def make_named(self, name: str) -> None:
+        d = config.PERSONAS_DIR / name
+        d.mkdir(parents=True)
+        (d / "persona.md").write_text("---\nrole: Victim\nvault: none\n---\n\nbody\n")
+
+    def sweep_categories(self, check) -> None:
+        """Run *check* over one codepoint per Unicode general category, and ASSERT the
+        coverage instead of quietly skipping what did not fit.
+
+        A category can be unreachable HERE for one reason only — this machine cannot hold a
+        directory named with it. APFS validates a name against its own Unicode version and
+        answers EILSEQ for an unassigned codepoint, where ext4 takes any byte sequence; and
+        a lone surrogate has no UTF-8 encoding at all, so Python refuses it before the
+        syscall. The reachable set is therefore a property of the machine, and the number is
+        asserted so a run that silently covered two categories fails.
+
+        Nothing is left unchecked by that. `TestReadableIsDecidedNotEnumerated` asks the
+        same question of all 1,114,112 codepoints with no filesystem in the way; these
+        sweeps are here to prove the REPORT is wired to it, which is #498's actual shape —
+        `persona.lint` bounded its message while the row around it was built from the raw
+        name.
+        """
+        samples = one_per_category(could_be_a_filename)
+        self.assertGreater(len(samples), 20, "the sweep found almost no categories")
+        refused: list[tuple[str, str]] = []
+        covered = 0
+        for cat, ch in sorted(samples.items()):
+            name = ch * 3
+            held, why = self.can_hold(name)
+            if not held:
+                refused.append((cat, why))
+                continue
+            with self.subTest(category=cat, cp=f"U+{ord(ch):04X}"):
+                # Outside the try, deliberately. Wrapping `check` in one caught a genuine
+                # assertion failure that happened to raise the same class as the
+                # filesystem's refusal and recorded it as "this machine cannot hold the
+                # name" — a green sweep hiding a red report.
+                check(name)
+                covered += 1
+        self.assertGreater(covered, 20, f"only {covered} of {len(samples)} categories "
+                                        f"reached the report; this machine refused "
+                                        f"{refused}")
+
+    def can_hold(self, name: str) -> tuple[bool, str]:
+        """Can this machine hold a directory called *name*? Asked by creating one.
+
+        The whole of what may be skipped, and the reason is recorded in the assertion above
+        rather than swallowed. `UnicodeEncodeError` is caught alongside `OSError` because a
+        lone surrogate has no UTF-8 encoding at all — Python refuses it before the kernel is
+        asked, and "no filename on any machine" is the same answer as EILSEQ.
+        """
+        probe = config.PERSONAS_DIR / name
+        try:
+            probe.mkdir(parents=True)
+        except (OSError, ValueError) as e:
+            return False, getattr(e, "strerror", None) or str(e)
+        shutil.rmtree(probe, ignore_errors=True)
+        return True, ""
+
+    def lint_output(self) -> str:
+        err, out = io.StringIO(), io.StringIO()
+        with redirect_stderr(err), redirect_stdout(out):
+            commands_persona.cmd_persona_lint(SimpleNamespace(name=None, only=None))
+        return err.getvalue() + out.getvalue()
+
+
+class TestTheLintRowNamesItsPersona(ReportCase):
+    """`charter persona lint`, whose every row ends in *go and fix this persona*."""
+
+    def rows_about(self, name: str) -> list[str]:
+        """The per-persona rows that are not about the control standing beside the hostile
+        one. A control is declared alongside so "the bad name is not on a row" cannot pass
+        against a lint that printed nothing at all."""
+        self.reset()
+        self.make_persona("control", role="Control", vault="none")
+        self.make_named(name)
+        lines = [ln for ln in self.lint_output().splitlines() if ln.strip()]
+        self.assertTrue(any("control" in ln for ln in lines), lines)
+        # `":" in ln` drops the trailing "N error(s) — …" summary, which is charter's own
+        # sentence and not a row about anybody.
+        return [ln for ln in lines if ":" in ln and "control" not in ln]
+
+    def test_the_row_names_a_persona_that_renders_as_nothing(self):
+        for label, ch in BLANK_RENDERING.items():
+            with self.subTest(codepoint=label):
+                rows = self.rows_about(ch * 3)
+                self.assertTrue(rows, "lint said nothing about an unloadable persona")
+                for row in rows:
+                    named = named_in(row)
+                    self.assertTrue(named, f"row names no persona: {row!r}")
+                    self.assertTrue(printable_ascii(named), repr(named))
+                    self.assertIn(f"{ord(ch):04x}", named.lower())
+
+    def test_every_category_of_codepoint_reaches_a_row_that_names_something(self):
+        def check(name: str) -> None:
+            rows = self.rows_about(name)
+            self.assertTrue(rows, "lint said nothing about an unloadable persona")
+            for row in rows:
+                named = named_in(row)
+                self.assertTrue(named, f"row names no persona: {row!r}")
+                self.assertTrue(printable_ascii(named), repr(named))
+
+        self.sweep_categories(check)
+
+    def test_an_ordinary_persona_keeps_its_own_name_on_the_row(self):
+        """The control that would catch an over-eager fix: `devops` is `devops`."""
+        self.reset()
+        self.make_persona("devops", role="Ops", vault="none")
+        out = self.lint_output()
+        rows = [ln for ln in out.splitlines() if ":" in ln and ln.strip()]
+        self.assertTrue(rows, out)
+        for row in rows:
+            self.assertEqual(named_in(row), "devops", row)
+        self.assertNotIn("\\u", out)
+
+
+class TestTheDoesNotLoadSentenceNamesItsPersona(ReportCase):
+    """`persona '<name>' does not load` — the sentence whose whole job is to say which."""
+
+    def sentence_for(self, name: str) -> str:
+        self.reset()
+        self.make_named(name)
+        msgs = [m for lvl, m in persona.lint(name)
+                if lvl == "error" and "does not load" in m]
+        self.assertEqual(len(msgs), 1, msgs)
+        return msgs[0]
+
+    def test_the_sentence_contains_the_name(self):
+        for label, ch in BLANK_RENDERING.items():
+            with self.subTest(codepoint=label):
+                named = self.sentence_for(ch * 3).split("'", 2)[1]
+                self.assertTrue(named, "the sentence names no persona")
+                self.assertTrue(printable_ascii(named), repr(named))
+                self.assertIn(f"{ord(ch):04x}", named.lower())
+
+    def test_every_category_reaches_a_sentence_that_names_something(self):
+        def check(name: str) -> None:
+            named = self.sentence_for(name).split("'", 2)[1]
+            self.assertTrue(named, "the sentence names no persona")
+            self.assertTrue(printable_ascii(named), repr(named))
+
+        self.sweep_categories(check)
+
+    def test_a_loadable_persona_says_nothing_at_all(self):
+        """The complaint has to be caused by the name, not by having a persona."""
+        self.reset()
+        self.make_persona("devops", role="Ops", vault="none")
+        self.assertEqual([m for _l, m in persona.lint("devops") if "does not load" in m], [])
+
+
+class TestTheBriefNamesTheScriptItTellsTheAgentToRun(ReportCase):
+    """The `bin/` bullets in the generated sub-agent brief — the one document written for
+    the model, telling it to run these by path."""
+
+    def brief(self, script: str) -> str:
+        self.reset()
+        self.make_persona("seo", role="SEO", vault="none")
+        d = persona.bin_dir("seo")
+        d.mkdir(parents=True, exist_ok=True)
+        f = d / script
+        f.write_text("#!/bin/sh\necho hi\n")
+        f.chmod(0o755)
+        got = persona.load("seo")
+        return commands_persona._render_agent("seo", got["meta"], got["charter"])
+
+    def bullets(self, text: str) -> list[str]:
+        return [ln for ln in text.splitlines() if ln.strip().startswith("- `personas/")]
+
+    def test_the_bullet_names_the_script_and_not_just_its_directory(self):
+        for label, ch in BLANK_RENDERING.items():
+            with self.subTest(codepoint=label):
+                bullets = self.bullets(self.brief(ch * 3))
+                self.assertEqual(len(bullets), 1, bullets)
+                path = bullets[0].split("`")[1]
+                self.assertTrue(printable_ascii(path), repr(path))
+                leaf = path.rsplit("/", 1)[-1]
+                self.assertTrue(leaf.strip(), f"the bullet names a directory: {path!r}")
+                self.assertIn(f"{ord(ch):04x}", leaf.lower())
+
+    def test_every_category_reaches_a_bullet_that_names_a_file(self):
+        def check(script: str) -> None:
+            bullets = self.bullets(self.brief(script))
+            self.assertEqual(len(bullets), 1, bullets)
+            path = bullets[0].split("`")[1]
+            self.assertTrue(printable_ascii(path), repr(path))
+            self.assertTrue(path.rsplit("/", 1)[-1].strip(),
+                            f"the bullet names a directory: {path!r}")
+
+        self.sweep_categories(check)
+
+    def test_a_long_path_gets_the_PATH_budget_and_not_the_display_one(self):
+        """Which constant this call site passes is not a detail, and nothing pinned it.
+
+        `DISPLAY_LIMIT` is 160 — wide enough for a name, and narrower than a plane's real
+        paths. Swapping the two here clips a long script path to 160 characters and the
+        agent is told to run something that is not a path at all, which is this issue's own
+        failure with a different cause. Found by hand-checking a constant swap the deletion
+        sweep has no operator for (#569).
+        """
+        deep = "d" * 200
+        text = self.brief(deep + ".sh")
+        bullets = self.bullets(text)
+        self.assertEqual(len(bullets), 1, bullets)
+        path = bullets[0].split("`")[1]
+        self.assertTrue(path.endswith(deep + ".sh"), f"clipped: {path[-40:]!r}")
+        self.assertGreater(len(path), contain.DISPLAY_LIMIT)
+        self.assertLessEqual(len(path), contain.PATH_DISPLAY_LIMIT)
+
+    def test_an_ordinary_script_reaches_the_brief_unchanged(self):
+        """The control: an agent told to run `site-health.sh` is told exactly that."""
+        text = self.brief("site-health.sh")
+        self.assertIn("`personas/seo/bin/site-health.sh`", text)
+        self.assertNotIn("\\u", text)
+
+    def test_the_bullet_is_still_one_bullet(self):
+        """#453's own property on this surface, unchanged: a separator in a filename must
+        not write a second bullet formatted like charter's own."""
+        for sep in ("\u2028", "\u2029", "\x85", "\v"):
+            with self.subTest(sep=repr(sep)):
+                self.assertEqual(len(self.bullets(self.brief(f"a{sep}- `evil`"))), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_server_name_cannot_declare_a_server.py
+++ b/tests/test_a_server_name_cannot_declare_a_server.py
@@ -600,6 +600,13 @@ class TestTheNextSpellingIsANameCharterDidNotMint(NameBase):
         report that printed nothing at all, so the row is checked to still name the
         persona — and to carry it in its bounded spelling, which says *why* the count held
         rather than leaving a different guard free to have caught it.
+
+        That spelling is `contain.readable` rather than `contain.one_line` since #498. The
+        row prefix was moved because `one_line` decides on five general categories and a
+        name that renders as nothing is on none of them, so this row named no persona at
+        all — a different property from the one measured here, on the same row. The name
+        checked for is asked of the function the row uses, so this test measures line
+        structure and does not also pin which escape delivers it.
         """
         benign = self._lint_report("evil  - stolen: yes")
         self.assertEqual(len(benign), 2, benign)  # one error row + the count line
@@ -609,7 +616,7 @@ class TestTheNextSpellingIsANameCharterDidNotMint(NameBase):
                 name = f"evil{sep}  - stolen: yes"
                 rows = self._lint_report(name)
                 self.assertEqual(len(rows), len(benign), rows)
-                self.assertIn(contain.one_line(name), rows[0])
+                self.assertIn(contain.readable(name), rows[0])
 
     def test_a_script_filename_cannot_forge_a_line_in_the_brief(self):
         """`bin/` is committed and its filenames go into the brief the sub-agent reads.


### PR DESCRIPTION
Closes #498.

`charter persona lint` printed `✗ : no role` for a persona directory named with three
U+3164 HANGUL FILLERs. The sentence beside it read `persona '' does not load`. The brief a
dispatched sub-agent reads listed `` `personas/<name>/bin/` `` under the words *run them by
path*. Three reports whose every row ends in *go and fix this*, none of them saying which
thing.

## The decision the issue asks for, and the argument for it

`contain.one_line` escapes a character whose general category is in
`{"Cc", "Cf", "Cs", "Zl", "Zp"}`, or that is whitespace other than the ASCII space. That is
a list of spellings; U+3164 and U+115F/U+1160 are `Lo`, U+2800 is `So`, none is `isspace`,
all survive `strip`.

**`one_line` is not widened.** Its docstring promises line structure and states in the same
breath that it does not promise readability — so this was never a defect in it. Enumerated
before choosing: **89 call sites**, across `frame/` (registry, component, action, actions,
ctx, picker, switch, overlay, panel, slots, choose, palette), `commands_persona`,
`commands_frame`, `persona` and `news`. Most print workspace names, roles, component titles
and forge text into a TUI, where a non-ASCII value is content that should reach the screen
as glyphs. Widening it would escape all 89 to make 3 legible — the over-eager fix that
mangles the names it was not about. `TestOneLineKeptItsContract` fails if a later round
tries. 86 remain on `one_line`; 3 moved.

**The three callers get `contain.readable` instead**, which decides on the complement —
printable ASCII is what a report line may hold, everything else prints as its `\uXXXX`
escape. No list, and the next codepoint is covered without an entry.

## Reused, not re-derived

The parent brief pointed at `charter/tui.py`. **It is the wrong property and I did not use
it:** `tui.width` measures cells occupied, and answers `6` for three HANGUL FILLERs — the
same as `devops`. `2` for U+3164, `1` for U+2800. It cannot decide "renders as nothing".

The reuse that does exist is `mcpseen._safe`/`_esc`, which made this exact complement
argument one surface over and already backs the `Refused …` row and the
`mcp: server name '<name>' is refused` lint error — rows in the *same two reports* as these
three. The escape table moved down into `contain` (`escape_char`, `escaped`) and `mcpseen`
now calls it, so the two halves of one report cannot spell a name two ways. Verified
byte-identical over all 1,114,112 codepoints × 4 probe shapes before the call sites moved,
so no stored consent fingerprint changes.

## What it costs, stated rather than hidden

A legitimately non-ASCII value at these three sites now prints as escapes. Bounded on
purpose: `persona.valid_name` mints names from `[a-z0-9][a-z0-9._-]`, so a name these
reports are asked about is ASCII by construction and comes back byte-identical, and no
prose surface (`role:`, memories, workspace titles, anything in the frame) goes near this.
The one real bite is a `personas/*/bin/` script with a non-ASCII filename, which now shows
escaped; the alternative was a bullet naming no file at all. `escaped` is reversible, so the
value is re-spelled and never destroyed.

## Verification

**Tests** — `tests/test_a_name_that_renders_as_nothing_is_still_a_name.py`, 32 tests, none
skipped, no tmux/locale gate. Sweeps the whole codespace for the property, and asserts the
three reports end to end on the printed row. Mutation-checked against three tempting wrong
fixes:

| put back in place of `readable` | failing subtests |
| --- | --- |
| `one_line` — the shipped bug | 94 |
| a blocklist of the four codepoints | 79 |
| a rule decided on `str.isprintable` | 91 |

The blocklist mutant passes the four named codepoints and still dies — which is the point:
the derivation is tested, not the contents.

**CI green at the head sha**, read from `check-runs` rather than `gh pr checks` (#561):
`test (3.11)`, `test (3.12)`, `test (3.13)`, `test (3.14)` all `success` at `aa11c98`, on
both the push and the pull_request trigger; zero failures.

**Full suite, two environments**, both on the rebased branch:

```
python3.14  Ran 6498 tests in 319.374s  OK
python3.12  Ran 6498 tests in 318.731s  OK   (CHARTER_*/CLAUDE_*/ANTHROPIC_*/TMUX* unset)
```

**`tools/sweep.py`** on this branch, twice. The first run found two survivors, both on one
line of `readable`, and both were addressed: one was an equivalent mutant
(`value if isinstance(value, str) else str(value)` — `str` hands a string straight back, so
the type test could not change an answer) and is deleted; the other was a real untested
branch (the non-str coercion) and is now pinned. The confirming run on the rebased branch:

```
mutations applied : 19
pinned            : 19
SURVIVED          : 0
UNRESOLVED        : 0
baseline          : Ran 6498 tests — OK
```

**Hand-checked** for the string/constant/semantic swaps the tool has no operator for (#569)
— 17 of them, each in its own sandbox with the full suite behind it, plus an **unmutated
baseline**, because a swap's failure COUNT is not a verdict. That baseline is what made the
run worth doing: four swaps whose count said "caught" were failing only the test the
baseline already failed, so they had survived.

| survivor | verdict |
| --- | --- |
| brief passes `DISPLAY_LIMIT` instead of `PATH_DISPLAY_LIMIT` | **real gap** — a script path over 160 chars was clipped and the agent told to run something that is not a path. Now pinned. |
| `mcpseen._safe` gains `quote=True` | **real gap** — the shared-escape refactor made a printed label one word away from changing, with nothing to say so. Now pinned, both directions. |
| `escape_char`'s `<=` becomes `<` | **equivalent** — U+FFFF gets the 8-digit form; still fixed-width, still injective, still printable ASCII. Recorded in the docstring rather than pinned. |
| `readable`'s `.strip(" ")` becomes `.strip()` | **equivalent** — after `escaped` the string is U+0020..U+007E, so there is no other whitespace to find. Recorded in the comment that explains why the space is named. |

Both new pins were re-verified to kill their swap.

## Filed, not absorbed

The alphabet sweep in this PR's own test turned up **#577**: `persona._NAME_RE` and
`instance.WORKSPACE_NAME_RE` end in `$`, which in Python matches before a *trailing
newline*, so `valid_name("evil\n")` is true and `personas/evil<LF>/` resolves, loads and
writes a blank line into a generated agent's YAML frontmatter. Nine anchored name regexes in
the tree share the shape. Same root cause one layer up — a check matching a spelling instead
of the property — and deliberately not fixed here: changing the alphabet every persona and
workspace name is validated against is a different question from three reports that do not
name what they are about. The test asserts the quirk rather than filtering it out, so
whoever switches to `fullmatch` sees what it was holding.

## Two notes for whoever is holding the frame work

- `docs/superpowers/specs/2026-08-25-agentic-ide-foundation.md` lists #498 in its Phase 3
  cluster (#498, #502, #503, #505, #508, #509 — "one reviewer, one shape"). With #502/#503
  landing in #573 this morning, three of the six are done. That spec is not touched here; it
  belongs to that workstream.
- `contain.readable` is available to the rest of that cluster. It is for **identifiers** — a
  name a sentence tells somebody to fix, a path something is told to run. A title or a note
  being drawn into a panel still wants `one_line` + `tui.width`, and this does not change
  that.

News entry included, `version: unreleased`. No bump, no stamp, no tag.
