### PR TITLE
A widget framework fits in a pane charter owns, and does not fit in the component contract (experiment)

### DIFF
--- a/docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md
+++ b/docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md
@@ -297,8 +297,9 @@ So `Registry.draw` sees a successful render, charter's "failed to draw" never ap
  1200ms | textual.live: app exited after 1s (clicks 0, scroll 0, keys 0)
 ```
 
-Confirmed out of tmux with stderr redirected: 19,358 bytes of Rich traceback ending
-`RuntimeError: injected fault inside Textual's message pump`, written to stderr, while
+Confirmed out of tmux with stderr redirected: the app writes 19,358 bytes to **stderr**
+(Textual's driver is `self._file = sys.__stderr__`), the last 2,520 of them a Rich traceback
+with locals ending `RuntimeError: injected fault inside Textual's message pump` — while
 stdout carries the two lines charter painted over it. **A crash inside a framework's own
 loop is indistinguishable, from charter's side, from a clean quit.**
 

--- a/docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md
+++ b/docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md
@@ -1,0 +1,626 @@
+# The Textual experiment — one frame component, drawn by a real widget framework
+
+**2026-08-28.** One charter frame component — the repo table — rendered with
+[Textual](https://github.com/textualize/textual) and shipped as a third-party provider
+through the existing `charter.components` entry point.
+
+The package is `providers/charter-textual-repos/`. It is **not** in `charter/`, it declares
+`textual` as its own dependency, and **charter's tree is unchanged**: `dependencies = []`
+still holds, `tests/test_packaging.py::test_runtime_has_zero_dependencies` still passes,
+and the full suite passes in two environments (counts at the end).
+
+Everything below was measured. The scripts are in `providers/charter-textual-repos/measure/`
+and each finding names the one that produced it. Every tmux claim is against real tmux
+3.7c, one socket per script, killed before unlinking.
+
+---
+
+## What was built
+
+Two components, because the experiment is a comparison and one of them could not exist.
+
+| id | shape | `render` |
+|---|---|---|
+| `textual.repos` | **adapter** — Textual on the headless driver, on a background thread; its composited screen copied out as lines | returns, per repaint, like every other component |
+| `textual.live` | **takeover** — Textual on the pane's own tty, alternate screen, own asyncio loop, `mouse=True` | never returns |
+
+Both draw the same table off `ctx.gather`: repo name, branch, dirty/ahead/behind markers,
+CI, open change, worktree badge, pieces indented underneath. Both are discovered by
+charter with no change to charter:
+
+```
+$ python -c "from importlib import metadata; [print(ep.name,'->',ep.value,'|',ep.dist.name)
+              for ep in metadata.entry_points(group='charter.components')]"
+textual.live  -> charter_textual_repos:live_component  | charter-textual-repos
+textual.repos -> charter_textual_repos:adapter_component | charter-textual-repos
+```
+
+and both are placeable from a committed `charter.toml`, resolved end to end into
+`layout.panel_command`'s argv:
+
+```toml
+[[frame.component]]
+use = "textual.live"
+edge = "bottom"
+size = 12
+key = "F9"
+```
+```
+components:
+  {'use': 'textual.live', 'slot': 'textual.live', 'edge': 'bottom',
+   'size': Fixed(n=12), 'visible': True, 'key': 'F9'}
+slots: ['top', 'bottom', 'textual.live']
+argv: [... 'panel', 'textual.live', '--session', 'f']
+
+# the same charter.toml on a machine WITHOUT the provider installed:
+components: []
+slots: ['top', 'bottom', 'repos', 'right']
+```
+
+That is §4b property 4 working exactly as designed. **The extension model is real.**
+
+It is a real distribution, not a `sys.path` trick: `uv build` produces
+`charter_textual_repos-0.1.0-py3-none-any.whl`, and installing that wheel into a **Python
+3.12** venv beside charter — no editable install, no `PYTHONPATH` — gives the same two
+entry points and the same two panes (`m7_shot.sh` under `venv312`, 14 provider tests pass).
+
+---
+
+## 1. Did the `Component` contract fit?
+
+**The declaration half fits. The rendering half fits one of the two shapes. The input half
+does not exist.** Six places it chafed, each named.
+
+### 1a. `render(ctx) -> list[str]` is a *renderer* contract, and a widget framework is not a renderer
+
+`component.Component.render` is `Callable[[Any], list[str]]`. `Registry.draw` calls it,
+type-checks what came back, escapes it, clips it to the rectangle and hands it to
+`panel._write`. A framework that owns the terminal has no seam there. The two ways out are
+the two components in this package, and the second one leaves the contract:
+
+* the **adapter** obeys the signature by running Textual where nobody can see it and
+  copying its screen out;
+* the **takeover** obeys the signature by never returning from it.
+
+Nothing in the contract distinguishes "a component that draws" from "a component that owns
+its pane", and the panel process has exactly one thread that a framework needs.
+
+### 1b. A provider's lines are escaped, so a provider component is monochrome
+
+`Registry.draw` ends in `_fit(lines, …, escape=cid in self._foreign)`, and every provider is
+foreign. `escape=True` runs `contain.one_line`, which replaces every `Cc` character with its
+own escape text — so `\x1b` arrives on screen as the four characters `\x1b`. The adapter
+therefore returns `Strip.text` (plain) rather than `Strip.render(console)` (SGR), and
+**every colour Textual computed is discarded at the boundary**:
+
+```
+m5_no_color.sh, SGR sequences visible in the pane:
+                  colour on   NO_COLOR=1
+  charter repos       54          0
+  textual.live        15         15
+  textual.repos        0          0
+```
+
+The zero in both columns is the finding. The comment in `Registry.draw` is right about
+*why* — a provider's row could otherwise move the cursor out of its own rectangle — but the
+consequence is not written down anywhere a provider author meets it: a third-party
+component can never be as legible as charter's own, and the widget framework's entire
+styling system is dead weight in the adapter shape.
+
+### 1c. `Component.events` is declared, validated, and read by nothing
+
+`grep -rn '\.events\b' charter/` returns two hits. One is
+`commands_worktree.py:275`'s `pieces.events(ws)`, an unrelated function. The other is
+`frame/component.py:320` — **the line that validates the field**. Nothing reads
+`Component.events`. There is no dispatcher. `frame/overlay.py` does decode SGR mouse
+reports and does know the modal rule, but it is charter's own palette surface and is not
+wired to components at all.
+
+So `EVENT_KINDS`' careful "declaring one of these is a declaration of what you HANDLE, never
+a promise that it FIRES" is currently the weaker statement of the two: **none of them
+fire, ever, for anybody.** `textual.live` declares `("key", "click", "scroll", "resize")`,
+receives all four, and receives them by having taken the tty — charter neither delivers
+them nor knows it is not delivering them. The adapter declares `()` and is the honest one:
+a headless app has no terminal to read from, so its `DataTable` cursor cannot be moved and
+its scrollbar cannot be reached. **A scrolling table that cannot scroll is the one thing
+the widget was worth having.**
+
+### 1d. `ctx` is one snapshot with no way to ask for another — which is right, and it is what freezes the takeover
+
+`frame/ctx.py` is explicit and correct: "A component never gets a way to fetch a fresher
+one: refreshing is the frame's decision, on the frame's clock." For the adapter that costs
+nothing, because charter calls `render` again. For the takeover it is fatal — `render` never
+returns, so nothing ever calls it again, and the table is frozen at the instant the pane
+started. Measured (`m6_repaint.sh`), across one `gather.save` + `state.bump` that flips CI
+from `failed` to `passed`:
+
+```
+                 before        after the bump
+  repos          ✗ failed      ? passed          charter's own renderer
+  textual.repos  fail          ok                the adapter — render returns
+  textual.live   fail          fail              frozen; snapshot 6s old and climbing
+  live+refresh   fail          ok                snapshot 2s old
+```
+
+That last row is `CHARTER_TEXTUAL_LIVE_REFRESH=1`, and it is the measurement of what
+un-freezing costs: the app imports `charter.frame.state` and `charter.frame.gather` and
+polls them itself. It works, and it reimplements inside a provider four things that are
+charter's — which file carries the version, that comparing it is how a panel learns
+anything happened, which workspace the *frame* resolved (#526), and that `gather.read` is
+the cache rather than a scan. A provider that gets any of those wrong gets it wrong quietly:
+a pane that stops updating, or a full `gather.scan` five times a second in every pane on the
+machine. **`ctx`'s one-snapshot rule is right; what is missing is a way for the frame to
+hand a long-lived component the next one.**
+
+### 1e. A provider can never be `Content()` or `Fill()` where anyone has configured it
+
+`instance.component_tables` requires a provider's `[[frame.component]]` table to carry both
+`edge` and `size`, and coerces `size` to `Fixed(n)`. The reasoning is sound and is
+`config.FRAME`-is-on-the-import-path — but the effect is that `Content(cap=…)` and `Fill()`
+are reachable only on a frame nobody has arranged, i.e. from `Registry.place` with no
+rectangle. charter's own `repos` is `Content()` and its height is what the plane's repos
+need; a provider's table of the same data is a fixed rectangle or nothing.
+
+### 1f. The contract is a Python class, so every provider hard-depends on charter
+
+`Providers._one` finishes with `isinstance(obj, self.kind)` where `kind` is
+`charter.frame.component.Component`. A provider cannot express a component without importing
+charter, so `charter-cp` is a real install-time dependency of this package. That costs
+nothing at runtime — charter is already in the process asking — but the entry-point group
+alone does not make the coupling loose, and it is worth being accurate about that.
+
+---
+
+## 2. `sys.stdout` — the one that would have shipped broken
+
+This is the sharpest finding and it is not about Textual specifically. It is about who owns
+`sys.stdout` in a panel process.
+
+`textual/app.py:3491` wraps the app's message pump in
+`contextlib.redirect_stdout(self._capture_stdout)`, so a `print()` inside a widget lands in
+the app's log rather than on the screen. `redirect_stdout` assigns `sys.stdout` — a
+**process-wide module global** — from the app's own thread, **headless or not**. And
+`_PrintCapture` (`textual/app.py:260`) answers:
+
+```python
+def isatty(self) -> bool: return True     # "Pretend we're a terminal."
+def fileno(self) -> int:  return -1       # "Return invalid fileno."
+```
+
+charter reaches `sys.stdout` in three places, and that object subverts all three:
+
+| charter | what it does | what it gets |
+|---|---|---|
+| `panel._out` | `sys.stdout.write(payload); flush()` | the paint goes into Textual's print log; the pane keeps whatever was on it |
+| `slots._width` / `slots._height` | `os.get_terminal_size(sys.stdout.fileno())` | `get_terminal_size(-1)` raises `OSError`, which is caught — charter silently falls back to **80x24** |
+| `chrome.colour_ok` | `sys.stdout.isatty()` | `True`, whatever the panel's stdout actually is |
+
+Measured symptom in a real 150x10 pane, with the workaround disabled
+(`m8_stdout.sh`, `CHARTER_TEXTUAL_KEEP_CAPTURE=1`):
+
+```
+  0.5s  restored=10  captured=10
+  2.0s  restored=10  captured=10
+  2.5s  restored=10  captured=1    <- version bumped at 2.0s
+  5.0s  restored=10  captured=1
+                                    (non-blank rows in each pane)
+
+== the captured pane, in full, after the bump ==
+  |
+  |            (nine blank rows)
+  | snapshot 0s old  ·  clicks 0  ·  scroll 0  ·  keys 0  ·  headless
+
+== and nothing was reported: pane alive, no charter error, no stderr ==
+  %2 dead=0 cmd=python3.14
+```
+
+The chain is all three rows of that table at once: charter measures 80x24 instead of
+150x10, the component lays itself out 24 rows tall, `panel._write` clamps to 24 and writes
+all of them into a 10-row pane, and the pane scrolls its own content away. **Nothing
+raises. `Registry.draw` has nothing to catch, because nothing failed.** The first paint is
+correct — the app is not up yet — which is exactly the shape of bug that ships.
+
+The provider's fix is four lines (`adapter._give_stdout_back`), in `render`'s `finally`
+rather than on the way in, because `panel._component_text` evaluates `slots._width()` and
+`_rows()` **as arguments to `ctx.build`**, i.e. before `render` is called. Restoring on
+entry fixes the paint and leaves the measurement one tick stale forever.
+
+**This is a charter finding, not a Textual one.** Any provider that uses any library that
+touches `sys.stdout` — a progress bar, a logging handler, `rich.Console(file=…)`, a
+debugger — lands somewhere on this table. §4b's four properties are all downstream of a
+`sys.stdout` a provider is able to take.
+
+---
+
+## 3. Does the alternate screen cost charter anything?
+
+**No. Measured, and it costs less than expected** (`m2_altscreen.sh`).
+
+```
+== alternate-screen flag (tmux's own view) ==
+%0 bash        alternate_on=0        the harness
+%2 python3.14  alternate_on=1        charter panel textual.live
+%1 python3.14  alternate_on=0        charter panel repos
+
+== history size per pane ==
+%0 history_size=191   harness
+%2 history_size=0     textual.live
+%1 history_size=0     charter's own repos
+
+== capture-pane -S -200 (scrollback) non-blank lines ==
+harness pane  : 204
+charter repos : 6
+textual live  : 10
+```
+
+* **Pane scrollback**: `history_size=0` for the Textual pane — and **also for charter's own
+  panel**, which clears with `\x1b[H\x1b[2J` and never scrolls. The alternate screen costs
+  nothing charter's own panels were not already costing. The harness pane, which is the one
+  anybody scrolls, is untouched.
+* **`capture-pane`**: works normally, `-p` and `-p -e` alike. tmux captures the alternate
+  screen buffer; the `-e` capture carries Textual's real 24-bit SGR.
+* **Resize**: `resize-window 150x40 -> 100x30 -> 150x40` — the pane goes 150x14 → 100x11 →
+  150x14 and Textual reflows correctly each way, longest captured line 76 cells throughout.
+  Textual installs its own SIGWINCH handler over charter's; charter's `_watch` is parked
+  inside `render` and has nothing to repaint anyway.
+* **Death**: `kill -9` with `remain-on-exit on` leaves `dead=1 alternate_on=1` and the pane
+  still showing Textual's content, minus the one line tmux scrolls off to write its own
+  message — identical to what `frame/panel.py`'s docstring measures for any pane.
+* **Respawn**: `respawn-pane -k … charter panel textual.live --session …`, the argv
+  `commands_frame.cmd_respawn` emits, brings the pane back clean: `dead=0 alternate_on=1`,
+  table drawn.
+
+---
+
+## 4. What does a crash cost?
+
+**Its own pane, every time — for three of the four failure modes.** The fourth loses the
+reason (`m3_crash.sh`, `m3b_crash_message.sh`). In every case charter's own `repos` pane
+beside it and the harness pane above it were untouched.
+
+| failure | the pane says |
+|---|---|
+| `render` raises before Textual starts | `textual.live failed to draw — RuntimeError: injected fault before the app started` |
+| provider's module raises on import | `charter-textual-repos 0.1.0 supplies textual.live, and importing charter_textual_repos raised ImportError: … Its pane says so; the rest of the frame is drawn` |
+| id nothing supplies | `charter: unknown slot 'notinstalled.thing' (known: bottom, repos, right, top)` |
+| **raises inside Textual's message pump** | `textual.live: app exited after 1s (clicks 0, scroll 0, keys 0)` |
+
+That last row is the finding. Textual **does not let the exception out of `run()`**: it
+catches it, prints a Rich traceback (with locals) to `sys.__stderr__`, and returns normally.
+So `Registry.draw` sees a successful render, charter's "failed to draw" never appears, and
+`panel._write` clears the pane a moment later with whatever `render` answered. Sampled every
+100 ms across the crash, the traceback is never visible even once:
+
+```
+ 1000ms |  repos 5  ·  harness-wrapper
+ 1100ms |                                              <- crash + traceback + charter's clear
+ 1200ms | textual.live: app exited after 1s (clicks 0, scroll 0, keys 0)
+```
+
+Confirmed out of tmux with stderr redirected: 19,358 bytes of Rich traceback ending
+`RuntimeError: injected fault inside Textual's message pump`, written to stderr, while
+stdout carries the two lines charter painted over it. **A crash inside a framework's own
+loop is indistinguishable, from charter's side, from a clean quit.**
+
+Two smaller ones from the same run:
+
+* **`NO_COLOR` is not honoured by a takeover component.** `textual/drivers/linux_driver.py:58`
+  sets `self._file = sys.__stderr__` and the app writes straight there — past
+  `panel._write`, past `chrome.plain`, past `sys.stderr` itself. `panel._write`'s claim to
+  be "the one place anything reaches a pane's screen" is true for the contract and false for
+  a component that takes the pane. Numbers in §1b.
+* **A thread-vs-mount race the provider hit and charter contained.** The adapter drives the
+  app from another thread, so a repaint can land between `compose` and `on_mount`;
+  `add_row` then raises `More values provided than there are columns`, and the pane read
+  `textual.repos failed to draw — ValueError: …`. Charter behaved perfectly. The provider
+  still shipped a broken pane until the columns were declared from whichever side asks
+  first.
+
+---
+
+## 5. Startup
+
+`split-window` to first non-blank paint, polled at 10 ms against real `capture-pane`, five
+runs each (`m1_startup.sh`):
+
+```
+repos            174ms 115ms 130ms 142ms 113ms
+textual.repos    339ms 273ms 242ms 241ms 245ms
+textual.live     231ms 212ms 228ms 272ms 262ms
+```
+
+**Roughly 2x charter's own, ~110-130 ms extra, paid once per pane.** Consistent with the
+import measurement (`m9_cost.py`, one fresh interpreter each):
+
+```
+charter.frame.slots     31 ms   25 MB peak RSS
+textual.app            102 ms   39 MB peak RSS
+charter_textual_repos  128 ms   43 MB peak RSS
+```
+
+Per-repaint, through `Registry.draw`, same rectangle, same snapshot, 8 repos:
+
+```
+charter _table_lines   median 0.38 ms   worst 0.70 ms
+textual.repos draw     median 4.79 ms   worst 6.41 ms
+```
+
+12x, and both are two orders of magnitude under `panel.TICK` (200 ms). **Cost is not the
+objection**, exactly as the brief said. The shape differs — a full compositor pass over a
+widget tree versus a string join — but neither is close to the budget.
+
+---
+
+## 6. Mouse — measured against real tmux, and the premise is half right
+
+`m4_mouse.py` attaches a real tmux client on a pty it owns and reads every byte tmux writes
+to a terminal. tmux 3.7c, session `mouse off` (charter's default).
+
+### The modal behaviour is real
+
+```
+select-pane -> textual.live : 1006l 1000l 1002l 1003l 1006h 1000h 1002h 1003h
+select-pane -> harness      : 1006l 1000l 1002l 1003l
+select-pane -> textual.live : 1006l 1000l 1002l 1003l 1006h 1000h 1002h 1003h
+```
+
+A pane running `App.run(mouse=True)` makes tmux turn the terminal's mouse reporting **on
+when that pane is active and off when it is not**, with tmux's own `mouse` off throughout.
+§4i's measurement extends exactly as predicted to a pane that genuinely wants the mouse.
+
+### The keyboard reaches it too, and charter has no path for that either
+
+```
+after j j k                 : clicks 0  ·  scroll 0  ·  keys 3
+```
+
+Three `send-keys` and the app's own counter moves. It moves because the app read its own
+tty, not because anything routed anything: `textual.live` declares `events=("key", …)` and
+charter validates that tuple and never reads it again (§1c).
+
+### And mouse events reach it — but not only when it is active
+
+```
+before                      : clicks 0  scroll 0
+click, textual.live active  : clicks 1  scroll 0
+wheel, textual.live active  : clicks 1  scroll 2
+same clicks, harness active : clicks 2  scroll 3     <- still delivered
+active pane after that click: %0 (harness is %0)     <- and the click did not focus it
+```
+
+**tmux routes a mouse report by POSITION, not by which pane is active.** The modality is
+entirely in the *terminal's reporting mode*, which the active pane alone sets. So:
+
+* the Textual pane gets clicks whenever *anything* has turned reporting on — including the
+  harness, and a full-screen TUI harness is exactly the kind of program that does. Confirmed
+  by having the harness pane print `?1000h ?1006h` for itself:
+  ```
+  select-pane -> harness (after it printed ?1000h ?1006h) : 1006l 1000l 1002l 1003l 1006h 1000h
+  ```
+* a click on the Textual pane does **not** make it active, so the operator has to focus it
+  with the keyboard before the modal behaviour helps at all.
+
+### Does it dissolve the trade?
+
+**No. It relocates it, and adds a step.** While the Textual pane is active, the terminal is
+reporting and the operator's native text-selection is gone **for the whole window**, not
+just for that pane — the modes tmux writes are the terminal's, not a pane's. The harness
+pane's own scrollback survives untouched (`history_size = 181` throughout, last line intact),
+so nothing is *lost*; what is unavailable is dragging to select while that pane has focus.
+
+So the honest statement is: `[frame] mouse` can stay `False`, a Textual panel can request the
+mouse for itself, and the result is a panel that is clickable **once you have focused it with
+a key** and that costs you selection **while you have**. That is better than
+`[frame] mouse = true`, which costs it unconditionally. It is not the free lunch the open
+question hoped for, and `EVENT_KINDS`' advice — give every pointer affordance a `key` as
+well — survives this measurement unchanged.
+
+---
+
+## 7. Does the version-bump model coexist with Textual's loop?
+
+**They do not fight — because in the takeover shape only one of them is running.**
+
+`render` blocks inside `Registry.draw`, so `panel._watch` never reaches its next `_tick`,
+never calls `state.version`, and never calls `_write`. There is no clear-screen underneath
+Textual, no flicker, no torn frame. The cost is §1d: charter also never hands the component
+another `ctx`.
+
+The adapter is the opposite and is entirely well-behaved: charter's loop drives, the app is
+a rendering service on a background thread, and a version bump updates the pane within one
+tick (§1d's table, row 2). The idle cost is unchanged — the panel still pays one `stat` per
+tick, because `render` is only called when something moved.
+
+There is a third shape that looks like the obvious compromise, and it is refuted rather than
+merely rejected (`m10_thread_takeover.py`): `render` starts a **non-headless** Textual app on
+a background thread and returns `[]` immediately, so charter's loop keeps running and keeps
+handing the component fresh snapshots while Textual owns the pixels.
+
+```json
+{
+  "raised_out_of_run": [],          <- App.run() returned normally
+  "started": true,
+  "bytes_to_the_pane": 16747,
+  "pane_got_a_traceback": true,
+  "reason": "ValueError('signal only works in main thread of the main interpreter')"
+}
+```
+
+`LinuxDriver.__init__` calls `signal.signal(SIGTSTP, …)` and `signal.signal(SIGCONT, …)`
+unconditionally, and Python refuses that off the main thread. Textual catches it, prints
+16,747 bytes of Rich traceback into the pane, and `run()` **returns with nothing raised** —
+the same swallow as §4's fourth row, one layer earlier. Even if that were fixed upstream,
+`panel._write` would then clear the alternate screen out from under the app on every version
+bump.
+
+**A component either owns the pane or returns lines. There is no in-between, and charter's
+contract only describes one of them.**
+
+---
+
+## 8. Would I ship it?
+
+**No — not this, and not yet.** Three reasons, in order of how much they matter.
+
+**1. The adapter is the only shape charter can host, and it is strictly worse than what
+charter already has.** No colour (§1b), no input (§1c), 12x the repaint cost and 2x the
+startup for a table charter draws better. Every advantage a widget framework has — scrolling
+a table longer than the pane, a cursor, click-to-open, styled cells — is on the far side of
+either `Registry.draw`'s escaping or a dispatcher that does not exist. There is nothing left
+to buy.
+
+**2. The takeover works, looks good, and is outside the contract in a way that is not a
+detail.** It draws well (§9), survives resize, respawn and death cleanly, and its crash costs
+one pane. But it freezes on the first snapshot, it silently ignores `NO_COLOR`, its crashes
+lose their reason, and the only way to make it live is to import charter's internals from a
+stranger's package. Shipping it would be shipping "components may own their pane" as
+folklore, discovered by whoever reads this package, rather than as a contract with rules.
+
+**3. The `sys.stdout` finding is the one that must land first, and it is charter's.** §2 is
+not a Textual problem. Any provider using any library that touches `sys.stdout` gets a pane
+that paints once and then goes blank, with nothing raised, nothing logged, and a silent
+80x24 geometry fallback underneath. Today the four properties in §4b rest on a global a
+provider can take by accident.
+
+### What it would take
+
+In rough order of value, and none of it is large:
+
+1. **Make charter's pane immune to `sys.stdout`.** Capture the panel's real fd once at
+   startup and write, measure and `isatty` through *that*, not through `sys.stdout`. Three
+   call sites: `panel._out`, `slots._width`/`_height`, `chrome.colour_ok`. This is worth
+   doing whether or not anything below happens — it is a latent silent-blank-pane bug for
+   every provider, not only this one.
+2. **Decide what an escaped provider line means.** Either say plainly in `EVENT_KINDS`'
+   neighbour ("a provider component is monochrome, and here is why") or give providers a
+   narrow, validated colour channel — charter's own markup, sanitised the way `tui.sanitize`
+   already sanitises everything else. The current state is a capability that looks available
+   and is not.
+3. **Deliver `events`, or delete the field.** A closed vocabulary that is validated and
+   never dispatched is a promise the code does not keep. `frame/overlay.py` already decodes
+   SGR mouse reports and already knows the modal rule; the missing piece is routing to a
+   focused component, not new mechanism.
+4. **Only then, and only if 1-3 land: a second component shape** — `owns_pane = True`, or a
+   `Component` whose `render` is replaced by a `run(ctx, updates)` handed a channel the frame
+   pushes fresh snapshots onto. That is the one thing that would make Textual worth its
+   dependencies, because it is the only thing that makes the widget's advantages reachable.
+
+**What the experiment proves, and it is the important part:** the provider model itself is
+sound. A package outside `charter/` declaring ten dependencies charter does not have was
+discovered, placed from a committed file, split into a pane, drawn, crashed four ways, and
+never cost the frame anything but its own pane. `dependencies = []` was never in question.
+The gaps found are in the *component* contract, not in the extension model, and every one of
+them is a few dozen lines from being closed.
+
+---
+
+## 9. What it looks like
+
+Real `capture-pane -p -e`, one pane per block, top to bottom, tmux 3.7c, 150x44, session
+`mouse off`. Escapes shown as `\e`; nothing else altered. Produced by `measure/m7_shot.sh`.
+
+The `alternate_on` column is the whole architectural difference between the two components,
+sitting side by side in one frame.
+
+```
+┌─ %0  rows 0-3  150x4  alternate_on=0  the harness (stand-in)
+│ The default interactive shell is now zsh.
+│ To update your account to use zsh, please run `chsh -s /bin/zsh`.
+│ For more details, please visit https://support.apple.com/kb/HT208050.
+│ bash-3.2$
+┌─ %5  rows 5-16  150x12  alternate_on=1  panel textual.live
+│ \e[48;2;36;47;56m \e[38;2;226;227;229mrepos 5  ·  harness-wrapper\e[39m
+│ \e[1m\e[38;2;224;224;224m\e[48;2;45;55;64m repo                 branch                      ci    change
+│ \e[38;2;33;21;5m\e[48;2;254;166;43m ▸ charter ⑂3         main               * ↑2     fail  !554
+│ \e[0m\e[38;2;224;224;224m\e[48;2;39;39;39m   easydmarc-app      feat/dmarc-rollup  ↓4       ok
+│    infra              main                        run   #88
+│    charter-docs       docs/frame         ? ↑1 ↓1  ok
+│    statusline-lab ⑂2  main
+│    ╰ pr-554                              ? ↑1     …
+│    ╰ pr-560                                       ok    !560
+│ 
+│ 
+│ \e[39m\e[48;2;36;47;56m \e[38;2;167;171;175msnapshot 4s old  ·  clicks 0  ·  scroll 0  ·  keys 0  ·  live · frozen\e[39m
+┌─ %4  rows 18-29  150x12  alternate_on=0  panel textual.repos
+│  repos 5  ·  harness-wrapper
+│  repo                 branch                      ci    change
+│  ▸ charter ⑂3         main               * ↑2     fail  !554
+│    easydmarc-app      feat/dmarc-rollup  ↓4       ok
+│    infra              main                        run   #88
+│    charter-docs       docs/frame         ? ↑1 ↓1  ok
+│    statusline-lab ⑂2  main
+│    ╰ pr-554                              ? ↑1     …
+│    ╰ pr-560                                       ok    !560
+│ 
+│ 
+│  snapshot 0s old  ·  clicks 0  ·  scroll 0  ·  keys 0  ·  headless
+┌─ %3  rows 31-39  150x9  alternate_on=0  panel repos
+│ \e[2m▪ \e[0;1mrepos\e[0;2m 5\e[0m
+│   \e[2m├─ \e[0;1;4m\e[35mcharter\e[0;2m ⑂3\e[0m                        \e[33mmain*\e[36m↑2\e[39m                             \e[31m✗ failed\e[39m      \e[32m!554\e[39m
+│   \e[2m├─ \e[0m\e[34measydmarc-app\e[39m                     \e[2mfeat/dmarc-rollup\e[0m\e[34m↓4\e[39m                 \e[2m? passed\e[0m
+│   \e[2m├─ \e[0m\e[36minfra\e[39m                             \e[2mmain\e[0m                                \e[36m● running\e[39m     \e[32m#88\e[39m
+│   \e[2m├─ \e[0m\e[32mcharter-docs\e[39m                      \e[33mdocs/frame*\e[36m↑1\e[34m↓1\e[39m                     \e[2m? passed\e[0m
+│   \e[2m└─ \e[0m\e[33mstatusline-lab\e[2m\e[39m ⑂2\e[0m                 \e[2mmain\e[0m
+│ 
+│ 
+│ 
+┌─ %2  rows 41-41  150x1  alternate_on=0  panel attention
+│ 0 todos · \e[33m⚠\e[39m \e[2mreinit\e[0m 9 \e[2mws · charter ws reinit --all\e[0m · F2 palette
+┌─ %1  rows 43-43  150x1  alternate_on=0  panel identity
+│  ⬢ default  \e[35m◆\e[39m \e[1msteward\e[0;2m · ◇ personas forge · reddit · release · statusline\e[0m                                                           charter 0.53.0 \e[2mdev\e[0m
+└─ tmux 3.7c · window 150x44 · session mouse off · python 3.14.2
+```
+
+Three things to look at:
+
+* `%5` is `alternate_on=1` and carries Textual's real 24-bit SGR — a widget framework
+  running in a pane charter split, at charter's own repaint clock's mercy and never
+  needing it.
+* `%4` is the same widget tree through charter's contract and has **not one escape in
+  it**. That is §1b, visible: `Registry.draw` escapes what a provider returns, so the
+  adapter can only ever hand back `Strip.text`.
+* `%3` is charter's own `repos`, in colour, from the same `gather` snapshot — the thing
+  the experiment set out to reimplement, and the one that still reads best.
+
+---
+
+## Reproducing
+
+```sh
+uv venv --python 3.14 .venv
+uv pip install --python .venv/bin/python -e . -e providers/charter-textual-repos
+.venv/bin/python -m pytest providers/charter-textual-repos     # 14 passed
+
+cd providers/charter-textual-repos/measure
+VENV=/abs/path/.venv WT=/abs/path/to/worktree bash m1_startup.sh    # and m2…m9
+```
+
+Each script owns one tmux socket named `charter-textualexp-<pid>` and kills the server
+before unlinking the file, in one trap — `tests/_tmuxreap.py`'s discipline, and the name is
+in charter's namespace so the suite's own reaper will also collect it if a script is killed
+before its trap runs (#590).
+
+## Suite
+
+The full charter suite, unchanged, in two environments:
+
+| | |
+|---|---|
+| Python 3.14.4 (Homebrew), inherited environment | **6975 tests, OK**, 506.8 s |
+| Python 3.12.13 (Homebrew), with every `CHARTER_*`, `CLAUDE_*`, `ANTHROPIC_*` and `TMUX*` variable unset (16 of them present, 0 after; the child process saw none) | **6975 tests, OK**, 468.7 s |
+
+`tests/test_packaging.py::test_runtime_has_zero_dependencies` passes in both, and both runs
+were of the **unmodified** `charter/` and `tests/` — `git status` for those paths is empty on
+this branch. The provider's own 14 tests pass on 3.14 (editable) and on 3.12 (from the built
+wheel).
+
+**CI validates none of the Textual half, and it should not be read as if it did.**
+`.github/workflows/test.yml` runs `python -m unittest discover -s tests -v` on 3.11-3.14 and
+installs nothing: not this provider, not Textual, not pytest. Nothing in
+`providers/` is built, imported or executed by any job, and no job starts a tmux server for
+these measurements. What CI does prove here is the thing that matters most —
+that charter is unchanged and its suite still passes — and what it does not prove is every
+number in §§1-7, each of which was taken by hand on this machine and is reproducible with
+the scripts named beside it.
+
+No charter production line was changed, so there is no news entry.

--- a/docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md
+++ b/docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md
@@ -69,7 +69,7 @@ entry points and the same two panes (`m7_shot.sh` under `venv312`, 14 provider t
 ## 1. Did the `Component` contract fit?
 
 **The declaration half fits. The rendering half fits one of the two shapes. The input half
-does not exist.** Six places it chafed, each named.
+does not exist.** Seven places it chafed, each named.
 
 ### 1a. `render(ctx) -> list[str]` is a *renderer* contract, and a widget framework is not a renderer
 
@@ -161,7 +161,33 @@ are reachable only on a frame nobody has arranged, i.e. from `Registry.place` wi
 rectangle. charter's own `repos` is `Content()` and its height is what the plane's repos
 need; a provider's table of the same data is a fixed rectangle or nothing.
 
-### 1f. The contract is a Python class, so every provider hard-depends on charter
+### 1f. A provider directory inside charter's repo costs exactly one line, and CI is what says so
+
+Committing `providers/` failed `test_plugin_freshness.
+TheHashCoversWhatThePluginLoads.test_every_top_level_directory_is_classified_one_way_or_the_other`
+on 3.11 and 3.13:
+
+```
+AssertionError: Items in the first set but not the second:
+'providers' : new top-level directory ['providers']: does a Claude Code plugin LOAD it?
+Add it to plugincache.PLUGIN_SURFACE, or to _NOT_PLUGIN_SURFACE in this file.
+```
+
+That is the check doing exactly its job — its own docstring says "add `mcp/` or `commands/`
+to charter tomorrow and this fails on the PR that commits it, until somebody decides which
+it is". The decision is made in `_NOT_PLUGIN_SURFACE`: a provider is a separate
+distribution, nothing under it is importable from charter, none of it ships in the wheel,
+and it must never become plugin surface, because a provider declares dependencies charter
+does not have and that is the whole property `test_runtime_has_zero_dependencies` protects.
+
+**Worth recording is how it was found, not that it happened.** The classification reads the
+**git index**, deliberately (#529, so an untracked `.charter/` or `.venv/` cannot reach it).
+Every local full-suite run before the commit therefore passed — `providers/` was untracked —
+and the failure appeared on the first CI run after `git commit`. The local suite was re-run
+on the committed tree afterwards; the counts at the end are from those runs. This is the one
+place in the experiment where CI caught something a hand-run could not.
+
+### 1g. The contract is a Python class, so every provider hard-depends on charter
 
 `Providers._one` finishes with `isinstance(obj, self.kind)` where `kind` is
 `charter.frame.component.Component`. A provider cannot express a component without importing

--- a/docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md
+++ b/docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md
@@ -645,17 +645,22 @@ before its trap runs (#590).
 
 ## Suite
 
-The full charter suite, unchanged, in two environments:
+The full charter suite, on the **committed** tree — §1f is why that distinction is stated —
+in two environments:
 
 | | |
 |---|---|
-| Python 3.14.4 (Homebrew), inherited environment | **6975 tests, OK**, 506.8 s |
-| Python 3.12.13 (Homebrew), with every `CHARTER_*`, `CLAUDE_*`, `ANTHROPIC_*` and `TMUX*` variable unset (16 of them present, 0 after; the child process saw none) | **6975 tests, OK**, 468.7 s |
+| Python 3.14.4 (Homebrew), inherited environment | **6975 tests, OK**, 362.6 s |
+| Python 3.12.13 (Homebrew), with every `CHARTER_*`, `CLAUDE_*`, `ANTHROPIC_*` and `TMUX*` variable unset (16 of them present, 0 after; the child process saw none) | **6975 tests, OK**, 380.0 s |
 
 `tests/test_packaging.py::test_runtime_has_zero_dependencies` passes in both, and both runs
 were of the **unmodified** `charter/` and `tests/` — `git status` for those paths is empty on
 this branch. The provider's own 14 tests pass on 3.14 (editable) and on 3.12 (from the built
 wheel).
+
+CI is green at this branch's head, asked of the sha rather than of the pull request (#561):
+`gh api repos/diazoxide/charter/commits/<HEAD>/check-runs` reports `test (3.11)`,
+`test (3.12)`, `test (3.13)` and `test (3.14)` all **success**.
 
 **CI validates none of the Textual half, and it should not be read as if it did.**
 `.github/workflows/test.yml` runs `python -m unittest discover -s tests -v` on 3.11-3.14 and

--- a/docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md
+++ b/docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md
@@ -187,6 +187,18 @@ and the failure appeared on the first CI run after `git commit`. The local suite
 on the committed tree afterwards; the counts at the end are from those runs. This is the one
 place in the experiment where CI caught something a hand-run could not.
 
+**And two places the directory travels anyway, neither of which costs the property that
+matters.** Charter's marketplace entry is `"source": "./"`, so the whole repository is copied
+into every plugin user's cache — `tests/` and `docs/` already, and now `providers/` too; the
+classification above is what keeps its *content* out of the freshness hash, so an edit to it
+is not reported as a stale plugin. And hatchling's default sdist is the whole repository, so
+`providers/` is 22 of the sdist's 985 entries, beside `tests/`' 356 and `docs/`' 183. Neither
+reaches the wheel (`packages = ["charter"]`; `unzip -l … | grep -c providers` is 0), so
+`pip install charter-cp` installs nothing of it and `dependencies = []` is untouched in
+every direction. If this were ever more than an experiment, the sdist is where somebody
+should decide whether 22 files of third-party-provider source belong in charter's release
+artifact.
+
 ### 1g. The contract is a Python class, so every provider hard-depends on charter
 
 `Providers._one` finishes with `isinstance(obj, self.kind)` where `kind` is
@@ -616,10 +628,14 @@ Three things to look at:
 ```sh
 uv venv --python 3.14 .venv
 uv pip install --python .venv/bin/python -e . -e providers/charter-textual-repos
-.venv/bin/python -m pytest providers/charter-textual-repos     # 14 passed
+uv pip install --python .venv/bin/python pytest
+.venv/bin/python -m pytest -q providers/charter-textual-repos     # 14 passed
 
-cd providers/charter-textual-repos/measure
-VENV=/abs/path/.venv WT=/abs/path/to/worktree bash m1_startup.sh    # and m2…m9
+M=providers/charter-textual-repos/measure
+VENV="$PWD/.venv" WT="$PWD" bash $M/m1_startup.sh                  # and m2 … m8
+VENV="$PWD/.venv" WT="$PWD" bash $M/m7_shot.sh esc                 # the capture in §9
+.venv/bin/python $M/m9_cost.py                                     # no tmux needed
+.venv/bin/python $M/m10_thread_takeover.py                         # writes /tmp/m10_*.json
 ```
 
 Each script owns one tmux socket named `charter-textualexp-<pid>` and kills the server

--- a/providers/charter-textual-repos/README.md
+++ b/providers/charter-textual-repos/README.md
@@ -1,0 +1,63 @@
+# charter-textual-repos
+
+**An experiment, not a product.** Charter's repo table drawn with
+[Textual](https://github.com/textualize/textual), shipped as a third-party provider through
+charter's existing `charter.components` entry point.
+
+The question it was built to answer: **does charter's provider model already permit a rich
+widget framework without charter taking the dependency?** The answer, the measurements
+behind it, and what it would take to ship something like this are in
+[`docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md`](../../docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md).
+
+## The premise, on one line
+
+charter's `pyproject.toml` says `dependencies = []`, asserted by
+`tests/test_packaging.py::test_runtime_has_zero_dependencies`. This package's says
+`dependencies = ["charter-cp", "textual>=0.80"]`. charter finds it with
+`importlib.metadata`, which is stdlib. **Nothing in `charter/` changed to make this work.**
+
+## Two components
+
+| id | shape | what it is for |
+|---|---|---|
+| `textual.repos` | Textual on the **headless** driver, on a background thread; its composited screen copied out as lines | obeys `render(ctx) -> list[str]` exactly as written |
+| `textual.live` | Textual on the **pane's own tty** — alternate screen, own event loop, `mouse=True` | `render` never returns; the only shape where keys, mouse and scrolling exist |
+
+Both read `ctx.gather` and nothing else. Place either from a committed `charter.toml`:
+
+```toml
+[[frame.component]]
+use = "textual.live"
+edge = "bottom"
+size = 12
+```
+
+## Install
+
+```sh
+uv venv --python 3.14 .venv
+uv pip install --python .venv/bin/python -e . -e providers/charter-textual-repos
+```
+
+## Layout
+
+```
+src/charter_textual_repos/
+  __init__.py   API_VERSION and the two Component factories the entry points name
+  rows.py       the data, derived from ctx.gather and from nothing else
+  ui.py         the Textual app — one class, driven two ways
+  adapter.py    textual.repos: headless, screen copied out as lines
+  live.py       textual.live: the takeover
+tests/          pytest (this package is not charter's tree, so not unittest)
+measure/        the tmux rig every number in the report was taken on
+```
+
+## Apparatus
+
+Three env vars exist only so the experiment is reproducible. None is a feature.
+
+| | |
+|---|---|
+| `CHARTER_TEXTUAL_LIVE_REFRESH=1` | the live app polls `charter.frame.state`/`gather` itself — i.e. reaches around `ctx`. Measures what "stay live" would cost a provider. |
+| `CHARTER_TEXTUAL_FAULT=render\|loop` | inject a crash before the app starts, or inside Textual's message pump. Measures blast radius. |
+| `CHARTER_TEXTUAL_KEEP_CAPTURE=1` | do not undo Textual's `sys.stdout` capture. Reproduces the silent blank pane described in §2 of the report. |

--- a/providers/charter-textual-repos/measure/m10_thread_takeover.py
+++ b/providers/charter-textual-repos/measure/m10_thread_takeover.py
@@ -1,0 +1,65 @@
+"""M10 — the third component shape, refuted.
+
+The shape neither component in this package uses, and the one that looks like the obvious
+compromise: `render` starts a real (non-headless) Textual app on a background thread and
+returns `[]` immediately, so charter's loop keeps running and keeps handing the component
+fresh snapshots while Textual owns the pixels.
+
+It does not work, it fails silently, and both halves are worth having measured.
+
+Run it on any tty; it writes its answer to stdout and nothing to your terminal.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pty
+import select
+import threading
+import time
+
+from charter_textual_repos.ui import ReposApp
+
+
+def main() -> int:
+    master, slave = pty.openpty()
+    os.dup2(slave, 0)
+    os.dup2(slave, 1)
+    os.dup2(slave, 2)
+
+    out = {"raised_out_of_run": [], "started": False, "bytes_to_the_pane": 0}
+    app = ReposApp(gathered={"repos": [], "gathered_at": time.time()}, note="thread")
+
+    def go() -> None:
+        try:
+            app.run(mouse=True)                 # the non-headless driver, off-main-thread
+        except BaseException as exc:            # noqa: BLE001
+            out["raised_out_of_run"].append(f"{type(exc).__name__}: {exc}")
+
+    thread = threading.Thread(target=go, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 4
+    while time.monotonic() < deadline:
+        if app.is_running:
+            out["started"] = True
+            break
+        time.sleep(0.02)
+    time.sleep(1.0)
+
+    blob = b""
+    while select.select([master], [], [], 0.1)[0]:
+        blob += os.read(master, 65536)
+    plain = blob.decode("utf-8", "replace")
+    out["bytes_to_the_pane"] = len(blob)
+    out["pane_got_a_traceback"] = "Traceback" in plain
+    out["reason"] = next((ln for ln in plain.splitlines() if "ValueError" in ln), "")
+
+    os.write(2, b"")                            # nothing; the answer goes to the file
+    with open("/tmp/m10_thread_takeover.json", "w") as fh:
+        json.dump(out, fh, indent=2)
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/charter-textual-repos/measure/m1_startup.sh
+++ b/providers/charter-textual-repos/measure/m1_startup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# M1 — how long from `split-window` to the first non-blank paint, for three panels:
+# charter's own `repos`, the Textual adapter (`textual.repos`) and the Textual takeover
+# (`textual.live`). Polled at 10 ms against real `capture-pane`, five runs each.
+source "$(dirname "${BASH_SOURCE[0]}")/rig.sh"
+
+seed
+start_session
+
+first_paint() {  # first_paint <component> <rows>
+  local pane start now
+  start=$("$PY" -c 'import time;print(time.time())')
+  pane=$(split_panel "$1" "$2")
+  for _ in $(seq 1 400); do
+    if tm capture-pane -p -t "$pane" | grep -q '[^[:space:]]'; then
+      now=$("$PY" -c 'import time;print(time.time())')
+      "$PY" -c "print(f'{1000*($now-$start):.0f}')"
+      tm kill-pane -t "$pane"
+      return
+    fi
+    "$PY" -c 'import time;time.sleep(0.01)'
+  done
+  echo "TIMEOUT"
+  tm kill-pane -t "$pane" 2>/dev/null || true
+}
+
+for comp in repos textual.repos textual.live; do
+  printf '%-16s' "$comp"
+  for _ in 1 2 3 4 5; do printf ' %sms' "$(first_paint "$comp" 14)"; done
+  printf '\n'
+done

--- a/providers/charter-textual-repos/measure/m2_altscreen.sh
+++ b/providers/charter-textual-repos/measure/m2_altscreen.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# M2 — what the alternate screen costs charter: pane scrollback, `capture-pane`, resize,
+# and what tmux is left holding when the pane's process goes away.
+source "$(dirname "${BASH_SOURCE[0]}")/rig.sh"
+
+seed
+start_session
+
+own=$(split_panel repos 14)
+live=$(split_panel textual.live 14)
+sleep 3
+
+# A panel writes into the pane it is given, so both panes have had output. The question is
+# whether tmux has any HISTORY for them: charter's own panel repaints with
+# `\x1b[H\x1b[2J` on the normal screen, and Textual runs on the alternate screen, where
+# tmux keeps no history at all.
+echo "== alternate-screen flag (tmux's own view) =="
+tm list-panes -t exp -F '#{pane_id} #{pane_current_command} alternate_on=#{alternate_on} height=#{pane_height}'
+
+echo
+echo "== history size per pane =="
+tm list-panes -t exp -F '#{pane_id} history_size=#{history_size} history_bytes=#{history_bytes}'
+
+echo
+echo "== capture-pane -p (visible) line counts =="
+echo "charter repos : $(tm capture-pane -p -t "$own"  | grep -c '[^[:space:]]') non-blank"
+echo "textual live  : $(tm capture-pane -p -t "$live" | grep -c '[^[:space:]]') non-blank"
+
+echo
+echo "== capture-pane -p -e first two lines of the Textual pane =="
+tm capture-pane -p -e -t "$live" | head -2 | cat -v
+
+echo
+echo "== capture-pane -S -200 (scrollback) line counts =="
+echo "harness pane  : $(tm capture-pane -p -S -200 -t exp:0.0 | grep -c '[^[:space:]]') non-blank"
+echo "charter repos : $(tm capture-pane -p -S -200 -t "$own"  | grep -c '[^[:space:]]') non-blank"
+echo "textual live  : $(tm capture-pane -p -S -200 -t "$live" | grep -c '[^[:space:]]') non-blank"
+
+echo
+echo "== resize the window 150x40 -> 100x30, then back =="
+tm resize-window -t exp -x 100 -y 30; sleep 1.5
+echo "--- textual pane at $(tm display -p -t "$live" '#{pane_width}x#{pane_height}') ---"
+tm capture-pane -p -t "$live" | head -4
+echo "  longest captured line: $(tm capture-pane -p -t "$live" | awk '{print length}' | sort -n | tail -1) cells"
+tm resize-window -t exp -x 150 -y 40; sleep 1.5
+echo "--- textual pane back at $(tm display -p -t "$live" '#{pane_width}x#{pane_height}') ---"
+tm capture-pane -p -t "$live" | head -4
+echo "  longest captured line: $(tm capture-pane -p -t "$live" | awk '{print length}' | sort -n | tail -1) cells"
+
+echo
+echo "== kill the panel process and see what tmux is holding =="
+tm set -t exp remain-on-exit on
+pid=$(tm list-panes -t exp -F '#{pane_id} #{pane_pid}' | awk -v p="$live" '$1==p{print $2}')
+kill -9 "$pid"; sleep 1
+tm list-panes -t exp -F '#{pane_id} dead=#{pane_dead} status=#{pane_dead_status} alternate_on=#{alternate_on}'
+echo "--- what the dead pane shows ---"
+tm capture-pane -p -t "$live" | head -6
+
+echo
+echo "== respawn-pane, the way commands_frame.cmd_respawn does after pane-died =="
+tm respawn-pane -k -t "$live" -- "$CHARTER" panel textual.live --session "$FID"
+sleep 3
+tm list-panes -t exp -F '  #{pane_id} dead=#{pane_dead} alternate_on=#{alternate_on} #{pane_width}x#{pane_height}'
+echo "  --- respawned pane ---"
+tm capture-pane -p -t "$live" | grep '[^[:space:]]' | head -3 | sed 's/^/  /'

--- a/providers/charter-textual-repos/measure/m3_crash.sh
+++ b/providers/charter-textual-repos/measure/m3_crash.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# M3 — what a crash costs. Four ways for a Textual component to fail, each in a real pane
+# beside a working charter panel and a working harness pane, so the blast radius is
+# something to look at rather than something to argue about.
+source "$(dirname "${BASH_SOURCE[0]}")/rig.sh"
+
+seed
+start_session
+own=$(split_panel repos 8)
+
+show() {   # show <label>
+  sleep 3
+  echo "== $1 =="
+  tm list-panes -t exp -F '  #{pane_id} dead=#{pane_dead} cmd=#{pane_current_command}'
+  echo "  --- the failing pane ---"
+  tm capture-pane -p -t "$victim" | grep '[^[:space:]]' | head -4 | sed 's/^/  /'
+  echo "  --- charter's own repos pane, beside it ---"
+  tm capture-pane -p -t "$own" | grep '[^[:space:]]' | head -2 | sed 's/^/  /'
+  echo "  --- the harness pane ---"
+  tm capture-pane -p -t exp:0.0 | grep '[^[:space:]]' | tail -1 | sed 's/^/  /'
+  tm kill-pane -t "$victim" 2>/dev/null || true
+  echo
+}
+
+# 1. render raises before the app starts.
+victim=$(tm split-window -t exp:0.0 -v -l 8 -P -F '#{pane_id}' \
+   -e CHARTER_TEXTUAL_FAULT=render -- "$CHARTER" panel textual.live --session "$FID")
+show "fault: render raises before Textual starts"
+
+# 2. the app raises from inside Textual's own message pump, one second after mount.
+victim=$(tm split-window -t exp:0.0 -v -l 8 -P -F '#{pane_id}' \
+   -e CHARTER_TEXTUAL_FAULT=loop -- "$CHARTER" panel textual.live --session "$FID")
+show "fault: raises inside Textual's message pump"
+
+# 3. the distribution is not installed at all — the id resolves to nothing.
+victim=$(tm split-window -t exp:0.0 -v -l 8 -P -F '#{pane_id}' \
+   -- "$CHARTER" panel notinstalled.thing --session "$FID")
+show "not installed: charter panel notinstalled.thing"
+
+# 4. the provider is installed but its module cannot be imported. Simulated by pointing
+#    PYTHONPATH at a shadowing module of the same name that raises on import.
+shadow="$(mktemp -d)"
+cat > "$shadow/charter_textual_repos.py" <<'PYEOF'
+raise ImportError("the provider's own module could not be imported")
+PYEOF
+victim=$(tm split-window -t exp:0.0 -v -l 8 -P -F '#{pane_id}' \
+   -e "PYTHONPATH=$shadow" -- "$CHARTER" panel textual.live --session "$FID")
+show "import raises: a shadowed provider module"
+rm -rf "$shadow"

--- a/providers/charter-textual-repos/measure/m3b_crash_message.sh
+++ b/providers/charter-textual-repos/measure/m3b_crash_message.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# M3b — where a Textual crash's REASON ends up.
+#
+# M3 showed the blast radius is one pane. This asks the follow-up question, which turned
+# out to be the more interesting one: Textual does not let the exception out of `run()`.
+# It catches it, prints a Rich traceback to **stderr**, and returns normally — so
+# `Registry.draw` never sees a failure, charter's "failed to draw" message never appears,
+# and `panel._write` clears the pane a moment later with whatever `render` answered.
+#
+# Sampled every 100 ms across the crash so the traceback can be seen arriving and being
+# wiped.
+source "$(dirname "${BASH_SOURCE[0]}")/rig.sh"
+
+seed
+start_session
+
+victim=$(tm split-window -t exp:0.0 -v -l 12 -P -F '#{pane_id}' \
+   -e CHARTER_TEXTUAL_FAULT=loop -- "$CHARTER" panel textual.live --session "$FID")
+
+for i in $(seq 1 22); do
+  "$PY" -c 'import time;time.sleep(0.1)'
+  line=$(tm capture-pane -p -t "$victim" | grep -m1 '[^[:space:]]' || true)
+  printf '%5sms | %s\n' "$((i*100))" "${line:0:110}"
+done

--- a/providers/charter-textual-repos/measure/m4_mouse.py
+++ b/providers/charter-textual-repos/measure/m4_mouse.py
@@ -1,0 +1,172 @@
+"""M4 — the mouse measurement, against a real tmux client on a real pty.
+
+§4i measured that **tmux enables mouse reporting on the outer terminal from the ACTIVE
+pane's mode alone**, and it measured that with charter's own panels, none of which ask for
+the mouse. It could not measure the other half — what happens when a pane genuinely wants
+it — because charter had no such program. `textual.live` is one: `App.run(mouse=True)`
+writes ``?1000h ?1003h ?1015h ?1006h`` to its pane the moment it starts.
+
+So this asks, of tmux 3.7c, with tmux's own ``mouse`` **off** (charter's default):
+
+1. Does the client get mouse reporting turned on when the Textual pane is active, and
+   turned off again when it is not?
+2. Does a mouse report injected into the client reach the Textual app — and does it reach
+   it only while that pane is active?
+3. Does the harness pane keep its scrollback throughout, i.e. is the operator's own
+   text-selection preserved while the Textual pane is *not* the one they are in?
+
+The client runs on a pty this script owns, so every byte tmux writes to a terminal is
+readable here. Nothing is inferred from tmux's own reporting of its state.
+
+Cleanup: the caller (`m4_mouse.sh`) owns the socket and kills the server before unlinking
+it — see `rig.sh`.
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import re
+import select
+import struct
+import subprocess
+import sys
+import termios
+import time
+
+SOCK = sys.argv[1]
+LIVE = sys.argv[2]          # pane id of the textual.live pane
+HARNESS = sys.argv[3]       # pane id of the harness pane
+COLS, ROWS = 150, 40
+
+#: The private modes that mean "report the mouse". 1000 = press/release, 1002 = drag,
+#: 1003 = any motion, 1006 = SGR encoding. tmux writes them to the CLIENT when it decides
+#: the terminal should report; that decision is what is being measured.
+MODE = re.compile(rb"\x1b\[\?(1000|1002|1003|1005|1006|1015)([hl])")
+
+
+def tmux(*args: str) -> str:
+    return subprocess.run(["tmux", "-L", SOCK, *args], capture_output=True,
+                          text=True).stdout.strip()
+
+
+def drain(fd, seconds: float = 0.6) -> bytes:
+    """Everything the client writes to its terminal in *seconds*."""
+    out = b""
+    end = time.monotonic() + seconds
+    while time.monotonic() < end:
+        r, _, _ = select.select([fd], [], [], 0.05)
+        if r:
+            try:
+                out += os.read(fd, 65536)
+            except OSError:
+                break
+    return out
+
+
+def modes(blob: bytes) -> str:
+    """The mouse modes in *blob*, in order, as ``1006h 1000l`` style text."""
+    seen = [f"{m.group(1).decode()}{m.group(2).decode()}" for m in MODE.finditer(blob)]
+    return " ".join(seen) if seen else "(none)"
+
+
+def counters(pane: str) -> str:
+    """The Textual app's own footer, which counts what it received."""
+    text = tmux("capture-pane", "-p", "-t", pane)
+    for line in reversed(text.split("\n")):
+        if "clicks" in line:
+            return line.strip()
+    return "(no footer)"
+
+
+def main() -> int:
+    master, slave = pty.openpty()
+    # The pty must be the session's size or tmux resizes the window under the experiment.
+    termios.tcsetwinsize(slave, (ROWS, COLS)) if hasattr(termios, "tcsetwinsize") else None
+    import fcntl
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", ROWS, COLS, 0, 0))
+
+    client = subprocess.Popen(
+        ["tmux", "-L", SOCK, "attach", "-t", "exp"],
+        stdin=slave, stdout=slave, stderr=slave, close_fds=True,
+        env=dict(os.environ, TERM="xterm-256color"))
+    os.close(slave)
+    print(f"tmux {tmux('-V')}  ·  session mouse = {tmux('show', '-t', 'exp', '-v', 'mouse')}")
+    drain(master, 1.5)
+
+    print("\n== 1. what tmux writes to the terminal as the active pane changes ==")
+    tmux("select-pane", "-t", HARNESS)
+    drain(master, 0.5)
+    tmux("select-pane", "-t", LIVE)
+    print(f"  select-pane -> textual.live : {modes(drain(master))}")
+    tmux("select-pane", "-t", HARNESS)
+    print(f"  select-pane -> harness      : {modes(drain(master))}")
+    tmux("select-pane", "-t", LIVE)
+    print(f"  select-pane -> textual.live : {modes(drain(master))}")
+
+    print("\n== 1b. and the keyboard, which charter has no path for either ==")
+    tmux("select-pane", "-t", LIVE)
+    time.sleep(0.3)
+    for key in ("j", "j", "k"):
+        tmux("send-keys", "-t", LIVE, key)
+        time.sleep(0.2)
+    print(f"  after j j k                 : {counters(LIVE)}")
+    print("  ^ the app reads its own tty. `Component.events` declaring `key` has nothing")
+    print("    to do with it: charter validates that tuple and never reads it again.")
+
+    print("\n== 2. does an injected mouse report reach the app? ==")
+    live_top = int(tmux("display", "-p", "-t", LIVE, "#{pane_top}"))
+    row = live_top + 4                       # a row inside the Textual pane, 0-based
+    col = 12
+
+    def send(seq: bytes) -> None:
+        os.write(master, seq)
+        time.sleep(0.35)
+
+    print(f"  before                      : {counters(LIVE)}")
+    tmux("select-pane", "-t", LIVE)
+    drain(master, 0.4)
+    send(f"\x1b[<0;{col + 1};{row + 1}M".encode())      # press
+    send(f"\x1b[<0;{col + 1};{row + 1}m".encode())      # release
+    print(f"  click, textual.live active  : {counters(LIVE)}")
+    send(f"\x1b[<64;{col + 1};{row + 1}M".encode())     # wheel up
+    send(f"\x1b[<65;{col + 1};{row + 1}M".encode())     # wheel down
+    print(f"  wheel, textual.live active  : {counters(LIVE)}")
+
+    tmux("select-pane", "-t", HARNESS)
+    drain(master, 0.5)
+    send(f"\x1b[<0;{col + 1};{row + 1}M".encode())
+    send(f"\x1b[<0;{col + 1};{row + 1}m".encode())
+    send(f"\x1b[<64;{col + 1};{row + 1}M".encode())
+    print(f"  same clicks, harness active : {counters(LIVE)}")
+    print(f"  active pane after that click: "
+          f"{tmux('display', '-p', '#{pane_id}')} (harness is {HARNESS})")
+    print("  ^ tmux routes a report by POSITION, not by which pane is active. The modal")
+    print("    part is the TERMINAL's reporting mode, which the active pane alone sets.")
+
+    print("\n== 2b. and with the harness pane itself asking for the mouse ==")
+    # What Claude Code actually does. The harness stand-in requests SGR reporting on its
+    # own pane; tmux then enables reporting on the terminal while the HARNESS is active,
+    # and every click anywhere in the window becomes bytes — including clicks that land on
+    # charter's panels.
+    tmux("send-keys", "-t", HARNESS, r"printf '\033[?1000h\033[?1006h'", "Enter")
+    time.sleep(0.4)
+    tmux("select-pane", "-t", HARNESS)
+    print(f"  select-pane -> harness      : {modes(drain(master))}")
+
+    print("\n== 3. the harness pane's scrollback, throughout ==")
+    print(f"  history_size = {tmux('display', '-p', '-t', HARNESS, '#{history_size}')}"
+          f"  ·  last line = "
+          f"{tmux('capture-pane', '-p', '-S', '-5', '-t', HARNESS).splitlines()[-1]!r}")
+
+    client.terminate()
+    try:
+        client.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        client.kill()
+    os.close(master)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/providers/charter-textual-repos/measure/m4_mouse.sh
+++ b/providers/charter-textual-repos/measure/m4_mouse.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# M4 — the mouse measurement. Builds the frame, then hands the socket to m4_mouse.py,
+# which attaches a real tmux client on a pty it owns and reads every byte tmux writes to
+# a terminal. See that file's docstring for what is being asked.
+source "$(dirname "${BASH_SOURCE[0]}")/rig.sh"
+
+seed
+start_session
+live=$(split_panel textual.live 14)
+sleep 2.5
+"$PY" "$HERE/m4_mouse.py" "$SOCK" "$live" "%0"

--- a/providers/charter-textual-repos/measure/m5_no_color.sh
+++ b/providers/charter-textual-repos/measure/m5_no_color.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# M5 — does `NO_COLOR` still reach the pane?
+#
+# `frame/panel.py:_write` calls itself "the one place anything reaches the pane's screen",
+# and that is where charter honours `NO_COLOR` (`chrome.colour_ok`) — for a component
+# charter did not write as much as for one it did. A takeover component makes the sentence
+# false: `textual/drivers/linux_driver.py:58` sets `self._file = sys.__stderr__` and the
+# app writes straight there, past `_write`, past `chrome.plain`, past `sys.stderr` itself.
+#
+# Whether the operator's `NO_COLOR` is honoured is then entirely up to the framework.
+source "$(dirname "${BASH_SOURCE[0]}")/rig.sh"
+
+seed
+start_session
+
+sgr() {  # how many SGR sequences are in this pane's captured output
+  tm capture-pane -p -e -t "$1" | grep -o $'\033\\[[0-9;]*m' | wc -l | tr -d ' '
+}
+
+own=$(split_panel repos 8)
+live=$(split_panel textual.live 10)
+adapt=$(tm split-window -t exp:0.0 -v -l 10 -P -F '#{pane_id}' \
+   -- "$CHARTER" panel textual.repos --session "$FID")
+sleep 3
+echo "== colour ON =="
+echo "  charter repos : $(sgr "$own") SGR sequences"
+echo "  textual.live  : $(sgr "$live") SGR sequences"
+echo "  textual.repos : $(sgr "$adapt") SGR sequences"
+tm kill-pane -t "$own"; tm kill-pane -t "$live"; tm kill-pane -t "$adapt"
+
+own=$(tm split-window -t exp:0.0 -v -l 8 -P -F '#{pane_id}' \
+   -e NO_COLOR=1 -- "$CHARTER" panel repos --session "$FID")
+live=$(tm split-window -t exp:0.0 -v -l 10 -P -F '#{pane_id}' \
+   -e NO_COLOR=1 -- "$CHARTER" panel textual.live --session "$FID")
+adapt=$(tm split-window -t exp:0.0 -v -l 10 -P -F '#{pane_id}' \
+   -e NO_COLOR=1 -- "$CHARTER" panel textual.repos --session "$FID")
+sleep 3
+echo "== NO_COLOR=1 =="
+echo "  charter repos : $(sgr "$own") SGR sequences"
+echo "  textual.live  : $(sgr "$live") SGR sequences"
+echo "  textual.repos : $(sgr "$adapt") SGR sequences"

--- a/providers/charter-textual-repos/measure/m6_repaint.sh
+++ b/providers/charter-textual-repos/measure/m6_repaint.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# M6 — does charter's version-bump repaint model coexist with Textual's own loop?
+#
+# charter's panel is a poll: `panel._tick` reads `state.version(fid)` five times a second
+# and repaints when it moves. Three panes are watched here through two bumps that change
+# the plane's CI state from `failed` to `passed`:
+#
+#   repos          charter's own renderer, the control
+#   textual.repos  the adapter — render returns, so charter calls it again
+#   textual.live   the takeover — render never returns, so charter never calls it again
+#   textual.live   the same, with CHARTER_TEXTUAL_LIVE_REFRESH=1, which polls the version
+#                  itself from inside the app
+source "$(dirname "${BASH_SOURCE[0]}")/rig.sh"
+
+seed failed
+start_session
+
+own=$(split_panel repos 8)
+adapt=$(tm split-window -t exp:0.0 -v -l 10 -P -F '#{pane_id}' \
+   -- "$CHARTER" panel textual.repos --session "$FID")
+live=$(split_panel textual.live 10)
+livep=$(tm split-window -t exp:0.0 -v -l 10 -P -F '#{pane_id}' \
+   -e CHARTER_TEXTUAL_LIVE_REFRESH=1 -- "$CHARTER" panel textual.live --session "$FID")
+sleep 3.5
+
+row() {  # the charter row for the current repo, from whichever pane
+  tm capture-pane -p -t "$1" | grep -m1 'charter' | tr -s ' ' | cut -c1-72
+}
+
+echo "== seeded with ci=failed =="
+printf '  %-14s %s\n' "repos"         "$(row "$own")"
+printf '  %-14s %s\n' "textual.repos" "$(row "$adapt")"
+printf '  %-14s %s\n' "textual.live"  "$(row "$live")"
+printf '  %-14s %s\n' "live+refresh"  "$(row "$livep")"
+
+seed passed          # rewrites the gather cache and bumps the frame's version
+sleep 2
+
+echo
+echo "== after gather rewritten to ci=passed and state.bump() =="
+printf '  %-14s %s\n' "repos"         "$(row "$own")"
+printf '  %-14s %s\n' "textual.repos" "$(row "$adapt")"
+printf '  %-14s %s\n' "textual.live"  "$(row "$live")"
+printf '  %-14s %s\n' "live+refresh"  "$(row "$livep")"
+
+echo
+echo "== the adapter pane in full, after the bump =="
+tm capture-pane -p -t "$adapt" | sed 's/^/  /'
+
+echo
+echo "== and the snapshot clock each pane is showing =="
+for p in "$adapt" "$live" "$livep"; do
+  printf '  %s %s\n' "$p" "$(tm capture-pane -p -t "$p" | grep -m1 snapshot | tr -s ' ')"
+done

--- a/providers/charter-textual-repos/measure/m7_shot.sh
+++ b/providers/charter-textual-repos/measure/m7_shot.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# M7 — the picture. A charter frame with charter's own `repos` table and both Textual
+# components in it at once, captured with `capture-pane -p -e` so the escapes are real.
+#
+# Panes are split in charter's own order (`layout.panel_argvs`: `top` is the only `-b`,
+# every other split is a plain `-v`, so a slot split later sits ABOVE one split earlier),
+# then printed top to bottom with each pane's real geometry.
+#
+#   ./m7_shot.sh          plain text, for reading and for a PR body
+#   ./m7_shot.sh esc      `capture-pane -p -e`, with ESC shown as `\e`
+source "$(dirname "${BASH_SOURCE[0]}")/rig.sh"
+
+seed
+COLS=150 ROWS=44 start_session
+
+split_panel identity 1  >/dev/null
+split_panel attention 1 >/dev/null
+split_panel repos 9     >/dev/null
+tm split-window -t exp:0.0 -v -l 12 -- "$CHARTER" panel textual.repos --session "$FID" >/dev/null
+split_panel textual.live 12 >/dev/null
+sleep 4
+tm select-pane -t "%0"
+sleep 0.5
+
+order=$(tm list-panes -t exp -F '#{pane_top} #{pane_id}' | sort -n | awk '{print $2}')
+for p in $order; do
+  read -r top bot w h alt cmd <<<"$(tm display -p -t "$p" \
+     '#{pane_top} #{pane_bottom} #{pane_width} #{pane_height} #{alternate_on} #{pane_start_command}')"
+  what=$(printf '%s' "$cmd" | sed -E 's#.*/charter (panel [a-z.]+).*#\1#; s#^sh -c.*#the harness (stand-in)#')
+  printf '┌─ %s  rows %s-%s  %sx%s  alternate_on=%s  %s\n' "$p" "$top" "$bot" "$w" "$h" "$alt" "$what"
+  if [ "${1:-plain}" = esc ]; then
+    # ESC shown as `\e`, and nothing else touched — `cat -v` would mangle the UTF-8
+    # glyphs the table is made of, which is half of what there is to look at.
+    tm capture-pane -p -e -t "$p" | sed $'s/\033/\\\\e/g' | sed 's/^/│ /'
+  else
+    tm capture-pane -p -t "$p" | sed 's/^/│ /'
+  fi
+done
+printf '└─ tmux %s · window %s · session mouse %s · %s\n' \
+  "$(tmux -V | cut -d" " -f2)" "$(tm display -p -t exp "#{window_width}x#{window_height}")" \
+  "$(tm show -t exp -v mouse)" "$("$PY" -c "import sys;print(\"python \"+sys.version.split()[0])")"

--- a/providers/charter-textual-repos/measure/m8_stdout.sh
+++ b/providers/charter-textual-repos/measure/m8_stdout.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# M8 — what Textual's `sys.stdout` capture does to a charter panel, with and without the
+# provider's four-line workaround (`adapter._give_stdout_back`).
+#
+# Two panes, identical but for `CHARTER_TEXTUAL_KEEP_CAPTURE=1`, watched across a version
+# bump. The captured pane paints once and then draws blank, silently — see
+# `adapter._give_stdout_back` for the chain (`panel._out` writes into Textual's print log,
+# `slots._width`/`_height` measure fd -1 and fall back to 80x24, `chrome.colour_ok` is
+# told the pane is a tty whatever it is).
+source "$(dirname "${BASH_SOURCE[0]}")/rig.sh"
+
+seed failed
+start_session
+
+fixed=$(tm split-window -t exp:0.0 -v -l 10 -P -F '#{pane_id}' \
+   -- "$CHARTER" panel textual.repos --session "$FID")
+broken=$(tm split-window -t exp:0.0 -v -l 10 -P -F '#{pane_id}' \
+   -e CHARTER_TEXTUAL_KEEP_CAPTURE=1 -- "$CHARTER" panel textual.repos --session "$FID")
+
+for i in $(seq 1 10); do
+  "$PY" -c 'import time;time.sleep(0.5)'
+  printf '%5.1fs  restored=%-2s  captured=%-2s  %s\n' \
+    "$(echo "$i*0.5" | bc)" \
+    "$(tm capture-pane -p -t "$fixed"  | grep -c '[^[:space:]]')" \
+    "$(tm capture-pane -p -t "$broken" | grep -c '[^[:space:]]')" \
+    "${note:-}"
+  if [ "$i" = 4 ]; then seed passed; note="(non-blank rows in each pane; bumped at 2.0s)"; fi
+done
+
+echo
+echo "== the captured pane, in full, after the bump =="
+tm capture-pane -p -t "$broken" | sed 's/^/  |/'
+echo
+echo "== and nothing was reported: pane alive, no charter error, no stderr =="
+tm list-panes -t exp -F '  #{pane_id} dead=#{pane_dead} cmd=#{pane_current_command}' \
+  | grep -E "$broken|$fixed"

--- a/providers/charter-textual-repos/measure/m9_cost.py
+++ b/providers/charter-textual-repos/measure/m9_cost.py
@@ -1,0 +1,86 @@
+"""M9 — what a repaint costs, charter's own repo table against the Textual adapter.
+
+Both measured through `Registry.draw`, at the same rectangle, off the same snapshot, in
+one process — so the number is the renderer and not the process start. The panel's tick is
+`panel.TICK` = 0.2 s, so the budget for a repaint is 200 ms and neither is close to it;
+what the comparison is for is the SHAPE of the cost, since a Textual repaint is a full
+compositor pass over a widget tree and charter's is a string join.
+
+Import cost and RSS are measured separately, in a fresh interpreter each, because both are
+paid once per panel process and a warm import measures nothing.
+"""
+
+from __future__ import annotations
+
+import resource
+import subprocess
+import sys
+import time
+
+from charter.frame import ctx as charter_ctx
+from charter.frame import registry
+
+SNAP = {
+    "gathered_at": time.time(), "workspace": "harness-wrapper",
+    "current_repo": "charter",
+    "repos": [{"name": f"repo-{i}", "branch": "main", "dirty": i % 2 == 0,
+               "tracked_dirty": True, "ahead": i, "behind": 0,
+               "ci": ("failed", "passed", "running")[i % 3], "change": i or None,
+               "sigil": "!", "current": i == 0, "worktree_count": i % 3}
+              for i in range(8)],
+    "worktrees": [], "todos": [], "todo_count": 0,
+}
+W, H = 120, 12
+
+
+def timed(fn, n=40):
+    fn()                                        # warm
+    ts = []
+    for _ in range(n):
+        a = time.perf_counter()
+        fn()
+        ts.append(time.perf_counter() - a)
+    ts.sort()
+    return ts[len(ts) // 2] * 1000, ts[-1] * 1000
+
+
+def main() -> int:
+    reg = registry.Registry()
+    reg.place("textual.repos")
+
+    def textual():
+        reg.draw("textual.repos", charter_ctx.build(("gather",), width=W, height=H,
+                                                    fid="m9", snapshot=SNAP))
+
+    from charter.frame import slots
+    from unittest import mock
+
+    def charter_own():
+        # `slots._table_lines` is the repo table itself, minus the pane chrome around it —
+        # the closest like-for-like to what the Textual widget draws.
+        slots._table_lines(SNAP, W, H - 1)
+
+    for name, fn in (("charter _table_lines", charter_own),
+                     ("textual.repos draw ", textual)):
+        med, worst = timed(fn)
+        print(f"  {name}  median {med:6.2f} ms   worst {worst:6.2f} ms")
+
+    from charter_textual_repos import adapter
+    adapter._HOST.stop()
+
+    print("\n  import cost and peak RSS, one fresh interpreter each:")
+    for label, mod in (("charter.frame.slots", "charter.frame.slots"),
+                       ("textual.app", "textual.app"),
+                       ("charter_textual_repos", "charter_textual_repos.ui")):
+        code = (f"import time,resource;a=time.perf_counter();import {mod};"
+                f"b=time.perf_counter();"
+                f"print(f'{{1000*(b-a):.0f}} "
+                f"{{resource.getrusage(resource.RUSAGE_SELF).ru_maxrss//(1024*1024)}}')")
+        out = subprocess.run([sys.executable, "-c", code], capture_output=True,
+                             text=True).stdout.split()
+        print(f"    {label:24s} {out[0]:>5s} ms   {out[1]:>3s} MB peak RSS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/providers/charter-textual-repos/measure/rig.sh
+++ b/providers/charter-textual-repos/measure/rig.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# The tmux rig every measurement in the report was taken on. Real tmux, real panes, real
+# `charter panel` processes — nothing here fakes a terminal.
+#
+# **One cleanup, killing before unlinking.** #590 took this machine from 14 leaked tmux
+# servers to 0 and the discipline that got it there is `tests/_tmuxreap.py`'s: a server
+# that is still listening is killed BEFORE its socket file is removed, because
+# unlink-then-kill points `kill-server` at a path with no server on it and leaves the real
+# one running. The socket is named `charter-<slug>-<pid>` so that `tests/_tmuxreap.py`
+# will also reap it if this script is killed before its trap can run.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV="${VENV:?set VENV to the venv root of the interpreter under test}"
+WT="${WT:?set WT to the charter worktree}"
+CHARTER="$VENV/bin/charter"
+PY="$VENV/bin/python"
+SOCK="charter-textualexp-$$"
+FID="${FID:-exp-$$}"
+
+export CHARTER_ROOT="$WT"
+export CHARTER_SESSION_ID="$FID"
+export CHARTER_WORKSPACE=""
+export CHARTER_PERSONA=""
+export CHARTER_HARNESS="claude"
+
+tm() { tmux -L "$SOCK" "$@"; }
+
+cleanup() {
+  # Kill first, unlink second — see the header. Both in one function, and the trap is the
+  # only caller, so there is no path out of this script that skips half of it.
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+  rm -f "/tmp/tmux-$(id -u)/$SOCK" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+seed() { "$PY" "$HERE/seed.py" "$FID" "${1:-failed}" >/dev/null; }
+
+# A harness stand-in: prints numbered lines so scrollback can be measured, then sleeps.
+# `charter frame` would launch Claude Code here; the experiment needs a pane that is
+# reproducible and that charter's launcher treats identically.
+HARNESS='for i in $(seq 1 200); do echo "harness line $i"; done; exec bash --norc --noprofile -i'
+
+start_session() {
+  tm new-session -d -s exp -x "${COLS:-150}" -y "${ROWS:-40}" -- sh -c "$HARNESS"
+  tm set -t exp mouse off          # charter's default (instance.FRAME_FIELDS)
+  tm set -t exp history-limit 50000
+  tm set -t exp status off
+}
+
+split_panel() {   # split_panel <component> <rows>
+  tm split-window -t exp:0.0 -v -l "$2" -P -F '#{pane_id}' \
+     -- "$CHARTER" panel "$1" --session "$FID"
+}

--- a/providers/charter-textual-repos/measure/seed.py
+++ b/providers/charter-textual-repos/measure/seed.py
@@ -1,0 +1,48 @@
+"""Write a gather cache and bump a frame's version, so a panel has something to draw.
+
+Stands in for the hooks that do it in production (`state.bump` from `posttooluse*`), and
+for `frame/gather.py`'s own scan — which would read whatever repos happen to be on the
+machine running the experiment, and therefore could not produce a repeatable screenshot.
+"""
+import sys, time
+from charter.frame import gather, state
+
+FID = sys.argv[1]
+CI = sys.argv[2] if len(sys.argv) > 2 else "failed"
+
+DATA = {
+    "gathered_at": time.time(),
+    "workspace": "harness-wrapper",
+    "current_repo": "charter",
+    "repos": [
+        {"name": "charter", "branch": "main", "dirty": True, "tracked_dirty": True,
+         "ahead": 2, "behind": 0, "ci": CI, "change": 554, "sigil": "!",
+         "current": True, "worktree_count": 3},
+        {"name": "easydmarc-app", "branch": "feat/dmarc-rollup", "dirty": False,
+         "tracked_dirty": False, "ahead": 0, "behind": 4, "ci": "passed",
+         "change": None, "sigil": "", "current": False, "worktree_count": 0},
+        {"name": "infra", "branch": "main", "dirty": False, "tracked_dirty": False,
+         "ahead": 0, "behind": 0, "ci": "running", "change": 88, "sigil": "#",
+         "current": False, "worktree_count": 0},
+        {"name": "charter-docs", "branch": "docs/frame", "dirty": True,
+         "tracked_dirty": False, "ahead": 1, "behind": 1, "ci": "passed",
+         "change": None, "sigil": "", "current": False, "worktree_count": 0},
+        {"name": "statusline-lab", "branch": "main", "dirty": False,
+         "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None, "change": None,
+         "sigil": "", "current": False, "worktree_count": 2},
+    ],
+    "worktrees": [
+        {"name": "pr-554", "branch": "pr-554", "dirty": True, "tracked_dirty": False,
+         "ahead": 1, "behind": 0, "ci": "pending", "change": None, "sigil": "",
+         "current": False, "worktree_count": 0},
+        {"name": "pr-560", "branch": "pr-560", "dirty": False, "tracked_dirty": False,
+         "ahead": 0, "behind": 0, "ci": "passed", "change": 560, "sigil": "!",
+         "current": False, "worktree_count": 0},
+    ],
+    "todos": [{"title": "measure the alternate screen"}],
+    "todo_count": 1,
+}
+
+gather.save(FID, DATA)
+state.bump(FID)
+print(state.version(FID))

--- a/providers/charter-textual-repos/pyproject.toml
+++ b/providers/charter-textual-repos/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[project]
+name = "charter-textual-repos"
+version = "0.1.0"
+description = "An experiment: charter's repo table drawn with Textual, shipped as a third-party charter.components provider"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.11"
+
+# THE WHOLE POINT OF THE EXPERIMENT LIVES ON THIS LINE.
+#
+# charter's own pyproject.toml says `dependencies = []`, asserted by
+# tests/test_packaging.py::test_runtime_has_zero_dependencies and led with in
+# CONTRIBUTING.md. Textual pulls ten transitive distributions. They are declared HERE, by
+# a package the operator chose to install, and charter discovers this package through
+# `importlib.metadata` — which is stdlib. Nothing in charter's tree changes.
+dependencies = ["charter-cp", "textual>=0.80"]
+
+[project.entry-points."charter.components"]
+# Two components, because the experiment is a comparison and not a demo.
+#
+# `textual.repos` is the ADAPTER: a Textual app driven headless, whose composited screen
+# is handed back to charter as a list of lines. It obeys `render(ctx) -> list[str]`
+# exactly as written.
+#
+# `textual.live` is the TAKEOVER: `render` starts a real Textual app on the pane's own
+# tty and never returns. It is the only shape in which Textual's event loop, mouse
+# handling and alternate screen actually exist — and it is outside the contract, which is
+# the finding.
+"textual.repos" = "charter_textual_repos:adapter_component"
+"textual.live" = "charter_textual_repos:live_component"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/charter_textual_repos"]
+
+[dependency-groups]
+dev = ["pytest>=8"]

--- a/providers/charter-textual-repos/src/charter_textual_repos/__init__.py
+++ b/providers/charter-textual-repos/src/charter_textual_repos/__init__.py
@@ -1,0 +1,100 @@
+"""A charter frame component provider, built with Textual — the experiment.
+
+charter's own ``pyproject.toml`` says ``dependencies = []`` and
+`tests/test_packaging.py::test_runtime_has_zero_dependencies` asserts it. This
+distribution declares ``textual`` and its ten transitive dependencies as **its own**, and
+charter finds it through ``importlib.metadata.entry_points(group="charter.components")``,
+which is stdlib. Nothing in charter's tree changes to make this work, which is the
+property the experiment was run to test.
+
+**Two components, because the experiment is a comparison.**
+
+``textual.repos``
+    The adapter. A Textual app on the headless driver, its composited screen copied out
+    as plain lines once per repaint. Obeys `render(ctx) -> list[str]` exactly as written,
+    and loses colour and every form of input on the way out — see :mod:`.adapter`.
+
+``textual.live``
+    The takeover. ``render`` starts a Textual app on the pane's own tty and never
+    returns. Keys, mouse and scrolling are real; the snapshot is frozen at the moment the
+    pane started, because a `ctx` is one repaint's snapshot and nothing calls `render`
+    again — see :mod:`.live`.
+
+**This module imports `charter.frame.component`, and that is worth saying out loud.** The
+contract is a Python dataclass, checked with ``isinstance`` in
+`frame/registry.py:Providers._one`, so a provider cannot express a component without
+importing charter. It is not a cost — charter is already in the process that asks — but it
+does mean ``charter-cp`` is a real install-time dependency of every provider, and the
+entry-point group alone does not make the coupling loose.
+"""
+
+from __future__ import annotations
+
+from charter.frame.component import Component, Fixed
+
+#: The contract's version, read by `frame/registry.py:Providers._one` **before** the entry
+#: point's own attribute is looked up. Charter refuses a provider declaring a different
+#: integer rather than negotiating one (§4g), and the refusal names this distribution.
+API_VERSION = 1
+
+#: What both components ask charter for: the whole gather snapshot, which is what
+#: charter's own `repos` component declares and for the reason `frame/builtins.py` gives —
+#: the narrower ``repos`` slice flattens "nothing has scanned yet" and "this workspace has
+#: no clones" to the same ``()``, and the table has to tell them apart.
+NEEDS = ("gather",)
+
+#: The rectangle either component takes when nothing says otherwise — a `Registry.place`
+#: with no ``edge``/``size`` passed, which is the shape `frame/panel.py:run` calls it in.
+#:
+#: A committed ``[[frame.component]]`` table beats this and must carry both keys
+#: (`instance.component_tables`), and when it does, the size it carries is coerced to
+#: ``Fixed(n)``. So a provider's ``Content()`` or ``Fill()`` is reachable only on a frame
+#: nobody has configured — which is the second place the contract chafed, and it is
+#: recorded in the report rather than worked around here.
+DEFAULT_EDGE = "bottom"
+DEFAULT_SIZE = Fixed(12)
+
+
+def adapter_component() -> Component:
+    """``textual.repos`` — Textual rendered headless, returned as lines.
+
+    ``events=()`` is the truthful declaration and not an omission. `EVENT_KINDS`' own
+    docstring says a declaration is "what you HANDLE, never a promise that it FIRES";
+    this component handles nothing, because a headless app has no terminal to read from
+    and charter has no dispatcher to read one for it.
+    """
+    from . import adapter
+    return Component(
+        id="textual.repos",
+        title="repos (textual, headless)",
+        edge=DEFAULT_EDGE,
+        size=DEFAULT_SIZE,
+        needs=NEEDS,
+        events=(),
+        render=adapter.render,
+    )
+
+
+def live_component() -> Component:
+    """``textual.live`` — Textual owning the pane, on its own loop.
+
+    ``events`` declares the four kinds the app genuinely handles. **Charter reads this
+    declaration and does nothing with it**: `component.names` validates it at
+    construction and no other production line in charter references
+    ``Component.events``. The app receives its keys and its mouse reports from the tty
+    directly, having taken the pane; the declaration is documentation with no mechanism
+    behind it, which is finding #1's sharpest edge.
+    """
+    from . import live
+    return Component(
+        id="textual.live",
+        title="repos (textual, live)",
+        edge=DEFAULT_EDGE,
+        size=DEFAULT_SIZE,
+        needs=NEEDS,
+        events=("key", "click", "scroll", "resize"),
+        render=live.render,
+    )
+
+
+__all__ = ["API_VERSION", "adapter_component", "live_component"]

--- a/providers/charter-textual-repos/src/charter_textual_repos/adapter.py
+++ b/providers/charter-textual-repos/src/charter_textual_repos/adapter.py
@@ -1,0 +1,229 @@
+"""The shape charter's contract actually describes: Textual as a renderer.
+
+`Component.render` is ``Callable[[Any], list[str]]`` and `Registry.draw` takes what it
+answers, escapes it, clips it to the pane and hands it to `panel._write`. So the only way
+a widget framework fits *as written* is to run it where nobody can see it and copy its
+screen out — which is what this module does: a `ReposApp` on Textual's **headless**
+driver, on a background thread, whose composited screen is read back through
+``Screen._compositor.render_strips()`` once per repaint.
+
+**This works, and three things are lost on the way out.** Each is measured in the
+experiment's report; each is a property of charter's contract rather than of Textual.
+
+1. **Colour.** `Registry.draw` escapes every line a provider returned
+   (``escape=cid in self._foreign``), and `contain.one_line` replaces ESC with the four
+   characters ``\\x1b``. A Textual strip rendered with ``Strip.render(console)`` is
+   almost entirely SGR, so returning it paints the escape sequences as literal text.
+   ``Strip.text`` is therefore what this module returns, and every colour, every
+   background, the cursor bar and the zebra stripes are dropped at the boundary. A
+   provider component is a **monochrome** component, and nothing in the contract says so.
+
+2. **Input.** `Component.events` is validated by `component.names` at construction and
+   read by no production code in charter (grep: the only reader is the validator itself).
+   There is no dispatch path, so the headless app receives no key, no click and no
+   scroll — the `DataTable`'s cursor cannot be moved and its scrollbar cannot be reached.
+   A scrolling table that cannot scroll is the one thing this widget was worth having.
+
+3. **The frame's clock.** That half survives intact and is the good news: charter calls
+   `render` again on every version bump and hands over a fresh `ctx`, so the table here
+   is as live as charter's own.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+
+from .ui import ReposApp
+
+#: How long a repaint will wait for the app to come up before drawing a placeholder. A
+#: panel repaints on a 0.2 s tick (`panel.TICK`) and must never block it: the app starts
+#: once per panel PROCESS, so this is paid at most once, and if it is not ready the pane
+#: says so for one tick rather than the loop stalling.
+START_TIMEOUT = float(os.environ.get("CHARTER_TEXTUAL_START_TIMEOUT", "3.0"))
+
+#: Experiment apparatus: set to ``1`` and :func:`_give_stdout_back` does nothing, which is
+#: what a provider author who has not read Textual's source ships. `measure/m8_stdout.sh`
+#: runs a pane both ways so the defect can be looked at rather than described — a pane
+#: that paints once, blanks on the next repaint, and reports nothing anywhere.
+KEEP_CAPTURE_VAR = "CHARTER_TEXTUAL_KEEP_CAPTURE"
+
+
+class _Headless:
+    """One background Textual app, kept for the life of the panel process.
+
+    **Started once, not per repaint**, for `panel._component_painter`'s own reason one
+    layer up: "The registry is built once and closed over, not rebuilt per tick." A
+    Textual app costs ~80 ms warm to import and a further event-loop start to run; paying
+    that five times a second is the cost §4's whole budget argument exists to keep off the
+    repaint path.
+
+    **Restarted on a resize, and only on a resize.** The headless driver takes its size
+    at ``run(size=…)``. Posting a synthetic ``Resize`` into a running app is the tidier
+    thing to do and is not what this does, because the tidier thing has a failure mode
+    the operator sees — a widget tree half-laid-out at two different widths — and a
+    restart costs one tick of a placeholder on an event that happens when a human drags a
+    window edge.
+    """
+
+    def __init__(self) -> None:
+        self.app: ReposApp | None = None
+        self.size: tuple[int, int] | None = None
+        self._thread: threading.Thread | None = None
+        #: Whatever the app thread died of, so a repaint can put it in the pane rather
+        #: than leaving a blank one — charter's own rule (§4b property 1) applied by the
+        #: provider to itself.
+        self.died: BaseException | None = None
+
+    def _run(self, app: ReposApp, size: tuple[int, int]) -> None:
+        try:
+            app.run(headless=True, size=size)
+        except BaseException as exc:            # noqa: BLE001 - reported, never swallowed
+            self.died = exc
+
+    def ensure(self, width: int, height: int, gathered) -> ReposApp | None:
+        """The running app at *width* x *height*, started or restarted if need be."""
+        want = (max(width, 1), max(height, 1))
+        if self.app is not None and self.size == want and self.app.is_running:
+            return self.app
+        self.stop()
+        self.died = None
+        app = ReposApp(gathered=gathered, note="headless")
+        self._thread = threading.Thread(
+            target=self._run, args=(app, want), daemon=True,
+            name="charter-textual-repos")
+        self._thread.start()
+        deadline = time.monotonic() + START_TIMEOUT
+        while time.monotonic() < deadline:
+            if self.died is not None:
+                return None
+            if app.ready.is_set():
+                self.app, self.size = app, want
+                return app
+            time.sleep(0.005)
+        return None
+
+    def stop(self) -> None:
+        app, self.app, self.size = self.app, None, None
+        if app is not None and app.is_running:
+            try:
+                app.call_from_thread(app.exit)
+            except Exception:
+                pass
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+            self._thread = None
+
+
+#: One per panel process. Module state, which is what a provider gets: charter builds the
+#: registry once and closes over it, and a component is a frozen dataclass whose `render`
+#: is an ordinary function — there is nowhere else for a long-lived handle to live.
+#: `frame/ctx.py` is explicit that this is not a sandbox and that a provider's module is
+#: ordinary Python; this is what "ordinary Python" looks like when a framework needs a
+#: process-lifetime object.
+_HOST = _Headless()
+
+
+def render(ctx) -> list[str]:
+    """*ctx*'s repos, drawn by Textual, as the plain lines charter's contract takes.
+
+    Never raises, though it does not have to: `Registry.draw` already catches everything a
+    provider's renderer does wrong and turns it into a pane naming the component. The
+    guard is here anyway because the *message* matters — "textual.repos failed to draw —
+    RuntimeError: …" tells an operator less than a line saying the app would not start —
+    and because a provider that leans on the host's containment for its own bugs is a
+    provider that never finds them.
+    """
+    width, height = int(ctx.width), int(ctx.height)
+    if width <= 0 or height <= 0:
+        return []
+    try:
+        app = _HOST.ensure(width, height, ctx.gather)
+        if app is None:
+            why = type(_HOST.died).__name__ if _HOST.died else "timeout"
+            return [f"textual.repos: app did not start ({why})"]
+        return app.call_from_thread(_screen, app, ctx.gather)
+    except Exception as exc:                    # noqa: BLE001
+        return [f"textual.repos: {type(exc).__name__}: {exc}"]
+    finally:
+        # In a `finally`, and it has to be: charter measures the pane BEFORE it calls
+        # render — `panel._component_text` evaluates `slots._width()` and `_rows()` as
+        # arguments to `ctx.build` — so restoring stdout on the way IN is one tick too
+        # late. See :func:`_give_stdout_back` for what the tick in between looked like.
+        _give_stdout_back()
+
+
+def _give_stdout_back() -> None:
+    """Undo Textual's process-wide stdout capture, because charter's pane IS `sys.stdout`.
+
+    **The sharpest finding of the experiment, and it is four lines of provider code
+    standing in for a hole in the contract.**
+
+    `textual/app.py:3491` wraps the app's message pump in
+    ``contextlib.redirect_stdout(self._capture_stdout)`` so that a ``print()`` inside a
+    widget lands in the app's log instead of on the screen. ``redirect_stdout`` assigns
+    ``sys.stdout`` — a process-wide module global — and it does it on the app's own
+    thread, headless or not. Measured: with a headless Textual app running in this
+    process, ``sys.stdout`` is a ``textual.app._PrintCapture``.
+
+    charter reaches `sys.stdout` in three places, and that object subverts all three,
+    because `_PrintCapture` (`textual/app.py:260`) answers ``isatty() -> True`` and
+    ``fileno() -> -1``:
+
+    * `panel._out` — ``sys.stdout.write(payload); sys.stdout.flush()``. The pane's paint
+      goes into Textual's print log. The pane keeps whatever was on it.
+    * `slots._width` / `slots._height` — ``os.get_terminal_size(sys.stdout.fileno())``,
+      i.e. of fd ``-1``, which raises ``OSError`` and is caught: charter silently falls
+      back to :data:`slots._DEFAULT_COLS` x :data:`slots._DEFAULT_ROWS`, **80x24**.
+    * `chrome.colour_ok` — ``sys.stdout.isatty()``, which answers True however the panel
+      was actually launched, so `NO_COLOR`'s companion check is answered by the framework
+      rather than by the terminal.
+
+    **Measured symptom, before this function existed**, in a real 150x10 pane: the first
+    paint is correct, and the second paint — the first one after the app is up — draws a
+    pane that is blank except for its last line. The chain is the three bullets together:
+    charter measures 80x24 instead of 150x10, the component lays itself out 24 rows tall,
+    `panel._write` clamps to 24 rows and writes all of them into a 10-row pane, and the
+    pane scrolls its own content away. Nothing raises. Nothing is logged. `Registry.draw`
+    has nothing to catch, because nothing failed.
+
+    Called from `render`'s ``finally`` and not on the way in, because charter measures the
+    pane BEFORE it calls render: `panel._component_text` evaluates ``slots._width()`` and
+    ``_rows()`` as arguments to `ctx.build`. Restoring on entry fixes the paint and leaves
+    the measurement one tick stale forever.
+    """
+    if os.environ.get(KEEP_CAPTURE_VAR) == "1":
+        return                                  # apparatus — see the constant
+    if sys.stdout is not sys.__stdout__ and sys.__stdout__ is not None:
+        sys.stdout = sys.__stdout__
+    if sys.stderr is not sys.__stderr__ and sys.__stderr__ is not None:
+        sys.stderr = sys.__stderr__
+
+
+def _screen(app: ReposApp, gathered) -> list[str]:
+    """Push *gathered* into *app* and copy its composited screen out, as plain text.
+
+    Runs on the app's own event loop thread (`App.call_from_thread`), which is the only
+    place a widget tree may be touched. Both halves are done in one hop deliberately: two
+    hops would let a repaint read a screen laid out for the previous snapshot, which is
+    the "everything on screen is from the same moment" property `frame/ctx.py` builds the
+    whole one-snapshot design around.
+
+    ``Strip.text`` and never ``Strip.render(console)`` — see this module's docstring.
+    """
+    app.apply(gathered)
+    # **Three private attributes of Textual's, and there is no public alternative.**
+    # `Screen._refresh_layout` is what arranges the widget tree into the compositor, and
+    # `Compositor.render_strips` is what a driver would write to a terminal. Textual's
+    # public surface for "give me my screen" is `save_screenshot`/`export_screenshot`,
+    # which answers SVG — an image, for a bug report. There is no supported way to ask a
+    # Textual app for its screen as terminal lines, because no supported use of Textual
+    # wants one: the framework's contract is that it owns the terminal. Charter's contract
+    # is that it owns the terminal. That is the collision, and reaching into
+    # `_refresh_layout` and `_compositor` is what it looks like from the provider's side —
+    # a component that breaks on a Textual point release, in a way charter would surface
+    # as "textual.repos failed to draw".
+    app.screen._refresh_layout(app.size)
+    return [strip.text for strip in app.screen._compositor.render_strips()]

--- a/providers/charter-textual-repos/src/charter_textual_repos/live.py
+++ b/providers/charter-textual-repos/src/charter_textual_repos/live.py
@@ -1,0 +1,148 @@
+"""The shape charter's contract does not describe: Textual owning the pane.
+
+`render(ctx)` starts a real Textual app on the panel process's own tty — alternate
+screen, its own asyncio loop, its own SIGWINCH handler, its own mouse request — and does
+not return until the app exits. For as long as it runs, the pane is Textual's: charter's
+`panel._watch` loop is parked inside `Registry.draw`, `panel._write` never fires, and
+nothing clears the screen underneath it.
+
+**This is the only shape in which the interesting half of the experiment exists.** Keys,
+the `DataTable` cursor, wheel scrolling and click-to-select are all real here and all
+absent from the adapter, because `Component.events` reaches no dispatcher in charter and
+a headless app has no terminal to read from.
+
+**And it costs exactly one thing, which the footer clock puts on screen.** `render` is
+called once, with one `ctx`, and a `ctx` is one repaint's snapshot with no way to ask for
+another (`frame/ctx.py`: "refreshing is the frame's decision, on the frame's clock"). By
+never returning, this component makes that decision unreachable: charter would hand it a
+fresh snapshot on the next version bump, and there is no next call. The table is frozen
+at the moment the pane started.
+
+``CHARTER_TEXTUAL_LIVE_REFRESH=1`` is the measurement of what un-freezing it would take,
+and it is deliberately NOT the default: it makes the app import `charter.frame.state` and
+`charter.frame.gather` and poll them itself. That works, and it is a provider reaching
+around the seam it was given — it re-reads the plane on its own clock, pays its own
+`gather.read`, and charter's "one snapshot, one timestamp" property no longer holds
+across the frame. Shipping it on by default would be answering finding #1 by pretending
+it is not there.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from .ui import ReposApp
+
+#: The env var that turns on the out-of-contract refresh. Read at render time rather than
+#: at import: a panel is a process per pane, and an operator flipping this wants the next
+#: pane to see it, not the next release.
+REFRESH_VAR = "CHARTER_TEXTUAL_LIVE_REFRESH"
+
+#: **Experiment apparatus, and it is here rather than in a second package on purpose.**
+#: The question "what does a Textual app crashing cost — its own pane, or more?" cannot be
+#: answered by reasoning about `Registry.draw`; it has to be answered by crashing one
+#: inside a real tmux pane and looking at the other panes. A fault injector reachable only
+#: from an env var nobody sets is the smallest thing that makes that repeatable.
+#:
+#: ``render`` raises before the app starts; ``loop`` raises from inside Textual's own
+#: message pump, which is the case that matters — a framework with its own event loop can
+#: fail somewhere charter has no frame on the stack.
+FAULT_VAR = "CHARTER_TEXTUAL_FAULT"
+
+#: How often the out-of-contract refresh checks the frame's version. `panel.TICK` is
+#: 0.2 s and this deliberately matches it: the point of the measurement is what a
+#: provider would have to reimplement, and half of that is charter's own poll interval.
+REFRESH_TICK = 0.2
+
+
+class LiveApp(ReposApp):
+    """:class:`ReposApp` with the out-of-contract poll bolted on, when asked.
+
+    A subclass rather than a flag inside the shared app, so that the code doing the thing
+    the report says a provider should not have to do is in one readable place and cannot
+    be reached from the adapter by accident.
+    """
+
+    def __init__(self, *, gathered, fid: str, refresh: bool) -> None:
+        super().__init__(gathered=gathered,
+                         note="live · reaching around ctx" if refresh else "live · frozen")
+        self._fid = fid
+        self._refresh = refresh
+        self._seen = ""
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        if os.environ.get(FAULT_VAR) == "loop":
+            self.set_timer(1.0, self._fault)
+        if self._refresh:
+            self.set_interval(REFRESH_TICK, self._poll)
+
+    def _fault(self) -> None:
+        raise RuntimeError("injected fault inside Textual's message pump")
+
+    def _poll(self) -> None:
+        """`panel._tick`'s decision, reimplemented inside a provider — the finding.
+
+        Every line of this is charter's own and none of it is reachable from `ctx`: which
+        file carries the frame's version, that comparing it is how a panel learns
+        anything happened, which workspace the FRAME resolved (#526), and that
+        `gather.read` is the cache rather than a scan. A provider that gets this wrong
+        gets it wrong quietly — a pane that stops updating, or one that runs a full
+        `gather.scan` five times a second in every pane on the machine.
+        """
+        try:
+            from charter.frame import gather, state
+        except Exception:
+            return
+        try:
+            now = state.version(self._fid)
+            if now == self._seen:
+                return
+            self._seen = now
+            self.apply(gather.read(self._fid))
+        except Exception:
+            return
+
+
+def render(ctx) -> list[str]:
+    """Hand the pane to Textual, and answer only once it hands the pane back.
+
+    The return value is what charter paints *after* the app has exited — which is the one
+    moment the contract and the framework agree on what a pane is. Charter's
+    `panel._write` then clears the pane and writes this, so an operator who quit the app
+    is left with a line saying so rather than with whatever the alternate screen restored.
+
+    **`mouse=True` is the request the experiment is about.** tmux enables mouse reporting
+    on the outer terminal from the ACTIVE pane's mode alone (§4i, re-measured here), so
+    this pane asks for SGR reporting and gets it exactly while it is the active pane —
+    which is the modal behaviour the spec listed as an open question and could not test
+    without a program that wanted the mouse.
+
+    **No try/except around `app.run`, and that is the measured decision rather than an
+    omission.** Anything raised on the way in — including :data:`FAULT_VAR`'s ``render``
+    injection — travels to `Registry.draw`, which names the component and paints the
+    reason into this pane and no other. That is §4b property 1 holding for a framework
+    charter never anticipated, and it is the result that came out better than expected.
+    A ``try: … except: raise`` here would change no outcome, which #568 is the standing
+    argument against: a line that cannot change an outcome is not documentation of an
+    intent.
+
+    What a guard here could NOT do is catch the case that actually matters. Measured: a
+    crash inside Textual's own message pump never reaches this frame at all. Textual
+    catches it, prints a Rich traceback to ``sys.__stderr__`` — 19,358 bytes of it —
+    and `run()` returns **normally**, so `Registry.draw` sees a successful render and
+    `panel._write` clears the pane over the traceback within one tick. The two lines
+    below are all the operator is left with, and they cannot say why.
+    """
+    if os.environ.get(FAULT_VAR) == "render":
+        raise RuntimeError("injected fault before the app started")
+    fid = str(ctx.fid)
+    refresh = os.environ.get(REFRESH_VAR) == "1"
+    started = time.time()
+    app = LiveApp(gathered=ctx.gather, fid=fid, refresh=refresh)
+    app.run(mouse=True)
+    ran = time.time() - started
+    return [f"textual.live: app exited after {ran:.0f}s "
+            f"(clicks {app.clicks}, scroll {app.scrolls}, keys {app.keys})",
+            "charter repaints this pane again on the next version bump"]

--- a/providers/charter-textual-repos/src/charter_textual_repos/live.py
+++ b/providers/charter-textual-repos/src/charter_textual_repos/live.py
@@ -130,7 +130,7 @@ def render(ctx) -> list[str]:
 
     What a guard here could NOT do is catch the case that actually matters. Measured: a
     crash inside Textual's own message pump never reaches this frame at all. Textual
-    catches it, prints a Rich traceback to ``sys.__stderr__`` — 19,358 bytes of it —
+    catches it, prints a 2,520-byte Rich traceback with locals to ``sys.__stderr__``,
     and `run()` returns **normally**, so `Registry.draw` sees a successful render and
     `panel._write` clears the pane over the traceback within one tick. The two lines
     below are all the operator is left with, and they cannot say why.

--- a/providers/charter-textual-repos/src/charter_textual_repos/rows.py
+++ b/providers/charter-textual-repos/src/charter_textual_repos/rows.py
@@ -1,0 +1,125 @@
+"""The repo table's DATA, derived from ``ctx.gather`` and from nothing else.
+
+This module is the honest half of the experiment. Everything here is computed from the
+mapping `charter.frame.ctx` serves under the name ``gather`` — the same snapshot
+`charter/frame/slots.py:_table_lines` draws from — and this package imports no part of
+charter at all. If a column below is wrong, the fix is in this file; if a column below is
+*missing*, the fix is in charter's `gather.scan`, and that is a finding rather than a
+patch.
+
+**What ``gather`` serves, exactly** (`charter/frame/gather.py:_entry` and `scan`):
+
+``name``, ``branch``, ``dirty``, ``tracked_dirty``, ``ahead``, ``behind``, ``ci``,
+``change``, ``sigil``, ``current``, ``worktree_count`` per repo row, plus a top-level
+``workspace``, ``current_repo``, ``repos``, ``worktrees``, ``todos``, ``todo_count`` and
+``gathered_at``.
+
+**What it does not serve, and what that cost this widget.** `slots._table_row` draws a
+*presence* column — "who else is standing in this tree" — and cannot fill it from the
+gather either; its own docstring concedes the cost. The Textual version has the same
+hole for the same reason, which is the correct outcome: the seam held, and a provider
+sees exactly what charter's own renderer sees. There is no back door here to make the
+column appear.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: What each CI state is drawn as. Charter's own `statusline._CI_MARK` is the model; the
+#: glyphs are re-spelled here rather than imported, because importing `charter.statusline`
+#: from a provider would make this package depend on charter's internals — which is the
+#: opposite of what the entry-point seam is for. The cost is stated: a change to charter's
+#: CI vocabulary does not reach this table, and a provider has no way to be told.
+CI_MARK = {
+    "passed": "ok",
+    "failed": "fail",
+    "running": "run",
+    "pending": "…",
+    None: "",
+}
+
+#: The dirty/ahead/behind marker column, in charter's own order: worktree dirt, then
+#: unpushed, then unpulled.
+def markers(row: dict) -> str:
+    """The one-cell-per-fact marker string for *row* — ``*`` dirty, ``↑n``, ``↓n``."""
+    out = []
+    if row.get("dirty"):
+        out.append("*" if row.get("tracked_dirty") else "?")
+    if row.get("ahead"):
+        out.append(f"↑{int(row['ahead'])}")
+    if row.get("behind"):
+        out.append(f"↓{int(row['behind'])}")
+    return " ".join(out)
+
+
+@dataclass(frozen=True)
+class Row:
+    """One line of the table, already reduced to text.
+
+    A frozen dataclass rather than the raw dict, because `ctx` hands a provider a
+    read-only *view* of the snapshot whose repo rows are still mutable dicts
+    (`ctx.SERVES`' own docstring says the containment is shallow and why). Copying the
+    six fields this widget draws is cheap, and it means nothing in this package can write
+    into the snapshot the next component in the repaint is about to read.
+    """
+
+    name: str
+    branch: str
+    marks: str
+    ci: str
+    change: str
+    current: bool
+    piece: bool
+
+
+def _change(row: dict) -> str:
+    """The open change cell — ``!123``, or the forge's own sigil where it has one."""
+    change = row.get("change")
+    if not change:
+        return ""
+    return f"{row.get('sigil') or '!'}{change}"
+
+
+def _row(raw: dict, *, piece: bool) -> Row:
+    name = str(raw.get("name") or "?")
+    branch = str(raw.get("branch") or "?")
+    pieces = int(raw.get("worktree_count") or 0)
+    if pieces and not piece:
+        name = f"{name} ⑂{pieces}"
+    return Row(name=name,
+               branch="" if piece and branch == raw.get("name") else branch,
+               marks=markers(raw),
+               ci=CI_MARK.get(raw.get("ci"), str(raw.get("ci") or "")),
+               change=_change(raw),
+               current=bool(raw.get("current")),
+               piece=piece)
+
+
+def rows_of(gather) -> list[Row]:
+    """Every repo, then every piece, as :class:`Row` — the order charter's table uses.
+
+    Repos first and pieces after, matching `slots._table_lines`' budget order ("a short
+    pane loses DETAIL rather than losing a repo"). The ranking `statusline._pick_rows`
+    applies when the pane is too short for every row is deliberately NOT reimplemented
+    here: it is charter's, it is not reachable from `ctx`, and guessing at it would
+    produce the unranked slice its own docstring records shipping once — thirteen clean
+    repos on `main` shown, and the one dirty repo you were standing in hidden.
+
+    So this returns everything and lets the *widget* scroll, which is the one thing a
+    widget framework can do that a line-based renderer cannot. That is the strongest
+    argument the experiment found for Textual, and it is worth being explicit that it
+    only pays off in the takeover mode where scrolling is reachable.
+    """
+    if not gather:
+        return []
+    out = [_row(r, piece=False) for r in (gather.get("repos") or [])]
+    out += [_row(w, piece=True) for w in (gather.get("worktrees") or [])]
+    return out
+
+
+def heading(gather) -> str:
+    """The pane's own heading — ``repos N`` over the workspace name."""
+    n = len(gather.get("repos") or []) if gather else 0
+    ws = (gather.get("workspace") or "") if gather else ""
+    return f"repos {n}" + (f"  ·  {ws}" if ws else "")

--- a/providers/charter-textual-repos/src/charter_textual_repos/ui.py
+++ b/providers/charter-textual-repos/src/charter_textual_repos/ui.py
@@ -1,0 +1,186 @@
+"""The Textual application — one app class, driven two ways.
+
+Both charter components in this package build the same :class:`ReposApp`. The adapter
+runs it with the **headless** driver on a background thread and reads its composited
+screen back as lines; the live component runs it with the **linux** driver on the pane's
+own tty, on the main thread, where it owns the terminal.
+
+**One app class for both on purpose.** The experiment's question is whether the
+`Component` contract survives contact with a real widget framework, and two different
+widget trees — one for the shape charter can host, one for the shape it cannot — would
+answer a question nobody asked. What differs between the two components is entirely the
+DRIVER and who owns the loop, which is exactly the axis the finding sits on.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.widgets import DataTable, Static
+
+from .rows import Row, heading, rows_of
+
+#: The columns, in charter's own left-to-right order: name, branch, markers, CI, change.
+COLUMNS = ("repo", "branch", "", "ci", "change")
+
+
+class ReposApp(App):
+    """Charter's repo table as a Textual `DataTable`.
+
+    The CSS is deliberately small and deliberately *dark-only*. Charter's own chrome is
+    theme-safe by default (`instance.FRAME_FIELDS`' ``chrome`` note: a default that can
+    make an existing working frame worse on upgrade must be opt-in), and Textual's
+    default theme is not — every widget paints its own background over the operator's
+    terminal colours. That difference is not a styling detail: it is the reason a Textual
+    panel cannot be turned on by default in a frame that promises not to repaint someone's
+    terminal in colours they did not choose.
+    """
+
+    CSS = """
+    Screen { background: $surface; layout: vertical; }
+    #head { dock: top; height: 1; background: $panel; color: $text; padding: 0 1; }
+    #foot { dock: bottom; height: 1; background: $panel; color: $text-muted;
+            padding: 0 1; }
+    DataTable { height: 1fr; }
+    DataTable > .datatable--cursor { background: $accent; }
+    """
+
+    BINDINGS = [
+        Binding("q", "quit", "quit", show=True),
+        Binding("j,down", "cursor_down", "down", show=False),
+        Binding("k,up", "cursor_up", "up", show=False),
+        Binding("r", "note_refresh", "refresh", show=False),
+    ]
+
+    def __init__(self, *, gathered=None, note: str = "") -> None:
+        super().__init__()
+        self._pending = gathered or {}
+        self._note = note
+        #: Every pointer event the app has seen, for the mouse measurement. A counter
+        #: rather than a log: the question is whether events arrive at all, and a log
+        #: would be a second thing to keep.
+        self.clicks = 0
+        self.scrolls = 0
+        self.keys = 0
+        #: Set once the widget tree is mounted and has been composited at least once.
+        #: `App.is_running` is true several milliseconds earlier (measured: running at
+        #: 5.6 ms, first non-blank composite at 18.2 ms), and a repaint that lands in that
+        #: window reads a screen of blank strips — a pane that is convincingly empty
+        #: rather than obviously broken, which is the failure mode #512 was about.
+        self.ready = threading.Event()
+
+    # -- composition -------------------------------------------------------- #
+
+    def compose(self) -> ComposeResult:
+        yield Static("", id="head")
+        with Vertical():
+            yield DataTable(id="table", cursor_type="row", zebra_stripes=False)
+        yield Static("", id="foot")
+
+    def on_mount(self) -> None:
+        self.apply(self._pending)
+        self.set_interval(1.0, self._retitle)
+        # One loop turn after mount, so the compositor has arranged the tree at least
+        # once before anything copies its screen out.
+        self.call_after_refresh(self.ready.set)
+
+    def _columns(self, table: DataTable) -> None:
+        """Declare the columns once, from wherever asks first.
+
+        Not in `on_mount`, and that is a bug this experiment hit and is worth keeping the
+        fix visible for: the adapter drives the app from *another thread*, so a repaint
+        can land between `compose` (the `DataTable` exists) and `on_mount` (the columns
+        exist). `add_row` then raises ``More values provided than there are columns``,
+        `Registry.draw` catches it, and the pane reads `textual.repos failed to draw`.
+        Charter contained it exactly as §4b promises — the provider still shipped a broken
+        pane.
+        """
+        if not table.columns:
+            for col in COLUMNS:
+                table.add_column(col or " ", key=col or "marks")
+
+    # -- data --------------------------------------------------------------- #
+
+    def apply(self, gathered) -> None:
+        """Replace the table's contents with *gathered* — one `ctx.gather` snapshot.
+
+        Rebuilt whole rather than diffed, which is charter's own choice one layer up
+        (`frame/panel.py`: "Repaints whole, never diffed: a five-row pane is a few hundred
+        cells"). A `DataTable` of fourteen rows is the same argument, and a diff would be
+        a second model of the plane's state living in this package with nothing keeping it
+        honest.
+        """
+        self._pending = gathered or {}
+        try:
+            table = self.query_one("#table", DataTable)
+        except Exception:
+            return                      # before compose; `on_mount` applies it
+        self._columns(table)
+        cursor = table.cursor_row
+        table.clear()
+        for r in rows_of(self._pending):
+            table.add_row(*self._cells(r))
+        if cursor:
+            try:
+                table.move_cursor(row=min(cursor, table.row_count - 1))
+            except Exception:
+                pass
+        self.query_one("#head", Static).update(heading(self._pending))
+        self._retitle()
+
+    def _cells(self, r: Row) -> tuple[str, ...]:
+        lead = "▸ " if r.current else ("  ╰ " if r.piece else "  ")
+        return (f"{lead}{r.name}", r.branch, r.marks, r.ci, r.change)
+
+    def _retitle(self) -> None:
+        """The footer: how old this snapshot is, and what the pointer has seen.
+
+        **The age is on screen because it is the finding.** A component's `render(ctx)`
+        is handed one snapshot and has no way to ask for another (`frame/ctx.py`:
+        "A component never gets a way to fetch a fresher one: refreshing is the frame's
+        decision, on the frame's clock"). In the adapter that is invisible, because
+        charter calls `render` again with a new one. In the live component `render` never
+        returns, so nothing ever calls it again, and this clock is the only thing on
+        screen that admits it.
+        """
+        at = self._pending.get("gathered_at") if self._pending else None
+        age = f"{time.time() - float(at):.0f}s" if at else "?"
+        parts = [f"snapshot {age} old", f"clicks {self.clicks}",
+                 f"scroll {self.scrolls}", f"keys {self.keys}"]
+        if self._note:
+            parts.append(self._note)
+        try:
+            self.query_one("#foot", Static).update("  ·  ".join(parts))
+        except Exception:
+            pass
+
+    # -- events, counted so the tmux measurement has something to read -------- #
+
+    def on_mouse_down(self, _event) -> None:
+        self.clicks += 1
+        self._retitle()
+
+    def on_mouse_scroll_down(self, _event) -> None:
+        self.scrolls += 1
+        self._retitle()
+
+    def on_mouse_scroll_up(self, _event) -> None:
+        self.scrolls += 1
+        self._retitle()
+
+    def on_key(self, _event) -> None:
+        self.keys += 1
+        self._retitle()
+
+    def action_cursor_down(self) -> None:
+        self.query_one("#table", DataTable).action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        self.query_one("#table", DataTable).action_cursor_up()
+
+    def action_note_refresh(self) -> None:
+        self.refresh(repaint=True, layout=True)

--- a/providers/charter-textual-repos/tests/test_provider.py
+++ b/providers/charter-textual-repos/tests/test_provider.py
@@ -1,0 +1,172 @@
+"""The provider's own tests.
+
+pytest, not `unittest` — CONTRIBUTING.md's rule ("Tests for anything you add to charter
+itself are stdlib unittest") is about charter's tree, and this package is not in it. That
+asymmetry is itself part of what the experiment is testing: a provider is a separate
+distribution with its own toolchain, and if it could not choose one the entry-point seam
+would not be doing its job.
+
+Nothing here starts a tmux server. Everything that needs a real terminal is in
+`measure/`, run by hand, and reported with the numbers it produced.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from charter.frame import ctx as charter_ctx
+from charter.frame import registry
+from charter.frame.component import Component
+
+import charter_textual_repos as prov
+from charter_textual_repos import rows
+
+
+SNAPSHOT = {
+    "gathered_at": time.time(),
+    "workspace": "harness-wrapper",
+    "current_repo": "charter",
+    "repos": [
+        {"name": "charter", "branch": "main", "dirty": True, "tracked_dirty": True,
+         "ahead": 2, "behind": 0, "ci": "failed", "change": 554, "sigil": "!",
+         "current": True, "worktree_count": 3},
+        {"name": "infra", "branch": "main", "dirty": False, "tracked_dirty": False,
+         "ahead": 0, "behind": 1, "ci": "passed", "change": None, "sigil": "",
+         "current": False, "worktree_count": 0},
+    ],
+    "worktrees": [
+        {"name": "pr-554", "branch": "pr-554", "dirty": True, "tracked_dirty": False,
+         "ahead": 1, "behind": 0, "ci": None, "change": None, "sigil": "",
+         "current": False, "worktree_count": 0},
+    ],
+    "todos": [], "todo_count": 0,
+}
+
+
+def build_ctx(width=90, height=10, snapshot=SNAPSHOT):
+    return charter_ctx.build(prov.NEEDS, width=width, height=height, fid="t",
+                             snapshot=snapshot)
+
+
+class TestDiscovery:
+    """Charter finds this package without charter changing — the whole premise."""
+
+    def test_both_components_are_declared_in_the_entry_point_group(self):
+        supplied = registry.Registry().providers.ids()
+        assert "textual.repos" in supplied
+        assert "textual.live" in supplied
+
+    def test_placing_loads_the_component_rather_than_a_standin(self):
+        reg = registry.Registry()
+        component = reg.place("textual.repos")
+        assert isinstance(component, Component)
+        assert reg.failures == {}
+
+    def test_the_entry_point_name_is_the_component_id(self):
+        # `Providers._one` refuses a mismatch, because the entry point name is what a
+        # committed charter.toml places and what charter resolves without importing.
+        assert prov.adapter_component().id == "textual.repos"
+        assert prov.live_component().id == "textual.live"
+
+    def test_the_api_version_is_the_one_charter_speaks(self):
+        from charter.frame.component import API_VERSION
+        assert prov.API_VERSION == API_VERSION
+
+
+class TestRows:
+    """The data reduction, which is where a column is right or wrong."""
+
+    def test_every_column_comes_from_the_gather_snapshot(self):
+        got = rows.rows_of(SNAPSHOT)
+        assert [r.name for r in got] == ["charter ⑂3", "infra", "pr-554"]
+        # The piece's branch is blank on purpose: `slots._table_lines` passes
+        # `branch_override=""` for a piece whose branch merely restates its own name, and
+        # a column repeating the cell beside it is a column spent saying nothing.
+        assert [r.branch for r in got] == ["main", "main", ""]
+        assert [r.marks for r in got] == ["* ↑2", "↓1", "? ↑1"]
+        assert [r.ci for r in got] == ["fail", "ok", ""]
+        assert [r.change for r in got] == ["!554", "", ""]
+
+    def test_a_tracked_dirty_tree_is_told_apart_from_an_untracked_one(self):
+        # charter's own `statusline._markers` makes this distinction and the frame's table
+        # shows it; a provider that flattened both to "dirty" would be quietly lying about
+        # whether there is anything to commit.
+        assert rows.markers({"dirty": True, "tracked_dirty": True}) == "*"
+        assert rows.markers({"dirty": True, "tracked_dirty": False}) == "?"
+        assert rows.markers({"dirty": False}) == ""
+
+    def test_a_cold_cache_draws_no_rows_rather_than_inventing_any(self):
+        assert rows.rows_of({}) == []
+        assert rows.rows_of(None) == []
+
+
+@pytest.fixture(scope="module")
+def reg():
+    """A registry with the adapter placed, and its background app stopped afterwards.
+
+    Module-scoped because the app is process-lifetime state by design
+    (`adapter._HOST`), exactly as it is in a panel process: charter builds the registry
+    once and closes over it, so a per-test app would be measuring a shape production
+    never has.
+    """
+    reg = registry.Registry()
+    reg.place("textual.repos")
+    yield reg
+    from charter_textual_repos import adapter
+    adapter._HOST.stop()
+
+
+class TestAdapterUnderCharter:
+    """The adapter, driven through `Registry.draw` — charter's own call path."""
+
+    def test_it_draws_the_repo_table_into_the_rectangle_it_was_given(self, reg):
+        drew = reg.draw("textual.repos", build_ctx())
+        assert len(drew) == 10
+        assert all(len(line) <= 90 for line in drew)
+        assert "repos 2" in drew[0]
+        assert "charter" in drew[2]
+
+    def test_a_later_snapshot_reaches_the_widget(self, reg):
+        later = dict(SNAPSHOT, repos=[dict(SNAPSHOT["repos"][0], ci="passed")],
+                     worktrees=[])
+        drew = reg.draw("textual.repos", build_ctx(snapshot=later))
+        assert any("ok" in line for line in drew)
+        assert not any("fail" in line for line in drew)
+
+    def test_the_lines_carry_no_escape_at_all(self, reg):
+        # Not a style choice: `Registry.draw` escapes every line a provider returned
+        # (`escape=cid in self._foreign`), so an ANSI-bearing line would be painted as the
+        # literal characters `\x1b[38;2;...`. `Strip.text` is what makes that a non-issue,
+        # at the cost of every colour Textual computed.
+        drew = reg.draw("textual.repos", build_ctx())
+        assert not any("\x1b" in line or "\\x1b" in line for line in drew)
+
+    def test_a_pane_with_no_room_is_no_lines_rather_than_a_crash(self, reg):
+        assert reg.draw("textual.repos", build_ctx(width=0, height=0)) == ()
+
+
+class TestTheContractItselfHeld:
+    """What the experiment set out to check, asserted rather than asserted about."""
+
+    def test_ctx_serves_only_what_was_declared(self):
+        c = build_ctx()
+        assert c.gather["current_repo"] == "charter"
+        with pytest.raises(AttributeError):
+            c.todos                                   # not in NEEDS
+        with pytest.raises(AttributeError):
+            c.subprocess                              # never served at all
+
+    def test_declaring_an_event_kind_charter_cannot_deliver_is_still_accepted(self):
+        # `component.EVENT_KINDS` is validated at construction and read by nothing else in
+        # charter. This test passes, and that it passes is finding #1: `textual.live`
+        # declares four kinds, receives them from the tty itself, and charter neither
+        # delivers them nor knows it is not delivering them.
+        assert prov.live_component().events == ("key", "click", "scroll", "resize")
+
+    def test_a_size_policy_other_than_fixed_survives_only_where_config_is_silent(self):
+        # `instance.component_tables` coerces a provider's committed `size` to `Fixed(n)`,
+        # so `Content(cap=…)` and `Fill()` are reachable only on a frame nobody arranged.
+        from charter.frame.component import Fixed
+        assert isinstance(prov.adapter_component().size, Fixed)

--- a/tests/test_plugin_freshness.py
+++ b/tests/test_plugin_freshness.py
@@ -88,8 +88,19 @@ def tracked_top_level_directories(repo: Path = REPO) -> set[str]:
 #: `tools/` is developer tooling — `tools/sweep.py` runs the deletion sweep over a branch.
 #: No plugin loads it, `pyproject.toml` names `charter` as the only package so no wheel
 #: ships it, and an edit to it is not a stale plugin.
+#:
+#: `providers/` holds SEPARATE distributions, each with its own `pyproject.toml` and its own
+#: dependencies — the `charter.components` entry-point seam, exercised from inside this repo
+#: (`providers/charter-textual-repos`, the Textual experiment). It is the same three
+#: arguments `tools/` gets and one more that matters more here: nothing under it is
+#: importable from charter, charter's `pyproject.toml` names `charter` as the only wheel
+#: package so none of it ships, no plugin loads it — and it must NEVER become plugin
+#: surface, because a provider declares dependencies charter does not have and
+#: `test_runtime_has_zero_dependencies` is the property that would quietly stop meaning
+#: anything if a third-party package could travel inside charter's own plugin cache.
 _NOT_PLUGIN_SURFACE = {
     ".github", ".claude", "charter", "docs", "tests", "personas", "workspaces", "tools",
+    "providers",
 }
 
 PLUGIN = {


### PR DESCRIPTION
**An experiment, not a feature. Do not merge to ship it — merge it, or close it, for what it
found.**

One charter frame component — the repo table — drawn with
[Textual](https://github.com/textualize/textual) and shipped as a third-party provider
through the existing `charter.components` entry point. The question was whether the provider
model already permits a rich widget framework **without charter taking the dependency**.

`charter/` is untouched on this branch and `pyproject.toml` still says `dependencies = []`;
`tests/test_packaging.py::test_runtime_has_zero_dependencies` still passes. The one line
changed under `tests/` is the classification a new top-level directory is *required* to make
(§ below) — no production line changed, so there is no news entry.

Full writeup, with every measurement and the script that produced it:
`docs/superpowers/specs/2026-08-28-textual-frame-component-experiment.md`.

---

## Show it — real `capture-pane -p -e`

tmux 3.7c, 150x44 window, session `mouse off` (charter's default), panes split in charter's
own order. `alternate_on` is the whole architectural difference between the two components,
sitting side by side in one frame. Produced by `measure/m7_shot.sh`.

```
┌─ %0  rows 0-3  150x4  alternate_on=0  the harness (stand-in)
│ The default interactive shell is now zsh.
│ To update your account to use zsh, please run `chsh -s /bin/zsh`.
│ For more details, please visit https://support.apple.com/kb/HT208050.
│ bash-3.2$
┌─ %5  rows 5-16  150x12  alternate_on=1  panel textual.live
│  repos 5  ·  harness-wrapper
│  repo                 branch                      ci    change
│  ▸ charter ⑂3         main               * ↑2     fail  !554
│    easydmarc-app      feat/dmarc-rollup  ↓4       ok
│    infra              main                        run   #88
│    charter-docs       docs/frame         ? ↑1 ↓1  ok
│    statusline-lab ⑂2  main
│    ╰ pr-554                              ? ↑1     …
│    ╰ pr-560                                       ok    !560
│ 
│ 
│  snapshot 5s old  ·  clicks 0  ·  scroll 0  ·  keys 0  ·  live · frozen
┌─ %4  rows 18-29  150x12  alternate_on=0  panel textual.repos
│  repos 5  ·  harness-wrapper
│  repo                 branch                      ci    change
│  ▸ charter ⑂3         main               * ↑2     fail  !554
│    easydmarc-app      feat/dmarc-rollup  ↓4       ok
│    infra              main                        run   #88
│    charter-docs       docs/frame         ? ↑1 ↓1  ok
│    statusline-lab ⑂2  main
│    ╰ pr-554                              ? ↑1     …
│    ╰ pr-560                                       ok    !560
│ 
│ 
│  snapshot 0s old  ·  clicks 0  ·  scroll 0  ·  keys 0  ·  headless
┌─ %3  rows 31-39  150x9  alternate_on=0  panel repos
│ ▪ repos 5
│   ├─ charter ⑂3                        main*↑2                             ✗ failed      !554
│   ├─ easydmarc-app                     feat/dmarc-rollup↓4                 ? passed
│   ├─ infra                             main                                ● running     #88
│   ├─ charter-docs                      docs/frame*↑1↓1                     ? passed
│   └─ statusline-lab ⑂2                 main
│ 
│ 
│ 
┌─ %2  rows 41-41  150x1  alternate_on=0  panel attention
│ 0 todos · ⚠ reinit 9 ws · charter ws reinit --all · F2 palette
┌─ %1  rows 43-43  150x1  alternate_on=0  panel identity
│  ⬢ default  ◆ steward · ◇ personas forge · reddit · release · statusline                                                           charter 0.53.0 dev
└─ tmux 3.7c · window 150x44 · session mouse off · python 3.14.2
```

The same thing with `-e`, ESC shown as `\e` (the two Textual panes only — the rest is in the
writeup):

```
┌─ %5  rows 5-16  150x12  alternate_on=1  panel textual.live
│ \e[48;2;36;47;56m \e[38;2;226;227;229mrepos 5  ·  harness-wrapper\e[39m
│ \e[1m\e[38;2;224;224;224m\e[48;2;45;55;64m repo                 branch                      ci    change
│ \e[38;2;33;21;5m\e[48;2;254;166;43m ▸ charter ⑂3         main               * ↑2     fail  !554
│ \e[0m\e[38;2;224;224;224m\e[48;2;39;39;39m   easydmarc-app      feat/dmarc-rollup  ↓4       ok
│    infra              main                        run   #88
│    charter-docs       docs/frame         ? ↑1 ↓1  ok
│    statusline-lab ⑂2  main
│    ╰ pr-554                              ? ↑1     …
│    ╰ pr-560                                       ok    !560
│ 
│ 
│ \e[39m\e[48;2;36;47;56m \e[38;2;167;171;175msnapshot 4s old  ·  clicks 0  ·  scroll 0  ·  keys 0  ·  live · frozen\e[39m
┌─ %4  rows 18-29  150x12  alternate_on=0  panel textual.repos
│  repos 5  ·  harness-wrapper
│  repo                 branch                      ci    change
│  ▸ charter ⑂3         main               * ↑2     fail  !554
│    easydmarc-app      feat/dmarc-rollup  ↓4       ok
│    infra              main                        run   #88
│    charter-docs       docs/frame         ? ↑1 ↓1  ok
│    statusline-lab ⑂2  main
│    ╰ pr-554                              ? ↑1     …
│    ╰ pr-560                                       ok    !560
│ 
│ 
│  snapshot 0s old  ·  clicks 0  ·  scroll 0  ·  keys 0  ·  headless
```

**Three things to look at.** `%5` is `alternate_on=1` and carries Textual's real 24-bit SGR:
a widget framework running in a pane charter split. `%4` is the *same widget tree* through
charter's contract and has **not one escape in it** — `Registry.draw` escapes what a provider
returns, so the adapter can only ever hand back `Strip.text`. `%3` is charter's own `repos`,
in colour, off the same `gather` snapshot, and it still reads best.

---

## What was built

| id | shape | `render` |
|---|---|---|
| `textual.repos` | **adapter** — Textual headless on a background thread, composited screen copied out as lines | returns per repaint, like every other component |
| `textual.live` | **takeover** — Textual on the pane's own tty, alternate screen, own asyncio loop, `mouse=True` | never returns |

`providers/charter-textual-repos/`, a real distribution: `uv build` makes a wheel, and
installing that wheel into a **3.12** venv beside charter — no editable install, no
`PYTHONPATH` — gives the same two entry points and the same two panes. It is placeable from a
committed `charter.toml`, and on a machine without it the arrangement falls back whole:

```
components: [{'use': 'textual.live', 'slot': 'textual.live', 'edge': 'bottom',
              'size': Fixed(n=12), 'visible': True, 'key': 'F9'}]
slots: ['top', 'bottom', 'textual.live']

# same charter.toml, provider not installed:
components: []
slots: ['top', 'bottom', 'repos', 'right']
```

**The extension model is real.** §4b property 4 works exactly as designed.

---

## What the experiment answers

### Did the contract fit? Where did it chafe?

The declaration half fits. The rendering half fits one of the two shapes. **The input half
does not exist.** Six named places, in the writeup; the three that matter:

* **`render(ctx) -> list[str]` is a renderer contract.** A framework that owns the terminal
  has no seam there. The adapter obeys it by running Textual where nobody can see it; the
  takeover obeys it by never returning from it. Nothing distinguishes "a component that
  draws" from "a component that owns its pane".
* **`Component.events` is validated and read by nothing.** `grep -rn '\.events\b' charter/`
  finds two hits: `commands_worktree.py:275` (unrelated) and `frame/component.py:320`, *the
  line that validates the field*. There is no dispatcher. No event kind fires for any
  component, ever. `textual.live` declares four and receives all four — by having taken the
  tty.
* **A provider's lines are escaped, so a provider component is monochrome.**
  `Registry.draw`'s `escape=cid in self._foreign` runs `contain.one_line`, which turns ESC
  into the four characters `\x1b`. Visible in the capture above.

Two smaller ones: a provider can never be `Content()` or `Fill()` where anyone has
configured it (`instance.component_tables` coerces `size` to `Fixed(n)`); and the contract is
a Python class checked with `isinstance`, so `charter-cp` is a real install-time dependency
of every provider.

**And one that CI found and a hand-run could not.** Committing `providers/` failed
`test_every_top_level_directory_is_classified_one_way_or_the_other` on 3.11 and 3.13 — the
check doing exactly what its docstring promises for a new top-level directory. The decision
it asks for is made in `_NOT_PLUGIN_SURFACE`: a provider is a separate distribution, nothing
under it is importable from charter, none of it ships in the wheel, and it must never become
plugin surface, because a provider declares dependencies charter does not have and that is
the property `test_runtime_has_zero_dependencies` protects. The classification reads the git
**index** (#529), so every local full-suite run before the commit passed with `providers/`
untracked; the suite was re-run on the committed tree afterwards. **So the cost of hosting a
provider inside charter's repo is exactly one line and a paragraph saying why.**

### The one that must be fixed regardless: `sys.stdout`

`textual/app.py:3491` wraps the message pump in `redirect_stdout(self._capture_stdout)`,
which assigns `sys.stdout` **process-wide**, headless or not. `_PrintCapture`
(`textual/app.py:260`) answers `isatty() -> True` and `fileno() -> -1`. charter reaches
`sys.stdout` in three places and that object subverts all three:

| charter | what it gets |
|---|---|
| `panel._out` — `sys.stdout.write(payload)` | the paint goes into Textual's print log |
| `slots._width`/`_height` — `os.get_terminal_size(sys.stdout.fileno())` | `OSError` on fd -1, caught, **silent 80x24 fallback** |
| `chrome.colour_ok` — `sys.stdout.isatty()` | `True`, whatever stdout actually is |

Measured in a real 150x10 pane (`measure/m8_stdout.sh`), with the provider's workaround
disabled:

```
  0.5s  restored=10  captured=10
  2.0s  restored=10  captured=10
  2.5s  restored=10  captured=1    <- version bumped at 2.0s
  5.0s  restored=10  captured=1        (non-blank rows in each pane)

== and nothing was reported: pane alive, no charter error, no stderr ==
  %2 dead=0 cmd=python3.14
```

charter measures 80x24, the component lays out 24 rows, `panel._write` writes 24 rows into a
10-row pane, the pane scrolls its own content away. **Nothing raises. `Registry.draw` has
nothing to catch, because nothing failed.** The first paint is correct, which is the shape
of bug that ships.

This is charter's, not Textual's. Any provider using any library that touches `sys.stdout` —
a progress bar, a logging handler, `rich.Console`, a debugger — lands somewhere on that
table. §4b's four properties all rest on a global a provider can take by accident.

### Does the alternate screen cost anything charter cares about?

**No, and less than expected** (`measure/m2_altscreen.sh`).

```
%2 python3.14 alternate_on=1   charter panel textual.live   history_size=0
%1 python3.14 alternate_on=0   charter panel repos          history_size=0
%0 bash       alternate_on=0   the harness                  history_size=191
```

`history_size=0` for the Textual pane **and for charter's own panel** — the alternate screen
costs nothing charter's panels were not already costing. `capture-pane -p` and `-p -e` work
normally. `resize-window 150x40 -> 100x30 -> 150x40` reflows correctly (pane 150x14 → 100x11
→ 150x14). `kill -9` with `remain-on-exit on` leaves the pane showing Textual's content,
minus tmux's usual one scrolled line. `respawn-pane -k`, the argv `cmd_respawn` emits, brings
it back clean.

### What happens when the Textual app crashes?

**Its own pane, every time** — but one of the four modes loses the reason
(`measure/m3_crash.sh`, `m3b_crash_message.sh`). charter's own `repos` pane and the harness
pane were untouched in every case.

| failure | the pane says |
|---|---|
| `render` raises before Textual starts | `textual.live failed to draw — RuntimeError: injected fault before the app started` |
| provider module raises on import | `charter-textual-repos 0.1.0 supplies textual.live, and importing charter_textual_repos raised ImportError: … Its pane says so; the rest of the frame is drawn` |
| id nothing supplies | `charter: unknown slot 'notinstalled.thing' (known: bottom, repos, right, top)` |
| **raises inside Textual's message pump** | `textual.live: app exited after 1s (clicks 0, scroll 0, keys 0)` |

Textual does not let that last one out of `run()`: it catches it, prints a 2,520-byte Rich
traceback with locals to `sys.__stderr__`, and returns **normally**. `Registry.draw` sees a successful
render and `panel._write` clears the pane over the traceback within one tick — sampled every
100 ms, it is never visible even once. **A crash inside a framework's own loop is
indistinguishable, from charter's side, from a clean quit.**

Also: **`NO_COLOR` is not honoured by a takeover component.**
`textual/drivers/linux_driver.py:58` sets `self._file = sys.__stderr__` and the app writes
straight there, past `panel._write` and `chrome.plain`. Measured SGR sequences in the pane:
charter's `repos` 54 → 0; `textual.live` 15 → 15.

### Startup: `split-window` to first paint

Polled at 10 ms against real `capture-pane`, five runs each (`measure/m1_startup.sh`):

```
repos            174ms 115ms 130ms 142ms 113ms
textual.repos    339ms 273ms 242ms 241ms 245ms
textual.live     231ms 212ms 228ms 272ms 262ms
```

~2x charter's own, ~110-130 ms extra, paid once per pane. Per repaint through
`Registry.draw`: charter `_table_lines` 0.38 ms median, `textual.repos` 4.79 ms — 12x, and
both two orders of magnitude under `panel.TICK` (200 ms). Import: `charter.frame.slots`
31 ms / 25 MB, `textual.app` 102 ms / 39 MB, this package 128 ms / 43 MB. **Cost is not the
objection.**

### Mouse — measured against real tmux, and the premise is half right

`measure/m4_mouse.py` attaches a real tmux client on a pty it owns and reads every byte tmux
writes to a terminal. tmux 3.7c, session `mouse off`.

```
== what tmux writes to the terminal as the active pane changes ==
  select-pane -> textual.live : 1006l 1000l 1002l 1003l 1006h 1000h 1002h 1003h
  select-pane -> harness      : 1006l 1000l 1002l 1003l
  select-pane -> textual.live : 1006l 1000l 1002l 1003l 1006h 1000h 1002h 1003h

== does an injected report reach the app? ==
  click, textual.live active  : clicks 1  scroll 0
  wheel, textual.live active  : clicks 1  scroll 2
  same clicks, harness active : clicks 2  scroll 3     <- still delivered
  active pane after that click: %0 (harness is %0)     <- and it did not focus the pane

== the harness pane's scrollback, throughout ==
  history_size = 181  ·  last line = 'bash-3.2$'
```

**The modal behaviour is real** — reporting follows the active pane, exactly as §4i predicts,
now confirmed with a program that actually wants the mouse. **And it does not dissolve the
trade.** tmux routes a report by POSITION, not by active pane, so the modality lives entirely
in the *terminal's* reporting mode; a click does not focus the pane, so the operator must
focus it with a key first; and while it is focused, native selection is gone for the **whole
window**. The harness pane's scrollback is untouched throughout, so nothing is lost — what is
unavailable is dragging to select while that pane has focus.

Net: `[frame] mouse` can stay `False` and a Textual panel can request the mouse for itself.
That is better than `mouse = true`, which costs selection unconditionally. It is not free, and
`EVENT_KINDS`' "give every pointer affordance a `key` as well" survives unchanged.

### Do the two loops fight?

**No — because in the takeover shape only one of them is running.** `render` blocks inside
`Registry.draw`, so `_watch` never ticks, never calls `state.version`, never calls `_write`.
No clear-screen underneath Textual, no flicker. The cost is that charter also never hands it
another `ctx`, so the table freezes at the snapshot the pane started with — visible on screen
as a climbing "snapshot Ns old" clock. The adapter is the opposite and entirely well-behaved:
a version bump updates it within one tick, idle cost unchanged at one `stat`.

The obvious compromise — start the app on a thread and return `[]` — is **refuted**, not
merely rejected (`measure/m10_thread_takeover.py`): `LinuxDriver.__init__` calls
`signal.signal(SIGTSTP, …)`, Python refuses that off the main thread, Textual catches it,
prints 16,747 bytes of traceback into the pane and `run()` returns with nothing raised.

---

## Would you ship it?

**No — not this, and not yet.**

1. **The adapter is the only shape charter can host, and it is strictly worse than what
   charter already has.** No colour, no input, 12x the repaint cost and 2x the startup, for a
   table charter draws better. Every advantage a widget framework has is on the far side of
   either `Registry.draw`'s escaping or a dispatcher that does not exist.
2. **The takeover works and is outside the contract in a way that is not a detail.** It draws
   well, survives resize/respawn/death, costs one pane when it fails — but it freezes on the
   first snapshot, silently ignores `NO_COLOR`, loses its crash reasons, and the only way to
   make it live is to import charter's internals from a stranger's package. Shipping it would
   ship "components may own their pane" as folklore rather than as a contract.
3. **The `sys.stdout` finding must land first, and it is charter's.**

**What it would take**, smallest first:

1. Make charter's pane immune to `sys.stdout` — capture the panel's real fd once at startup
   and write, measure and `isatty` through *that*. Three call sites. Worth doing whether or
   not anything else here happens.
2. Decide what an escaped provider line means: say plainly that a provider component is
   monochrome, or give providers a narrow validated colour channel.
3. Deliver `events`, or delete the field. A closed vocabulary that is validated and never
   dispatched is a promise the code does not keep.
4. Only then: a second component shape — `owns_pane = True`, or a `run(ctx, updates)` handed
   a channel the frame pushes fresh snapshots onto. That is the only thing that makes the
   widget's advantages reachable, and therefore the only thing that makes Textual worth its
   dependencies.

**What the experiment proves, and it is the important part:** the provider model is sound. A
package outside `charter/` declaring ten dependencies charter does not have was discovered,
placed from a committed file, split into a pane, drawn, crashed four ways, and never cost the
frame anything but its own pane. The gaps are in the *component* contract, not in the
extension model, and each is a few dozen lines from closed.

---

## Suite, and what CI does and does not validate

| | |
|---|---|
| Python 3.14.4 (Homebrew), inherited environment | **6975 tests, OK**, 362.6 s |
| Python 3.12.13 (Homebrew), every `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset (16 present → 0; the child saw none) | **6975 tests, OK**, 380.0 s |

Both on the **committed** tree — the classification check reads the git index, so a
pre-commit run cannot stand in for one. CI green at the branch head, asked of the sha rather
than of the PR (#561): `gh api repos/diazoxide/charter/commits/<HEAD>/check-runs` reports
`test (3.11)`, `test (3.12)`, `test (3.13)` and `test (3.14)` all **success**.

`test_runtime_has_zero_dependencies` passes in both, and both were of the **unmodified**
`charter/` and `tests/` — `git diff origin/main -- charter tests pyproject.toml` is empty.
The provider's own 14 pytest tests pass on 3.14 (editable) and 3.12 (from the built wheel).

**CI validates none of the Textual half, and it should not be read as if it did.**
`.github/workflows/test.yml` runs `python -m unittest discover -s tests -v` on 3.11-3.14 and
installs nothing: not this provider, not Textual, not pytest. Nothing in `providers/` is
built, imported or executed by any job, and no job starts a tmux server for these
measurements. What CI proves is the thing that matters most — charter is unchanged and its
suite still passes. Every number above was taken by hand on this machine and is reproducible
with the script named beside it.

No charter production line was changed, so there is no news entry. No bump, no stamp, no tag.

Every tmux claim is real tmux 3.7c. Each script owns one socket named
`charter-textualexp-<pid>`, killed before unlinking in a single trap, in charter's own
namespace so `tests/_tmuxreap.py` collects it if a script is interrupted (#590). Verified: no
leaked sockets and no leaked servers after the run.
