### PR TITLE
A column is measured in cells, and a frame answers for its own workspace (#592, #506, #526, #524)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -604,10 +604,19 @@ def _status_for_workspace(ws: str, inv_by_name: dict, active: str) -> None:
     # of the inventory, so neither width was ever charter's to guess — and `str.format`
     # counts characters where a terminal lays out cells, so a CJK repo name misaligned
     # its row without going anywhere near either constant.
-    body = [(name, inv_by_name.get(name, {}).get("stack", "?"), _clone_note(d))
-            for name, d in sorted(clones.items())]
-    nw = tui.column("REPO", [r[0] for r in body])
-    sw = tui.column("STACK", [r[1] for r in body])
+    #
+    # **Measured from the two columns that cost nothing to know, and only those.** A repo
+    # name is a dictionary key and a stack is an inventory lookup; the third column runs
+    # two `git` invocations per clone. Sizing from all three would mean collecting every
+    # row before printing any — on a workspace with twenty clones the operator waits for
+    # forty git calls before the header appears, where today the table draws as it goes.
+    # Nothing is lost by it: the last column has nothing to its right, so it needs no
+    # width at all. That is the same rule `_STATS_HEADS` keeps for its own trailing
+    # STATUS column.
+    rows = sorted(clones.items())
+    stacks = {n: inv_by_name.get(n, {}).get("stack", "?") for n, _ in rows}
+    nw = tui.column("REPO", [n for n, _ in rows])
+    sw = tui.column("STACK", stacks.values())
 
     def line(repo, stack, note) -> str:
         """Header and data rows through ONE function. They are sibling rows of the same
@@ -616,8 +625,8 @@ def _status_for_workspace(ws: str, inv_by_name: dict, active: str) -> None:
         return f"  {tui.pad(repo, nw)}{tui.pad(stack, sw)}{note}".rstrip()
 
     print(line("REPO", "STACK", "BRANCH / NOTE"))
-    for row in body:
-        print(line(*row))
+    for name, d in rows:
+        print(line(name, stacks[name], _clone_note(d)))
     print()
 
 

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -7,7 +7,7 @@ import json
 import re
 from pathlib import Path
 
-from . import (config, contain, docsrc, doctor, instance, inventory, render, util,
+from . import (config, contain, docsrc, doctor, instance, inventory, render, tui, util,
                workspace, worktree)
 # One committer for the control plane, in charter/planegit.py. Re-exported rather
 # than moved-and-updated so every existing caller and test keeps working — the point
@@ -596,11 +596,28 @@ def _status_for_workspace(ws: str, inv_by_name: dict, active: str) -> None:
         hint = f"`charter clone <repo> --workspace {ws}` to populate"
         print(f"  (empty; {hint})\n")
         return
-    fmt = "  {:<38} {:<12} {}"
-    print(fmt.format("REPO", "STACK", "BRANCH / NOTE"))
-    for name, d in sorted(clones.items()):
-        stack = inv_by_name.get(name, {}).get("stack", "?")
-        print(fmt.format(name, stack, _clone_note(d)))
+    # Sized from the values, measured in CELLS (#592). `{:<38} {:<12}` was two of the
+    # three shipped instances of #508's constant, and the STACK one is wrong on a value
+    # charter itself produces: `node-monorepo` is thirteen characters in a column of
+    # twelve, so every monorepo row PUSHED its branch note one column right of every
+    # other row's. A repo name is a directory somebody else cloned and a stack comes out
+    # of the inventory, so neither width was ever charter's to guess — and `str.format`
+    # counts characters where a terminal lays out cells, so a CJK repo name misaligned
+    # its row without going anywhere near either constant.
+    body = [(name, inv_by_name.get(name, {}).get("stack", "?"), _clone_note(d))
+            for name, d in sorted(clones.items())]
+    nw = tui.column("REPO", [r[0] for r in body])
+    sw = tui.column("STACK", [r[1] for r in body])
+
+    def line(repo, stack, note) -> str:
+        """Header and data rows through ONE function. They are sibling rows of the same
+        table, and two code paths that each believe they agree about the widths is the
+        fastest way back to a misaligned report (#508's own finding, one command over)."""
+        return f"  {tui.pad(repo, nw)}{tui.pad(stack, sw)}{note}".rstrip()
+
+    print(line("REPO", "STACK", "BRANCH / NOTE"))
+    for row in body:
+        print(line(*row))
     print()
 
 
@@ -2359,23 +2376,37 @@ def cmd_recall(args) -> int:
         if got.undated:
             util.info(f"{got.undated} undated memory(ies) skipped — no recorded date to compare.")
         return 0
-    width = max((len(h.label) for h in results), default=8)
+    # Sized from the values it holds, measured in CELLS (#592). This column was ALREADY
+    # sized from the data, which is the half a constant gets wrong — and it still
+    # misaligned, because `len` counts characters and a terminal lays out cells. A base
+    # label is a persona or workspace directory name, so a CJK one is two cells per glyph
+    # and `len` under-pads it by its own length; a combining mark is zero cells and `len`
+    # over-pads. Either way the TITLE column lands somewhere on that row it lands on no
+    # other. Sizing and padding have to be the same unit or the arithmetic was for
+    # nothing, which is why `tui.pad` fills these rather than `{:<n}`.
+    dates = [h.date.isoformat() if h.date else "—" for h in results]
+    dw = tui.column("", dates)
+    lw = tui.column("", [h.label for h in results])
     full = getattr(args, "full", False)
-    for h in results:
+    # The address line hangs under the TITLE, so its indent is the two columns in front of
+    # it and not a number that happens to equal them today. It was `14` written out, which
+    # is `2 + 10 + 2` — correct only while the date column is exactly ten wide.
+    hang = " " * (2 + dw)
+    for h, date in zip(results, dates):
         tag = f"  ({h.score})" if h.score else ""
         # The date leads because when listing it IS the sort key — and the column order
         # stays identical under a query (where score orders instead), since a layout that
         # rearranges itself per mode is harder to read than one that never moves.
-        print(f"  {h.date.isoformat() if h.date else '—':<10}  {h.label:<{width}}  {h.title}{tag}")
+        print(f"  {tui.pad(date, dw)}{tui.pad(h.label, lw)}{h.title}{tag}".rstrip())
         # The ADDRESS, on every hit. This used to be a closing sentence telling the reader
         # to go and find the file, which is a direction rather than a location — and the
         # slug rules differ per base (the journal timestamps its filenames, persona memory
         # does not), so following it cost an inference and a `Read` per hit.
-        print(f"              {_rel_to_root(h.path)}")
+        print(f"{hang}{_rel_to_root(h.path)}")
         if full:
             snip = _body_snippet(h.path)
             if snip:
-                print(f"              {snip}")
+                print(f"{hang}{snip}")
     where = "every workspace" if all_ws else ", ".join(scopes)
     util.info(f"{len(results)} memory(ies) across {where}."
               + ("" if full else "  Pass --full for a line of each body."))

--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from . import config, pieces, util, workspace, worktree
+from . import config, pieces, tui, util, workspace, worktree
 from . import root as _root
 
 #: Exit code for "this piece is already claimed", distinct from the generic 1 every other
@@ -281,11 +281,25 @@ def cmd_worktree_history(args) -> int:
                   "`charter worktree add`.")
         return 0
 
-    for e in rows:
-        who = pieces.claimant(e)
-        reason = f" — {e['reason']}" if e.get("reason") else ""
-        print(f"    {e.get('ts', ''):<22} {e.get('repo', ''):<16} "
-              f"{e.get('piece', ''):<24} {e.get('event', ''):<10} {who}{reason}")
+    # Sized from the values, measured in CELLS (#592). `{ts:<22}` is the instance of
+    # #508's constant that is wrong on charter's OWN output rather than on an unusual
+    # name: `pieces.record` writes `datetime.isoformat(timespec="seconds")`, which is 25
+    # characters with an offset on it, so EVERY row of this table pushed its repo, piece
+    # and event three columns right of the next one — the table has never once lined up.
+    # A repo and a piece name are somebody else's directory names, so `:<16`/`:<24` were
+    # guesses about content too, and `str.format` counts characters where a terminal lays
+    # out cells.
+    #
+    # A second thing the kit brings that the format string could not: these values come
+    # out of a COMMITTED log, so `tui.pad` sanitising them (a newline becomes a space) is
+    # what stops one event's field shearing every column below it.
+    body = [(e.get("ts", ""), e.get("repo", ""), e.get("piece", ""), e.get("event", ""),
+             pieces.claimant(e) + (f" — {e['reason']}" if e.get("reason") else ""))
+            for e in rows]
+    widths = [tui.column("", [r[i] for r in body]) for i in range(4)]
+    for row in body:
+        cells = "".join(tui.pad(c, w) for c, w in zip(row, widths))
+        print(f"    {cells}{row[4]}".rstrip())
     return 0
 
 

--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -293,7 +293,15 @@ def cmd_worktree_history(args) -> int:
     # A second thing the kit brings that the format string could not: these values come
     # out of a COMMITTED log, so `tui.pad` sanitising them (a newline becomes a space) is
     # what stops one event's field shearing every column below it.
-    body = [(e.get("ts", ""), e.get("repo", ""), e.get("piece", ""), e.get("event", ""),
+    #
+    # `ts`, `repo` and `event` need their fallbacks and `piece` does not, which looks
+    # inconsistent and is not: `pieces.events` keeps a line only `if obj.get("piece")`, so
+    # a row without one never reaches here — the deletion sweep reported the fourth
+    # fallback as equivalent and it was right. Subscripted rather than `.get`, so if that
+    # filter ever goes the failure is a loud `KeyError` naming the field rather than
+    # `tui.pad(None, w)` three frames down. The other three are reachable the moment a
+    # process is killed mid-append, which is what `events()` tolerates by design.
+    body = [(e.get("ts", ""), e.get("repo", ""), e["piece"], e.get("event", ""),
              pieces.claimant(e) + (f" — {e['reason']}" if e.get("reason") else ""))
             for e in rows]
     widths = [tui.column("", [r[i] for r in body]) for i in range(4)]

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -1105,12 +1105,32 @@ def todo_section(fid: str, width: int, budget: int, *, terse: bool) -> list[str]
 
     How SHORT is too short is `_todo_rows`' rule and is asked there once: this decides
     only whether there is any room at all.
+
+    **The workspace is the FRAME's, handed in, never one the panel resolved for itself**
+    (#526) — :func:`_frame_workspace`, the rule every other surface of the frame asks.
+    `gather.read` falls through to `gather.scan` on a cold cache, and `scan` with no
+    workspace argument calls `workspace.resolve()` **in the panel process**, which #512
+    established reaches none of the rungs that can speak for the frame: `$CHARTER_WORKSPACE`
+    arrives empty by design (#411), the cwd is the plane root, the per-session pointer is
+    keyed on the FRAME id, and the per-terminal pointer on the panel's own `$TMUX_PANE`.
+    It lands on the declared default. So a frame's first paint listed **`default`'s** open
+    todos under this plane's `▪ todos N` heading — and that is worse here than the blank
+    repo table #512 fixed, because a populated list reads as an answer: three todos an
+    operator has never seen read as three todos they have.
+
+    **The scan fallback stays, and that is a decision rather than an inheritance.** #525
+    took it away from `bottom` and gave that slot a `⋯ gathering…` placeholder instead,
+    on the grounds that `bottom` is the one ANIMATED slot — it repaints five times a
+    second while work is in flight, and a cold `scan()` is a git sweep per repaint. The
+    sidebar is not animated: one scan, on one paint, and a column that draws its todos
+    immediately is worth having. The two slots therefore read the cache by two different
+    rules, deliberately, and the difference is the repaint rate rather than the section.
     """
     from . import gather
     budget = min(budget, _TERSE_ROWS if terse else _MAX_TODO_LINES)
     if budget <= 0:
         return []
-    return _todo_rows(gather.read(fid), width, budget)
+    return _todo_rows(gather.read(fid, workspace=_frame_workspace(fid)), width, budget)
 
 
 def _right(fid: str) -> str:

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -946,18 +946,18 @@ def _row_plan(budget: int) -> _RowPlan:
     it. It takes the other of #506's two honest options: a narrower row SHAPE, whose
     losing order is written down.
 
-    The order, and why each item is where it is:
+    What a narrow pane gives up, and why in that order:
 
-    1. **The branch text shrinks first.** It is the widest column and the least urgent —
-       "which branch" is a fact you go and look up, where a red pipeline is one you act
-       on. It stops at :data:`_BRANCH_MIN_W`, which is the markers, because dirty/ahead/
-       behind are true of the TREE and outlive its name.
-    2. **Then the repo name shrinks**, to :data:`_NAME_MIN_W`.
-    3. **Then whole cells go**, in the order change → branch → CI. Whole, never trimmed:
-       `✗ fa…` is the false-clean reading a trimmed cell produces, and the CI mark is the
-       last thing standing because it is the one cell that changes what a reader does
+    1. **The branch text is the first thing to go and the CI mark the last.** "Which
+       branch" is a fact you go and look up; a red pipeline is one you act on. So the
+       branch is the widest column at a wide pane and the first to reach its floor, and
+       that floor is :data:`_BRANCH_MIN_W` — the markers — because dirty/ahead/behind are
+       true of the TREE and outlive what it is called.
+    2. **A cell that cannot be shown whole is not shown**, in the order change → branch →
+       CI. `✗ fa…` is the false-clean reading a trimmed cell produces, and the CI mark is
+       the last thing standing because it is the one cell that changes what a reader does
        next.
-    4. **Anything a drop left over goes back**, name first. A dropped cell frees more
+    3. **Anything a drop left over goes back**, name first. A dropped cell frees more
        columns than the deficit demanded, and leaving them blank while the repo name is
        cut to twelve characters spends a narrow pane on nothing.
 
@@ -965,26 +965,24 @@ def _row_plan(budget: int) -> _RowPlan:
     status-line PANE's width, so any split reaches here — lays out at 72 and loses
     exactly 23 columns of branch text. Nothing else moves.
     """
-    # **No early return for a wide pane, and no `break` in the loop below.** Both were
-    # here, and a deletion sweep reported both as equivalent — correctly. A pane at
-    # `_LEFT_W` or wider walks the whole function and comes back with `_FULL_ROW` anyway:
-    # `over` clamps to zero so nothing shrinks, the drop loop finds the plan already
-    # inside the budget, and the leftover loop caps each cell at its full width. Saying it
-    # twice bought a branch nothing could reach.
+    # **Written as "start at the floors and spend upward", not "start full and shrink".**
+    # It was the second, with an early return for a wide pane and a shrink loop in front
+    # of the two below — and a deletion sweep took all of it apart: the early return was
+    # unreachable behaviour (a wide pane comes back with `_FULL_ROW` from the general path
+    # anyway), and the shrink loop was redundant with the give-back loop, which recomputes
+    # the same allocation from the floors. Verified as a whole function rather than
+    # reasoned: the two spellings agree at every budget from 1 to 400.
     #
-    # What replaces the `break` is what the `break` was really for: `max(0, …)` makes the
-    # shrink loop unable to GROW a cell. That is a property of the arithmetic now rather
-    # than of an early exit somebody has to keep in step with it — and it IS pinned, by
-    # `_row_plan(200) == _FULL_ROW`: unclamp it and a 200-column pane plans a 139-column
-    # branch cell.
-    plan = _FULL_ROW
-    for i, floor in ((1, _BRANCH_MIN_W), (0, _NAME_MIN_W)):
-        over = max(0, _plan_width(plan) - budget)
-        plan = plan._replace(**{plan._fields[i]: max(floor, plan[i] - over)})
+    # And this way the two orders are each written down exactly once — the drop order, and
+    # the give-back order that makes the branch narrow before the name does — instead of
+    # the give-back silently overruling a shrink that had already made the same decision.
+    plan = _RowPlan(_NAME_MIN_W, _BRANCH_MIN_W, _CI_W, _MR_W)
     for i in (3, 1, 2):                       # change, then branch, then CI
         if _plan_width(plan) <= budget:
             break
         plan = plan._replace(**{plan._fields[i]: 0})
+    # The name is filled to its full width before the branch gets a column, which is what
+    # "the branch narrows first" means from this direction.
     for i, full in ((0, _FULL_ROW.name), (1, _FULL_ROW.branch)):
         spare = budget - _plan_width(plan)
         if plan[i] and spare > 0:

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -983,9 +983,17 @@ def _row_plan(budget: int) -> _RowPlan:
         plan = plan._replace(**{plan._fields[i]: 0})
     # The name is filled to its full width before the branch gets a column, which is what
     # "the branch narrows first" means from this direction.
+    #
+    # `spare > 0` and not `plan[i] and spare > 0`. The second conjunct read as "never
+    # resurrect a cell the drop loop took away", which sounds load-bearing and is not: the
+    # only droppable cell here is the branch, the name is filled first and can absorb
+    # twenty columns, and every budget narrow enough to have dropped the branch has fewer
+    # than twenty spare. A deletion sweep said so. `spare > 0` IS load-bearing — below the
+    # name's own floor `spare` goes negative, and without the guard the name is planned
+    # narrower than the floor it was just given.
     for i, full in ((0, _FULL_ROW.name), (1, _FULL_ROW.branch)):
         spare = budget - _plan_width(plan)
-        if plan[i] and spare > 0:
+        if spare > 0:
             plan = plan._replace(**{plan._fields[i]: min(full, plan[i] + spare)})
     return plan
 

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -108,6 +108,21 @@ _HEAD_PAD = f"{_MARK_HEAD} "
 # Visible width of the whole left/repo block: "  " + "├─ " + name + gaps + branch + ci + mr.
 _LEFT_W = 2 + 3 + _NAME_W + 2 + _BRANCH_W + 2 + _CI_W + 2 + _MR_W
 _RIGHT_MIN_W = 36  # a persona column narrower than this is not worth showing
+
+# --- what a row gives up when the pane cannot hold all of it (#506) ------------------
+#
+# The name cell's floor: the indent, the tree glyphs, and enough label to tell one repo
+# from another. Never zero — a row with no name is not a row about anything.
+_NAME_MIN_W = 2 + 3 + 12
+# The branch cell's floor. `*↑9↓9` is five cells, so this is the markers plus one: the
+# markers are true of the TREE (dirty, unpushed, behind) and the branch name is only what
+# the tree is called, so what this floor protects is the markers.
+_BRANCH_MIN_W = 6
+# Below this much room left over after the markers, the branch NAME is dropped whole
+# rather than cut: `fe…` is not a branch anybody can act on, and spending the cell on the
+# markers instead is the same shown-whole-or-dropped-whole rule :func:`_row_plan` keeps
+# one level up.
+_BRANCH_TEXT_MIN_W = 4
 # Render to (COLUMNS − this). The pane gives LESS than `$COLUMNS` advertises, and the
 # amount was measured rather than guessed: at 2, a line ending exactly at COLUMNS−2 lost
 # its final character to the host's own `…` crop (the brand rendered `⬢ charter 0.10…`),
@@ -819,7 +834,8 @@ def _presence_text(ws: str, repo: str, piece: str | None) -> str:
 
 
 def _branch_cell_for(branch_text: str, presence: str, marks_plain: str = "",
-                     marks_col: str = "", is_dirty: bool = False) -> str:
+                     marks_col: str = "", is_dirty: bool = False,
+                     width: int = _BRANCH_W) -> str:
     """The branch cell's contents: branch, markers, and presence **if it still fits**.
 
     The losing order matters more than the layout. Markers and the branch name are true of
@@ -827,15 +843,30 @@ def _branch_cell_for(branch_text: str, presence: str, marks_plain: str = "",
     the branch is truncated only so far as the markers demand — the rule this cell already
     kept — and presence is appended only out of whatever room is genuinely left over. On a
     narrow pane presence disappears and nothing that was there before moves.
+
+    *width* is the cell the caller is about to pad this into, and it is a parameter rather
+    than :data:`_BRANCH_W` because :func:`_row_plan` narrows this cell first on a pane that
+    cannot hold the whole row (#506). Measuring against the constant while the caller pads
+    to something smaller is the defect one layer down from the one #506 is about: the cell
+    would compose 34 columns of branch-and-markers and `tui.Cell` would then cut the
+    markers off the right-hand end — the markers being exactly what the narrowing was
+    protecting.
+
+    **Below :data:`_BRANCH_TEXT_MIN_W` of room the branch name is dropped whole**, not
+    truncated to a stub. `fe…` names no branch a reader can act on, while `*↑2` says the
+    tree is dirty and unpushed whatever it is called — so on the last few columns the
+    markers take the cell outright.
     """
-    br = tui.truncate(branch_text, max(1, _BRANCH_W - tui.width(marks_plain)))
+    room = width - tui.width(marks_plain)
+    if room < _BRANCH_TEXT_MIN_W:
+        return marks_col
+    br = tui.truncate(branch_text, max(1, room))
     out = f"{_YELLOW if is_dirty else _DIM}{br}{_R}{marks_col}"
     if not presence:
         return out
     used = tui.width(br) + tui.width(marks_plain)
-    room = _BRANCH_W - used
     need = tui.width(_strip(presence)) + 1        # +1 for the separating space
-    return out + f" {presence}" if room >= need else out
+    return out + f" {presence}" if width - used >= need else out
 
 
 def _strip(text: str) -> str:
@@ -860,7 +891,89 @@ def _presence_for_dir(d) -> str:
         return ""
 
 
-def _tree_cells(lead: str, label: str, d, states, branches, gl, branch=None) -> tui.Row:
+class _RowPlan(NamedTuple):
+    """The four cell widths one repo row is composed at. ``0`` means *not drawn at all*.
+
+    A plan is made once per render from the columns the pane actually has, and every row
+    is built from the same one — which is what keeps sibling rows aligned, the property
+    this layout has paid for repeatedly.
+    """
+
+    name: int
+    branch: int
+    ci: int
+    mr: int
+
+
+#: The row every pane at :data:`_LEFT_W` or wider gets. Spelled from the same terms
+#: `_LEFT_W` is, so the two cannot drift.
+_FULL_ROW = _RowPlan(2 + 3 + _NAME_W, _BRANCH_W, _CI_W, _MR_W)
+
+
+def _plan_width(plan: _RowPlan) -> int:
+    """Visible columns a row composed at *plan* occupies — dropped cells cost nothing,
+    and neither does the gap that would have followed one."""
+    drawn = [w for w in plan if w]
+    return sum(drawn) + len(_GAP) * max(0, len(drawn) - 1)
+
+
+def _row_plan(budget: int) -> _RowPlan:
+    """The cell widths for a repo row on a pane *budget* columns wide (#506).
+
+    **The decision is made here, where the row is COMPOSED, and not by the crop at the
+    end.** Composing every row at :data:`_LEFT_W` (95) and letting `_columns` clamp it to
+    the terminal is what #506 reports: each column sits at a fixed offset past the name
+    and the branch, so the cells cut off an 80-column pane are the last two — the CI mark
+    and the open change. A dirty, CI-failing, unpushed repo then read as one that was
+    merely dirty, because the dirty marker rides on the branch cell and survived. A crop
+    cannot know which column it just ate; this can.
+
+    That is the same reading `frame/slots._table_lines` refuses for its own pane ("too
+    narrow for the table is NO table, not a cut one", #488) — but the status line is what
+    an operator sees when they are NOT in a frame, so drawing nothing is not available to
+    it. It takes the other of #506's two honest options: a narrower row SHAPE, whose
+    losing order is written down.
+
+    The order, and why each item is where it is:
+
+    1. **The branch text shrinks first.** It is the widest column and the least urgent —
+       "which branch" is a fact you go and look up, where a red pipeline is one you act
+       on. It stops at :data:`_BRANCH_MIN_W`, which is the markers, because dirty/ahead/
+       behind are true of the TREE and outlive its name.
+    2. **Then the repo name shrinks**, to :data:`_NAME_MIN_W`.
+    3. **Then whole cells go**, in the order change → branch → CI. Whole, never trimmed:
+       `✗ fa…` is the false-clean reading a trimmed cell produces, and the CI mark is the
+       last thing standing because it is the one cell that changes what a reader does
+       next.
+    4. **Anything a drop left over goes back**, name first. A dropped cell frees more
+       columns than the deficit demanded, and leaving them blank while the repo name is
+       cut to twelve characters spends a narrow pane on nothing.
+
+    An 80-column terminal — `render`'s ordinary narrow case, and `$COLUMNS` is the
+    status-line PANE's width, so any split reaches here — lays out at 72 and loses
+    exactly 23 columns of branch text. Nothing else moves.
+    """
+    plan = _FULL_ROW
+    if budget >= _LEFT_W:
+        return plan
+    for i, floor in ((1, _BRANCH_MIN_W), (0, _NAME_MIN_W)):
+        over = _plan_width(plan) - budget
+        if over <= 0:
+            break
+        plan = plan._replace(**{plan._fields[i]: max(floor, plan[i] - over)})
+    for i in (3, 1, 2):                       # change, then branch, then CI
+        if _plan_width(plan) <= budget:
+            break
+        plan = plan._replace(**{plan._fields[i]: 0})
+    for i, full in ((0, _FULL_ROW.name), (1, _FULL_ROW.branch)):
+        spare = budget - _plan_width(plan)
+        if plan[i] and spare > 0:
+            plan = plan._replace(**{plan._fields[i]: min(full, plan[i] + spare)})
+    return plan
+
+
+def _tree_cells(lead: str, label: str, d, states, branches, gl, branch=None,
+                plan: _RowPlan = _FULL_ROW) -> tui.Row:
     """One table row — ``<lead><label>`` in the name column, then branch+markers, CI, change.
 
     Shared by repo rows and nested worktree rows so the two cannot drift: a worktree's row
@@ -875,22 +988,31 @@ def _tree_cells(lead: str, label: str, d, states, branches, gl, branch=None) -> 
     *branch* overrides the looked-up branch text — pass ``""`` to print the markers alone.
     The markers are never part of that override: dirty and ahead/behind are true of the
     tree whatever its branch is called, so they survive an emptied branch cell.
+
+    *plan* is what the pane can afford (:func:`_row_plan`). A cell whose planned width is
+    zero is **not built**, so no gap is spent on it either — the alternative, a zero-width
+    `Cell`, leaves the row carrying `_GAP` for a column that is not there and every row
+    after the drop starts two columns further right than the header above it.
     """
-    name = tui.Cell(f"{lead}{label}", 2 + 3 + _NAME_W)
+    cells: list[tui.Cell] = [tui.Cell(f"{lead}{label}", plan.name)]
 
     # branch + markers: truncate the *branch* so the markers always survive
     marks_plain, marks_col, is_dirty = _markers(states.get(d, {}))
     text = branches.get(d, "?") if branch is None else branch
-    branch = tui.Cell(_branch_cell_for(text, _presence_for_dir(d),
-                                       marks_plain, marks_col, is_dirty), _BRANCH_W)
+    if plan.branch:
+        cells.append(tui.Cell(_branch_cell_for(text, _presence_for_dir(d), marks_plain,
+                                               marks_col, is_dirty, plan.branch),
+                              plan.branch))
 
     info = gl.get(d, {})
-    ci = tui.Cell(_ci_part(info.get("ci")), _CI_W)
-    change = info.get("change")
-    sigil = info.get("sigil") or "!"   # old caches (pre-forge-protocol) carry no sigil
-    mr_cell = tui.Cell(f"{_GREEN}{sigil}{change}{_R}" if change else "", _MR_W)
+    if plan.ci:
+        cells.append(tui.Cell(_ci_part(info.get("ci")), plan.ci))
+    if plan.mr:
+        change = info.get("change")
+        sigil = info.get("sigil") or "!"   # old caches (pre-forge-protocol) carry no sigil
+        cells.append(tui.Cell(f"{_GREEN}{sigil}{change}{_R}" if change else "", plan.mr))
 
-    return tui.Row(name, branch, ci, mr_cell, gap=_GAP)
+    return tui.Row(*cells, gap=_GAP)
 
 
 def _pick_rows(dirs, budget: int, cur_repo, states, gl) -> list[Path]:
@@ -1037,7 +1159,8 @@ def _silence_rank(age: str) -> int:
         return 0
 
 
-def _repo_rows(dirs, active, cur, states, branches, gl, detail_wts=()) -> list[tui.Node]:
+def _repo_rows(dirs, active, cur, states, branches, gl, detail_wts=(),
+               budget: int = _LEFT_W) -> list[tui.Node]:
     """One table row per clone, nested under the workspace like a tree:
 
         ├─ <repo>   <branch><markers>   <ci>   <sigil><change>
@@ -1048,6 +1171,13 @@ def _repo_rows(dirs, active, cur, states, branches, gl, detail_wts=()) -> list[t
 
     Column widths are declared per cell; the kit pads/truncates so sibling
     rows stay aligned and nothing ever exceeds the render width.
+
+    *budget* is the columns the caller actually has for this block, and every row here is
+    composed at :func:`_row_plan`'s answer for it — ONE plan, made once, shared by every
+    row and by the two `tui.Text` lines below them. A per-row plan would be the same
+    mistake as a per-row width: the rows are siblings, and a table whose rows disagree
+    about their columns is not a table. See :func:`_row_plan` for what a narrow pane gives
+    up and in what order (#506).
 
     Bounded by `_MAX_REPO_LINES` TOTAL rows, not by repo count: repos are prioritised
     over worktree rows (every repo gets its own row before any repo's worktrees get
@@ -1061,6 +1191,7 @@ def _repo_rows(dirs, active, cur, states, branches, gl, detail_wts=()) -> list[t
     """
     if not dirs:
         return []
+    plan = _row_plan(budget)
     # `cur[0] is None` = the cwd is in the root tree, which is a member of EVERY
     # workspace, so it is current whichever one is active.
     cur_repo = cur[1] if (cur and (cur[0] is None or cur[0] == active)) else None
@@ -1102,7 +1233,7 @@ def _repo_rows(dirs, active, cur, states, branches, gl, detail_wts=()) -> list[t
         # indent + tree + name (padding lands outside the style, not underlined)
         rows.append(_tree_cells(f"  {_DIM}{tree}{_R}",
                                 f"{emph}{color}{d.name}{_R}{badge}",
-                                d, states, branches, gl))
+                                d, states, branches, gl, plan=plan))
 
         if kids:
             wt_budget -= len(kids)
@@ -1129,7 +1260,8 @@ def _repo_rows(dirs, active, cur, states, branches, gl, detail_wts=()) -> list[t
                 rows.append(_tree_cells(f"  {_DIM}{_TREE_PIPE}{mark}{_R}",
                                         f"{emph_w}{_DIM}{w.name}{_R}",
                                         w, states, branches, gl,
-                                        branch=state if wb == w.name else wb))
+                                        branch=state if wb == w.name else wb,
+                                        plan=plan))
         # ONE summary line per repo, newest piece first — a fixed cost no matter how many
         # worktrees exist, so the footer can't grow with them (the ⑂N badge above carries
         # the true total, and overflow truncates with … rather than dropping pieces
@@ -1141,7 +1273,7 @@ def _repo_rows(dirs, active, cur, states, branches, gl, detail_wts=()) -> list[t
             wt_budget -= 1
             lead = f"  {_DIM}{_TREE_PIPE}{_R} {_DIM}{_TREE_WT}{_R}"
             pieces = tui.truncate(" · ".join(w.name for w in wts),
-                                  max(1, _LEFT_W - tui.width("  │   ╰─ ")))
+                                  max(1, budget - tui.width("  │   ╰─ ")))
             rows.append(tui.Text(f"{lead}{_DIM}{pieces}{_R}"))
 
     if capped:
@@ -2319,9 +2451,17 @@ def render(payload: dict | None = None) -> str:
         ]))
 
         sid = payload.get("session_id")
-        repo_lines = [r.render(_LEFT_W)[0]
+        # The columns the repo block actually gets, and the one number every row below is
+        # composed for (#506). `min` covers both layouts with one expression rather than
+        # by asking which one is about to be chosen: the two-column branch below hands the
+        # left column exactly `_LEFT_W`, and it is only taken when `width` is at least
+        # `_LEFT_W + _RIGHT_MIN_W`, so `min` already answers `_LEFT_W` there. The
+        # single-column branches truncate each line to `width`, which is the crop #506 is
+        # about — so on a narrow pane this is what stops the CI mark being eaten by it.
+        repo_w = min(width, _LEFT_W)
+        repo_lines = [r.render(repo_w)[0]
                       for r in _repo_rows(dirs, active, cur, states, branches, gl,
-                                          detail_wts)]
+                                          detail_wts, repo_w)]
         chips = _persona_chips(sid)
     except Exception:
         return f"{_CYAN}⬢{_R} charter"

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -2493,13 +2493,16 @@ def render(payload: dict | None = None) -> str:
 
         sid = payload.get("session_id")
         # The columns the repo block actually gets, and the one number every row below is
-        # composed for (#506). `min` covers both layouts with one expression rather than
-        # by asking which one is about to be chosen: the two-column branch below hands the
-        # left column exactly `_LEFT_W`, and it is only taken when `width` is at least
-        # `_LEFT_W + _RIGHT_MIN_W`, so `min` already answers `_LEFT_W` there. The
-        # single-column branches truncate each line to `width`, which is the crop #506 is
-        # about — so on a narrow pane this is what stops the CI mark being eaten by it.
-        repo_w = min(width, _LEFT_W)
+        # composed for (#506). The single-column branches truncate each line to `width`,
+        # which is the crop #506 is about — so on a narrow pane this is what stops the CI
+        # mark being eaten by it.
+        #
+        # `width`, with no `min(width, _LEFT_W)` in front of it, and a deletion sweep is
+        # why: `_row_plan` cannot return a plan wider than the table — `_LEFT_W` IS what
+        # the full plan sums to, both spelled from the same four cells — so the clamp
+        # restated a property the plan already has. It is pinned where it belongs, on
+        # `_row_plan`, rather than at each caller that would otherwise have to remember it.
+        repo_w = width
         repo_lines = [r.render(repo_w)[0]
                       for r in _repo_rows(dirs, active, cur, states, branches, gl,
                                           detail_wts, repo_w)]

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -122,6 +122,13 @@ _BRANCH_MIN_W = 6
 # rather than cut: `fe…` is not a branch anybody can act on, and spending the cell on the
 # markers instead is the same shown-whole-or-dropped-whole rule :func:`_row_plan` keeps
 # one level up.
+#
+# **Bounded from both sides by a property, and 4/5/6 are indistinguishable between them.**
+# Measured, so the next reader does not go looking: below 4 a stub is drawn again (`a-…`
+# beside the markers, which the tests refuse); above 6 the branch vanishes from an
+# ordinary CLEAN row at the floor, because `main` is four cells in a six-cell cell and
+# there are no markers to pay for. Inside that band no user-facing property can tell one
+# value from another, and a test asserting the number would only pin the spelling.
 _BRANCH_TEXT_MIN_W = 4
 # Render to (COLUMNS − this). The pane gives LESS than `$COLUMNS` advertises, and the
 # amount was measured rather than guessed: at 2, a line ending exactly at COLUMNS−2 lost
@@ -860,7 +867,12 @@ def _branch_cell_for(branch_text: str, presence: str, marks_plain: str = "",
     room = width - tui.width(marks_plain)
     if room < _BRANCH_TEXT_MIN_W:
         return marks_col
-    br = tui.truncate(branch_text, max(1, room))
+    # `room`, not `max(1, room)`. The clamp was here before the refusal above was, and the
+    # refusal makes it dead: reaching this line means `room` is at least
+    # `_BRANCH_TEXT_MIN_W`. A deletion sweep said so, and two guards where one decides is
+    # the shape this repo keeps shipping — the second one passes because the first one
+    # caught it, and no mutation can turn it red.
+    br = tui.truncate(branch_text, room)
     out = f"{_YELLOW if is_dirty else _DIM}{br}{_R}{marks_col}"
     if not presence:
         return out
@@ -953,13 +965,21 @@ def _row_plan(budget: int) -> _RowPlan:
     status-line PANE's width, so any split reaches here — lays out at 72 and loses
     exactly 23 columns of branch text. Nothing else moves.
     """
+    # **No early return for a wide pane, and no `break` in the loop below.** Both were
+    # here, and a deletion sweep reported both as equivalent — correctly. A pane at
+    # `_LEFT_W` or wider walks the whole function and comes back with `_FULL_ROW` anyway:
+    # `over` clamps to zero so nothing shrinks, the drop loop finds the plan already
+    # inside the budget, and the leftover loop caps each cell at its full width. Saying it
+    # twice bought a branch nothing could reach.
+    #
+    # What replaces the `break` is what the `break` was really for: `max(0, …)` makes the
+    # shrink loop unable to GROW a cell. That is a property of the arithmetic now rather
+    # than of an early exit somebody has to keep in step with it — and it IS pinned, by
+    # `_row_plan(200) == _FULL_ROW`: unclamp it and a 200-column pane plans a 139-column
+    # branch cell.
     plan = _FULL_ROW
-    if budget >= _LEFT_W:
-        return plan
     for i, floor in ((1, _BRANCH_MIN_W), (0, _NAME_MIN_W)):
-        over = _plan_width(plan) - budget
-        if over <= 0:
-            break
+        over = max(0, _plan_width(plan) - budget)
         plan = plan._replace(**{plan._fields[i]: max(floor, plan[i] - over)})
     for i in (3, 1, 2):                       # change, then branch, then CI
         if _plan_width(plan) <= budget:

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -991,8 +991,18 @@ def _tree_cells(lead: str, label: str, d, states, branches, gl, branch=None,
 
     *plan* is what the pane can afford (:func:`_row_plan`). A cell whose planned width is
     zero is **not built**, so no gap is spent on it either — the alternative, a zero-width
-    `Cell`, leaves the row carrying `_GAP` for a column that is not there and every row
-    after the drop starts two columns further right than the header above it.
+    `Cell`, leaves the row carrying `_GAP` for a column that is not there and every cell
+    after the drop starts two columns further right than the plan believes, which pushes
+    the row over its budget and lets `tui.Row` truncate the CI label off the end.
+
+    **Only the BRANCH guard is observable, and that follows from the losing order rather
+    than from luck** — recorded because a deletion sweep will report the other two as
+    equivalent and the next reader deserves to know why rather than deleting them. The
+    change and the CI mark are dropped last and second-last, so each is the final cell on
+    its row by the time it goes, and `tui`'s own `_finish` strips the trailing gap that
+    would have followed it. The branch is dropped from the MIDDLE, with the CI mark still
+    to its right. All three are written the same way anyway: three cells built by one
+    rule is what stops the fourth one somebody adds from being written by a different one.
     """
     cells: list[tui.Cell] = [tui.Cell(f"{lead}{label}", plan.name)]
 
@@ -1272,8 +1282,13 @@ def _repo_rows(dirs, active, cur, states, branches, gl, detail_wts=(),
         elif wts and wt_budget > 0:
             wt_budget -= 1
             lead = f"  {_DIM}{_TREE_PIPE}{_R} {_DIM}{_TREE_WT}{_R}"
-            pieces = tui.truncate(" · ".join(w.name for w in wts),
-                                  max(1, budget - tui.width("  │   ╰─ ")))
+            # Clamped by `tui.Text` at render time and NOT here. This used to pre-truncate
+            # to `_LEFT_W` minus the lead, which #506 would have made `budget` minus the
+            # lead — and a deletion sweep says neither is worth writing: `Text.render` gets
+            # the same budget, so cropping the joined names first and cropping the finished
+            # line afterwards produce the same string for every input. Two crops to one
+            # width is one crop, and the redundant one was carrying a constant.
+            pieces = " · ".join(w.name for w in wts)
             rows.append(tui.Text(f"{lead}{_DIM}{pieces}{_R}"))
 
     if capped:

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -81,6 +81,57 @@ def for_session(sid: str) -> str | None:
     return val if val and valid_name(val) else None
 
 
+def for_frame(sid: str | None) -> str | None:
+    """The workspace the frame *sid* names was LAUNCHED for, or ``None``.
+
+    A rung of :func:`chosen`, and the answer to #524. Inside a charter frame
+    ``$CHARTER_SESSION_ID`` holds the FRAME's id (`session.current`'s own docstring says
+    so, and ADR 0019 is why), so "this session's id" and "the frame this session is
+    running inside" are the same string — which is what makes the launcher's recorded
+    answer readable from here at all. Outside a frame the id names a conversation, there
+    is no frame directory under it, and this answers ``None``.
+
+    **Why a rung and not a hook.** #524's own framing was that the session-start hook is
+    where this lands — `hooks.sessionstart` already picks a workspace and writes the
+    per-session pointer, and a framed harness is the one caller with a recorded answer it
+    does not consult. But the issue's own third constraint rules that out as the
+    mechanism: *a non-Claude harness has no session-start hook at all*, and neither does
+    a bare `charter ws current` typed into the frame's shell. A hook would fix the
+    harness charter ships hooks for and leave every other one re-resolving. A rung in the
+    ladder itself needs no harness cooperation, so it degrades to nothing rather than to
+    a wrong answer.
+
+    Its POSITION is the reconciliation #524 says charter cannot leave silent, and it is
+    the same one `frame/state.workspace_for` already spells for the panels:
+
+    * **Below the per-session pointer.** `charter workspace use <name>` typed inside the
+      frame writes that pointer under the frame's id, so an operator's explicit choice
+      still wins and the panels still follow it — the direction #517 asks for, and the
+      documented promise that `ws use` "moves the panels too". The launcher's answer is a
+      SEED, never a pin; nothing here takes `ws use` away from a framed session, which is
+      exactly what handing the harness `$CHARTER_WORKSPACE` would have done.
+    * **Above the per-terminal pointer.** That rung is not merely absent inside a frame,
+      it is *wrong*: it is keyed on `$TMUX_PANE`, and the harness's pane is one charter
+      created — not the operator's terminal, whose pointer it would otherwise read or
+      (on a recycled pane id) mistake for its own. Same for the declared default below
+      it: both answer for the asking process, and the record is here to outrank exactly
+      those two.
+
+    Name-checked through `frame/state.frame_workspace`, which owns that guard for this
+    value; ``None`` covers a frame launched by a charter predating the record, a corrupt
+    file, and every process that is not in a frame.
+    """
+    if not sid:
+        return None
+    try:
+        from .frame import state as _state
+        return _state.frame_workspace(sid)
+    except Exception:
+        # A rung, on the path every command takes to answer "where am I". It reports what
+        # it can read and never becomes the reason a command cannot run.
+        return None
+
+
 def _terminal_id(explicit: str | None = None) -> str | None:
     """This terminal PANE's id, or ``None`` — see :func:`charter.session.terminal`,
     which owns it. Kept as a module-level name because it is the seam tests patch to
@@ -287,7 +338,8 @@ def clear_declared_default() -> None:
 def resolve(explicit: str | None = None, session_id: str | None = None,
             cwd=None) -> str:
     """Active workspace by precedence: ``--workspace`` → ``$CHARTER_WORKSPACE`` → **the
-    tree you are standing in** → per-session pointer → per-terminal pointer → ``default``.
+    tree you are standing in** → per-session pointer → **the frame you are inside**
+    (:func:`for_frame`) → per-terminal pointer → ``default``.
 
     The cwd sits above the pointers because it cannot be wrong: a workspace's trees live
     at paths that name the workspace, so being inside one is not a hint about which
@@ -346,6 +398,13 @@ def chosen(explicit: str | None = None, session_id: str | None = None,
         val = _read(_session_file(sid))
         if val:
             return val
+    # The frame this session is running inside, if it is running inside one (#524). Below
+    # the pointer above — an operator's `ws use` outranks a launch — and above the two
+    # rungs below, which answer for the ASKING PROCESS and inside a frame are therefore
+    # about the wrong terminal. See :func:`for_frame` for the whole reconciliation.
+    framed = for_frame(sid)
+    if framed:
+        return framed
     tid = _terminal_id()
     if tid:
         val = _read(_terminal_file(tid))
@@ -382,6 +441,8 @@ def source(explicit: str | None = None, session_id: str | None = None,
     sid = _session_id(session_id)
     if sid and _read(_session_file(sid)):
         return "session"
+    if for_frame(sid):
+        return "frame"
     tid = _terminal_id()
     if tid and _read(_terminal_file(tid)):
         return "terminal"

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -120,6 +120,16 @@ def for_frame(sid: str | None) -> str | None:
     Name-checked through `frame/state.frame_workspace`, which owns that guard for this
     value; ``None`` covers a frame launched by a charter predating the record, a corrupt
     file, and every process that is not in a frame.
+
+    **The empty-id refusal below is a COST guard, and a deletion sweep is right that
+    nothing observable depends on it.** Deleted, this still answers ``None`` —
+    `contain.child` refuses a falsy name and `frame_workspace` degrades — so it is kept
+    for what it avoids rather than for what it decides: this rung sits on :func:`resolve`,
+    which the status line calls on every turn, and without it a session-less call pays a
+    module import, a path resolution and a failed `read_text` to learn what one boolean
+    already knew. The contract is pinned (`for_frame(None) is None`); the shortcut is
+    not, deliberately, because a test that could tell the two apart would be asserting the
+    shortcut rather than the answer.
     """
     if not sid:
         return None

--- a/docs/news/unreleased-columns-are-measured-and-a-frame-answers-for-itself.md
+++ b/docs/news/unreleased-columns-are-measured-and-a-frame-answers-for-itself.md
@@ -1,0 +1,95 @@
+---
+version: unreleased
+headline: Tables measure their columns in terminal cells, and everything inside a frame answers for the frame's workspace
+---
+
+Two unrelated properties, fixed together because each one had shipped in more than one
+place and neither was going to be finished by patching a single call site.
+
+## A column is measured in cells, from the values it holds
+
+`charter worktree history` printed its timestamp into `{ts:<22}`. The timestamp charter
+writes is `2026-08-28T01:09:13+00:00` — twenty-five characters, on every event, forever.
+`str.format` pads and never truncates, so the field did nothing at all and the repo name
+that follows it ran into a single space. `charter status` printed its stack into
+`{:<12}`; `node-monorepo` is thirteen, and it is one of charter's own stack names, so on
+any plane holding a node monorepo that row's branch column sat one column right of every
+other row's — and one column right of the header above it.
+
+`charter recall` had already got the harder half right: it sized its label column from the
+data rather than from a constant. It then measured that column with `len`, which counts
+*characters* while a terminal lays out *cells*. A CJK persona name is two cells per glyph
+and a combining mark is zero, so a label well inside any budget still shifted its row —
+and no constant, however large, could have fixed that half.
+
+All three now go through `tui.column`, which landed for `charter persona stats` and does
+both things at once: it takes the width from the values about to be printed, and it
+measures them with `tui.width`. `tui.pad` fills, because sizing and padding have to be the
+same unit or the arithmetic was for nothing.
+
+One thing worth stating because it is counter-intuitive, and because it decided how this
+was tested: **"do the columns line up" cannot see a mis-measured column.** `tui.pad`
+truncates, so putting a too-small width back leaves every row perfectly aligned with the
+value quietly cut off inside one of them. The probe that catches it is whether the value
+is still readable off its row, and both probes are now on every table here.
+
+## A repo row narrower than the table gives up a column, not the end of one
+
+The status line composed each repo row at ninety-five columns and let the final crop trim
+it to whatever the terminal actually had. Every cell after the branch sits at a fixed
+offset, so on an eighty-column terminal — which is ordinary, and `$COLUMNS` is the status
+line *pane's* width, so any split reaches it — the last two cells were what got cut:
+
+```
+w= 80   ├─ charter    main*    ✗ fa…
+w= 70   ├─ charter    main*          …
+```
+
+The CI mark and the open change went off the right-hand end. The dirty marker rides on the
+branch cell and survived, so a dirty, CI-failing, unpushed repo with an open merge request
+read as one that was merely dirty. `✗ fa…` is worse than no CI cell at all: it is a
+false-clean reading wearing a real one's clothes.
+
+The row now decides its own shape from the columns it will actually get, and gives them up
+in a written-down order: the branch text narrows first (the widest column and the least
+urgent — which branch is a fact you look up, a red pipeline is one you act on), then the
+repo name, and only then whole cells, change first and the CI mark last. Nothing is ever
+drawn as a fragment. At eighty columns you now get the repo, `main*↑2`, `✗ failed` and
+`#500`, all four whole, with the branch column paying for it.
+
+The dirty/ahead/behind markers are the branch cell's floor rather than its first casualty:
+they are true of the tree whatever it is called.
+
+## Everything inside a frame answers for the frame's workspace
+
+A frame is launched *for* a workspace, and nothing inside it can re-derive which one —
+`$CHARTER_WORKSPACE` arrives empty by design so a second frame cannot inherit the first
+one's pin, the working directory is the plane root, the per-session pointer is keyed on
+the frame's own id, and the per-terminal pointer is keyed on a pane charter created. So
+the launcher writes the answer down and the panels read it back. Two things were still
+asking for themselves.
+
+**The sidebar's todos.** On a cold cache the todo section fell through to a live gather
+that resolved a workspace from the panel process, so a frame's very first paint could list
+*another* workspace's open todos under this one's `todos N` heading. That is worse than the
+blank repo table it sits beside: a populated list reads as an answer, and three todos you
+have never seen read as three todos you have. It is handed the frame's workspace now. The
+cold-cache scan stays, deliberately — the repo strip dropped its own because it repaints
+five times a second while work is in flight, and the sidebar repaints once.
+
+**The pane you type in.** The agent's shell reached the same dead rungs, so the frame could
+correctly draw `harness-wrapper` in its header while every command typed inside it acted on
+`default`. `charter` now consults the frame you are running inside as a rung of its own,
+between the per-session pointer and the per-terminal one. The order is the answer to which
+of the two wins:
+
+* **`charter workspace use <name>` typed inside the frame still wins**, and still moves the
+  panels. The launch is a seed, never a pin — handing the harness `CHARTER_WORKSPACE`
+  would have worked and would also have taken `ws use` away from every framed session.
+* **The frame outranks the pointer for the pane and the declared default**, because inside
+  a frame those two answer for the asking process and the asking process is not the
+  operator's terminal.
+
+Deliberately a rung rather than a session-start hook: a harness that is not Claude Code has
+no such hook, and neither does a bare `charter ws current` typed into the frame's shell.
+`charter workspace current` says `frame` when that is what decided.

--- a/tests/test_a_frame_answers_for_the_frames_workspace.py
+++ b/tests/test_a_frame_answers_for_the_frames_workspace.py
@@ -1,0 +1,307 @@
+"""Everything inside a frame answers about the FRAME's workspace (#526, #524).
+
+#512 established the shape and #525 built the mechanism: a frame is launched FOR a
+workspace, nothing inside it can re-derive which one, so the launcher writes it down
+(`frame/state.record_workspace`) and every surface reads it back. `workspace.resolve`'s
+rungs are all dead inside a frame — `$CHARTER_WORKSPACE` arrives empty by design (#411),
+the cwd is the plane root, the per-session pointer is keyed on the FRAME id, and the
+per-terminal pointer on the asking pane's own `$TMUX_PANE`, which charter created — so a
+process that asks for itself lands on the declared default.
+
+Two things were still asking for themselves:
+
+* **The sidebar's todos (#526).** `slots.todo_section` called `gather.read(fid)` with no
+  workspace, and on a cold cache `gather.read` falls through to `gather.scan`, which
+  resolves one from the panel process. A frame's first paint listed **`default`'s** open
+  todos under this plane's `todos N` heading. Worse than #512's blank repo table, because
+  a populated list reads as an answer: three todos an operator has never seen read as
+  three todos they have.
+* **The harness pane (#524).** The agent's own shell reaches the same dead rungs, so the
+  frame could correctly draw `harness-wrapper` while every command typed inside it acted
+  on `default`.
+
+**The reconciliation is one ladder, and its ORDER is the decision #524 says charter
+cannot leave silent.** A choice made inside the frame outranks the launch (`charter
+workspace use` writes the per-session pointer under the frame's id, and "it moves the
+panels too" is a documented promise); the launch outranks the two rungs that answer for
+the ASKING PROCESS rather than for the frame. So both directions of #524's question are
+answered, and neither silently: the frame follows the session when the session chose, and
+the session follows the frame when it did not.
+
+**Not a hook**, which is where #524 expected this to land. Its own third constraint rules
+that out: a non-Claude harness has no session-start hook at all, and neither does a bare
+`charter ws current` typed into the frame's shell. A rung in the ladder needs no harness
+cooperation.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+from charter import config, session, statusline, todos, tui, workspace
+from charter.frame import gather, slots, state
+from tests._isolation import PersonaIso
+
+#: The workspace the FRAME was launched for, and the one nothing inside it can re-derive.
+FRAMED = "harness-wrapper"
+#: What a process inside the frame resolves when it asks for itself — the answer #512
+#: measured on the reporting plane, and the wrong one.
+OTHER = "user-reporting"
+
+
+class FramedCase(PersonaIso):
+    """A frame launched for :data:`FRAMED`, on a plane where every rung a panel or a
+    harness can actually reach names :data:`OTHER` instead.
+
+    That is not a contrived plane. It is the one #524 measured: three per-terminal
+    pointers naming one workspace, one naming another, and a `default` with no clones in
+    it. The fixture's whole job is that resolving-for-yourself and reading-the-record give
+    DIFFERENT answers — a fixture where they agree tests nothing at all.
+    """
+
+    FID = "harness_wrapper-4242"
+
+    def setUp(self) -> None:
+        super().setUp()
+        for name in (FRAMED, OTHER):
+            workspace.ensure(name)
+            workspace.scaffold(name)
+        state.record_workspace(self.FID, FRAMED)
+        # The rung a process inside the frame WOULD reach: a per-terminal pointer, keyed
+        # on the pane it happens to be in. Written directly rather than through
+        # `set_active`, which also writes the per-session pointer — and the per-session
+        # pointer is the rung that is allowed to win.
+        self.pane = "%17"
+        config.private_mkdir(config.TERMINALS_DIR)
+        # Keyed through `session.terminal`, never through the raw variable: the id is
+        # sanitised on its way to becoming a filename (`%17` is stored as `-17`), and a
+        # fixture that wrote the raw spelling would leave the pointer unreadable and the
+        # rung it stands for silently absent — a fixture failing to build the very
+        # disagreement the file is about.
+        tid = session.terminal(self.pane)
+        (config.TERMINALS_DIR / f"{tid}.workspace").write_text(OTHER)
+        self.enterContext(mock.patch.dict(os.environ, {"TMUX_PANE": self.pane}))
+
+    def inside_the_frame(self):
+        """`$CHARTER_SESSION_ID` holds the FRAME's id — that is what `session.current`
+        answers inside a frame (ADR 0019), and it is the whole channel through which the
+        launcher's record is addressable from in there."""
+        return mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID})
+
+    def assert_the_fixture_still_disagrees(self) -> None:
+        """The guard that keeps every case below meaningful.
+
+        If the plane's own rungs happened to answer :data:`FRAMED` too, every assertion
+        here would pass with the fix reverted — the shape #588 names, a fixture agreeing
+        with the machine's default. So this asserts the DISAGREEMENT exists before the
+        frame is asked anything.
+        """
+        self.assertEqual(workspace.resolve(), OTHER,
+                         "fixture: outside the frame this plane must resolve something "
+                         "OTHER than the frame's workspace, or nothing here can fail")
+
+
+class TheHarnessAnswersForTheFrameItRunsIn(FramedCase):
+    """#524 — the pane the agent types in."""
+
+    def test_a_process_inside_the_frame_resolves_the_frames_workspace(self):
+        self.assert_the_fixture_still_disagrees()
+        with self.inside_the_frame():
+            self.assertEqual(workspace.resolve(), FRAMED)
+
+    def test_it_says_the_frame_is_what_decided(self):
+        """`source` must mirror `chosen`'s rungs or the status line explains the active
+        workspace by naming a rung that did not decide it — this module's own standing
+        rule, and the reason the two walkers are kept in step."""
+        with self.inside_the_frame():
+            self.assertEqual(workspace.source(), "frame")
+
+    def test_a_choice_typed_inside_the_frame_still_wins(self):
+        """The direction #517 asks for, and the promise `charter ws use` already makes.
+        The launcher's answer is a SEED, never a pin: pinning the session to the frame is
+        the option #524 weighs and rejects, because it would take `ws use` away from every
+        framed session."""
+        with self.inside_the_frame():
+            workspace.set_active(OTHER, terminal_id="")
+            self.assertEqual(workspace.resolve(), OTHER)
+            self.assertEqual(workspace.source(), "session")
+
+    def test_the_pin_still_outranks_the_record(self):
+        """`$CHARTER_WORKSPACE` means the same thing inside a frame as everywhere else —
+        `state.workspace_for`'s rung 0 says so, and this rung sits far below it."""
+        with self.inside_the_frame(), \
+             mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": OTHER}):
+            self.assertEqual(workspace.resolve(), OTHER)
+
+    def test_the_tree_you_are_standing_in_still_outranks_the_record(self):
+        """The cwd rung cannot be wrong — a workspace's trees live at paths that name it
+        — so a harness launched from inside a clone keeps answering for that clone."""
+        clone = workspace.workspace_dir(OTHER) / "svc"
+        clone.mkdir(parents=True, exist_ok=True)
+        with self.inside_the_frame():
+            self.assertEqual(workspace.resolve(cwd=clone), OTHER)
+
+    def test_outside_a_frame_nothing_changes(self):
+        """The control, and the one that says this rung cannot leak. A session id that
+        names no frame has no record to read, so the ladder is the ladder it was."""
+        with mock.patch.dict(os.environ,
+                             {"CHARTER_SESSION_ID": "a-claude-conversation-uuid"}):
+            self.assertEqual(workspace.resolve(), OTHER)
+            self.assertEqual(workspace.source(), "terminal")
+
+    def test_a_frame_whose_record_predates_the_mechanism_falls_through(self):
+        """A frame launched by a charter that never wrote the file, still running across
+        the upgrade. It must degrade to today's answer rather than to an exception on the
+        path every command takes to ask where it is."""
+        state.frame_dir(self.FID, create=True).joinpath("workspace").unlink()
+        with self.inside_the_frame():
+            self.assertEqual(workspace.resolve(), OTHER)
+
+    def test_a_corrupt_record_names_no_workspace(self):
+        """The record is charter's own file, but it lands in `workspace_dir()`'s join and
+        on a panel's screen, and #442 is what an unchecked `../../` in that position cost
+        once. `state.frame_workspace` owns the name check; this is the assertion that this
+        rung actually goes through it."""
+        state.frame_dir(self.FID, create=True).joinpath("workspace").write_text("../../esc")
+        with self.inside_the_frame():
+            self.assertEqual(workspace.resolve(), OTHER)
+
+    def test_the_frame_and_its_panels_now_give_the_same_answer(self):
+        """The point of the whole thing, stated as the two halves meeting. `workspace_for`
+        is what every PANEL asks and `resolve` is what the harness asks; #524 is that the
+        two could disagree."""
+        with self.inside_the_frame():
+            self.assertEqual(state.workspace_for(self.FID), workspace.resolve())
+
+    def test_asking_costs_no_exception_when_the_state_directory_is_unreadable(self):
+        """This runs on `resolve`, which every command and every status-line render calls.
+        It reports what it can read and never becomes the reason a command cannot run."""
+        with self.inside_the_frame(), \
+             mock.patch.object(state, "frame_workspace",
+                               side_effect=OSError("no state dir")):
+            self.assertEqual(workspace.resolve(), OTHER)
+
+
+class TheSidebarsTodosAreTheFramesTodos(FramedCase):
+    """#526 — the section that reads as an answer whether or not it is one."""
+
+    #: SHORT titles, and that is the whole of why they are short. The pane is 44 columns
+    #: and `_todo_rows` truncates a row to fit it — so a descriptive title like "a todo
+    #: from a workspace nobody in this frame is looking at" renders as
+    #: `- a todo from a workspace nobody in this fr…`, and the `assertNotIn` below then
+    #: passes against the defect it exists to catch because the string it looks for was
+    #: never going to be on the row whole. Measured: it did, on `origin/main`.
+    MINE = "FRAMES-OWN-TODO"
+    THEIRS = "OTHER-WORKSPACES-TODO"
+
+    def setUp(self) -> None:
+        super().setUp()
+        todos.add(FRAMED, self.MINE)
+        todos.add(OTHER, self.THEIRS)
+        gather.discard(self.FID)          # what `cmd_launch` runs before it draws
+
+    def assert_a_todo_row_is_not_truncated(self, lines: list[str]) -> None:
+        """No todo row ended in the kit's ellipsis.
+
+        Without this, an `assertNotIn` for a title the pane was going to cut anyway is an
+        assertion that cannot fail — and `assertIn` for one is a case that fails for the
+        wrong reason. Either way the pane's width, not the workspace, decides the result.
+        """
+        cut = [ln for ln in lines if ln.startswith("- ") and ln.endswith(tui.ELLIPSIS)]
+        self.assertEqual(cut, [], f"a todo row was cut by the pane, so a membership "
+                                  f"assertion about its title decides nothing:\n{cut}")
+
+    def sidebar(self, *, cols=44, rows=26) -> list[str]:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = slots.render("right", self.FID)
+        return [tui.strip_ansi(ln) for ln in out.split("\n")]
+
+    def test_a_cold_first_paint_lists_the_frames_todos(self):
+        self.assert_the_fixture_still_disagrees()
+        lines = self.sidebar()
+        self.assert_a_todo_row_is_not_truncated(lines)
+        self.assertIn(f"- {self.MINE}", lines)
+
+    def test_it_never_lists_another_workspaces_todos(self):
+        """The half that matters more. An empty column reads as "nothing to do"; a
+        POPULATED one reads as an answer, and an operator would take three todos they
+        have never seen as three todos they have."""
+        lines = self.sidebar()
+        self.assert_a_todo_row_is_not_truncated(lines)
+        self.assertNotIn(self.THEIRS, "\n".join(lines), "\n".join(lines))
+
+    def test_the_heading_counts_the_frames_workspace(self):
+        self.assertIn(f"{statusline._HEAD_PAD}todos 1", self.sidebar())
+
+    def test_the_scan_fallback_is_still_there(self):
+        """**A decision, not an inheritance.** #525 took the cold-cache scan away from
+        `bottom` and gave it a `⋯ gathering…` placeholder, because `bottom` is the one
+        ANIMATED slot — five repaints a second, each a git sweep. The sidebar is not
+        animated: one scan, one paint, and a column that draws its todos immediately is
+        worth having. Pinned so the difference stays deliberate rather than drifting into
+        "the two slots happen to differ"."""
+        with mock.patch.object(gather, "scan", wraps=gather.scan) as scanned:
+            self.sidebar()
+        self.assertTrue(scanned.called,
+                        "the cold-cache scan was dropped — a first paint now says this "
+                        "workspace has no todos, which is #526's own worse reading")
+
+    def test_the_scan_is_asked_for_the_frames_workspace_by_name(self):
+        """Not "the answer happened to be right". The gather is handed the workspace, and
+        that is the property — a `scan()` left to resolve one for itself is the defect
+        whatever it lands on, because on the next plane it lands somewhere else."""
+        with mock.patch.object(gather, "scan", wraps=gather.scan) as scanned:
+            self.sidebar()
+        self.assertEqual([c.kwargs.get("workspace") for c in scanned.call_args_list],
+                         [FRAMED] * scanned.call_count, scanned.call_args_list)
+
+    def test_a_warm_cache_still_never_touches_the_todo_directory(self):
+        """The idle-cost rule this section already kept (#387): `todos.open_todos` is one
+        file read per todo and a panel repaints on every version bump. Re-asked because
+        this change moved the call, and the cheapest way to get the workspace right would
+        have been to read the directory here.
+
+        The cache is SEEDED rather than warmed by a first render: `gather.read` scans on a
+        miss and does not save what it scanned, so a test that rendered twice would be
+        making two cold scans and pinning nothing about the cache at all."""
+        gather.save(self.FID, gather.scan(workspace=FRAMED))
+        with mock.patch.object(todos, "open_todos",
+                               side_effect=AssertionError("read the workspace directory")):
+            lines = self.sidebar()
+        self.assert_a_todo_row_is_not_truncated(lines)
+        self.assertIn(f"- {self.MINE}", lines)
+
+
+class TheSessionIdIsTheFramesId(FramedCase):
+    """Why the record is addressable from inside the frame at all.
+
+    Recorded because it is the load-bearing and least obvious fact in this whole file: the
+    rung reads `state.frame_workspace(session.current())`, and that only finds anything
+    because `$CHARTER_SESSION_ID` inside a frame holds the FRAME's id rather than the
+    harness's own. If that ever stops being true, this rung answers `None` everywhere and
+    every case above goes green while the defect comes back — so the fact is pinned here
+    rather than assumed there.
+    """
+
+    def test_the_session_id_inside_a_frame_is_the_frame_id(self):
+        with self.inside_the_frame():
+            self.assertEqual(session.current(), self.FID)
+
+    def test_the_record_is_keyed_on_exactly_that_id(self):
+        self.assertEqual(state.frame_workspace(self.FID), FRAMED)
+
+    def test_a_second_frame_does_not_inherit_the_first_ones_record(self):
+        """#411's protection, re-asked one rung down. The record is per-frame, so a frame
+        that never recorded anything reads nothing — the failure mode a `$CHARTER_WORKSPACE`
+        handed to the harness would have brought back."""
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "other_frame-99"}):
+            self.assertEqual(workspace.resolve(), OTHER)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_a_frame_answers_for_the_frames_workspace.py
+++ b/tests/test_a_frame_answers_for_the_frames_workspace.py
@@ -295,6 +295,27 @@ class TheSessionIdIsTheFramesId(FramedCase):
     def test_the_record_is_keyed_on_exactly_that_id(self):
         self.assertEqual(state.frame_workspace(self.FID), FRAMED)
 
+    def test_a_session_with_no_id_names_no_frame(self):
+        """`for_frame`'s own precondition, asked of `for_frame`.
+
+        A shell with no `$CHARTER_SESSION_ID` and no `$CLAUDE_CODE_SESSION_ID` reaches
+        this rung with `None`, which is the ordinary case for anyone typing `charter ws
+        current` in a plain terminal — the rung has to answer "no frame", not go looking
+        for a directory named after nothing.
+
+        Written because a deletion sweep deleted the refusal and reported that fifty-nine
+        test modules execute this file and **not one of them names this function**. It
+        happens to degrade the same way through `contain.child` today, which is exactly
+        the kind of accident that stops being true when the other module changes.
+        """
+        for sid in (None, ""):
+            with self.subTest(sid=sid):
+                self.assertIsNone(workspace.for_frame(sid))
+
+    def test_an_id_that_names_no_frame_answers_none(self):
+        """The other half: a real session id that is simply not a frame's."""
+        self.assertIsNone(workspace.for_frame("a-claude-conversation-uuid"))
+
     def test_a_second_frame_does_not_inherit_the_first_ones_record(self):
         """#411's protection, re-asked one rung down. The record is per-frame, so a frame
         that never recorded anything reads nothing — the failure mode a `$CHARTER_WORKSPACE`

--- a/tests/test_a_narrow_repo_row_drops_a_column_whole.py
+++ b/tests/test_a_narrow_repo_row_drops_a_column_whole.py
@@ -83,6 +83,21 @@ class RowPlanCase(unittest.TestCase):
             with self.subTest(width=w):
                 self.assertEqual(sl._row_plan(w), sl._FULL_ROW)
 
+    def test_no_plan_is_ever_wider_than_the_table(self):
+        """`_LEFT_W` is not a width the plan is clamped to, it is what the full plan
+        SUMS to — both are spelled from the same four cells and the same gaps.
+
+        Pinned because `render` relies on it and a deletion sweep proved the reliance
+        invisible: `repo_w = min(width, _LEFT_W)` measured identical to `repo_w = width`,
+        because no plan can exceed the table anyway. That is a property worth stating once
+        here rather than a clamp restating it at every call site — the left column of the
+        two-column layout is `_LEFT_W` wide, and a row composed for more than that would
+        be composed for a width it is never going to get."""
+        self.assertEqual(sl._plan_width(sl._FULL_ROW), sl._LEFT_W)
+        for w in range(1, 400):
+            with self.subTest(width=w):
+                self.assertLessEqual(sl._plan_width(sl._row_plan(w)), sl._LEFT_W)
+
     def test_an_eighty_column_terminal_keeps_the_ci_mark_and_the_change(self):
         """#506's headline case, at the width it was reported from. Both cells WHOLE."""
         row = tui.strip_ansi(_row(74))

--- a/tests/test_a_narrow_repo_row_drops_a_column_whole.py
+++ b/tests/test_a_narrow_repo_row_drops_a_column_whole.py
@@ -143,6 +143,22 @@ class RowPlanCase(unittest.TestCase):
         self.assertIn("*↑2", tui.strip_ansi(cell), cell)
         self.assertLessEqual(tui.width(cell), sl._BRANCH_MIN_W, cell)
 
+    def test_a_clean_repo_still_shows_its_branch_at_the_floor(self):
+        """The floor bounded from ABOVE, where the case below bounds it from below.
+
+        With no markers to pay for, the branch cell's whole floor is the branch's — and
+        `main` is four cells in six, so an ordinary clean repo keeps its branch name right
+        down to the narrowest cell the plan will draw. Raise `_BRANCH_TEXT_MIN_W` past the
+        floor and the branch simply vanishes from every clean row on a narrow pane, which
+        is a column silently going blank rather than a column being given up.
+
+        Between the two cases the constant is bounded rather than spelled. What is left
+        inside those bounds — four, five or six — no user-facing property can tell apart,
+        and that is recorded rather than papered over with an assertion on the number."""
+        cell = tui.strip_ansi(
+            sl._branch_cell_for("main", "", "", "", False, sl._BRANCH_MIN_W))
+        self.assertEqual(cell, "main", cell)
+
     def test_at_the_floor_the_cell_holds_the_markers_and_no_stub(self):
         """Shown whole or dropped whole, one layer down from `_row_plan`'s own version.
 

--- a/tests/test_a_narrow_repo_row_drops_a_column_whole.py
+++ b/tests/test_a_narrow_repo_row_drops_a_column_whole.py
@@ -1,0 +1,284 @@
+"""A repo row narrower than the table gives up a column, not the end of one (#506).
+
+`statusline.render` composed every repo row at `_LEFT_W` (95) and let `_columns` crop it
+to whatever the terminal actually had. Every cell after the branch sits at a fixed offset
+past the name and the branch, so on a narrower pane the CI mark and the open change were
+cut off the right-hand end — and because the dirty marker rides on the BRANCH cell and
+survived, a dirty, CI-failing, unpushed repo with an open change read as one that was
+merely dirty.
+
+    w= 90 |  ├─ charter    main*    ✗ failed      …|
+    w= 80 |  ├─ charter    main*    ✗ fa…|
+    w= 70 |  ├─ charter    main*          …|
+
+An 80-column terminal is ordinary, and `$COLUMNS` is the status-line PANE's width — so
+any split reaches it. This is the exact reading `frame/slots._table_lines` refuses one
+surface over ("too narrow for the table is NO table, not a cut one", #488); the status
+line cannot answer with nothing, because it is what an operator sees when they are not in
+a frame, so it takes #506's other honest option — a narrower row SHAPE, decided where the
+row is composed.
+
+**The property under test is not "the row fits".** It fitted before: a crop always fits.
+It is that a column is either drawn WHOLE or not drawn at all, and that the two cells a
+reader acts on are the last ones to go. `✗ fa…` is worse than no CI cell, because it is a
+false-clean reading wearing a real one's clothes.
+
+Two levels, deliberately. The plan cases pin the losing ORDER at every width, where a
+matrix is readable; the render cases pin that the crop at the end of `render()` no longer
+eats what the plan decided — which is the actual defect, and which no amount of unit
+testing of `_row_plan` would have caught.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import statusline as sl
+from charter import tui
+from tests._isolation import PersonaIso
+
+D = Path("/tmp/a-plane/workspaces/w/charter")
+
+#: A repo in the state that made #506 worth filing: dirty, unpushed, red pipeline, open
+#: change. Every one of those four is a different cell, so a row drawn from it exercises
+#: the whole losing order at once.
+STATES = {D: {"dirty": True, "ahead": 2}}
+BRANCHES = {D: "main"}
+GL = {D: {"ci": "failed", "change": "500", "sigil": "#"}}
+
+#: What the CI cell says when it is drawn at all. The LABEL, not the glyph: `✗` alone
+#: survives a crop that ate the word, and "the glyph is there" is exactly the assertion
+#: that would have passed against the defect.
+CI_WHOLE = "✗ failed"
+CHANGE_WHOLE = "#500"
+
+
+def _row(budget: int) -> str:
+    plan = sl._row_plan(budget)
+    return sl._tree_cells(f"  ├─ ", "charter", D, STATES, BRANCHES, GL,
+                          plan=plan).render(budget)[0]
+
+
+class RowPlanCase(unittest.TestCase):
+    """`_row_plan` alone: what a pane of N columns buys, at every N worth naming."""
+
+    #: 95 is `_LEFT_W`; 74 is what an 80-column terminal lays out at (`render` takes
+    #: `_SAFETY` off `$COLUMNS` and then the box's own chrome off that); the rest walk the
+    #: plan down through every drop it can make. `24` is `render`'s own floor.
+    WIDTHS = (200, 95, 94, 90, 80, 74, 72, 70, 60, 50, 45, 40, 35, 31, 24)
+
+    def test_no_row_ever_exceeds_the_pane_it_was_planned_for(self):
+        for w in self.WIDTHS:
+            with self.subTest(width=w):
+                self.assertLessEqual(tui.width(_row(w)), w, _row(w))
+
+    def test_the_full_row_is_unchanged_at_the_table_width_and_above(self):
+        """The regression guard on everything this did NOT set out to change. A pane at
+        `_LEFT_W` or wider draws exactly what it drew before, cell for cell."""
+        for w in (sl._LEFT_W, 200):
+            with self.subTest(width=w):
+                self.assertEqual(sl._row_plan(w), sl._FULL_ROW)
+
+    def test_an_eighty_column_terminal_keeps_the_ci_mark_and_the_change(self):
+        """#506's headline case, at the width it was reported from. Both cells WHOLE."""
+        row = tui.strip_ansi(_row(74))
+        self.assertIn(CI_WHOLE, row, row)
+        self.assertIn(CHANGE_WHOLE, row, row)
+
+    def test_the_branch_is_what_narrows_first(self):
+        """The widest column and the least urgent: "which branch" is a fact you look up,
+        a red pipeline is one you act on. Nothing else moves until it has run out."""
+        plan = sl._row_plan(sl._LEFT_W - 10)
+        self.assertEqual((plan.name, plan.ci, plan.mr),
+                         (sl._FULL_ROW.name, sl._FULL_ROW.ci, sl._FULL_ROW.mr))
+        self.assertEqual(plan.branch, sl._FULL_ROW.branch - 10)
+
+    def test_the_ci_cell_is_the_last_of_the_three_to_go(self):
+        """A strict order over the widths, asserted as an order rather than as three
+        thresholds — a threshold is a constant, and a constant is what #592 is about."""
+        gone = {"mr": None, "branch": None, "ci": None}
+        for w in range(sl._LEFT_W, 15, -1):
+            plan = sl._row_plan(w)
+            for cell in gone:
+                if gone[cell] is None and not getattr(plan, cell):
+                    gone[cell] = w
+        self.assertTrue(all(v is not None for v in gone.values()), gone)
+        self.assertGreater(gone["mr"], gone["branch"], gone)
+        self.assertGreater(gone["branch"], gone["ci"], gone)
+
+    def test_a_cell_is_never_drawn_narrower_than_the_value_it_would_hold(self):
+        """Shown whole or dropped whole, and this is the assertion that says so: at no
+        width does the CI cell exist while holding a PREFIX of its label. `✗ fa…` is the
+        false-clean reading a crop produces, and it is worse than an absent cell."""
+        for w in self.WIDTHS:
+            with self.subTest(width=w):
+                row = tui.strip_ansi(_row(w))
+                if "✗" in row:
+                    self.assertIn(CI_WHOLE, row, row)
+                if "#" in row:
+                    self.assertIn(CHANGE_WHOLE, row, row)
+
+    def test_the_markers_outlive_the_branch_name(self):
+        """Dirty and ahead are true of the TREE; `main` is only what it is called. So the
+        branch cell's floor is the markers, and a cell too narrow to hold both spends
+        itself on them rather than on `ma…`."""
+        narrow = sl._row_plan(60)
+        self.assertTrue(narrow.branch, narrow)
+        row = tui.strip_ansi(_row(60))
+        self.assertIn("*", row, row)
+        self.assertIn("↑2", row, row)
+
+    def test_a_marker_is_never_cut_by_a_branch_name_beside_it(self):
+        """The cell that `_row_plan` narrowed is then filled by `_branch_cell_for`, and
+        the second half of the same rule lives there: measuring the branch against
+        `_BRANCH_W` while the caller pads to something smaller composes 34 columns and
+        lets `tui.Cell` cut the markers off the right-hand end — the markers being what
+        the narrowing was protecting."""
+        cell = sl._branch_cell_for("a-very-long-branch-name-indeed", "", "*↑2",
+                                   "*↑2", True, sl._BRANCH_MIN_W)
+        self.assertIn("*↑2", tui.strip_ansi(cell), cell)
+        self.assertLessEqual(tui.width(cell), sl._BRANCH_MIN_W, cell)
+
+    def test_the_name_is_the_one_cell_that_is_never_dropped(self):
+        """A row with no name is not a row about anything."""
+        for w in (*self.WIDTHS, 20, 16, 10, 1):
+            with self.subTest(width=w):
+                self.assertTrue(sl._row_plan(w).name, w)
+
+    def test_a_drop_gives_its_leftover_back_rather_than_leaving_it_blank(self):
+        """A dropped cell frees more columns than the deficit demanded. Leaving them
+        blank while the repo name is cut to twelve characters spends a narrow pane on
+        nothing — so the plan is never more than one cell short of its budget."""
+        for w in range(sl._LEFT_W, 24, -1):
+            plan = sl._row_plan(w)
+            spare = w - sl._plan_width(plan)
+            self.assertGreaterEqual(spare, 0, (w, plan))
+            if plan.name < sl._FULL_ROW.name or (plan.branch and
+                                                 plan.branch < sl._FULL_ROW.branch):
+                self.assertEqual(spare, 0, (w, plan, "a shrunk cell left columns unspent"))
+
+
+class SiblingRowsCase(unittest.TestCase):
+    """One plan per render, shared by every row — because the rows are siblings.
+
+    A per-row plan would be the same defect as a per-row width: a table whose rows
+    disagree about their columns is not a table, and this layout has paid for that more
+    than once (`_tree_cells`' own docstring is about exactly this).
+    """
+
+    OTHER = Path("/tmp/a-plane/workspaces/w/iam-service")
+
+    def _pair(self, budget: int) -> tuple[str, str]:
+        plan = sl._row_plan(budget)
+        states = {**STATES, self.OTHER: {}}
+        branches = {**BRANCHES, self.OTHER: "release/2026-08"}
+        gl = {**GL, self.OTHER: {"ci": "success"}}
+        rows = [sl._tree_cells(f"  ├─ ", label, d, states, branches, gl,
+                               plan=plan).render(budget)[0]
+                for label, d in (("charter", D), ("iam-service", self.OTHER))]
+        return rows[0], rows[1]
+
+    def test_two_rows_start_their_ci_cell_in_the_same_column(self):
+        for w in (200, 95, 80, 74, 60, 50):
+            with self.subTest(width=w):
+                a, b = (tui.strip_ansi(r) for r in self._pair(w))
+                if "✗" not in a or "✓" not in b:
+                    continue
+                self.assertEqual(tui.width(a[:a.index("✗")]),
+                                 tui.width(b[:b.index("✓")]),
+                                 "\n".join([a, b]))
+
+    def test_a_cjk_repo_name_does_not_push_the_row_past_its_pane(self):
+        """`tui.Cell` measures cells, and the name column is the one holding a value
+        charter did not mint."""
+        plan = sl._row_plan(74)
+        row = sl._tree_cells("  ├─ ", "日本語のリポジトリ", D, STATES, BRANCHES, GL,
+                             plan=plan).render(74)[0]
+        self.assertLessEqual(tui.width(row), 74, row)
+        self.assertIn(CI_WHOLE, tui.strip_ansi(row), row)
+
+
+class RenderCase(PersonaIso):
+    """End to end through `statusline.render`, which is where #506 actually lived.
+
+    `_row_plan` could be perfect and the defect remain: the rows were composed at
+    `_LEFT_W` and cropped afterwards by `_columns`, so what has to be pinned is that
+    `render` hands the composer the width it is really going to get. Everything below the
+    layout is stubbed — git, the forge cache, the worktree scan — because none of it is
+    what is under test and all of it is slow.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        from charter import glstate, workspace
+        workspace.ensure("w")
+        workspace.scaffold("w")
+        self.enterContext(mock.patch.object(sl, "_repo_trees", return_value=[D]))
+        self.enterContext(mock.patch.object(sl, "_repo_states", return_value=STATES))
+        self.enterContext(mock.patch.object(sl, "_branch", return_value="main"))
+        self.enterContext(mock.patch.object(sl, "_detail_worktrees", return_value=[]))
+        self.enterContext(mock.patch.object(glstate, "read_for", return_value=GL))
+        self.enterContext(mock.patch.object(glstate, "maybe_spawn", return_value=None))
+
+    def render(self, columns: int) -> list[str]:
+        with mock.patch.dict(os.environ, {"COLUMNS": str(columns)}):
+            out = sl.render({"workspace": {"current_dir": str(D)}})
+        return [re.sub(r"\x1b\[[0-9;]*m", "", ln) for ln in out.split("\n")]
+
+    def repo_row(self, columns: int) -> str:
+        # The tree glyph is `└─` on the last repo and `├─` otherwise, and the one repo
+        # here is the last one. Matched on either so the probe is about the ROW
+        # rather than about which elbow `_repo_rows` chose.
+        rows = [ln for ln in self.render(columns)
+                if "charter" in ln and ("├─" in ln or "└─" in ln)]
+        self.assertEqual(len(rows), 1, "\n".join(self.render(columns)))
+        return rows[0]
+
+    def test_the_ci_mark_survives_an_eighty_column_terminal(self):
+        """The reported case, through the real renderer. `$COLUMNS` is what Claude Code
+        sets to the pane width, so 80 here is an ordinary split, not a stress test."""
+        row = self.repo_row(80)
+        self.assertIn(CI_WHOLE, row, row)
+
+    def test_the_open_change_survives_an_eighty_column_terminal(self):
+        self.assertIn(CHANGE_WHOLE, self.repo_row(80), self.repo_row(80))
+
+    def test_no_narrow_pane_ever_shows_half_a_ci_label(self):
+        """Every width from the table down to the floor: if the glyph is on the row, the
+        word is too. This is the assertion the old renderer fails at nine widths."""
+        for cols in range(40, 106, 2):
+            with self.subTest(columns=cols):
+                row = self.repo_row(cols)
+                if "✗" in row:
+                    self.assertIn(CI_WHOLE, row, row)
+
+    def test_the_dirty_marker_is_not_what_pays_for_the_ci_mark(self):
+        """The reading #506 is named for, asserted from the other end: at 80 columns the
+        old row said "dirty, on main" about a repo whose pipeline was red. Both facts are
+        on the row now, and neither displaced the other."""
+        row = self.repo_row(80)
+        self.assertIn("main*", row, row)
+        self.assertIn(CI_WHOLE, row, row)
+
+    def test_a_wide_terminal_is_unchanged(self):
+        """The control. At 200 columns nothing about this touches the row at all, so a
+        failure here says the change reached a width it had no business reaching."""
+        row = self.repo_row(200)
+        for want in ("charter", "main*", "↑2", CI_WHOLE, CHANGE_WHOLE):
+            self.assertIn(want, row, row)
+
+    def test_no_rendered_line_ever_exceeds_the_pane(self):
+        """`tui`'s one hard guarantee, re-asked because this changed what is handed to
+        it: a line that overruns wraps, and a wrapped line shears every column below."""
+        for cols in (40, 60, 74, 80, 95, 131, 200):
+            with self.subTest(columns=cols):
+                for line in self.render(cols):
+                    self.assertLessEqual(tui.width(line), cols, line)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_a_narrow_repo_row_drops_a_column_whole.py
+++ b/tests/test_a_narrow_repo_row_drops_a_column_whole.py
@@ -113,14 +113,36 @@ class RowPlanCase(unittest.TestCase):
     def test_a_cell_is_never_drawn_narrower_than_the_value_it_would_hold(self):
         """Shown whole or dropped whole, and this is the assertion that says so: at no
         width does the CI cell exist while holding a PREFIX of its label. `✗ fa…` is the
-        false-clean reading a crop produces, and it is worse than an absent cell."""
+        false-clean reading a crop produces, and it is worse than an absent cell.
+
+        **Asked of the PLAN, not of the rendered row**, and the difference is the whole
+        assertion. `if "✗" in row` skips itself the moment the glyph is gone — so a plan
+        that pushed the row over its budget and let `tui.Row` truncate the CI cell away
+        entirely satisfied it by drawing nothing. Found by the deletion sweep, which
+        unclamped a cell's floor and produced exactly that.
+        """
         for w in self.WIDTHS:
             with self.subTest(width=w):
+                plan = sl._row_plan(w)
                 row = tui.strip_ansi(_row(w))
-                if "✗" in row:
-                    self.assertIn(CI_WHOLE, row, row)
-                if "#" in row:
-                    self.assertIn(CHANGE_WHOLE, row, row)
+                if plan.ci:
+                    self.assertIn(CI_WHOLE, row, f"plan={tuple(plan)} row={row!r}")
+                if plan.mr:
+                    self.assertIn(CHANGE_WHOLE, row, f"plan={tuple(plan)} row={row!r}")
+
+    def test_no_cell_is_ever_planned_narrower_than_its_own_floor(self):
+        """A cell is at its full width, at its floor, or gone. Never between, and never
+        negative — a negative width is TRUTHY, so it reads as a drawn cell, spends a gap,
+        and pushes the row over the budget the plan just computed for it."""
+        for w in range(1, 200):
+            with self.subTest(width=w):
+                plan = sl._row_plan(w)
+                self.assertGreaterEqual(plan.name, sl._NAME_MIN_W, (w, plan))
+                if plan.branch:
+                    self.assertGreaterEqual(plan.branch, sl._BRANCH_MIN_W, (w, plan))
+                    self.assertLessEqual(plan.branch, sl._BRANCH_W, (w, plan))
+                self.assertIn(plan.ci, (0, sl._CI_W), (w, plan))
+                self.assertIn(plan.mr, (0, sl._MR_W), (w, plan))
 
     def test_the_markers_outlive_the_branch_name(self):
         """Dirty and ahead are true of the TREE; `main` is only what it is called. So the

--- a/tests/test_a_narrow_repo_row_drops_a_column_whole.py
+++ b/tests/test_a_narrow_repo_row_drops_a_column_whole.py
@@ -143,6 +143,44 @@ class RowPlanCase(unittest.TestCase):
         self.assertIn("*↑2", tui.strip_ansi(cell), cell)
         self.assertLessEqual(tui.width(cell), sl._BRANCH_MIN_W, cell)
 
+    def test_at_the_floor_the_cell_holds_the_markers_and_no_stub(self):
+        """Shown whole or dropped whole, one layer down from `_row_plan`'s own version.
+
+        `assertIn("*↑2")` alone does not say this: a cell drawn as `a-…*↑2` contains the
+        markers too, so a stub of the branch name passes that probe while spending the
+        reader's last three columns on three characters of a name they cannot look up.
+        The assertion has to be that the branch name is NOT there — measured, by a
+        hand-check that dropped the floor to zero and watched every other case stay
+        green."""
+        cell = tui.strip_ansi(sl._branch_cell_for(
+            "a-very-long-branch-name-indeed", "", "*↑2", "*↑2", True, sl._BRANCH_MIN_W))
+        self.assertEqual(cell, "*↑2", cell)
+        self.assertNotIn(tui.ELLIPSIS, cell, cell)
+
+    def test_a_cell_the_plan_dropped_costs_no_gap_either(self):
+        """A dropped cell built as a ZERO-WIDTH one still contributes `_GAP`, so every
+        cell after it starts two columns further right than the plan believes and the row
+        overruns the pane it was planned for — `tui.Row` then truncates, and what it
+        truncates is the CI label.
+
+        The BRANCH cell is the one this can be asked about, and that is a property of the
+        losing order rather than an accident: the change and the CI mark are dropped last
+        and second-last, so each is the final cell on its row when it goes and `_finish`
+        strips the gap that would have followed it. The branch is dropped from the
+        MIDDLE, with the CI mark still to its right. (`_tree_cells` says the same thing in
+        its docstring, so a reader deleting one of the other two guards knows why nothing
+        goes red.)"""
+        w = 31                                   # narrow enough that the branch is gone
+        plan = sl._row_plan(w)
+        self.assertFalse(plan.branch, plan)
+        self.assertTrue(plan.ci, plan)
+        row = tui.strip_ansi(_row(w))
+        self.assertLessEqual(tui.width(row), w, row)
+        self.assertIn(CI_WHOLE, row, row)
+        # And the gap really was the only thing between them: the CI cell begins exactly
+        # one gap past the name cell, not two.
+        self.assertEqual(tui.width(row[:row.index("✗")]), plan.name + len(sl._GAP), row)
+
     def test_the_name_is_the_one_cell_that_is_never_dropped(self):
         """A row with no name is not a row about anything."""
         for w in (*self.WIDTHS, 20, 16, 10, 1):
@@ -237,6 +275,55 @@ class SiblingRowsCase(unittest.TestCase):
                     for n in ("svc", name)]
                 self.assertEqual(*[tui.width(r[:r.index("✗")]) for r in rows],
                                  "\n".join(rows))
+
+
+class TheWorktreeSummaryLineCase(unittest.TestCase):
+    """The other line `_repo_rows` emits, and it carried the same constant.
+
+    A repo with worktrees nobody is drawing as full rows gets one summary line beneath it
+    — `│ ╰─ piece · piece · piece`. It carried its own `_LEFT_W` while everything above it
+    moved to the pane's real width.
+
+    **And the sweep's answer was to delete the crop, not to re-point it.** `tui.Text`
+    clamps the finished line to the same budget, so cropping the joined names first and
+    the line afterwards produce the same string for every input — the pre-crop was
+    redundant either way it was spelled, which is exactly the "equivalent mutant and dead
+    code are the same finding" `tools/sweep.py` argues for. What these cases pin is the
+    property that survived it: the line fits the pane, and it says when it left something
+    out.
+    """
+
+    def _lines(self, budget: int, pieces: int = 6) -> list[str]:
+        wt_dirs = [Path(f"/tmp/a-plane/.worktrees/w/charter/piece-number-{i}")
+                   for i in range(pieces)]
+        with mock.patch("charter.worktree.dirs_for", return_value=wt_dirs):
+            rows = sl._repo_rows([D], "w", None, STATES, BRANCHES, GL, (), budget)
+        return [tui.strip_ansi(ln) for r in rows for ln in r.render(budget)]
+
+    def test_the_summary_line_fits_the_pane_it_was_composed_for(self):
+        for w in (95, 80, 74, 60, 50, 40):
+            with self.subTest(width=w):
+                for line in self._lines(w):
+                    self.assertLessEqual(tui.width(line), w, line)
+
+    def test_it_says_when_it_left_a_piece_out(self):
+        """A summary that silently drops pieces is a summary a reader trusts wrongly. The
+        `…` is the only thing that says otherwise, and it has to survive whatever crop the
+        line went through."""
+        line = next(ln for ln in self._lines(60) if "piece-number-0" in ln)
+        self.assertTrue(line.endswith(tui.ELLIPSIS),
+                        f"the overflow mark is not on the line, so the reader is not "
+                        f"told anything was dropped:\n{line!r}")
+
+    def test_a_pane_wide_enough_shows_every_piece(self):
+        """The control on the case above: with room for all six, none of them is dropped
+        and there is no overflow mark to find. Without this, a line that dropped
+        EVERYTHING would satisfy the ellipsis assertion perfectly."""
+        lines = [ln for ln in self._lines(200) if "piece-number-0" in ln]
+        self.assertEqual(len(lines), 1, lines)
+        for i in range(6):
+            self.assertIn(f"piece-number-{i}", lines[0], lines[0])
+        self.assertNotIn(tui.ELLIPSIS, lines[0], lines[0])
 
 
 class RenderCase(PersonaIso):

--- a/tests/test_a_narrow_repo_row_drops_a_column_whole.py
+++ b/tests/test_a_narrow_repo_row_drops_a_column_whole.py
@@ -187,6 +187,37 @@ class RowPlanCase(unittest.TestCase):
             with self.subTest(width=w):
                 self.assertTrue(sl._row_plan(w).name, w)
 
+    def test_two_repos_sharing_a_prefix_stay_apart_at_every_width(self):
+        """What the name floor is FOR, asserted as the property rather than as its number.
+
+        A test that spells `_NAME_MIN_W`'s value passes forever and sees nothing — #508's
+        own finding about `28`, and the whole reason none of these cases names a width.
+        What a floor on the name column actually buys is that a row still says WHICH repo
+        it is about, and the sharp case is two repos in one workspace whose names share a
+        prefix: `analytics-api` and `analytics-web` are indistinguishable the moment the
+        column can no longer reach past `analytics-`.
+
+        Found by the deletion sweep, which dropped a term from the floor and watched every
+        other case here stay green. Measured against the mutants it produces: the floor as
+        it stands has zero indistinguishable widths, and each smaller one has six, nine and
+        nineteen.
+        """
+        a, b = Path("/tmp/p/analytics-api"), Path("/tmp/p/analytics-web")
+        states = {a: {"dirty": True}, b: {}}
+        branches = {a: "main", b: "main"}
+        gl = {a: {"ci": "failed"}, b: {"ci": "success"}}
+        for w in range(28, sl._LEFT_W + 1):
+            with self.subTest(width=w):
+                plan = sl._row_plan(w)
+                cells = [tui.strip_ansi(
+                    sl._tree_cells("  ├─ ", d.name, d, states, branches, gl,
+                                   plan=plan).render(w)[0])[:plan.name].rstrip()
+                    for d in (a, b)]
+                self.assertNotEqual(
+                    cells[0], cells[1],
+                    f"at {w} columns both repos draw {cells[0]!r} — the name column is "
+                    f"too narrow to say which row is about which repo")
+
     def test_a_drop_gives_its_leftover_back_rather_than_leaving_it_blank(self):
         """A dropped cell frees more columns than the deficit demanded. Leaving them
         blank while the repo name is cut to twelve characters spends a narrow pane on

--- a/tests/test_a_narrow_repo_row_drops_a_column_whole.py
+++ b/tests/test_a_narrow_repo_row_drops_a_column_whole.py
@@ -192,14 +192,51 @@ class SiblingRowsCase(unittest.TestCase):
                                  tui.width(b[:b.index("✓")]),
                                  "\n".join([a, b]))
 
-    def test_a_cjk_repo_name_does_not_push_the_row_past_its_pane(self):
-        """`tui.Cell` measures cells, and the name column is the one holding a value
-        charter did not mint."""
-        plan = sl._row_plan(74)
-        row = sl._tree_cells("  ├─ ", "日本語のリポジトリ", D, STATES, BRANCHES, GL,
-                             plan=plan).render(74)[0]
-        self.assertLessEqual(tui.width(row), 74, row)
-        self.assertIn(CI_WHOLE, tui.strip_ansi(row), row)
+    #: Real repo names, one per shape a width can be got wrong on. The name column is the
+    #: one cell holding a value charter did not mint — a clone is a directory somebody
+    #: else made — so it is where a character-versus-cell mistake would enter.
+    #:
+    #: `svc` is the CONTROL: it is inside every budget, so a failure naming it is about
+    #: the table rather than about the name. The combining mark is built with `chr` and
+    #: uses `q`, which has no precomposed form with an acute — the obvious `é` spelling
+    #: is one codepoint and one cell, so `len` and `tui.width` agree about it and it
+    #: quietly tests nothing.
+    NAMES = {
+        "short ascii control": "svc",
+        "exactly the name column's width": "a" * sl._NAME_W,
+        "one character over it": "a" * (sl._NAME_W + 1),
+        "far past it": "a-repo-name-far-past-any-column-width-anybody-guessed",
+        "CJK — two cells per glyph": "日本語のリポジトリ",
+        "combining mark — zero cells": "svc-q" + chr(0x0301) + "ueue",
+        "emoji — two cells, one character": "🚀-launcher",
+    }
+
+    def test_no_real_name_pushes_its_row_past_the_pane(self):
+        """`tui.Cell` measures cells, so a name is padded and cut in the unit the terminal
+        lays out in. Asserted at the narrow widths, where the row has the least room to
+        absorb a mistake, and with the CI cell — the thing #506 is about — still whole."""
+        for label, name in self.NAMES.items():
+            for w in (95, 80, 74, 60):
+                with self.subTest(name=label, width=w):
+                    plan = sl._row_plan(w)
+                    row = sl._tree_cells("  ├─ ", name, D, STATES, BRANCHES, GL,
+                                         plan=plan).render(w)[0]
+                    self.assertLessEqual(tui.width(row), w, row)
+                    self.assertIn(CI_WHOLE, tui.strip_ansi(row), row)
+
+    def test_an_awkward_name_starts_its_ci_cell_where_an_ordinary_one_does(self):
+        """The alignment half. Every name in the matrix is drawn beside `svc`, and the two
+        rows have to agree about where the CI column begins — which is the whole reason
+        the name cell has a declared width rather than a natural one."""
+        for label, name in self.NAMES.items():
+            with self.subTest(name=label):
+                plan = sl._row_plan(74)
+                rows = [tui.strip_ansi(
+                    sl._tree_cells("  ├─ ", n, D, STATES, BRANCHES, GL,
+                                   plan=plan).render(74)[0])
+                    for n in ("svc", name)]
+                self.assertEqual(*[tui.width(r[:r.index("✗")]) for r in rows],
+                                 "\n".join(rows))
 
 
 class RenderCase(PersonaIso):

--- a/tests/test_a_table_column_is_measured_in_cells.py
+++ b/tests/test_a_table_column_is_measured_in_cells.py
@@ -271,6 +271,21 @@ class TestWorktreeHistoryColumnsLineUp(WorktreeHistoryCase):
                             for r in rows), "\n".join(rows))
         self.assert_aligned(rows, "slice", least=1)
 
+    def test_a_line_with_no_piece_never_reaches_the_renderer(self):
+        """The reason `piece` is subscripted where its three neighbours are not.
+
+        `events()` keeps a line only `if obj.get("piece")`, so the renderer is entitled to
+        assume the field — and the sweep proved it, by reporting a fourth `""` fallback as
+        equivalent. This is the coupling that entitles it, pinned where the assumption is
+        made rather than only where the filter is written."""
+        self.record("svc", "slice")
+        log = pieces.log_path(self.WS)
+        log.write_text(log.read_text()
+                       + '{"ts": "2026-01-01T00:00:00+00:00", "repo": "NOPIECE"}\n')
+        self.assertEqual([e for e in pieces.events(self.WS) if not e.get("piece")], [])
+        rows = self.history()
+        self.assertNotIn("NOPIECE", "\n".join(tui.strip_ansi(r) for r in rows))
+
     def test_the_timestamp_column_is_wider_than_the_timestamp_charter_writes(self):
         """`{ts:<22}` on the 25-character stamp `pieces.record` writes on every event.
 

--- a/tests/test_a_table_column_is_measured_in_cells.py
+++ b/tests/test_a_table_column_is_measured_in_cells.py
@@ -1,0 +1,460 @@
+"""A shipped table's columns are sized from the values it holds, in CELLS (#592).
+
+#508 fixed this for `persona stats` and left seven tables carrying the same shape. Three
+of them ship it, and #592 enumerates them: **`worktree history`** pads a 25-character ISO
+timestamp into 22, **`status`** pads `node-monorepo` (13) into 12, and **`recall`** sizes
+its label column from the data — which is right — and then measures it with `len`, which
+is not.
+
+**Two of the three are wrong on values charter itself produces.** `pieces.record` writes
+`datetime.isoformat(timespec="seconds")` on an aware datetime, which is 25 characters,
+every time; `node-monorepo` is a stack name out of charter's own inventory vocabulary.
+Neither needs an unusual name to misalign, which is why the fixtures below are mostly
+ordinary and only some of them are awkward.
+
+**Two probes, and they answer different questions.** The alignment probe asks whether the
+columns line up; the readability probe asks whether the value is still there. #508 measured
+why one cannot stand in for the other: `tui.pad` TRUNCATES, so restoring a mis-measured
+width leaves every column lining up perfectly with the value quietly cut off inside one of
+them. Every alignment assertion in #508's own suite passed against the restored constant.
+So a table that is only checked for alignment is a table whose measuring is untested.
+
+**And offsets are read in cells, never in characters.** `line.index(marker)` counts
+characters, which is the unit that was wrong in the first place — a test using it reports
+a CJK row as aligned while the terminal draws it eight columns out.
+
+Fixtures are real names: one at each constant's boundary, one over it, one CJK, one
+carrying a combining mark, one emoji, and a short ASCII control. The control is what says
+a failure is about the awkward name rather than about the table.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+import unicodedata
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import (commands, commands_worktree, config, persona, pieces, tui,
+                     workspace)
+from tests._isolation import PersonaIso
+
+#: A base character with a combining acute, built with `chr` so no editor and no
+#: filesystem can quietly turn it into one codepoint.
+#:
+#: **`q` on purpose, and this is the whole fixture.** The obvious spelling —
+#: `équipe-mémoire`, which is what #508's own roster fixture uses — has a PRECOMPOSED
+#: `é` available, so the source file, the filesystem and `unicodedata.normalize` all
+#: agree on one codepoint and `len` equals `tui.width`. That fixture is a silent control:
+#: it passes against the very defect it is named for, measured, and it does. There is no
+#: precomposed "q with acute" in Unicode, so this one stays two codepoints and one cell
+#: wherever it is written down or read back.
+#: :meth:`TableCase.assert_a_cell_and_a_character_disagree` keeps that true rather
+#: than assumed.
+COMBINING = "svc-q" + chr(0x0301) + "ueue"
+
+
+class TableCase(PersonaIso):
+    """The two probes, and the environment every table below is rendered in."""
+
+    def assert_a_cell_and_a_character_disagree(self, value: str) -> None:
+        """Fixture guard: *value* must be one `len` and a different `tui.width`.
+
+        A case named for the character-versus-cell defect that measures the same either
+        way is not a case, it is a control that reads like one — and both directions have
+        shipped in this repo (#588's UTF-8 round trip that passed on any UTF-8 machine).
+        The value has to have gone through whatever normalisation the filesystem does
+        before this is asked, which is why callers pass what they READ BACK.
+        """
+        self.assertNotEqual(
+            len(value), tui.width(value),
+            f"fixture: {value!r} is {len(value)} characters AND {tui.width(value)} cells, "
+            "so `len` and `tui.width` agree about it and this case cannot fail")
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Pinned rather than inherited: `$COLUMNS` is read by `tui` and has flipped five
+        # tests in this suite before (#544). None of these tables clips to the terminal,
+        # and pinning it is what keeps that true by detection rather than by hope.
+        self.enterContext(mock.patch.dict(os.environ, {"COLUMNS": "220"}))
+
+    @staticmethod
+    def run_cmd(fn, args) -> list[str]:
+        out = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(io.StringIO()):
+            fn(args)
+        return out.getvalue().splitlines()
+
+    @staticmethod
+    def cells_before(line: str, marker: str) -> int:
+        """How many terminal CELLS precede *marker* on *line*.
+
+        Not `line.index(marker)`. That is a character count, and a character count is the
+        defect: it reports a CJK row as starting its tail where the ASCII row starts its
+        own while the terminal draws them eight columns apart.
+        """
+        return tui.width(tui.strip_ansi(line)[:tui.strip_ansi(line).index(marker)])
+
+    def assert_aligned(self, rows: list[str], marker: str, *, least: int = 2) -> None:
+        """*marker* begins in the same cell on every row that carries it."""
+        data = [r for r in rows if marker in tui.strip_ansi(r)]
+        self.assertGreaterEqual(len(data), least,
+                                f"{marker!r} is on {len(data)} row(s), needed {least} to "
+                                f"compare offsets:\n" + "\n".join(rows))
+        at = {self.cells_before(r, marker) for r in data}
+        self.assertEqual(
+            len(at), 1,
+            f"the column holding {marker!r} starts at cells {sorted(at)} — different on "
+            f"different rows, so it was sized by a guess or measured in characters:\n"
+            + "\n".join(data))
+
+    def assert_readable(self, rows: list[str], value: str) -> None:
+        """*value* appears IN FULL on some row.
+
+        The half alignment cannot see. `tui.pad` truncates whatever does not fit, so a
+        column sized too small stays perfectly aligned and loses the end of its value —
+        and a repo, piece or persona name a reader cannot read back off the row is one
+        they cannot go and act on.
+        """
+        self.assertTrue(any(value in tui.strip_ansi(r) for r in rows),
+                        f"{value!r} appears in full on no row — the column was sized by a "
+                        f"guess and the value was cut to fit it:\n" + "\n".join(rows))
+
+
+# --------------------------------------------------------------------------- #
+# worktree history — `{ts:<22} {repo:<16} {piece:<24} {event:<10}`             #
+# --------------------------------------------------------------------------- #
+class WorktreeHistoryCase(TableCase):
+    """`charter worktree history` reads ONLY the log, never git (its own docstring), so
+    these rows are recorded rather than produced by a real worktree — the table under
+    test is the rendering, and `tests/test_piece_history.py` covers the record."""
+
+    WS = "alpha"
+
+    #: One value per column shape the constants get wrong. `svc` and `slice` are the
+    #: CONTROLS: they fit every constant, so they are drawn identically with the fix and
+    #: without it, and a failure that names them is about the table rather than the name.
+    REPOS = {
+        "short ascii control": "svc",
+        "exactly the old 16-char boundary": "sixteen-char-svc",
+        "one character over the boundary": "seventeen-char-sv",
+        "well over the boundary": "charter-control-plane-service",
+        "CJK — two cells per glyph": "日本語のリポジトリ",
+        "combining mark — zero cells": COMBINING,
+        "emoji — two cells, one character": "🚀-launcher",
+    }
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure(self.WS)
+        workspace.scaffold(self.WS)
+
+    def record(self, repo: str, piece: str, *, event: str = "claimed",
+               reason: str = "SO-SAID", when=None):
+        pieces.record(self.WS, event, repo, piece, reason=reason, when=when)
+
+    def history(self, **kw) -> list[str]:
+        args = SimpleNamespace(repo=None, piece=None, workspace=self.WS, **kw)
+        return self.run_cmd(commands_worktree.cmd_worktree_history, args)
+
+    #: The tail every row ends with. `pieces.claimant` answers the same string for every
+    #: row here (no persona, no session — the host), so a reason identical across rows
+    #: gives one marker whose offset is the SUM of every width the renderer computed.
+    TAIL = "— SO-SAID"
+
+
+class TestWorktreeHistoryColumnsLineUp(WorktreeHistoryCase):
+    def test_a_repo_name_over_the_constant_does_not_push_its_row(self):
+        """One case per name, so a failure says WHICH kind of name broke the table."""
+        for label, repo in self.REPOS.items():
+            with self.subTest(name=label):
+                pieces.dir_for(self.WS).exists() and [
+                    f.unlink() for f in pieces.dir_for(self.WS).glob("*.jsonl")]
+                self.record("svc", "slice")
+                self.record(repo, "slice")
+                self.assert_aligned(self.history(), self.TAIL)
+
+    def test_the_whole_awkward_log_lines_up_at_once(self):
+        """Together, not one at a time: the column is sized from the widest value in the
+        table, so the interesting row is the one that is NOT the widest and still has to
+        be padded to a width somebody else's name decided."""
+        for repo in self.REPOS.values():
+            self.record(repo, "slice")
+        self.assert_aligned(self.history(), self.TAIL, least=len(self.REPOS))
+
+    def test_a_piece_name_over_the_constant_does_not_push_its_row(self):
+        """`{piece:<24}`, and a piece is named like a branch — `charter worktree add`
+        names the branch after it — so twenty-four characters is a guess that ordinary
+        work walks past. This branch's own name is thirty-four."""
+        self.record("svc", "slice")
+        self.record("svc", "fix-table-cells-and-frame-workspace")
+        self.assert_aligned(self.history(), self.TAIL)
+
+    def test_every_name_is_still_readable_off_its_row(self):
+        """Sizing the column, not clipping to it — the half the alignment cases cannot
+        see, because `tui.pad` truncates and the columns go on lining up while it does."""
+        for repo in self.REPOS.values():
+            self.record(repo, "slice")
+        rows = self.history()
+        for repo in self.REPOS.values():
+            with self.subTest(repo=repo):
+                self.assert_readable(rows, repo)
+
+    def test_the_timestamp_column_is_wider_than_the_timestamp_charter_writes(self):
+        """`{ts:<22}` on the 25-character stamp `pieces.record` writes on every event.
+
+        `str.format` pads and never truncates, so what a too-small field costs here is
+        not a cut value — it is the SEPARATION, which is the only thing telling a reader
+        where one column ends and the next begins. Every row of this table ran its
+        timestamp into a single space in front of the repo name, and a single space is a
+        word space rather than a column boundary.
+
+        The fixture is charter's OWN stamp (`pieces.record`'s default `when`), not a
+        constructed one, because that is #592's point: the constant was already wrong on
+        the only value this column ever holds.
+        """
+        self.record("svc", "slice")
+        row = next(r for r in self.history() if self.TAIL in r)
+        plain = tui.strip_ansi(row)
+        ts = plain.split()[0]
+        self.assertGreaterEqual(len(ts), 25, f"fixture: {ts!r} is not the 25-character "
+                                             "stamp #592 is about")
+        after = plain[plain.index(ts) + len(ts):]
+        self.assertGreaterEqual(
+            len(after) - len(after.lstrip(" ")), 2,
+            f"the timestamp column is narrower than the timestamp it holds, so it "
+            f"degraded to a word space in front of the next column:\n{plain}")
+
+    def test_a_newline_in_a_recorded_value_cannot_write_its_own_row(self):
+        """The log is COMMITTED and append-only, so a value in it is somebody else's
+        machine's. A format string counts a newline as one character and prints it as a
+        line break, which shears every column below it; going through `tui.pad` means the
+        kit's own `sanitize` sees it first."""
+        self.record("svc\nFORGED  fake  fake  fake", "slice")
+        rows = self.history()
+        self.assertEqual([r for r in rows if tui.strip_ansi(r).startswith("FORGED")], [],
+                         "\n".join(rows))
+
+
+# --------------------------------------------------------------------------- #
+# status — `  {repo:<38} {stack:<12} {note}`                                  #
+# --------------------------------------------------------------------------- #
+class StatusTableCase(TableCase):
+    WS = "alpha"
+    #: The third column, identical on every row, so its offset is the sum of the two
+    #: measured widths in front of it. Stubbed because it shells out to git per clone and
+    #: what is under test is the arithmetic, not the note.
+    NOTE = "main · clean"
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure(self.WS)
+        workspace.scaffold(self.WS)
+        self.enterContext(mock.patch.object(commands, "_clone_note",
+                                            return_value=self.NOTE))
+
+    def clone(self, name: str, stack: str = "python") -> str:
+        # `workspace.clones` counts a directory as a clone only if it has a `.git` — that
+        # is how `memory/` and `refs/` stay out of the list — so the fixture needs one.
+        d = workspace.workspace_dir(self.WS) / name
+        try:
+            (d / ".git").mkdir(parents=True, exist_ok=True)
+        except OSError:
+            self.skipTest(f"filesystem refuses {name!r}")
+        self.stacks[name] = {"name": name, "stack": stack}
+        return name
+
+    def on_disk(self, name: str) -> str:
+        """The clone's name AS THE RENDERER WILL SEE IT — read back off the filesystem.
+
+        `workspace.clones` lists directories, so a filesystem that normalises a name on
+        the way in hands the table a different string than the fixture wrote. Asking the
+        directory is the only way a fixture guard can speak for the value under test.
+
+        Matched under NFC rather than by equality, because normalising is exactly the
+        thing being looked for: an equality match would fail to find the very entry whose
+        recomposition is the case worth catching."""
+        want = unicodedata.normalize("NFC", name)
+        d = workspace.workspace_dir(self.WS)
+        return next((p.name for p in d.iterdir()
+                     if unicodedata.normalize("NFC", p.name) == want), name)
+
+    def status(self) -> list[str]:
+        self.stacks = getattr(self, "stacks", {})
+        with mock.patch.object(commands.inventory, "repos",
+                               return_value=list(self.stacks.values())):
+            return self.run_cmd(commands.cmd_status,
+                                SimpleNamespace(workspace=self.WS, all=False))
+
+
+class TestStatusColumnsLineUp(StatusTableCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.stacks: dict[str, dict] = {}
+
+    def test_the_stack_charter_itself_names_does_not_push_its_row(self):
+        """`node-monorepo` is thirteen characters in a column of twelve, and it is one of
+        charter's OWN stack names — so this table has never lined up on a plane holding a
+        node monorepo. The `go` row is what it fails to line up WITH."""
+        self.clone("svc", stack="go")
+        self.clone("web", stack="node-monorepo")
+        self.assert_aligned(self.status(), self.NOTE)
+
+    def test_the_header_lines_up_with_the_rows_it_heads(self):
+        """The header used to go through the same format string as the rows, which looks
+        like one code path and is not: `{:<12}` agrees with itself only while every value
+        is inside the constant. A header sitting one column left of the values under it is
+        the tell #508 names — the thing a reader notices before any row does."""
+        self.clone("web", stack="node-monorepo")
+        rows = self.status()
+        head = next(r for r in rows if "BRANCH / NOTE" in r)
+        row = next(r for r in rows if self.NOTE in r)
+        self.assertEqual(self.cells_before(head, "BRANCH / NOTE"),
+                         self.cells_before(row, self.NOTE),
+                         "\n".join([head, row]))
+
+    def test_a_repo_name_past_the_constant_does_not_push_its_row(self):
+        self.clone("svc")
+        self.clone("a-repo-name-far-past-any-fixed-column-width-somebody-guessed")
+        self.assert_aligned(self.status(), self.NOTE)
+
+    def test_a_cjk_repo_name_does_not_push_its_row(self):
+        """The `len` half, which no constant can fix: two cells per glyph, so a name well
+        inside any budget still shifts its row by its own length."""
+        name = self.clone("日本語のリポジトリ")
+        self.clone("svc")
+        rows = self.status()
+        self.assert_a_cell_and_a_character_disagree(self.on_disk(name))
+        self.assert_aligned(rows, self.NOTE)
+
+    def test_a_combining_mark_does_not_pull_its_row(self):
+        """The other direction, and the one a bigger constant makes WORSE: a combining
+        mark is ZERO cells, so `len` over-pads and the row drifts right.
+
+        The fixture is checked as it came back OFF THE FILESYSTEM, because that is where
+        this one can quietly stop being a fixture — a filesystem that composes the pair
+        into one codepoint hands the renderer a value `len` and `tui.width` agree about,
+        and the case then passes against the defect it is named for."""
+        name = self.clone(COMBINING)
+        self.clone("svc")
+        rows = self.status()
+        self.assert_a_cell_and_a_character_disagree(self.on_disk(name))
+        self.assert_aligned(rows, self.NOTE)
+
+    def test_every_repo_and_stack_is_still_readable_off_its_row(self):
+        long_repo = "a-repo-name-far-past-any-fixed-column-width-somebody-guessed"
+        self.clone("svc", stack="go")
+        self.clone(long_repo, stack="node-monorepo")
+        rows = self.status()
+        self.assert_readable(rows, long_repo)
+        self.assert_readable(rows, "node-monorepo")
+
+
+# --------------------------------------------------------------------------- #
+# recall — `  {date:<10}  {label:<len(widest)}  {title}`                       #
+# --------------------------------------------------------------------------- #
+class RecallCase(TableCase):
+    """`recall` is the one of the three that already sized its column from the data.
+
+    Which is why it is here: sizing is half the answer, and this half is the one a reader
+    of the code would call done. `max(len(h.label) …)` measures CHARACTERS, so a base
+    label carrying a persona's own directory name misaligns every row of the report
+    without any value going near a constant — there is no constant left to go near.
+    """
+
+    WS = "w"
+    QUERY = "keycloak"
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure(self.WS)
+        workspace.scaffold(self.WS)
+        from charter import memstore
+        memstore.write(workspace.memory_dir(self.WS),
+                       "the keycloak token rotates every ninety days",
+                       title="keycloak token policy", timestamped=True)
+
+    def with_persona(self, name: str) -> str:
+        try:
+            self.make_persona(name, role="Role")
+        except OSError:
+            self.skipTest(f"filesystem refuses {name!r}")
+        persona.remember(name, "keycloak deploys need the staging realm first")
+        return name
+
+    def persona_on_disk(self, name: str) -> str:
+        """The persona DIRECTORY name as `recall` will label it — read back, matched
+        under NFC, for the reason `StatusTableCase.on_disk` gives."""
+        want = unicodedata.normalize("NFC", name)
+        return next((p.name for p in config.PERSONAS_DIR.iterdir()
+                     if unicodedata.normalize("NFC", p.name) == want), name)
+
+    def recall(self, name: str) -> list[str]:
+        return self.run_cmd(commands.cmd_recall, SimpleNamespace(
+            query=self.QUERY, scope=None, ephemeral=False, persona=name,
+            workspace=self.WS, all_workspaces=False, since=None, limit=8, full=False))
+
+    @staticmethod
+    def hit_rows(rows: list[str]) -> list[str]:
+        """Only the `date · label · title` rows.
+
+        The report interleaves each hit with its ADDRESS line, and a memory's filename is
+        slugged from its title — so the query word appears on both, and an offset probe
+        that took the address rows for hit rows would compare a hanging indent against a
+        column. The two are different kinds of line; only one of them is the table.
+        """
+        return [r for r in rows
+                if re.match(r"^ {2}\d{4}-\d{2}-\d{2} ", tui.strip_ansi(r))]
+
+
+class TestRecallColumnsLineUp(RecallCase):
+    def test_a_cjk_persona_label_does_not_push_its_row(self):
+        """`persona:日本語のペルソナ` beside `workspace:w`: eight glyphs the terminal draws
+        as sixteen cells, padded by `len` to eight — so the TITLE column on that row lands
+        eight columns left of every other row's."""
+        name = self.with_persona("日本語のペルソナ")
+        self.assert_aligned(self.hit_rows(self.recall(name)), "keycloak", least=2)
+
+    def test_a_combining_mark_in_a_label_does_not_pull_its_row(self):
+        """The direction a bigger constant makes worse — zero cells, one character, so
+        `len` over-pads and the row drifts RIGHT of every other. The fixture is guarded as
+        the persona directory came back off the filesystem: a normalising filesystem hands
+        the label one codepoint, `len` and `tui.width` then agree, and the case would pass
+        against exactly the defect it is named for."""
+        name = self.with_persona(COMBINING)
+        rows = self.hit_rows(self.recall(name))
+        self.assert_a_cell_and_a_character_disagree(self.persona_on_disk(name))
+        self.assert_aligned(rows, "keycloak", least=2)
+
+    def test_an_ascii_roster_is_the_control(self):
+        """Named a control so a failure here reads as "the table broke", not "the awkward
+        name broke it". `len` and `tui.width` agree on every label in this case."""
+        self.assert_aligned(self.hit_rows(self.recall(self.with_persona("dev"))),
+                            "keycloak", least=2)
+
+    def test_every_label_is_still_readable_off_its_row(self):
+        name = self.with_persona("日本語のペルソナ")
+        rows = self.recall(name)
+        self.assert_readable(rows, f"persona:{name}")
+        self.assert_readable(rows, f"workspace:{self.WS}")
+
+    def test_the_address_hangs_under_the_title_it_addresses(self):
+        """The address line's indent used to be `14` written out, which is `2 + 10 + 2` —
+        correct only while the date column is exactly ten wide. Pinned as a relationship
+        so the two cannot drift apart the first time either end moves."""
+        rows = self.recall(self.with_persona("dev"))
+        hit = next(i for i, r in enumerate(rows) if "keycloak" in tui.strip_ansi(r))
+        addr = tui.strip_ansi(rows[hit + 1])
+        row = tui.strip_ansi(rows[hit])
+        date = row.split()[0]
+        self.assertEqual(len(addr) - len(addr.lstrip(" ")),
+                         row.index(date) + len(date) + 2,
+                         "\n".join([row, addr]))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_a_table_column_is_measured_in_cells.py
+++ b/tests/test_a_table_column_is_measured_in_cells.py
@@ -57,6 +57,23 @@ from tests._isolation import PersonaIso
 #: than assumed.
 COMBINING = "svc-q" + chr(0x0301) + "ueue"
 
+#: The pair that makes `len`-sizing OBSERVABLE, and it took a mutation to find out that
+#: nothing else does.
+#:
+#: A CJK name on its own does not catch a column sized with `len` and padded with
+#: `tui.pad`: `pad` measures in cells, so every row is still padded to the same number of
+#: cells and the table still lines up. And if some ASCII name is the widest by CHARACTERS,
+#: the column it sizes is wide enough that the CJK value is not cut either — so the
+#: readability probe passes too. Measured: a hand-check restored `len` here and the whole
+#: file stayed green.
+#:
+#: What breaks is a value that is **widest in cells while another value is widest in
+#: characters**. `len` then sizes the column to the ASCII name and `tui.pad` cuts the CJK
+#: one down to it. So the fixture is a pair, and :meth:`TableCase.assert_the_widest_two
+#: _disagree` is what keeps it one.
+WIDEST_IN_CHARACTERS = "sixteen-char-svc"          # 16 characters, 16 cells
+WIDEST_IN_CELLS = "日本語のリポジトリです"          # 11 characters, 22 cells
+
 
 class TableCase(PersonaIso):
     """The two probes, and the environment every table below is rendered in."""
@@ -74,6 +91,18 @@ class TableCase(PersonaIso):
             len(value), tui.width(value),
             f"fixture: {value!r} is {len(value)} characters AND {tui.width(value)} cells, "
             "so `len` and `tui.width` agree about it and this case cannot fail")
+
+    def assert_the_widest_two_disagree(self, by_chars: str, by_cells: str) -> None:
+        """Fixture guard for the pair that makes `len`-sizing observable at all.
+
+        *by_chars* must be the longer by `len` and *by_cells* the wider by `tui.width`.
+        Only then does sizing with `len` produce a column too narrow for the value it
+        holds — with any other pairing the column is wide enough by accident and the
+        readability probe passes against the defect. See :data:`WIDEST_IN_CELLS`.
+        """
+        self.assertGreater(len(by_chars), len(by_cells), "fixture: wrong way round")
+        self.assertGreater(tui.width(by_cells), tui.width(by_chars),
+                           "fixture: wrong way round")
 
     def setUp(self) -> None:
         super().setUp()
@@ -196,13 +225,51 @@ class TestWorktreeHistoryColumnsLineUp(WorktreeHistoryCase):
 
     def test_every_name_is_still_readable_off_its_row(self):
         """Sizing the column, not clipping to it — the half the alignment cases cannot
-        see, because `tui.pad` truncates and the columns go on lining up while it does."""
+        see, because `tui.pad` truncates and the columns go on lining up while it does.
+
+        Measured — with only the awkward names in here, restoring `len` left every case
+        in this file green, because the widest name by characters was also wide enough in
+        cells for every other value to fit inside it. The case that catches `len` is the
+        one below, and it is a PAIR and nothing else."""
         for repo in self.REPOS.values():
             self.record(repo, "slice")
         rows = self.history()
         for repo in self.REPOS.values():
             with self.subTest(repo=repo):
                 self.assert_readable(rows, repo)
+
+    def test_the_widest_in_cells_is_readable_beside_the_widest_in_characters(self):
+        """The two-value fixture, ALONE in its table — and alone is load-bearing.
+
+        `len`-sizing is only observable when the value that decides the width and the
+        value that overflows it are different values. Put a sixty-character ASCII name in
+        the same table and it decides the width for both, the CJK one fits inside it with
+        room to spare, and the case passes against exactly the defect it is named for.
+        Measured: it did, in the sibling case above, until this one was split out."""
+        self.assert_the_widest_two_disagree(WIDEST_IN_CHARACTERS, WIDEST_IN_CELLS)
+        for repo in (WIDEST_IN_CHARACTERS, WIDEST_IN_CELLS):
+            self.record(repo, "slice")
+        rows = self.history()
+        self.assert_readable(rows, WIDEST_IN_CELLS)
+        self.assert_aligned(rows, self.TAIL)
+
+    def test_a_log_line_missing_a_field_still_draws_a_row(self):
+        """`events()` skips a line it cannot parse and keeps every line that has a
+        `piece` — so a half-written record, or one from a charter that wrote fewer
+        fields, arrives here with `ts`, `repo` or `event` simply absent. The `""`
+        fallbacks are what stand between that and `tui.pad(None, w)`, which raises and
+        takes the whole command down.
+
+        A killed process mid-append is exactly what an append-only log collects, which is
+        `events()`' own stated reason for tolerating it. Nothing was asserting that the
+        renderer tolerates it too — found by the deletion sweep."""
+        self.record("svc", "slice")
+        log = pieces.log_path(self.WS)
+        log.write_text(log.read_text() + '{"piece": "a-piece-and-nothing-else"}\n')
+        rows = self.history()
+        self.assertTrue(any("a-piece-and-nothing-else" in tui.strip_ansi(r)
+                            for r in rows), "\n".join(rows))
+        self.assert_aligned(rows, "slice", least=1)
 
     def test_the_timestamp_column_is_wider_than_the_timestamp_charter_writes(self):
         """`{ts:<22}` on the 25-character stamp `pieces.record` writes on every event.
@@ -317,6 +384,22 @@ class TestStatusColumnsLineUp(StatusTableCase):
                          self.cells_before(row, self.NOTE),
                          "\n".join([head, row]))
 
+    def test_a_clone_the_inventory_does_not_know_still_gets_a_stack_cell(self):
+        """`inv_by_name.get(name, {}).get("stack", "?")` — two fallbacks, and both are
+        reachable: a clone made by hand, or one whose repo has left the inventory, has no
+        entry at all. Without them the cell is `None`, `tui.pad` raises on it, and
+        `charter status` — the command whose whole job is "where am I" — dies on the one
+        plane where the question is hardest to answer another way.
+
+        Found by the deletion sweep: nothing asserted either fallback.
+        """
+        self.clone("svc", stack="go")
+        unknown = self.clone("cloned-by-hand")
+        del self.stacks[unknown]          # in the workspace, absent from the inventory
+        rows = self.status()
+        self.assert_readable(rows, "?")
+        self.assert_aligned(rows, self.NOTE)
+
     def test_a_repo_name_past_the_constant_does_not_push_its_row(self):
         self.clone("svc")
         self.clone("a-repo-name-far-past-any-fixed-column-width-somebody-guessed")
@@ -346,12 +429,28 @@ class TestStatusColumnsLineUp(StatusTableCase):
         self.assert_aligned(rows, self.NOTE)
 
     def test_every_repo_and_stack_is_still_readable_off_its_row(self):
+        """A constant's half: a name and a stack past the width somebody guessed."""
         long_repo = "a-repo-name-far-past-any-fixed-column-width-somebody-guessed"
         self.clone("svc", stack="go")
         self.clone(long_repo, stack="node-monorepo")
         rows = self.status()
-        self.assert_readable(rows, long_repo)
-        self.assert_readable(rows, "node-monorepo")
+        for value in (long_repo, "node-monorepo"):
+            with self.subTest(value=value):
+                self.assert_readable(rows, value)
+
+    def test_the_widest_in_cells_is_readable_beside_the_widest_in_characters(self):
+        """`len`'s half, and it needs the pair ALONE in the table.
+
+        The width has to be decided by one value and overflowed by another. A sixty-
+        character ASCII repo name in the same table decides it for both, the CJK name fits
+        inside with room to spare, and the case passes against the defect — measured, in
+        the sibling case above, until this one was split out of it."""
+        self.assert_the_widest_two_disagree(WIDEST_IN_CHARACTERS, WIDEST_IN_CELLS)
+        self.clone(WIDEST_IN_CHARACTERS, stack="go")
+        self.clone(WIDEST_IN_CELLS, stack="python")
+        rows = self.status()
+        self.assert_readable(rows, WIDEST_IN_CELLS)
+        self.assert_aligned(rows, self.NOTE)
 
 
 # --------------------------------------------------------------------------- #
@@ -399,6 +498,11 @@ class RecallCase(TableCase):
             workspace=self.WS, all_workspaces=False, since=None, limit=8, full=False))
 
     @staticmethod
+    def hit_rows_or_undated(rows: list[str]) -> list[str]:
+        """Hit rows whose date column holds the `—` an undated memory renders."""
+        return [r for r in rows if re.match(r"^ {2}—", tui.strip_ansi(r))]
+
+    @staticmethod
     def hit_rows(rows: list[str]) -> list[str]:
         """Only the `date · label · title` rows.
 
@@ -442,7 +546,7 @@ class TestRecallColumnsLineUp(RecallCase):
         self.assert_readable(rows, f"persona:{name}")
         self.assert_readable(rows, f"workspace:{self.WS}")
 
-    def test_the_address_hangs_under_the_title_it_addresses(self):
+    def test_the_address_hangs_under_the_label_it_addresses(self):
         """The address line's indent used to be `14` written out, which is `2 + 10 + 2` —
         correct only while the date column is exactly ten wide. Pinned as a relationship
         so the two cannot drift apart the first time either end moves."""
@@ -454,6 +558,48 @@ class TestRecallColumnsLineUp(RecallCase):
         self.assertEqual(len(addr) - len(addr.lstrip(" ")),
                          row.index(date) + len(date) + 2,
                          "\n".join([row, addr]))
+
+    def test_an_undated_result_narrows_the_date_column_and_the_indent_with_it(self):
+        """The case that makes both of those measurable at all.
+
+        Every dated hit renders a ten-character ISO date, so a `10`-wide constant and a
+        `14`-wide indent are correct for every dated report — a hand-check restored both
+        and nothing went red. An UNDATED memory renders `—`, one cell, and a column sized
+        from the values is then three wide and the indent five. That is the difference
+        between a column that is measured and one that happens to be right.
+
+        Undated is ordinary rather than exotic: `recall` counts them (`got.undated`) and
+        a memory file with no recorded date is what `memstore` writes when nothing dated
+        it.
+        """
+        name = self.with_persona("dev")
+        # A memory's date is its in-body `_YYYY-MM-DD …_` stamp, falling back to a
+        # `YYYYMMDD-` filename prefix (`memstore.memory_date`). BOTH have to go, and the
+        # filename one is why the workspace journal file is renamed rather than edited —
+        # `memstore.write(timestamped=True)` puts the date in the name as well as in the
+        # body, so stripping only the stamp leaves the hit dated and the fixture inert.
+        for base in (persona.memory_dir(name), workspace.memory_dir(self.WS)):
+            for f in list(base.glob("*.md")):
+                body = re.sub(r"^_\d{4}-\d{2}-\d{2}[^\n]*$", "_undated_", f.read_text(),
+                              flags=re.M)
+                f.write_text(body)
+                f.rename(base / re.sub(r"^\d{8}-\d{6}-", "", f.name))
+        rows = self.hit_rows_or_undated(self.recall(name))
+        self.assertTrue(rows, "fixture: no hits at all")
+        self.assertTrue(all(tui.strip_ansi(r).lstrip().startswith("—") for r in rows),
+                        "fixture: a hit still carries a date, so the date column is ten "
+                        "wide and this case cannot fail:\n" + "\n".join(rows))
+        row = tui.strip_ansi(rows[0])
+        self.assertEqual(row.index("—"), 2, row)
+        # The label starts one gap past a column holding a single cell — not eleven.
+        self.assertLess(tui.width(row[:row.index("persona:")]), 10, row)
+        # And the address line follows the column it hangs under. This is the assertion
+        # that makes the hardcoded `14` fail: with every hit dated, `2 + dw` IS 14 and a
+        # literal is indistinguishable from the expression.
+        addr = tui.strip_ansi(next(ln for ln in self.recall(name)
+                                   if "/memory/" in ln))
+        self.assertEqual(len(addr) - len(addr.lstrip(" ")),
+                         row.index("persona:"), "\n".join([row, addr]))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -1856,8 +1856,13 @@ class TheSidebarListsTheWorkspacesTodos(PersonaIso, unittest.TestCase):
 
         WHICH workspace that live gather is for is a separate question and a real one —
         `gather.scan` resolves it from the panel process, which #512 showed reaches none
-        of the rungs that speak for the frame. Filed as **#526** rather than fixed here:
-        the mechanism it wants (`state.workspace_for`) arrives with #525.
+        of the rungs that speak for the frame. Settled since, as **#526**: `todo_section`
+        hands `gather.read` the frame's own workspace (`_frame_workspace`), so the scan
+        this case forces is a scan for the workspace the frame was launched for.
+        `tests/test_a_frame_answers_for_the_frames_workspace.py` is where that half is
+        pinned, on a plane whose own rungs answer something else — which is the fixture
+        this one deliberately does not build, because what it is about is the SCAN
+        happening at all.
         """
         from charter import todos, workspace
         todos.add(workspace.resolve(), "written before the frame ever launched")


### PR DESCRIPTION
Closes #592
Closes #506
Closes #526
Closes #524

Four issues, **two properties**, and they are stated separately because they are separate.

---

## Property one — a column is measured in cells, from the values it holds (#592, #506)

`tui.column()` landed in #585/#589 for `persona stats` and answers both halves of what a
hand-rolled `{name:<28}` gets wrong: the width comes from the values about to be printed,
and it is measured in `tui.width` rather than `len`. This extends it rather than writing a
second answer.

### `worktree history` — wrong on charter's own output

`pieces.record` writes `datetime.isoformat(timespec="seconds")` on an aware datetime: 25
characters, on every event. `{ts:<22}` pads and never truncates, so the field did nothing
and the repo name that follows ran into a single space — a word space, not a column
boundary. `{repo:<16}` and `{piece:<24}` are guesses about somebody else's directory
names; this branch's own name is 34.

### `status` — wrong on charter's own vocabulary

`node-monorepo` is 13 in a `{:<12}`, so on any plane holding a node monorepo that row's
branch note sat one column right of every other row's — and one column right of the header
above it.

### `recall` — sized from the data and measured with `len`

The half a reader of the code would call done. `len` counts characters; a CJK persona name
is two cells per glyph and a combining mark is zero, so a label well inside any budget
still shifted its row. **No constant can fix that half**, which is why it is here.

### `statusline`'s repo rows — the same property one surface over (#506)

Rows were composed at `_LEFT_W` (95) and cropped afterwards by `_columns`. Every cell after
the branch sits at a fixed offset, so an 80-column pane lost the last two — and the dirty
marker rides on the branch cell and survived, so a dirty, CI-failing, unpushed repo with an
open change read as one that was merely dirty:

```
w= 90   ├─ charter    main*    ✗ failed      …
w= 80   ├─ charter    main*    ✗ fa…
w= 70   ├─ charter    main*          …
```

`✗ fa…` is worse than no CI cell: a false-clean reading wearing a real one's clothes.

`_row_plan(budget)` decides the shape **where the row is composed**, because a crop cannot
know which column it just ate. It is #506's second honest option (a narrower row shape) —
the frame's `_table_lines` answer ("no table at all", #488) is not available to the status
line, which is what an operator sees when they are *not* in a frame. The losing order is
written down: branch text → repo name → change → branch → CI. Nothing is drawn as a
fragment, and the dirty/ahead/behind markers are the branch cell's *floor* rather than its
first casualty. At 80 columns you now get `├─ charter`, `main*↑2`, `✗ failed` and `#500`,
all four whole.

---

## Property two — a panel answers about the frame's workspace (#526, #524)

Not a width question at all. #512 established the shape and #525 built the mechanism: a
frame is launched *for* a workspace, nothing inside it can re-derive which one, so the
launcher writes it down and every surface reads it back. Two things were still asking for
themselves.

### #526 — the sidebar's todos

`slots.todo_section` called `gather.read(fid)` with no workspace. On a cold cache that
falls through to `gather.scan`, which resolves one **from the panel process** — and #512
measured that a panel reaches none of the rungs that speak for the frame. A first paint
could list another workspace's todos under this one's `▪ todos N` heading, which is worse
than #512's blank repo table: a populated list reads as an answer.

One line: `gather.read(fid, workspace=_frame_workspace(fid))`.

The issue asks two things to be settled with it, and both are:

* **The cold-cache scan stays.** #525 took it from `bottom` and gave that slot a
  `⋯ gathering…` placeholder because `bottom` is the one *animated* slot — five repaints a
  second, each a git sweep. The sidebar is not animated: one scan, one paint. The two
  slots read the cache by two different rules **deliberately**, and the difference is the
  repaint rate rather than the section. Written into `todo_section`'s docstring.
* **`tests/test_frame_slots.py`'s pinned cold-cache case** is re-read: its "filed as #526
  rather than fixed here" paragraph now says what was settled and points at the new file.

### #524 — the pane you type in

The harness reaches the same dead rungs, so the frame could correctly draw
`harness-wrapper` while every command typed inside it acted on `default`.

`workspace.chosen` gains a rung — `for_frame(sid)`, the frame this session is running
inside. The issue says charter cannot have both directions silently; its **position** is
the answer, and it is the same one `state.workspace_for` already spells for the panels:

* **Below the per-session pointer.** `charter workspace use <name>` typed inside the frame
  writes that pointer under the frame's id, so it still wins and still moves the panels —
  #517's direction, and a documented promise. The launch is a *seed*, never a pin. Handing
  the harness `$CHARTER_WORKSPACE` would have worked and would also have taken `ws use`
  away from every framed session; that is the option #524 weighs and this declines.
* **Above the per-terminal pointer and the declared default**, which answer for the
  *asking process*. Inside a frame the pane is one charter created, not the operator's
  terminal.

**A rung rather than a session-start hook**, which is where #524 expected this to land. Its
own third constraint rules the hook out: a non-Claude harness has none, and neither does a
bare `charter ws current` typed into the frame's shell. A rung needs no harness cooperation.
`source()` mirrors it and says `frame`.

---

## Coordination

**Nothing under `frame/panel.py`, `frame/layout.py` or `commands_frame.py` is touched.**
The one file in the frame this changes is `charter/frame/slots.py`, and the change is
**one line — `slots.py:1043`**, the `return` at the end of `todo_section` — plus that
function's docstring. `tools/sweep.py` is untouched. Rebased onto `main` after #598, #599
and #590 landed; the diff is five source files and four test files, nothing else.

---

## Verification

**Full suite, two environments. Both green.**

| environment | result |
|---|---|
| python 3.14.4, `COLUMNS=200` | **6975 tests — OK** |
| python 3.12.13, `COLUMNS=120`, every `CHARTER_*` / `CLAUDE*` / `ANTHROPIC_*` / `TMUX*` unset | **6975 tests — OK** |

`$COLUMNS` is set explicitly in both, and pinned inside every new test class, because it
flips five tests in this suite (#544).

**CI green at the head sha** on 3.11, 3.12, 3.13 and 3.14, read from
`repos/diazoxide/charter/commits/<sha>/check-runs` rather than `gh pr checks` (#561).

**Every new test fails on the merge-base**, checked by copying each file onto a clean
worktree there:

| file | at the merge-base | on this branch |
|---|---|---|
| `test_a_table_column_is_measured_in_cells.py` | **16 of 17 fail** — the 17th is the declared ASCII control | pass |
| `test_a_narrow_repo_row_drops_a_column_whole.py` | every `RenderCase` behaviour case fails; the plan cases error (new API) | pass |
| `test_a_frame_answers_for_the_frames_workspace.py` | **6 of 19 fail** | pass |

**Real names**, per the fixture matrix in each file: at the boundary, one over, far over,
CJK, a real combining mark, an emoji, and a short ASCII control named as a control.

### `tools/sweep.py` — 33 pinned, 2 survivors, both argued in the code

Run on the real tree with a **verified-green baseline** (no skips; the `frame/panel.py`
failure that used to block it was fixed by #598 while this was in flight).

Eleven survivors were reported across the run and **nine were closed by deleting the
line, not by testing it** — `tools/sweep.py`'s own rule that an equivalent mutant and dead
code are the same finding. What went:

* **`_row_plan`'s early return and its whole shrink loop.** The give-back loop recomputes
  the same allocation from the floors, so the shrink loop in front of it decided nothing.
  The function now starts at the floors and spends upward, and each order is written down
  exactly once. Verified as a whole function rather than reasoned: the two spellings agree
  at **every budget from 1 to 400.**
* **`max(1, room)`** in `_branch_cell_for`, dead the moment the refusal above it landed.
* **`min(width, _LEFT_W)`** in `render`, which restated a property the plan already has —
  `_LEFT_W` *is* what the full plan sums to. Pinned on `_row_plan` instead.
* **`plan[i] and`** in the give-back guard, and **`e.get("piece", "")`**'s fallback, which
  `pieces.events`' own filter makes unreachable.

The **two remaining survivors are deliberate, and the argument is in the code**:

1. **`_BRANCH_TEXT_MIN_W`'s exact value.** Bounded from both sides by properties instead:
   below 4 a stub is drawn beside the markers, above 6 an ordinary *clean* row loses its
   branch at the floor. 4, 5 and 6 are indistinguishable between them — measured, and
   recorded at the constant so nobody re-derives it. A test asserting the number would pin
   the spelling and nothing else.
2. **`for_frame`'s `if not sid`.** Genuinely decides nothing — deleted, it still answers
   `None` through `contain.child`. Kept for **cost**: this rung sits on `resolve`, which
   the status line calls every turn, and a session-less call would otherwise pay a module
   import, a path resolution and a failed read to learn what one boolean knew. The
   contract is pinned (`for_frame(None) is None`); the shortcut deliberately is not,
   because a test that could tell them apart would be asserting the shortcut.

### Hand-check: 45 mutations, 0 survivors

The sweep has **no operator for a string constant or a semantic swap** (#569), and a width
literal is exactly that. So 45 were applied by hand — every new constant, both orders, the
ladder rung moved to each of the three positions it could occupy, each table's sizing
reverted to `len` and to a constant, and every reachable fallback removed. On a
**verified-green unmutated baseline**, with **each mutation asserting its own edit
applied** (a pattern occurring 0 or 2 times is reported `NOT-APPLIED`, never as a verdict
— two were, mid-run, when the code moved under them, and were rewritten rather than
counted), and **every survivor re-run against the full suite** before being called one.

**Nine live gaps found and closed.** The three worth repeating:

1. **A CJK name alone does not catch `len`-sizing.** `tui.pad` measures in cells, so a
   mis-sized column stays aligned and the value is *cut* instead — and if some ASCII name
   is the widest by characters, the column is wide enough that nothing is cut either. What
   catches it is a **pair**: one value widest in characters, another widest in cells,
   **alone in the table**. A sixty-character ASCII name in the same fixture defeats it,
   and did. Both tables now have that pair in its own case, with a fixture guard on the
   pairing.
2. **`équipe-mémoire` is a silent control.** It is what #508's own roster fixture uses, and
   `é` has a precomposed form — so the source file, the filesystem and `normalize` all
   agree on one codepoint and `len` equals `tui.width`. The fixture here is `q` + U+0301,
   built with `chr` (no precomposed form exists), checked **as it came back off the
   filesystem**, because that is where it could quietly stop being a fixture.
3. **`recall`'s date column is ten wide for every dated hit**, so a `10` constant and a
   `14` indent were indistinguishable from the measured ones. An *undated* memory renders
   `—` and narrows both — the case that makes them measurable at all.

And one probe was fixed rather than a line: `if "✗" in row` **skips itself** the moment the
glyph is gone, so a plan that pushed the row over its budget and let `tui.Row` truncate the
CI cell away entirely satisfied it by drawing nothing. It asks the **plan** now.

Two findings are recorded in the code rather than tested, with the argument, because they
are genuinely equivalent: the **CI and change drop guards** in `_tree_cells` cannot be
caught (each is the final cell on its row by the time it is dropped, so `tui`'s `_finish`
strips the gap that would have followed it — only the **branch** guard is observable, and
it is tested), and the **worktree summary line's pre-crop**, which was redundant rather
than mis-pointed and is now gone.

### Also

News entry, `version: unreleased`. No bump, no stamp, no tag.
