### PR TITLE
A pane's geometry comes from the pane, and a stale reading is refused (#591, #510, #501, #536)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -202,6 +202,16 @@ _DEAD_FORMAT = "#{pane_dead}:#{pane_dead_status}"
 #: window has ample room for.
 _WINDOW_SIZE_FORMAT = "#{window_width}:#{window_height}"
 
+#: The format that reports ONE PANE's own width, which is the question
+#: :func:`_variable_pane_cols` asks and which the window's width above is not the answer to
+#: (#510). A `[frame] slots` naming `right` before the table insets that pane by 23
+#: columns, so charter has always had to turn the one into the other by arithmetic
+#: (`layout.repos_cols`); this is the number tmux itself holds. Separate from
+#: :data:`_WINDOW_SIZE_FORMAT` and not a third field appended to it, because they are
+#: asked at different moments and of different targets — the window before anything moves,
+#: the pane after the side panels have been put back where they belong.
+_PANE_WIDTH_FORMAT = "#{pane_width}"
+
 #: How long `_wait_for_harness` leaves between asks. There is no `attach` to block on
 #: inside an operator's tmux — the operator is already attached, to their own server —
 #: so the launcher watches the pane instead, and this is the cost of that: one local
@@ -1877,13 +1887,22 @@ def _reap_this_server(socket: str) -> None:
         state.reap(live, server=socket)
 
 
-def _window_size(socket: str, harness_pane: str) -> tuple[int, int]:
-    """The size of the WINDOW *harness_pane* is in, or `_FALLBACK_SIZE`.
+def _measure_window(socket: str, harness_pane: str) -> tuple[int, int] | None:
+    """The size of the WINDOW *harness_pane* is in, or ``None`` when tmux would not say.
 
     Never `os.get_terminal_size()` on this path: that measures the pane `charter` was
     typed in, which is a fraction of the window the frame gets the moment the operator
     has a split open — and `_drawable_slots` would then drop panels a full-width window
     has ample room for.
+
+    **``None`` rather than a fallback, and :func:`_window_size` is where the fallback still
+    lives.** A launcher that cannot measure the window still has to draw a frame, so it
+    takes `_FALLBACK_SIZE` and gets on with it. A `window-resized` child is the opposite
+    case: it exists only to apply a decision made from a measurement, and "charter could
+    not read the window" is not a measurement — applying an 80x24 layout to a window that
+    is very probably not 80x24 is the same destructive move as applying a stale one, with
+    less excuse. Telling the two apart is what lets `cmd_resize` refuse (#501) while
+    `cmd_launch` proceeds.
     """
     out = tmuxctl.run("measuring the frame's window",
                       tmuxctl.server_argv(socket, "display-message", "-p", "-t",
@@ -1891,8 +1910,102 @@ def _window_size(socket: str, harness_pane: str) -> tuple[int, int]:
                       timeout=5, report=False)
     w, _, hgt = out.stdout.strip().partition(":")
     if out.returncode != 0 or not w.isdigit() or not hgt.isdigit():
-        return _FALLBACK_SIZE
+        return None
     return int(w), int(hgt)
+
+
+def _window_size(socket: str, harness_pane: str) -> tuple[int, int]:
+    """:func:`_measure_window`, with `_FALLBACK_SIZE` for a window tmux would not report.
+
+    The launch-shaped half: every caller here has already decided it is going to lay a
+    frame out and needs a number to do it with. See :func:`_measure_window` for why the
+    resize path takes the other one.
+    """
+    return _measure_window(socket, harness_pane) or _FALLBACK_SIZE
+
+
+def _window_still(socket: str, harness_pane: str,
+                  measured: tuple[int, int]) -> bool:
+    """Is the window still the size *measured* said it was?
+
+    **The whole of #501's fix, and it is a re-READ rather than a lock.** `window-resized`
+    fires once per size change and each event starts its own backgrounded `charter
+    frame-resize` (`_resize_hook_argv`). Nothing serialises them and `run-shell -b` gives
+    no completion ordering, so during a drag several children are in flight at once, each
+    having measured the window at a different instant — and a child that measured a
+    TALLER window computes a taller `bottom`. Applied after the child that measured the
+    final, shorter one, that hands a pane a size for a window which no longer exists;
+    tmux does not refuse an over-large `-y`, it grants it and takes the difference out of
+    the neighbour, and the neighbour is the agent's own session (measured on 3.7c:
+    `resize-pane -y 40` in a 20-row window left the harness pane **1 row tall**).
+
+    A lock file the newest child STEALS would give last-writer-wins, which is the correct
+    semantics; a plain mutex would give first-writer-wins, which is the wrong end. This
+    gets last-writer-wins without either, because the window itself is the record: the
+    newest measurement is by definition the one that still matches, and every child
+    holding an older one asks this and finds it does not. Cheaper than a lock, and there
+    is no file to leave behind when a child is killed mid-drag.
+
+    **It narrows the window rather than closing it, and that is the honest claim.** The
+    size can still change between this answer and the `resize-pane` that follows it —
+    what is gone is the case the whole issue is about, a child sitting on a measurement
+    the window left milliseconds ago while a newer child has already applied the right
+    one. What remains is self-correcting in the direction that was always safe: the
+    change that beat this check fired its own `window-resized`, and that event's child
+    measures the window as it now is.
+
+    An unmeasurable window answers ``False`` — see :func:`_measure_window`. That is the
+    same direction as a stale one, and for a stronger reason.
+    """
+    return _measure_window(socket, harness_pane) == measured
+
+
+#: How long a `window-resized` child waits for the window to STOP moving before it will
+#: add or remove a pane, rather than merely re-size the ones this frame already has.
+#:
+#: **Re-sizing out of order is self-correcting; re-splitting out of order is not** (#536,
+#: quoting #501). The next resize event fixes a pane given the wrong height. A pane killed
+#: and split back costs a new interpreter, a cold charter import and a first paint, and
+#: spends one of the three lives `_arm_panel_respawn` gives it — so a drag dragged through
+#: the width where the repo table stops fitting must not thrash panes in and out at every
+#: step of it.
+#:
+#: **A trailing-edge wait, because there is no timer and no shared state to debounce
+#: with.** `notify._last` is a module-level dict, which works there because one process
+#: makes every call; every one of these children is a separate `run-shell -b` process, so
+#: the only thing they share is the window itself. A child that wants to change the shape
+#: therefore sleeps, then asks whether the window is still where it was
+#: (:func:`_window_still`). The one whose size the drag actually ended on is the only one
+#: that gets a yes.
+#:
+#: **The number is a floor with a measurement under it, not a taste.** It has to exceed the
+#: time one re-layout takes, or a second crossing lands inside the first. Measured on tmux
+#: 3.7c on this machine, the command list `_relayout` issues to grow a frame from two panes
+#: to four — two `set -p pane-died`, two `split-window`s, the `window-resized` hook, the
+#: window and pane measurements, four `resize-pane`s and a `select-pane` — took a **median
+#: 72ms over 5 runs** (69–72). That is the tmux side only: `split-window` returns as soon
+#: as the pane exists, so each new panel's own cold charter import and first paint (of the
+#: order of #501's measured 20ms per child, and more for one that actually renders) lands
+#: after it. 400ms clears the measured floor five times over and sits under the ~500ms at
+#: which an operator reads a delay as the frame having missed the resize entirely.
+_SETTLE_SECONDS = 0.4
+
+
+def _window_settled(socket: str, harness_pane: str,
+                    measured: tuple[int, int]) -> bool:
+    """Has the window held the size *measured* for :data:`_SETTLE_SECONDS`?
+
+    :func:`_window_still` with a wait in front of it, which is the whole mechanism — see
+    :data:`_SETTLE_SECONDS` for why a wait and not a debounce, and `cmd_resize` for what is
+    gated on it.
+
+    The sleep is in a backgrounded child nothing waits on (`_resize_hook_argv`'s
+    `run-shell -b`), so what it costs is one idle process per size change for the length of
+    the wait, and only for the size changes that would actually move a pane. tmux's own
+    command queue never blocks on it.
+    """
+    time.sleep(_SETTLE_SECONDS)
+    return _window_still(socket, harness_pane, measured)
 
 
 def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
@@ -2982,6 +3095,111 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
     return keep
 
 
+def _apply_sizes(socket: str, *, panes: dict[str, str], sizes: dict[str, int],
+                 flag: str) -> None:
+    """`resize-pane <flag>` every slot in *panes* that *sizes* has a number for and
+    :data:`_RESIZE_FLAG` gives exactly *flag*.
+
+    One loop, called twice by :func:`_reassert_sizes` — once for the columns and once for
+    the rows — rather than one loop over both, because the two are separated by a
+    MEASUREMENT that only the first one makes truthful (:func:`_variable_pane_cols`).
+
+    `layout.VARIABLE_ROW_SLOTS` is not in :data:`_RESIZE_FLAG` at all, which is what leaves
+    the table pane as the stack's dependent one — see that constant's own comment for the
+    tmux measurement, and note that a second check for it here would be a guard no mutation
+    could turn red, because this one already catches it.
+
+    Every pane id is checked before it is used, even though both callers of
+    :func:`_reassert_sizes` already checked theirs. `_panel_died_hook_argv`'s own rule
+    ("every value that reaches the text is what decides, never where it came from") applies
+    to a `-t` argument too, and #475 was exactly a builder that documented "safe because my
+    caller checked" growing a second caller.
+
+    `report=False`: a pane that has since died (the operator closed it, a panel crashed
+    between the map being read and this running) makes `resize-pane` fail, and that is not
+    an integration failure worth printing over the agent's own screen.
+    """
+    for slot, pane_id in panes.items():
+        if _RESIZE_FLAG.get(slot) != flag or slot not in sizes:
+            continue
+        if not _PANE_ID_RE.fullmatch(pane_id):
+            continue
+        tmuxctl.run(f"restoring the {slot} panel's size",
+                    tmuxctl.server_argv(socket, "resize-pane", "-t", pane_id,
+                                        flag, str(sizes[slot])),
+                    report=False)
+
+
+def _variable_pane_cols(socket: str, *, panes: dict[str, str], window_cols: int) -> int:
+    """How wide the variable-row pane (`repos`) actually is — **asked, not derived** (#510).
+
+    `layout.repos_cols` turns the WINDOW's width into the PANE's by walking the order those
+    panes were split in and subtracting every side panel split before it. That derivation
+    is correct, and it is a derivation where a measurement is available: the pane's id is
+    right there in *panes*, and one `display-message -p -t <pane> '#{pane_width}'` asks the
+    only authority there is. The derivation stays as the answer for a pane that cannot be
+    asked, which keeps `layout.repos_cols` the launcher's answer too — at launch the pane
+    does not exist yet, so nothing there can measure anything.
+
+    **The two part company in exactly the ways #510 names, and both are silent.** The
+    order comes out of `state.panes`, a JSON file in the frame's own state directory:
+    `state.panes` validates the VALUES (`isinstance(v, str)`) and says nothing about the
+    order, so a truncated write, a hand edit, or a charter that wrote a different shape all
+    reach here as a plausible-looking map whose order is fiction. And a future re-layout
+    that MOVED a surviving pane rather than killing and re-splitting it would change the
+    geometry without changing the map. In both cases the derivation's failure is an
+    over-tall pane re-asserted on every step of a drag with the rows taken off the harness
+    — measured on tmux 3.7c at 110x40 in the `right`-first order: 15 rows granted, 1 drawn,
+    and the harness left 22 where it should have had 36.
+
+    **The order this is called in is the whole of why the answer is trustworthy, and it was
+    measured rather than assumed.** tmux redistributes every pane proportionally on a window
+    resize, so a sidebar mid-drag is not 22 columns wide and the pane beside it is not the
+    width it is about to be. On tmux 3.7c, a 120x40 frame with `right` split first, grown to
+    200x40: `right` came back **62** columns and the table pane read **137** — where the
+    truth, one `resize-pane -x 22` later, is **177**. Measuring first would therefore have
+    been WORSE than the derivation, not better. `_reassert_sizes` applies the columns before
+    it calls this, and with that ordering tmux's own answer agrees with `repos_cols`
+    exactly, at 60, 110, 200 and 300 columns. The measurement is the authority and the
+    derivation is what has to agree with it.
+
+    One extra `display-message` on the `window-resized` path, which already runs one
+    (`_window_size`). That is the cost #510 filed itself over rather than assuming; it is
+    one round trip on a path whose own docstring is explicit that everything it reads is
+    cheap by construction, and it buys the difference between a geometry charter believes
+    and a geometry tmux reports.
+    """
+    # `next` and not a loop with a `break` in it. There is exactly ONE variable-row slot
+    # by construction — `layout.VARIABLE_ROW_SLOTS` is derived from charter's own six
+    # components, and a `[[frame.component]]` this plane places is always a FIXED row
+    # (`layout._is_fixed_row`'s second branch reads its edge, and the config boundary
+    # refuses a table without a number) — so a loop here had two ways to leave it that
+    # could never differ, which `tools/sweep.py` correctly reported as one line doing
+    # nothing.
+    pane_id = next((p for s, p in panes.items()
+                    if layout._key(s) in layout.VARIABLE_ROW_SLOTS), "")
+    # #475's rule, applied to the one value on this path that arrives off disk: `panes`
+    # is JSON in the frame's own state directory and `state.panes` validates that a value
+    # is a STRING, not that it is a pane. Nothing off disk becomes a `-t` until it has
+    # tmux's own shape, whatever the argv it is going into.
+    if _PANE_ID_RE.fullmatch(pane_id):
+        out = tmuxctl.run("measuring the table panel's own pane",
+                          tmuxctl.server_argv(socket, "display-message", "-p", "-t",
+                                              pane_id, _PANE_WIDTH_FORMAT),
+                          timeout=5, report=False)
+        cols = out.stdout.strip()
+        # Three separate ways not to have an answer, and the first is not covered by the
+        # other two: `tmuxctl.run` folds a TIMEOUT into a return code (`tmuxctl.TIMED_OUT`)
+        # and hands back whatever the killed process had already written, so a partial read
+        # can be a failure whose stdout still parses as a number. A zero is the third: not
+        # an answer tmux has for a live pane, and telling `repos_rows_wanted` the table has
+        # no room at all would floor the pane for a reason that is a read failure rather
+        # than a geometry.
+        if out.returncode == 0 and cols.isdigit() and int(cols) > 0:
+            return int(cols)
+    return layout.repos_cols(list(panes), window_cols=window_cols)
+
+
 def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str], harness_pane: str,
                     window_cols: int, window_rows: int) -> None:
     """Re-apply every pane in *panes* the size `layout.slot_sizes` says it should have in
@@ -3007,17 +3225,25 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str], harness_pan
     narrowed terminal keep a table-sized pane it could no longer draw a table in, on every
     step of the drag rather than only at launch.
 
-    **And the window's width is not the PANE's.** `layout.repos_cols` turns one into the
-    other from the order *panes* is in, which is the order those panes were split in. A
-    frame whose `[frame] slots` names `right` before `repos` has a 97-column table pane
-    in a 120-column window, and this is the site that re-applied the wrong height for it
-    on every step of a drag — the launch-time defect's longer-lived half.
+    **And the window's width is not the PANE's.** A frame whose `[frame] slots` names
+    `right` before `repos` has a 97-column table pane in a 120-column window, and this is
+    the site that re-applied the wrong height for it on every step of a drag — the
+    launch-time defect's longer-lived half.
+
+    **So the pane is ASKED how wide it is, and the columns are applied first so that the
+    answer is true (#510).** `layout.repos_cols` derived the pane's width from the order
+    *panes* is in, and that order is a JSON file's insertion order — right until it is not
+    (a truncated write, a hand edit, a future re-layout that moves a pane instead of
+    re-splitting it), at which point the derivation is silently fiction. tmux holds the
+    real number. It cannot simply be asked for it, though: a window resize leaves every
+    pane proportionally scaled until this function corrects it, so the table pane read
+    **137** columns in the 200-column window where the truth is **177** (measured on 3.7c).
+    Hence two passes with the measurement between them — the columns, then
+    :func:`_variable_pane_cols`, then the rows. See that function for the full measurement
+    and for what happens when the pane cannot be asked.
 
     Every pane id is checked before it is used, even though both callers already checked
-    theirs. `_panel_died_hook_argv`'s own rule ("every value that reaches the text is
-    what decides, never where it came from") applies to a `-t` argument too, and #475 was
-    exactly a builder that documented "safe because my caller checked" growing a second
-    caller.
+    theirs — see :func:`_apply_sizes`, which is where that check now lives for both passes.
 
     **The HARNESS is told its height too, and the variable slot is left as the remainder
     — #515.** tmux's `resize-pane -y` moves exactly ONE boundary: the one below the pane,
@@ -3038,34 +3264,28 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str], harness_pan
     *harness_pane* is checked like every other id here and for the same reason: it is read
     off disk (`state.harness_pane`) by `cmd_resize`, which is exactly the shape #475 was.
 
-    `report=False`: a pane that has since died (the operator closed it, a panel crashed
-    between the map being read and this running) makes `resize-pane` fail, and that is
-    not an integration failure worth printing over the agent's own screen.
+    `report=False` throughout: a pane that has since died (the operator closed it, a panel
+    crashed between the map being read and this running) makes `resize-pane` fail, and that
+    is not an integration failure worth printing over the agent's own screen.
     """
-    # `list(panes)` twice, and it is the same list for two different questions:
-    # `slot_sizes` needs to know which OTHER horizontal strips are charging `repos`
-    # rows, and `repos_cols` needs the order they were split in to know how wide
-    # `repos` is. Both callers hand a map whose insertion order is that split order —
-    # `_draw_panels` records a launch in split order, `_relayout` keeps survivors ahead
-    # of new splits, and `state.panes` is JSON, which round-trips a dict's order.
+    # `list(panes)`, and the ORDER in it is a fact rather than an artefact: both callers
+    # hand a map whose insertion order is the order those panes were split in —
+    # `_draw_panels` records a launch in split order, `_relayout` keeps survivors ahead of
+    # new splits, and `state.panes` is JSON, which round-trips a dict's order. `column_sizes`
+    # and `slot_sizes` both read it, and `_variable_pane_cols` reads it again for the
+    # derivation it falls back to when the pane cannot be measured.
     order = list(panes)
+    # Pass one: the COLUMNS. A side panel's width is a constant and depends on nothing
+    # here, and it has to land before anything is measured — see :func:`_variable_pane_cols`
+    # for the tmux measurement that makes this an order rather than a preference.
+    _apply_sizes(socket, panes=panes, sizes=layout.column_sizes(order), flag="-x")
     sizes = layout.slot_sizes(
         order, window_rows=window_rows,
         content_rows=frame_slots.repos_rows_wanted(
-            fid, pane_cols=layout.repos_cols(order, window_cols=window_cols)))
-    for slot, pane_id in panes.items():
-        # `layout.VARIABLE_ROW_SLOTS` is not in `_RESIZE_FLAG` at all, which is what
-        # leaves the table pane as the stack's dependent one — see that constant's own
-        # comment for the tmux measurement, and note that a second check for it here
-        # would be a guard no mutation could turn red, because this one already caught it.
-        if slot not in _RESIZE_FLAG or slot not in sizes:
-            continue
-        if not _PANE_ID_RE.fullmatch(pane_id):
-            continue
-        tmuxctl.run(f"restoring the {slot} panel's size",
-                    tmuxctl.server_argv(socket, "resize-pane", "-t", pane_id,
-                                        _RESIZE_FLAG[slot], str(sizes[slot])),
-                    report=False)
+            fid, pane_cols=_variable_pane_cols(socket, panes=panes,
+                                               window_cols=window_cols)))
+    # Pass two: the ROWS, and the harness below them.
+    _apply_sizes(socket, panes=panes, sizes=sizes, flag="-y")
     if _PANE_ID_RE.fullmatch(harness_pane or ""):
         tmuxctl.run("restoring the harness pane's height",
                     tmuxctl.server_argv(
@@ -3095,12 +3315,53 @@ def cmd_resize(args) -> int:
 
     * no frame on the argv and no `$CHARTER_SESSION_ID` — not fired by a frame at all;
     * a harness pane that is not tmux's own `%<digits>` — it arrives off disk, and
-      `_window_size` is about to target it;
-    * no panes recorded — a frame whose panels all failed to draw has nothing to resize.
+      `_measure_window` is about to target it;
+    * no panes recorded — a frame whose panels all failed to draw has nothing to resize;
+    * **a window tmux would not report a size for** (#501) — this used to take
+      `_FALLBACK_SIZE` and re-assert an 80x24 layout over a window that is very probably
+      not 80x24, which is the same destructive move as applying a stale measurement with
+      less excuse. A launcher still falls back, because it has to draw SOMETHING; this has
+      the option of doing nothing and letting the next resize try again;
+    * **a window that has moved since this child measured it** (#501), checked immediately
+      before the sizes are applied — see :func:`_window_still` for the race and for why a
+      re-read gives last-writer-wins where a lock would give the wrong end of it.
 
     The frame comes off the argv first and the environment only as a fallback, matching
     `cmd_respawn`: on the operator's own server there IS no `$CHARTER_SESSION_ID` to
     read, because that variable is a session option charter does not write there.
+
+    **A resize can now add and remove panes, not only re-size them (#536).** Which slots a
+    frame had used to be decided once, at launch: `_drawable_slots` ran against the
+    terminal the frame started in and nothing afterwards re-ran it except a density change.
+    So a frame launched at 200 columns and dragged to 80 kept a sidebar the same frame
+    would have refused to draw had it started there, and — since #515 gave the repo table
+    its own pane — kept a `repos` pane that could only say `⋯ too narrow for the repo
+    table`, honestly, because it could not be un-split. The other direction was worse: a
+    frame launched at 80 and widened to 200 never gained the panes it was now big enough
+    for, until the next launch or the next `F2`.
+
+    So the drawable set is recomputed here and handed to `_apply_arrangement` — the ONE
+    live re-layout path, the same one a density level and a component's toggle key go
+    through, rather than a second answer to "what does this frame look like now". Two rules
+    keep that from being destructive, and each is a measured hazard rather than caution:
+
+    * **It waits for the window to stop** (:data:`_SETTLE_SECONDS`). Re-applying a size out
+      of order is self-correcting on the next event; killing and re-splitting panes out of
+      order is not, and a drag through the width where the table stops fitting would
+      otherwise thrash panes in and out with a `charter panel` process started and killed
+      at each step, spending respawn lives on nothing.
+    * **It never drops the LAST pane.** `_relayout` with an empty want-list makes
+      `_install_resize_hook` remove the `window-resized` hook itself (correctly — see there)
+      and that is a one-way door on this path specifically: the hook is the only thing that
+      would notice the terminal being widened again. Below half the size floors, where
+      `layout.visible_slots` answers `[]`, this frame therefore keeps the panes it has,
+      exactly as it did before #536. A density change reaching the same state is a
+      keypress, and the operator who pressed it can press another.
+
+    **What the operator chose is never quietly undone.** The recompute starts from
+    :func:`_visible_now` — this frame's own arrangement minus its own hidden set — not from
+    `config.FRAME["slots"]`, so a panel hidden with a toggle key or by a `minimal` density
+    stays hidden across every resize. Only the SIZE filter is re-run.
 
     **Both dimensions are used, not just the rows (#500).** The window's WIDTH decides
     whether `repos` can draw its table at all (`statusline._LEFT_W`), so narrowing a
@@ -3113,11 +3374,21 @@ def cmd_resize(args) -> int:
     **This is the hot path of the whole feature.** A terminal drag fires `window-resized`
     once per size change, so this runs repeatedly and in the background while the
     operator is still dragging. Everything it reads is cheap by construction:
-    `state.harness_pane`/`state.panes` are two small files, `_window_size` is one
-    `display-message`, and `frame_slots.repos_rows_wanted` goes through
-    `gather.row_count`, which answers from the frame's cache and never runs a git sweep
-    (see its own docstring) — and at a width below `_LEFT_W` it does not even ask, since
-    the answer is one row whatever the count is.
+    `state.harness_pane`/`state.panes` are two small files, `frame_slots.repos_rows_wanted`
+    goes through `gather.row_count`, which answers from the frame's cache and never runs a
+    git sweep (see its own docstring) — and at a width below `_LEFT_W` it does not even
+    ask, since the answer is one row whatever the count is.
+
+    **Three `display-message` calls now where there was one**, and the cost is stated
+    rather than waved at: the window before, the pane in the middle (#510), the window
+    again before anything is applied (#501). Measured on this machine against a real tmux
+    3.7c, one round trip is **~5ms** — dominated by spawning the `tmux` CLIENT process, not
+    by the server — so this child grows from #501's measured median of 20ms to roughly
+    35ms. That is a real 75%, on a path that runs once per size change during a drag, and
+    it buys the two things the extra reads are: a geometry tmux reports instead of one
+    charter believes, and a refusal to apply a measurement the window has already left. The
+    expensive addition is the settle wait, and it is paid only by a resize that would
+    change the frame's SHAPE.
     """
     fid = getattr(args, "frame", None) or os.environ.get("CHARTER_SESSION_ID", "")
     if not fid:
@@ -3129,9 +3400,29 @@ def cmd_resize(args) -> int:
     if not panes:
         return 0
     socket = state.frame_server(fid) or SOCKET
-    cols, rows = _window_size(socket, harness_pane)
-    _reassert_sizes(socket, fid=fid, panes=panes, harness_pane=harness_pane,
-                    window_cols=cols, window_rows=rows)
+    measured = _measure_window(socket, harness_pane)
+    if measured is None:
+        return 0
+    cols, rows = measured
+    # Read ONCE and used twice — to decide whether the shape has to change, and as what
+    # the re-layout is then given. A second `_visible_now` call for the second question
+    # would be a second answer to "what is this frame showing", and it would be the wrong
+    # kind of safe: a `want` computed from the config while `_apply_arrangement` got this
+    # would still lay the frame out correctly, so nothing would go red — it would only
+    # spend a settle wait and a version bump on a resize that had nothing to do.
+    visible = _visible_now(fid, config.FRAME)
+    # The SHAPE first, because a re-layout re-asserts every size on its way out
+    # (`_relayout`) and doing both would size the panes twice — once for the set this
+    # frame is about to stop having.
+    want = _drawable_slots(cols, rows, visible)
+    if want and set(want) != set(panes) and _window_settled(socket, harness_pane, measured):
+        where = _relayout_target(fid)
+        if where is not None:
+            _apply_arrangement(fid, where=where, want=visible, window=measured)
+            return 0
+    if _window_still(socket, harness_pane, measured):
+        _reassert_sizes(socket, fid=fid, panes=panes, harness_pane=harness_pane,
+                        window_cols=cols, window_rows=rows)
     return 0
 
 
@@ -3278,7 +3569,8 @@ def _relayout_target(fid: str):
     return (state.frame_server(fid) or SOCKET), harness_pane, v
 
 
-def _apply_arrangement(fid: str, *, where, want: list[str]) -> None:
+def _apply_arrangement(fid: str, *, where, want: list[str],
+                       window: tuple[int, int] | None = None) -> None:
     """Make *fid*'s panes match *want*, and let every surviving panel know.
 
     **The one live re-layout path**, and having exactly one is Task 5's actual
@@ -3294,9 +3586,17 @@ def _apply_arrangement(fid: str, *, where, want: list[str]) -> None:
     its decision BEFORE calling here for the mirror-image reason — a re-layout that fails
     halfway still leaves the panels that survive drawing the arrangement that was asked
     for.
+
+    *window* is a measurement the caller has ALREADY taken and already checked, and only
+    `cmd_resize` has one (#501): it measured the window, waited for it to stop moving and
+    re-read it, so a third reading here would be a fresh chance to disagree with the one
+    the decision was made from — the exact shape the settle exists to close. The two
+    keypress callers pass nothing and this measures for them, as it always has: they act on
+    a key rather than on a measurement, so there is no earlier reading for this one to
+    contradict.
     """
     socket, harness_pane, v = where
-    cols, rows = _window_size(socket, harness_pane)
+    cols, rows = window if window is not None else _window_size(socket, harness_pane)
     panes = _relayout(socket, fid=fid, harness_pane=harness_pane,
                       panels=state.panes(fid),
                       want=_drawable_slots(cols, rows, want), v=v,
@@ -3338,6 +3638,23 @@ def _hidden_now(fid: str, frame: dict) -> list[str]:
         return list(recorded)
     visible = set(frame.get("slots") or ())
     return [n for n in instance.frame_arrangement(frame) if n not in visible]
+
+
+def _visible_now(fid: str, frame: dict) -> list[str]:
+    """Which components *fid* IS drawing right now, in the arrangement's own order — the
+    complement of :func:`_hidden_now` over `instance.frame_arrangement`, and the same
+    expression `cmd_toggle` and `cmd_density` both end on.
+
+    **Size does not come into it**, and that separation is the point: this answers what the
+    OPERATOR has asked for (a density level, a toggle key, or the committed `[frame]
+    slots` when neither has been used), and `_drawable_slots` is what then decides which of
+    them a terminal of a given size can actually hold. `cmd_resize` needs exactly this
+    split — it must recompute the second without ever quietly undoing the first, and
+    recomputing from `config.FRAME["slots"]` instead would put a hidden panel back on
+    screen on the operator's next terminal drag.
+    """
+    hidden = set(_hidden_now(fid, frame))
+    return [n for n in instance.frame_arrangement(frame) if n not in hidden]
 
 
 def cmd_toggle(args) -> int:

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -494,6 +494,35 @@ def repos_rows(*, content_rows: int, window_rows: int,
     return max(floor, min(content_rows, cap))
 
 
+def column_sizes(slots: list[str] | tuple[str, ...]) -> dict[str, int]:
+    """Every slot in *slots* whose split costs COLUMNS, mapped to how many it costs.
+
+    The half of :func:`slot_sizes` that depends on nothing else: a side panel is
+    :data:`SLOT_SIZE` columns wide in every window it is ever drawn in, whatever the rows
+    are and whatever the table has to say. Read through :func:`_size_of` and
+    :func:`_edge_of`, the same two questions :func:`slot_sizes` asks — so this is a second
+    loop over one answer, never a second table of how wide a side panel is.
+
+    **Split out because the ORDER the two are applied in is load-bearing (#510).**
+    `commands_frame._reassert_sizes` has to put the side panels back at their own width
+    before it may ask tmux how wide the variable-row pane beside them is, because tmux
+    redistributes every pane proportionally on a window resize and a scaled sidebar
+    answers for a geometry that is one command away from not existing. Measured on tmux
+    3.7c, a 120x40 frame with `right` split first, grown to 200x40: `right` came back
+    **62** columns and the table pane read **137**; after `resize-pane -x 22` on `right`
+    the same pane read **177**, which is what :func:`repos_cols` says it is. Same
+    agreement at 60, 110 and 300 columns.
+    """
+    out: dict[str, int] = {}
+    for slot in slots:
+        if _edge_of(slot) not in _COLUMN_EDGES:
+            continue
+        cells = _size_of(slot)
+        if cells is not None:
+            out[slot] = cells
+    return out
+
+
 def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int) -> dict[str, int]:
     """Every slot in *slots* mapped to the size it should be given — rows for the
     horizontal strips, columns for the side.

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -3,17 +3,25 @@
 Content comes from the renderers `statusline.py` already has — they are composed here,
 never rewritten, so a fix to a repo row or an alert lands in both surfaces at once.
 
-**A panel measures its own pane, never `$COLUMNS`.** A panel process is started as a
-tmux pane command, which inherits the *launching* shell's environment whole. Measured: a
-tmux pane 22 columns wide, launched from a shell that had exported `COLUMNS=200`, ran a
-probe that saw `COLUMNS env='200'` while its real tty was 22 columns.
-`charter.tui.term_width()` reads `$COLUMNS` first — correctly, for the status line, where
-stdout is a pipe and the environment is the only source of the truth. That order is
-exactly wrong here: trusting it would lay every panel out at the OUTER terminal's width
-and wrap catastrophically inside its own narrow pane. `tui.term_width()` itself is left
-alone (the status line depends on its env-first order); `_width` below asks the pane's
-own tty directly instead, and only reaches for `tui.term_width()` as a last resort, when
-there is no tty to measure at all.
+**A panel measures its own pane, never `$COLUMNS` — and not as a fallback either.** A
+panel process is started as a tmux pane command, which inherits the *launching* shell's
+environment whole. Measured: a tmux pane 22 columns wide, launched from a shell that had
+exported `COLUMNS=200`, ran a probe that saw `COLUMNS env='200'` while its real tty was
+22 columns. `charter.tui.term_width()` reads `$COLUMNS` first — correctly, for the status
+line, where stdout is a pipe and the environment is the only source of the truth. That
+order is exactly wrong here: trusting it would lay every panel out at the OUTER
+terminal's width and wrap catastrophically inside its own narrow pane. `tui.term_width()`
+itself is left alone (the status line depends on its env-first order); :func:`_width`
+asks the pane's own tty directly.
+
+**The last resort is a constant, not the environment** (#591). :func:`_width` used to
+fall through to `tui.term_width()` when the pane could not be measured, which put
+`$COLUMNS` back on the path by the back door: a panel whose stdout has no tty behind it
+laid itself out at the launching terminal's width, and `panel._hold` — the failure paint,
+which runs precisely when something has already gone wrong — painted a 400-column line
+into a 24-column pane. :data:`_DEFAULT_COLS` is what it answers instead, beside
+:data:`_DEFAULT_ROWS`, which has always been a constant for exactly this reason. Both
+halves of a pane's size now come from the same place and neither comes from the shell.
 """
 
 from __future__ import annotations
@@ -157,23 +165,39 @@ def _sidebar_live(fid: str) -> bool:
     return "right" in state.panes(fid)
 
 
+#: Columns a renderer assumes when this pane's own tty cannot be measured at all — the
+#: width half of the pair :data:`_DEFAULT_ROWS` is the height half of, and the same case:
+#: stdout piped somewhere with no tty behind it (a test, or `charter panel bottom
+#: --session x > /tmp/log` run by hand).
+#:
+#: **80 rather than `tui.term_width()`, and #591 is why.** That helper is env-first by
+#: design, so reaching for it here answered with the LAUNCHING terminal's `$COLUMNS` —
+#: which a panel process inherits whole (see this module's own docstring) and which
+#: describes a terminal the pane is a small rectangle inside. The number is the same one
+#: `tui.term_width`'s own *default* carried, so a pane with nothing to measure and nothing
+#: exported is laid out exactly as it was; what is gone is the branch that let a 400-column
+#: shell decide a 24-column pane's paint.
+_DEFAULT_COLS = 80
+
+
 def _width() -> int:
-    """The pane's own width in columns — measured, never read out of `$COLUMNS`.
+    """The pane's own width in columns — measured, never read out of the environment.
 
     `os.get_terminal_size(sys.stdout.fileno())` asks the file descriptor this process is
     actually writing to, which for a panel launched as a tmux pane command IS the pane —
     not a pipe, not the launching terminal. Only when that raises (stdout redirected to
-    something with no tty behind it at all, e.g. a test, or a panel run for debugging
-    with its output piped to a file) does this fall back to `tui.term_width()`, which is
-    the env-first helper the status line also uses. The measured value is returned as
-    reported, with no artificial floor clamped over it: a pane that really is 10 columns
-    wide getting reported as 20 would be exactly the theorising this function exists to
-    avoid — it would tell every caller here there is room that the real pane does not have.
+    something with no tty behind it at all, e.g. a test, or a panel run for debugging with
+    its output piped to a file) does this answer :data:`_DEFAULT_COLS`, the way
+    :func:`_height` has always answered :data:`_DEFAULT_ROWS`. The measured value is
+    returned as reported, with no artificial floor clamped over it: a pane that really is
+    10 columns wide getting reported as 20 would be exactly the theorising this function
+    exists to avoid — it would tell every caller here there is room that the real pane does
+    not have.
     """
     try:
         return os.get_terminal_size(sys.stdout.fileno()).columns
     except OSError:
-        return tui.term_width(default=80, floor=20)
+        return _DEFAULT_COLS
 
 
 #: Rows a renderer assumes when this pane's own tty cannot be measured at all — the same

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -303,6 +303,13 @@ configured for it. A density change goes through the same floors, so choosing `f
 terminal with no room for a side panel gives you the edges that fit rather than a failed
 split.
 
+A resize goes through them too, so a *running* frame degrades and recovers the same way a
+launch would — with one exception. Dragging below half the floors does not take the last
+panel away: a frame with no panels also has no resize hook, and that hook is the only thing
+that would notice you making the terminal big again, so charter would have no way back.
+It keeps what it has at that size. `F2` still turns everything off, because a keypress can
+be followed by another one.
+
 `bottom` is never dropped by those floors, and it is the only slot that never is: it is
 the attention strip — one alert and the command that fixes it — which is the whole reason
 a cramped terminal is worth framing at all. It is one row at every size.
@@ -319,10 +326,11 @@ table comes out 23 columns narrower, and it is that width the pane is sized for.
 is recomputed on every terminal resize, not remembered from the launch — tmux does not
 refuse an over-large pane height, it takes the difference out of the neighbouring pane,
 and the neighbour is your agent session. Recomputing means charter runs for a moment on
-each resize (median 20ms, in the background, so nothing waits on it). During a fast drag
-those runs can finish out of order and leave the table sized for a window you have already
-resized past; it corrects itself the next time you resize, and #501 tracks closing it
-properly.
+each resize (~35ms, in the background, so nothing waits on it). During a fast drag those
+runs finish out of order — nothing serialises them — so each one re-reads the window
+immediately before it applies anything and does nothing at all if the size has moved since
+it measured. The newest measurement is the only one that still matches, which is the one
+worth applying.
 
 If the frame ends up narrower than the repo table's own columns (95), the table is not
 drawn rather than drawn with its right-hand columns cut off: a row trimmed past the branch
@@ -333,11 +341,16 @@ exotic one, so an 80-column frame is the two strips and your session, with the t
 rows going back to the harness rather than being taken and left blank. A `slots` list
 naming `right` before `repos` moves the threshold up by the sidebar's 23 columns: such a
 frame needs 118 columns of terminal before the table appears. Narrow a frame that is
-*already running* below 95 and the pane cannot be un-split — a resize changes sizes, not
-which panes exist — so it shrinks to one row and says `⋯ too narrow for the repo table —
-95 columns needed` rather than sitting there blank. The attention strip is unaffected
-either way: it drops whole fields instead, in priority order. (The status line outside a
-frame still crops instead of refusing; that is #506.)
+*already running* below 95 and the pane goes away too — a resize adds and removes panes,
+not only sizes them, so a running frame ends up with the panes a launch at its current size
+would have drawn, in either direction. Panes are only moved once the window has held one
+size for 400ms, so dragging through 95 columns does not thrash them in and out at every
+step; until that settles the pane you are dragging past says `⋯ too narrow for the repo
+table — 95 columns needed` rather than sitting there blank. A panel you hid with its own
+key, or a density you chose from the palette, is never undone by a resize — only the size
+filter is re-run. The attention strip is unaffected either way: it drops whole fields
+instead, in priority order. (The status line outside a frame still crops instead of
+refusing; that is #506.)
 
 If a future `[frame] slots` ever names an edge charter sizes but has no renderer for, that
 slot is skipped rather than drawn as a dead pane — the harness keeps the space — and

--- a/docs/news/unreleased-a-resize-changes-which-panes-a-frame-has.md
+++ b/docs/news/unreleased-a-resize-changes-which-panes-a-frame-has.md
@@ -1,0 +1,106 @@
+---
+version: unreleased
+headline: A resize changes which panes a frame has, and a size measured for a window you have already left is not applied
+---
+
+Resize a running frame and it now ends up with the panes a launch at that size would have
+drawn — in both directions.
+
+Until now, which panels a frame *had* was decided once, at launch. Only the size of each
+one was re-applied afterwards. So a frame started in a 200-column terminal and dragged
+down to 80 kept a sidebar the same frame would have refused to draw had it started there
+— 22 columns plus a border taken off a session that is now the narrow thing on screen —
+and kept a repo table pane too narrow to draw a table in, which said so honestly and
+could not do anything about it. Widen back and nothing came back that had not been there.
+Getting the panes you had room for meant relaunching, or pressing `F2` and choosing a
+density.
+
+```
+                                   drag 200 → 80              drag 80 → 200
+
+before   ⬢ identity                ⬢ identity (cramped)       ⬢ identity
+         │ session      │ chips    │ session     │ chips      │ session
+         │ repo table   │          │ ⋯ too narrow│            │ session
+         │ 0 todos · …  │          │ 0 todos · … │            │ 0 todos · …
+
+now      ⬢ identity                ⬢ identity                 ⬢ identity
+         │ session      │ chips    │ session                  │ session      │ chips
+         │ repo table   │          │ session                  │ repo table   │
+         │ 0 todos · …  │          │ 0 todos · …              │ 0 todos · …  │
+```
+
+**What you chose is never undone by a resize.** A panel you hid with its own key, or a
+density you picked from the palette, stays hidden however you drag the terminal. Only the
+size filter is re-run — the one that decides an 80-column terminal has no room for a
+95-column table — and it is re-run over *your* arrangement, not over what
+`charter.toml` says.
+
+**Panes only move once the terminal has stopped.** A drag fires a resize event per size
+change, and killing and re-splitting a pane at each step would start and kill a panel
+process every time — each one a fresh interpreter and a first paint, and each one spending
+one of the three respawn lives that pane gets. So a resize that would change the frame's
+*shape* waits 400ms for the window to hold still and checks again; the one your drag
+actually ended on is the one that acts. A resize that only changes sizes waits for nothing
+and behaves exactly as it did before.
+
+The 400ms is a floor with a measurement under it rather than a taste: re-laying a frame
+out takes a measured 72ms of tmux commands on this machine before the new panels have even
+started, so a shorter wait would let one crossing land inside the last one.
+
+There is one thing a resize will not do: drop your *last* panel. Below half the size
+floors charter would draw no panels at all, and a frame with no panels also has no resize
+hook — the very thing that would notice you widening the terminal again. So at that size
+the frame keeps what it has. `F2` still turns everything off, because a keypress can be
+followed by another one.
+
+## A size computed for a window you have already left is refused
+
+Every resize event starts its own background charter, and nothing serialises them, so
+during a drag several are in flight at once — each holding a measurement from a different
+instant. One that measured a *taller* window computes a taller table pane; landing after
+the one that measured the size you actually stopped at, it hands tmux a height for a
+window that no longer exists. tmux does not refuse an over-large height. It grants it, and
+takes the difference out of the neighbouring pane — which is your agent session (measured:
+asking for 40 rows in a 20-row window left the session pane **one row tall**).
+
+Each of those runs now re-reads the window immediately before it applies anything, and
+does nothing at all if the size has moved since it measured. The newest measurement is the
+only one that still matches, which is the only one worth applying — and it costs a re-read
+rather than a lock file, so nothing is left behind when a run is killed mid-drag.
+
+A window tmux will not report a size for is refused the same way. That used to fall back
+to 80x24 and assert it, which is the same wrong move as applying a stale measurement with
+less of an excuse; the next resize tries again.
+
+## The table pane's width comes from tmux now, not from charter's arithmetic
+
+How wide the repo table's pane is depends on what was split before it: a `slots` list
+naming `right` first insets it by the sidebar's 23 columns, so a 110-column window has an
+87-column table pane. Charter worked that out from the order the panes were recorded in —
+a file in the frame's own state directory. That is right until the file and the window
+disagree, and nothing inside charter can tell when they do.
+
+tmux knows. It is asked, and its answer wins; the arithmetic stays as the answer for a
+pane that cannot be asked (at launch, the pane does not exist yet). The order matters and
+was measured: tmux stretches every pane proportionally when a window resizes, so the
+sidebar has to be put back to its own width *before* the pane beside it is measured — on a
+120x40 frame grown to 200x40, the sidebar came back 62 columns wide and the table pane
+read 137, where the truth one correction later is 177.
+
+## A panel that fails no longer lays itself out from your shell
+
+A panel that cannot start paints the reason into its own pane and stays alive so you can
+read it. It measured its own pane for that, and fell back to `$COLUMNS` when there was no
+pane to measure — but `$COLUMNS` describes the terminal charter was *launched* from, which
+a panel inherits whole and which has nothing to do with the rectangle it is drawing in
+(measured: a 22-column pane whose launcher had exported `COLUMNS=200` sees `200`). So on a
+wide terminal, the one message that exists to explain a failure could be painted wider
+than the pane holding it, and wrap itself out of view.
+
+A pane charter cannot measure now gets a plain 80 columns, exactly as it has always got a
+plain 24 rows. Nothing about a panel's size comes out of your shell any more.
+
+## What to do
+
+Nothing. If you never resize your terminal you will not notice any of this; if you do, the
+frame follows.

--- a/docs/news/unreleased-the-repo-table-becomes-its-own-panel.md
+++ b/docs/news/unreleased-the-repo-table-becomes-its-own-panel.md
@@ -70,9 +70,11 @@ frame narrower than the table's own columns never drew one — a row trimmed pas
 loses the CI glyph and the open-change count, and a dirty, failing repo then reads as
 clean. That used to be invisible, because the pane went on drawing the status row above the
 missing table. On its own it would be a bordered box with nothing in it, so the slot is
-dropped and its rows go back to your session. If you narrow a frame that is *already*
-running, the pane cannot be un-split — a resize changes sizes, not which panes exist — so
-it shrinks to one row and says `⋯ too narrow for the repo table — 95 columns needed`.
+dropped and its rows go back to your session. Narrow a frame that is *already* running and
+the pane goes away too — a resize adds and removes panes now, not only sizes them (see
+*A resize changes which panes a frame has*, in this same release). While you are still
+dragging past the boundary the pane is still there and says `⋯ too narrow for the repo
+table — 95 columns needed`.
 
 **The density levels are re-derived rather than patched.** They differ by edges again,
 which is what a preset over `slots` can honestly express:

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -65,15 +65,33 @@ class _Tmux:
     only way a test can prove an ORDER of tmux calls.
     """
 
-    def __init__(self, *, size="200:50", new_panes=("%7", "%8", "%9")):
+    def __init__(self, *, size="200:50", new_panes=("%7", "%8", "%9"),
+                 sizes=(), pane_cols=None):
         self.size = size
+        #: Window sizes handed out IN ORDER, one per `#{window_width}` query, the LAST one
+        #: sticking once the list runs out. A window that is still moving is the whole of
+        #: #501, and a fake with one answer cannot express one: `cmd_resize` measures, and
+        #: then asks again immediately before it applies, so a two-element list is a
+        #: terminal that changed size between those two moments — and a terminal that has
+        #: stopped moving keeps answering the size it stopped at, which is why the tail
+        #: sticks rather than reverting to *size*.
+        self.sizes = list(sizes)
+        #: What tmux answers for `#{pane_width}` (#510). ``None`` means "declines to say",
+        #: which is an empty stdout and the case `_variable_pane_cols` falls back to
+        #: `layout.repos_cols`' derivation for — the answer every test written before #510
+        #: was asserting against, so leaving this alone keeps them exercising it.
+        self.pane_cols = pane_cols
         self.new_panes = list(new_panes)
         self.calls: list[list[str]] = []
 
     def __call__(self, action, argv, *, env=None, timeout=None, report=True):
         self.calls.append(list(argv))
         out = ""
-        if "display-message" in argv:
+        if commands_frame._PANE_WIDTH_FORMAT in argv:
+            out = "" if self.pane_cols is None else str(self.pane_cols)
+        elif "display-message" in argv:
+            if self.sizes:
+                self.size = self.sizes.pop(0)
             out = self.size
         elif "split-window" in argv:
             out = self.new_panes.pop(0) if self.new_panes else ""
@@ -1368,8 +1386,21 @@ class ResizeRecomputesForBothDimensions(PersonaIso, unittest.TestCase):
         super().setUp()
         self.fid = f"rsz-{_a_dead_pid()}"
         state.record_harness_pane(self.fid, "%0")
-        state.record_panes(self.fid,
-                           panels={"top": "%1", "bottom": "%2", "repos": "%5"})
+        # Every slot this plane's arrangement names, so a resize at the sizes below finds
+        # the frame ALREADY the shape it should be and re-sizes rather than re-lays-out.
+        # #536 made that distinction matter: a map missing `right` is a frame that would
+        # gain a sidebar on its next resize, which is correct behaviour and is not what
+        # this class is about.
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2",
+                                             "repos": "%5", "right": "%3"})
+        # `_relayout_target` asks the real binary otherwise, so a machine with no tmux (or
+        # one too old for `window-resized`) would take a different branch here than CI —
+        # #519's shape exactly. `LiveOverride` above pins its own for the same reason.
+        self.enterContext(mock.patch("charter.frame.tmuxctl.version",
+                                     return_value=(3, 7)))
+        # The settle wait is pinned by `TheShapeWaitsForTheWindowToStop` below and would
+        # otherwise cost this class a real 400ms per shape change.
+        self.enterContext(mock.patch.object(commands_frame, "_SETTLE_SECONDS", 0.0))
         rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
                  "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
                  "change": None, "sigil": "", "current": False, "worktree_count": 0}
@@ -1426,12 +1457,32 @@ class ResizeRecomputesForBothDimensions(PersonaIso, unittest.TestCase):
         the two below the harness trade rows with each other and never with it."""
         self.assertEqual(self._heights("200:50"), {"%1": 1, "%2": 1, "%0": 38})
 
-    def test_narrowing_the_terminal_shrinks_the_pane_back_to_its_one_row(self):
+    def test_a_table_pane_that_stays_is_shrunk_to_the_one_row_it_can_draw(self):
         """The panel draws no table below `statusline._LEFT_W`, so every row past the
-        first was blank — and came out of the harness."""
+        first was blank — and came out of the harness.
+
+        **Driven through `_reassert_sizes` rather than `cmd_resize` since #536**, and the
+        change of call site is the fix rather than a convenience: a `cmd_resize` at these
+        widths now removes the pane outright (the test below), so the one-row height is
+        what the SIZING half answers for a table pane that is still there — a re-layout
+        that has not settled yet, a frame whose kill failed, a `[frame] slots` a plane
+        committed by hand. That arithmetic is #500's and it must not rot just because the
+        commonest route to it changed.
+
+        Read back the way `_table_rows` reads it: the window's rows minus every height
+        asserted, minus one border per horizontal pane.
+        """
         for cols in (60, 80, statusline._LEFT_W - 1):
             with self.subTest(cols=cols):
-                self.assertEqual(self._table_rows(f"{cols}:50"), 1)
+                fake = _Tmux(size=f"{cols}:50")
+                panes = {"top": "%1", "bottom": "%2", "repos": "%5"}
+                with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+                    commands_frame._reassert_sizes(
+                        "sock", fid=self.fid, panes=panes, harness_pane="%0",
+                        window_cols=cols, window_rows=50)
+                heights = {c[c.index("-t") + 1]: int(c[c.index("-y") + 1])
+                           for c in fake.calls if "resize-pane" in c and "-y" in c}
+                self.assertEqual(50 - sum(heights.values()) - len(heights), 1)
 
     def test_the_density_the_operator_chose_is_read_here_too(self):
         """`cmd_density` and `cmd_resize` are different processes minutes apart, so the
@@ -1469,6 +1520,467 @@ class ResizeRecomputesForBothDimensions(PersonaIso, unittest.TestCase):
                              panels={"top": "%1", "bottom": "%2", "repos": "%5",
                                      "right": "%3"}),
             1 + 6)
+
+
+class _ResizeFixture(PersonaIso, unittest.TestCase):
+    """One running frame at four slots, and one way to drive `charter frame-resize` at it.
+
+    Shared by the three classes below because #591, #510, #501 and #536 are one property
+    said at four call sites — *a pane's geometry comes from the pane, and a decision made
+    from a stale reading is refused rather than applied* — and a second fixture would be a
+    second frame for them to disagree about.
+    """
+
+    #: Every slot this plane's arrangement names, in split order, already drawn. A resize
+    #: at a size that keeps all four therefore finds the frame the shape it should be.
+    PANES = {"top": "%1", "bottom": "%2", "repos": "%5", "right": "%3"}
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"rsz-{_a_dead_pid()}"
+        state.record_harness_pane(self.fid, "%0")
+        state.record_panes(self.fid, panels=dict(self.PANES))
+        self.enterContext(mock.patch("charter.frame.tmuxctl.version",
+                                     return_value=(3, 7)))
+        self.enterContext(mock.patch.object(commands_frame, "_SETTLE_SECONDS", 0.0))
+        rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
+                 "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
+                 "change": None, "sigil": "", "current": False, "worktree_count": 0}
+                for i in range(6)]
+        gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
+                               "current_repo": None, "repos": rows, "worktrees": []})
+
+    def _resize(self, **kwargs) -> _Tmux:
+        """Fire one `charter frame-resize` child and hand back what it said to tmux."""
+        fake = _Tmux(**kwargs)
+        with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            self.assertEqual(commands_frame.cmd_resize(SimpleNamespace(frame=self.fid)), 0)
+        return fake
+
+    @staticmethod
+    def _resized(fake: _Tmux) -> list[list[str]]:
+        return [c for c in fake.calls if "resize-pane" in c]
+
+    @staticmethod
+    def _killed(fake: _Tmux) -> list[str]:
+        return [c[c.index("-t") + 1] for c in fake.calls if "kill-pane" in c]
+
+    @staticmethod
+    def _split(fake: _Tmux) -> list[list[str]]:
+        return [c for c in fake.calls if "split-window" in c]
+
+
+class AStaleMeasurementIsRefusedRatherThanApplied(_ResizeFixture):
+    """#501. `window-resized` fires per size change and each event starts its own
+    backgrounded `charter frame-resize`; nothing serialises them and `run-shell -b` gives
+    no completion ordering, so during a drag several children are in flight at once, each
+    holding a measurement from a different instant.
+
+    That is not cosmetic. `bottom`'s height is `min(content, cap)` where the cap is what
+    the window can spare, so a child that measured a TALLER window computes a taller pane;
+    landing after the child that measured the final, shorter one, it hands tmux a size for
+    a window that no longer exists — and tmux does not refuse an over-large `-y`, it grants
+    it out of the neighbour, which is the agent's own session (measured on 3.7c:
+    `resize-pane -y 40` in a 20-row window left the harness pane **1 row tall**).
+
+    Reachable by construction rather than by hand, exactly as #501 said: the fake below
+    answers one window size to the measurement and a different one to the re-read, which is
+    what a second child changing the window underneath this one looks like from in here.
+    """
+
+    def test_a_size_the_window_has_already_left_is_not_applied(self):
+        """The measurement says 50 rows; by the time this child is ready to apply, the
+        window is 22. Nothing may be resized — the change that beat this check fired its
+        own `window-resized`, and that event's child measures the window as it now is."""
+        fake = self._resize(sizes=["200:50", "200:22"])
+        self.assertEqual(self._resized(fake), [],
+                         "a child applied a size for a window it had already been told "
+                         "was gone")
+
+    def test_the_measurement_that_still_matches_is_applied(self):
+        """The control, and it is what makes the assertion above mean anything: the same
+        code path with a window that has NOT moved must still do its whole job, or
+        "nothing was resized" would be satisfied by a `cmd_resize` that had simply stopped
+        working."""
+        fake = self._resize(sizes=["200:50", "200:50"])
+        self.assertTrue(self._resized(fake),
+                        "a stable window was refused too — the check is not a check, it "
+                        "is an off switch")
+
+    def test_a_window_tmux_will_not_report_is_not_guessed_at(self):
+        """The refusal one step earlier. `_window_size` answers `_FALLBACK_SIZE` for a
+        window tmux would not report, which is right for a LAUNCHER — it has to draw
+        something — and wrong here: 80x24 asserted over a window that is very probably not
+        80x24 is the same destructive move as a stale measurement, with less excuse.
+        `_measure_window` says `None` and this child does nothing at all."""
+        fake = self._resize(size="not-a-size")
+        self.assertEqual(self._resized(fake), [])
+        self.assertEqual(self._killed(fake), [])
+
+    def test_the_re_read_happens_before_anything_is_applied_not_after(self):
+        """The ordering the whole fix is. A re-read AFTER the `resize-pane` calls would
+        satisfy every assertion above about the final state while still having applied the
+        stale size first — and tmux takes an over-large height out of the harness the
+        moment it is asked, not when charter finds out it was wrong."""
+        fake = self._resize(sizes=["200:50", "200:50"])
+        window_reads = [i for i, c in enumerate(fake.calls)
+                        if commands_frame._WINDOW_SIZE_FORMAT in c]
+        first_apply = min(i for i, c in enumerate(fake.calls) if "resize-pane" in c)
+        self.assertEqual(len(window_reads), 2,
+                         f"the window was read {len(window_reads)} times, not measured "
+                         f"and then re-read: {fake.calls}")
+        self.assertLess(window_reads[1], first_apply,
+                        "the re-read landed after the sizes had already been applied")
+
+
+class TheTablePaneIsAskedHowWideItIs(_ResizeFixture):
+    """#510. `layout.repos_cols` turns the WINDOW's width into the PANE's by walking the
+    order those panes were split in — correct, and a derivation where a measurement is
+    available: the pane's id is in the recorded map and tmux will answer for it.
+
+    The two part company silently. The order comes off disk as JSON, and `state.panes`
+    validates the VALUES and says nothing about the order, so a truncated write or a hand
+    edit reaches here as a plausible map whose order is fiction; the failure is an
+    over-tall pane re-asserted on every step of a drag with the rows taken off the harness.
+    """
+
+    def test_the_panes_own_width_is_asked_of_tmux_and_beats_the_derivation(self):
+        """The map says the shipped order, in which nothing insets the table — so the
+        derivation says 200 and sizes the pane for all six repos. tmux says the pane is
+        actually 60 columns, which is below `statusline._LEFT_W` and draws no table at
+        all. The measurement wins, and the harness gets the five rows back."""
+        fake = self._resize(size="200:50", pane_cols=60)
+        heights = {c[c.index("-t") + 1]: int(c[c.index("-y") + 1])
+                   for c in self._resized(fake) if "-y" in c}
+        self.assertEqual(50 - sum(heights.values()) - len(heights), 1,
+                         f"the table pane was sized from the derivation, not from the "
+                         f"width tmux reported for it: {heights}")
+
+    def test_a_pane_tmux_will_not_measure_falls_back_to_the_derivation(self):
+        """The launcher cannot measure a pane that does not exist yet, so `repos_cols`
+        stays charter's answer and this is the running frame's version of the same case: a
+        pane that has died between the map being read and this running. Same window, same
+        map, no answer from tmux — the six-repo table comes back."""
+        fake = self._resize(size="200:50", pane_cols=None)
+        heights = {c[c.index("-t") + 1]: int(c[c.index("-y") + 1])
+                   for c in self._resized(fake) if "-y" in c}
+        self.assertEqual(50 - sum(heights.values()) - len(heights), 1 + 6)
+
+    def test_a_zero_is_not_an_answer(self):
+        """`repos_cols` floors at 0 and a pane that has gone away can report one. Telling
+        `repos_rows_wanted` the table has no room at all would floor the pane at one row
+        for a reason that is a read failure rather than a geometry."""
+        fake = self._resize(size="200:50", pane_cols=0)
+        heights = {c[c.index("-t") + 1]: int(c[c.index("-y") + 1])
+                   for c in self._resized(fake) if "-y" in c}
+        self.assertEqual(50 - sum(heights.values()) - len(heights), 1 + 6)
+
+    def test_the_side_panels_width_lands_before_the_pane_is_measured(self):
+        """**The order is the whole of why the measurement can be trusted, and it was
+        measured rather than reasoned.** tmux redistributes every pane proportionally on a
+        window resize, so a sidebar mid-drag is not 22 columns wide and the pane beside it
+        is not the width it is about to be: on tmux 3.7c a 120x40 frame with `right` split
+        first, grown to 200x40, came back with `right` at **62** columns and the table pane
+        reading **137** — where the truth, one `resize-pane -x 22` later, is **177**.
+        Measuring first would have been worse than deriving. So the columns are applied,
+        and only then is the pane asked."""
+        fake = self._resize(size="200:50", pane_cols=177)
+        first_x = min(i for i, c in enumerate(fake.calls)
+                      if "resize-pane" in c and "-x" in c)
+        measured = min(i for i, c in enumerate(fake.calls)
+                       if commands_frame._PANE_WIDTH_FORMAT in c)
+        self.assertLess(first_x, measured,
+                        "the table pane was measured while the sidebar was still "
+                        "wherever tmux's proportional redistribution had left it")
+
+    def test_the_rows_land_after_the_measurement(self):
+        """The other half of the same order: a height computed from the measured width is
+        worth nothing if it was asserted before the width was known."""
+        fake = self._resize(size="200:50", pane_cols=60)
+        measured = min(i for i, c in enumerate(fake.calls)
+                       if commands_frame._PANE_WIDTH_FORMAT in c)
+        first_y = min(i for i, c in enumerate(fake.calls)
+                      if "resize-pane" in c and "-y" in c)
+        self.assertLess(measured, first_y)
+
+
+class TheMeasurementsOwnRefusals(PersonaIso, unittest.TestCase):
+    """`_variable_pane_cols`, asked directly rather than through `cmd_resize`.
+
+    `tools/sweep.py` found two survivors sitting inside this one function and said the
+    thing that matters about them: two guards in sequence mask each other, so neither is
+    safe to call equivalent on its own. Both were reachable only through `cmd_resize`,
+    where a later filter happened to catch what an earlier one let past. Each is asked its
+    own question here.
+    """
+
+    _PANES = {"top": "%1", "bottom": "%2", "repos": "%5"}
+
+    def _cols(self, *, returncode=0, stdout="", panes=None) -> tuple[int, list[list[str]]]:
+        calls: list[list[str]] = []
+
+        def fake(action, argv, *, env=None, timeout=None, report=True):
+            calls.append(list(argv))
+            return subprocess.CompletedProcess(argv, returncode, stdout=stdout, stderr="")
+
+        with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            got = commands_frame._variable_pane_cols(
+                "sock", panes=dict(self._PANES if panes is None else panes),
+                window_cols=200)
+        return got, calls
+
+    def test_tmuxs_answer_is_the_answer(self):
+        """The control. Without it every refusal below is satisfied by a function that
+        never believes tmux at all."""
+        self.assertEqual(self._cols(stdout="87\n")[0], 87)
+
+    def test_a_failure_whose_stdout_still_parses_is_not_an_answer(self):
+        """The `out.returncode == 0` half, which `cols.isdigit()` looks like it already
+        covers and does not. `tmuxctl.run` folds a TIMEOUT into a return code
+        (`tmuxctl.TIMED_OUT`) and hands back whatever the killed process had already
+        written — so a partial read is a failure whose stdout is a perfectly good number.
+        Believing it sizes the table pane from a truncated measurement."""
+        self.assertEqual(self._cols(returncode=1, stdout="6")[0], 200,
+                         "a failed `display-message` was believed because its stdout "
+                         "happened to parse")
+
+    def test_a_zero_is_not_an_answer(self):
+        self.assertEqual(self._cols(stdout="0")[0], 200)
+
+    def test_nothing_at_all_is_not_an_answer(self):
+        self.assertEqual(self._cols(stdout="")[0], 200)
+
+    def test_a_recorded_pane_id_that_is_not_tmuxs_own_shape_never_reaches_a_target(self):
+        """#475's rule on the one value this path reads off disk. `state.panes` is JSON in
+        the frame's own state directory and it validates that a value is a STRING, not
+        that it is a pane — `%1;kill-server` is a string. The guard is asserted on what was
+        ISSUED rather than on the number that came back, because the derivation is the
+        answer either way: a version that skipped the check would return 200 too, having
+        first handed that text to tmux."""
+        got, calls = self._cols(stdout="87",
+                                panes={"top": "%1", "repos": "%1;kill-server"})
+        self.assertEqual(got, 200)
+        self.assertEqual([c for c in calls if "display-message" in c], [],
+                         f"a pane id off disk was used as a `-t` without ever having "
+                         f"tmux's own shape: {calls}")
+
+    def test_a_frame_with_no_variable_row_pane_asks_nothing(self):
+        """A `[frame] slots` without `repos` — an ordinary frame, and the launcher's own
+        case. There is nothing to measure, so nothing is measured and the derivation
+        answers for a pane that would be split rather than one that is."""
+        got, calls = self._cols(stdout="87", panes={"top": "%1", "bottom": "%2"})
+        self.assertEqual(got, 200)
+        self.assertEqual(calls, [])
+
+
+class AResizeAddsAndRemovesPanesNotOnlySizesThem(_ResizeFixture):
+    """#536. Which slots a frame HAD was decided once, at launch: `_drawable_slots` ran
+    against the terminal the frame started in and only a density change re-ran it. So a
+    frame launched at 200 columns and dragged to 80 kept a sidebar the same frame would
+    have refused to draw had it started there, and a frame launched at 80 and widened to
+    200 never gained one — the repo table's pane saying `⋯ too narrow for the repo table`
+    is #515 being honest about a pane it could not un-split.
+    """
+
+    def test_narrowing_past_the_table_width_removes_the_pane_rather_than_shrinking_it(self):
+        """`layout.visible_slots` drops `repos` below `statusline._LEFT_W` and `right`
+        below `[frame] min-cols`, because a pane too narrow for the table is a bordered
+        rectangle that reads as "this workspace has no repos" on a plane that has six. A
+        LAUNCH at 80 columns already got that right; this is the drag getting it right."""
+        fake = self._resize(size="80:50")
+        self.assertEqual(sorted(self._killed(fake)), ["%3", "%5"],
+                         f"the panes a launch at this size would not have drawn are still "
+                         f"there: {fake.calls}")
+
+    def test_widening_gains_the_pane_a_launch_at_that_size_would_have_had(self):
+        """The direction that was strictly worse, because nothing at all brought it back:
+        a frame launched narrow and then widened had to be relaunched, or sent through the
+        F2 palette, to get the panes it now had room for."""
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+        fake = self._resize(size="200:50")
+        split = [c for c in self._split(fake)]
+        self.assertEqual(len(split), 2,
+                         f"a widened frame did not gain the two panes it now has room "
+                         f"for: {fake.calls}")
+
+    def test_a_size_that_changes_nothing_moves_no_panes_at_all(self):
+        """The control this whole class needs, and the property that keeps a drag cheap:
+        every step of a drag that does not cross a boundary must be a re-SIZE and nothing
+        else. A `cmd_resize` that killed and re-split at each step would spend a
+        `charter panel` process, a cold charter import and one of three respawn lives per
+        step."""
+        fake = self._resize(size="200:50")
+        self.assertEqual(self._killed(fake), [])
+        self.assertEqual(self._split(fake), [])
+        self.assertTrue(self._resized(fake))
+
+    def test_the_last_pane_is_never_dropped(self):
+        """Below half the size floors `layout.visible_slots` answers `[]`, and a
+        `_relayout` with nothing left makes `_install_resize_hook` REMOVE the
+        `window-resized` hook — correctly, and it is a one-way door reached from here: the
+        hook is the only thing that would notice the terminal being widened again. So this
+        frame keeps what it has at that size, exactly as it did before #536, and the
+        operator who wants nothing drawn has a keypress that says so."""
+        self.assertEqual(commands_frame._drawable_slots(
+            40, 8, commands_frame._visible_now(self.fid, config.FRAME)), [],
+            "this window is not below the floors — the case is not being exercised")
+        fake = self._resize(size="40:8")
+        self.assertEqual(self._killed(fake), [],
+                         "a resize killed the last pane, and with it the hook that would "
+                         "have brought any of them back")
+
+    def test_a_panel_the_operator_hid_is_not_brought_back_by_a_resize(self):
+        """The recompute starts from this frame's own arrangement minus its own hidden set
+        (`_visible_now`), never from `config.FRAME["slots"]`. Recomputing from the config
+        would put a panel the operator toggled off back on screen on their next terminal
+        drag — a resize silently undoing a keypress."""
+        state.record_hidden(self.fid, ["right", "repos"])
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+        fake = self._resize(size="200:50")
+        self.assertEqual(self._split(fake), [],
+                         f"a resize re-split panels the operator had hidden: {fake.calls}")
+
+    def test_the_density_the_operator_chose_survives_a_resize_too(self):
+        """The same property reached through the other key. A `minimal` frame is `top` and
+        `bottom` and nothing else; a resize must not grow it back to `full` merely because
+        the terminal is wide enough for one."""
+        state.record_density(self.fid, "minimal")
+        state.record_hidden(self.fid, [n for n in instance.frame_arrangement(config.FRAME)
+                                       if n not in instance.density_slots("minimal")])
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+        fake = self._resize(size="200:50")
+        self.assertEqual(self._split(fake), [])
+
+
+class TheShapeWaitsForTheWindowToStop(_ResizeFixture):
+    """#536's second half, and it is #501's mechanism used for a slower question.
+
+    Re-applying a size out of order is self-correcting: the next event fixes it. Killing
+    and re-splitting panes out of order is not — each split is a new interpreter, a cold
+    charter import and a first paint, and it spends one of the three lives
+    `_arm_panel_respawn` gives that pane. So a drag through the width where the table stops
+    fitting must not thrash panes in and out at every step of it.
+
+    There is no timer here and no state to debounce with: `notify._last` works because one
+    process makes every call, and every one of these children is its own `run-shell -b`
+    process. What they share is the window, so a child that wants to change the shape
+    sleeps and then asks whether the window is still where it was. The one the drag
+    actually ended on is the only one that gets a yes.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Undo the fixture's own zero — this class is what pins the wait, so it has to be
+        # the real mechanism being exercised, only faster than 400ms.
+        self.enterContext(mock.patch.object(commands_frame, "_SETTLE_SECONDS", 0.0))
+
+    def test_a_window_still_moving_moves_no_panes(self):
+        """Two sizes: the one this child measured, and the one the window is by the time
+        the wait is over. Both are narrow enough to want the table pane gone, so a version
+        that killed on the first measurement alone would still look right in the final
+        state — hence the assertion is on what was ISSUED, not on what was wanted."""
+        fake = self._resize(sizes=["80:50", "70:50"])
+        self.assertEqual(self._killed(fake), [],
+                         f"panes were killed for a window the drag had already left: "
+                         f"{fake.calls}")
+
+    def test_the_window_the_drag_ended_on_is_the_one_that_gets_acted_on(self):
+        """The control. The same two-read path with a window that settled must do the
+        whole job, or "nothing was killed" above is satisfied by a mechanism that never
+        acts at all."""
+        fake = self._resize(sizes=["80:50", "80:50"])
+        self.assertEqual(sorted(self._killed(fake)), ["%3", "%5"])
+
+    def test_the_layout_uses_the_measurement_that_settled_not_a_fresh_one(self):
+        """The last place a third reading could sneak in, and `tools/sweep.py` found it:
+        `_apply_arrangement` takes the window it is to lay out for, and collapsing that to
+        its own `_window_size` call left every other test green.
+
+        It is the same defect as #501 one layer up. This child measured 200x50, waited, and
+        confirmed 200x50 — that is the window the decision was made from and the only one it
+        may be applied to. A `_apply_arrangement` that measured again would get whatever the
+        window happens to be at that instant, and act on a size nothing checked: three
+        answers here, and the third is a terminal that has moved to 80 columns, where
+        `_drawable_slots` wants two panes rather than four. Asserted on the SPLITS, because
+        the two readings disagree about exactly which panes this frame should have.
+        """
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+        fake = self._resize(sizes=["200:50", "200:50", "80:50"])
+        self.assertEqual(len(self._split(fake)), 2,
+                         f"the re-layout was laid out for a window nobody checked — the "
+                         f"settled 200x50 measurement was thrown away: {fake.calls}")
+
+    def test_the_wait_is_actually_waited(self):
+        """`_SETTLE_SECONDS` is patched to zero everywhere above, which is exactly the
+        shape of a settle that has been accidentally deleted. This asserts the sleep is
+        reached — with the real constant's own value, and only on the path that changes
+        the frame's shape."""
+        slept: list[float] = []
+        with mock.patch.object(commands_frame, "_SETTLE_SECONDS", 0.25), \
+             mock.patch("charter.commands_frame.time.sleep", slept.append):
+            self._resize(size="80:50")
+        self.assertEqual(slept, [0.25])
+
+    def test_a_resize_that_changes_no_panes_never_waits(self):
+        """The cost bound. A drag that stays on one side of every boundary is the ordinary
+        case and must pay nothing for a mechanism it does not use — otherwise every step
+        of every drag leaves a sleeping interpreter behind for the length of the wait."""
+        slept: list[float] = []
+        with mock.patch("charter.commands_frame.time.sleep", slept.append):
+            self._resize(size="200:50")
+        self.assertEqual(slept, [])
+
+    def test_a_frame_already_the_shape_its_operator_asked_for_never_waits_either(self):
+        """The same bound, for the frame where "what this shows" and "what the config
+        says" differ — which is every frame whose operator has pressed a key.
+
+        Hand-mutating found this: computing `want` from `config.FRAME["slots"]` while
+        `_apply_arrangement` still got `_visible_now`'s answer left every geometry
+        assertion green, because the re-layout laid out the right thing. All it cost was a
+        settle wait and a version bump on a resize with nothing to do — which is invisible
+        in the final state and is exactly the "a second line hides the consequence" shape.
+        A hidden `right` with the other three drawn is a frame that IS its own shape, so a
+        resize must decide that in the same breath it decides what to lay out.
+        """
+        state.record_hidden(self.fid, ["right"])
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2", "repos": "%5"})
+        slept: list[float] = []
+        with mock.patch("charter.commands_frame.time.sleep", slept.append):
+            fake = self._resize(size="200:50")
+        self.assertEqual(slept, [],
+                         "a frame already showing exactly what its operator asked for "
+                         "waited out a settle to change nothing")
+        self.assertEqual(self._split(fake), [])
+        self.assertEqual(self._killed(fake), [])
+
+
+class TheSettleIsLongEnoughToBeOne(unittest.TestCase):
+    """`_SETTLE_SECONDS`' own VALUE, which every test that exercises the settle patches
+    away and therefore cannot see: set it to `0.0` and `TheShapeWaitsForTheWindowToStop`
+    above stays entirely green while the mechanism is gone. Found by hand-mutating the
+    constant — `tools/sweep.py` has no operator for a number (#569).
+
+    Deliberately a bare `TestCase` with no fixture at all: any class that drives
+    `cmd_resize` has to patch this constant to stay fast, and a test reading a constant its
+    own `setUp` replaced is asserting against the patch.
+    """
+
+    def test_the_wait_clears_one_measured_re_layout(self):
+        """A re-layout's own tmux command list — two `set -p pane-died`, two
+        `split-window`s, the `window-resized` hook, the window and pane measurements, four
+        `resize-pane`s and a `select-pane` — was measured at a **median 72ms over 5 runs**
+        on tmux 3.7c, and that is before either new panel's cold charter import and first
+        paint. A wait under that lets one crossing of the boundary land inside the last
+        one, which is the pane-thrash this mechanism exists to prevent."""
+        self.assertGreater(commands_frame._SETTLE_SECONDS, 0.072,
+                           "the settle is shorter than one measured re-layout — a second "
+                           "crossing of the boundary lands inside the first")
+
+    def test_the_wait_is_not_long_enough_to_read_as_a_missed_resize(self):
+        """The ceiling, and it is the other failure rather than tidiness: the panes do not
+        move until this elapses, so a settle an operator can sit through reads as the frame
+        having ignored their resize."""
+        self.assertLessEqual(commands_frame._SETTLE_SECONDS, 1.0)
 
 
 class DensityIsWiredIntoTheCli(unittest.TestCase):

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -497,6 +497,46 @@ class TheTablesWidthIsWhateverTheSplitOrderLeftIt(unittest.TestCase):
                     "panel_argvs and repos_cols disagree about this slot's direction")
 
 
+class ColumnSizesIsTheHalfThatCanBeAppliedFirst(unittest.TestCase):
+    """`column_sizes` exists so `commands_frame._reassert_sizes` can put the side panels
+    back at their own width BEFORE it asks tmux how wide the pane beside them is (#510) —
+    tmux redistributes every pane proportionally on a window resize, so a sidebar mid-drag
+    answers for a geometry that is one command away from not existing.
+
+    Pinned here rather than only through that caller, and `tools/sweep.py` is why: deleting
+    the edge filter left the whole suite green, because `_apply_sizes` filters again by
+    `_RESIZE_FLAG` on its way to the `-x` and swallowed every extra entry. Two guards in
+    sequence, the second hiding the first. This asks the function its own question.
+    """
+
+    def test_it_answers_the_column_slots_and_only_those(self):
+        self.assertEqual(layout.column_sizes(["top", "bottom", "repos", "right"]),
+                         {"right": layout.SLOT_SIZE["right"]})
+
+    def test_a_list_with_no_side_panel_answers_empty_rather_than_the_strips(self):
+        """The direction the deleted filter fails in: with it gone this answered `top`,
+        `bottom` and `repos` as well, and a caller applying the result as `-x` would be
+        asserting a WIDTH on three horizontal strips."""
+        self.assertEqual(layout.column_sizes(["top", "bottom", "repos"]), {})
+
+    def test_it_agrees_with_slot_sizes_about_how_wide_a_side_panel_is(self):
+        """Two loops, one fact. Both read `_size_of`, so the day they disagree is the day
+        one of them grew a table of its own — which is the shape `layout.py`'s own
+        docstring says these constants exist to stop."""
+        slots = ["top", "bottom", "repos", "right"]
+        full = layout.slot_sizes(slots, window_rows=50, content_rows=6)
+        columns = layout.column_sizes(slots)
+        self.assertTrue(columns, "nothing was compared — the check is vacuous")
+        for slot, cells in columns.items():
+            self.assertEqual(cells, full[slot], slot)
+
+    def test_an_unknown_name_is_dropped_rather_than_raised_on(self):
+        """`[frame] slots` is committed, untrusted input, and `slot_sizes` already
+        degrades rather than refusing for exactly that reason."""
+        self.assertEqual(layout.column_sizes(["sideways", "right"]),
+                         {"right": layout.SLOT_SIZE["right"]})
+
+
 class SlotSizesAnswersEverySlotAtOnce(unittest.TestCase):
     def test_the_fixed_slots_keep_their_declared_size(self):
         got = layout.slot_sizes(["top", "bottom", "right"], window_rows=50,

--- a/tests/test_frame_panel.py
+++ b/tests/test_frame_panel.py
@@ -120,15 +120,59 @@ class FailureIsVisibleInThePane(PersonaIso, unittest.TestCase):
         failure INSIDE the render path cannot take the message about it down too — which
         means it also does not inherit `render`'s own truncation. A message wider than a
         22-column `left` pane would wrap and scroll itself out of a pane it was written
-        to be readable in."""
+        to be readable in.
+
+        **The assertion is untouched by #591 and the fixture is the half that moved.** The
+        `fileno` patch used to sit OUTSIDE `redirect_stdout`, which patched whatever
+        `sys.stdout` was at that moment — `PersonaIso`'s own `StringIO`, not `out` — and
+        then `redirect_stdout` swapped a different object in underneath it. So
+        `sys.stdout.fileno()` raised `io.UnsupportedOperation` (an `OSError`), this ran on
+        `slots._width`'s FALLBACK, and the fallback read `$COLUMNS`: the test passed on a
+        machine with no `$COLUMNS` and failed at `COLUMNS=400`, painting an 88-cell line
+        into a 24-column pane. Both halves were wrong and only one of them is a test's
+        business — the fallback no longer reads the shell at all (`slots._DEFAULT_COLS`,
+        pinned in `test_frame_slots.py::Width`), and the ordering below is what makes this
+        case exercise what its name says: a pane whose own tty answers 24.
+
+        `PaintClampsToRealHeight` and `RendersToItsOwnPaneWidth` in this file already nest
+        the two the right way round; this is now the third.
+        """
         out = io.StringIO()
-        with mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
-             mock.patch("os.get_terminal_size", return_value=os.terminal_size((24, 1))):
-            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+        with redirect_stdout(out), redirect_stderr(io.StringIO()):
+            with mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+                 mock.patch("os.get_terminal_size",
+                            return_value=os.terminal_size((24, 1))):
                 panel.run("a-very-long-slot-name-indeed", "f-1", once=True)
         painted = out.getvalue().split("\x1b[2J", 1)[1]
         for line in painted.split("\n"):
             self.assertLessEqual(tui.width(line), 24, painted)
+
+    def test_a_pane_that_cannot_be_measured_is_not_measured_by_the_shell_instead(self):
+        """#591's live half, at the call site that has to hold it.
+
+        The case above states a pane's real width; this one takes the width away. A panel
+        whose stdout has no tty behind it (`charter panel top --session x > /tmp/log`, the
+        case `_DEFAULT_ROWS` already exists for) has nothing to measure — and the paint
+        that runs at that moment is a FAILURE paint, so whatever it lays out against is
+        what an operator gets in place of a working pane. Reaching for `$COLUMNS` there
+        answered with the terminal charter was launched from, which a panel process
+        inherits whole; a 400-column shell put an 88-cell line where 80 was the most
+        anything could claim.
+
+        Asserted against `slots._DEFAULT_COLS` rather than a literal, because the number
+        is not the property — the property is that the answer does not move when the shell
+        does. Red before the fix at exactly the value #591 reproduced with.
+        """
+        out = io.StringIO()
+        with mock.patch.dict(os.environ, {"COLUMNS": "400"}):
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                with mock.patch("os.get_terminal_size",
+                                side_effect=OSError("not a tty")):
+                    panel.run("a-very-long-slot-name-indeed", "f-1", once=True)
+        painted = out.getvalue().split("\x1b[2J", 1)[1]
+        self.assertTrue(painted.strip(), "nothing was painted at all")
+        for line in painted.split("\n"):
+            self.assertLessEqual(tui.width(line), slots._DEFAULT_COLS, painted)
 
 
 class Height(unittest.TestCase):

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -73,11 +73,22 @@ class Render(PersonaIso, unittest.TestCase):
 
     def test_a_slot_never_exceeds_the_pane_width(self):
         """`tui.width` counts display cells, not characters — a wide glyph that fits by
-        len() still wraps the pane and pushes the frame apart."""
-        for slot in ("top", "bottom"):
-            for line in slots.render(slot, "f-1").splitlines():
-                with self.subTest(slot=slot):
-                    self.assertLessEqual(tui.width(line), tui.term_width(default=80))
+        len() still wraps the pane and pushes the frame apart.
+
+        **The pane is stated, not read off the machine** (#591). This used to bound the
+        render by `tui.term_width(default=80)` while the render itself was laid out by
+        `slots._width()` — and until #591 both of those read `$COLUMNS`, so the two sides
+        of the assertion collapsed onto the same ambient value and the test could not fail
+        whatever width it was given. That is #525's shape exactly. `_width` answers a
+        constant now, so the bound has to come from somewhere that is not the shell
+        either: the size is mocked, and 80 is what this pane IS.
+        """
+        with mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch("os.get_terminal_size", return_value=os.terminal_size((80, 24))):
+            for slot in ("top", "bottom"):
+                for line in slots.render(slot, "f-1").splitlines():
+                    with self.subTest(slot=slot):
+                        self.assertLessEqual(tui.width(line), 80)
 
     def test_a_failing_renderer_yields_a_line_rather_than_an_exception(self):
         """A panel that raises leaves a hole in the frame; `statusline.render` makes the
@@ -243,13 +254,58 @@ class Width(unittest.TestCase):
                          return_value=os.terminal_size((22, 5))):
             self.assertEqual(slots._width(), 22)
 
-    def test_width_falls_back_to_env_first_term_width_when_no_tty_is_available(self):
-        """The one case `tui.term_width()` is allowed to answer: no tty behind the fd at
-        all (stdout piped to a file, say), not merely a pane that disagrees with
-        `$COLUMNS`."""
-        with mock.patch.dict(os.environ, {"COLUMNS": "55"}), \
-             mock.patch("os.get_terminal_size", side_effect=OSError("not a tty")):
-            self.assertEqual(slots._width(), 55)
+    def test_width_falls_back_to_a_constant_and_never_to_the_shells_columns(self):
+        """#591. This used to assert the opposite — that `tui.term_width()` answers when
+        there is no tty behind the fd — and calling that "the one case `$COLUMNS` is
+        allowed to answer" was the defect written down as a property.
+
+        There is no such case. `$COLUMNS` describes the LAUNCHING terminal (this module's
+        own docstring measures a 22-column pane seeing `COLUMNS='200'`), so an
+        unmeasurable pane laid out from it is laid out from a rectangle that is not this
+        one — and `panel._hold`, the paint that runs when a panel has already failed, is
+        the call site where that is worst. A pane nobody can measure gets
+        :data:`slots._DEFAULT_COLS`, exactly as it has always got `_DEFAULT_ROWS` for its
+        height.
+
+        Both directions, because one alone is satisfiable by an accident: a `$COLUMNS`
+        WIDER than the constant would wrap the paint out of its own pane, and a NARROWER
+        one is the same wrong source pointing the other way (and would have been the
+        arithmetic every renderer downstream then spends).
+        """
+        for columns in ("400", "55"):
+            with self.subTest(columns=columns):
+                with mock.patch.dict(os.environ, {"COLUMNS": columns}), \
+                     mock.patch("os.get_terminal_size", side_effect=OSError("not a tty")):
+                    self.assertEqual(slots._width(), slots._DEFAULT_COLS)
+
+    def test_the_fallback_width_is_the_one_charter_already_falls_back_to(self):
+        """The VALUE, which the two tests above cannot see: both assert against
+        `_DEFAULT_COLS` itself, so setting it to 400 satisfies them and lays every
+        unmeasurable pane out four hundred columns wide. Found by hand-mutating the
+        constant — `tools/sweep.py` has no operator for a number (#569).
+
+        Pinned as an agreement rather than as a literal, which is the same argument
+        `_DEFAULT_ROWS`' own docstring makes about `panel._DEFAULT_ROWS`: "how big is a
+        rectangle nobody can measure" must have ONE answer in charter, or the two copies
+        are free to drift. `commands_frame._FALLBACK_SIZE` is the frame's own — the
+        traditional default screen, 80x24 — and `tui.term_width`'s default is the same 80
+        this used to reach through. Both dimensions, so a fix that lined one up and left
+        the other is still red.
+        """
+        from charter import commands_frame
+        self.assertEqual((slots._DEFAULT_COLS, slots._DEFAULT_ROWS),
+                         commands_frame._FALLBACK_SIZE,
+                         "a pane charter cannot measure is laid out at a different size "
+                         "than the window charter cannot measure")
+
+    def test_the_unmeasurable_pane_answers_the_same_for_both_dimensions(self):
+        """The pair, said once. A pane with no tty behind it has neither a width nor a
+        height to read, and before #591 those two facts came from different places —
+        `_height` from a constant, `_width` from the environment — which is how one of
+        them came to describe a different terminal than the other."""
+        with mock.patch("os.get_terminal_size", side_effect=OSError("not a tty")):
+            self.assertEqual((slots._width(), slots._height()),
+                             (slots._DEFAULT_COLS, slots._DEFAULT_ROWS))
 
 
 class RenderFollowsThePane(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -86,7 +86,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import commands_frame, config, hooks, instance, todos
+from charter import commands_frame, config, hooks, instance, statusline, todos
 from charter.frame import gather, layout, notify
 from charter.frame import slots as frame_slots
 from charter.frame import state, tmuxctl
@@ -1522,6 +1522,111 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
                 f"the pane #515 has to name explicitly, because with three strips the "
                 f"two below it trade rows with each other and never with it")
 
+    def test_the_table_panes_width_is_tmuxs_answer_and_not_the_recorded_order(self):
+        """#510, against the one authority there is.
+
+        `layout.repos_cols` derives the table pane's width from the ORDER the recorded map
+        is in, and that order is a JSON file in the frame's own state directory:
+        `state.panes` validates the VALUES and says nothing about the order, so a truncated
+        write, a hand edit, or a charter that wrote a different shape all arrive as a
+        plausible-looking map whose order is fiction. Nothing about that is detectable from
+        inside charter — which is the point of asking tmux instead.
+
+        So this builds the `right`-FIRST geometry for real, where the table pane is 87
+        columns in a 110-column window, and then hands `_reassert_sizes` the SHIPPED order,
+        which claims the same pane is the full 110. The derivation says the table fits (110
+        >= `statusline._LEFT_W`) and sizes the pane for six repos; tmux says 87, which draws
+        no table at all. One row is the measurement's answer and only the measurement's, so
+        this is red on `main` and red on any version that quietly keeps deriving.
+
+        **And the order the two passes run in is what makes tmux's answer true**, which is
+        the other half of the fix and is asserted here rather than argued: the window is
+        resized first, leaving `right` proportionally scaled to a width it is not supposed
+        to have, and `_reassert_sizes` has to put it back before it may believe anything
+        about its neighbour. Measured on this binary during development: `right` came back
+        62 columns wide after a 120x40 -> 200x40 grow, and the table pane read 137 where
+        the truth one `resize-pane -x 22` later is 177.
+        """
+        fid = state.frame_id("rsz-measured", os.getpid())
+        r = _tmux("new-session", "-d", "-s", "rsz-measured", "-x", "120", "-y", "40",
+                  "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness_pane = r.stdout.strip()
+
+        def _split(*flags: str) -> str:
+            p = _tmux("split-window", "-t", harness_pane, *flags,
+                      "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+            self.assertEqual(p.returncode, 0, p.stderr)
+            return p.stdout.strip()
+
+        # `right` FIRST, which is the geometry an operator's own `[frame] slots` order
+        # produces and which `instance.frame_of` keeps verbatim.
+        right = _split("-h", "-l", "22")
+        top = _split("-v", "-b", "-l", "1")
+        bottom = _split("-v", "-l", "1")
+        table = _split("-v", "-l", "6")
+        self.assertEqual(_tmux("resize-window", "-t", "rsz-measured",
+                               "-x", "110", "-y", "50").returncode, 0)
+
+        # The map's order is a LIE about this frame: it says the shipped order, in which
+        # nothing insets the table. The panes themselves are in the other one.
+        lying_order = {"top": top, "bottom": bottom, "repos": table, "right": right}
+        self.assertGreaterEqual(
+            layout.repos_cols(list(lying_order), window_cols=110),
+            statusline._LEFT_W,
+            "the recorded order does not claim a table-wide pane — the derivation this "
+            "test exists to disagree with is not even being exercised")
+
+        with mock.patch("charter.frame.slots.repos_rows_wanted",
+                        side_effect=lambda fid, *, pane_cols:
+                            1 if pane_cols < statusline._LEFT_W else 6):
+            commands_frame._reassert_sizes(SOCKET, fid=fid, panes=lying_order,
+                                           harness_pane=harness_pane,
+                                           window_cols=110, window_rows=50)
+
+        self.assertEqual(
+            _tmux("display-message", "-p", "-t", right, "#{pane_width}").stdout.strip(),
+            "22",
+            "the sidebar was not put back to its own width before the pane beside it was "
+            "measured — every number after this point is about a geometry that no longer "
+            "exists")
+        self.assertEqual(
+            _tmux("display-message", "-p", "-t", table, "#{pane_width}").stdout.strip(),
+            "87",
+            "tmux does not agree the table pane is inset — the fixture is not the "
+            "geometry this test is about")
+        height = _tmux("display-message", "-p", "-t", table,
+                       "#{pane_height}").stdout.strip()
+        self.assertEqual(height, "1",
+                         f"the table pane is {height} rows in a window where its own pane "
+                         f"is 87 columns and draws no table — sized from the recorded "
+                         f"order, which tmux has just contradicted")
+
+    def test_a_pane_that_cannot_be_measured_still_gets_the_derivations_answer(self):
+        """The other side of #510, and the reason `layout.repos_cols` stays. The launcher
+        cannot measure a pane that does not exist yet, and a running frame can lose one
+        between the map being read and the resize being applied. Same real window, same
+        real panes, and a recorded id for the table that names nothing tmux has — the
+        derivation answers, and it answers 110, which draws the six-row table.
+        """
+        fid = state.frame_id("rsz-underived", os.getpid())
+        r = _tmux("new-session", "-d", "-s", "rsz-underived", "-x", "110", "-y", "50",
+                  "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness_pane = r.stdout.strip()
+        top = _tmux("split-window", "-t", harness_pane, "-v", "-b", "-l", "1",
+                    "-P", "-F", "#{pane_id}", "--", "sleep", "600").stdout.strip()
+        rows_seen: list[int] = []
+        with mock.patch("charter.frame.slots.repos_rows_wanted",
+                        side_effect=lambda fid, *, pane_cols:
+                            rows_seen.append(pane_cols) or 6):
+            commands_frame._reassert_sizes(
+                SOCKET, fid=fid, panes={"top": top, "repos": "%999"},
+                harness_pane=harness_pane, window_cols=110, window_rows=50)
+        self.assertEqual(rows_seen, [110],
+                         "a pane tmux would not measure did not fall through to "
+                         "`layout.repos_cols` — it fell through to something else")
+
     # -- 5. Session-scoped id delivery for the hotkey menu --------------------------- #
 
     def test_a_second_frames_own_id_does_not_leak_the_firsts(self):
@@ -2422,6 +2527,89 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         harness = int(_tmux("display-message", "-p", "-t", harness_pane,
                             "#{pane_height}").stdout.strip())
         self.assertGreaterEqual(harness, layout.HARNESS_MIN_ROWS, harness)
+
+    def test_a_real_drag_across_the_table_width_removes_the_pane_and_brings_it_back(self):
+        """#536, end to end: a real `window-resized` hook, a real `resize-window`, a real
+        `charter frame-resize` child, and a pane that actually leaves the window and
+        actually comes back.
+
+        Which slots a frame HAD was decided once, at launch — `_drawable_slots` ran against
+        the terminal the frame started in and nothing re-ran it except a density change. So
+        a frame launched at 120 columns and narrowed to 80 kept a `repos` pane whose
+        renderer refuses to draw a table below `statusline._LEFT_W`, leaving a bordered
+        rectangle saying so; and a frame narrowed and then WIDENED never got it back at
+        all, because nothing could un-refuse a slot that had already been dropped.
+
+        Asserted as a pane COUNT and a pane's presence in the window, not as a size:
+        #500/#488 already prove the sizes hold, and every one of those assertions passes
+        just as well against the pane that could not be un-split. The only thing that
+        distinguishes this fix is that the rectangle is gone.
+
+        **Both directions, and the second is why one is not enough.** A resize that only
+        ever removed would pass "the pane is gone"; a resize that only ever added would
+        pass "the pane came back". The frame has to end this test with exactly the panes a
+        launch at its final size would have drawn.
+        """
+        fid = state.frame_id("four-edge-shape", os.getpid())
+        harness_pane, panes = self._spawn_frame(fid)
+        state.record_harness_pane(fid, harness_pane)
+        state.record_panes(fid, panels=panes)
+        state.record_server(fid, SOCKET)
+
+        hook = commands_frame._resize_hook_argv(socket=SOCKET,
+                                                harness_pane=harness_pane, fid=fid)
+        self.assertIsNotNone(hook, "the frame's own id was refused by the hook builder")
+        self.assertEqual(self._run_env(hook).returncode, 0,
+                         "installing the resize hook failed")
+
+        def _panes_now() -> set[str]:
+            out = _tmux("list-panes", "-t", fid, "-F", "#{pane_id}").stdout.split()
+            return set(out)
+
+        def _await_shape(slots: list[str], what: str) -> set[str]:
+            """Wait for the frame's own RECORD to name *slots*, then read the window.
+
+            The record is what `cmd_resize` rewrites LAST (`_apply_arrangement`: relayout,
+            record, bump), so it is the only readiness condition that means the child has
+            finished rather than that its panes happen to exist yet — polling the window
+            alone caught a re-layout mid-flight, with five panes up and the map still
+            naming two.
+            """
+            deadline = time.monotonic() + _DEADLINE
+            while time.monotonic() < deadline and sorted(state.panes(fid)) != sorted(slots):
+                time.sleep(0.1)
+            self.assertEqual(sorted(state.panes(fid)), sorted(slots),
+                             f"{what}: the frame's own record names "
+                             f"{sorted(state.panes(fid))}")
+            seen = _panes_now()
+            self.assertEqual(len(seen), len(slots) + 1,
+                             f"{what}: the record says {sorted(slots)} but the window "
+                             f"holds {sorted(seen)} panes counting the harness")
+            return seen
+
+        self.assertEqual(len(_panes_now()), 5,
+                         "the fixture did not come up with a harness and four panels")
+
+        # Narrow past both boundaries at once: 80 is under `[frame] min-cols` (which drops
+        # `right`) and under `statusline._LEFT_W` (which drops `repos`).
+        self.assertEqual(_tmux("resize-window", "-t", fid,
+                               "-x", "80", "-y", "40").returncode, 0)
+        left = _await_shape(["top", "bottom"],
+                            "a frame narrowed to 80 columns still has the two panes a "
+                            "launch at 80 columns would have refused to draw")
+        self.assertNotIn(panes["repos"], left)
+        self.assertNotIn(panes["right"], left)
+
+        # And back. The panes that come back are NEW ones — `_relayout` splits rather than
+        # un-kills — so this is asserted on the recorded map and the window's own count,
+        # never on the old ids.
+        self.assertEqual(_tmux("resize-window", "-t", fid,
+                               "-x", "160", "-y", "40").returncode, 0)
+        back = _await_shape(["top", "bottom", "repos", "right"],
+                            "a frame widened back to 160 columns never regained the "
+                            "panes it now has room for")
+        for pane in back:
+            self.addCleanup(_kill_pid, self._pane_pid(pane))
 
     def test_a_state_bump_through_the_real_hook_repaints_the_table_and_the_alert_row(self):
         """Closes the gap `PanelIntegration`'s own hook test


### PR DESCRIPTION
Four issues, one property, one PR — because each of the four is the frame deciding a size
or a width **from the wrong source**, and three of them are in the same forty lines.

> A pane's geometry comes from the pane, and a decision made from a stale reading is
> refused rather than applied.

| | was | is |
| --- | --- | --- |
| **#591** a failure paint | `slots._width()` falls back to `tui.term_width()` — `$COLUMNS`-first | falls back to `slots._DEFAULT_COLS`, the way `_height` has always fallen back to `_DEFAULT_ROWS` |
| **#510** the table pane's width | derived from the recorded pane map's ORDER | asked of tmux (`#{pane_width}`), with the derivation as the answer for a pane that cannot be asked |
| **#501** a `window-resized` child | measures, then applies | measures, re-reads immediately before applying, and does nothing if the window has moved |
| **#536** a resize | re-sizes panes, never adds or removes one | recomputes the drawable set and hands it to `_apply_arrangement`, once the window has settled |

Split was considered and rejected: #536's whole "why this is filed rather than done" is
#501 ("re-applying a size out of order is self-correcting; killing and re-splitting panes
out of order is not"), and the fix for #536 **is** #501's mechanism with a wait in front of
it. #510 and #536 both land in `_reassert_sizes`/`cmd_resize`. #591 is the same property in
`slots.py`, and it is load-bearing for the frame visual-design spec merged in #595, whose
§6.2 exit criterion is "one measurement, not two — the fill uses the same width the
renderer used" over a full-width background that shears the pane at W+1.

## #591 — the paint, not the test

Reproduced on pristine `main` exactly as filed: `COLUMNS=400 python3 -m unittest
tests.test_frame_panel -k clamped` fails, unset it passes.

The mechanism, traced rather than guessed: the test's `patch.object(sys.stdout, "fileno")`
sat OUTSIDE `redirect_stdout`, so it patched `PersonaIso`'s `StringIO` and then a different
object was swapped in under it. `sys.stdout.fileno()` therefore raised
`io.UnsupportedOperation` — **an `OSError`** — and `slots._width()` took its fallback. That
fallback was `tui.term_width(default=80, floor=20)`, which is env-first by design, so an
88-cell line was painted into a 24-column pane at `COLUMNS=400`.

**The paint is what changed.** `_width` now answers `_DEFAULT_COLS` for a pane it cannot
measure and never reads the environment, which is what `_height` has always done for rows.
The value is the same 80 `tui.term_width`'s own *default* carried, so a pane with nothing to
measure and nothing exported lays out exactly as before; what is gone is the branch that let
a 400-column shell decide a 24-column pane's paint.

Three consequences worth naming:

* `tests/test_frame_slots.py::Width::test_width_falls_back_to_env_first_term_width_when_no_tty_is_available`
  **pinned the defect as a property** — "the one case `tui.term_width()` is allowed to
  answer". There is no such case; that test is rewritten to assert the opposite, in both
  directions (a `$COLUMNS` wider *and* narrower than the constant).
* The #591 test's own **assertion is untouched**. Its context-manager nesting is corrected
  so it exercises what its name says — a pane whose own tty answers 24 — matching
  `PaintClampsToRealHeight` and `RendersToItsOwnPaneWidth`, which already nest them the right
  way round. A second test covers the branch that actually changed: an unmeasurable pane at
  `COLUMNS=400`.
* `Render::test_a_slot_never_exceeds_the_pane_width` bounded the render by
  `tui.term_width(default=80)` while the render itself was laid out by `slots._width()` —
  and until this PR both read `$COLUMNS`, so the two sides of the assertion collapsed onto
  one ambient value (#525's shape). It states its pane now.

**#544 remains the right home for stopping the test depending on the ambient terminal.** This
PR does not touch the scrub, and the other five tests #544 names are untouched. What it does
is remove the `$COLUMNS` read from *production*, which no scrub could have reached — and,
incidentally, makes `slots._width()` deterministic for every test in the suite that renders a
panel without mocking `os.get_terminal_size`, which today is most of them.

## #510 — the pane is asked, and the order is what makes the answer true

`layout.repos_cols` turns the window's width into the pane's by walking the order the panes
were split in. That order arrives as JSON from the frame's own state directory, and
`state.panes` validates the *values* (`isinstance(v, str)`) and says nothing about the order.
tmux holds the real number and `cmd_resize` already runs one `display-message`.

**Measuring naively would have been worse than deriving, and that is measured, not argued.**
tmux redistributes every pane proportionally on a window resize, so mid-drag a sidebar is not
22 columns wide. On tmux 3.7c, a 120x40 frame with `right` split first, grown to 200x40:

```
after resize, before any correction:  right w=62   table w=137
after `resize-pane -t right -x 22`:   right w=22   table w=177   [repos_cols says 177]
```

Same agreement at 60 (37), 110 (87) and 300 (277) columns. So `_reassert_sizes` is two
passes with the measurement between them — apply the **columns**, then ask the pane, then
apply the **rows** and the harness. `layout.column_sizes` is the half of `slot_sizes` that
can be applied first; both read `_size_of`, so there is one answer to how wide a side panel
is, not two.

The measurement is refused for a return code, a non-digit, a zero, and a recorded pane id
that is not tmux's own `%<digits>` (#475's rule — `panes` is a file on disk). Each falls
through to `repos_cols`, which stays charter's answer for the launcher too: at launch the
pane does not exist yet.

Verified against a real tmux in `test_the_table_panes_width_is_tmuxs_answer_and_not_the_recorded_order`:
the `right`-first geometry is built for real (87-column table pane in a 110-column window)
and `_reassert_sizes` is handed a map claiming the *shipped* order, which says 110. The
derivation would draw a six-row table; tmux says 87 and the pane comes out one row.

## #501 — a re-read, not a lock

`window-resized` fires per size change, each event starts its own `run-shell -b` child, and
nothing serialises them. A child that measured a taller window computes a taller `bottom`;
landing after the child that measured the final one, it sizes a pane for a window that is
gone — and tmux grants an over-large `-y` out of the neighbour, which is the agent's session.

`_window_still` re-reads `#{window_height}` immediately before anything is applied and
refuses if it has moved. #501 itself sets out the two options: a lock file a later child
*steals* (last-writer-wins, the correct semantics — a plain mutex gives the wrong end), or a
re-read. The re-read gets last-writer-wins **without** either, because the window itself is
the record: the newest measurement is by definition the one that still matches. Nothing is
left behind when a child is killed mid-drag.

It narrows the window rather than closing it, which is the honest claim and is what #501
asked to be decided. What remains is self-correcting in the direction that was always safe:
the change that beat the check fired its own `window-resized`.

This is the same shape the frame already uses everywhere else, which is why it belongs here
rather than in a new primitive: a panel does not learn charter did something, it notices
`state.version` moved (#411/#412's mechanism, `panel.py`'s own "liveness is a poll, not a
push"). A resize child does not learn the window moved either — it asks the thing that
knows. Nothing new is written to disk and nothing has to be cleaned up after a child that
is killed mid-drag.

One refusal added alongside: a window tmux will not report a size for. That used to take
`_FALLBACK_SIZE` and assert an 80x24 layout — the same destructive move as a stale
measurement with less excuse. `_measure_window` answers `None`; `_window_size` keeps the
fallback for the launcher, which has to draw *something*.

## #536 — the shape is recomputed, once the drag stops

`cmd_resize` recomputes the drawable slot list and hands it to **`_apply_arrangement`** — the
one live re-layout path, the same one a density level and a component's toggle key already
go through. Not a second answer to "what does this frame look like now".

Three rules, each a hazard #536 named:

* **It waits.** `_SETTLE_SECONDS = 0.4`, a trailing-edge wait rather than a debounce, because
  `notify._last` works only where one process makes every call and every one of these
  children is its own process. The number is a floor with a measurement under it: the tmux
  command list `_relayout` issues to grow a frame from two panes to four took a **median 72ms
  over 5 runs** on tmux 3.7c (69–72), before either new panel's cold charter import. Pinned
  by `TheSettleIsLongEnoughToBeOne`, in its own fixture-free class — every class that drives
  `cmd_resize` has to patch the constant, and a test reading a constant its own `setUp`
  replaced is asserting against the patch.
* **It never drops the last pane.** `_relayout` with an empty want-list makes
  `_install_resize_hook` remove the `window-resized` hook — correctly, and that is a one-way
  door reached from here, since the hook is the only thing that would notice the terminal
  being widened again. Below half the size floors the frame keeps what it has, exactly as
  before. A density change reaching the same state is a keypress, and can be followed by
  another one.
* **What the operator chose is never undone.** The recompute starts from `_visible_now` —
  this frame's arrangement minus its own hidden set — never from `config.FRAME["slots"]`, and
  that value is read **once** and used for both the decision and the payload.

End to end against a real tmux, through a real hook and a real child, in
`test_a_real_drag_across_the_table_width_removes_the_pane_and_brings_it_back`: 160 → 80 → 160,
asserted on the frame's own record (the last thing `_apply_arrangement` writes) and then on
the window's pane count.

**Known and bounded:** a frame with a slot that permanently fails to `split-window` now
retries it once per settled window size, where before it never retried at all. That is the
correct behaviour for the ordinary case (a transient failure at launch) and costs a re-layout
per settled resize in the pathological one.

## Verification

* **CI green at this head sha**, read from `gh api repos/diazoxide/charter/commits/<sha>/check-runs`
  rather than `gh pr checks` (#561): `test (3.11)`, `test (3.12)`, `test (3.13)`,
  `test (3.14)` all `success`.
* **Full suite locally, two environments.** python3.14.4 with `COLUMNS=200`: **6741 tests, OK** (355s).
  python3.12.13 with `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset: **6741 tests, OK** (422s).
  `$COLUMNS` is set explicitly in both (it flips a test today — #544).
* **Baseline on `main`, for the record:** 6703 tests, one failure, and it is #591's.
* **Real tmux 3.7c** for every resize claim: the proportional-redistribution measurement, the
  two-pass agreement at four window widths, the `_relayout` cost, and the two integration
  tests above. Servers are killed **and** their sockets unlinked in one cleanup, through the
  fixtures' own `_teardown_socket`; nothing leaked (checked).
* **`tools/sweep.py`**, run twice. The first run (19 mutations, unmutated baseline green at
  6741) reported **4 survivors**; each is fixed below and the second run reports **18 of 19
  pinned**, its one survivor being `_apply_arrangement`'s `window if window is not None else
  _window_size(...)`. That is now pinned too, by
  `test_the_layout_uses_the_measurement_that_settled_not_a_fresh_one`, verified by applying
  the sweep's own mutant text by hand: **RED with it, GREEN without**. It is the same defect
  as #501 one layer up — a re-layout laid out for a window nobody checked.
* **Hand-checked mutations, reported separately** because sweep has no operator for a string,
  a regex or a semantic swap (#569): **26 built, 26 caught, 0 survivors**, from a verified
  green unmutated baseline (#579 — a hand-check without one is not a verdict). Every mutation
  asserts its edit matched exactly once and that the file took it, so none of them ran an
  unmutated tree (#585/#586). They include both flag swaps in `_apply_sizes`, the
  `#{pane_width}` → `#{window_width}` format swap, `_SETTLE_SECONDS` → 0, `_window_still` →
  `True`, `_visible_now` → the config, and the two constants.
* **The first sweep found 4 survivors and all four were the "a second line hides the
  consequence" shape** the coordinator warned has appeared seven times here. Each is fixed
  rather than declared equivalent:
  * `_variable_pane_cols`' pane-id guard — deletable, because the derivation answered either
    way; the observable is what was *issued*, so it is asserted on the argv now.
  * its `out.returncode == 0` conjunct — masked by `cols.isdigit()`, except that
    `tmuxctl.run` folds a TIMEOUT into a return code and hands back a partial read that can
    parse. Pinned with a failure whose stdout is a good number.
  * `column_sizes`' edge filter — masked by `_apply_sizes`' own `_RESIZE_FLAG` filter
    downstream. `column_sizes` is asked its own question now.
  * `_DEFAULT_COLS`' value — retune-survivor; pinned as agreeing with
    `commands_frame._FALLBACK_SIZE`, since "how big is a rectangle nobody can measure" must
    have one answer.
  * A hand-check found a fifth of the same shape: `want` computed from the config while
    `_apply_arrangement` still got `_visible_now`'s answer laid the frame out *correctly* and
    only cost a settle wait and a version bump on a resize with nothing to do. The two reads
    are one read now, pinned by a frame that is already its own shape never waiting.
* Also removed: a `break`/`continue` pair in `_variable_pane_cols` that could never differ,
  since `layout.VARIABLE_ROW_SLOTS` holds exactly one slot by construction.

News entry at `version: unreleased`. No bump, no stamp, no tag. `docs/frame.md` and the
`repo-table-becomes-its-own-panel` entry both said "a resize changes sizes, not which panes
exist"; both are corrected, since that entry ships in the same release.

Closes #591, closes #510, closes #536, closes #501.
