### PR TITLE
A width is validated wherever it came from, and four more tables are measured from their values (#594, #600, #601)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2279,11 +2279,14 @@ def cmd_doctor(args) -> int:
         # had already passed — so a hang looked identical to a crash. Now the last line
         # printed names where it stopped.
         print("charter preflight:\n")
-        # The NAME column is stated BEFORE the run, not measured from it: rows are drawn
-        # as their checks land (above), so there is no completed table to size from —
-        # `doctor.name_width` asks the checks what they are called instead of a `:<16`
-        # guessing (#600). `Result.render` treats it as a floor, so a name the width did
-        # not know about pushes its own row rather than being cut out of the report.
+        # The NAME column is stated BEFORE the run, not measured from it: this loop is
+        # written to draw each row as its check lands, so there is no completed table to
+        # size from — `doctor.name_width` asks the checks what they are called instead of
+        # a `:<16` guessing (#600). `Result.render` treats it as a floor, so a name the
+        # width did not know about pushes its own row rather than being cut out of the
+        # report. (`doctor._checks` is an eager list today, so nothing actually streams
+        # yet; sizing from the results would make that unfixable rather than merely
+        # unfixed — see `_FIXED_CHECK_NAMES`.)
         name_w = doctor.name_width()
         results = []
         for r in doctor.iter_all():

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2279,10 +2279,16 @@ def cmd_doctor(args) -> int:
         # had already passed — so a hang looked identical to a crash. Now the last line
         # printed names where it stopped.
         print("charter preflight:\n")
+        # The NAME column is stated BEFORE the run, not measured from it: rows are drawn
+        # as their checks land (above), so there is no completed table to size from —
+        # `doctor.name_width` asks the checks what they are called instead of a `:<16`
+        # guessing (#600). `Result.render` treats it as a floor, so a name the width did
+        # not know about pushes its own row rather than being cut out of the report.
+        name_w = doctor.name_width()
         results = []
         for r in doctor.iter_all():
             results.append(r)
-            print(r.render(), flush=True)
+            print(r.render(name_w), flush=True)
         print()
 
     failed = [r for r in results if r.status == doctor.FAIL]

--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -61,6 +61,19 @@ _ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 #: `tui.column` counts the gap inside the width it returns, so the rule for a column is
 #: that width less this — never a second constant beside the first, which is what the
 #: old `"-" * 18` under a `{:<18}` was.
+#:
+#: **Its value is deliberately not pinned, and that is measured rather than assumed.**
+#: Raise it to 3 and every case in `test_a_table_column_is_measured_in_cells` stays green,
+#: because both sides move together: the column is sized `gap=_GAP` and the rule is drawn
+#: `w - _GAP`, so every offset is unchanged and only the whitespace between columns grows.
+#: A test spelling `2` would pass forever and see nothing — #508's own finding about `28`,
+#: in the other direction.
+#:
+#: What a gap BUYS is pinned, and the boundary is 0: at zero the widest value in a column
+#: runs straight into the next cell and nothing on the row says where the column ended.
+#: `test_the_widest_value_in_a_column_is_still_followed_by_a_separator` holds that, and
+#: the measurement is recorded here so nobody re-derives it (`_BRANCH_TEXT_MIN_W`'s
+#: precedent, #597).
 _GAP = 2
 
 

--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -24,7 +24,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from . import config, util
+from . import config, tui, util
 from .secrets import base, fingerprint, registry
 
 
@@ -55,6 +55,13 @@ def _portable_file(p) -> str:
 #: it prevents surfaces much later and in disguise: a typo'd source name is simply unset,
 #: and an unset source is (deliberately) a hard error at read time about a credential.
 _ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+#: Cells between one column of `vault list` and the next, stated once because the rule
+#: under the header has to be drawn from the same number the columns are SIZED with.
+#: `tui.column` counts the gap inside the width it returns, so the rule for a column is
+#: that width less this — never a second constant beside the first, which is what the
+#: old `"-" * 18` under a `{:<18}` was.
+_GAP = 2
 
 
 def _env_bindings(args) -> dict | None:
@@ -303,10 +310,38 @@ def cmd_vault_list(args) -> int:
     # SCOPE earns a column because a two-file registry invites exactly two questions —
     # "why can't my teammate see this vault" and "why is this vault in git" — and both are
     # answered by where it is registered.
-    fmt = "{:<18} {:<16} {:<12} {:<7} {}"
-    print(fmt.format("VAULT", "PROVIDER", "PERSONA", "SCOPE", "STATUS"))
-    print(fmt.format("-" * 18, "-" * 16, "-" * 12, "-" * 7, "-" * 28))
-    for name in sorted(vs):
+    #
+    # `{:<18}`/`{:<16}`/`{:<12}` were guesses about names charter did not mint: a vault
+    # name and a persona name are the operator's and a provider name is a plugin's, so any
+    # of the three can be longer than its constant — at which point `:<n` PUSHES that row's
+    # remaining columns right of every other row's and the table stops lining up.
+    # `str.format` also counts CHARACTERS where a terminal lays out cells, so a persona
+    # named in CJK measures well inside the constant and still shifts its row by one column
+    # per glyph (#508, #592, #600).
+    #
+    # Sized from the four columns that cost nothing to know — the registry document is
+    # already loaded — and never from STATUS, which is one `health()` per vault and may
+    # reach a keychain, a file that is not there, or a helper waiting on input.
+    # `_status_for_workspace` records the same trade (#597): collecting every row before
+    # drawing one makes the operator wait for every vault before the header appears. STATUS
+    # has nothing to its right, so it needs no width anyway.
+    heads = ("VAULT", "PROVIDER", "PERSONA", "SCOPE")
+    body = [(name, vs[name].get("provider", "?"), vs[name].get("persona") or "—",
+             registry.scope_of(name)) for name in sorted(vs)]
+    widths = [tui.column(h, [row[i] for row in body], gap=_GAP)
+              for i, h in enumerate(heads)]
+
+    def line(cells, last: str) -> str:
+        return ("".join(tui.pad(c, w) for c, w in zip(cells, widths)) + last).rstrip()
+
+    # One padder for the header, the rule and every row. Two code paths that each believe
+    # they agree about the widths is the fastest way back to a misaligned report (#508),
+    # and the rule was exactly that: five constants written a second time, which lined up
+    # with the header only for values shorter than what they both spelled.
+    print(line(heads, "STATUS"))
+    print(line(tuple("-" * max(1, w - _GAP) for w in widths), "-" * len("STATUS")))
+    for row in body:
+        name = row[0]
         try:
             prov = registry.provider_for(name, doc)
             # `env_overlay` raises when a declared identity's variable is unset, which is
@@ -316,9 +351,7 @@ def cmd_vault_list(args) -> int:
             ok, detail = prov.health()
         except base.VaultError as e:
             detail = str(e).split("\n")[0]
-        persona = vs[name].get("persona") or "—"
-        print(fmt.format(name, vs[name].get("provider", "?"), persona,
-                         registry.scope_of(name), detail))
+        print(line(row, detail))
     return 0
 
 

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -16,7 +16,7 @@ import sys
 import time
 from types import SimpleNamespace
 
-from . import config, contain, gitpolicy, planegit, util, workspace, worktree
+from . import config, contain, gitpolicy, planegit, tui, util, workspace, worktree
 from .commands import (_cred_flag, _git, _origin_https, cmd_clone, commit_memory_reactive,
                        commit_push)
 
@@ -30,14 +30,40 @@ def cmd_workspace_list(args) -> int:
         return 0
     print(f"Active workspace: {active}  (via {workspace.source()})\n")
     live = workspace.live_workspaces()
-    fmt = "{}{:<22}{:<7}{:<7}{}"
-    print(fmt.format("  ", "WORKSPACE", "MODE", "CLONES", "REPOS"))
+    # `{:<22}` was a guess about a name the operator minted, and `{:<7}` twice over about
+    # values charter mints — `:<n` pads a short value and PUSHES a long one, so a workspace
+    # named past 22 sent its mode, clone count and repo list somewhere no other row's
+    # landed. `str.format` counts characters as well, which is the half no constant can
+    # fix: the stale marker appended here is ``" ⚠"``, two characters and three cells, so
+    # every flagged row was already drawn one column right of the rest (#508, #592, #600).
+    #
+    # The numeric column is measured from its values too, for the reason `tui.column`'s
+    # own docstring gives — sizing every column this way is what makes the table
+    # unpushable by ANY value, rather than by none of the values somebody thought of.
+    #
+    # Nothing here costs a subprocess: `clones` is a directory listing and `needs_reinit`
+    # reads a file, so unlike `status` (#597) there is no reason to draw before measuring.
+    heads = ("WORKSPACE", "MODE", "CLONES")
+    body = []
     for n in names:
         cl = workspace.clones(n)
-        repos = ", ".join(d.name for d in cl) if cl else "—"
-        mark = "* " if n == active else "  "
         stale = " ⚠" if workspace.needs_reinit(n) else ""
-        print(fmt.format(mark, n + stale, "live" if n in live else "local", str(len(cl)), repos))
+        body.append(("* " if n == active else "  ", n + stale,
+                     "live" if n in live else "local", str(len(cl)),
+                     ", ".join(d.name for d in cl) if cl else "—"))
+    widths = [tui.column(h, [row[i + 1] for row in body]) for i, h in enumerate(heads)]
+
+    def line(mark, cells, last: str) -> str:
+        return (mark + "".join(tui.pad(c, w) for c, w in zip(cells, widths))
+                + last).rstrip()
+
+    # The mark is an INSET, not a column: it is charter's own two-cell "you are here"
+    # marker rather than a value measured from anything, which is how `frame.slots` and
+    # `persona list` both spell theirs. One padder for the header and the rows, so the
+    # two cannot disagree about a width the way a second format string would.
+    print(line("  ", heads, "REPOS"))
+    for row in body:
+        print(line(row[0], row[1:4], row[4]))
     stale_names = [n for n in names if workspace.needs_reinit(n)]
     if stale_names:
         util.warn(f"⚠ {len(stale_names)} workspace(s) need reinit ({', '.join(stale_names)}) — "

--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -265,7 +265,8 @@ def cmd_worktree_list(args) -> int:
                 said = f"silent {quiet}" if quiet else ""
             body.append((r["piece"], branch, state, who, said))
         # Four widths, not five: the outcome has nothing to its right, so padding it would
-        # buy trailing space `_finish` strips anyway — `_STATS_HEADS`' own rule.
+        # buy trailing space the `.rstrip()` below takes straight off again — the rule
+        # `_STATS_HEADS` states for the same shape one command over.
         widths = [tui.column("", [row[i] for row in body]) for i in range(4)]
         for row in body:
             cells = "".join(tui.pad(c, w) for c, w in zip(row, widths))

--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -232,6 +232,22 @@ def cmd_worktree_list(args) -> int:
         if not rows:
             continue
         util.info(f"{clone.name}")
+        # `{branch:<28}` was the sharpest of the four constants and the only one wrong on
+        # ORDINARY input: a branch name past 28 characters is a Tuesday, and `:<n` pads a
+        # short value while doing nothing at all to a long one — it PUSHES, so that row's
+        # state, claimant and outcome land where no other row's do and the table stops
+        # being a table. `:<24` on a piece and `:<16` on a claimant are guesses about
+        # somebody else's names for the same reason, and `str.format` counts characters
+        # where a terminal lays out cells, so a CJK piece name well inside the constant
+        # still shifted its row by one column per glyph (#508, #592, #600).
+        #
+        # Sized per clone rather than across the whole listing, and that is the same
+        # trade `_status_for_workspace` records (#597): `is_dirty` is a `git status` per
+        # worktree, so sizing every clone's rows together would make an operator wait for
+        # every repo's git before the first line appeared. A clone's own worktrees are one
+        # table under one heading, its rows are already materialised by `list_for`, and
+        # the heading above them has already told the reader where the wait is going.
+        body = []
         for r in rows:
             if r["prunable"]:
                 # The worktree dir is gone (deleted without `git worktree prune`) — git
@@ -247,7 +263,13 @@ def cmd_worktree_list(args) -> int:
                 # An age, never a verdict. Whether `silent 3d` is a problem is the reader's
                 # call — charter has not verified that the worker is gone (ADR 0009).
                 said = f"silent {quiet}" if quiet else ""
-            print(f"    {r['piece']:<24} {branch:<28} {state:<8} {who:<16} {said}".rstrip())
+            body.append((r["piece"], branch, state, who, said))
+        # Four widths, not five: the outcome has nothing to its right, so padding it would
+        # buy trailing space `_finish` strips anyway — `_STATS_HEADS`' own rule.
+        widths = [tui.column("", [row[i] for row in body]) for i in range(4)]
+        for row in body:
+            cells = "".join(tui.pad(c, w) for c, w in zip(row, widths))
+            print(f"    {cells}{row[4]}".rstrip())
             total += 1
     if not total:
         util.info("No worktrees. Create one: "

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -15,7 +15,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import inventory, util
+from . import inventory, tui, util
 from .forge.gitlab import GitLabForge
 
 OK, WARN, FAIL = "ok", "warn", "fail"
@@ -34,11 +34,31 @@ class Result:
     detail: str = ""
     hint: str = ""
 
-    def render(self) -> str:
+    def render(self, name_w: int = 0) -> str:
+        """One preflight row. *name_w* is the NAME column's width for the whole table.
+
+        ``{self.name:<16}`` was the constant #600 names, and it is a guess about content
+        in a report where three checks (`credential paths`, `workspace clones`,
+        `plane-root guard`) already sit exactly on it — so the next check named one
+        character longer pushes its detail right of every other row's and the column stops
+        being a column. `cmd_doctor` states the width from :func:`name_width`, which asks
+        the checks rather than guessing.
+
+        **The width is a floor, never a cap.** `tui.pad` truncates, and a check name cut
+        in half is a failure the reader cannot go and look up (#589's readability probe is
+        the whole reason that distinction is written down). So a name wider than the
+        stated column pushes its own row instead — loud, and in the direction that keeps
+        the value readable — and :func:`name_width` plus its pin is what stops that from
+        being how the table normally renders.
+
+        A row rendered with no width stated is as wide as itself, which is what a single
+        `Result` printed on its own should be.
+        """
         code, glyph = _SYMBOL[self.status]
         if _color():
             glyph = f"\033[{code}m{glyph}\033[0m"
-        line = f"  {glyph}  {self.name:<16} {self.detail}".rstrip()
+        line = f"  {glyph}  {tui.pad(self.name, max(name_w, tui.column('', [self.name])))}" \
+               f"{self.detail}".rstrip()
         if self.hint and self.status != OK:
             line += f"\n        → {self.hint}"
         return line
@@ -2320,6 +2340,66 @@ def _checks():
                 check_credential_paths(),
                 check_mcp_launchers(), check_plugin_skew(), check_plugin_freshness()]
     return results
+
+
+#: Every name a check in :func:`_checks` produces that does not depend on this plane's
+#: forges, in the order `_checks` runs them. The forge cli/auth pair belongs at index 3
+#: and is spliced in by :func:`check_names`, because which forge that is is a property of
+#: the control plane rather than of this list.
+#:
+#: **A second spelling of something the checks already say, and it is here because the
+#: alternative is worse.** `Result.render` needs the column's width before the first row
+#: is drawn, and `cmd_doctor` draws each row as its check lands — deliberately, so a
+#: preflight killed by its hook timeout names where it stopped instead of printing nothing
+#: at all. Sizing from the results would mean collecting every check before drawing one,
+#: which is precisely the behaviour that streaming replaced.
+#:
+#: So the names are stated ahead of the run and **pinned by equality** against what
+#: `run_all` actually produces — the same discipline `MIN_PYTHON` has against
+#: `pyproject.toml`, and the same one `NOT_ROUTED_YET` has in the state-mode suite: a
+#: check renamed, added or removed fails that test on the commit that does it. Unpinned
+#: this would be a list that rots into a wrong width; pinned, it cannot.
+_FIXED_CHECK_NAMES = (
+    "python3", "git", "git identity",
+    # ← the forge cli/auth pair is spliced in here, see `check_names`
+    "git auth", "charter.toml", "schema", "plane root", "harness", "frame",
+    "plane-root guard", "guard seen", "nested plane", "workspace clones",
+    "inventory", "vaults", "vault registry", "version lock", "memory indexes",
+    "personas", "persona grant", "front door", "news", "ask rules", "shadowed docs",
+    "credential paths", "mcp", "plugin", "plugin files",
+)
+
+#: Where the forge pair goes in `_FIXED_CHECK_NAMES` — after `git identity`, which is
+#: where `_checks` runs it. A number rather than a marker entry so the tuple holds only
+#: names and the pin below compares like with like.
+_FORGE_NAMES_AT = 3
+
+
+def check_names() -> list[str]:
+    """Every name this plane's preflight will print, **without running a single check**.
+
+    The forge pair is asked of `declared_or_default_forges` — the same call `_checks`
+    makes, so the two cannot disagree about which forge this plane declares. A GitHub-only
+    plane sizes for ``gh``/``gh auth`` and a GitLab one for ``glab``/``glab auth``, rather
+    than for whichever of them somebody wrote down.
+    """
+    pair = []
+    for forge in declared_or_default_forges():
+        pair += [forge.cli, f"{forge.cli} auth"]
+    return (list(_FIXED_CHECK_NAMES[:_FORGE_NAMES_AT]) + pair
+            + list(_FIXED_CHECK_NAMES[_FORGE_NAMES_AT:]))
+
+
+def name_width() -> int:
+    """The NAME column of `charter doctor`, measured in cells from the names it holds.
+
+    In cells rather than characters because cells are what a terminal lays out — the unit
+    `tui.column` measures every other table in this package with. Every check name is
+    ASCII today, so the two agree and this looks like a distinction without a difference;
+    it is the same distinction that drew an 8-glyph CJK name 8 columns wide of every other
+    row in `persona stats` (#508), and it is not something to get right later.
+    """
+    return tui.column("", check_names())
 
 
 def run_all() -> list[Result]:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -2348,17 +2348,22 @@ def _checks():
 #: the control plane rather than of this list.
 #:
 #: **A second spelling of something the checks already say, and it is here because the
-#: alternative is worse.** `Result.render` needs the column's width before the first row
-#: is drawn, and `cmd_doctor` draws each row as its check lands — deliberately, so a
-#: preflight killed by its hook timeout names where it stopped instead of printing nothing
-#: at all. Sizing from the results would mean collecting every check before drawing one,
-#: which is precisely the behaviour that streaming replaced.
+#: alternative forecloses something.** `Result.render` needs the column's width before the
+#: first row is drawn, and `cmd_doctor` is written to draw each row as its check lands —
+#: deliberately, so a preflight killed by its hook timeout names where it stopped instead
+#: of printing nothing at all. Sizing the column from the results would mean collecting
+#: every check before drawing one, which is exactly the shape streaming replaced.
+#:
+#: That streaming is **not delivered today**, and the honest note is worth more than the
+#: convenient one: :func:`_checks` is an eager list literal, so `iter_all` yields from a
+#: run that has already finished and `cmd_doctor` prints its rows all at once. Sizing from
+#: the results would therefore cost nothing *right now* — and would silently make the
+#: streaming fix unavailable to whoever writes it. This costs a list instead.
 #:
 #: So the names are stated ahead of the run and **pinned by equality** against what
 #: `run_all` actually produces — the same discipline `MIN_PYTHON` has against
-#: `pyproject.toml`, and the same one `NOT_ROUTED_YET` has in the state-mode suite: a
-#: check renamed, added or removed fails that test on the commit that does it. Unpinned
-#: this would be a list that rots into a wrong width; pinned, it cannot.
+#: `pyproject.toml`: a check renamed, added or removed fails that test on the commit that
+#: does it. Unpinned this would be a list that rots into a wrong width; pinned, it cannot.
 _FIXED_CHECK_NAMES = (
     "python3", "git", "git identity",
     # ← the forge cli/auth pair is spliced in here, see `check_names`

--- a/charter/tui.py
+++ b/charter/tui.py
@@ -250,6 +250,30 @@ def column(header: str, cells: Iterable[str], gap: int = 2,
     return (w if cap is None else min(w, cap)) + gap
 
 
+def _env_columns() -> int | None:
+    """``$COLUMNS`` as a number, or ``None`` when it is unset or is not one.
+
+    Answers what the variable *says*, never whether it is usable — see
+    :func:`term_width` for why that judgement is made in exactly one place.
+    """
+    try:
+        return int(os.environ[TERMINAL_SIZE_VARS[0]])
+    except (KeyError, ValueError):
+        return None
+
+
+def _tty_columns() -> int | None:
+    """The tty's own column count, or ``None`` when there is no tty to ask.
+
+    Same contract as :func:`_env_columns`: a number or nothing, and no opinion about
+    whether the number is a width.
+    """
+    try:
+        return os.get_terminal_size().columns
+    except OSError:
+        return None
+
+
 def term_width(default: int = 80, floor: int = 1) -> int:
     """Terminal width: ``$COLUMNS`` (:data:`TERMINAL_SIZE_VARS`), else the tty size,
     else *default*.
@@ -257,22 +281,35 @@ def term_width(default: int = 80, floor: int = 1) -> int:
     Clamped to at least *floor*. Status-line style programs get their size via
     ``$COLUMNS`` because stdout is a pipe, hence the env-first order.
 
-    Only a **positive** ``$COLUMNS`` counts. A real environment in this project exports
-    ``COLUMNS=0``; ``int("0")`` parses happily, so the env branch accepted it and
-    ``max(floor, 0)`` turned a meaningless value into a plausible-looking floor-width
-    render — the whole status line silently squeezed into 24 columns. Zero and
-    negatives now fall through to the tty size like any other unusable value.
+    **A width is a positive number, whichever source produced it — and that is asked
+    once, here, rather than by each source about itself.** The env branch used to carry
+    its own ``if w <= 0: raise ValueError(w)``, because a real environment in this
+    project exports ``COLUMNS=0`` and ``int("0")`` parses happily: ``max(floor, 0)``
+    turned a meaningless value into a plausible-looking floor-width render, and the whole
+    status line squeezed into 24 columns. The guard was right and it was attached to a
+    **spelling** — ``$COLUMNS`` being zero — instead of to the property, so one rung
+    lower on the same ladder the identical value walked straight through: a tty that
+    reports zero columns handed back ``max(1, 0) == 1`` and charter drew every table,
+    row and panel one column wide (#594).
+
+    That tty is ordinary, not exotic. A pty created without a window size reports zero
+    until someone calls ``TIOCSWINSZ`` — which is what :func:`os.openpty` gives you, and
+    so what tooling, some CI shells and a terminal attached before its size is negotiated
+    all give you. The suite has been carrying the evidence: under a real pty, 28 failures
+    across 8 modules were all terminal-size, and giving that pty a size made all 28 pass.
+
+    So each source answers with a number or with nothing (:func:`_env_columns`,
+    :func:`_tty_columns`), the *answer* is what is judged, and a source with no usable
+    answer is indistinguishable from a source with no answer at all. Adding a third
+    source is then one entry in the tuple rather than a fourth place to remember the
+    zero. *default* is not asked the question: it is the caller's own stated fallback for
+    "nothing could be measured", and *floor* is the last word on all three paths.
     """
-    try:
-        w = int(os.environ["COLUMNS"])
-        if w <= 0:
-            raise ValueError(w)
-    except (KeyError, ValueError):
-        try:
-            w = os.get_terminal_size().columns
-        except OSError:
-            w = default
-    return max(floor, w)
+    for ask in (_env_columns, _tty_columns):
+        w = ask()
+        if w is not None and w > 0:
+            return max(floor, w)
+    return max(floor, default)
 
 
 # Internal aliases: node methods take a ``width`` parameter by API contract,

--- a/docs/news/unreleased-a-width-is-validated-wherever-it-came-from.md
+++ b/docs/news/unreleased-a-width-is-validated-wherever-it-came-from.md
@@ -1,0 +1,104 @@
+---
+version: unreleased
+headline: a terminal that reports no size no longer squeezes charter into one column, and four more tables are measured from the values they hold
+---
+
+Two things a width can be wrong about, and charter had one of each left.
+
+## A tty that says zero columns
+
+`tui.term_width` asks two sources in order: `$COLUMNS`, then the tty. The first was
+guarded, and correctly — a real environment in this project exports `COLUMNS=0`, `int("0")`
+parses happily, and `max(floor, 0)` used to turn that meaningless value into a
+plausible-looking floor-width render. The guard was written like this:
+
+```python
+w = int(os.environ["COLUMNS"])
+if w <= 0:
+    raise ValueError(w)          # the environment's zero IS guarded
+```
+
+One rung further down the same function, the identical value walked straight through:
+
+```python
+w = os.get_terminal_size().columns   # the syscall's zero is NOT
+```
+
+so a terminal reporting zero columns produced `max(1, 0)` — **one column** — and charter
+drew every table, row and panel into it.
+
+That terminal is ordinary. A pty created without a window size reports zero until somebody
+calls `TIOCSWINSZ`, which is exactly what `openpty` gives you: tooling that starts a pty,
+some CI shells, a terminal attached before its size is negotiated. The suite has been
+carrying the evidence for a while — run under a real pty, **28 failures across 8 modules
+were all terminal-size**, and giving that pty a size made all 28 pass. Nothing had ever
+asked.
+
+The fix is not a second zero-check beside the first. Each source now answers with a number
+or with nothing, the **answer** is what gets judged, and a source with no usable answer is
+indistinguishable from a source with no answer at all — so a third source would be one
+entry in a tuple rather than a fourth place to remember the zero. A width nobody could
+measure falls to the caller's stated default (80 unless they say otherwise), which is what
+that parameter was always for.
+
+This is the sixth instance this month of a guard matching a spelling rather than a
+property — [#547](https://github.com/diazoxide/charter/issues/547) (a flag's spelling, not
+its parse), [#558](https://github.com/diazoxide/charter/issues/558) (the ref's spelling,
+not whether the check ran), [#537](https://github.com/diazoxide/charter/issues/537),
+[#498](https://github.com/diazoxide/charter/issues/498),
+[#577](https://github.com/diazoxide/charter/issues/577) — and the first where the right
+idea was already sitting at the top of the very ladder that leaked at the bottom.
+
+## Four more tables sized from a constant
+
+`tui.column()`/`tui.pad` measured `persona stats`
+([#508](https://github.com/diazoxide/charter/issues/508)), then `worktree history`,
+`status` and `recall` ([#592](https://github.com/diazoxide/charter/issues/592)). The last
+four now go the same way:
+
+* **`worktree list`** — `{branch:<28}`, and this one was wrong *today*: a branch name past
+  28 characters is a Tuesday, and `:<n` pads a short value while doing nothing at all to a
+  long one. It pushes, so that row's state, claimant and outcome land where no other row's
+  do. A worktree on a detached HEAD writes its whole path into that cell, so it did not
+  even need an unusual branch name.
+* **`vault list`** — `{:<18} {:<16} {:<12}` over a vault name the operator typed, a
+  provider name a plugin supplies and a persona name that is a committed directory. The
+  rule under the header was those same constants written a *second* time, which is how it
+  went on agreeing with the header while both sat left of the rows they described.
+* **`workspace list`** — `{:<22}` over a name the operator minted. `list_workspaces` lists
+  every directory under `workspaces/`, not only the ones `workspace create` would accept,
+  so the values this has to draw are bounded by what the *listing* can return.
+* **`charter doctor`** — `{name:<16}`, with three checks (`credential paths`, `workspace
+  clones`, `plane-root guard`) sitting exactly on it, so they got a single word space where
+  every shorter name got a column.
+
+`doctor` is the one of the four that cannot size from its rows: it prints each row as its
+check lands, deliberately, so that a preflight killed by its hook timeout says where it
+stopped instead of printing nothing at all. Its NAME column is therefore sized from the
+names the checks *carry*, before the run — asked of `declared_or_default_forges` for the
+`gh`/`glab` pair, and pinned by equality against what `run_all()` actually produces, so a
+check renamed or added fails on the commit that does it. And the width is a **floor**: a
+name the column did not know about pushes its own row rather than being cut, because
+`tui.pad` truncates and a check name cut in half is a failure nobody can go and look up.
+
+## What the tests had to avoid
+
+Three traps, all measured, all recorded in the cases rather than in a commit message.
+
+**A precomposed accent is a silent control.** `équipe-mémoire` is 14 characters and 14
+cells — it tests nothing at all. The fixtures use a base letter with a combining acute
+that Unicode has no precomposed form for, checked as it came back *off the filesystem*,
+because a filesystem that composes the pair hands the renderer a value `len` and
+`tui.width` agree about.
+
+**A CJK name alone does not catch `len`-sizing**, because `tui.pad` measures in cells and
+the table stays aligned while the value is cut. What catches it is a **pair** — one value
+widest in characters, another widest in cells, alone in the table — and a fixture guard
+keeps it a pair.
+
+**And an alignment assertion cannot see a mis-measured column at all.** Every alignment
+test in #508's own suite passed against a restored constant. The probe that works is
+whether the value is still readable off its row.
+
+`charter doctor`'s NAME column is one cell wider than it was; nothing else about these
+tables changes for values that already fit. Nothing to adopt.

--- a/tests/_tmuxsocket.py
+++ b/tests/_tmuxsocket.py
@@ -1,0 +1,79 @@
+"""The socket path a real tmux would hand this machine — asked, never spelled (#601).
+
+`tests/test_frame_launcher.py` carried a socket path with ``tmux-502`` in the middle of
+it — **502 is one developer's uid**, baked into a path. On any other machine that path is
+either absent or — worse — someone else's socket directory. Five more modules carried the
+same string, and `test_no_test_reads_the_operators_shell.py` carried a `501`.
+
+It is the same defect class the whole test-hygiene cluster closed: **the suite reads the
+machine instead of the repo.** The shell (#519/#521/#528), the plane (#402/#492), the
+filesystem (#529), the clock (#494), the working directory (#537), real credentials and a
+real keyboard (#546/#545), forked children and leaked servers (#542/#564) and ``$COLUMNS``
+(#544) all went the same way: ask, or state — never assume the developer's answer.
+
+**How tmux itself computes it, because that is what makes this a measurement rather than a
+second guess.** ``$TMUX_TMPDIR`` when it is set and non-empty, otherwise ``_PATH_TMP`` —
+which is the literal ``/tmp`` in tmux's own source, **not** ``$TMPDIR``. That distinction
+is load-bearing on macOS, where ``tempfile.gettempdir()`` answers a per-user
+``/var/folders/…`` directory that tmux never puts anything in. Then ``tmux-<uid>``, then
+the socket name (``default`` unless ``-L``/``-S`` says otherwise).
+
+**And the result is RESOLVED**, which is the other half of #601 and the reason the
+operator's measurement said ``/private/tmp`` rather than ``/tmp``: tmux calls
+``realpath()`` on that base before it uses it, and on macOS ``/tmp`` is a symlink to
+``/private/tmp``. The same distinction is what made `tools/sweep.py` unusable on macOS with
+its default workdir (#572) — ``os.getcwd()`` returns the resolved path while a constructed
+prefix does not, so ``startswith`` never matched and the selection map came back empty. A
+test that spells one form asserts something false on the platform that hands it the other,
+so this hands back the resolved form on every platform and no caller has to know which
+spelling it is on.
+
+Nothing here touches the filesystem: `os.path.realpath` resolves what exists and leaves
+the rest lexical, so a socket directory that has never been created still gets the right
+answer and the suite still starts no tmux server it did not mean to.
+"""
+
+from __future__ import annotations
+
+import os
+
+#: tmux's ``_PATH_TMP``, verbatim: a literal in its source, not ``$TMPDIR``.
+DEFAULT_TMPDIR = "/tmp"
+
+#: The socket name tmux uses when nobody passes ``-L``.
+DEFAULT_SOCKET = "default"
+
+
+def socket_dir(tmpdir: str | None = None) -> str:
+    """``<tmpdir or $TMUX_TMPDIR or /tmp>/tmux-<uid>``, resolved.
+
+    *tmpdir* is for the cases that state one; leaving it None asks the environment, which
+    is what a tmux started right now would do.
+    """
+    base = tmpdir if tmpdir is not None else (os.environ.get("TMUX_TMPDIR") or "")
+    return os.path.realpath(os.path.join(base or DEFAULT_TMPDIR, f"tmux-{os.getuid()}"))
+
+
+def socket_path(name: str = DEFAULT_SOCKET, tmpdir: str | None = None) -> str:
+    """The full path of the *name* socket in :func:`socket_dir`."""
+    return os.path.join(socket_dir(tmpdir), name)
+
+
+def tmux_env(socket: str | None = None, *, server_pid: int = 70029,
+             session: str = "1") -> str:
+    """A ``$TMUX`` value shaped exactly as a real tmux exports it into every pane.
+
+    ``<socket path>,<server pid>,<session id>`` — measured by printing ``$TMUX`` from
+    inside a tmux 3.7c pane. The pid and the session id are synthetic on purpose: they are
+    charter's *input* here, not something about the machine, and a real pid would make the
+    fixture no more true and considerably less stable.
+    """
+    return f"{socket or socket_path()},{int(server_pid)},{session}"
+
+
+#: The socket a tmux started on this machine right now would listen on, computed once at
+#: import. Every module that used to spell one developer's uid uses this.
+OPERATOR_SOCKET = socket_path()
+
+#: The ``$TMUX`` that goes with it.
+OPERATOR_TMUX = tmux_env(OPERATOR_SOCKET)

--- a/tests/test_a_table_column_is_measured_in_cells.py
+++ b/tests/test_a_table_column_is_measured_in_cells.py
@@ -684,6 +684,16 @@ class WorktreeListCase(TableCase):
         self.rows.append({"piece": piece, "branch": branch if branch is not None else piece,
                           "path": f"/w/{piece}", "prunable": False})
 
+    def claim(self, piece: str, *, repo: str | None = None) -> None:
+        """Record a real claim so the WHO column holds something.
+
+        Unclaimed rows render `pieces.claimant(None)` — the string `unknown` — on every
+        row, which is a column that cannot tell "drawn" from "dropped": with every row
+        identical, removing the cell entirely leaves the rows still agreeing with each
+        other. A claimed piece puts a value on the row that only that row has.
+        """
+        pieces.record(self.WS, "claimed", repo or self.REPO, piece, reason="SO-SAID")
+
     def listing(self) -> list[str]:
         return self.run_cmd(commands_worktree.cmd_worktree_list,
                             SimpleNamespace(workspace=self.WS, repo=None))
@@ -741,6 +751,27 @@ class TestWorktreeListColumnsLineUp(WorktreeListCase):
         self.worktree_row("slice")
         self.worktree_row(COMBINING)
         self.assert_aligned(self.listing(), self.TAIL)
+
+    def test_the_claimant_is_on_the_row_and_not_merely_between_two_that_line_up(self):
+        """The column the alignment probe cannot see, because dropping it keeps the rows
+        agreeing with each other.
+
+        Measured by a hand mutation: sizing four columns as three drops WHO out of every
+        row — `zip(row, widths)` simply stops early — and the tail's offset stays
+        identical on every row, so every alignment case stayed green. What catches it is
+        asking whether the claimant is readable off the row it belongs to (#589's probe,
+        one column over).
+        """
+        self.worktree_row("slice")
+        self.worktree_row("other")
+        self.claim("slice")
+        rows = self.listing()
+        who = pieces.claimant(pieces.claims(self.WS).get((self.REPO, "slice")))
+        self.assertNotEqual(who, "unknown",
+                            "fixture: the claim did not land, so WHO is the same string "
+                            "on every row and this case cannot fail")
+        self.assert_readable(rows, who)
+        self.assert_aligned(rows, self.TAIL)
 
     def test_an_ascii_listing_is_the_control(self):
         """Every value inside every constant, so this row is drawn identically with the
@@ -882,6 +913,27 @@ class TestVaultListColumnsLineUp(VaultListCase):
         moment one value passed its constant."""
         self.add("the-shared-team-credentials-vault")
         self.assert_heads(self.listing(), "STATUS", self.TAIL)
+
+    def test_the_widest_value_in_a_column_is_still_followed_by_a_separator(self):
+        """What the gap buys, pinned by what it buys rather than by its number.
+
+        `_GAP`'s VALUE is deliberately invisible: the rule under the header is drawn from
+        ``w - _GAP`` and the column is sized with ``gap=_GAP``, so moving it moves both
+        sides together and every offset stays consistent — measured by a hand mutation
+        that raised it to 3 with the whole file green. A gap of ZERO is not invisible:
+        the widest value in a column then runs straight into the next cell, and a reader
+        has nothing telling them where one column ends. Same measurement `worktree
+        history`'s timestamp column carries (#592).
+        """
+        self.add("the-shared-team-credentials-vault")
+        rows = self.listing()
+        widest = "the-shared-team-credentials-vault"
+        row = next(r for r in rows if widest in tui.strip_ansi(r))
+        after = tui.strip_ansi(row)[tui.strip_ansi(row).index(widest) + len(widest):]
+        self.assertGreaterEqual(
+            len(after) - len(after.lstrip(" ")), 1,
+            f"the widest value in the VAULT column touches the next one, so nothing on "
+            f"this row says where the column ends:\n{row}")
 
     def test_every_vault_and_persona_is_still_readable_off_its_row(self):
         long_vault = "the-shared-team-credentials-vault"
@@ -1079,15 +1131,49 @@ class TestDoctorSizesItsNameColumnFromTheChecks(TableCase):
         self.assertEqual(doctor.check_names(), [r.name for r in doctor.run_all()])
 
     def test_the_forge_pair_comes_from_the_plane_rather_than_from_the_list(self):
-        """A GitHub-only plane sizes for `gh`/`gh auth`. Hardcoding either would make the
-        column right on one kind of plane and wrong on the other — FINDING I3's shape,
-        which `declared_or_default_forges` exists to have settled once."""
+        """A GitHub-only plane sizes for `gh`/`gh auth`, and this plane is made one.
+
+        **The obvious version of this case agrees with the default and tests nothing.**
+        `declared_or_default_forges` falls back to GitLab when a plane declares none, so
+        asserting "whatever it resolved is in the list" passes against a hardcoded
+        ``glab`` — measured by a hand mutation that did exactly that, with the case green.
+        #588's shape: a fixture the machine would have chosen anyway.
+
+        So the plane declares GitHub, which is the value charter would never pick on its
+        own, and the pair asserted is the one that declaration produces.
+        """
+        (Path(config.ROOT) / "charter.toml").write_text(
+            'schema = 1\n\n[[forge]]\nkind = "github"\nhost = "github.com"\n'
+            'group = "acme"\n')
         clis = [f.cli for f in doctor.declared_or_default_forges()]
-        self.assertTrue(clis, "fixture: no forge resolved, so there is nothing to check")
-        for cli in clis:
-            with self.subTest(cli=cli):
-                self.assertIn(cli, doctor.check_names())
-                self.assertIn(f"{cli} auth", doctor.check_names())
+        self.assertEqual(clis, ["gh"],
+                         "fixture: the plane's own `[[forge]]` did not reach "
+                         "`declared_or_default`, so this case is about the default again")
+        names = doctor.check_names()
+        self.assertIn("gh", names)
+        self.assertIn("gh auth", names)
+        self.assertNotIn("glab", names)
+        self.assertNotIn("glab auth", names)
+
+    def test_the_name_column_is_measured_in_cells_and_not_in_characters(self):
+        """`name_width` asks `tui.column`, which measures cells — and every check name is
+        ASCII, so `len` and `tui.width` agree about all of them and the unit is
+        unobservable on the real list. Measured: a hand mutation to `max(len(...)) + 2`
+        left the whole file green.
+
+        A check name is a literal in `doctor.py` today, so this states one that is not,
+        rather than pretending doctor has a CJK check. What is under test is the
+        function's contract — the same unit every other table in this package is measured
+        in — not the roster it happens to be asked about.
+        """
+        wide = "\u65e5\u672c\u8a9e\u30c1\u30a7\u30c3\u30af"      # 7 characters, 14 cells
+        self.assert_a_cell_and_a_character_disagree(wide)
+        with mock.patch.object(doctor, "_FIXED_CHECK_NAMES", ("git", wide)):
+            self.assertEqual(doctor.name_width(), tui.column("", ["git", wide]))
+            self.assertGreater(doctor.name_width(), len(wide) + 2,
+                               "the NAME column was sized by characters, so a name that "
+                               "is 7 characters and 14 cells would be drawn 7 columns "
+                               "wide of every other row")
 
     def test_the_detail_column_starts_in_the_same_cell_on_every_row(self):
         """The property, on the two names that sit exactly ON the old constant beside one

--- a/tests/test_a_table_column_is_measured_in_cells.py
+++ b/tests/test_a_table_column_is_measured_in_cells.py
@@ -36,11 +36,13 @@ import re
 import unicodedata
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import (commands, commands_worktree, config, persona, pieces, tui,
-                     workspace)
+from charter import (commands, commands_secrets, commands_worktree, commands_workspace,
+                     config, doctor, persona, pieces, tui, workspace)
+from charter.secrets import registry as vault_registry
 from tests._isolation import PersonaIso
 
 #: A base character with a combining acute, built with `chr` so no editor and no
@@ -140,6 +142,27 @@ class TableCase(PersonaIso):
             f"the column holding {marker!r} starts at cells {sorted(at)} — different on "
             f"different rows, so it was sized by a guess or measured in characters:\n"
             + "\n".join(data))
+
+    def assert_heads(self, rows: list[str], head_marker: str, marker: str,
+                     *, least: int = 2) -> None:
+        """The header's *head_marker* begins in the same cell as *marker* on EVERY row.
+
+        Every row, not the first one that carries it: the rows are sorted by name, so
+        "the one the assertion happens to reach" is decided by the alphabet rather than by
+        the case, and a short row lines up with the header under a broken width exactly as
+        it does under a correct one. Measured — a probe reading `next(...)` here passed
+        against the constant it was written to catch.
+        """
+        data = [r for r in rows if marker in tui.strip_ansi(r)]
+        self.assertGreaterEqual(len(data), least,
+                                f"{marker!r} is on {len(data)} row(s), needed {least}:\n"
+                                + "\n".join(rows))
+        head = next(r for r in rows if head_marker in tui.strip_ansi(r))
+        at = self.cells_before(head, head_marker)
+        for r in data:
+            self.assertEqual(at, self.cells_before(r, marker),
+                             f"the header sits at cell {at} and this row's column does "
+                             f"not:\n{head}\n{r}")
 
     def assert_readable(self, rows: list[str], value: str) -> None:
         """*value* appears IN FULL on some row.
@@ -615,6 +638,496 @@ class TestRecallColumnsLineUp(RecallCase):
                                    if "/memory/" in ln))
         self.assertEqual(len(addr) - len(addr.lstrip(" ")),
                          row.index("persona:"), "\n".join([row, addr]))
+
+
+# --------------------------------------------------------------------------- #
+# worktree list — `{piece:<24} {branch:<28} {state:<8} {who:<16} {said}` (#600) #
+# --------------------------------------------------------------------------- #
+class WorktreeListCase(TableCase):
+    """`worktree list` starts from GIT and joins the record onto what git found (ADR
+    0011), so the rows are stubbed and the record is real.
+
+    `list_for` shells out to `git worktree list --porcelain` and `is_dirty` to `git
+    status` per row; what is under test is the arithmetic between them, and a real
+    worktree per fixture name would be a `git init` per case for values git never sees.
+    `tests/test_worktree.py` drives the real thing.
+    """
+
+    WS = "alpha"
+    REPO = "svc"
+
+    #: The last column, identical on every row, so its offset is the SUM of the four
+    #: widths in front of it — one marker that fails if any of them is wrong.
+    TAIL = "silent 3d"
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure(self.WS)
+        workspace.scaffold(self.WS)
+        self.rows: list[dict] = []
+        self.enterContext(mock.patch.object(
+            commands_worktree.workspace, "repo_trees",
+            return_value=[workspace.workspace_dir(self.WS) / self.REPO]))
+        self.enterContext(mock.patch.object(
+            commands_worktree.worktree, "list_for",
+            side_effect=lambda clone, ws: list(self.rows)))
+        self.enterContext(mock.patch.object(
+            commands_worktree.worktree, "is_dirty", return_value=False))
+        # An age, not a verdict — and a FIXED one, so `said` is the same string on every
+        # row. A real `silence()` returns the age of the claim, which differs per row by
+        # however long the fixture took to build and would make the tail unusable as a
+        # single offset.
+        self.enterContext(mock.patch.object(
+            commands_worktree.pieces, "silence", return_value="3d"))
+
+    def worktree_row(self, piece: str, branch: str | None = None) -> None:
+        self.rows.append({"piece": piece, "branch": branch if branch is not None else piece,
+                          "path": f"/w/{piece}", "prunable": False})
+
+    def listing(self) -> list[str]:
+        return self.run_cmd(commands_worktree.cmd_worktree_list,
+                            SimpleNamespace(workspace=self.WS, repo=None))
+
+
+class TestWorktreeListColumnsLineUp(WorktreeListCase):
+    def test_a_branch_name_past_the_constant_does_not_push_its_row(self):
+        """`{branch:<28}`, and #600's own words: **a branch name past 28 characters is
+        ordinary**, so this table is wrong today rather than one commit away.
+
+        The name here is this repo's own convention — `charter worktree add` names the
+        branch after the piece, and the pieces in this project's log run to thirty-four
+        characters. Nothing unusual has to happen for the row after it to be misaligned.
+        """
+        self.worktree_row("slice")
+        self.worktree_row("fix-the-four-tables-that-pad-into-a-constant")
+        self.assert_aligned(self.listing(), self.TAIL)
+
+    def test_a_piece_name_past_the_constant_does_not_push_its_row(self):
+        self.worktree_row("slice")
+        self.worktree_row("a-piece-named-well-past-twenty-four-characters")
+        self.assert_aligned(self.listing(), self.TAIL)
+
+    def test_a_detached_worktree_writes_its_whole_path_into_the_branch_cell(self):
+        """`branch = r["branch"] or f"detached {r['path']}"` — a path, in a 28-wide
+        column. A worktree on a detached HEAD is first-class here (`list_for` reports what
+        git reports), and the cell it produces is longer than the constant by construction
+        rather than by an unlucky name."""
+        self.worktree_row("slice")
+        self.rows.append({"piece": "loose", "branch": "",
+                          "path": "/very/long/path/to/a/detached/worktree/checkout",
+                          "prunable": False})
+        rows = self.listing()
+        self.assert_aligned(rows, self.TAIL)
+        self.assert_readable(rows, "/very/long/path/to/a/detached/worktree/checkout")
+
+    def test_a_cjk_piece_name_does_not_push_its_row(self):
+        """The `len` half, which no constant can fix: `str.format` pads to CHARACTERS, so
+        a name that measures well inside 24 is drawn one column wide of every other row
+        per glyph."""
+        name = "日本語のピース"
+        self.assert_a_cell_and_a_character_disagree(name)
+        self.worktree_row("slice")
+        self.worktree_row(name)
+        self.assert_aligned(self.listing(), self.TAIL)
+
+    def test_a_combining_mark_does_not_pull_its_row(self):
+        """The other direction, the one a BIGGER constant makes worse: a combining mark is
+        zero cells and one character, so `len` over-pads and the row drifts right.
+
+        `COMBINING` and not `équipe-mémoire`: the obvious spelling has a precomposed `é`,
+        which is one codepoint and one cell, so `len` and `tui.width` agree about it and
+        the case would pass against the defect it is named for (measured, #600)."""
+        self.assert_a_cell_and_a_character_disagree(COMBINING)
+        self.worktree_row("slice")
+        self.worktree_row(COMBINING)
+        self.assert_aligned(self.listing(), self.TAIL)
+
+    def test_an_ascii_listing_is_the_control(self):
+        """Every value inside every constant, so this row is drawn identically with the
+        fix and without it — a failure naming it is about the table, not the name."""
+        self.worktree_row("slice")
+        self.worktree_row("other")
+        self.assert_aligned(self.listing(), self.TAIL)
+
+    def test_every_piece_and_branch_is_still_readable_off_its_row(self):
+        """The half alignment cannot see — and here it guards the FIX rather than the
+        defect, which is worth saying because it changes what a failure means.
+
+        `{piece:<24}` pushes and never cuts, so this passes against the old code too;
+        `tui.pad` TRUNCATES, so a column the new code sizes too small stays perfectly
+        aligned and quietly loses the end of its value. Every alignment assertion in
+        #508's own suite passed against a restored constant for exactly that reason
+        (#589). A branch a reader cannot read back is one they cannot check out."""
+        long_piece = "a-piece-named-well-past-twenty-four-characters"
+        long_branch = "a-branch-named-well-past-twenty-eight-characters"
+        self.worktree_row("slice")
+        self.worktree_row(long_piece, long_branch)
+        rows = self.listing()
+        for value in (long_piece, long_branch):
+            with self.subTest(value=value):
+                self.assert_readable(rows, value)
+
+    def test_the_widest_in_cells_is_readable_beside_the_widest_in_characters(self):
+        """The pair, ALONE in the table, and alone is what makes it a case.
+
+        `len`-sizing is observable only when the value that DECIDES the width and the
+        value that OVERFLOWS it are different rows. Put a sixty-character ASCII piece in
+        here as well and it decides the width for both, the CJK one fits inside with room
+        to spare, and every assertion passes against the defect."""
+        self.assert_the_widest_two_disagree(WIDEST_IN_CHARACTERS, WIDEST_IN_CELLS)
+        self.worktree_row(WIDEST_IN_CHARACTERS)
+        self.worktree_row(WIDEST_IN_CELLS)
+        rows = self.listing()
+        self.assert_readable(rows, WIDEST_IN_CELLS)
+        self.assert_aligned(rows, self.TAIL)
+
+
+# --------------------------------------------------------------------------- #
+# vault list — `{:<18} {:<16} {:<12} {:<7} {}` (#600)                          #
+# --------------------------------------------------------------------------- #
+class VaultListCase(TableCase):
+    """Registered through the call `charter vault add` makes, so the table under test is
+    fed by the registry rather than by a hand-built document.
+
+    STATUS is stubbed, and for the reason `StatusTableCase` stubs its note: it is one
+    `health()` per vault — the column `cmd_vault_list` deliberately does not size from —
+    and a real one names the vault's own file, so it is a DIFFERENT string on every row.
+    A tail that differs per row cannot be an offset, and what is under test here is the
+    arithmetic in front of it. `tests/test_vault_dir_mode.py` drives the real health line.
+    """
+
+    #: The tail, identical on every row, so its offset is the sum of the four measured
+    #: widths in front of it — one marker that fails if any of them is wrong.
+    TAIL = "STATUS-STANDS-IN"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.object(
+            commands_secrets.registry, "provider_for",
+            return_value=SimpleNamespace(env_overlay=lambda: None,
+                                         health=lambda: (True, self.TAIL))))
+
+    def add(self, name: str, *, provider: str = "plain-file",
+            persona_name: str | None = None) -> str:
+        vault_registry.add_vault(
+            name, provider, {"file": str(config.STATE_DIR / "vaults" / f"{name}.json")},
+            persona=persona_name)
+        return name
+
+    def listing(self) -> list[str]:
+        return self.run_cmd(commands_secrets.cmd_vault_list, SimpleNamespace())
+
+
+class TestVaultListColumnsLineUp(VaultListCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.add("devops")
+
+    def test_a_vault_name_past_the_constant_does_not_push_its_row(self):
+        """`{:<18}` on a name the OPERATOR minted — `charter vault add <name>` takes
+        whatever they type."""
+        self.add("the-shared-team-credentials-vault")
+        self.assert_aligned(self.listing(), self.TAIL)
+
+    def test_a_persona_name_past_the_constant_does_not_push_its_row(self):
+        """`{:<12}` on a persona name, which is a committed directory name charter did not
+        mint either — #508's finding about `persona stats`, one table over."""
+        self.make_persona("a-persona-named-past-twelve", role="Role")
+        self.add("scoped", persona_name="a-persona-named-past-twelve")
+        self.assert_aligned(self.listing(), self.TAIL)
+
+    def test_a_cjk_persona_name_does_not_push_its_row(self):
+        """The `len` half. Two cells per glyph, measured as one character each, so the row
+        is drawn one column right per glyph while sitting well inside the constant."""
+        name = "日本語のペルソナ"
+        self.assert_a_cell_and_a_character_disagree(name)
+        try:
+            self.make_persona(name, role="Role")
+        except OSError:  # pragma: no cover - a filesystem that refuses the name
+            self.skipTest(f"filesystem refuses {name!r}")
+        self.add("wide", persona_name=name)
+        self.assert_aligned(self.listing(), self.TAIL)
+
+    @staticmethod
+    def _starts(line: str) -> list[int]:
+        """The cell each non-blank run on *line* begins at.
+
+        Positional, never `line.index(run)`: every run of dashes is a substring of every
+        longer one, so an index lookup finds the first and reports four columns as
+        starting in the same cell — a probe that cannot fail.
+        """
+        plain = tui.strip_ansi(line)
+        return [tui.width(plain[:m.start()]) for m in re.finditer(r"\S+", plain)]
+
+    def test_the_rule_under_the_header_is_as_wide_as_the_column_it_underlines(self):
+        """The rule was five constants written a SECOND time (`"-" * 18` under `{:<18}`),
+        which is the two-code-paths shape #508 names: it agreed with the header only while
+        every value was inside the number they both spelled.
+
+        Asserted as a relationship — each run of dashes begins where the header cell above
+        it begins — rather than against a number, so it cannot be satisfied by re-spelling
+        today's widths."""
+        self.add("the-shared-team-credentials-vault")
+        rows = self.listing()
+        head = next(r for r in rows if "VAULT" in r)
+        rule = next(r for r in rows if set(tui.strip_ansi(r).strip()) == set("- "))
+        self.assertEqual(self._starts(rule), self._starts(head),
+                         f"the rule does not line up with the header it underlines:"
+                         f"\n{head}\n{rule}")
+
+    def test_the_header_lines_up_with_the_rows_it_heads(self):
+        """The rule case above cannot see this and neither could the old code's own eye
+        test: header and rule went through the SAME format string, so they agreed with
+        each other for every input while both sat left of the rows they described the
+        moment one value passed its constant."""
+        self.add("the-shared-team-credentials-vault")
+        self.assert_heads(self.listing(), "STATUS", self.TAIL)
+
+    def test_every_vault_and_persona_is_still_readable_off_its_row(self):
+        long_vault = "the-shared-team-credentials-vault"
+        self.make_persona("a-persona-named-past-twelve", role="Role")
+        self.add(long_vault, persona_name="a-persona-named-past-twelve")
+        rows = self.listing()
+        for value in (long_vault, "a-persona-named-past-twelve"):
+            with self.subTest(value=value):
+                self.assert_readable(rows, value)
+
+    def test_the_widest_in_cells_is_readable_beside_the_widest_in_characters(self):
+        """The pair, and nothing else in the table but the control it is compared to."""
+        self.assert_the_widest_two_disagree(WIDEST_IN_CHARACTERS, WIDEST_IN_CELLS)
+        self.add(WIDEST_IN_CHARACTERS)
+        self.add(WIDEST_IN_CELLS)
+        rows = self.listing()
+        self.assert_readable(rows, WIDEST_IN_CELLS)
+        self.assert_aligned(rows, self.TAIL)
+
+
+# --------------------------------------------------------------------------- #
+# workspace list — `{}{:<22}{:<7}{:<7}{}` (#600)                               #
+# --------------------------------------------------------------------------- #
+class WorkspaceListCase(TableCase):
+    """Real directories on disk: `list` reads a directory listing and a structure marker,
+    neither of which costs a subprocess, so nothing here needs stubbing.
+
+    **Made with `mkdir`, not with `workspace.ensure`, and that is the case rather than a
+    shortcut.** `ensure` refuses anything outside ``[A-Za-z0-9._-]``
+    (`instance.workspace_name_ok`), but `list_workspaces` lists **every** directory under
+    ``workspaces/`` that is not hidden and not itself a clone — so a workspace directory
+    made by hand, restored from a tarball, or created by a charter with a different rule
+    reaches this renderer with a name the creation path would never have minted. The
+    values a table has to draw are bounded by what the LISTING can return, not by what
+    the constructor accepts.
+    """
+
+    #: One clone per workspace, so REPOS holds the same string on every row and its offset
+    #: is the sum of the three measured widths in front of it. Named so it cannot appear
+    #: anywhere else on the line: `cells_before` takes the FIRST occurrence, and a marker
+    #: that is also a substring of a workspace name measures the wrong column — `svc` was,
+    #: inside `sixteen-char-svc`, and every row then "lined up" at cell 2.
+    CLONE = "the-only-clone"
+
+    def make(self, name: str) -> str:
+        d = workspace.workspace_dir(name)
+        try:
+            (d / self.CLONE / ".git").mkdir(parents=True, exist_ok=True)
+        except OSError:  # pragma: no cover - a filesystem that refuses the name
+            self.skipTest(f"filesystem refuses {name!r}")
+        return name
+
+    def on_disk(self, name: str) -> str:
+        """The workspace directory name as the RENDERER will see it, matched under NFC —
+        `StatusTableCase.on_disk`'s reason, and the same trap."""
+        want = unicodedata.normalize("NFC", name)
+        return next((n for n in workspace.list_workspaces()
+                     if unicodedata.normalize("NFC", n) == want), name)
+
+    def listing(self) -> list[str]:
+        return self.run_cmd(commands_workspace.cmd_workspace_list, SimpleNamespace())
+
+
+class TestWorkspaceListColumnsLineUp(WorkspaceListCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.make("alpha")
+
+    def test_a_workspace_name_past_the_constant_does_not_push_its_row(self):
+        """`{:<22}` on a name the operator minted with `charter workspace create`, which
+        takes whatever they type inside its character class."""
+        self.make("a-workspace-named-well-past-twenty-two")
+        self.assert_aligned(self.listing(), self.CLONE)
+
+    def test_a_cjk_workspace_name_does_not_push_its_row(self):
+        """The `len` half, which no constant can fix: two cells per glyph measured as one
+        character each, so the row is drawn one column right of the others per glyph.
+
+        Reachable because the LISTING does not validate — see the class docstring."""
+        name = self.make("日本語のワークスペース")
+        self.assert_a_cell_and_a_character_disagree(self.on_disk(name))
+        self.assert_aligned(self.listing(), self.CLONE)
+
+    def test_a_combining_mark_does_not_pull_its_row(self):
+        """The other direction, the one a bigger constant makes worse: zero cells, one
+        character, so `len` over-pads and the row drifts right.
+
+        Checked as it came back OFF THE FILESYSTEM: a filesystem that composes the pair
+        hands the renderer one codepoint, `len` and `tui.width` then agree, and the case
+        passes against the defect it is named for."""
+        name = self.make(COMBINING)
+        self.assert_a_cell_and_a_character_disagree(self.on_disk(name))
+        self.assert_aligned(self.listing(), self.CLONE)
+
+    def test_an_ascii_roster_is_the_control(self):
+        """Every value inside every constant, so these rows are drawn identically with the
+        fix and without it — a failure naming them is about the table, not the name."""
+        self.make("beta")
+        self.assert_aligned(self.listing(), self.CLONE)
+
+    def test_the_header_lines_up_with_the_rows_it_heads(self):
+        """The header went through the same format string as the rows, which looks like
+        one code path and is not: `{:<22}` agrees with itself only while every value is
+        shorter than the constant it spells."""
+        self.make("a-workspace-named-well-past-twenty-two")
+        self.assert_heads(self.listing(), "REPOS", self.CLONE)
+
+    def test_the_stale_marker_is_measured_with_the_name_it_is_appended_to(self):
+        """The name cell is ``n + stale``, so the column has to be sized from the value
+        the row actually draws rather than from the workspace name alone.
+
+        **The marker itself is NOT a cells-versus-characters fixture, and this is where
+        that is written down so nobody builds one on it.** ``" \u26a0"`` measures two
+        characters and two cells — `tui.width` calls U+26A0 one cell — so a case named for
+        `len`-sizing that used it would be a silent control, which is #600's first trap in
+        the other alphabet. What it IS is a value charter appends after the name, and a
+        column sized from the name would be one cell too narrow for every flagged row.
+        """
+        marker = " \u26a0"
+        self.assertIn(f'stale = "{marker}" if',
+                      Path(commands_workspace.__file__).read_text(),
+                      "fixture: `cmd_workspace_list` no longer appends this marker, so "
+                      "what this case measures is not what the table draws")
+        self.assertEqual(len(marker), tui.width(marker),
+                         f"{marker!r} now measures {tui.width(marker)} cells against "
+                         f"{len(marker)} characters — it has become a `len`-sizing "
+                         f"fixture, and the note above needs rewriting rather than "
+                         f"deleting")
+        self.make("beta")
+        with mock.patch.object(commands_workspace.workspace, "needs_reinit",
+                               side_effect=lambda n: n == "beta"):
+            rows = self.listing()
+        self.assertTrue(any(marker in tui.strip_ansi(r) for r in rows),
+                        "fixture: no row carries the marker\n" + "\n".join(rows))
+        self.assert_aligned(rows, self.CLONE)
+
+    def test_every_workspace_name_is_still_readable_off_its_row(self):
+        """The half alignment cannot see, guarding the FIX: `{:<22}` pushed and never
+        cut, so this passes against the old code as well — `tui.pad` truncates, and a
+        column it sizes too small goes on lining up while losing the end of the name
+        (#589)."""
+        long_name = "a-workspace-named-well-past-twenty-two"
+        self.make(long_name)
+        self.assert_readable(self.listing(), long_name)
+
+    def test_the_widest_in_cells_is_readable_beside_the_widest_in_characters(self):
+        """The pair, and it needs to be a pair: `len`-sizing is observable only when the
+        value that DECIDES the width and the value that overflows it are different rows.
+
+        `alpha` from `setUp` is inside both, so it decides neither."""
+        self.assert_the_widest_two_disagree(WIDEST_IN_CHARACTERS, WIDEST_IN_CELLS)
+        self.make(WIDEST_IN_CHARACTERS)
+        self.make(WIDEST_IN_CELLS)
+        rows = self.listing()
+        self.assert_readable(rows, self.on_disk(WIDEST_IN_CELLS))
+        self.assert_aligned(rows, self.CLONE, least=3)
+
+
+# --------------------------------------------------------------------------- #
+# doctor — `  {glyph}  {name:<16} {detail}` (#600)                             #
+# --------------------------------------------------------------------------- #
+class TestDoctorSizesItsNameColumnFromTheChecks(TableCase):
+    """`doctor` is the one of the four that CANNOT size from its rows.
+
+    `cmd_doctor` prints each row as its check lands, deliberately — a preflight killed by
+    its hook timeout used to emit nothing at all, not even the checks that had already
+    passed. So the width is stated ahead of the run from the names the checks carry, and
+    what has to be pinned is that the stated names and the produced names are the same
+    set.
+    """
+
+    def rendered(self, *results) -> list[str]:
+        w = doctor.name_width()
+        return [r.render(w) for r in results]
+
+    def test_the_stated_names_are_the_names_the_checks_produce(self):
+        """The pin, by EQUALITY in both directions — the `NOT_ROUTED_YET` discipline. A
+        check renamed or added fails here as an unlisted name; one removed fails as a
+        stale entry. Without this the list rots into a wrong width and nothing says so.
+
+        `run_all()` rather than a stub: the forge pair is resolved from this plane's
+        `charter.toml`, and a list checked against anything else would not be checked
+        against what `cmd_doctor` prints.
+        """
+        self.assertEqual(sorted(set(doctor.check_names())),
+                         sorted({r.name for r in doctor.run_all()}),
+                         "`doctor._FIXED_CHECK_NAMES` and `_checks()` disagree about "
+                         "which checks exist, so the NAME column is sized for the wrong "
+                         "set of names")
+
+    def test_the_names_are_stated_in_the_order_the_checks_run(self):
+        """Order is not what the width needs, and it IS what a reader of the constant
+        needs — a list in a different order than the report is a list nobody can check by
+        eye against the output they are looking at."""
+        self.assertEqual(doctor.check_names(), [r.name for r in doctor.run_all()])
+
+    def test_the_forge_pair_comes_from_the_plane_rather_than_from_the_list(self):
+        """A GitHub-only plane sizes for `gh`/`gh auth`. Hardcoding either would make the
+        column right on one kind of plane and wrong on the other — FINDING I3's shape,
+        which `declared_or_default_forges` exists to have settled once."""
+        clis = [f.cli for f in doctor.declared_or_default_forges()]
+        self.assertTrue(clis, "fixture: no forge resolved, so there is nothing to check")
+        for cli in clis:
+            with self.subTest(cli=cli):
+                self.assertIn(cli, doctor.check_names())
+                self.assertIn(f"{cli} auth", doctor.check_names())
+
+    def test_the_detail_column_starts_in_the_same_cell_on_every_row(self):
+        """The property, on the two names that sit exactly ON the old constant beside one
+        that does not: `workspace clones` and `credential paths` are both sixteen, so
+        `{:<16}` gave them a single word space where every shorter name got a column."""
+        rows = self.rendered(
+            doctor.Result("git", doctor.OK, detail="DETAIL"),
+            doctor.Result("workspace clones", doctor.OK, detail="DETAIL"),
+            doctor.Result("credential paths", doctor.OK, detail="DETAIL"))
+        self.assert_aligned(rows, "DETAIL", least=3)
+
+    def test_a_name_at_the_old_constant_is_still_separated_from_its_detail(self):
+        """What `{:<16}` cost on a sixteen-character name was not a cut value — it was the
+        SEPARATION, and a single space is a word space rather than a column boundary. The
+        same measurement `worktree history`'s timestamp column carries."""
+        row = tui.strip_ansi(self.rendered(
+            doctor.Result("workspace clones", doctor.OK, detail="3 clones"))[0])
+        after = row[row.index("workspace clones") + len("workspace clones"):]
+        self.assertGreaterEqual(
+            len(after) - len(after.lstrip(" ")), 2,
+            f"the name column is no wider than the name it holds, so it degraded to a "
+            f"word space in front of the detail:\n{row}")
+
+    def test_a_name_wider_than_the_stated_column_pushes_rather_than_being_cut(self):
+        """The direction that matters when the pin above is what has gone wrong.
+
+        `tui.pad` truncates, so a stated width that does not know about a name would cut
+        the one thing the row is FOR — which check this is. `render` treats the width as a
+        floor, so an unknown name pushes its own row instead: loud, and readable.
+        """
+        name = "a-check-nobody-told-the-column-about"
+        row = tui.strip_ansi(doctor.Result(name, doctor.OK, detail="DETAIL").render(4))
+        self.assertIn(name, row, row)
+        self.assertIn("DETAIL", row, row)
+
+    def test_a_row_rendered_with_no_width_is_as_wide_as_itself(self):
+        """`render()` with nothing stated is what a single `Result` printed on its own
+        should be, and what the cases that assert on one row's text already call."""
+        row = tui.strip_ansi(doctor.Result("git", doctor.OK, detail="DETAIL").render())
+        self.assertTrue(row.endswith("git  DETAIL"), row)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_a_width_is_validated_wherever_it_came_from.py
+++ b/tests/test_a_width_is_validated_wherever_it_came_from.py
@@ -1,0 +1,178 @@
+"""`tui.term_width` judges the ANSWER, not the source that produced it (#594).
+
+The guard that mattered was already written, one rung up its own ladder: ``$COLUMNS=0``
+is refused because a real environment in this project exports it and ``int("0")`` parses
+happily. One rung down, the identical value walked through — ``os.get_terminal_size()``
+answering zero columns produced ``max(1, 0) == 1``, and charter drew every table, row and
+panel one column wide.
+
+**Why these cases construct the condition instead of measuring the machine.** A test that
+asks `term_width()` what this machine's terminal is answers whatever the runner happens to
+have and would have passed against the defect on every developer box and in CI — the
+defect only shows on a terminal whose size was never set. So both sources are stated here:
+``$COLUMNS`` explicitly (`_envguard` removes the operator's own, and this suite states the
+value it wants — #544), and `os.get_terminal_size` through the same `mock.patch` escape
+`_ttyguard` documents.
+
+**And the consequence is probed, not only the number.** ``1`` is a plausible-looking
+integer; what it means is a report nobody can read. The readability probe renders a real
+`tui` node at whatever `term_width` answered and asks whether the value is still there —
+the same distinction #589 measured for a mis-sized column, where every alignment assertion
+passed against the broken width because the value was silently *cut* rather than pushed.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import unittest
+from unittest import mock
+
+from charter import tui
+from tests import _ttyguard
+
+#: A width no machine running this would hand back by accident, so a case that passes
+#: because the real terminal leaked in is a case that fails here instead (#588's shape:
+#: a fixture agreeing with the machine's default tests nothing).
+STATED = 137
+
+#: What a terminal whose size was never negotiated reports. Not a hypothetical — see
+#: :meth:`ThePremise.test_a_pty_with_no_window_size_reports_zero_columns`.
+NO_SIZE = os.terminal_size((0, 0))
+
+
+def _tty(cols: int):
+    """`os.get_terminal_size` answering *cols*, via the escape `_ttyguard` documents."""
+    return mock.patch("os.get_terminal_size",
+                      return_value=os.terminal_size((cols, 24)))
+
+
+@contextlib.contextmanager
+def _columns(value: str | None):
+    """``$COLUMNS`` stated outright — set to *value*, or ABSENT when it is None.
+
+    Absent rather than empty: ``int("")`` raises too, so an empty string would exercise
+    the same branch while claiming to test the other one.
+    """
+    with mock.patch.dict(os.environ, {} if value is None else {"COLUMNS": value}):
+        if value is None:
+            os.environ.pop("COLUMNS", None)     # `patch.dict` puts the whole dict back
+        yield
+
+
+class ThePremise(unittest.TestCase):
+    """A tty reporting zero columns is ordinary, and this is where that is measured."""
+
+    def test_a_pty_with_no_window_size_reports_zero_columns(self):
+        """`os.openpty` sets no window size, so the slave reports 0x0 until somebody
+        calls ``TIOCSWINSZ``. That is what tooling, some CI shells and a terminal attached
+        before its size is negotiated all hand a process — the production case #594 is
+        about, asserted against the real syscall rather than described in a comment.
+
+        `_ttyguard.real_get_terminal_size` because the suite's own `os.get_terminal_size`
+        refuses to read a terminal at all (#544); this asks the kernel about a pty this
+        test made, which is not the operator's terminal by construction.
+        """
+        master, slave = os.openpty()
+        try:
+            self.assertEqual(_ttyguard.real_get_terminal_size(slave).columns, 0)
+        finally:
+            os.close(master)
+            os.close(slave)
+
+
+class TheAnswerIsWhatIsJudged(unittest.TestCase):
+    """Zero is not a width, and which source said it is not part of the question."""
+
+    def test_a_tty_reporting_zero_columns_falls_through_to_the_default(self):
+        """The defect verbatim: this answered ``max(floor, 0)`` — the floor — because the
+        zero-check was attached to ``$COLUMNS`` rather than to the width."""
+        with _columns(None), _tty(0):
+            self.assertEqual(tui.term_width(default=80, floor=24), 80)
+
+    def test_a_tty_reporting_zero_columns_does_not_become_one_column(self):
+        """At the DEFAULT floor of 1 — which is what `commands_frame` and every caller
+        that does not state one gets — the old spelling returned literally 1."""
+        with _columns(None), _tty(0):
+            self.assertEqual(tui.term_width(), 80)
+
+    def test_a_report_rendered_at_that_width_is_still_readable(self):
+        """The consequence, not the integer. One column is a plausible number and an
+        unreadable report; `tui.Text` truncates to fit, so the probe is whether the value
+        survived rather than whether the line is the right length."""
+        name = "charter-control-plane"
+        with _columns(None), _tty(0):
+            drawn = tui.Text(name).render(tui.term_width())
+        self.assertEqual(drawn, [name],
+                         "the width came back unusable and the whole line was truncated "
+                         "into it — this is what `term_width() == 1` looks like on screen")
+
+    def test_a_zero_in_the_environment_still_falls_through(self):
+        """The rung that was already right stays right, and now falls through to a tty
+        that CAN answer rather than to whatever came next."""
+        with _columns("0"), _tty(STATED):
+            self.assertEqual(tui.term_width(default=80, floor=24), STATED)
+
+    def test_a_negative_in_the_environment_still_falls_through(self):
+        with _columns("-5"), _tty(STATED):
+            self.assertEqual(tui.term_width(default=80, floor=24), STATED)
+
+    def test_unparseable_columns_still_falls_through(self):
+        with _columns("wide"), _tty(STATED):
+            self.assertEqual(tui.term_width(default=80, floor=24), STATED)
+
+    def test_both_sources_unusable_lands_on_the_stated_default(self):
+        """``COLUMNS=0`` and a tty answering zero are two unusable answers, not one
+        unusable answer and one absent source — and the caller's *default* is what a
+        function that could measure nothing is for."""
+        with _columns("0"), _tty(0):
+            self.assertEqual(tui.term_width(default=STATED, floor=24), STATED)
+
+    def test_a_usable_environment_width_still_wins_over_the_tty(self):
+        """The env-first order is the reason the function exists: a status line's stdout
+        is a pipe, so ``$COLUMNS`` is the only thing that knows the rectangle."""
+        with _columns(str(STATED)), _tty(40):
+            self.assertEqual(tui.term_width(default=80, floor=24), STATED)
+
+    def test_a_usable_tty_width_is_taken_when_the_environment_is_silent(self):
+        with _columns(None), _tty(STATED):
+            self.assertEqual(tui.term_width(default=80, floor=24), STATED)
+
+    def test_the_floor_is_the_last_word_on_every_path(self):
+        """Three paths reach a return and the clamp has to be on all of them, which is
+        the other half of asking the question once."""
+        with _columns("10"), _tty(0):
+            self.assertEqual(tui.term_width(default=80, floor=24), 24)   # env
+        with _columns(None), _tty(10):
+            self.assertEqual(tui.term_width(default=80, floor=24), 24)   # tty
+        with _columns(None), _tty(0):
+            self.assertEqual(tui.term_width(default=10, floor=24), 24)   # default
+
+
+class EachSourceAnswersOrDeclines(unittest.TestCase):
+    """The two readers state a number or nothing, and neither has an opinion about
+    whether the number is a width — that is what keeps the judgement in one place."""
+
+    def test_the_environment_reader_declines_rather_than_guessing(self):
+        with _columns(None):
+            self.assertIsNone(tui._env_columns())
+        with _columns("wide"):
+            self.assertIsNone(tui._env_columns())
+
+    def test_the_environment_reader_passes_an_unusable_number_on_unchanged(self):
+        """It reports what the variable SAYS. A reader that filtered here would be the
+        defect rebuilt one function lower down."""
+        with _columns("0"):
+            self.assertEqual(tui._env_columns(), 0)
+
+    def test_the_tty_reader_declines_when_there_is_no_terminal(self):
+        with mock.patch("os.get_terminal_size", side_effect=OSError("not a tty")):
+            self.assertIsNone(tui._tty_columns())
+
+    def test_the_tty_reader_passes_an_unusable_number_on_unchanged(self):
+        with _tty(0):
+            self.assertEqual(tui._tty_columns(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -36,6 +36,7 @@ from unittest import mock
 from charter import (commands_frame, config, inflight, instance, statusline, tui,
                      util)
 from charter.frame import builtin_actions, gather, layout, panel, slots, state
+from tests._tmuxsocket import OPERATOR_SOCKET
 
 from tests._isolation import PersonaIso
 
@@ -1149,7 +1150,7 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         that tuple has already grown from four names to five, and a test carrying a
         parallel copy would go on passing while the fifth never reached a re-laid-out
         pane."""
-        for server in (None, "/private/tmp/tmux-502/default"):
+        for server in (None, OPERATOR_SOCKET):
             with self.subTest(server=server or "charter's own"):
                 # Reset the map each time: the previous iteration left the frame AT
                 # `full`, so without this the second subtest splits nothing and its
@@ -1251,7 +1252,7 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         against `_FRAME_IDENTITY` excludes them by construction. A separate test asserting
         just those four was written first and deleted — it could not fail while this one
         passed, which makes it a claim rather than a check."""
-        state.record_server(self.fid, "/private/tmp/tmux-502/default")
+        state.record_server(self.fid, OPERATOR_SOCKET)
         with mock.patch.dict(os.environ, {"AWS_SECRET_ACCESS_KEY": "SENTINEL-0xC0FFEE"}):
             _, fake = self._run("full")
         carried = self._split_env(fake.calls)
@@ -1275,7 +1276,7 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         server" is now a ROW that says why: `detach-client -s <fid>` names a SESSION, and
         inside an operator's tmux a frame is a WINDOW, so the row is offered with the
         operator's own prefix key named in place of the thing charter cannot do."""
-        state.record_server(self.fid, "/private/tmp/tmux-502/default")
+        state.record_server(self.fid, OPERATOR_SOCKET)
         self._run("full")
         reg = builtin_actions.build(self.fid, current_density="full")
         offer = [o for o in reg.offers(fid=self.fid, snapshot={})
@@ -1302,13 +1303,13 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         The `-S` is what this asserts, not merely that some hook was installed: a hook
         armed with `-L /private/tmp/…` would satisfy "a pane-died command was issued" and
         still be the whole defect."""
-        state.record_server(self.fid, "/private/tmp/tmux-502/default")
+        state.record_server(self.fid, OPERATOR_SOCKET)
         _, fake = self._run("full")
         armed = [c for c in fake.calls if "pane-died" in c and "-u" not in c]
         self.assertEqual(len(armed), 1, fake.calls)
         for cmd in armed:
             self.assertEqual(cmd[:3],
-                             ["tmux", "-S", "/private/tmp/tmux-502/default"])
+                             ["tmux", "-S", OPERATOR_SOCKET])
             self.assertIn(f"--frame {self.fid}", cmd[-1])
 
     def test_a_new_pane_on_charters_own_server_is_armed_for_respawn(self):

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -42,7 +42,7 @@ from tests._isolation import PersonaIso
 from charter import commands_frame, config, instance, statusline, util
 from charter.frame import (builtin_actions, gather, layout, overlay, slots, state,
                            tmuxctl)
-from tests import _envguard
+from tests import _envguard, _tmuxsocket
 
 #: The plane this test PROCESS was started in, captured at IMPORT — before any `setUp`
 #: has had a chance to repoint `config`, so it is unavoidably the developer's REAL
@@ -456,8 +456,8 @@ class Chrome(unittest.TestCase):
         operator's socket PATH it aims at a server NAMED by that path, which does not
         exist — and a chrome setting that lands on a server nobody is looking at is the
         quietest possible way for this fix to do nothing."""
-        for cmd in self._argvs(socket="/private/tmp/tmux-502/default"):
-            self.assertEqual(cmd[:3], ["tmux", "-S", "/private/tmp/tmux-502/default"])
+        for cmd in self._argvs(socket=OPERATOR_SOCKET):
+            self.assertEqual(cmd[:3], ["tmux", "-S", OPERATOR_SOCKET])
             self.assertNotIn("-L", cmd)
         for cmd in self._argvs(socket="charter"):
             self.assertEqual(cmd[:3], ["tmux", "-L", "charter"])
@@ -677,9 +677,9 @@ class PanelRespawnHook(unittest.TestCase):
         that tmux would start empty. `tmuxctl.server_argv` is the one place that knows
         `-L` from `-S`, and asking it is what makes the two shapes impossible to disagree.
         """
-        cmd = self._argv(socket="/private/tmp/tmux-502/default")
+        cmd = self._argv(socket=OPERATOR_SOCKET)
         self.assertEqual(cmd[:4],
-                         ["tmux", "-S", "/private/tmp/tmux-502/default", "set-hook"])
+                         ["tmux", "-S", OPERATOR_SOCKET, "set-hook"])
         self.assertNotIn("-L", cmd)
 
     def test_an_interpreter_path_that_means_something_else_is_not_armed_at_all(self):
@@ -1030,19 +1030,19 @@ class Respawn(PersonaIso, unittest.TestCase):
         `state.frame_server`.
 
         Asserts the SHAPE of both commands, not just that a respawn happened: `-L
-        /private/tmp/…` would still be a `respawn-pane` and would still be the bug."""
-        state.record_server("f-1", "/private/tmp/tmux-502/default")
+        …/tmux-<uid>/…` would still be a `respawn-pane` and would still be the bug."""
+        state.record_server("f-1", OPERATOR_SOCKET)
         fake = _RespawnTmux()
         rc = _respawn(fake, on_argv=True)
         self.assertEqual(rc, 0)
         self.assertEqual([c[:3] for c in fake.liveness],
-                         [["tmux", "-S", "/private/tmp/tmux-502/default"]], fake.calls)
+                         [["tmux", "-S", OPERATOR_SOCKET]], fake.calls)
         self.assertIn("list-windows", fake.liveness[0],
                       "a frame in the operator's tmux is a WINDOW; `list-sessions` "
                       "there asks about sessions that are all theirs")
         self.assertEqual(len(fake.respawns), 1, fake.calls)
         self.assertEqual(fake.respawns[0][:3],
-                         ["tmux", "-S", "/private/tmp/tmux-502/default"])
+                         ["tmux", "-S", OPERATOR_SOCKET])
 
     def test_a_frame_on_charters_own_server_is_still_reached_by_name(self):
         """The other direction, so the test above cannot be satisfied by a `-S` for
@@ -1063,7 +1063,7 @@ class Respawn(PersonaIso, unittest.TestCase):
         Without this the empty stdout of a FAILED `list-windows` would read as "no
         windows", which is the same shape as a torn-down frame and would look like it
         passed for the wrong reason — hence `list_rc`, not an empty live list."""
-        state.record_server("f-1", "/private/tmp/tmux-502/default")
+        state.record_server("f-1", OPERATOR_SOCKET)
         fake = _RespawnTmux(live=("f-1",), list_rc=1)
         rc = _respawn(fake, on_argv=True)
         self.assertEqual(rc, 0)
@@ -3945,8 +3945,13 @@ class PaletteCommands(PersonaIso, unittest.TestCase):
 
 #: The `$TMUX` a real tmux 3.7c exports into every pane it starts —
 #: `<socket path>,<server pid>,<session id>` (measured by printing it from inside one).
-OPERATOR_TMUX = "/private/tmp/tmux-502/default,70029,1"
-OPERATOR_SOCKET = "/private/tmp/tmux-502/default"
+#:
+#: Both halves used to be written out, socket path included — `…/tmux-502/default`,
+#: with **one developer's uid** in the middle of it (#601). `_tmuxsocket` computes the path
+#: the way tmux computes it — `$TMUX_TMPDIR` or `/tmp`, `tmux-<uid>`, resolved — so this is
+#: the socket a tmux started on THIS machine would listen on rather than on that one.
+OPERATOR_SOCKET = _tmuxsocket.OPERATOR_SOCKET
+OPERATOR_TMUX = _tmuxsocket.OPERATOR_TMUX
 
 #: How many "is the harness still there?" asks `_FakeOperatorTmux` answers before it
 #: calls the launcher stuck. Every test here drives the wait loop through at most a

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 from charter import util
 from charter.frame import layout
+from tests._tmuxsocket import OPERATOR_SOCKET
 
 
 SESSION = dict(session="charter-demo-1234", conf="/tmp/f/tmux.conf",
@@ -590,9 +591,9 @@ class WindowInTheOperatorsServer(unittest.TestCase):
     """
 
     def test_the_window_is_created_in_the_operators_own_session(self):
-        cmd = layout.window_argv(socket="/private/tmp/tmux-502/default", session="$1",
+        cmd = layout.window_argv(socket=OPERATOR_SOCKET, session="$1",
                                  window="charter-demo-1234", cwd="/work/repo")
-        self.assertEqual(cmd[:3], ["tmux", "-S", "/private/tmp/tmux-502/default"])
+        self.assertEqual(cmd[:3], ["tmux", "-S", OPERATOR_SOCKET])
         self.assertIn("new-window", cmd)
         self.assertEqual(cmd[cmd.index("-t") + 1], "$1")
         self.assertEqual(cmd[cmd.index("-n") + 1], "charter-demo-1234")
@@ -705,9 +706,9 @@ class ServerSelection(unittest.TestCase):
         """`panel_argvs` and `session_argv` grew no new parameter for this: the socket
         they already take is now either charter's own server NAME or a socket PATH, and
         `tmuxctl.server_argv` is the one place that difference turns into `-L` or `-S`."""
-        cmds = layout.panel_argvs(slots=["top"], session="f", socket="/tmp/tmux-1/default",
+        cmds = layout.panel_argvs(slots=["top"], session="f", socket=OPERATOR_SOCKET,
                                   harness_pane="%3")
-        self.assertEqual(cmds[0][:3], ["tmux", "-S", "/tmp/tmux-1/default"])
+        self.assertEqual(cmds[0][:3], ["tmux", "-S", OPERATOR_SOCKET])
 
 
 class NothingUnnamedReachesACommandLine(unittest.TestCase):
@@ -749,7 +750,7 @@ class NothingUnnamedReachesACommandLine(unittest.TestCase):
     def _builders(self, env):
         return {
             "respawn_argv": lambda: layout.respawn_argv(
-                socket="/tmp/tmux-1/default", harness_pane="%7", env=env, cwd="/w",
+                socket=OPERATOR_SOCKET, harness_pane="%7", env=env, cwd="/w",
                 harness_argv=["claude"]),
             "session_argv": lambda: layout.session_argv(
                 session="f", conf="/c", socket="charter", cols=80, rows=24,

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -25,6 +25,7 @@ from charter import config, instance, persona, statusline, todos, tui, workspace
 from charter.frame import gather, layout, slots, state
 
 from tests._isolation import PersonaIso
+from tests._tmuxsocket import OPERATOR_SOCKET
 
 
 def _row(name, *, branch="main", dirty=False, tracked_dirty=False, ahead=0, behind=0,
@@ -127,7 +128,7 @@ class Render(PersonaIso, unittest.TestCase):
         on every repaint, forever — the same defect
         `test_the_bottom_row_names_the_configured_hotkey_not_a_hardcoded_one` exists
         for, reached through the other server instead of the wrong config value."""
-        state.record_server("f-in-tmux", "/private/tmp/tmux-502/default")
+        state.record_server("f-in-tmux", OPERATOR_SOCKET)
         with mock.patch.dict(config.FRAME, {"hotkey": "F1"}):
             out = slots.render("bottom", "f-in-tmux")
         self.assertNotIn("palette", out)

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -15,6 +15,7 @@ from unittest import mock
 
 from tests._isolation import PersonaIso
 from charter.frame import state
+from tests._tmuxsocket import OPERATOR_SOCKET
 
 
 def _a_dead_pid() -> int:
@@ -506,7 +507,7 @@ class ReapAcrossServers(PersonaIso, unittest.TestCase):
     check deleted outright.
     """
 
-    THEIRS = "/private/tmp/tmux-502/default"
+    THEIRS = OPERATOR_SOCKET
 
     def _frame_on(self, stem, server):
         fid = f"{stem}-{_a_dead_pid()}"

--- a/tests/test_frame_tmuxctl.py
+++ b/tests/test_frame_tmuxctl.py
@@ -13,6 +13,7 @@ import unittest
 from unittest import mock
 
 from charter.frame import tmuxctl
+from tests._tmuxsocket import OPERATOR_SOCKET, OPERATOR_TMUX
 
 
 class Version(unittest.TestCase):
@@ -170,9 +171,9 @@ class OperatorServer(unittest.TestCase):
     """
 
     def test_a_real_tmux_environment_yields_the_socket_and_the_session(self):
-        env = {"TMUX": "/private/tmp/tmux-502/default,70029,1"}
+        env = {"TMUX": OPERATOR_TMUX}
         self.assertEqual(tmuxctl.operator_server(env),
-                         ("/private/tmp/tmux-502/default", "$1"))
+                         (OPERATOR_SOCKET, "$1"))
 
     def test_no_tmux_variable_means_charter_is_not_inside_one(self):
         self.assertIsNone(tmuxctl.operator_server({}))
@@ -223,8 +224,8 @@ class ServerArgv(unittest.TestCase):
 
     def test_an_absolute_path_selects_the_operators_existing_server(self):
         self.assertEqual(
-            tmuxctl.server_argv("/private/tmp/tmux-502/default", "list-windows", "-a"),
-            ["tmux", "-S", "/private/tmp/tmux-502/default", "list-windows", "-a"])
+            tmuxctl.server_argv(OPERATOR_SOCKET, "list-windows", "-a"),
+            ["tmux", "-S", OPERATOR_SOCKET, "list-windows", "-a"])
 
     def test_nothing_is_ever_joined(self):
         """The argv rule, at the one place every tmux command in charter now passes
@@ -328,7 +329,7 @@ class ChainedCommands(unittest.TestCase):
         other — so it is refused, not guessed at."""
         self.assertIsNone(tmuxctl.chain([
             tmuxctl.server_argv("charter", "kill-pane", "-t", "%1"),
-            tmuxctl.server_argv("/private/tmp/tmux-502/default", "kill-pane", "-t", "%2")]))
+            tmuxctl.server_argv(OPERATOR_SOCKET, "kill-pane", "-t", "%2")]))
 
     def test_nothing_to_chain_is_nothing_to_run(self):
         """`overlay.close_argvs` answers `[]` when it will not build a close at all, and

--- a/tests/test_no_test_bakes_a_uid_into_a_socket_path.py
+++ b/tests/test_no_test_bakes_a_uid_into_a_socket_path.py
@@ -1,0 +1,165 @@
+"""No test writes a tmux socket path with a uid in it, and the helper that replaces them
+answers what tmux would answer (#601).
+
+`tests/test_frame_launcher.py` carried ``OPERATOR_SOCKET = "/private/tmp/tmux-502/default"``.
+**502 is one developer's uid.** Six modules carried that string or a `501` cousin, and on
+anybody else's machine each of them names either nothing or somebody else's socket
+directory.
+
+It is the last narrow instance of the shape the test-hygiene cluster closed everywhere
+else — **the suite reads the machine instead of the repo** — and it is closed the same way
+those were: a helper that asks (`tests/_tmuxsocket.py`), plus a tripwire so the next one
+fails on the commit that writes it rather than on the machine that cannot run it.
+
+**The two halves are separate on purpose.** The scan below would pass if `_tmuxsocket`
+returned nonsense, and `_tmuxsocket`'s own cases would pass with six literals still in the
+suite. Neither alone is the property.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tests import _tmuxsocket
+
+#: Every ``*.py`` under `tests/`, which is the whole of what this claims about.
+TESTS_DIR = Path(__file__).resolve().parent
+
+#: A tmux socket path with a **literal** uid in it: ``/tmp/tmux-502`` or
+#: ``/private/tmp/tmux-502``.
+#:
+#: Keyed to the PATH shape rather than to ``tmux-<digits>`` anywhere in a line, and the
+#: difference is one real case: `test_the_suite_reaps_its_own_tmux_servers` lists
+#: ``"tmux-502"`` among socket *names* charter must not claim as its own, where the digits
+#: are an arbitrary label rather than an assertion about where a socket lives. Widening
+#: this to catch that would be asking a guard to reach into a name it does not own, which
+#: is the very call `_tmuxreap` documents making the other way.
+BAKED = re.compile(r"/(?:private/)?tmp/tmux-\d")
+
+#: The two files allowed to contain the pattern: the one that defines what a baked path
+#: looks like (this one) and nothing else. `_tmuxsocket` builds the path from
+#: `os.getuid()` and so does not match at all — which is the point, and is asserted below
+#: rather than assumed.
+ALLOWED = {Path(__file__).name}
+
+
+class NoTestSpellsAUid(unittest.TestCase):
+    def test_no_module_under_tests_writes_a_socket_path_with_a_uid_in_it(self):
+        found = {}
+        for f in sorted(TESTS_DIR.rglob("*.py")):
+            if f.name in ALLOWED:
+                continue
+            hits = [(i, ln.strip()) for i, ln in enumerate(f.read_text().splitlines(), 1)
+                    if BAKED.search(ln)]
+            if hits:
+                found[f.name] = hits
+        self.assertEqual(
+            found, {},
+            "a tmux socket path with a literal uid in it is one developer's machine "
+            "written into the suite — on anyone else's it names nothing, or somebody "
+            "else's socket directory. Use `tests._tmuxsocket.OPERATOR_SOCKET` / "
+            "`OPERATOR_TMUX`, which compute it the way tmux does:\n"
+            + "\n".join(f"  {name}:{ln}  {text}"
+                        for name, hits in found.items() for ln, text in hits))
+
+    def test_the_helper_itself_does_not_spell_one(self):
+        """The escape hatch is not an exemption: `_tmuxsocket` clears the same scan the
+        modules it replaced now clear, because it builds the path rather than naming it."""
+        self.assertIsNone(BAKED.search(Path(_tmuxsocket.__file__).read_text()))
+
+    def test_the_scan_would_catch_the_line_it_was_written_for(self):
+        """A tripwire nobody has seen fire is a tripwire nobody trusts. Both spellings the
+        suite actually carried, and the one it did not (`/tmp` on Linux)."""
+        for line in ('OPERATOR_SOCKET = "/private/tmp/tmux-502/default"',
+                     '"TMUX": "/tmp/tmux-501/default,1,0"',
+                     'sock = "/tmp/tmux-0/default"'):
+            with self.subTest(line=line):
+                self.assertTrue(BAKED.search(line))
+
+    def test_the_scan_leaves_a_computed_path_alone(self):
+        """The shape every remaining site now has — and the one
+        `test_frame_tmux_integration` already had before any of this."""
+        for line in ('(Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)',
+                     'os.path.join(os.environ.get("TMUX_TMPDIR") or "/tmp", '
+                     'f"tmux-{os.getuid()}")'):
+            with self.subTest(line=line):
+                self.assertIsNone(BAKED.search(line))
+
+
+class TheHelperAsksTheMachine(unittest.TestCase):
+    def test_the_uid_is_this_process_and_not_a_number(self):
+        self.assertIn(f"tmux-{os.getuid()}", _tmuxsocket.socket_path())
+
+    def test_tmux_tmpdir_wins_when_it_is_set(self):
+        """tmux reads ``$TMUX_TMPDIR`` first, so a machine that sets it puts its sockets
+        somewhere else entirely and a helper that ignored it would be back to guessing."""
+        with mock.patch.dict(os.environ, {"TMUX_TMPDIR": "/var/run"}):
+            self.assertTrue(_tmuxsocket.socket_path().startswith(
+                os.path.realpath("/var/run")), _tmuxsocket.socket_path())
+
+    def test_an_empty_tmux_tmpdir_is_not_a_directory(self):
+        """tmux tests ``*tmux_tmpdir != '\\0'``, not merely that the variable exists —
+        an exported-but-empty one falls back to ``/tmp`` rather than making the socket
+        directory ``/tmux-<uid>`` at the filesystem root."""
+        with mock.patch.dict(os.environ, {"TMUX_TMPDIR": ""}):
+            self.assertEqual(_tmuxsocket.socket_path(),
+                             _tmuxsocket.socket_path(tmpdir="/tmp"))
+
+    def test_the_default_is_slash_tmp_and_not_the_temp_directory_python_would_pick(self):
+        """tmux's ``_PATH_TMP`` is the literal ``/tmp``. On macOS `tempfile.gettempdir()`
+        answers a per-user ``/var/folders/…`` path that tmux never writes to, so a helper
+        built on it would be wrong on exactly the platform this was measured on."""
+        import tempfile
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TMUX_TMPDIR", None)
+            got = _tmuxsocket.socket_path()
+        self.assertEqual(got, _tmuxsocket.socket_path(tmpdir="/tmp"))
+        if os.path.realpath(tempfile.gettempdir()) != os.path.realpath("/tmp"):
+            self.assertFalse(got.startswith(os.path.realpath(tempfile.gettempdir())), got)
+
+    def test_the_path_is_resolved_so_the_platform_decides_its_spelling(self):
+        """The other half of #601, and #572's measurement one directory over: on macOS
+        ``/tmp`` is a symlink to ``/private/tmp``, tmux calls ``realpath()`` on its base
+        before using it, and a test that spelled one form asserted something false on the
+        platform handing it the other.
+
+        Asserted as a fixed point — the path is its own `realpath` — rather than against
+        either spelling, so it is one case on both platforms instead of two that disagree.
+        """
+        got = _tmuxsocket.socket_path()
+        self.assertEqual(got, os.path.realpath(got))
+
+    def test_the_resolution_is_what_a_real_tmux_would_have_produced(self):
+        """Not merely resolved — resolved to the same place. On macOS this is the
+        assertion that says `/private/tmp`; on Linux it says `/tmp`; neither is written
+        down here."""
+        self.assertEqual(_tmuxsocket.socket_dir(),
+                         os.path.realpath(f"/tmp/tmux-{os.getuid()}"))
+
+    def test_nothing_is_created_on_disk_by_asking(self):
+        """`realpath` resolves what exists and leaves the rest lexical, so a machine with
+        no tmux server running still gets the right answer and the suite still starts no
+        server it did not mean to (#542/#564's whole subject)."""
+        d = _tmuxsocket.socket_dir(tmpdir="/tmp")
+        before = os.path.isdir(d)
+        _tmuxsocket.socket_path()
+        self.assertEqual(os.path.isdir(d), before)
+
+    def test_the_tmux_value_is_shaped_the_way_tmux_exports_it(self):
+        """``<socket path>,<server pid>,<session id>`` — and `tmuxctl` parses it, so the
+        shape is charter's input rather than decoration."""
+        parts = _tmuxsocket.OPERATOR_TMUX.split(",")
+        self.assertEqual(len(parts), 3, _tmuxsocket.OPERATOR_TMUX)
+        self.assertEqual(parts[0], _tmuxsocket.OPERATOR_SOCKET)
+        self.assertTrue(parts[1].isdigit() and parts[2])
+
+    def test_the_socket_name_is_the_one_tmux_uses_with_no_dash_l(self):
+        self.assertTrue(_tmuxsocket.OPERATOR_SOCKET.endswith("/default"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_no_test_bakes_a_uid_into_a_socket_path.py
+++ b/tests/test_no_test_bakes_a_uid_into_a_socket_path.py
@@ -40,10 +40,10 @@ TESTS_DIR = Path(__file__).resolve().parent
 #: is the very call `_tmuxreap` documents making the other way.
 BAKED = re.compile(r"/(?:private/)?tmp/tmux-\d")
 
-#: The two files allowed to contain the pattern: the one that defines what a baked path
-#: looks like (this one) and nothing else. `_tmuxsocket` builds the path from
-#: `os.getuid()` and so does not match at all — which is the point, and is asserted below
-#: rather than assumed.
+#: The one file allowed to contain the pattern: this one, which has to spell a baked path
+#: in order to define what one is. `_tmuxsocket` is deliberately NOT on this list — it
+#: builds its path from `os.getuid()` and so does not match at all, which is the point,
+#: and is asserted below rather than assumed.
 ALLOWED = {Path(__file__).name}
 
 
@@ -93,6 +93,23 @@ class NoTestSpellsAUid(unittest.TestCase):
 class TheHelperAsksTheMachine(unittest.TestCase):
     def test_the_uid_is_this_process_and_not_a_number(self):
         self.assertIn(f"tmux-{os.getuid()}", _tmuxsocket.socket_path())
+
+    def test_the_uid_is_asked_rather_than_agreed_with(self):
+        """The case above passes on the ONE machine where it proves nothing: put `502`
+        back into the helper and it still holds, because 502 is this developer's uid —
+        which is the whole of #601, reappearing inside the test written to close it
+        (measured by a hand mutation, green).
+
+        Asked instead of compared: the answer has to MOVE when the uid does. `os.getuid`
+        is patched to a number no machine running this has, so a helper that spells any
+        uid at all — 502, or the one this process happens to own — fails here.
+        """
+        with mock.patch("os.getuid", return_value=424242):
+            got = _tmuxsocket.socket_path()
+        self.assertIn("tmux-424242", got, got)
+        self.assertNotIn(f"tmux-{os.getuid()}", got,
+                         "the helper answered for this process rather than for the uid "
+                         "it was asked about, so it is not asking at all")
 
     def test_tmux_tmpdir_wins_when_it_is_set(self):
         """tmux reads ``$TMUX_TMPDIR`` first, so a machine that sets it puts its sockets

--- a/tests/test_no_test_reads_the_operators_shell.py
+++ b/tests/test_no_test_reads_the_operators_shell.py
@@ -27,7 +27,7 @@ import unittest
 from unittest import mock
 
 from charter import commands_frame, legacyenv, session, workspace
-from tests import _envguard
+from tests import _envguard, _tmuxsocket
 from tests._isolation import PersonaIso, child_plane_env
 
 
@@ -256,7 +256,7 @@ class WhatIsScrubbed(unittest.TestCase):
         it is what makes this case fail on the tree that had the hole.
         """
         planted = {"CHARTER_SESSION_ID": "ambient-sess", "CHARTER_WORKSPACE": "ambient-ws",
-                   "TMUX": "/tmp/tmux-501/default,1,0", "TMUX_PANE": "%9",
+                   "TMUX": _tmuxsocket.tmux_env(server_pid=1, session="0"), "TMUX_PANE": "%9",
                    "EDM_WORKSPACE": "legacy-ws"}
         probe = ("import json, os, tests;"
                  "from tests import _envguard;"


### PR DESCRIPTION
Closes #594, #600, #601.

One property, three issues: **a width is validated wherever it came from, and a column is measured from the values it holds.**

## `tui.term_width` judged the source, not the answer (#594)

The `$COLUMNS <= 0` guard was right and it was attached to a spelling. One rung down its own ladder the identical value walked through:

```python
w = int(os.environ["COLUMNS"])
if w <= 0:
    raise ValueError(w)              # the environment's zero IS guarded
except (KeyError, ValueError):
    w = os.get_terminal_size().columns   # the syscall's zero is NOT
```

A tty reporting zero columns produced `max(1, 0)` — **one column** — and charter drew every table, row and panel into it. That tty is ordinary: `openpty` sets no window size, so a pty reports 0x0 until somebody calls `TIOCSWINSZ`. The suite has been carrying the evidence — under a real pty, 28 failures across 8 modules were all terminal-size.

Each source now answers with a number or with nothing, and the **answer** is judged once. A third source is one entry in a tuple rather than a fourth place to remember the zero.

## Four tables padded into a constant (#600)

`worktree list` (`{branch:<28}` — **wrong today**, a branch name past 28 is ordinary, and a detached worktree writes its whole path into that cell), `vault list`, `workspace list` and `charter doctor` all go through `tui.column`/`tui.pad` now.

`doctor` is the one that cannot size from its rows — it prints each row as its check lands, so a preflight killed by its hook timeout says where it stopped. Its NAME column is sized from the names the checks *carry*, before the run, and pinned by equality against `run_all()`. The width is a **floor**: a name the column did not know about pushes its own row rather than being cut, because `tui.pad` truncates and a check name cut in half is a failure nobody can look up.

## A uid baked into a socket path (#601)

`/private/tmp/tmux-502/default` — 502 is one developer's uid — in six modules. `tests/_tmuxsocket.py` computes it the way tmux does (`$TMUX_TMPDIR` or the literal `/tmp`, `tmux-<uid>`, **resolved**, which is why the operator's measurement said `/private/tmp`), and a tripwire refuses the next one.

## What the tests had to avoid, all measured

* **A precomposed accent is a silent control** — `équipe-mémoire` is 14 characters and 14 cells. The fixture is a base letter with a combining acute Unicode has no precomposed form for, checked as it came back off the filesystem.
* **A CJK name alone does not catch `len`-sizing** — it needs a pair, widest-in-characters and widest-in-cells on different rows, alone in the table. A fixture guard keeps it a pair.
* **An alignment assertion cannot see a mis-measured column** (#589) — the probe is whether the value is readable off its row. Where `str.format` was the old code, that probe guards the *fix* rather than the defect, and the cases say so.
* Two fixtures were **refuted by their own guards** while writing this and are recorded rather than deleted: `" ⚠"` measures 2 characters and 2 cells, so it is not a `len`-sizing fixture; and a workspace name cannot be non-ASCII via `workspace create` — but `list_workspaces` lists *every* directory under `workspaces/`, so the renderer sees names the constructor would never mint, and that is how the case is built.

Baselines: every new case was run against the unmutated tree first. #594's cases: 4 failures + 4 errors. #600's: 16 failures + 6 errors across the four tables. #601's tripwire found six sites the initial grep had missed.

Suite: 7033 tests, OK.
