### PR TITLE
A bare string is a program name, and the terminal-size caveat says what it measured (#546/#545 follow-up)

### DIFF
--- a/docs/news/unreleased-the-suite-cannot-reach-your-vault-or-your-keyboard.md
+++ b/docs/news/unreleased-the-suite-cannot-reach-your-vault-or-your-keyboard.md
@@ -62,9 +62,13 @@ mutation that dies under a pipe "reported OK under a pty".
 
 **What this run still cannot promise.** The suite now gives the same verdict from a pipe and
 from a terminal for the two classes above, and a full run under a pty no longer hangs. It is
-not yet identical: 27 tests across eight modules still fail only under a terminal, all of
-them tracing to `os.get_terminal_size()` — the size of the window the suite happens to be
-running in, which is issue #544 and is not fixed here. Measured and written down rather than
-left for the next person to rediscover.
+not yet identical: 28 tests across eight modules still fail only under a terminal, and every
+one of them traces to `os.get_terminal_size()` — the size of the window the run happens to
+be in, not whether it is one. That is issue #544 and it is not fixed here. What the
+measurement adds to it: the pty those 28 were run under had never been given a window size,
+so `get_terminal_size()` answered **0 columns**, and `tui.term_width` guards `$COLUMNS <= 0`
+while doing nothing about a tty that reports zero — the same defect one rung down its own
+ladder, and reachable outside a test by any terminal whose size was never set. Give the same
+pty a size and all 28 pass.
 
 None of this reaches you unless you run charter's own test suite. Nothing to adopt.

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -1004,11 +1004,23 @@ class TheOperatorsCredentialStoreIsNeverReached(unittest.TestCase):
             subprocess.Popen(Path(self.dir / "op"))
         self.assertFalse(self.marker.exists())
 
-    def test_a_bare_string_as_the_whole_command_is_refused(self):
-        """Without `shell=True` a string is one program name and no arguments — a
-        different branch from the shell case below, and from the argv list above."""
+    def test_a_bare_string_is_a_program_name_and_is_not_lexed(self):
+        """Without `shell=True` a string is one program NAME — spaces and all — while with
+        it the string is a command line for `/bin/sh`. The two must not be conflated, and
+        a path with no space in it cannot tell them apart: `shlex.split` returns the same
+        one word either way. This one lexes into two, neither of which is `op`, so lexing
+        it would read as "not a credential CLI" for a spawn that is about to run one.
+
+        The directory is not called `vault something`, and that is not fussiness: the first
+        spelling of this case used `vault dir`, whose first lexed word is `vault` — itself
+        a guarded CLI — so the mutation it exists to catch stayed green by being refused
+        for the wrong reason."""
+        spaced = self.dir / "somebodys credentials"
+        spaced.mkdir()
+        shutil.copy(self.dir / "op", spaced / "op")
+        (spaced / "op").chmod(0o755)
         with self.assertRaises(_planeguard.RealVaultReach):
-            subprocess.Popen(str(self.dir / "op"))
+            subprocess.Popen(str(spaced / "op"))
         self.assertFalse(self.marker.exists())
 
     def test_a_command_that_is_all_wrapper_leaves_no_program_to_name(self):


### PR DESCRIPTION
Follow-up to #587, which was merged at `746613f` while the last two commits of the branch
were still being verified. Nothing here changes behaviour; both are things the verification
turned up after the merge.

**1. The last sweep survivor of that branch, closed.** `tools/sweep.py --path tests` on the
merged head left one mutation of mine alive: forcing `opts.get("shell")` on in
`_reaches_a_credential_cli` changed nothing, because `shlex.split` returns the same single
word as `[command]` for any path without a space in it. Without `shell=True` a string is one
program **name**, spaces and all; with it, it is a command line for `/bin/sh`. A path with a
space is the only input that can tell the two apart.

The first spelling of this case put `op` under a directory called `vault dir`, whose first
lexed word is `vault` — itself a guarded CLI — so the mutation it exists to catch stayed
green by being refused for the wrong reason. Renamed, and verified in **both** directions:
forcing the branch on and forcing it off each redden this case, against an unmutated
baseline, with each edit asserting it applied (#585).

What is left in that sweep's report is the `if __name__ == "__main__"` trailer, which 330 of
this repo's 337 test modules carry and which discovery never runs.

**2. The news entry's terminal-size caveat is off by one, and was vague about the cause.**
It said 27; the measured figure is 28 (27 failures and one error). More usefully, it said
only "`os.get_terminal_size()`" where the measurement says something #544 can act on: the
pty those 28 were run under had never been given a window size, so `get_terminal_size()`
answered **0 columns**, and `tui.term_width` guards `$COLUMNS <= 0` while doing nothing
about a tty that reports zero — the same defect one rung down its own ladder, and reachable
outside a test by any terminal whose size was never set. Give the same pty a size and all 28
pass.

## Verification

Full suite on this branch, in a fresh clone, with a logging stand-in for `op` first on
`$PATH`: `Ran 6703 tests` **OK**, 0 real `op` spawns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
