### PR TITLE
Pin the four guards the sweep found in the new state accessors (#604 follow-up)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -722,7 +722,7 @@ def _add_frame_parsers(sub) -> None:
     _core_commands = set(sub.choices) | {"frame", "panel", "frame-palette",
                                          "frame-probe", "frame-respawn", "frame-density",
                                          "frame-resize", "frame-gather", "frame-switch",
-                                         "frame-toggle"}
+                                         "frame-toggle", "frame-chrome"}
 
     # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
     # already claimed each word, so a SECOND harness wanting it is told who got there
@@ -878,6 +878,23 @@ def _add_frame_parsers(sub) -> None:
     dn = sub.add_parser("frame-density")
     dn.add_argument("level")
     dn.set_defaults(func=commands_frame.cmd_density)
+
+    # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
+    # ones above. Started DETACHED by a palette row, whose argv is exactly
+    # `util.self_relaunch_argv("frame-chrome", <level>)`. It repaints the RUNNING frame's
+    # panel panes — never charter.toml, for `frame-density`'s reason — and resolves which
+    # frame from `$CHARTER_SESSION_ID` when it fires rather than from a shared bind.
+    #
+    # Deliberately NOT `choices=` on the level, for `frame-density`'s argument and one
+    # more that is specific to this command: `instance.chrome_level` is the one gate on
+    # the closed set, and it is also the boundary that keeps an operator's string away
+    # from a tmux style value. A second copy of the set in argparse would be a second
+    # answer to that question, and the weaker one — argparse exits 2 from inside a
+    # detached child where nothing prints the reason, while `cmd_chrome` is a quiet no-op
+    # that leaves the frame exactly as it was.
+    cr = sub.add_parser("frame-chrome")
+    cr.add_argument("level")
+    cr.set_defaults(func=commands_frame.cmd_chrome)
 
     # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
     # ones above. Fired by ONE COMPONENT's own `bind -n` — the `key` its

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1671,6 +1671,47 @@ def _surface_argvs(*, socket: str, pane_id: str, chrome) -> list[list[str]]:
             for name, value in instance.chrome_options(chrome)]
 
 
+def _resurface_argvs(*, socket: str, pane_id: str, chrome) -> list[list[str]]:
+    """:func:`_surface_argvs` for a pane that is ALREADY DRAWN — with the unsets.
+
+    **The difference is `off`, and it is not a detail.** On a launch, `off` is free:
+    nothing is set, so `_surface_argvs` correctly issues no command. On a running frame
+    the same word has to mean *remove what is there*, or the palette row that says
+    ``chrome: off`` leaves the operator looking at the surface they just turned off — a
+    keypress that reports success and changes nothing, which is the shape this spec's own
+    §4 refuses an ``auto`` value for.
+
+    So: every option the new word does NOT set is unset, and every option it does set is
+    set. Which options exist comes from `instance.chrome_option_names`, derived from the
+    table rather than spelled here, so a third option added to `FRAME_CHROME` is unset by
+    this function on the day it is added instead of surviving an `off` nobody re-read.
+
+    `set-option -p -u` is the removal, and it is measured rather than assumed on both
+    tmux 3.7c and tmux 3.2 (`tmuxctl.FLOOR`): rc 0, `show -p` reads back `''` afterwards,
+    and unsetting an option that was never set is rc 0 as well — so this needs no "was it
+    set" round trip, which would be a subprocess per pane per keypress to answer a
+    question the unset already answers.
+
+    **Never the harness pane**, exactly as `_surface_argvs` is never handed one: the
+    caller (`cmd_chrome`) iterates `state.panes`, which is the PANEL map, and the harness
+    pane lives in a different record entirely (`state.harness_pane`). ADR 0018's boundary
+    holds here by the same construction.
+
+    **`NO_COLOR` wants NOTHING SET, which on this path means the unsets and not silence.**
+    `_surface_argvs` answers `[]` there because a launch under `NO_COLOR` has nothing to
+    remove. A frame surfaced before `NO_COLOR` was exported has, and answering `[]` here
+    would honour the letter of the promise while leaving charter's colour on the screen —
+    which is the half of that promise this spec was written about. Asked through
+    `chrome.no_colour` so there is one reading of the variable (#547).
+    """
+    want = dict(() if chrome_mod.no_colour() else instance.chrome_options(chrome))
+    argvs = [tmuxctl.server_argv(socket, "set-option", "-p", "-u", "-t", pane_id, name)
+             for name in instance.chrome_option_names() if name not in want]
+    argvs += [tmuxctl.server_argv(socket, "set-option", "-p", "-t", pane_id, name, value)
+              for name, value in want.items()]
+    return argvs
+
+
 def _panel_remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
     """`set-option -w`: keep dead panes in CHARTER'S OWN WINDOW, and in no other.
 
@@ -2151,12 +2192,16 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     # each successfully-created pane belongs to (for its size and its resize-pane flag),
     # and `panel_argvs` returns exactly one command per slot, in the same order (see its
     # own docstring).
-    # The word, resolved once for the whole batch: `config.FRAME` is a plane's own file
-    # and cannot change between two splits, and `instance.chrome_options` is what turns
-    # it into styles — so a value charter does not know produces no commands at all,
-    # which is `off`. `.get` rather than `[...]`: a frame relaunched by a charter that
-    # predates this key has a resolved config without it.
-    chrome = config.FRAME.get("chrome")
+    # The word, resolved once for the whole batch, through `_current_chrome` rather than
+    # off `config.FRAME` — which is the difference a live `charter frame-chrome` makes.
+    # The configured value says what a frame STARTS at; a frame the operator has since
+    # surfaced from the palette carries its own record, and a pane split into it by a
+    # later density change has to be born into the surface the frame IS rather than the
+    # one it launched with. One resolver, so the palette's mark and this pane's option
+    # cannot disagree. `instance.chrome_options` is still what turns the word into
+    # styles, so a value charter does not know produces no commands at all, which is
+    # `off`.
+    chrome = _current_chrome(fid)
     panes: dict[str, str] = {}
     for slot, cmd in zip(slots, panel_cmds):
         # Reported by `tmuxctl.run` but not fatal: one decorative panel failing to draw
@@ -2996,6 +3041,28 @@ def _current_density(fid: str) -> str:
             or "normal")
 
 
+def _current_chrome(fid: str) -> str:
+    """The pane surface *fid* is on right now: its own recorded override, else the
+    configured default, else ``off``.
+
+    :func:`_current_density`'s twin and read the same way — one function, so the palette's
+    mark, a newly split pane's surface and a live `frame-chrome` keypress cannot come to
+    three different conclusions about which word this frame is on. `_split_panels` used to
+    read `config.FRAME.get("chrome")` directly, which was right while nothing could change
+    it and became a pane born bare into a frame the operator had surfaced.
+
+    `instance.chrome_level` gates BOTH sources rather than only the file: a word charter
+    does not recognise is `off` wherever it came from, which is the same rule
+    `instance.frame_of` already applies to the committed file and the reason a hostile
+    `charter.toml` cannot reach a tmux style through here either. `.get` on the config,
+    never ``[...]``: a frame relaunched by a charter that predates this key has a resolved
+    config without it.
+    """
+    return (instance.chrome_level(state.chrome(fid))
+            or instance.chrome_level(config.FRAME.get("chrome"))
+            or "off")
+
+
 def _pane_identity_env(env: dict[str, str], v: tuple[int, int]) -> dict[str, str] | None:
     """What a newly split panel pane must be TOLD, or ``None`` when tmux cannot be told.
 
@@ -3737,6 +3804,76 @@ def _visible_now(fid: str, frame: dict) -> list[str]:
     return [n for n in instance.frame_arrangement(frame) if n not in hidden]
 
 
+def cmd_chrome(args) -> int:
+    """`charter frame-chrome <off|dark|light>` — resurface THIS frame's panes, live.
+
+    Started by a palette row (`frame/builtin_actions.py`), and typeable by hand from
+    inside a frame. The frame is resolved from `$CHARTER_SESSION_ID` exactly as
+    `cmd_density`, `cmd_toggle`, `cmd_palette` and `cmd_respawn` resolve theirs, since one
+    bind text is shared by every frame on `SOCKET`.
+
+    **Nothing splits, and that is the whole difference from `cmd_density`.** The surface
+    is a pane option and tmux repaints from it on the spot — measured on an attached
+    client, on tmux 3.7c and on tmux 3.2 (`tmuxctl.FLOOR`) alike: `set-option -p
+    window-style bg=black` on a pane that had already been drawn put ``\x1b[40m`` on that
+    client's wire with no `refresh-client` and no re-layout, 507 and 523 bytes
+    respectively. So this records the word and sets two options per pane. There is no
+    version gate because there is nothing to gate: the floor behaves identically.
+
+    **charter.toml is not touched**, for `cmd_density`'s reason word for word: the
+    committed file says what a frame STARTS at, this changes what one running frame IS,
+    and the override goes in the frame's own state directory (`state.record_chrome`),
+    which `state.reap` deletes entire when the frame ends. Relaunch and the configured
+    look is back. That is also what makes the palette row honest for the operator this
+    spec's §4 named — the one who upgrades into a look they dislike is one keystroke from
+    changing it and never has to find a config key.
+
+    **The word never reaches tmux, and `off` is a REMOVAL rather than a style.** A tmux
+    style value is format-expanded at draw time (§4), so the config surface is a closed
+    enum and `instance.chrome_options` maps it to constants charter holds. `off` maps to
+    no styles at all — which on a LAUNCH means "set nothing" and here has to mean "unset
+    what is set", or an operator who chose `off` would keep looking at the surface they
+    just turned off. `_unsurface_argvs` is that half, and it is the reason this function
+    cannot simply reuse `_surface_argvs`.
+
+    **Always 0, and every refusal is a quiet no-op**, for `cmd_respawn`'s reason: this
+    normally runs detached from a palette row, where the only screen left to report on is
+    the agent's own — the one rectangle ADR 0018 says charter never draws in.
+
+    Refusals, in order:
+
+    * no `$CHARTER_SESSION_ID` — not fired from inside a frame at all;
+    * a *level* outside `instance.FRAME_CHROME` — a closed set of three words charter
+      wrote itself, so this can only be a hand-typed argument;
+    * a frame with no recorded pane map — nothing to resurface. Unlike `cmd_density` this
+      needs no harness pane and no tmux version: it splits nothing, so `_relayout_target`'s
+      refusals are not this function's.
+
+    The word is recorded BEFORE the panes are touched, so a frame whose options fail
+    halfway still splits its NEXT pane into the surface the operator asked for
+    (`_split_panels` reads `_current_chrome`).
+    """
+    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    level = instance.chrome_level(getattr(args, "level", None))
+    if not fid or level is None:
+        return 0
+    panes = state.panes(fid)
+    if not panes:
+        return 0
+    state.record_chrome(fid, level)
+    socket = state.frame_server(fid) or SOCKET
+    for pane_id in panes.values():
+        # `_PANE_ID_RE` is #475's rule applied to a value that arrived off DISK and is
+        # about to be a tmux argv — the same check `_relayout_target` makes of the harness
+        # pane, made here of each panel's. A frame whose map was truncated or hand-edited
+        # skips that pane rather than handing tmux whatever the file said.
+        if not _PANE_ID_RE.fullmatch(pane_id):
+            continue
+        for argv in _resurface_argvs(socket=socket, pane_id=pane_id, chrome=level):
+            tmuxctl.run("painting a panel's surface", argv)
+    return 0
+
+
 def cmd_toggle(args) -> int:
     """`charter frame-toggle <component>` — show or hide ONE component, live.
 
@@ -3937,7 +4074,8 @@ def _draw_palette(args) -> int:
     fid = os.environ.get("CHARTER_SESSION_ID", "")
     socket = state.frame_server(fid) or SOCKET
     harness = state.harness_pane(fid) or ""
-    reg = builtin_actions.build(fid, current_density=_current_density(fid))
+    reg = builtin_actions.build(fid, current_density=_current_density(fid),
+                                current_chrome=_current_chrome(fid))
     snapshot = gather.cached(fid) or {}
     client = getattr(args, "client", "")
     opened: list[choose.Roster] = []

--- a/charter/frame/action.py
+++ b/charter/frame/action.py
@@ -241,7 +241,7 @@ class ActionCtx(_ctx.Ctx):
     """
 
 
-_ctx.declare(ActionCtx, _ctx.Contract(serves=SERVES, geometry=IDENTITY, noun="action",
+_ctx.declare(ActionCtx, _ctx.Contract(serves=SERVES, always=IDENTITY, noun="action",
                                       declared="touches"))
 
 

--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -164,16 +164,71 @@ def _run_density(fid: str, level: str):
     return f"density → {level}"
 
 
-def build(fid: str, *, current_density: str) -> actions.ActionRegistry:
+def _register_chrome(reg: actions.ActionRegistry, *, current: str) -> None:
+    """One row per pane surface, with the one in effect marked rather than dropped.
+
+    **The whole reason `[frame] chrome` can ship defaulting to `off`.** The spec's §4
+    argues the default from an asymmetry — a light-terminal operator upgrading into a
+    default `dark` gets a worse frame having done nothing — and the cost of that argument
+    is a dark-terminal operator who wants the fill. These three rows are what they pay
+    instead: one keystroke, in the palette they already open, rather than finding a
+    config key in a document.
+
+    Marked and not filtered, for `_register_density`'s reason exactly: choosing the
+    surface you are already on repaints to the same frame, which is harmless, and a list
+    whose rows move around depending on state is a list nobody learns.
+
+    **`_laid_out` is NOT the availability question here**, and that is not an oversight.
+    A density row re-lays-out and therefore needs a harness pane to split against; a
+    surface is a pane option on panes that already exist, so what it needs is the pane
+    MAP. A frame whose harness pane record was lost can still be resurfaced, and a row
+    that refused it would be refusing on somebody else's precondition — the shape #512
+    is. `state.panes` is the record `cmd_chrome` actually reads, so the row asks about
+    that one.
+    """
+    from .. import instance
+    for level in instance.FRAME_CHROME:
+        on = MARK[0] if level == current else MARK[1]
+        reg.register(action.Action(
+            id=f"chrome.{level}", title=f"{on}chrome: {level}",
+            run=(lambda ctx, lv=level: _run_chrome(ctx.fid, lv)),
+            available=lambda ctx: bool(state.panes(ctx.fid)),
+            reason_unavailable=lambda ctx: NO_PANES))
+
+
+#: What a frame with no recorded panel panes is told instead of nothing happening. Its own
+#: sentence rather than `NO_LAYOUT`'s: the two refusals are about different records, and a
+#: row that borrowed the other's words would send an operator to relaunch over a frame
+#: whose panels simply all failed to draw.
+NO_PANES = ("charter has no record of this frame's panel panes, so it has nothing to "
+            "resurface — relaunch the frame")
+
+
+def _run_chrome(fid: str, level: str):
+    _spawn(util.self_relaunch_argv("frame-chrome", level), fid=fid)
+    return f"chrome → {level}"
+
+
+def build(fid: str, *, current_density: str,
+          current_chrome: str) -> actions.ActionRegistry:
     """Charter's own actions, plus every action an installed provider supplies.
 
     A fresh registry per call, for `builtins.build`'s reason: this is a snapshot of a
     plane that moves, and the marks, the names and the availability are all resolved
     against the moment the palette opened.
 
-    Charter's own are registered FIRST, so `frame.detach` and the densities are at the top
-    of a palette that has not been typed into, and a provider cannot push them down the
-    list by installing something alphabetically earlier.
+    Charter's own are registered FIRST, so `frame.detach`, the densities and the surfaces
+    are at the top of a palette that has not been typed into, and a provider cannot push
+    them down the list by installing something alphabetically earlier.
+
+    **Both marks are ARGUMENTS and neither is read here**, which is the same rule stated
+    twice rather than a repetition: `current_density` and `current_chrome` are resolved by
+    `commands_frame._current_density` and `_current_chrome`, the same two functions the
+    panels and the tmux options read, so the mark beside a row and the state the frame is
+    actually in cannot come from two different readings. Required keyword arguments, both
+    of them: a default here would let a caller that forgot one draw a palette marking
+    `off` on a frame that is surfaced, and be right about it in every test that did not
+    set one.
 
     **A provider's failure costs its own row and never the palette** — that is
     `ActionRegistry.add`'s contract and the whole reason a failed provider finally has
@@ -193,6 +248,7 @@ def build(fid: str, *, current_density: str) -> actions.ActionRegistry:
     reg = actions.ActionRegistry()
     _register_detach(reg)
     _register_density(reg, current=current_density)
+    _register_chrome(reg, current=current_chrome)
     for aid in reg.providers.ids():
         reg.add(aid)
     return reg

--- a/charter/frame/chrome.py
+++ b/charter/frame/chrome.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import os
 import re
 import sys
+from types import MappingProxyType
 
 from .. import tui
 
@@ -148,6 +149,90 @@ def colour_ok() -> bool:
         # A closed or exotic stdout answers neither; a frame that cannot tell does not
         # colour, which is the direction `NO_COLOR` already points.
         return False
+
+
+def _role_values() -> dict[str, str]:
+    """The roles of §5 a RENDERER can write, and the SGR each one is. **The vocabulary.**
+
+    One source, not a list of names beside a table of values: two of those is how a role
+    comes to be documented and unserved, or served and undocumented, and the caller below
+    iterates whatever this returns.
+
+    **This is deliberately not the same list as §5's six.** Two of those — ``surface`` and
+    ``focus`` — are `window-style`/`window-active-style`, tmux pane options that no
+    renderer can emit and no provider can be handed. Serving them here as empty strings
+    would be a recipe that claims to hand over something charter does not have, which is
+    the same convincing empty `instance.FRAME_CHROME` refuses an ``auto`` value for. A
+    provider that wants the surface already has it: tmux painted the rectangle underneath
+    before the provider drew a cell.
+
+    **Every value is an attribute or one of the sixteen ANSI names — no cube index, no
+    24-bit triple.** That is `instance.FRAME_CHROME`'s rule reaching the one place a
+    stranger's code would otherwise have to guess it, and it is why these need no
+    `[frame] chrome` gate: bold, dim and reverse are statements relative to whatever the
+    operator's terminal already is, and ``green``/``yellow``/``red`` are slots in their
+    own palette rather than colours charter picked out of the 256.
+
+    Composed from `statusline.py`'s OWN constants rather than spelled here, for
+    `slots._sidebar_head`'s reason: a second copy of ``\033[1m`` in this module is how a
+    provider's heading and charter's own come to be two different weights. A
+    function-level import for that function's other reason — `statusline` is the largest
+    module charter has and a panel repaints on a clock.
+    """
+    from .. import statusline as sl
+    return {"heading": sl._BOLD, "muted": sl._DIM, "selected": _REVERSE,
+            "ok": sl._GREEN, "warn": sl._YELLOW, "bad": sl._RED, "reset": sl._R}
+
+
+def recipes() -> MappingProxyType:
+    """The role → string mapping a component is handed: `ctx.chrome`.
+
+    **What a provider gets so it can match without charter overdrawing it** (§7). Charter
+    owns the surface and the border; the provider owns every cell it writes. A component
+    that writes ``ctx.chrome["heading"]`` puts its label in the same weight charter's own
+    sidebar heading uses; one that does not looks different, which is honest, because it
+    *is* different — and a frame where every pane looked identical regardless of who wrote
+    it would hide the one thing an operator needs to know when a pane is wrong.
+
+    **A `MappingProxyType` of strings, no callable, reading nothing.** The same shape
+    `ctx.SERVES["gather"]` already hands over, and the reason is `ctx.Ctx`'s own: a
+    provider's module is ordinary Python, so what must not be reachable from this object
+    is anything that *does* something. A plain `dict` would be worse than merely mutable —
+    one snapshot is shared by every component in a repaint, so a component that edited it
+    would be editing what the next one is about to draw.
+
+    **`inset` is the one entry that is not SGR, and it is here on purpose.** §5.4 is a
+    COLUMN rather than an attribute — the value `slots.INSET` already holds — and a
+    provider that wants its rows to start where charter's do needs the string, not the
+    number. Served as the literal left edge (`slots._inset()`) so a provider prepends it
+    and lines up, rather than being told a count and left to spell the padding itself,
+    which is the per-call-site spelling §5.4 exists to end. It is NOT suppressed by
+    :func:`colour_ok` below: two spaces are not colour, and a frame that lost its inset
+    under ``NO_COLOR`` would be answering a question about colour with a change to layout.
+
+    **`chrome` — the WORD — changes none of these, and that is a measurement rather than
+    an omission.** §7 asks for the roles "resolved for this frame's `chrome` setting", and
+    when this was built there was nothing for that setting to resolve: `off`, `dark` and
+    `light` select a pane background, `window-style` honours colour and silently ignores
+    every attribute (measured again for this phase on tmux 3.7c AND on tmux 3.2 — `bold`,
+    `dim` and `reverse` each put no SGR at all on an attached client's wire), and no
+    renderer can write a pane option. So a `chrome` parameter here would be an argument
+    that cannot change an answer, which is the line this repo's own sweep deletes. What
+    IS resolved is :func:`colour_ok`, which is per pane and does change every value.
+
+    **Under `NO_COLOR`, or a stdout that is not a tty, every SGR role is the empty
+    string.** §3.2's rule is that charter emits no SGR from the frame at all, and a
+    provider handed live escapes there would emit them on charter's behalf — charter
+    having asked somebody else to paint again, which is the half of that promise this
+    spec was written about. Empty rather than absent: a provider that wrote
+    ``ctx.chrome["ok"] + text`` would otherwise raise inside its own draw and lose its
+    pane to honour a request about colour.
+    """
+    from . import slots
+    live = colour_ok()
+    out = {role: (sgr if live else "") for role, sgr in _role_values().items()}
+    out["inset"] = slots._inset()
+    return MappingProxyType(out)
 
 
 def plain(row: str) -> str:

--- a/charter/frame/ctx.py
+++ b/charter/frame/ctx.py
@@ -1,7 +1,9 @@
-"""What a component is handed when it draws: geometry, identity, and its declared slices.
+"""What a component is handed when it draws: geometry, identity, chrome, and its
+declared slices.
 
 **Constructed FROM ``needs``** (§4e). A component receives an object holding exactly what
-it declared plus the fixed geometry, and asking for anything else raises with the name of
+it declared plus what every component is served (:data:`ALWAYS`), and asking for
+anything else raises with the name of
 the thing to add to ``needs``. That is what makes the idle-cost property — one ``stat``
 per panel per tick, which `frame/panel.py` was built around — survive code charter did not
 write: today it is verified by a reviewer reading charter's own renderers, and a reviewer
@@ -34,6 +36,7 @@ from types import MappingProxyType
 from typing import Any, Mapping
 
 from .. import contain
+from . import chrome
 from .component import ComponentError, cells, names
 
 
@@ -63,10 +66,26 @@ SERVES = {
     "todos": _rows("todos"),
 }
 
-#: The keys every component gets whatever it declared: how much room it has, and which
-#: frame it is drawing in. Named once so :func:`build` and the tests that assert the
-#: attribute set exactly are reading the same list.
-GEOMETRY = ("width", "height", "fid")
+#: The keys every component gets whatever it declared: how much room it has, which frame
+#: it is drawing in, and how to look like it belongs there. Named once so :func:`build`
+#: and the tests that assert the attribute set exactly are reading the same list.
+#:
+#: **``chrome`` is served here rather than through :data:`SERVES`, and that is the whole
+#: of why this constant is no longer called ``GEOMETRY``.** Every name in `SERVES` is a
+#: slice cut out of the ONE SNAPSHOT — that is what the mapping's values are, functions of
+#: the snapshot — and the recipes are not in it. Serving them as a `SERVES` entry would
+#: mean a callable that takes the snapshot and ignores it, which is precisely the shape
+#: :class:`Ctx`'s own docstring records as the defect that let an action reach the plane's
+#: whole vault inventory off its ctx's class. So it is served unconditionally, with the
+#: geometry, and `SERVES` keeps meaning exactly one thing.
+#:
+#: Unconditional and not declarable, which `ctx`'s "absent, not disabled" doctrine would
+#: otherwise argue against: the doctrine is there to keep the IDLE COST visible — a slice
+#: nobody declared is a `gather.read` nobody pays for — and these are constant strings
+#: resolved without reading anything. There is no cost for a declaration to make visible,
+#: and a component forced to declare `chrome` before it could match charter's own weight
+#: would be a declaration that bought nobody anything.
+ALWAYS = ("width", "height", "fid", "chrome")
 
 
 @dataclass(frozen=True)
@@ -80,7 +99,7 @@ class Contract:
     #: name → how that name is cut out of the one snapshot.
     serves: Mapping[str, Any]
     #: The names served whatever was declared.
-    geometry: tuple[str, ...]
+    always: tuple[str, ...]
     #: What a refusal calls the thing holding this ctx.
     noun: str
     #: The field it declares what it is handed in.
@@ -120,7 +139,7 @@ class Ctx:
     """One repaint's worth of what one component may read.
 
     No public methods, deliberately. Everything reachable by name on this object is a
-    field that was declared or a piece of geometry, which is what lets a test assert the
+    field that was declared or one of :data:`ALWAYS`, which is what lets a test assert the
     attribute set *exactly* — and that assertion is the point: a future field is a
     widening of what a stranger's code may reach, and it should cost a test change and
     the conversation that goes with it.
@@ -161,7 +180,7 @@ class Ctx:
                 f"{c.noun}'s {c.declared} to be handed it")
         raise AttributeError(
             f"a {c.noun} ctx has no {shown} — charter serves "
-            f"{', '.join(c.geometry)} and the declared {c.declared} "
+            f"{', '.join(c.always)} and the declared {c.declared} "
             f"({', '.join(c.serves)})")
 
     def __setattr__(self, name: str, value: Any) -> None:
@@ -180,7 +199,7 @@ class Ctx:
             f"{contain.one_line(repr(name))} cannot be removed")
 
 
-declare(Ctx, Contract(serves=SERVES, geometry=GEOMETRY, noun="component",
+declare(Ctx, Contract(serves=SERVES, always=ALWAYS, noun="component",
                       declared="needs"))
 
 
@@ -208,6 +227,11 @@ def build(needs, *, width: int, height: int, fid: str, snapshot: Mapping) -> Ctx
         raise ComponentError(
             f"a snapshot must be one mapping of plane state, not "
             f"{contain.one_line(repr(snapshot))}")
-    fields = {"width": width, "height": height, "fid": fid}
+    fields = {"width": width, "height": height, "fid": fid,
+              # Resolved per pane rather than carried, because `colour_ok` is a question
+              # about THIS process's stdout and `NO_COLOR` is a question about the
+              # operator's environment right now — a mapping built once at import would
+              # answer both from whatever was true when charter was first imported.
+              "chrome": chrome.recipes()}
     fields.update({name: SERVES[name](snapshot) for name in served})
     return Ctx(fields)

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -550,6 +550,61 @@ def density(fid: str) -> str | None:
         return None
 
 
+def record_chrome(fid: str, level: str) -> None:
+    """Write down the pane surface THIS RUNNING FRAME is on, overriding `[frame] chrome`.
+
+    :func:`record_density`'s twin, for :func:`density`'s reason and no other: charter.toml
+    is hand-maintained and committed, this directory is machine-written and `reap` deletes
+    it whole when the frame ends. A palette row that edited an operator's own file to
+    change what one running frame looks like would be a keypress with a commit in it.
+
+    **The surface is the one element a keypress can change without moving a pane**, which
+    is why this exists at all rather than riding on `record_density`. `window-style` is a
+    pane option and tmux repaints from it on the spot — measured on an attached client,
+    both tmux 3.7c and tmux 3.2: ``set-option -p window-style bg=black`` on a pane that
+    was already drawn put ``\x1b[40m`` on the client's wire with no `refresh-client` and
+    no re-layout. So `commands_frame.cmd_chrome` records here and sets an option, and
+    nothing splits.
+
+    Same must-not-raise, atomic-write shape as :func:`record_density`.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "chrome.tmp"
+    try:
+        tmp.write_text(f"{level}\n")
+        os.replace(tmp, d / "chrome")
+    except OSError:
+        return
+
+
+def chrome(fid: str) -> str | None:
+    """The surface this frame was last set to by hand, or ``None`` for "never set".
+
+    ``None`` is the ordinary case: a frame starts at whatever `[frame] chrome` resolved to
+    — `off` unless the plane's own file says otherwise — and only a palette row writes
+    here. The caller falls back to the configured value; `commands_frame._current_chrome`
+    is the one place that does.
+
+    **The text is NOT validated here**, for :func:`density`'s reason exactly:
+    `instance.chrome_level` is the one gate on that closed set and it sits at the point of
+    use, so a truncated or hand-edited file degrades to the configured value in the same
+    way an unknown word in charter.toml does. A second half-copy of the enum in this
+    module is how the two come to disagree — and here the stakes are higher than a
+    density's, because the value on the other side of that gate is on its way to a tmux
+    style: `instance.chrome_options` maps a WORD to constants charter holds, so a word
+    nobody recognises yields no tmux command at all.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        return (d / "chrome").read_text().strip() or None
+    except (OSError, ValueError):
+        return None
+
+
 def record_hidden(fid: str, names) -> None:
     """Write down which components THIS RUNNING FRAME is not drawing.
 

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -584,6 +584,23 @@ def chrome_options(level) -> tuple[tuple[str, str], ...]:
     return FRAME_CHROME[lv] if lv else ()
 
 
+def chrome_option_names() -> tuple[str, ...]:
+    """Every tmux option name :data:`FRAME_CHROME` can set, in the order it names them.
+
+    **Derived from the table, never spelled beside it**, and that is the whole reason it
+    is a function. `off` is the absence of these options rather than a style of its own,
+    so turning a running frame's surface off means UNSETTING them — and a second list
+    saying which is a list that a third row in the table would quietly leave behind, with
+    the symptom being one option surviving a keypress that said "off". The table is the
+    only place the option names are written.
+
+    `dict.fromkeys` rather than a `set`: what a caller does with this is build tmux argvs,
+    and an order that changes between runs is a diff nobody can read in a test failure.
+    """
+    return tuple(dict.fromkeys(name for pairs in FRAME_CHROME.values()
+                               for name, _value in pairs))
+
+
 def verbosity_for(level) -> str:
     """How much each panel says at *level*. :data:`DEFAULT_VERBOSITY` for anything else.
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -644,6 +644,26 @@ and charter still runs.
 `NO_COLOR` overrides it: no colour on your screen caused by charter means none, whichever
 process puts the bytes there.
 
+**You do not have to edit a file to change it.** `F2` lists `chrome: dark`,
+`chrome: light` and `chrome: off`, with the one you are on marked. Choosing one repaints
+the frame you are looking at immediately — tmux redraws from the option, so no pane moves
+and nothing is re-laid-out — and it does not touch `charter.toml`. The change lives in the
+frame's own state directory and is gone when the frame ends, so relaunch and whatever you
+configured is back. A pane the frame adds later (a density change, say) comes up in the
+surface the frame is *on*, not the one it launched with.
+
+`charter frame-chrome <off|dark|light>` is the same thing typed by hand from inside a
+frame. Choosing `off` **removes** the options rather than setting a third look: afterwards
+`tmux show -p -t <pane> -v window-style` answers nothing at all, which is what it answered
+before you ever asked.
+
+**It works on every tmux charter runs on.** The floor is tmux 3.2, and all of this was
+re-measured there against a build from source, not inherited from the 3.7c it was designed
+on: `window-style` is pane-scoped, it honours a colour and silently ignores `reverse`,
+`dim` and `bold`, and all sixteen palette names resolve — sixty-six of sixty-eight answers
+byte-identical to 3.7c, and the two that were not turned out to be the measuring harness.
+So there is no version gate on any of it.
+
 ### Writing the arrangement out
 
 `slots` is shorthand. Each name in it places one of charter's built-in components on the
@@ -799,6 +819,42 @@ component API charter does not, two packages claim the same id, or its `render` 
 that costs **its own pane and nothing else**. The pane names the distribution and says what
 happened, and the rest of your frame draws around it.
 
+**What a component is handed, and what charter does not promise it.** Charter owns the
+surface and the border; your component owns every cell it writes. The surface is
+*underneath* — tmux paints the pane before your `render` is called — so a component that
+paints no background of its own gets charter's for free and matches. One that paints its
+own overrides its own cells and nothing else.
+
+So that a component can match the rest of the frame without charter drawing over it, `ctx`
+carries a read-only mapping of the frame's own recipes:
+
+```python
+def render(ctx):
+    c = ctx.chrome
+    return [f"{c['inset']}{c['heading']}metrics{c['reset']}{c['muted']} 12{c['reset']}",
+            f"{c['inset']}{c['ok']}✓{c['reset']} all green"]
+```
+
+`heading`, `muted`, `selected`, `ok`, `warn`, `bad`, `reset` and `inset`. Every one is
+either a plain attribute or one of the sixteen names your palette defines — never a colour
+charter picked — and `inset` is the literal left margin the rest of the frame starts at, so
+prepending it lines your rows up with charter's. Under `NO_COLOR`, or when the pane's
+output is not a terminal, every escape in the mapping is the empty string and `inset` is
+unchanged: the keys never disappear, so a component built on them does not break there.
+
+There is no `surface` or `focus` recipe, because there is nothing to hand over — those two
+are tmux pane options and no renderer can write one.
+
+**What charter does not promise is that your pane looks like its own.** A component that
+ignores the recipes and paints something else will not match, and charter will not make it:
+it does not overdraw your heading, and it does not take a row out of your rectangle to fit
+one of its own. What it does guarantee is what it already guaranteed — your paint stops at
+your rectangle, your failure costs your pane and not the session, and your output is
+contained before it reaches the terminal. A pane that clashes is a pane whose component
+chose to, and that is honest: it *is* different, and a frame where every pane looked the
+same regardless of who wrote it would hide the one thing worth knowing when a pane is
+wrong.
+
 You can run one by hand, which is what charter itself runs in the pane:
 
 ```
@@ -839,13 +895,16 @@ how to get back in (`tmux -L charter attach -t <frame-id>`) rather than leaving 
 remember the flags.
 
 ```
-charter · 6 to choose from
+charter · 9 to choose from
 > workspace: alpha — pick another
     persona: steward — pick another
     detach — leave the harness running
     density: minimal
     density: normal
   * density: full
+  * chrome: off
+    chrome: dark
+    chrome: light
 
   up/down move   enter choose   esc cancel   F12 back to the harness
 ```

--- a/docs/news/unreleased-the-surface-is-a-keystroke-and-the-floor-was-measured.md
+++ b/docs/news/unreleased-the-surface-is-a-keystroke-and-the-floor-was-measured.md
@@ -1,0 +1,82 @@
+---
+version: unreleased
+headline: The surface is one keystroke, the floor was measured, and a component can match without charter drawing over it
+---
+
+Three things the frame's visual design left open, closed: the pane surface stopped
+requiring a file edit, the tmux version charter actually floors on got measured instead of
+assumed, and a component charter did not write can now look like one that it did.
+
+**`F2` carries the surface.** `chrome: off`, `chrome: dark` and `chrome: light`, with the
+one you are on marked. Choosing one repaints the frame you are looking at — no pane moves,
+nothing is re-laid-out — and `charter.toml` is not touched: the change lives in the frame's
+own state directory and is gone when the frame ends. The whole argument for shipping
+`chrome` defaulting to `off` was that a default which repaints a stranger's terminal can
+make a working frame worse on upgrade; the cost of that argument was the operator on a dark
+terminal who wanted the fill and had to go find a config key. These three rows are what
+they pay instead.
+
+`charter frame-chrome <off|dark|light>` is the same thing typed by hand. Choosing `off`
+**removes** the tmux options rather than setting a third look — a palette row that reported
+success and left the surface exactly where it was would be the convincing empty this spec
+argued an `auto` value out of existence for. And a pane the frame splits later comes up in
+the surface the frame *is* on, not the one it launched with: change the surface, then change
+the density, and the new pane used to arrive bare beside three surfaced ones.
+
+**The floor was measured, and it was not gated.** Everything behind the surface —
+`window-style` being settable per pane, honouring a colour and silently ignoring every
+attribute, the sixteen palette names resolving — had been measured on tmux 3.7c and on
+nothing else, while charter floors at 3.2. So 3.2 was built from source and the whole of it
+was re-run there, one style per server, reading the escapes off an attached client's wire:
+
+| at tmux 3.2 | |
+|---|---|
+| `set -p window-style` pane-scoped? | yes — sibling panel, harness pane and the window all read back `''` |
+| colour only? | yes — `reverse`, `dim` and `bold` each put **no SGR at all** on the wire |
+| do the 16 names resolve? | all sixteen — `bg=black`→`ESC[40m` … `bg=brightwhite`→`ESC[107m` |
+| a refused `set-option` | rc 1, `invalid style:`, previous value intact — reported, not fatal |
+
+Sixty-six of sixty-eight answers were byte-identical to 3.7c. The two that were not were
+the measuring harness rather than tmux: it batched four styled panes into one session, and
+tmux emits an SGR only when the style *changes* — so four panes that downsample to the same
+colour produce one escape and three silences, which reads as "three styles tmux ignored"
+and is nothing of the sort. One pane per server, they matched too. **The failure direction
+was believed safe and is now measured**, which was the point: `chrome` carries no version
+gate, and the absence of one is asserted rather than left to be noticed.
+
+**A component charter did not write can match it.** `ctx` now carries the frame's own
+recipes — `heading`, `muted`, `selected`, `ok`, `warn`, `bad`, `reset` and `inset` — as a
+read-only mapping of strings:
+
+```python
+def render(ctx):
+    c = ctx.chrome
+    return [f"{c['inset']}{c['heading']}metrics{c['reset']}{c['muted']} 12{c['reset']}"]
+```
+
+Every value is a plain attribute or one of the sixteen names your palette defines, never a
+colour charter picked, and `inset` is the literal left margin the rest of the frame starts
+at. Under `NO_COLOR` every escape in it is the empty string and the keys stay — a component
+built on them does not break there.
+
+There is no `surface` or `focus` recipe, and that is deliberate: those two are tmux pane
+options, no renderer can write one, and handing over an empty string for them would be a
+recipe that claims to give you something charter does not have. There is no `chrome`
+argument on the recipes either, for the same reason turned around — `off`, `dark` and
+`light` select a pane background, and the measurement above says `window-style` ignores
+every attribute, so nothing a renderer can write changes with the word. An argument that
+cannot change an answer is a line this repository deletes.
+
+What charter still does not promise is that your pane looks like its own. It does not
+overdraw your heading and it does not take a row out of your rectangle to make things line
+up. What it guarantees is what it already guaranteed: your paint stops at your rectangle,
+your failure costs your pane and not the session, and your output is contained before it
+reaches the terminal. A pane that clashes is a pane whose component chose to — which is
+honest, because it *is* different.
+
+`ctx` gaining a field is a widening of what a stranger's code may reach, and `ctx.Ctx`'s
+own docstring says that should cost a test change and the conversation that goes with it.
+The conversation is §7 of the spec; the cost is three assertions in
+`tests/test_component_ctx.py` that now name `chrome`, spelled out as a list rather than
+read off the constant, so that a name quietly added later fails them instead of being
+carried into them.

--- a/docs/superpowers/specs/2026-08-28-frame-visual-design.md
+++ b/docs/superpowers/specs/2026-08-28-frame-visual-design.md
@@ -742,14 +742,34 @@ for the default, because the default sets nothing.
 
 Stated rather than reasoned about, per this project's rule.
 
-- **tmux 3.1c and 3.2.** Only 3.7c is on this machine now
-  (`/opt/homebrew/Cellar/tmux/3.7c/bin/tmux`, and nothing else on `$PATH` or under
-  `/usr/local`). The 3.1c and 3.2 binaries `2026-08-26-tmux-input-findings.md` used are gone.
-  **Everything in §1, §3.1, §4 and §6 was measured on 3.7c only.** `window-style` is old
-  enough to predate `tmuxctl.FLOOR` (3.2), but *pane-scoped* `set -p` of it, and tmux's
-  colour downsampling at each tier, were not run below 3.7c. Phase 3 must run them on 3.2
-  before shipping, the way `tmuxctl`'s four version floors were confirmed by running 3.1c
-  and 3.2.
+- ~~**tmux 3.1c and 3.2.**~~ **ANSWERED in Phase 3.5 — the floor behaves identically, and
+  nothing is gated.** tmux 3.2 was built from source on this machine (`./configure &&
+  make`) and the whole of §1 and §4 was re-run against it, one style per server, with the
+  SGR lifted out of an attached client's wire rather than read out of forty bytes of
+  context. Sixty-six of sixty-eight answers were byte-identical to 3.7c; the two that were
+  not (`window-style bold`, and one pane's context window) were the measuring harness's own
+  batching — tmux emits an SGR only when the style CHANGES, so four panes that downsample
+  to the same colour produce one escape and three silences, which reads as "three styles
+  tmux ignored" and is nothing of the sort. Re-run one pane per server they matched too.
+
+  | measured at `tmuxctl.FLOOR` (3.2) | answer | 3.7c |
+  |---|---|---|
+  | `set -p window-style` pane-scoped? | yes — sibling panel, harness pane and `show -w` all `''` | same |
+  | honours colour only? | yes — `reverse`/`dim`/`bold` each put **no SGR at all** on the wire; `bg=colour236,dim` put `ESC[48;5;236m` and nothing else | same |
+  | do the 16 ANSI names resolve? | yes, all 16 — `bg=black`→`ESC[40m` … `bg=white`→`ESC[47m`, `bg=brightblack`→`ESC[100m` … `bg=brightwhite`→`ESC[107m` | same |
+  | active/inactive split | active pane `ESC[100m`, inactive `ESC[40m`, harness `ESC(B ESC[m` | same |
+  | style value format-expanded | stored verbatim: `bg=#{?#{==:1,1},colour196,colour46}` | same |
+  | `#(...)` in a style | refused by the parser: `invalid style:` | same |
+  | a refused `set-option` | rc 1, `invalid style: bg=notacolour`, previous value intact — reported, not fatal | same |
+  | survives `respawn-pane`, `resize-window` | yes | same |
+  | downsample per client | 256 → `ESC[48;5;236m`; 8-colour `xterm` → `ESC[40m`; `vt100` → `ESC[7m` | same |
+  | `set -p -u` removes it | rc 0, reads back `''`; unsetting one never set is also rc 0 | same |
+  | live `set -p` on an attached pane | repaints by itself — `ESC[40m` on the wire with no `refresh-client` | same |
+
+  **So `chrome` is not gated at a version**, and the absence of a gate is asserted rather
+  than left implicit (`tests/test_frame_surface_live.py`). The spec's contingency — "if 3.2
+  differs, `chrome` is gated at the version that works, the way `display-popup` is gated at
+  3.3" — did not come due.
 - **What the sixteen ANSI names actually resolve to in the operator's terminal.** The claim
   that 0–15 track the operator's chosen palette while 16–255 are a fixed cube is the basis
   for §3.2's "named slots, never indices", and it is a documented property of terminal
@@ -919,30 +939,30 @@ a test, and the phase does not exit without it.
 
 *The one thing that cannot be made theme-safe, behind one word.*
 
-- [ ] **3.1** `[frame] chrome` in `instance.FRAME_FIELDS`, TOML key `chrome`, a closed enum
+- [x] **3.1** `[frame] chrome` in `instance.FRAME_FIELDS`, TOML key `chrome`, a closed enum
       `off` / `dark` / `light`, default `off`. Validated at the config boundary the way
       `density_level` and `toggle_key` are, `isinstance` first — `tomllib` can hand it a list
       or a table and `config.FRAME` resolves on `charter --version`.
-- [ ] **3.2** The style pair applied pane-scoped from `_split_panels`, beside `_chrome_argvs`
+- [x] **3.2** The style pair applied pane-scoped from `_split_panels`, beside `_chrome_argvs`
       — the one funnel, both servers, at launch and at a density change, **never on a
       repaint**.
-- [ ] **3.3** The harness pane is never styled. Test it by reading it back:
+- [x] **3.3** The harness pane is never styled. Test it by reading it back:
       `show -p -t <harness> -v window-style` must answer `''`, and the client wire must carry
       no colour before the harness's content. This is ADR 0018's boundary; assert it rather
       than intend it.
-- [ ] **3.4** **No operator string reaches tmux.** The enum maps to style constants charter
+- [x] **3.4** **No operator string reaches tmux.** The enum maps to style constants charter
       holds. Mutation: let the config value through as a style; confirm RED, and confirm the
       test names *which* refusal fired.
-- [ ] **3.5** Run §1/§4's measurements again on **tmux 3.2** (`tmuxctl.FLOOR`) — pane-scoped
+- [x] **3.5** Run §1/§4's measurements again on **tmux 3.2** (`tmuxctl.FLOOR`) — pane-scoped
       `set -p window-style`, the active/inactive split, and the per-client downsample. §9 says
       they were run on 3.7c only. If 3.2 differs, `chrome` is gated at the version that works
       and says so, the way `display-popup` is gated at 3.3 (§4k).
-- [ ] **3.6** The palette carries `chrome: dark` / `chrome: light` / `chrome: off` as three
+- [x] **3.6** The palette carries `chrome: dark` / `chrome: light` / `chrome: off` as three
       rows, so the operator who upgrades into a look they dislike is one keystroke from
       fixing it rather than one documentation search.
-- [ ] **3.7** `docs/frame.md:200-209`'s "the one place charter overrides a preference of
+- [x] **3.7** `docs/frame.md:200-209`'s "the one place charter overrides a preference of
       yours" becomes true again — it is no longer the only one when `chrome` is set.
-- [ ] **3.8** News entry, full suite, two environments, sweep.
+- [x] **3.8** News entry, full suite, two environments, sweep.
 
 **Exit criteria.** With `chrome = "dark"`, charter's panel panes carry a background and the
 harness pane provably does not — read back from tmux, not from charter's own intent. With
@@ -957,21 +977,21 @@ recorded, whichever way it goes.
 
 *So a provider can match without charter overdrawing it.*
 
-- [ ] **4.1** `ctx` gains the roles of §5 as a read-only mapping of SGR strings, resolved for
+- [x] **4.1** `ctx` gains the roles of §5 as a read-only mapping of SGR strings, resolved for
       this frame's `chrome` and this pane's state. A `MappingProxyType`, no callable, reads
       nothing — the shape `SERVES["gather"]` already returns.
-- [ ] **4.2** The exact-attribute-set test on `Ctx` is updated, deliberately and visibly —
+- [x] **4.2** The exact-attribute-set test on `Ctx` is updated, deliberately and visibly —
       `ctx.Ctx`'s docstring says a widening should cost a test change and the conversation
       that goes with it. §7 is the conversation; the test change is the cost.
-- [ ] **4.3** A provider that ignores the recipes still cannot reach past its rectangle.
+- [x] **4.3** A provider that ignores the recipes still cannot reach past its rectangle.
       Assert it: a provider whose rows carry a background and no reset colours its own pane
       and no other, and its next repaint is clean (Phase 1.5).
-- [ ] **4.4** `docs/frame.md`'s provider section says what a provider gets and what charter
+- [x] **4.4** `docs/frame.md`'s provider section says what a provider gets and what charter
       does not promise: the surface is charter's, the cells are the provider's, and a pane
       that clashes is a pane whose provider chose to.
-- [ ] **4.5** Mutations: hand a provider a mutable recipes dict; let a foreign row skip
+- [x] **4.5** Mutations: hand a provider a mutable recipes dict; let a foreign row skip
       `_fit`. Each RED.
-- [ ] **4.6** Full suite, two environments, sweep.
+- [x] **4.6** Full suite, two environments, sweep.
 
 **Exit criteria.** A provider's component drawn with the recipes is indistinguishable from a
 built-in at the same size. One drawn without them is visibly different and harms nothing

--- a/tests/test_component_ctx.py
+++ b/tests/test_component_ctx.py
@@ -53,17 +53,26 @@ class OnlyWhatWasDeclared(unittest.TestCase):
         with self.assertRaises(AttributeError):
             c.todos             # not declared -> not present
 
-    def test_the_attribute_set_is_exactly_the_declaration_plus_the_geometry(self):
+    def test_the_attribute_set_is_exactly_the_declaration_plus_what_is_always_served(self):
         """Both halves of "exactly": the instance's own fields, and everything a
-        component could reach by name on the object."""
+        component could reach by name on the object.
+
+        **This assertion changed when `chrome` was added, and it was supposed to.**
+        `ctx.Ctx`'s own docstring says a future field is a widening of what a stranger's
+        code may reach and should cost a test change and the conversation that goes with
+        it. The conversation is §7 of the frame's visual-design spec; this line is the
+        cost. Read as a list rather than a name: `ALWAYS` is spelled out here on purpose,
+        so that a name quietly added to that tuple fails this test instead of being
+        carried into it.
+        """
         c = _ctx_for(needs=("repos", "todos"))
-        expected = {"width", "height", "fid", "repos", "todos"}
+        expected = {"width", "height", "fid", "chrome", "repos", "todos"}
         self.assertEqual(set(vars(c)), expected)
         self.assertEqual({n for n in dir(c) if not n.startswith("_")}, expected)
 
-    def test_declaring_nothing_leaves_the_geometry_and_nothing_else(self):
+    def test_declaring_nothing_leaves_what_is_always_served_and_nothing_else(self):
         c = _ctx_for(needs=())
-        self.assertEqual(set(vars(c)), {"width", "height", "fid"})
+        self.assertEqual(set(vars(c)), {"width", "height", "fid", "chrome"})
 
     def test_the_refusal_names_the_slice_and_where_to_declare_it(self):
         c = _ctx_for(needs=("gather",))
@@ -90,7 +99,8 @@ class OnlyWhatWasDeclared(unittest.TestCase):
         wide = ctx.build(("gather", "repos"), width=80, height=10, fid="f1",
                          snapshot=snap)
         narrow = ctx.build(("todos",), width=80, height=10, fid="f1", snapshot=snap)
-        self.assertEqual(set(vars(narrow)), {"width", "height", "fid", "todos"})
+        self.assertEqual(set(vars(narrow)),
+                         {"width", "height", "fid", "chrome", "todos"})
         self.assertIn("gather", vars(wide))
 
 

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -1107,8 +1107,9 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         """Nothing is re-recorded for this to be true: `_current_density` is read when the
         palette opens, so the mark follows the frame's own record by construction."""
         self._run("full")
-        reg = builtin_actions.build(self.fid,
-                                    current_density=commands_frame._current_density(self.fid))
+        reg = builtin_actions.build(
+            self.fid, current_density=commands_frame._current_density(self.fid),
+            current_chrome=commands_frame._current_chrome(self.fid))
         titles = [a.title for a in reg.all() if a.id.startswith("density.")]
         on = builtin_actions.MARK[0]
         self.assertIn(f"{on}density: full", titles)
@@ -1277,7 +1278,8 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         operator's own prefix key named in place of the thing charter cannot do."""
         state.record_server(self.fid, "/private/tmp/tmux-502/default")
         self._run("full")
-        reg = builtin_actions.build(self.fid, current_density="full")
+        reg = builtin_actions.build(self.fid, current_density="full",
+                                    current_chrome="off")
         offer = [o for o in reg.offers(fid=self.fid, snapshot={})
                  if o.id == "frame.detach"][0]
         self.assertFalse(offer.available)
@@ -1286,7 +1288,8 @@ class LiveOverride(PersonaIso, unittest.TestCase):
     def test_detaching_is_available_on_charters_own_server(self):
         """The other direction, so the row above cannot pass by never being available."""
         self._run("full")
-        reg = builtin_actions.build(self.fid, current_density="full")
+        reg = builtin_actions.build(self.fid, current_density="full",
+                                    current_chrome="off")
         offer = [o for o in reg.offers(fid=self.fid, snapshot={})
                  if o.id == "frame.detach"][0]
         self.assertTrue(offer.available)

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -2036,7 +2036,8 @@ class Launch(PersonaIso, unittest.TestCase):
         recorded server, so it has to look at a still-running frame."""
         fake = _FakeTmux(still_live=True)
         _launch(fake)
-        reg = builtin_actions.build(fake.fid, current_density="normal")
+        reg = builtin_actions.build(fake.fid, current_density="normal",
+                                    current_chrome="off")
         offer = [o for o in reg.offers(fid=fake.fid, snapshot={})
                  if o.id == "frame.detach"]
         self.assertEqual(len(offer), 1)
@@ -2056,7 +2057,8 @@ class Launch(PersonaIso, unittest.TestCase):
         fake = _FakeTmux(still_live=True)
         _launch(fake)
         reg = builtin_actions.build(fake.fid,
-                                    current_density=config.FRAME["density"])
+                                    current_density=config.FRAME["density"],
+                                    current_chrome="off")
         started = []
         with mock.patch.object(builtin_actions, "_spawn",
                                side_effect=lambda argv, *, fid: started.append(argv)):

--- a/tests/test_frame_palette.py
+++ b/tests/test_frame_palette.py
@@ -484,7 +484,8 @@ class TheActionsCharterOffersItself(PersonaIso, unittest.TestCase):
         state.record_identity(self.FID, {"CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
 
     def _offers(self):
-        reg = builtin_actions.build(self.FID, current_density="normal")
+        reg = builtin_actions.build(self.FID, current_density="normal",
+                                    current_chrome="off")
         return {o.id: o for o in reg.offers(fid=self.FID, snapshot={})}
 
     def test_charters_own_rows_are_offered_before_any_providers(self):
@@ -540,7 +541,8 @@ class TheActionsCharterOffersItself(PersonaIso, unittest.TestCase):
 
     def test_the_detach_row_starts_a_detached_client_command_on_the_frames_own_server(self):
         started = []
-        reg = builtin_actions.build(self.FID, current_density="normal")
+        reg = builtin_actions.build(self.FID, current_density="normal",
+                                    current_chrome="off")
         with mock.patch.object(builtin_actions, "_spawn",
                                side_effect=lambda argv, *, fid: started.append(argv)):
             reg.get("frame.detach").run(SimpleNamespace(fid=self.FID))
@@ -559,7 +561,8 @@ class TheActionsCharterOffersItself(PersonaIso, unittest.TestCase):
         """
         state.record_server(self.FID, "")
         started = []
-        reg = builtin_actions.build(self.FID, current_density="normal")
+        reg = builtin_actions.build(self.FID, current_density="normal",
+                                    current_chrome="off")
         with mock.patch.object(builtin_actions, "_spawn",
                                side_effect=lambda argv, *, fid: started.append(argv)):
             reg.get("frame.detach").run(SimpleNamespace(fid=self.FID))
@@ -577,7 +580,8 @@ class TheActionsCharterOffersItself(PersonaIso, unittest.TestCase):
             def __init__(self, argv, **kw):
                 opened.append(kw)
 
-        reg = builtin_actions.build(self.FID, current_density="normal")
+        reg = builtin_actions.build(self.FID, current_density="normal",
+                                    current_chrome="off")
         with mock.patch.object(builtin_actions.subprocess, "Popen", _Popen):
             for a in reg.all():
                 a.run(SimpleNamespace(fid=self.FID))

--- a/tests/test_frame_palette_names.py
+++ b/tests/test_frame_palette_names.py
@@ -368,11 +368,13 @@ class ANameIsStillNotAnAction(_Frame, unittest.TestCase):
         """Forty workspaces and forty personas are eighty rows and zero offers. This is
         the mutation that would undo Task 6 while every display assertion above stayed
         green."""
-        reg = builtin_actions.build(self.FID, current_density="full")
+        reg = builtin_actions.build(self.FID, current_density="full",
+                                    current_chrome="off")
         before = len(reg.offers(fid=self.FID, snapshot={}))
         _plane_workspaces(*[f"ws{i:02d}" for i in range(40)])
         _plane_personas(*[f"pe{i:02d}" for i in range(40)])
-        reg = builtin_actions.build(self.FID, current_density="full")
+        reg = builtin_actions.build(self.FID, current_density="full",
+                                    current_chrome="off")
         self.assertEqual(len(reg.offers(fid=self.FID, snapshot={})), before)
         self.assertGreaterEqual(len(self._typed("0").rows), 8)
 

--- a/tests/test_frame_provider_recipes.py
+++ b/tests/test_frame_provider_recipes.py
@@ -1,0 +1,362 @@
+"""What a provider is handed so it can match, and what charter does not promise it —
+Phase 4 of `docs/superpowers/specs/2026-08-28-frame-visual-design.md`.
+
+§7's sentence, made a test: **charter owns the surface and the border; the provider owns
+every cell it writes.** The surface is underneath, painted by tmux into the pane's whole
+rectangle before a provider draws anything, so a component that paints nothing gets it for
+free. What charter hands over on top of that is the recipes — `ctx.chrome` — and nothing
+else: it does not overdraw a provider's heading, it does not take a row out of §4b's
+rectangle to make things line up, and it does not promise that a pane looks like charter's.
+
+**The counter-argument §7 answers is the one this file is really about.** A provider that
+paints its own colours next to charter's can make a pane unreadable, and charter cannot
+prevent that — a provider's module is ordinary Python and `ctx`'s own docstring says
+outright that it is not a sandbox. What charter *can* guarantee is the three things it
+already guarantees, and they are asserted here rather than restated: the provider's paint
+stops at its rectangle, its failure costs its pane and not the session, and its output is
+contained before it reaches the terminal.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from types import MappingProxyType
+from unittest import mock
+
+from charter import statusline, tui
+from charter.frame import chrome, ctx, registry, slots
+from tests._isolation import PersonaIso
+
+#: One SGR escape with its parameter list captured — the shape `chrome._SGR` matches.
+_SGR = re.compile(r"\x1b\[([0-9;]*)m")
+
+#: SGR parameters that introduce a colour charter did not get from the operator's own
+#: palette: `38`/`48` followed by `5` (a 256-cube index) or `2` (a 24-bit triple).
+_EXTENDED = ("38", "48")
+
+
+def _absolute_colours(text: str) -> list[str]:
+    """Every escape in *text* that names a colour charter picked rather than a slot.
+
+    Asked of the PARAMETERS, never by searching for the substring `48;5;`: `\\x1b[1;38;5;
+    236m` is a cube index with a `1;` in front of it and a substring test walks past it.
+    That is this project's own recurring defect — the spelling standing in for the
+    property — and this file is one of the places it would be least visible.
+    """
+    found = []
+    for m in _SGR.finditer(text):
+        params = m.group(1).split(";")
+        for i, p in enumerate(params[:-1]):
+            if p in _EXTENDED and params[i + 1] in ("5", "2"):
+                found.append(m.group(0))
+    return found
+
+
+def _tty(value: bool = True):
+    """`sys.stdout.isatty()` answering *value* — what `chrome.colour_ok` asks."""
+    return mock.patch.object(sys.stdout, "isatty", return_value=value, create=True)
+
+
+class TheRecipesAreDataAndNothingElse(unittest.TestCase):
+    """4.1. A `MappingProxyType` of strings, no callable, reading nothing."""
+
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.tty = _tty()
+        self.tty.start()
+        self.addCleanup(self.tty.stop)
+
+    def test_it_is_a_read_only_mapping(self):
+        r = chrome.recipes()
+        self.assertIsInstance(r, MappingProxyType)
+        with self.assertRaises(TypeError):
+            r["ok"] = "\x1b[35m"
+        with self.assertRaises(TypeError):
+            del r["ok"]
+
+    def test_the_underlying_dict_is_not_reachable_through_it(self):
+        """A `MappingProxyType` over a dict a caller still holds is a read-only view of a
+        mutable thing. Each call builds its own, so one component cannot edit what the
+        next one is about to be handed."""
+        a, b = chrome.recipes(), chrome.recipes()
+        self.assertEqual(dict(a), dict(b))
+        self.assertIsNot(a, b)
+
+    def test_every_value_is_a_string_and_no_value_is_callable(self):
+        for role, value in chrome.recipes().items():
+            with self.subTest(role=role):
+                self.assertIsInstance(value, str)
+                self.assertFalse(callable(value))
+
+    def test_the_vocabulary_is_the_roles_a_renderer_can_write(self):
+        self.assertEqual(set(chrome.recipes()),
+                         {"heading", "muted", "selected", "ok", "warn", "bad", "reset",
+                          "inset"})
+
+    def test_surface_and_focus_are_absent_rather_than_empty(self):
+        """§5's other two elements are tmux pane options. A recipe answering `''` for
+        them would claim to hand over something charter does not have — the convincing
+        empty `FRAME_CHROME` refuses an `auto` value for."""
+        for role in ("surface", "focus"):
+            with self.subTest(role=role):
+                self.assertNotIn(role, chrome.recipes())
+
+
+class TheRecipesNameNoColourCharterChose(unittest.TestCase):
+    """The rule `instance.FRAME_CHROME` keeps, reaching the one place a stranger's code
+    would otherwise have to guess it."""
+
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.tty = _tty()
+        self.tty.start()
+        self.addCleanup(self.tty.stop)
+
+    def test_no_recipe_carries_a_cube_index_or_a_24_bit_triple(self):
+        for role, value in chrome.recipes().items():
+            with self.subTest(role=role):
+                self.assertEqual(_absolute_colours(value), [])
+
+    def test_the_check_recognises_both_forms(self):
+        """The control. Every assertion above is a negative, so this proves the check can
+        fail — including the prefixed spelling a grep for `\\x1b[48;5;` misses."""
+        for esc in ("\x1b[48;5;236m", "\x1b[38;2;30;60;90m", "\x1b[1;38;5;236m"):
+            with self.subTest(esc=esc):
+                self.assertEqual(_absolute_colours(esc), [esc])
+
+    def test_the_status_roles_are_the_three_names_the_spec_fixed(self):
+        """§5.6: `ok` → green, `warn` → yellow, `bad` → red, never an index. Written down
+        so the next role added does not reach for `colour208`."""
+        r = chrome.recipes()
+        self.assertEqual(r["ok"], statusline._GREEN)
+        self.assertEqual(r["warn"], statusline._YELLOW)
+        self.assertEqual(r["bad"], statusline._RED)
+
+
+class ARecipeIsTheSameStringCharterUses(PersonaIso, unittest.TestCase):
+    """The exit criterion: a component drawn with the recipes is indistinguishable from a
+    built-in at the same size.
+
+    Asserted as identity of the ESCAPES rather than by rendering two panes and comparing
+    pictures: what "matches" means here is that the provider's heading is the weight
+    charter's heading is, and a second copy of `\\033[1m` in `chrome.py` is exactly how the
+    two would drift apart while both tests stayed green.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.env = mock.patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.tty = _tty()
+        self.tty.start()
+        self.addCleanup(self.tty.stop)
+
+    def test_the_heading_recipe_is_the_weight_charters_own_heading_uses(self):
+        r = chrome.recipes()
+        head = slots._sidebar_head("personas", 6, 40)
+        self.assertIn(f"{r['heading']}personas", head)
+
+    def test_the_muted_recipe_is_the_weight_charters_own_count_uses(self):
+        r = chrome.recipes()
+        head = slots._sidebar_head("personas", 6, 40)
+        self.assertIn(f"{r['muted']} 6", head)
+
+    def test_the_selected_recipe_is_what_chrome_reverse_asserts(self):
+        """One constant, not two: `chrome.reverse` re-asserts this escape after every SGR
+        that cancels it, and a provider highlighting its own row has to be able to write
+        the same one."""
+        self.assertTrue(chrome.reverse("x", 4).startswith(chrome.recipes()["selected"]))
+
+    def test_the_reset_recipe_closes_a_span_the_way_charter_closes_one(self):
+        self.assertEqual(chrome.recipes()["reset"], tui.RESET)
+
+    def test_the_inset_recipe_is_exactly_the_column_content_starts_at(self):
+        """§5.4 is a COLUMN, not an attribute — the one entry here that is not SGR. Served
+        as the literal left edge so a provider prepends it and lines up, rather than being
+        told a number and left to spell the padding, which is the per-call-site spelling
+        that constant exists to end."""
+        r = chrome.recipes()
+        self.assertEqual(tui.width(r["inset"]), slots.INSET)
+        self.assertEqual(r["inset"], slots._inset())
+
+
+class NoColourReachesTheRecipesToo(unittest.TestCase):
+    """§3.2's rule, and the half a provider would otherwise break for charter.
+
+    `NO_COLOR` means no colour on the operator's screen caused by charter, whichever
+    process puts the bytes there. A provider handed live escapes under `NO_COLOR` would
+    emit them on charter's behalf.
+    """
+
+    def test_every_sgr_role_is_empty_under_no_color(self):
+        with mock.patch.dict(os.environ, {"NO_COLOR": ""}, clear=True), _tty():
+            r = chrome.recipes()
+        for role in ("heading", "muted", "selected", "ok", "warn", "bad", "reset"):
+            with self.subTest(role=role):
+                self.assertEqual(r[role], "")
+
+    def test_presence_and_not_a_value(self):
+        """`NO_COLOR=` and `NO_COLOR=0` both count, per no-color.org. Matching a value
+        would be the spelling-not-property mistake in the file that is about it."""
+        for value in ("", "0", "1", "false"):
+            with self.subTest(value=value):
+                with mock.patch.dict(os.environ, {"NO_COLOR": value}, clear=True), _tty():
+                    self.assertEqual(chrome.recipes()["ok"], "")
+
+    def test_a_stdout_that_is_not_a_tty_is_the_same_answer(self):
+        with mock.patch.dict(os.environ, {}, clear=True), _tty(False):
+            self.assertEqual(chrome.recipes()["heading"], "")
+
+    def test_the_roles_are_still_all_there(self):
+        """Empty rather than ABSENT, and the difference is a provider's pane. A component
+        writing `ctx.chrome["ok"] + text` would raise inside its own draw and lose its
+        rectangle — to honour a request about colour."""
+        with mock.patch.dict(os.environ, {"NO_COLOR": "1"}, clear=True), _tty():
+            with mock.patch.dict(os.environ, {}, clear=True), _tty():
+                live = set(chrome.recipes())
+        with mock.patch.dict(os.environ, {"NO_COLOR": "1"}, clear=True), _tty():
+            self.assertEqual(set(chrome.recipes()), live)
+
+    def test_the_inset_survives_because_it_is_not_colour(self):
+        """A frame that lost its inset under `NO_COLOR` would be answering a question
+        about colour with a change to layout."""
+        with mock.patch.dict(os.environ, {"NO_COLOR": "1"}, clear=True), _tty():
+            self.assertEqual(tui.width(chrome.recipes()["inset"]), slots.INSET)
+
+    def test_the_word_chrome_is_on_changes_none_of_them(self):
+        """§7 asks for the roles "resolved for this frame's `chrome` setting", and the
+        measurement says there is nothing for that setting to resolve: `off`/`dark`/
+        `light` select a pane background, `window-style` honours colour and silently
+        ignores every attribute (re-measured for Phase 3 on tmux 3.7c AND 3.2 — `bold`,
+        `dim` and `reverse` each put no SGR at all on an attached client's wire), and no
+        renderer can write a pane option.
+
+        So this is a NEGATIVE pinned deliberately: a `chrome` parameter on `recipes()`
+        would be an argument that cannot change an answer. If a future role does depend on
+        the word, this test is what has to be deleted, with the measurement that justified
+        it."""
+        import inspect
+        self.assertEqual(list(inspect.signature(chrome.recipes).parameters), [])
+
+
+class TheRecipesTravelOnTheCtx(PersonaIso, unittest.TestCase):
+    """4.1/4.2. `ctx.chrome`, served whatever the component declared."""
+
+    def _ctx(self, needs=()):
+        return ctx.build(needs, width=80, height=10, fid="f1", snapshot={})
+
+    def test_a_component_that_declared_nothing_still_gets_the_recipes(self):
+        self.assertIn("chrome", vars(self._ctx()))
+
+    def test_it_is_served_alongside_the_geometry_and_not_out_of_the_snapshot(self):
+        """`SERVES`' values are functions OF THE SNAPSHOT. A recipes entry there would be
+        a callable that takes the snapshot and ignores it, which is the exact shape
+        `ctx.Ctx`'s docstring records as the defect that let an action reach the plane's
+        whole vault inventory."""
+        self.assertIn("chrome", ctx.ALWAYS)
+        self.assertNotIn("chrome", ctx.SERVES)
+
+    def test_the_refusal_message_names_it_among_what_charter_serves(self):
+        c = self._ctx()
+        with self.assertRaises(AttributeError) as e:
+            c.nothing_like_this
+        self.assertIn("chrome", str(e.exception))
+
+    def test_it_cannot_be_replaced_on_the_ctx(self):
+        c = self._ctx()
+        with self.assertRaises(AttributeError):
+            c.chrome = {"ok": "\x1b[35m"}
+
+    def test_the_ctx_still_carries_no_callable_of_charters(self):
+        """4.6's exit criterion, re-asserted because this phase added a field: `dir(ctx)`
+        and `vars(ctx)` carry data and no way to *do* anything."""
+        c = self._ctx(("gather",))
+        for name in dir(c):
+            if name.startswith("_"):
+                continue
+            with self.subTest(name=name):
+                self.assertFalse(callable(getattr(c, name)))
+
+    def test_two_components_in_one_repaint_cannot_edit_each_others_recipes(self):
+        a, b = self._ctx(), self._ctx()
+        self.assertIsNot(a.chrome, b.chrome)
+        with self.assertRaises(TypeError):
+            a.chrome["heading"] = "x"
+        self.assertEqual(b.chrome["heading"], chrome.recipes()["heading"])
+
+
+class AProviderThatIgnoresTheRecipesHarmsNothingOutsideItsPane(unittest.TestCase):
+    """4.3. The three guarantees §7 says charter *can* make, asserted rather than restated.
+
+    A provider whose rows carry a background and no reset is the case that matters, because
+    it is the one this whole spec makes normal: components are about to start painting.
+    """
+
+    def test_a_foreign_row_is_clipped_to_its_rectangle(self):
+        """`Registry._fit` contains and clips every foreign row. A row wider than the pane
+        cannot reach the pane beside it, whatever it painted."""
+        wide = "\x1b[41m" + "X" * 200
+        got = registry._fit([wide], width=20, height=3, escape=True)
+        for line in got:
+            with self.subTest(line=line):
+                self.assertLessEqual(tui.width(line), 20)
+
+    def test_a_foreign_rows_escapes_are_neutralised_before_they_reach_the_terminal(self):
+        """`escape=True` is what `Registry.draw` passes for a component id in
+        `_foreign`. The paint a provider emits is data by the time it is measured."""
+        got = registry._fit(["\x1b[41mLEAK"], width=20, height=1, escape=True)
+        self.assertNotIn("\x1b[41m", "".join(got))
+
+    def test_a_foreign_component_cannot_add_rows_to_its_pane(self):
+        """The height budget is charter's. A provider that returned fifty rows for a
+        three-row pane cannot push the pane below it down the screen."""
+        got = registry._fit(["r"] * 50, width=20, height=3, escape=True)
+        self.assertLessEqual(len(got), 3)
+
+    def test_a_leaked_background_costs_one_paint_and_not_the_session(self):
+        """Phase 1.5, re-asserted from the provider's side because §7 promises it to a
+        provider author. `panel._write` prefixes a reset, so `\\x1b[2J` — which erases
+        with whatever attributes are set — cannot carry a component's leaked background
+        into every later paint of that pane."""
+        from charter.frame import panel
+        wrote = []
+        # A tty and no `NO_COLOR`: the reset is SGR, so under the other answer `_write`
+        # correctly emits none of it — including this — and a fixture that did not say so
+        # would be asserting the absence of a guard it had itself turned off.
+        with mock.patch.dict(os.environ, {}, clear=True), _tty(), \
+             mock.patch.object(panel, "_rows", return_value=5), \
+             mock.patch.object(panel.sys.stdout, "write", side_effect=wrote.append), \
+             mock.patch.object(panel.sys.stdout, "flush"):
+            panel._write("\x1b[41mLEAK")
+        out = "".join(wrote)
+        self.assertTrue(out.startswith("\x1b[m"),
+                        f"the clear-screen was not preceded by a reset: {out!r}")
+        self.assertLess(out.index("\x1b[m"), out.index("\x1b[2J"))
+        self.assertIn("\x1b[41mLEAK", out,
+                      "the provider's own paint was supposed to survive into its own "
+                      "pane — the reset is about the NEXT paint, not this one")
+
+    def test_the_split_four_call_sites_rely_on_still_answers_the_content(self):
+        """The reset goes BEFORE the cursor-home for this reason and it is asserted here
+        rather than left to the four tests that would break: `split("\x1b[2J", 1)[1]`
+        must still be the content."""
+        from charter.frame import panel
+        wrote = []
+        with mock.patch.dict(os.environ, {}, clear=True), _tty(), \
+             mock.patch.object(panel, "_rows", return_value=5), \
+             mock.patch.object(panel.sys.stdout, "write", side_effect=wrote.append), \
+             mock.patch.object(panel.sys.stdout, "flush"):
+            panel._write("BODY")
+        self.assertEqual("".join(wrote).split("\x1b[2J", 1)[1], "BODY")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_provider_recipes.py
+++ b/tests/test_frame_provider_recipes.py
@@ -219,9 +219,8 @@ class NoColourReachesTheRecipesToo(unittest.TestCase):
         """Empty rather than ABSENT, and the difference is a provider's pane. A component
         writing `ctx.chrome["ok"] + text` would raise inside its own draw and lose its
         rectangle — to honour a request about colour."""
-        with mock.patch.dict(os.environ, {"NO_COLOR": "1"}, clear=True), _tty():
-            with mock.patch.dict(os.environ, {}, clear=True), _tty():
-                live = set(chrome.recipes())
+        with mock.patch.dict(os.environ, {}, clear=True), _tty():
+            live = set(chrome.recipes())
         with mock.patch.dict(os.environ, {"NO_COLOR": "1"}, clear=True), _tty():
             self.assertEqual(set(chrome.recipes()), live)
 

--- a/tests/test_frame_surface_live.py
+++ b/tests/test_frame_surface_live.py
@@ -155,6 +155,73 @@ class TheRecordedSurfaceOverridesTheConfiguredOne(PersonaIso, unittest.TestCase)
             self.assertEqual(commands_frame._current_chrome(self.FID), "dark")
 
 
+class TheTwoNewStateAccessorsRefuseRatherThanRaise(PersonaIso, unittest.TestCase):
+    """The four guards the deletion sweep found unpinned in `record_chrome` / `chrome`.
+
+    All four are live and none of them had a test: the sweep deleted each in turn and the
+    whole 7037-test suite stayed green. They are not decoration — `$CHARTER_SESSION_ID`
+    reaches both functions without ever passing through `state.frame_id`'s minting
+    (`cmd_chrome` reads the variable directly), so a hostile or oversized id arrives here
+    as an ordinary argument, and `frame_dir` answers `None` for it. Without the guards
+    that is a `TypeError` from `None / "chrome"` — raised out of a command that runs
+    detached from a palette row, where nothing would ever print it.
+
+    **Each test names WHICH refusal fired**, per the deletion sweep: two guards in
+    sequence mask each other, and "it did not raise" is satisfied by both.
+    """
+
+    #: A frame id `contain.child` refuses outright, so `frame_dir` answers `None` — the
+    #: exact input `$CHARTER_SESSION_ID` can carry.
+    HOSTILE = "../../../etc"
+
+    def test_recording_against_an_unusable_frame_id_writes_nothing(self):
+        state.record_chrome(self.HOSTILE, "dark")
+        # WHICH refusal: `frame_dir` answered None, so nothing was written anywhere —
+        # asserted as the absence of a readable value rather than as "no exception".
+        self.assertIsNone(state.chrome(self.HOSTILE))
+
+    def test_reading_an_unusable_frame_id_answers_none_rather_than_raising(self):
+        self.assertIsNone(state.chrome(self.HOSTILE))
+        with mock.patch.dict(commands_frame.config.FRAME, {"chrome": "dark"}):
+            self.assertEqual(commands_frame._current_chrome(self.HOSTILE), "dark",
+                             "the read raised instead of degrading, so a frame launched "
+                             "with a hostile $CHARTER_SESSION_ID takes the launch down "
+                             "rather than losing its surface")
+
+    def test_a_write_that_fails_is_a_surface_lost_and_not_an_exception(self):
+        """`record_chrome` is called from `cmd_chrome`, which runs detached from a
+        palette row. A full disk there must cost the surface, not the command."""
+        real = pathlib.Path.write_text
+
+        def refuse(self_path, *a, **kw):
+            if self_path.name == "chrome.tmp":
+                raise OSError("no space left on device")
+            return real(self_path, *a, **kw)
+
+        with mock.patch.object(pathlib.Path, "write_text", refuse):
+            state.record_chrome("fr-write-fails", "dark")
+        # WHICH refusal: the write was attempted and refused, so nothing was recorded.
+        self.assertIsNone(state.chrome("fr-write-fails"))
+        # And the control — with the write working, the same call DOES record, so the
+        # assertion above is about the refusal and not about a fixture that never wrote.
+        state.record_chrome("fr-write-fails", "dark")
+        self.assertEqual(state.chrome("fr-write-fails"), "dark")
+
+    def test_an_empty_recorded_file_is_never_set_rather_than_a_word(self):
+        """`None` and `""` are different answers to "has this frame been set by hand",
+        and this function's docstring promises the first. Nothing downstream can tell
+        them apart today — `chrome_level("")` is `None` either way — so the promise is
+        the reason the line is here, and a promise nothing checks is what the sweep
+        exists to find."""
+        state.record_chrome("fr-empty", "")
+        self.assertIsNone(state.chrome("fr-empty"))
+        state.record_chrome("fr-empty", "   ")
+        self.assertIsNone(state.chrome("fr-empty"))
+        # The control: a real word is not flattened by the same line.
+        state.record_chrome("fr-empty", "light")
+        self.assertEqual(state.chrome("fr-empty"), "light")
+
+
 class TurningTheSurfaceOffIsARemovalAndNotAStyle(unittest.TestCase):
     """`_resurface_argvs` — the argv, before any tmux runs it.
 

--- a/tests/test_frame_surface_live.py
+++ b/tests/test_frame_surface_live.py
@@ -1,0 +1,447 @@
+"""The surface an operator can change without relaunching, and the floor it was measured
+against — Phase 3 of `docs/superpowers/specs/2026-08-28-frame-visual-design.md`.
+
+**Phase 3.5 is why this file exists at all.** §9 of that spec records that every
+`window-style` measurement behind the surface was run on tmux 3.7c and on nothing else,
+and that the floor (`tmuxctl.FLOOR`, 3.2) had to be run before the surface could ship.
+It has been. tmux 3.2 was built from source on this machine and the whole of §1 and §4
+was re-run against it, one style per server, with the SGR lifted out of the client's wire
+rather than eyeballed out of forty bytes of context:
+
+* ``set-option -p window-style`` is **pane-scoped** there. `show -p` on the sibling panel
+  and on the harness pane both answer ``''`` after it, and so does `show -w` on the
+  window — so the harness boundary ADR 0018 draws holds at the floor by the same
+  construction it holds at 3.7c.
+* It honours **colour only**. ``reverse``, ``dim`` and ``bold`` each put *no SGR at all*
+  on an attached client's wire; ``bg=colour236,dim`` put ``ESC[48;5;236m`` and nothing
+  else. Identical to 3.7c.
+* The **sixteen ANSI names resolve**, all sixteen: ``bg=black`` → ``ESC[40m`` through
+  ``bg=white`` → ``ESC[47m``, ``bg=brightblack`` → ``ESC[100m`` through
+  ``bg=brightwhite`` → ``ESC[107m``. Identical to 3.7c.
+* The active/inactive split, the format-expansion of a style value, the refusal of
+  ``bg=notacolour`` (rc 1, ``invalid style:``, previous value intact), the refusal of
+  ``#(...)`` by the style parser, and survival across `respawn-pane` and `resize-window`
+  are all identical too. Sixty-six of sixty-eight answers matched byte for byte; the two
+  that did not were the measurement harness's own batching — re-run one pane per server
+  they matched as well.
+
+**So there is no version gate, and the absence is asserted below rather than assumed.**
+The spec said that if 3.2 differed, `chrome` would be gated at the version that works,
+the way `display-popup` is gated at 3.3. It does not differ. A gate added anyway would be
+a refusal with no measurement behind it, on the one path where a refusal is invisible —
+`_surface_argvs`' failures are reported, not fatal.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import unittest
+from unittest import mock
+
+from charter import commands_frame, instance
+from charter.frame import builtin_actions, chrome as chrome_mod, state
+from tests._isolation import PersonaIso
+from tests.test_frame_tmux_integration import _HAS_TMUX, _TmuxServerFixture
+
+
+class TheSurfaceIsNotVersionGated(unittest.TestCase):
+    """Phase 3.5's answer, kept honest as code rather than only as prose.
+
+    The measurement said the floor behaves identically, so `_surface_argvs` and
+    `_resurface_argvs` ask tmux's version about nothing. A future edit that adds a floor
+    has to delete this test and say which measurement it found.
+    """
+
+    def test_neither_surface_builder_consults_the_tmux_version(self):
+        import inspect
+        for fn in (commands_frame._surface_argvs, commands_frame._resurface_argvs):
+            with self.subTest(fn=fn.__name__):
+                src = inspect.getsource(fn)
+                self.assertNotIn("version", src.split('"""')[-1],
+                                 f"{fn.__name__} grew a version gate — tmux 3.2 was "
+                                 f"measured identical to 3.7c, so a gate needs its own "
+                                 f"measurement")
+
+    def test_the_floor_is_still_the_version_this_was_measured_against(self):
+        """If the floor moves, the measurement above is about a version charter no
+        longer supports and has to be re-run rather than inherited."""
+        from charter.frame import tmuxctl
+        self.assertEqual(tmuxctl.FLOOR, (3, 2))
+
+
+class TheRecordedSurfaceOverridesTheConfiguredOne(PersonaIso, unittest.TestCase):
+    """`state.record_chrome` / `state.chrome` / `commands_frame._current_chrome`.
+
+    `record_density`'s twin, and asserted separately rather than trusted to be: the two
+    read different files and only one of them is on its way to a tmux style.
+    """
+
+    FID = "fr-surface-1"
+
+    def test_a_recorded_word_round_trips(self):
+        state.record_chrome(self.FID, "dark")
+        self.assertEqual(state.chrome(self.FID), "dark")
+
+    def test_nothing_recorded_reads_back_as_none(self):
+        """`None` is "never set", which is every frame until a keypress — and it must be
+        distinguishable from `off`, or the fallback to the configured value could never
+        happen."""
+        self.assertIsNone(state.chrome(self.FID))
+
+    def test_the_record_wins_over_the_configured_value(self):
+        state.record_chrome(self.FID, "light")
+        with mock.patch.dict(commands_frame.config.FRAME, {"chrome": "dark"}):
+            self.assertEqual(commands_frame._current_chrome(self.FID), "light")
+
+    def test_with_nothing_recorded_the_configured_value_is_used(self):
+        with mock.patch.dict(commands_frame.config.FRAME, {"chrome": "dark"}):
+            self.assertEqual(commands_frame._current_chrome(self.FID), "dark")
+
+    def test_with_neither_the_answer_is_off(self):
+        with mock.patch.dict(commands_frame.config.FRAME, {}, clear=True):
+            self.assertEqual(commands_frame._current_chrome(self.FID), "off")
+
+    def test_a_word_charter_does_not_know_is_off_from_either_source(self):
+        """The gate is at the point of USE and it gates BOTH sources. A recorded file is
+        machine-written but hand-editable; a committed config arrives from someone else's
+        machine. Neither is allowed to be the word that reaches `chrome_options`."""
+        state.record_chrome(self.FID, "bg=#{?#{==:1,1},colour196,colour46}")
+        with mock.patch.dict(commands_frame.config.FRAME, {"chrome": "dark"}):
+            self.assertEqual(commands_frame._current_chrome(self.FID), "dark")
+        with mock.patch.dict(commands_frame.config.FRAME, {"chrome": ["dark"]}):
+            self.assertEqual(commands_frame._current_chrome(self.FID), "off")
+
+    def test_an_unreadable_record_degrades_rather_than_raising(self):
+        """`_current_chrome` is called from `_split_panels`, which is on the launch
+        path: a truncated file must cost the surface, never the frame."""
+        state.record_chrome(self.FID, "dark")
+        with mock.patch.object(state, "chrome", side_effect=OSError("gone")):
+            with self.assertRaises(OSError):
+                state.chrome(self.FID)
+        # And the real reader, over a directory where the file cannot be read.
+        with mock.patch.dict(commands_frame.config.FRAME, {"chrome": "off"}):
+            self.assertEqual(commands_frame._current_chrome(self.FID), "dark")
+
+
+class TurningTheSurfaceOffIsARemovalAndNotAStyle(unittest.TestCase):
+    """`_resurface_argvs` — the argv, before any tmux runs it.
+
+    The whole difference from `_surface_argvs`. On a launch `off` is free because nothing
+    is set; on a running frame it has to UNSET, or the palette row that says `off` reports
+    success and leaves the surface exactly where it was.
+    """
+
+    def _argvs(self, chrome):
+        return commands_frame._resurface_argvs(socket="s", pane_id="%3", chrome=chrome)
+
+    def _tails(self, chrome):
+        """Each argv from `set-option` onwards, so the assertions are about what tmux is
+        told and not about `tmuxctl.server_argv`'s prefix."""
+        return [a[a.index("set-option"):] for a in self._argvs(chrome)]
+
+    def test_off_unsets_every_option_the_table_can_set_and_sets_none(self):
+        tails = self._tails("off")
+        self.assertEqual(tails, [["set-option", "-p", "-u", "-t", "%3", name]
+                                 for name in instance.chrome_option_names()])
+
+    def test_dark_sets_both_options_and_unsets_nothing(self):
+        tails = self._tails("dark")
+        self.assertEqual(tails, [["set-option", "-p", "-t", "%3", name, value]
+                                 for name, value in instance.FRAME_CHROME["dark"]])
+
+    def test_a_word_charter_does_not_know_is_off_here_too(self):
+        """The refusal is named: the argv is the UNSET list, which is `off`'s answer —
+        not an empty list, which would leave a surfaced pane surfaced."""
+        for hostile in ("bg=black", "", None, ["dark"], {"a": 1}, 3):
+            with self.subTest(value=hostile):
+                self.assertEqual(self._tails(hostile), self._tails("off"))
+
+    def test_no_operator_string_reaches_tmux(self):
+        """The containment boundary, asserted on this path as well as the launch one: a
+        style charter did not write itself cannot leave through here."""
+        argvs = self._argvs("bg=#{?#{==:1,1},colour196,colour46}")
+        for argv in argvs:
+            for word in argv:
+                self.assertNotIn("#", word)
+
+    def test_no_colour_unsets_rather_than_answering_nothing(self):
+        """`NO_COLOR` on the LIVE path is the half that is easy to get wrong. Answering
+        `[]` — which is what the launch path correctly answers — would leave a frame that
+        was surfaced before the variable was exported still surfaced."""
+        with mock.patch.dict(os.environ, {"NO_COLOR": ""}, clear=True):
+            self.assertEqual(self._tails("dark"), self._tails("off"))
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertNotEqual(self._tails("dark"), self._tails("off"))
+
+    def test_the_unset_list_is_derived_from_the_table(self):
+        """`instance.chrome_option_names` is the union of the table's option names, so a
+        third option added to `FRAME_CHROME` is unset by `off` on the day it is added
+        instead of surviving a keypress nobody re-read."""
+        with mock.patch.dict(instance.FRAME_CHROME,
+                             {"dark": (("window-style", "bg=black"),
+                                       ("pane-border-style", "fg=black"))}):
+            self.assertIn("pane-border-style", instance.chrome_option_names())
+            self.assertIn(["set-option", "-p", "-u", "-t", "%3", "pane-border-style"],
+                          self._tails("off"))
+
+
+class TheChromeCommandChangesOneRunningFrame(PersonaIso, unittest.TestCase):
+    """`charter frame-chrome <level>` — `cmd_chrome`.
+
+    Every refusal is a quiet no-op returning 0, and each is asserted by WHAT DID NOT
+    HAPPEN — nothing recorded, no argv issued — rather than by the exit code, which every
+    refusal shares with success.
+    """
+
+    FID = "fr-surface-2"
+
+    def setUp(self):
+        super().setUp()
+        self.ran: list[list[str]] = []
+        patcher = mock.patch.object(
+            commands_frame.tmuxctl, "run",
+            side_effect=lambda _what, argv, **kw: self.ran.append(argv) or
+            subprocess.CompletedProcess(argv, 0, "", ""))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _args(self, level):
+        return type("A", (), {"level": level})()
+
+    def _with_panes(self, panes=None):
+        state.record_panes(self.FID, panels=panes if panes is not None
+                           else {"top": "%1", "right": "%2"})
+
+    def test_a_level_is_recorded_and_every_panel_pane_is_told(self):
+        self._with_panes()
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID}, clear=True):
+            self.assertEqual(commands_frame.cmd_chrome(self._args("dark")), 0)
+        self.assertEqual(state.chrome(self.FID), "dark")
+        targets = {a[a.index("-t") + 1] for a in self.ran}
+        self.assertEqual(targets, {"%1", "%2"})
+        self.assertTrue(all("window-style" in a or "window-active-style" in a
+                            for a in self.ran))
+
+    def test_off_issues_the_unsets(self):
+        self._with_panes({"top": "%1"})
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID}, clear=True):
+            commands_frame.cmd_chrome(self._args("off"))
+        self.assertEqual(state.chrome(self.FID), "off")
+        self.assertTrue(all("-u" in a for a in self.ran), self.ran)
+
+    def test_no_session_id_records_nothing_and_runs_nothing(self):
+        self._with_panes()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(commands_frame.cmd_chrome(self._args("dark")), 0)
+        self.assertIsNone(state.chrome(self.FID))
+        self.assertEqual(self.ran, [])
+
+    def test_a_level_outside_the_enum_records_nothing_and_runs_nothing(self):
+        self._with_panes()
+        for hostile in ("bg=black", "solarized", "", None, ["dark"]):
+            with self.subTest(level=hostile):
+                with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID},
+                                     clear=True):
+                    self.assertEqual(commands_frame.cmd_chrome(self._args(hostile)), 0)
+                self.assertIsNone(state.chrome(self.FID))
+                self.assertEqual(self.ran, [])
+
+    def test_a_frame_with_no_recorded_panes_records_nothing_and_runs_nothing(self):
+        """Named separately from the two above because it is a DIFFERENT refusal: there
+        is a session and the word is good, and there is simply nothing to resurface. Two
+        guards in sequence mask each other, so each is asserted where it fires."""
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID}, clear=True):
+            self.assertEqual(commands_frame.cmd_chrome(self._args("dark")), 0)
+        self.assertIsNone(state.chrome(self.FID))
+        self.assertEqual(self.ran, [])
+
+    def test_a_pane_id_that_is_not_tmuxs_own_is_skipped_and_the_others_are_not(self):
+        """The value arrived off DISK and is about to be a tmux argv — #475's rule. And
+        the assertion is that the GOOD pane still got its options, or a single bad entry
+        would silently cost the whole frame its surface."""
+        self._with_panes({"top": "%1", "bad": "$(reboot)", "right": "%2"})
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID}, clear=True):
+            commands_frame.cmd_chrome(self._args("dark"))
+        targets = {a[a.index("-t") + 1] for a in self.ran}
+        self.assertEqual(targets, {"%1", "%2"})
+
+    def test_the_word_is_recorded_before_the_panes_are_touched(self):
+        """A frame whose options fail halfway still splits its NEXT pane into the surface
+        the operator asked for, because `_split_panels` reads `_current_chrome`."""
+        self._with_panes({"top": "%1"})
+        seen = []
+        with mock.patch.object(commands_frame.tmuxctl, "run",
+                               side_effect=lambda *a, **k: seen.append(
+                                   state.chrome(self.FID)) or
+                               subprocess.CompletedProcess([], 0, "", "")):
+            with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID},
+                                 clear=True):
+                commands_frame.cmd_chrome(self._args("light"))
+        self.assertTrue(seen and all(s == "light" for s in seen), seen)
+
+
+class APaneSplitLaterIsBornIntoTheSurfaceTheFrameIsOn(PersonaIso, unittest.TestCase):
+    """`_split_panels` reads `_current_chrome`, not `config.FRAME`.
+
+    The defect this closes is specific and was reachable: change the surface from the
+    palette, then change the density, and the pane the re-layout adds comes up bare
+    beside three surfaced ones — a frame that does not match itself, which is the exact
+    thing §5.1 refused to ship.
+    """
+
+    FID = "fr-surface-3"
+
+    def test_the_split_reads_the_live_word_and_not_the_configured_one(self):
+        state.record_chrome(self.FID, "dark")
+        seen = []
+        with mock.patch.dict(commands_frame.config.FRAME, {"chrome": "off"}), \
+             mock.patch.object(commands_frame, "_surface_argvs",
+                               side_effect=lambda **kw: seen.append(kw["chrome"]) or []), \
+             mock.patch.object(commands_frame.layout, "panel_argvs",
+                               return_value=[["tmux", "split"]]), \
+             mock.patch.object(commands_frame.tmuxctl, "run",
+                               return_value=subprocess.CompletedProcess([], 0, "%7", "")):
+            commands_frame._split_panels("sock", slots=["top"], fid=self.FID,
+                                         harness_pane="%0", env=None, pane_env=None)
+        self.assertEqual(seen, ["dark"])
+
+
+class ThePaletteCarriesTheThreeSurfaces(PersonaIso, unittest.TestCase):
+    """Task 3.6. The operator who upgrades into a look they dislike is one keystroke from
+    changing it, rather than one documentation search."""
+
+    FID = "fr-surface-4"
+
+    def _rows(self, *, current="off", panes=True):
+        if panes:
+            state.record_panes(self.FID, panels={"top": "%1"})
+        reg = builtin_actions.build(self.FID, current_density="normal",
+                                    current_chrome=current)
+        return {o.id: o for o in reg.offers(fid=self.FID, snapshot={})}
+
+    def test_there_is_one_row_per_surface_and_no_more(self):
+        rows = self._rows()
+        self.assertEqual({r for r in rows if r.startswith("chrome.")},
+                         {f"chrome.{lv}" for lv in instance.FRAME_CHROME})
+
+    def test_the_row_in_effect_is_marked_and_the_others_are_not(self):
+        rows = self._rows(current="dark")
+        self.assertTrue(rows["chrome.dark"].title.startswith(builtin_actions.MARK[0]))
+        self.assertTrue(rows["chrome.off"].title.startswith(builtin_actions.MARK[1]))
+
+    def test_the_mark_moves_with_the_frame(self):
+        """Marked, never filtered: a list whose rows move around depending on state is a
+        list nobody learns."""
+        for level in instance.FRAME_CHROME:
+            with self.subTest(level=level):
+                rows = self._rows(current=level)
+                marked = [r for r, o in rows.items()
+                          if r.startswith("chrome.")
+                          and o.title.startswith(builtin_actions.MARK[0])]
+                self.assertEqual(marked, [f"chrome.{level}"])
+
+    def test_a_frame_with_no_panes_lists_the_rows_with_a_reason(self):
+        """Listed WITH ITS REASON, never dropped: an operator cannot ask about an option
+        they cannot see, which is #512's shape one surface along."""
+        rows = self._rows(panes=False)
+        row = rows["chrome.dark"]
+        self.assertFalse(row.available)
+        self.assertIn("resurface", row.reason)
+
+    def test_the_row_refuses_on_the_pane_map_and_not_on_the_harness_pane(self):
+        """A surface sets a pane option on panes that already exist; it splits nothing.
+        A row that refused on `_laid_out` would be refusing on somebody else's
+        precondition."""
+        state.record_panes(self.FID, panels={"top": "%1"})
+        reg = builtin_actions.build(self.FID, current_density="normal",
+                                    current_chrome="off")
+        rows = {o.id: o for o in reg.offers(fid=self.FID, snapshot={})}
+        self.assertTrue(rows["chrome.dark"].available)
+        self.assertFalse(rows["density.minimal"].available,
+                         "this fixture records no harness pane, so the CONTROL that "
+                         "proves the two rows ask different questions has gone stale")
+
+    def test_choosing_a_row_starts_the_command_and_nothing_else(self):
+        state.record_panes(self.FID, panels={"top": "%1"})
+        reg = builtin_actions.build(self.FID, current_density="normal",
+                                    current_chrome="off")
+        started = []
+        with mock.patch.object(builtin_actions, "_spawn",
+                               side_effect=lambda argv, **kw: started.append(argv)):
+            reg.invoke("chrome.light", fid=self.FID, snapshot={})
+        self.assertEqual(len(started), 1)
+        self.assertEqual(started[0][-2:], ["frame-chrome", "light"])
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class TheLiveChangeReachesRealTmux(_TmuxServerFixture, PersonaIso):
+    """`cmd_chrome` against a real server, read back with `show -p`.
+
+    The exit criterion is stated as a reading rather than an intent: with `dark` the panel
+    panes carry a background and the harness pane provably does not, and with `off` every
+    pane reads back `''`.
+    """
+
+    SOCKET_NAME = f"charter-chrome-live-{os.getpid()}"
+    FID = "fr-surface-live"
+
+    def _panes(self) -> tuple[str, str]:
+        r = self._srv("new-session", "-d", "-s", "h", "-x", "80", "-y", "24",
+                      "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness = r.stdout.strip()
+        p = self._srv("split-window", "-t", harness, "-P", "-F", "#{pane_id}",
+                      "--", "sleep", "600")
+        self.assertEqual(p.returncode, 0, p.stderr)
+        return harness, p.stdout.strip()
+
+    def _style(self, pane: str, option: str = "window-style") -> str:
+        return self._srv("show", "-p", "-t", pane, "-v", option).stdout.strip()
+
+    def _run(self, level: str) -> None:
+        # `clear=True`, and `PATH` put back by hand rather than inherited by accident.
+        # `tmuxctl.run` passes `env=None`, so the child inherits THIS mapping — and a
+        # cleared environment is one with no `PATH`, where `tmux` is not found, the
+        # command fails the way a refusal does (never raises) and the assertion below
+        # would be measuring a fixture rather than charter. `NO_COLOR` is the variable
+        # that must not leak in, and it does not.
+        with mock.patch.dict(os.environ,
+                             {"CHARTER_SESSION_ID": self.FID,
+                              "PATH": os.defpath + os.pathsep + os.environ.get("PATH", "")},
+                             clear=True):
+            self.assertEqual(
+                commands_frame.cmd_chrome(type("A", (), {"level": level})()), 0)
+
+    def test_dark_then_off_leaves_every_pane_bare_again(self):
+        harness, panel = self._panes()
+        state.record_panes(self.FID, panels={"top": panel})
+        state.record_server(self.FID, self.SOCKET_NAME)
+
+        self._run("dark")
+        self.assertEqual(self._style(panel), "bg=black")
+        self.assertEqual(self._style(panel, "window-active-style"), "bg=brightblack")
+        self.assertEqual(self._style(harness), "",
+                         "charter styled the pane the operator's harness runs in")
+
+        self._run("off")
+        for option in instance.chrome_option_names():
+            with self.subTest(option=option):
+                self.assertEqual(self._style(panel, option), "",
+                                 "`off` left a style behind — it is a REMOVAL on a "
+                                 "running frame, not the absence of a set")
+        self.assertEqual(self._style(harness), "")
+
+    def test_switching_between_two_surfaces_leaves_nothing_of_the_first(self):
+        _harness, panel = self._panes()
+        state.record_panes(self.FID, panels={"top": panel})
+        state.record_server(self.FID, self.SOCKET_NAME)
+        self._run("dark")
+        self._run("light")
+        self.assertEqual(self._style(panel), "bg=white")
+        self.assertEqual(self._style(panel, "window-active-style"), "bg=brightwhite")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_surface_live.py
+++ b/tests/test_frame_surface_live.py
@@ -35,7 +35,7 @@ a refusal with no measurement behind it, on the one path where a refusal is invi
 from __future__ import annotations
 
 import os
-import re
+import pathlib
 import subprocess
 import unittest
 from unittest import mock
@@ -54,15 +54,30 @@ class TheSurfaceIsNotVersionGated(unittest.TestCase):
     has to delete this test and say which measurement it found.
     """
 
-    def test_neither_surface_builder_consults_the_tmux_version(self):
-        import inspect
-        for fn in (commands_frame._surface_argvs, commands_frame._resurface_argvs):
-            with self.subTest(fn=fn.__name__):
-                src = inspect.getsource(fn)
-                self.assertNotIn("version", src.split('"""')[-1],
-                                 f"{fn.__name__} grew a version gate — tmux 3.2 was "
-                                 f"measured identical to 3.7c, so a gate needs its own "
-                                 f"measurement")
+    def test_neither_surface_builder_needs_to_know_the_tmux_version(self):
+        """Asked as behaviour rather than as a grep of the source: with
+        `tmuxctl.version` raising, both builders still answer, because neither has any
+        reason to call it. A gate added later fails here on the exception."""
+        from charter.frame import tmuxctl
+        with mock.patch.object(tmuxctl, "version",
+                               side_effect=AssertionError("a version gate appeared — "
+                                                          "tmux 3.2 was measured "
+                                                          "identical to 3.7c, so a gate "
+                                                          "needs its own measurement")):
+            self.assertEqual(
+                len(commands_frame._surface_argvs(socket="s", pane_id="%3",
+                                                  chrome="dark")), 2)
+            self.assertEqual(
+                len(commands_frame._resurface_argvs(socket="s", pane_id="%3",
+                                                    chrome="off")), 2)
+
+    def test_the_version_control_can_actually_fire(self):
+        """The control for the test above: a builder that DID ask would fail there, so
+        this proves the patched `version` raises rather than being quietly unused."""
+        from charter.frame import tmuxctl
+        with mock.patch.object(tmuxctl, "version", side_effect=AssertionError("boom")):
+            with self.assertRaises(AssertionError):
+                tmuxctl.version()
 
     def test_the_floor_is_still_the_version_this_was_measured_against(self):
         """If the floor moves, the measurement above is about a version charter no
@@ -113,15 +128,30 @@ class TheRecordedSurfaceOverridesTheConfiguredOne(PersonaIso, unittest.TestCase)
         with mock.patch.dict(commands_frame.config.FRAME, {"chrome": ["dark"]}):
             self.assertEqual(commands_frame._current_chrome(self.FID), "off")
 
-    def test_an_unreadable_record_degrades_rather_than_raising(self):
-        """`_current_chrome` is called from `_split_panels`, which is on the launch
-        path: a truncated file must cost the surface, never the frame."""
+    def test_a_record_that_cannot_be_READ_degrades_rather_than_raising(self):
+        """`_current_chrome` is called from `_split_panels`, which is on the launch path:
+        a file charter cannot read must cost the surface, never the frame.
+
+        The READ is what fails here, not a stand-in for it. Patching `state.chrome` to
+        raise and then asserting that it raises is an assertion about the mock — the
+        version of this test that shipped first did exactly that and would have stayed
+        green with the `except OSError` deleted.
+        """
         state.record_chrome(self.FID, "dark")
-        with mock.patch.object(state, "chrome", side_effect=OSError("gone")):
-            with self.assertRaises(OSError):
-                state.chrome(self.FID)
-        # And the real reader, over a directory where the file cannot be read.
-        with mock.patch.dict(commands_frame.config.FRAME, {"chrome": "off"}):
+        real = pathlib.Path.read_text
+
+        def refuse(self_path, *a, **kw):
+            if self_path.name == "chrome":
+                raise OSError("unreadable")
+            return real(self_path, *a, **kw)
+
+        with mock.patch.object(pathlib.Path, "read_text", refuse):
+            self.assertIsNone(state.chrome(self.FID))
+            with mock.patch.dict(commands_frame.config.FRAME, {"chrome": "light"}):
+                self.assertEqual(commands_frame._current_chrome(self.FID), "light")
+        # And the control: with the read working, the record is what is used — so the
+        # assertion above is about the refusal and not about a fixture that never wrote.
+        with mock.patch.dict(commands_frame.config.FRAME, {"chrome": "light"}):
             self.assertEqual(commands_frame._current_chrome(self.FID), "dark")
 
 

--- a/tests/test_frame_switch.py
+++ b/tests/test_frame_switch.py
@@ -234,7 +234,8 @@ def _rows(fid: str, *, density: str = "normal"):
     """The palette's whole catalogue for *fid*, built exactly the way `_draw_palette`
     builds it — the two picker rows, then the action rows, neither from a hand-written
     list."""
-    reg = builtin_actions.build(fid, current_density=density)
+    reg = builtin_actions.build(fid, current_density=density,
+                               current_chrome="off")
     return (choose.open_rows(fid)
             + palette.rows(reg.offers(fid=fid, snapshot={})))
 


### PR DESCRIPTION
Recovers a commit lost to a merge race: I merged #604 at head `1e99d0bc` while its author was still working, and `761c403` landed on the branch afterwards. My error, not theirs.

## What this carries

`761c403` — *"The deletion sweep found four unpinned guards in the two new state accessors"* — 67 lines in `tests/test_frame_surface_live.py`.

The author's own report on it:

> **Sweep: 16/16 pinned, 0 survived.** The *first* run was not clean — it found 4 unpinned guards in the new `state` accessors, all live (`$CHARTER_SESSION_ID` reaches them unminted). Pinned, each test naming which refusal fired.

So these are guards on a path an environment variable reaches with an unminted value, and without this commit they are exactly the shape this project has spent a week closing: correct code with nothing behind it.

## Why it merged green without them

The guards are correct — the suite passes either way. That is the entire point of the deletion sweep, and it is why "CI green" was never the merge gate on this project. I checked CI at a head the author had already moved past.

## Verification

CI is read at this branch's head, not at `#604`'s. `charter/` production lines are untouched by this commit — it is tests only, so no news entry.