### PR TITLE
The suite reaches no real vault and waits on no real keyboard (#546, #545)

### DIFF
--- a/docs/news/unreleased-the-suite-cannot-reach-your-vault-or-your-keyboard.md
+++ b/docs/news/unreleased-the-suite-cannot-reach-your-vault-or-your-keyboard.md
@@ -1,0 +1,70 @@
+---
+version: unreleased
+headline: charter's own test suite no longer reaches your 1Password vault, and no longer stops to wait for you to type
+---
+
+Two tests in charter's suite ran the operator's **real `op` binary against their real
+1Password vault**. `charter vault add --provider 1password` finishes by asking the provider
+whether the vault is healthy, and for a 1Password vault that shells out — so the vault names
+those fixtures spell, `Eng` and `Engineering`, were being looked up on whatever machine ran
+the suite, as whoever was signed in. Measured by putting a logging stand-in for `op` first
+on `$PATH` and running the whole suite: four invocations, from two tests, and none anywhere
+else in 6636.
+
+They had passed for as long as they had because an unauthenticated `op` **fails fast** — it
+exits non-zero in well under a second, charter reports a vault it could not read, and the
+assertions (about a refusal to migrate, and about an account pin not travelling) held for
+the right reason by luck. `op` does not fail fast when it thinks a human could be asked. It
+**prompts**, and the suite then sits in `subprocess.communicate` behind a biometric dialog:
+measured at 15 minutes inside a fresh tmux pane, with `python3 -m unittest discover -s tests`
+never finishing. Running charter's own tests should not touch anybody's actual credentials,
+and it certainly should not park behind a fingerprint reader.
+
+**The second half is the same failure with no vault in it.** Run the suite from an ordinary
+terminal — which is where anyone working on charter actually runs it — and it hung, forever,
+in `test_frame_launcher`. charter's workspace picker opens on **two** independent questions,
+`sys.stdin.isatty() and sys.stdout.isatty()`, deliberately, because `charter claude <
+/dev/null` at a terminal has one and not the other. The launcher's test helpers pinned the
+second of that pair and left the first to whatever shell the suite was launched from. Under
+a pipe — CI, an agent's shell, `... | grep` — the answer was "nobody is there" and the suite
+went green. Under a terminal, it stopped at charter's own prompt and waited for a human who
+was never going to type. Measured with `input()` replaced by a recording raise and the suite
+run under a pty: **122 tests reached that prompt**, in one module, on a tree whose CI had
+been green throughout.
+
+A hang is the worst outcome available. It is not a pass, not a fail, and not a report — and
+the environment that reports the suite's health is precisely the one that cannot see it,
+because CI's stdin is never a terminal.
+
+**Both are fixed as a class, on the shape the plane guards already settled.** 0.52.0 refused
+writes into your real `.charter/`; 0.53.0 refused reads of the `[update] channel` your own
+`charter.toml` declares; the entry beside this one removes charter's variables from the
+suite's environment and refuses an undeclared read of one. This is the same move twice more:
+
+* **The credential CLI is refused at the spawn.** A test that runs `op`, `vault` or the
+  browser lane's `npx` now fails, by name, on the line that reached for it, having read
+  nothing. Which CLIs count is asked of charter's own resolver table rather than listed, so
+  a provider added there is covered on the commit that adds it. The two tests that were
+  reaching drive a fake instead — the pattern five sibling modules in the suite already use.
+* **The terminal is answered, and one question about it is refused.** All three streams
+  report what CI reports, before charter is imported at all, so `input()` ends rather than
+  blocks and charter's own colour decision no longer depends on where the run happened. On
+  top of that, a test that asks whether stdin is a terminal without saying which answer it
+  wants is refused: the launcher's helpers now state both halves of the pair, and the
+  refusal is what makes those two lines load-bearing rather than decoration.
+
+Removal alone would only have silenced the red. Every one of those 122 tests would still
+have been asserting against a terminal-ness it never chose, and the next test that *means*
+"there is a human here" would have got `False` and passed vacuously — which is not a
+hypothetical: `test_mcp_approval` already records an instance going the other way, where
+ANSI codes from a real terminal joined a transcript it derives its expectations from and a
+mutation that dies under a pipe "reported OK under a pty".
+
+**What this run still cannot promise.** The suite now gives the same verdict from a pipe and
+from a terminal for the two classes above, and a full run under a pty no longer hangs. It is
+not yet identical: 27 tests across eight modules still fail only under a terminal, all of
+them tracing to `os.get_terminal_size()` — the size of the window the suite happens to be
+running in, which is issue #544 and is not fixed here. Measured and written down rather than
+left for the next person to rediscover.
+
+None of this reaches you unless you run charter's own test suite. Nothing to adopt.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,6 +30,17 @@ os.environ["CODEX_HOME"] = os.path.join(_SANDBOX, "codex")
 os.makedirs(os.environ["XDG_CONFIG_HOME"], exist_ok=True)
 os.makedirs(os.environ["CODEX_HOME"], exist_ok=True)
 
+# The FOURTH fixture, installed FIRST because it is the one thing here that must be true
+# before `charter` is imported at all: the suite's own file descriptors. `charter.util`
+# computes `_USE_COLOR` from `sys.stderr.isatty()` at import, and `sys.stdin`'s tty-ness
+# decides whether charter stops and asks a human — which is how 122 tests in one module sat
+# on charter's own workspace picker, forever, whenever the suite was run from a terminal
+# (#545). See `tests/_ttyguard.py`: all three streams now answer what CI answers, and a
+# test that wants a different answer for stdin has to say so.
+from . import _ttyguard      # noqa: E402  (imports no charter module, by design)
+
+_ttyguard.install()
+
 # The third fixture a test can inherit without noticing, after the plane root and these
 # config directories: the SHELL the suite was launched from. `$CHARTER_SESSION_ID`,
 # `$TMUX` and `$CHARTER_WORKSPACE` reach the code under test the same way `$XDG_CONFIG_HOME`

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -1,6 +1,6 @@
 """Suite-wide tripwires: no test may WRITE into the developer's real ``.charter/``, none
-may READ a setting off the developer's real ``charter.toml``, and none may SPAWN a charter
-that would resolve it.
+may READ a setting off the developer's real ``charter.toml``, none may SPAWN a charter that
+would resolve it, and none may SPAWN the CLI that reads their real credential store.
 
 `PersonaIso` isolates a test that remembers to derive from it. Nothing made the
 *forgetting* visible, so the same defect kept arriving in a new file: the suite wrote
@@ -115,6 +115,23 @@ two drift apart again.
 satisfies this without knowing it exists. What is left for the tripwire is the case that
 was never covered: a test that spawns charter by hand, and a test that never isolated
 `config.ROOT` in the first place.
+
+**The fourth tripwire, and the only one that is not about the plane at all.**
+:class:`RealVaultReach`. Two tests in `test_vault_registration.py` ran the operator's real
+``op`` binary against their real 1Password vault — `cmd_vault_add` finishes with
+``prov.health()``, which for a ``1password`` vault shells out, and the vault names came
+from the fixtures' own strings (#546). Measured with a logging stand-in for ``op`` first on
+``$PATH``: four invocations from two tests, and none anywhere else in 6636. They passed
+because an unauthenticated ``op`` exits non-zero fast enough to look like a healthy answer;
+they HANG when it prompts instead, which is what a machine that has 1Password installed and
+a session that has expired produces — the operator's, in other words, and never CI's.
+
+Guarded here rather than only fixed there for the reason #542 sets out: a stub in the base
+class silences an instance, and a refusal at the spawn fails the pull request that adds the
+next one. It is checked BEFORE the plane question and without waiting on :data:`_REAL_ROOT`,
+because reading somebody's credential store is wrong on a machine with no control plane at
+all. Which CLIs count is asked of `reference._RESOLVERS` — production's own scheme table —
+so a provider added there is covered on the commit that adds it.
 """
 
 from __future__ import annotations
@@ -370,6 +387,114 @@ def _guard_reads(config) -> None:
 
 class RealPlaneSpawn(BaseException):
     """A test spawned a charter that would resolve the developer's own control plane."""
+
+
+class RealVaultReach(BaseException):
+    """A test spawned the CLI that reads the developer's own credential store."""
+
+
+_VAULT_CLIS: frozenset[str] = frozenset()
+
+
+def _credential_clis() -> frozenset[str]:
+    """The CLI names charter shells out to in order to read a real credential store.
+
+    **Asked of production's own resolver table**, not listed here. `reference._RESOLVERS`
+    is the map from URI scheme to *(argv, CLI name)* that `ReferenceProvider.get` and
+    `health` both use, so a scheme added there is guarded on the commit that adds it —
+    the same reason `_envguard` asks `session._PANE_ID_VARS` rather than spelling
+    ``TMUX_PANE``. Each builder is called with a syntactically valid URI of its own scheme
+    because the name is what the builder RETURNS; there is no constant to read it out of.
+
+    ``op`` is added unconditionally as well, for `OnePasswordProvider`, whose ``_argv``
+    spells the program inline and has no table to ask. The addition is free — the reference
+    provider's ``op://`` scheme produces the same name — and it is what keeps this correct
+    if the two ever stop agreeing.
+
+    Additive and best effort: a builder that raises contributes nothing and can only cost
+    precision, never correctness, because the names already collected still refuse.
+    """
+    names = {"op"}
+    probes = {"op": "op://vault/item/field", "vault": "vault://secret/data/app#FIELD",
+              "browser": "browser://session/localstorage/key"}
+    try:
+        from charter.secrets import reference
+    except Exception:                                # pragma: no cover - import can't fail
+        return frozenset(names)
+    for scheme, build in reference._RESOLVERS.items():
+        try:
+            names.add(build(probes[scheme], {})[1])
+        except Exception:
+            continue
+    return frozenset(names)
+
+
+def _explain_vault(parts: list[str], name: str) -> str:
+    return (
+        f"REFUSED: spawning `{name}` — the operator's own credential store\n"
+        f"{_current_test()} is about to run `{' '.join(parts)}`. That is not a fake: it is "
+        f"the CLI charter reads real secrets through, on this machine, against whatever "
+        f"vault the argv names and whatever identity the operator is signed in as. Running "
+        f"charter's own suite must not touch anybody's actual credentials.\n"
+        f"  It is also a HANG waiting to happen, which is how it was found (#546). `op` "
+        f"exits non-zero in well under a second when it has no session, so two tests here "
+        f"passed for years by luck; it PROMPTS instead when a human could be asked, and the "
+        f"suite then parks in `subprocess.communicate` behind a biometric prompt — measured "
+        f"at 15 minutes, with `python3 -m unittest discover -s tests` never finishing.\n"
+        f"  The way out is the one five modules here already take: drive a fake. Set the "
+        f"provider's `runner` (on the CLASS when the provider is built inside the command "
+        f"under test — `registry.provider_for` gives a test no instance to reach) and stub "
+        f"`shutil.which` so the provider believes the CLI is installed: "
+        f"`tests/test_vault_registration.py::_no_real_op` is the smallest example, and "
+        f"`test_op_reads_the_item_once.py` the fullest. A test that genuinely needs a real "
+        f"credential store is not a unit test.")
+
+
+def _reaches_a_credential_cli(args, opts: dict) -> tuple[list[str], str] | None:
+    """``(argv, CLI name)`` when *args* would run one of :func:`_credential_clis`.
+
+    Deliberately narrower than :func:`_charter_argv`, and the asymmetry is the point.
+    That function has to chase every spelling because charter re-spawns ITSELF and the
+    interesting cases are the indirect ones; this one is asking about a third-party binary
+    that only ever arrives as ``argv[0]`` of a list charter built (`onepassword._argv`,
+    `reference._RESOLVERS`). Wrappers are still unwrapped through `_launcher_argv`, since
+    that is free and `env VAR=x op read …` is a shape a test could plausibly write, and the
+    program name is resolved through `_program_names` so a path or a symlink cannot walk
+    past a basename compare.
+    """
+    if not _VAULT_CLIS or args is None:
+        return None
+    if isinstance(args, os.PathLike):
+        args = os.fspath(args)
+    if isinstance(args, (str, bytes)):
+        command = _decoded(args)
+        parts = [command] if command is not None else None
+        if parts and opts.get("shell"):
+            # ``shell=True`` hands the whole string to ``/bin/sh -c``. Splitting it is the
+            # shell's job and `shlex` is only an approximation of it, so a string that will
+            # not tokenize is answered "not a credential CLI" rather than guessed at —
+            # nothing in charter spells a vault read that way, and this guard would rather
+            # miss a shape nobody writes than refuse an unrelated `shell=True` command.
+            try:
+                parts = shlex.split(command)
+            except ValueError:
+                return None
+    else:
+        try:
+            parts = [_decoded(a) for a in args]
+        except TypeError:
+            return None
+        if any(p is None for p in parts):
+            return None
+    if not parts:
+        return None
+    argv, _consumed = _launcher_argv(parts)
+    if not argv:
+        return None
+    for name in _program_names(argv[0], opts.get("cwd"), opts.get("env")):
+        if name in _VAULT_CLIS:
+            return parts, name
+    return None
 
 
 #: An interpreter whose ``-c`` is Python SOURCE and whose first bare argument is a Python
@@ -1023,15 +1148,22 @@ def _guard_spawns() -> None:
     a call to one of them that is not the two known non-charter uses. The day a charter
     spawn is written that way, that case turns red and this docstring is what it points at.
     """
-    global _SPAWN_GUARDED
+    global _SPAWN_GUARDED, _VAULT_CLIS
     if _SPAWN_GUARDED:
         return
     _SPAWN_GUARDED = True
+    _VAULT_CLIS = _credential_clis()
     original = subprocess.Popen.__init__
 
     def __init__(self, args=None, *rest, **kw):
         opts = dict(zip(_POPEN_POSITIONAL, rest))
         opts.update(kw)
+        # Before the plane question, and unconditional where that one waits on
+        # `_REAL_ROOT`: a real `op` reads the operator's 1Password vault whatever plane
+        # the child would resolve, and on a machine with no plane at all.
+        reached = _reaches_a_credential_cli(args, opts)
+        if reached is not None:
+            raise RealVaultReach(_explain_vault(*reached))
         parts = _charter_argv(args, opts)
         if parts is not None and _REAL_ROOT:
             plane = _child_plane(opts)

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -467,15 +467,23 @@ def _reaches_a_credential_cli(args, opts: dict) -> tuple[list[str], str] | None:
     that is free and `env VAR=x op read …` is a shape a test could plausibly write, and the
     program name is resolved through `_program_names` so a path or a symlink cannot walk
     past a basename compare.
+
+    **Every branch below is one a test drives**, which is the other half of that asymmetry.
+    The first version of this function copied `_charter_argv`'s full defensive shape — a
+    ``None`` from `_decoded`, an empty *parts*, a `TypeError` from iterating *args* — and
+    the sweep found nine of those unreachable: `_decoded` answers ``None`` only for a value
+    that is neither `str`, `bytes` nor `PathLike`, and `os.fsdecode`'s surrogateescape
+    means it cannot fail on the two spellings that reach it here. An unreachable guard is
+    dead code wearing a guard's clothes, and this file's own doctrine — no suppression
+    list, "equivalent mutant" and "dead code" are the same finding — applies to it.
     """
-    if not _VAULT_CLIS or args is None:
+    if args is None:
         return None
     if isinstance(args, os.PathLike):
         args = os.fspath(args)
     if isinstance(args, (str, bytes)):
         command = _decoded(args)
-        parts = [command] if command is not None else None
-        if parts and opts.get("shell"):
+        if opts.get("shell"):
             # ``shell=True`` hands the whole string to ``/bin/sh -c``. Splitting it is the
             # shell's job and `shlex` is only an approximation of it, so a string that will
             # not tokenize is answered "not a credential CLI" rather than guessed at —
@@ -485,17 +493,14 @@ def _reaches_a_credential_cli(args, opts: dict) -> tuple[list[str], str] | None:
                 parts = shlex.split(command)
             except ValueError:
                 return None
+        else:
+            parts = [command]
     else:
-        try:
-            parts = [_decoded(a) for a in args]
-        except TypeError:
-            return None
-        if any(p is None for p in parts):
-            return None
-    if not parts:
-        return None
+        parts = [_decoded(a) for a in args]
     argv, _consumed = _launcher_argv(parts)
     if not argv:
+        # A command line that is ALL wrapper — `Popen(["env"])` is the ordinary one — has
+        # no program left to name. Reached on every such spawn, not a hypothetical.
         return None
     for name in _program_names(argv[0], opts.get("cwd"), opts.get("env")):
         if name in _VAULT_CLIS:

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -411,16 +411,22 @@ def _credential_clis() -> frozenset[str]:
     provider's ``op://`` scheme produces the same name — and it is what keeps this correct
     if the two ever stop agreeing.
 
-    Additive and best effort: a builder that raises contributes nothing and can only cost
-    precision, never correctness, because the names already collected still refuse.
+    A builder that will not answer contributes nothing and is skipped. That is not defensive
+    padding: the probe URIs are written HERE and the builders are written in production, so
+    the day a scheme arrives whose URI has a shape this file has not learned, the lookup
+    raises — and the choice is between guarding one CLI fewer and refusing to import the
+    `tests` package at all. `test_plane_spawn_guard` pins that it degrades rather than
+    explodes, and the seeded ``op`` is what stops the degraded answer from being empty.
+
+    The import is deliberately NOT wrapped. This runs from `install()`, after
+    `charter.config` is already loaded, so an `ImportError` here would mean charter itself
+    is broken — and swallowing it would leave every credential CLI unguarded while the
+    suite carried on looking healthy, which is the exact failure the guard exists to stop.
     """
+    from charter.secrets import reference
     names = {"op"}
     probes = {"op": "op://vault/item/field", "vault": "vault://secret/data/app#FIELD",
               "browser": "browser://session/localstorage/key"}
-    try:
-        from charter.secrets import reference
-    except Exception:                                # pragma: no cover - import can't fail
-        return frozenset(names)
     for scheme, build in reference._RESOLVERS.items():
         try:
             names.add(build(probes[scheme], {})[1])

--- a/tests/_ttyguard.py
+++ b/tests/_ttyguard.py
@@ -1,0 +1,216 @@
+"""Suite-wide tripwire: the TERMINAL the suite was launched from is not a fixture either.
+
+`_planeguard` isolates the plane this process resolves and the state directory it writes;
+`_envguard` removes the charter variables the operator's shell exports. Both are about what
+that shell *says*. This is the fourth fixture, and it is about what the shell *is*: three
+open file descriptors, and whether they are a terminal.
+
+**The failure this closes is a HANG, which is worse than a wrong answer.** A wrong answer
+is a verdict; a hang is not a pass, not a fail, and not a report::
+
+    $ python3 -m unittest discover -s tests            # stdin a pipe, or CI
+    Ran 6636 tests in 442s
+    OK
+    $ python3 -m unittest discover -s tests            # stdin a terminal
+    test_the_frames_own_workspace_is_written_down_on_both_paths
+    (tests.test_frame_launcher.ALaunchFillsTheCacheItJustEmptied…)
+       ← blocks here, indefinitely
+
+`commands_frame._picker_wanted` gates #518's workspace picker on **two** independent
+questions — ``sys.stdin.isatty() and sys.stdout.isatty()`` — by design, because
+``charter claude < /dev/null`` in a terminal has one and not the other.
+`tests/test_frame_launcher.py` pinned the second of that pair and left the first to the
+ambient shell, so what happened next was decided by whichever stdin the runner happened to
+have: a pipe answered "no picker" and went green, and a terminal sat on charter's own
+prompt waiting for a human who was never going to type (#545). Measured with `input()`
+replaced by a recording raise and the suite run under a pty: **122 tests reached that
+prompt**, in one module, on a tree whose CI has been green throughout. CI has never seen it
+and never can — its stdin is not a terminal — so the environment that reports the suite's
+health is precisely the one blind to this.
+
+**And the same fixture goes the other way, quietly.** `test_mcp_approval` records its own
+instance in full: `util._USE_COLOR` is ``sys.stderr.isatty()`` evaluated at import, so
+running from a terminal put charter's own ANSI codes into a transcript that test derives
+its expectations from — and a mutation that dies under a pipe "reported OK under a pty".
+A test that stops testing when the run happens to be interactive is worse than one that
+hangs, because nothing about it looks wrong.
+
+**Two moves, closing opposite directions — the shape `_envguard` settled.**
+
+1. *The ambient answer is removed*, once, before `charter` is first imported. ``sys.stdin``
+   is replaced with a stream that is not a terminal and holds nothing, and ``sys.stdout``
+   and ``sys.stderr`` answer :meth:`isatty` ``False``. That is the answer CI gives and the
+   one every assertion in this suite was written against. It takes effect for every test at
+   once, it covers the reads that happen at import (`util._USE_COLOR` above) where no test
+   is running to declare anything, and — because ``input()`` reads ``sys.stdin`` — it means
+   a path that does reach a prompt raises ``EOFError`` instead of blocking forever.
+2. *A targeted read of* ``sys.stdin.isatty()`` *is REFUSED* while a test runs, unless that
+   test said which answer it wanted. Removal alone would only silence the red: every one of
+   those 122 tests would still be asserting against a terminal-ness it never chose, and the
+   next test that MEANS "there is a human here" would get ``False`` and pass vacuously.
+
+**Only stdin is refused, and the boundary is the same one `_envguard` draws for its loud
+set.** Every stream is answered, so no test's result can differ between two machines
+either way; loudness is worth its cost only where the answer is a CLAIM ABOUT THE WORLD the
+test runs in. ``sys.stdout.isatty()`` decides *formatting and routing* — colour, and whether
+`cmd_launch` bypasses the frame — and the suite already treats it as a stated fixture: it is
+pinned at thirteen sites in the launcher module alone. ``sys.stdin.isatty()`` decides
+whether charter **stops and asks a human**, which is the one question whose wrong answer is
+a process that never returns. That is the tier-two criterion, and it selects exactly the
+half nobody was pinning.
+
+**How a test declares.** Three ways, and two of them are what tests already do:
+
+* ``mock.patch("sys.stdin.isatty", return_value=False)`` — the pair to the
+  ``sys.stdout.isatty`` pin sitting next to it, and what `_launch` and `_launch_inside` in
+  `test_frame_launcher.py` now carry. ``True`` for a test that wants the prompt (it must
+  then drive `_read` itself, which is the right way round).
+* ``mock.patch("sys.stdin", <something>)`` — replacing the stream entirely, the way the
+  hook-driving helpers and `test_mcp_approval`'s ``_Tty`` do. The guard's stream is not
+  consulted at all, so this declares by construction.
+* :func:`no_terminal`, for a case with nothing to patch that simply means "nobody is
+  watching this run".
+
+**Scoped to one test and reset at its boundary**, by wrapping `unittest.TestCase.run` — the
+same mechanism and the same save/restore as `_envguard`, and for the same reason: a few
+tests run an inner `TestCase` inside their own body, and the inner run must not disarm the
+outer one.
+
+**Disarmed outside a test, deliberately.** Import-time reads happen before any test could
+declare anything, and refusing there would refuse the suite's own boot. Move 1 has already
+made those reads deterministic; it is only the *loudness* that waits for a test to run.
+
+**Raised as a `BaseException`**, for the reason `_planeguard.RealPlaneRead` documents:
+charter is full of ``except Exception`` fallbacks that would turn this tripwire into a
+degraded code path, and `unittest` records a `BaseException` against the test that raised
+it, so the failure keeps its name.
+
+**What this cannot see.** A subprocess gets its own file descriptors, and it inherits this
+process's — so a child charter really can find a terminal on fd 0. Nothing in the suite
+reaches a prompt that way today (`RealPlaneSpawn` already refuses the children that would
+resolve a real plane, and the rest are driven with explicit input), and closing it would
+mean rewriting fd 0 for every child, which is a bigger change than the hole justifies. It
+is written down here rather than left to be discovered.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+
+class AmbientTerminalRead(BaseException):
+    """A test asked whether stdin is a terminal without saying which answer it wanted."""
+
+
+#: What the three streams actually answered when the suite started, for anything that
+#: genuinely has to know what the operator's terminal looked like. Nothing needs it today;
+#: it exists so that such a case has somewhere honest to ask instead of the guard being
+#: switched off. `_envguard.scrubbed` is the same courtesy for the same reason.
+_AMBIENT: dict[str, bool] = {}
+
+#: The replacement stream. Kept so `install` is idempotent and so a test can recognise it.
+_STDIN = None
+
+_installed = False
+
+#: Armed only while a test is running. See the module docstring.
+_active = False
+
+#: Whether THIS test has said which answer it wants. Reset — saved and restored — around
+#: every `TestCase.run`.
+_declared = False
+
+
+def _explain() -> str:
+    from . import _planeguard
+    return (
+        "REFUSED: read of sys.stdin.isatty()\n"
+        f"{_planeguard._current_test()} asked whether stdin is a terminal without saying "
+        f"which answer it wants, so the answer would be a reading of the shell the suite "
+        f"was launched from. That question decides whether charter STOPS AND ASKS A HUMAN: "
+        f"`commands_frame._picker_wanted` opens #518's workspace picker on it, "
+        f"`commands_secrets._read_value` falls through to `getpass`, and "
+        f"`commands_report._body` waits on a pipe. Under a pipe (CI, an agent's shell) all "
+        f"three answer 'nobody is there' and the test goes green; under a terminal — a "
+        f"developer, a charter frame — it blocks forever, which is not a pass, not a fail "
+        f"and not a report. 122 tests reached that prompt in one module (#545). Three ways "
+        f"out, and pick the one that says what this test means:\n"
+        f"  - `mock.patch(\"sys.stdin.isatty\", return_value=False)` — the pair to the "
+        f"`sys.stdout.isatty` pin that is probably already beside it;\n"
+        f"  - `mock.patch(\"sys.stdin\", io.StringIO(\"...\"))` if the test has input to "
+        f"give, or a stub whose `isatty` says True if it MEANS to drive the prompt;\n"
+        f"  - `tests._ttyguard.no_terminal()` for a case with nothing to patch.")
+
+
+def _isatty() -> bool:
+    if _active and not _declared:
+        raise AmbientTerminalRead(_explain())
+    return False
+
+
+def no_terminal() -> None:
+    """Declare, for the rest of this test, that nobody is watching the run.
+
+    The answer CI gives. For a case that has no stdin to patch and simply needs charter to
+    take the non-interactive branch — the equivalent of `_envguard.unset`.
+    """
+    global _declared
+    _declared = True
+
+
+def ambient() -> dict[str, bool]:
+    """What ``stdin``/``stdout``/``stderr`` answered before the guard replaced them."""
+    return dict(_AMBIENT)
+
+
+def install() -> None:
+    """Answer for all three streams, and arm the stdin refusal per test. Idempotent.
+
+    Called at import of the `tests` package, and **first** — above `_envguard`, which is
+    what pulls `charter` in. `charter.util` computes ``_USE_COLOR`` from
+    ``sys.stderr.isatty()`` at ITS import, so an install one line later would leave the
+    whole suite's output decoration decided by the operator's terminal.
+    """
+    global _installed, _STDIN
+    if _installed:
+        return
+    _installed = True
+
+    for name in ("stdin", "stdout", "stderr"):
+        stream = getattr(sys, name, None)
+        try:
+            _AMBIENT[name] = bool(stream.isatty())
+        except (AttributeError, OSError, ValueError):
+            # A stream that cannot answer is not a terminal for any purpose here, and a
+            # guard that raised while installing would take the suite down at import.
+            _AMBIENT[name] = False
+
+    # A REAL file object, not a stub: `fileno()`, `read()`, `buffer` and `close()` all have
+    # to keep working, because tests hand stdin to subprocesses and to `input()`. `devnull`
+    # is also the only choice that makes a read return "" rather than block — so a path
+    # that reaches a prompt despite everything raises `EOFError` instead of hanging.
+    _STDIN = open(os.devnull)
+    _STDIN.isatty = _isatty
+    sys.stdin = _STDIN
+
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.isatty = lambda: False
+        except (AttributeError, TypeError):     # pragma: no cover - not seen on CPython
+            pass
+
+    original_run = unittest.TestCase.run
+
+    def run(self, result=None):
+        global _active, _declared
+        outer_active, outer_declared = _active, _declared
+        _active, _declared = True, False
+        try:
+            return original_run(self, result)
+        finally:
+            _active, _declared = outer_active, outer_declared
+
+    run.__module__ = __name__
+    unittest.TestCase.run = run

--- a/tests/_ttyguard.py
+++ b/tests/_ttyguard.py
@@ -165,6 +165,35 @@ def ambient() -> dict[str, bool]:
     return dict(_AMBIENT)
 
 
+def says_it_is_a_terminal(stream) -> bool:
+    """Whether *stream* claims to be a terminal — ``False`` for one that cannot say.
+
+    A stream that raises when asked is not a terminal for any purpose here, and a guard
+    that raised while INSTALLING would take the suite down at import — before any test
+    exists to name in the traceback. Reachable: a closed stream raises `ValueError`, and
+    under some runners `sys.stdout` is not a file object at all.
+    """
+    try:
+        return bool(stream.isatty())
+    except (AttributeError, OSError, ValueError):
+        return False
+
+
+def answer_not_a_terminal(stream) -> bool:
+    """Make *stream* report ``isatty()`` false. ``False`` if it will not take the answer.
+
+    Every stream CPython hands a `python -m unittest` run accepts this, so the fallback is
+    for the runner that does not — a C-level object with no instance dictionary raises
+    `AttributeError`, and one with a read-only slot raises `TypeError`. Answering two
+    streams and failing on the third is strictly better than answering none.
+    """
+    try:
+        stream.isatty = lambda: False
+    except (AttributeError, TypeError):
+        return False
+    return True
+
+
 def install() -> None:
     """Answer for all three streams, and arm the stdin refusal per test. Idempotent.
 
@@ -179,13 +208,7 @@ def install() -> None:
     _installed = True
 
     for name in ("stdin", "stdout", "stderr"):
-        stream = getattr(sys, name, None)
-        try:
-            _AMBIENT[name] = bool(stream.isatty())
-        except (AttributeError, OSError, ValueError):
-            # A stream that cannot answer is not a terminal for any purpose here, and a
-            # guard that raised while installing would take the suite down at import.
-            _AMBIENT[name] = False
+        _AMBIENT[name] = says_it_is_a_terminal(getattr(sys, name, None))
 
     # A REAL file object, not a stub: `fileno()`, `read()`, `buffer` and `close()` all have
     # to keep working, because tests hand stdin to subprocesses and to `input()`. `devnull`
@@ -196,10 +219,7 @@ def install() -> None:
     sys.stdin = _STDIN
 
     for stream in (sys.stdout, sys.stderr):
-        try:
-            stream.isatty = lambda: False
-        except (AttributeError, TypeError):     # pragma: no cover - not seen on CPython
-            pass
+        answer_not_a_terminal(stream)
 
     original_run = unittest.TestCase.run
 

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1252,6 +1252,7 @@ class Probe(unittest.TestCase):
         sentinel = AssertionError("workspace resolved — the launch path was reached")
         with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
              mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("sys.stdin.isatty", return_value=False), \
              _harness_binary_installed(), \
              mock.patch("charter.workspace.resolve", side_effect=sentinel):
             with self.assertRaises(AssertionError) as ctx:
@@ -1667,12 +1668,32 @@ def _no_real_detached_child(sink: list):
 
 def _launch(fake: _FakeTmux, *, cols=200, rows=50, version=(3, 7), harness="claude",
            rest=(), which=None, detached=None):
+    """A launch in a terminal nobody is typing at — BOTH halves stated, not one (#545).
+
+    `commands_frame._picker_wanted` reads a PAIR: ``sys.stdin.isatty() and
+    sys.stdout.isatty()``, by design, because ``charter claude < /dev/null`` on a real
+    terminal has one and not the other. This helper pinned `stdout` and left `stdin` to
+    whatever the runner happened to have, and nothing here sets `args.workspace` or
+    `args.pick` — so on a pipe the picker was skipped and on a TERMINAL every launch below
+    stopped at charter's own prompt and waited for a human. 122 tests in this module,
+    measured under a pty; green in CI, whose stdin is not a terminal, which is why it went
+    unseen for as long as it did.
+
+    ``False`` narrows what these tests inherit and widens nothing: no case here exercises
+    the picker (none drives `_read`, none passes `pick=`), and one that wanted to would pin
+    `stdin` ``True`` itself and drive the prompt, which is the right way round.
+
+    `tests._ttyguard` is what makes this line load-bearing rather than a comment — an
+    undeclared read of `sys.stdin.isatty()` is refused while a test runs, so deleting it
+    fails these tests by name instead of hanging them.
+    """
     _refuse_the_real_plane()
     args = SimpleNamespace(harness=harness, rest=list(rest), no_frame=False)
     with _outside_tmux(), \
          _no_real_detached_child(detached if detached is not None else []), \
          mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
          mock.patch("sys.stdout.isatty", return_value=True), \
+         mock.patch("sys.stdin.isatty", return_value=False), \
          _harness_binary_installed(which), \
          mock.patch("charter.frame.tmuxctl.version", return_value=version), \
          mock.patch("charter.workspace.resolve", return_value="demo"), \
@@ -2147,6 +2168,7 @@ class Launch(PersonaIso, unittest.TestCase):
              _no_real_detached_child([]), \
              mock.patch("charter.commands_frame.subprocess.run", side_effect=_peek), \
              mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("sys.stdin.isatty", return_value=False), \
              _harness_binary_installed(), \
              mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
              mock.patch("charter.workspace.resolve", return_value="demo"), \
@@ -2630,6 +2652,7 @@ class Launch(PersonaIso, unittest.TestCase):
              _no_real_detached_child([]), \
              mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
              mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("sys.stdin.isatty", return_value=False), \
              _harness_binary_installed(), \
              mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
              mock.patch("charter.workspace.resolve", return_value="demo"), \
@@ -2842,6 +2865,7 @@ class Launch(PersonaIso, unittest.TestCase):
         with _outside_tmux(), \
              mock.patch("charter.commands_frame.subprocess.run") as run, \
              mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("sys.stdin.isatty", return_value=False), \
              _harness_binary_installed(), \
              mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
              mock.patch("charter.workspace.resolve", return_value="demo"), \
@@ -4070,7 +4094,12 @@ def _frame_id():
 
 def _launch_inside(fake: _FakeOperatorTmux, *, version=(3, 7), harness="claude",
                    rest=(), tmux_env=OPERATOR_TMUX, slots=None, detached=None):
-    """Run `cmd_launch` as if the operator typed it inside their own tmux."""
+    """Run `cmd_launch` as if the operator typed it inside their own tmux.
+
+    Both halves of the tty pair are stated, for the reason `_launch` sets out at length
+    (#545): a tmux pane IS a terminal, so this is the helper most likely to be reached with
+    a real one on stdin.
+    """
     _refuse_the_real_plane()
     args = SimpleNamespace(harness=harness, rest=list(rest), no_frame=False)
     env = dict(os.environ, TMUX=tmux_env, TMUX_PANE="%0")
@@ -4079,6 +4108,7 @@ def _launch_inside(fake: _FakeOperatorTmux, *, version=(3, 7), harness="claude",
            mock.patch("charter.commands_frame.subprocess.run", side_effect=fake),
            mock.patch("charter.commands_frame.time.sleep"),
            mock.patch("sys.stdout.isatty", return_value=True),
+           mock.patch("sys.stdin.isatty", return_value=False),
            _harness_binary_installed(),
            mock.patch("charter.frame.tmuxctl.version", return_value=version),
            mock.patch("charter.workspace.resolve", return_value="demo")]
@@ -4648,6 +4678,7 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
              mock.patch("charter.commands_frame.subprocess.run", side_effect=_route), \
              mock.patch("charter.commands_frame.time.sleep"), \
              mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("sys.stdin.isatty", return_value=False), \
              _harness_binary_installed(), \
              mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
              mock.patch("charter.workspace.resolve", return_value="demo"), \

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -3416,9 +3416,16 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
             # 'demo']` and `CHARTER_ROOT=''`. This test is about what a launch writes on
             # somebody else's tmux SERVER; the gather child is not part of that question,
             # and it is the one part of a launch that escapes the isolation.
+            # BOTH halves of the tty pair, for the reason `test_frame_launcher._launch`
+            # sets out (#545) and with one aggravation of its own: this launch runs on a
+            # worker THREAD, so `_picker_wanted` finding a terminal here does not merely
+            # hang the test — it hangs a daemon thread nobody is waiting on a prompt from,
+            # and what the assertion below reports is "the frame's own window never
+            # appeared", which is a true sentence about the wrong subject.
             with mock.patch.dict(os.environ, env, clear=True), \
                  _no_real_detached_child([]), \
                  mock.patch("sys.stdout.isatty", return_value=True), \
+                 mock.patch("sys.stdin.isatty", return_value=False), \
                  mock.patch("charter.workspace.resolve", return_value="demo"), \
                  mock.patch.dict(config.FRAME, {"slots": []}):
                 rc.append(commands_frame.cmd_launch(args))

--- a/tests/test_no_test_reads_the_operators_terminal.py
+++ b/tests/test_no_test_reads_the_operators_terminal.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import io
 import os
+import pathlib
 import sys
 import unittest
 from types import SimpleNamespace
@@ -54,6 +55,31 @@ class WhatIsAnswered(unittest.TestCase):
         a mutation that dies under a pipe "reported OK under a pty"."""
         from charter import util
         self.assertFalse(util._USE_COLOR)
+
+    def test_the_answer_is_installed_rather_than_inherited(self):
+        """Under a pipe the guard's answer and the ambient one are both ``False``, so
+        every assertion above passes with `install()`'s three lines deleted — and goes on
+        passing in CI, which is the one environment that can never tell the difference.
+        This asks the question that has a different answer either way: is the ``isatty``
+        being called ours, or the stream's own? A hand-check of the sweep's blind spot
+        (#569), and the reason it is worth a case of its own.
+        """
+        self.assertIn("isatty", vars(sys.stdout))
+        self.assertIn("isatty", vars(sys.stderr))
+        self.assertIs(sys.stdin, _ttyguard._STDIN)
+        self.assertIs(sys.stdin.isatty, _ttyguard._isatty)
+
+    def test_the_guard_is_installed_before_charter_is_imported(self):
+        """`charter.util` reads `sys.stderr.isatty()` at ITS import, so this ordering is
+        the whole of `_USE_COLOR`'s determinism — and the mutation that moves the install
+        down is invisible under a pipe, where the two answers coincide. Read off the
+        source because that is where the ordering lives; `tests/__init__.py` says the same
+        thing in a comment, and a comment is not a test.
+        """
+        src = (pathlib.Path(__file__).parent / "__init__.py").read_text()
+        self.assertLess(src.index("_ttyguard.install()"), src.index("import _envguard"),
+                        "_envguard pulls `charter` in — the streams must be answered "
+                        "before that, not after")
 
     def test_what_the_terminal_actually_said_is_still_available(self):
         """`_envguard.scrubbed`'s counterpart: a case that genuinely has to know what the

--- a/tests/test_no_test_reads_the_operators_terminal.py
+++ b/tests/test_no_test_reads_the_operators_terminal.py
@@ -124,6 +124,41 @@ class TheGuardIsNotBlind(unittest.TestCase):
         self.assertTrue(issubclass(_ttyguard.AmbientTerminalRead, BaseException))
         self.assertFalse(issubclass(_ttyguard.AmbientTerminalRead, Exception))
 
+    def test_a_read_outside_any_test_is_answered_rather_than_refused(self):
+        """Disarmed outside a test, for `_envguard`'s reason: module import happens before
+        anything could declare, and a tripwire that fired there would refuse the suite's
+        own boot rather than name a test. Move one has already made those reads
+        deterministic; only the loudness waits for a test to be running."""
+        with mock.patch.object(_ttyguard, "_active", False):
+            self.assertFalse(sys.stdin.isatty())
+
+    def test_installing_twice_does_not_replace_the_stream_a_test_may_have_pinned(self):
+        """`install()` is idempotent because it is reachable twice — `tests` can be
+        imported by a child process that also imports a test module. A second install
+        would hand out a NEW stdin, silently discarding whatever a running test had
+        patched onto the old one."""
+        before = sys.stdin
+        _ttyguard.install()
+        self.assertIs(sys.stdin, before)
+
+    def test_a_stream_that_cannot_answer_is_not_a_terminal(self):
+        """Install must not be the thing that breaks the run: a closed stream raises
+        `ValueError` from `isatty()`, and under some runners `sys.stdout` is not a file
+        object at all."""
+        class _Closed:
+            def isatty(self):
+                raise ValueError("I/O operation on closed file")
+
+        self.assertFalse(_ttyguard.says_it_is_a_terminal(_Closed()))
+        self.assertFalse(_ttyguard.says_it_is_a_terminal(None))
+        self.assertTrue(_ttyguard.says_it_is_a_terminal(SimpleNamespace(isatty=lambda: 1)))
+
+    def test_a_stream_that_will_not_take_the_answer_costs_only_itself(self):
+        """Answering two streams and failing on the third beats answering none — so the
+        refusal is reported rather than raised."""
+        self.assertTrue(_ttyguard.answer_not_a_terminal(SimpleNamespace()))
+        self.assertFalse(_ttyguard.answer_not_a_terminal(object()))
+
     def test_stdout_is_deliberately_not_refused(self):
         """The boundary, stated as a test rather than only as prose. Answering every
         stream is what makes the suite machine-independent; LOUDNESS is spent only on the

--- a/tests/test_no_test_reads_the_operators_terminal.py
+++ b/tests/test_no_test_reads_the_operators_terminal.py
@@ -1,0 +1,160 @@
+"""The fourth tripwire: the terminal the suite was launched from is not a fixture either.
+
+`test_plane_write_guard` and `test_plane_spawn_guard` cover the plane;
+`test_no_test_reads_the_operators_shell` covers what that shell EXPORTS. This covers what
+it IS — three file descriptors, and whether they are a terminal.
+
+The defect it closes is not a wrong answer, it is a **hang**: `commands_frame._picker_wanted`
+opens #518's workspace picker on ``sys.stdin.isatty() and sys.stdout.isatty()``, the
+launcher module pinned only the second, and under a pty 122 of its tests sat at charter's
+own prompt waiting for a human (#545). A hang is not a pass, not a fail, and not a report —
+and CI, whose stdin is a pipe, cannot see it at all.
+
+**Every case here is a control**, for the reason `test_no_test_reads_the_operators_shell`
+gives: a guard nobody has watched fail is a guard nobody knows works. `TheGuardIsNotBlind`
+makes the refusal happen for real, `EveryWayOutOfTheRefusalWorks` exercises each documented
+escape — a tripwire with no usable exit is deleted by whoever hits it next — and
+`WhatIsAnswered` pins the other half, which is silent by design.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame
+from tests import _ttyguard
+
+
+class WhatIsAnswered(unittest.TestCase):
+    """Move one: every stream answers what CI answers, on every machine."""
+
+    def test_no_stream_reports_a_terminal(self):
+        """`stdout` and `stderr` are answered and never refused — see the module docstring
+        of `tests/_ttyguard.py` for why only `stdin` is loud."""
+        self.assertFalse(sys.stdout.isatty())
+        self.assertFalse(sys.stderr.isatty())
+
+    def test_stdin_holds_nothing_so_a_prompt_ends_rather_than_blocks(self):
+        """The half that matters when a path reaches a prompt anyway: `input()` reads
+        `sys.stdin`, and `devnull` is at EOF. `commands_frame`'s picker treats `EOFError`
+        as "no answer" and cancels, which is a verdict; blocking is not."""
+        with self.assertRaises(EOFError):
+            input()
+
+    def test_charters_own_colour_decision_was_made_before_the_terminal_could_decide_it(self):
+        """`util._USE_COLOR` is `sys.stderr.isatty()` evaluated at IMPORT of `charter.util`,
+        which is why `_ttyguard.install()` runs above the import that pulls charter in.
+        `test_mcp_approval` records what it cost when it did not: ANSI codes from the
+        operator's terminal joined a transcript that test derives its expectations from, and
+        a mutation that dies under a pipe "reported OK under a pty"."""
+        from charter import util
+        self.assertFalse(util._USE_COLOR)
+
+    def test_what_the_terminal_actually_said_is_still_available(self):
+        """`_envguard.scrubbed`'s counterpart: a case that genuinely has to know what the
+        operator's terminal looked like has somewhere honest to ask, so the guard is never
+        the thing standing in its way."""
+        ambient = _ttyguard.ambient()
+        self.assertEqual(sorted(ambient), ["stderr", "stdin", "stdout"])
+        for value in ambient.values():
+            self.assertIsInstance(value, bool)
+
+
+class TheGuardIsNotBlind(unittest.TestCase):
+    """Move two: an undeclared read of `sys.stdin.isatty()` is refused, for real."""
+
+    def test_asking_whether_anybody_is_watching_gets_refused(self):
+        with self.assertRaises(_ttyguard.AmbientTerminalRead):
+            sys.stdin.isatty()
+
+    def test_the_production_read_that_hung_the_suite_is_the_one_refused(self):
+        """Not a synthetic call: `_picker_wanted` is the function that decides whether
+        `charter claude` stops and asks, and it is where #545 lived."""
+        args = SimpleNamespace(workspace=None, pick=False)
+        with self.assertRaises(_ttyguard.AmbientTerminalRead):
+            commands_frame._picker_wanted(args, None)
+
+    def test_the_message_names_the_test_the_question_and_the_ways_out(self):
+        with self.assertRaises(_ttyguard.AmbientTerminalRead) as e:
+            sys.stdin.isatty()
+        msg = str(e.exception)
+        self.assertIn("test_the_message_names_the_test_the_question_and_the_ways_out", msg)
+        self.assertIn("sys.stdin.isatty", msg)
+        self.assertIn("_picker_wanted", msg)          # what the answer decides
+        self.assertIn("return_value=False", msg)      # way out 1
+        self.assertIn('mock.patch("sys.stdin"', msg)  # way out 2
+        self.assertIn("no_terminal", msg)             # way out 3
+
+    def test_it_is_a_base_exception_so_charters_own_fallbacks_cannot_eat_it(self):
+        """The same reasoning `_planeguard.RealPlaneRead` carries: charter is full of
+        `except Exception` fallbacks that would turn this tripwire into a degraded code
+        path — `commands_frame` alone has several — and a tripwire something catches is a
+        tripwire that reports a benign state instead of failing."""
+        self.assertTrue(issubclass(_ttyguard.AmbientTerminalRead, BaseException))
+        self.assertFalse(issubclass(_ttyguard.AmbientTerminalRead, Exception))
+
+    def test_stdout_is_deliberately_not_refused(self):
+        """The boundary, stated as a test rather than only as prose. Answering every
+        stream is what makes the suite machine-independent; LOUDNESS is spent only on the
+        question whose wrong answer is a process that never returns."""
+        self.assertFalse(sys.stdout.isatty())
+
+
+class EveryWayOutOfTheRefusalWorks(unittest.TestCase):
+    def test_pinning_isatty_beside_the_stdout_pin(self):
+        with mock.patch("sys.stdin.isatty", return_value=False):
+            self.assertFalse(sys.stdin.isatty())
+
+    def test_pinning_it_true_is_how_a_test_says_it_wants_the_prompt(self):
+        args = SimpleNamespace(workspace=None, pick=False)
+        with mock.patch("sys.stdin.isatty", return_value=True), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(commands_frame._picker_wanted(args, None))
+
+    def test_replacing_the_stream_declares_by_construction(self):
+        """What the hook-driving helpers and `test_mcp_approval`'s `_Tty` already do: the
+        guard's own stream is not consulted at all."""
+        with mock.patch("sys.stdin", io.StringIO("hello\n")):
+            self.assertFalse(sys.stdin.isatty())
+            self.assertEqual(input(), "hello")
+
+    def test_saying_nobody_is_watching(self):
+        _ttyguard.no_terminal()
+        self.assertFalse(sys.stdin.isatty())
+
+    def test_the_pin_is_restored_afterwards_so_the_next_read_is_refused_again(self):
+        with mock.patch("sys.stdin.isatty", return_value=True):
+            self.assertTrue(sys.stdin.isatty())
+        with self.assertRaises(_ttyguard.AmbientTerminalRead):
+            sys.stdin.isatty()
+
+
+class TheDeclarationDoesNotOutliveItsTest(unittest.TestCase):
+    """The same save/restore `_envguard` needs, for the same reason: a few cases run an
+    inner `TestCase` inside their own body, and the inner run must not disarm the outer."""
+
+    class _Inner(unittest.TestCase):
+        def runTest(self):
+            _ttyguard.no_terminal()
+            assert sys.stdin.isatty() is False
+
+    def test_this_tests_own_state_survives_running_an_inner_case(self):
+        self._Inner().run(unittest.TestResult())
+        with self.assertRaises(_ttyguard.AmbientTerminalRead):
+            sys.stdin.isatty()
+
+    def test_a_completed_declaring_case_leaves_the_guard_armed(self):
+        result = unittest.TestResult()
+        self._Inner().run(result)
+        self.assertEqual(result.errors, [])
+        self.assertTrue(_ttyguard._active)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -910,5 +910,108 @@ class NoBackgroundRefreshWithoutAPlane(unittest.TestCase):
         popen.assert_not_called()
 
 
+class TheOperatorsCredentialStoreIsNeverReached(unittest.TestCase):
+    """`RealVaultReach` — the fourth tripwire, and the only one not about the plane.
+
+    Two tests in `test_vault_registration.py` ran the operator's real `op` against their
+    real 1Password vault, because `cmd_vault_add` ends in `prov.health()` and a
+    `1password` vault answers that by shelling out (#546). Measured with a logging
+    stand-in first on `$PATH`: four invocations, two tests, none anywhere else in 6636.
+    They passed because an unauthenticated `op` fails fast; they HANG when it prompts.
+
+    A control, on the same terms as `ARefusedSpawn` above: the refusal is made to happen
+    for real, and the evidence that nothing ran is a marker file that is absent while the
+    same marker is PRESENT in the allowed case — "the child never started" and "the child
+    started and could not write" look identical without it.
+    """
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp(prefix="vaultguard-"))
+        self.addCleanup(shutil.rmtree, self.dir, True)
+        self.marker = self.dir / "the-cli-ran"
+        for name in ("op", "vault", "npx", "git"):
+            p = self.dir / name
+            p.write_text(f"#!/bin/sh\necho {name} >> {self.marker}\n")
+            p.chmod(0o755)
+
+    def _run(self, argv, **kw):
+        subprocess.run(argv, **kw)
+
+    def test_the_names_are_asked_of_productions_own_resolver_table(self):
+        """Derived, not spelled — the rule `_envguard` states for its own loud set. A
+        scheme added to `reference._RESOLVERS` is guarded on the commit that adds it,
+        which is the difference between a guard and a list somebody has to remember."""
+        from charter.secrets import reference
+        self.assertEqual(sorted(_planeguard._VAULT_CLIS), ["npx", "op", "vault"])
+        self.assertEqual(sorted(reference._RESOLVERS), ["browser", "op", "vault"])
+
+    def test_reading_a_real_1password_item_is_refused(self):
+        """The exact argv the four measured invocations carried."""
+        with self.assertRaises(_planeguard.RealVaultReach) as caught:
+            self._run([str(self.dir / "op"), "item", "get", "charter-devops",
+                       "--vault", "Eng", "--format", "json"])
+        self.assertFalse(self.marker.exists(), "refused, and yet it ran")
+        self.assertIn("REFUSED", str(caught.exception))
+
+    def test_a_bare_name_on_the_path_is_refused_too(self):
+        """How charter actually spells it: `onepassword._argv` builds `["op", …]` and
+        lets `$PATH` resolve it, so a guard that only recognised full paths would miss
+        every real call."""
+        with self.assertRaises(_planeguard.RealVaultReach):
+            self._run(["op", "read", "--no-newline", "op://Eng/charter-devops/AWS_KEY"],
+                      env={**os.environ, "PATH": f"{self.dir}:{os.environ['PATH']}"})
+        self.assertFalse(self.marker.exists())
+
+    def test_the_other_resolvers_are_refused_on_the_same_terms(self):
+        """`vault kv get` and the browser lane's `npx` read credentials just as `op`
+        does — one reaches a HashiCorp Vault, the other a logged-in browser session (and
+        pulls a package off the network to do it)."""
+        for argv in (["vault", "kv", "get", "-field=TOKEN", "secret/data/app"],
+                     ["npx", "--yes", "@playwright/cli@0.1.18", "session", "read"]):
+            with self.subTest(cli=argv[0]), \
+                    self.assertRaises(_planeguard.RealVaultReach):
+                self._run(argv, env={**os.environ,
+                                     "PATH": f"{self.dir}:{os.environ['PATH']}"})
+        self.assertFalse(self.marker.exists())
+
+    def test_a_wrapper_in_front_of_it_is_followed(self):
+        """`_launcher_argv` is production's own command reader, and it is used here for
+        the same reason `_charter_argv` uses it: a wrapper is not a disguise."""
+        with self.assertRaises(_planeguard.RealVaultReach):
+            self._run(["env", "OP_ACCOUNT=x", str(self.dir / "op"), "item", "list"])
+        self.assertFalse(self.marker.exists())
+
+    def test_the_message_names_the_test_the_cli_and_the_way_out(self):
+        with self.assertRaises(_planeguard.RealVaultReach) as caught:
+            self._run([str(self.dir / "op"), "item", "list"])
+        msg = str(caught.exception)
+        self.assertIn("TheOperatorsCredentialStoreIsNeverReached."
+                      "test_the_message_names_the_test_the_cli_and_the_way_out", msg)
+        self.assertIn("op", msg)
+        self.assertIn("runner", msg)             # the way out five modules already take
+        self.assertIn("shutil.which", msg)       # and its second half
+
+    def test_it_is_a_base_exception_so_charters_own_fallbacks_cannot_eat_it(self):
+        """`ReferenceProvider.health` answers a `VaultError` with a status string, and
+        `doctor` catches broadly around every check: a tripwire either of those can
+        swallow becomes a red line in a report instead of a failed test."""
+        self.assertTrue(issubclass(_planeguard.RealVaultReach, BaseException))
+        self.assertFalse(issubclass(_planeguard.RealVaultReach, Exception))
+
+    def test_an_unrelated_binary_of_the_same_shape_really_runs(self):
+        """The half that proves an absent marker above means "never started". `git` is
+        spawned by this suite constantly and must stay spawnable."""
+        self._run([str(self.dir / "git"), "status"])
+        self.assertEqual(self.marker.read_text().strip(), "git")
+
+    def test_the_guard_does_not_wait_on_a_plane(self):
+        """Checked BEFORE the plane question and without `_REAL_ROOT`: reading somebody's
+        1Password vault is wrong on a machine that has no control plane at all, and a
+        guard armed only when one is resolvable would be off in exactly that case."""
+        with mock.patch.object(_planeguard, "_REAL_ROOT", ()), \
+                self.assertRaises(_planeguard.RealVaultReach):
+            self._run([str(self.dir / "op"), "item", "list"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -996,6 +996,35 @@ class TheOperatorsCredentialStoreIsNeverReached(unittest.TestCase):
         self.assertFalse(self.marker.exists(), "refused, and yet it ran")
         self.assertIn("REFUSED", str(caught.exception))
 
+    def test_a_path_object_as_the_whole_command_is_refused(self):
+        """`Popen` accepts one path-like as the entire command, and it is not iterable —
+        so the branch that normalises it is the difference between recognising this and
+        answering "not a credential CLI" for something that is about to run `op`."""
+        with self.assertRaises(_planeguard.RealVaultReach):
+            subprocess.Popen(Path(self.dir / "op"))
+        self.assertFalse(self.marker.exists())
+
+    def test_a_bare_string_as_the_whole_command_is_refused(self):
+        """Without `shell=True` a string is one program name and no arguments — a
+        different branch from the shell case below, and from the argv list above."""
+        with self.assertRaises(_planeguard.RealVaultReach):
+            subprocess.Popen(str(self.dir / "op"))
+        self.assertFalse(self.marker.exists())
+
+    def test_a_command_that_is_all_wrapper_leaves_no_program_to_name(self):
+        """`Popen(["env"])` really runs `env`, and `_launcher_argv` strips the wrapper —
+        so what reaches the name check is an EMPTY argv. Not a hypothetical branch: the
+        guard runs on every spawn in the suite, and one that indexed `argv[0]` here would
+        turn an ordinary command into an `IndexError` raised from inside a tripwire."""
+        p = subprocess.run(["env"], capture_output=True)
+        self.assertEqual(p.returncode, 0)
+
+    def test_a_spawn_with_no_command_at_all_is_left_to_subprocess(self):
+        """Asked of the decision function directly, because `Popen(None)` never gets far
+        enough to prove anything: the guard must decline rather than raise a `TypeError`
+        of its own from inside somebody else's spawn."""
+        self.assertIsNone(_planeguard._reaches_a_credential_cli(None, {}))
+
     def test_a_bare_name_on_the_path_is_refused_too(self):
         """How charter actually spells it: `onepassword._argv` builds `["op", …]` and
         lets `$PATH` resolve it, so a guard that only recognised full paths would miss

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -954,6 +954,23 @@ class TheOperatorsCredentialStoreIsNeverReached(unittest.TestCase):
         with mock.patch("charter.secrets.reference._RESOLVERS", {}):
             self.assertEqual(_planeguard._credential_clis(), frozenset({"op"}))
 
+    def test_a_scheme_whose_uri_this_file_cannot_spell_costs_one_name_not_the_suite(self):
+        """The probe URIs live here and the builders live in production, so a scheme
+        arriving with a shape this file has not learned makes the lookup raise. The choice
+        is between guarding one CLI fewer and refusing to import the `tests` package, and
+        the skip is what picks the first — with the seeded `op` keeping the degraded answer
+        from being empty. A sweep survivor until it had this case (#569)."""
+        from charter.secrets import reference
+
+        def _never_called(uri, config):     # pragma: no cover - the lookup raises first
+            raise AssertionError("a scheme with no probe URI must not reach its builder")
+
+        with mock.patch("charter.secrets.reference._RESOLVERS",
+                        {"quantum": _never_called, "vault": reference._vault_argv}):
+            self.assertEqual(_planeguard._credential_clis(),
+                             frozenset({"op", "vault"}),
+                             "the unspellable scheme took the rest of the table with it")
+
     def test_a_shell_string_that_runs_it_is_refused(self):
         """`shell=True` hands the whole string to `/bin/sh -c`, so the program name is
         inside it rather than in `argv[0]`. Nothing in charter spells a vault read that

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -945,6 +945,32 @@ class TheOperatorsCredentialStoreIsNeverReached(unittest.TestCase):
         self.assertEqual(sorted(_planeguard._VAULT_CLIS), ["npx", "op", "vault"])
         self.assertEqual(sorted(reference._RESOLVERS), ["browser", "op", "vault"])
 
+    def test_op_is_named_even_if_the_table_stops_naming_it(self):
+        """`OnePasswordProvider._argv` spells `op` inline and has no table to ask, so the
+        derivation seeds it unconditionally. Today the `op://` resolver produces the same
+        name and the seed looks redundant — this is what makes it not: with the table
+        emptied, the provider charter writes 1Password items through is still guarded.
+        """
+        with mock.patch("charter.secrets.reference._RESOLVERS", {}):
+            self.assertEqual(_planeguard._credential_clis(), frozenset({"op"}))
+
+    def test_a_shell_string_that_runs_it_is_refused(self):
+        """`shell=True` hands the whole string to `/bin/sh -c`, so the program name is
+        inside it rather than in `argv[0]`. Nothing in charter spells a vault read that
+        way; a test could, and the point of a tripwire is the spelling nobody planned."""
+        with self.assertRaises(_planeguard.RealVaultReach):
+            subprocess.run(f"{self.dir}/op item list", shell=True)
+        self.assertFalse(self.marker.exists())
+
+    def test_a_shell_string_that_will_not_lex_is_not_guessed_at(self):
+        """The direction this guard chooses to be wrong in, said out loud: splitting a
+        shell string is the shell's job and `shlex` only approximates it, so an unlexable
+        command is answered "not a credential CLI" rather than refused. `RealPlaneSpawn`
+        chooses the opposite for charter, because there the cost of a miss is a write to a
+        live plane; here a miss is a `git`-shaped command that nobody could run."""
+        subprocess.run(f"{self.dir}/git 'unclosed", shell=True, capture_output=True)
+        self.assertFalse(self.marker.exists())      # sh refused it; nothing was reached
+
     def test_reading_a_real_1password_item_is_refused(self):
         """The exact argv the four measured invocations carried."""
         with self.assertRaises(_planeguard.RealVaultReach) as caught:
@@ -972,6 +998,17 @@ class TheOperatorsCredentialStoreIsNeverReached(unittest.TestCase):
                     self.assertRaises(_planeguard.RealVaultReach):
                 self._run(argv, env={**os.environ,
                                      "PATH": f"{self.dir}:{os.environ['PATH']}"})
+        self.assertFalse(self.marker.exists())
+
+    def test_a_program_that_merely_resolves_to_it_is_refused(self):
+        """`_program_names` follows the link and the `$PATH` lookup, so a basename compare
+        cannot be walked past. charter's own spellings would never do this — which is the
+        point: a guard is for the spelling nobody planned, and this one was a survivor of
+        the hand-check until it had a case (#569)."""
+        link = self.dir / "not-op-at-all"
+        link.symlink_to(self.dir / "op")
+        with self.assertRaises(_planeguard.RealVaultReach):
+            self._run([str(link), "item", "list"])
         self.assertFalse(self.marker.exists())
 
     def test_a_wrapper_in_front_of_it_is_followed(self):

--- a/tests/test_vault_registration.py
+++ b/tests/test_vault_registration.py
@@ -10,17 +10,102 @@ unreachable. Observed during a real migration, where three vaults were re-regist
 It also broke the rule the rest of charter states and follows — additive: never delete or
 rename a user's thing to make room; name the blocker and refuse. `init`, `reinit` and
 `_create_baseline_dirs` all work that way.
+
+**Nothing here may reach a real credential store, and until #546 two cases did.**
+`cmd_vault_add` finishes by calling `prov.health()`, and for a `1password` vault that
+shells out — so `test_force_does_not_migrate_and_says_so` and
+`test_the_account_pin_never_travels` ran the operator's OWN `op` binary against the vault
+names their own fixtures spell (`Eng`, `Engineering`). Measured by putting a logging
+stand-in for `op` first on `$PATH` and running the whole suite: four invocations, from
+those two tests, and no others anywhere in 6636. They passed because an unauthenticated
+`op` exits non-zero in well under a second and the provider then reports a vault it cannot
+read — the right answer, by luck. `op` **blocks** instead when it has no usable session and
+a human could be asked, and the suite then parks in `subprocess.communicate` behind a
+biometric prompt: measured at 15 minutes inside a fresh tmux pane, with
+`python3 -m unittest discover -s tests` never finishing.
+
+So `_no_real_op` is applied to every case in this file rather than to the two that were
+caught, on the same reasoning `_launch`'s tty pins carry: the next case here will be
+written by copying its neighbour. It is the pattern the five sibling `op` modules already
+use — a fake on `OnePasswordProvider.runner` plus a stubbed `shutil.which` — spelled the
+way `test_op_schema_is_told_the_same_everywhere.py` spells it, because that module drives
+`cmd_vault_add` too and therefore has to reach the provider the same indirect way.
+
+The suite-wide half is `tests._planeguard.RealVaultReach`, which refuses the spawn itself,
+so instance three fails on the pull request that adds it rather than on the machine most
+likely to have `op` installed — the operator's.
 """
 from __future__ import annotations
 
 import io
+import json
+import os
 import unittest
 from contextlib import redirect_stderr
 from types import SimpleNamespace
+from unittest import mock
 
 from charter import commands_secrets, config
 from charter.secrets import base, registry
+from charter.secrets.onepassword import OnePasswordProvider
 from tests._isolation import PersonaIso
+
+#: `git init` and `git check-ignore` are real subprocesses here (see
+#: `PlaintextMustNotLandInGit`), and both read the machine's git configuration:
+#: `check-ignore` honours `core.excludesFile`, so a developer whose global ignore names
+#: `*.json` or `cfg/` would watch `test_a_tracked_path_is_refused` fail for a reason that
+#: has nothing to do with charter, and `init` honours `init.templateDir`, which can run
+#: hooks. The same two lines a dozen other modules here already carry (`test_git_policy`,
+#: `test_freshness`, `test_reactive_memory`, …).
+_HERMETIC_GIT = {"GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull}
+
+
+class _FakeOp:
+    """Stands in for the `op` CLI, for a vault that has just been registered.
+
+    Deliberately the smallest fake that answers `health()` — the only path `cmd_vault_add`
+    reaches — rather than a sixth full model of `op`. `health()` asks `keys()`, which is
+    one `item get`; a failed `item get` is followed by an `item list` to decide whether the
+    item is absent or merely unreadable (#322), so both are answered. Every value below is
+    an inert fixture string; there is no 1Password vault on this machine to record one
+    from, and nothing here asserts on one.
+    """
+
+    def __init__(self, title: str = "charter-devops") -> None:
+        self.title = title
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv, input=None, **kw):
+        self.calls.append(list(argv))
+        bare = [a for a in argv if not a.startswith("--")]
+        if bare[:3] == ["op", "item", "get"]:
+            return SimpleNamespace(returncode=0, stderr="", stdout=json.dumps({
+                "id": "itm1", "title": self.title, "category": "PASSWORD", "fields": []}))
+        if bare[:3] == ["op", "item", "list"]:
+            return SimpleNamespace(returncode=0, stderr="",
+                                   stdout=json.dumps([{"title": self.title}]))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+def _no_real_op(case) -> _FakeOp:
+    """Point this case's 1Password provider at a fake, and say `op` is installed.
+
+    Both halves are needed and they close different holes. The runner is what a real
+    `op` would be spawned through, and it is set on the CLASS because the provider these
+    tests exercise is built inside `cmd_vault_add` by `registry.provider_for` — there is no
+    instance for a test to reach. `shutil.which` is what the provider checks BEFORE running
+    anything, so without stubbing it the answer would still be the machine's: "op CLI not
+    on PATH" on a bare runner and a real spawn on a laptop that has 1Password installed.
+    """
+    real_runner = OnePasswordProvider.__dict__["runner"]
+    op = _FakeOp()
+    OnePasswordProvider.runner = op
+    case.addCleanup(lambda: setattr(OnePasswordProvider, "runner", real_runner))
+    import charter.secrets.onepassword as mod
+    real_which = mod.shutil.which
+    mod.shutil.which = lambda n: "/usr/local/bin/op" if n == "op" else None
+    case.addCleanup(lambda: setattr(mod.shutil, "which", real_which))
+    return op
 
 
 def _args(name: str, provider: str = "plain-file", **kw) -> SimpleNamespace:
@@ -29,7 +114,16 @@ def _args(name: str, provider: str = "plain-file", **kw) -> SimpleNamespace:
                            persona=kw.pop("persona", None), force=kw.pop("force", False))
 
 
-class RegisteringOverAnExistingName(PersonaIso):
+class VaultRegistrationCase(PersonaIso):
+    """`PersonaIso`, plus the two things this file must not read off the machine."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.op = _no_real_op(self)
+        self.enterContext(mock.patch.dict(os.environ, _HERMETIC_GIT))
+
+
+class RegisteringOverAnExistingName(VaultRegistrationCase):
     def setUp(self) -> None:
         super().setUp()
         registry.add_vault("devops", "plain-file", {"file": str(self.tmp / "devops.json")})
@@ -89,7 +183,7 @@ class RegisteringOverAnExistingName(PersonaIso):
         self.assertIn("fresh", registry.vaults())
 
 
-class TheRegistryIsPortable(PersonaIso):
+class TheRegistryIsPortable(VaultRegistrationCase):
     """Issue #21. The registry recorded one developer's home directory, so a team that
     commits its reference vaults — they hold `op://` URIs, never values — found the vault
     files present on a fresh clone and the index that locates them useless, and scripted
@@ -148,7 +242,7 @@ class TheRegistryIsPortable(PersonaIso):
         self.assertEqual(registry.provider_for("b").path, self.tmp / "x" / "b.json")
 
 
-class SharedAndLocalHalves(PersonaIso):
+class SharedAndLocalHalves(VaultRegistrationCase):
     """#21's remaining half: the registry that *locates* committed vaults must travel too.
 
     `vaults.json` at the plane root is committed; `.charter/vaults.json` stays local and
@@ -242,7 +336,7 @@ class SharedAndLocalHalves(PersonaIso):
         self.assertEqual(_stat.S_IMODE(config.VAULTS_REGISTRY.stat().st_mode), 0o600)
 
 
-class PlaintextMustNotLandInGit(PersonaIso):
+class PlaintextMustNotLandInGit(VaultRegistrationCase):
     """A plain-file vault holds PLAINTEXT. The default sits under `.charter/`, which
     `charter init` gitignores — but `--file` accepts any path, and a vault pointed at one
     git tracks commits the credentials on the next `charter save`. Nothing said so:
@@ -251,6 +345,13 @@ class PlaintextMustNotLandInGit(PersonaIso):
     The PATH is refused, not `--share`: a team that provisions the file out of band has a
     legitimate use for a shared pointer, and the unignored path is the actual defect — it
     also catches the far more common case where `--share` was never passed at all.
+
+    This is the class that runs REAL git — `git init` here, and `git check-ignore` inside
+    `_unignored_plaintext` — so it is also the class whose answer the machine could decide.
+    That is not charter being wrong: `check-ignore` honours global excludes on purpose, and
+    `_unignored_plaintext` says so, because the question is "would git take this file" and
+    git is the authority. It is the FIXTURE that must not be the operator's. See
+    `test_the_machines_own_git_configuration_does_not_decide_this` for the measurement.
     """
 
     def setUp(self) -> None:
@@ -270,6 +371,19 @@ class PlaintextMustNotLandInGit(PersonaIso):
         self.assertEqual(rc, 1)
         self.assertIn("NOT gitignored", err)
         self.assertNotIn("leaky", registry.vaults())
+
+    def test_the_machines_own_git_configuration_does_not_decide_this(self):
+        """Whether `cfg/leaky.json` is "tracked" is git's answer, and git's answer includes
+        `core.excludesFile` — so a developer whose global ignore names `cfg/` or `*.json`
+        would watch the case above go red for a reason that has nothing to do with charter.
+
+        Measured, not supposed: with a global config whose `excludesFile` holds `cfg/`,
+        `test_a_tracked_path_is_refused` fails (`0 != 1`) without the two variables below
+        and passes with them. `init.templateDir` is the other half — `git init` runs hooks
+        out of it — which is why the system config is neutralised too.
+        """
+        self.assertEqual(os.environ["GIT_CONFIG_GLOBAL"], os.devnull)
+        self.assertEqual(os.environ["GIT_CONFIG_SYSTEM"], os.devnull)
 
     def test_the_gitignored_default_is_fine(self):
         rc, _ = self._add("ok")

--- a/tests/test_vault_registration.py
+++ b/tests/test_vault_registration.py
@@ -60,37 +60,41 @@ from tests._isolation import PersonaIso
 _HERMETIC_GIT = {"GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull}
 
 
+#: What `op` writes for an item that is not there. charter deliberately does not match on
+#: this text — absence is PROVEN by a successful listing (#322) — so nothing depends on its
+#: wording. Copied from `test_op_reads_the_item_once.py`, which recorded it against
+#: op 2.34.0.
+_NO_SUCH_ITEM = '[ERROR] 2026/08/20 11:02:31 "charter-devops" isn\'t an item.'
+
+
 class _FakeOp:
-    """Stands in for the `op` CLI, for a vault that has just been registered.
+    """`op`, for the one vault state `cmd_vault_add` can ever be looking at: a vault that
+    was registered a moment ago and whose item therefore does not exist yet.
 
     Deliberately the smallest fake that answers `health()` — the only path `cmd_vault_add`
-    reaches — rather than a sixth full model of `op`. `health()` asks `keys()`, which is
-    one `item get`; a failed `item get` is followed by an `item list` to decide whether the
-    item is absent or merely unreadable (#322), so both are answered. Every value below is
-    an inert fixture string; there is no 1Password vault on this machine to record one
-    from, and nothing here asserts on one.
+    reaches — rather than a sixth full model of `op`. Modelling the item as ABSENT is what
+    makes both of its branches live: `keys()` makes one `item get`, which fails, and a
+    failed `item get` is followed by an `item list` because a vault charter could not read
+    is not a vault with no secrets (#322). A fake whose `item get` succeeded would leave
+    the listing unreachable, and a fake with an unreachable branch is a fake nobody can
+    tell is still right.
+
+    Anything else asked of it is an error rather than a bland success: a silent
+    ``returncode=0, stdout=""`` is how a fake starts answering a question it does not
+    model, and `op`'s callers read empty output as data.
     """
 
     def __init__(self) -> None:
         self.calls: list[list[str]] = []
-        #: Titles the fake vault holds. Filled from whatever item was last asked for, so
-        #: `_legacy_items` — which matches on `charter-<vault>-` — is answered about the
-        #: item under test rather than about a name this fake invented.
-        self.titles: list[str] = []
 
     def __call__(self, argv, input=None, **kw):
         self.calls.append(list(argv))
-        bare = [a for a in argv if not a.startswith("--")]
-        if bare[:3] == ["op", "item", "get"]:
-            title = bare[3] if len(bare) > 3 else "charter-devops"
-            if title not in self.titles:
-                self.titles.append(title)
-            return SimpleNamespace(returncode=0, stderr="", stdout=json.dumps({
-                "id": "itm1", "title": title, "category": "PASSWORD", "fields": []}))
-        if bare[:3] == ["op", "item", "list"]:
-            return SimpleNamespace(returncode=0, stderr="",
-                                   stdout=json.dumps([{"title": t} for t in self.titles]))
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if argv[1:3] == ["item", "get"]:
+            return SimpleNamespace(returncode=1, stdout="", stderr=_NO_SUCH_ITEM)
+        if argv[1:3] == ["item", "list"]:
+            return SimpleNamespace(returncode=0, stdout=json.dumps([]), stderr="")
+        raise AssertionError(f"the fake `op` was asked for something `cmd_vault_add` does "
+                             f"not do: {argv}")
 
 
 def _no_real_op(case) -> _FakeOp:
@@ -178,6 +182,15 @@ class RegisteringOverAnExistingName(VaultRegistrationCase):
         self.assertIn("no secrets yet in item 'charter-devops'", out)
         self.assertNotIn("not on PATH", out)
         self.assertTrue(self.op.calls, "the fake was never reached")
+
+    def test_the_op_stub_answers_for_op_and_for_nothing_else(self):
+        """`shutil.which` is patched on the MODULE object, so the stub is global for the
+        duration of every case here — `charter.util.run`, `doctor` and anything else that
+        asks goes through it. Answering every name would put a different lie in place of
+        the one it removes, which is why the stub is a conditional and not a constant."""
+        import shutil as _sh
+        self.assertEqual(_sh.which("op"), "/usr/local/bin/op")
+        self.assertIsNone(_sh.which("charter-definitely-not-a-real-binary-xyz"))
 
     def test_force_does_not_migrate_and_says_so(self):
         """`--force` is an override, not a migration. Moving secrets between providers is

--- a/tests/test_vault_registration.py
+++ b/tests/test_vault_registration.py
@@ -71,19 +71,25 @@ class _FakeOp:
     from, and nothing here asserts on one.
     """
 
-    def __init__(self, title: str = "charter-devops") -> None:
-        self.title = title
+    def __init__(self) -> None:
         self.calls: list[list[str]] = []
+        #: Titles the fake vault holds. Filled from whatever item was last asked for, so
+        #: `_legacy_items` — which matches on `charter-<vault>-` — is answered about the
+        #: item under test rather than about a name this fake invented.
+        self.titles: list[str] = []
 
     def __call__(self, argv, input=None, **kw):
         self.calls.append(list(argv))
         bare = [a for a in argv if not a.startswith("--")]
         if bare[:3] == ["op", "item", "get"]:
+            title = bare[3] if len(bare) > 3 else "charter-devops"
+            if title not in self.titles:
+                self.titles.append(title)
             return SimpleNamespace(returncode=0, stderr="", stdout=json.dumps({
-                "id": "itm1", "title": self.title, "category": "PASSWORD", "fields": []}))
+                "id": "itm1", "title": title, "category": "PASSWORD", "fields": []}))
         if bare[:3] == ["op", "item", "list"]:
             return SimpleNamespace(returncode=0, stderr="",
-                                   stdout=json.dumps([{"title": self.title}]))
+                                   stdout=json.dumps([{"title": t} for t in self.titles]))
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
 
@@ -152,6 +158,26 @@ class RegisteringOverAnExistingName(VaultRegistrationCase):
     def test_force_replaces(self):
         registry.add_vault("devops", "1password", {"op-vault": "Eng"}, force=True)
         self.assertEqual(registry.vaults()["devops"]["provider"], "1password")
+
+    def test_the_fake_answers_the_health_line_rather_than_the_machine(self):
+        """The other half of `_no_real_op`, and the half a passing suite does not prove.
+
+        Faking the runner alone stops the SPAWN; it does not stop `health()` reading the
+        machine, because the provider checks `shutil.which("op")` before it runs anything
+        and returns "op CLI not on PATH" when it is absent. So without the `which` stub
+        this command's last line is one thing on a bare CI runner and another on a laptop
+        with 1Password installed — the same ambient read as the spawn, one layer up, and
+        `cmd_vault_add`'s output is where it shows. Found as a survivor of the hand-check
+        (#569): every other case here passed with that stub deleted.
+        """
+        err = io.StringIO()
+        with redirect_stderr(err):
+            commands_secrets.cmd_vault_add(
+                _args("devops", "1password", op_vault="Eng", force=True))
+        out = err.getvalue()
+        self.assertIn("no secrets yet in item 'charter-devops'", out)
+        self.assertNotIn("not on PATH", out)
+        self.assertTrue(self.op.calls, "the fake was never reached")
 
     def test_force_does_not_migrate_and_says_so(self):
         """`--force` is an override, not a migration. Moving secrets between providers is


### PR DESCRIPTION
Closes #546. Closes #545.

Two ways charter's own suite reached out of the repo and blocked. Both are fixed the way
the plane guards were: **remove the reach, then refuse the next one** — a stub silences an
instance, a tripwire fails the pull request that adds instance N+1.

## #546 — two tests read the operator's real 1Password vault

`cmd_vault_add` finishes with `prov.health()`, and a `1password` vault answers that by
shelling out. So `test_force_does_not_migrate_and_says_so` and
`test_the_account_pin_never_travels` ran the operator's own `op` against the vault names
their own fixtures spell.

**Reproduced on `b3dbd54`** with a logging stand-in for `op` first on `$PATH`, full suite:

```
op item get  charter-devops --vault Eng         --format json
op item list                --vault Eng         --format json
op item get  charter-ops    --vault Engineering --format json
op item list                --vault Engineering --format json
```

Four invocations, two tests, none anywhere else in 6636 — exactly what the issue reported.
They pass because an unauthenticated `op` exits non-zero in well under a second; they
**hang** when it prompts instead, which is what a machine with 1Password installed and an
expired session produces. That machine is the operator's, never CI's — which is why
"skip it if `op` is missing" would have removed the test from precisely the place it
matters.

* `tests/test_vault_registration.py` now drives a fake, in the shape the five sibling `op`
  modules already use — `OnePasswordProvider.runner` set on the **class** (the provider is
  built inside `cmd_vault_add` by `registry.provider_for`, so a test has no instance to
  reach) plus a stubbed `shutil.which`. Spelled the way
  `test_op_schema_is_told_the_same_everywhere.py` spells it, because that module drives
  `cmd_vault_add` too. Applied to every case in the file, not the two that were caught.
* `tests/_planeguard.RealVaultReach` refuses a `Popen` of `op`, `vault` or the browser
  lane's `npx` from any test, before the plane question and without waiting on
  `_REAL_ROOT` — reading somebody's credential store is wrong on a machine with no plane
  at all. Which CLIs count is asked of `reference._RESOLVERS`, production's own scheme
  table, so a provider added there is covered on the commit that adds it.

## #545 — a hang, and it was 123 tests rather than two

`_picker_wanted` gates the workspace picker on **two** questions,
`sys.stdin.isatty() and sys.stdout.isatty()`. The launcher helpers pinned the second and
inherited the first.

**Measured on `b3dbd54`**, `input()` replaced by a recording raise and the full suite run
under a pty: **126 blocked calls across 122 tests**, all in `test_frame_launcher` — plus a
123rd in `test_frame_tmux_integration`, whose launch runs on a worker thread and so
reported "the frame's own window never appeared" instead of hanging. The issue named two
helpers; the enumeration found seven declaration sites in `test_frame_launcher` and one in
a second file.

* `tests/_ttyguard.py` — installed **first** in `tests/__init__.py`, above the import that
  pulls charter in, because `util._USE_COLOR` is `sys.stderr.isatty()` read at *that*
  import. All three streams answer what CI answers, and `sys.stdin` is `devnull`, so a
  path that reaches a prompt anyway raises `EOFError` rather than blocking.
* And a **targeted read of `sys.stdin.isatty()` is refused** while a test runs unless the
  test said which answer it wants. Only stdin is loud, on `_envguard`'s own boundary:
  stdout decides formatting and routing and is already pinned at thirteen sites; stdin
  decides whether charter *stops and asks a human*, which is the one whose wrong answer is
  a process that never returns. The refusal is what makes the eight one-line pins
  load-bearing instead of decorative — delete one and those tests fail by name.

## Siblings found by enumerating rather than fixing what was named

* **`test_frame_tmux_integration.py`** — the 123rd instance above, in a file neither issue
  names.
* **`test_vault_registration.py` runs real `git`** — `git init` in `setUp`, and
  `git check-ignore` inside `_unignored_plaintext`, which honours `core.excludesFile` by
  design. Measured: with `cfg/` in a global ignore, `test_a_tracked_path_is_refused` fails
  (`0 != 1`). Neutralised with the `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pair a dozen
  other modules here already carry.

## Verification

Full suite in three environments, each in a fresh clone (so `config.ROOT` is the clone,
not the operator's plane), with a logging stand-in for `op` first on `$PATH`:

| environment | result | real `op` spawns |
|---|---|---|
| python3.14, stdin a pipe | `Ran 6679 tests` **OK** | 0 |
| python3.12, `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset | `Ran 6679 tests` **OK** | 0 |
| python3.14, **real pty on stdin, stdout and stderr** | `Ran 6679 tests`, 28 failures, **no hang** | 0 |

Baseline for comparison, the same measurement on `b3dbd54`: **OK** under a pipe with 4 real
`op` spawns, and under a pty 126 blocked `input()` calls plus 32 failures.

The third row is the one CI structurally cannot run — #545 only reproduces where stdin is
a terminal, and a runner's never is.

**Still not identical from a terminal, and said out loud.** Those 28 are all
terminal-**size**, not tty-ness: the pty was opened without a window size, so
`os.get_terminal_size()` reports **0 columns**, `tui.term_width` clamps that to its
24-column floor, and eight rendering modules assert against a squeezed status line. Set the
same pty to 200x50 and all 28 pass. That is #544's family and it is not touched here — but
the measurement sharpens it: `term_width` guards `$COLUMNS <= 0` and does **not** guard
`os.get_terminal_size().columns <= 0`, which is the same defect one rung down its own
ladder, and reachable in production by any pty whose size was never set.

## Mutation testing

`tools/sweep.py --path charter`: nothing under `charter/` changed, so nothing to sweep.

`tools/sweep.py --path tests` was run twice. First pass, on the first head: **32 mutations,
12 pinned, 20 survivors.** Second pass, after fixing them: **24 mutations, 22 pinned, 2
survivors** — one of which is the `if __name__ == "__main__"` trailer that 330 of this
repo's 337 test modules carry and that discovery never runs; the other is fixed in the last
commit and hand-verified in both directions.

Nine of the twenty were one finding: `_reaches_a_credential_cli` had copied
`_charter_argv`'s full defensive shape, most of which is unreachable in a function that
only ever sees a third-party binary in `argv[0]` — `_decoded` answers `None` only for a
value that is neither `str`, `bytes` nor `PathLike`, and `os.fsdecode`'s surrogateescape
means it cannot fail on the two spellings that get there. Deleted rather than suppressed;
this repo's own doctrine is that "equivalent mutant" and "dead code" are the same finding.
The rest are reachable and are now driven: `_ttyguard`'s two install fallbacks became named
functions so a stream that cannot answer and one that will not take an answer can both be
handed to them; `install()`'s idempotence, the `_active` disarm, and the globalness of the
`shutil.which` stub each got the case they were missing; and `_FakeOp` now models the vault
state `cmd_vault_add` can actually be looking at — an item that does not exist yet — which
is what makes both of its branches live.

One of those fixes was itself wrong the first time, and the sweep is what said so: the case
for "a bare string is a program name, not a command line" first put `op` under a directory
called `vault dir`, whose first lexed word is `vault` — itself a guarded CLI — so the
mutation it exists to catch stayed green by being refused for the wrong reason.

`tools/sweep.py` has no operator for string constants or semantic swaps (#569), so those
were hand-checked in two passes, **33 mutations, 33 pinned**, each asserting its edit
actually applied (#585 — an edit whose old text never matched runs an unmutated tree and
reports a false survivor) and each subset run against an unmutated baseline first.

News entry added, `version: unreleased`. No bump, no stamp, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
