### PR TITLE
Files under `.charter/` are 0600 because charter says so (#505)

### DIFF
--- a/charter/commands_update.py
+++ b/charter/commands_update.py
@@ -114,7 +114,7 @@ def _stamp_baseline(version: str) -> None:
     try:
         p = _baseline_file()
         config.private_mkdir(p.parent)
-        p.write_text(version)
+        config.write_for(p, version)
     except OSError:
         pass          # a missing baseline degrades the news RANGE, never the update
 

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -707,7 +707,7 @@ def cmd_workspace_autosave(args) -> int:
         if commit_push(config.ROOT, ["add", "--", *rel],
                        f"workspace({name}): auto-save memo + manifest", no_push=True) != 0:
             return 0
-        marker.write_text(str(time.time()))
+        config.write_for(marker, str(time.time()))
         if share == "push":
             # detached background push — the turn returns immediately
             _spawn_pushbg(config.ROOT)

--- a/charter/config.py
+++ b/charter/config.py
@@ -16,6 +16,7 @@ calls `use()` rather than knowing what to copy.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import sys
@@ -165,8 +166,12 @@ def _repoint_vault_registry(legacy_dir: Path, new_dir: Path) -> None:
                 cfg["file"] = new_prefix + path[len(old_prefix):]
                 changed += 1
         if changed:
-            registry.write_text(json.dumps(doc, indent=2) + "\n")
-            os.chmod(registry, 0o600)
+            # `write_text` then `chmod` was the #437 window one more time: the rewritten
+            # registry sat at whatever mode the pre-0.52 file had for the whole of the
+            # write, and only then became 0600. `_open_private` settles it on the
+            # descriptor first, so there is no such window (#505).
+            with _open_private(registry, "w") as f:
+                f.write(json.dumps(doc, indent=2) + "\n")
             print(f"charter: repointed {changed} vault path(s) to {new_dir}",
                   file=sys.stderr)
     except (OSError, ValueError) as e:
@@ -333,6 +338,154 @@ def mkdir_for(p, parents: bool = True) -> None:
         private_mkdir(p, parents=parents)
         return
     p.mkdir(parents=parents, exist_ok=True)
+
+
+#: The mode a file holding this plane's state is written at: owner read/write, nobody
+#: else. A constant rather than a per-writer decision, for the reason `_OTHERS` in
+#: `charter.secrets.base` is a mask rather than a list — "which of charter's state files
+#: are sensitive" is a question that gets answered wrong once and then stays wrong. It is
+#: the mode `docs/secrets.md` already promises for a vault file, applied to the rest of the
+#: state directory, and it is the same posture as the 0700 the directories get: the
+#: contents of ``.charter/`` are one account's.
+STATE_FILE_MODE = 0o600
+
+
+def _private_fd(p: "Path", *, append: bool) -> int:
+    """A descriptor on *p* with `STATE_FILE_MODE` settled on the **inode**, before any
+    content of charter's can reach it.
+
+    ``os.open(..., O_CREAT, 0o600)`` is not this, and that is the whole of #437's lesson
+    repeated one surface over: the *mode* argument applies **only when the call creates
+    the inode**. For a file that already exists — one written by a charter older than
+    this, or restored from a tarball, or made by hand — it is ignored entirely, so the
+    old contents and every byte written after them sit at whatever mode the file already
+    had. The mode is therefore settled with `os.fchmod` on the descriptor this call
+    holds, which is also why it is `fchmod` and not `chmod`: nothing swapped at the path
+    in between can be affected, and nothing at the path can be affected instead of the
+    inode charter is about to write.
+
+    ``O_TRUNC`` is deliberately NOT in the flags. Truncating first would empty the file
+    while it is still at its old mode; the caller truncates after the `fchmod`, so there
+    is no window in which new content is readable by an account the finished file is not.
+
+    A `fchmod` that fails is swallowed rather than raised. Filesystems with fixed
+    permissions (exFAT, many network mounts) accept the state directory and cannot hold a
+    mode, and every caller here is a hook, a status line or a marker file — refusing to
+    write ``guard-seen.json`` would take the plane down to protect a mode the filesystem
+    was never going to keep. `charter.secrets.plain_file` makes the opposite trade for the
+    one file where it is right to (plaintext secrets: it reads the mode back and refuses),
+    and `charter.secrets.registry._write` makes this one, for these reasons.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | (os.O_APPEND if append else 0)
+    fd = os.open(str(p), flags, STATE_FILE_MODE)
+    try:
+        os.fchmod(fd, STATE_FILE_MODE)
+    except OSError:
+        pass
+    return fd
+
+
+@contextlib.contextmanager
+def open_for(p, mode: str = "w", *, encoding: str | None = "utf-8"):
+    """Open *p* for writing — **privately when it is charter's own state, ordinarily when
+    it is not**. The file half of :func:`mkdir_for`, and the same dispatch (#505).
+
+    #470 answered "the umask must not decide the mode of charter's state" for
+    directories. The **files** were never asked: every one of them was written at
+    ``0o777 & ~umask``, i.e. 0644 on the default ``umask 022`` and 0666 under ``umask
+    000``. That was harmless only as long as the directory above them was 0700 — which is
+    exactly the case charter deliberately does **not** guarantee. `private_mkdir` leaves a
+    directory it did not create exactly as it is (#331: ``$CHARTER_HOME`` can point the
+    state directory at a home or a shared team directory, so "chmod whatever we land in"
+    is how charter comes to tighten one unprompted), and `vault list` / `doctor` report
+    the loose one rather than fixing it. So on a plane whose ``.charter/`` predates charter
+    — or was made by ``mkdir -p`` before 0.52.x — every account on the machine could read
+    the trace log, the ephemeral persona store and ``guard-seen.json``, and under ``umask
+    000`` could *rewrite* the last of those and decide what charter treats as consented.
+
+    **The property is "this file holds plane state", not "charter made the folder".** So
+    the dispatch is on where the path is, at runtime, exactly as `mkdir_for`'s is — not on
+    whether charter created the directory, and not on a list of the files somebody
+    remembered were sensitive.
+
+    **A file that already exists is tightened; a directory that already exists is not.**
+    That looks like two answers and is one: charter tightens what is *its own*, and
+    reports what is not. A directory under ``$CHARTER_HOME`` may be somebody's home or a
+    team share that charter merely landed in, and has a life of its own — so charter names
+    it and prints the ``chmod`` (`base.loose_dir_note`, `doctor`). A file charter is
+    putting its own bytes into is charter's whatever its history, and leaving the old mode
+    on it is the #437 defect verbatim. `secrets.registry._write` and
+    `secrets.plain_file._write_private` have settled the mode on the descriptor of a
+    pre-existing file since then; this is the same discipline for the rest of the state
+    directory, not a second policy.
+
+    A path **outside** the state directory is opened with a plain :func:`open` and NOT
+    tightened, which is what makes this a dispatch rather than a privatiser: `memstore`
+    writes a committed ``personas/<n>/memory/`` file through the same call, and those are
+    the operator's to mode. `mkdir_for` documents the same half.
+
+    *mode* is a `open` mode string; only the writing ones reach here. ``"a"`` appends
+    (``O_APPEND``, no truncation), anything else truncates **after** the mode is settled.
+    """
+    p = Path(p)
+    if not under_state(p):
+        with open(p, mode, encoding=(None if "b" in mode else encoding)) as f:
+            yield f
+        return
+    with _open_private(p, mode, encoding=encoding) as f:
+        yield f
+
+
+@contextlib.contextmanager
+def _open_private(p, mode: str = "w", *, encoding: str | None = "utf-8"):
+    """:func:`open_for`'s private branch, unconditionally — for the one caller that knows
+    it is writing charter's own state before ``STATE_DIR`` exists to be compared against.
+
+    `_repoint_vault_registry` runs *during* the migration that produces the state
+    directory, so `under_state` has nothing to answer with yet. Reaching past the dispatch
+    is right there and wrong everywhere else, which is why it is private and says so.
+    """
+    append = "a" in mode
+    fd = _private_fd(Path(p), append=append)
+    try:
+        if not append:
+            os.ftruncate(fd, 0)     # after the fchmod, never before: see `_private_fd`
+        f = os.fdopen(fd, mode, encoding=(None if "b" in mode else encoding))
+    except BaseException:
+        os.close(fd)
+        raise
+    with f:                         # the file object owns the descriptor now
+        yield f
+
+
+def write_for(p, data) -> None:
+    """`Path.write_text` for a path that may be charter's own state — the whole content,
+    written into a file charter has already made private if that is where it belongs.
+
+    This is the ``config.private_write`` #505 asks for, under the name that matches
+    :func:`mkdir_for`: it is a **dispatch**, not a privatiser, and calling it
+    ``private_write`` would invite the next writer to reach for it on a committed path and
+    quietly tighten one. ``_for`` is what this package spells "ask where the path is".
+    """
+    with open_for(p, "wb" if isinstance(data, (bytes, bytearray)) else "w") as f:
+        f.write(data)
+
+
+def touch_for(p) -> None:
+    """`Path.touch` for a path that may be charter's own state.
+
+    A marker file carries its meaning in *existing*, not in its bytes — which is exactly
+    why it was easy to miss that ``Path.touch()`` creates at ``0o666 & ~umask`` like every
+    other writer. An empty file another account can create, delete or re-time is a marker
+    that account gets to set: `hooks._ask_mark_set` and `toolgate.snapshot` both decide
+    what a later turn is allowed to do from one.
+    """
+    p = Path(p)
+    if not under_state(p):
+        p.touch()
+        return
+    os.close(_private_fd(p, append=True))
+    os.utime(p, None)       # `Path.touch` bumps the mtime of an existing file too
 
 
 def derive(root: Path, start: Path | None = None) -> dict:

--- a/charter/glstate.py
+++ b/charter/glstate.py
@@ -86,7 +86,7 @@ def _write_lock(pid: int | None) -> None:
     try:
         lock = _lock_file()
         config.private_mkdir(lock.parent)
-        lock.write_text(str(pid) if pid else "")
+        config.write_for(lock, str(pid) if pid else "")
     except Exception:
         pass
 
@@ -148,7 +148,7 @@ def _save(cache: dict) -> None:
     f = _cache_file()
     try:
         config.private_mkdir(f.parent)
-        f.write_text(json.dumps(cache))
+        config.write_for(f, json.dumps(cache))
     except Exception:
         pass
 

--- a/charter/guardseen.py
+++ b/charter/guardseen.py
@@ -80,9 +80,9 @@ def mark(harness: str | None = None, when: datetime | None = None,
     p = path()
     try:
         config.private_mkdir(p.parent)
-        p.write_text(json.dumps({"ts": when.isoformat(timespec="seconds"),
-                                 "harness": harness, "source": src},
-                                sort_keys=True) + "\n")
+        config.write_for(p, json.dumps({"ts": when.isoformat(timespec="seconds"),
+                                       "harness": harness, "source": src},
+                                      sort_keys=True) + "\n")
         return p
     except OSError:
         return None

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -281,7 +281,7 @@ def _ask_mark_set(sid, tuid, kind) -> None:
         return
     try:
         config.private_mkdir(f.parent)
-        f.touch()
+        config.touch_for(f)
     except OSError:
         pass
 
@@ -4118,7 +4118,7 @@ def _ws_edit_first_this_session(session, ws) -> bool:
         marker = d / key
         if marker.exists():
             return False
-        marker.write_text("1")
+        config.write_for(marker, "1")
         return True
     except Exception:
         return True
@@ -4151,7 +4151,7 @@ def _memnudge_set(sid: str, n: int) -> None:
     try:
         f = _memnudge_file(sid)
         config.private_mkdir(f.parent)
-        f.write_text(str(n))
+        config.write_for(f, str(n))
     except OSError:
         pass
 
@@ -4326,7 +4326,7 @@ def _configver_file(sid: str) -> Path:
 def _write_configver(f: Path, sha: str) -> None:
     try:
         config.private_mkdir(f.parent)
-        f.write_text(sha + "\n")
+        config.write_for(f, sha + "\n")
     except OSError:
         pass
 
@@ -4531,7 +4531,7 @@ def _agent_map_remember(agent_id: str, persona_name: str) -> None:
         data[agent_id] = persona_name
         if len(data) > _AGENT_MAP_MAX:                 # keep the newest, drop the tail
             data = dict(list(data.items())[-_AGENT_MAP_MAX:])
-        f.write_text(json.dumps(data, sort_keys=True))
+        config.write_for(f, json.dumps(data, sort_keys=True))
     except OSError:
         pass
 
@@ -4631,7 +4631,7 @@ def _commit_dispatch(path, agent: str) -> None:
     lock = _cfg.STATE_DIR / "dispatch-commit.lock"
     try:
         _cfg.private_mkdir(lock.parent)
-        with open(lock, "w") as fh:
+        with _cfg.open_for(lock, "w") as fh:
             fcntl.flock(fh, fcntl.LOCK_EX)
             try:
                 rel = str(Path(path).relative_to(_cfg.ROOT))
@@ -4744,9 +4744,9 @@ def _commit_gate_due(sid: str | None) -> bool:
         f = d / re.sub(r"[^A-Za-z0-9._-]", "", sid)
         n = int(f.read_text().strip()) if f.exists() else 0
         if n > 0:
-            f.write_text(str(n - 1))
+            config.write_for(f, str(n - 1))
             return False
-        f.write_text(str(_COMMIT_COOLDOWN))
+        config.write_for(f, str(_COMMIT_COOLDOWN))
         return True
     except Exception:
         return True
@@ -4788,7 +4788,7 @@ def _route_mark_set(sid: str | None, names: list[str]) -> None:
         # The roster's NAMES, so the ask can list them without re-deriving the roster from
         # a persona that may have changed mid-turn. Names only — the same counts-and-names
         # discipline the tally keeps; no prompt text goes anywhere near this file.
-        f.write_text(",".join(names) + "\n")
+        config.write_for(f, ",".join(names) + "\n")
     except OSError:
         pass
 

--- a/charter/mcpseen.py
+++ b/charter/mcpseen.py
@@ -238,7 +238,7 @@ def approve(persona_name: str, fingerprints) -> None:
     doc[persona_name] = sorted({f for f in fingerprints if f})
     p = path()
     config.private_mkdir(p.parent)
-    p.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
+    config.write_for(p, json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
 
 
 def _escape(ch: str) -> str:

--- a/charter/memstore.py
+++ b/charter/memstore.py
@@ -62,7 +62,7 @@ def ensure_index(mem_dir: Path, header: str) -> Path:
     idx = writable(index_path(mem_dir))
     mkdir_for(mem_dir)
     if not idx.exists():
-        idx.write_text(header if header.endswith("\n") else header + "\n")
+        config.write_for(idx, header if header.endswith("\n") else header + "\n")
     return idx
 
 
@@ -96,7 +96,8 @@ def write(mem_dir: Path, text: str, title: str | None = None, *, timestamped: bo
     writable(p)
     if index:
         writable(index_path(mem_dir))
-    p.write_text(f"# {title}\n\n_{now.strftime('%Y-%m-%d %H:%M')} · {kind}_\n\n{text}\n")
+    config.write_for(
+        p, f"# {title}\n\n_{now.strftime('%Y-%m-%d %H:%M')} · {kind}_\n\n{text}\n")
     if index:
         index_append(index_path(mem_dir), p.name, title)
     return p
@@ -106,8 +107,8 @@ def index_append(idx: Path, filename: str, title: str) -> None:
     idx = writable(idx)
     if not idx.exists():
         mkdir_for(idx.parent)
-        idx.write_text("# Memory Index\n\n")
-    with idx.open("a") as f:
+        config.write_for(idx, "# Memory Index\n\n")
+    with config.open_for(idx, "a") as f:
         f.write(f"- [{title}]({filename})\n")
 
 
@@ -394,7 +395,7 @@ def _drop_index_line(mem_dir: Path, filename: str) -> None:
     if not idx.exists() or contain.dir_refusal(mem_dir, "write") or contain.file_refusal(idx):
         return
     keep = [ln for ln in idx.read_text().splitlines() if f"({filename})" not in ln]
-    idx.write_text("\n".join(keep) + ("\n" if keep else ""))
+    config.write_for(idx, "\n".join(keep) + ("\n" if keep else ""))
 
 
 def body(text: str) -> str:

--- a/charter/planegit.py
+++ b/charter/planegit.py
@@ -246,7 +246,7 @@ def record_push(res: PushResult, head: str = "") -> PushResult:
             p.unlink(missing_ok=True)
             return res
         config.private_mkdir(p.parent)
-        p.write_text(json.dumps({
+        config.write_for(p, json.dumps({
             "outcome": res.outcome, "branch": res.branch, "landed": res.landed,
             "url": res.url, "detail": res.detail, "head": head, "at": time.time(),
         }, indent=2))

--- a/charter/report.py
+++ b/charter/report.py
@@ -298,7 +298,7 @@ def all_reports() -> list[dict]:
 
 def _write(rec: dict) -> str:
     config.private_mkdir(config.REPORTS_DIR)
-    _path(rec["id"]).write_text(json.dumps(rec, indent=2))
+    config.write_for(_path(rec["id"]), json.dumps(rec, indent=2))
     return rec["id"]
 
 

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -237,7 +237,7 @@ def _record_turn(sid: str, hit: int, read: int, write: int,
     rows = rows[-_TREND_KEEP:]
     try:
         config.private_mkdir(f.parent)
-        f.write_text("\n".join(rows) + "\n")
+        config.write_for(f, "\n".join(rows) + "\n")
     except OSError:
         pass
     return _hits(rows)
@@ -656,7 +656,7 @@ def _repo_states(dirs: list[Path]) -> dict:
     if changed:
         try:
             config.private_mkdir(cache_file.parent)
-            cache_file.write_text(json.dumps(cache))
+            config.write_for(cache_file, json.dumps(cache))
         except Exception:
             pass
     return out
@@ -1312,7 +1312,7 @@ def _vault_health(vault: str) -> tuple[bool, str]:
     cache[vault] = {"ok": bool(ok), "detail": detail or "", "ts": now}
     try:
         config.private_mkdir(cache_file.parent)
-        cache_file.write_text(json.dumps(cache))
+        config.write_for(cache_file, json.dumps(cache))
     except Exception:
         pass
     _vault_memo[vault] = (ok, detail)

--- a/charter/toolgate.py
+++ b/charter/toolgate.py
@@ -794,9 +794,9 @@ def snapshot(session_id: str | None = None) -> dict:
 
         f = _ceiling_file(sid)
         config.private_mkdir(f.parent)
-        _marker_file(sid).touch()   # before the ceiling: see `_marker_file`
+        config.touch_for(_marker_file(sid))   # before the ceiling: see `_marker_file`
         tmp = f.with_name(f.name + ".tmp")
-        tmp.write_text(json.dumps(data, sort_keys=True))
+        config.write_for(tmp, json.dumps(data, sort_keys=True))
         os.replace(tmp, f)
     except OSError:
         return {}

--- a/charter/trace.py
+++ b/charter/trace.py
@@ -83,7 +83,7 @@ def record(event: str, session: str | None = None, **fields) -> None:
         config.private_mkdir(f.parent)
         rec = {"ts": datetime.datetime.now().isoformat(timespec="seconds"), "event": event}
         rec.update({k: v for k, v in fields.items() if v is not None})
-        with f.open("a") as fh:
+        with config.open_for(f, "a") as fh:
             fh.write(contain.json_line(rec) + "\n")
     except Exception:
         pass

--- a/charter/update.py
+++ b/charter/update.py
@@ -267,7 +267,7 @@ def fetch_and_store() -> str | None:
     try:
         p = _cache_file()
         config.private_mkdir(p.parent)
-        p.write_text(json.dumps(record))
+        config.write_for(p, json.dumps(record))
     except OSError:
         return None
     return latest
@@ -293,7 +293,7 @@ def maybe_spawn() -> None:
         return
     try:
         config.private_mkdir(lock.parent)
-        lock.touch()          # touch FIRST: a spawn storm is worse than a missed check
+        config.touch_for(lock)  # touch FIRST: a spawn storm is worse than a missed check
         # -P (util.self_relaunch_argv, #390): this ALSO runs on the status line's own
         # render path (see the module docstring's mirror of glstate) — without it, a
         # project directory with its own `charter/` package would shadow the installed

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -480,12 +480,12 @@ def set_active(name: str, session_id: str | None = None, force: bool = False,
     tid = _terminal_id() if terminal_id is None else terminal_id
     if tid:
         config.private_mkdir(config.TERMINALS_DIR)
-        _terminal_file(tid).write_text(name + "\n")
+        config.write_for(_terminal_file(tid), name + "\n")
     sid = _session_id(session_id)
     if sid:
         config.private_mkdir(config.SESSIONS_DIR)
-        _session_file(sid).write_text(name + "\n")
-        _lock_file(sid).write_text(name + "\n")  # confirming = locking for the session
+        config.write_for(_session_file(sid), name + "\n")
+        config.write_for(_lock_file(sid), name + "\n")  # confirming = locking
     _prune()
     _trace("workspace-use", session_id, workspace=name,
            scope=("terminal" if tid else "session" if sid else "none"),
@@ -512,7 +512,7 @@ def reconcile(session_id: str | None = None, terminal_id: str | None = None) -> 
     val = _read(_terminal_file(tid)) if tid else None
     if val:
         config.private_mkdir(config.SESSIONS_DIR)
-        _session_file(sid).write_text(val + "\n")
+        config.write_for(_session_file(sid), val + "\n")
         # The one pointer write nobody typed. If any write is ever going to look as though
         # it came from nowhere, it is this one — so it says where it came from.
         _trace("workspace-seeded", session_id, workspace=val, **{"from": "terminal"})
@@ -750,7 +750,7 @@ def _rename_active_pointers(old: str, new: str) -> None:
         for f in list(d.glob("*.workspace")) + list(d.glob("*.lock")):
             try:
                 if f.read_text().strip() == old:
-                    f.write_text(new + "\n")
+                    config.write_for(f, new + "\n")
             except OSError:
                 pass
 

--- a/docs/news/unreleased-the-files-under-charter-are-charters-to-choose.md
+++ b/docs/news/unreleased-the-files-under-charter-are-charters-to-choose.md
@@ -1,0 +1,80 @@
+---
+version: unreleased
+headline: the files under `.charter/` are 0600 because charter says so — a state directory charter did not create no longer leaks every one of them
+security: true
+---
+
+0.53.0 settled the mode of every **directory** charter creates under `.charter/`: whichever
+writer gets there first, each level comes out 0700, and the umask does not get a say
+([#470](https://github.com/diazoxide/charter/issues/470)). The **files** inside them were
+never asked. They were written at `0o777 & ~umask` — 0644 on the default `umask 022`, 0666
+under `umask 000` — and that was harmless for exactly as long as the directory above them
+was 0700.
+
+Which is the one thing charter deliberately does **not** guarantee. `private_mkdir` leaves a
+directory it did not create exactly as it is, on purpose: `$CHARTER_HOME` can point the
+state directory at any path on the machine, so "chmod whatever we land in" is how charter
+would come to tighten someone's home or a shared team directory unprompted
+([#331](https://github.com/diazoxide/charter/issues/331)). `charter vault list` and `charter
+doctor` report the loose one and print the `chmod` instead. So on a plane whose `.charter/`
+predates charter, or was made by a `mkdir -p` under the umask default, doctor was correctly
+telling you about a directory whose contents charter went on writing world-readable
+([#505](https://github.com/diazoxide/charter/issues/505)).
+
+Measured, in a plane with `.charter` at 0755 and `umask 022`:
+
+```
+-rw-r--r--  .charter/guard-seen.json
+-rw-r--r--  .charter/persona-state/trace/<session>.jsonl
+-rw-r--r--  .charter/persona-state/ephemeral/<session>/<persona>/<note>.md
+```
+
+The trace log carries which persona did what, when, and with what title — and `charter
+persona remember`'s titles are the first line of the memory, so the text is in there. The
+ephemeral store is session scratch memory in full. Under `umask 000` those are 0666, which
+means another account could not merely read `guard-seen.json` but **rewrite** it, and decide
+what charter treats as already consented.
+
+**The property is "this file holds plane state", not "charter made the folder".** So the
+answer is the one #470 gave the directories, asked at runtime about a file:
+`config.write_for` / `open_for` / `touch_for` dispatch on where the path *is*, and every
+state writer in the package goes through them — the guard sighting, the trace log, the
+ephemeral and committed memory stores, the session/terminal/workspace pointers, the MCP
+approvals, the commit gate, the route and ask markers, the update and status-line caches,
+the tool ceiling, the push record, the reports. A path **outside** `.charter/` is written
+with a plain `open` and left at your umask, because committed files are yours to mode:
+`memstore` writes both quadrants through the same call and `personas/<n>/memory/` keeps its
+0644.
+
+**A file that already exists is tightened; a directory that already exists is not.** That
+looks like two answers and is one — charter tightens what is its own and reports what is
+not. A directory under `$CHARTER_HOME` may be a home or a team share charter merely landed
+in, and has a life of its own. A file charter is putting its own bytes into is charter's
+whatever its history, and leaving the old mode on it is
+[#437](https://github.com/diazoxide/charter/issues/437) verbatim — the mode argument to
+`os.open` is ignored for an inode that already exists, so the vault writers have settled the
+mode on the **descriptor** since then. The rest of the state directory does the same now:
+open without `O_TRUNC`, `fchmod` the descriptor, truncate, and only then write. There is no
+window in which the new content is on disk at the old mode, and that is measured from inside
+the write rather than asserted in a comment.
+
+`.charter/` itself is untouched by this. If yours predates 0.53.0 it is still 0755, doctor
+still says so, and `chmod 700 .charter` is still the fix — what changed is that the files in
+it are no longer readable while you decide.
+
+**The coverage half.** `tests/_statedirscan.py` reads the package and asks whether any
+`mkdir` can still create a directory under `.charter/` without going through `config`. It
+now asks the same two questions about `write_text` / `write_bytes` / `touch` / `open` /
+`os.open` — the named half, where the writer spells a state path itself, and the handed
+half, where one arrives as a parameter and no line in the callee mentions the state
+directory at all. That second half is what caught `memstore` for the directories in #470,
+and it is what caught it again here. An `os.open` clears the scan by settling the mode on
+the descriptor rather than by being on a list, because the three writers that do it directly
+— the vault file, the fingerprint key, the registry — each have a policy the dispatch does
+not: two of them read the mode back and refuse to write rather than write into a file they
+could not make private.
+
+Nothing to adopt. Existing state files are tightened the next time charter writes them; a
+file charter never writes again keeps the mode it has, so a plane that has been around a
+while is worth one `chmod 600` sweep — or one `chmod 700 .charter`, which settles it for
+everything at once.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -43,6 +43,33 @@ directory and the `chmod` to run. It stays a **green** line rather than a warnin
 will not fix this one for you, so saying it is the remedy, and a warning at every session
 start about a directory you have decided to leave alone is a check nobody reads twice.
 
+**The files in it are a different answer, and on purpose.** Every file charter writes under
+`.charter/` — the vault registry, `guard-seen.json`, the trace log, the ephemeral persona
+store, the session and workspace pointers, the caches — is **0600**, whatever your umask
+says and whatever mode the file had before. Until 0.54 they were written at `0o777 & ~umask`
+instead, which was safe only while the directory above them was 0700 — i.e. not in the case
+this whole section is about
+([#505](https://github.com/diazoxide/charter/issues/505)).
+
+That charter *tightens* a file it did not create while it *reports* a directory it did not
+create is one policy, not two: charter tightens what is **its own** and reports what is not.
+A directory under `$CHARTER_HOME` may be your home or a team share charter merely landed in.
+A file charter is writing this plane's state into is charter's file whatever its history —
+and leaving the old mode on it is exactly the defect
+[#437](https://github.com/diazoxide/charter/issues/437) fixed for vault files, where
+`os.open`'s mode argument turned out to be ignored for an inode that already exists. The
+mode is settled on the **descriptor** before any content is written, so the new contents are
+never on disk at the old mode.
+
+A file charter never writes again keeps whatever mode it has. On a plane that predates this,
+`chmod 700 .charter` settles the directory and everything under it in one go.
+
+**If you deliberately share a plane between accounts, this is not the tool for it.** charter
+has one posture — `.charter/` is 0700 and its contents are 0600, one account's — and both
+`vault list` and `doctor` have told you to `chmod 700` any directory that says otherwise
+since 0.53. A group-readable state directory was already being reported as wrong; the files
+in it now match what the report asks for.
+
 If you want encryption at rest, use your **OS keychain** (macOS Keychain, a real
 password manager, or a proper secrets backend) to hold the credential, and treat
 `charter`'s vault as a *thin, disposable staging area* your agent reads from — or wait

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -46,7 +46,7 @@ start about a directory you have decided to leave alone is a check nobody reads 
 **The files in it are a different answer, and on purpose.** Every file charter writes under
 `.charter/` — the vault registry, `guard-seen.json`, the trace log, the ephemeral persona
 store, the session and workspace pointers, the caches — is **0600**, whatever your umask
-says and whatever mode the file had before. Until 0.54 they were written at `0o777 & ~umask`
+says and whatever mode the file had before. They used to be written at `0o777 & ~umask`
 instead, which was safe only while the directory above them was 0700 — i.e. not in the case
 this whole section is about
 ([#505](https://github.com/diazoxide/charter/issues/505)).

--- a/tests/_statedirscan.py
+++ b/tests/_statedirscan.py
@@ -1,10 +1,18 @@
-"""Which ``mkdir`` calls in `charter/` can create a directory under the state directory.
+"""Which writes in `charter/` can leave a loose inode under the state directory.
 
-Static, and deliberately so: the question is *coverage* — has every writer that can make
-``.charter/`` been routed through `config.private_mkdir` / `config.mkdir_for` — and
-coverage is a question about code that was not executed. The behavioural half lives in
-`test_the_state_directory_is_charters_to_choose.py`, which runs real commands and measures
-the mode that comes out; this half is what notices the writer nobody ran.
+Two kinds of inode, one question. A ``mkdir`` that can create a directory under
+``.charter/`` without going through `config.private_mkdir` / `config.mkdir_for` (#470),
+and a ``write_text``/``touch``/``open``/``os.open`` that can create a **file** there
+without going through `config.write_for` / `open_for` / `touch_for` (#505). Both are the
+same property — *the umask does not decide the mode of charter's own state* — and both are
+asked here in the same two halves, because a directory scan that had grown its own copy of
+the reachability machinery is how the two answers would drift apart.
+
+Static, and deliberately so: the question is *coverage* — has every writer that can reach
+``.charter/`` been routed — and coverage is a question about code that was not executed.
+The behavioural half lives in `test_the_state_directory_is_charters_to_choose.py`, which
+runs real commands and measures the mode that comes out; this half is what notices the
+writer nobody ran.
 
 Not a ``test_*`` module, so discovery skips it. Its own accuracy is tested there, against
 sources built for the purpose.
@@ -62,6 +70,25 @@ does not matter" — that was false on the exact flow above, where the loose dir
 ``.charter/``. It is that `config.mkdir_for` decides at **runtime**, on where the path
 actually is, so a writer routed through it is right about a path this reader cannot name.
 The scan's job is to prove every writer is routed; the guard is `config`.
+
+A **function that returns a local** (``d = contain.child(...)`` … ``return d``) is not
+recognised as a state-path source: :func:`_returns` reads the return expression, and
+substituting locals into it was measured to over-taint catastrophically — every function
+returning any local out of a module that touches the state directory becomes a state path,
+including the ones returning strings and ints, and the scan starts reporting committed
+directories it can never be cleaned of. `frame.state.frame_dir` has that shape, so the
+frame's per-frame files are outside both halves. Their directory is created through
+`config.private_mkdir`, so the exposure is the narrower one — a ``.charter/frame/`` that
+pre-existed loose — but it is a gap and it is filed rather than papered over.
+
+**``os.replace``/``os.rename`` destinations are not scanned**, which is a decision rather
+than an oversight. An atomic writer's temp file carries its own mode onto the destination,
+so the question is whether the *source* was private — and a source is either a state path
+this scan already sees (an ``os.replace`` cannot cross filesystems, so an atomic write into
+``.charter/`` is written next to its destination) or a `tempfile.mkstemp` file, which is
+0600 by construction. Both are pinned behaviourally in
+`TheDispatchOnWhereTheFileIs.test_the_atomic_writers_temp_file_is_private_by_construction`,
+so the reasoning is measured rather than assumed.
 """
 
 from __future__ import annotations
@@ -84,6 +111,18 @@ ROUTED = ("private_mkdir", "mkdir_for")
 #: to route through itself. Named in full — ``module.function`` — so an unrelated
 #: ``_mkdir_0700`` appearing elsewhere would still be scanned.
 THE_WALK = ("config.private_mkdir", "config._mkdir_0700", "config.mkdir_for")
+
+#: The routed spellings for a FILE (#505). Same shape as `ROUTED`, and the same reason it
+#: is documentation rather than a filter: none of these is named ``write_text``/``open``/
+#: ``touch``, so a routed call is simply not a site.
+ROUTED_WRITE = ("write_for", "open_for", "touch_for")
+
+#: `config`'s own file writers, exempt for the reason `THE_WALK` is: they **are** the
+#: routing. ``_open_private``/``_private_fd`` are the private opener itself; ``open_for``'s
+#: bare `open` is the branch it takes having just decided the path is not state;
+#: ``touch_for``'s bare ``Path.touch`` is the same branch.
+THE_WRITE_WALK = ("config._private_fd", "config._open_private", "config.open_for",
+                  "config.write_for", "config.touch_for")
 
 
 def state_attribute_names() -> set[str]:
@@ -233,14 +272,38 @@ def _enclosing(scopes, lineno):
 
 
 def _local_assigns(fn) -> dict[str, str]:
-    """``{name: source of what it was assigned}`` for simple local assignments in *fn*."""
+    """``{name: source of what it was assigned}`` for the local bindings in *fn*.
+
+    Three shapes, and the first cut had only one. ``f = _path()`` is the obvious one.
+
+    ``sf, tf = _pointer_files(…)`` binds two names to one expression, and each of them
+    gets the whole call: which element of the tuple a name took is not decidable here, and
+    the safe direction is that both carry whatever the call does. Reading only single-Name
+    targets meant `persona.set_active`'s pointer files were bound by a spelling the scan
+    could not see, and its writes went unreported.
+
+    ``for f in (sf, tf):`` is the same question worn as a loop, and the same answer: *f* is
+    whatever the iterable is. `workspace._rename_active_pointers` rewrites every session
+    and terminal pointer through two nested loops of exactly this shape, and a scan that
+    read neither reported the module clean while it wrote at the umask (#505).
+
+    A binding is approximate on purpose — the point is reachability, and a name that might
+    carry a state path is a name that does.
+    """
     assigns: dict[str, str] = {}
     if fn is None:
         return assigns
     for n in ast.walk(fn):
-        if isinstance(n, ast.Assign) and len(n.targets) == 1 \
-                and isinstance(n.targets[0], ast.Name):
-            assigns.setdefault(n.targets[0].id, ast.unparse(n.value))
+        if isinstance(n, ast.Assign) and len(n.targets) == 1:
+            target = n.targets[0]
+            if isinstance(target, ast.Name):
+                assigns.setdefault(target.id, ast.unparse(n.value))
+            elif isinstance(target, (ast.Tuple, ast.List)):
+                for el in target.elts:
+                    if isinstance(el, ast.Name):
+                        assigns.setdefault(el.id, ast.unparse(n.value))
+        elif isinstance(n, (ast.For, ast.AsyncFor)) and isinstance(n.target, ast.Name):
+            assigns.setdefault(n.target.id, ast.unparse(n.iter))
     return assigns
 
 
@@ -294,6 +357,146 @@ def _mkdir_sites(tree: ast.AST):
         exprs += [ast.unparse(k.value) for k in node.keywords if k.arg in _PATH_KWARGS]
         if exprs:
             yield node, tuple(exprs), _enclosing(scopes, node.lineno)
+
+
+# --------------------------------------------------------------------------- #
+# the same two questions, about FILES (#505)                                   #
+# --------------------------------------------------------------------------- #
+#: Every spelling of "put bytes in a file here" that carries a mode with it. ``write_text``
+#: / ``write_bytes`` / ``touch`` create at ``0o666 & ~umask``; ``open`` and ``os.open`` do
+#: the same for the modes that create. Named as a set of NAMES for the same reason
+#: `_mkdir_sites` yields every position that could hold the path: a shape decided here is
+#: a shape that can be wrong silently.
+_WRITE_NAMES = ("write_text", "write_bytes", "touch", "open")
+
+#: The keywords the stdlib gives the path of a file-opening call: ``open(file=…)`` and
+#: ``os.open(path=…)``. Read from the signatures, not invented.
+_FILE_KWARGS = ("file", "path")
+
+#: A mode string with any of these in it opens for writing. ``"r"``/``"rb"`` have none of
+#: them and are not a site at all — a scan that flagged every read of a state file would
+#: be asking `charter` to route a read through a writer, which is not a thing, and the
+#: noise would take the real answers with it.
+_WRITE_MODE_CHARS = frozenset("wax+")
+
+#: ``os.open`` says the same thing in flags. ``O_RDONLY`` is 0 and names nothing, so the
+#: presence of any of these IS the question.
+_WRITE_FLAGS = ("O_WRONLY", "O_RDWR", "O_CREAT", "O_APPEND", "O_TRUNC")
+
+
+def _opens_for_writing(node: ast.Call, is_attr: bool) -> bool:
+    """Does this ``open``/``os.open`` call write?
+
+    Three shapes share the name and keep the mode in different places: ``open(p, "w")``
+    (argument 1), ``p.open("w")`` (argument 0) and ``os.open(p, flags)` (argument 1). As
+    with the path, the shape is not decided — every position that could hold a mode is
+    read, and a writing mode in **any** of them makes it a site.
+
+    **An unrecognisable mode counts as a write.** ``open(p, mode)`` with *mode* computed
+    somewhere else cannot be read here, and the safe direction is the false positive: a
+    reader wrongly asked to route is loud, a writer wrongly skipped is the defect.
+
+    No mode argument at all is the one case answered "no" — that is `open`'s documented
+    default of ``"r"``, which is a fact about the stdlib rather than a guess about this
+    call.
+    """
+    texts = [ast.unparse(a) for a in node.args[0 if is_attr else 1:2]]
+    texts += [ast.unparse(k.value) for k in node.keywords if k.arg in ("mode", "flags")]
+    if not texts:
+        return False
+    for t in texts:
+        if t[:1] in ("'", '"'):
+            if _WRITE_MODE_CHARS & set(t):
+                return True
+        elif any(f in t for f in _WRITE_FLAGS):
+            return True
+        elif t.startswith("0o") or t.lstrip("-").isdigit():
+            continue          # `os.open`'s third argument is the creation mode, not flags
+        else:
+            return True       # unreadable — the safe direction
+    return False
+
+
+def _settles_the_mode(fn) -> bool:
+    """Does *fn* settle the mode on the descriptor it opened?
+
+    ``os.open(p, O_CREAT, 0o600)`` is **not** private: the *mode* argument applies only
+    when the call creates the inode, so a file that already exists keeps whatever mode it
+    had and every byte written into it sits at that mode (#437, measured). What makes an
+    `os.open` writer correct is the ``fchmod`` on the descriptor — and charter has three
+    that do it directly rather than through `config`, because each has a policy of its own
+    the dispatch does not have: `secrets.plain_file` reads the mode back and **refuses**
+    to write plaintext into a file it could not make private, `secrets.fingerprint` does
+    the same for key material, and `secrets.registry` writes the committed shared half at
+    0644 on purpose.
+
+    So this asks the **property** — is the mode settled on the descriptor — rather than
+    naming those three functions in a list. A list is a spelling, and the fourth writer
+    nobody adds to it is the one that matters.
+
+    **What it cannot see, said out loud:** the mode `fchmod` is given is not read. A
+    writer that fchmods to 0644 on a state path passes this and should not. That is the
+    residual, and it is bounded by the fact that a `fchmod` is a deliberate line — the
+    defect this scans for is the writer that never thought about the mode at all.
+    """
+    if fn is None:
+        return False
+    return any(isinstance(n, ast.Call) and getattr(n.func, "attr", None) == "fchmod"
+               for n in ast.walk(fn))
+
+
+def _write_sites(tree: ast.AST):
+    """``(call node, candidate path expressions, enclosing function)`` per file write.
+
+    The file half of :func:`_mkdir_sites`, and the same discipline: ``p.write_text(…)``
+    keeps its path in the RECEIVER, ``open(p, "w")`` and ``os.open(p, …)`` in the first
+    ARGUMENT, and ``Path.write_text(p, …)`` — the unbound spelling — in the first argument
+    of an attribute call. Every position that could hold the path is yielded.
+
+    An ``os.open`` whose enclosing function settles the mode on the descriptor is not a
+    site: see :func:`_settles_the_mode` for why that is a property and not an exemption.
+    """
+    scopes = _scopes(tree)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        is_attr = isinstance(fn, ast.Attribute)
+        name = getattr(fn, "attr", None) or getattr(fn, "id", None)
+        if name not in _WRITE_NAMES:
+            continue
+        here = _enclosing(scopes, node.lineno)
+        if name == "open":
+            if not _opens_for_writing(node, is_attr):
+                continue
+            if _settles_the_mode(here):
+                continue
+        exprs = [ast.unparse(fn.value)] if is_attr else []
+        exprs += [ast.unparse(a) for a in node.args[:1]]
+        exprs += [ast.unparse(k.value) for k in node.keywords if k.arg in _FILE_KWARGS]
+        if exprs:
+            yield node, tuple(exprs), here
+
+
+def write_violations(source: str, state_names: set[str]) -> list[tuple[int, str]]:
+    """``(line, path expression)`` per file write in *source* on a path that is
+    state-derived **by its own spelling** — the named half, for files.
+
+    :func:`violations` with :func:`_write_sites` in place of :func:`_mkdir_sites`; the two
+    are one question asked about two kinds of inode, so they share every piece of the
+    reasoning below them.
+    """
+    tree = ast.parse(source)
+    state_funcs = state_path_functions(tree, state_names)
+    out = []
+    for node, exprs, enclosing in _write_sites(tree):
+        assigns = _local_assigns(enclosing)
+        for expr in exprs:
+            full = _expand(expr, assigns)
+            if _mentions_state(full, state_names) or _calls(full, state_funcs):
+                out.append((node.lineno, expr))
+                break
+    return out
 
 
 def _params(fn) -> list[str]:
@@ -489,18 +692,25 @@ def tainted_params(mods, state_names: set[str], state_funcs: set[str]) -> set[st
     return tainted
 
 
-def handed_violations(mods, state_names: set[str]) -> dict[str, list[tuple[int, str]]]:
+def handed_violations(mods, state_names: set[str], *, sites=_mkdir_sites,
+                      walk=THE_WALK) -> dict[str, list[tuple[int, str]]]:
     """``{relative path: [(line, expr)]}`` for every ``mkdir`` on a **handed** state path.
 
     The half the named scan cannot see, and the one `memstore` fell through.
+
+    *sites* and *walk* are what make this the same function for files (#505):
+    :func:`handed_write_violations` passes :func:`_write_sites` and `THE_WRITE_WALK`.
+    "A state path reached this callee as an argument" is one question, and the kind of
+    inode the callee then creates is not part of it — writing it twice is how the two
+    answers drift apart, which is the failure this file's own history is made of.
     """
     state_funcs = package_state_functions(mods, state_names)
     tainted = tainted_params(mods, state_names, state_funcs)
     found: dict[str, list[tuple[int, str]]] = {}
     for module, (path, tree) in mods.items():
         scopes = _scopes(tree)
-        for node, exprs, here in _mkdir_sites(tree):
-            if here is None or f"{module}.{here.name}" in THE_WALK:
+        for node, exprs, here in sites(tree):
+            if here is None or f"{module}.{here.name}" in walk:
                 continue
             mine = [q.rpartition(".")[2] for q in tainted
                     if q.startswith(f"{module}.{here.name}.")]
@@ -517,20 +727,54 @@ def handed_violations(mods, state_names: set[str]) -> dict[str, list[tuple[int, 
     return found
 
 
+def handed_write_violations(mods, state_names: set[str]) \
+        -> dict[str, list[tuple[int, str]]]:
+    """``{relative path: [(line, expr)]}`` per file write on a **handed** state path.
+
+    `memstore.write(mem_dir, …)` again, one inode-kind over: it is handed the committed
+    ``personas/<n>/memory`` on one call and the gitignored
+    ``PERSONA_STATE_DIR/ephemeral/<session>/<n>`` on the next, and the file it writes there
+    was at the umask exactly as the directory used to be.
+    """
+    return handed_violations(mods, state_names, sites=_write_sites, walk=THE_WRITE_WALK)
+
+
 def scan_package() -> dict[str, list[tuple[int, str]]]:
     """``{relative path: violations}`` over the whole package — both halves, merged.
 
     Named and handed are one answer because they are one property: a ``mkdir`` that can
     run on a path under ``.charter/`` without going through `config`.
     """
+    return _scan(violations, handed_violations)
+
+
+def scan_package_writes() -> dict[str, list[tuple[int, str]]]:
+    """The same sweep, asked about **files** (#505).
+
+    Kept as its own answer rather than merged into :func:`scan_package` so the failure a
+    developer reads names the right remedy — ``config.mkdir_for`` and ``config.write_for``
+    are different calls, and one report that says "route this" for both would make the
+    reader guess which.
+    """
+    return _scan(write_violations, handed_write_violations)
+
+
+def _scan(named, handed) -> dict[str, list[tuple[int, str]]]:
+    """One sweep of the package: the *named* half per module, then the *handed* half.
+
+    Named and handed are one answer because they are one property — a writer that can run
+    on a path under ``.charter/`` without going through `config`.
+    """
     names = state_attribute_names()
     mods = load_package()
     found: dict[str, list[tuple[int, str]]] = {}
     for module, (path, tree) in mods.items():
-        hits = violations(path.read_text(), names)
+        hits = named(path.read_text(), names)
         if hits:
             found[str(path.relative_to(PACKAGE.parent))] = hits
-    for f, hits in handed_violations(mods, names).items():
-        merged = sorted(set(found.get(f, [])) | set(hits))
-        found[f] = merged
-    return found
+    for f, hits in handed(mods, names).items():
+        found[f] = list(set(found.get(f, [])) | set(hits))
+    # Sorted unconditionally: the named half yields in `ast.walk` order, which is neither
+    # line order nor stable across Python versions, and a report a reader diffs against
+    # last week's should not reshuffle for having been asked twice.
+    return {f: sorted(hits) for f, hits in found.items()}

--- a/tests/_statedirscan.py
+++ b/tests/_statedirscan.py
@@ -39,8 +39,13 @@ mention a state name is itself a state path source (``_cache_file()``, ``_route_
 ``persona.ephemeral_dir()``), and so is one that returns a call to such a function. That
 fixpoint is now **cross-module** — a caller reaching `persona.ephemeral_dir` through the
 alias it imported it under is the same question as one calling a helper in its own file.
-Local assignments inside the calling function are substituted before the test, so
-``f = _cache_file()`` … ``f.parent.mkdir(…)`` is seen for what it is.
+Local bindings inside the calling function are substituted before the test, so
+``f = _cache_file()`` … ``f.parent.mkdir(…)`` is seen for what it is — and so are the two
+shapes that are not a plain assignment: ``sf, tf = _pointer_files(…)`` binds both names to
+the call, and ``for f in (sf, tf):`` binds the loop variable to what it walks. Reading
+single-Name assignments only is what hid `persona.set_active` and
+`workspace._rename_active_pointers`, both of which wrote pointer files at the umask while
+the scan reported their modules clean (#505). See :func:`_local_assigns`.
 
 **The handed half.** :func:`handed_violations` propagates *arguments*: a call that passes
 a state path (or a parameter already known to carry one) into a package function taints
@@ -79,7 +84,8 @@ including the ones returning strings and ints, and the scan starts reporting com
 directories it can never be cleaned of. `frame.state.frame_dir` has that shape, so the
 frame's per-frame files are outside both halves. Their directory is created through
 `config.private_mkdir`, so the exposure is the narrower one — a ``.charter/frame/`` that
-pre-existed loose — but it is a gap and it is filed rather than papered over.
+pre-existed loose — but it is a gap and it is filed rather than papered over (#582, which
+carries the measurement of what full substitution does to this scan).
 
 **``os.replace``/``os.rename`` destinations are not scanned**, which is a decision rather
 than an oversight. An atomic writer's temp file carries its own mode onto the destination,
@@ -379,41 +385,45 @@ _FILE_KWARGS = ("file", "path")
 #: noise would take the real answers with it.
 _WRITE_MODE_CHARS = frozenset("wax+")
 
-#: ``os.open`` says the same thing in flags. ``O_RDONLY`` is 0 and names nothing, so the
-#: presence of any of these IS the question.
-_WRITE_FLAGS = ("O_WRONLY", "O_RDWR", "O_CREAT", "O_APPEND", "O_TRUNC")
-
 
 def _opens_for_writing(node: ast.Call, is_attr: bool) -> bool:
     """Does this ``open``/``os.open`` call write?
 
     Three shapes share the name and keep the mode in different places: ``open(p, "w")``
-    (argument 1), ``p.open("w")`` (argument 0) and ``os.open(p, flags)` (argument 1). As
+    (argument 1), ``p.open("w")`` (argument 0) and ``os.open(p, flags)`` (argument 1). As
     with the path, the shape is not decided — every position that could hold a mode is
-    read, and a writing mode in **any** of them makes it a site.
+    read, and anything in any of them that is not *demonstrably* a read makes it a site.
 
-    **An unrecognisable mode counts as a write.** ``open(p, mode)`` with *mode* computed
-    somewhere else cannot be read here, and the safe direction is the false positive: a
-    reader wrongly asked to route is loud, a writer wrongly skipped is the defect.
+    So the question is asked in the negative, and that is not a stylistic choice: the only
+    thing this can be sure of is a **read**, because ``"r"``/``"rb"`` are string literals
+    the stdlib documents. Everything else — a mode computed elsewhere, an `os.open` flag
+    expression, the path argument that shares a position with `Path.open`'s mode — is
+    unreadable here, and the safe direction for unreadable is "write": a reader wrongly
+    asked to route is loud, a writer wrongly skipped is the defect itself.
 
-    No mode argument at all is the one case answered "no" — that is `open`'s documented
-    default of ``"r"``, which is a fact about the stdlib rather than a guess about this
-    call.
+    An earlier cut asked it in the positive and carried a list of ``O_WRONLY``/``O_CREAT``/
+    … flag names beside the mode characters. That list was **dead**, and the hand-check
+    for #505 is what showed it: with an unreadable expression already answering "write",
+    a branch that answers "write" for a recognised flag cannot change any outcome, and
+    deleting any entry from it changed nothing measurable. A list that cannot be wrong is
+    a list that is not being consulted.
+
+    No mode argument at all is the one case answered "no" — `open`'s documented default of
+    ``"r"``, which is a fact about the stdlib rather than a guess about this call.
+
+    **The residual, said out loud:** ``os.open(p, os.O_RDONLY)`` on a state path is
+    reported, because nothing here can tell that expression from a writing one. It is a
+    false positive in the safe direction; there are none in the package today, and the way
+    out of one is the same as for a real writer — settle the mode on the descriptor.
     """
     texts = [ast.unparse(a) for a in node.args[0 if is_attr else 1:2]]
     texts += [ast.unparse(k.value) for k in node.keywords if k.arg in ("mode", "flags")]
     if not texts:
         return False
     for t in texts:
-        if t[:1] in ("'", '"'):
-            if _WRITE_MODE_CHARS & set(t):
-                return True
-        elif any(f in t for f in _WRITE_FLAGS):
-            return True
-        elif t.startswith("0o") or t.lstrip("-").isdigit():
-            continue          # `os.open`'s third argument is the creation mode, not flags
-        else:
-            return True       # unreadable — the safe direction
+        if t[:1] in ("'", '"') and not (_WRITE_MODE_CHARS & set(t)):
+            continue          # a read-mode string literal — the one thing we can be sure of
+        return True
     return False
 
 

--- a/tests/test_the_state_directory_is_charters_to_choose.py
+++ b/tests/test_the_state_directory_is_charters_to_choose.py
@@ -616,7 +616,7 @@ class TheDispatchOnWhereTheFileIs(PersonaIso):
         A mode written down here would be a second thing to keep in step with the
         platform; a file written beside it cannot drift.
         """
-        c = Path(self.tmp) / f"control-{um:03o}-{id(self):x}"
+        c = Path(self.tmp) / f"control-{um:03o}"
         c.write_text("x")
         return c
 

--- a/tests/test_the_state_directory_is_charters_to_choose.py
+++ b/tests/test_the_state_directory_is_charters_to_choose.py
@@ -679,13 +679,62 @@ class TheDispatchOnWhereTheFileIs(PersonaIso):
         for mode in (0o644, 0o666, 0o604, 0o640):
             with self.subTest(existing=oct(mode)):
                 p = self.sd / f"pre-{mode:03o}.json"
-                p.write_text("old")
+                # LONGER than what replaces it. A dropped truncate leaves the tail of the
+                # old value behind, and an equal-length fixture cannot tell the difference
+                # — which is how this case first passed against a `write_for` that had
+                # stopped truncating at all.
+                p.write_text('{"old": "a value long enough to leave a tail"}')
                 os.chmod(p, mode)
-                config.write_for(p, "new")
-                self.assertEqual(p.read_text(), "new")
+                config.write_for(p, "{}")
+                self.assertEqual(p.read_text(), "{}",
+                                 "the previous contents were not truncated away")
                 self.assertEqual(stat.S_IMODE(p.stat().st_mode) & 0o077, 0,
                                  f"a file that was {oct(mode)[-3:]} kept it while charter "
                                  f"wrote this plane's state into it")
+
+    def test_the_mode_is_settled_before_anything_is_destroyed(self) -> None:
+        """The order inside `_private_fd`, which the finished mode cannot show.
+
+        Moving the truncate above the `fchmod` leaves the *finished* file at 0600 either
+        way, so every mode assertion in this class passes — and a crash in between leaves
+        an empty world-readable file instead of the previous contents at 0600, which is
+        the strictly worse of the two. The descriptor is opened and inspected here without
+        writing, which is the only moment that ordering is visible.
+        """
+        p = self.sd / "order.json"
+        p.write_text("the previous contents")
+        os.chmod(p, 0o666)
+        fd = config._private_fd(p, append=False)
+        try:
+            self.assertEqual(stat.S_IMODE(os.fstat(fd).st_mode), 0o600,
+                             "the descriptor is not private yet")
+            self.assertEqual(p.read_text(), "the previous contents",
+                             "the file was truncated before its mode was settled")
+        finally:
+            os.close(fd)
+
+    def test_touch_for_outside_the_state_directory_keeps_the_umask(self) -> None:
+        """`touch_for` is a dispatch too. One that privatised every marker would pass every
+        case above while tightening committed files — `mkdir_for`'s other half, again."""
+        old = os.umask(0o022)
+        try:
+            control = self.control(0o022)
+            p = config.PERSONAS_DIR / "steward" / "marker"
+            config.mkdir_for(p.parent)
+            config.touch_for(p)
+        finally:
+            os.umask(old)
+        self.assertEqual(stat.S_IMODE(p.stat().st_mode), stat.S_IMODE(control.stat().st_mode),
+                         "charter tightened a committed marker it merely created")
+
+    def test_bytes_are_written_as_bytes(self) -> None:
+        """`write_for` replaces both `write_text` and `write_bytes` — the scan counts
+        `write_bytes` as a site it covers, so the routed call has to accept one."""
+        p = self.sd / "blob.bin"
+        payload = b"\x00\x01\xff not utf-8: \xc3\x28"
+        config.write_for(p, payload)
+        self.assertEqual(p.read_bytes(), payload)
+        self.assertEqual(stat.S_IMODE(p.stat().st_mode) & 0o077, 0)
 
     def test_the_content_is_never_on_disk_at_the_loose_mode(self) -> None:
         """The ordering `_private_fd` exists for, measured rather than asserted in prose.
@@ -1122,6 +1171,22 @@ class TheWriteScanSeesWhatItClaims(unittest.TestCase):
                 self.assertEqual(scan.write_violations(src, self.names), [],
                                  f"{label}: a read was reported as an unrouted write")
 
+    def test_an_os_open_for_reading_is_reported_and_that_is_the_residual(self) -> None:
+        """Stated as a case rather than left to be discovered.
+
+        `Path.open`'s mode and `os.open`'s path share argument 0, so an `os.open` flag
+        expression is unreadable here and the safe direction reports it. There are none
+        in the package, the cost is a false positive, and the way out of one is the same
+        as for a real writer: settle the mode on the descriptor.
+        """
+        src = "import os\ndef f():\n    os.open(config.STATE_DIR / 'x', os.O_RDONLY)\n"
+        self.assertEqual([e for _ln, e in scan.write_violations(src, self.names)],
+                         ["config.STATE_DIR / 'x'"])
+        settled = ("import os\ndef f():\n"
+                   "    fd = os.open(config.STATE_DIR / 'x', os.O_RDONLY)\n"
+                   "    os.fchmod(fd, 384)\n")
+        self.assertEqual(scan.write_violations(settled, self.names), [])
+
     def test_a_mode_it_cannot_read_counts_as_a_write(self) -> None:
         """The safe direction, stated as a case. ``open(p, mode)`` with *mode* computed
         elsewhere cannot be judged here, and a false positive is loud where a skipped
@@ -1284,7 +1349,7 @@ class EveryStateWriterGoesThroughTheWalk(unittest.TestCase):
     #: (``f``, bound by ``for f in (sf, tf)``) and the plane-wide ``active-persona``. They
     #: are three lines and they are out of this change only because two other branches
     #: were live in `charter/persona.py` when it landed, and an edit in the middle of them
-    #: buys a conflict for no schedule. Filed as its own issue.
+    #: buys a conflict for no schedule. Filed as #581, with the measurement.
     #:
     #: This list is a **ratchet, not an allowance**. The assertion below is equality, so a
     #: writer that gets routed fails here as a stale entry and a new unrouted one fails as

--- a/tests/test_the_state_directory_is_charters_to_choose.py
+++ b/tests/test_the_state_directory_is_charters_to_choose.py
@@ -64,6 +64,22 @@ guard is `config`.
 ``charter _version-check``, and no test in this suite makes a network call, directly or by
 proxy. It reaches the state directory through `update.maybe_spawn`'s lock file, which the
 scan covers.
+
+**And the same sentence about the files (#505).** Everything above is about directories,
+and the files inside them were written at ``0o777 & ~umask`` the whole time — harmless for
+exactly as long as the directory above them was 0700, which is the one thing charter
+deliberately does not guarantee. `TheFilesInItAreChartersToChooseToo` is therefore the
+issue's own reproduction: a ``.charter/`` that **already existed at 0755**, three commands,
+and ``st_mode`` read off every file underneath. `TheDispatchOnWhereTheFileIs` is
+`config.write_for` / `open_for` / `touch_for` at the level the CLI cannot reach, including
+the one place the two halves give different answers — a pre-existing loose *file* is
+tightened where a pre-existing loose *directory* is not, because charter tightens what is
+its own and reports what is not.
+
+Every mode assertion in this file sets the umask **explicitly** and compares against a
+control file or directory made by this process under the same umask. A case that inherited
+the ambient umask would pass on a laptop at 022 and say something different on a CI runner
+at 002, and neither run would be measuring independence from it.
 """
 
 from __future__ import annotations
@@ -101,12 +117,18 @@ def modes_up_to(leaf, stop) -> dict:
         cur = cur.parent
 
 
-class TheCliDecidesIt(unittest.TestCase):
-    """The real binary, in a real plane, with no ``.charter/`` in it yet.
+class APlaneTheCliCanRunIn(unittest.TestCase):
+    """One `charter init` plane, copied per case — the fixture, with no cases of its own.
 
     A subprocess rather than a handler call, because the umask is a property of the
     process and because the defect was in the *order commands run in* — which is a thing
     only the CLI actually has.
+
+    No ``test_`` methods, so unittest never builds the template for this class itself; the
+    two suites below inherit it. Extracted when #505 added the second (`.charter/`'s
+    **files**, not its directories): building the plane twice would have doubled the
+    slowest fixture in the suite, and copying the twenty lines would have been the usual
+    way for two measurements of the same thing to drift.
     """
 
     #: One plane, built once by `charter init` and copied per case. Building it per case
@@ -223,6 +245,10 @@ class TheCliDecidesIt(unittest.TestCase):
             len(set(seen.values())), 1,
             f"the umask still decides it: {[(oct(u), oct(m)[-3:]) for u, m in seen.items()]}")
 
+
+class TheCliDecidesIt(APlaneTheCliCanRunIn):
+    """The real binary, in a real plane, with no ``.charter/`` in it yet."""
+
     def test_vault_add_is_the_flow_from_the_issue(self) -> None:
         """`charter vault add` writes the local registry first, and that write is what
         created `.charter/` at the umask default on the flow the issue reproduces."""
@@ -296,6 +322,132 @@ class TheCliDecidesIt(unittest.TestCase):
         self.charter(plane, "vault", "add", "devops", "--provider", "plain-file")
         self.assertEqual(stat.S_IMODE(sd.stat().st_mode), 0o755,
                          "charter chmod-ed a directory it did not create")
+
+
+class TheFilesInItAreChartersToChooseToo(APlaneTheCliCanRunIn):
+    """#505: the same sentence about the **files**, in the plane where it matters.
+
+    #470 settled the mode of every directory charter creates. The files inside them were
+    still written at ``0o777 & ~umask``, and that was harmless only for as long as the
+    directory above them was 0700 — which is exactly the case charter deliberately does
+    **not** guarantee. So the plane here is the one from the issue's reproduction: a
+    ``.charter/`` that **already existed**, at 0755, made by somebody's ``mkdir -p``.
+    charter will not chmod it (`test_an_existing_loose_state_directory_is_left_exactly_as_it_is`
+    above pins that, and this case re-pins it as a precondition), so every file charter
+    writes into it is reachable by every account on the machine unless the file itself
+    says otherwise.
+
+    **Measured, not reasoned.** ``os.stat().st_mode`` over every regular file under
+    ``.charter/`` after a run of the CLI, under three umasks. The control is a file
+    written by *this* process under the same umask, so "the umask no longer decides it" is
+    a comparison rather than a constant somebody typed — and a case that asserted 0600
+    against a machine whose umask happened to be 077 would pass while proving nothing.
+    """
+
+    #: The three commands the issue reproduces with, each of which writes a different file
+    #: through a different writer: the vault registry, the guard sighting, the trace log
+    #: and the ephemeral persona store. Run in one plane, in this order, because what the
+    #: issue exhibits is the *set* of files left behind rather than any one of them.
+    FLOWS = (
+        (("vault", "add", "devops", "--provider", "plain-file"), ""),
+        (("persona", "remember", "steward", "an ordinary scratch note", "--ephemeral"), ""),
+        (("hook", "pretooluse"),
+         json.dumps({"session_id": "sess-505", "cwd": ".", "tool_name": "Bash",
+                     "tool_input": {"command": "ls"}})),
+    )
+
+    def _run_the_issue(self, plane: Path) -> list[Path]:
+        for args, stdin in self.FLOWS:
+            proc = self.charter(plane, *args, stdin=stdin)
+            self.assertNotIn("Traceback (most recent call last):",
+                             (proc.stdout or "") + (proc.stderr or ""),
+                             f"`charter {' '.join(args)}` crashed:\n{proc.stdout}\n{proc.stderr}")
+        files = sorted(p for p in (plane / ".charter").rglob("*") if p.is_file())
+        self.assertGreaterEqual(
+            len(files), 4,
+            f"only {len(files)} file(s) under `.charter/` — the flows this case names "
+            f"stopped writing, so it is measuring nothing: {files}")
+        return files
+
+    def test_every_file_under_a_pre_existing_loose_state_directory_is_private(self) -> None:
+        seen: dict[int, set] = {}
+        for um in UMASKS:
+            with self.subTest(umask=oct(um)):
+                plane = self.plane(f"files-{um:03o}")
+                sd = plane / ".charter"
+                sd.mkdir()
+                os.chmod(sd, 0o755)              # the pre-existing loose one, by hand
+                old = os.umask(um)
+                try:
+                    control = plane / f"control-{um:03o}"
+                    control.write_text("x")
+                    files = self._run_the_issue(plane)
+                finally:
+                    os.umask(old)
+
+                self.assertEqual(
+                    stat.S_IMODE(sd.stat().st_mode), 0o755,
+                    "precondition: charter must NOT have chmod-ed the directory it did "
+                    "not create — if it did, this case stopped being about the files")
+                self.assertEqual(
+                    stat.S_IMODE(control.stat().st_mode), 0o666 & ~um,
+                    "precondition: the umask must actually be in force in this process, "
+                    "or 'the umask no longer decides it' is not being tested at all")
+                for f in files:
+                    self.assertEqual(
+                        stat.S_IMODE(f.stat().st_mode) & 0o077, 0,
+                        f"under umask {oct(um)}, {f.relative_to(plane)} came out "
+                        f"{oct(stat.S_IMODE(f.stat().st_mode))[-3:]} inside a 0755 "
+                        f"`.charter/` — another account on this machine can read it")
+                seen[um] = {stat.S_IMODE(f.stat().st_mode) for f in files}
+        self.assertEqual(
+            len(set(map(frozenset, seen.values()))), 1,
+            f"the umask still decides it: "
+            f"{[(oct(u), sorted(map(oct, m))) for u, m in seen.items()]}")
+
+    def test_the_charter_created_directories_have_not_regressed(self) -> None:
+        """The control #470 owns, re-run here because a fix to the files is exactly the
+        kind of change that reaches for a chmod and takes the directories with it."""
+        plane = self.plane("dirs-control")
+        old = os.umask(0o022)
+        try:
+            self._run_the_issue(plane)
+        finally:
+            os.umask(old)
+        dirs = [p for p in (plane / ".charter").rglob("*") if p.is_dir()]
+        self.assertGreaterEqual(len(dirs), 2, "no directories to measure")
+        for d in [plane / ".charter", *dirs]:
+            self.assertEqual(
+                stat.S_IMODE(d.stat().st_mode) & 0o077, 0,
+                f"{d.relative_to(plane)} came out "
+                f"{oct(stat.S_IMODE(d.stat().st_mode))[-3:]} — #470 regressed")
+
+    def test_a_committed_file_is_still_the_operators_to_mode(self) -> None:
+        """The other half of the dispatch, and the one a `write_for` that privatised
+        everything would fail: `charter persona remember` without ``--ephemeral`` writes
+        into ``personas/<n>/memory/``, which is committed and belongs to the operator's
+        umask. Measured against a control file written by this process, so the assertion
+        is "whatever the umask says" rather than a mode written down here.
+        """
+        plane = self.plane("committed-file")
+        old = os.umask(0o022)
+        try:
+            control = plane / "control.txt"
+            control.write_text("x")
+            proc = self.charter(plane, "persona", "remember", "steward", "a committed fact")
+        finally:
+            os.umask(old)
+        self.assertEqual(proc.returncode, 0, f"{proc.stdout}\n{proc.stderr}")
+        written = sorted((plane / "personas" / "steward" / "memory").glob("*.md"))
+        self.assertTrue(written, "nothing was committed, so this case measures nothing")
+        for f in written:
+            self.assertEqual(
+                stat.S_IMODE(f.stat().st_mode), stat.S_IMODE(control.stat().st_mode),
+                f"charter tightened {f.name}, which is committed and the operator's")
+        self.assertNotEqual(
+            stat.S_IMODE(written[0].stat().st_mode) & 0o077, 0,
+            "under umask 022 an ordinary file is 0644 — a 0600 here means `write_for` "
+            "stopped dispatching and is privatising everything")
 
 
 class ThePrivateWalkItself(PersonaIso):
@@ -441,6 +593,181 @@ class TheDispatchOnWhereThePathIs(PersonaIso):
                          "precondition: the lexical spelling must NOT match, or this "
                          "case is not about resolution at all")
         self.assertTrue(config.under_state(link / "cache"))
+
+
+class TheDispatchOnWhereTheFileIs(PersonaIso):
+    """`config.write_for` / `open_for` / `touch_for` — `mkdir_for` for an inode with
+    contents (#505), at the level the CLI sweep cannot reach.
+
+    Every case runs in a **pre-existing 0755** state directory, because that is the case
+    the whole issue is about: charter will not chmod a directory it did not create, so if
+    the files do not decide their own mode nothing does.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.sd = Path(config.STATE_DIR)
+        self.sd.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.sd, 0o755)
+
+    def control(self, um: int) -> Path:
+        """A file this process wrote under the same umask — what "not tightened" means.
+
+        A mode written down here would be a second thing to keep in step with the
+        platform; a file written beside it cannot drift.
+        """
+        c = Path(self.tmp) / f"control-{um:03o}-{id(self):x}"
+        c.write_text("x")
+        return c
+
+    def test_a_state_file_is_private_under_every_umask(self) -> None:
+        for um in UMASKS:
+            with self.subTest(umask=oct(um)):
+                old = os.umask(um)
+                try:
+                    control = self.control(um)
+                    for name, write in (
+                        ("write.json", lambda p: config.write_for(p, "{}")),
+                        ("append.log", lambda p: self._append(p, "line\n")),
+                        ("marker", config.touch_for),
+                    ):
+                        p = self.sd / f"{um:03o}-{name}"
+                        write(p)
+                        self.assertEqual(
+                            stat.S_IMODE(p.stat().st_mode) & 0o077, 0,
+                            f"{name} came out {oct(stat.S_IMODE(p.stat().st_mode))[-3:]}")
+                finally:
+                    os.umask(old)
+                self.assertEqual(stat.S_IMODE(control.stat().st_mode), 0o666 & ~um,
+                                 "precondition: the umask was not actually in force, so "
+                                 "this round proves nothing about independence from it")
+
+    @staticmethod
+    def _append(p: Path, text: str) -> None:
+        with config.open_for(p, "a") as f:
+            f.write(text)
+
+    def test_a_file_outside_it_keeps_the_umask_and_is_not_tightened(self) -> None:
+        """The half that makes this a dispatch: `memstore` writes a committed
+        ``personas/<n>/memory`` file through the same call, and those are the operator's.
+        A `write_for` that privatised everything passes every case above and fails here."""
+        old = os.umask(0o022)
+        try:
+            control = self.control(0o022)
+            p = config.PERSONAS_DIR / "steward" / "memory" / "a.md"
+            config.mkdir_for(p.parent)
+            config.write_for(p, "committed")
+        finally:
+            os.umask(old)
+        self.assertEqual(stat.S_IMODE(p.stat().st_mode), stat.S_IMODE(control.stat().st_mode),
+                         "charter tightened a committed file it merely wrote")
+        self.assertNotEqual(stat.S_IMODE(p.stat().st_mode) & 0o077, 0,
+                            "0600 here means the dispatch stopped dispatching")
+
+    def test_a_pre_existing_loose_state_file_is_tightened(self) -> None:
+        """The file charter did not create — and the one answer here that differs from the
+        directories', on purpose.
+
+        A directory under ``$CHARTER_HOME`` may be somebody's home or a team share that
+        charter merely landed in, so charter names it and prints the ``chmod`` (#331). A
+        file charter is putting its own bytes into is charter's whatever its history, and
+        leaving the old mode on it is #437 verbatim — which is why
+        `secrets.registry._write` and `secrets.plain_file._write_private` have settled the
+        mode on the descriptor of a pre-existing file since then. This is the same
+        discipline, not a second policy.
+        """
+        for mode in (0o644, 0o666, 0o604, 0o640):
+            with self.subTest(existing=oct(mode)):
+                p = self.sd / f"pre-{mode:03o}.json"
+                p.write_text("old")
+                os.chmod(p, mode)
+                config.write_for(p, "new")
+                self.assertEqual(p.read_text(), "new")
+                self.assertEqual(stat.S_IMODE(p.stat().st_mode) & 0o077, 0,
+                                 f"a file that was {oct(mode)[-3:]} kept it while charter "
+                                 f"wrote this plane's state into it")
+
+    def test_the_content_is_never_on_disk_at_the_loose_mode(self) -> None:
+        """The ordering `_private_fd` exists for, measured rather than asserted in prose.
+
+        ``open(p, "w")`` truncates as it opens, so a fix that wrote first and chmod-ed
+        afterwards would leave the new content readable for the length of the write. The
+        mode is read *from inside the write*, on the same inode, while the file object is
+        open — the only moment at which "there is no window" is falsifiable.
+        """
+        p = self.sd / "window.json"
+        p.write_text("old")
+        os.chmod(p, 0o666)
+        during = []
+        with config.open_for(p, "w") as f:
+            during.append(stat.S_IMODE(os.fstat(f.fileno()).st_mode))
+            f.write("secret")
+        self.assertEqual(during, [0o600],
+                         f"the file was {oct(during[0])[-3:]} while charter was writing "
+                         f"this plane's state into it")
+
+    def test_it_does_not_chmod_the_directory_it_writes_into(self) -> None:
+        """The overreach the directories' half refuses (#331), which a file writer reaching
+        for `os.chmod` on a parent would reintroduce from the other side."""
+        config.write_for(self.sd / "x.json", "{}")
+        self.assertEqual(stat.S_IMODE(self.sd.stat().st_mode), 0o755,
+                         "charter chmod-ed the state directory it did not create")
+
+    def test_append_does_not_truncate(self) -> None:
+        """`trace` and `memstore`'s index are appenders, and an `O_TRUNC` reached for on
+        the way to a private mode would silently empty the trace log."""
+        p = self.sd / "trace.jsonl"
+        self._append(p, "one\n")
+        self._append(p, "two\n")
+        self.assertEqual(p.read_text(), "one\ntwo\n")
+
+    def test_touch_keeps_an_existing_file_and_bumps_its_mtime(self) -> None:
+        """`Path.touch`'s own contract — every caller here uses it as a marker, and one
+        that truncated would be a different function wearing the name."""
+        p = self.sd / "mark"
+        p.write_text("payload")
+        os.utime(p, (1, 1))
+        config.touch_for(p)
+        self.assertEqual(p.read_text(), "payload")
+        self.assertGreater(p.stat().st_mtime, 1)
+        self.assertEqual(stat.S_IMODE(p.stat().st_mode) & 0o077, 0)
+
+    def test_a_state_path_reached_through_a_symlink_is_still_state(self) -> None:
+        """The dispatch is `under_state`, which resolves — so the file half inherits the
+        answer the directory half already argued for, rather than asking a second time."""
+        link = Path(self.tmp) / "link-to-state"
+        link.symlink_to(self.sd)
+        old = os.umask(0o000)
+        try:
+            config.write_for(link / "through-a-link.json", "{}")
+        finally:
+            os.umask(old)
+        self.assertEqual(
+            stat.S_IMODE((self.sd / "through-a-link.json").stat().st_mode) & 0o077, 0)
+
+    def test_the_mode_is_a_mask_not_a_value(self) -> None:
+        """`STATE_FILE_MODE` is asserted through ``& 0o077`` everywhere above for the
+        reason `base._OTHERS` is a mask: 0644 is the mode everybody pictures, and 0604,
+        0620 and 0606 hand the file to another account just as completely. This is the
+        one place the constant itself is named, so a change to it is a decision somebody
+        made rather than a test quietly following along."""
+        self.assertEqual(config.STATE_FILE_MODE, 0o600)
+
+    def test_the_atomic_writers_temp_file_is_private_by_construction(self) -> None:
+        """`inflight` and `toolgate` write through a temp file and `os.replace`, which
+        carries the SOURCE's mode onto the destination — so the scan not looking at
+        `os.replace` is only honest if the sources are already private.
+
+        `toolgate`'s temp file is a state path the write scan sees. `inflight`'s comes
+        from `tempfile.mkstemp`, whose 0600 is documented rather than incidental — pinned
+        here because the claim is load-bearing and a change to it would be silent.
+        """
+        fd, name = tempfile.mkstemp(dir=self.tmp)
+        os.close(fd)
+        self.addCleanup(os.unlink, name)
+        self.assertEqual(stat.S_IMODE(os.stat(name).st_mode) & 0o077, 0,
+                         "mkstemp stopped creating at 0600; every atomic writer that "
+                         "leans on it now leaks its destination's mode")
 
 
 class TheHandedWriterAsksWhereItIs(PersonaIso):
@@ -710,6 +1037,234 @@ class TheHandedScanSeesWhatItClaims(unittest.TestCase):
             "of the scan by naming a function `mkdir_for`")
 
 
+class TheWriteScanSeesWhatItClaims(unittest.TestCase):
+    """The file half of the scanner's accuracy, against sources written for the purpose.
+
+    Same treatment the directory half gets, and for the same reason: a scan that has
+    quietly stopped seeing anything reports a clean package, which is the most comfortable
+    way for a coverage test to become decorative.
+    """
+
+    def setUp(self) -> None:
+        self.names = scan.state_attribute_names()
+
+    #: Every spelling of "put bytes in a file here", and where each keeps its path. The
+    #: table IS the test, for the reason `TheScanSeesWhatItClaims.MAKERS` is: keying on the
+    #: shape ("``write_text`` takes a receiver, ``open`` an argument") trades one spelling
+    #: for another, and the one nobody listed is the one that ships.
+    WRITERS = {
+        "bound method, path is the receiver":
+            "def f():\n    (config.STATE_DIR / 'x').write_text('y')\n",
+        "bytes, same shape":
+            "def f():\n    (config.STATE_DIR / 'x').write_bytes(b'y')\n",
+        "a marker file — no content, same mode":
+            "def f():\n    (config.STATE_DIR / 'x').touch()\n",
+        "builtin open, path is argument 0":
+            "def f():\n    open(config.STATE_DIR / 'x', 'w').close()\n",
+        "builtin open, appending":
+            "def f():\n    open(config.STATE_DIR / 'x', 'a').close()\n",
+        "builtin open, exclusive create":
+            "def f():\n    open(config.STATE_DIR / 'x', 'x').close()\n",
+        "builtin open, read-plus still writes":
+            "def f():\n    open(config.STATE_DIR / 'x', 'r+').close()\n",
+        "Path.open, path is the receiver":
+            "def f():\n    (config.STATE_DIR / 'x').open('w').close()\n",
+        "the mode arrives by keyword":
+            "def f():\n    open(config.STATE_DIR / 'x', mode='w').close()\n",
+        "the path arrives by keyword":
+            "def f():\n    open(file=config.STATE_DIR / 'x', mode='w').close()\n",
+        "os.open, path is argument 0":
+            "import os\ndef f():\n"
+            "    os.open(config.STATE_DIR / 'x', os.O_WRONLY | os.O_CREAT, 438)\n",
+        "os.open by keyword":
+            "import os\ndef f():\n    os.open(path=config.STATE_DIR / 'x', flags=os.O_CREAT)\n",
+        "unbound, path is argument 0 of an attribute call":
+            "from pathlib import Path\ndef f():\n"
+            "    Path.write_text(config.STATE_DIR / 'x', 'y')\n",
+    }
+
+    def test_every_spelling_of_writing_a_file_is_scanned(self) -> None:
+        for label, src in self.WRITERS.items():
+            with self.subTest(label):
+                hits = scan.write_violations(src, self.names)
+                self.assertEqual([e for _ln, e in hits], ["config.STATE_DIR / 'x'"],
+                                 f"{label}: a state file written here went unseen")
+
+    def test_the_same_spellings_on_a_committed_path_are_left_alone(self) -> None:
+        """The other half of the claim: widening where the path is looked for must not
+        widen WHAT counts as one, or the fix is to privatise committed files."""
+        for label, src in self.WRITERS.items():
+            with self.subTest(label):
+                self.assertEqual(
+                    scan.write_violations(src.replace("STATE_DIR", "PERSONAS_DIR"),
+                                          self.names),
+                    [], f"{label}: a committed file was flagged as state")
+
+    #: Reads of a state file, which are not sites at all. A scan that flagged these would
+    #: be asking charter to route a read through a writer — which is not a thing — and the
+    #: noise would take the real answers with it.
+    READERS = {
+        "open with no mode is `open`'s documented default of 'r'":
+            "def f():\n    open(config.STATE_DIR / 'x').close()\n",
+        "an explicit text read":
+            "def f():\n    open(config.STATE_DIR / 'x', 'r').close()\n",
+        "a binary read":
+            "def f():\n    open(config.STATE_DIR / 'x', 'rb').close()\n",
+        "Path.open with no mode":
+            "def f():\n    (config.STATE_DIR / 'x').open().close()\n",
+        "read_text is not a write":
+            "def f():\n    (config.STATE_DIR / 'x').read_text()\n",
+    }
+
+    def test_reading_a_state_file_is_not_a_violation(self) -> None:
+        for label, src in self.READERS.items():
+            with self.subTest(label):
+                self.assertEqual(scan.write_violations(src, self.names), [],
+                                 f"{label}: a read was reported as an unrouted write")
+
+    def test_a_mode_it_cannot_read_counts_as_a_write(self) -> None:
+        """The safe direction, stated as a case. ``open(p, mode)`` with *mode* computed
+        elsewhere cannot be judged here, and a false positive is loud where a skipped
+        writer is the defect itself."""
+        src = "def f(mode):\n    open(config.STATE_DIR / 'x', mode).close()\n"
+        self.assertEqual([e for _ln, e in scan.write_violations(src, self.names)],
+                         ["config.STATE_DIR / 'x'"])
+
+    def test_the_routed_calls_are_not_flagged(self) -> None:
+        for name in scan.ROUTED_WRITE:
+            with self.subTest(name):
+                src = f"def f():\n    config.{name}(config.STATE_DIR / 'x', 'y')\n"
+                self.assertEqual(scan.write_violations(src, self.names), [])
+
+    def test_the_routed_names_exist_in_config(self) -> None:
+        """Asserted against `config` so a rename cannot leave the list stale — the same
+        guard `ROUTED` gets for the directory half."""
+        for name in scan.ROUTED_WRITE:
+            self.assertTrue(callable(getattr(config, name, None)),
+                            f"`config.{name}` no longer exists; ROUTED_WRITE is stale")
+        for qual in scan.THE_WRITE_WALK:
+            module, _, fn = qual.rpartition(".")
+            self.assertTrue(hasattr(config, fn),
+                            f"{qual} no longer exists in `config`; the exemption is stale")
+
+    def test_settling_the_mode_on_the_descriptor_is_what_clears_an_os_open(self) -> None:
+        """`secrets.plain_file`, `secrets.fingerprint` and `secrets.registry` open state
+        files directly because each has a policy the dispatch does not have — two of them
+        read the mode back and REFUSE. What makes them correct is the ``fchmod``, so that
+        is what the scan asks for, rather than naming the three functions in a list.
+        """
+        leaks = ("import os\ndef f():\n"
+                 "    fd = os.open(config.STATE_DIR / 'x', os.O_WRONLY | os.O_CREAT, 384)\n"
+                 "    os.write(fd, b'y')\n")
+        settles = ("import os\ndef f():\n"
+                   "    fd = os.open(config.STATE_DIR / 'x', os.O_WRONLY | os.O_CREAT, 384)\n"
+                   "    os.fchmod(fd, 384)\n"
+                   "    os.write(fd, b'y')\n")
+        self.assertEqual([e for _ln, e in scan.write_violations(leaks, self.names)],
+                         ["config.STATE_DIR / 'x'"],
+                         "`os.open`'s mode argument is ignored for an inode that already "
+                         "exists (#437) — a creation mode is not a private file")
+        self.assertEqual(scan.write_violations(settles, self.names), [])
+
+    def test_one_hop_of_indirection_does_not_hide_it(self) -> None:
+        """The shape most of the writers actually have: a module-level path helper, then
+        a write in the function that uses it."""
+        src = ("def _cache_file():\n    return config.STATE_DIR / 'cache' / 'x.json'\n\n"
+               "def save():\n    f = _cache_file()\n"
+               "    f.write_text('y')\n")
+        self.assertEqual([ln for ln, _ in scan.write_violations(src, self.names)], [6])
+
+    def test_the_module_alias_does_not_hide_it(self) -> None:
+        src = "def f():\n    (_cfg.STATE_DIR / 'x').write_text('y')\n"
+        self.assertEqual([ln for ln, _ in scan.write_violations(src, self.names)], [2])
+
+    #: How the two writers this scan could not see were *bound*, rather than what they
+    #: wrote. `_local_assigns` read single-Name assignments only, so a name that arrived
+    #: by tuple-unpack or as a loop variable expanded to itself and named nothing —
+    #: `persona.set_active` and `workspace._rename_active_pointers` were both invisible on
+    #: that alone, and both wrote pointer files at the umask.
+    BINDINGS = {
+        "tuple unpack — which element is which is not decidable, so both carry it":
+            "def _pointers():\n    return config.SESSIONS_DIR / 'a', config.TERMINALS_DIR / 'b'\n\n"
+            "def go():\n    sf, tf = _pointers()\n    sf.write_text('y')\n",
+        "a loop over the names that were just unpacked":
+            "def _pointers():\n    return config.SESSIONS_DIR / 'a', config.TERMINALS_DIR / 'b'\n\n"
+            "def go():\n    sf, tf = _pointers()\n"
+            "    for f in (sf, tf):\n        f.write_text('y')\n",
+        "a loop over what a state directory globs":
+            "def go():\n    for f in config.SESSIONS_DIR.glob('*.workspace'):\n"
+            "        f.write_text('y')\n",
+        "a loop over the state directories themselves":
+            "def go():\n    for d in (config.SESSIONS_DIR, config.TERMINALS_DIR):\n"
+            "        (d / 'x').write_text('y')\n",
+    }
+
+    def test_how_the_name_was_bound_does_not_hide_the_write(self) -> None:
+        for label, src in self.BINDINGS.items():
+            with self.subTest(label):
+                self.assertTrue(scan.write_violations(src, self.names),
+                                f"{label}: the write went unseen")
+
+    def test_the_same_bindings_on_a_committed_path_are_left_alone(self) -> None:
+        """Widening how a name is followed must not widen what counts as state, or the
+        remedy for the noise is to privatise the committed tree."""
+        for label, src in self.BINDINGS.items():
+            with self.subTest(label):
+                committed = src.replace("SESSIONS_DIR", "PERSONAS_DIR") \
+                               .replace("TERMINALS_DIR", "PERSONAS_DIR")
+                self.assertEqual(scan.write_violations(committed, self.names), [],
+                                 f"{label}: a committed file was flagged as state")
+
+    def test_the_handed_half_is_the_same_question_about_files(self) -> None:
+        """`memstore.write(mem_dir, …)` again, one inode-kind over: nothing in the callee
+        spells a state name, and the file it writes was at the umask exactly as the
+        directory used to be."""
+        caller = ("from . import store\n\n"
+                  "def go():\n    store.write(config.STATE_DIR / 'x', 'y')\n")
+        for label, body in (
+                ("write_text", "    (mem_dir / 'a').write_text(text)\n"),
+                ("open for append", "    (mem_dir / 'a').open('a').close()\n"),
+                ("touch", "    (mem_dir / 'a').touch()\n")):
+            with self.subTest(label):
+                mods = scan.modules_from({
+                    "store": "def write(mem_dir, text):\n" + body, "caller": caller})
+                self.assertEqual(scan.handed_write_violations(mods, self.names),
+                                 {"charter/store.py": [(2, "mem_dir / 'a'")]})
+
+    def test_a_committed_path_handed_the_same_way_is_not(self) -> None:
+        mods = scan.modules_from({
+            "store": "def write(mem_dir, text):\n    (mem_dir / 'a').write_text(text)\n",
+            "caller": "from . import store\n\n"
+                      "def go():\n    store.write(config.PERSONAS_DIR / 'x', 'y')\n"})
+        self.assertEqual(scan.handed_write_violations(mods, self.names), {})
+
+    def test_the_routed_call_clears_the_handed_half_too(self) -> None:
+        mods = scan.modules_from({
+            "store": "def write(mem_dir, text):\n"
+                     "    config.write_for(mem_dir / 'a', text)\n",
+            "caller": "from . import store\n\n"
+                      "def go():\n    store.write(config.STATE_DIR / 'x', 'y')\n"})
+        self.assertEqual(scan.handed_write_violations(mods, self.names), {})
+
+    def test_config_own_writers_are_exempt_and_named_in_full(self) -> None:
+        """`config`'s own `open`/`touch` ARE the routing — flagging them would be asking
+        the guard to route through itself. Exempted by ``module.function``, so the same
+        function name in another module is still scanned."""
+        callee = "def write_for(p, t):\n    open(p, 'w').close()\n"
+        caller = "from . import {alias}\n\ndef go():\n    {alias}.write_for(config.STATE_DIR / 'x', 'y')\n"
+        self.assertEqual(
+            scan.handed_write_violations(
+                scan.modules_from({"config": callee,
+                                   "caller": caller.format(alias="config")}), self.names),
+            {})
+        self.assertEqual(
+            scan.handed_write_violations(
+                scan.modules_from({"other": callee,
+                                   "caller": caller.format(alias="other")}), self.names),
+            {"charter/other.py": [(2, "p")]},
+            "any module could opt out of the scan by naming a function `write_for`")
+
+
 class EveryStateWriterGoesThroughTheWalk(unittest.TestCase):
     def test_no_mkdir_in_the_package_can_make_a_loose_state_directory(self) -> None:
         found = scan.scan_package()
@@ -720,6 +1275,42 @@ class EveryStateWriterGoesThroughTheWalk(unittest.TestCase):
             "the state directory (#470):\n"
             + "\n".join(f"  {f}:{ln}  {expr}.mkdir(…)"
                         for f, hits in found.items() for ln, expr in hits))
+
+    #: The writers #505 did **not** close, by file and by the path expression at the site
+    #: — never by line number, which two people editing the same module would invalidate
+    #: without either of them touching a mode.
+    #:
+    #: Both are `persona.set_active`: the per-session and per-terminal persona pointers
+    #: (``f``, bound by ``for f in (sf, tf)``) and the plane-wide ``active-persona``. They
+    #: are three lines and they are out of this change only because two other branches
+    #: were live in `charter/persona.py` when it landed, and an edit in the middle of them
+    #: buys a conflict for no schedule. Filed as its own issue.
+    #:
+    #: This list is a **ratchet, not an allowance**. The assertion below is equality, so a
+    #: writer that gets routed fails here as a stale entry and a new unrouted one fails as
+    #: an unlisted leak — neither direction can happen quietly, and "add a line to make the
+    #: test pass" is a diff a reviewer sees.
+    NOT_ROUTED_YET = {"charter/persona.py": ["config.ACTIVE_PERSONA_FILE", "f"]}
+
+    def test_no_write_in_the_package_can_leave_a_loose_state_file(self) -> None:
+        found = {f: sorted(expr for _ln, expr in hits)
+                 for f, hits in scan.scan_package_writes().items()}
+        expected = {f: sorted(e) for f, e in self.NOT_ROUTED_YET.items()}
+        self.assertEqual(
+            found, expected,
+            "a file under `.charter/` written without `config.write_for` / `open_for` / "
+            "`touch_for` comes out at `0o777 & ~umask`, and the directory above it is not "
+            "guaranteed to be 0700 — charter does not chmod a state directory it did not "
+            "create (#331, #505). Route it. If it really is out of reach, move it into "
+            "`NOT_ROUTED_YET` and say why there; if it is now routed, delete its entry.\n"
+            f"  found:  {found}\n  listed: {expected}")
+
+    def test_the_ratchet_names_files_that_exist(self) -> None:
+        """The one way an equality assertion cannot notice a stale entry: the module gets
+        renamed or deleted, and the list keeps naming a path nobody will look at again."""
+        for f in self.NOT_ROUTED_YET:
+            self.assertTrue((REPO_ROOT / f).is_file(),
+                            f"NOT_ROUTED_YET names {f}, which is not a file any more")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #505

## The defect

#470 settled the mode of every **directory** charter creates under `.charter/`. The
**files** were never asked — they were written at `0o777 & ~umask`, which is safe only
while the directory above them is 0700.

That is the one thing charter deliberately does *not* guarantee. `private_mkdir` leaves a
directory it did not create exactly as it is, because `$CHARTER_HOME` can point the state
directory at a home or a team share and tightening one unprompted is worse than the thing
it fixes (#331). `vault list` and `doctor` report the loose one instead. So on a plane
whose `.charter/` pre-existed at 0755, doctor was correctly naming a directory whose
contents charter went on writing world-readable.

Measured, `.charter` at 0755, `umask 022`:

```
-rw-r--r--  .charter/guard-seen.json
-rw-r--r--  .charter/persona-state/trace/<session>.jsonl
-rw-r--r--  .charter/persona-state/ephemeral/<session>/<persona>/<note>.md
```

Under `umask 000` those are 0666 — another account can *rewrite* `guard-seen.json` and
decide what charter treats as already consented.

## The fix

`config.write_for` / `open_for` / `touch_for`: `mkdir_for` for an inode with contents.
**The dispatch is on where the path is, at runtime** — not on whether charter created the
folder, and not on a list of the files somebody remembered were sensitive. A path outside
`.charter/` is written with a plain `open` and left at the operator's umask, so `memstore`
writes both quadrants through one call and `personas/<n>/memory/` keeps its 0644.

Explicit modes at creation, no umask games: `os.open` without `O_TRUNC`, `os.fchmod` the
descriptor, truncate, then write. `os.open`'s mode argument is ignored for an inode that
already exists (#437), which is why the mode is settled on the descriptor and not on the
path.

**Directory that is already wrong: reported, not tightened — unchanged.** File that is
already wrong: **tightened**. That looks like two answers and is one — charter tightens
what is its own and reports what is not. A directory under `$CHARTER_HOME` may be a home
or a team share charter merely landed in; a file charter is putting its own bytes into is
charter's whatever its history. `secrets.registry._write` and
`secrets.plain_file._write_private` have done exactly this since #437, so this is that
discipline extended, not a second policy. `doctor`'s loose-state-directory surface is
untouched and `test_an_existing_loose_state_directory_is_left_exactly_as_it_is` still
passes.

**Shared planes:** charter has one stated posture — `.charter/` is 0700, `docs/secrets.md`
and both report surfaces have said so since 0.53. A group-readable state directory was
already being reported as wrong; the files in it now match what the report asks for. Said
out loud in `docs/secrets.md` rather than left implied.

## Every write path, enumerated before any were fixed

`tests/_statedirscan.py` now asks its two existing questions about files as well as
directories, sharing the reachability machinery rather than copying it. That found more
than the issue named: **31 named** sites and the **handed** one (`memstore`, which fell
through for directories in #470 and again here). Closing `_local_assigns` over
tuple-unpack and loop bindings found two more that no spelling could reach —
`workspace._rename_active_pointers` (routed here) and `persona.set_active`.

`config._repoint_vault_registry` was doing `write_text` then `chmod` — the #437 window at
the one site that runs during the `.edm` → `.charter` migration. Fixed too.

## What is not closed, and why

| | |
|---|---|
| `persona.set_active` — 3 sites | #581. Two branches were live in `charter/persona.py`; listed in `NOT_ROUTED_YET`, which the coverage test asserts **equality** against, so routing them fails as a stale entry and a new one fails as an unlisted leak. |
| `charter/frame/*` — 11 sites | #582. Invisible to both halves because `frame_dir` returns a local, and substituting locals into return expressions over-taints catastrophically (measured: 52 functions become "state paths", and the *directory* half then reports three false positives on committed paths). Their directory is `private_mkdir`-created, so the exposure is the narrower pre-existing-directory one. |

Both are stated in the scan's own "what it cannot see" section rather than left to be
found.

## Verification

**Behaviour, measured against a real filesystem.** `TheFilesInItAreChartersToChooseToo`
is the issue's reproduction: a `.charter/` **created by hand at 0755**, three CLI commands
in a subprocess, `st_mode` read off every file underneath, under `umask 000 / 022 / 077`.
Every umask is set **explicitly** and compared against a control file written by the test
process under the same umask — a case that inherited the ambient umask would pass on a
laptop at 022 and mean nothing on a Linux runner. Controls: charter-created directories
must still be 0700 (#470 not regressed), and committed files must still be the operator's.

**Sweep.** `tools/sweep.py`'s first run aborted — its unmutated baseline ran 0 tests in
2965s under machine load, which it correctly refused to treat as green rather than pinning
41 mutants for a reason that had nothing to do with the guards. Re-run reported below.

**Hand-check** — the class the sweep has no operator for (#569), reported separately from
it. 41 mutations of the octal modes, the name/flag tables and the orderings, each run
against an unmutated baseline **before and after** the batch, so a sandbox that failed to
restore cannot turn the table into a lie. First pass **32/41 caught, 9 survived**; six of
those were the tests asserting too little and are now caught, giving **38/41**. The three
that remain are equivalent, and each was checked for a second unpinned line hiding its
consequence rather than waved through — the reasoning is in `64a0b40`.

**Suite:** 6528 tests green in two environments — Python 3.14.4, and Python 3.12.13 with
every `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` variable unset.

### The survivor worth reading

The `os.open` cases named `O_WRONLY | O_CREAT` together, so dropping either from the
scan's flag list still matched on the other. Adding one case per flag did not fix it —
and that is the finding. With an unreadable expression already answering "write", a branch
that answers "write" for a *recognised* flag cannot change any outcome: `_WRITE_FLAGS` was
**dead**, and so was the numeric branch beside it. A list that cannot be wrong is a list
that is not being consulted. `_opens_for_writing` asks the question in the negative now —
the one thing it can be sure of is a read-mode string literal, everything else is a site —
which gives the same answers on the package with four fewer lines, every one of them
killable by a mutation. Two survivors remain genuinely equivalent (`touch_for`'s
`append=True`, which only selects `O_APPEND` for a call that writes nothing, and the
migration writer whose end state is identical); both are stated in the commit message with
the second-order reasoning rather than called equivalent and dropped.

News entry: `docs/news/unreleased-the-files-under-charter-are-charters-to-choose.md`,
`version: unreleased`. No bump, no stamp, no tag.

