### PR TITLE
The suite stops spending the machine it runs on (#542, #544, #564)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,23 @@ command.
   outside a frame with `_envguard.unset_all()`, or states the value it needs with
   `mock.patch.dict(os.environ, …)`; a test that spawns a subprocess has to hand it the
   throwaway plane as `$CHARTER_ROOT`, which no guard in this process can do for you.
+  `tests/_ttyguard.py` is the fourth, for what that shell *is* rather than what it says: it
+  answers whether your streams are a terminal, and **how wide they are**. `$COLUMNS` is
+  scrubbed with the rest, and — because removing it only moves the reading to an ioctl on
+  stdout — `os.get_terminal_size()` answers what a pipe answers, so a render is the same
+  width in your window as it is in CI. A test that wants a size states one with
+  `mock.patch("os.get_terminal_size", …)`.
+- **The suite spends nothing it was not asked to.** `tests/_planeguard.py` also refuses a
+  charter child started with `start_new_session=True` — charter's own shape for a
+  background refresh that outlives the process that started it. Those fire in tests and
+  almost never in the field, because both spawners are throttled by state in
+  `config.STATE_DIR` and every test gets a fresh temp one, so `charter _version-check`
+  (a PyPI request) and `charter gl-refresh` (the forge client) went off 63 times in one
+  green run. If your case renders a status line and does not care, call
+  `tests._isolation.no_background_refresh(self)`; if it is *about* the child, call
+  `tests._planeguard.allow_background_children(self)`. A test that starts a real tmux
+  server names its socket with `tests._tmuxreap.name("<slug>")`, so the next run can reap
+  it when this one is killed before its cleanup runs.
 - **Comments explain *why*.** The codebase leans hard on this: a comment that restates the
   code earns nothing, one that records the failure a line prevents is worth several
   paragraphs of docs. Read a few modules before writing your first one.
@@ -115,6 +132,16 @@ developer's terminal. And once, more quietly, both sides of an assertion collaps
 ambient `$CHARTER_WORKSPACE` and the test agreed with itself: a mutation that dies with a
 clean environment survived under the pin. `tests/_envguard.py` closes both directions, but
 it only knows about charter's own names; yours is still yours to pin.
+
+The fifth was the *size* of that terminal, and it is the one worth studying, because the
+obvious fix was half a fix. `$COLUMNS` is exported by many shells and `charter/tui.py`
+reads it, so it was added to the scrub — after which `term_width()` fell straight through
+to `os.get_terminal_size()`, an ioctl on stdout. Measured with both variables unset: three
+modules gave three failures and an error on a 40-column pty and passed on a 200-column one.
+Nobody had hit it because that ioctl raises when stdout is a pipe, which it is under CI and
+under every agent-launched run — so the only person who could see it was the one running
+the suite in their own narrow window. Scrubbing a name is not the same as ending a reading,
+and a scrub that is a list of spellings will always be one name behind.
 
 **So: a test pins what it depends on.** Anything that changes behaviour and comes from
 outside the test — git config, `$PATH`, locale, the default shell, an env var, the

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1357,12 +1357,18 @@ def _frame_env(fid: str, h) -> dict[str, str]:
     NAMED (`_guest_harness_env`, `_pane_identity_env`). A second copy of "what a framed
     harness's environment is" would be two answers to one question.
 
-    COLUMNS/LINES go, and that is belt and braces rather than the fix itself: every pane
-    (harness or panel) measures its OWN tty (`frame/slots.py`, `frame/panel.py`), so a
-    stale value here cannot mislay anything charter draws. But this environment is
-    inherited WHOLE by every process tmux starts for this frame — the harness's shell
-    among them — and both variables describe the LAUNCHING terminal, not any pane the
-    frame creates.
+    `tui.TERMINAL_SIZE_VARS` go, and that is belt and braces rather than the fix itself:
+    every pane (harness or panel) measures its OWN tty (`frame/slots.py`,
+    `frame/panel.py`), so a stale value here cannot mislay anything charter draws. But
+    this environment is inherited WHOLE by every process tmux starts for this frame — the
+    harness's shell among them — and both variables describe the LAUNCHING terminal, not
+    any pane the frame creates.
+
+    Asked of `tui`, which is the module that READS ``$COLUMNS``, rather than spelled here
+    a second time. Two copies of "which variables describe the launching terminal" is two
+    answers to one question, and the second copy is the one the test harness could not
+    ask: `tests/_envguard.py` scrubs before `charter.config` loads, and this module pulls
+    `config` in at import (#544).
 
     TMUX/TMUX_PANE go for a sharper reason: they describe the pane `charter` was TYPED
     in. tmux sets both itself for a pane it creates, and carrying the launcher's own
@@ -1380,7 +1386,7 @@ def _frame_env(fid: str, h) -> dict[str, str]:
     client environment, and the server born from it inherits every name in it.
     """
     env = dict(os.environ, CHARTER_SESSION_ID=fid)
-    for stale in ("COLUMNS", "LINES", "TMUX", "TMUX_PANE"):
+    for stale in (*tui.TERMINAL_SIZE_VARS, "TMUX", "TMUX_PANE"):
         env.pop(stale, None)
     if h:
         env["CHARTER_HARNESS"] = h.name

--- a/charter/tui.py
+++ b/charter/tui.py
@@ -42,6 +42,26 @@ from collections.abc import Iterable, Sequence
 RESET = "\x1b[0m"
 ELLIPSIS = "…"
 
+#: The environment variables that describe **the terminal a process was launched from**,
+#: as opposed to the one it is drawing into. :func:`term_width` reads the first of them;
+#: `commands_frame._frame_env` strips both out of every child a frame starts, because a
+#: captured size is wrong the moment the child is a different rectangle.
+#:
+#: A named constant rather than two string literals at each of those places, and the
+#: reason is `charter.legacyenv`'s verbatim: **a tuple of strings was never what needed a
+#: plane.** `tests/_envguard.py` removes the shell's own answers from the suite before
+#: `charter.config` is first imported — before a plane is resolved out of the operator's
+#: shell — so it cannot ask `commands_frame`, which pulls `config` in at import. It can
+#: ask this module, which imports ``os``, ``re``, ``unicodedata`` and nothing else. Asked
+#: rather than re-spelled, a third geometry variable is covered by that scrub on the
+#: commit that adds it instead of on the commit that debugs it (#544).
+#:
+#: ``LINES`` is here although nothing in charter reads it yet, for the reason
+#: `tests._envguard._scrubbed_names` gives about `session._WINDOW_ID_VARS`: "deliberately
+#: not read" is a decision that can change, and a scrub costs nothing if it is wrong.
+#: `commands_frame` already strips it, so the pair is charter's own answer already.
+TERMINAL_SIZE_VARS = ("COLUMNS", "LINES")
+
 _SGR = re.compile(r"\x1b\[[0-9;]*m")
 #: Trailing whitespace hiding *behind* trailing SGR escapes ("a \x1b[0m").
 _HIDDEN_TRAIL = re.compile(r"[ \t]+((?:\x1b\[[0-9;]*m)+)$")
@@ -231,7 +251,8 @@ def column(header: str, cells: Iterable[str], gap: int = 2,
 
 
 def term_width(default: int = 80, floor: int = 1) -> int:
-    """Terminal width: ``$COLUMNS``, else the tty size, else *default*.
+    """Terminal width: ``$COLUMNS`` (:data:`TERMINAL_SIZE_VARS`), else the tty size,
+    else *default*.
 
     Clamped to at least *floor*. Status-line style programs get their size via
     ``$COLUMNS`` because stdout is a pipe, hence the env-first order.

--- a/docs/news/unreleased-the-suite-stops-spending-your-machine.md
+++ b/docs/news/unreleased-the-suite-stops-spending-your-machine.md
@@ -1,0 +1,126 @@
+---
+version: unreleased
+headline: charter's own test suite stops spending the machine it runs on — no PyPI request per render, no terminal read, and no tmux server left running after a killed run
+---
+
+The last three fixtures a test could inherit without noticing were the plane (0.52.0), the
+shell (0.53.0) and the `[update] channel` in your own `charter.toml` (0.53.0). This closes
+the three that are not fixtures at all but **costs**: what the suite spends on your
+network, what it reads off your terminal, and what it leaves running on your machine after
+it is gone. One defect wearing three hats — the suite reading or spending the machine
+instead of the repository — and they are fixed together because the deletion sweep runs
+the suite once per mutation, so whatever one run spends, a sweep spends again per mutation.
+
+## Ninety children was the wrong number, and the right one was still 66
+
+The suite forked **66 detached charter children per green run**: 27 `charter
+_version-check`, each of them a GET to PyPI; 36 `charter gl-refresh`, each running the
+forge client over every clone in the workspace; and 3 `charter frame-gather`. Every one of
+them correctly pointed at a throwaway plane since #527, and not one of them was waited for
+or asserted about.
+
+The count was taken in-process, by wrapping `subprocess.Popen.__init__` before the test
+package is imported. That matters: the first attempt at this number sampled a running
+suite with `ps | grep`, and the grep matched its own command line. The figure that
+produced — around 90 — was an artefact, and it is the reason the measurement is now
+something the repository can repeat rather than something somebody remembers doing.
+
+They fire in a test and almost never on a real machine for one reason: both spawners are
+throttled by state in `config.STATE_DIR`, and every test gets a fresh temp one — so the
+cache is always absent and the cooldown lock never exists. The throttles that make this
+rare in the field are exactly what a throwaway plane removes. Six test modules had stubbed
+the spawner by hand because of it, with the same comment twice over. Twelve had not.
+
+**The fix refuses the fork, not the spawner, and the difference is the whole design.**
+Stubbing `maybe_spawn` in the shared base class would have been one line and would have
+made a test that cannot fail: four modules call those functions directly to assert on the
+argv and the cooldown, and two of their cases only assert that nothing raises — so a
+base-class stub would have passed them without running anything, and would have done the
+same for every case written afterwards. Refusing the `start_new_session=True` `Popen`
+instead leaves every one of those cases running its throttle logic and asserting on it,
+and refuses only the part nobody was asserting about. A case that never wanted a child
+says `no_background_refresh(self)`; a case that is *about* the child — the four-edge frame
+integration, which proves the detached `frame-gather` really starts, really gathers and
+really writes the cache — says `allow_background_children(self)`.
+
+Turning it on found 43 cases across six modules, and one of them was a module that had
+stubbed the version check by hand and named the reason ("a suite that quietly reaches the
+network is not hermetic") while forking a real `gl-refresh` straight past it.
+
+**After: zero.**
+
+## `$COLUMNS` was half of it. The other half was the ioctl
+
+`charter/tui.py` reads `$COLUMNS`, which many shells export, and at `COLUMNS=40` with
+everything else already scrubbed the suite returned four failures and an error. The
+obvious fix is to add `COLUMNS` to the list of names the suite scrubs — and that fix is
+wrong, in a way worth writing down, because the same argument produced the hole in the
+first place.
+
+With `$COLUMNS` gone, `term_width()` falls through to `os.get_terminal_size()`, an ioctl on
+the process's own stdout. Measured on the fixed tree, with both variables unset, running
+three of the modules the issue named against a real pty:
+
+| terminal | result |
+|---|---|
+| 40 columns | `FAILED (failures=3, errors=1)` |
+| 200 columns | `OK` |
+
+Same tree, same commit, 172 tests either way. The only difference was how wide the window
+was. Scrubbing the variable moved the reading; it did not end it. Nobody had hit it because
+`os.get_terminal_size()` raises when stdout is a pipe — which it is under CI, under `| tee`
+and under every agent-launched run — so the only person who ever sees it is the one running
+the suite in their own narrow terminal, which is the person least likely to look.
+
+Both halves are closed. The two variables are scrubbed, and they are **asked of
+`charter.tui`**, the module that reads them, rather than spelled in the test harness: a
+third geometry variable is covered on the commit that invents it. The frame's own
+"variables that describe the launching terminal" list now asks the same constant instead of
+carrying a second copy. And the ioctl answers what a pipe answers, in the same module that
+already answers whether those file descriptors are a terminal at all — "is this a terminal"
+and "how wide is it" are two questions about the same three streams, and one guard owns
+both — so every caller takes the no-tty path it already documents and is already tested on.
+A test that wants a size
+states one — `mock.patch("os.get_terminal_size", …)`, which fifty-odd cases in this suite
+already write.
+
+The exit test is the measurement itself: two suite processes on two real ptys of different
+widths, each reporting the width it was handed *and* the width charter answered with, and
+the case fails unless the first two differ and the second two agree.
+
+## Fourteen tmux servers, the oldest running for two and a half days
+
+`ps` on the machine this was written on found 14 live tmux servers left over from test
+runs, each holding a session and a `cat`, `sleep` or `charter panel` child. The socket
+directory held 658 files, 497 of them from one test module, all dated inside the previous
+48 hours.
+
+Three things could have caused it, and they were told apart by experiment rather than by
+argument. A clean run of that module left the socket directory one file *smaller* than it
+found it — teardown works. The same run `kill -9`'d two seconds in left exactly one socket
+file and one live tmux server behind.
+
+**So it is not a test bug at all.** It is the signal that skips every `addCleanup` there
+is, and the deletion sweep sends one every time a mutation makes the suite hang. 497 files
+in two days is what "once per mutation" looks like from the socket directory's side, and no
+`tearDown`, `atexit` or exit-time reaper can ever reach it — a run that had no exit has no
+exit hook.
+
+The only moment that can is the start of the *next* run, which is where the reaper now is.
+It touches a socket only if the name is one this suite hands out (charter's own prefix and
+the pid of the process that made it — the operator's own frame runs on `charter`, with no
+suffix, and cannot match) and only if that pid is gone, so a concurrent run is never
+disturbed. Whether a server is still listening is asked of the socket with one `AF_UNIX`
+connect rather than by running `tmux` 497 times, and a live one is killed *before* its file
+is unlinked, never after — `kill-server` returns 0 with the socket still bound for up to
+1.3 ms, and unlink-then-kill points the kill at a path with no server on it and leaves the
+real one running.
+
+The four modules that name a socket now get the name from one helper, so the reaper cannot
+fail to recognise one, and a fifth module that spells its own is refused by a test that
+parses this directory looking for exactly that.
+
+First run on the machine described above: **658 socket files → 127, and 14 leaked servers →
+0.**
+
+None of this reaches you unless you run charter's own test suite. Nothing to adopt.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -37,6 +37,12 @@ os.makedirs(os.environ["CODEX_HOME"], exist_ok=True)
 # on charter's own workspace picker, forever, whenever the suite was run from a terminal
 # (#545). See `tests/_ttyguard.py`: all three streams now answer what CI answers, and a
 # test that wants a different answer for stdin has to say so.
+#
+# The same module answers how WIDE they are, which is the same fixture one question along:
+# `os.get_terminal_size()` is an ioctl on this process's stdout, and removing `$COLUMNS`
+# from the environment only moves `tui.term_width`'s reading onto it. Measured with both
+# geometry variables already unset: three modules give three failures and an error on a
+# 40-column pty and pass on a 200-column one (#544).
 from . import _ttyguard      # noqa: E402  (imports no charter module, by design)
 
 _ttyguard.install()
@@ -61,3 +67,14 @@ _envguard.install()
 from . import _planeguard      # noqa: E402  (env above must be set before charter loads)
 
 _planeguard.install()
+
+# And the one thing no guard can prevent, only clean up after: a run that was KILLED.
+# Measured — a `kill -9` two seconds into `test_frame_overlay_escape_hatch` leaves a live
+# tmux server and its socket file behind, because the signal skips every `addCleanup`
+# there is. 14 such servers and 497 stale socket files were on this machine when #564 was
+# fixed. This runs at START, which is the only moment that can clean up after a run that
+# had no exit — and it touches nothing whose pid is still alive, so a concurrent run is
+# safe.
+from . import _tmuxreap      # noqa: E402
+
+_tmuxreap.install()

--- a/tests/_envguard.py
+++ b/tests/_envguard.py
@@ -36,12 +36,22 @@ under test asks for.
 
 **What counts as a charter environment variable is a property, not a list.** It is any
 name in charter's own namespace (``CHARTER_*``, ``CLAUDE*``), plus the terminal-identity
-variables `charter.session` derives a session and a pane from, plus charter's FORMER
-namespace — each asked of the constant production reads it from (`session._PANE_ID_VARS`,
-`session._WINDOW_ID_VARS`, `legacyenv.NAMES`) rather than copied out of them, for the same
-reason `PersonaIso` asks `config.derive` instead of re-listing twenty-five settings. A
-``CHARTER_`` variable invented next month is guarded the day it is invented, and #519's
-specific four are covered by the property rather than by being spelled.
+variables `charter.session` derives a session and a pane from, plus the terminal-GEOMETRY
+variables `charter.tui` measures a width from, plus charter's FORMER namespace — each
+asked of the constant production reads it from (`session._PANE_ID_VARS`,
+`session._WINDOW_ID_VARS`, `tui.TERMINAL_SIZE_VARS`, `legacyenv.NAMES`) rather than copied
+out of them, for the same reason `PersonaIso` asks `config.derive` instead of re-listing
+twenty-five settings. A ``CHARTER_`` variable invented next month is guarded the day it is
+invented, and #519's specific four are covered by the property rather than by being
+spelled.
+
+``$COLUMNS`` arrived here as the counter-example that proves the paragraph above is worth
+writing: it is not in charter's namespace, it has no charter in its name at all, and it
+flipped five tests (#544). What made it reachable was a list of spellings; what makes it
+covered is asking the module that reads it. Its other half — the tty ioctl that
+`term_width` falls through to once the variable is gone — is not an environment variable
+at all and lives in `tests/_ttyguard.py`, with the
+streams whose size it is asking about.
 
 **The former namespace is here because the first version of this file forgot it, and the
 way it forgot is the argument for the paragraph above.** That version spelled ``TMUX`` and
@@ -136,14 +146,34 @@ def _scrubbed_names() -> frozenset[str]:
     forward and would reach sideways into whatever unrelated tool on the machine happens to
     share three letters.
 
+    `tui.TERMINAL_SIZE_VARS` is ``$COLUMNS`` and ``$LINES`` — the SIZE of the terminal the
+    suite was launched in, which is a fact about the operator's window and not about
+    anything in this repository. `tui.term_width` reads the first, and at ``COLUMNS=40``
+    with everything else already cleared the suite returned four failures and an error
+    (#544). Asked of `charter.tui` because that is the module that reads it and because
+    `tui` imports ``os``, ``re`` and ``unicodedata`` and nothing else — the same reason
+    `legacyenv` exists as a separate module, stated in its own docstring: a tuple of
+    strings was never what needed a plane, and `commands_frame`, which strips the same two
+    names out of every child a frame starts, cannot be asked here because importing it
+    resolves one.
+
+    **Removing these two is only half of that defect, and the smaller half.** With
+    ``$COLUMNS`` absent `term_width` falls through to `os.get_terminal_size()`, an ioctl on
+    this process's stdout — so the scrub moves the reading from the shell to the tty rather
+    than ending it. Measured at b3dbd54 with both variables unset: the same three modules
+    give 3 failures and 1 error on an 80x24 pty at 40 columns and pass at 200. That half is
+    closed by `tests/_ttyguard.py`, which owns the file descriptors and where the whole
+    argument lives; this entry exists so that the shell's answer cannot reach a
+    `dict(os.environ)` or a child process either.
+
     ``TMUX`` is the one name spelled out, and it has to be: it is tmux's variable, not
     charter's, read in half a dozen places to answer "is this process inside a tmux" with
     no constant to derive it from. Its pane counterpart arrives from `_PANE_ID_VARS`, so
     inventing a constant for one of a pair would buy nothing.
     """
-    from charter import legacyenv, session
+    from charter import legacyenv, session, tui
     return frozenset(session._PANE_ID_VARS + session._WINDOW_ID_VARS + ("TMUX",)
-                     + legacyenv.NAMES)
+                     + legacyenv.NAMES + tui.TERMINAL_SIZE_VARS)
 
 
 def _loud_names() -> frozenset[str]:
@@ -336,11 +366,12 @@ def install() -> None:
     _installed = True
 
     # `charter.session` imports `os` and `re`, `charter.legacyenv` imports `os` and `sys`,
-    # and neither imports anything else — in particular not `charter.config` — so asking
-    # them for the pane variables and the pre-rename names here cannot pull the plane
-    # resolution in ahead of the scrub below. `legacyenv` is a separate module for exactly
-    # this reason: those three names used to live in `config`, where nobody could ask for
-    # them without resolving a plane, so this file did not ask and they leaked (#540).
+    # `charter.tui` imports `os`, `re` and `unicodedata`, and none of them imports anything
+    # else — in particular not `charter.config` — so asking them for the pane variables,
+    # the pre-rename names and the terminal geometry here cannot pull the plane resolution
+    # in ahead of the scrub below. `legacyenv` is a separate module for exactly this
+    # reason: those three names used to live in `config`, where nobody could ask for them
+    # without resolving a plane, so this file did not ask and they leaked (#540).
     _SCRUB_NAMES = _scrubbed_names()
 
     for key in [k for k in os.environ if _in_namespace(k)]:

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -142,6 +142,43 @@ class ReportIso(PersonaIso):
         self.consent_home = home
 
 
+def no_background_refresh(case) -> None:
+    """Stop this case's renders from forking charter's two background refreshers.
+
+    One spelling of the three lines six modules already wrote by hand, with the same
+    comment twice over::
+
+        spawn = update.maybe_spawn          # never fork a network child from the suite
+        update.maybe_spawn = lambda: None
+        self.addCleanup(lambda: setattr(update, "maybe_spawn", spawn))
+
+    `statusline.render` calls both spawners on its own path, and a case that renders a
+    status line is almost never a case about refreshing anything. On a real machine neither
+    fires: both are throttled by state in `config.STATE_DIR`, and the cache is fresh and the
+    cooldown lock is held. A test's plane is a fresh temp directory, so the cache is always
+    absent and the lock never exists — the throttles that make this rare in real use are
+    exactly what a throwaway plane removes, and `test_statusline_brand` has said so in a
+    comment for as long as it has had one: *"a temp STATE_DIR always looks stale"*.
+
+    **Called by the case, never by `PersonaIso`, and the difference is the whole design.**
+    A base class that stubbed these for every test would make `test_glstate_respawn`'s
+    "must not raise" cases pass without running anything, and would do the same for the
+    next such case somebody writes — the trap #542 names. What refuses the fork itself is
+    `tests._planeguard.BackgroundCharterChild`, which fires at the `Popen` and therefore
+    lets every one of those cases run their throttle logic and assert on it exactly as
+    before. This helper is only for the cases that never wanted a child at all.
+
+    Named for what it prevents rather than for what it patches: a case that grows a third
+    background refresher gets it here, once, instead of in eighteen modules.
+    """
+    from charter import glstate, update
+
+    for module, name in ((update, "maybe_spawn"), (glstate, "maybe_spawn")):
+        patcher = mock.patch.object(module, name, lambda *a, **k: None)
+        patcher.start()
+        case.addCleanup(patcher.stop)
+
+
 def child_plane_env(case, **extra: str) -> tuple[Path, dict]:
     """A throwaway plane, and the environment that points a CHILD charter at it.
 

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -132,6 +132,30 @@ next one. It is checked BEFORE the plane question and without waiting on :data:`
 because reading somebody's credential store is wrong on a machine with no control plane at
 all. Which CLIs count is asked of `reference._RESOLVERS` — production's own scheme table —
 so a provider added there is covered on the commit that adds it.
+
+**The fifth, and the other half of the measurement above:
+:class:`BackgroundCharterChild`.** #527 answered WHICH plane a spawned charter lands on;
+it did not answer HOW MANY a unit test forks. Counted in-process on one green run at
+b3dbd54 — by wrapping `Popen.__init__` before this package is imported, because a
+``ps | grep`` of a running suite matches its own command line — the answer was 66 detached
+charter children: 27 ``charter _version-check``, each of them a GET to PyPI, 36 ``charter
+gl-refresh``, each running the forge client over every clone in the workspace, and 3
+``charter frame-gather``. All correctly planed, none waited for, none asserted about. On a
+sweep that runs the suite once per mutation, 27 becomes thousands.
+
+They fire in a test and almost never on a real machine for the same reason a temp plane is
+an isolated one: both spawners are throttled by state in `config.STATE_DIR`, and
+`PersonaIso` hands every case a fresh one — so the cache is always absent and the cooldown
+lock never exists. Six modules stubbed the spawner by hand because of it; twelve did not.
+
+The refusal is at the FORK rather than at the spawner, and that is what keeps it from
+being the stub it replaces. A `PersonaIso` that stubbed `update.maybe_spawn` and
+`glstate.maybe_spawn` would silently swallow `test_glstate_respawn`'s "must not raise"
+cases and every case written after it. Refusing the `start_new_session=True` `Popen`
+leaves all of them running their throttle logic and asserting on it, and refuses only the
+part nobody was asserting about. `tests._isolation.no_background_refresh` is the way out
+for a case that never wanted a child, :func:`allow_background_children` for the one that
+did.
 """
 
 from __future__ import annotations
@@ -391,6 +415,10 @@ class RealPlaneSpawn(BaseException):
 
 class RealVaultReach(BaseException):
     """A test spawned the CLI that reads the developer's own credential store."""
+
+
+class BackgroundCharterChild(BaseException):
+    """A test forked a detached charter the test itself will never wait for."""
 
 
 _VAULT_CLIS: frozenset[str] = frozenset()
@@ -1086,6 +1114,57 @@ def _explain_spawn(parts: list[str], plane) -> str:
         f"the tree — `test_no_test_reads_the_operators_shell` does exactly that.")
 
 
+#: Whether the case now running has said it wants real detached charter children. Set by
+#: :func:`allow_background_children`, which restores the previous value when the case ends.
+_BACKGROUND_ALLOWED = False
+
+
+def allow_background_children(case) -> None:
+    """Declare that *case* means to fork a real detached charter, and let it.
+
+    The way out :class:`BackgroundCharterChild` names, for the handful of cases that are
+    ABOUT the fork rather than merely downstream of one — a test measuring that
+    `glstate.maybe_spawn` records the child's pid, say, which needs a pid that exists.
+
+    Scoped to the case and restored on its cleanup, the shape `_isolation.isolate_state_dir`
+    and `pin_update_channel` already use. A module-level switch would have the same problem
+    a module-level `maybe_spawn` stub has: it silently covers the cases written after it.
+    """
+    global _BACKGROUND_ALLOWED
+    previous = _BACKGROUND_ALLOWED
+    _BACKGROUND_ALLOWED = True
+
+    def restore() -> None:
+        global _BACKGROUND_ALLOWED
+        _BACKGROUND_ALLOWED = previous
+
+    case.addCleanup(restore)
+
+
+def _explain_background(parts: list[str]) -> str:
+    return (
+        f"REFUSED: forking a detached charter child from a test\n"
+        f"{_current_test()} is about to fork `{' '.join(parts)}` with "
+        f"`start_new_session=True` — charter's own shape for \"a child that outlives this "
+        f"process\" (`util.detach_self`, `update.maybe_spawn`, `glstate.maybe_spawn`). "
+        f"Nothing in this test waits for it, so whatever it does happens after the test is "
+        f"over and cannot be asserted on: `_version-check` is a GET to PyPI (and a second "
+        f"to GitHub on a dev plane) and `gl-refresh` runs the forge client for every clone "
+        f"in the workspace. Measured on one green run at b3dbd54: 27 `_version-check` and "
+        f"36 `gl-refresh` children, 66 detached charter children in total, none of them "
+        f"waited for and none of them asserted about (#542).\n"
+        f"They fire here and almost never in real use for the same reason a temp plane is "
+        f"an isolated one: both spawners are throttled by state in `config.STATE_DIR`, and "
+        f"a fresh one has no cache to be fresh and no cooldown lock to hold. Two ways "
+        f"out:\n"
+        f"  - if the test is not about the fork, stop the spawner rather than the fork: "
+        f"`tests._isolation.no_background_refresh(self)` stubs `update.maybe_spawn` and "
+        f"`glstate.maybe_spawn` for this case, which is the three lines six modules "
+        f"already write by hand; or\n"
+        f"  - if the test IS about the fork, say so: "
+        f"`tests._planeguard.allow_background_children(self)`.")
+
+
 def _child_plane(opts: dict):
     """The plane the child described by *opts* would resolve -- or ``None`` for none.
 
@@ -1136,7 +1215,13 @@ _SPAWN_GUARDED = False
 
 
 def _guard_spawns() -> None:
-    """Refuse a charter child that would resolve the real plane. Idempotent.
+    """Refuse a charter child that would resolve the real plane, or that nobody waits for.
+
+    Idempotent. Two refusals share one wrapper because they share one question — is this
+    `Popen` starting charter? — and asking it twice would be two readers of a grammar whose
+    whole design note is that a second copy drifts. The plane check goes first: a child on
+    the operator's live plane is the worse of the two, and its message is the one a reader
+    needs even when both apply.
 
     Wrapped on ``subprocess.Popen.__init__``, the CLASS, rather than on the
     ``subprocess.Popen`` module attribute. Two reasons, and both are holes the attribute
@@ -1176,16 +1261,19 @@ def _guard_spawns() -> None:
         if reached is not None:
             raise RealVaultReach(_explain_vault(*reached))
         parts = _charter_argv(args, opts)
-        if parts is not None and _REAL_ROOT:
-            plane = _child_plane(opts)
-            if plane is not None:
-                try:
-                    here = os.path.abspath(str(plane))
-                except (OSError, TypeError, ValueError):
-                    here = None
-                if here is not None and (here in _REAL_ROOT
-                                         or os.path.realpath(here) in _REAL_ROOT):
-                    raise RealPlaneSpawn(_explain_spawn(parts, plane))
+        if parts is not None:
+            if _REAL_ROOT:
+                plane = _child_plane(opts)
+                if plane is not None:
+                    try:
+                        here = os.path.abspath(str(plane))
+                    except (OSError, TypeError, ValueError):
+                        here = None
+                    if here is not None and (here in _REAL_ROOT
+                                             or os.path.realpath(here) in _REAL_ROOT):
+                        raise RealPlaneSpawn(_explain_spawn(parts, plane))
+            if opts.get("start_new_session") and not _BACKGROUND_ALLOWED:
+                raise BackgroundCharterChild(_explain_background(parts))
         return original(self, args, *rest, **kw)
 
     __init__.__module__ = __name__

--- a/tests/_tmuxreap.py
+++ b/tests/_tmuxreap.py
@@ -1,0 +1,244 @@
+"""Reap the tmux servers and socket files left behind by suite runs that were killed.
+
+**Measured before it was fixed, and the measurement is the whole design.** On the machine
+this was written on, at b3dbd54:
+
+* 14 live tmux servers named ``charter-integration-*``, the oldest running for two and a
+  half days, each holding a session and a ``cat``/``sleep``/``charter panel`` child;
+* 658 files in ``/tmp/tmux-<uid>/``, 497 of them ``charter-overlay-hatch-*`` — every one
+  dated inside the previous 48 hours, at roughly 250 a day.
+
+Three explanations were open (#564): a test aborting before its cleanup, a `kill-server`
+that does not take, or a run interrupted before `addCleanup` could run at all. They were
+told apart by experiment rather than by argument:
+
+* One clean run of `test_frame_overlay_escape_hatch` — 7 tests, all passing — left the
+  socket directory one file SMALLER than it found it. Teardown works.
+* The same run `kill -9`'d two seconds in left exactly one socket file **and one live tmux
+  server** behind: ``tmux -L charter-overlay-hatch-7754 … new-session -d -s s … cat``.
+
+So it is the third, and **it is not a test bug**. Nothing a `tearDown`, an `addCleanup` or
+an `atexit` hook can do survives the signal that skips them, and the deletion sweep runs
+this suite once per mutation — killing it whenever a mutation makes it hang. 497 files in
+two days is what "once per mutation" looks like from the socket directory's side.
+
+**Which is why this runs at START.** Exit-time cleanup by definition cannot clean up after
+a run that had no exit; the only moment that can is the beginning of the NEXT one. A
+reaper here is also the only kind that shrinks the backlog already on the machine, rather
+than merely declining to add to it.
+
+**What it will touch, stated as a rule rather than a list.**
+
+1. The name must be one this suite hands out: :func:`name`'s ``charter-<slug>-<pid>``.
+   The operator's own frame runs on ``charter`` — `commands_frame.SOCKET`, no suffix — and
+   cannot match. ``probe-menu-80053`` and the other hand-rolled probe sockets on this
+   machine cannot match either, and that is deliberate: they are not in charter's
+   namespace, and `tests/_envguard.py` makes the same call about ``EDM_`` for the same
+   reason — a guard must not reach sideways into names charter does not own.
+2. The pid in the name must be **gone**. A concurrent suite run's socket carries a live
+   pid and is left alone, which is what makes this safe to run from every process that
+   imports the `tests` package, including two at once.
+3. A server that is still listening is **killed before its file is unlinked**, never
+   after. `TmuxIntegration._teardown_socket` documents why at length and it holds here
+   too: unlink-then-kill points `kill-server` at a path with no server on it and leaves
+   the real one running.
+
+**Whether a server is listening is asked of the socket, not of tmux.** A
+``tmux -L … kill-server`` per candidate would have been 497 subprocesses on this machine's
+first run. One `AF_UNIX` connect answers the same question in microseconds: a live server
+accepts, a stale file gives ``ECONNREFUSED``. Only the ones that accept cost a tmux
+invocation, and in the steady state there are none.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import re
+import shutil
+import socket
+import stat
+import subprocess
+from pathlib import Path
+
+#: ``charter-<slug>-<pid>``: charter's own prefix at the front and the pid of the process
+#: that started the server at the back — the two halves that make a name both OURS and
+#: datable. Kept next to :func:`name`, which is the only thing in the suite that produces
+#: one, so the rule and its producer cannot drift.
+#:
+#: Matched with `re.fullmatch`, and written WITHOUT ``^``/``$`` because with `fullmatch`
+#: they would buy nothing — a mutation deleting either survived every test in this suite,
+#: which is the sweep's own definition of a line that should not be there. ``$`` was worse
+#: than redundant: it also matches before a trailing newline, so ``"charter-x-1\n"`` —
+#: which is a legal filename — was ours under ``match`` and is not under `fullmatch`.
+_OURS = re.compile(r"charter-[a-z0-9]+(?:-[a-z0-9]+)*-(\d+)")
+
+#: How long a `kill-server` on a socket we already know is listening gets. Generous, and
+#: spent only on the way to giving up: nothing here waits for it to succeed.
+_KILL_TIMEOUT = 10.0
+
+
+def name(slug: str) -> str:
+    """The socket name a test module starts its real tmux server on.
+
+    *slug* says which module owns it (``"overlay-hatch"``, ``"integration-test"``), and the
+    pid makes it this PROCESS's — so two suite runs at once cannot collide, which is the
+    property the ``-<pid>`` suffix was introduced for, and so a later run can tell whether
+    the process that made it is still there, which is the property this module needs.
+
+    One producer for the whole suite, rather than four modules each writing
+    ``f"charter-…-{os.getpid()}"``. Four spellings of a rule is four chances for the fifth
+    to be spelled in a way the reaper does not recognise — and a socket the reaper does not
+    recognise is exactly the leak this exists to end.
+    """
+    return f"charter-{slug}-{os.getpid()}"
+
+
+def owns(candidate: str) -> bool:
+    """Whether *candidate* is a socket name this suite hands out."""
+    return _OURS.fullmatch(candidate) is not None
+
+
+def socket_dir() -> Path:
+    """Where tmux puts a ``-L`` socket, computed the way tmux computes it.
+
+    A COPY of a rule that lives in tmux's source (``$TMUX_TMPDIR`` or ``/tmp``, then
+    ``tmux-<uid>/``), which is why nothing here asserts anything about it: there is no
+    query command for the directory, only for a running server's own path. Being wrong
+    about it costs a reap that finds nothing, never a file removed that should have stayed.
+    """
+    return Path(os.environ.get("TMUX_TMPDIR") or "/tmp") / f"tmux-{os.getuid()}"
+
+
+def _alive(pid: int) -> bool:
+    """Whether *pid* is a process on this machine.
+
+    ``PermissionError`` counts as alive: the pid exists and belongs to somebody else, which
+    is the answer that makes this decline to touch anything.
+    """
+    if pid <= 0:
+        return True                       # not a pid we handed out; leave it alone
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except (PermissionError, OSError):
+        return True
+    return True
+
+
+def _listening(path: Path) -> bool:
+    """Whether a tmux server may still be accepting on *path*.
+
+    A connect rather than a ``tmux`` invocation, for the cost reason in the module
+    docstring — and it is the same act a real client performs, which is why
+    `TmuxIntegration._teardown_socket` can measure a server that answers for 0.4 ms after
+    ``kill-server`` returned. Connected and closed immediately looks to tmux like a client
+    that went away before identifying itself, which it handles as it handles any client
+    dying.
+
+    **Only a refusal is taken as "no server".** ``ECONNREFUSED`` and ``ENOENT`` are
+    positive answers — nobody is bound, the file is a leftover — and everything else is
+    treated as "there might be", because the whole subject here is a server that outlived
+    the process named in its socket. Guessing wrong the cautious way costs one ``tmux``
+    invocation that prints "no server running"; guessing wrong the other way is the
+    resident process #564 counted 14 of.
+    """
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.settimeout(0.5)
+        sock.connect(str(path))
+        return True
+    except OSError as exc:
+        return exc.errno not in (errno.ECONNREFUSED, errno.ENOENT)
+    finally:
+        sock.close()
+
+
+def reapable() -> list[Path]:
+    """Every socket file in :func:`socket_dir` this suite left behind and nobody is using.
+
+    Separate from :func:`reap` so a test can ask what would be removed without removing it,
+    and so the "assert zero" claim has something to make its claim ABOUT.
+    """
+    found = []
+    try:
+        entries = sorted(socket_dir().iterdir())
+    except OSError:                       # no socket directory: nothing was ever left
+        return found
+    for path in entries:
+        matched = _OURS.fullmatch(path.name)
+        if matched is None:
+            continue
+        try:
+            if not stat.S_ISSOCK(os.stat(path, follow_symlinks=False).st_mode):
+                continue                  # not a socket; not ours to remove
+        except OSError:
+            continue
+        if _alive(int(matched.group(1))):
+            continue                      # a run still going — possibly this one
+        found.append(path)
+    return found
+
+
+def reap() -> list[str]:
+    """Kill and unlink everything :func:`reapable` names. Returns the names removed.
+
+    **A file whose server would not die is left where it is**, and that is the whole of
+    the ordering argument turned round. Unlinking after a kill that TOOK is #554's fix:
+    ``kill-server`` returns 0 with the socket still bound for up to 1.3 ms, and removing
+    the file is what closes that window. Unlinking after a kill that did NOT take is #564
+    with the evidence destroyed — a resident tmux server holding a session, and no file
+    left naming it, so no later run can find it either. Measured, on this file's own first
+    draft: 24 servers on this machine with their socket files already gone, unreapable by
+    anything short of `ps`.
+
+    So the unlink is gated on the kill's exit status, and a server that refuses to die
+    keeps its file and is simply tried again on the next run — which costs one more reap
+    and loses nothing, because the file was going to be found again anyway.
+
+    Never raises. This runs at import of the `tests` package, and a machine whose socket
+    directory cannot be read must still be able to run the suite — the cost of skipping a
+    reap is the backlog this found, and the cost of raising here is no suite at all.
+    """
+    removed = []
+    for path in reapable():
+        if _listening(path):
+            try:
+                killed = subprocess.run(
+                    ["tmux", "-L", path.name, "kill-server"],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    timeout=_KILL_TIMEOUT, check=False).returncode == 0
+            except (OSError, subprocess.SubprocessError):
+                killed = False
+            if not killed:
+                continue                  # still running: keep the file that names it
+        try:
+            path.unlink()
+        except OSError:
+            continue
+        removed.append(path.name)
+    return removed
+
+
+_installed = False
+
+
+def install() -> None:
+    """Reap once, at import of the `tests` package. Idempotent, and silent.
+
+    Silent because the interesting number is zero and a line saying so on every run is a
+    line nobody reads. `test_the_suite_reaps_its_own_tmux_servers` is where the count is
+    asserted on, and `reap()` returns it for anyone who wants to look.
+
+    Skipped entirely where tmux is not installed: nothing can have started a server, so
+    nothing can be waiting to be reaped, and a machine without tmux should not pay a
+    directory scan for it.
+    """
+    global _installed
+    if _installed:
+        return
+    _installed = True
+    if shutil.which("tmux") is None:
+        return
+    reap()

--- a/tests/_ttyguard.py
+++ b/tests/_ttyguard.py
@@ -85,12 +85,57 @@ charter is full of ``except Exception`` fallbacks that would turn this tripwire 
 degraded code path, and `unittest` records a `BaseException` against the test that raised
 it, so the failure keeps its name.
 
+**And the same three descriptors answer a SECOND question, which is how wide they are.**
+`charter.tui.term_width` asks it twice — ``$COLUMNS`` first, then `os.get_terminal_size()`,
+an ioctl on this process's own stdout — and both answers come off the operator's window
+rather than out of this repository. At ``COLUMNS=40`` the suite returned four failures and
+an error (#544).
+
+Scrubbing the variable is the obvious fix and it is **half** of one, which is the part
+worth writing down: with ``$COLUMNS`` gone, `term_width` falls straight through to the
+ioctl. Measured on real ptys with both geometry variables already unset,
+`test_frame_panel` + `test_frame_slots` + `test_nested_plane_named`, 172 tests either way:
+
+===============  ==================================
+pty width        result
+===============  ==================================
+40 columns       ``FAILED (failures=3, errors=1)``
+200 columns      ``OK``
+===============  ==================================
+
+Same tree, same commit; the only difference was the size of the window, and the suite read
+it. Nobody had hit it because `os.get_terminal_size()` raises when stdout is not a
+terminal — under CI, under ``| tee``, under every agent-launched run — so the only person
+who could see it is the one running the suite in their own narrow window, which is #545's
+observation about `isatty` one question further along.
+
+`os.environ` is `_envguard`'s to scrub, and it asks `charter.tui.TERMINAL_SIZE_VARS` for
+the names. The ioctl is here, with the streams whose size it is asking about:
+`os.get_terminal_size` is replaced with one that raises the `OSError` a pipe raises, so
+every caller takes the no-tty path it already documents and is already tested on —
+`term_width`'s *default*, `frame/slots.py`'s `panel_cols` fallback, `commands_frame`'s
+`_ASSUMED_SIZE`. Nothing new is invented for them to fall back to.
+
+**Neutralised, not refused, and that is this module's own tier test applied.** Loudness is
+worth its cost where the answer is a claim about the world the test runs in — whether
+anybody is watching. "There is no tty to measure" is not such a claim: it is the state a
+piped run is in, charter's answer to it is a documented default rather than a decision, and
+refusing would fire inside every one of the several hundred tests that render anything. A
+test that wants a size states one — ``mock.patch("os.get_terminal_size",
+return_value=os.terminal_size((22, 3)))``, which fifty-odd cases here already write, and
+which replaces the same module attribute this installs.
+
 **What this cannot see.** A subprocess gets its own file descriptors, and it inherits this
 process's — so a child charter really can find a terminal on fd 0. Nothing in the suite
 reaches a prompt that way today (`RealPlaneSpawn` already refuses the children that would
 resolve a real plane, and the rest are driven with explicit input), and closing it would
 mean rewriting fd 0 for every child, which is a bigger change than the hole justifies. It
-is written down here rather than left to be discovered.
+is written down here rather than left to be discovered. The same goes for the size: a child
+resolves its own, but the suite spawns its children with pipes, so their answer is the
+pipe's answer, which is this one. A test that reads the winsize through `fcntl` directly
+also goes around this — nothing in charter does, and
+`test_no_test_reads_the_terminals_size` does it deliberately, as the control that proves
+the pty it opened really was 40 columns wide.
 """
 
 from __future__ import annotations
@@ -148,6 +193,25 @@ def _isatty() -> bool:
     if _active and not _declared:
         raise AmbientTerminalRead(_explain())
     return False
+
+
+#: What `os.get_terminal_size` raises on a pipe, and so what every caller in charter
+#: already handles. Written for whoever finds it in a traceback: a test that wanted a size
+#: and did not state one is the only way to get here.
+_NO_SIZE = ("[Errno 25] Inappropriate ioctl for device: this is `tests/_ttyguard.py`, not "
+            "your terminal. The suite answers 'stdout is not a tty' on every machine, so a "
+            "render cannot come out one width in a 200-column window and another in a "
+            "40-column one (#544). A test that wants a size states it: "
+            "`mock.patch(\"os.get_terminal_size\", return_value=os.terminal_size((80, 24)))`.")
+
+#: The real measurement, kept for anything that genuinely has to take one — the courtesy
+#: :func:`ambient` extends for the `isatty` answers, for the same reason: a guard with no
+#: honest way past it is a guard somebody deletes.
+real_get_terminal_size = os.get_terminal_size
+
+
+def _no_terminal_size(fd=None):
+    raise OSError(_NO_SIZE)
 
 
 def no_terminal() -> None:
@@ -220,6 +284,13 @@ def install() -> None:
 
     for stream in (sys.stdout, sys.stderr):
         answer_not_a_terminal(stream)
+
+    # And how WIDE those streams are, which is the same fixture one question along. The
+    # attribute on the `os` module rather than a wrapper around a caller: `charter.tui`,
+    # `charter.frame.slots`, `charter.frame.palette` and `charter.commands_frame` all look
+    # it up there at call time, so one replacement covers every reader — including
+    # `shutil.get_terminal_size`, which is what `argparse`'s help formatter measures with.
+    os.get_terminal_size = _no_terminal_size
 
     original_run = unittest.TestCase.run
 

--- a/tests/test_frame_gather.py
+++ b/tests/test_frame_gather.py
@@ -26,7 +26,7 @@ from unittest import mock
 from charter import config
 from charter.frame import gather, state
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, no_background_refresh
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -57,6 +57,12 @@ class ClonedRepoIso(PersonaIso):
         super().setUp()
         (self.tmp / "charter.toml").write_text("schema = 1\n")
         config.HAS_CONTROL_PLANE = True
+        # `gather.scan` calls `glstate.maybe_spawn` on its own path, and a plane this test
+        # just created has no cache to be fresh and no cooldown lock to hold — so every
+        # case in this class forked a real detached `charter gl-refresh` that nothing here
+        # waits for or asserts about (#542). What this class measures is what `scan`
+        # returns, not what it kicks off.
+        no_background_refresh(self)
         self.repo = config.WORKSPACES_DIR / config.DEFAULT_WORKSPACE / "demo"
         _init_repo(self.repo)
 

--- a/tests/test_frame_overlay_escape_hatch.py
+++ b/tests/test_frame_overlay_escape_hatch.py
@@ -36,12 +36,16 @@ import unittest
 
 from charter import commands_frame
 from charter.frame import overlay, tmuxctl
+from tests import _tmuxreap
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
 #: This module's own server, unique per test PROCESS so an interrupted earlier run's
-#: socket can never be mistaken for this one's.
-SOCKET = f"charter-overlay-hatch-{os.getpid()}"
+#: socket can never be mistaken for this one's — and, since #564, so an interrupted
+#: earlier run's socket can be RECOGNISED and reaped by the next one. This module's own
+#: leftovers were 497 of the 658 files in the socket directory when that was measured, all
+#: of them from runs the deletion sweep killed mid-flight, which no teardown can reach.
+SOCKET = _tmuxreap.name("overlay-hatch")
 
 #: Where tmux puts :data:`SOCKET`'s FILE, computed the way tmux computes it — and only
 #: the FALLBACK for it. `TheHatch._teardown_socket` asks the live server for

--- a/tests/test_frame_palette_integration.py
+++ b/tests/test_frame_palette_integration.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from charter import commands_frame, config, util
 from charter.frame import overlay, state, tmuxctl
 
+from tests import _tmuxreap
 from tests._isolation import PersonaIso
 
 _HAS_TMUX = shutil.which("tmux") is not None
@@ -52,8 +53,9 @@ _HAS_TMUX = shutil.which("tmux") is not None
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 #: This module's own server, unique per test PROCESS so an interrupted earlier run's socket
-#: can never be mistaken for this one's — `test_frame_overlay_escape_hatch.py`'s rule.
-SOCKET = f"charter-palette-integ-{os.getpid()}"
+#: can never be mistaken for this one's, and so the next run can reap it —
+#: `test_frame_overlay_escape_hatch.py`'s rule, now `tests._tmuxreap.name`'s (#564).
+SOCKET = _tmuxreap.name("palette-integ")
 
 #: Where tmux puts :data:`SOCKET`'s FILE, computed the way tmux computes it, and only as
 #: the FALLBACK for it: :meth:`_ThePalette._teardown_socket` asks the live server first,

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -91,7 +91,9 @@ from charter.frame import gather, layout, notify
 from charter.frame import slots as frame_slots
 from charter.frame import state, tmuxctl
 
+from tests import _tmuxreap
 from tests._isolation import PersonaIso, run_hook
+from tests._planeguard import allow_background_children
 # Imported rather than re-declared: a second copy of the stub that keeps a launch's
 # detached `frame-gather` child off the developer's real plane is a copy that can drift
 # out of step with the production call it stands in for, and `tests/_planeguard.py`
@@ -104,7 +106,14 @@ _HAS_TMUX = shutil.which("tmux") is not None
 
 #: Unique per test PROCESS, not merely per class — a socket left behind by an earlier,
 #: interrupted run must never collide with (or be mistaken for) this one's.
-SOCKET = f"charter-integration-test-{os.getpid()}"
+#:
+#: Built by `tests._tmuxreap.name` rather than spelled here, and that is the other half of
+#: the same sentence: an interrupted run's socket is not merely something this one must not
+#: collide with, it is something this one must CLEAN UP — 14 live servers and 497 stale
+#: files had accumulated before anything did (#564). The reaper recognises a socket by the
+#: shape that function produces, so a module spelling its own name is a module whose leaks
+#: nobody reaps.
+SOCKET = _tmuxreap.name("integration-test")
 
 #: `tests/_isolation.py`'s `PersonaIso` isolates the paths a Python IMPORT of `charter`
 #: reads inside THIS process; `PanelIntegration` below needs a SUBPROCESS to see the
@@ -2109,6 +2118,14 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         # back on if the ordering is wrong — getting it right here is the only
         # thing standing between a `sleep 600` harness pane and an orphan).
         self.addCleanup(self._teardown_socket)
+        # This class WANTS the detached child, which is why it declares it rather than
+        # stubbing it: `_spawn_frame` runs the real `commands_frame._spawn_gather`, and
+        # "the detached `charter frame-gather` really starts, really gathers the workspace
+        # it was told to, really writes the cache and really bumps the frame" is the
+        # composition this class exists to prove. `tests._planeguard` refuses a detached
+        # charter child by default (#542) precisely so the 43 cases that did NOT mean to
+        # fork one say so instead of forking it.
+        allow_background_children(self)
         (self.tmp / "charter.toml").write_text("")
         self.env = dict(os.environ, CHARTER_ROOT=str(self.tmp), CHARTER_WORKSPACE="demo")
         self.env.pop("CHARTER_HOME", None)  # derive STATE_DIR under CHARTER_ROOT, like
@@ -2899,7 +2916,7 @@ class EarlyDeathIntegration(_VoidDeaths, unittest.TestCase):
 #: whether charter makes a dead PANEL reachable was answered by the fixture. It stayed
 #: green with the production call deleted. This one is never configured by anything: what
 #: it does with a dying pane is tmux's own default, which is what an operator's tmux is.
-OP_SOCKET = f"charter-integration-operator-{os.getpid()}"
+OP_SOCKET = _tmuxreap.name("integration-operator")
 
 #: The socket FILE tmux computes for `-L OP_SOCKET` — the same path `_teardown_socket`
 #: already has to know. Needed as a path (not a name) by `WindowInsideAnOperatorsTmux`,

--- a/tests/test_nested_plane_named.py
+++ b/tests/test_nested_plane_named.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from charter import commands, commands_worktree, config, root, statusline, util
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, no_background_refresh
 
 
 class NestedCase(PersonaIso):
@@ -43,6 +43,15 @@ class NestedCase(PersonaIso):
     Built on disk rather than mocked: the behaviour is a path relationship, and a stubbed
     answer would pass while the arithmetic was wrong.
     """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # The planes below are real ones, written a line before they are rendered, so
+        # charter's two background refreshers both find a cache that has never existed and
+        # fork — a real detached `charter gl-refresh` per render, which nothing here waits
+        # for and nothing here asserts about (#542). What these cases are about is which
+        # PLANE the renderer names.
+        no_background_refresh(self)
 
     def dirs(self) -> tuple[Path, Path]:
         # A name that cannot collide with anything the renderer already prints — the brand

--- a/tests/test_no_test_forks_a_background_charter.py
+++ b/tests/test_no_test_forks_a_background_charter.py
@@ -1,0 +1,329 @@
+"""No test forks a charter child that nothing waits for.
+
+#527 closed **which plane** a test-spawned charter lands on. This is the other half: **how
+many charter children a test forks at all**, and the answer at b3dbd54 was 66 detached ones
+per green run — 27 `charter _version-check`, each a GET to PyPI, 36 `charter gl-refresh`,
+each running the forge client for every clone in the workspace, and 3 `charter
+frame-gather`. Counted in-process, by wrapping `subprocess.Popen.__init__` before the
+`tests` package is imported, because a ``ps | grep`` sample of a running suite matches its
+own command line and reports a number that is not real.
+
+**They fire in a test and almost never in real use for the same reason a temp plane is an
+isolated one.** Both spawners are throttled by state in `config.STATE_DIR` — a cache TTL
+and a cooldown lock — and `PersonaIso` hands every case a fresh one, so the cache is always
+absent and the lock never exists. `test_statusline_brand` has said so in a comment for as
+long as it has had one: *"a temp STATE_DIR always looks stale"*. Six modules stubbed the
+spawner by hand because of it; the other twelve did not, and forked.
+
+**The fix refuses the FORK, and that is what keeps it from being a stub.** The obvious move
+— `PersonaIso` stubs `update.maybe_spawn` and `glstate.maybe_spawn` for every case — makes
+a test that cannot fail: `test_glstate`, `test_glstate_respawn`, `test_dev_channel` and
+`test_self_relaunch_argv` call those functions directly to assert on the argv and the
+cooldown, and a base-class stub would swallow them, silently for the "must not raise"
+cases. Refusing at `subprocess.Popen` leaves every one of those running its throttle logic
+and asserting on it exactly as before; what it refuses is the `start_new_session=True`
+child at the end, which is the only part nobody was asserting about.
+
+Every case here is a control. `TheGuardIsNotBlind` makes the refusal happen for real and
+`EitherWayOutWorks` exercises both documented escapes, because a tripwire with no usable
+exit is a tripwire whoever hits it next deletes.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import glstate, update
+from tests import _planeguard
+from tests._isolation import PersonaIso, make_plane, no_background_refresh
+
+
+class WhatIsRefused(unittest.TestCase):
+    """The discriminator is a Popen KEYWORD, not a list of subcommand spellings.
+
+    ``start_new_session=True`` is charter's own shape for "a child that outlives this
+    process" — `util.detach_self`'s docstring calls it the load-bearing part — so a
+    background refresher nobody has written yet is refused on the commit that writes it.
+    """
+
+    def test_a_detached_charter_child_is_refused(self):
+        with self.assertRaises(_planeguard.BackgroundCharterChild):
+            subprocess.Popen(["charter", "_version-check"], start_new_session=True,
+                             cwd="/nonexistent-so-nothing-can-actually-start")
+
+    def test_a_charter_child_the_test_will_wait_for_is_not(self):
+        """`subprocess.run`, `check_output` and a plain `Popen` all construct the class
+        without that keyword. Those children are the ones a test drives on purpose and
+        waits for, and this guard is not about them — it is about the ones nobody waits
+        for. Refused here only by the CWD, which proves the guard let it past."""
+        with self.assertRaises(FileNotFoundError):
+            subprocess.Popen(["charter", "_version-check"],
+                             cwd="/nonexistent-so-nothing-can-actually-start")
+
+    def test_a_detached_child_that_is_not_charter_is_not_refused(self):
+        """The suite forks plenty of detached things that are nobody's control plane."""
+        with self.assertRaises(FileNotFoundError):
+            subprocess.Popen(["tmux", "-L", "nothing", "kill-server"],
+                             start_new_session=True,
+                             cwd="/nonexistent-so-nothing-can-actually-start")
+
+
+class TheGuardIsNotBlind(unittest.TestCase):
+    """The refusal, made to happen, and read."""
+
+    def _refusal(self) -> str:
+        with self.assertRaises(_planeguard.BackgroundCharterChild) as raised:
+            subprocess.Popen(["charter", "gl-refresh"], start_new_session=True,
+                             cwd="/nonexistent-so-nothing-can-actually-start")
+        return str(raised.exception)
+
+    def test_the_message_names_the_test_the_argv_and_both_ways_out(self):
+        said = self._refusal()
+        self.assertIn("test_the_message_names_the_test_the_argv_and_both_ways_out", said)
+        self.assertIn("charter gl-refresh", said)
+        self.assertIn("no_background_refresh", said)
+        self.assertIn("allow_background_children", said)
+        self.assertIn("#542", said)
+
+    def test_the_message_says_why_a_test_sees_this_and_a_real_machine_does_not(self):
+        """The single most useful sentence in it: the reader's next thought is "this never
+        happens to me", and the answer is that their plane has a cache and a cooldown lock
+        and a test's plane is one line old."""
+        said = self._refusal()
+        self.assertIn("STATE_DIR", said)
+        self.assertIn("cooldown", said)
+
+    def test_the_refusal_is_not_an_exception(self):
+        """Both spawners wrap their `Popen` in ``try/except Exception`` and return — so an
+        `Exception` here would be swallowed into "the spawn did not happen", which is
+        exactly what the guard is trying to report. `_planeguard.RealPlaneWrite` and
+        `_envguard.AmbientEnvRead` are `BaseException` for the same reason."""
+        self.assertTrue(issubclass(_planeguard.BackgroundCharterChild, BaseException))
+        self.assertFalse(issubclass(_planeguard.BackgroundCharterChild, Exception))
+
+
+class EitherWayOutWorks(unittest.TestCase):
+    """Both documented escapes, exercised rather than described."""
+
+    def test_declaring_the_case_wants_one_lets_it_through(self):
+        """The A half of an A/B: the same call `WhatIsRefused` above is refused for, made
+        after the declaration. `FileNotFoundError` is the REAL `Popen` reporting a cwd that
+        does not exist, which is proof the guard is no longer what stopped it."""
+        _planeguard.allow_background_children(self)
+        with self.assertRaises(FileNotFoundError):
+            subprocess.Popen(["charter", "_version-check"], start_new_session=True,
+                             cwd="/nonexistent-so-nothing-can-actually-start")
+
+    def test_the_declaration_does_not_outlive_its_case(self):
+        """Scoped by `addCleanup`, so the case after this one is guarded again. Run as an
+        inner case rather than asserted on the flag, because what matters is the state the
+        NEXT test runs in."""
+        class Declares(unittest.TestCase):
+            def runTest(inner):        # noqa: N805
+                _planeguard.allow_background_children(inner)
+
+        Declares().run(unittest.TestResult())
+        with self.assertRaises(_planeguard.BackgroundCharterChild):
+            subprocess.Popen(["charter", "_version-check"], start_new_session=True,
+                             cwd="/nonexistent-so-nothing-can-actually-start")
+
+
+class StoppingTheSpawnerIsTheOtherWayOut(PersonaIso):
+    """`no_background_refresh` — the one spelling of what six modules wrote by hand."""
+
+    def test_without_it_a_render_path_call_forks(self):
+        """The control. `make_plane` gives this case a REAL plane, which is what both
+        spawners require, and a plane one line old has no cache and no cooldown lock — so
+        this is the state twelve modules were in."""
+        make_plane(self)
+        with self.assertRaises(_planeguard.BackgroundCharterChild):
+            update.maybe_spawn()
+
+    def test_with_it_the_same_call_forks_nothing(self):
+        make_plane(self)
+        no_background_refresh(self)
+        update.maybe_spawn()                  # must not raise
+        glstate.maybe_spawn([self.tmp], "default")
+
+    def test_it_covers_the_forge_refresh_as_well_as_the_version_check(self):
+        """The half the hand-rolled stubs missed. `test_statusline_plane_root_warning`
+        stubbed `update.maybe_spawn` and named the reason — "a suite that quietly reaches
+        the network is not hermetic" — and then forked a real `charter gl-refresh` past it
+        on every dirty-root render (#542)."""
+        make_plane(self)
+        with self.assertRaises(_planeguard.BackgroundCharterChild):
+            glstate.maybe_spawn([self.tmp], "default")
+
+
+class EveryCharterCharterStartsForItselfIsDetached(PersonaIso):
+    """Why one keyword is enough, asked of production rather than assumed of it.
+
+    The guard recognises a background child by ``start_new_session=True``. That is only a
+    complete answer while every charter that charter starts for itself passes it — so this
+    is where that stops being an assumption. Two cases, behaviour first and source second:
+    the behavioural one fails if a spawner drops the flag, the AST one fails if a NEW
+    spawner is written without it.
+    """
+
+    def _kwargs_of_the_spawn(self, call) -> dict:
+        seen = {}
+
+        def spy(args=None, *rest, **kw):
+            seen["args"], seen["kw"] = args, kw
+            raise RuntimeError("no child, thank you")
+
+        make_plane(self)
+        with mock.patch("subprocess.Popen", spy):
+            call()
+        return seen
+
+    def test_the_version_check_is_started_detached(self):
+        seen = self._kwargs_of_the_spawn(update.maybe_spawn)
+        self.assertIn("_version-check", seen["args"])
+        self.assertTrue(seen["kw"].get("start_new_session"))
+
+    def test_the_forge_refresh_is_started_detached(self):
+        seen = self._kwargs_of_the_spawn(
+            lambda: glstate.maybe_spawn([self.tmp], "default"))
+        self.assertIn("gl-refresh", seen["args"])
+        self.assertTrue(seen["kw"].get("start_new_session"))
+
+    #: ``<module>:<function>`` → why this `subprocess.Popen` starts a child nothing
+    #: waits for. **Frozen deliberately**, the way
+    #: `NoCharterEscapesThroughTheExecFamily.KNOWN` in `test_plane_spawn_guard.py` is: the
+    #: point is that a NEW spawner is noticed, and a set that grew by itself would notice
+    #: nothing.
+    #:
+    #: It is also the CONTROL, and that is what earns it over a bare "nothing is
+    #: undetached" assertion. Four separate mutations to this case's own reader survived
+    #: the version that only checked for undetached spawns — including one that made the
+    #: reader answer ``None`` for every `subprocess.Popen`, so it found nothing at all and
+    #: reported success for it. A census that does not say what it expected to find cannot
+    #: tell "nothing is wrong" from "I looked at nothing".
+    DETACHED = {
+        "charter/update.py:maybe_spawn":
+            "`charter _version-check` — a GET to PyPI, kicked off the status line's own "
+            "render path so a render never blocks on the network.",
+        "charter/glstate.py:maybe_spawn":
+            "`charter gl-refresh` — the forge client over every clone in the workspace, "
+            "same render path, same reason.",
+        "charter/util.py:detach_self":
+            "The helper the other three go through: `charter <args>` in a process that "
+            "outlives this one, which is what a hook's `\"async\": true` used to buy.",
+        "charter/planegit.py:_spawn_bg_push":
+            "A push of the plane's own repo, after the turn that dirtied it.",
+        "charter/commands_workspace.py:_spawn_pushbg":
+            "The workspace half of the same push, from the Stop hook.",
+        "charter/frame/builtin_actions.py:_spawn":
+            "A palette action re-entering charter, with the overlay pane's tty already "
+            "closed under it — which is why its streams go to DEVNULL as well.",
+    }
+
+    @staticmethod
+    def _popens_in(source: str, where: str = "<source>") -> dict[str, bool]:
+        """``{where:function -> passes start_new_session}`` for every `Popen` in *source*.
+
+        Parsed, not grepped, so a `mock.patch("subprocess.Popen")` written in a docstring
+        or a string is what it is. A function of its own, taking TEXT, so
+        :meth:`test_it_sees_a_popen_written_either_way` can hand it both spellings and
+        watch it answer — the reader's ``ast.Name`` branch is unexercised by charter, which
+        writes ``subprocess.Popen`` everywhere, and a mutation deleting it survived the
+        version of this case that only ever ran the reader over the real tree. It is not
+        dead code: ``from subprocess import Popen`` is a shape `_guard_spawns`'s own
+        docstring names as one it has to cover, so the branch stays and gets a control.
+        """
+        parsed = ast.parse(source)
+        for enclosing in ast.walk(parsed):
+            for node in ast.iter_child_nodes(enclosing):
+                node.parent = enclosing
+        found = {}
+        for node in ast.walk(parsed):
+            if not (isinstance(node, ast.Call) and _called_name(node.func) == "Popen"):
+                continue
+            found[f"{where}:{_enclosing_name(node)}"] = any(
+                kw.arg == "start_new_session" for kw in node.keywords)
+        return found
+
+    def _popens_in_charter(self) -> dict[str, bool]:
+        """The same reader over every module in `charter/`.
+
+        Deliberately NOT wrapped in a try/except: a file under `charter/` that will not
+        parse is a defect in charter, and skipping it would leave whatever it contains
+        unguarded while this case carried on looking healthy.
+        """
+        tree = Path(__file__).resolve().parent.parent
+        found = {}
+        for path in sorted((tree / "charter").glob("**/*.py")):
+            found.update(self._popens_in(path.read_text(encoding="utf-8"),
+                                         path.relative_to(tree).as_posix()))
+        return found
+
+    def test_it_sees_a_popen_written_either_way(self):
+        """The control. Both spellings, both answers, and the enclosing function named —
+        a reader that quietly stopped recognising one of them would report "nothing
+        undetached" for the best of reasons."""
+        seen = self._popens_in(
+            "import subprocess\n"
+            "from subprocess import Popen\n"
+            "def attribute_form():\n"
+            "    subprocess.Popen(['x'], start_new_session=True)\n"
+            "def bare_name_form():\n"
+            "    Popen(['x'])\n")
+        self.assertEqual(seen, {"<source>:attribute_form": True,
+                                "<source>:bare_name_form": False})
+
+    def test_it_names_a_spawn_that_sits_at_module_scope(self):
+        """`_enclosing_name`'s other answer. Nothing in charter does this today; a reader
+        that raised on it would fail the day something did, which is the day this census
+        matters most."""
+        self.assertEqual(self._popens_in("import subprocess\nsubprocess.Popen(['x'])\n"),
+                         {"<source>:<module>": False})
+
+    def test_every_charter_child_charter_starts_is_started_detached(self):
+        """One keyword is a complete answer only while every self-relaunch passes it."""
+        found = self._popens_in_charter()
+        undetached = sorted(k for k, detached in found.items() if not detached)
+        self.assertEqual(
+            undetached, [],
+            f"{undetached} starts a child from `subprocess.Popen` without "
+            f"`start_new_session=True`. `tests._planeguard.BackgroundCharterChild` "
+            f"recognises a background charter child by exactly that keyword, so a spawner "
+            f"without it is one no test can be refused for forking (#542). Either detach "
+            f"it — every other one in charter does — or, if this child is one its caller "
+            f"really waits for, say so in `DETACHED` and give the guard another way to "
+            f"see it.")
+
+    def test_the_census_still_finds_every_spawner_it_was_written_against(self):
+        """The control. Without it, a reader that quietly stopped recognising
+        `subprocess.Popen` would report "nothing undetached" for the best of reasons —
+        which is what four mutations to the previous version of this case did."""
+        self.assertEqual(sorted(self._popens_in_charter()), sorted(self.DETACHED))
+
+
+def _enclosing_name(node) -> str:
+    """The name of the function *node* sits in, or ``<module>``.
+
+    `ast` carries no parent links, so `_popens_in_charter` adds them on the way past. A
+    `Popen` at module scope has no enclosing function and is named for what it is.
+    """
+    while getattr(node, "parent", None) is not None:
+        node = node.parent
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return node.name
+    return "<module>"
+
+
+def _called_name(func) -> str | None:
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()

--- a/tests/test_no_test_reads_the_terminals_size.py
+++ b/tests/test_no_test_reads_the_terminals_size.py
@@ -1,0 +1,281 @@
+"""How wide the operator's window is decides nothing here.
+
+`tests/_ttyguard.py` is one guard answering two questions about the same three file
+descriptors: whether they are a terminal (#545) and how big it is (#544).
+`test_no_test_reads_the_operators_terminal.py` covers the first; this file covers the
+second, the way `test_plane_write_guard` and `test_plane_spawn_guard` split `_planeguard`
+between them. `test_no_test_reads_the_operators_shell.py` is the other sibling and this
+file's model — that one is about what a shell EXPORTS, this one about what a shell cannot
+express. Charter asks the size question twice (`tui.term_width`: ``$COLUMNS`` first, then
+an ioctl on stdout) and both answers come off the machine rather than out of this
+repository.
+
+**Both halves are here because fixing only the first one is the trap #544 walked into.**
+Its own suggested fix was "add ``COLUMNS`` to the scrub". Measured at b3dbd54 with
+``$COLUMNS`` and ``$LINES`` already unset — that fix, applied — running the three modules
+it names on a real pty: ``FAILED (failures=3, errors=1)`` at 40 columns and ``OK`` at 200.
+Removing the variable moves the reading to the tty; it does not end it. So the scrub is
+pinned here, and so is the ioctl, and the case that matters most
+(:meth:`TheTerminalIsNotAFixture.test_the_width_the_suite_sees_is_the_same_in_any_window`)
+runs the probe on two real ptys of different widths and demands one answer.
+
+**Every case is a control, in `test_no_test_reads_the_operators_shell`'s own sense.** The
+pty case carries its own: it reads the winsize back through `fcntl` and asserts the
+terminal really was 40 columns wide, because a probe that quietly got a pipe would agree
+with itself for free and prove nothing.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import pathlib
+import pty
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import unittest
+from unittest import mock
+
+from charter import commands_frame, tui
+from tests import _envguard, _ttyguard
+from tests._isolation import child_plane_env
+
+
+class TheNamesAreAskedOfTheModuleThatReadsThem(unittest.TestCase):
+    """The scrub half, and the derivation rather than its contents.
+
+    A guard that spelled ``("COLUMNS", "LINES")`` in `tests/_envguard.py` would pass every
+    case in this class that merely checked the two names were covered — which is exactly
+    how ``$COLUMNS`` got in: `_envguard` covered a list of spellings and called it a
+    property. So each case here moves the AUTHORITY and demands the guard move with it.
+    """
+
+    def test_every_terminal_size_variable_charter_reads_is_scrubbed(self):
+        for name in tui.TERMINAL_SIZE_VARS:
+            with self.subTest(variable=name):
+                self.assertTrue(
+                    _envguard._in_namespace(name),
+                    f"${name} is in `tui.TERMINAL_SIZE_VARS`, so charter reads it to "
+                    f"decide how wide to draw — and a shell that exports it hands this "
+                    f"suite a fixture nobody chose (#544)")
+
+    def test_the_scrub_asks_tui_rather_than_spelling_the_names(self):
+        """The #579 move: a name invented in `tui` must be scrubbed on the commit that
+        invents it, not on the commit that debugs it. A `_envguard` that carried its own
+        copy of the pair passes the case above and fails this one."""
+        with mock.patch.object(tui, "TERMINAL_SIZE_VARS",
+                               (*tui.TERMINAL_SIZE_VARS, "TERMINAL_ACRES")):
+            self.assertIn("TERMINAL_ACRES", _envguard._scrubbed_names())
+
+    def test_the_frame_strips_whatever_tui_names(self):
+        """`_frame_env`'s stale list is the same fact, one process out: the environment a
+        frame hands its panes must not describe the window `charter` was typed in. It used
+        to spell the pair itself, which is the second copy of one answer — and the copy
+        that could not be asked from the test harness, because importing `commands_frame`
+        resolves a plane."""
+        with mock.patch.object(tui, "TERMINAL_SIZE_VARS",
+                               (*tui.TERMINAL_SIZE_VARS, "TERMINAL_ACRES")), \
+                mock.patch.dict(os.environ, {"TERMINAL_ACRES": "3", "COLUMNS": "200"}):
+            env = commands_frame._frame_env("fid-1", None)
+        self.assertNotIn("TERMINAL_ACRES", env)
+        self.assertNotIn("COLUMNS", env)
+
+    def test_both_halves_of_the_pair_are_stripped_from_a_frames_children(self):
+        """``$LINES`` earns its place in the tuple HERE and nowhere else, which is why it
+        needs a case of its own: nothing in charter reads it, so removing it from
+        `TERMINAL_SIZE_VARS` changes no rendered width and every other case in this file
+        stays green — measured, by deleting it. What it does change is what a frame hands
+        the processes it starts, and a shell's ``$LINES`` describes the terminal `charter`
+        was typed in rather than any pane the frame creates."""
+        with mock.patch.dict(os.environ, {"COLUMNS": "200", "LINES": "50"}):
+            env = commands_frame._frame_env("fid-1", None)
+        for name in ("COLUMNS", "LINES"):
+            with self.subTest(variable=name):
+                self.assertNotIn(
+                    name, env,
+                    f"${name} reached a frame's children, describing the terminal charter "
+                    f"was typed in rather than the pane the child runs in. Both names are "
+                    f"in `tui.TERMINAL_SIZE_VARS` for this, and only one of them for "
+                    f"anything else.")
+
+    def test_the_size_variables_are_scrubbed_but_not_refused(self):
+        """Tier one only, and `_envguard._loud_names`' own test decides that: loudness is
+        worth its cost where "unset" is a CLAIM ABOUT THE WORLD — whose session is this, is
+        this a real tmux. "No ``$COLUMNS``" is not such a claim; it is the state a piped
+        run is in, and charter's answer to it is a documented default. A refusal here would
+        fire inside every one of the several hundred tests that render anything."""
+        for name in tui.TERMINAL_SIZE_VARS:
+            with self.subTest(variable=name):
+                self.assertNotIn(name, _envguard._LOUD)
+
+
+class TheTerminalIsNotAFixture(unittest.TestCase):
+    """The ioctl half — the one the scrub cannot reach, measured on real ptys."""
+
+    #: Written for whoever has to read a failure here: what the probe reports back.
+    _PROBE = (
+        "import fcntl, json, os, struct, sys, termios;"
+        # BEFORE `import tests`, and deliberately through `fcntl` rather than
+        # `os.get_terminal_size`: this is the CONTROL, and it has to read the terminal the
+        # way the guard cannot intercept, or it would be agreeing with the guard about
+        # what the guard did.
+        "raw = struct.unpack('HHHH', fcntl.ioctl("
+        "    sys.stdout.fileno(), termios.TIOCGWINSZ, b'\\0' * 8));"
+        "tty = sys.stdout.isatty();"
+        "import tests;"
+        "from charter import tui;"
+        "open(sys.argv[1], 'w').write(json.dumps({"
+        "    'raw_cols': raw[1], 'raw_rows': raw[0], 'isatty': tty,"
+        "    'columns': os.environ.get('COLUMNS'),"
+        "    'width': tui.term_width()}))")
+
+    def _seen_on_a_pty(self, cols: int, rows: int = 24, **planted: str) -> dict:
+        """What a fresh suite process reports for `tui.term_width` on a *cols*-wide tty.
+
+        A real pty, because that is the whole question: `os.get_terminal_size` raises on a
+        pipe, so a probe run down a pipe would report the guarded answer whether or not
+        anything was guarded. `pty.openpty` and `subprocess` rather than `pty.fork` and
+        `os.execvp` — `NoCharterEscapesThroughTheExecFamily` writes down every exec in this
+        tree, and a new one here would be a spawn the plane guard cannot see.
+
+        The child writes to a FILE rather than to its stdout: its stdout is the pty, and
+        reading a pty while the child is still writing to it is a deadlock waiting for a
+        buffer size.
+
+        Run from a throwaway plane with ``$PYTHONPATH`` carrying the tree, for the reason
+        `_planeguard._explain_spawn` names: a child that imports the `tests` package has
+        ``$CHARTER_ROOT`` scrubbed out from under it before `charter.config` loads, so its
+        cwd is the only thing left deciding whose plane it resolves.
+        """
+        master, slave = pty.openpty()
+        self.addCleanup(os.close, master)
+        try:
+            fcntl.ioctl(slave, termios.TIOCSWINSZ,
+                        struct.pack("HHHH", rows, cols, 0, 0))
+            out = pathlib.Path(tempfile.mkdtemp(prefix="charter-termprobe-")) / "seen.json"
+            self.addCleanup(lambda: out.parent.exists() and __import__("shutil").rmtree(
+                out.parent, ignore_errors=True))
+            tree = pathlib.Path(__file__).resolve().parent.parent
+            plane, _ = child_plane_env(self)
+            done = subprocess.run(
+                [sys.executable, "-c", self._PROBE, str(out)],
+                env={**os.environ.copy(), **planted, "PYTHONPATH": str(tree)},
+                cwd=str(plane), stdout=slave, stderr=subprocess.PIPE, text=True,
+                timeout=120)
+        finally:
+            os.close(slave)
+        self.assertEqual(done.returncode, 0, done.stderr)
+        return json.loads(out.read_text())
+
+    def test_the_width_the_suite_sees_is_the_same_in_any_window(self):
+        """#544's exit test, run rather than described.
+
+        Two suite processes, identical but for the size of the terminal they were handed.
+        On the tree that had this defect they answered 40 and 200 and three renders came
+        out different; here they answer the same number twice, and the number is
+        `term_width`'s own documented default rather than either window.
+        """
+        narrow = self._seen_on_a_pty(40)
+        wide = self._seen_on_a_pty(200)
+
+        # The control, first: a probe that got a pipe instead of a terminal would report
+        # the guarded answer for free, and this whole case would be true of a tree with no
+        # guard in it at all.
+        for name, got, want in (("narrow", narrow, 40), ("wide", wide, 200)):
+            with self.subTest(pty=name):
+                self.assertTrue(got["isatty"],
+                                "the probe's stdout was not a terminal, so this case "
+                                "cannot tell a guarded suite from a piped one")
+                self.assertEqual(got["raw_cols"], want,
+                                 "the pty was not the width this case set, so what it "
+                                 "measured is not what it says it measured")
+                self.assertIsNone(got["columns"],
+                                  "$COLUMNS reached the child, so this case is measuring "
+                                  "the scrub rather than the ioctl it is about")
+
+        self.assertEqual(
+            narrow["width"], wide["width"],
+            f"the suite is reading the terminal: `tui.term_width()` answered "
+            f"{narrow['width']} in a 40-column window and {wide['width']} in a "
+            f"200-column one, so every render this suite compares against a fixed string "
+            f"depends on how wide the operator's terminal happened to be (#544)")
+        self.assertEqual(narrow["width"], 80,
+                         "not the terminal, and not an invented number either: "
+                         "`term_width`'s documented default is what a piped run — CI, and "
+                         "every agent-launched run — already gets")
+
+    def test_a_shell_that_exports_columns_changes_nothing_either(self):
+        """The scrub's own end-to-end control, and the one that fails on a tree that never
+        had the hole would look green without: ``COLUMNS=40`` is PLANTED in the child's
+        environment, the way a real shell exports it, and the child still answers 80."""
+        got = self._seen_on_a_pty(200, COLUMNS="40", LINES="5")
+        self.assertIsNone(got["columns"], "$COLUMNS survived the scrub into a fresh suite")
+        self.assertEqual(got["width"], 80)
+
+
+class TheIoctlAnswersWhatAPipeAnswers(unittest.TestCase):
+    """In-process: what `_ttyguard` replaced, and that its documented exit works."""
+
+    def test_os_get_terminal_size_is_the_guarded_one(self):
+        """Structural, the way `_envguard`'s own case is: `charter.tui`,
+        `charter.frame.slots`, `charter.frame.palette` and `charter.commands_frame` all
+        look this up on `os` at call time, so replacing the attribute is what covers every
+        reader — `shutil.get_terminal_size`, and so `argparse`'s help formatter, included."""
+        self.assertEqual(getattr(os.get_terminal_size, "__module__", None),
+                         "tests._ttyguard")
+
+    def test_asking_the_tty_raises_the_error_a_pipe_raises(self):
+        with self.assertRaises(OSError):
+            os.get_terminal_size()
+        with self.assertRaises(OSError):
+            os.get_terminal_size(sys.stdout.fileno())
+
+    def test_the_message_says_where_it_came_from_and_how_to_state_a_size(self):
+        """A tripwire nobody can find their way out of is a tripwire somebody deletes."""
+        with self.assertRaises(OSError) as raised:
+            os.get_terminal_size()
+        said = str(raised.exception)
+        self.assertIn("_ttyguard", said)
+        self.assertIn("#544", said)
+        self.assertIn("os.get_terminal_size", said)
+
+    def test_a_test_that_wants_a_size_states_one_and_gets_it(self):
+        """The escape is the idiom this suite already writes fifty-odd times, unchanged:
+        `mock.patch` replaces the same module attribute the guard installed."""
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((22, 3))):
+            self.assertEqual(tui.term_width(), 22)
+        with self.assertRaises(OSError):        # and it is put back afterwards
+            os.get_terminal_size()
+
+    def test_term_width_falls_to_its_documented_default(self):
+        _envguard.unset("COLUMNS")
+        self.assertEqual(tui.term_width(), 80)
+        self.assertEqual(tui.term_width(default=132), 132)
+
+    def test_the_real_measurement_is_kept_for_anything_that_needs_it(self):
+        """Neutralised, not destroyed — `_envguard.scrubbed()`'s courtesy, for the same
+        reason. Asserted as a shape rather than a value: under a pipe the real call raises,
+        which is correct there and must stay green."""
+        self.assertIsNot(_ttyguard.real_get_terminal_size, os.get_terminal_size)
+        self.assertTrue(callable(_ttyguard.real_get_terminal_size))
+
+    def test_installing_twice_does_not_stack(self):
+        """`tests/__init__` calls this once, but a child process importing the package
+        while a parent already did is the shape `_planeguard.install` guards the same way.
+        Load-bearing here in a way it is not elsewhere: a second install would capture the
+        REFUSING function as `real_get_terminal_size` and there would be no way back to a
+        real measurement at all."""
+        guarded = os.get_terminal_size
+        real = _ttyguard.real_get_terminal_size
+        _ttyguard.install()
+        self.assertIs(os.get_terminal_size, guarded)
+        self.assertIs(_ttyguard.real_get_terminal_size, real)
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()

--- a/tests/test_statusline_brand.py
+++ b/tests/test_statusline_brand.py
@@ -17,14 +17,15 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from charter import config, statusline, tui, update
-from tests._isolation import PersonaIso, pin_update_channel
+from tests._isolation import PersonaIso, no_background_refresh, pin_update_channel
 
 
 class BrandLayout(unittest.TestCase):
     def setUp(self) -> None:
-        self._spawn = update.maybe_spawn      # never fork a network child from a test
-        update.maybe_spawn = lambda: None
-        self.addCleanup(lambda: setattr(update, "maybe_spawn", self._spawn))
+        # Never fork a network child from a test. One call rather than three lines of
+        # hand-rolled stubbing, and it covers the forge refresh beside the version
+        # check — a file that stubbed only one of the two forked the other (#542).
+        no_background_refresh(self)
         # `_brand` renders the `dev` chip from `config.UPDATE`, so every width assertion
         # below is a function of the channel unless it is pinned (#459). This class is
         # about LAYOUT and runs against the real plane on purpose; the chip belongs to
@@ -91,9 +92,7 @@ class UpdateIndicator(PersonaIso):
         # _brand() calls maybe_spawn(), and a temp STATE_DIR always looks stale — so
         # without this every test here forks a real network child. A suite that
         # quietly reaches the internet is not hermetic.
-        self._spawn = update.maybe_spawn
-        update.maybe_spawn = lambda: None
-        self.addCleanup(lambda: setattr(update, "maybe_spawn", self._spawn))
+        no_background_refresh(self)
 
     def _cache(self, latest: str, age: float = 0) -> None:
         p = config.STATE_DIR / "cache" / "update.json"

--- a/tests/test_statusline_gauge.py
+++ b/tests/test_statusline_gauge.py
@@ -17,7 +17,8 @@ from unittest import mock
 
 from charter import config, statusline
 from tests import _envguard
-from tests._isolation import PersonaIso, isolate_state_dir, pin_update_channel
+from tests._isolation import (PersonaIso, isolate_state_dir, no_background_refresh,
+                              pin_update_channel)
 
 
 def _plain(parts):
@@ -62,8 +63,7 @@ class ContextGaugeCase(unittest.TestCase):
         # against it, and `tests._planeguard.RealPlaneSpawn` refuses that outright (#527).
         # In `setUp` rather than in the one case that first needed it: three of the cases
         # below call `render`, and the precaution had been remembered in exactly one.
-        from charter import update
-        self.enterContext(mock.patch.object(update, "maybe_spawn", lambda: None))
+        no_background_refresh(self)
 
     def test_shows_context_percentage(self):
         self.assertIn("ctx 37%", _plain(statusline._context_gauge(_payload(pct=37.4))))

--- a/tests/test_statusline_inflight_chips.py
+++ b/tests/test_statusline_inflight_chips.py
@@ -30,7 +30,7 @@ import unittest
 from pathlib import Path
 
 from charter import config, inflight, statusline
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, no_background_refresh
 
 
 def _plain(s: str) -> str:
@@ -174,10 +174,9 @@ class RowsStayTrue(PersonaIso):
 
     def setUp(self) -> None:
         super().setUp()
-        from charter import update
-        spawn = update.maybe_spawn          # never fork a network child from the suite
-        update.maybe_spawn = lambda: None
-        self.addCleanup(lambda: setattr(update, "maybe_spawn", spawn))
+        # Never fork a network child from the suite — the version check AND the forge
+        # refresh, in one call rather than three lines covering half of it (#542).
+        no_background_refresh(self)
         # A roster where every conditional badge is both present and absent: `flying`
         # declares a vault this machine has never registered (`◦`) and is in flight;
         # `stuck` is in flight past the presumed-dead threshold, so it carries the `?`

--- a/tests/test_statusline_pieces.py
+++ b/tests/test_statusline_pieces.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from charter import config, pieces, statusline, workspace
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, no_background_refresh
 
 
 def git(repo: Path, *args: str) -> subprocess.CompletedProcess:
@@ -40,6 +40,10 @@ class PieceStatusCase(PersonaIso):
         super().setUp()
         (self.tmp / "charter.toml").write_text("schema = 1\n")
         config.HAS_CONTROL_PLANE = True
+        # A render kicks charter's two background refreshers, and a plane built one line
+        # ago always looks stale to both — so these cases forked a real detached
+        # `charter gl-refresh` apiece, which nothing here waits for (#542).
+        no_background_refresh(self)
         self.ws = config.DEFAULT_WORKSPACE
         self.repo = config.WORKSPACES_DIR / self.ws / "demo"
         self.repo.mkdir(parents=True, exist_ok=True)

--- a/tests/test_statusline_plane_root_warning.py
+++ b/tests/test_statusline_plane_root_warning.py
@@ -25,8 +25,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from charter import config, statusline, update
-from tests._isolation import PersonaIso
+from charter import config, statusline
+from tests._isolation import PersonaIso, no_background_refresh
 
 
 def git(repo: Path, *args: str) -> subprocess.CompletedProcess:
@@ -85,9 +85,12 @@ class PlaneRootIso(PersonaIso):
         for n in ("alpha", "beta"):
             self.make_persona(n, role=n.title(), **{"delegate-when": f"{n} work"})
         init_repo(self.tmp)
-        # `_brand` forks a detached version check. A suite that quietly reaches the
-        # network is not hermetic.
-        self.enterContext(mock.patch.object(update, "maybe_spawn", lambda: None))
+        # `_brand` forks a detached version check, and a render kicks the forge refresh
+        # beside it. A suite that quietly reaches the network is not hermetic. Both are
+        # stopped by one call now: this file used to stub only `update.maybe_spawn` by
+        # hand, and `ADirtyRootSpeaks` forked a real `charter gl-refresh` right past it
+        # (#542).
+        no_background_refresh(self)
 
     # -- the two ways a root gets worked in ------------------------------------ #
 

--- a/tests/test_statusline_session_block.py
+++ b/tests/test_statusline_session_block.py
@@ -18,9 +18,9 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from charter import config, statusline, update
+from charter import config, statusline
 from tests import _envguard
-from tests._isolation import pin_update_channel
+from tests._isolation import no_background_refresh, pin_update_channel
 
 
 def _plain(lines):
@@ -88,11 +88,10 @@ class NeverBreaksTheStatusLine(unittest.TestCase):
         # (#519, #521, #528).
         _envguard.unset_all()
 
-        # render() reaches _brand() -> update.maybe_spawn(), which forks a real
-        # network child. A suite that quietly reaches the internet is not hermetic.
-        self._spawn = update.maybe_spawn
-        update.maybe_spawn = lambda: None
-        self.addCleanup(lambda: setattr(update, "maybe_spawn", self._spawn))
+        # render() reaches _brand() -> update.maybe_spawn() and glstate.maybe_spawn(),
+        # both of which fork a real network child. A suite that quietly reaches the
+        # internet is not hermetic.
+        no_background_refresh(self)
         # Also redirect STATE_DIR: these render against the REAL plane on purpose,
         # and the render path now writes a vault-health cache under it. A test that
         # writes into the developer's own `.charter/` is the bug this suite fixed

--- a/tests/test_statusline_worktree_rows.py
+++ b/tests/test_statusline_worktree_rows.py
@@ -25,7 +25,7 @@ import unittest
 from pathlib import Path
 
 from charter import config, statusline, util, workspace
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, no_background_refresh
 
 
 def git(repo: Path, *args: str) -> subprocess.CompletedProcess:
@@ -69,6 +69,10 @@ class ClonedRepoIso(PersonaIso):
         super().setUp()
         (self.tmp / "charter.toml").write_text("schema = 1\n")
         config.HAS_CONTROL_PLANE = True
+        # A render kicks charter's two background refreshers, and a plane built one line
+        # ago always looks stale to both — so these cases forked a real detached
+        # `charter gl-refresh` apiece, which nothing here waits for (#542).
+        no_background_refresh(self)
         self.repo = config.WORKSPACES_DIR / config.DEFAULT_WORKSPACE / "demo"
         self.repo.mkdir(parents=True, exist_ok=True)
         init_repo(self.repo)

--- a/tests/test_the_suite_reaps_its_own_tmux_servers.py
+++ b/tests/test_the_suite_reaps_its_own_tmux_servers.py
@@ -1,0 +1,610 @@
+"""A run that was killed leaves a tmux server running; the next run is what ends it.
+
+`tests/_tmuxreap.py` carries the measurement that produced this: a clean run of
+`test_frame_overlay_escape_hatch` leaves the socket directory smaller than it found it, and
+the same run `kill -9`'d two seconds in leaves a live server and its socket file behind.
+So the leak is not a missing `addCleanup` — it is the signal that skips every `addCleanup`
+there is, and the deletion sweep sends one every time a mutation makes the suite hang.
+
+**Every case here is a control, in `test_no_test_reads_the_operators_shell`'s sense.** The
+reap is proved on a REAL tmux server planted on a socket named for a dead pid — killed and
+unlinked — and the refusals are proved on real files too: a live pid's socket, a name
+outside charter's namespace, and the operator's own ``charter``. A reaper nobody has
+watched decline is a reaper nobody knows is safe to run from every suite process at once.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import commands_frame
+from tests import _tmuxreap
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: Where this module puts a temp directory it will BIND a socket in.
+#:
+#: Not `$TMPDIR`. An `AF_UNIX` path is capped at 104 bytes on macOS, and macOS spells
+#: `$TMPDIR` `/var/folders/<two>/<28 chars>/T/` — which leaves 40 for a prefix, a random
+#: suffix, a `tmux-<uid>` directory and a socket name, and does not fit. `bind` then
+#: fails with `OSError: AF_UNIX path too long`, which is a fact about this machine's
+#: temp directory and not about anything under test. tmux picks `/tmp` for its own
+#: sockets for the same reason.
+_SHORT_TMP = "/tmp"
+
+
+def _really_gone(pid: int) -> bool:
+    """Whether *pid* is gone, asked of the kernel directly.
+
+    **Deliberately not `_tmuxreap._alive`, and a mutation is why.** `_alive` is the thing
+    under test here; a fixture that used it to decide whether it had a usable pid would
+    ask the mutant whether the mutant was working. Measured: with `_alive`'s
+    ``except ProcessLookupError`` narrowed to something nothing raises — so every dead pid
+    reports as alive — the case below did not fail, it SKIPPED, and a skip is a green.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return True
+    except OSError:
+        return False
+    return False
+
+
+def _a_pid_that_is_gone(case) -> int:
+    """The pid of a process this test started and waited for.
+
+    Not a large constant: ``pid_max`` differs per platform, and a number picked for looking
+    "obviously too big" is a number that becomes somebody's shell one day. Confirmed gone
+    rather than assumed gone — a waited-for pid is free for reuse the instant it is reaped,
+    and this machine runs several suites at once.
+
+    **It FAILS rather than skipping when it cannot find one, and that is not pedantry.**
+    The first version called `skipTest`, and a skip is a green: three separate mutations to
+    `_really_gone` above — narrowing either `except`, or deleting the branch that returns
+    the pid — make every candidate look alive, so the loop runs out and every case that
+    depends on this helper reports success without running. A fixture whose failure mode is
+    a skip cannot be the thing a guard's tests stand on. Twenty consecutive reuses of pids
+    this process itself freed is not an environment charter has to tolerate; it is this
+    helper being broken, and it should say so.
+    """
+    for _ in range(20):
+        proc = subprocess.Popen(["/bin/sh", "-c", "exit 0"])
+        proc.wait()
+        if _really_gone(proc.pid):
+            return proc.pid
+    raise AssertionError(
+        "twenty processes this case started, waited for and reaped all still answer "
+        "`os.kill(pid, 0)`. Either this machine reused every one of those pids "
+        "immediately — which nothing here has ever seen — or `_really_gone` has stopped "
+        "recognising a dead pid, which is the state three mutations to it produce and the "
+        "reason this raises instead of skipping.")
+
+
+class TheNameIsWhatMakesASocketReapable(unittest.TestCase):
+    """The rule, and the three shapes it must refuse."""
+
+    def test_what_the_helper_produces_is_what_the_reaper_recognises(self):
+        """The derivation, not its contents: a slug nobody has invented yet is reapable on
+        the commit that invents it, because the producer and the pattern live together."""
+        for slug in ("integration-test", "overlay-hatch", "palette-integ", "a", "x9-y7"):
+            with self.subTest(slug=slug):
+                made = _tmuxreap.name(slug)
+                self.assertTrue(_tmuxreap.owns(made), made)
+                self.assertTrue(made.endswith(f"-{os.getpid()}"))
+
+    def test_the_operators_own_frame_socket_is_not_ours(self):
+        """`commands_frame.SOCKET` — asked of production, not spelled — is the socket the
+        operator's live frame runs on, and three of them were on this machine while #564
+        was being measured. It carries no pid, so the rule cannot reach it; this is the
+        case that fails if the rule is ever loosened to a bare prefix."""
+        self.assertFalse(_tmuxreap.owns(commands_frame.SOCKET))
+
+    def test_a_name_outside_charters_namespace_is_not_ours(self):
+        """`probe-menu-80053` and friends were on this machine too, left by hand-run probe
+        scripts. They are not charter's to remove — `_envguard` makes the same call about
+        an ``EDM_`` prefix, and for the same reason: a guard that reaches sideways into
+        names charter does not own is a guard that deletes somebody else's work.
+
+        The last three are the ones a mutation found. ``charter-integration-test-`` — the
+        prefix with the pid missing — is what a rule spelt ``(\\d*)`` accepts, and
+        `reapable` would then hand ``int("")`` a `ValueError` on its way to deleting it.
+        The newline pair is what ``$`` accepts and `fullmatch` does not: ``$`` matches
+        before a trailing newline, and a filename may end in one.
+        """
+        for outside in ("probe-menu-80053", "default", "tmux-502", "charter-sk2",
+                        "charter", "charter-", "notcharter-integration-test-1",
+                        "charter-integration-test-", "charter-integration-test-1\n",
+                        "\ncharter-integration-test-1"):
+            with self.subTest(name=outside):
+                self.assertFalse(_tmuxreap.owns(outside))
+
+
+class WhetherAPidIsStillThere(unittest.TestCase):
+    """`_alive` decides everything the reaper does, so it is asked directly.
+
+    Reaching it only through `reap()` left two of its lines unpinned, and the covering
+    case answered a mutation with a SKIP rather than a failure (see :func:`_really_gone`).
+    A predicate this load-bearing gets its own cases.
+    """
+
+    def test_a_pid_that_is_gone_reads_as_gone(self):
+        self.assertFalse(_tmuxreap._alive(_a_pid_that_is_gone(self)))
+
+    def test_this_process_reads_as_alive(self):
+        self.assertTrue(_tmuxreap._alive(os.getpid()))
+
+    def test_pid_zero_is_answered_without_signalling_anything(self):
+        """``os.kill(0, …)`` is a PROCESS GROUP operation — it addresses every process in
+        this one's group, which is the suite runner and every child it has. Signal 0 makes
+        that a permission check rather than a delivery, so the answer would come back
+        "alive" either way; the guard is there so the reaper never makes that call at all.
+        A mutation deleting it survived every test that went through `reap()`, because a
+        socket named ``charter-x-0`` is not a thing that exists on disk to be reaped.
+        """
+        calls = []
+        with mock.patch("os.kill", side_effect=lambda *a: calls.append(a)):
+            self.assertTrue(_tmuxreap._alive(0))
+            self.assertTrue(_tmuxreap._alive(-1))
+        self.assertEqual(calls, [], "the reaper signalled a process group")
+
+    def test_a_pid_that_belongs_to_somebody_else_reads_as_alive(self):
+        """The one answer that decides in the SAFE direction, and the one no fixture on
+        this machine can produce: `os.kill` raises `PermissionError` for a pid that exists
+        and is not ours. The pid exists, so the run that named it may still be going, so
+        the reaper must not touch its socket. Patched rather than staged, because staging
+        it needs a second user account — which is exactly the "unreachable on the platform
+        the sweep ran on" case `tools/sweep.py` names for a `narrow-except` survivor."""
+        with mock.patch("os.kill", side_effect=PermissionError(1, "not yours")):
+            self.assertTrue(_tmuxreap._alive(4242))
+
+    def test_an_unreadable_answer_also_reads_as_alive(self):
+        """Any other `OSError` lands the same way, for the same reason: not knowing is not
+        a licence to delete."""
+        with mock.patch("os.kill", side_effect=OSError(999, "who knows")):
+            self.assertTrue(_tmuxreap._alive(4242))
+
+
+class TheScanRefusesEverythingItCannotBeSureOf(unittest.TestCase):
+    """`reapable` walks a directory it does not own, and every branch there decides
+    whether something gets DELETED. Each one is asked directly, because reaching them
+    through `reap()` needs a machine in a state no fixture can arrange, and a branch only
+    a real leak can reach is a branch nothing pins.
+    """
+
+    def _own_dir(self) -> Path:
+        """A socket directory of this case's own, so nothing here can see the machine's."""
+        tmp = Path(tempfile.mkdtemp(prefix="charter-reapscan-", dir=_SHORT_TMP))
+        self.addCleanup(shutil.rmtree, tmp, True)
+        home = tmp / f"tmux-{os.getuid()}"
+        home.mkdir()
+        self.enterContext(mock.patch.dict(os.environ, {"TMUX_TMPDIR": str(tmp)}))
+        return home
+
+    def test_a_missing_socket_directory_is_not_an_error(self):
+        """A machine that has never run tmux has no such directory, and the suite must
+        still start. Nothing was ever left there, so there is nothing to reap."""
+        tmp = Path(tempfile.mkdtemp(prefix="charter-reapscan-", dir=_SHORT_TMP))
+        self.addCleanup(shutil.rmtree, tmp, True)
+        with mock.patch.dict(os.environ, {"TMUX_TMPDIR": str(tmp / "never-created")}):
+            self.assertEqual(_tmuxreap.reapable(), [])
+            self.assertEqual(_tmuxreap.reap(), [])
+
+    def test_a_plain_file_with_a_reapable_name_is_not_reaped(self):
+        """`S_ISSOCK`, and it is not decoration: the name rule is about NAMES, and a
+        directory somebody keeps notes in can hold a file called anything at all. A reaper
+        that deleted by name alone would delete those."""
+        home = self._own_dir()
+        decoy = home / f"charter-reaper-probe-{_a_pid_that_is_gone(self)}"
+        decoy.write_text("not a socket\n")
+        self.assertEqual(_tmuxreap.reapable(), [])
+        self.assertEqual(_tmuxreap.reap(), [])
+        self.assertTrue(decoy.exists(), "the reaper deleted a file that is not a socket")
+
+    def test_an_entry_that_cannot_be_stat_ed_is_skipped_rather_than_reaped(self):
+        """The race the scan is walking into: a file listed a moment ago and gone now, or
+        one whose directory turns unreadable mid-walk. Not knowing what something is, is
+        not a licence to delete it."""
+        home = self._own_dir()
+        (home / f"charter-reaper-probe-{_a_pid_that_is_gone(self)}").write_text("x")
+        with mock.patch("os.stat", side_effect=OSError(5, "I/O error")):
+            self.assertEqual(_tmuxreap.reapable(), [])
+
+    def test_a_name_that_does_not_match_at_all_is_passed_over(self):
+        """The `continue` before the pid is parsed. Without it the scan reaches
+        `matched.group(1)` on `None` and dies on the first unrelated file in a directory
+        every tmux on the machine shares."""
+        home = self._own_dir()
+        (home / "default").write_text("somebody else's")
+        (home / "probe-menu-80053").write_text("somebody else's")
+        self.assertEqual(_tmuxreap.reapable(), [])
+
+
+class TheListeningProbe(unittest.TestCase):
+    """One `AF_UNIX` connect stands between a socket file and a `kill-server`."""
+
+    def test_a_path_with_nothing_at_it_is_not_listening(self):
+        tmp = Path(tempfile.mkdtemp(prefix="charter-reapprobe-", dir=_SHORT_TMP))
+        self.addCleanup(shutil.rmtree, tmp, True)
+        self.assertFalse(_tmuxreap._listening(tmp / "nothing-here"))
+
+    def test_a_bound_socket_with_nobody_accepting_is_not_listening(self):
+        """What a leftover file looks like once its server is gone: bound, on disk, and
+        refusing every connection."""
+        tmp = Path(tempfile.mkdtemp(prefix="charter-reapprobe-", dir=_SHORT_TMP))
+        self.addCleanup(shutil.rmtree, tmp, True)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.addCleanup(sock.close)
+        sock.bind(str(tmp / "s"))
+        self.assertFalse(_tmuxreap._listening(tmp / "s"))
+
+    def test_a_socket_that_accepts_is_listening(self):
+        tmp = Path(tempfile.mkdtemp(prefix="charter-reapprobe-", dir=_SHORT_TMP))
+        self.addCleanup(shutil.rmtree, tmp, True)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.addCleanup(sock.close)
+        sock.bind(str(tmp / "s"))
+        sock.listen(1)
+        self.assertTrue(_tmuxreap._listening(tmp / "s"))
+
+    def test_an_error_that_is_not_a_refusal_is_read_as_maybe(self):
+        """The safe direction, and the reason it is written as a set membership rather
+        than a bare `return False`: a timeout, an `EACCES`, anything that is not "nobody is
+        bound" leaves a `kill-server` on the table, because the thing this module is about
+        is a server that outlived the process named in its socket."""
+        with mock.patch("socket.socket") as made:
+            made.return_value.connect.side_effect = OSError(60, "timed out")
+            self.assertTrue(_tmuxreap._listening(Path("/whatever")))
+
+
+class TheReapNeverRaises(unittest.TestCase):
+    """This runs at import of the `tests` package, so it is the suite's own boot.
+
+    A machine whose socket directory has turned hostile mid-reap must still be able to run
+    the suite: the cost of a skipped reap is the backlog #564 found, and the cost of
+    raising here is no suite at all. Asked directly, because neither branch can be reached
+    by arranging files on a working machine.
+    """
+
+    def _a_stale_file(self) -> Path:
+        """A bound `AF_UNIX` socket with nobody accepting — what 497 of the files on this
+        machine were. Deliberately no `listen()`: a connect gets `ECONNREFUSED`, which is
+        the positive "nobody is bound here" answer, so `reap` goes straight to the unlink
+        without spending a `tmux` invocation."""
+        tmp = Path(tempfile.mkdtemp(prefix="charter-reapraise-", dir=_SHORT_TMP))
+        self.addCleanup(shutil.rmtree, tmp, True)
+        home = tmp / f"tmux-{os.getuid()}"
+        home.mkdir()
+        self.enterContext(mock.patch.dict(os.environ, {"TMUX_TMPDIR": str(tmp)}))
+        path = home / f"charter-reaper-probe-{_a_pid_that_is_gone(self)}"
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.addCleanup(sock.close)
+        sock.bind(str(path))
+        self.assertFalse(_tmuxreap._listening(path))
+        self.assertEqual([p.name for p in _tmuxreap.reapable()], [path.name])
+        return path
+
+    def test_a_file_that_cannot_be_unlinked_is_reported_as_not_removed(self):
+        """And does not stop the reap, or the suite behind it. Reported honestly rather
+        than optimistically: `reap` returns what it actually removed, which is what
+        `test_nothing_that_was_reapable_survives_the_reap` measures against."""
+        path = self._a_stale_file()
+        with mock.patch("pathlib.Path.unlink", side_effect=OSError(13, "read-only")):
+            self.assertEqual(_tmuxreap.reap(), [])
+        self.assertTrue(path.exists())
+
+    def test_a_stale_file_with_nobody_behind_it_costs_no_tmux_invocation(self):
+        """The 497-files case, and the reason `_listening` exists at all: running
+        `tmux … kill-server` once per candidate would have been 497 subprocesses on this
+        machine's first run."""
+        path = self._a_stale_file()
+        with mock.patch("subprocess.run") as never:
+            self.assertEqual(_tmuxreap.reap(), [path.name])
+        never.assert_not_called()
+        self.assertFalse(path.exists())
+
+
+class TheReaperRunsOnceAtStart(unittest.TestCase):
+    """`install` is called from `tests/__init__`, and only the first call does anything."""
+
+    def setUp(self) -> None:
+        self.addCleanup(setattr, _tmuxreap, "_installed", _tmuxreap._installed)
+
+    def test_a_second_install_reaps_nothing(self):
+        """Idempotent, the way `_planeguard.install` and `_envguard.install` are: a child
+        process importing the package while a parent already did must not pay for a second
+        directory walk, and a test calling it must not silently re-reap."""
+        with mock.patch.object(_tmuxreap, "reap") as spy:
+            _tmuxreap.install()
+        spy.assert_not_called()
+
+    def test_a_machine_with_no_tmux_does_not_even_look(self):
+        """Nothing can have started a server, so nothing can be waiting to be reaped, and
+        a machine without tmux should not pay a directory scan to find that out."""
+        _tmuxreap._installed = False
+        with mock.patch.object(_tmuxreap.shutil, "which", return_value=None), \
+                mock.patch.object(_tmuxreap, "reap") as spy:
+            _tmuxreap.install()
+        spy.assert_not_called()
+
+    def test_the_first_install_on_a_machine_with_tmux_reaps(self):
+        """The control for the two above: without it they would both be green on an
+        `install` that had been gutted entirely."""
+        _tmuxreap._installed = False
+        with mock.patch.object(_tmuxreap.shutil, "which", return_value="/usr/bin/tmux"), \
+                mock.patch.object(_tmuxreap, "reap") as spy:
+            _tmuxreap.install()
+        spy.assert_called_once_with()
+
+
+class WhereTmuxPutsItsSockets(unittest.TestCase):
+    """`socket_dir` follows tmux's own rule, and a test says so rather than a comment."""
+
+    def test_tmux_tmpdir_wins_when_the_environment_names_one(self):
+        with mock.patch.dict(os.environ, {"TMUX_TMPDIR": "/somewhere/else"}):
+            self.assertEqual(_tmuxreap.socket_dir(),
+                             Path("/somewhere/else") / f"tmux-{os.getuid()}")
+
+    def test_without_it_the_directory_is_the_one_under_tmp(self):
+        env = dict(os.environ)
+        env.pop("TMUX_TMPDIR", None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertEqual(_tmuxreap.socket_dir(),
+                             Path("/tmp") / f"tmux-{os.getuid()}")
+
+    def test_an_empty_value_is_not_a_directory(self):
+        """``TMUX_TMPDIR=`` is what an exported-but-unset variable looks like, and joining
+        an empty string would point the reaper at ``tmux-<uid>`` relative to the cwd —
+        every suite run's own checkout. tmux itself falls back on empty, which is why this
+        is written ``or`` and not ``get(…, "/tmp")``."""
+        with mock.patch.dict(os.environ, {"TMUX_TMPDIR": ""}):
+            self.assertEqual(_tmuxreap.socket_dir(),
+                             Path("/tmp") / f"tmux-{os.getuid()}")
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class TheReaperEndsWhatAKilledRunLeftRunning(unittest.TestCase):
+    """A real server on a real socket, killed and unlinked — or deliberately not."""
+
+    def _plant(self, pid: int) -> tuple[str, Path]:
+        """Start a real tmux server on a socket named for *pid*, and return both."""
+        name = f"charter-reaper-probe-{pid}"
+        path = _tmuxreap.socket_dir() / name
+        started = subprocess.run(
+            ["tmux", "-L", name, "-f", "/dev/null", "new-session", "-d", "-s", "s",
+             "-x", "80", "-y", "24", "cat"],
+            capture_output=True, text=True, timeout=30)
+        self.assertEqual(started.returncode, 0, started.stderr)
+        self.addCleanup(self._make_sure_it_is_gone, name, path)
+        self.assertTrue(path.exists(), f"tmux did not put a socket at {path}")
+        return name, path
+
+    @staticmethod
+    def _make_sure_it_is_gone(name: str, path: Path) -> None:
+        """Belt and braces for the cases that expect the reaper NOT to act — this module
+        must not become the thing it is about."""
+        subprocess.run(["tmux", "-L", name, "kill-server"], stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL, timeout=30, check=False)
+        try:
+            path.unlink()
+        except OSError:
+            pass
+
+    def _server_pid(self, name: str) -> int:
+        """The pid of the tmux server on *name*, asked of tmux.
+
+        `#{pid}` is the server's own process id — the thing that outlives the run and holds
+        the session, and therefore the thing "was it killed" has to be asked about.
+        """
+        said = subprocess.run(["tmux", "-L", name, "display-message", "-p", "#{pid}"],
+                              capture_output=True, text=True, timeout=30)
+        self.assertEqual(said.returncode, 0, said.stderr)
+        return int(said.stdout.strip())
+
+    def test_a_dead_runs_server_is_killed_and_its_socket_removed(self):
+        """The whole issue, run rather than described: `kill-server` FIRST, unlink second,
+        and both — a `kill-server` that returns 0 leaves the file (#554), and an unlink
+        without a kill leaves a resident tmux holding a session for two days (#564).
+
+        **The server's death is asserted against its PROCESS, and it has to be.** The first
+        version of this asked the socket instead — "is anything still accepting on that
+        path" — which a reaper that only unlinks satisfies for free, because a path with no
+        file gives `ECONNREFUSED` exactly like a path with no server. Measured: with the
+        `kill-server` deleted outright, this case stayed green. That is #564's own failure
+        mode reproduced inside the test written to prevent it, so the claim now names a pid
+        and watches it go.
+        """
+        pid = _a_pid_that_is_gone(self)
+        name, path = self._plant(pid)
+        self.assertTrue(_tmuxreap._listening(path), "the planted server never came up")
+        server = self._server_pid(name)
+
+        removed = _tmuxreap.reap()
+
+        self.assertIn(name, removed)
+        self.assertFalse(path.exists(), f"{path} survived the reap")
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and _tmuxreap._alive(server):
+            time.sleep(0.05)
+        self.assertFalse(
+            _tmuxreap._alive(server),
+            f"the socket file is gone and tmux {server} is still running — an unlink "
+            f"without a kill is what leaves the resident processes #564 counted 14 of, "
+            f"and it hides them by removing the only file that named them")
+
+    def test_a_socket_whose_name_merely_STARTS_like_ours_is_left_alone(self):
+        """`reapable` scans a directory, and a directory scan is where "ours" has to mean
+        the WHOLE name. ``charter-reaper-probe-<dead pid>-something-else`` begins with a
+        name this suite could have handed out and is not one; a rule asked with `re.match`
+        says yes to it and deletes somebody else's socket. Measured as a survivor —
+        `owns()` had moved to `fullmatch` and the scan had not, and every other case here
+        stayed green because none of them put such a file on disk.
+
+        A real `AF_UNIX` socket, bound here rather than started by tmux, because
+        `reapable` refuses anything that is not a socket and a plain file would pass this
+        for the wrong reason.
+        """
+        pid = _a_pid_that_is_gone(self)
+        path = _tmuxreap.socket_dir() / f"charter-reaper-probe-{pid}-and-then-some"
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.addCleanup(sock.close)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+        sock.bind(str(path))
+
+        self.assertNotIn(path, _tmuxreap.reapable())
+        self.assertNotIn(path.name, _tmuxreap.reap())
+        self.assertTrue(path.exists(), f"{path} is not a name this suite hands out, and "
+                                       f"the reaper deleted it anyway")
+
+    def test_a_kill_that_did_not_take_leaves_the_file_that_names_the_server(self):
+        """The ordering argument turned round, and this module's own first draft got it
+        wrong. Unlinking after a kill that TOOK is #554's fix — `kill-server` returns 0
+        with the socket still bound for a measured 0.4 ms, and removing the file is what
+        closes that window. Unlinking after a kill that did NOT take is #564 with the
+        evidence destroyed: a resident tmux server holding a session, and nothing left on
+        disk naming it, so no later run can find it either.
+
+        Measured rather than reasoned. While this module was being written, 24 servers
+        accumulated on this machine exactly that way — alive, with their socket files
+        already gone, unreapable by anything short of `ps`. A server that refuses to die
+        keeps its file and is tried again on the next run, which costs one more reap and
+        loses nothing.
+        """
+        name, path = self._plant(_a_pid_that_is_gone(self))
+        for failing in (mock.Mock(side_effect=OSError(2, "no tmux")),
+                        mock.Mock(side_effect=subprocess.TimeoutExpired("tmux", 10)),
+                        mock.Mock(return_value=subprocess.CompletedProcess([], 1))):
+            with self.subTest(kill=failing._mock_side_effect or "exit 1"):
+                with mock.patch("subprocess.run", failing):
+                    self.assertEqual(_tmuxreap.reap(), [])
+                self.assertTrue(
+                    path.exists(),
+                    "the file naming a server that is still running was removed, which "
+                    "leaves the server and takes away the only way to find it")
+        self.assertTrue(_tmuxreap._listening(path), "the planted server died on its own")
+
+    def test_a_live_runs_socket_is_left_alone(self):
+        """What makes this safe to run from every process that imports the `tests` package,
+        two suite runs at once included. Planted under THIS process's pid, which is as
+        alive as a pid gets."""
+        name, path = self._plant(os.getpid())
+
+        removed = _tmuxreap.reap()
+
+        self.assertNotIn(name, removed)
+        self.assertTrue(path.exists(), f"{path} was reaped out from under a live run")
+        self.assertTrue(_tmuxreap._listening(path), "a live run's server was killed")
+
+    def test_nothing_that_was_reapable_survives_the_reap(self):
+        """The zero, and it is stated against what was there BEFORE rather than against
+        the directory afterwards. Several suites run on this machine at once and one of
+        them can be killed while this case is between two calls; a socket that arrived
+        after the reap is not something the reap failed to remove, and asserting an empty
+        directory would make this case fail for the very event it exists to describe."""
+        before = {p.name for p in _tmuxreap.reapable()}
+        _tmuxreap.reap()
+        survived = before & {p.name for p in _tmuxreap.reapable()}
+        self.assertEqual(survived, set(),
+                         f"{sorted(survived)} was reapable before the reap and still is")
+
+    def test_reaping_twice_removes_nothing_the_second_time(self):
+        pid = _a_pid_that_is_gone(self)
+        name, _ = self._plant(pid)
+        self.assertIn(name, _tmuxreap.reap())
+        self.assertNotIn(name, _tmuxreap.reap())
+
+
+class EverySocketTheSuiteStartsGoesThroughTheHelper(unittest.TestCase):
+    """The pin that stops the next module leaking a socket nobody reaps.
+
+    Four modules each spelled ``f"charter-…-{os.getpid()}"`` before this. Four spellings of
+    one rule is four chances for the fifth to be written a way the reaper does not
+    recognise — and the reaper is the only thing that cleans up after a killed run.
+    """
+
+    def test_the_modules_that_start_a_server_name_it_through_the_helper(self):
+        """Asked of the module attribute, so a module that reverts to an f-string producing
+        the same text still passes this one — and fails the case below."""
+        from tests import (test_frame_overlay_escape_hatch, test_frame_palette_integration,
+                           test_frame_tmux_integration)
+        for module, attr in ((test_frame_tmux_integration, "SOCKET"),
+                             (test_frame_tmux_integration, "OP_SOCKET"),
+                             (test_frame_overlay_escape_hatch, "SOCKET"),
+                             (test_frame_palette_integration, "SOCKET")):
+            with self.subTest(module=module.__name__, attribute=attr):
+                self.assertTrue(_tmuxreap.owns(getattr(module, attr)))
+
+    @staticmethod
+    def _hand_built(source: str) -> list[str]:
+        """``NAME`` for every module-level ``*SOCKET`` bound to an f-string in *source*.
+
+        Parsed, not grepped: a `mock.patch("...SOCKET")` in a docstring is a string. An
+        f-string is what "built by hand" looks like — `f"charter-overlay-hatch-{os.getpid()}"`
+        is how all four of the leaking modules spelled it — and `SOCKET_PATH` is exempt
+        because that is a PATH derived from a name, and the name is what this is about.
+
+        A function of its own so that :meth:`test_it_recognises_a_hand_built_name` can hand
+        it one and watch it answer. Without that control, a reader that quietly stopped
+        recognising anything would report "no offenders" for the best of reasons — measured:
+        the `drop-if` mutation that deletes the collecting branch survived the version of
+        this case that only ever ran the reader over a clean tree.
+        """
+        found = []
+        for node in ast.parse(source).body:
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                if (isinstance(target, ast.Name) and target.id.endswith("SOCKET")
+                        and isinstance(node.value, ast.JoinedStr)):
+                    found.append(target.id)
+        return found
+
+    def test_it_recognises_a_hand_built_name(self):
+        """The control, and the one shape it must see: exactly what the four modules that
+        leaked used to say."""
+        self.assertEqual(
+            self._hand_built('import os\nSOCKET = f"charter-overlay-hatch-{os.getpid()}"\n'),
+            ["SOCKET"])
+        self.assertEqual(
+            self._hand_built('OP_SOCKET = f"charter-integration-operator-{PID}"\n'),
+            ["OP_SOCKET"])
+
+    def test_it_passes_over_the_shapes_that_are_not_one(self):
+        """The other half of the control: a reader that answered "offender" to everything
+        would satisfy the case above and fail every module in the tree."""
+        for benign in ('from tests import _tmuxreap\nSOCKET = _tmuxreap.name("x")\n',
+                       'SOCKET = "charter"\n',
+                       'SOCKET_PATH = f"/tmp/tmux-{UID}/{SOCKET}"\n',
+                       'def f():\n    SOCKET = f"charter-x-{1}"\n'):
+            with self.subTest(source=benign):
+                self.assertEqual(self._hand_built(benign), [])
+
+    def test_no_module_builds_a_socket_name_by_hand(self):
+        """The census itself, over every test module in this directory."""
+        tree = Path(__file__).resolve().parent
+        offenders = []
+        for path in sorted(tree.glob("test_*.py")):
+            # Not wrapped in a try/except: a module under `tests/` that will not parse is
+            # a defect, and skipping it would leave whatever socket it names unreapable
+            # while this case carried on looking healthy.
+            offenders += [f"{path.name}:{name}"
+                          for name in self._hand_built(path.read_text(encoding="utf-8"))]
+        self.assertEqual(
+            offenders, [],
+            f"{offenders} builds a tmux socket name by hand. Use "
+            f"`tests._tmuxreap.name(\"<slug>\")`: the reaper recognises what that "
+            f"function produces, and a socket it does not recognise is one nobody cleans "
+            f"up after the next killed run (#564).")
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Closes #542. Closes #544. Closes #564.

**One PR, because they are one defect wearing three hats: the suite reading or spending the
machine it runs on rather than the repository.** They share `tests/__init__.py`, they share
the guard family the last four of these landed in (`_planeguard` #402/#459/#546, `_envguard`
#519/#521/#528, `_ttyguard` #545), and #542's guard and #564's reaper both have to be armed
before any test module is collected — one file and one ordering argument, not three. #544
lands *inside* `_ttyguard`, because "is this a terminal" and "how wide is it" are two
questions about the same three file descriptors. Splitting them would have produced three
PRs each touching the same twenty lines and one news entry written three times.

Rebased onto `5e73797` (#587). Nothing there changed the measurements — the before-counts
below were taken on the rebased base and are identical to the ones taken at `b3dbd54`.

## The numbers

Full suite, `python3 -m unittest discover -s tests`, with `CHARTER_*`/`CLAUDE_*`/
`ANTHROPIC_*`/`TMUX*`/`EDM_*` unset. Children counted **in-process**, by wrapping
`subprocess.Popen.__init__` before the `tests` package is imported.

| | before (`5e73797`, py3.14) | after (py3.14) | after (py3.12) |
|---|---|---|---|
| tests | 6703, OK | 6768, OK | 6768, OK |
| detached `charter _version-check` (a PyPI GET each) | **27** | **0** | **0** |
| detached `charter gl-refresh` (the forge client per clone) | **36** | **0** | **0** |
| detached `charter frame-gather` | 3 | 3 (declared) | 3 (declared) |
| total detached charter children | **66** | **3** | **3** |
| wall clock | 345.5 s | 460.9 s | 479.4 s |

Wall clock is the least trustworthy row and I would not read anything into it. This machine
carried between one and four other agents' `tools/sweep.py` runs throughout, at load
averages between 12 and 138, and the three columns above were measured hours apart. Three
before/after pairs taken close together read 431.9 → 419.9 s, 345.5 → 351.9 s and, for the
final head, 345.5 → 460.9 s; the spread between those is the machine, not the branch. The
child counts are exact and load-independent, which is why they are the row to read.

**#542 says "~90 `_version-check`". The real number is 27, and the ~90 was an artefact** —
it came from a `ps | grep` sample of a running suite whose grep matched its own command
line. Measured in-process it is 27 `_version-check` and 36 `gl-refresh`; the 131 that
`_planeguard`'s docstring records for #527 was correct then and has since come down. The
measurement is now something the repository can repeat rather than something somebody
remembers doing.

The instrumentation still logs one `['charter', '_version-check']` construction after the
fix. That is the guard's own A/B control in `test_no_test_forks_a_background_charter`, whose
`cwd` does not exist, so no process is ever started.

**#587 removed none of these forks.** 27/36/3 before it and 27/36/3 after it, byte for byte.

### tmux servers and sockets

Before, on this machine: **14 live tmux servers** left by test runs (oldest 2 d 16 h,
holding `cat`, `sleep 600` and two `charter panel` children from other agents' worktrees),
and **658 files** in `/tmp/tmux-$(id -u)`, 497 of them `charter-overlay-hatch-*` — all dated
inside the previous 48 hours, accumulating at ~250/day.

After one run of the fixed tree: **127 files, 0 leaked servers.** The 127 that remain are
names outside charter's namespace (`probe-menu-*`, `revsock-*`, `t7-*`) left by hand-run
probe scripts, which the reaper deliberately does not touch.

### Which path actually leaked — #564 asked, and did not answer

Told apart by experiment rather than by argument. A clean run of
`test_frame_overlay_escape_hatch` leaves the socket directory *one file smaller* than it
found it — teardown works, and #554's fix is doing its job. The same run `kill -9`'d the
instant its socket appears leaves **one socket file and one live tmux server**:

```
0. start:            hatch-sockets=0 hatch-servers=0
1. after kill -9:    hatch-sockets=1 hatch-servers=1
```

**So it is the third hypothesis, and it is not a test bug at all:** the signal skips every
`addCleanup` there is, and the sweep sends one whenever a mutation makes the suite hang. 497
files in two days is what "once per mutation" looks like from the socket directory's side.

And no exit-time cleanup, in any test, can ever reach it. Planting exactly what a killed run
leaves — a real tmux server on a socket named for a pid the allocator has already moved past
— in a socket directory of its own, so no other agent's run on this machine can interfere:

```
0. planted (what a killed run leaves):  file=yes  server=1
1. a clean run of 5e73797:              file=yes  server=1
2. one run of this branch:              file=no   server=0
```

Line 1 is the point. The only moment that can clean up after a run that had no exit is the
start of the next one.

*(The first two attempts at that measurement were contaminated and are worth naming: one was
cleaned by pid reuse — the freed pid was handed straight to the next `python3`, which adopted
the socket name and killed "its own" leftover, which is exactly the confusing failure #564
predicts — and one by this branch's own reaper running inside a background `tools/sweep.py`.
Hence the walked-past pid and the private `$TMUX_TMPDIR`.)*

## What changed

### #542 — refuse the fork, not the spawner

`tests._planeguard.BackgroundCharterChild` refuses a `Popen` that launches charter with
`start_new_session=True` — charter's own shape for "a child that outlives this process"
(`util.detach_self`, `update.maybe_spawn`, `glstate.maybe_spawn`). A keyword, not a list of
subcommand spellings, so a background refresher nobody has written yet is refused on the
commit that writes it.

The obvious fix — `PersonaIso` stubs both `maybe_spawn`s — is the one the issue warns about,
and it would have made a test that cannot fail: `test_glstate`, `test_glstate_respawn`,
`test_dev_channel` and `test_self_relaunch_argv` call those functions directly to assert on
the argv and the cooldown, and two of those cases only assert that nothing raises. Refusing
at the `Popen` leaves every one of them running its throttle logic and asserting on it; only
the fork nobody was asserting about is refused.

Turning it on found **43 cases across six modules** — `test_frame_gather`,
`test_statusline_pieces`, `test_statusline_worktree_rows`, `test_nested_plane_named`,
`test_statusline_plane_root_warning` and `test_frame_tmux_integration`. Six, not the twelve
the issue expected, because `PersonaIso` writes no `charter.toml` and both spawners refuse
to fork without a plane; the modules that fork are the ones that build a real one.

They say `tests._isolation.no_background_refresh(self)` — one spelling of the three lines
six modules already wrote by hand, and those six now call it too. One of them,
`test_statusline_plane_root_warning`, had stubbed `update.maybe_spawn` and written the
reason ("a suite that quietly reaches the network is not hermetic") while forking a real
`gl-refresh` straight past it; the shared helper covers both.

`FourEdgeIntegration` is the one class that *wants* the child — it proves the detached
`frame-gather` really starts, really gathers and really writes the cache — and says
`tests._planeguard.allow_background_children(self)`.

### #544 — the scrub was a list of spellings; so was the obvious fix

`$COLUMNS` and `$LINES` are scrubbed, **asked of `charter.tui.TERMINAL_SIZE_VARS`** rather
than spelled in the harness, and `commands_frame._frame_env` now asks the same constant
instead of carrying the second copy it had. A mutation that adds a name to that constant
must show up in the scrub, and one that replaces the ask with a hardcoded `("COLUMNS",
"LINES")` is refused — both are cases in `test_no_test_reads_the_terminals_size`.

**Scrubbing the variable is only half of it, and the smaller half.** With `$COLUMNS` gone,
`tui.term_width()` falls through to `os.get_terminal_size()` — an ioctl on stdout. Measured
with both geometry variables already unset, on real ptys:

| terminal | `test_frame_panel` + `test_frame_slots` + `test_nested_plane_named` |
|---|---|
| 40 columns | `FAILED (failures=3, errors=1)` |
| 200 columns | `OK` |

Same tree, same commit, 172 tests either way. Nobody had hit it because that ioctl raises
when stdout is a pipe — under CI, under `| tee`, under every agent-launched run — so the
only person who ever sees it is the one running the suite in their own narrow window, which
is #545's observation one question further along. That is why the fix lands **inside
`tests/_ttyguard.py`** rather than in a module of its own: #587 had just made that file the
owner of the suite's three file descriptors, and how wide they are is the same fixture.
It now answers the ioctl the way a pipe answers it, so every caller takes the no-tty path
it already documents and is already tested on. A test that wants a size states one with
`mock.patch("os.get_terminal_size", …)`, which fifty-odd cases here already write.

The exit test is the measurement: two suite processes on two real ptys of different widths,
each reporting through `fcntl` the width it was handed *and* the width charter answered
with. It fails unless the first two differ (the control — a probe that quietly got a pipe
would agree with itself for free) and the second two agree.

### #564 — a reaper at start, because exit-time cleanup cannot follow a killed run

`tests/_tmuxreap.py` runs at import of the `tests` package. It touches a socket only when
the name is one this suite hands out (`charter-<slug>-<pid>` — the operator's own frame runs
on `charter`, no suffix, and cannot match; `probe-*` is not charter's namespace and is left
alone for the same reason `_envguard` refuses an `EDM_` prefix) **and** the pid in it is
gone, so a concurrent run is never disturbed. Whether a server is still listening is asked
of the socket with one `AF_UNIX` connect rather than by running `tmux` 497 times, and a live
one is killed *before* its file is unlinked — `kill-server` returns 0 with the socket still
bound for up to 1.3 ms, and unlink-then-kill points the kill at a path with no server on it
and leaves the real one running.

The four modules that name a socket get it from `_tmuxreap.name("<slug>")`, and a test
parses this directory for a module-level `*SOCKET` built from an f-string, so a fifth module
spelling its own is refused.

## Verification

**Full suite, two environments, both green, at the head sha:**

* `python3.14.4`, `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*`/`EDM_*` unset —
  `Ran 6768 tests … OK`
* `python3.12.13`, same environment — `Ran 6768 tests … OK`
* baseline for comparison, `5e73797` on `python3.14.4` — `Ran 6703 tests … OK`

**Leaked servers and sockets, counted before and after** — the tables above — and asserted
in a test: `test_the_suite_reaps_its_own_tmux_servers` plants a real tmux server on a socket
named for a pid it has just watched die, reaps, and asserts the socket file is gone *and the
server's own pid is gone with it*; a second case plants one under a live pid and asserts it
survives; a third asserts nothing that was reapable before a reap is reapable after it.

**CI** is checked at the head sha with
`gh api repos/diazoxide/charter/commits/<sha>/check-runs`, not `gh pr checks` (#561).
**CI cannot validate #564 and I am not claiming it does:** a runner is ephemeral, so a
leaked tmux server there dies with the machine and a green matrix says nothing about whether
one was leaked. The evidence for that half is the local A/B above.

**`tools/sweep.py`** over `charter` and `tests`, scoped to this branch's diff against the
merge-base, at the head sha: **43 mutations, 33 pinned, 7 survived, 3 unresolved** (its own
unmutated baseline `Ran 6768 tests — OK`, a third independent green full run). The first
time it was run against this branch it was 29 survivors out of 47; every one that was a
real gap is closed, and the seven that remain are classified rather than suppressed:

* **three** are the `if __name__ == "__main__": unittest.main()` footer, one per new
  module — 333 of this repository's 340 test modules carry it;
* **two** are the bounded-wait loop `while time.monotonic() < deadline and
  _tmuxreap._alive(server)`, whose `drop-conjunct` mutants are equivalent by construction:
  the loop is a tolerance for a slow machine around a condition that is already true, and
  the assertion after it is the claim. `_await` in three integration modules is the same
  shape;
* **one** is `except (OSError, TypeError, ValueError)` at `tests/_planeguard.py:1270`,
  which is **pre-existing code my diff only re-indents** — the plane check moved one level
  in to sit under a shared `if parts is not None:`, so `git diff` shows the same line as a
  `-` and a `+`, and a diff-scoped sweep charges the `+`;
* **one** is `except OSError` in the fixture that confirms a pid is gone, for a
  `PermissionError` a fixture that only ever asks about its own children cannot produce.
  `tools/sweep.py`'s own `PLATFORM_SENSITIVE` names this case for `narrow-except`
  survivors. Its production counterpart, `_tmuxreap._alive`, *is* pinned on that branch,
  with `os.kill` patched.

The **three unresolved** are timeouts, not verdicts — this box carried other agents' sweeps
throughout at load averages up to 138, and `tools/sweep.py`'s own rule is that a timeout is
neither green nor red. Each has a dedicated case: `_planeguard.py:1275 [drop-conjunct]` is
the hand-check's *"the fork guard ignores the declaration"*, `_tmuxreap.py:110
[no-fallback]` is `test_an_empty_value_is_not_a_directory`, and `_tmuxreap.py:171
[drop-if]` is `test_a_name_that_does_not_match_at_all_is_passed_over`.

**Hand-checked separately, because the sweep has no operator for string constants or
semantic swaps (#569):** 24 mutations, each an exact substitution verified to have landed
before anything runs — the file on disk is compared against the intended mutated text, since
a mutation whose edit never matched runs an unmutated tree and reports a false survivor
(#585) — each run against a green unmutated baseline for the same test set. **24/24 pinned,
zero survivors.**

Between them the two found **eleven real gaps**, all closed. The six worth reading:

1. **Deleting the reaper's `kill-server` survived.** The case asked the *socket* whether
   anything was still accepting, and an unlinked path answers `ECONNREFUSED` exactly like a
   dead server — so #564's own failure mode had been reproduced inside the test written to
   prevent it. It asks tmux for the server's pid now and watches that pid go.
2. **Narrowing `_alive`'s `except ProcessLookupError` survived, and the test did not fail —
   it SKIPPED.** The fixture that finds a dead pid asked `_alive` whether it had one, so the
   mutant was asked to certify itself, and a skip is a green. Fixtures ask the kernel now,
   and `_alive` has its own cases.
3. **Four mutations to the AST census's own reader survived**, including one that made it
   answer `None` for every `subprocess.Popen` — so it found nothing and reported success for
   it. Both census tests now carry a frozen expected set, the way
   `NoCharterEscapesThroughTheExecFamily.KNOWN` does: a scan that does not say what it
   expected to find cannot tell "nothing is wrong" from "I looked at nothing".
4. **Deleting the `^` anchor from the socket-name rule survived, and had to:** `re.match`
   anchors at position 0 regardless. The rule is a `fullmatch` with no redundant anchors
   now, which also stops `$` accepting a filename that ends in a newline, and a following
   mutation showed the scan and the predicate could disagree about what "ours" means — so a
   socket whose name merely *starts* like ours has a case of its own.
5. **The same "a skip is a green" shape, one level down and found by the second sweep.**
   Three mutations to the fixture that finds a dead pid — narrowing either `except`, or
   deleting the branch that returns it — make every candidate look alive, so the loop runs
   out and every case standing on that fixture reports success without running. It now
   raises instead of calling `skipTest`, and says why in the message: twenty consecutive
   reuses of pids this process itself freed is not an environment to tolerate, it is the
   helper being broken.
6. **The reaper itself made the leak it was written to fix — found by `ps`, not by a
   test.** `kill-server` ran with `check=False` and the unlink followed regardless, so a
   kill that did not take left a resident tmux server *and no file naming it*, which is
   #564 with the evidence destroyed. 24 of them accumulated on this machine that way while
   this branch was being written, alive with their sockets already gone. The unlink is
   gated on the kill's exit status now — a server that refuses to die keeps its file and is
   tried again next run — and both directions have a case against a real server. The gate
   is on the exit status rather than a second probe deliberately: tmux answers normally for
   0.4 ms after `kill-server` has returned 0, so re-probing would report it alive and
   nothing would ever be unlinked.

Two survivors are reported rather than fixed, both conventions this repository already
carries: the `if __name__ == "__main__": unittest.main()` footer (in 333 of 340 test
modules), and the bounded-wait loop `while time.monotonic() < deadline and …`, whose two
`drop-conjunct` mutants are equivalent by construction — the loop is a tolerance for a slow
machine around a condition that is already true, and the assertion after it is the claim.

**News entry** at `docs/news/unreleased-the-suite-stops-spending-your-machine.md`,
`version: unreleased`. No version bump, no stamp, no tag.

## Not fixed here, noticed on the way

`tests/test_frame_launcher.py:3925` hardcodes
`OPERATOR_SOCKET = "/private/tmp/tmux-502/default"` — a uid baked into a path, which is the
same defect class as everything above. It is only ever used as a string in argv assertions,
so nothing depends on it being a real path today. Left alone because #587 was working in
that file; worth its own issue.
