### PR TITLE
A roster column is measured from the names it prints, in cells (#508)

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -17,7 +17,7 @@ import json
 import os
 import sys
 
-from . import commands_secrets, config, contain, mcpseen, persona, trace, util
+from . import commands_secrets, config, contain, mcpseen, persona, trace, tui, util
 from .secrets import base, registry
 
 #: The scaffold a new persona starts from.
@@ -169,12 +169,23 @@ def cmd_persona_list(args) -> int:
     # display transform, never a lookup key.
     named = {n: (persona.vault_of(n) or "—") for n in names}
     vaults = {n: contain.one_line(v) for n, v in named.items()}
-    # dynamic column widths so long persona/role/vault names don't collide
-    nw = max([len("PERSONA")] + [len(s) for s in shown.values()]) + 2
-    rw = min(38, max([len("ROLE")] + [len(r) for r in roles.values()])) + 2
-    vw = max([len("VAULT")] + [len(v) for v in vaults.values()]) + 2
-    fmt = f"{{}}{{:<{nw}}}{{:<{rw}}}{{:<{vw}}}{{}}"
-    print(fmt.format("  ", "PERSONA", "ROLE", "VAULT", "VAULT STATUS"))
+    # Dynamic column widths so long persona/role/vault names don't collide — measured in
+    # terminal CELLS, not characters. `len` was the same defect #508 named one command
+    # over, one layer down: it sizes and pads a CJK name to 28 characters, the terminal
+    # draws 56, and that row's ROLE, VAULT and VAULT STATUS all land 28 columns right of
+    # every other row's. `tui.column` measures and `tui.pad` pads, and the pair have to
+    # agree or the arithmetic was for nothing — which is why the rows below are padded
+    # rather than run through `str.format`, whose `{:<nw}` counts characters too.
+    nw = tui.column("PERSONA", shown.values())
+    rw = tui.column("ROLE", roles.values(), cap=38)
+    vw = tui.column("VAULT", vaults.values())
+
+    def row(mark, name, role, vault, status) -> str:
+        """Header and data rows through one function, so there is no second code
+        path left to disagree with this one about a width."""
+        return (f"{mark}{tui.pad(name, nw)}{tui.pad(role, rw)}"
+                f"{tui.pad(vault, vw)}{status}").rstrip()
+    print(row("  ", "PERSONA", "ROLE", "VAULT", "VAULT STATUS"))
     for n in names:
         # Identity, not display: `one_line` maps `evil\n` and a literal `evil\x0a` onto the same
         # rendered string, so deciding the marker from the rendered form would mark every
@@ -185,9 +196,15 @@ def cmd_persona_list(args) -> int:
         # (`listed by other accounts: .charter 755 (want 700 — chmod 700)`), and a remedy
         # clipped at 160 characters is one the reader cannot act on. Still a fixed budget,
         # for the reason `contain` gives: a budget the input can grow is no budget.
-        print(fmt.format(mark, shown[n], roles[n][:rw - 2], vaults[n],
-                         contain.one_line(_vault_status(named[n]),
-                                          contain.PATH_DISPLAY_LIMIT)))
+        #
+        # ROLE is the one column with a cap, because it is the one holding prose rather
+        # than an identifier. `tui.pad` applies it, so an over-long role is cut at the
+        # column in CELLS and marked `…`; the old `roles[n][:rw - 2]` cut it at rw-2
+        # *characters*, which for a CJK role left a cell that was still too wide for the
+        # column it had just been cut to fit.
+        print(row(mark, shown[n], roles[n], vaults[n],
+                  contain.one_line(_vault_status(named[n]),
+                                   contain.PATH_DISPLAY_LIMIT)))
     return 0
 
 
@@ -1208,6 +1225,52 @@ def cmd_persona_lint(args) -> int:
     return 0
 
 
+#: The `persona stats` table, as ``(header, alignment)`` pairs. STATUS is deliberately
+#: absent: it is the last column, so nothing sits to its right to be pushed and it needs
+#: no width at all. Every column that DOES have something to its right is measured.
+_STATS_HEADS = (("PERSONA", "left"), ("MEM", "right"), ("RECENT", "right"),
+                ("VERIFY", "right"), ("DUP", "right"), ("DISP", "right"))
+
+#: Between the measured columns and the trailing STATUS text. A right-aligned column
+#: carries its own gutter on the LEFT (that is what ``{'MEM':>5}`` was doing), so the one
+#: place a separator has to be written out is after the last of them.
+_STATS_GAP = "  "
+
+
+def _stats_table(heads, body) -> list[str]:
+    """The header row and *body* rows of the stats table, columns measured from *body*.
+
+    **One function for the header and the rows, called once each.** They are sibling rows
+    of the same table, and the fastest way back to a misaligned report is two code paths
+    that each believe they agree about the widths. Before #508 there were two: a format
+    string in the `print` for the header and another in the loop, and they agreed only for
+    names shorter than the constant they both spelled.
+
+    The widths come from :func:`tui.column`, which explains the two things a hand-rolled
+    ``{name:<28}`` gets wrong — a constant is a guess about content, and `str.format`
+    counts characters where a terminal lays out cells. Both were live here: a persona
+    directory is a committed name charter did not mint, so a 30-cell one pushed that row's
+    other six columns right, and an 8-glyph CJK one that fits the constant twice over
+    still shifted its row by 8 because ``:<28`` had padded it to 28 *characters* (#508).
+
+    Not clipped to the terminal, and that is a decision rather than an omission. #472 asks
+    this report to name each persona in its bounded spelling, because the steward reading
+    it acts on that name — `persona show`, `persona retire`. A column capped at the
+    terminal edge would hand them a prefix they cannot look up, which is a worse report
+    than a wide one. The bound on the name is `contain.one_line`'s, applied to the value
+    once, the same as on every other surface; this column honours it rather than inventing
+    a second, smaller one.
+    """
+    widths = [tui.column(h, [row[i] for row in body])
+              for i, (h, _) in enumerate(heads)]
+
+    def line(cells) -> str:
+        out = "".join(tui.pad(c, w, a) for c, w, (_, a) in zip(cells, widths, heads))
+        return (out + _STATS_GAP + "".join(cells[len(heads):])).rstrip()
+
+    return [line([h for h, _ in heads] + ["STATUS"])] + [line(row) for row in body]
+
+
 def cmd_persona_stats(args) -> int:
     """Roster health mined from committed memory — a persona's memory IS its activity
     trace, so this is the usage + (in-corpus) quality signal for the steward's observe
@@ -1226,8 +1289,8 @@ def cmd_persona_stats(args) -> int:
     disp = dispatch.tally()
     glyph = {"active": "●", "idle": "○", "dormant": "✗", "draft": "⚑",
              "orchestrator": "⬡", "standby": "◇", "advisory": "◇"}
-    print(f"{'PERSONA':<28}{'MEM':>5}{'RECENT':>8}{'VERIFY':>8}{'DUP':>6}{'DISP':>6}  STATUS")
     dormant = idle = unused = drafts = 0
+    body: list[tuple[str, ...]] = []
     for r in rows:
         v = f"{r['verify_pct']}%" if r["verify_pct"] is not None else "—"
         d = f"{r['dup_pct']}%" if r["dup_pct"] is not None else "—"
@@ -1249,11 +1312,14 @@ def cmd_persona_stats(args) -> int:
         # `skilluse.drift` below all ask the filesystem and the committed dispatch log
         # about this persona, and the answer for a name holding a separator is not the answer for its
         # rendered spelling. See `cmd_persona_list` for why the name needs bounding at all.
-        print(f"{contain.one_line(r['persona']):<28}{r['count']:>5}{rec:>8}{v:>8}{d:>6}"
-              f"{(n_disp if not shared_row else '—'):>6}  "
-              f"{glyph.get(status, '⚑' if status == 'never dispatched' else '·')} {status}")
+        body.append((contain.one_line(r["persona"]), f"{r['count']}", rec, v, d,
+                     f"{n_disp}" if not shared_row else "—",
+                     f"{glyph.get(status, '⚑' if status == 'never dispatched' else '·')}"
+                     f" {status}"))
         dormant += r["status"] == "dormant"
         idle += r["status"] == "idle"
+    for ln in _stats_table(_STATS_HEADS, body):
+        print(ln)
     print()
 
     # Declared-vs-used skills. A separate block rather than a column, because it is per
@@ -1270,18 +1336,24 @@ def cmd_persona_stats(args) -> int:
             drifted.append((r["persona"], d))
     if drifted:
         print("SKILLS — declared vs actually invoked")
+        # A name column with no header of its own, and the same rule as the table above:
+        # measured from the names it is about to print, in cells rather than characters.
+        # It was `{shown:<26}` and carried #508 identically — one drifted persona with a
+        # long or a CJK name and the `unused:`/`used but not declared:` labels stop
+        # lining up down the block.
+        nw = tui.column("", [contain.one_line(n) for n, _ in drifted])
         for name, d in drifted:
             # Same rule as the table: the persona name and the skill names are committed
             # values landing in a report of one-line rows.
-            shown = contain.one_line(name)
+            shown = tui.pad(contain.one_line(name), nw)
             if d["unused"]:
                 # Not untidy: `skills:` preloads full text on EVERY dispatch, so an unused
                 # declaration is a standing context cost bought for nothing.
-                print(f"  {shown:<26} unused: "
+                print(f"  {shown} unused: "
                       f"{', '.join(contain.one_line(s) for s in d['unused'])}"
                       f"   (preloaded every dispatch)")
             if d["undeclared"]:
-                print(f"  {shown:<26} used but not declared: "
+                print(f"  {shown} used but not declared: "
                       f"{', '.join(contain.one_line(s) for s in d['undeclared'])}")
         print()
     util.info(f"RECENT = memories in the last {getattr(args, 'recent_days', 14)} days · "

--- a/charter/tui.py
+++ b/charter/tui.py
@@ -22,6 +22,7 @@ Vocabulary::
 
     sanitize                  drop everything that is not charter's own markup
     width / truncate / pad    ANSI-aware string primitives
+    column                    how wide one table column has to be for its values
     Text                      markup line(s), clamped at render time
     Cell + Row                one line of fixed/natural-width cells
     Stack                     vertical composition of nodes
@@ -36,7 +37,7 @@ from __future__ import annotations
 import os
 import re
 import unicodedata
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 RESET = "\x1b[0m"
 ELLIPSIS = "…"
@@ -192,6 +193,41 @@ def pad(s: str, w: int, align: str = "left") -> str:
         left = fill // 2
         return " " * left + s + " " * (fill - left)
     return s + " " * fill
+
+
+def column(header: str, cells: Iterable[str], gap: int = 2,
+           cap: int | None = None) -> int:
+    """Visible width for one table column: its *header*, its widest cell, and *gap*.
+
+    The one number a hand-rolled table gets wrong. A column written as ``{name:<28}``
+    is two mistakes at once, and this function is the answer to both:
+
+    * **28 is a guess about content.** ``:<28`` pads a short value and does nothing at
+      all to a long one — it pushes, so that row's remaining columns land somewhere no
+      other row's do and the table stops being a table. The width has to come from the
+      values about to be printed, which is what *cells* is. Sizing every column this
+      way — the numeric ones too — means the report cannot be pushed out of alignment
+      by any value at all, rather than by none of the values somebody thought of.
+    * **``:<28`` counts characters.** A terminal lays out *cells*: a CJK name is two
+      per glyph and a combining mark is zero, so `len` over-pads the first and
+      under-pads the second, and a name well inside the budget still shifts its row.
+      Every measurement here is :func:`width`, and callers pad with :func:`pad` for the
+      same reason — the two have to agree or the arithmetic was for nothing.
+
+    *gap* is the separation from the next column, counted inside the returned width so
+    a caller pads once rather than padding and then adding spaces. Passing a *cap*
+    bounds the content (never the gap) for a column whose values are prose rather than
+    identifiers; the cells then truncate with an ellipsis inside their column instead of
+    widening it. Leave it ``None`` where the reader has to be able to read the value
+    back off the row — a clipped name is one they cannot go and act on.
+
+    What this leaves unanswered is whether a cell is **legible**. :func:`width` reports the
+    cells a value *declares*, which is what alignment is made of; three U+3164 HANGUL
+    FILLERs declare six and render as nothing (#498). Use `contain.readable` where the
+    question is whether a reader can name the value, not where it sits.
+    """
+    w = max([width(header)] + [width(c) for c in cells])
+    return (w if cap is None else min(w, cap)) + gap
 
 
 def term_width(default: int = 80, floor: int = 1) -> int:

--- a/docs/news/unreleased-a-roster-column-is-measured-not-guessed.md
+++ b/docs/news/unreleased-a-roster-column-is-measured-not-guessed.md
@@ -1,0 +1,84 @@
+---
+version: unreleased
+headline: The roster tables size their columns from the names they are about to print, measured in terminal cells
+---
+
+`charter persona stats` printed its name column like this.
+
+```python
+print(f"{'PERSONA':<28}{'MEM':>5}{'RECENT':>8}{'VERIFY':>8}{'DUP':>6}{'DISP':>6}  STATUS")
+...
+print(f"{contain.one_line(r['persona']):<28}{r['count']:>5}{rec:>8}...")
+```
+
+That constant is two different mistakes wearing one number, and each of them on its own is
+enough to stop the report being a table.
+
+**28 is a guess about content.** `:<28` pads a short name and does nothing at all to a long
+one — it *pushes*, so MEM, RECENT, VERIFY, DUP, DISP and STATUS land on that row where they
+land on no other row, while the header and every other row stay put. A persona is a
+DIRECTORY under `personas/`, so the name arrives from whoever last pushed rather than from
+the person reading the report, and `contain.one_line` **grows** it on the way to the
+screen: a line separator becomes a four-character escape, so a committed 22-character name
+renders at 30 without anybody having typed a long one.
+
+**`:<28` counts characters, and a terminal lays out cells.** A CJK name is two cells per
+glyph, a combining mark is zero, and an emoji is two cells in one character. So an
+eight-glyph name that fits the constant three times over was padded to 28 *characters* and
+drawn as 36 *columns*, and its row shifted by eight without ever going near the boundary.
+This half is why widening the constant was never the fix: at any width, `str.format` is
+still counting the wrong thing.
+
+## Sized from the names, in cells
+
+`tui.column` is the new answer to "how wide does this column have to be": the header, the
+widest cell it is about to hold, and the gutter — every measurement `tui.width`, which is
+what the terminal actually does. `tui.pad` fills the cells, because a column measured in
+cells and padded in characters is arithmetic done twice in two units and thrown away.
+
+Every column is sized this way, not only the one the issue named. MEM, RECENT, VERIFY, DUP
+and DISP were the same shape with a threshold nobody had reached yet — a seven-digit
+dispatch tally pushes STATUS exactly the way a 29-character name pushed the other six, and
+"no plane has that many dispatches" is a fact about today's data rather than a property of
+the renderer. The header and the rows are now built by one function called twice, so there
+is no second code path left to disagree about a width.
+
+`persona list` had already sized its columns from its names, which is where the fix's shape
+comes from — but it measured them with `len`, so it carried the second half of this defect
+in full. It measures with `tui.column` now, and its ROLE column, the one holding prose
+rather than an identifier, keeps its cap and truncates *inside* the column with an ellipsis
+instead of being cut to a character count that was never its width.
+
+## Sized, not clipped — and that is a choice
+
+The other defensible policy is to clip the name to a fixed column, and it is rejected here
+for a reason that predates this issue. #472 asks these reports to name each persona in its
+bounded spelling, because the steward reading them acts on that name — `persona show`,
+`persona retire`. A column capped at some display constant would satisfy every alignment
+case and hand back a prefix nobody can look up, which is a worse report than a wide one.
+The bound on the name stays `contain.one_line`'s, applied to the value once, the same as
+on every other surface; the column honours that bound rather than inventing a second,
+smaller one. An ordinary roster now renders *narrower* than before, because 28 was always
+more than a roster of real names needs.
+
+## What this does not fix
+
+Alignment is about the cells a value **declares**, and that is all `tui.width` can report.
+Whether a cell is legible is a different question, left unanswered: three U+3164 HANGUL
+FILLERs measure six cells, the same as `devops`, and render as nothing at all (#498). A persona named with them still gets
+a correctly sized, correctly padded, entirely blank name cell. That is the other half, it
+belongs to `contain.readable`, and deciding whether the roster tables are identifier
+surfaces in that sense is a judgement worth making on its own rather than smuggling in
+behind a column-width fix.
+
+The same shape survives in seven other tables, and they were enumerated rather than
+assumed. Some of their constants are safe by construction — a column holding
+`ask`/`allow`, or `claimed`/`done`/`abandoned`, cannot be pushed by a value that has
+nowhere else to come from. Others hold a committed name with no bound on it at all: a
+workspace name, a vault name, a git branch, a repo, a worktree piece. Two are already
+wrong today rather than one commit away from it — `worktree history` pads a 25-character
+ISO timestamp into a 22-wide column, and `status` pads the 13-character stack name
+`node-monorepo` into a 12-wide one, so both push every time they are printed. `recall`
+sizes its label column from the data and then measures it with `len`, which is this
+issue's second half exactly. None of that is changed here; it is written down in the pull
+request so the next person starts from a list instead of a grep.

--- a/tests/test_a_roster_column_is_measured_not_guessed.py
+++ b/tests/test_a_roster_column_is_measured_not_guessed.py
@@ -1,0 +1,399 @@
+"""A roster table's columns line up for EVERY name, not for the short ASCII ones (#508).
+
+`charter persona stats` printed its name into `{...:<28}`, and that is two failures
+wearing one constant:
+
+* **28 is a guess about content.** `:<28` pads a short value and does nothing at all to a
+  long one — it pushes, so MEM, RECENT, VERIFY, DUP, DISP and STATUS land somewhere on
+  that row that they land on no other row. A persona is a DIRECTORY under `personas/`, so
+  the name arrives from whoever last pushed, and `contain.one_line` *grows* it: a
+  separator becomes a four-character escape, so a committed 22-character name renders at
+  30 without anyone having typed a long one.
+* **`:<28` counts characters, and a terminal lays out CELLS.** A CJK name is two cells per
+  glyph and a combining mark is zero, so an 8-glyph name that fits the constant three
+  times over is padded to 28 characters and drawn as 36 columns — its row shifts by 8
+  without ever going near the boundary. `persona list` measured its own columns and still
+  had this half, because it measured them with `len`.
+
+**The property is that the columns line up, not that any field has a particular width.**
+So nothing here asserts a number the renderer also spells: a test pinning `28`, or
+pinning the new width, passes forever and sees neither failure. Every case renders the
+real report and compares row offsets against the header's.
+
+**And offsets are read in cells, never in characters.** `row.index(marker)` is a character
+index, which is exactly the unit that was wrong in the first place — a test using it would
+report the CJK row as aligned while the terminal drew it eight columns out. `tui.width` of
+the prefix is the measurement, and using it here is the same act as using it there.
+
+Fixtures are real names rather than `"x" * 29`: one exactly at the old boundary, one over
+it, one CJK, one carrying a combining mark, one emoji, and a short ASCII control. The
+control is what says a failure is about the awkward name rather than about the table.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
+
+from charter import commands_persona, config, contain, tui
+from tests._isolation import PersonaIso
+
+#: The status every fixture persona below lands on: no memories, and no dispatch log at
+#: all, so `status` stays the memory-derived "dormant" for all of them. That the whole
+#: tail is IDENTICAL across rows is what lets a single offset probe stand for the sum of
+#: every width the renderer computed.
+DORMANT = "✗ dormant"
+
+#: `persona list`'s last column for a persona with no vault — the same probe #472 uses,
+#: measured in cells here rather than in characters.
+NO_VAULT = "no vault"
+
+
+class Args:
+    name = None
+    recent_days = 14
+
+
+class RosterWidths(PersonaIso):
+    """Names chosen so each one fails a DIFFERENT half of the defect."""
+
+    #: `len` and `tui.width` disagree on all but the first three.
+    #:
+    #: Two of these are CONTROLS and are expected to pass with or without the fix, which
+    #: is stated here because a case that cannot fail is worth nothing unless the reader
+    #: knows it is a control. `short ascii control` is one. So is the 28-char name: it
+    #: fills `{:<28}` exactly, so the old renderer aligned it correctly — the boundary was
+    #: never the broken case, ONE OVER it was, and having both is what says so.
+    #:
+    #: No name ends in `---`. That is not cosmetic: a persona whose name ends in a triple
+    #: hyphen closes its own frontmatter fence early, so `persona.load` returns a partial
+    #: parse and the ROLE column comes back empty — a real defect, reported separately,
+    #: and one that would quietly make this fixture assert less than it looks like it does.
+    NAMES = {
+        "short ascii control": "ok",
+        "exactly the old 28-char boundary": "persona-with-twentyeight-abc",
+        "one character over the boundary": "persona-with-twentynine-abcde",
+        "well over the boundary": "a-persona-name-far-past-any-fixed-column-width",
+        "CJK — two cells per glyph": "日本語のペルソナ",
+        "combining mark — zero cells": "équipe-mémoire",
+        "emoji — two cells, one character": "🚀-launcher",
+    }
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Pinned rather than inherited: `$COLUMNS` is read by `tui` and has flipped tests
+        # in this suite before (#544). Nothing under test reads it today — the roster
+        # tables are deliberately not clipped to the terminal — and pinning it is what
+        # keeps that true by accident-detection rather than by hope.
+        self.enterContext(mock.patch.dict(os.environ, {"COLUMNS": "200"}))
+
+    def _roster(self, *names: str) -> list[str]:
+        """Replace the roster with exactly *names* and return the ones the filesystem
+        actually kept — a name is a directory, and not every filesystem takes every one."""
+        import shutil
+
+        for sub in config.PERSONAS_DIR.iterdir():
+            shutil.rmtree(sub) if sub.is_dir() else sub.unlink()
+        kept = []
+        for n in names:
+            try:
+                self.make_persona(n, role="Role")
+            except OSError:
+                continue
+            kept.append(n)
+        if len(kept) < 2:
+            self.skipTest("filesystem refuses these names")
+        return kept
+
+    @staticmethod
+    def _run(fn) -> list[str]:
+        out = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(io.StringIO()):
+            fn(Args())
+        return out.getvalue().splitlines()
+
+    @staticmethod
+    def _cells_before(line: str, marker: str) -> int:
+        """How many terminal CELLS precede *marker* on *line*.
+
+        Not `line.index(marker)`. That is a character count, and a character count is the
+        bug: it reports the CJK row as starting its tail in the same place as the ASCII
+        one while the terminal draws it eight columns further right.
+        """
+        return tui.width(line[:line.index(marker)])
+
+    def _assert_aligned(self, rows: list[str], header: str, head_col: str,
+                        marker: str) -> None:
+        """Every row puts *marker* where *header* puts *head_col*."""
+        want = self._cells_before(header, head_col)
+        data = [r for r in rows if marker in r]
+        self.assertTrue(data, "no data rows to check:\n" + "\n".join(rows))
+        for r in data:
+            self.assertEqual(
+                self._cells_before(r, marker), want,
+                f"this row's last column starts at cell "
+                f"{self._cells_before(r, marker)}, the header's at {want} — the column "
+                f"was sized by a guess, or measured in characters:\n" + "\n".join(rows))
+
+
+class TestPersonaStatsColumnsLineUp(RosterWidths):
+    def test_every_name_puts_the_status_column_where_the_header_does(self):
+        """One case per name, so a failure says WHICH kind of name broke the table."""
+        for label, name in self.NAMES.items():
+            with self.subTest(name=label):
+                kept = self._roster("ok", name)
+                if name not in kept:
+                    self.skipTest(f"filesystem refuses {name!r}")
+                rows = self._run(commands_persona.cmd_persona_stats)
+                header = next(r for r in rows if r.startswith("PERSONA"))
+                self._assert_aligned(rows, header, "STATUS", DORMANT)
+
+    def test_the_whole_awkward_roster_lines_up_at_once(self):
+        """Together, not one at a time: the column is sized from the widest name in the
+        table, so the interesting row is the one that is NOT the widest and still has to
+        be padded to a width somebody else's name decided."""
+        self._roster(*self.NAMES.values())
+        rows = self._run(commands_persona.cmd_persona_stats)
+        header = next(r for r in rows if r.startswith("PERSONA"))
+        self._assert_aligned(rows, header, "STATUS", DORMANT)
+
+    def test_every_name_is_still_readable_off_its_row(self):
+        """Sizing the column, not clipping to it — and the half the alignment cases miss.
+
+        A column padded with `tui.pad` stays aligned however badly it was measured,
+        because `pad` TRUNCATES whatever does not fit. That makes alignment the wrong
+        probe for the *measuring*: put the old constant back and the columns still line
+        up, with the name quietly cut off inside one of them. Measured, not reasoned —
+        it is what the hand-check for this change actually found. So this asks the other
+        question, whether the value is still there, and that is what the measuring is for.
+
+        #472 asks this report to name each persona in its bounded spelling, because the
+        steward reading it acts on that name: `persona show`, `persona retire`. A prefix
+        is not a name they can look up.
+        """
+        kept = self._roster(*self.NAMES.values())
+        rows = self._run(commands_persona.cmd_persona_stats)
+        for name in kept:
+            with self.subTest(name=name):
+                self.assertTrue(
+                    any(contain.one_line(name) in r for r in rows),
+                    f"{name!r} appears in full on no row — the column was sized by a "
+                    f"guess and the name was cut to fit it:\n" + "\n".join(rows))
+
+    def test_a_wide_number_is_still_readable_off_its_row(self):
+        """The same question for the numeric columns, and the same reason. A DISP tally
+        clipped to `1234…` reports a number nobody can act on, and every row would go on
+        lining up perfectly while it happened."""
+        self._roster("ok", "other")
+        from charter import dispatch
+
+        with mock.patch.object(dispatch, "tally",
+                               return_value={"ok": 1234567, "other": 2}):
+            rows = self._run(commands_persona.cmd_persona_stats)
+        self.assertTrue(any("1234567" in r for r in rows),
+                        "the dispatch tally was cut to fit a column sized by a guess:\n"
+                        + "\n".join(rows))
+
+    def test_a_committed_separator_still_lines_up(self):
+        """`contain.one_line` GROWS the name, and the growth happens before the measure.
+
+        This is #472's fixture asked #508's question: measuring the raw name and printing
+        the rendered one misaligns every row in the table, and it is what a fix that
+        bounds the value at the `print` produces.
+
+        A REAL separator, not a run of spaces. `one_line` leaves spaces alone, so a
+        space-padded fixture renders to itself, raw and bounded are the same string,
+        and the case passes under exactly the mutation it exists to catch — measured,
+        and it did. U+2028 becomes a six-character escape, which is the growth the
+        measure has to happen after. Built with `chr` so the fixture is one
+        unambiguous codepoint rather than an escape a later editor might normalise.
+        """
+        name = "evil" + chr(0x2028) + "  fake     Fake role"
+        try:
+            (config.PERSONAS_DIR / name).mkdir()
+            (config.PERSONAS_DIR / name).rmdir()
+        except OSError:
+            self.skipTest(f"filesystem refuses {name!r}")
+        self.assertNotEqual(
+            contain.one_line(name), name,
+            "fixture: this name must GROW when bounded, or the case asserts "
+            "nothing about measure-versus-print order")
+        self._roster("ok", name)
+        rows = self._run(commands_persona.cmd_persona_stats)
+        header = next(r for r in rows if r.startswith("PERSONA"))
+        self.assertTrue(any(contain.one_line(name) in r for r in rows), rows)
+        self._assert_aligned(rows, header, "STATUS", DORMANT)
+
+
+class TestTheSkillsBlockIsMeasuredToo(RosterWidths):
+    """The second block the same command prints, and it carried the same constant.
+
+    `{shown:<26}` under `SKILLS — declared vs actually invoked`. It is a name column with
+    no header of its own, so it looks less like a table than the one above and misaligns
+    in exactly the same way: one drifted persona with a long name and the `unused:` label
+    on its row no longer lines up with the label on any other.
+
+    Written because the hand-check found nothing covering this block at all — the
+    constant could be put straight back and the whole suite stayed green.
+    """
+
+    #: Declared but never invoked, so `skilluse.drift` reports `unused` and the block
+    #: renders. `make_persona` writes frontmatter, and `skills:` is comma-separated.
+    SKILL = "some-declared-skill"
+
+    def _drifting(self, *names: str) -> list[str]:
+        import shutil
+
+        for sub in config.PERSONAS_DIR.iterdir():
+            shutil.rmtree(sub) if sub.is_dir() else sub.unlink()
+        for n in names:
+            self.make_persona(n, role="Role", skills=self.SKILL)
+        return self._run(commands_persona.cmd_persona_stats)
+
+    def test_the_labels_line_up_across_drifted_personas(self):
+        rows = self._drifting("ok", self.NAMES["well over the boundary"])
+        block = [r for r in rows if "unused:" in r]
+        self.assertEqual(len(block), 2, "\n".join(rows))
+        at = {tui.width(r[:r.index("unused:")]) for r in block}
+        self.assertEqual(
+            len(at), 1,
+            "the `unused:` label starts in a different column on each row — the name "
+            f"column was sized by a guess (offsets {sorted(at)}):\n" + "\n".join(block))
+
+    def test_a_long_name_is_not_cut_out_of_the_block(self):
+        """`tui.pad` truncates, so alignment alone would survive a constant here too."""
+        long = self.NAMES["well over the boundary"]
+        rows = self._drifting("ok", long)
+        self.assertTrue(any(long in r and "unused:" in r for r in rows),
+                        "the drifted persona is not named in full:\n" + "\n".join(rows))
+
+
+class TestPersonaListColumnsLineUp(RosterWidths):
+    """The sibling table. It measured its columns and still had half the defect: `len`
+    over the bounded names, so every non-ASCII name shifted its own row."""
+
+    def test_every_name_puts_the_last_column_where_the_header_does(self):
+        for label, name in self.NAMES.items():
+            with self.subTest(name=label):
+                kept = self._roster("ok", name)
+                if name not in kept:
+                    self.skipTest(f"filesystem refuses {name!r}")
+                rows = self._run(commands_persona.cmd_persona_list)
+                header = next(r for r in rows if "VAULT STATUS" in r)
+                self._assert_aligned(rows, header, "VAULT STATUS", NO_VAULT)
+
+    def test_the_whole_awkward_roster_lines_up_at_once(self):
+        self._roster(*self.NAMES.values())
+        rows = self._run(commands_persona.cmd_persona_list)
+        header = next(r for r in rows if "VAULT STATUS" in r)
+        self._assert_aligned(rows, header, "VAULT STATUS", NO_VAULT)
+
+    def test_every_name_is_still_readable_off_its_row(self):
+        """The half alignment cannot see, and the one that caught `len` here.
+
+        `tui.pad` truncates, so once the rows are padded in cells they line up however
+        the column was measured — a `len` measurement merely makes the column too NARROW,
+        and the name is cut rather than pushed. Every alignment case in this class passes
+        with `len` restored; this one does not. It is the difference between a table that
+        looks right and a report a steward can act on.
+
+        One name at a time on purpose: `len` under-measures only when the widest-in-cells
+        name is not also the widest-in-characters, so a roster containing one long ASCII
+        name hides the defect for every other name in it.
+        """
+        for label, name in self.NAMES.items():
+            with self.subTest(name=label):
+                kept = self._roster("ok", name)
+                if name not in kept:
+                    self.skipTest(f"filesystem refuses {name!r}")
+                rows = self._run(commands_persona.cmd_persona_list)
+                self.assertTrue(
+                    any(contain.one_line(name) in r for r in rows),
+                    f"{name!r} appears in full on no row — the PERSONA column was "
+                    f"measured in characters, so it is too narrow for this name and "
+                    f"`tui.pad` cut it:\n" + "\n".join(rows))
+
+
+class TestEveryColumnIsMeasuredNotOnlyTheName(RosterWidths):
+    """PERSONA was the column the issue named; it was not the only one holding a guess.
+
+    MEM, RECENT, VERIFY, DUP and DISP were `{:>5}`/`{:>8}`/`{:>6}` — the same shape with a
+    threshold high enough that nobody had reached it. A seven-digit dispatch tally pushes
+    STATUS on its row exactly the way a 29-character name pushed the other six, and
+    "nobody has that many yet" is a fact about today's data rather than a property of the
+    renderer.
+
+    **Driven through the real command, with the tally stubbed rather than the table called
+    directly.** Calling the new helper would make this pass on the branch and *error* on
+    an unfixed tree for want of a symbol — which looks like a red and demonstrates
+    nothing about the defect. Stubbing `dispatch.tally` runs the same `cmd_persona_stats`
+    either way, so the case fails on the old renderer for the reason it names.
+    """
+
+    def _stats_with_tally(self, tally: dict) -> list[str]:
+        from charter import dispatch
+
+        with mock.patch.object(dispatch, "tally", return_value=tally):
+            return self._run(commands_persona.cmd_persona_stats)
+
+    def test_a_wide_dispatch_tally_moves_every_row_together(self):
+        self._roster("ok", "other")
+        rows = self._stats_with_tally({"ok": 1234567, "other": 2})
+        header = next(r for r in rows if r.startswith("PERSONA"))
+        self._assert_aligned(rows, header, "STATUS", DORMANT)
+
+    def test_a_wide_name_and_a_wide_number_at_once(self):
+        """Both guesses in one table — the case where fixing only the column the issue
+        named looks like a fix and still leaves the report misaligned."""
+        cjk = self.NAMES["CJK — two cells per glyph"]
+        kept = self._roster("ok", cjk)
+        if cjk not in kept:
+            self.skipTest(f"filesystem refuses {cjk!r}")
+        rows = self._stats_with_tally({"ok": 1234567, cjk: 2})
+        header = next(r for r in rows if r.startswith("PERSONA"))
+        self._assert_aligned(rows, header, "STATUS", DORMANT)
+
+
+class TestTuiColumn(unittest.TestCase):
+    """The measurement itself, at the level a table cannot reach: `tui.column` is where
+    "how wide does this column have to be" is decided, and it decides in cells."""
+
+    def test_it_measures_cells_not_characters(self):
+        """The whole reason a fixed constant could not simply be widened."""
+        self.assertEqual(tui.column("", ["日本語"], gap=0), 6)
+        self.assertNotEqual(tui.column("", ["日本語"], gap=0), len("日本語"))
+
+    def test_a_combining_mark_costs_nothing(self):
+        self.assertEqual(tui.column("", ["é"], gap=0), 1)
+
+    def test_the_header_is_a_floor(self):
+        self.assertEqual(tui.column("PERSONA", ["ok"], gap=0), len("PERSONA"))
+
+    def test_the_widest_cell_wins_over_the_header(self):
+        self.assertEqual(tui.column("MEM", ["1", "123456"], gap=0), 6)
+
+    def test_no_cells_still_fits_the_header(self):
+        self.assertEqual(tui.column("VAULT", [], gap=0), 5)
+
+    def test_the_gap_is_inside_the_returned_width(self):
+        self.assertEqual(tui.column("ok", [], gap=2), 4)
+
+    def test_a_cap_bounds_the_content_and_not_the_gap(self):
+        self.assertEqual(tui.column("", ["x" * 100], gap=2, cap=38), 40)
+
+    def test_a_cap_does_not_pad_short_content_out_to_it(self):
+        self.assertEqual(tui.column("", ["xx"], gap=0, cap=38), 2)
+
+    def test_padding_to_the_measured_width_produces_equal_cells(self):
+        """The pair has to agree or the arithmetic was for nothing: `column` measures and
+        `pad` pads, and every cell padded to a computed width must render to it."""
+        cells = ["ok", "日本語のペルソナ", "équipe", "🚀-launcher", "x" * 29]
+        w = tui.column("PERSONA", cells)
+        self.assertEqual({tui.width(tui.pad(c, w)) for c in cells}, {w})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`charter persona stats` printed its name column as `{contain.one_line(name):<28}`, with the
header spelling the same constant in a second format string. That single number is two
different defects, and each one on its own is enough to stop the report being a table.

**28 is a guess about content.** `:<28` pads a short name and does nothing to a long one —
it *pushes*, so MEM, RECENT, VERIFY, DUP, DISP and STATUS land on that row where they land
on no other row. A persona is a directory under `personas/`, so the name comes from
whoever last pushed, and `contain.one_line` **grows** it: a separator becomes a
four-character escape, so a committed 22-character name renders at 30.

**`:<28` counts characters; a terminal lays out cells.** CJK is two cells per glyph, a
combining mark is zero, an emoji is two cells in one character. An 8-glyph name that fits
the constant three times over was padded to 28 characters and drawn as 36 columns. This is
why widening the constant was never available as a fix.

## The policy: sized from the names, in cells — not clipped

`tui.column(header, cells, gap, cap)` is new in `charter/tui.py`: the header, the widest
cell, and the gutter, every measurement `tui.width`. `tui.pad` fills the cells, because a
column measured in cells and padded in characters is the same arithmetic done twice in two
units.

**Sized rather than clipped, deliberately.** #472 requires this report to name each persona
in its bounded spelling, because the steward acts on that name (`persona show`,
`persona retire`). A column capped at a display constant satisfies every alignment test and
hands back a prefix nobody can look up. The bound on the name stays `contain.one_line`'s,
applied to the value once; the column honours it rather than inventing a second, smaller
one. An ordinary roster now renders **narrower** than before — 28 was always more than real
names need.

**Every column, not only the one the issue names.** MEM/RECENT/VERIFY/DUP/DISP were the
same shape with a threshold nobody had reached; a seven-digit tally pushes STATUS exactly
as a 29-character name pushed the other six. Header and rows now come from one function
called twice, so no second code path is left to disagree about a width.

## Which problem this solves, and which it does not

This solves **alignment**, which is about the cells a value *declares* — all `tui.width`
can report. It does **not** make a cell legible: three U+3164 HANGUL FILLERs measure six
cells, the same as `devops`, and render as nothing. Such a persona now gets a correctly
sized, correctly padded, entirely blank name cell. That half belongs to `contain.readable`
(#579), and whether the roster tables are identifier surfaces in its sense is a judgement
worth making on its own rather than smuggling in behind a column-width change. Not
conflated here.

## Files

- `charter/tui.py` — new `column()`; no change to `width`/`truncate`/`pad`.
- `charter/commands_persona.py` — `cmd_persona_stats` (+ new `_stats_table`), the `SKILLS`
  block's own `{:<26}`, and `cmd_persona_list`.
- **`charter/persona.py` is untouched.** `cmd_persona_stats` lives in
  `charter/commands_persona.py`; the fix never needed the other file.

`cmd_persona_list` is not in the issue. It is included because the issue cites it as the
model, and it carried the second half of the defect in full: it sized its columns from the
names but measured them with `len`, so every non-ASCII name shifted its own row and, worse,
under-sized its column so `tui.pad` cut the name off.

## Verification

**Baseline first.** The new cases were run against pristine `bf58b46` before being trusted:
**13 genuine failures**. The other 9 assertions are unit tests of `tui.column`, which
*error* on a tree without the symbol — reported separately, because an error for want of a
symbol evidences nothing about the defect. Four cases pass on both sides and are labelled
controls in the file (a short ASCII name; a name at exactly 28, which filled `{:<28}`
perfectly and was never the broken case — one over it was).

**Hand-check, since `tools/sweep.py` has no operator for constants or semantic swaps
(#569).** 17 hand-written mutations, **17/17 caught**. Every mutation asserts that it
actually applied — the first pass of this table reported two survivors that turned out to
be mutations whose quoting never matched, and a mutation that does not apply runs a
pristine tree and reports SURVIVED. Two real gaps were found and closed this way:

1. **`tui.pad` truncates, so alignment cannot see a mis-measured column.** Once rows are
   padded in cells they line up however badly the width was computed — the measurement only
   decides whether content gets *clipped*. Every alignment assertion passed with the fixed
   28 restored. Fixed by asserting the value is still readable off its row (both tables,
   and the numeric columns).
2. **The `SKILLS` block had no coverage at all** — its `{:<26}` could be restored with the
   whole suite green.

Also corrected: the separator fixture used spaces, which `one_line` leaves alone, so raw
and bounded were the same string and the case passed under the exact mutation it existed to
catch. It uses a real U+2028 now.

**`tools/sweep.py`, run on the branch.** 15 mutations, **8 pinned, 7 survived** on the
first commit. Six of the seven were real and are now closed; the seventh is provably
equivalent. They are not width bugs — they are guarantees the old `print` statements
carried that nothing asserted, and the sweep charges them here because these are the lines
this change rewrote. A rewrite that dropped any of them would have passed every alignment
case in the file.

| survivor | verdict |
|---|---|
| `_vault_status` uncontained | **real** — VAULT STATUS is the last column and *unpadded*, so a bound at the column cannot help it; a newline in provider health text forges a row. Pinned. |
| shared row's DISP conditional collapsed | **real** — `_shared` is a namespace; a number there counts something that cannot happen. Pinned. |
| never-dispatched glyph collapsed to `·` | **real** — the flag is the whole signal a steward prunes on; the words stay and nothing draws the eye. Pinned. |
| `one_line` in the skills block, twice (2 survivors) | **real** — measured from one string, printed as another (#472's mis-measure). Fixed structurally: the name is bound once into the list both the measure and the print read, so there is no second call left to disagree. |
| `if d["undeclared"]` deleted | **real** — only `unused` had a test, so the half answering the more interesting question could stop printing silently. Pinned. |
| glyph fallback collapsed to `⚑` | **equivalent, and provably so.** `persona.stats` returns only `active`/`idle`/`dormant`/`orchestrator`/`standby`/`advisory`, all of which are keys in `glyph`; with `draft` also a key, `never dispatched` is the only status that reaches the `.get` default. The `else '·'` branch is unreachable today. Kept as the neutral marker for a status added later. |

Closing those needed one more fix in the test helper itself: its roster builder floored at
two personas, so a case asking for a roster of one *silently skipped*. A test that does not
run is not a test, and that one was the guard on the shared row's DISP cell.

**Suites:** full suite in two environments — CPython 3.14 and 3.12, the second with
`CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset. `$COLUMNS` is pinned explicitly inside
the new tests (#544). The sweep's own unmutated baseline is a third green full run.

## Pre-existing failure found, not caused here

`tests/test_frame_panel.py::FailureIsVisibleInThePane::test_the_painted_reason_is_clamped_to_the_panes_own_width`
fails on **pristine `bf58b46`**, standalone, whenever `$COLUMNS` is set to a large value,
and passes with `$COLUMNS` unset — the pane's failure paint is not clamped to the pane's
width. Reproduced on main with this branch's files removed. It lives in `charter/frame/*`
and is untouched here.

## Enumerated, not fixed here

The same shape in seven other tables, classified rather than assumed:

| site | column | verdict |
|---|---|---|
| `commands_worktree.py:287` | `ts` `{:<22}` | **already wrong** — a 25-char ISO timestamp pushes on every row |
| `commands.py:599` | `STACK` `{:<12}` | **already wrong** — `node-monorepo` is 13 |
| `commands.py:2369` | `label` `{:<{width}}` | sized from data but with `len` — this issue's second half |
| `commands_workspace.py:33` | workspace name `{:<22}` | unbounded committed name; also a `⚠` glyph inside the padded cell |
| `commands_secrets.py:306` | vault `{:<18}`, persona `{:<12}` | unbounded, unvalidated |
| `commands_worktree.py:250` | piece `{:<24}`, branch `{:<28}`, who `{:<16}` | unbounded; `who` is routinely a 36-char session UUID |
| `doctor.py:41` | check name `{:<16}` | minted literals, longest is exactly 16 — fits with zero headroom |

Provably safe and correctly left alone: `ask`/`allow`, `claimed`/`done`/`abandoned`,
`shared`/`local`/`both`, `missing`/`dirty`/`clean`, and the ISO date at `commands.py:2369`.

Closes #508
