### PR TITLE
The frame reads as an application, and tmux is what paints the background (spec §5, Phases 1–2)

### DIFF
--- a/charter.toml
+++ b/charter.toml
@@ -31,6 +31,17 @@ default = "steward"
 # more — it drew a 22-column copy of the rows `repos` now draws at full width.
 slots = ["top", "bottom", "repos", "right"]
 
+# This plane opts into the pane surface. `off` is the shipped default and stays that way:
+# charter cannot detect a terminal's theme (OSC 11 through tmux answers nothing, and
+# `$COLORTERM` inside a pane describes the terminal that started the SERVER, not the one
+# looking at the pane), so no colour is right on both themes and a default that repaints a
+# stranger's terminal can make an upgraded frame worse for them. This file is not a
+# stranger's — it is this plane's own, and this plane's operator asked for the look. Same
+# posture and same recorded reason as `[frame] mouse`: `FRAME_DEFAULTS` says what a plane
+# looks like before anybody has said anything, and this line says what THIS one looks
+# like. Three words: `off`, `dark`, `light`.
+chrome = "dark"
+
 [update]
 # Track main instead of the last release. `charter update` installs straight from git;
 # nothing is published, and PEP 610 gives `charter --version` the exact commit.

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -141,6 +141,10 @@ from .frame import (builtin_actions, choose, component, gather, layout, overlay,
 # lookup after that point would silently resolve to the wrong thing (an `AttributeError`
 # on a `list`, not a helpful one).
 from .frame import slots as frame_slots
+# Aliased for the same reason: `_split_panels` names its resolved `[frame] chrome` word
+# `chrome`, and `_surface_argvs` takes it as a parameter of that name — the module and
+# the value are two different things and the value is the one the reader is following.
+from .frame import chrome as chrome_mod
 
 #: One shared tmux server for every frame this machine runs, sessions (not servers) told
 #: apart by name — the frame id. Never the operator's own default socket: a frame's
@@ -1602,6 +1606,55 @@ def _chrome_argvs(*, socket: str, harness_pane: str) -> list[list[str]]:
             for name, value in _CHROME]
 
 
+def _surface_argvs(*, socket: str, pane_id: str, chrome) -> list[list[str]]:
+    """`set-option -p`: the pane surface `[frame] chrome` asked for, on ONE panel pane.
+
+    **tmux paints the background; charter sets an option.** `window-style` and
+    `window-active-style` are settable pane-scoped on 3.7c, and tmux fills the pane's
+    whole rectangle from them — the cells no renderer wrote included, on resize, on
+    reattach. Measured, three panes with styles on the two panels and not on the harness,
+    and what tmux then put on an attached client's wire::
+
+        HARNESS : b'...\\x1b(B\\x1b[m\\x1b[1;1HHARNESS'        <- no colour at all
+        PANELA  : b'...\\x1b[K\\x1b[48;5;24m\\x1b[2BPANELA'    <- the ACTIVE style
+        PANELB  : b'...\\x1b[K\\x1b[48;5;236m\\x1b[2BPANELB'   <- the INACTIVE style
+
+    So nothing here is on the repaint path (constraint 3 is untouched because nothing new
+    repaints), the fill has no width to get wrong and therefore cannot wrap a pane
+    (constraint 5, #553), and the focused/unfocused split is drawn by tmux from its own
+    pane focus — it needs no `focus-events` and works inside an operator's own tmux where
+    charter writes no config at all.
+
+    **PANE-scoped, and that is the whole of the harness boundary.** `-p -t <pane id>`
+    reaches exactly the pane charter just split off for a panel; the harness pane is never
+    an argument here, so ADR 0018's line — charter "never decides what a cursor or a
+    colour means inside it" — holds by construction rather than by care. Read back rather
+    than intended: `show -p -t <harness> -v window-style` answers `''`.
+
+    **It survives a panel respawn**, which a renderer-side fill would not: `pane-died`
+    respawns a dead panel into the SAME pane, and these are properties of the rectangle
+    rather than of the process in it.
+
+    *chrome* is the word from `[frame] chrome`, and `instance.chrome_options` is what
+    turns it into styles — so what reaches tmux is charter's own constant whatever the
+    word was. An unknown word yields no commands at all, which is `off`.
+
+    All four of charter's panes, not only the two bars: two chrome-coloured panes beside
+    two uncoloured ones is a frame that does not match itself.
+
+    **`NO_COLOR` refuses this, and that is the half that is easy to miss.** The fill is
+    tmux's paint, not charter's, so gating only the panels' own SGR would leave an
+    operator who asked for no colour looking at a coloured frame — charter having asked
+    somebody else to paint it. `NO_COLOR` means no colour on their screen caused by
+    charter, whichever process puts the bytes there. Asked through `chrome.no_colour` so
+    there is one reading of the variable and not a second one out here (#547).
+    """
+    if chrome_mod.no_colour():
+        return []
+    return [tmuxctl.server_argv(socket, "set-option", "-p", "-t", pane_id, name, value)
+            for name, value in instance.chrome_options(chrome)]
+
+
 def _panel_remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
     """`set-option -w`: keep dead panes in CHARTER'S OWN WINDOW, and in no other.
 
@@ -1948,6 +2001,14 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     the only way for the two servers to agree about them is for one call site to set them
     on both.
 
+    **And the pane SURFACE is set here too, one pane at a time** (`_surface_argvs`). It
+    is the same funnel and the same argument, one scope down: `window-style` is a PANE
+    option, so unlike the border it has to be set on each panel as it appears — which is
+    also exactly why the harness pane never gets it. Both launch paths and every density
+    change reach panels through this function, so a frame cannot come out surfaced on one
+    server and bare on the other, and a pane added by a later `_relayout` is surfaced when
+    it is created rather than by a second pass that could forget it.
+
     Reported but not fatal, like the splits themselves: a frame whose panels cannot be
     respawned is still a frame, and the harness pane's own `remain-on-exit` was armed
     separately and earlier (`_remain_on_exit_argv`), so the exit code does not ride on
@@ -1971,6 +2032,12 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     # each successfully-created pane belongs to (for its size and its resize-pane flag),
     # and `panel_argvs` returns exactly one command per slot, in the same order (see its
     # own docstring).
+    # The word, resolved once for the whole batch: `config.FRAME` is a plane's own file
+    # and cannot change between two splits, and `instance.chrome_options` is what turns
+    # it into styles — so a value charter does not know produces no commands at all,
+    # which is `off`. `.get` rather than `[...]`: a frame relaunched by a charter that
+    # predates this key has a resolved config without it.
+    chrome = config.FRAME.get("chrome")
     panes: dict[str, str] = {}
     for slot, cmd in zip(slots, panel_cmds):
         # Reported by `tmuxctl.run` but not fatal: one decorative panel failing to draw
@@ -1982,6 +2049,13 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
         pane_id = p.stdout.strip()
         if pane_id and _PANE_ID_RE.fullmatch(pane_id):
             panes[slot] = pane_id
+            # The pane surface, on the pane that was just created and on no other — the
+            # one place charter has a panel's `%N` in hand. The harness pane is never an
+            # argument (`_surface_argvs`), which is how ADR 0018's boundary holds by
+            # construction. Not fatal, like the splits: a frame whose panes kept the
+            # terminal's own background is a frame that looks plainer, not one that fails.
+            for surface in _surface_argvs(socket=socket, pane_id=pane_id, chrome=chrome):
+                tmuxctl.run("painting a panel's surface", surface, env=env)
     return panes
 
 

--- a/charter/frame/chrome.py
+++ b/charter/frame/chrome.py
@@ -1,0 +1,271 @@
+"""The frame's paint: filling a row to the pane's edge, and highlighting one.
+
+**Everything here takes a FINISHED row** — a string some `tui` node has already
+composed and clamped — and hands back a string that must not go back through `tui`.
+That ordering is the whole reason this module exists rather than a `tui` node.
+`tui._finish` strips trailing whitespace, *including* whitespace hiding behind trailing
+SGR escapes, and it is right to: `tui` also draws the status line, which writes into a
+line it does not own and must never leave painted cells trailing across somebody else's
+prompt. Measured on this machine, a 20-cell fill in and an 8-cell line out, both ways
+round::
+
+    fill inside the span  in ='\\x1b[48;5;236m charter            \\x1b[0m'   width 20
+                          out='\\x1b[48;5;236m charter\\x1b[0m'               width  8
+    pad outside the span  in ='\\x1b[48;5;236m charter\\x1b[0m            '   width 20
+                          out='\\x1b[48;5;236m charter\\x1b[0m'               width  8
+
+So a caller who reverses the order — fills first, composes second — gets a row that
+silently comes back at its natural width with the paint gone, and nothing raises.
+Compose through `tui` as today, **then** hand the finished string here.
+
+**Charter does not paint the pane's background.** tmux does, per pane, from
+`window-style`/`window-active-style` (`instance.FRAME_CHROME`), which is why nothing
+in this module is on the repaint path for a *surface*. What is here is the one element
+that cannot be a pane option: a single row picked out of a list.
+
+**Nothing here names a colour.** Reverse video is defined as the operator's own
+foreground and background exchanged, so it is correct on every theme — including the
+Solarized palettes, where every named grey charter could have chosen *is* somebody's
+background — and it survives every terminal tier tmux downsamples for: `tui.sanitize`
+keeps SGR 7, tmux passes `ESC[7m` through to `xterm` and `vt100` alike, and on a client
+with no colour at all tmux converts its own colour *to* reverse.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+from .. import tui
+
+#: Reverse video on, and everything off. `_OFF` is a FULL reset rather than SGR 27
+#: ("reverse off"): a row that left an attribute open — a provider's, or a charter row
+#: after a future edit — would otherwise carry it past the end of the highlight into the
+#: rest of the pane. Reverse is one of the attributes a full reset clears, so this is the
+#: stronger form of the same statement rather than a different one.
+_REVERSE = "\x1b[7m"
+_OFF = tui.RESET
+
+#: One SGR escape, with its parameter list captured. Deliberately the same shape
+#: `tui._SGR` matches, because :func:`tui.sanitize` has already deleted everything else
+#: that claims to be an escape by the time a row reaches this module.
+_SGR = re.compile(r"\x1b\[([0-9;]*)m")
+
+
+def resets_everything(params: str) -> bool:
+    """True when the SGR parameter list *params* turns every attribute off.
+
+    **The property is the NUMBER, not the spelling**, and this function exists because
+    the first version of :func:`reverse` got that wrong in the way this project has now
+    got it wrong six times (#547, #558, #537, #498, #577, #594). "An SGR that resets
+    everything" is not the string ``\\x1b[0m``. It is a parameter list containing a
+    parameter whose *numeric value* is zero — and an **empty** parameter is zero (ECMA-48
+    §5.4.2: an omitted parameter takes its default, and SGR's default is 0), and leading
+    zeros are legal digits. Measured, the six spellings that matter::
+
+        spelling      params    string-match ("" or "0")   numeric value == 0
+        '\\x1b[0m'     '0'       True                       True
+        '\\x1b[m'      ''        True                       True
+        '\\x1b[00m'    '00'      False   <- MISSED          True
+        '\\x1b[1;00m'  '1;00'    False   <- MISSED          True
+        '\\x1b[2m'     '2'       False                      False
+        '\\x1b[22;39m' '22;39'   False                      False
+
+    A row carrying ``\\x1b[00m`` would highlight for half its width and every test
+    written against ``\\x1b[0m`` would pass. Charter writes ``\\x1b[0m`` today
+    (`statusline._R`), so the string test would be right about charter's own rows and
+    wrong about a provider's — and what a provider writes is not charter's to choose.
+
+    ANY zero in the list, not only a leading one: parameters apply left to right, so
+    ``1;0`` is bold-then-reset and ``0;1`` is reset-then-bold. Reverse is off after
+    either, which is the question this answers.
+    """
+    # Every piece is digits or empty — `_SGR` admits nothing else — so `int` cannot
+    # raise here, and an empty piece is spelled as the zero it means.
+    return any(int(p or "0") == 0 for p in params.split(";"))
+
+
+#: SGR parameters that turn reverse video off: 0 (everything off) and 27 (reverse off).
+#: Named as a set so :func:`cancels_reverse` reads as the question it asks.
+_REVERSE_OFF = frozenset({0, 27})
+
+
+def cancels_reverse(params: str) -> bool:
+    """True when the SGR parameter list *params* leaves reverse video OFF.
+
+    :func:`resets_everything`'s question asked about one attribute — the same numeric
+    reading, and **one parameter more**: SGR 27 turns reverse off on its own without
+    touching anything else. Charter writes no `\\x1b[27m` today, but a provider's
+    component is ordinary Python writing into a row charter is about to highlight, and a
+    highlight that survived `\\x1b[0m` and died at `\\x1b[27m` would be the same defect
+    with a different spelling.
+
+    Not folded into :func:`resets_everything`, because the two are asked by different
+    callers about different things: `_split_at_close` wants to know whether a trailing
+    escape leaves any span open, and `\\x1b[27m` leaves a colour open.
+    """
+    return any(int(p or "0") in _REVERSE_OFF for p in params.split(";"))
+
+
+def no_colour() -> bool:
+    """Whether the operator has asked for no colour at all.
+
+    **One question asked in one place.** Two implementations of "did they set
+    ``NO_COLOR``" is how the two come to disagree about ``NO_COLOR=""``, which is #547's
+    shape and the reason this is a function rather than a check spelled at each call
+    site — here, in :func:`colour_ok`, and in `commands_frame._surface_argvs`, which is a
+    different process on a different path asking the same thing.
+
+    Honoured by **presence**, per the `no-color.org` convention: any value, including the
+    empty string and ``0``, means no colour. Matching a *value* (``== "1"``) would be the
+    spelling-not-property mistake in the one file that is about that mistake — and it is
+    the reading that breaks first, because a shell that exports ``NO_COLOR=`` has set it.
+
+    **It reaches the tmux surface too**, which is the half that is easy to miss. The pane
+    background is painted by tmux rather than by charter, so gating only charter's own
+    SGR would leave an operator who asked for no colour looking at a coloured frame —
+    charter having asked somebody else to paint it. That is honouring the letter of the
+    promise and not the property.
+    """
+    return os.environ.get("NO_COLOR") is not None
+
+
+def colour_ok() -> bool:
+    """Whether the frame may emit SGR into this pane.
+
+    :func:`no_colour` and one more question. ``isatty`` does almost nothing in a real
+    frame and is here for completeness rather than as the mechanism: a panel's stdout
+    *is* its pane, so it is always a tty in production. The one case it catches is the
+    redirect `panel.py`'s own docstring documents — ``charter panel top --session x >
+    /tmp/log`` — which before this wrote a clear-screen and full SGR into a file.
+    """
+    if no_colour():
+        return False
+    try:
+        return bool(sys.stdout.isatty())
+    except (AttributeError, ValueError):
+        # A closed or exotic stdout answers neither; a frame that cannot tell does not
+        # colour, which is the direction `NO_COLOR` already points.
+        return False
+
+
+def plain(row: str) -> str:
+    """*row* as the text a terminal with no colour would show — every SGR removed.
+
+    Trailing whitespace goes with it, which is :func:`fill`'s pad: with nothing painted
+    there is nothing for it to paint, and a row of invisible spaces is only something to
+    copy out of the pane by accident.
+    """
+    return tui.strip_ansi(row).rstrip()
+
+
+def _split_at_close(row: str) -> tuple[str, str]:
+    """*row* split where a pad belongs: before a trailing run that only CLOSES a span.
+
+    The pad has to land where the row's style is the style the pad should carry, and
+    that position is not "the end" and not "before the last escape" — it depends on what
+    the trailing escapes do:
+
+    * ``'\\x1b[48;5;236m charter\\x1b[0m'`` ends by closing its span, so the pad goes
+      **inside** it — before the reset — or the fill stops at the text.
+    * ``'…\\x1b[0m\\x1b[7m'`` (what :func:`reverse` composes) ends with a span still
+      OPEN, so the pad goes **after** it and is painted.
+
+    So the split is at the start of the trailing SGR run **only when every escape in it
+    resets everything**. Asked as a property of the parameters (:func:`resets_everything`)
+    rather than by looking for ``\\x1b[0m``.
+    """
+    start = len(row)
+    for m in reversed(list(_SGR.finditer(row))):
+        if m.end() != start:        # the trailing run has ended: text below it
+            break
+        if not resets_everything(m.group(1)):
+            return row, ""          # a span is still open — the pad belongs after it
+        start = m.start()
+    return row[:start], row[start:]
+
+
+def fill(row: str, width: int) -> str:
+    """*row* padded to exactly *width* visible cells, the pad inside its style span.
+
+    Takes a **finished** row (see the module docstring) and returns one that must not be
+    handed back to `tui`.
+
+    **Exactly *width*, never more, and the clamp is not decoration.** Measured in a real
+    20-column tmux pane, one row each at W−1, W and W+1 cells::
+
+        row 0: '\\x1b[48;5;196mAAAAAAAAAAAAAAAAAAA\\x1b[49m '   <- 19 cells: bg stops short
+        row 1: '\\x1b[48;5;46mBBBBBBBBBBBBBBBBBBBB'            <- 20 cells, exactly W: SAFE
+        row 2: '\\x1b[48;5;21mCCCCCCCCCCCCCCCCCCCC'            <- 21 cells: wraps…
+        row 3: 'C\\x1b[49m    '                                <- …one cell onto the next
+        row 4: '\\x1b[48;5;226mDDD\\x1b[49m  '                  <- every row below shifted
+
+    Exactly W is safe — the deferred-wrap state is resolved by the following newline and
+    produces no blank row. **W+1 shears the pane**, which is #553 arriving through a new
+    door. Today's rows are ragged and short, so an off-by-one is a cosmetic gap; a row
+    painted to the edge is one cell from shearing. `tui.truncate` is what enforces it, so
+    an over-wide row comes back cut with an ellipsis rather than wrapped — the same
+    answer every other row in the frame already gets, and a visible one.
+
+    *width* must be the width the RENDERER measured (`slots._width()`, the pane's own
+    tty). A panel inherits the launching shell's `$COLUMNS` whole — measured, a
+    22-column pane whose launcher had exported `COLUMNS=200` — so a fill computed at 200
+    in a 22-column pane wraps every row four times over. One measurement, not two.
+
+    **A pane with no columns at all gets nothing, and that is `tui.truncate`'s refusal
+    rather than a second one here.** An `if width <= 0: return ""` above this line was
+    written first and then deleted: `truncate` already answers `""` for a non-positive
+    width, so the pad below is never reached and the guard could not change an outcome.
+    A line that cannot is not documentation of an intent — it is a second, weaker answer
+    to a question that was already answered, which is why #568 deleted the last one of
+    those. `reverse` keeps its own, because there it is live.
+    """
+    row = tui.truncate(row, width)
+    # `" " * n` is "" for every n <= 0 and `_split_at_close` partitions the row, so a row
+    # that already fills the pane comes back out of this line unchanged. An
+    # `if gap <= 0: return row` above it was written first and deleted: the deletion
+    # sweep found it surviving, correctly — it could not change an outcome.
+    head, close = _split_at_close(row)
+    return head + " " * (width - tui.width(row)) + close
+
+
+def reverse(row: str, width: int) -> str:
+    """*row* highlighted to the pane's last column: full-width reverse video.
+
+    **A highlight cannot be a wrapper around an already-composed row**, and that is the
+    defect this function exists to answer. Charter's rows carry `statusline._R` after
+    every coloured span, and a full reset cancels *reverse* along with everything else.
+    Measured, the real sidebar row wrapped naively::
+
+        row : '\\x1b[35m▸ \\x1b[1msteward\\x1b[0m   \\x1b[32m✎47\\x1b[0m'
+        out : '\\x1b[7m\\x1b[35m▸ \\x1b[1msteward\\x1b[0m   \\x1b[32m✎47\\x1b[0m<pad>\\x1b[27m'
+                                                ^^^^^^^^ reverse ends here, 22 chars in
+
+    The row is highlighted for two words and plain for the rest. So reverse is
+    **re-asserted after every SGR that leaves it off** — and what counts as one is
+    :func:`cancels_reverse`'s numeric question, not a search for ``\\x1b[0m``. Its
+    parameter 27 half is not hypothetical tidiness: a provider's component writes into a
+    row charter is about to highlight, and a highlight that survived ``\\x1b[0m`` and
+    died at ``\\x1b[27m`` would be the same defect wearing a different number.
+
+    **Only where it was cancelled, and not after every escape.** Re-asserting
+    unconditionally keeps the row highlighted just as well and says so three times as
+    often — bytes written into a pane on every repaint that change nothing on the screen.
+
+    Applied to the row a renderer has already finished, at the width that renderer
+    measured. It needs no `[frame] chrome` gate: reverse names no colour, so there is no
+    theme it can be wrong on.
+
+    **The no-columns refusal is live here and it is not in `fill`.** Without it a pane of
+    zero width still gets `_OFF` written into it — a bare `\\x1b[0m` where the caller
+    asked for nothing at all. `fill` needs no such line because `tui.truncate` answers
+    the same question one call earlier; `reverse` appends after that answer, so it has to
+    ask for itself.
+    """
+    if width <= 0:
+        return ""
+    body = _SGR.sub(
+        lambda m: m.group(0) + (_REVERSE if cancels_reverse(m.group(1)) else ""),
+        tui.truncate(row, width))
+    return fill(_REVERSE + body, width) + _OFF

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -97,7 +97,7 @@ import sys
 import time
 
 from .. import contain, tui
-from . import slots, state
+from . import chrome, slots, state
 
 #: How often the version file is checked when nothing else has woken this panel. A
 #: `stat` at this rate is indistinguishable from zero cost (see `state.version`'s own
@@ -140,9 +140,42 @@ def _write(text: str) -> None:
     the same clear-then-write discipline as a panel doing its job, rather than a second
     hand-rolled write that could leave half of tmux's own dead-pane text on screen
     beside it.
+
+    **The clear is prefixed with a reset, because `\\x1b[2J` erases with whatever
+    attributes are currently set.** A renderer that leaves a background on — a
+    provider's, or charter's own after a future edit — makes the NEXT repaint's
+    clear-screen fill the whole pane with it. Measured in a real 20-column pane: after a
+    paint that omitted its reset, the following `\\x1b[H\\x1b[2J` + content came out with
+    row 0 carrying the leaked background and every other row filled with it, and nothing
+    in the session ever cleared it. Constraint 4 still holds — it costs that pane and no
+    other — but it cost it for the rest of the session rather than for one paint. One
+    escape, on a path that already writes two.
+
+    It goes BEFORE the cursor-home rather than after the clear, so
+    ``split("\\x1b[2J", 1)[1]`` still answers the content: four test call sites read the
+    pane that way (`tests/test_frame_panel.py:129,172,193`,
+    `tests/test_component_id_is_the_currency.py:110`).
+
+    **And this is where `NO_COLOR` is honoured** (`chrome.colour_ok`), because it is the
+    one place anything reaches a pane's screen — so a component charter did not write is
+    covered by the same answer as a renderer charter did, and neither has to ask. The
+    strip is `tui.strip_ansi` per LINE and never over the whole write: `sanitize` drops
+    every CSI that is not SGR, so stripping the assembled string would delete the
+    clear-screen that makes a repaint a repaint.
     """
     lines = text.split("\n")[:_rows()]
-    sys.stdout.write("\x1b[H\x1b[2J" + "\n".join(lines))
+    if not chrome.colour_ok():
+        # No SGR at all, the reset included: there is nothing to reset when nothing is
+        # painted, and "no colour on the operator's screen caused by charter" is the
+        # promise rather than "no colour except charter's own housekeeping".
+        return _out("\x1b[H\x1b[2J" + "\n".join(chrome.plain(ln) for ln in lines))
+    _out("\x1b[m\x1b[H\x1b[2J" + "\n".join(lines))
+
+
+def _out(payload: str) -> None:
+    """The write itself — one statement, so the two branches above cannot come to
+    disagree about flushing."""
+    sys.stdout.write(payload)
     sys.stdout.flush()
 
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -803,6 +803,34 @@ _NAME_MIN_W = 12
 #: that it does, not a replacement for it.
 _MAX_TODO_LINES = 8
 
+#: The screen column every row's content starts in, everywhere in the frame — one
+#: constant, read, rather than a `"  "` spelled at each call site.
+#:
+#: It is `statusline._HEAD_PAD`'s own width, and `TheInsetIsOneConstant` pins the two
+#: equal rather than this module importing `statusline` at import time (every other
+#: reference here is a deliberate function-level import — a panel repaints on a clock and
+#: `statusline` is the largest module charter has). So the number lives here and the
+#: agreement is a test, which is the same trade `panel._DEFAULT_ROWS` makes with
+#: `slots._DEFAULT_ROWS`.
+#:
+#: "Content is inside something" is what an inset says, and it says it for free: no row
+#: is added, no width changes, and the value is the one already in use. What changes is
+#: that a renderer added next year asks for it instead of typing two spaces, which is how
+#: the sidebar's sections came to line up in the first place (`_HEAD_PAD`'s own comment
+#: in `statusline.py` records the two ways that shipped broken).
+INSET = 2
+
+
+def _inset(marker: str = "") -> str:
+    """*marker* fitted to exactly :data:`INSET` columns — a row's own left edge.
+
+    `tui.pad`, never `marker + " "`: `_persona_chip_cells`' own comment records that this
+    layout has twice been broken by a glyph a font drew wider than the Unicode tables
+    claim, and `pad` measures with `tui.width` so a two-cell marker takes the inset it
+    already has rather than pushing its row one column right of every other.
+    """
+    return tui.pad(marker, INSET)
+
 
 def _sidebar_head(label: str, count: int, width: int) -> str:
     """One section heading for the `right` sidebar — ``▪ personas 6``.
@@ -818,9 +846,23 @@ def _sidebar_head(label: str, count: int, width: int) -> str:
     comment in `statusline.py` records that a decorative glyph on a header shipped broken
     twice: a header is the one row with no sibling beneath it to reveal that a font drew
     it wider than the Unicode tables claim.
+
+    **The label is BOLD and the count stays dim, and no row is added.** A region with a
+    name is what makes a pane read as part of an application rather than as output, and
+    weight is the whole of what it costs here: `tui.strip_ansi` sees `▪ personas 6`
+    before and after, the width arithmetic is untouched (SGR is zero columns), and the
+    fifteen-plus tests that assert a panel's exact LINE COUNT never learn this happened.
+    A heading ROW is the change with the widest blast radius in the frame and it buys
+    nothing weight does not.
+
+    Bold on the label only. The marker keeps the dim it had — it is furniture, not the
+    name — and the count keeps it too, so the heading reads as one word with a number
+    after it rather than as two equal facts.
     """
     from .. import statusline as sl
-    return tui.truncate(f"{sl._DIM}{sl._HEAD_PAD}{label}{sl._R} {count}", width)
+    return tui.truncate(
+        f"{sl._DIM}{sl._HEAD_PAD}{sl._R}{sl._BOLD}{label}{sl._R}{sl._DIM} {count}{sl._R}",
+        width)
 
 
 def _persona_total(cells) -> int:
@@ -855,7 +897,8 @@ def _cap_personas(cells: list, keep: int) -> list:
     shown = cells[:max(0, keep - 1)]
     hidden = _persona_total(cells[len(shown):])
     return [*shown,
-            sl.PersonaChip(None, f"{sl._DIM}  …(+{hidden} more){sl._R}", "", hidden)]
+            sl.PersonaChip(None, f"{sl._DIM}{_inset()}…(+{hidden} more){sl._R}", "",
+                           hidden)]
 
 
 def _persona_rows(cells: list, width: int) -> list[str]:
@@ -955,8 +998,10 @@ def _todo_rows(data: dict, width: int, budget: int) -> list[str]:
         #
         # Two columns of marker, so a title begins in the same column as a persona name
         # and as both headings — `_HEAD_PAD` exists to make that one column, and a section
-        # whose rows started somewhere else would undo it.
-        rows.append(tui.truncate(f"{sl._DIM}-{sl._R} {title}", width))
+        # whose rows started somewhere else would undo it. :data:`INSET` is that column,
+        # asked for rather than spelled: a marker plus a hand-typed space is the same
+        # arithmetic done again, and the second copy is the one that moves.
+        rows.append(tui.truncate(f"{sl._DIM}{_inset('-')}{sl._R}{title}", width))
     hidden = total - len(shown)
     if hidden > 0:
         # The count alone, with no command beside it — unlike `_persona_chip_cells`'
@@ -965,7 +1010,7 @@ def _todo_rows(data: dict, width: int, budget: int) -> list[str]:
         # `…(+4 more · charter ws todo)` is 28: the command would be cut off on every
         # frame charter actually draws, and half a command name is worse than none —
         # it is a thing to type that does not work.
-        rows.append(tui.truncate(f"{sl._DIM}  …(+{hidden} more){sl._R}", width))
+        rows.append(tui.truncate(f"{sl._DIM}{_inset()}…(+{hidden} more){sl._R}", width))
     return rows
 
 
@@ -986,7 +1031,26 @@ def persona_section(width: int, height: int, *, terse: bool) -> list[str]:
     A plane with no personas at all says so in one line. It is not an empty column:
     an empty column is indistinguishable from a pane that failed to draw, which is the
     reading the frame refuses everywhere else.
+
+    **The active persona's row is the whole row, in reverse video, to the pane's edge**
+    — the element that most makes a list read as a list you are *in* rather than a list
+    you are looking at. Three things about where it is applied:
+
+    * **To the FINISHED row `_persona_rows` returns**, never to the cells it composes.
+      Line 892 is a `tui.Row(...).render(width)[0]` and `tui._finish` deletes a pad that
+      goes in before it — measured, a 40-cell highlighted row back at 15 (`chrome.py`).
+    * **Here, not in `_right`**, so the composite pane and its `personas` component reach
+      it through the same helper. `tests/test_builtin_components.py:272` asserts raw byte
+      equality between `slots.render("right")` and its two parts joined; a highlight
+      applied one level up would be the one thing the two sides did not share.
+    * **From `PersonaChip.active`**, which the chips carry as data — not by looking for
+      `▸` or magenta in a rendered head.
+
+    It needs no `[frame] chrome`: reverse video names no colour (it is the operator's own
+    foreground and background exchanged), so it is right on every theme, and tmux
+    converts even its own colours to reverse on a client that has none.
     """
+    from . import chrome
     from .. import statusline as sl
     cells = sl._persona_chip_cells()
     if not cells:
@@ -995,8 +1059,10 @@ def persona_section(width: int, height: int, *, terse: bool) -> list[str]:
     if terse:
         keep = min(keep, _TERSE_ROWS)
     cells = _cap_personas(cells, keep)
+    rows = _persona_rows(cells, width)
     return [_sidebar_head("personas", _persona_total(cells), width),
-            *_persona_rows(cells, width)]
+            *(chrome.reverse(row, width) if c.active else row
+              for c, row in zip(cells, rows))]
 
 
 def todo_section(fid: str, width: int, budget: int, *, terse: bool) -> list[str]:

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -498,6 +498,92 @@ def density_slots(level) -> list[str]:
     return list(FRAME_DENSITY[lv]["slots"]) if lv else []
 
 
+#: What ``[frame] chrome`` may say, and the pane options each word means.
+#:
+#: **The surface is tmux's, not charter's.** ``window-style`` and ``window-active-style``
+#: are settable PANE-scoped, and tmux fills the pane's whole rectangle from them —
+#: including the cells no renderer wrote, on resize, on reattach, at zero cost on the
+#: repaint path. So charter sets an option and never paints a fill: nothing new is on the
+#: repaint path, a background cannot wrap a pane, focused-versus-unfocused comes from
+#: tmux's own pane focus for free, and the harness pane is untouched by construction
+#: rather than by care (ADR 0018). Measured on 3.7c: with these set on a panel pane,
+#: ``show -p -t <harness> -v window-style`` reads back ``''``.
+#:
+#: **Two named slots one step apart, and never an index.** ``black``/``brightblack`` and
+#: ``white``/``brightwhite`` are slots in the operator's own palette; ``colour236`` is a
+#: fixed point in the xterm cube that no theme moves. The sharp form of that argument is
+#: the inverse of the obvious one: an absolute colour is unsafe precisely on the terminals
+#: that render it faithfully — a 16-colour client gets charter's grey downsampled to the
+#: operator's own black and looks fine, while a truecolor client on a light theme gets it
+#: verbatim and looks broken. tmux is already the colour ladder (measured: 24-bit ->
+#: ``colour237`` -> ``ESC[40m`` -> ``ESC[7m`` as clients of four capabilities attached in
+#: turn), it recomputes it per client per attach, and a second ladder inside charter
+#: computed from ``$COLORTERM`` would be a second answer built on the one input measured
+#: to be stale (``COLORTERM`` is not in tmux's ``update-environment``, so a pane carries
+#: the terminal that started the SERVER, not the one looking at it).
+#:
+#: **``off`` is the default and there is no ``auto``.** Charter cannot detect the
+#: operator's background — OSC 11 through tmux got no answer in a second of reading, and
+#: 3.7c's own ``client-light-theme``/``client-dark-theme`` hooks did not fire against a
+#: pty client that answered — and ``window-style`` honours colour ONLY (``reverse``,
+#: ``dim`` and ``bold`` are accepted and silently ignored, measured), so the one
+#: theme-relative style is unavailable. A default that repaints a stranger's terminal can
+#: make a working frame WORSE on upgrade, which is the same asymmetry ``mouse`` is off
+#: for. An ``auto`` that resolved to ``off`` would be a config value that changes nothing
+#: while claiming to decide something; an ``auto`` that guessed would be a guess wearing
+#: the word for a measurement.
+#:
+#: **The value is a WORD and never a style string, and that is a containment boundary.**
+#: A tmux style value is format-expanded at draw time — measured, stored verbatim and
+#: evaluated: ``bg=#{?#{==:1,1},colour196,colour46}`` reached the wire as
+#: ``ESC[48;5;196m``. charter.toml is committed and arrives from someone else's machine,
+#: so a free style string there would be a committed value reaching a tmux evaluator,
+#: which is :data:`_HOTKEY_RE`'s class exactly. Execution was NOT achieved on 3.7c
+#: (``#(...)`` is refused by the style parser outright) and that is not the same as it
+#: being safe: the category is confirmed and one version was tested. The asymmetry
+#: ``_HOTKEY_RE`` already argues holds — a word charter refuses that an operator wanted
+#: costs them a rename; a style string charter accepted that tmux evaluates costs an
+#: unknown amount on a version nobody ran.
+#:
+#: Whole-frame, not per component: one frame has one look, and a colour key per component
+#: would be thirty knobs whose first product is a frame that does not match itself.
+FRAME_CHROME: dict[str, tuple[tuple[str, str], ...]] = {
+    #: Nothing set at all — `show -p` answers `''` for every pane and the frame is
+    #: whatever the operator's own terminal already was.
+    "off": (),
+    "dark": (("window-style", "bg=black"),
+             ("window-active-style", "bg=brightblack")),
+    "light": (("window-style", "bg=white"),
+              ("window-active-style", "bg=brightwhite")),
+}
+
+
+def chrome_level(name) -> str | None:
+    """*name* if it names a :data:`FRAME_CHROME` surface, else ``None``.
+
+    The one place a chrome value arriving from outside charter's own constants — a
+    hand-edited charter.toml, committed and shared — is admitted, and the whole of what
+    stands between `[frame] chrome` and a style string tmux would expand. ``isinstance``
+    first for :func:`density_level`'s reason: ``value in FRAME_CHROME`` raises
+    ``TypeError`` for an unhashable value (``tomllib`` can hand this a list or a table),
+    and this module is imported by every command including ``charter --version``.
+    """
+    return name if isinstance(name, str) and name in FRAME_CHROME else None
+
+
+def chrome_options(level) -> tuple[tuple[str, str], ...]:
+    """The ``(option, value)`` pairs *level* means — empty for anything charter does not
+    know, which is ``off``'s own answer and therefore the safe fallback.
+
+    Callers hand these to tmux, so what comes back is charter's own constant and never
+    the caller's argument: a value this function did not recognise cannot leave through
+    it, which is what makes "no operator string reaches tmux" a property of the code
+    rather than a promise about its call sites.
+    """
+    lv = chrome_level(level)
+    return FRAME_CHROME[lv] if lv else ()
+
+
 def verbosity_for(level) -> str:
     """How much each panel says at *level*. :data:`DEFAULT_VERBOSITY` for anything else.
 
@@ -589,6 +675,20 @@ FRAME_FIELDS = {
     #: The palette is the exception and does not need this flag: while it is open it is
     #: the active surface, so its own request is the one that reaches the terminal.
     "mouse": (False, "mouse"),
+    #: The pane surface, off by default — see :data:`FRAME_CHROME` for what the three
+    #: words mean, why there is no fourth, and why the value is a word rather than a
+    #: style. Off for `mouse`'s own reason, said about a different cost: a default that
+    #: can make an existing working frame WORSE on upgrade must be opt-in, and a
+    #: light-terminal operator upgrading into a default `dark` gets a frame worse than
+    #: the one they had, on a surface they never touched, having done nothing. A
+    #: dark-terminal operator upgrading into a default `off` gets a frame BETTER than the
+    #: one they had — the heading, the inset, the selected row and the status rule are
+    #: theme-safe and ship on — and one line short of the one they wanted. Those are not
+    #: symmetric, and the asymmetry is the argument.
+    #:
+    #: One word, so `docs/frame.md`'s hyphen rule (`history-limit`, not `history_limit`)
+    #: does not arise.
+    "chrome": ("off", "chrome"),
     "hotkey": ("F2", "hotkey"),
     "history_limit": (50000, "history-limit"),
     "min_cols": (100, "min-cols"),
@@ -691,10 +791,11 @@ def frame_of(cfg: dict) -> dict:
     module is imported by every command, including ``charter --version``, so a
     hand-edited charter.toml must degrade to the defaults rather than raise.
 
-    Three keys need more than a type check, and all three get it here rather than
+    Four keys need more than a type check, and all four get it here rather than
     downstream: ``slots`` is filtered against :data:`FRAME_SLOTS`, ``density`` against
-    :data:`FRAME_DENSITY`, and ``hotkey`` against :data:`_HOTKEY_RE` — see that constant
-    for the injection a bare ``isinstance(value, str)`` let through. All three degrade to
+    :data:`FRAME_DENSITY`, ``chrome`` against :data:`FRAME_CHROME`, and ``hotkey``
+    against :data:`_HOTKEY_RE` — see those two constants for the injection a bare
+    ``isinstance(value, str)`` lets through in each case. All four degrade to
     the shipped default, which is the contract every other key in this function already
     keeps: a charter.toml charter cannot make sense of never stops charter from running.
 
@@ -742,6 +843,14 @@ def frame_of(cfg: dict) -> dict:
             continue
         if key == "density":
             if density_level(value):
+                out[key] = value
+            continue
+        if key == "chrome":
+            # The closed enum, checked at the boundary the way `density` is — and for a
+            # sharper reason: a tmux style value is FORMAT-EXPANDED at draw time, so a
+            # bare `isinstance(value, str)` here would carry a committed string from
+            # someone else's machine into a tmux evaluator. See :data:`FRAME_CHROME`.
+            if chrome_level(value):
                 out[key] = value
             continue
         if key == "hotkey":

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1535,12 +1535,21 @@ class PersonaChip(NamedTuple):
     DATA rather than left to be read back out of the rendered text — a caller that wants
     the true total (a column heading, say) adds it to the rows that do name a persona,
     instead of parsing a sentence whose wording is a rendering choice.
+
+    *active* is whether this row is the persona the session is currently being — carried
+    as DATA for the same reason *hidden* is. The frame highlights that row across the
+    whole pane (`frame/chrome.reverse`), and the only other way to find it is to look for
+    `_MARK_ACTIVE` or `_MAGENTA` in the rendered head — which would tie a highlight to a
+    marker glyph and a colour name, exactly the spelling-for-property trade this class's
+    *hidden* field already refuses. Defaulted, so a caller building a chip by hand (the
+    fixtures in `tests/test_frame_slots.py` do) gets a row that is not the active one.
     """
 
     name: str | None
     head: str
     badges: str
     hidden: int = 0
+    active: bool = False
 
 
 def _persona_chips(session: str | None = None) -> list[str]:
@@ -1597,7 +1606,8 @@ def _persona_chip_cells(session: str | None = None) -> list[PersonaChip]:
             # so its width never reaches a name.
             head = (f"{_MAGENTA}{_MARK_ACTIVE} {_BOLD}{n}{_R}{dot}" if n == active
                     else f"{_DIM}{_MARK_IDLE} {n}{_R}{dot}")
-            chips.append(PersonaChip(n, head, f"{badge}{health}{flight}"))
+            chips.append(PersonaChip(n, head, f"{badge}{health}{flight}",
+                                     active=n == active))
         if len(chips) > _MAX_PERSONA_LINES:
             # Which ones survive matters more than how many. Keeping the first N
             # alphabetically would drop exactly the personas worth seeing, so the order is

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -201,8 +201,10 @@ the sentence above:
   five of the options tmux draws a border from — both border styles, plus
   `pane-border-lines`, `pane-border-indicators` and `pane-border-status` — so every rule in
   the frame is one colour and the frame looks the same in your tmux as in charter's own.
-  This is the one place charter overrides a preference of yours rather than deferring to
-  it, and the reason is that two of those options make one rule differ from its neighbour:
+  With `[frame] chrome` left at its default this is the only place charter overrides a
+  preference of yours rather than deferring to it; setting `chrome` adds a second, on
+  charter's own panel panes and never on the pane your harness runs in. The reason for
+  the borders is that two of those options make one rule differ from its neighbour:
   the active-pane colour and the arrow indicators mark some borders and not others, and
   `pane-border-status top` writes your hostname into every rule and takes a row the
   frame's height arithmetic never budgeted for. Window-scoped, so your own windows keep
@@ -441,6 +443,7 @@ none.
 slots = ["top", "bottom", "repos", "right"]
 density = "full"
 mouse = false
+chrome = "off"
 hotkey = "F2"
 history-limit = 50000
 min-cols = 100
@@ -555,6 +558,78 @@ the other way for `repos`, which is a *new* name: a committed `slots = ["top", "
 "right"]` still launches and simply has no table, because an explicit list is the
 primitive and charter does not add to a list you wrote by hand. Add `repos` to it, or
 delete the line and take the default.
+
+### What it looks like
+
+Five things make the frame read as an application rather than as output, and four of them
+are on whatever you write in `charter.toml`:
+
+- **A heading.** Each section of the sidebar and the repo table carries its name in bold
+  with its count still dim — `▪ personas 6`. No row is added anywhere; it is weight, not
+  furniture.
+- **One inset.** Every row's text starts in the same column, whether it is a persona name,
+  a todo title or a heading. One constant, so a panel added later lines up with the ones
+  already there.
+- **The row you are on.** The active persona's row in the sidebar is inverted across the
+  whole pane, to its last column — not a marker at the start of it. Reverse video is your
+  own foreground and background exchanged, so it is right on every colour scheme,
+  including the ones where every grey charter could have picked is somebody's background.
+- **A status you can read without colour.** Every status in the frame carries a glyph or a
+  word that says the same thing as its colour: `⚠` on an alert, `⚑`/`✗` on a persona whose
+  charter is a draft or broken, a count next to a badge. Colour is the second channel,
+  never the only one. charter's own test suite strips every escape from each panel and
+  fails if a status stops being distinguishable.
+- **The surface**, which is the one that is off unless you ask. See below.
+
+**`NO_COLOR` is honoured.** Set it to anything at all — including the empty string, which
+is what a shell that exports it with no value gives you — and the panels emit no escape
+sequences at all. So does a panel whose output is not a terminal, which is what
+`charter panel top --session x > /tmp/log` does. Both were previously written in full
+colour whatever you had asked for.
+
+**Charter never picks a colour out of the 256-colour cube.** Everything it draws is either
+one of the sixteen names your terminal palette defines or a plain attribute (bold, dim,
+reverse) — so what you see is your own scheme, not charter's idea of one. The reason is the
+inverse of the obvious one: an absolute colour is unsafe precisely on the terminals that
+render it faithfully. A 16-colour terminal would downsample charter's grey to your own
+black and look fine; a truecolor terminal on a light theme would get the dark grey
+verbatim.
+
+### A background behind the panels
+
+```toml
+[frame]
+chrome = "dark"     # or "light", or "off" — the default
+```
+
+`chrome` gives charter's own panes a background, so the frame reads as chrome around your
+session rather than as more text beside it. The focused panel is one shade off the others,
+which is also how you can see which pane is live.
+
+tmux paints it, not charter: the value sets `window-style` and `window-active-style` on
+charter's panel panes. That is why it costs nothing on a repaint, cannot wrap a line, fills
+the cells no renderer wrote, survives a resize and a reattach, and comes back by itself if
+a panel dies and is respawned into the same pane — all measured against a real tmux, not
+reasoned about. It is set per pane, so **the pane your
+harness runs in is never touched** — charter does not decide what a colour means inside
+your agent's own rectangle.
+
+**Three words, and no `auto`.** Charter cannot see your theme. A pane cannot ask the
+terminal (a colour query through tmux gets no reply), and `$COLORTERM` inside a pane
+describes the terminal that started the tmux *server* — detach at your desk and reattach
+over ssh and every panel still reads the old answer. So an `auto` would be a guess wearing
+the word for a measurement, and `off` is the default because a background charter chose is
+wrong on somebody's terminal and a frame that was fine before an upgrade should not come
+back worse.
+
+It is a word and not a style string on purpose: tmux expands formats inside a style value
+at draw time, and `charter.toml` is a committed file that arrives from someone else's
+machine. `chrome` names one of three looks charter holds itself; nothing you write there
+reaches tmux. Anything else — a fourth word, a style, a list — leaves the frame at `off`
+and charter still runs.
+
+`NO_COLOR` overrides it: no colour on your screen caused by charter means none, whichever
+process puts the bytes there.
 
 ### Writing the arrangement out
 
@@ -735,7 +810,7 @@ your frame's own `hotkey` are on that list too.
 Precedence, most explicit first: `[[frame.component]]`, then an explicit `slots`, then
 `density`, then the shipped default.
 
-`slots`/`density`/`mouse`/`hotkey` are spelled the same on both sides. `history-limit`,
+`slots`/`density`/`mouse`/`chrome`/`hotkey` are spelled the same on both sides. `history-limit`,
 `min-cols` and `min-rows` are the three that are not: charter.toml spells them with a
 hyphen: the
 resolved settings charter's own code reads back use an underscore

--- a/docs/news/unreleased-the-frame-reads-as-an-application.md
+++ b/docs/news/unreleased-the-frame-reads-as-an-application.md
@@ -1,0 +1,86 @@
+---
+version: unreleased
+headline: The frame reads as an application, and tmux is what paints the background
+---
+
+*"lets add some background to our top/bottom/side bars. making them like a UI APP"*
+
+A fill on a one-row bar is a colour, not a UI. What makes a terminal frame read as an
+application is a region with a name, a consistent inset, a row you can see you are on, and
+a status you can read without colour vision — and all four of those are on now, whatever
+your `charter.toml` says, because none of them names a colour charter chose.
+
+```
+ ▪ personas 5
+▸ steward          ✎47      <- the whole row, inverted, to the pane's edge
+ ▫ forge            ✎9
+ ▫ reddit           ✎7
+ ▪ todos 3
+ - ship the sidebar
+```
+
+**The heading is bold and the count stays dim.** No row is added anywhere — the frame's
+panels are the same height they were, and the fifteen-plus tests that assert a panel's
+exact line count never had to change.
+
+**The active persona's row is the whole row**, inverted across the pane to its last
+column, rather than a `▸` at the start of it. Reverse video is your own foreground and
+background exchanged, so it is correct on every colour scheme — including the Solarized
+palettes, where every grey charter could have picked is somebody's background.
+
+That one had a defect worth naming, because it only appears once you build it: **a reverse
+row cancels itself at the first escape inside it that resets everything**, and charter's
+rows carry one after every coloured span. Highlighted naively, `▸ steward ✎47` is inverted
+for two words and plain for the rest of the pane. The fix re-asserts reverse after each
+reset — and its own first version was this project's recurring bug for the sixth time:
+"resets everything" is a *numeric* parameter value, so `\x1b[00m` and `\x1b[1;00m` reset
+everything too and a test written against the string `\x1b[0m` passes with the row half
+highlighted.
+
+**A status is never colour alone.** Every one in the frame carries a glyph or a word that
+says the same thing — `⚠` on an alert, `⚑`/`✗` on a persona whose charter is a draft or
+broken, a number beside a badge. That is now a test rather than a habit: every panel is
+drawn healthy and drawn wanting attention, every escape is stripped from both, and the two
+must still differ.
+
+**`NO_COLOR` is honoured, and until now nothing in charter honoured it.** Set it to
+anything at all — including the empty string, which is what a shell that exports it with
+no value gives you — and the panels emit no escape sequences at all. The same is true of a
+panel whose output is not a terminal (`charter panel top --session x > /tmp/log`), which
+used to write a clear-screen and full colour into the file.
+
+## A background behind the panels, if you want one
+
+```toml
+[frame]
+chrome = "dark"     # or "light", or "off" — the default
+```
+
+**tmux paints it; charter sets an option.** `window-style` and `window-active-style` are
+settable per pane, and tmux fills the pane's whole rectangle from them. So the background
+costs nothing on a repaint, cannot wrap a line, covers the cells no renderer wrote,
+survives a resize and a reattach, comes back by itself when a dead panel is respawned into
+the same pane — and the focused panel is a shade off the others for free, drawn from tmux's
+own idea of which pane is live. It is set per pane, so **the pane your agent runs in is
+never touched.**
+
+**It ships `off`, and there is no `auto`.** Charter cannot see your theme: a colour query
+through tmux gets no answer, and `$COLORTERM` inside a pane describes the terminal that
+started the tmux *server* — detach at your desk, reattach over ssh, and every panel still
+reads the old answer. An `auto` that guessed would be a guess wearing the word for a
+measurement, and a default background charter picked would make a frame that was fine
+before an upgrade come back worse for anyone whose terminal is the other colour. Turning it
+on is one line; the four elements above are on either way.
+
+**It is a word and never a style string**, and that is a boundary rather than a
+simplification: tmux expands formats inside a style value at draw time, and `charter.toml`
+is a committed file that arrives from someone else's machine. Anything that is not one of
+the three words — a fourth word, a style, a list, a table — leaves the frame at `off` and
+charter still runs. `NO_COLOR` refuses the background too: no colour on your screen caused
+by charter means none, whichever process puts the bytes there.
+
+## To adopt
+
+Nothing, for the four elements — upgrading is the whole of it. For the background, add
+`chrome = "dark"` (or `"light"`) to `[frame]` in your plane's `charter.toml` and relaunch
+the frame. charter's own plane has done exactly that.

--- a/tests/test_frame_appearance.py
+++ b/tests/test_frame_appearance.py
@@ -1,0 +1,675 @@
+"""What makes the frame read as an application rather than as output.
+
+Six elements, and only one of them is a colour. A named region, a consistent inset, a
+row you can see you are on and a status you can read with every escape stripped are the
+four that ship on by default, because none of them names a colour charter chose — and
+`_CHROME_STYLE`'s rule (*"never a colour charter picked out of the 256 and imposed on a
+theme it cannot see"*) is what says they may. The pane surface and the focus indicator
+are the two that cannot be said relatively — tmux's `window-style` honours colour ONLY,
+`reverse`/`dim`/`bold` are accepted and silently ignored — so they are behind one word.
+
+`tests/test_frame_chrome.py` holds the primitive these are built on.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import instance, statusline, tui
+from charter.frame import chrome, gather, slots
+
+from tests._isolation import PersonaIso
+from tests.test_frame_tmux_integration import _HAS_TMUX, _TmuxServerFixture
+
+
+def _plain(out: str) -> list[str]:
+    """*out* as the rows a terminal would show, split BEFORE the colour is stripped —
+    `tui.strip_ansi` sanitises first, and `sanitize` turns a newline into a space."""
+    return [tui.strip_ansi(ln) for ln in out.split("\n")]
+
+
+class AHeadingHasWeightAndNotARow(PersonaIso, unittest.TestCase):
+    """§5.3. `_sidebar_head`'s label becomes bold; nothing else about it moves.
+
+    A heading ROW is the single change with the widest blast radius in the frame —
+    fifteen-plus tests assert a panel's exact line count — and it buys nothing weight
+    does not. So the assertions here are as much about what did NOT change: same text,
+    same width, same number of rows.
+    """
+
+    def test_the_label_is_bold(self):
+        head = slots._sidebar_head("personas", 6, 40)
+        self.assertIn(f"{statusline._BOLD}personas", head)
+
+    def test_the_count_stays_dim_and_the_label_is_not(self):
+        """Two facts, not one: a heading whose count shouted as loudly as its name would
+        read as two equal things rather than as a named region with a size."""
+        head = slots._sidebar_head("personas", 6, 40)
+        self.assertIn(f"{statusline._DIM} 6", head)
+        self.assertNotIn(f"{statusline._DIM}personas", head)
+
+    def test_the_plain_text_is_exactly_what_it_was(self):
+        """`tui.strip_ansi` is what the existing heading tests compare through
+        (`tests/test_frame_slots.py:814,1539`), so this is the assertion that says they
+        stay green for the right reason rather than by accident."""
+        self.assertEqual(tui.strip_ansi(slots._sidebar_head("personas", 6, 40)),
+                         f"{statusline._HEAD_PAD}personas 6")
+
+    def test_the_heading_costs_no_columns(self):
+        """SGR is zero visible width, and the width arithmetic downstream is measured in
+        columns — so weight is free in exactly the way a row is not."""
+        self.assertEqual(tui.width(slots._sidebar_head("personas", 6, 40)),
+                         tui.width(f"{statusline._HEAD_PAD}personas 6"))
+
+    def test_a_narrow_pane_still_gets_one_line(self):
+        for w in (1, 4, 8, 22):
+            with self.subTest(width=w):
+                head = slots._sidebar_head("personas", 6, w)
+                self.assertNotIn("\n", head)
+                self.assertLessEqual(tui.width(head), w)
+
+    def test_the_repo_table_is_headed_the_same_way(self):
+        """One helper, both sections — asserted rather than assumed, because "the label
+        is bold" applied in one renderer and not the other is exactly the drift
+        `_sidebar_head` was extracted to stop."""
+        self.assertIn(f"{statusline._BOLD}repos", slots._sidebar_head("repos", 2, 40))
+
+
+class TheInsetIsOneConstant(PersonaIso, unittest.TestCase):
+    """§5.4. Every row's content starts in the same column, and that column is `INSET`.
+
+    The value already existed — `statusline._HEAD_PAD` is two columns and its own comment
+    records the two ways a header that computed its own indent shipped broken. What this
+    adds is that it is ASKED FOR rather than spelled: a `"  "` typed at a call site is
+    the same arithmetic done again, and the second copy is the one that moves.
+    """
+
+    def test_the_inset_is_the_status_lines_own_header_pad(self):
+        """The agreement `slots.INSET` cannot import at module scope, pinned instead —
+        the same trade `panel._DEFAULT_ROWS` makes with `slots._DEFAULT_ROWS`."""
+        self.assertEqual(slots.INSET, tui.width(statusline._HEAD_PAD))
+
+    def test_a_marker_is_fitted_to_the_inset_rather_than_padded_by_hand(self):
+        self.assertEqual(tui.width(slots._inset("-")), slots.INSET)
+        self.assertEqual(tui.width(slots._inset()), slots.INSET)
+
+    def test_a_wide_marker_still_takes_exactly_the_inset(self):
+        """`tui.pad` measures in cells. A `marker + " "` would give a two-cell glyph three
+        columns and push its row one right of every other — the drift
+        `_persona_chip_cells`' own comment says has broken this layout twice."""
+        self.assertEqual(tui.width(slots._inset("⚡")), slots.INSET)
+
+    def test_every_row_of_the_sidebar_starts_in_the_same_column(self):
+        """The property the constant exists for, asserted end to end through the real
+        renderer: a persona name, a todo title and both headings begin in one column."""
+        self.make_persona("alice")
+        gather.save("f-1", {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+                            "repos": [], "worktrees": [],
+                            "todos": [{"title": "ship the sidebar"}], "todo_count": 1})
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((40, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            rows = [ln for ln in _plain(slots.render("right", "f-1")) if ln.strip()]
+        self.assertGreaterEqual(len(rows), 3, rows)
+        for row in rows:
+            with self.subTest(row=row):
+                self.assertEqual(tui.width(row[:slots.INSET]), slots.INSET)
+                self.assertNotEqual(row[slots.INSET], " ",
+                                    f"content does not start at the inset: {row!r}")
+
+    def test_the_more_row_is_inset_too(self):
+        """It is a sentence about the list rather than a persona, and it still begins
+        where the names do — which is what the two literal spaces used to say."""
+        cells = [statusline.PersonaChip(f"p{i}", f"▫ p{i}", "") for i in range(9)]
+        capped = slots._cap_personas(cells, 4)
+        note = tui.strip_ansi(capped[-1].head)
+        self.assertTrue(note.startswith(" " * slots.INSET), repr(note))
+        self.assertIn("…(+", note)
+
+
+class TheRowYouAreOnIsTheWholeRow(PersonaIso, unittest.TestCase):
+    """§5.5. The active persona's row is inverted to the pane's last column.
+
+    `▸ steward` is a glyph in a list; the whole row inverted is the row you are on. It is
+    the one element that needed new painting machinery, because it has to REACH the last
+    column — `tui` strips exactly the pad that would take it there — and the one with a
+    defect that only appears when you build it (a reverse row cancels itself at the first
+    full reset inside it, and charter's rows are full of them).
+    """
+
+    def _render(self, *, cols=22, rows=24, fid="f-1") -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return slots.render("right", fid)
+
+    def _rows(self, out: str) -> list[str]:
+        return out.split("\n")
+
+    def test_the_active_personas_row_is_painted_to_the_pane_edge(self):
+        self.make_persona("alice")
+        self.make_persona("bob")
+        with mock.patch("charter.persona.resolve_active", return_value="alice"):
+            rows = self._rows(self._render())
+        painted = [r for r in rows if "\x1b[7m" in r]
+        self.assertEqual(len(painted), 1, f"exactly one row is the one you are on: {rows}")
+        self.assertIn("alice", tui.strip_ansi(painted[0]))
+        self.assertEqual(tui.width(painted[0]), 22)
+
+    def test_no_other_row_is_painted(self):
+        """The control for the assertion above: a `persona_section` that highlighted
+        every row would satisfy "the active row is painted" perfectly."""
+        self.make_persona("alice")
+        self.make_persona("bob")
+        with mock.patch("charter.persona.resolve_active", return_value="alice"):
+            rows = self._rows(self._render())
+        for row in rows:
+            if "alice" in tui.strip_ansi(row):
+                continue
+            with self.subTest(row=row):
+                self.assertNotIn("\x1b[7m", row)
+
+    def test_a_plane_with_no_active_persona_paints_nothing(self):
+        self.make_persona("alice")
+        with mock.patch("charter.persona.resolve_active", return_value=None):
+            self.assertNotIn("\x1b[7m", self._render())
+
+    def test_the_highlight_is_not_cancelled_by_the_rows_own_resets(self):
+        """The whole defect, end to end through the real renderer: the row carries
+        `statusline._R` after the name and after each badge, and a naive wrapper would
+        leave it highlighted for two words."""
+        self.make_persona("alice")
+        with mock.patch("charter.persona.resolve_active", return_value="alice"):
+            painted = [r for r in self._rows(self._render()) if "\x1b[7m" in r][0]
+        # Every full reset inside the row is followed immediately by a re-assertion.
+        for m in re.finditer(r"\x1b\[([0-9;]*)m", painted[:-len(tui.RESET)]):
+            if chrome.resets_everything(m.group(1)):
+                with self.subTest(at=m.start()):
+                    self.assertTrue(painted[m.end():].startswith("\x1b[7m"),
+                                    f"reverse dies here: {painted!r}")
+
+    def test_the_pane_is_still_exactly_its_two_parts(self):
+        """`tests/test_builtin_components.py:272` compares `slots.render("right")` byte
+        for byte against its two sections joined — the most brittle assertion in the
+        suite for this change. It stays green because both sides reach the highlight
+        through `persona_section`; this says so here too, so a future move to `_right`
+        is red in the file that argued against it rather than only in that one."""
+        self.make_persona("alice")
+        with mock.patch("charter.persona.resolve_active", return_value="alice"), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((22, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            whole = slots.render("right", "f-1")
+            parts = slots.persona_section(22, 24, terse=False)
+        self.assertEqual(whole.split("\n")[:len(parts)], parts)
+
+    def test_the_row_count_is_unchanged(self):
+        """No renderer gains or loses a row. The highlight is paint on a row that was
+        already there."""
+        cells = [statusline.PersonaChip(f"p{i}", f"▫ p{i}", "", active=i == 0)
+                 for i in range(9)]
+        with mock.patch("charter.statusline._persona_chip_cells", return_value=cells):
+            rows = self._rows(self._render(rows=26))
+        self.assertEqual(len(rows), 9 + 1)
+
+    def test_a_chip_built_by_hand_is_not_the_active_row(self):
+        """`PersonaChip.active` is defaulted, so the fixtures that build chips
+        positionally (`tests/test_frame_slots.py`, `tests/test_frame_density.py`) keep
+        describing a list nobody is standing in."""
+        self.assertFalse(statusline.PersonaChip("p", "▫ p", "").active)
+        self.assertFalse(statusline.PersonaChip(None, "  …(+7 more)", "", 7).active)
+
+    def test_the_chips_themselves_know_which_one_is_active(self):
+        """Read as data off the chip rather than found in its rendered head — the half
+        that makes the highlight independent of `▸` and of magenta."""
+        self.make_persona("alice")
+        self.make_persona("bob")
+        with mock.patch("charter.persona.resolve_active", return_value="bob"):
+            cells = statusline._persona_chip_cells()
+        self.assertEqual([c.name for c in cells if c.active], ["bob"])
+
+
+class NoStatusIsCarriedByColourAlone(PersonaIso, unittest.TestCase):
+    """§5.6, made a test rather than a habit.
+
+    > A status conveyed by colour alone is a status some operators cannot read. Every
+    > status in the frame carries a glyph or a word that says the same thing. Colour is
+    > the second channel, never the only one.
+
+    Asked the way `tests/test_frame_slots.py:140`'s `NoPanelDrawsItsOwnChrome` asks its
+    own question — as a structural property over every slot in `slots.SLOTS`, with live
+    controls proving the check can fail. The property here needs two renders rather than
+    one: a status is only a status because it differs from the absence of one, so each
+    slot is drawn healthy and drawn wanting attention, and the two must still differ once
+    every SGR is gone.
+    """
+
+    def _render(self, slot: str, *, cols=200, rows=24, fid="f-1") -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return slots.render(slot, fid)
+
+    def _seed(self, **overrides) -> None:
+        data = {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+                "repos": [], "worktrees": []}
+        data.update(overrides)
+        gather.save("f-1", data)
+
+    def _repo(self, **overrides) -> dict:
+        row = {"name": "demo", "branch": "main", "dirty": False, "tracked_dirty": False,
+               "ahead": 0, "behind": 0, "ci": None, "change": None, "sigil": "",
+               "current": False, "worktree_count": 0}
+        row.update(overrides)
+        return row
+
+    # -- the probes: one pair per slot, driven through real state ------------------
+
+    def _probe_top(self) -> tuple[str, str]:
+        """A workspace pinned by the environment carries a `*`. The pin is the top bar's
+        one status and it was already a glyph — this is what keeps it one."""
+        quiet = self._render("top")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "default"}):
+            loud = self._render("top")
+        return quiet, loud
+
+    def _probe_bottom(self) -> tuple[str, str]:
+        """Open todos. `_bottom`'s count is unconditional, so the number is the word.
+
+        `_todo_count` is the DATA (it counts files on disk), not the rendering — the
+        same seam `tests/test_frame_density.py:379` drives this row through."""
+        with mock.patch("charter.statusline._todo_count", return_value=0):
+            quiet = self._render("bottom")
+        with mock.patch("charter.statusline._todo_count", return_value=3):
+            loud = self._render("bottom")
+        return quiet, loud
+
+    def _probe_repos(self) -> tuple[str, str]:
+        """A dirty repo against a clean one — `_needs_attention`'s own first fact."""
+        self._seed(repos=[self._repo()])
+        quiet = self._render("repos")
+        self._seed(repos=[self._repo(dirty=True, sigil="●")])
+        return quiet, self._render("repos")
+
+    def _probe_right(self) -> tuple[str, str]:
+        """A persona whose charter is a draft: `_health_mark` speaks only when something
+        is wrong, and `⚑` is what it says."""
+        self.make_persona("alice")
+        quiet = self._render("right", cols=40)
+        with mock.patch("charter.persona.is_draft", return_value=True):
+            loud = self._render("right", cols=40)
+        return quiet, loud
+
+    def test_every_slot_is_probed(self):
+        """The coverage half. A slot added without a probe is red here rather than
+        silently unexamined — which is the difference between a structural test and a
+        list of four examples."""
+        probed = {n[len("_probe_"):] for n in dir(self) if n.startswith("_probe_")}
+        self.assertEqual(probed, set(slots.SLOTS))
+
+    def test_a_status_survives_every_escape_being_stripped(self):
+        for slot in sorted(slots.SLOTS):
+            with self.subTest(slot=slot):
+                quiet, loud = getattr(self, f"_probe_{slot}")()
+                self.assertNotEqual(quiet, loud,
+                                    f"{slot}'s probe changed nothing at all")
+                self.assertNotEqual(
+                    _plain(quiet), _plain(loud),
+                    f"{slot} says this only in colour — an operator who cannot see "
+                    f"the hue cannot read it: {loud!r}")
+
+    def test_the_check_would_catch_a_status_that_was_only_a_colour(self):
+        """The live control this class cannot do without: every assertion above is a
+        negative, and a broken comparison passes just as happily as a correct frame."""
+        ok = f"{statusline._GREEN}build{statusline._R}"
+        bad = f"{statusline._RED}build{statusline._R}"
+        self.assertNotEqual(ok, bad, "the two fixtures must differ before stripping")
+        self.assertEqual(_plain(ok), _plain(bad),
+                         "a colour-only difference must vanish when SGR is stripped")
+
+    def test_the_check_passes_a_status_that_carries_a_glyph(self):
+        """The other control — a check that called everything colour-only would satisfy
+        the one above."""
+        self.assertNotEqual(_plain(f"{statusline._GREEN}✎4{statusline._R}"),
+                            _plain(f"{statusline._YELLOW}⚑{statusline._R}"))
+
+
+class TheFrameNamesColoursAndNeverIndexes(PersonaIso, unittest.TestCase):
+    """§3.2, enforced instead of remembered.
+
+    Only three things may appear in charter's own chrome: `default`, the sixteen ANSI
+    names, and the SGR attributes. Not a 256-cube index, not a 24-bit triple, ever — a
+    name like `brightblack` is a slot in the operator's own palette while `colour236` is
+    a fixed point in the cube that no theme moves.
+
+    The sharp form of the argument is the inverse of the obvious one: **an absolute
+    colour is unsafe precisely on the terminals that render it faithfully.** A 16-colour
+    client gets charter's `colour236` downsampled to the operator's own black and looks
+    fine; a truecolor client with a light theme gets the dark grey verbatim.
+
+    Asked of the PARAMETERS rather than by grepping for `48;5`: the extended-colour form
+    is "38 or 48, then a 5 or a 2", and `\\x1b[1;38;5;236m` is the same escape wearing a
+    prefix.
+    """
+
+    #: SGR parameters that introduce a colour charter did not get from the operator.
+    _EXTENDED = ("38", "48")
+
+    def _absolute_colours(self, out: str) -> list[str]:
+        found = []
+        for m in re.finditer(r"\x1b\[([0-9;]*)m", out):
+            params = m.group(1).split(";")
+            for i, p in enumerate(params[:-1]):
+                if p in self._EXTENDED and params[i + 1] in ("5", "2"):
+                    found.append(m.group(0))
+        return found
+
+    def _render(self, slot: str) -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((200, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return slots.render(slot, "f-1")
+
+    def test_no_slot_emits_a_cube_index_or_a_24_bit_triple(self):
+        self.make_persona("alice")
+        gather.save("f-1", {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+                            "repos": [{"name": "demo", "branch": "main", "dirty": True,
+                                       "tracked_dirty": True, "ahead": 2, "behind": 0,
+                                       "ci": "failed", "change": None, "sigil": "●",
+                                       "current": True, "worktree_count": 0}],
+                            "worktrees": [],
+                            "todos": [{"title": "ship it"}], "todo_count": 1})
+        for slot in sorted(slots.SLOTS):
+            with self.subTest(slot=slot):
+                self.assertEqual(self._absolute_colours(self._render(slot)), [])
+
+    def test_the_check_recognises_both_forms(self):
+        """The control. Every assertion above is a negative; these are the two escapes it
+        is supposed to find, plus the prefixed spelling a grep for `\\x1b[48;5;` misses."""
+        for esc in ("\x1b[48;5;236m", "\x1b[38;2;30;60;90m", "\x1b[1;38;5;236m"):
+            with self.subTest(esc=esc):
+                self.assertEqual(self._absolute_colours(esc), [esc])
+
+    def test_the_check_passes_the_names_charter_does_use(self):
+        for esc in (statusline._GREEN, statusline._YELLOW, statusline._RED,
+                    statusline._DIM, statusline._BOLD, tui.RESET, "\x1b[7m"):
+            with self.subTest(esc=esc):
+                self.assertEqual(self._absolute_colours(esc), [])
+
+    def test_the_styles_charter_hands_tmux_name_colours_too(self):
+        """The same rule on the other side of the boundary: `window-style` takes a
+        colour, and the words in `FRAME_CHROME` are palette slots, not cube indices."""
+        for level, pairs in instance.FRAME_CHROME.items():
+            for name, value in pairs:
+                with self.subTest(level=level, option=name):
+                    self.assertNotRegex(value, r"colour\d|#[0-9a-fA-F]{6}")
+
+
+class TheChromeValueIsAWordAndNeverAStyle(unittest.TestCase):
+    """`[frame] chrome` — a closed enum at the config boundary.
+
+    A tmux style value is FORMAT-EXPANDED at draw time. Measured on 3.7c: the option is
+    stored verbatim and evaluated when the pane is drawn —
+
+        $ tmux set -p -t %1 window-style 'bg=#{?#{==:1,1},colour196,colour46}'
+        $ tmux show -p -t %1 -v window-style
+        bg=#{?#{==:1,1},colour196,colour46}          <- stored as written
+           wire: b'...\\x1b[48;5;196m\\x1b[2BPANEL'    <- tmux evaluated the conditional
+
+    charter.toml is committed and arrives from someone else's machine, so a free style
+    string there would be a committed value reaching a tmux evaluator — `[frame] hotkey`'s
+    class exactly, where a newline once ran a second tmux command at launch with no
+    keypress. Execution was not achieved through a style on 3.7c (`#(...)` is refused by
+    the style parser outright) and that is not the same as it being safe.
+    """
+
+    def test_the_three_words_are_the_whole_enum(self):
+        self.assertEqual(set(instance.FRAME_CHROME), {"off", "dark", "light"})
+
+    def test_off_is_the_shipped_default(self):
+        self.assertEqual(instance.FRAME_DEFAULTS["chrome"], "off")
+
+    def test_off_sets_nothing_at_all(self):
+        """Not "sets a default style" — sets nothing. `show -p` must answer `''`, which
+        is a claim about the absence of a command rather than about its argument."""
+        self.assertEqual(instance.chrome_options("off"), ())
+
+    def test_each_word_names_two_pane_options_one_step_apart(self):
+        for level in ("dark", "light"):
+            with self.subTest(level=level):
+                pairs = dict(instance.chrome_options(level))
+                self.assertEqual(set(pairs), {"window-style", "window-active-style"})
+                self.assertNotEqual(pairs["window-style"],
+                                    pairs["window-active-style"],
+                                    "the focused pane must be a shade off the others")
+
+    def test_a_style_string_is_refused_and_leaves_the_frame_off(self):
+        """The containment assertion, and it names WHICH refusal fired: the value is
+        gone AND the resolved setting is the shipped default rather than some other
+        word."""
+        hostile = "bg=#{?#{==:1,1},colour196,colour46}"
+        f = instance.frame_of({"frame": {"chrome": hostile}})
+        self.assertEqual(f["chrome"], "off")
+        self.assertIsNone(instance.chrome_level(hostile))
+        self.assertEqual(instance.chrome_options(hostile), ())
+
+    def test_a_word_charter_does_not_know_leaves_the_frame_off(self):
+        for value in ("auto", "DARK", "dark ", "", "solarized"):
+            with self.subTest(value=value):
+                self.assertEqual(
+                    instance.frame_of({"frame": {"chrome": value}})["chrome"], "off")
+
+    def test_a_value_that_is_not_a_string_does_not_raise(self):
+        """`tomllib` can hand this a list or a table, and `instance` is imported by every
+        command including `charter --version`. `isinstance` first, for `density_level`'s
+        own reason: `value in FRAME_CHROME` raises `TypeError` on an unhashable value."""
+        for value in (["dark"], {"chrome": "dark"}, 7, True, None):
+            with self.subTest(value=value):
+                self.assertEqual(
+                    instance.frame_of({"frame": {"chrome": value}})["chrome"], "off")
+
+    def test_the_three_words_are_actually_read(self):
+        for value in ("off", "dark", "light"):
+            with self.subTest(value=value):
+                self.assertEqual(
+                    instance.frame_of({"frame": {"chrome": value}})["chrome"], value)
+
+    def test_the_toml_spelling_is_the_bare_word(self):
+        """One word, so the hyphen question (`history-limit`, not `history_limit`) does
+        not arise — and the underscore form is not a second, undocumented alias."""
+        self.assertEqual(instance.FRAME_FIELDS["chrome"][1], "chrome")
+
+    def test_the_defaults_view_and_the_fields_table_agree(self):
+        self.assertIn("chrome", instance.FRAME_DEFAULTS)
+        self.assertEqual(set(instance.FRAME_DEFAULTS), set(instance.FRAME_FIELDS))
+
+
+class ThisPlaneOptsIntoTheSurface(unittest.TestCase):
+    """charter's own charter.toml asks for the fill; `FRAME_DEFAULTS` does not.
+
+    That division is what `[frame]` already runs on: the plane's own committed file says
+    what THIS plane looks like, and the shipped default says what a stranger's plane looks
+    like before they have said anything at all. Both halves are asserted, because either
+    one alone is the mistake — a default that repaints a stranger's terminal, or a plane
+    whose operator asked for a look and did not get it.
+    """
+
+    def test_charters_own_plane_declares_a_surface(self):
+        import tomllib
+        root = Path(__file__).resolve().parent.parent
+        cfg = tomllib.loads((root / "charter.toml").read_text())
+        self.assertEqual(cfg["frame"]["chrome"], "dark")
+
+    def test_the_shipped_default_is_still_off(self):
+        self.assertEqual(instance.FRAME_DEFAULTS["chrome"], "off")
+
+
+class TheSurfaceIsSetOnPanelPanesAndNoOther(unittest.TestCase):
+    """`commands_frame._surface_argvs` — the argv, before any tmux runs it."""
+
+    def test_off_issues_no_commands(self):
+        from charter import commands_frame
+        self.assertEqual(
+            commands_frame._surface_argvs(socket="s", pane_id="%3", chrome="off"), [])
+
+    def test_a_surface_is_pane_scoped(self):
+        """`-p -t %N`, never `-g` and never `-w`: a window option would reach the harness
+        pane, which is the one thing ADR 0018 says charter may not colour."""
+        from charter import commands_frame
+        argvs = commands_frame._surface_argvs(socket="s", pane_id="%3", chrome="dark")
+        self.assertEqual(len(argvs), 2)
+        for argv in argvs:
+            with self.subTest(argv=argv):
+                self.assertIn("-p", argv)
+                self.assertEqual(argv[argv.index("-t") + 1], "%3")
+                self.assertNotIn("-g", argv)
+                self.assertNotIn("-w", argv)
+
+    def test_no_color_refuses_the_surface_too(self):
+        """The half that is easy to miss: the fill is tmux's paint, so gating only the
+        panels' own SGR would leave an operator who asked for no colour looking at a
+        coloured frame — charter having asked somebody else to paint it. Asserted with
+        the empty value, which is the spelling a `== "1"` reading gets wrong."""
+        from charter import commands_frame
+        for value in ("", "0", "1"):
+            with self.subTest(value=value), \
+                 mock.patch.dict(os.environ, {"NO_COLOR": value}, clear=True):
+                self.assertEqual(
+                    commands_frame._surface_argvs(socket="s", pane_id="%3",
+                                                  chrome="dark"), [])
+
+    def test_without_no_color_the_surface_is_issued(self):
+        """The control: `test_no_color_refuses_the_surface_too` is a negative, and a
+        `_surface_argvs` that always answered `[]` would pass it."""
+        from charter import commands_frame
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(
+                len(commands_frame._surface_argvs(socket="s", pane_id="%3",
+                                                  chrome="dark")), 2)
+
+    def test_no_color_is_read_the_same_way_on_both_paths(self):
+        """One reading of the variable, not two. `panel._write` and this are different
+        processes on different paths asking the same question, and #547 is what two
+        spellings of one question cost."""
+        from charter import commands_frame
+        self.assertIs(commands_frame.chrome_mod.no_colour, chrome.no_colour)
+
+    def test_the_value_that_reaches_tmux_is_charters_own_constant(self):
+        """The mutation this refuses: letting the config value through as a style. The
+        argv carries a word out of `FRAME_CHROME`, and a value charter did not recognise
+        produces no argv at all."""
+        from charter import commands_frame
+        hostile = "bg=#{?#{==:1,1},colour196,colour46}"
+        self.assertEqual(
+            commands_frame._surface_argvs(socket="s", pane_id="%3", chrome=hostile), [])
+        argvs = commands_frame._surface_argvs(socket="s", pane_id="%3", chrome="dark")
+        values = [a[-1] for a in argvs]
+        self.assertEqual(set(values),
+                         {v for _n, v in instance.FRAME_CHROME["dark"]})
+        for v in values:
+            self.assertNotIn("#", v)
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class TheHarnessPaneIsNeverStyled(_TmuxServerFixture, PersonaIso):
+    """ADR 0018's boundary, read back out of tmux rather than intended in charter.
+
+    A real server, a real split, charter's real `_surface_argvs` — and then `show -p` on
+    both panes. The harness pane must answer `''`: not "a style charter considers
+    harmless", not "the same style", nothing at all.
+    """
+
+    SOCKET_NAME = f"charter-chrome-surface-{os.getpid()}"
+
+    def _panes(self) -> tuple[str, str]:
+        r = self._srv("new-session", "-d", "-s", "h", "-x", "80", "-y", "24",
+                      "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness = r.stdout.strip()
+        p = self._srv("split-window", "-t", harness, "-P", "-F", "#{pane_id}",
+                      "--", "sleep", "600")
+        self.assertEqual(p.returncode, 0, p.stderr)
+        return harness, p.stdout.strip()
+
+    def _style(self, pane: str, option: str = "window-style") -> str:
+        return self._srv("show", "-p", "-t", pane, "-v", option).stdout.strip()
+
+    def _apply(self, pane: str, chrome: str) -> None:
+        from charter import commands_frame
+        for argv in commands_frame._surface_argvs(
+                socket=self.SOCKET_NAME, pane_id=pane, chrome=chrome):
+            r = subprocess.run(argv, capture_output=True, text=True, timeout=10)
+            self.assertEqual(r.returncode, 0, f"{argv}: {r.stderr}")
+
+    def test_a_surfaced_panel_leaves_the_harness_pane_bare(self):
+        harness, panel = self._panes()
+        self._apply(panel, "dark")
+        self.assertEqual(self._style(panel), "bg=black")
+        self.assertEqual(self._style(panel, "window-active-style"), "bg=brightblack")
+        self.assertEqual(self._style(harness), "",
+                         "charter styled the pane the operator's harness runs in")
+        self.assertEqual(self._style(harness, "window-active-style"), "")
+
+    def test_with_the_surface_off_every_pane_reads_back_empty(self):
+        """The other direction, and the default's own exit criterion: `off` is not a
+        style charter chose to be invisible, it is no option at all."""
+        harness, panel = self._panes()
+        self._apply(panel, "off")
+        for pane in (harness, panel):
+            with self.subTest(pane=pane):
+                self.assertEqual(self._style(pane), "")
+                self.assertEqual(self._style(pane, "window-active-style"), "")
+
+    def test_tmux_accepts_the_style_charter_actually_sends(self):
+        """The claim that would otherwise be untested: `bg=brightwhite` is a style this
+        tmux parses. A refused `set-option` is silent in production (reported, not
+        fatal), so a typo would ship as a frame that simply never coloured."""
+        _harness, panel = self._panes()
+        for level in ("dark", "light"):
+            with self.subTest(level=level):
+                self._apply(panel, level)
+                self.assertEqual(dict(instance.FRAME_CHROME[level])["window-style"],
+                                 self._style(panel))
+
+    def test_the_surface_belongs_to_the_pane_and_not_to_the_process_in_it(self):
+        """`commands_frame`'s `pane-died` hook respawns a dead panel INTO THE SAME PANE,
+        and a renderer-side fill would have to be re-established by whatever came back.
+        These are pane options, so the surface is a property of the rectangle. Measured
+        rather than reasoned, because `docs/frame.md` says it to an operator."""
+        harness, panel = self._panes()
+        self._srv("set", "-g", "remain-on-exit", "on")
+        self._apply(panel, "dark")
+        r = self._srv("respawn-pane", "-k", "-t", panel, "--", "sleep", "600")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(self._style(panel), "bg=black")
+        self.assertEqual(self._style(harness), "")
+
+    def test_the_surface_survives_the_window_being_resized(self):
+        """The other half of the same claim, and the one #553 makes worth asserting: a
+        fill charter painted would have to be redrawn at the new width and could be one
+        cell wrong. An option has no width to get wrong."""
+        _harness, panel = self._panes()
+        self._apply(panel, "dark")
+        r = self._srv("resize-window", "-t", "h", "-x", "120", "-y", "40")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(self._style(panel), "bg=black")
+
+    def test_a_format_string_would_have_been_stored_verbatim(self):
+        """The measurement behind the enum, run here rather than quoted: tmux keeps a
+        style value as written and expands it at draw time, so the boundary that matters
+        is the one in `instance.frame_of` — not anything tmux does on the way in."""
+        _harness, panel = self._panes()
+        r = self._srv("set-option", "-p", "-t", panel, "window-style",
+                      "bg=#{?#{==:1,1},colour196,colour46}")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(self._style(panel), "bg=#{?#{==:1,1},colour196,colour46}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_chrome.py
+++ b/tests/test_frame_chrome.py
@@ -1,0 +1,497 @@
+"""The frame's paint primitive, and the promises it is built on.
+
+Nothing in this file is visible in a frame. It exists so the visible half can be
+believed: `frame/chrome.py` builds on a `tui` guarantee that nothing tested in either
+direction, on a pane width that has to be the one the renderer measured, and on a
+clear-screen that did not reset the attributes it clears with.
+
+**The `tui._finish` pin lives here rather than in `tests/test_tui.py`** — beside the
+module that depends on it, and named for the dependency. `test_tui.py` covers
+`term_width`; `test_tui_control_chars.py` covers `width`/`sanitize`/`truncate`/`pad`;
+the only file that mentions `_HIDDEN_TRAIL` at all classifies it in a substitution
+inventory. So the strip was a documented promise with nothing checking it, in either
+direction, on the day `chrome.fill` started depending on it.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from charter import statusline, tui
+from charter.frame import chrome, panel, slots
+
+from tests._isolation import PersonaIso
+
+
+class AFinishedLineCarriesNoTrailingPaint(unittest.TestCase):
+    """`tui._finish`, pinned in BOTH directions — the promise `chrome.fill` inverts.
+
+    `tui`'s module docstring says "Rendered lines also never carry trailing whitespace,
+    even when it hides behind trailing colour escapes", and until this class nothing
+    asserted it. It is not a detail: `tui` also renders the status line, which writes
+    into a line it does not own and must never leave painted cells trailing across
+    somebody else's prompt, and a line with no trailing whitespace is what keeps a copy
+    out of the frame clean.
+
+    Both directions, because a one-sided test passes on a `_finish` that strips
+    everything: the second half asserts a line that has no trailing whitespace comes
+    back BYTE-IDENTICAL, escapes and all.
+    """
+
+    def test_a_pad_inside_the_style_span_does_not_survive_a_node(self):
+        """The exact measurement `chrome.py` is built around: 20 cells in, 8 out."""
+        row = tui.Text("\x1b[36m charter            \x1b[0m").render(40)[0]
+        self.assertEqual(row, "\x1b[36m charter\x1b[0m")
+        self.assertEqual(tui.width(row), 8)
+
+    def test_a_pad_outside_the_style_span_does_not_survive_either(self):
+        """The other spelling of the same 20-cell fill, so a `_finish` that stripped
+        only plain trailing spaces — or only the hidden kind — is red for one of them."""
+        row = tui.Text("\x1b[36m charter\x1b[0m            ").render(40)[0]
+        self.assertEqual(row, "\x1b[36m charter\x1b[0m")
+
+    def test_whitespace_behind_several_escapes_goes_too(self):
+        """`_HIDDEN_TRAIL` loops rather than matching once: `' \\x1b[0m \\x1b[2m'` hides a
+        space behind an escape behind a space behind an escape, and one pass leaves the
+        inner one painted."""
+        self.assertEqual(tui.Text("x \x1b[0m \x1b[2m").render(40)[0], "x\x1b[0m\x1b[2m")
+
+    def test_a_row_node_strips_a_fixed_width_cells_own_padding(self):
+        """`tui.Cell(markup, 20)` pads to 20 and `_finish` takes it straight back off —
+        which is why a fill cannot be composed as a wide cell and why `chrome.fill` takes
+        an already-finished row instead."""
+        row = tui.Row(tui.Cell("\x1b[36m charter", 20)).render(40)[0]
+        self.assertEqual(tui.width(row), 8)
+
+    def test_a_line_with_nothing_trailing_comes_back_byte_identical(self):
+        """The other direction. Without this, `_finish` could strip every escape and the
+        four assertions above would all still pass."""
+        for line in ("\x1b[36m charter\x1b[0m", "plain text", "\x1b[7ma b\x1b[0m", ""):
+            with self.subTest(line=line):
+                self.assertEqual(tui.Text(line).render(40)[0], line)
+
+
+class WhatCountsAsAResetIsTheNumber(unittest.TestCase):
+    """`chrome.resets_everything` — the sixth instance of #547/#558/#537/#498/#577/#594,
+    caught inside the fix for the defect it enables rather than after it shipped.
+
+    "An SGR that resets everything" is a parameter list containing a parameter whose
+    NUMERIC VALUE is zero. An empty parameter is zero and leading zeros are legal, so
+    `\\x1b[00m` and `\\x1b[1;00m` reset everything and a string test (`p in ("", "0")`)
+    misses both. The spellings below are the table, and the two marked MISSED are why
+    this class exists.
+    """
+
+    def test_every_spelling_of_a_full_reset_is_one(self):
+        for params in ("0", "", "00", "1;00", "0;1", "000000", ";1", "22;0"):
+            with self.subTest(params=params):
+                self.assertTrue(chrome.resets_everything(params),
+                                f"\\x1b[{params}m resets everything and was not read as one")
+
+    def test_a_list_with_no_zero_in_it_is_not_a_full_reset(self):
+        for params in ("2", "1", "22;39", "7", "27", "38;5;236", "10"):
+            with self.subTest(params=params):
+                self.assertFalse(chrome.resets_everything(params))
+
+    def test_reverse_off_on_its_own_is_not_a_full_reset(self):
+        """SGR 27 turns reverse off and touches nothing else, so it is not the same
+        question — `_split_at_close` asks whether a trailing escape leaves any span open,
+        and `\\x1b[27m` leaves a colour open."""
+        self.assertFalse(chrome.resets_everything("27"))
+        self.assertTrue(chrome.cancels_reverse("27"))
+
+    def test_what_cancels_reverse_is_zero_or_twenty_seven_and_nothing_else(self):
+        for params in ("0", "", "27", "1;27", "27;1", "0027", "22;0"):
+            with self.subTest(params=params):
+                self.assertTrue(chrome.cancels_reverse(params))
+        for params in ("7", "2", "22;39", "270", "2;7"):
+            with self.subTest(params=params):
+                self.assertFalse(chrome.cancels_reverse(params))
+
+    def test_the_string_test_this_replaces_would_miss_two_real_spellings(self):
+        """The control. Every assertion above is about a function this file also wrote,
+        so the check is proved against the implementation it replaced: a reader can see
+        that the two tables disagree, and on which rows."""
+        def string_test(params: str) -> bool:      # the version that shipped nowhere
+            return params in ("", "0")
+        missed = [p for p in ("0", "", "00", "1;00")
+                  if chrome.resets_everything(p) and not string_test(p)]
+        self.assertEqual(missed, ["00", "1;00"],
+                         "the numeric test must be strictly stronger than the string one")
+
+
+class AFillReachesTheLastColumnAndStops(unittest.TestCase):
+    """`chrome.fill` — exactly the pane's width, never one more.
+
+    Measured in a real 20-column tmux pane: exactly W is safe (the deferred-wrap state is
+    resolved by the following newline and produces no blank row), and **W+1 shears the
+    pane** — the fill wraps one cell onto the next row and every row below it shifts
+    down. That is #553 arriving through a new door, so the clamp is the point of the
+    function and not a safety net on it.
+    """
+
+    def test_a_short_row_is_padded_to_exactly_the_width(self):
+        out = chrome.fill("\x1b[36m charter\x1b[0m", 20)
+        self.assertEqual(tui.width(out), 20)
+        self.assertEqual(out, "\x1b[36m charter            \x1b[0m")
+
+    def test_the_pad_goes_inside_a_span_the_row_closes(self):
+        """A pad appended after the reset is a pad the terminal paints in the default
+        background — a fill with a gap in it, which is what a caller would see and not be
+        able to explain."""
+        out = chrome.fill("\x1b[7mabc\x1b[0m", 10)
+        self.assertTrue(out.endswith("\x1b[0m"), out)
+        self.assertNotIn(" \x1b[0m ", out)
+        self.assertEqual(out.index(" " * 7), out.index("abc") + 3)
+
+    def test_the_pad_goes_after_a_span_the_row_leaves_open(self):
+        """The other half of the same rule, and the case `reverse` composes: a row ending
+        in `\\x1b[0m\\x1b[7m` has reverse ON at its end, so the pad belongs after it."""
+        out = chrome.fill("\x1b[7mabc\x1b[0m\x1b[7m", 10)
+        self.assertTrue(out.endswith("\x1b[0m\x1b[7m       "), repr(out))
+
+    def test_a_row_that_already_fills_the_pane_is_returned_unchanged(self):
+        self.assertEqual(chrome.fill("abcde", 5), "abcde")
+
+    def test_a_row_wider_than_the_pane_is_cut_rather_than_wrapped(self):
+        """**Which refusal fired** is asserted, not merely the width: the ellipsis is the
+        clamp's own signature, so this cannot pass on a `fill` that happened to return a
+        short row for some other reason."""
+        out = chrome.fill("x" * 30, 20)
+        self.assertEqual(tui.width(out), 20)
+        self.assertTrue(out.endswith(tui.ELLIPSIS),
+                        f"the row was not cut by the clamp: {out!r}")
+
+    def test_a_pane_with_no_columns_at_all_gets_nothing(self):
+        """The other refusal, asserted separately — two guards in sequence mask each
+        other, and `width <= 0` is reachable from a real `tui.term_width` floor.
+
+        The refusal that fires is `tui.truncate`'s, and `fill` deliberately does not have
+        a second one: the mutation table for this branch found an `if width <= 0` here
+        SURVIVING, because `truncate` had already answered and the guard could not change
+        an outcome. It was deleted rather than pinned. `reverse` keeps its own, which the
+        class below asserts is live — the two are not the same line twice."""
+        for w in (0, -1):
+            with self.subTest(width=w):
+                self.assertEqual(chrome.fill("charter", w), "")
+
+    def test_a_filled_row_survives_a_truncate_at_the_pane_width(self):
+        """`panel._write` does not re-measure, but `Registry._fit` clips a foreign row —
+        so a filled row must be a fixed point of the clamp it may still meet."""
+        out = chrome.fill("\x1b[36m charter\x1b[0m", 22)
+        self.assertEqual(tui.truncate(out, 22), out)
+
+    def test_a_wide_glyph_is_measured_in_cells_not_characters(self):
+        """`tui.width`, never `len`: `⚡` is East-Asian Wide, so a fill counted in
+        characters comes out one cell over — which is the W+1 that shears the pane."""
+        out = chrome.fill("⚡2", 10)
+        self.assertEqual(tui.width(out), 10)
+        self.assertEqual(len(out), 9)
+
+
+class AHighlightedRowIsHighlightedToItsLastColumn(unittest.TestCase):
+    """`chrome.reverse` — the element that most makes the frame read as an application,
+    and the one with a defect that only appears once it is built.
+
+    A reverse row cancels itself at the first SGR inside it that resets everything, and
+    charter's rows carry one after every coloured span. The naive wrapper highlights two
+    words of a persona row and leaves the rest plain.
+    """
+
+    #: The real sidebar row, as `statusline._persona_chip_cells` composes it.
+    ROW = "\x1b[35m▸ \x1b[1msteward\x1b[0m   \x1b[32m✎47\x1b[0m"
+
+    def _reverse_runs(self, out: str) -> list[int]:
+        """The visible columns *out* is drawn in reverse video, walked as a terminal
+        would walk it: SGR 7 turns it on, a full reset or SGR 27 turns it off."""
+        on, col, cols, i = False, 0, [], 0
+        while i < len(out):
+            m = chrome._SGR.match(out, i)
+            if m:
+                for p in m.group(1).split(";"):
+                    v = int(p or "0")
+                    on = True if v == 7 else False if v in (0, 27) else on
+                i = m.end()
+                continue
+            if on:
+                cols.append(col)
+            col += tui.width(out[i])
+            i += 1
+        return cols
+
+    def test_a_row_carrying_a_plain_reset_stays_highlighted_to_the_end(self):
+        out = chrome.reverse(self.ROW, 40)
+        self.assertEqual(tui.width(out), 40)
+        self.assertEqual(self._reverse_runs(out), list(range(40)))
+
+    def test_a_row_carrying_a_leading_zero_reset_stays_highlighted_too(self):
+        """`\\x1b[00m`. A `p in ("", "0")` implementation passes every test written
+        against `\\x1b[0m` and fails this one — which is why it is written first."""
+        out = chrome.reverse("a\x1b[00mb", 12)
+        self.assertEqual(tui.width(out), 12)
+        self.assertEqual(self._reverse_runs(out), list(range(12)))
+
+    def test_a_row_carrying_a_reset_with_another_parameter_stays_highlighted_too(self):
+        """`\\x1b[1;00m` — the second spelling the string test misses."""
+        out = chrome.reverse("a\x1b[1;00mb", 12)
+        self.assertEqual(self._reverse_runs(out), list(range(12)))
+
+    def test_the_naive_wrapper_would_fail_both_of_those(self):
+        """The live control. Every assertion above is about reverse REACHING the end, and
+        a broken `_reverse_runs` would report that just as happily — so the walker is
+        proved against the wrapper this function replaced."""
+        naive = "\x1b[7m" + self.ROW + " " * 25 + "\x1b[27m"
+        self.assertEqual(max(self._reverse_runs(naive)) + 1, 9,
+                         "the naive wrapper is supposed to stop at the first reset")
+
+    def test_a_row_carrying_a_bare_reverse_off_stays_highlighted_too(self):
+        """`\\x1b[27m` turns reverse off and nothing else, so a re-assertion keyed on
+        "resets everything" walks straight past it and the row goes plain from there.
+        Charter writes none today; a provider's component is ordinary Python."""
+        out = chrome.reverse("a\x1b[27mb", 12)
+        self.assertEqual(self._reverse_runs(out), list(range(12)))
+
+    def test_reverse_is_re_asserted_only_where_it_was_cancelled(self):
+        """An escape that changes nothing is bytes written into a pane on every repaint
+        for no change on screen. Re-asserting after EVERY SGR keeps the row highlighted
+        just as well, which is why the assertions above cannot tell the two apart — this
+        counts. The fixture carries two escapes that cancel reverse (`\\x1b[0m`,
+        `\\x1b[27m`) and two that do not (`\\x1b[35m`, `\\x1b[2m`), so the answer is the
+        one leading assertion plus two."""
+        out = chrome.reverse("\x1b[35ma\x1b[0mb\x1b[2mc\x1b[27md", 20)
+        self.assertEqual(out.count("\x1b[7m"), 3, repr(out))
+        self.assertEqual(self._reverse_runs(out), list(range(20)),
+                         "and it is still highlighted the whole way")
+
+    def test_a_row_with_no_escapes_at_all_is_highlighted_whole(self):
+        out = chrome.reverse("steward", 20)
+        self.assertEqual(self._reverse_runs(out), list(range(20)))
+
+    def test_a_row_wider_than_the_pane_is_cut_and_still_highlighted_whole(self):
+        out = chrome.reverse("s" * 40, 20)
+        self.assertEqual(tui.width(out), 20)
+        self.assertEqual(self._reverse_runs(out), list(range(20)))
+
+    def test_a_highlighted_row_ends_with_every_attribute_off(self):
+        """A row that left an attribute open would carry it past the highlight into the
+        rest of the pane. SGR 27 alone would not: it turns reverse off and nothing else."""
+        self.assertTrue(chrome.reverse("\x1b[1msteward", 20).endswith(tui.RESET))
+
+    def test_a_pane_with_no_columns_at_all_gets_nothing(self):
+        """`reverse`'s own refusal, and it is a LIVE one: without it a zero-width pane
+        still gets `\\x1b[0m` written into it, because the closing reset is appended after
+        `fill` has already answered. Deleting the line makes this red — which is what
+        `fill`'s equivalent line did not do, and why `fill` no longer has one."""
+        for w in (0, -1):
+            with self.subTest(width=w):
+                self.assertEqual(chrome.reverse("steward", w), "")
+
+    def test_a_highlighted_row_survives_a_truncate_at_the_pane_width(self):
+        out = chrome.reverse(self.ROW, 22)
+        self.assertEqual(tui.truncate(out, 22), out)
+
+
+class ColourIsARequestTheOperatorCanRefuse(unittest.TestCase):
+    """`chrome.colour_ok` — `NO_COLOR` by PRESENCE, and one function asking it.
+
+    `NO_COLOR` appeared nowhere in `charter/` before this: `util._USE_COLOR` gates
+    `util.info/ok/warn/err` and nothing else, and the frame renderers coloured
+    unconditionally — measured, `panel.run` with stdout a `StringIO` wrote a
+    clear-screen and full SGR into it.
+
+    The property is `os.environ.get("NO_COLOR") is not None`, per the no-color.org
+    convention. `== "1"` is the spelling-not-property mistake in the one file that is
+    about that mistake, and it breaks first on `NO_COLOR=` — which is what a shell that
+    exports the variable with no value has set.
+    """
+
+    def _tty(self, answer: bool):
+        return mock.patch.object(sys.stdout, "isatty", return_value=answer,
+                                 create=True)
+
+    def test_an_empty_no_color_still_means_no_colour(self):
+        with mock.patch.dict(os.environ, {"NO_COLOR": ""}, clear=True), self._tty(True):
+            self.assertFalse(chrome.colour_ok())
+
+    def test_a_falsey_looking_no_color_still_means_no_colour(self):
+        """`NO_COLOR=0` is set, so it means no colour. A value test reads it as "off",
+        which is the opposite of what the operator wrote."""
+        with mock.patch.dict(os.environ, {"NO_COLOR": "0"}, clear=True), self._tty(True):
+            self.assertFalse(chrome.colour_ok())
+
+    def test_any_other_value_means_no_colour_too(self):
+        for value in ("1", "yes", "true", "  "):
+            with self.subTest(value=value), \
+                 mock.patch.dict(os.environ, {"NO_COLOR": value}, clear=True), \
+                 self._tty(True):
+                self.assertFalse(chrome.colour_ok())
+
+    def test_an_unset_no_color_on_a_tty_colours(self):
+        with mock.patch.dict(os.environ, {}, clear=True), self._tty(True):
+            self.assertTrue(chrome.colour_ok())
+
+    def test_a_stdout_that_cannot_answer_does_not_colour(self):
+        """A closed stdout raises `ValueError` from `isatty()` and a replacement object
+        without the method raises `AttributeError` — both are real, and a frame that
+        cannot tell does not colour, which is the direction `NO_COLOR` already points.
+
+        Pinned because the deletion sweep found the catch unreached: narrowing it to
+        `ZeroDivisionError` left the whole suite green, which is a guard with nothing
+        behind it."""
+        class _Closed:
+            def isatty(self):
+                raise ValueError("I/O operation on closed file")
+
+        class _Silent:
+            pass
+
+        for stdout in (_Closed(), _Silent()):
+            with self.subTest(stdout=type(stdout).__name__), \
+                 mock.patch.dict(os.environ, {}, clear=True), \
+                 mock.patch.object(sys, "stdout", stdout):
+                self.assertFalse(chrome.colour_ok())
+
+    def test_a_redirected_panel_does_not_colour_a_file(self):
+        """`charter panel top --session x > /tmp/log`, the case `panel.py`'s own
+        docstring documents. It is the only thing `isatty` catches in a real frame — a
+        panel's stdout IS its pane — and it is written down here so nobody reads it as
+        the mechanism."""
+        with mock.patch.dict(os.environ, {}, clear=True), self._tty(False):
+            self.assertFalse(chrome.colour_ok())
+
+
+class AClearScreenClearsWithWhateverIsSet(PersonaIso, unittest.TestCase):
+    """`panel._write` prefixes a reset — §6.3, measured in a real pane.
+
+    A renderer that leaves a background set makes the NEXT repaint's `\\x1b[2J` fill the
+    whole pane with it, because erase uses the current attributes. Constraint 4 still
+    holds (it costs that pane and no other) but the pane stays wrong until something
+    resets it, and nothing did. Measured, two paints in one 20-column pane::
+
+        after the next '\\x1b[H\\x1b[2J' + 'second paint':
+          row 0: '\\x1b[48;5;196msecond paint        '   <- the leak survived the clear
+          row 1: '                    '                 <- and filled every other row
+
+    The reset goes BEFORE the cursor-home, so `split("\\x1b[2J", 1)[1]` still answers the
+    content — four call sites structurally depend on that
+    (`tests/test_frame_panel.py:129,172,193`, `tests/test_component_id_is_the_currency.py:110`).
+    """
+
+    def _paint(self, text: str) -> str:
+        buf = io.StringIO()
+        with redirect_stdout(buf), \
+             mock.patch.object(sys.stdout, "isatty", return_value=True, create=True), \
+             mock.patch("charter.frame.panel._rows", return_value=4):
+            panel._write(text)
+        return buf.getvalue()
+
+    def test_a_paint_resets_before_it_clears(self):
+        out = self._paint("second paint")
+        self.assertTrue(out.startswith("\x1b[m\x1b[H\x1b[2J"), repr(out[:20]))
+
+    def test_the_reset_is_a_full_one_and_not_only_a_background_reset(self):
+        """`\\x1b[49m` would leave a foreground, a bold or a reverse from the leaking
+        paint in place, and the erase would be clean while every glyph after it was not."""
+        head = self._paint("x").split("\x1b[H", 1)[0]
+        self.assertTrue(chrome.resets_everything(head[2:-1]), repr(head))
+
+    def test_the_content_is_still_reachable_by_splitting_on_the_clear(self):
+        """The compatibility half, asserted rather than assumed: the reset is before the
+        cursor-home precisely so this keeps working."""
+        self.assertEqual(self._paint("second paint").split("\x1b[2J", 1)[1],
+                         "second paint")
+
+
+class TheFrameEmitsNoColourWhenTheOperatorRefusedIt(PersonaIso, unittest.TestCase):
+    """`NO_COLOR` reaches the pane, not merely the helper.
+
+    Asked in `panel._write`, the one place anything reaches a pane's screen — so a
+    component charter did not write is covered by the same answer as a renderer charter
+    did, and neither has to remember to ask.
+    """
+
+    def _paint(self, env: dict, *, tty: bool = True) -> str:
+        buf = io.StringIO()
+        with mock.patch.dict(os.environ, env, clear=True), redirect_stdout(buf), \
+             mock.patch.object(sys.stdout, "isatty", return_value=tty, create=True), \
+             mock.patch("charter.frame.panel._rows", return_value=4):
+            panel._write("\x1b[35m▸ \x1b[1msteward\x1b[0m \x1b[32m✎47\x1b[0m")
+        return buf.getvalue()
+
+    def test_no_color_leaves_the_pane_with_no_sgr_at_all(self):
+        out = self._paint({"NO_COLOR": ""})
+        self.assertNotIn("\x1b[", out.split("\x1b[2J", 1)[1])
+        self.assertIn("steward", out, "the content itself must survive")
+
+    def test_no_color_drops_the_reset_prefix_too(self):
+        """There is nothing to reset when nothing is painted, and "no SGR from the frame
+        at all" is the promise — a reset is an SGR."""
+        self.assertTrue(self._paint({"NO_COLOR": "1"}).startswith("\x1b[H\x1b[2J"))
+
+    def test_no_color_leaves_no_invisible_pad_behind_either(self):
+        """`chrome.fill`'s pad is only meaningful under paint. Stripped with it, so a
+        `NO_COLOR` pane copies out as the text it shows."""
+        buf = io.StringIO()
+        with mock.patch.dict(os.environ, {"NO_COLOR": ""}, clear=True), \
+             redirect_stdout(buf), \
+             mock.patch.object(sys.stdout, "isatty", return_value=True, create=True), \
+             mock.patch("charter.frame.panel._rows", return_value=4):
+            panel._write(chrome.reverse("\x1b[1msteward\x1b[0m", 30))
+        self.assertEqual(buf.getvalue().split("\x1b[2J", 1)[1], "steward")
+
+    def test_an_ordinary_pane_still_gets_its_colour(self):
+        """The control: every assertion above is a negative, and a `_write` that emitted
+        nothing would satisfy all of them."""
+        self.assertIn("\x1b[35m", self._paint({}))
+
+    def test_the_clear_screen_survives_either_way(self):
+        """`\\x1b[H\\x1b[2J` is not colour and is not charter's markup — it is the thing
+        that makes a repaint a repaint. A `NO_COLOR` implementation written as
+        `tui.strip_ansi(whole_output)` would delete it, because `sanitize` drops every
+        CSI that is not SGR."""
+        for env in ({"NO_COLOR": ""}, {}):
+            with self.subTest(env=env):
+                self.assertIn("\x1b[H\x1b[2J", self._paint(env))
+
+
+class TheFillUsesTheWidthTheRendererMeasured(PersonaIso, unittest.TestCase):
+    """One measurement, not two — the mutation `slots._width()` exists to refuse.
+
+    A panel process inherits the LAUNCHING shell's `$COLUMNS` whole (measured: a
+    22-column pane whose launcher had exported `COLUMNS=200`). A fill computed against
+    that number in a 22-column pane is 178 cells over, and every row wraps four times.
+    """
+
+    def _render(self, cols: int) -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return slots.render("right", "f-1")
+
+    def test_a_painted_sidebar_row_never_exceeds_the_panes_own_columns(self):
+        self.make_persona("a-persona-with-quite-a-long-name")
+        with mock.patch.dict(os.environ, {"COLUMNS": "200"}):
+            out = self._render(22)
+        for line in out.split("\n"):
+            with self.subTest(line=line):
+                self.assertLessEqual(tui.width(line), 22, repr(line))
+
+    def test_a_painted_row_reaches_the_panes_own_last_column(self):
+        """The other direction, so the test above cannot be satisfied by a panel that
+        stopped painting. The selected row is the one that fills."""
+        self.make_persona("alice")
+        with mock.patch("charter.persona.resolve_active", return_value="alice"):
+            out = self._render(22)
+        painted = [ln for ln in out.split("\n") if "\x1b[7m" in ln]
+        self.assertTrue(painted, f"no row was painted at all: {out!r}")
+        for line in painted:
+            self.assertEqual(tui.width(line), 22, repr(line))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements Phases 1 and 2 of `docs/superpowers/specs/2026-08-28-frame-visual-design.md`
(#595), plus the `[frame] chrome` enum and the pane surface the operator asked for.

The spec's central finding is confirmed on this build, not quoted: **tmux paints the pane
background itself.** With `instance.chrome_options("dark")` applied pane-scoped to two
panels and nothing applied to the harness, this is what tmux put on a real
`xterm-256color` client's wire —

```
HARNESS -> b'...\x1b(B\x1b[m\x1b[1;1HHARNESS'      <- no colour at all
PANELA  -> b'...\x1b[K\x1b[100m\x1b[2BPANELA'      <- active:   bg=brightblack
PANELB  -> b'...\x1b[K\x1b[40m\x1b[2BPANELB'       <- inactive: bg=black
```

So charter sets an option and never paints a fill: nothing new is on the repaint path, the
fill has no width to get wrong (#553 cannot arrive this way), focused-vs-unfocused comes
from tmux's own pane focus for free, and ADR 0018's harness boundary holds by construction.

---

## Phase 1 — nothing visible ships

**`tui._finish` is pinned, in both directions.** It was unpinned on the day this started
depending on it: `test_tui.py` covers `term_width`, `test_tui_control_chars.py` covers
`width`/`sanitize`/`truncate`/`pad`, and the only file naming `_HIDDEN_TRAIL` classifies it
in a substitution inventory. Five assertions now cover a pad inside the span, a pad outside
it, whitespace behind several escapes, a fixed-width cell's own padding — and a line with
nothing trailing coming back **byte-identical**, without which a `_finish` that stripped
every escape would pass the other four. `charter/tui.py` is byte-identical to `main`.

**`charter/frame/chrome.py`** takes a *finished* row and says so. `fill` pads to exactly
the pane's measured width with the pad inside the style span; `tui.truncate` is the clamp,
so an over-wide row is cut with an ellipsis rather than wrapped, and the test asserts
*which* refusal fired (the ellipsis is the clamp's signature, not merely a short row).

**`chrome.reverse` re-asserts reverse after every SGR that resets everything — and that is
a numeric parameter value.** `\x1b[00m` and `\x1b[1;00m` both reset everything; a
`p in ("", "0")` implementation passes every test written against `\x1b[0m` and fails those
two, which is why they are the tests. This is the sixth instance of
#547/#558/#537/#498/#577/#594's shape and it was found inside the fix for the defect it
enables, before it shipped. The mutation `numeric test -> string test` is RED.

**`panel._write` prefixes `\x1b[m`.** `\x1b[2J` erases with whatever attributes are set, so
a component that leaked a background used to colour every subsequent paint of that pane for
the rest of the session. The reset goes *before* the cursor-home, so
`split("\x1b[2J", 1)[1]` still answers the content — `tests/test_frame_panel.py:129,172,193`
and `tests/test_component_id_is_the_currency.py:110` pass unmodified, and a mutation that
moves the reset after the clear is RED in all three files.

**`NO_COLOR` is honoured, and nothing in charter honoured it before.** By **presence**
(`os.environ.get("NO_COLOR") is not None`), per no-color.org — `NO_COLOR=` and `NO_COLOR=0`
both count, and the `== "1"` mutation is RED on both. One function, asked in `panel._write`
(the one place anything reaches a pane's screen, so a provider's component is covered by
the same answer) **and** in `_surface_argvs`: the fill is tmux's paint, so gating only
charter's own SGR would honour the letter of the promise and not the property.

## Phase 2 — the elements, on by default

| element | what changed | blast radius |
|---|---|---|
| `heading` | label **bold**, count still dim | none — plain text byte-identical, no row added |
| `inset` | one `slots.INSET`, read not spelled | none — same value, same width |
| `selected` | active persona row, full-width reverse | one row's paint |
| `status` | the rule made a test over every slot | none |

**The heading is weight, not a row.** `tui.strip_ansi` sees `▪ personas 6` before and
after, so `tests/test_frame_slots.py:814,1539` and every exact-line-count test in the spec's
Global Constraints pass **unmodified**.

**The selected row is applied to the row `_persona_rows` finished** (a fill composed before
that `tui.Row(...).render()` is stripped by `_finish` — 40 cells in, 15 out) and **inside
`persona_section`**, so `tests/test_builtin_components.py:272`'s raw byte equality between
`slots.render("right")` and its two parts holds — both sides reach the highlight through the
same helper. Which row is active comes off `PersonaChip.active`, carried as data, not found
by looking for `▸` or magenta in a rendered head.

**Status is enforced rather than asked for.** Every slot in `slots.SLOTS` is drawn healthy
and drawn wanting attention, every escape is stripped from both, and the two must still
differ — with a coverage assertion so a new slot without a probe is red, and two live
controls (a colour-only difference must vanish; a glyph difference must not). Plus: charter
emits no 256-cube index and no 24-bit triple anywhere in its own chrome, asked of the SGR
*parameters* (`38`/`48` followed by `5`/`2`) rather than by grepping for `48;5`, so
`\x1b[1;38;5;236m` is caught too.

## `[frame] chrome` — the surface, opt-in

A closed enum: `off` (default) / `dark` / `light`, validated at the config boundary the way
`density` is, `isinstance` first. **Never a style string**, and that is a containment
boundary rather than a simplification — a tmux style value is format-expanded at draw time
(measured again here: the option is stored verbatim and `bg=#{?#{==:1,1},colour196,colour46}`
reaches the wire as `\x1b[48;5;196m`), and `charter.toml` is committed and arrives from
someone else's machine. That is `_HOTKEY_RE`'s class exactly. The mutation *let the config
value through as a style* is RED.

Two named palette slots one step apart, never an index — the inverse of the obvious
argument: an absolute colour is unsafe precisely on the terminals that render it faithfully.
The mutations *swap active and inactive*, *make both panes the same colour* and *use
`colour236` instead of `black`* are each RED.

Applied pane-scoped from `_split_panels`, on the pane that was just created and no other —
the one funnel both launch paths and every density change reach panels through. A real-tmux
test reads it back rather than intending it: `show -p -t <harness> -v window-style` answers
`''`, and with `chrome` off every pane answers `''`.

### The default is `off` and charter's own plane sets `dark`

A default that repaints a stranger's terminal is hostile in a way `off` never is, and
charter cannot detect the theme — the spec measured why (`$COLORTERM` inside a pane
describes the terminal that started the *server*; OSC 11 through tmux is never answered;
3.7c's own theme hooks did not fire). A light-terminal operator upgrading into a default
`dark` gets a frame worse than the one they had, on a surface they never touched, having
done nothing. A dark-terminal operator upgrading into a default `off` gets a frame *better*
than the one they had — the four theme-safe elements ship on — and one line short of the one
they wanted. Those are not symmetric.

This plane's operator asked for the look, so charter's own committed `charter.toml` opts in.
Same posture and same recorded reason as `[frame] mouse`: `FRAME_DEFAULTS` says what a
stranger's plane looks like before they have said anything; the plane's own file says what
this plane looks like. Both halves are asserted (`ThisPlaneOptsIntoTheSurface`), and the
mutations *charter's own plane stops asking* and *the shipped default becomes dark* are both
RED.

---

## Verification

**Full suite, two environments, both agree, no existing test modified.**

| environment | result |
|---|---|
| Python 3.14.4, this shell | `Ran 6799 tests` — OK |
| Python 3.12, `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset | `Ran 6799 tests` — OK |

**CI green at this head sha**, read from `check-runs` rather than `gh pr checks` (#561):
10 check-runs at `e6515dd` (two workflow runs — `push` and `pull_request`). All eight
`test (3.11 / 3.12 / 3.13 / 3.14)` are `success`; the two
`A dev-channel install from main actually installs` are `skipped` (a main-only job).
The 3.14 job's own log reads `Ran 6799 tests` / `OK (skipped=2)` — the same count as both
local environments, and neither skip is new: the four real-tmux tests in this branch ran
there (`test_frame_appearance.TheHarnessPaneIsNeverStyled...`, `ok`), so nothing about the
surface is being taken on trust from this laptop.

### `tools/sweep.py`

Run against `origin/main` at `d9dd72a`. **The first run found four survivors, all four in
`charter/frame/chrome.py`, and all four are closed** — two by deletion, because a line that
cannot change an outcome is not documentation of an intent (#568's shape):

| survivor | what it was | what happened |
|---|---|---|
| `fill` `if width <= 0: return ""` | `tui.truncate` already answers `""` for a non-positive width, so the pad below was unreachable | **deleted**; the property is still asserted, and `reverse`'s equivalent line **is** live (without it a zero-width pane receives a bare `\x1b[0m`) and is now pinned |
| `fill` `if gap <= 0: return row` | `" " * n` is `""` for every `n <= 0` and `_split_at_close` partitions the row, so the line reconstructed its own input | **deleted** |
| `colour_ok` `except (AttributeError, ValueError)` | narrowing it to `ZeroDivisionError` left the suite green — a catch with nothing behind it | **pinned**: a stdout whose `isatty` raises `ValueError`, and one with no `isatty` at all |
| `reverse`'s re-assertion condition collapsed to "always" | equivalent for the highlight, and **it had a real defect behind it** | the condition was keyed on "resets everything", which walks straight past `\x1b[27m`. It now asks `cancels_reverse` (0 **or** 27, numerically), a row carrying `\x1b[27m` is pinned, and the "always" mutant is killed by counting: re-asserting where reverse was not cancelled is bytes written into a pane on every repaint that change nothing |

Re-run at this head with `--second-order 6`: **18 mutations applied, 18 pinned, 0 survived, 0 unresolved**, against an
unmutated baseline of `Ran 6797 tests — OK`, 29.4 min wall clock. The sweep's own closing
line: *"Every mutation this diff offered goes red. Nothing added here is a line the suite
would not miss."* (It also has a `retune-constant` operator, which reached `slots.INSET`
and found it pinned.) That run was at the tree before the last commit, which adds two
tests and one docs sentence and no `charter/` code — the sweep charges added lines under
`charter/`, so its verdict covers exactly the production code on this branch.

**Hand mutation table — 40/40 killed**, run against an unmutated baseline before *and* after
(#579), with every edit asserting it matched exactly once before the run (#585/#586) and
`__pycache__` cleared between runs. Baseline GREEN (339 tests), restored baseline GREEN.

<details><summary>the 40</summary>

```
RED  1.3 reverse: drop the re-assertion after a full reset
RED  1.4 fill: drop the width clamp
RED  1.4 reverse: drop the no-columns refusal
RED  1.4 fill: measured width replaced by a constant 80
RED  1.4 fill: the pad goes outside the span it should be inside
RED  1.5 _write: drop the reset prefix
RED  1.6 NO_COLOR: presence test -> value test
RED  1.6 NO_COLOR: drop the isatty half
RED  1.6 NO_COLOR: never asked in _write
RED  2.1 heading: label loses its bold
RED  2.2 inset: widened in one renderer only
RED  2.3 selected: drop the reverse on the active row
RED  2.3 selected: every row highlighted, not the one you are on
RED  2.3 selected: the chips stop recording which one is active
RED  2.4 status: a glyph dropped, its colour kept
RED  3.1 chrome: the enum check dropped for a bare isinstance
RED  3.4 chrome: the config value let through as a style
RED  3.3 surface: pane scope widened to the window
RED  NO_COLOR: the surface ignores it
RED  HAND: _REVERSE is SGR 27 instead of SGR 7
RED  HAND: _OFF is the weak close (SGR 27) instead of a full reset
RED  HAND: _SGR stops matching multi-parameter escapes
RED  HAND: the reset prefix is a background-only reset
RED  HAND: the reset goes AFTER the clear instead of before
RED  HAND: NO_COLOR is spelled NOCOLOR
RED  HAND: INSET is 3 rather than the header pad's width
RED  HAND: the heading is underlined rather than bold
RED  HAND: dark's active and inactive surfaces are swapped
RED  HAND: dark's two panes are the same colour (no focus indicator)
RED  HAND: a cube index instead of a palette name
RED  HAND: both options are window-style (the second is never set)
RED  HAND: charter's own plane stops asking for the surface
RED  HAND: the shipped default becomes dark
RED  HAND: the more-row loses its inset
RED  HAND: _inset pads with len() rather than tui.width
RED  1.3 fill: resets_everything as a string test misses a leading-zero close
RED  survivor 1: colour_ok's catch narrowed
RED  survivor 3: reverse re-asserts after EVERY sgr
RED  survivor 3b: reverse keyed on resets_everything (misses SGR 27)
RED  cancels_reverse: numeric -> string test
```
</details>

The sixteen `HAND:` rows are **reported separately because `tools/sweep.py` has no operator
for them** (#569): a colour name, an escape sequence and a swapped pair of style values are
string constants and semantic swaps, which the sweep does not mutate. They were run by the
same harness, against the same baseline, with the same applied-check.

## Files another agent owns

Smallest possible edits, named:

- **`charter/frame/panel.py`** (#591/#510/#536/#501's owner) — the import line, and
  `_write`'s body: the `\x1b[m` prefix and the `NO_COLOR` branch, plus a two-line `_out`
  helper so the two branches cannot disagree about flushing. Nothing in the resize path,
  `_rows`, `_tick`, `_watch` or `run` is touched.
- **`charter/statusline.py`** (the statusline persona's) — one defaulted field on
  `PersonaChip` (`active: bool = False`) and the one call that sets it. Every existing
  positional construction still works; `_persona_chips` is unchanged.
- **`charter/commands_frame.py`** — `_surface_argvs` (new, beside `_chrome_argvs`), one
  aliased import, and five lines inside `_split_panels`'s existing per-pane loop. The
  **resize path is untouched**.
- **`tests/`** — two new files only (`test_frame_chrome.py`, `test_frame_appearance.py`).
  No existing test modified. `tests/test_frame_tmux_integration.py` is *imported from* for
  `_TmuxServerFixture` (kill-and-unlink in one cleanup, #564) and not edited; the new tmux
  class uses its own socket name and leaks nothing.

## What I could not do

- **Phase 3.5 — re-run the measurements on tmux 3.2 (`tmuxctl.FLOOR`).** Only 3.7c exists
  on this machine (`/opt/homebrew/Cellar/tmux/3.7c`, nothing else on `$PATH`), which is what
  the spec's §9 already recorded. `window-style` predates 3.2, but pane-scoped `set -p` of
  it and the per-client downsample were run on 3.7c only. The failure direction is the safe
  one — an option 3.2 refuses is a `set-option` charter reports and does not die on, which
  is `off`.
- **Phase 3.5** above, and one more measured gap: the surface's behaviour under
  `tmux -CC` (control mode, iTerm2's native integration) was not run — it needs iTerm2,
  which is not scriptable here. The failure direction is the safe one: the renderer
  elements are SGR the panel writes into its own pane, so they survive control mode
  unchanged, and a surface that does not reach a `-CC` client is simply absent, which is
  `chrome = "off"`.
- **Phase 2's "a human has looked at it on a light terminal and on a dark one."** §9 says
  this is not satisfiable by a test and it is not satisfiable by me either. What I can offer
  is the render, captured out of a real 22-column tmux pane:

  ```
  ^[[2m▪ ^[[0;1mpersonas^[[0;2m 3^[[0m
  ^[[7m^[[35m▸ ^[[1msteward^[[0;7m         ^[[32m✎47^[[39m
  ^[[0;2m▫ forge^[[0m           ^[[32m✎9^[[39m
  ^[[2m▪ ^[[0;1mtodos^[[0;2m 2^[[0m
  ^[[2m- ^[[0mship the sidebar
  ```

  The `^[[0;7m` on the second row is the re-assertion doing its job — tmux's own capture
  shows reverse surviving the row's internal reset. **Someone still has to look at it.**
