### PR TITLE
An option is its letter, an assignment is whatever will do the assigning, and an export reaches the next segment (#555, #556, #496)

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -1694,11 +1694,17 @@ _SHELL_KEYWORDS = frozenset(
 #: which is a fail-OPEN on the exact input this table exists to catch. Same reasoning as
 #: :data:`_TAKES_VALUE` a few hundred lines up, and the same failure it was written for.
 _WRAPPER_VALUE_FLAGS = {
-    "env": ("-u", "--unset", "-C", "--chdir"),
+    # `-P` (BSD `env -P utilpath`, the PATH the utility is looked up on) was missing, and a
+    # missing value flag is the same fail-open as a missing bundle letter: `env -P /bin cat
+    # <vault>` named `/bin` as the program, `cat` as an argument, and printed the vault.
+    # Found by the #556 sweep, not by the issue.
+    "env": ("-u", "--unset", "-C", "--chdir", "-P"),
+    # `-T` (`--command-timeout`) was missing for the same reason: `sudo -T 5 cat <vault>`
+    # named `5` as the program.
     "sudo": ("-u", "--user", "-g", "--group", "-p", "--prompt", "-C", "--close-from",
              "-r", "--role", "-t", "--type", "-h", "--host", "-D", "--chdir",
-             "-R", "--chroot", "-U", "--other-user"),
-    "doas": ("-u", "-C"),
+             "-R", "--chroot", "-U", "--other-user", "-T", "--command-timeout"),
+    "doas": ("-u", "-C", "-a"),
     "nice": ("-n", "--adjustment"),
     "ionice": ("-c", "--class", "-n", "--classdata", "-p", "--pid"),
     "chrt": ("-p", "--pid"),
@@ -1713,7 +1719,44 @@ _WRAPPER_VALUE_FLAGS = {
     # separate value and stays. Attached spellings are handled by the `=`/glued branches.
     "xargs": ("-I", "--replace", "-n", "--max-args", "-L", "--max-lines", "-P",
               "--max-procs", "-d", "--delimiter", "-s", "--max-chars", "-a",
-              "--arg-file", "-E"),
+              "--arg-file", "-E", "-J", "-R", "-S"),
+}
+
+#: Short option LETTERS that take NO value, per wrapper — the other half of
+#: :data:`_WRAPPER_VALUE_FLAGS`, and the half a bundle walk cannot do without.
+#:
+#: getopt bundles short options, so `-iC<dir>` is `-i -C <dir>` and the chdir flag is not
+#: the first thing in its own token. A reader that matches a flag by `tok.startswith(flag)`
+#: only ever sees a short option written FIRST, so `env -iC.charter/vaults cat x.json`
+#: relocated into the vault directory and printed it while three other spellings of the same
+#: flag were denied (#556). `xargs -0a<file>` and `sudo -bD<dir>` are the same token by
+#: construction.
+#:
+#: Per wrapper for the reason the value table is: `env -i` takes nothing while `stdbuf -i`
+#: takes a value, and one flat set is a fail-open on the exact input both tables exist to
+#: catch. **The value table is consulted FIRST for every letter in the walk**, so a letter
+#: that appears in both would behave as value-taking — the fail-closed way round. That
+#: ordering is deliberately NOT load-bearing: `TestTheTwoLetterTablesCannotDisagree` holds
+#: the two tables disjoint per wrapper, which is why a hand-check can swap the order and see
+#: nothing change, and why swapping it back is not a repair anyone will need to make.
+#:
+#: A letter in NEITHER table ends the walk rather than being guessed at — and since #555's
+#: round the end of a walk is no longer silent: an option this grammar could not place
+#: leaves the program unnamed, and `_split_env_chdir` reports the rest of the segment as
+#: files this command may open. That is what stops the next missing letter from being a
+#: bypass rather than a false negative (`env -P <path>` and `sudo -T <n>` were both live
+#: fail-opens found that way, and are in the value table above/below now).
+_WRAPPER_NOVALUE_LETTERS = {
+    "env": "0iv",           # BSD: `env [-0iv] [-C workdir] [-P utilpath] [-S string]`
+    "sudo": "ABbEeHiKklNnPSsVv",
+    "doas": "Lns",
+    "xargs": "0oprtx",
+    "timeout": "v",
+    "exec": "cl",           # bash: `exec [-cl] [-a name]`
+    "command": "pvV",
+    "setsid": "cfw",
+    "time": "alpqv",
+    "ionice": "th",
 }
 
 #: Wrapper flags naming a file the WRAPPER ITSELF opens, per wrapper. A wrapper normally
@@ -1784,6 +1827,122 @@ _SPLIT_STRING_FLAGS = ("-S", "--split-string")
 
 #: `timeout 5 cat <vault>` — the duration is a bare positional, not a flag.
 _DURATION_RE = re.compile(r"^\d+(?:\.\d+)?[smhd]?$")
+
+#: Bare POSITIONAL operands a wrapper takes BEFORE the program, per wrapper.
+#:
+#: A wrapper normally hands its own argv straight to the program, which is why naming
+#: `toks[0]` after the flags is right for almost all of them. Two put an argument of their
+#: own in front of the program, and the parser named that argument as the program:
+#:
+#:     chrt 5 cat .charter/vaults/x.json          -> ALLOW, `5` read as the program
+#:     su-exec root cat .charter/vaults/x.json    -> ALLOW, `root` read as the program
+#:
+#: `timeout`'s duration is the same shape and was the only instance modelled — found by
+#: sweeping that branch rather than by a report. It keeps its own `_DURATION_RE` branch
+#: below instead of joining this table, because "the token looks like a duration" is what
+#: `timeout 5\n` needs to NOT be a duration (#577) and a count would lose that.
+#:
+#: Consuming a leading operand moves the program rightward and can never swallow one, so a
+#: wrapper listed here by mistake costs a denial and one missing costs a vault.
+_WRAPPER_LEADING_OPERANDS = {
+    "chrt": 1,        # `chrt [options] <priority> <command> [<arg>…]`
+    "su-exec": 1,     # `su-exec <user-spec> <command> [<arg>…]`
+}
+
+#: Wrappers whose OPERAND SCAN accepts `name=value` — and accepts it by its own rule, which
+#: is not the shell's.
+#:
+#: **This is the two-questions-one-constant defect (#555).** `_ENV_ASSIGN_RE` is a shell
+#: IDENTIFIER, and that is right for the front of a segment: bash answers *"a-b=1: command
+#: not found"*, so `a-b=1` there is a program name and not an assignment. `env` is a
+#: different parser reading the same bytes, and its operand scan is `strchr(arg, '=')` —
+#: GNU coreutils and BSD alike, verified on both this machine's `env` and the source: ANY
+#: argument containing an `=` is an assignment, and the scan keeps going until it meets one
+#: without. So `env a-b=1 cat .charter/vaults/x.json` sets a variable named `a-b` and the
+#: utility is the `cat`, while the guard named `a-b=1` as the program, found no reader, and
+#: printed the vault. `a.b=1`, `1FOO=1`, `x y=1` and `=1` are the same token; so is a `--`
+#: in front of any of them.
+#:
+#: The naive repair — widen `_ENV_ASSIGN_RE` — moves denials in both directions, because the
+#: same constant answers the shell's question at the front of a segment (`git -c a.b=c`, an
+#: operand with a query string). Two parsers, two predicates: the shell's stays where the
+#: shell decides, and this one is applied ONLY inside the operand scan of a wrapper that
+#: really does the assigning.
+#:
+#: Consuming a token here is the fail-CLOSED direction — it moves the program rightward and
+#: can never swallow one — so a wrapper listed by mistake costs a denial of a command that
+#: would not have run anyway, while one missing costs a vault.
+#:
+#: **Still grammar-driven and not padded**, because "fail-closed" is not a licence to list
+#: every wrapper. These two are the ones whose own usage carries the operand — `sudo -h`
+#: prints `[VAR=value]` on this machine, and `env`'s whole purpose is the assignment.
+#: `doas` was in this set for a round and is not any more: its usage is
+#: `doas [-Lns] [-a style] [-C config] [-u user] command [args]`, with no assignment operand
+#: at all, so `doas a-b=1 cat <vault>` execs a program named `a-b=1` and reads nothing. A
+#: hand-check found it — deleting it changed no test, which is what a row with no grammar
+#: behind it looks like.
+_WRAPPER_ASSIGN_OPERANDS = frozenset(("env", "sudo"))
+
+
+def _wrapper_option(base: str, tok: str) -> tuple[str, str, bool, bool]:
+    """``(flag, attached value, the value is the NEXT token, this grammar placed it)`` for
+    one of *base*'s option tokens.
+
+    **A short option is its LETTER, not its position in the token** — that is the property
+    #556 is, and `tok.startswith(flag)` is the spelling that stood in for it. getopt bundles,
+    so `-iC<dir>` is `-i -C <dir>`; the flag the guard models was sitting behind one letter
+    it also models, and the whole token matched nothing.
+
+    So the token is read in this order, and the order is what keeps the two halves from
+    disagreeing (the #547 repair, applied one level in):
+
+    1. :func:`_flag_name_value` — the LONG `--flag=value` form and a value glued to a short
+       flag that is FIRST. Unchanged, and still ahead of everything else.
+    2. otherwise, for a single-dash token, the letters are walked. A letter in
+       :data:`_WRAPPER_VALUE_FLAGS` takes the rest of the token as its value (or the next
+       token when nothing is left); a letter in :data:`_WRAPPER_NOVALUE_LETTERS` is stepped
+       over; anything else ENDS the walk unplaced rather than being guessed at, because
+       guessing in the permissive direction is what `env -i cat <vault>` punishes.
+
+    The fourth field is the honest half. ``False`` means this grammar could not account for
+    the token, so **the next token is not reliably the program** — a value flag nobody has
+    listed looks exactly like a flag that takes nothing, and the caller has no way to tell
+    from here. Callers that may not miss treat the rest of the segment as reachable; see
+    :func:`_split_env_chdir`.
+    """
+    if tok == "--":
+        # POSIX end-of-options: placed, and it takes nothing. Not left to the walk below,
+        # where it would come back UNPLACED and put the whole rest of the segment into
+        # `reads` for a token that means nothing more than "the options stop here".
+        return "", "", False, True
+    takes = _WRAPPER_VALUE_FLAGS.get(base, ())
+    if base == "env":
+        takes = takes + _SPLIT_STRING_FLAGS
+    name, value = _flag_name_value(tok, takes)
+    if value:
+        return name, value, False, True         # `--chdir=<dir>`, `-C<dir>`, `-Sfoo=1`
+    if name in takes:
+        return name, "", True, True             # `-C <dir>`, `--chdir <dir>`
+    # **A long option needs no branch of its own, and it had one.** `--nonesuch` walks into
+    # the loop below, whose first character is the second `-`; that is in no wrapper's
+    # no-value letters, so the walk ends UNPLACED on its first step — the same answer an
+    # early return gave, which is why deleting the early return changed nothing across
+    # 6.9M (wrapper, token) pairs. `takes` is likewise not filtered down to two-character
+    # spellings first: `"-" + ch` is two characters, so the membership test does that
+    # filtering itself. Both invariants are asserted rather than assumed —
+    # `TestTheWalkNeedsNoFilterOfItsOwn` in
+    # `tests/test_an_option_is_its_letter_not_its_position.py` — because a `-` appearing in
+    # a no-value table, or a bare `--` in a value table, is what would make either line
+    # start mattering again, and an unpinned reason is how dead code comes back to life.
+    short = frozenset(takes)
+    novalue = _WRAPPER_NOVALUE_LETTERS.get(base, "")
+    for j, ch in enumerate(tok[1:], start=1):
+        if "-" + ch in short:
+            attached = tok[j + 1:]
+            return "-" + ch, attached, not attached, True
+        if ch not in novalue:
+            return "", "", False, False         # a letter this grammar cannot place
+    return "", "", False, True                  # every letter placed, none takes a value
 
 
 def _flag_name_value(tok: str, spellings: tuple[str, ...]) -> tuple[str, str]:
@@ -1878,33 +2037,74 @@ def _split_env_chdir(
         if tok not in _SHELL_KEYWORDS and base not in _WRAPPERS:
             break
         toks.pop(0)
-        # the wrapper's OWN options, and the operands that are not the program
+        # the wrapper's OWN options, and the operands that are not the program.
+        #
+        # **A `-…` token is read as an OPTION wherever it stands, even past the point where
+        # the wrapper's own grammar has stopped reading options.** `env` is
+        # `option* assignment* utility arg*` — verified on this machine in both directions:
+        # `env FOO=1 -i sh -c …` answers *"env: -i: No such file or directory"* (the `-i` is
+        # the UTILITY), and `env -Sfoo=1 -Sbar=2 sh -c …` leaves `bar` unset and a variable
+        # literally named `-Sbar` in the environment (the second `-S…` is an ASSIGNMENT).
+        # Modelling that faithfully would make this parser deny LESS than `origin/main`
+        # does on both rows, which `tests/test_guard_differential.py` forbids outright and
+        # which is the wrong direction anyway: reading a stray `-Sbar=2` as one more `-S`
+        # unpacks it and keeps scanning rightward for a program, and reading a stray `-i` as
+        # a flag steps over a token that cannot be a reader. Both reach the same verdict on
+        # a command that RUNS, and neither can hand the guard a program that is not there.
+        leading = _WRAPPER_LEADING_OPERANDS.get(base, 0)
         while toks:
             nxt = toks[0]
-            if base == "env" and nxt.startswith(_SPLIT_STRING_FLAGS):
-                toks.pop(0)
-                rest = _flag_name_value(nxt, _SPLIT_STRING_FLAGS)[1]
-                if not rest and toks:
-                    rest = toks.pop(0)
-                try:
-                    import shlex
-                    toks = shlex.split(rest) + toks
-                except ValueError:
-                    toks = rest.split() + toks
-                continue
             if nxt.startswith("-") and len(nxt) > 1:
                 toks.pop(0)
                 # ONE reading of the flag, giving both its NAME and its VALUE: the name is
                 # what decides whether the next token is the program, the value is where a
                 # chdir flag relocates to. Two readings is how the value came to be lost.
-                takes = _WRAPPER_VALUE_FLAGS.get(base, ())
-                name, value = _flag_name_value(nxt, takes)
-                if not value and nxt in takes and toks:
+                name, value, wants_next, placed = _wrapper_option(base, nxt)
+                if wants_next and toks:
                     value = toks.pop(0)             # the value is the NEXT token
+                    if nxt != name:
+                        # A value taken from the next token because a letter INSIDE a
+                        # bundle asked for it (`env -iC <dir>`, which really does chdir —
+                        # verified). That token is the program if this grammar is wrong
+                        # about the letter's arity, so the rest of the segment is reported
+                        # as reachable and the leak guard keeps its eyes on it. Same
+                        # reasoning as the unplaced branch below; the difference is only
+                        # how much of the token was placed.
+                        reads.extend(toks)
+                if not placed:
+                    # An option this wrapper's grammar could not account for. The token
+                    # after it is NOT reliably the program — a value flag nobody listed is
+                    # indistinguishable from one that takes nothing, which is how `env -P
+                    # /bin cat <vault>` came to name `/bin` as the program and print the
+                    # vault. So the guard stops trusting the program and reports the rest of
+                    # the segment as files this command may open; the leak guard asks the
+                    # same `_names_a_vault_path` of them it asks of a reader's operands.
+                    # This is what keeps a SHORT table a false negative instead of a bypass.
+                    reads.extend(toks)
+                    continue
+                if name in _SPLIT_STRING_FLAGS and base == "env":
+                    # `env -S 'cat <vault>'` packs a whole command into one token, and
+                    # `env -iS…` packs it behind a bundled `-i` (#556's sweep: a live vault
+                    # read). Treated as tokens rather than skipped, because skipping leaves
+                    # an empty argv and the guard sees no program at all.
+                    try:
+                        import shlex
+                        toks = shlex.split(value) + toks
+                    except ValueError:
+                        toks = value.split() + toks
+                    continue
                 if value and name in _WRAPPER_CHDIR_FLAGS.get(base, ()):
                     chdir = value
                 if value and name in _WRAPPER_READ_FLAGS.get(base, ()):
                     reads.append(value)
+                continue
+            if base in _WRAPPER_ASSIGN_OPERANDS and "=" in nxt:
+                # THIS wrapper's rule for what an assignment is, not the shell's (#555).
+                env.append(toks.pop(0))
+                continue
+            if leading:
+                leading -= 1
+                toks.pop(0)     # the wrapper's own operand, not the program
                 continue
             if base == "timeout" and _DURATION_RE.match(nxt):
                 toks.pop(0)     # the duration, not the program
@@ -2294,6 +2494,107 @@ def _git_target(cwd: str, pre: list[str], env: list[str] = ()) -> list[Path]:
     return out
 
 
+#: Builtins that put a variable into the environment every LATER segment inherits.
+#: `declare`/`typeset` do it only with `-x`; `export` always does.
+_EXPORT_BUILTINS = ("export", "declare", "typeset")
+
+
+def _exported_env(segments: list[list[str]]) -> list[list[str]]:
+    """For each segment, the ``VAR=value`` assignments an EARLIER segment of the same
+    command line has exported into the environment that segment will run in.
+
+    **The property is "what this command line has set for its later segments", and the
+    spelling that stood in for it was "an assignment attached to the invocation" (#496).**
+    `_split_env` hands a guard the prefix on the command itself, so
+    `GIT_DIR=<plane>/.git git checkout feature` was refused — and `export
+    GIT_DIR=<plane>/.git && git checkout feature`, the same variable reaching the same git
+    for the same reason, was allowed. Verified end to end against git 2.50.1: the plane
+    root's HEAD moved and nothing was printed. The one-credential guard had the identical
+    gap on `export GIT_SSH_COMMAND=…` (found by this sweep, not by the issue) and is wired
+    to the same answer.
+
+    Parallel to *segments* rather than folded into the caller's walk, because two guards
+    ask it and a second hand-written copy would grow its own blind spots — the reason
+    :func:`_plane_root_git` exists at all.
+
+    **The shapes modelled, each because a shell really does it** (checked against bash 5
+    and zsh, both of which agree):
+
+    * ``export NAME=VALUE`` — and ``declare -x`` / ``typeset -x``, which are `export`
+      spelled two other ways and bundle their `x` (`declare -gx`).
+    * ``NAME=VALUE`` as a segment of its own, then ``export NAME``. A bare assignment
+      segment sets a SHELL variable and exports nothing — `FOO=1; <child>` really does
+      leave `FOO` unset in the child, so it is tracked but not exported until something
+      exports it.
+    * ``set -a`` (``set -o allexport``), after which a bare assignment segment IS exported.
+
+    **This environment only ever GROWS**, which is the same invariant `_git_target`'s
+    subject list keeps and for the same reason. `unset`, ``export -n`` and a subshell that
+    ends are not modelled: forgetting a variable is the fail-OPEN direction, and a list that
+    gets shorter as the command line gets longer is a bypass by construction. The cost is
+    refusing `export GIT_DIR=<plane>/.git && unset GIT_DIR && git checkout feature`, a
+    command nobody types by accident.
+
+    **The honest boundary is `cd`'s.** charter models the shell effects it has evidence for
+    in the argv it was handed: a `$(…)`, a sourced file, a `~/.bashrc`, and a `GIT_DIR`
+    already in the session's environment before the hook ran are all outside it — the
+    `PreToolUse` payload carries the command and the cwd, not the environment the command
+    will inherit, so for the last one there is nothing to read. Stated limits, not gaps.
+    """
+    out: list[list[str]] = []
+    exported: list[str] = []
+    shell_vars: dict[str, str] = {}
+    allexport = False
+    for toks in segments:
+        out.append(list(exported))
+        i = 0
+        while i < len(toks) and toks[i] in _SHELL_KEYWORDS:
+            i += 1
+        rest = toks[i:]
+        if not rest:
+            continue
+        prog = os.path.basename(rest[0]).lower()
+        args = rest[1:]
+        if prog == "set":
+            # `set -a`, `set -ax`, `set -o allexport` — the letter, not the token, for the
+            # reason `_wrapper_option` walks letters: `-ax` is `-a -x`.
+            if any((a.startswith("-") and not a.startswith("--") and "a" in a[1:])
+                   or a == "allexport" for a in args):
+                allexport = True
+            continue
+        if prog in _EXPORT_BUILTINS:
+            if prog != "export" and not any(
+                    a.startswith("-") and not a.startswith("--") and "x" in a[1:]
+                    for a in args):
+                # `declare FOO=1` without `-x` is a shell variable, not an export.
+                for a in args:
+                    if _ENV_ASSIGN_RE.match(a):
+                        shell_vars[a.split("=", 1)[0]] = a
+                continue
+            # No `startswith("-")` skip here, and that is deliberate rather than an
+            # oversight: `shell_vars`' keys all come from `_ENV_ASSIGN_RE`, so every one of
+            # them is a shell identifier and none starts with `-`. A flag token can
+            # therefore neither be recorded by the first arm nor found by the second, which
+            # is what a differential over 213,927 segment lists says too. The skip was here
+            # and was deleted; `test_a_flag_cannot_be_mistaken_for_a_variable_name` pins the
+            # reason, since an unpinned reason is how dead code comes back to life.
+            for a in args:
+                if _ENV_ASSIGN_RE.match(a):
+                    shell_vars[a.split("=", 1)[0]] = a
+                    exported.append(a)
+                elif a in shell_vars:
+                    exported.append(shell_vars[a])   # `FOO=1; export FOO`
+            continue
+        if all(_ENV_ASSIGN_RE.match(t) for t in rest):
+            # A segment that is NOTHING but assignments: a shell variable each, exported
+            # only under `set -a`.
+            for t in rest:
+                shell_vars[t.split("=", 1)[0]] = t
+                if allexport:
+                    exported.append(t)
+    return out
+
+
 def _plane_root_git(cmd: str, cwd: str, root: Path):
     """Yield ``(subcommand, args-after-it)`` for every git invocation in *cmd* that acts on
     the PLANE ROOT — the walk both plane-root guards share.
@@ -2327,7 +2628,8 @@ def _plane_root_git(cmd: str, cwd: str, root: Path):
     if not parsed:
         return
     here = cwd
-    for _toks in segments:
+    carried = _exported_env(segments)
+    for _toks, before in zip(segments, carried):
         prog, env, args = _split_env(_toks)
         base = os.path.basename(prog or "")
         # A `cd` earlier in the SAME command moves where the later segments run. Without
@@ -2345,7 +2647,10 @@ def _plane_root_git(cmd: str, cwd: str, root: Path):
         if not rest:
             continue                        # global options only: no subcommand to judge
         try:
-            if not any(t.resolve() == root for t in _git_target(here, pre, env)):
+            # `before + env`, in that order: an assignment attached to THIS invocation
+            # overrides one an earlier `export` set, which is what git itself does.
+            if not any(t.resolve() == root
+                       for t in _git_target(here, pre, before + env)):
                 continue
         except OSError:
             continue
@@ -2952,8 +3257,14 @@ def _single_credential_hit(cmd: str) -> tuple[str, str] | None:
     # straight through it.
     lower_prefix_hosts = {p.lower(): h for p, h in ssh_prefix_hosts.items()}
     lower_prefixes = tuple(lower_prefix_hosts)
-    for _toks in _segment_argv(cmd):
-        prog, env, argv = _split_env(_toks)
+    segments = _segment_argv(cmd)
+    # The environment an earlier segment EXPORTED reaches this git exactly as an attached
+    # prefix does, and `export GIT_SSH_COMMAND=/tmp/k && git push` walked past this guard
+    # while the attached spelling was denied — the same defect as #496, in the guard next
+    # door, found by sweeping its shape rather than by a report.
+    for _toks, before in zip(segments, _exported_env(segments)):
+        prog, seg_env, argv = _split_env(_toks)
+        env = before + seg_env
         # Case-folded for the reason `_is_charter` and `_VAULT_PATH_RE` are: APFS and NTFS
         # resolve `GIT` and `git` to the same binary, so a case-sensitive compare here is
         # one Shift key from absent — `GIT push git@host:o/r.git` walked straight past it.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -121,11 +121,17 @@ rule while one who reads a bare refusal files an issue.
   is the branch creation it is rather than a directory called `<branch>`
   ([#483](https://github.com/diazoxide/charter/issues/483)). Every one of those is a row in
   the guard's corpus (`tests/test_plane_root_checkout_is_two_commands.py`), crossed with the
-  commands rather than listed beside them. What the walk still does not carry across
-  segments is an environment assignment: `export GIT_DIR=<plane>/.git && git checkout
-  <branch>` reaches the root and is allowed
-  ([#496](https://github.com/diazoxide/charter/issues/496)), pinned as an `ALLOW` row so
-  closing it turns the row red rather than passing unnoticed.
+  commands rather than listed beside them. The walk also carries the **environment a command
+  line establishes for its later segments**, so `export GIT_DIR=<plane>/.git && git checkout
+  <branch>` reaches the same denial the attached `GIT_DIR=… git …` does
+  ([#496](https://github.com/diazoxide/charter/issues/496)) — as do `declare -x`/`typeset
+  -x`, `GIT_DIR=…; export GIT_DIR`, and a bare assignment under `set -a`. A bare
+  `GIT_DIR=…;` segment on its own is *not* one of them, because a shell exports nothing
+  there. That environment only ever grows: `unset` and `export -n` are not modelled, since
+  forgetting a variable is the direction that opens a door. What is still outside it is the
+  same boundary `cd` has — a `$(…)`, a sourced file, and a `GIT_DIR` already in the
+  session's environment before the hook ran, which the `PreToolUse` payload does not carry
+  at all.
 - **Plane-root history wipe.** A `git reset --hard` (or `--merge`/`--keep`) in the plane root
   that would take commits off the branch which no remote has a copy of — the command that
   destroyed eleven memory commits in one session. Only that: the unstage

--- a/docs/news/unreleased-a-value-glued-to-a-short-flag-is-read-as-one.md
+++ b/docs/news/unreleased-a-value-glued-to-a-short-flag-is-read-as-one.md
@@ -49,16 +49,18 @@ spawn charter against your live plane. It had been repairing this ordering on it
 since the defect was filed; that repair is deleted with this fix, which makes its removal a
 second regression test — the suite stays green on production's parse alone.
 
-Two neighbours found while measuring this one are **not** fixed here, and are filed rather
+Two neighbours found while measuring this one are **not** fixed here, and were filed rather
 than quietly absorbed: [#556](https://github.com/diazoxide/charter/issues/556), a value
 attached to a *bundled* short option (`env -iC<dir> cat x.json`, which relocates into the
 vault directory and is allowed), and
 [#555](https://github.com/diazoxide/charter/issues/555), `env` accepting assignments to
 names that are not shell identifiers while the parser stops at the first token it cannot
-read as one (`env a-b=1 cat <vault>`). Both are live, both are unchanged in either direction
-by this fix, and both are a different question from the one #547 asked — a fix that widens
-its own scope until it is answering three questions is how a guard change stops being
-reviewable. `SECURITY.md`'s position is unmoved: guard rails, not guarantees — four
+read as one (`env a-b=1 cat <vault>`). Both were live, both were unchanged in either
+direction by this fix, and both are a different question from the one #547 asked — a fix
+that widens its own scope until it is answering three questions is how a guard change stops
+being reviewable. *(Both are closed in this same release, by their own change: see "An
+option is its letter, and an assignment is whatever will do the assigning".)*
+`SECURITY.md`'s position is unmoved: guard rails, not guarantees — four
 rounds of adversarial review established that deciding what a shell will execute, without
 executing it, is not winnable in a Python tokeniser. This was a mis-ordering with a correct
 answer, and it has one now.

--- a/docs/news/unreleased-an-option-is-its-letter-and-an-export-reaches-the-next-segment.md
+++ b/docs/news/unreleased-an-option-is-its-letter-and-an-export-reaches-the-next-segment.md
@@ -1,0 +1,179 @@
+---
+version: unreleased
+headline: An option is its letter, an assignment is whatever will do the assigning, and an `export` reaches the next segment — three vault-reachable bypasses closed
+security: true
+---
+
+Three commands printed a fabricated vault, or moved the plane root's HEAD, on a plane built
+by `charter init` — each while the spelling next to it was refused. All three are the same
+defect wearing three costumes: **a guard matching a spelling instead of the property behind
+it.** That is the seventh time this month, so each fix below names its property and is
+written against that, and each swept its own siblings before stopping.
+
+Measured against the real `charter hook pretooluse`, one command at a time (the decision is
+nested under `hookSpecificOutput`; reading `permissionDecision` from the root answers
+nothing for every input and looks exactly like a guard that has stopped working):
+
+| command | before | after |
+| --- | --- | --- |
+| `cat .charter/vaults/x.json` | DENY | DENY |
+| `env -C .charter/vaults cat x.json` | DENY | DENY |
+| `env a-b=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
+| `env a.b=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
+| `env 1FOO=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
+| `env -- a-b=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
+| `env -Sfoo=1 -Sbar=2 cat .charter/vaults/x.json` | **ALLOW** | DENY |
+| `env -iC.charter/vaults cat x.json` | **ALLOW** | DENY |
+| `env -iC .charter/vaults cat x.json` | **ALLOW** | DENY |
+| `env -viC.charter/vaults cat x.json` | **ALLOW** | DENY |
+| `env -iS'cat .charter/vaults/x.json'` | **ALLOW** | DENY |
+| `sudo -bD.charter/vaults cat x.json` | **ALLOW** | DENY |
+| `env -P /bin cat .charter/vaults/x.json` | **ALLOW** | DENY |
+| `sudo -T 5 cat .charter/vaults/x.json` | **ALLOW** | DENY |
+| `chrt 5 cat .charter/vaults/x.json` | **ALLOW** | DENY |
+| `su-exec root cat .charter/vaults/x.json` | **ALLOW** | DENY |
+| `export GIT_DIR=<plane>/.git && git checkout feature` | **ALLOW** | DENY |
+| `export GIT_SSH_COMMAND=/tmp/k && git push` | **ALLOW** | DENY |
+
+Every row marked ALLOW really did the thing: each `cat` printed
+`{"k":"FABRICATED-NOT-A-REAL-SECRET-9271"}`, the `export GIT_DIR` line moved the plane
+root's HEAD (`git -C <plane> symbolic-ref --short HEAD` answers `feature` afterwards), and
+the hook printed nothing in any of them. The two exceptions are the `chrt` and `su-exec`
+rows: those are Linux tools this machine does not have, so they come from their documented
+grammars rather than from a run here.
+
+## An option is its LETTER, not its position in the token
+
+[#556](https://github.com/diazoxide/charter/issues/556). The parser matched a wrapper's
+value-taking flags with `tok.startswith(flag)`, so it only ever saw a short option written
+**first**. getopt bundles: `-iC<dir>` is `-i -C <dir>`, and `env`'s `-i` takes no value, so
+the `C` after it is the chdir flag and the rest of the token is where the program will run.
+`env -iC.charter/vaults cat x.json` relocated into the vault directory, printed it, and was
+allowed — while `env -C <dir>`, `env -C<dir>` and `env --chdir=<dir>` were all denied. Three
+spellings of one flag refused is what a spelling-shaped guard looks like from the inside.
+
+The guard now walks the letters. Two per-wrapper tables decide each one — the existing
+`_WRAPPER_VALUE_FLAGS` (letters that take a value, consulted **first**) and a new
+`_WRAPPER_NOVALUE_LETTERS` (letters that take none) — and a letter in neither ends the walk
+rather than being guessed at. Guessing "takes a value" swallows the program, which is the
+fail-open `env -i cat <vault>` punishes; guessing "takes none" walks into somebody's data.
+
+**And the end of a walk is no longer silent**, which is the part that stops this being a
+longer list. An option the grammar could not place leaves the program unnamed — a value flag
+nobody has listed is indistinguishable from one that takes nothing — so the rest of the
+segment is reported as files the command may open, and the leak guard asks them the same
+question it asks a reader's operands. The sweep found two live fail-opens of exactly that
+kind and they are the last two vault rows in the table: BSD's `env -P <utilpath>` and
+`sudo -T <n>`, both of which had their value read as the program. They are in the value
+table now *and* covered by the fallback, so the next missing letter is a false negative
+instead of a way in.
+
+**One branch over, the same sweep found a third thing.** `timeout 5 cat <vault>` is the only
+wrapper whose leading *positional* was modelled, and the branch that models it reads as if
+`timeout` were the only wrapper with one. `chrt [options] <priority> <command>` and
+`su-exec <user-spec> <command>` each put an argument of their own in front of the program,
+and the parser named that argument as the program — so `chrt 5 cat <vault>` and
+`su-exec root cat <vault>` were both allowed. Those two are Linux tools rather than macOS
+ones, so unlike every other row above they come from their documented grammars rather than
+from a run on the reporting machine; the guard runs on planes where they exist.
+
+## An assignment is whatever will do the assigning
+
+[#555](https://github.com/diazoxide/charter/issues/555). One constant,
+`^[A-Za-z_][A-Za-z0-9_]*=`, was answering two different parsers' questions. At the front of
+a shell command it is exactly right — bash answers *"a-b=1: command not found"*, so
+`a-b=1 cat <vault>` runs a program with that name and reads nothing. `env` is a different
+parser reading the same bytes: its operand scan is `strchr(arg, '=')`, GNU and BSD alike, so
+**any** argument containing an `=` is an assignment and the scan keeps going until it meets
+one without. The guard stopped at the first token it could not read as a shell identifier
+and called that token the program.
+
+Widening the constant would have moved denials in both directions, because the same
+predicate stands in front of ordinary segments where a token with an `=` is not an
+assignment (`git -c a.b=c …`). So there are two predicates now: the shell's rule stays where
+the shell decides, and a second one is applied only inside the operand scan of a wrapper that
+really does the assigning — `env`, and `sudo`, whose usage prints `[VAR=value]`. Not `doas`,
+whose usage has no assignment operand in it: a table that is fail-closed is still a table,
+and padding it because padding is safe is the same reflex as a longer list of spellings.
+Consuming a token there can only move the
+program rightward, never swallow one, so the fail-closed direction is also the correct one.
+
+## An `export` reaches the next segment
+
+[#496](https://github.com/diazoxide/charter/issues/496). The plane-root guards read
+`GIT_DIR` / `GIT_WORK_TREE` off the env-assignment prefix attached to a git invocation. An
+`export` in an earlier segment of the same command line sets the same variable for the same
+shell and reaches the same git, and nothing read it.
+
+`_plane_root_git` already carried one shell effect across segments — a `cd`. The environment
+a command line establishes is the same shape of carried state, and it is computed once and
+read by **both** plane-root guards and the one-credential guard, because a second
+hand-written copy grows its own blind spots on its own schedule. The shapes modelled are the
+ones a shell really exports with, each checked against bash 5 and zsh: `export NAME=VALUE`;
+`declare -x` / `typeset -x`, whose `x` bundles; `NAME=VALUE` in one segment and `export NAME`
+in a later one; and `set -a`, after which a bare assignment segment is exported too. A bare
+`NAME=VALUE` segment on its own is deliberately **not** — `FOO=1; <child>` leaves `FOO`
+unset in the child, so treating it as an export would be a denial invented out of nothing.
+
+That environment only ever grows. `unset`, `export -n` and a subshell ending are not
+modelled, because forgetting a variable is the direction that opens a door — the same
+invariant `_git_target`'s subject list keeps. The boundary is `cd`'s boundary: a `$(…)`, a
+sourced file, and a `GIT_DIR` already in the session's environment before the hook ran are
+outside it, and for the last one the `PreToolUse` payload carries the command and the cwd,
+not the environment the command will inherit. Those are stated limits with tests on them,
+not gaps.
+
+**The sibling this one found.** The golden rule's one-credential guard reads the same env
+prefix, and had the identical hole:
+`export GIT_SSH_COMMAND=/tmp/k && git push` walked past it while
+`GIT_SSH_COMMAND=/tmp/k git push` was refused. Nobody had reported it. Both guards are wired
+to the same carried environment, so neither can be fixed while the other is left behind —
+which is how `GIT_DIR` came to be refused in one spelling and allowed in the next.
+
+## Three lines deleted, and one table row that had no grammar behind it
+
+`tools/sweep.py` and the hand-check beside it — the sweep has no operator for a string table
+or a parse rule, so those are mutated by hand — killed three guards and a table row, and
+nothing noticed. A differential then showed why for each, and each is gone:
+
+* two guards inside the letter walk. Over 6.9 million `(wrapper, token)` pairs, neither one
+  alone nor both together changes a single answer: a long option's first walked character is
+  the second `-`, which is in no wrapper's no-value letters, so the walk already ends on its
+  first step; and the walk asks `"-" + ch in takes`, which is two characters, so filtering
+  the table down to two-character spellings first could only ever have removed `--` itself.
+* a "skip the flags" branch in the export scan. Every shell-variable key comes from the
+  identifier regex, so a `-…` token can neither be recorded as a variable nor found as one —
+  213,927 segment lists, no divergence.
+* `doas` in the list of wrappers whose operands can be `VAR=value`. Its usage is
+  `doas [-Lns] [-a style] [-C config] [-u user] command [args]`, with no assignment operand
+  in it at all. That one was not equivalent — it was wrong, and it was invented by symmetry
+  with `sudo`. A fail-closed table is still a table.
+
+Every one of those deletions rests on a fact, and every one of those facts is now an
+assertion, because "it happens to be equivalent today" is how a deleted guard comes back to
+life as a bypass.
+
+**The opposite finding is the more useful one**, and there were five: the `()` default on the
+value-flag lookup (without it `nohup -q cat <vault>` raises out of the leak guard, and a
+guard that raises is a guard that is not there); the `and toks` that stops `env -C` at the
+end of a segment popping from an empty list; the `except ValueError` that keeps an
+unbalanced `env -S "cat '<vault>"` from doing the same; the `base == "env"` beside the
+split-string test, without which `xargs -S 4096 cat <vault>` — `xargs` has a `-S` of its own,
+and it means something else — would unpack `4096` as a command and lose the reader; and the
+test that keeps a *separated* value from reporting its whole segment, which is what lets
+`env -C /tmp echo <vault>` stay allowed, because printing a path is not reading a file.
+
+## What did not change
+
+`SECURITY.md`'s position is unmoved: guard rails, not guarantees. Deciding what a shell will
+execute, without executing it, is not winnable in a Python tokeniser, and none of this is an
+attempt to close that class. What it does close is three cases where the guard already
+modelled the thing and was matching one way of writing it — plus the sweep's four, which
+nobody had reported.
+
+Nothing to adopt: upgrading is the whole of it.
+
+[#555](https://github.com/diazoxide/charter/issues/555),
+[#556](https://github.com/diazoxide/charter/issues/556),
+[#496](https://github.com/diazoxide/charter/issues/496), each confirmed live on `main` by
+reproduction against a plane built by `charter init` before anything was changed.

--- a/tests/test_an_export_reaches_the_next_segment.py
+++ b/tests/test_an_export_reaches_the_next_segment.py
@@ -1,0 +1,219 @@
+"""The guards read the environment a command line ESTABLISHES, not the prefix attached to
+one invocation (#496).
+
+`_git_target` learned to read `GIT_DIR` / `GIT_WORK_TREE` from the env-assignment prefix of
+a git invocation in #477 — the form `_split_env` was already holding. An `export` in an
+earlier segment of the same command line sets the same variable for the same shell and
+reaches the same git, and nothing read it.
+
+## The measurement
+
+Verified end to end against git 2.50.1: a plane root on `main`, a shell standing in a
+workspace clone.
+
+    GIT_DIR=<plane>/.git git checkout feature                -> DENY   (as of #477)
+    export GIT_DIR=<plane>/.git && git checkout feature      -> ALLOW  <-- the bypass
+    export GIT_WORK_TREE=<plane> && git checkout feature     -> ALLOW
+    declare -x GIT_DIR=<plane>/.git && git checkout feature  -> ALLOW
+    GIT_DIR=<plane>/.git; export GIT_DIR; git checkout feature -> ALLOW
+    set -a; GIT_DIR=<plane>/.git; git checkout feature       -> ALLOW
+
+and the plane root's HEAD really moved: `git -C <plane> symbolic-ref --short HEAD` answers
+`feature` afterwards, with the hook having printed nothing.
+
+**And the guard next door had it too**, found by sweeping the shape rather than from a
+report — the golden rule's one-credential guard reads the same env prefix:
+
+    GIT_SSH_COMMAND=/tmp/k git push                          -> DENY
+    export GIT_SSH_COMMAND=/tmp/k && git push                -> ALLOW  <-- the sibling
+
+## The property
+
+`_plane_root_git` already carried one shell effect across segments — a `cd`, whose
+destination it tracks in `here` (#183). The environment a command line has set for its later
+segments is the same shape of carried state, and `hooks._exported_env` is it: computed once,
+parallel to the segments, and read by BOTH guards, because a second hand-written copy grows
+its own blind spots on its own schedule.
+
+**The shapes are the ones a shell really exports with**, each checked against bash 5 and
+zsh: `export NAME=VALUE`; `declare -x` / `typeset -x`, which bundle their `x`; `NAME=VALUE`
+in one segment and `export NAME` in a later one; and `set -a`, after which a bare assignment
+segment is exported too. A bare `NAME=VALUE` segment on its own is deliberately NOT
+exported — `FOO=1; <child>` really does leave `FOO` unset in the child, verified — so
+tracking it as an export would be a false denial invented out of nothing.
+
+**This environment only ever GROWS.** `unset`, `export -n` and a subshell ending are not
+modelled: forgetting a variable is the fail-OPEN direction, and a list that gets shorter as
+the command line gets longer is a bypass by construction. It is the same invariant
+`_git_target`'s subject list keeps, and it costs a denial on
+`export GIT_DIR=… && unset GIT_DIR && git checkout feature`.
+
+**The boundary is `cd`'s boundary.** A `$(…)`, a sourced file, a `~/.bashrc`, and a `GIT_DIR`
+already in the session's environment before the hook ran are all outside it — for the last
+one the `PreToolUse` payload carries the command and the cwd, not the environment the
+command will inherit, so there is nothing to read. Stated limits, not gaps, and
+`TestTheStatedLimits` holds them stated.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import hooks
+
+
+def _seg(cmd: str):
+    return hooks._segment_argv(cmd)
+
+
+def _carried(cmd: str) -> list[list[str]]:
+    return hooks._exported_env(_seg(cmd))
+
+
+class TestWhatAShellReallyExports(unittest.TestCase):
+    """`_exported_env` on its own, one row per spelling — because the guards above it can
+    deny for other reasons and a carried env that stopped carrying would not show there."""
+
+    def test_export_with_a_value_reaches_the_next_segment(self):
+        self.assertEqual(_carried("export FOO=1 && git status")[-1], ["FOO=1"])
+
+    def test_a_semicolon_carries_it_as_far_as_an_and(self):
+        self.assertEqual(_carried("export FOO=1; git status")[-1], ["FOO=1"])
+
+    def test_declare_and_typeset_export_only_with_x(self):
+        """`declare -x FOO=1` is `export` spelled another way; `declare FOO=1` is a shell
+        variable and exports nothing. Both verified against bash 5."""
+        self.assertEqual(_carried("declare -x FOO=1 && git status")[-1], ["FOO=1"])
+        self.assertEqual(_carried("typeset -x FOO=1 && git status")[-1], ["FOO=1"])
+        self.assertEqual(_carried("declare FOO=1 && git status")[-1], [])
+
+    def test_the_x_is_a_letter_and_may_be_bundled(self):
+        """`declare -gx FOO=1` — the same walk-the-letters property `_wrapper_option` is."""
+        self.assertEqual(_carried("declare -gx FOO=1 && git status")[-1], ["FOO=1"])
+
+    def test_a_bare_assignment_segment_exports_nothing(self):
+        """The row that keeps this from inventing denials: `FOO=1; <child>` leaves `FOO`
+        unset in the child — verified against bash 5 and zsh. It is a SHELL variable."""
+        self.assertEqual(_carried("FOO=1; git status")[-1], [])
+
+    def test_a_bare_assignment_then_an_export_by_name_does_export(self):
+        self.assertEqual(_carried("FOO=1; export FOO; git status")[-1], ["FOO=1"])
+
+    def test_set_a_exports_the_bare_assignments_after_it(self):
+        """`set -a; FOO=1; <child>` really does export — verified. `set -o allexport` is the
+        same switch spelled long, and `-ax` bundles it."""
+        for prefix in ("set -a", "set -o allexport", "set -ax"):
+            with self.subTest(prefix=prefix):
+                self.assertEqual(
+                    _carried(f"{prefix}; FOO=1; git status")[-1], ["FOO=1"])
+
+    def test_the_environment_is_the_one_in_force_before_each_segment(self):
+        """A parallel list, not one answer for the whole line: the export's own segment has
+        not run yet when the export is read."""
+        carried = _carried("export FOO=1 && export BAR=2 && git status")
+        self.assertEqual(carried, [[], ["FOO=1"], ["FOO=1", "BAR=2"]])
+
+    def test_a_name_without_a_value_is_not_a_shell_variable(self):
+        """`declare GIT_DIR` declares a name and assigns nothing, so a later
+        `export GIT_DIR` has nothing to export.
+
+        Recording it anyway is not harmless bookkeeping: a valueless `GIT_DIR` reaches
+        `_git_target`, which reads it as "the directory I am standing in" and quietly adds
+        the cwd's PARENT to the subjects of every later git command in the line. Found by
+        `tools/sweep.py`, which dropped the `_ENV_ASSIGN_RE` test and watched nothing
+        notice.
+        """
+        self.assertEqual(_carried("declare GIT_DIR; export GIT_DIR; git status")[-1], [])
+        self.assertEqual(_carried("declare FOO BAR; export BAR; git status")[-1], [])
+        self.assertEqual(_carried("declare FOO=1 BAR; export BAR; git status")[-1], [])
+
+    def test_a_flag_cannot_be_mistaken_for_a_variable_name(self):
+        """The reason the export loop needs no "skip the flags" branch, pinned rather than
+        assumed — the branch was there, had no observable consequence over 213,927 segment
+        lists, and was deleted.
+
+        Every key in the shell-variable table comes from `_ENV_ASSIGN_RE`, which is a shell
+        IDENTIFIER: it cannot match a token starting with `-`, so a flag can neither be
+        recorded as a variable nor found as one. If that regex ever admitted a leading `-`,
+        `export -n` would start exporting a variable called `-n`, and the deleted branch
+        would be load-bearing again.
+        """
+        self.assertIsNone(hooks._ENV_ASSIGN_RE.match("-n=1"))
+        self.assertIsNone(hooks._ENV_ASSIGN_RE.match("-x"))
+        self.assertEqual(_carried("export -n FOO && git status")[-1], [])
+        self.assertEqual(_carried("declare -x -- GIT_DIR=/p/.git && git status")[-1],
+                         ["GIT_DIR=/p/.git"])
+
+    def test_it_only_ever_grows(self):
+        """`unset` is not modelled, and that is the fail-CLOSED direction. Pinned so a later
+        round cannot add it without meeting this note first."""
+        self.assertEqual(_carried("export FOO=1 && unset FOO && git status")[-1], ["FOO=1"])
+
+
+class TestThePlaneRootGuardSeesIt(unittest.TestCase):
+    """`_git_target` is handed `carried + segment prefix`, in that order, so an assignment
+    attached to THIS invocation still overrides one an earlier `export` set — which is what
+    git itself does."""
+
+    def test_an_exported_git_dir_names_the_repository(self):
+        carried = _carried("export GIT_DIR=/p/.git && git checkout feature")[-1]
+        targets = [str(t) for t in hooks._git_target("/clone", [], carried)]
+        self.assertIn("/p/.git", targets)
+
+    def test_an_attached_assignment_still_wins_over_an_earlier_export(self):
+        carried = _carried("export GIT_DIR=/p/.git && GIT_DIR=/q/.git git checkout f")[-1]
+        targets = [str(t) for t in
+                   hooks._git_target("/clone", [], carried + ["GIT_DIR=/q/.git"])]
+        self.assertIn("/q/.git", targets)
+        self.assertNotIn("/p/.git", targets)
+
+
+class TestTheGuardNextDoorSeesItToo(unittest.TestCase):
+    """The sibling the sweep found. Both guards read the same carried env, from one place,
+    so neither can be fixed while the other is left behind — which is how `GIT_DIR` came to
+    be refused in one spelling and allowed in the next."""
+
+    def test_an_exported_ssh_command_is_still_a_golden_rule_violation(self):
+        for cmd in ("export GIT_SSH_COMMAND=/tmp/k && git push",
+                    "export GIT_SSH_COMMAND=/tmp/k; git push",
+                    "declare -x GIT_SSH_COMMAND=/tmp/k && git push",
+                    "export GIT_SSH=/tmp/k && git fetch"):
+            with self.subTest(cmd=cmd):
+                reason = hooks._single_credential_reason(cmd)
+                self.assertIsNotNone(reason, cmd)
+                self.assertIn("SSH", reason)
+
+    def test_the_attached_spelling_is_unchanged(self):
+        self.assertIsNotNone(
+            hooks._single_credential_reason("GIT_SSH_COMMAND=/tmp/k git push"))
+
+    def test_an_unrelated_export_is_not_a_violation(self):
+        """The precision half: carrying the environment may not turn every `export` into a
+        credential finding."""
+        self.assertIsNone(hooks._single_credential_reason("export PAGER=cat && git log"))
+
+    def test_the_trigger_shape_still_names_no_value(self):
+        """A guard that exists to keep secrets out of the transcript may not start writing
+        them into the trace because the variable arrived by a different route."""
+        shape, _detail = hooks._single_credential_hit(
+            "export GIT_SSH_COMMAND=/keys/id_rsa && git push")
+        self.assertEqual(shape, "git GIT_SSH_COMMAND=")
+        self.assertNotIn("id_rsa", shape)
+
+
+class TestTheStatedLimits(unittest.TestCase):
+    """Pinned as limits, so a later round meets the reasoning rather than the silence."""
+
+    def test_a_command_substitution_is_not_followed(self):
+        """The same boundary `cd` has: charter models the shell effects it has evidence for
+        in the argv it was handed. A `$(…)` is a segment boundary to `_segment_argv`, so
+        what is carried is the literal text in front of it and never the substitution's
+        RESULT — which is the fail-open direction, and stated rather than hidden."""
+        carried = _carried("export GIT_DIR=$(cat /tmp/p) && git status")[-1]
+        self.assertEqual(carried, ["GIT_DIR=$"])
+        self.assertNotIn("GIT_DIR=/tmp/p", carried)
+
+    def test_an_environment_set_before_the_hook_ran_is_not_visible(self):
+        """The `PreToolUse` payload carries the command and the cwd, not the environment the
+        command will inherit. Nothing to read, so nothing is claimed."""
+        self.assertEqual(_carried("git checkout feature")[-1], [])

--- a/tests/test_an_option_is_its_letter_not_its_position.py
+++ b/tests/test_an_option_is_its_letter_not_its_position.py
@@ -1,0 +1,399 @@
+"""A short option is its LETTER, wherever the letter sits in the token (#556).
+
+`hooks._split_env_chdir` matched a wrapper's value-taking flags with `tok.startswith(flag)`,
+which is a spelling and not the property. getopt BUNDLES short options — `-iC<dir>` is
+`-i -C <dir>` — so the flag the guard already modelled in three other forms was sitting one
+letter in, matched nothing, fell through the generic "starts with `-`, skip it" branch, and
+its value was never recovered.
+
+## The measurement
+
+A plane built by `charter init`, a fabricated value in `.charter/vaults/x.json`, every
+command fed to the real `charter hook pretooluse` (the decision is nested under
+`hookSpecificOutput`; empty stdout is an allow):
+
+    env -C .charter/vaults cat x.json        -> DENY   (control)
+    env -C.charter/vaults cat x.json         -> DENY   (control)
+    env --chdir=.charter/vaults cat x.json   -> DENY   (control)
+    env -iC.charter/vaults cat x.json        -> ALLOW  <-- the bypass
+    env -iC .charter/vaults cat x.json       -> ALLOW  <-- and its separated twin
+    env -viC.charter/vaults cat x.json       -> ALLOW
+    env -iS'cat .charter/vaults/x.json'      -> ALLOW  <-- found by the sweep below
+
+and each of the four really runs: `env -iC.charter/vaults pwd` answers the vault directory,
+`env -viC.charter/vaults cat x.json` and `env -iS'cat …'` both print the fabricated value.
+Three spellings of one flag denied, which is exactly what a spelling-shaped guard looks like
+from the inside.
+
+## The property, and what it costs
+
+**Walk the letters; consult the value table first for every one of them; end the walk at a
+letter neither table places.** That is `hooks._wrapper_option`, and the two tables it reads
+are `_WRAPPER_VALUE_FLAGS` (letters that take a value) and `_WRAPPER_NOVALUE_LETTERS`
+(letters that do not). Both are per-wrapper, because `env -i` takes nothing while
+`stdbuf -i` takes a value and one flat set would swallow the program on `env -i cat <vault>`
+— the fail-open the value table was written per-wrapper to avoid.
+
+**A letter in neither table ends the walk, and since this round the end of a walk is no
+longer silent.** An option this grammar could not place leaves the program unnamed: a value
+flag nobody listed is indistinguishable from one that takes nothing, so `_split_env_chdir`
+reports the rest of the segment as files the command may open and the leak guard asks
+`_names_a_vault_path` of them. That is what keeps a short table a false NEGATIVE rather than
+a bypass — and the sweep found two live fail-opens of exactly that kind, both now in the
+value table as well:
+
+    env -P /bin cat .charter/vaults/x.json   -> ALLOW  (BSD `env -P utilpath`)
+    sudo -T 5 cat .charter/vaults/x.json     -> ALLOW  (`sudo --command-timeout`)
+
+`/bin` and `5` were named as the program, the `cat` was an argument of nothing, and the
+vault was an operand of nothing. A longer list of spellings would have closed those two and
+left the next one open; the fallback is what makes the list an optimisation instead of the
+guard.
+
+`tests/_planeguard._bundled_option` has walked a bundle since `bash -lc` was found to be a
+way past the spawn guard, and its docstring gives the reason in one line — *"a list of
+SPELLINGS is only ever as long as the last audit"*. This is that walk, on the other side of
+the module.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import hooks
+from tests._isolation import PersonaIso, run_hook
+
+VAULT = ".charter/vaults/x.json"
+VAULTS = ".charter/vaults"
+
+#: `(command, must be denied)` — the measurement above, verbatim. The controls are not
+#: padding: they are the three spellings whose denial made a hand probe conclude the flag
+#: was covered, and without them a later refactor can trade one spelling for another and
+#: stay green.
+BUNDLE_ROWS = (
+    (f"cat {VAULT}", True),                                  # the control
+    (f"env -C {VAULTS} cat x.json", True),                   # control: separated
+    (f"env -C{VAULTS} cat x.json", True),                    # control: glued, first
+    (f"env --chdir={VAULTS} cat x.json", True),              # control: long form
+    (f"env -iC{VAULTS} cat x.json", True),                   # #556
+    (f"env -iC {VAULTS} cat x.json", True),                  # #556, separated value
+    (f"env -viC{VAULTS} cat x.json", True),                  # #556, two letters deep
+    (f"env -iS'cat {VAULT}'", True),                         # the sweep's find
+    (f"sudo -bD{VAULTS} cat x.json", True),
+    (f"xargs -0a{VAULT} echo", True),
+    (f"env -P /bin cat {VAULT}", True),                       # the unplaced-flag fallback
+    (f"sudo -T 5 cat {VAULT}", True),
+)
+
+
+def _decision(r) -> str | None:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+class TestEveryBundledSpellingOfOneVaultRead(unittest.TestCase):
+    """`_leak_reason`, the guard's own answer, over the whole table."""
+
+    def test_the_table_still_holds_its_controls(self):
+        """A table that quietly loses the spellings that already denied stops being able to
+        show that a fix traded one spelling for another."""
+        cmds = [c for c, _ in BUNDLE_ROWS]
+        self.assertEqual(len(BUNDLE_ROWS), 12)
+        for control in (f"env -C {VAULTS} cat x.json", f"env -C{VAULTS} cat x.json",
+                        f"env --chdir={VAULTS} cat x.json"):
+            self.assertIn(control, cmds)
+
+    def test_every_row_is_denied(self):
+        for cmd, denied in BUNDLE_ROWS:
+            with self.subTest(cmd=cmd):
+                reason = hooks._leak_reason(cmd)
+                self.assertEqual(reason is not None, denied, cmd)
+                self.assertIn("reads a vault/secret file directly", reason or "")
+
+
+class TestTheSameTableThroughTheRealHook(PersonaIso):
+    """The same rows through `hooks.pretooluse`, which is where they were measured — the
+    JSON a harness acts on, nested under `hookSpecificOutput` (reading `permissionDecision`
+    from the root answers `None` for every input and looks exactly like a guard that has
+    stopped working)."""
+
+    def test_every_row_is_denied_end_to_end(self):
+        for cmd, denied in BUNDLE_ROWS:
+            with self.subTest(cmd=cmd):
+                r = run_hook(hooks.pretooluse,
+                             {"tool_name": "Bash", "tool_input": {"command": cmd},
+                              "session_id": "s"})
+                self.assertEqual(_decision(r), "deny" if denied else None, cmd)
+
+
+class TestTheWalkReadsLettersAndNotTokens(unittest.TestCase):
+    """Stated as the PARSE rather than as the verdict, because a denial arriving from
+    somewhere else — the raw-string arm, the unplaced-flag fallback — can stand in for the
+    walk being right and hide it going wrong."""
+
+    def test_a_bundled_chdir_comes_back_as_the_chdir(self):
+        for tok in ("-iC" + VAULTS, "-viC" + VAULTS, "-0iC" + VAULTS):
+            with self.subTest(tok=tok):
+                _p, _e, _a, chdir, _r = hooks._split_env_chdir(
+                    ["env", tok, "cat", "x.json"])
+                self.assertEqual(chdir, VAULTS)
+
+    def test_a_bundled_value_may_also_be_the_next_token(self):
+        """`env -iC <dir>` really does chdir — verified against this machine's `env`, which
+        answers the named directory for `env -iC /tmp pwd`."""
+        _p, _e, _a, chdir, _r = hooks._split_env_chdir(
+            ["env", "-iC", VAULTS, "cat", "x.json"])
+        self.assertEqual(chdir, VAULTS)
+
+    def test_a_bundled_file_flag_is_still_a_file_the_wrapper_opens(self):
+        """`xargs -a <file>` is not wrapping a read, it IS the read — the only program on
+        the line is `echo`. Bundling it behind `-0` must not lose that."""
+        _p, _e, _a, _c, reads = hooks._split_env_chdir(["xargs", "-0a" + VAULT, "echo"])
+        self.assertIn(VAULT, reads)
+
+    def test_a_bundled_split_string_is_still_unpacked(self):
+        """`env -iS'cat <vault>'` — the packed command is behind a bundled `-i`. Skipping it
+        leaves an empty argv and the guard sees no program at all, which is the fail-open
+        `_SPLIT_STRING_FLAGS` exists against."""
+        prog, _e, argv, _c, _r = hooks._split_env_chdir(["env", "-iScat " + VAULT])
+        self.assertEqual(prog, "cat")
+        self.assertEqual(argv, ["cat", VAULT])
+
+    def test_a_packed_command_that_will_not_tokenize_still_names_its_reader(self):
+        """`env -S` takes a STRING, and a string can be unbalanced. `shlex.split` raises
+        `ValueError` on `cat '<vault>`, and without the fallback to a plain whitespace split
+        that exception leaves the leak guard — a guard that raises is a guard that is not
+        there. Found by `tools/sweep.py`, which narrowed the `except` and watched nothing
+        notice."""
+        import shlex
+        packed = "cat '" + VAULT
+        with self.assertRaises(ValueError):
+            shlex.split(packed)
+        prog, _e, argv, _c, _r = hooks._split_env_chdir(["env", "-S" + packed])
+        self.assertEqual(prog, "cat")
+        self.assertIn(VAULT, " ".join(argv))
+        self.assertIsNotNone(hooks._leak_reason(f'env -S"{packed}"'))
+
+    def test_the_walk_stops_at_a_value_taking_letter(self):
+        """`env -Ci /tmp pwd` answers *"cannot change directory to 'i'"* — the `i` is `-C`'s
+        VALUE, not a bundled flag. A walk that kept going past a value-taking letter would
+        read somebody's data as options."""
+        name, value, wants_next, placed = hooks._wrapper_option("env", "-Ci")
+        self.assertEqual((name, value, wants_next, placed), ("-C", "i", False, True))
+
+    def test_a_letter_neither_table_places_ends_the_walk(self):
+        """Not guessed at in either direction: guessing "takes a value" swallows the
+        program, guessing "takes none" walks into somebody's data."""
+        self.assertEqual(hooks._wrapper_option("env", "-iq"), ("", "", False, False))
+        self.assertEqual(hooks._wrapper_option("env", "-q"), ("", "", False, False))
+
+    def test_a_flag_that_takes_no_value_still_takes_none(self):
+        """The fail-open the per-wrapper tables exist for: `env -i` must not swallow the
+        `cat`, and this is the row that catches a walk that got greedy."""
+        prog, _e, _a, _c, _r = hooks._split_env_chdir(["env", "-i", "cat", VAULT])
+        self.assertEqual(prog, "cat")
+        self.assertEqual(hooks._wrapper_option("env", "-i"), ("", "", False, True))
+
+    def test_end_of_options_is_placed_rather_than_unknown(self):
+        """`--` means "the options stop here" and nothing else. Leaving it to the walk would
+        report the whole rest of the segment as reachable for a token that names no flag."""
+        self.assertEqual(hooks._wrapper_option("env", "--"), ("", "", False, True))
+
+    def test_a_long_option_is_still_read_as_a_long_form(self):
+        """The letter walk may not start eating long options because they happen to contain
+        a short flag's letters — `--chdir` holds `C`'s neighbours and is not a bundle."""
+        name, value, _w, placed = hooks._wrapper_option("env", "--chdir=" + VAULTS)
+        self.assertEqual((name, value, placed), ("--chdir", VAULTS, True))
+        self.assertEqual(hooks._wrapper_option("env", "--not-a-flag"),
+                         ("", "", False, False))
+
+    def test_a_flag_whose_value_is_missing_does_not_take_one(self):
+        """`env -C` at the end of a segment has no next token to take. Popping one anyway
+        raises `IndexError` inside the leak guard, and a guard that raises is a guard that
+        is not there. Found by the hand-check, which killed the `and toks` conjunct and
+        watched nothing notice."""
+        self.assertEqual(hooks._split_env_chdir(["env", "-C"]), ("", [], [], "", []))
+        self.assertIsNone(hooks._leak_reason("env -C"))
+        self.assertIsNone(hooks._leak_reason("sudo -u"))
+
+    def test_a_wrapper_with_no_value_flags_at_all_is_still_walked(self):
+        """`_WRAPPER_VALUE_FLAGS` has no entry for these, and the walk still runs for them:
+        the `()` default is what makes `takes` a sequence rather than `None`. Without it
+        `nohup -q cat <vault>` raises `TypeError` out of the leak guard — which the hand-
+        check found and no test did, because every wrapper the suite exercised happened to
+        be in the table."""
+        for wrapper in ("nohup", "setsid", "command", "builtin", "unbuffer"):
+            with self.subTest(wrapper=wrapper):
+                self.assertNotIn(wrapper, hooks._WRAPPER_VALUE_FLAGS)
+                self.assertIn(wrapper, hooks._WRAPPERS)
+                self.assertIsNotNone(hooks._leak_reason(f"{wrapper} -q cat {VAULT}"))
+
+
+class TestTheWalkNeedsNoFilterOfItsOwn(unittest.TestCase):
+    """Two lines that guarded the walk were **deleted** rather than left unpinned.
+
+    The hand-check killed each of them and nothing noticed; a differential over 6.9M
+    `(wrapper, token)` pairs then showed why — neither alone nor both together changes a
+    single answer. So they are gone, and the two facts that make them unnecessary are
+    asserted here instead, because "it happens to be equivalent today" is how a deleted
+    guard becomes a bypass tomorrow.
+    """
+
+    def test_no_no_value_table_places_a_dash(self):
+        """This is what makes the deleted `tok.startswith("--")` early return unnecessary: a
+        long option's first walked character is the second `-`, and a `-` in one of these
+        strings would make the walk step over it and start reading a long option's letters
+        as a bundle."""
+        for wrapper, letters in hooks._WRAPPER_NOVALUE_LETTERS.items():
+            with self.subTest(wrapper=wrapper):
+                self.assertNotIn("-", letters)
+
+    def test_no_value_table_holds_a_bare_double_dash(self):
+        """And this is what makes the deleted `len(f) == 2 and not f.startswith("--")`
+        filter unnecessary: the walk asks `"-" + ch in takes`, which is two characters, so
+        the only spelling the filter could ever have removed is `--` itself."""
+        for wrapper, flags in hooks._WRAPPER_VALUE_FLAGS.items():
+            with self.subTest(wrapper=wrapper):
+                self.assertNotIn("--", flags)
+        self.assertNotIn("--", hooks._SPLIT_STRING_FLAGS)
+
+    def test_a_long_option_ends_the_walk_unplaced(self):
+        """The behaviour the two deletions have to preserve, stated directly."""
+        for wrapper in sorted(hooks._WRAPPER_NOVALUE_LETTERS):
+            for tok in ("--nonesuch", "--chdir-ish", "---", "--0i"):
+                with self.subTest(wrapper=wrapper, tok=tok):
+                    self.assertEqual(hooks._wrapper_option(wrapper, tok),
+                                     ("", "", False, False))
+
+
+class TestTheTwoLetterTablesCannotDisagree(unittest.TestCase):
+    """The value table is consulted FIRST for every letter in the walk, so a letter in both
+    tables would behave as value-taking and the no-value entry would be dead. That is a
+    silent way for an audit to be wrong, so the tables are held apart instead."""
+
+    def test_no_letter_is_in_both_tables_for_the_same_wrapper(self):
+        for wrapper, letters in hooks._WRAPPER_NOVALUE_LETTERS.items():
+            valued = {f[1] for f in hooks._WRAPPER_VALUE_FLAGS.get(wrapper, ())
+                      if len(f) == 2 and not f.startswith("--")}
+            with self.subTest(wrapper=wrapper):
+                self.assertEqual(valued & set(letters), set(),
+                                 f"{wrapper}: a letter in both tables — the no-value entry "
+                                 f"is dead code and the audit that added it is wrong")
+
+    def test_every_no_value_table_names_a_wrapper_this_module_strips(self):
+        """A table keyed on a name `_WRAPPERS` does not hold is never read, and a walk that
+        is never read looks exactly like one that works."""
+        for wrapper in hooks._WRAPPER_NOVALUE_LETTERS:
+            self.assertIn(wrapper, hooks._WRAPPERS, wrapper)
+
+
+class TestAnOptionThisGrammarCannotPlaceIsNotALicenceToStopLooking(unittest.TestCase):
+    """The fallback, stated on its own — because the two rows it was found by are now in the
+    value table, and a fix that only added them would leave the NEXT missing letter a bypass
+    rather than a false negative.
+
+    A flag charter has never heard of, taking a value it has never heard of, standing in
+    front of a vault read."""
+
+    def test_an_unknown_wrapper_flag_leaves_the_rest_of_the_segment_reachable(self):
+        _p, _e, _a, _c, reads = hooks._split_env_chdir(
+            ["env", "--not-a-real-flag", "/bin", "cat", VAULT])
+        self.assertIn(VAULT, reads)
+        self.assertIsNotNone(hooks._leak_reason(f"env --not-a-real-flag /bin cat {VAULT}"))
+
+    def test_a_flag_the_sweep_added_is_PLACED_and_not_merely_caught(self):
+        """The four value flags this round added were each a live fail-open — the flag's
+        value was named as the program — and each is now covered TWICE: by the table, and by
+        the fallback standing behind it.
+
+        **That is exactly the shape where a test can pass for the wrong reason.** The
+        fallback alone gets the vault row right, so a row asserting only the denial stays
+        green with the table entry deleted — which is what the hand-check found for all four
+        of them. What the entry actually buys is PRECISION: with the flag placed, the guard
+        trusts the program after it, and `echo <vault>` stays allowed, because printing a
+        path is not reading a file. Both halves are asserted, so deleting an entry fails
+        here rather than quietly widening the guard.
+        """
+        for wrapper, flag, value in (("env", "-P", "/bin"), ("sudo", "-T", "5"),
+                                     ("doas", "-a", "style"), ("xargs", "-J", "%"),
+                                     ("xargs", "-R", "2"), ("xargs", "-S", "4096")):
+            with self.subTest(wrapper=wrapper, flag=flag):
+                self.assertIn(flag, hooks._WRAPPER_VALUE_FLAGS[wrapper])
+                self.assertIsNotNone(
+                    hooks._leak_reason(f"{wrapper} {flag} {value} cat {VAULT}"))
+                self.assertIsNone(
+                    hooks._leak_reason(f"{wrapper} {flag} {value} echo {VAULT}"))
+
+    def test_the_fallback_does_not_deny_a_command_that_names_nothing_guarded(self):
+        """It reports paths the command MAY open; the leak guard still asks the same
+        `_names_a_vault_path` of them it asks of a reader's operands. An unknown flag is not
+        by itself a reason to refuse anything."""
+        self.assertIsNone(hooks._leak_reason("env --not-a-real-flag /bin cat notes.md"))
+
+    def test_a_placed_flag_does_not_trip_the_fallback(self):
+        """Otherwise every wrapped command would carry its whole argv into `reads` and the
+        distinction this class rests on would not exist."""
+        _p, _e, _a, _c, reads = hooks._split_env_chdir(["env", "-i", "cat", "notes.md"])
+        self.assertEqual(reads, [])
+
+    def test_only_a_BUNDLED_separated_value_reports_the_rest_of_the_segment(self):
+        """The precision the `nxt != name` test buys, which the hand-check killed and
+        nothing noticed.
+
+        A flag written on its own — `env -C <dir>`, `env --chdir <dir>` — is placed exactly,
+        so the guard trusts the program after it and `echo <vault>` stays allowed: printing
+        a path is not reading a file. The same flag found INSIDE a bundle is a guess about
+        one letter's arity, so the rest of the segment stays reachable and the same `echo`
+        is refused. Without the test, every separated value would report its whole segment
+        and the difference would be invisible.
+        """
+        self.assertIsNone(hooks._leak_reason(f"env -C /tmp echo {VAULT}"))
+        self.assertIsNone(hooks._leak_reason(f"env --chdir /tmp echo {VAULT}"))
+        self.assertIsNone(hooks._leak_reason(f"sudo -u root echo {VAULT}"))
+        self.assertIsNotNone(hooks._leak_reason(f"env -iC /tmp echo {VAULT}"))
+
+
+class TestAWrappersOwnOperandIsNotTheProgram(unittest.TestCase):
+    """The third thing this sweep found, and it is the same shape one branch over.
+
+    `timeout 5 cat <vault>` was the only wrapper whose leading POSITIONAL was modelled, and
+    the branch that models it reads as if `timeout` were the only wrapper with one. Two more
+    put an argument of their own in front of the program, and the parser named that argument
+    as the program:
+
+        chrt 5 cat .charter/vaults/x.json        -> ALLOW, `5` read as the program
+        su-exec root cat .charter/vaults/x.json  -> ALLOW, `root` read as the program
+
+    Both are Linux tools rather than macOS ones, so these are by construction from their
+    documented grammars (`chrt [options] <priority> <command>`,
+    `su-exec <user-spec> <command>`) rather than reproduced on this machine — the guard runs
+    on planes where they exist.
+    """
+
+    def test_the_operand_is_stepped_over_and_the_program_is_found(self):
+        for cmd in (f"chrt 5 cat {VAULT}", f"su-exec root cat {VAULT}",
+                    f"chrt -r 5 cat {VAULT}", f"timeout 5 cat {VAULT}"):
+            with self.subTest(cmd=cmd):
+                self.assertIsNotNone(hooks._leak_reason(cmd), cmd)
+
+    def test_only_the_documented_number_of_operands_is_taken(self):
+        """One each. Taking two would step over the program itself, which is the fail-open
+        direction and the reason this is a count per wrapper and not a `while`."""
+        self.assertEqual(hooks._split_env(["chrt", "5", "cat", VAULT])[0], "cat")
+        self.assertEqual(hooks._split_env(["su-exec", "root", "cat", VAULT])[0], "cat")
+
+    def test_a_wrapper_with_no_leading_operand_is_untouched(self):
+        """`nohup cat <vault>` has no argument of its own, and stepping over one would name
+        the vault path as the program and lose the reader."""
+        for wrapper in ("nohup", "setsid", "unbuffer", "command"):
+            with self.subTest(wrapper=wrapper):
+                self.assertEqual(hooks._split_env([wrapper, "cat", VAULT])[0], "cat")
+                self.assertNotIn(wrapper, hooks._WRAPPER_LEADING_OPERANDS)
+
+    def test_timeout_keeps_its_own_rule(self):
+        """`timeout` is deliberately NOT in the table. Its operand is matched rather than
+        counted, and `tests/test_the_end_of_a_name_is_the_end_of_the_string.py` holds
+        `_DURATION_RE` to what a tightened version of it would answer (#577) — a bare count
+        would make that measurement unreachable, since a count never looks at the token."""
+        self.assertNotIn("timeout", hooks._WRAPPER_LEADING_OPERANDS)
+        self.assertEqual(hooks._split_env_chdir(["timeout", "notaduration", "cat"])[0],
+                         "notaduration")

--- a/tests/test_guard_attached_option_values.py
+++ b/tests/test_guard_attached_option_values.py
@@ -39,15 +39,19 @@ so the answer cannot depend on which one a reviewer happened to try.
 **What this file does NOT claim.** `SECURITY.md` says guard rails, not guarantees, and
 deciding what a shell will execute without executing it is not winnable in a Python
 tokeniser. This is one mis-ordering with a correct answer — getopt gives a short option
-everything glued after it, `=` included — not an attempt to close the class. Two neighbours
-found while measuring this one are NOT fixed here and are filed rather than pinned as
-limits, because they are defects and not decisions: #556, a value attached to a BUNDLED
-short option (`env -iC<dir> cat x.json`), and #555, `env` accepting assignments to names
-that are not shell identifiers while this parser stops at the first token it cannot read as
-one (`env a-b=1 cat <vault>`). Both are live on `main` and both are unchanged by this fix,
-in either direction. They are deliberately absent from the tables below: a row asserting
-today's ALLOW would have to be deleted by whoever closes them, and a test that has to be
-deleted to make a fix pass teaches the wrong reflex.
+everything glued after it, `=` included — not an attempt to close the class.
+
+**The two neighbours found while measuring this one are closed now, and they have their own
+files** rather than rows here, because each is its own property and this table is #547's
+measurement verbatim:
+
+* #556 — a value attached to a BUNDLED short option (`env -iC<dir> cat x.json`).
+  `tests/test_an_option_is_its_letter_not_its_position.py`. The `bundled` spelling in
+  `TestEveryFlagWhoseValueCanBeAttached` below is that fix crossed with this file's axis,
+  which is where the two meet.
+* #555 — `env` accepting assignments to names that are not shell identifiers while this
+  parser stopped at the first token it could not read as one (`env a-b=1 cat <vault>`).
+  `tests/test_the_assignment_rule_belongs_to_the_parser.py`.
 """
 
 from __future__ import annotations
@@ -153,10 +157,12 @@ class TestTheSixSpellingsThroughTheRealHook(PersonaIso):
 #: `(wrapper, flag whose value may be attached, what the value has to reach)`. One row per
 #: flag in `_WRAPPER_CHDIR_FLAGS`/`_WRAPPER_READ_FLAGS` — the two tables where a LOST value
 #: is a lost denial rather than a cosmetic misparse.
+#: The fifth field is a letter of the SAME wrapper that takes no value, so the flag can be
+#: bundled behind it — #556's spelling, crossed with this file's axis.
 ATTACHED_VALUE_FLAGS = (
-    ("env", "-C", "--chdir", "cat x.json"),
-    ("sudo", "-D", "--chdir", "cat x.json"),
-    ("xargs", "-a", "--arg-file", "echo"),
+    ("env", "-C", "--chdir", "cat x.json", "i"),
+    ("sudo", "-D", "--chdir", "cat x.json", "b"),
+    ("xargs", "-a", "--arg-file", "echo", "0"),
 )
 
 
@@ -169,20 +175,35 @@ class TestEveryFlagWhoseValueCanBeAttached(unittest.TestCase):
     four name the same file; the `=` in it is the whole point.
     """
 
-    def _cmds(self, wrapper: str, short: str, long: str, tail: str):
+    def _cmds(self, wrapper: str, short: str, long: str, tail: str, lead: str):
         target = ".charter/vaults" if wrapper != "xargs" else VAULT
         return {
             "separated": f"{wrapper} {short} {target} {tail}",
             "glued": f"{wrapper} {short}{target} {tail}",
             "long with =": f"{wrapper} {long}={target} {tail}",
             "glued, = in the value": f"{wrapper} {short}x=y/../{target} {tail}",
+            # #556: the same flag, one letter in. `-iC<dir>` is `-i -C <dir>` to getopt, and
+            # a reader that matches by `tok.startswith(flag)` sees a short option only when
+            # it is written first.
+            "bundled, glued": f"{wrapper} -{lead}{short[1:]}{target} {tail}",
+            "bundled, separated": f"{wrapper} -{lead}{short[1:]} {target} {tail}",
         }
 
     def test_every_spelling_is_denied(self):
-        for wrapper, short, long, tail in ATTACHED_VALUE_FLAGS:
-            for spelling, cmd in self._cmds(wrapper, short, long, tail).items():
+        for wrapper, short, long, tail, lead in ATTACHED_VALUE_FLAGS:
+            for spelling, cmd in self._cmds(wrapper, short, long, tail, lead).items():
                 with self.subTest(wrapper=wrapper, spelling=spelling):
                     self.assertIsNotNone(hooks._leak_reason(cmd), cmd)
+
+    def test_the_bundling_letter_really_takes_no_value(self):
+        """Non-vacuity for the two rows above: if `lead` took a value of its own, the
+        `bundled` spellings would be testing a different command than they claim and would
+        pass for the wrong reason."""
+        for wrapper, _short, _long, _tail, lead in ATTACHED_VALUE_FLAGS:
+            with self.subTest(wrapper=wrapper):
+                self.assertIn(lead, hooks._WRAPPER_NOVALUE_LETTERS[wrapper])
+                self.assertNotIn(
+                    "-" + lead, hooks._WRAPPER_VALUE_FLAGS.get(wrapper, ()))
 
     def test_the_value_itself_comes_back_whole(self):
         """Stated as the parse, because "denied" can be true for the wrong reason. A short

--- a/tests/test_plane_root_checkout_is_two_commands.py
+++ b/tests/test_plane_root_checkout_is_two_commands.py
@@ -735,6 +735,22 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
                f"GIT_DIR={self.root}/.git git {tail}")
         yield ("GIT_WORK_TREE in the environment", self.clone,
                f"GIT_WORK_TREE={self.root} GIT_DIR={self.root}/.git git {tail}")
+        # #496: the SAME variable, set by an earlier segment of the SAME command line
+        # instead of attached to the invocation. The attached spelling was refused as of
+        # #477 and this one was allowed — verified end to end against git 2.50.1, the plane
+        # root's HEAD moved and the hook printed nothing. `_exported_env` is the carried
+        # state that answers them together; every shape a shell really exports with is a
+        # route, because "a list of the ones somebody thought of" is what #477 already was.
+        yield ("GIT_DIR exported by an earlier segment", self.clone,
+               f"export GIT_DIR={self.root}/.git && git {tail}")
+        yield ("GIT_WORK_TREE exported by an earlier segment", self.clone,
+               f"export GIT_WORK_TREE={self.root}; git {tail}")
+        yield ("GIT_DIR assigned, then exported by name", self.clone,
+               f"GIT_DIR={self.root}/.git; export GIT_DIR; git {tail}")
+        yield ("GIT_DIR exported by declare -x", self.clone,
+               f"declare -x GIT_DIR={self.root}/.git && git {tail}")
+        yield ("GIT_DIR exported by set -a", self.clone,
+               f"set -a; GIT_DIR={self.root}/.git; git {tail}")
 
     def test_a_head_move_is_denied_by_every_route(self):
         movers = []
@@ -754,7 +770,7 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
         # would leave every remaining assertion green while covering less than it did.
         self.assertGreaterEqual(len(movers), 8, movers)
         labels = {label for label, _cwd, _cmd in self.routes("checkout", "feature")}
-        self.assertGreaterEqual(len(labels), 20, sorted(labels))
+        self.assertGreaterEqual(len(labels), 25, sorted(labels))
         for must in ("--git-dir, separated", "--git-dir=, attached",
                      "--work-tree and --git-dir", "--git-dir relative to a -C",
                      "GIT_DIR in the environment", "GIT_WORK_TREE in the environment",
@@ -763,7 +779,16 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
                      # both of these were live bypasses that a generous floor would hide.
                      "--work-tree alone", "--work-tree elsewhere, from the ROOT",
                      "GIT_WORK_TREE elsewhere, from the ROOT",
-                     "--git-dir through a .. segment", "GIT_DIR through a .. segment"):
+                     "--git-dir through a .. segment", "GIT_DIR through a .. segment",
+                     # Round six (#496). Named individually for the same reason: each is a
+                     # shell spelling a real shell exports with, and the guard reads the
+                     # environment a command line ESTABLISHES rather than a list of the
+                     # spellings that establish it.
+                     "GIT_DIR exported by an earlier segment",
+                     "GIT_WORK_TREE exported by an earlier segment",
+                     "GIT_DIR assigned, then exported by name",
+                     "GIT_DIR exported by declare -x",
+                     "GIT_DIR exported by set -a"):
             self.assertIn(must, labels)
 
     def test_a_restore_is_allowed_by_every_route(self):
@@ -1075,10 +1100,30 @@ PINNED: tuple[tuple[str, str, str, str], ...] = (
     #     HEAD and is not refused. Pinned as facts rather than left as silent gaps, each
     #     naming the issue that tracks it. Closing one turns its row RED, which is the
     #     point: a limit should not disappear without somebody noticing and saying so.
-    ("ALLOW", "clone", "export GIT_DIR={root}/.git && git checkout feature",
-     "LIMIT #496: the shared walk carries a `cd` across segments and not an env assignment, "
-     "so the ATTACHED spelling `GIT_DIR=… git …` is refused (#477) and this one is not. "
-     "git: Switched to branch 'feature', and the root's symbolic-ref follows"),
+    # #496 CLOSED. This row was recorded as a limit — the shared walk carried a `cd` across
+    # segments and not an env assignment, so the ATTACHED spelling `GIT_DIR=… git …` was
+    # refused (#477) and the exported one was not. `_exported_env` carries the environment a
+    # command line establishes, so both reach the same `_git_target`. Flipped rather than
+    # deleted, for the reason the #430 rows below were.
+    ("DENY", "clone", "export GIT_DIR={root}/.git && git checkout feature",
+     "#496: an `export` reaches the next segment, and now the guard reads it"),
+    ("DENY", "clone", "export GIT_WORK_TREE={root}; git checkout feature",
+     "#496: the other repository-naming variable, and a `;` carries as far as an `&&`"),
+    ("DENY", "clone", "declare -x GIT_DIR={root}/.git && git checkout feature",
+     "#496: `declare -x` is `export` spelled another way, and its `x` bundles"),
+    ("DENY", "clone", "GIT_DIR={root}/.git; export GIT_DIR; git checkout feature",
+     "#496: a shell variable exported by name in a later segment"),
+    ("DENY", "clone", "set -a; GIT_DIR={root}/.git; git checkout feature",
+     "#496: under `set -a` a bare assignment segment IS exported — verified against bash"),
+    ("ALLOW", "clone", "GIT_DIR={root}/.git; git checkout feature",
+     "the precision half of #496: a bare assignment segment exports NOTHING — "
+     "`FOO=1; <child>` leaves FOO unset in the child, verified — so git never sees it"),
+    ("ALLOW", "clone",
+     "export GIT_DIR={root}/.git && GIT_DIR={clone}/.git git checkout feature",
+     "the other precision half: an assignment ATTACHED to the invocation overrides one an "
+     "earlier `export` set, which is git's own rule. The carried environment is passed "
+     "BEFORE the segment's own prefix for exactly this; swapping the two makes this row "
+     "red and nothing else, which is how a hand-check found it unpinned"),
     # #430 CLOSED. These six rows were recorded as limits — `prog` came from token 0, so a
     # wrapper word or a shell keyword standing in front of `git` hid it from every guard in
     # the module. `_split_env_chdir` strips the wrapper run before naming the program and
@@ -1226,7 +1271,9 @@ class TestThePinnedCorpusIsTheBaseline(CheckoutCase):
     #: to lower the number, which is indistinguishable from a limit quietly reappearing. An
     #: exact set fails in BOTH directions and says which issue moved: closing one leaves an
     #: issue listed here with no row, and adding one leaves a row citing an issue not here.
-    LIMIT_ISSUES = {"#430", "#496"}
+    #: #496 left this set in round six: `_exported_env` carries what a command line exports
+    #: into its later segments, so the row that recorded it moved to DENY above.
+    LIMIT_ISSUES = {"#430"}
 
     def test_every_known_limit_names_the_issue_that_tracks_it(self):
         """A limit with no issue behind it is a gap somebody decided to live with and then
@@ -1258,7 +1305,11 @@ class TestThePinnedCorpusIsTheBaseline(CheckoutCase):
                      "alias", "ambig", "notes/a.md", "$(echo",
                      # Round five's axes: #483's separated short `-C`, and #477's three
                      # spellings of "the repository is over there".
-                     "--git-dir=", "--git-dir ", "--work-tree", "GIT_DIR=", "GIT_WORK_TREE="):
+                     "--git-dir=", "--git-dir ", "--work-tree", "GIT_DIR=", "GIT_WORK_TREE=",
+                     # Round six's axis (#496): the environment a command line ESTABLISHES
+                     # for its later segments, in every shape a shell really exports with.
+                     "export GIT_DIR", "export GIT_WORK_TREE", "declare -x", "set -a;",
+                     "export GIT_DIR;"):
             with self.subTest(axis=axis):
                 self.assertIn(axis, commands, f"no row covers {axis!r} any more")
 

--- a/tests/test_the_assignment_rule_belongs_to_the_parser.py
+++ b/tests/test_the_assignment_rule_belongs_to_the_parser.py
@@ -1,0 +1,197 @@
+"""What counts as an assignment is decided by the parser that will do the assigning (#555).
+
+`hooks._ENV_ASSIGN_RE` is `^[A-Za-z_][A-Za-z0-9_]*=` — a shell IDENTIFIER — and one constant
+was answering two different parsers' questions with it.
+
+For the front of a segment the identifier rule is exactly right, and that is not an
+accident of taste: bash answers *"a-b=1: command not found"*, so `a-b=1 cat <vault>` runs a
+program literally named `a-b=1` and reads nothing. Widening the constant everywhere would
+have moved denials in both directions, because the same predicate stands in front of
+ordinary segments where a token containing `=` is not an assignment at all (`git -c
+a.b=c …`, an operand carrying a query string).
+
+`env` is a different parser reading the same bytes. Its operand scan is `strchr(arg, '=')`
+— GNU coreutils and BSD alike — so ANY argument containing an `=` is an assignment, and the
+scan keeps going until it meets one without. The guard stopped at the first token it could
+not read as a shell identifier and named that token the program.
+
+## The measurement
+
+A plane built by `charter init`, a fabricated value in `.charter/vaults/x.json`, every
+command fed to the real `charter hook pretooluse` (the decision is nested under
+`hookSpecificOutput`; empty stdout is an allow):
+
+    cat .charter/vaults/x.json                       -> DENY   (control)
+    env FOO=1 cat .charter/vaults/x.json             -> DENY   (control)
+    env a-b=1 cat .charter/vaults/x.json             -> ALLOW
+    env a.b=1 cat .charter/vaults/x.json             -> ALLOW
+    env 1FOO=1 cat .charter/vaults/x.json            -> ALLOW
+    env 'x y=1' cat .charter/vaults/x.json           -> ALLOW
+    env a=1 b-c=2 cat .charter/vaults/x.json         -> ALLOW
+    env -- a-b=1 cat .charter/vaults/x.json          -> ALLOW
+    env -Sfoo=1 -Sbar=2 cat .charter/vaults/x.json   -> ALLOW
+
+Every one of the seven printed `{"k":"FABRICATED-NOT-A-REAL-SECRET-9271"}` on this machine
+(macOS 15, BSD `env`). The last row is the one wearing #547's clothes: after `-Sfoo=1`
+unpacks, `env` has left its option scan, and `-Sbar=2` is an assignment to a variable
+literally named `-Sbar` — confirmed, `env -Sfoo=1 -Sbar=2 sh -c 'echo $foo $bar'` prints
+`1` and an empty `bar` while the `cat` runs.
+
+## The property
+
+**Two parsers, two predicates.** `_ENV_ASSIGN_RE` stays where the SHELL decides — the front
+of a segment, `_invocation`, the trace's redaction — and `_WRAPPER_ASSIGN_OPERANDS` names
+the wrappers whose own operand scan takes any `name=value`, applied only inside that
+wrapper's argv. Neither question is answered with the other's constant, so widening one
+cannot move the other.
+
+Consuming a token there is the fail-CLOSED direction — it moves the program rightward and
+can never swallow one — which is why the second `-S…` above is read as one more `-S` rather
+than modelled as the assignment `env` makes of it: unpacking it reaches the same verdict on
+a command that RUNS, and `tests/test_guard_differential.py` forbids denying less than
+`origin/main` in any case.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import hooks
+from tests._isolation import PersonaIso, run_hook
+
+VAULT = ".charter/vaults/x.json"
+
+#: `(command, must be denied)` — the measurement above, verbatim. The two controls are the
+#: neighbours whose denial made the guard look present.
+ASSIGNMENT_ROWS = (
+    (f"cat {VAULT}", True),                              # the control
+    (f"env FOO=1 cat {VAULT}", True),                    # control: a shell identifier
+    (f"env a-b=1 cat {VAULT}", True),                    # #555, as filed
+    (f"env a.b=1 cat {VAULT}", True),
+    (f"env 1FOO=1 cat {VAULT}", True),
+    (f"env 'x y=1' cat {VAULT}", True),
+    (f"env a=1 b-c=2 cat {VAULT}", True),                # a valid one first
+    (f"env -- a-b=1 cat {VAULT}", True),                 # past end-of-options
+    (f"env -Sfoo=1 -Sbar=2 cat {VAULT}", True),          # #555, second row
+    (f"sudo a-b=1 cat {VAULT}", True),                   # `sudo [VAR=value]`, same scan
+)
+
+
+def _decision(r) -> str | None:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+class TestEveryAssignmentSpellingOfOneVaultRead(unittest.TestCase):
+    def test_the_table_still_holds_its_controls(self):
+        cmds = [c for c, _ in ASSIGNMENT_ROWS]
+        self.assertEqual(len(ASSIGNMENT_ROWS), 10)
+        self.assertIn(f"env FOO=1 cat {VAULT}", cmds)
+        self.assertIn(f"cat {VAULT}", cmds)
+
+    def test_every_row_is_denied(self):
+        for cmd, denied in ASSIGNMENT_ROWS:
+            with self.subTest(cmd=cmd):
+                reason = hooks._leak_reason(cmd)
+                self.assertEqual(reason is not None, denied, cmd)
+                self.assertIn("reads a vault/secret file directly", reason or "")
+
+
+class TestTheSameTableThroughTheRealHook(PersonaIso):
+    def test_every_row_is_denied_end_to_end(self):
+        for cmd, denied in ASSIGNMENT_ROWS:
+            with self.subTest(cmd=cmd):
+                r = run_hook(hooks.pretooluse,
+                             {"tool_name": "Bash", "tool_input": {"command": cmd},
+                              "session_id": "s"})
+                self.assertEqual(_decision(r), "deny" if denied else None, cmd)
+
+
+class TestTheTwoPredicatesStayApart(unittest.TestCase):
+    """The half of the fix that is about NOT widening: one constant answering two parsers is
+    the defect, so replacing it with one WIDER constant would be the same defect."""
+
+    def test_the_shell_rule_is_still_a_shell_identifier(self):
+        """At the front of a segment `a-b=1` is a program name, because that is what bash
+        makes of it — *"a-b=1: command not found"*, verified. A guard that read it as an
+        assignment there would name `cat` as the program of a command that never runs."""
+        self.assertIsNone(hooks._ENV_ASSIGN_RE.match("a-b=1"))
+        self.assertIsNone(hooks._ENV_ASSIGN_RE.match("1FOO=1"))
+        self.assertIsNotNone(hooks._ENV_ASSIGN_RE.match("FOO=1"))
+        self.assertEqual(hooks._split_env(["a-b=1", "cat", VAULT])[0], "a-b=1")
+
+    def test_a_wrapper_with_no_assignment_operands_keeps_the_shell_rule(self):
+        """`nice a-b=1 cat <vault>` execs a program named `a-b=1` and reads nothing — `nice`
+        has no `[VAR=value]` in its grammar. The wide rule is scoped to the wrappers that
+        really do the assigning, not applied to every wrapper because it is convenient.
+
+        **`doas` is the row that made this a test rather than a comment.** It was in the
+        table for a round on the assumption that it is `sudo` with a shorter name; its usage
+        is `doas [-Lns] [-a style] [-C config] [-u user] command [args]`, with no assignment
+        operand in it. A hand-check deleted the entry and no test noticed, which is what a
+        table row with no grammar behind it looks like — and padding a fail-closed table
+        because it is fail-closed is the same reflex as padding a list of spellings.
+        """
+        for wrapper in ("nice", "doas", "timeout", "xargs", "nohup"):
+            with self.subTest(wrapper=wrapper):
+                self.assertNotIn(wrapper, hooks._WRAPPER_ASSIGN_OPERANDS)
+                self.assertEqual(
+                    hooks._split_env([wrapper, "a-b=1", "cat", VAULT])[0], "a-b=1")
+        self.assertEqual(hooks._WRAPPER_ASSIGN_OPERANDS, frozenset(("env", "sudo")))
+
+    def test_every_assignment_wrapper_is_one_this_module_strips(self):
+        for wrapper in hooks._WRAPPER_ASSIGN_OPERANDS:
+            self.assertIn(wrapper, hooks._WRAPPERS, wrapper)
+
+    def test_a_git_config_flag_is_still_gits_option_and_not_an_assignment(self):
+        """The false-positive direction the issue warned about. `git -c a.b=c <sub>` carries
+        an `=` in a token that is an option VALUE; nothing here may start reading it as an
+        environment assignment."""
+        prog, env, argv = hooks._split_env(["git", "-c", "a.b=c", "status"])
+        self.assertEqual((prog, env), ("git", []))
+        self.assertEqual(argv, ["git", "-c", "a.b=c", "status"])
+
+
+class TestTheParseAndNotJustTheVerdict(unittest.TestCase):
+    """A denial can arrive from somewhere else — the raw-string arm, the unplaced-flag
+    fallback — so the rows above are restated as the parse they depend on."""
+
+    def test_a_name_that_is_not_an_identifier_is_still_an_assignment_to_env(self):
+        prog, env, argv, _c, _r = hooks._split_env_chdir(
+            ["env", "a-b=1", "cat", VAULT])
+        self.assertEqual(prog, "cat")
+        self.assertEqual(env, ["a-b=1"])
+        self.assertEqual(argv, ["cat", VAULT])
+
+    def test_the_scan_keeps_going_until_a_token_without_an_equals(self):
+        """`env`'s operand scan is a loop, not a single test: `env a=1 b-c=2 cat <vault>`
+        sets both and the utility is the `cat`."""
+        prog, env, _a, _c, _r = hooks._split_env_chdir(
+            ["env", "a=1", "b-c=2", "cat", VAULT])
+        self.assertEqual((prog, env), ("cat", ["a=1", "b-c=2"]))
+
+    def test_end_of_options_does_not_end_the_assignment_scan(self):
+        """Verified: `env -- a-b=1 cat <vault>` prints the vault, so `--` stops the OPTIONS
+        and nothing else."""
+        prog, env, _a, _c, _r = hooks._split_env_chdir(
+            ["env", "--", "a-b=1", "cat", VAULT])
+        self.assertEqual((prog, env), ("cat", ["a-b=1"]))
+
+    def test_a_second_packed_split_string_still_reaches_the_reader(self):
+        """#555's second row. `env` reads `-Sbar=2` as an assignment because its option scan
+        has ended; this parser reads it as one more `-S` and unpacks it. Different model,
+        same program — and the guard's reading is the one that cannot lose a reader."""
+        prog, _e, argv, _c, _r = hooks._split_env_chdir(
+            ["env", "-Sfoo=1", "-Sbar=2", "cat", VAULT])
+        self.assertEqual(prog, "cat")
+        self.assertIn(VAULT, argv)
+
+    def test_an_assignment_prefix_still_reaches_the_guards_that_read_it(self):
+        """The env list is not a bin. `env a-b=1 GIT_SSH_COMMAND=/tmp/k git push` was
+        allowed on `main` for this same reason — the golden-rule guard reads the prefix, and
+        the prefix stopped at the token this parser could not place."""
+        prog, env, _a, _c, _r = hooks._split_env_chdir(
+            ["env", "a-b=1", "GIT_SSH_COMMAND=/tmp/k", "git", "push"])
+        self.assertEqual(prog, "git")
+        self.assertIn("GIT_SSH_COMMAND=/tmp/k", env)
+        self.assertIsNotNone(
+            hooks._single_credential_reason("env a-b=1 GIT_SSH_COMMAND=/tmp/k git push"))


### PR DESCRIPTION
Closes #555. Closes #556. Closes #496.

Three vault-reachable bypasses. All three are the same defect — **a guard matching a
spelling instead of the property behind it** — which is the seventh instance this month, so
each fix below names its property first and is written against that. A longer list of
spellings would have been the eighth.

Every row was reproduced on current `main` before anything changed: a plane built by
`charter init`, a fabricated value in `.charter/vaults/x.json`, every command fed to the
real `charter hook pretooluse`. The decision is nested under `hookSpecificOutput` — reading
`permissionDecision` from the root answers nothing for every input and looks exactly like a
guard that has stopped working.

## The measurement

| command | on `main` | here |
| --- | --- | --- |
| `cat .charter/vaults/x.json` | DENY | DENY |
| `env -C .charter/vaults cat x.json` | DENY | DENY |
| `env -C.charter/vaults cat x.json` | DENY | DENY |
| `env --chdir=.charter/vaults cat x.json` | DENY | DENY |
| `env a-b=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `env a.b=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `env 1FOO=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `env 'x y=1' cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `env a=1 b-c=2 cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `env -- a-b=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `env -Sfoo=1 -Sbar=2 cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `sudo a-b=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `env -iC.charter/vaults cat x.json` | **ALLOW** | DENY |
| `env -iC .charter/vaults cat x.json` | **ALLOW** | DENY |
| `env -viC.charter/vaults cat x.json` | **ALLOW** | DENY |
| `env -iS'cat .charter/vaults/x.json'` | **ALLOW** | DENY |
| `sudo -bD.charter/vaults cat x.json` | **ALLOW** | DENY |
| `xargs -0a.charter/vaults/x.json echo` | **ALLOW** | DENY |
| `env -P /bin cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `sudo -T 5 cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `chrt 5 cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `su-exec root cat .charter/vaults/x.json` | **ALLOW** | DENY |
| `export GIT_DIR=<plane>/.git && git checkout feature` | **ALLOW** | DENY |
| `export GIT_WORK_TREE=<plane>; git checkout feature` | **ALLOW** | DENY |
| `declare -x GIT_DIR=<plane>/.git && git checkout feature` | **ALLOW** | DENY |
| `GIT_DIR=<plane>/.git; export GIT_DIR; git checkout feature` | **ALLOW** | DENY |
| `set -a; GIT_DIR=<plane>/.git; git checkout feature` | **ALLOW** | DENY |
| `export GIT_SSH_COMMAND=/tmp/k && git push` | **ALLOW** | DENY |
| `GIT_DIR=<plane>/.git; git checkout feature` | ALLOW | ALLOW |
| `cat notes.md`, `env -i cat notes.md`, `env -C /tmp cat notes.md`, `env -iC /tmp cat notes.md`, `grep -rn vaults .charter/vaults.json`, `export PAGER=cat && git log` | ALLOW | ALLOW |

Every `env`/`sudo`/`xargs` row marked ALLOW printed
`{"k":"FABRICATED-NOT-A-REAL-SECRET-9271"}` when run; the `export GIT_DIR` row moved the
plane root's HEAD (`git -C <plane> symbolic-ref --short HEAD` answers `feature`
afterwards). The `chrt` and `su-exec` rows come from their documented grammars — they are
Linux tools this machine does not have — and the last two lines are the negative controls,
including the one that must **stay** allowed because a bare `GIT_DIR=…;` segment exports
nothing (`FOO=1; <child>` leaves `FOO` unset, verified against bash 5 and zsh).

## The properties

**#556 — a short option is its LETTER, not its position in the token.** getopt bundles, so
`-iC<dir>` is `-i -C <dir>`. `_split_env_chdir` matched a wrapper's value-taking flags with
`tok.startswith(flag)`, which only ever sees a short option written first, so the chdir
whose value makes a later relative operand resolve was never recovered — and three other
spellings of the same flag were denied the whole time.

`_wrapper_option` walks the letters. `_WRAPPER_VALUE_FLAGS` is consulted **first** for each
one, a new `_WRAPPER_NOVALUE_LETTERS` says which take none, and a letter in neither table
ends the walk rather than being guessed at — guessing "takes a value" swallows the program
(the fail-open `env -i cat <vault>` punishes), guessing "takes none" walks into somebody's
data. A test holds the two tables disjoint per wrapper, because the value-first order makes
a letter in both silently dead.

**And the end of a walk is no longer silent, which is what keeps this from being a longer
list.** An option this grammar cannot place leaves the program unnamed — a value flag nobody
listed is indistinguishable from one that takes nothing — so the rest of the segment is
reported as files the command may open and the leak guard asks them the same
`_names_a_vault_path` it asks a reader's operands. That fallback is what the sweep's
`env -P <path>` and `sudo -T <n>` needed: both had their value read as the program. They are
in the value table now *and* covered by the fallback, so the next missing letter is a false
negative instead of a way in.

**#555 — what counts as an assignment is decided by the parser that will do the assigning.**
One constant, `^[A-Za-z_][A-Za-z0-9_]*=`, was answering two parsers. At the front of a shell
command the identifier rule is right: bash answers *"a-b=1: command not found"*, so
`a-b=1 cat <vault>` runs a program with that name and reads nothing. `env`'s operand scan is
`strchr(arg, '=')` — GNU and BSD alike — so **any** argument containing an `=` is an
assignment and the scan continues until one without.

Widening the constant would have moved denials in both directions, because the same
predicate stands in front of ordinary segments where a token with an `=` is not an
assignment (`git -c a.b=c …`). So there are two predicates: the shell's stays where the
shell decides, and `_WRAPPER_ASSIGN_OPERANDS` scopes the wide one to the wrappers that
really assign. Consuming a token there can only move the program rightward, never swallow
one, so the fail-closed direction is also the correct one.

**#496 — the guards read the environment a command line ESTABLISHES for its later segments,
not only the prefix attached to one invocation.** `_plane_root_git` already carried a `cd`
across segments; `_exported_env` is the same shape of carried state, computed once and read
by both plane-root guards *and* the one-credential guard. The shapes modelled are the ones a
shell really exports with, each checked against bash 5 and zsh: `export NAME=VALUE`;
`declare -x`/`typeset -x`, whose `x` bundles; `NAME=VALUE` then `export NAME`; and `set -a`.
A bare `NAME=VALUE` segment is deliberately not one, because a shell exports nothing there.

That environment only ever grows — `unset` and `export -n` are not modelled, since
forgetting a variable is the direction that opens a door, the same invariant `_git_target`'s
subject list keeps. The boundary is `cd`'s: a `$(…)`, a sourced file, and a `GIT_DIR` already
in the session's environment before the hook ran are outside it, and for the last one the
`PreToolUse` payload does not carry the environment at all. All three are pinned as limits.

## The sibling sweep

Assumed to exist until looked for. Four beyond the three briefed, none of them reported:

1. **`export GIT_SSH_COMMAND=/tmp/k && git push`** walked past the golden rule's
   one-credential guard while the attached spelling was denied — #496's defect in the guard
   next door. Both guards now read the same carried environment from one place, so neither
   can be fixed while the other is left behind.
2. **`env -iS'cat <vault>'`** — a live vault read. `-S` behind a bundle was not reachable at
   all; the walk reaches it now.
3. **`env -P <path>` and `sudo -T <n>`** — two value-taking flags missing from
   `_WRAPPER_VALUE_FLAGS`, each naming its own value as the program. Added, and the
   unplaced-option fallback above is the answer to the next two.
4. **`chrt <priority> <command>` and `su-exec <user-spec> <command>`** — `timeout`'s leading
   positional was the only one modelled, and the branch that models it reads as if `timeout`
   were the only wrapper with one.

## Verification

* **Full suite, environment 1** — python 3.14.4, on the rebased tree: `Ran 7296 tests ... OK`
  in 308s.
* **Full suite, environment 2** — python 3.12.13, with every `CHARTER_*`, `CLAUDE_*`,
  `ANTHROPIC_*` and `TMUX*` variable unset (asserted from inside the interpreter, not
  assumed): `Ran 7296 tests ... OK` in 325s.
* **CI at the head sha**, read from `gh api repos/diazoxide/charter/commits/<sha>/check-runs`
  rather than `gh pr checks` (#561): `test (3.11)`, `(3.12)`, `(3.13)`, `(3.14)` all
  `success`.
* **`tools/sweep.py`** on the diff, and **a hand-check for the constants and semantic swaps**
  beside it, both against an unmutated baseline (#579), every mutation asserting on disk
  that its edit applied (#585/#586).

**A note on the `deletion sweep` CI job, which reads `cancelled` here.** It is not a failure
of this branch: the job has `timeout-minutes: 60`, and it ran the full hour twice
(`09:03:44Z → 10:04:20Z` and `10:17:02Z → 11:17:21Z`) before being cut off. This diff is 334
added lines, which is 62 mutations once #615's `retune-string` operator is counted — roughly
double the 30-to-52 the job's own header sizes itself for. The job blocks nothing today
(`--enforce` is deliberately absent), but the hour is going to be short for any diff this
size, and that is worth knowing before `--enforce` goes on. The sweep evidence below is from
running the same tool locally.

### The sweep, and the hand-check beside it

**What ran, and on which tree.** `tools/sweep.py` completed on the pre-rebase head — 27
mutations, unmutated baseline green — and the 44-mutation hand-check completed beside it.
Every survivor either got a test or was deleted, and every one of them was then re-mutated
against the *final* head and confirmed killed. On the rebased tree the sweep enumerates
**62** mutations (#615's `retune-string` operator roughly doubles the count for a diff that
is mostly tables), its baseline is green there too — `Ran 7296 tests — OK in 305s` — and the
run itself does not finish: at this machine's current share, 171 selected modules per
mutation puts it at hours, and it was killed twice by memory pressure before that. The
string mutations it adds are the flag tables, which the hand-check below mutated by hand.

The two together mutated 27 + 44 lines. **Nine survived, and all nine were findings** — five
were a real consequence with no test behind it, three were lines with no consequence at all,
and one was a table row that should not have existed:

| survivor | what it turned out to be |
| --- | --- |
| `_WRAPPER_VALUE_FLAGS.get(base, ())` loses its default | real: `nohup -q cat <vault>` raises `TypeError` out of the leak guard. Every wrapper the suite exercised happened to be in the table. Test added. |
| `wants_next and toks` loses its conjunct | real: `env -C` at the end of a segment pops from an empty list. Test added. |
| `except ValueError` narrowed | real: `env -S "cat '<vault>"` will not tokenize, and without the fallback the exception leaves the guard. Test added. |
| `name in _SPLIT_STRING_FLAGS and base == "env"` loses a conjunct | real, and the sharpest one: `xargs` has a `-S` of its own that means something else, so without `base == "env"` the guard unpacks `xargs -S 4096 cat <vault>` as a command and loses the reader. Test added. |
| `if nxt != name` dropped | real: it is what keeps a *separated* value from reporting its whole segment, which is what lets `env -C /tmp echo <vault>` stay allowed. Test added. |
| the four value flags this round added, dropped one at a time | real but doubly covered — the unplaced-option fallback gets the vault row right on its own, so a test asserting only the denial passes with the table entry deleted. The precision half (`… echo <vault>` stays allowed) is asserted now too. |
| `if tok.startswith("--")` in the walk | **no consequence**: a long option's first walked character is the second `-`, which is in no no-value table, so the walk already ends on its first step. Deleted; the invariant that makes it so is asserted. |
| `len(f) == 2 and not f.startswith("--")` in the walk | **no consequence**: the walk asks `"-" + ch in takes`, two characters, so the filter could only ever remove `--` itself. Deleted; same. |
| `if a.startswith("-"): continue` in the export scan | **no consequence** over 213,927 segment lists: shell-variable keys all come from the identifier regex, so a flag can neither be recorded nor found. Deleted; same. |
| `doas` in `_WRAPPER_ASSIGN_OPERANDS` | **wrong, not dead**: `doas [-Lns] [-a style] [-C config] [-u user] command [args]` has no assignment operand. Invented by symmetry with `sudo`. Removed. |
| the two letter tables' consultation order | genuinely **equivalent**, and what makes it so — the tables being disjoint per wrapper — is itself asserted, so the order can never quietly start mattering. The only one left standing. |

Two of the hand-check's own mutations were written as `X = {} or {…}`, which is a no-op
rather than an empty table, and they were reported as survivors until that was noticed —
#585/#586's failure mode in a second costume. Rewritten and re-run: both killed.

## What did not change

`SECURITY.md`'s position is unmoved: guard rails, not guarantees. Deciding what a shell will
execute without executing it is not winnable in a Python tokeniser, and none of this claims
to close that class. What it closes is seven cases where the guard already modelled the
thing and was matching one way of writing it.

#473 is **not** in this PR and is not closed by it — see the note there. It is a
supply-chain decision about how charter releases itself rather than a runtime guard, the
files it needs are another agent's this session, and its owner has already ruled its two
substantive options out of a subagent's remit.
