### PR TITLE
Close the sweep survivors on the roster row builders (#508 follow-up)

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -1339,13 +1339,18 @@ def cmd_persona_stats(args) -> int:
         # A name column with no header of its own, and the same rule as the table above:
         # measured from the names it is about to print, in cells rather than characters.
         # It was `{shown:<26}` and carried #508 identically — one drifted persona with a
-        # long or a CJK name and the `unused:`/`used but not declared:` labels stop
-        # lining up down the block.
-        nw = tui.column("", [contain.one_line(n) for n, _ in drifted])
-        for name, d in drifted:
-            # Same rule as the table: the persona name and the skill names are committed
-            # values landing in a report of one-line rows.
-            shown = tui.pad(contain.one_line(name), nw)
+        # long or a CJK name and the `unused:`/`used but not declared:` labels stop lining
+        # up down the block.
+        #
+        # Bounded ONCE, into the list that both the measure and the print read. Calling
+        # `one_line` twice — inside the width and again at the row — is how a column ends
+        # up measured from one string and filled with another, which is #472's mis-measure
+        # and is not a mistake worth leaving available to make. The persona name and the
+        # skill names are committed values landing in a report of one-line rows.
+        shown_names = [(contain.one_line(n), d) for n, d in drifted]
+        nw = tui.column("", [n for n, _ in shown_names])
+        for name, d in shown_names:
+            shown = tui.pad(name, nw)
             if d["unused"]:
                 # Not untidy: `skills:` preloads full text on EVERY dispatch, so an unused
                 # declaration is a standing context cost bought for nothing.

--- a/docs/news/unreleased-a-roster-column-is-measured-not-guessed.md
+++ b/docs/news/unreleased-a-roster-column-is-measured-not-guessed.md
@@ -61,6 +61,31 @@ on every other surface; the column honours that bound rather than inventing a se
 smaller one. An ordinary roster now renders *narrower* than before, because 28 was always
 more than a roster of real names needs.
 
+## What the sweep charged for the rewrite
+
+Replacing a `print` statement makes its line a new line, and `tools/sweep.py` charges new
+lines against the diff. Six guarantees the old prints carried turned out to have no test
+behind them — none of them about column width, all of them things a rewrite could have
+dropped in silence while every alignment case stayed green.
+
+`persona list`'s VAULT STATUS is the last column and is *unpadded*, so a bound at the
+column cannot help it; a newline in provider health text writes a second row wearing the
+table's layout. `_shared` is a namespace rather than a persona, so its DISP cell is an em
+dash instead of a count of something that cannot happen. The `never dispatched` flag is the
+signal a steward prunes on, and collapsing its conditional leaves the words in place with
+nothing drawing the eye to them. The skills block reported only one of its two directions
+of drift under test, so the half answering the more interesting question could stop
+printing unnoticed. And that block bounded its name twice — once inside the width, once at
+the row — which is the measure-one-string-print-another shape this entry is about, one
+block further down; it now binds the name once into the list both readers share, so there
+is no second call left to disagree with the first.
+
+One of the seven was genuinely equivalent, and it is worth saying which rather than
+quietly pinning it: `persona.stats` returns only statuses that are already keys in the
+glyph table, so `never dispatched` is the sole status reaching the `.get` default and the
+`·` fallback beside it is unreachable today. It stays as the neutral marker for a status
+somebody adds later.
+
 ## What this does not fix
 
 Alignment is about the cells a value **declares**, and that is all `tui.width` can report.

--- a/tests/test_a_roster_column_is_measured_not_guessed.py
+++ b/tests/test_a_roster_column_is_measured_not_guessed.py
@@ -104,7 +104,10 @@ class RosterWidths(PersonaIso):
             except OSError:
                 continue
             kept.append(n)
-        if len(kept) < 2:
+        # `min(2, ...)`, not a flat 2: a caller asking for ONE persona gets a roster of
+        # one, and a flat floor turned that into a silent skip — a test that does not run
+        # is not a test, and this one was the guard on the shared row's DISP cell.
+        if len(kept) < min(2, len(names)):
             self.skipTest("filesystem refuses these names")
         return kept
 
@@ -355,6 +358,48 @@ class TestEveryColumnIsMeasuredNotOnlyTheName(RosterWidths):
         rows = self._stats_with_tally({"ok": 1234567, cjk: 2})
         header = next(r for r in rows if r.startswith("PERSONA"))
         self._assert_aligned(rows, header, "STATUS", DORMANT)
+
+
+class TestTheRewrittenRowsKeptWhatTheyGuarded(RosterWidths):
+    """Two guards on the rows this change rewrote, found unpinned by `tools/sweep.py`.
+
+    Neither is about column width. Both are behaviour the old `print` statements carried
+    and the new row builders still carry, and the sweep charges them here because these
+    are the lines this change touched. A rewrite that silently dropped either would have
+    passed every alignment case in this file, which is the point of running the sweep on
+    a diff rather than only asserting the thing you set out to fix.
+    """
+
+    def test_a_vault_status_cannot_write_a_second_row(self):
+        """VAULT STATUS is the last column of `persona list` and it is UNPADDED, so it is
+        the one field a bound at the column cannot help with. `_vault_status` returns
+        provider health text — a path, an error from a credential helper — and a newline
+        in it writes a second physical line wearing this table's own layout. That is
+        #453's mechanism, and `contain.one_line` is what stops it."""
+        self._roster("ok", "other")
+        hostile = "no vault\nfake      Fake role   vault2   no vault"
+        with mock.patch.object(commands_persona, "_vault_status", return_value=hostile):
+            rows = self._run(commands_persona.cmd_persona_list)
+        forged = [r for r in rows if r.startswith("fake")]
+        self.assertEqual(
+            forged, [],
+            "a vault status wrote its own table row:\n" + "\n".join(rows))
+
+    def test_the_shared_namespace_reports_no_dispatch_count(self):
+        """`_shared` is a namespace, not a persona: nothing is ever dispatched AS it, so a
+        number in its DISP cell would be a count of something that cannot happen. The row
+        prints an em dash, and the tally is not consulted for it even when one exists."""
+        self._roster("ok")
+        from charter import dispatch
+
+        with mock.patch.object(dispatch, "tally",
+                               return_value={config.SHARED_PERSONA: 7, "ok": 3}):
+            rows = self._run(commands_persona.cmd_persona_stats)
+        shared = [r for r in rows if r.startswith(config.SHARED_PERSONA)]
+        self.assertEqual(len(shared), 1, "\n".join(rows))
+        self.assertNotIn("7", shared[0],
+                         "the shared namespace reported a dispatch count:\n" + shared[0])
+        self.assertIn("—", shared[0], shared[0])
 
 
 class TestTuiColumn(unittest.TestCase):

--- a/tests/test_a_roster_column_is_measured_not_guessed.py
+++ b/tests/test_a_roster_column_is_measured_not_guessed.py
@@ -266,6 +266,61 @@ class TestTheSkillsBlockIsMeasuredToo(RosterWidths):
             "the `unused:` label starts in a different column on each row — the name "
             f"column was sized by a guess (offsets {sorted(at)}):\n" + "\n".join(block))
 
+    def test_a_hostile_name_cannot_forge_a_row_in_this_block(self):
+        """The block prints a persona DIRECTORY name, so it needs #472's bound too.
+
+        Reachable, not theoretical. `drift` reports a persona whose name appears in
+        `personas/_skills/*.jsonl`, and `skilluse.record` writes whatever string it is
+        given into that committed log with no `valid_name` between — so the same commit
+        that adds a directory named with a separator can add the log line that pulls it
+        into this block. Without the bound the name writes a second physical line wearing
+        the block's own layout, which is #453's mechanism two reports over.
+        """
+        name = "evil" + chr(0x2028) + "  fake     used but not declared: nothing"
+        try:
+            (config.PERSONAS_DIR / name).mkdir()
+            (config.PERSONAS_DIR / name).rmdir()
+        except OSError:
+            self.skipTest(f"filesystem refuses {name!r}")
+        from charter import skilluse
+
+        drift = {"unused": [], "undeclared": ["a-skill"]}
+        self._roster("ok", name)
+        with mock.patch.object(skilluse, "drift", return_value=drift):
+            rows = self._run(commands_persona.cmd_persona_stats)
+        self.assertEqual(
+            [r for r in rows if r.startswith("  fake")], [],
+            "the persona name wrote its own line in the skills block:\n"
+            + "\n".join(rows))
+        self.assertTrue(
+            any(contain.one_line(name) in r and "a-skill" in r for r in rows),
+            "the bounded name is not in the block:\n" + "\n".join(rows))
+
+    def test_both_directions_of_drift_are_reported(self):
+        """`unused` and `undeclared` are two `if`s, and only the first had a test.
+
+        The sweep deleted the `undeclared` branch and the whole suite stayed green — the
+        half of the block that answers the more interesting question could stop printing
+        and nothing would say so. They are different findings: `unused` is a context cost,
+        `undeclared` is a persona working outside its charter (ADR 0013).
+
+        `drift` is stubbed rather than driven through a usage log, because the property
+        under test is that the report PRINTS both directions, not how `skilluse` derives
+        them.
+        """
+        from charter import skilluse
+
+        drift = {"unused": ["declared-never-used"], "undeclared": ["used-never-declared"]}
+        self._roster("ok")
+        with mock.patch.object(skilluse, "drift", return_value=drift):
+            rows = self._run(commands_persona.cmd_persona_stats)
+        self.assertTrue(any("unused: declared-never-used" in r for r in rows),
+                        "the unused half is missing:\n" + "\n".join(rows))
+        self.assertTrue(
+            any("used but not declared: used-never-declared" in r for r in rows),
+            "the undeclared half is missing — the block reports only one direction of "
+            "drift:\n" + "\n".join(rows))
+
     def test_a_long_name_is_not_cut_out_of_the_block(self):
         """`tui.pad` truncates, so alignment alone would survive a constant here too."""
         long = self.NAMES["well over the boundary"]

--- a/tests/test_a_roster_column_is_measured_not_guessed.py
+++ b/tests/test_a_roster_column_is_measured_not_guessed.py
@@ -385,6 +385,27 @@ class TestTheRewrittenRowsKeptWhatTheyGuarded(RosterWidths):
             forged, [],
             "a vault status wrote its own table row:\n" + "\n".join(rows))
 
+    def test_a_never_dispatched_persona_is_flagged_not_dotted(self):
+        """The glyph fallback, which is the one column cell that is not a lookup.
+
+        `glyph` has no entry for "never dispatched" — that status is decided in the loop,
+        not by `persona.stats` — so the row's marker comes from the `.get` default, and
+        the flag is the whole signal a steward prunes on. Collapse that conditional to its
+        other branch and the loudest row in the report becomes an ordinary `·` bullet,
+        with the words still there and nothing drawing the eye to them. Unpinned until the
+        sweep asked.
+        """
+        self._roster("ok", "other")
+        from charter import dispatch
+
+        with mock.patch.object(dispatch, "tally", return_value={"ok": 3}):
+            rows = self._run(commands_persona.cmd_persona_stats)
+        row = [r for r in rows if r.startswith("other")]
+        self.assertEqual(len(row), 1, "\n".join(rows))
+        self.assertIn("never dispatched", row[0])
+        self.assertIn("⚑ never dispatched", row[0],
+                      "the never-dispatched row lost its flag glyph:\n" + row[0])
+
     def test_the_shared_namespace_reports_no_dispatch_count(self):
         """`_shared` is a namespace, not a persona: nothing is ever dispatched AS it, so a
         number in its DISP cell would be a count of something that cannot happen. The row


### PR DESCRIPTION
Follow-up to #585, which was merged at its first commit. The #508 column fix landed there;
this carries the work that came out of running `tools/sweep.py` on it, which finished after
the merge.

## What the sweep found

`tools/sweep.py` charges **added** lines against the diff, and replacing a `print` makes
its line a new line. 15 mutations on #585's first commit: **8 pinned, 7 survived**.

None of the seven is a column-width bug. All are guarantees the old `print` statements
carried and the new row builders still carry — things a rewrite could have dropped in
silence while every alignment case in the file stayed green. That is the argument for
sweeping a diff rather than only asserting the thing you set out to fix.

| survivor | verdict |
|---|---|
| `_vault_status` uncontained | **real** — `persona list`'s VAULT STATUS is the last column and *unpadded*, so a bound at the column cannot reach it; a newline in provider health text forges a row. Pinned. |
| shared row's DISP conditional collapsed | **real** — `_shared` is a namespace, not a persona; a number there counts something that cannot happen. Pinned. |
| never-dispatched glyph collapsed to `·` | **real** — the flag is the signal a steward prunes on; collapsing it leaves the words with nothing drawing the eye to them. Pinned. |
| `contain.one_line` in the skills block, twice (2 survivors) | **real** — measured from one string, printed as another: #472's mis-measure, one block below the table this change fixed. **Fixed structurally**, not pinned — the name is now bound once into the list both the measure and the print read, so there is no second call left to disagree. |
| `if d["undeclared"]` deleted | **real** — only `unused` had a test, so the half answering the more interesting question (a persona working outside its charter, ADR 0013) could stop printing unnoticed. Pinned. |
| glyph fallback collapsed to `⚑` | **equivalent, and provably.** `persona.stats` returns only `active`/`idle`/`dormant`/`orchestrator`/`standby`/`advisory`, all keys in `glyph`; with `draft` also a key, `never dispatched` is the only status reaching the `.get` default, so the `else '·'` is unreachable today. Kept as the neutral marker for a status added later. |

## Reachability, checked rather than assumed

The skills-block name bound looked like it might be unreachable — a persona needs
`persona.load` to succeed to declare skills, and `load` gates on `valid_name`, which is
ASCII. It is reachable by the other route: `drift` also reports a persona whose name
appears in `personas/_skills/*.jsonl`, and `skilluse.record` writes whatever string it is
handed into that committed log with no `valid_name` in between. So the commit that adds a
directory named with a separator can add the log line that pulls it into the block.

## A test that was silently skipping

Closing these needed a fix in the test helper itself. `_roster` floored at two personas, so
a case asking for a roster of one **skipped** instead of running — and that case was the
guard on the shared row's DISP cell. A test that does not run is not a test.

## Verification

- **Hand-check:** 17 mutations covering the constant/semantic-swap class `tools/sweep.py`
  has no operator for (#569) — **17/17 caught**. Every mutation asserts that it actually
  applied; the first pass of this table reported two "survivors" that were mutations whose
  quoting never matched, and an unapplied mutation runs a pristine tree and looks pinned.
- **Suites:** full suite in two environments (CPython 3.14 and 3.12, the second with
  `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset), `$COLUMNS` pinned inside the tests
  (#544).

Refs #508.
