### PR TITLE
Pin the twelve guards the sweep found unpinned in #505

### DIFF
--- a/tests/test_memstore.py
+++ b/tests/test_memstore.py
@@ -91,6 +91,58 @@ class MemstoreCase(PersonaIso):
         self.assertFalse(memstore.forget(self.d, "nope"))
 
 
+class TheIndexIsExactlyTheLinesThatSurvive(MemstoreCase):
+    """Two one-line conditionals in `memstore`, neither of which had a case.
+
+    Both sit on lines #505 rewrote (`write_text` → `config.write_for`), so the sweep
+    charged them to that change and found them unpinned. The logic predates it; the cases
+    do not, and "the line was already like that" is not a reason to leave a guard nobody
+    can delete safely.
+    """
+
+    def test_the_header_gets_exactly_one_trailing_newline(self) -> None:
+        """`ensure_index` adds one only when the caller did not. Collapsed either way the
+        index starts with a doubled blank line or with none, and every later append lands
+        against a header that is not the shape `index_append` writes after."""
+        for label, header in (("caller ended it", "# Memory Index\n"),
+                              ("caller did not", "# Memory Index")):
+            with self.subTest(label):
+                d = persona.memory_dir(f"hdr-{len(header)}")
+                d.mkdir(parents=True, exist_ok=True)
+                idx = memstore.ensure_index(d, header)
+                self.assertEqual(idx.read_text(), "# Memory Index\n",
+                                 "the header did not come out with exactly one newline")
+
+    def test_dropping_the_only_line_leaves_an_empty_index_not_a_blank_one(self) -> None:
+        """`_drop_index_line` appends a trailing newline only when something is left.
+
+        Reaching "nothing is left" takes an index with no header — a hand-written one, or
+        one an older charter wrote — because otherwise the header lines survive every drop
+        and the conditional never takes its other branch. That is also what makes it worth
+        a case: the branch is only ever exercised by a file charter did not write, which is
+        the class of input nobody runs by hand. A lone ``"\n"`` is a file with one blank
+        line in it, and `index_drift` reads a blank line back as an entry that does not
+        resolve.
+        """
+        memstore.write(self.d, "only fact", "Solo")
+        idx = memstore.index_path(self.d)
+        idx.write_text("- [Solo](solo.md)\n")      # no header: the drop empties it
+        memstore.forget(self.d, "solo")
+        self.assertEqual(idx.read_text(), "",
+                         "the index kept a blank line where its last entry had been")
+
+    def test_dropping_one_of_several_keeps_the_rest_newline_terminated(self) -> None:
+        """The other side of the same conditional — a file that does not end in a newline
+        is one every later append runs onto the end of."""
+        memstore.write(self.d, "first", "Alpha")
+        memstore.write(self.d, "second", "Beta")
+        memstore.forget(self.d, "alpha")
+        text = memstore.index_path(self.d).read_text()
+        self.assertNotIn("(alpha.md)", text)
+        self.assertIn("(beta.md)", text)
+        self.assertTrue(text.endswith("\n"), f"index does not end in a newline: {text!r}")
+
+
 class SearchFindsShortAndDistinctiveTerms(PersonaIso):
     """`_terms` discarded every token of two characters or fewer.
 

--- a/tests/test_the_state_directory_is_charters_to_choose.py
+++ b/tests/test_the_state_directory_is_charters_to_choose.py
@@ -84,6 +84,8 @@ at 002, and neither run would be measuring independence from it.
 
 from __future__ import annotations
 
+import errno
+import fcntl
 import json
 import os
 import shutil
@@ -801,6 +803,137 @@ class TheDispatchOnWhereTheFileIs(PersonaIso):
         one place the constant itself is named, so a change to it is a decision somebody
         made rather than a test quietly following along."""
         self.assertEqual(config.STATE_FILE_MODE, 0o600)
+
+    def test_append_is_o_append_on_the_descriptor_and_truncation_is_not(self) -> None:
+        """`O_APPEND` is a kernel flag, not a starting position, and the difference only
+        shows under concurrency — which is exactly where `trace.record` lives.
+
+        `os.fdopen(fd, "a")` seeks to the end even on a descriptor that lacks `O_APPEND`,
+        so appending *looks* correct either way and every content assertion in this class
+        passes. What `O_APPEND` buys is that each write is positioned at the end **by the
+        kernel, atomically**: two hooks appending to the same trace log in the same instant
+        interleave rather than overwrite. The flag is read back off the descriptor here
+        because there is no non-flaky way to observe that through two processes, and
+        "measured on the wrong thing" is worse than measuring the flag.
+        """
+        for append, want in ((True, True), (False, False)):
+            with self.subTest(append=append):
+                p = self.sd / f"flags-{append}"
+                fd = config._private_fd(p, append=append)
+                try:
+                    got = bool(fcntl.fcntl(fd, fcntl.F_GETFL) & os.O_APPEND)
+                finally:
+                    os.close(fd)
+                self.assertEqual(got, want,
+                                 f"O_APPEND {'missing from' if want else 'set on'} the "
+                                 f"descriptor for append={append}")
+
+    def test_a_filesystem_that_cannot_hold_a_mode_still_gets_its_write(self) -> None:
+        """The trade `_private_fd` documents, as a case rather than a paragraph.
+
+        exFAT and many network mounts accept the state directory and cannot hold a mode.
+        `secrets.plain_file` refuses to write there — the right call for plaintext secrets,
+        which it reads the mode back to prove. Everything else under `.charter/` is a hook,
+        a status line or a marker, and refusing would take the plane down to protect a mode
+        the filesystem was never going to keep. So the `fchmod` failure is swallowed and
+        the write happens; deleting that `except` would turn every `charter` invocation on
+        such a mount into a traceback.
+        """
+        real = os.fchmod
+        calls = []
+
+        def refuse(fd, mode):
+            calls.append(mode)
+            raise OSError(45, "Operation not supported")
+
+        p = self.sd / "fixed-mode.json"
+        os.fchmod = refuse
+        try:
+            config.write_for(p, "written anyway")
+            self._append(self.sd / "fixed-mode.log", "line\n")
+            config.touch_for(self.sd / "fixed-mode.marker")
+        finally:
+            os.fchmod = real
+        self.assertTrue(calls, "the mode was never even attempted")
+        self.assertEqual(p.read_text(), "written anyway")
+
+    def test_a_failure_between_the_open_and_the_wrapper_does_not_leak_the_descriptor(self) -> None:
+        """`BaseException`, not `Exception`, and that width is the whole point.
+
+        Between `os.open` and `os.fdopen` the descriptor is owned by nothing: no `with`
+        holds it and no file object has taken it over yet. `KeyboardInterrupt` and
+        `GeneratorExit` are not `Exception`s, and both reach exactly that window — a
+        status line rendering on every prompt, a hook interrupted mid-turn. A narrower
+        `except` leaks one descriptor per interrupted write, which is invisible until a
+        long-lived process runs out of them.
+        """
+        seen = []
+        real = os.fdopen
+
+        def interrupt(fd, *a, **kw):
+            seen.append(fd)
+            raise KeyboardInterrupt
+
+        os.fdopen = interrupt
+        try:
+            with self.assertRaises(KeyboardInterrupt):
+                config.write_for(self.sd / "interrupted.json", "{}")
+        finally:
+            os.fdopen = real
+        self.assertEqual(len(seen), 1, "the descriptor was never opened")
+        with self.assertRaises(OSError) as caught:
+            os.fstat(seen[0])
+        self.assertEqual(caught.exception.errno, errno.EBADF,
+                         "the descriptor is still open — an interrupted write leaked it")
+
+    def test_text_is_utf_8_whatever_the_locale_says(self) -> None:
+        """Both branches of the dispatch, because both name the encoding.
+
+        `open()` with no *encoding* uses the platform's locale, which on a runner with a
+        C locale is ASCII — and a trace line carries whatever a persona was called, a
+        memory note whatever somebody wrote. A round-trip of pure ASCII cannot tell the
+        two apart, so the fixture is not ASCII.
+        """
+        text = "persona: Ուսուցիչ · naïve café — 日本語 🔐\n"
+        state = self.sd / "utf8.jsonl"
+        committed = config.PERSONAS_DIR / "steward" / "memory" / "utf8.md"
+        config.mkdir_for(committed.parent)
+        for label, p in (("state", state), ("committed", committed)):
+            with self.subTest(label):
+                config.write_for(p, text)
+                self.assertEqual(p.read_bytes(), text.encode("utf-8"))
+                self.assertEqual(p.read_text(encoding="utf-8"), text)
+
+    def test_the_encoding_argument_is_honoured_on_both_branches(self) -> None:
+        """The case above states the DEFAULT; this one states that it is a default.
+
+        A version of `open_for` that dropped *encoding* and let `open()` fall back to the
+        platform locale passes the utf-8 round-trip on every machine whose locale is
+        already utf-8 — which is this laptop, and was how the first cut of that case went
+        green while proving nothing. utf-16 is not any platform's default: a write that
+        ignored the argument would land utf-8 bytes, or raise on an ASCII locale, and
+        either way it cannot come back as the four bytes below.
+        """
+        want = "é".encode("utf-16")
+        state = self.sd / "utf16.txt"
+        committed = config.PERSONAS_DIR / "steward" / "memory" / "utf16.md"
+        config.mkdir_for(committed.parent)
+        for label, path in (("state", state), ("committed", committed)):
+            with self.subTest(label):
+                with config.open_for(path, "w", encoding="utf-16") as f:
+                    f.write("é")
+                self.assertEqual(path.read_bytes(), want,
+                                 "the encoding argument was not the one used")
+
+    def test_bytes_outside_the_state_directory_are_bytes_too(self) -> None:
+        """The committed branch selects its encoding separately, so it needs its own case:
+        passing an encoding along with a binary mode is a `ValueError`, and only a bytes
+        payload on a committed path reaches that line."""
+        p = config.PERSONAS_DIR / "steward" / "refs" / "blob.bin"
+        config.mkdir_for(p.parent)
+        payload = b"\x00\x01\xff not utf-8: \xc3\x28"
+        config.write_for(p, payload)
+        self.assertEqual(p.read_bytes(), payload)
 
     def test_the_atomic_writers_temp_file_is_private_by_construction(self) -> None:
         """`inflight` and `toolgate` write through a temp file and `os.replace`, which


### PR DESCRIPTION
Follow-up to #584 (#505). **Tests only — no production code changes**, because none of
the twelve findings was a defect. All twelve were the tests asserting too little.

## Why this is a second PR

`tools/sweep.py`'s run against #584 could not reach a verdict: its unmutated baseline ran
**0 tests in 2965s** under machine load, and it correctly refused to call 41 mutants
pinned for a reason that had nothing to do with the guards. Re-run on a quiet box with a
green baseline (6615 tests, 290s) it reported **20 mutations, 11 pinned, 9 survived**,
plus 3 more from the same lines in the second-order pass.

## The findings

| survivor | why it survived |
|---|---|
| `os.O_APPEND if append else 0` (both collapses) | `os.fdopen(fd, "a")` seeks to the end even without the flag, so appending *looks* right either way. What `O_APPEND` buys is that the kernel positions each write atomically — the difference between two hooks interleaving in the trace log and overwriting each other. |
| `except OSError` around the `fchmod` | the exFAT / network-mount trade the docstring describes, and nothing exercised it. |
| `except BaseException` around the un-owned descriptor | wide on purpose: `KeyboardInterrupt` and `GeneratorExit` are not `Exception`s and both reach the window between `os.open` and `os.fdopen`. Narrowed, an interrupted status-line render leaks one descriptor per write. |
| `None if "b" in mode else encoding` ×3 | survived only in the direction that **drops** the encoding — a utf-8 round-trip passes on any machine whose locale is already utf-8, which is this one. |
| `memstore`'s two index conditionals ×4 | pre-existing logic on lines #505 rewrote, so the sweep charged them there. |

## What the cases do about it

- **The `O_APPEND` flag is read back off the descriptor.** There is no non-flaky way to
  observe kernel-atomic append through two processes, and measuring the wrong thing is
  worse than measuring the flag.
- **`os.fchmod` is made to fail** and the write still lands — which is the trade, stated as
  a case rather than a paragraph. `secrets.plain_file` makes the opposite call for the one
  file where refusing is right, and that is already pinned.
- **The descriptor is checked with `os.fstat` after an interrupt** — `EBADF` or it leaked.
- **The encoding fixture is utf-16.** Not any platform's default, so a write that ignored
  the argument lands utf-8 bytes or raises on an ASCII locale, and cannot produce those
  bytes on any runner. The utf-8 case stays as the statement of the *default*; this one
  states that it is a default. Same class of mistake as a test inheriting the ambient
  umask, one environment variable over.
- **`memstore`'s header newline and empty-index branches get cases.** "The line was already
  like that" is not a reason to leave a guard nobody can delete safely. Reaching the second
  took an index with no header — the branch only a file charter did not write can
  exercise, which is also why nobody had run it.

## Verification

Each of the twelve re-applied by hand against an unmutated baseline **before and after**
the batch, so a sandbox that failed to restore cannot turn the table into a lie:
**12/12 caught, 0 survived.**

### And the second-order pass, which is the part that could still have been wrong

"Each half is caught" is exactly the claim second-order testing exists to disprove: one
mutation can mask the other's detection, and a pair then stays green while every mutant in
it looks pinned alone. The sweep's `--second-order` run named **three pairs still green
together** on `64a0b40`, all in `_private_fd` and `_open_private`:

| pair | |
|---|---|
| A | `O_APPEND if append else 0` → `0` **+** `except OSError` → `except ZeroDivisionError` |
| B | `O_APPEND if append else 0` → `os.O_APPEND` **+** `except OSError` → `except ZeroDivisionError` |
| C | `None if "b" in mode else encoding` → `None` **+** `except BaseException` → `except ZeroDivisionError` |

Applied together against this branch, with a baseline before and after: **3/3 caught, 0
survived.**

One note on the sweep's own advice. It marked the `except OSError` narrowing `PLATFORM` —
"on darwin this clause may never be entered at all, which is unreachable rather than
unpinned; push the mutant to a throwaway branch and let CI answer before writing a test."
That is good advice for a clause the OS decides, and it is not needed here: the case makes
`os.fchmod` fail rather than waiting for a filesystem that does, so the clause is entered
on every platform and the question never has to be asked of CI.

Suite green in two environments: **6655 tests** on Python 3.14.4, and on Python 3.12.13
with every `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` variable unset.

No news entry: `CONTRIBUTING.md` asks for one on a user-visible change, and nothing here
is one.

