### PR TITLE
A persona frontmatter key is honoured or reported, and `Borrows:` no longer fails open (#575, #509)

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -599,19 +599,18 @@ def _credential_rule() -> str:
     )
 
 
-#: Frontmatter keys `_render_agent` copies straight into the generated sub-agent.
-#: Anything a charter sets that isn't here (and isn't consumed by charter itself)
-#: reaches `.claude/agents/<name>.md` never — a typo is silently inert today, which
-#: `persona lint` now reports.
-_AGENT_PASSTHROUGH_KEYS = ("model", "color", "memory")
-
-#: Keys charter reads itself rather than emitting. Together with the passthrough set
-#: this is the full vocabulary of a persona charter's frontmatter.
-_CHARTER_OWN_KEYS = (
-    "name", "role", "vault", "extends", "uses", "delegate-when", "description",
-    "agent-description", "agent-tools", "tools", "activity", "dispatch-isolation",
-    "draft", "skills", "disallowed-tools", "routing", "routes-to", "borrows",
-)
+#: Frontmatter keys `_render_agent` copies straight into the generated sub-agent, and the
+#: keys charter reads itself. Anything a charter sets that is in neither reaches
+#: `.claude/agents/<name>.md` never — a typo is silently inert, which `persona lint`
+#: reports.
+#:
+#: Both now DEFINED in `persona.py` and re-exported here under the names this module has
+#: always used. The vocabulary of a persona definition is a fact about the parser, not
+#: about the command that renders one, and `persona.structural_errors` — which runs on
+#: every turn for the status line — says in its own docstring that it cannot afford to
+#: import this module to fetch it.
+_AGENT_PASSTHROUGH_KEYS = persona.AGENT_PASSTHROUGH_KEYS
+_CHARTER_OWN_KEYS = persona.CHARTER_OWN_KEYS
 
 
 def _rel(path) -> str:
@@ -877,11 +876,35 @@ isolated context. Adopt the charter below as your role.
 
 
 def _write_agent(name: str) -> str | None:
-    """Generate/refresh one persona's sub-agent. Returns 'written'|'skipped'|'draft'|None.
-    Uses the RESOLVED persona (inheritance applied: merged charter + unioned tools)."""
+    """Generate/refresh one persona's sub-agent. Returns
+    'written'|'skipped'|'draft'|'unreadable'|None. Uses the RESOLVED persona (inheritance
+    applied: merged charter + unioned tools)."""
     d = persona.resolve(name)
     if not d:
         return None
+    if persona.key_issues(name):
+        # The sibling of #575's named bug, and the one with the wider blast radius. A key
+        # charter cannot read is not inert HERE — three of the fields this function renders
+        # are enforced by their PRESENCE, so misspelling one deletes the enforcement:
+        #
+        #   * `Agent-tools:` → no `tools:` line is emitted, and no `tools:` line means the
+        #     sub-agent inherits EVERY tool. The allowlist does not narrow; it vanishes.
+        #   * `Disallowed-tools:` → no `disallowedTools:` line. The denylist vanishes.
+        #   * `Draft:` → `is_draft` is False, so the unfinished charter this function
+        #     refuses to ship becomes a sub-agent's system prompt after all.
+        #
+        # All three were reached by `charter persona sync-agents` printing `✓ Synced 1
+        # persona sub-agent(s)`. Same answer as a draft, for the same reason the draft
+        # branch gives: the generated file IS the sub-agent's system prompt, and one built
+        # from a definition charter could not read is not the committed charter. The stale
+        # agent goes too — leaving it keeps the persona dispatchable under whatever it said
+        # before, which is exactly the grant the author was editing the file to remove.
+        #
+        # Deliberately NOT gated on lint's other findings, or on an unknown key generally:
+        # `key_issues` is the narrow set charter can prove was meant to be read (a key it
+        # reads, miscased or written twice), so `modell:` still renders an agent.
+        _remove_agent(name)
+        return "unreadable"
     if persona.is_draft(name):
         # The generated file IS the sub-agent's system prompt, so an unfinished charter
         # must not become one. Any agent generated BEFORE the persona was marked draft is
@@ -1646,6 +1669,7 @@ def cmd_persona_sync_agents(args) -> int:
     outcomes = {n: _write_agent(n) for n in names}
     written = [n for n, o in outcomes.items() if o == "written"]
     drafts = [n for n, o in outcomes.items() if o == "draft"]
+    unreadable = [n for n, o in outcomes.items() if o == "unreadable"]
     withheld = {n: persona.mcp_withheld(n) for n in written}
     withheld = {n: v for n, v in withheld.items() if v}
     # A server name the committed sidecar chose and `mcp_name_ok` refused. Said on the run
@@ -1669,6 +1693,21 @@ def cmd_persona_sync_agents(args) -> int:
         util.warn(f"Skipped {len(drafts)} draft persona(s): {', '.join(drafts)} — "
                   "an unfinished charter must not become a sub-agent's system prompt. "
                   "Finish it, drop the `draft: true` line, then re-run.")
+    if unreadable:
+        # Said on the run that would have written the agent, not left to `lint`. A
+        # miscased `Agent-tools:` does not narrow a sub-agent's tools, it removes the
+        # allowlist entirely — so a green tick over this is the shape #453 keeps arriving
+        # in, a bound that degrades in silence.
+        util.warn(f"Skipped {len(unreadable)} persona(s) whose frontmatter charter cannot "
+                  f"read: {', '.join(unreadable)}. A key spelled in another case, or "
+                  f"declared twice, is read by nothing — and `agent-tools:`, "
+                  f"`disallowed-tools:` and `draft:` are enforced by being PRESENT, so a "
+                  f"misspelling drops the allowlist, the denylist or the draft guard "
+                  f"rather than narrowing anything. No agent is generated until the key is "
+                  f"fixed:")
+        for n in unreadable:
+            for _lvl, msg in persona.key_issues(n):
+                util.info(f"  {contain.readable(n)}: {msg}")
     if removed:
         util.info("Removed stale generated agents: " + ", ".join(removed))
     if refused:

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -258,9 +258,9 @@ def parse(text: str) -> tuple[dict, str]:
 
     **Lossy, and now provably so.** Two lines carrying one key collapse to the last of
     them, which is a fact about a `dict` and not a decision anyone made: the file said two
-    things and this says one. Callers that need to know a key was written twice ask
-    :func:`duplicate_keys` — :func:`load` does, so every persona-shaped consumer gets the
-    answer without a second read.
+    things and this says one. A caller holding only text asks :func:`duplicate_keys` for
+    what the dict dropped; :func:`load` reads both off one walk of the same file, so every
+    persona-shaped consumer gets the answer without a second parse.
     """
     pairs, body = _frontmatter(text)
     return dict(pairs), body
@@ -1088,17 +1088,36 @@ def uses_of(name: str) -> list[str]:
 BORROWS_NONE = "none"
 
 
+#: The keys whose unreadability makes :func:`borrows_of`'s ``None`` a lie, and therefore
+#: the ones a grant may not be widened over.
+#:
+#: ``borrows`` is #575's own defect: the answer is read off the key's ABSENCE, so a
+#: spelling charter cannot read is indistinguishable from an author who never opted in.
+#:
+#: ``extends`` is the same fail-open one key over, and it was found by asking this list the
+#: question rather than by trusting the issue's. A child declaring ``Extends: parent`` does
+#: not inherit its parent's ``borrows:``, so a chain that opted OUT of the legacy grant
+#: hands the child the wide one:
+#:
+#:     parent:  borrows: none
+#:     kid:     Extends: parent   uses: forge   → forge's tools, auto-approved
+#:
+#: Charter cannot follow a chain it could not read, which is precisely why it must not
+#: conclude "this persona declared no ``borrows:``" from the end of one.
+_GRANT_DECIDING_KEYS = ("borrows", "extends")
+
+
 def _borrows_unreadable(resolved: dict) -> bool:
-    """Did the author write a ``borrows:`` declaration charter could not read?
+    """Did the author write a grant-deciding declaration charter could not read?
 
     The whole of #575's teeth live in the difference between that and "the author never
     mentioned borrowing", because :func:`effective_tools` widens on the second one.
     Two spellings of unreadable, both of which used to answer *absent*:
 
-    * a key that differs from ``borrows`` only by case — ``Borrows: none`` was read by
-      nothing, so the persona kept the legacy grant it had just written the word to give
-      up, and
-    * ``borrows:`` on two lines, where the dict keeps whichever is lower in the file, so
+    * a key that differs from one of :data:`_GRANT_DECIDING_KEYS` only by case —
+      ``Borrows: none`` was read by nothing, so the persona kept the legacy grant it had
+      just written the word to give up, and
+    * one of them on two lines, where the dict keeps whichever is lower in the file, so
       ``borrows: none`` above ``borrows: forge`` grants `forge`'s tools by line order.
 
     Both are asked of the whole inheritance chain, unlike :func:`key_issues`, and that
@@ -1106,16 +1125,21 @@ def _borrows_unreadable(resolved: dict) -> bool:
     GRANT belongs to the persona the tool gate is deciding about. A parent whose
     ``Borrows:`` charter could not read must not hand its children the wide grant either.
 
+    Deliberately NOT "any key charter could not read". A persona with an unrelated typo
+    would silently lose its legacy `uses:` grant, which is a fail-closed nobody asked for
+    and nothing would explain — the same over-reach that made the general unknown-key
+    finding a warning rather than an error.
+
     The case half is read off the *resolved* meta, which costs nothing — `resolve` copies
     a key it does not recognise straight through, so an ancestor's ``Borrows`` is already
     sitting in the merged dict under that spelling. Only the duplicate half needs the
     per-file answer, and only that half walks.
     """
-    if any(misspelled_key(k) == "borrows" for k in resolved["meta"]):
+    if any(misspelled_key(k) in _GRANT_DECIDING_KEYS for k in resolved["meta"]):
         return True
     for a in resolved.get("lineage") or ():
         d = load(a)
-        if d and "borrows" in (d.get("dupes") or ()):
+        if d and any(k in (d.get("dupes") or ()) for k in _GRANT_DECIDING_KEYS):
             return True
     return False
 

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -218,13 +218,23 @@ def list_personas() -> list[str]:
     return sorted(names)
 
 
-def parse(text: str) -> tuple[dict, str]:
-    """Split frontmatter markdown into (metadata, charter body).
+def _frontmatter(text: str) -> tuple[list[tuple[str, str]], str]:
+    """The frontmatter as ``[(key, value)]`` **in file order**, plus the body.
 
-    Minimal, dependency-free: flat ``key: value`` lines. Good enough for our
-    small, controlled frontmatter (``role``, ``vault``, …).
+    The one line-walk. :func:`parse` collapses these pairs into a dict and :func:`load`
+    also asks them what the dict cannot answer — which keys were written more than once
+    (#509). Two questions, one reading of the file, so the answers cannot disagree about
+    what the file said.
+
+    Splitting this out is what let #509 be fixed without the change it feared. That issue
+    read the choice as "either change what `parse` returns or give it a second output",
+    both of which land on `persona.load`, `structural_errors`, `resolve`, `tools_of`,
+    `vault_of`, `docsrc`, `news._read` and the skill lint at once. Neither happened:
+    `parse` still returns ``(dict, body)`` and every caller of it is untouched. The second
+    answer is carried by the *loader*, which is where the persona-shaped questions are
+    already asked.
     """
-    meta: dict = {}
+    pairs: list[tuple[str, str]] = []
     body = text
     if text.startswith("---"):
         parts = text.split("---", 2)
@@ -236,8 +246,144 @@ def parse(text: str) -> tuple[dict, str]:
                 key, _, value = line.partition(":")
                 key, value = key.strip(), value.strip()
                 if key:
-                    meta[key] = value
-    return meta, body.strip()
+                    pairs.append((key, value))
+    return pairs, body.strip()
+
+
+def parse(text: str) -> tuple[dict, str]:
+    """Split frontmatter markdown into (metadata, charter body).
+
+    Minimal, dependency-free: flat ``key: value`` lines. Good enough for our
+    small, controlled frontmatter (``role``, ``vault``, …).
+
+    **Lossy, and now provably so.** Two lines carrying one key collapse to the last of
+    them, which is a fact about a `dict` and not a decision anyone made: the file said two
+    things and this says one. Callers that need to know a key was written twice ask
+    :func:`duplicate_keys` — :func:`load` does, so every persona-shaped consumer gets the
+    answer without a second read.
+    """
+    pairs, body = _frontmatter(text)
+    return dict(pairs), body
+
+
+def duplicate_keys(text: str) -> list[str]:
+    """Frontmatter keys *text* declares more than once, first-declaration order.
+
+    A key written twice is a contradiction in the file, not a value to be picked (#509).
+    :func:`parse` keeps the last line because that is what building a dict does, so the
+    first value is gone before any consumer sees the dict — ``vault:`` twice hands out
+    whichever vault is lower in the file, ``tools:`` twice auto-approves whichever list
+    is lower, and nothing anywhere said a word.
+
+    Exposed on the TEXT rather than folded into `parse`'s return type, so the news reader
+    and the skill lint can ask the same question of the same parser when their owners want
+    it, without this changing under them first.
+    """
+    return [k for k, n in _key_counts(_frontmatter(text)[0]).items() if n > 1]
+
+
+#: Frontmatter keys `commands_persona._render_agent` copies straight into the generated
+#: sub-agent.
+AGENT_PASSTHROUGH_KEYS = ("model", "color", "memory")
+
+#: Keys charter reads itself rather than emitting. Together with the passthrough set this
+#: is the full vocabulary of a persona charter's frontmatter.
+CHARTER_OWN_KEYS = (
+    "name", "role", "vault", "extends", "uses", "delegate-when", "description",
+    "agent-description", "agent-tools", "tools", "activity", "dispatch-isolation",
+    "draft", "skills", "disallowed-tools", "routing", "routes-to", "borrows",
+)
+
+#: The whole vocabulary, and the only spelling of each word charter answers to.
+#:
+#: Declared HERE rather than in `commands_persona`, where it lived, because
+#: :func:`structural_errors` needs it and its docstring says in as many words that it
+#: cannot afford the import — it runs on every turn for the status line. The vocabulary of
+#: a persona definition is a fact about the parser, not about the command that renders one,
+#: so the lower layer is where it belongs; `commands_persona` still exports the old names.
+KNOWN_KEYS = frozenset(AGENT_PASSTHROUGH_KEYS) | frozenset(CHARTER_OWN_KEYS)
+
+#: `KNOWN_KEYS` folded, for :func:`misspelled_key` — built once rather than per key per
+#: persona per turn.
+_FOLDED_KEYS = {k.casefold(): k for k in KNOWN_KEYS}
+
+
+def misspelled_key(key: str) -> str | None:
+    """The key charter reads that *key* differs from **only by case**, or None.
+
+    This is not the case-folding #573 refused, and the difference is which question gets
+    folded. There, folding was proposed for the *lookup* — `meta.get(key.casefold())` —
+    which would have made ``Vault:`` work and left ``vualt:``, ``borrow:`` and
+    ``delegate_when:`` exactly as silent, a guard against one spelling rather than the
+    property. Nothing here is looked up: a value is never read out of a miscased key, and
+    charter never guesses which field the author meant.
+
+    What is folded is the **sentence and the severity**. A key outside the vocabulary is
+    caught by :data:`KNOWN_KEYS` being closed — that is #573's mechanism, unchanged, and it
+    is what catches ``vualt:``. This only asks, of a key already caught, whether charter can
+    name the word the author was reaching for. When it can, the report says so and the
+    grant stops trusting the key's absence (:func:`borrows_of`), because ``Borrows: none``
+    is not a key charter has no opinion about — it is a key charter reads, one shift away,
+    and the author who wrote it was opting OUT of a permission grant.
+
+    ``casefold``, matching `news._flag`'s reading of ``TRUE``/``True``, so the whole tree
+    folds text one way.
+    """
+    if key in KNOWN_KEYS:
+        return None
+    return _FOLDED_KEYS.get(key.casefold())
+
+
+def key_issues(name: str) -> list[tuple[str, str]]:
+    """Frontmatter keys in *name*'s own definition that charter can neither honour nor
+    let pass — ``[(level, message)]``, all of them errors.
+
+    **The property: a frontmatter key is honoured or reported, never silently resolved.**
+    Two ways a key goes unhonoured while charter can still prove which word the author
+    meant, and both used to end in a value chosen by accident with nothing said:
+
+    * **Declared twice** (#509). ``vault: safe`` above ``vault: prod`` hands out ``prod``
+      because that is what building a dict does — the file states a contradiction and
+      charter resolves it by LINE ORDER. Charter does not pick; it names the key.
+    * **Spelled in another case** (#575). ``Vault:`` is read by nothing, so the persona
+      declares a vault and has none; ``Extends:`` declares a parent and inherits nothing.
+
+    A key charter simply does not read — ``modell:``, ``delegate_when:`` — is *not* here.
+    It stays the warning :func:`lint` has always given it, because charter has no claim
+    about it: a harness's own field is a legitimate thing to carry in a committed file, and
+    an error would break planes that are correct. These two are different in kind. Charter
+    can say which key charter reads the author was writing, which is what makes the finding
+    an error and what lets :func:`borrows_of` act on it.
+
+    Own definition only, matching :func:`structural_errors`' framing — a parent's bad key
+    is a finding about the parent, reported when the parent is linted, and the parent's own
+    sub-agent is the one withheld for it.
+    """
+    d = load(name)
+    if not d:
+        return []
+    issues: list[tuple[str, str]] = []
+    # Bounded, because a key is a string from a committed file on its way into a report a
+    # human reads and acts on. `splitlines` already makes a second ROW impossible — it
+    # splits on \r, \x85, U+2028 and U+2029 alike, so none of those survives into a key —
+    # but a key of U+3164 HANGUL FILLER strips to nothing visible and printed as
+    # `frontmatter key '' …`: #498's finding, a row telling somebody to go and edit a key
+    # it does not name. `readable` decides on the complement, so the key named here is one
+    # they can find in the file.
+    for key in sorted(d.get("dupes") or ()):
+        issues.append(("error", f"frontmatter key '{contain.readable(key)}' is declared "
+                                f"more than once — charter keeps the LAST line and the "
+                                f"first is lost before anything reads it. Two lines are a "
+                                f"contradiction in the file, not a value to pick: delete "
+                                f"one"))
+    for key in sorted(set(d["meta"])):
+        meant = misspelled_key(key)
+        if meant:
+            issues.append(("error", f"frontmatter key '{contain.readable(key)}' is read by "
+                                    f"nothing — charter matches keys exactly, so this is "
+                                    f"not `{meant}:` and its value never reaches charter. "
+                                    f"Spell it `{meant}:`"))
+    return issues
 
 
 def definition_refusal(name: str) -> str | None:
@@ -277,9 +423,22 @@ def load(name: str) -> dict | None:
     p = def_path(name)
     if not p.exists() or definition_refusal(name):
         return None
-    meta, charter = parse(p.read_text())
+    pairs, charter = _frontmatter(p.read_text())
+    meta = dict(pairs)
     meta.setdefault("name", name)
-    return {"meta": meta, "charter": charter}
+    # The second answer the dict cannot carry, from the same read (#509). A third key
+    # rather than a changed return type: every consumer indexes `["meta"]`/`["charter"]`,
+    # so nothing downstream has to learn about this to keep working — only the two
+    # functions that report it do.
+    dupes = [k for k, n in _key_counts(pairs).items() if n > 1]
+    return {"meta": meta, "charter": charter, "dupes": dupes}
+
+
+def _key_counts(pairs) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for key, _v in pairs:
+        counts[key] = counts.get(key, 0) + 1
+    return counts
 
 
 # --------------------------------------------------------------------------- #
@@ -929,6 +1088,38 @@ def uses_of(name: str) -> list[str]:
 BORROWS_NONE = "none"
 
 
+def _borrows_unreadable(resolved: dict) -> bool:
+    """Did the author write a ``borrows:`` declaration charter could not read?
+
+    The whole of #575's teeth live in the difference between that and "the author never
+    mentioned borrowing", because :func:`effective_tools` widens on the second one.
+    Two spellings of unreadable, both of which used to answer *absent*:
+
+    * a key that differs from ``borrows`` only by case — ``Borrows: none`` was read by
+      nothing, so the persona kept the legacy grant it had just written the word to give
+      up, and
+    * ``borrows:`` on two lines, where the dict keeps whichever is lower in the file, so
+      ``borrows: none`` above ``borrows: forge`` grants `forge`'s tools by line order.
+
+    Both are asked of the whole inheritance chain, unlike :func:`key_issues`, and that
+    asymmetry is deliberate: a REPORT belongs to the file that has to be edited, while a
+    GRANT belongs to the persona the tool gate is deciding about. A parent whose
+    ``Borrows:`` charter could not read must not hand its children the wide grant either.
+
+    The case half is read off the *resolved* meta, which costs nothing — `resolve` copies
+    a key it does not recognise straight through, so an ancestor's ``Borrows`` is already
+    sitting in the merged dict under that spelling. Only the duplicate half needs the
+    per-file answer, and only that half walks.
+    """
+    if any(misspelled_key(k) == "borrows" for k in resolved["meta"]):
+        return True
+    for a in resolved.get("lineage") or ():
+        d = load(a)
+        if d and "borrows" in (d.get("dupes") or ()):
+            return True
+    return False
+
+
 def borrows_of(name: str) -> list[str] | None:
     """Personas whose tools and vault this one may use — its ``borrows:``, or ``None`` when
     the key is absent.
@@ -937,9 +1128,28 @@ def borrows_of(name: str) -> list[str] | None:
     absent means "I have not opted in, keep the legacy `uses:` grant", while
     ``borrows: none`` means "I borrow nothing". Collapsing them would either break every
     existing plane or make opting out unsayable.
+
+    **`None` means the author never mentioned borrowing, and nothing else (#575).** It used
+    to also mean "the author mentioned it and charter did not read the key", which made
+    this the one field in the file that fails OPEN: every other miscased key costs the
+    persona something — a miscased ``Vault:`` means no credentials, a miscased ``Tools:``
+    means no auto-approvals — while a miscased ``Borrows:`` fell through to the legacy
+    ``uses:`` grant, which is the WIDER one. An author writing ``Borrows: none`` to opt out
+    of #257's grant got #257's grant, both borrowed personas' tools auto-approved at
+    `toolgate.decide`, and `structural_errors` empty.
+
+    So an unreadable declaration answers ``[]`` — borrow nothing — and never ``None``. That
+    is narrower than the author asked for whenever they meant ``Borrows: forge``, and
+    narrower is the direction this may be wrong in: the persona pays a permission prompt it
+    did not expect and `persona lint` names the line to fix, which is a cost measured in one
+    edit. The other direction is measured in a vault.
     """
     r = resolve(name)
-    if not r or "borrows" not in r["meta"]:
+    if not r:
+        return None
+    if _borrows_unreadable(r):
+        return []
+    if "borrows" not in r["meta"]:
         return None
     vals = _csv_list(r["meta"].get("borrows"))
     return [v for v in vals if v != BORROWS_NONE]
@@ -1152,14 +1362,26 @@ def structural_errors(name: str, known: set[str] | None = None) -> list[tuple[st
     rather than untidy — the resolver cannot build it. Split out from :func:`lint`
     (which calls this, so there is still one implementation) because the status line
     needs exactly this subset on **every turn** and none of the rest: no ``vault_of``,
-    no role/delegate-when, no unknown-key scan, and in particular no import of
-    ``commands_persona`` to fetch the key whitelist.
+    no role/delegate-when, no walk of the plugin cache, and no import of any command
+    module.
 
     ``known`` lets a caller sweeping the whole roster pass ``list_personas()`` once
     instead of paying for it per persona — 1.6ms of a 5.2ms 13-persona sweep.
+
+    :func:`key_issues` is here, and it is the one thing this gained. A key charter could
+    not honour is the same kind of broken as a dangling reference — the resolver builds a
+    persona out of a file that says something else — and it is where the fail-open shows:
+    ``Borrows: none`` narrows the grant now (#575), so the operator has to be told which
+    line did it by the signal that is on screen, not by a command they may never run.
+
+    It cost nothing to move here. This function used to be unable to ask about keys at
+    all, because the vocabulary lived in `commands_persona` and the import was the whole
+    expense; the vocabulary is :data:`KNOWN_KEYS` in this module now, and `lint`'s own
+    unknown-key scan stopped paying for that import too. The general unknown-key WARNING
+    stays in `lint` — it is not an error and this half is the error half.
     """
     allnames = known if known is not None else set(list_personas())
-    issues: list[tuple[str, str]] = []
+    issues: list[tuple[str, str]] = list(key_issues(name))
     refused = definition_refusal(name)
     if refused:
         # First, and on its own terms: every check below reads through `load`, which
@@ -1309,12 +1531,29 @@ def lint(name: str, deep: bool = True) -> list[tuple[str, str]]:
                                "charter, drop the line, then `charter persona sync-agents`"))
     # A frontmatter key charter neither reads nor emits reaches nothing: it is not copied
     # into .claude/agents/<name>.md and no charter code consults it, so a typo (`modell:`,
-    # `delegate_when:`) is silently inert. Imported lazily — persona.py is the lower layer
-    # and must not import the command module at import time.
-    from .commands_persona import _AGENT_PASSTHROUGH_KEYS, _CHARTER_OWN_KEYS
-    for key in sorted(set(meta) - (set(_AGENT_PASSTHROUGH_KEYS) | set(_CHARTER_OWN_KEYS))):
-        issues.append(("warn", f"frontmatter key '{key}' is neither read by charter nor "
-                               f"emitted into the sub-agent — it does nothing (typo?)"))
+    # `delegate_when:`) is silently inert.
+    #
+    # A WARNING, and it stays one. Charter has no claim about `modell:` — a harness's own
+    # field is a legitimate thing to carry in a committed file, and this line firing as an
+    # error would break planes that are correct. The two kinds of key charter CAN make a
+    # claim about — one it reads spelled in another case, and one it reads written twice —
+    # are errors, and they come from `structural_errors` below.
+    #
+    # Skipping the keys `key_issues` already named is not tidiness. "It does nothing
+    # (typo?)" is the wrong sentence for `Borrows:`: the key does nothing and its ABSENCE
+    # does a great deal, and a reader who acts on the milder of two sentences about one
+    # line acts on the wrong one.
+    #
+    # `contain.readable` because a key is a string from a committed file printed into a row
+    # whose whole job is to say which key to go and edit. `splitlines` already rules out a
+    # second row — it splits on \r, \x85, U+2028 and U+2029 — but a key of U+3164 HANGUL
+    # FILLER strips to nothing and printed as `frontmatter key '' …`, #498's finding on a
+    # row that had not been given the escape.
+    named = {k for k in meta if misspelled_key(k)}
+    for key in sorted((set(meta) - KNOWN_KEYS) - named):
+        issues.append(("warn", f"frontmatter key '{contain.readable(key)}' is neither read "
+                               f"by charter nor emitted into the sub-agent — it does "
+                               f"nothing (typo?)"))
     issues += structural_errors(name)
     issues += bin_issues(name)
     if deep:

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1375,8 +1375,13 @@ def _health_mark(name: str, known: set[str] | None = None) -> str:
 
     Cost is why this calls :func:`persona.structural_errors` rather than `lint`: the
     full lint walks the plugin cache, and even `lint(deep=False)` pays for the vault,
-    role, delegate-when and unknown-key checks (plus an import of `commands_persona`)
-    that produce nothing a chip can show. This renders on every single turn.
+    role, delegate-when and unknown-key checks that produce nothing a chip can show.
+    This renders on every single turn.
+
+    A key charter could not read — miscased, or declared twice — IS shown, because
+    `structural_errors` reports it (#575, #509). That is not a soft finding: one of them
+    changes a tool grant, and the chip is the signal the operator was looking straight at
+    while `Borrows: none` handed out the wide one.
     """
     try:
         from . import persona

--- a/docs/news/unreleased-a-persona-key-is-honoured-or-reported.md
+++ b/docs/news/unreleased-a-persona-key-is-honoured-or-reported.md
@@ -1,0 +1,99 @@
+---
+version: unreleased
+headline: A persona frontmatter key is honoured or reported — and a miscased `Borrows:` no longer hands out the wide tool grant it was written to give up
+security: true
+---
+
+Two defects in the persona parser, and one property between them: **a key the author
+declared is honoured or reported, never silently resolved.** One is "the key was not
+recognised", the other is "the key was recognised twice", and both used to end in a value
+chosen by accident with nothing said.
+
+## `Borrows:` failed OPEN
+
+charter's frontmatter parser matches keys exactly, so `Vault:` puts `Vault` in the dict and
+the lookup for `vault` finds nothing. Almost every key fails that way toward *less*: a
+miscased `Vault:` means no credentials, a miscased `Tools:` means no auto-approvals. The
+persona declares a vault and has none, which is wrong but not dangerous.
+
+`borrows:` is the exception, because it is answered by **absence**. `borrows_of` returns
+`None` for an absent key on purpose, and `None` means "I have not opted in — keep the
+legacy `uses:` grant", which is the *wider* one. So the author who wrote the word that
+grants nothing got the grant they were opting out of:
+
+```
+uses: forge, release
+Borrows: none            ← read by nothing
+```
+
+```
+borrows_of(front):      None
+effective_tools(front): ['Bash(gh:*)', 'Bash(git push:*)']
+structural_errors:      []
+```
+
+Both borrowed personas' tools auto-approved at the tool gate, from a definition whose
+author had written the opposite, with the lint that exists to say so reporting nothing at
+error level. That is the grant `borrows:` was added to take back, reached through one shift
+key.
+
+**A `borrows:` charter cannot read now answers `[]` — borrow nothing — and never `None`.**
+`None` means the author never mentioned borrowing, and nothing else. This is narrower than
+the author asked for whenever they meant `Borrows: forge`, and narrower is the direction
+this is allowed to be wrong in: the persona pays a permission prompt it did not expect and
+the lint names the line to fix. The other direction is measured in a vault.
+
+## The sibling was wider than the named bug
+
+Three of the fields the generated sub-agent carries are enforced by being **present**, so
+misspelling one does not narrow the enforcement — it deletes it:
+
+* `Agent-tools:` — no `tools:` line is emitted, and no `tools:` line means the sub-agent
+  inherits **every tool**. The allowlist does not shrink; it vanishes.
+* `Disallowed-tools:` — the denylist vanishes the same way.
+* `Draft:` — an unfinished charter becomes a sub-agent's system prompt, which is precisely
+  what `sync-agents` refuses to let happen.
+
+All three were reached through a run that printed `✓ Synced 1 persona sub-agent(s)`.
+`sync-agents` now generates no agent from a definition charter could not read, removes any
+stale one, and prints which key to fix — the same answer it already gives a draft, for the
+same reason.
+
+## A key written twice was resolved by line order
+
+`vault: safe` above `vault: prod` handed out `prod`, because that is what building a dict
+does. The file stated a contradiction and charter resolved it by which line was lower,
+losing the first value before any consumer saw the dict — the same silence over `tools:`
+twice, `extends:` twice, `borrows:` twice.
+
+A key declared more than once is reported by name now. Charter does not pick.
+
+## Refused, not case-folded
+
+Folding the lookup would answer `Vault:` and leave `vualt:`, `borrow:` and
+`delegate_when:` exactly as silent — a guard against one spelling rather than the property.
+What catches every one of them is the vocabulary being **closed**, which charter already
+had: `persona lint` has long warned about a key it neither reads nor emits.
+
+What changed is which of those findings carries weight. A key charter simply does not read
+stays a **warning** — charter has no claim about `modell:`, a harness's own field is a
+legitimate thing to carry in a committed file, and an error there would break planes that
+are correct. A key charter *does* read, spelled in another case or written twice, is an
+**error**: charter can name the word the author was reaching for, and that is what makes it
+actionable and what lets the grant act on it. Nothing is ever read out of the miscased key.
+
+## If you have one committed today
+
+Five shipped personas and all 109 shipped news entries are clean, so this is about your
+plane, not charter's.
+
+* A miscased or duplicated key goes from a lint **warning** to an **error**, and now shows
+  on the status line rather than only in `charter persona lint`.
+* Your tool grant changes in exactly one case: a miscased `Borrows:`, which today silently
+  grants the borrowed personas' tools and after this grants none of them.
+* `charter persona sync-agents` writes no agent for that persona until the key is fixed,
+  and names it.
+* Nothing changes for a definition whose keys are all spelled once and correctly —
+  including the legacy `uses:` grant for a persona that declares no `borrows:` at all.
+
+Fix is one edit: spell the key the way the error line spells it, or delete the duplicate.

--- a/tests/test_a_persona_key_is_honoured_or_reported.py
+++ b/tests/test_a_persona_key_is_honoured_or_reported.py
@@ -1,0 +1,416 @@
+"""A persona frontmatter key is honoured or reported — never silently resolved (#575, #509).
+
+Two issues, one property, and one of them is a permission grant.
+
+**#575 — the key was not recognised.** `persona.parse` keeps a key exactly as written, so
+``Vault:`` puts ``Vault`` in the dict, ``meta.get("vault")`` finds nothing, and the persona
+declares a vault and has none. Every such key failed toward LESS — except one. ``borrows:``
+is answered by ABSENCE: `borrows_of` returns None for an absent key on purpose, and None
+means "keep the legacy `uses:` grant", which is the wider one. So an author writing
+``Borrows: none`` to opt OUT of #257's grant got #257's grant, both borrowed personas' tools
+auto-approved at `toolgate.decide`, with `structural_errors` empty.
+
+**#509 — the key was recognised twice.** Two lines carrying one key collapse to the last,
+because that is what building a dict does. ``vault: safe`` above ``vault: prod`` hands out
+`prod` by LINE ORDER, and the first value is gone before any consumer sees the dict.
+
+Both end in a value chosen by accident with no diagnostic, and the fix is one property.
+
+**Refused, not folded — #573's call, kept.** Case-folding the LOOKUP would answer ``Vault:``
+and leave ``vualt:``, ``borrow:`` and ``delegate_when:`` exactly as silent. The closed
+vocabulary is what catches every one of them; `persona.misspelled_key` only sharpens the
+SENTENCE and the SEVERITY for the sub-case where charter can name the word the author was
+reaching for — and that is what lets the grant act on it. `test_folding_is_not_the_catch`
+pins the difference.
+
+**The sibling was wider than the named bug.** Three of the fields `_render_agent` emits are
+enforced by being PRESENT, so misspelling one deletes the enforcement rather than narrowing
+it: ``Agent-tools:`` emits no ``tools:`` line and no ``tools:`` line means the sub-agent
+inherits EVERY tool; ``Disallowed-tools:`` drops the denylist; ``Draft:`` ships the
+unfinished charter `sync-agents` refuses to ship. All three were reached through a run that
+printed `✓ Synced 1 persona sub-agent(s)`.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import commands_persona as cp
+from charter import config, persona
+from tests._isolation import PersonaIso
+
+
+def _front(**keys) -> str:
+    """A persona file with these keys in this order — duplicates included, which is the
+    whole point: `make_persona` takes **kwargs and a dict cannot hold one key twice."""
+    return "".join(f"{k}: {v}\n" for k, v in keys.items())
+
+
+class KeyCase(PersonaIso):
+    def write(self, name: str, frontmatter: str, body: str = "charter body") -> str:
+        d = config.PERSONAS_DIR / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "persona.md").write_text(f"---\nname: {name}\n{frontmatter}---\n\n{body}\n")
+        return name
+
+    def errors(self, name: str) -> list[str]:
+        return [m for lvl, m in persona.structural_errors(name) if lvl == "error"]
+
+    def warns(self, name: str) -> list[str]:
+        return [m for lvl, m in persona.lint(name, deep=False) if lvl == "warn"]
+
+
+# --------------------------------------------------------------------------- #
+# #575 — the fail-open. The priority: `borrows_of` must never fall through to  #
+# a wider grant than the author wrote.                                         #
+# --------------------------------------------------------------------------- #
+class BorrowsFailsOpen(KeyCase):
+    def grant_world(self, front_key: str = "Borrows", front_val: str = "none") -> None:
+        self.write("forge", "role: f\nvault: none\ntools: Bash(gh:*)\n")
+        self.write("release", "role: r\nvault: none\ntools: Bash(git push:*)\n")
+        self.write("front", f"role: fr\nvault: none\nuses: forge, release\n"
+                            f"{front_key}: {front_val}\ntools: Bash(ls:*)\n")
+
+    def test_the_reproduction_from_the_issue(self):
+        """`Borrows: none` — the word that grants nothing — granted both personas' tools."""
+        self.grant_world()
+        self.assertEqual(persona.borrows_of("front"), [],
+                         "a `borrows:` charter could not read must not answer 'absent'")
+        self.assertEqual(persona.effective_tools("front"), {"Bash(ls:*)"},
+                         "the author opted OUT; the borrowed tools must not be granted")
+
+    def test_the_fallback_cannot_come_back(self):
+        """The regression this exists to stop: None here IS the wide grant.
+
+        Asserted on the sentinel and not only on the tool set, because the two are one
+        line apart in `effective_tools` and a future edit could restore the fallback while
+        some other narrowing kept this fixture's tools looking right.
+        """
+        self.grant_world()
+        self.assertIsNotNone(persona.borrows_of("front"))
+        self.assertNotIn("Bash(gh:*)", persona.effective_tools("front"))
+        self.assertNotIn("Bash(git push:*)", persona.effective_tools("front"))
+
+    def test_a_miscased_borrows_naming_personas_also_fails_closed(self):
+        """Narrower than the author asked for, which is the direction this may be wrong in.
+
+        `Borrows: forge` meant "forge only". Charter cannot read the key, so it grants
+        nothing and says which line to fix — one edit. Reading it as the legacy grant costs
+        `release`'s tools as well, which is what the file was written to stop.
+        """
+        self.grant_world(front_val="forge")
+        self.assertEqual(persona.borrows_of("front"), [])
+        self.assertEqual(persona.effective_tools("front"), {"Bash(ls:*)"})
+
+    def test_borrows_declared_twice_fails_closed(self):
+        """#509 reaching the grant: `borrows: none` above `borrows: forge` granted forge."""
+        self.write("forge", "role: f\nvault: none\ntools: Bash(gh:*)\n")
+        self.write("front", "role: fr\nvault: none\nuses: forge\ntools: Bash(ls:*)\n"
+                            + _front(borrows="none") + "borrows: forge\n")
+        self.assertEqual(persona.borrows_of("front"), [])
+        self.assertEqual(persona.effective_tools("front"), {"Bash(ls:*)"})
+
+    def test_an_inherited_miscased_borrows_does_not_widen_the_child(self):
+        """A report belongs to the file being edited; a GRANT belongs to the persona the
+        tool gate is deciding about. A parent charter could not read must not hand its
+        children the wide grant either."""
+        self.write("forge", "role: f\nvault: none\ntools: Bash(gh:*)\n")
+        self.write("parent", "role: p\nvault: none\nuses: forge\nBorrows: none\n")
+        self.write("kid", "role: k\nvault: none\nextends: parent\ntools: Bash(ls:*)\n")
+        self.assertEqual(persona.borrows_of("kid"), [])
+        self.assertNotIn("Bash(gh:*)", persona.effective_tools("kid"))
+
+    def test_an_inherited_duplicate_borrows_does_not_widen_the_child(self):
+        """The half `resolve` cannot see: a dict merged from an ancestor carries that
+        ancestor's LAST line and no trace that there were two."""
+        self.write("forge", "role: f\nvault: none\ntools: Bash(gh:*)\n")
+        self.write("parent", "role: p\nvault: none\nuses: forge\n"
+                             "borrows: none\nborrows: forge\n")
+        self.write("kid", "role: k\nvault: none\nextends: parent\ntools: Bash(ls:*)\n")
+        self.assertEqual(persona.borrows_of("kid"), [])
+        self.assertNotIn("Bash(gh:*)", persona.effective_tools("kid"))
+
+    def test_an_absent_borrows_still_means_the_legacy_grant(self):
+        """The back-compat #257 was built on, and the thing narrowing must not break:
+        opting one persona in must never alter a persona that declared nothing."""
+        self.write("forge", "role: f\nvault: none\ntools: Bash(gh:*)\n")
+        self.write("plain", "role: p\nvault: none\nuses: forge\ntools: Bash(ls:*)\n")
+        self.assertIsNone(persona.borrows_of("plain"))
+        self.assertEqual(persona.effective_tools("plain"), {"Bash(ls:*)", "Bash(gh:*)"})
+
+    def test_a_correctly_spelled_borrows_none_still_borrows_nothing(self):
+        self.write("forge", "role: f\nvault: none\ntools: Bash(gh:*)\n")
+        self.write("opted", "role: o\nvault: none\nuses: forge\nborrows: none\n"
+                            "tools: Bash(ls:*)\n")
+        self.assertEqual(persona.borrows_of("opted"), [])
+        self.assertEqual(persona.effective_tools("opted"), {"Bash(ls:*)"})
+
+    def test_a_correctly_spelled_borrows_still_grants_what_it_names(self):
+        self.write("forge", "role: f\nvault: none\ntools: Bash(gh:*)\n")
+        self.write("release", "role: r\nvault: none\ntools: Bash(git push:*)\n")
+        self.write("opted", "role: o\nvault: none\nuses: forge, release\nborrows: forge\n"
+                            "tools: Bash(ls:*)\n")
+        self.assertEqual(persona.borrows_of("opted"), ["forge"])
+        self.assertEqual(persona.effective_tools("opted"), {"Bash(ls:*)", "Bash(gh:*)"})
+
+
+# --------------------------------------------------------------------------- #
+# #575 — the report                                                            #
+# --------------------------------------------------------------------------- #
+class AMiscasedKeyIsReported(KeyCase):
+    def test_structural_errors_names_the_key_and_the_spelling(self):
+        """The signal on screen every turn, not a command the operator may never run."""
+        self.write("demo", "role: A demo\nVault: devops\nExtends: base\n")
+        msgs = self.errors("demo")
+        self.assertTrue(any("'Vault'" in m and "`vault:`" in m for m in msgs), msgs)
+        self.assertTrue(any("'Extends'" in m and "`extends:`" in m for m in msgs), msgs)
+
+    def test_it_is_an_error_not_a_warning(self):
+        """A warning is what this had, and it read `it does nothing (typo?)` — the wrong
+        sentence for `Borrows:`, whose absence does a great deal."""
+        self.write("demo", "role: A demo\nVault: devops\n")
+        self.assertEqual([lvl for lvl, m in persona.lint("demo", deep=False)
+                          if "'Vault'" in m], ["error"])
+
+    def test_the_milder_sentence_is_not_also_printed(self):
+        """One line, one finding. A reader who acts on the milder of two sentences about
+        one line acts on the wrong one."""
+        self.write("demo", "role: A demo\nBorrows: none\n")
+        about = [m for _l, m in persona.lint("demo", deep=False) if "'Borrows'" in m]
+        self.assertEqual(len(about), 1, about)
+        self.assertNotIn("does nothing", about[0])
+
+    def test_folding_is_not_the_catch(self):
+        """#573's argument, pinned. `vualt:` is caught by the vocabulary being CLOSED —
+        the same mechanism, unchanged. What the fold adds is one sentence, for the one
+        sub-case where charter can name the word the author meant."""
+        self.write("typo", "role: t\nvault: none\nvualt: devops\n")
+        reported = [m for _l, m in persona.lint("typo", deep=False) if "vualt" in m]
+        self.assertEqual(len(reported), 1, "a key charter does not read is still caught")
+        self.assertIsNone(persona.misspelled_key("vualt"))
+
+    def test_an_unknown_key_stays_a_warning(self):
+        """The blast-radius decision, stated as a test. Charter has no claim about
+        `modell:` — a harness's own field is a legitimate thing to carry in a committed
+        file — so this fires as a warning and nothing narrows."""
+        self.write("hk", "role: h\nvault: none\nmodell: opus\nuses: hk2\n")
+        self.write("hk2", "role: h2\nvault: none\ntools: Bash(ls:*)\n")
+        levels = [lvl for lvl, m in persona.lint("hk", deep=False) if "modell" in m]
+        self.assertEqual(levels, ["warn"])
+        self.assertEqual(self.errors("hk"), [])
+        self.assertEqual(persona.effective_tools("hk"), {"Bash(ls:*)"},
+                         "an unknown key must not touch the grant")
+
+    def test_the_value_is_never_read_out_of_the_miscased_key(self):
+        """Not case-folding: charter refuses, it does not guess."""
+        self.write("demo", "role: A demo\nVault: devops\n")
+        self.assertIsNone(persona.vault_of("demo"))
+
+    def test_misspelled_key_answers_only_for_a_case_variant(self):
+        self.assertIsNone(persona.misspelled_key("vault"), "a key charter reads is fine")
+        self.assertEqual(persona.misspelled_key("VAULT"), "vault")
+        self.assertEqual(persona.misspelled_key("Delegate-When"), "delegate-when")
+        self.assertIsNone(persona.misspelled_key("delegate_when"), "underscore is not case")
+        self.assertIsNone(persona.misspelled_key("borrow"), "a shorter word is not case")
+
+    def test_a_key_that_renders_as_nothing_is_named_by_its_escape(self):
+        """#498's finding on this row. U+3164 HANGUL FILLER is `Lo`, survives `strip`, and
+        prints as nothing — so an unescaped row said `frontmatter key '' …`, telling
+        somebody to go and edit a key it does not name."""
+        self.write("blank", "role: b\nvault: none\nㅤvault: devops\n")
+        msgs = [m for _l, m in persona.lint("blank", deep=False) if "frontmatter key" in m]
+        self.assertTrue(msgs, "the key is reported at all")
+        self.assertFalse(any("key ''" in m for m in msgs), msgs)
+        self.assertTrue(any("3164" in m for m in msgs), msgs)
+
+
+# --------------------------------------------------------------------------- #
+# #509 — the key recognised twice                                             #
+# --------------------------------------------------------------------------- #
+class AKeyWrittenTwice(KeyCase):
+    def test_duplicate_keys_reads_the_text(self):
+        text = ("---\nversion: 0.60.0\nheadline: important\n"
+                "security: true\nsecurity: false\n---\nbody\n")
+        self.assertEqual(persona.duplicate_keys(text), ["security"])
+
+    def test_parse_still_returns_the_dict_and_the_body(self):
+        """#509 read the fix as 'either change what `parse` returns or give it a second
+        output', both landing on every caller in the tree. Neither happened."""
+        meta, body = persona.parse("---\na: 1\nb: 2\nb: 3\n---\nbody\n")
+        self.assertEqual(meta, {"a": "1", "b": "3"})
+        self.assertEqual(body, "body")
+
+    def test_load_carries_the_answer_the_dict_cannot(self):
+        self.write("dup", "role: d\nvault: alpha\nvault: beta\n")
+        d = persona.load("dup")
+        self.assertEqual(d["dupes"], ["vault"])
+        self.assertEqual(d["meta"]["vault"], "beta", "the dict is unchanged; the report is new")
+
+    def test_it_is_reported_by_name(self):
+        self.write("dup", "role: d\nvault: alpha\nvault: beta\n"
+                          "tools: Bash(ls:*)\ntools: Bash(rm:*)\n")
+        msgs = self.errors("dup")
+        self.assertTrue(any("'vault'" in m and "more than once" in m for m in msgs), msgs)
+        self.assertTrue(any("'tools'" in m and "more than once" in m for m in msgs), msgs)
+
+    def test_the_report_says_which_line_charter_obeyed(self):
+        """Half the value of the sentence: the author's first line is the one they meant."""
+        self.write("dup", "role: d\nvault: alpha\nvault: beta\n")
+        self.assertTrue(any("LAST" in m for m in self.errors("dup")), self.errors("dup"))
+
+    def test_a_key_written_once_is_never_reported(self):
+        """A false positive here would train people to scroll past the row."""
+        self.write("ok", "role: o\nvault: v\nuses: other\ntools: Bash(ls:*)\n")
+        self.write("other", "role: o2\nvault: none\n")
+        self.assertEqual(persona.load("ok")["dupes"], [])
+        self.assertEqual(self.errors("ok"), [])
+
+    def test_whitespace_around_a_key_is_the_same_key(self):
+        """#509 asks which spellings collide. `parse` strips the key, so `vault :` IS
+        `vault` and always did collide — stated here rather than left to be rediscovered."""
+        self.assertEqual(persona.duplicate_keys("---\nvault: a\nvault : b\n---\nx\n"),
+                         ["vault"])
+
+    def test_case_is_not_the_same_key(self):
+        """The other half of that question. `Vault:` does NOT collide with `vault:` — it is
+        a different key, reported as a miscased one rather than as a duplicate."""
+        self.assertEqual(persona.duplicate_keys("---\nvault: a\nVault: b\n---\nx\n"), [])
+        self.write("both", "role: b\nvault: a\nVault: b\n")
+        msgs = self.errors("both")
+        self.assertTrue(any("'Vault'" in m for m in msgs), msgs)
+        self.assertFalse(any("more than once" in m for m in msgs), msgs)
+
+
+# --------------------------------------------------------------------------- #
+# The sibling: three fields enforced by their PRESENCE                        #
+# --------------------------------------------------------------------------- #
+class TheSubAgentIsNotGeneratedFromAKeyCharterCannotRead(KeyCase):
+    def sync(self) -> str:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            cp.cmd_persona_sync_agents(SimpleNamespace(persona=None, dry_run=False,
+                                                       approve_mcp=False, yes=False))
+        return out.getvalue() + err.getvalue()
+
+    def agent_path(self, name: str):
+        return config.ROOT / ".claude" / "agents" / f"{name}.md"
+
+    def test_a_miscased_agent_tools_does_not_ship_an_agent_with_every_tool(self):
+        """The widest of the three. No `tools:` line in a generated agent does not mean a
+        narrow agent — it means the sub-agent inherits EVERY tool, so a misspelling here
+        deletes the allowlist rather than narrowing it."""
+        self.write("gated", "role: g\nvault: none\nAgent-tools: Read, Grep\n")
+        self.assertEqual(cp._write_agent("gated"), "unreadable")
+        self.assertFalse(self.agent_path("gated").exists())
+
+    def test_a_miscased_disallowed_tools_does_not_ship_an_agent_with_no_denylist(self):
+        self.write("gated", "role: g\nvault: none\nDisallowed-tools: Bash\n")
+        self.assertEqual(cp._write_agent("gated"), "unreadable")
+
+    def test_a_miscased_draft_does_not_ship_the_unfinished_charter(self):
+        """`sync-agents` refuses to make a draft into a system prompt. `Draft: true` made
+        `is_draft` False and shipped it anyway."""
+        self.write("wip", "role: w\nvault: none\nDraft: true\n")
+        self.assertFalse(persona.is_draft("wip"), "the key is still read by nothing")
+        self.assertEqual(cp._write_agent("wip"), "unreadable")
+        self.assertFalse(self.agent_path("wip").exists())
+
+    def test_a_duplicated_agent_tools_does_not_ship_the_lower_line(self):
+        self.write("dup", "role: d\nvault: none\n"
+                          "agent-tools: Read\nagent-tools: Read, Bash\n")
+        self.assertEqual(cp._write_agent("dup"), "unreadable")
+
+    def test_a_stale_agent_is_removed_rather_than_left_dispatchable(self):
+        """The same call the draft branch makes. Leaving the old file keeps the persona
+        dispatchable under whatever it said BEFORE — which is the grant the author was
+        editing the file to remove."""
+        self.write("gated", "role: g\nvault: none\nagent-tools: Read\n")
+        self.assertEqual(cp._write_agent("gated"), "written")
+        self.assertTrue(self.agent_path("gated").exists())
+        self.write("gated", "role: g\nvault: none\nAgent-tools: Read\n")
+        self.assertEqual(cp._write_agent("gated"), "unreadable")
+        self.assertFalse(self.agent_path("gated").exists())
+
+    def test_the_run_that_would_have_written_it_says_so(self):
+        """Not left to `lint`. A green tick over a dropped allowlist is the shape #453
+        keeps arriving in."""
+        self.write("gated", "role: g\nvault: none\nAgent-tools: Read\n")
+        out = self.sync()
+        self.assertIn("gated", out)
+        self.assertIn("'Agent-tools'", out, "the report names the key to go and edit")
+        self.assertIn("agent-tools:", out, "and the spelling that would have worked")
+        self.assertNotIn("Synced 1 persona", out, "no green tick over a dropped allowlist")
+
+    def test_an_unknown_key_still_generates_an_agent(self):
+        """The narrow gate, pinned from the other side: `modell:` is not `key_issues`, so
+        a plane carrying a harness field keeps its sub-agent."""
+        self.write("hk", "role: h\nvault: none\nmodell: opus\n")
+        self.assertEqual(cp._write_agent("hk"), "written")
+        self.assertTrue(self.agent_path("hk").exists())
+
+
+# --------------------------------------------------------------------------- #
+# the vocabulary                                                              #
+# --------------------------------------------------------------------------- #
+class TheVocabulary(unittest.TestCase):
+    def test_every_key_a_real_charter_uses_is_in_it(self):
+        """A false positive here is now an ERROR and a withheld sub-agent, so this matters
+        more than it did when the same list only produced a warning."""
+        for key in ("name", "role", "vault", "extends", "uses", "delegate-when", "tools",
+                    "agent-tools", "model", "color", "memory", "activity", "borrows",
+                    "draft", "skills", "disallowed-tools", "routing", "routes-to",
+                    "description", "agent-description", "dispatch-isolation"):
+            self.assertIn(key, persona.KNOWN_KEYS, f"real charters use {key!r}")
+
+    def test_the_two_sets_do_not_overlap(self):
+        self.assertEqual(set(persona.AGENT_PASSTHROUGH_KEYS)
+                         & set(persona.CHARTER_OWN_KEYS), set())
+
+    def test_every_key_charter_actually_reads_is_declared(self):
+        """The failure this cannot have: a key charter READS that the vocabulary omits.
+
+        That key is spelled correctly in a correct file, `misspelled_key` answers None for
+        it — so it lands as an unknown-key warning on a persona that is right. Read off the
+        source rather than a hand-kept list, so a `meta.get("newfield")` added tomorrow
+        fails here rather than on somebody's roster.
+        """
+        import re
+        from pathlib import Path
+        src = Path(persona.__file__).parent
+        found = set()
+        for mod in ("persona.py", "commands_persona.py"):
+            text = (src / mod).read_text()
+            found |= set(re.findall(r'meta(?:\[|\.get\()"([a-z][a-z-]*)"', text))
+        missing = found - set(persona.KNOWN_KEYS)
+        self.assertEqual(missing, set(), f"read by charter but not in KNOWN_KEYS: {missing}")
+
+    def test_commands_persona_still_exports_the_old_names(self):
+        """Moved to the lower layer for `structural_errors`, which says in its own
+        docstring that it cannot afford to import the command module."""
+        self.assertEqual(cp._AGENT_PASSTHROUGH_KEYS, persona.AGENT_PASSTHROUGH_KEYS)
+        self.assertEqual(cp._CHARTER_OWN_KEYS, persona.CHARTER_OWN_KEYS)
+
+    def test_the_status_line_path_imports_no_command_module(self):
+        """The cost that kept this check out of the status line's signal in the first
+        place: the vocabulary lived in `commands_persona`, and `structural_errors` runs on
+        every turn. Asserted on the STATEMENTS rather than the text — the docstring names
+        the module it is careful not to import.
+        """
+        import ast
+        import inspect
+        import textwrap
+        for fn in (persona.structural_errors, persona.key_issues, persona.misspelled_key):
+            tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+            names = [a.name for n in ast.walk(tree) if isinstance(n, ast.Import)
+                     for a in n.names]
+            names += [n.module or "" for n in ast.walk(tree)
+                      if isinstance(n, ast.ImportFrom)]
+            self.assertEqual([n for n in names if "commands" in n], [],
+                             f"{fn.__name__} imports a command module")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_persona_key_is_honoured_or_reported.py
+++ b/tests/test_a_persona_key_is_honoured_or_reported.py
@@ -133,6 +133,33 @@ class BorrowsFailsOpen(KeyCase):
         self.assertEqual(persona.borrows_of("kid"), [])
         self.assertNotIn("Bash(gh:*)", persona.effective_tools("kid"))
 
+    def test_a_miscased_extends_does_not_restore_the_wide_grant(self):
+        """The fail-open one key over, found by asking the whole grant path rather than
+        the issue's list.
+
+        A child declaring `Extends: parent` inherits nothing, so a parent that opted OUT
+        with `borrows: none` hands the child the legacy `uses:` grant it had renounced.
+        Charter cannot follow a chain it could not read, so it must not conclude "this
+        persona declared no `borrows:`" from the end of one.
+        """
+        self.write("forge", "role: f\nvault: none\ntools: Bash(gh:*)\n")
+        self.write("parent", "role: p\nvault: none\nborrows: none\n")
+        self.write("kid", "role: k\nvault: none\nExtends: parent\nuses: forge\n"
+                          "tools: Bash(ls:*)\n")
+        self.assertEqual(persona.borrows_of("kid"), [])
+        self.assertEqual(persona.effective_tools("kid"), {"Bash(ls:*)"})
+
+    def test_a_duplicated_extends_does_not_pick_a_parent_by_line_order(self):
+        """Two `extends:` lines choose which parent's tools and vault are inherited, by
+        which one is lower in the file."""
+        self.write("forge", "role: f\nvault: none\ntools: Bash(gh:*)\n")
+        self.write("a", "role: a\nvault: none\nborrows: none\n")
+        self.write("b", "role: b\nvault: none\n")
+        self.write("kid", "role: k\nvault: none\nextends: a\nextends: b\n"
+                          "uses: forge\ntools: Bash(ls:*)\n")
+        self.assertEqual(persona.borrows_of("kid"), [])
+        self.assertEqual(persona.effective_tools("kid"), {"Bash(ls:*)"})
+
     def test_an_absent_borrows_still_means_the_legacy_grant(self):
         """The back-compat #257 was built on, and the thing narrowing must not break:
         opting one persona in must never alter a persona that declared nothing."""
@@ -147,6 +174,33 @@ class BorrowsFailsOpen(KeyCase):
                             "tools: Bash(ls:*)\n")
         self.assertEqual(persona.borrows_of("opted"), [])
         self.assertEqual(persona.effective_tools("opted"), {"Bash(ls:*)"})
+
+    def test_a_key_that_only_casefold_reaches_borrows_still_fails_closed(self):
+        """`casefold`, not `lower`, and this is the difference between them.
+
+        U+017F LATIN SMALL LETTER LONG S lowers to itself and casefolds to `s`, so
+        ``Borrowſ:`` is one codepoint from the key that decides a permission grant:
+        `lower` reads it as an unrelated word and restores the fail-open, `casefold`
+        names it. Found by hand — the sweep has no operator for swapping one string
+        method for another (#569).
+        """
+        self.grant_world(front_key="Borrowſ")
+        self.assertEqual(persona.misspelled_key("Borrowſ"), "borrows")
+        self.assertEqual(persona.borrows_of("front"), [])
+        self.assertEqual(persona.effective_tools("front"), {"Bash(ls:*)"})
+
+    def test_a_miscased_key_that_is_not_borrows_leaves_the_grant_alone(self):
+        """The narrow trigger, pinned from the other side.
+
+        `_borrows_unreadable` asks whether a key was reaching for ``borrows`` — not
+        whether the definition has any bad key at all. Widening it to "any miscased key"
+        would silently drop the legacy `uses:` grant of every persona with an unrelated
+        typo, which is a fail-closed nobody asked for and nothing would explain.
+        """
+        self.write("forge", "role: f\nvault: none\ntools: Bash(gh:*)\n")
+        self.write("plain", "role: p\nVault: devops\nuses: forge\ntools: Bash(ls:*)\n")
+        self.assertIsNone(persona.borrows_of("plain"), "`Vault:` is not about borrowing")
+        self.assertEqual(persona.effective_tools("plain"), {"Bash(ls:*)", "Bash(gh:*)"})
 
     def test_a_correctly_spelled_borrows_still_grants_what_it_names(self):
         self.write("forge", "role: f\nvault: none\ntools: Bash(gh:*)\n")
@@ -216,6 +270,22 @@ class AMiscasedKeyIsReported(KeyCase):
         self.assertIsNone(persona.misspelled_key("delegate_when"), "underscore is not case")
         self.assertIsNone(persona.misspelled_key("borrow"), "a shorter word is not case")
 
+    def test_the_miscased_row_names_a_non_ascii_key_by_its_escape(self):
+        """A case variant can be non-ASCII, which is what makes this row need the escape
+        as much as the others.
+
+        `Borrowſ` casefolds to `borrows` — so it reaches the miscased row, not the
+        unknown-key row — and U+017F has no ASCII spelling. Without the bound, the row
+        that exists to say which key to edit prints a glyph the reader cannot type and
+        cannot grep for. Found by hand: the sweep has no operator for removing a call
+        and leaving the interpolation (#569).
+        """
+        self.write("odd", "role: o\nvault: none\nBorrowſ: none\n")
+        msgs = [m for m in self.errors("odd") if "read by nothing" in m]
+        self.assertTrue(msgs, "the miscased key is reported")
+        self.assertIn("017f", msgs[0].lower())
+        self.assertNotIn("ſ", msgs[0])
+
     def test_a_key_that_renders_as_nothing_is_named_by_its_escape(self):
         """#498's finding on this row. U+3164 HANGUL FILLER is `Lo`, survives `strip`, and
         prints as nothing — so an unescaped row said `frontmatter key '' …`, telling
@@ -260,6 +330,15 @@ class AKeyWrittenTwice(KeyCase):
         """Half the value of the sentence: the author's first line is the one they meant."""
         self.write("dup", "role: d\nvault: alpha\nvault: beta\n")
         self.assertTrue(any("LAST" in m for m in self.errors("dup")), self.errors("dup"))
+
+    def test_the_duplicate_row_names_the_key_by_its_escape_too(self):
+        """The same bound as the miscased row, on the other sentence `key_issues` writes.
+        Both exist to say which key to go and edit, so neither may print nothing."""
+        self.write("blank", "role: b\nvault: none\nㅤv: 1\nㅤv: 2\n")
+        msgs = self.errors("blank")
+        self.assertTrue(any("more than once" in m for m in msgs), msgs)
+        self.assertFalse(any("key ''" in m for m in msgs), msgs)
+        self.assertTrue(any("3164" in m for m in msgs), msgs)
 
     def test_a_key_written_once_is_never_reported(self):
         """A false positive here would train people to scroll past the row."""
@@ -344,6 +423,19 @@ class TheSubAgentIsNotGeneratedFromAKeyCharterCannotRead(KeyCase):
         self.assertIn("agent-tools:", out, "and the spelling that would have worked")
         self.assertNotIn("Synced 1 persona", out, "no green tick over a dropped allowlist")
 
+    def test_a_draft_with_a_bad_key_is_reported_as_the_bad_key(self):
+        """Both are true and the agent is withheld either way, so this is about which
+        sentence the operator gets.
+
+        The draft is temporary and self-evident — they wrote `draft: true`. The key is the
+        latent one, and it bites the moment the draft is finished, so it is the finding
+        worth spending the line on. Ordering, which no deletion operator can charge.
+        """
+        self.write("wip", "role: w\nvault: none\ndraft: true\nAgent-tools: Read\n")
+        self.assertTrue(persona.is_draft("wip"), "it really is a draft as well")
+        self.assertEqual(cp._write_agent("wip"), "unreadable")
+        self.assertIn("'Agent-tools'", self.sync())
+
     def test_an_unknown_key_still_generates_an_agent(self):
         """The narrow gate, pinned from the other side: `modell:` is not `key_issues`, so
         a plane carrying a harness field keeps its sub-agent."""
@@ -368,6 +460,18 @@ class TheVocabulary(unittest.TestCase):
     def test_the_two_sets_do_not_overlap(self):
         self.assertEqual(set(persona.AGENT_PASSTHROUGH_KEYS)
                          & set(persona.CHARTER_OWN_KEYS), set())
+
+    def test_the_vocabulary_is_lowercase(self):
+        """The invariant that makes "miscased" mean anything.
+
+        `misspelled_key` folds the key it is handed and looks it up in a table folded the
+        same way. If a vocabulary key were ever spelled with a capital, the two halves
+        would disagree: the table would hold a folded key that no correct file writes, and
+        the correctly-spelled key would report ITSELF as miscased. Stated here rather than
+        left to the day somebody adds `agentTools`.
+        """
+        for key in persona.KNOWN_KEYS:
+            self.assertEqual(key, key.casefold(), f"{key!r} is not lowercase")
 
     def test_every_key_charter_actually_reads_is_declared(self):
         """The failure this cannot have: a key charter READS that the vocabulary omits.


### PR DESCRIPTION
Two defects in `persona.parse`'s handling of frontmatter keys, fixed as one property:
**a frontmatter key is honoured or reported — never silently resolved.** One is "the key
was not recognised" (#575), the other "the key was recognised twice" (#509), and both ended
in a value chosen by accident with no diagnostic. One of them is a permission grant.

## The fail-open, which is the point

`borrows_of` answers from the key's **absence**: `None` means "I have not opted in — keep
the legacy `uses:` grant", which is the *wider* one. Every other miscased key fails toward
less (a miscased `Vault:` means no credentials); this one failed toward more.

```
uses: forge, release
Borrows: none            ← read by nothing
```
```
borrows_of(front):      None
effective_tools(front): ['Bash(gh:*)', 'Bash(git push:*)']
structural_errors:      []
```

Both borrowed personas' tools auto-approved at `toolgate.decide`, from a definition whose
author wrote the word that grants nothing.

**A `borrows:` charter cannot read now answers `[]` and never `None`.** `None` means the
author never mentioned borrowing, and nothing else. Pinned by
`test_the_fallback_cannot_come_back`, which asserts on the sentinel as well as the tool set
— the two are one line apart in `effective_tools`, and a later edit could restore the
fallback while some other narrowing kept the fixture's tools looking right.

## I checked the other keys, and found two more fail-opens

The brief asked for `vault:`, `extends:`, `uses:`, `role:`. Those four fail *closed*
(no credentials, no inheritance, no reuse, no role) — but the sweep of the whole grant path
turned up three the issues did not name:

| key | miscased consequence |
|---|---|
| `Agent-tools:` | **no `tools:` line is emitted, and no `tools:` line means the sub-agent inherits EVERY tool.** The allowlist does not narrow — it vanishes. |
| `Disallowed-tools:` | the denylist vanishes the same way |
| `Draft:` | `is_draft` is False, so the unfinished charter `sync-agents` exists to withhold becomes a sub-agent's system prompt |
| `Extends:` | a child inherits nothing, so a parent that opted out with `borrows: none` hands the child the legacy grant it renounced |

All four were reached through a run printing `✓ Synced 1 persona sub-agent(s)`. As in #573,
the sibling was wider than the named bug. `sync-agents` now generates no agent from a
definition charter could not read, removes the stale one, and names the key;
`_GRANT_DECIDING_KEYS` covers the `extends:` path.

## What happens to somebody with a miscased key committed today

Stated explicitly, because it is a behaviour change:

* A miscased or duplicated key goes from a lint **warning** to an **error**, and appears on
  the status line rather than only in `charter persona lint`.
* The tool grant changes in exactly one shape: a `Borrows:`/`Extends:` charter could not
  read, which today silently grants the borrowed personas' tools and after this grants none.
* `sync-agents` writes no agent for that persona until the key is fixed.
* **Nothing changes** for a definition whose keys are spelled once and correctly —
  including the legacy `uses:` grant for a persona declaring no `borrows:` at all
  (`test_an_absent_borrows_still_means_the_legacy_grant`).

charter's own five personas and all 109 shipped news entries are clean.

## Refused, not case-folded — #573's call, kept

Folding the *lookup* answers `Vault:` and leaves `vualt:`, `borrow:` and `delegate_when:`
exactly as silent. The **closed vocabulary** is what catches all of them, and it already
existed — `persona lint` has long warned about a key charter neither reads nor emits.
(#575's claim that lint "says the definition is fine" is half right: `structural_errors` was
empty, but `lint` did warn. The warning's wording was the problem — "it does nothing
(typo?)" is exactly wrong for `Borrows:`, whose *absence* does a great deal.)

What changed is which finding carries weight:

* a key charter **does not read** stays a **warning** — a harness's own field is a
  legitimate thing to carry in a committed file, and an error there would break planes that
  are correct;
* a key charter **does read**, miscased or written twice, is an **error** — charter can name
  the word the author was reaching for, which is what makes it actionable and what lets the
  grant act on it.

Nothing is ever read out of the miscased key. `misspelled_key` folds the *sentence and the
severity*, never the lookup.

## #509 without the change it feared

The issue read the fix as "either change what `parse` returns or give it a second output",
both landing on `persona.load`, `structural_errors`, `resolve`, `tools_of`, `vault_of`,
`docsrc`, `news._read` and the skill lint at once. Neither happened: `_frontmatter` is the
one line-walk, **`parse` still returns `(dict, body)` and every caller of it is untouched**,
and the second answer is carried by `load` — where the persona-shaped questions already
are. `duplicate_keys(text)` is exposed for `news` and the skill lint to adopt when their
owners want it; I stayed out of `charter/news.py` per the brief, so #509's news half is
one call away rather than taken.

The issue also asks which spellings collide. Answered by test: `vault :` **is** `vault`
(`parse` strips), `Vault:` is **not** — it is reported as miscased rather than duplicated.

## Verification

* **Full suite, two local environments.** Python 3.14.4 → 6535 tests OK. Python 3.12 with
  `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset → see the comment below.
* **CI** at the head sha via `gh api .../check-runs` (3.11/3.12/3.13/3.14).
* **Baseline-diffed test verification.** All 45 new tests were run against unfixed
  `bf58b46`: **37 fail** (23 failures + 14 errors). The 8 that pass are exactly the
  no-change pins — an absent `borrows:` still meaning the legacy grant, a correctly spelled
  `borrows:` still granting what it names, an unknown key still a warning and still
  generating an agent, `parse` still returning `(dict, body)`, and the value never being
  read out of a miscased key.
* **`tools/sweep.py`** on the branch.
* **Hand-check, reported separately** (below), because the tool has no operator for string
  constants or semantic swaps (#569) — which is the shape of a key name and a case
  comparison.

### Hand-check: 30 mutations, 29 caught, 1 equivalent

Run against an **unmutated baseline** (`rc=0, failures=0`) and diffed against it, per #579:
a mutation only counts as caught when it adds a failure the baseline did not already have.

Three survived the first round, and none was equivalent:

* **`contain.readable` dropped from the miscased row** — the only unprintable-key fixture
  was an *unknown* key, which lands on a different row. A case variant can be non-ASCII:
  `Borrowſ` casefolds to `borrows` (U+017F). Pinned.
* **the gate moved after the draft check** — no fixture was both a draft and miscased. The
  agent is withheld either way, so this is about which sentence the operator gets. Pinned
  in that order.
* **`_FOLDED_KEYS` built unfolded** — genuinely equivalent, and only *because* every
  vocabulary key is lowercase. That invariant is what makes "miscased" mean anything, so it
  is now asserted rather than relied on.

`casefold` vs `lower` is **not** equivalent here and is pinned: `Borrowſ` folds to
`borrows` under one and not the other — one codepoint from the key that decides a grant.

## Collision with #580

#580 (`$`-anchored names, #577) also touches `charter/persona.py`. **No overlap:** it edits
`valid_name` (line ~64) and `reference_refusal` (line ~117); every line here is at 221+
(`_frontmatter` onward) plus `structural_errors`/`lint`. Semantically #580 only tightens
`reference_ok` → `load`, which is upstream of `key_issues` — it helps, it does not conflict.
Either order merges cleanly.

## Also

* The key vocabulary moved from `commands_persona` to `persona`
  (`KNOWN_KEYS`/`CHARTER_OWN_KEYS`/`AGENT_PASSTHROUGH_KEYS`, re-exported under the old
  names). That is what let `structural_errors` ask about keys at all — its docstring named
  that import as the reason it could not, and it runs on every turn for the status line.
* `contain.readable` on the key in all three report rows. A key cannot hold a line break
  (`splitlines` splits on `\r`, `\x85`, U+2028, U+2029), but U+3164 HANGUL FILLER survives
  `strip` and prints as nothing, so the row whose whole job is to say which key to edit
  said `frontmatter key ''` — #498's finding, on rows that had not been given the escape.

Closes #575
Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)
