### PR TITLE
A panel's pane is a fact of the process, not a reading of sys.stdout (#606)

### DIFF
--- a/charter/frame/chrome.py
+++ b/charter/frame/chrome.py
@@ -35,10 +35,10 @@ from __future__ import annotations
 
 import os
 import re
-import sys
 from types import MappingProxyType
 
 from .. import tui
+from . import pane
 
 #: Reverse video on, and everything off. `_OFF` is a FULL reset rather than SGR 27
 #: ("reverse off"): a row that left an attribute open — a provider's, or a charter row
@@ -140,15 +140,19 @@ def colour_ok() -> bool:
     *is* its pane, so it is always a tty in production. The one case it catches is the
     redirect `panel.py`'s own docstring documents — ``charter panel top --session x >
     /tmp/log`` — which before this wrote a clear-screen and full SGR into a file.
+
+    **Asked of the PANE, not of `sys.stdout`** (#606). Those were the same thing until a
+    provider's library rebound the global: Textual's `redirect_stdout` installs a
+    `_PrintCapture` that answers ``isatty() -> True`` from behind fd -1, so this said
+    "colour is fine" about a stream that is not a terminal and, more to the point, is not
+    the rectangle charter is painting. `frame/pane.py` holds the descriptor this process
+    was actually given and carries the "a stream that cannot say is not a terminal"
+    fallback this used to spell here — one answer, so the paint and the question about the
+    paint cannot be about two different streams.
     """
     if no_colour():
         return False
-    try:
-        return bool(sys.stdout.isatty())
-    except (AttributeError, ValueError):
-        # A closed or exotic stdout answers neither; a frame that cannot tell does not
-        # colour, which is the direction `NO_COLOR` already points.
-        return False
+    return pane.is_tty()
 
 
 def _role_values() -> dict[str, str]:

--- a/charter/frame/pane.py
+++ b/charter/frame/pane.py
@@ -1,0 +1,156 @@
+"""The pane this process was given.
+
+**A panel's pane IS `sys.stdout`.** The descriptor it paints into is the same one it
+measures its rectangle from, so that name is not an output stream here — it is the
+rectangle. Which makes it exactly the wrong thing to ask, because what is bound to it is a
+mutable global that any library the process imports may replace. Textual's
+`redirect_stdout` installs a `_PrintCapture` answering `isatty() -> True` and
+`fileno() -> -1`; `rich`, `click`, `tqdm`, `colorama`, a progress bar and a logging handler
+installed at import all reach for the same name. Measured on `main` in a real 150x10 pane
+(#605, #606)::
+
+    pane:            slots._width() = 150   slots._height() = 10
+    after a rebind:  slots._width() = 80    slots._height() = 24   colour_ok() = True
+
+A correct first paint, then blank on every repaint, and a frame laid out for a rectangle
+nobody has. **Nothing raised and nothing was logged**, so `registry.Registry.draw`'s catch
+never fired: §4b's promise that a broken component costs its own pane was not violated, it
+was evaded — which is worse than a crash, because a crash is at least a report.
+
+**The property is "the pane this process was given"; the spelling is "whatever
+`sys.stdout` is bound to at the instant of the ask".** Asking the spelling is the ninth
+instance of that mistake closed this month (#547, #558, #537, #498, #577, #594) and the
+only silent one. So the pane is claimed ONCE, by the process that owns one, above anything
+a stranger wrote: `panel.run` claims it before `builtins.build()`, which is where
+`registry.Registry.place` runs `importlib.import_module` on a provider's module for the
+first time. That ordering is `tests/_ttyguard`'s, one layer over — it installs ABOVE the
+import that pulls charter in, because `util._USE_COLOR` is `sys.stderr.isatty()` evaluated
+at THAT import (#545/#546). A claim is what "above" means when the thing to get above is a
+provider rather than an import of charter itself.
+
+**Not at import of this module, and the reason is that a claim is scoped work.** Charter
+is one CLI: the same interpreter runs `charter panel`, `charter statusline` and a hook,
+and only the first of those is handed a pane. Claiming at import would make every one of
+them hold a "pane" that is a pipe, and would make the claim outlive the panel that took it
+— `panel.run(once=True)` is called in-process by tests, exactly as `_install_sigwinch` is,
+and that function's own `finally` is the precedent for putting back what was replaced.
+
+**What a claim does not defend against, stated rather than implied.** It holds the stream
+OBJECT, so a library that rebinds `sys.stdout` cannot move charter's pane out from under
+it. A library that `dup2`s over fd 1, or closes the stream, has genuinely taken the
+descriptor away, and the only answer to that would be charter holding an `os.dup` of its
+own for the life of every panel — a second open fd, forever, against something no reported
+case does. Those failures are also LOUD: the write raises, and `panel.run` paints why and
+holds the pane. Silence is what this module is about.
+
+**And a size is a rectangle or it is nothing.** :func:`size` answers `None` for a pane it
+could not measure *and* for one that answers zero, which is #594's judgement made in the
+one place that has a single source to make it about. That zero is ordinary rather than
+exotic: a pty created without a window size reports zero columns until somebody calls
+`TIOCSWINSZ`, which is what `os.openpty` hands you, and so what tooling, some CI shells and
+a terminal attached before its size is negotiated all hand you. `slots._width` and
+`slots._height` are the halves that carry a stated fallback for a caller that has to draw
+anyway — the same split `commands_frame._measure_window`/`_window_size` already draws, and
+for the same reason it draws it: "charter could not read this" must never be spelled the
+same way as a real 80x24.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+#: The pane this process claimed, or ``None`` for a process that has claimed none.
+#:
+#: A module-level global because the thing it describes is one: a process is given one
+#: pane, and the panel that owns it, the renderer measuring it and the chrome deciding
+#: whether it takes colour must all be talking about that same rectangle — which is the
+#: entire defect (#606) said the other way round.
+_CLAIMED = None
+
+#: What every question here treats as "this stream cannot say". A `StringIO`'s `fileno`
+#: raises `io.UnsupportedOperation`, which is both an `OSError` and a `ValueError`; a
+#: closed stream raises `ValueError`; a library's stand-in may have no such attribute at
+#: all; and a real descriptor with no tty behind it raises `OSError`. The same set
+#: `tests/_ttyguard`'s `says_it_is_a_terminal` settled on, and named once so the two
+#: questions below cannot come to disagree about which stream is answerable.
+_CANNOT_SAY = (AttributeError, OSError, ValueError)
+
+
+def claim():
+    """Take what `sys.stdout` is bound to NOW as this process's pane, and answer whatever
+    claim this replaces so the caller can put it back.
+
+    Called once, at the top of the work that owns a pane, before anything a provider
+    supplies can be imported — see the module docstring for why that ordering is the whole
+    fix and not an implementation detail of it.
+
+    Returns the previous claim rather than nothing, which makes :func:`release` a restore
+    instead of a reset. `panel.run(once=True)` is called in-process by tests, so a claim
+    that ended by clearing the global would leave the NEXT caller in that process reading
+    "no pane" when there was one — the same reason `_install_sigwinch` hands `run` back the
+    handler it displaced instead of `SIG_DFL`.
+    """
+    global _CLAIMED
+    held, _CLAIMED = _CLAIMED, sys.stdout
+    return held
+
+
+def release(held) -> None:
+    """Put back the claim *held* — whatever :func:`claim` answered, ``None`` included."""
+    global _CLAIMED
+    _CLAIMED = held
+
+
+def stream():
+    """This process's pane, or `sys.stdout` for a process that claimed none.
+
+    **The fallback is not a second answer to the same question**, which is worth saying in
+    a module about exactly that mistake. A process that never claimed a pane does not have
+    one: a hook, `charter statusline`, a test calling `slots._width()` on its own. For all
+    of them "this process's ordinary output" IS `sys.stdout` and nothing has been captured
+    that could disagree with it. The claim is what turns that from a guess into a fact, and
+    only a process that is given a rectangle takes one.
+    """
+    return sys.stdout if _CLAIMED is None else _CLAIMED
+
+
+def size():
+    """This pane's own rectangle as the pane reports it, or ``None`` when charter has no
+    usable measurement of it.
+
+    ``None`` covers both ways of having nothing: a stream that cannot be asked (no
+    `fileno`, a closed one, a real descriptor with no tty behind it — a panel run by hand
+    with its output piped to a file), and a tty that answers with a zero. A zero is not a
+    size, and judging it here rather than at each caller is #594's shape with one source
+    instead of three: there, three sources each answered "a number or nothing" and
+    `tui.term_width` judged the answer, because the judgement belongs wherever there is
+    exactly one of it to write. Here there is one source and several callers, so it goes
+    the other way round — and `slots._width` and `slots._height` cannot then come to
+    disagree about whether this pane was measured at all.
+
+    The whole `os.terminal_size` rather than a column count, because a rectangle is what a
+    pane is: a caller that gets a size back has BOTH numbers from ONE reading of ONE
+    descriptor, which is the property the two separate `os.get_terminal_size` calls this
+    replaced could never state.
+    """
+    try:
+        measured = os.get_terminal_size(stream().fileno())
+    except _CANNOT_SAY:
+        return None
+    return measured if measured.columns > 0 and measured.lines > 0 else None
+
+
+def is_tty() -> bool:
+    """Whether this pane is a terminal — ``False`` for a pane that cannot say.
+
+    Asked of the claimed stream, so a library's stdout stand-in claiming ``True`` answers
+    for itself and not for charter's rectangle (#606: Textual's `_PrintCapture` says
+    ``isatty() -> True`` from behind fd -1). A stream that raises is not a terminal for any
+    purpose here, which is the direction `NO_COLOR` already points: a frame that cannot
+    tell does not colour.
+    """
+    try:
+        return bool(stream().isatty())
+    except _CANNOT_SAY:
+        return False

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -13,7 +13,7 @@ would put a hang inside the hook path that calls `state.bump` — a cost this fe
 never impose on the agent turn that triggers a redraw.
 
 **Width is `slots.py`'s job, not this module's.** `slots.render` already measures the
-pane's own tty (`os.get_terminal_size(sys.stdout.fileno())`) rather than trusting
+pane's own tty (`pane.size()`, the descriptor `run` claims below) rather than trusting
 `$COLUMNS` — which a panel process, started as a tmux pane command, inherits WHOLE from
 the launching shell (measured: a 22-column pane whose launcher had exported
 `COLUMNS=200` saw `COLUMNS='200'` in its own environment). See `charter/frame/slots.py`'s
@@ -72,6 +72,15 @@ whole pane and `Pane is dead (status 2)` is provably all that is left. It cost a
 argv by hand outside tmux. A pane whose process is still ALIVE keeps what it painted
 (measured the same way), so `_hold` paints the reason and then simply does not return.
 
+**And the pane is a fact of this process, not a reading of `sys.stdout`** (#606). Painting
+and measuring are the same descriptor here — a panel's pane IS its stdout — so the moment a
+provider's library rebinds that global (Textual's `redirect_stdout`, `rich`, `click`,
+`tqdm`, a logging handler installed at import) this module painted into the library's log
+and `slots` measured fd -1: a correct first paint, then blank on every repaint, and a frame
+laid out 80x24 in a 150x10 pane, with nothing raised and nothing logged. :func:`run` claims
+the pane before `builtins.build()` can import a stranger's module, and everything below
+paints and measures through that claim; `frame/pane.py` carries the argument.
+
 A panel that is held is also a panel tmux never sees die, so the respawn hook
 `commands_frame._panel_died_hook_argv` installs never fires for it — deliberately: the
 two mechanisms divide at exactly the line between a failure charter's own Python can
@@ -97,7 +106,7 @@ import sys
 import time
 
 from .. import contain, tui
-from . import chrome, slots, state
+from . import chrome, pane, slots, state
 
 #: How often the version file is checked when nothing else has woken this panel. A
 #: `stat` at this rate is indistinguishable from zero cost (see `state.version`'s own
@@ -173,10 +182,61 @@ def _write(text: str) -> None:
 
 
 def _out(payload: str) -> None:
-    """The write itself — one statement, so the two branches above cannot come to
-    disagree about flushing."""
-    sys.stdout.write(payload)
-    sys.stdout.flush()
+    """The write itself — one place, so the two branches above cannot come to disagree
+    about flushing.
+
+    Into the pane this process CLAIMED (`frame/pane.py`), never into whatever `sys.stdout`
+    is bound to at the instant of the write. Those are the same object until a provider's
+    library replaces the global, and then they are the operator's rectangle and a
+    framework's in-memory log — measured (#605): a correct first paint, then every repaint
+    landing somewhere nobody can see, with the pane keeping the first frame forever and
+    nothing raised to say so.
+    """
+    out = pane.stream()
+    out.write(payload)
+    out.flush()
+
+
+#: What a pane charter cannot measure is told, instead of a frame laid out from a number
+#: nobody took. Short on purpose: the one width that would make truncating it honest is the
+#: width this message exists because charter does not have, so a message that wraps a
+#: narrow pane is the smaller of the two wrongs — and `slots._DEFAULT_COLS` truncation
+#: here would be the fabrication itself, applied to the sentence reporting it.
+_UNMEASURED = " charter: pane size unknown"
+
+
+def _unmeasured() -> str | None:
+    """:data:`_UNMEASURED` for a pane charter cannot measure, ``None`` for one it can —
+    and ``None`` for a process that has no pane at all.
+
+    **This is where an 80x24 fallback stops being indistinguishable from a real 80x24
+    pane** (#606). `slots._width`/`_height` must answer a renderer with a number whatever
+    happened, so they take :data:`slots._DEFAULT_COLS`/`_DEFAULT_ROWS` and say nothing;
+    this is the caller with something to do about it, and it draws the difference the way
+    `commands_frame._measure_window` lets `cmd_resize` refuse while `_window_size` lets
+    `cmd_launch` proceed. Laying a frame out from a guess in a rectangle that is very
+    probably not that shape is the same destructive move as laying it out from a stale
+    measurement, with less excuse — #501 refused the stale one.
+
+    **The two halves of "cannot measure" are not the same case, and the tty is what tells
+    them apart** — which is the property, where "does `os.get_terminal_size` raise" is the
+    spelling. A pane that is not a terminal is not a pane: it is `charter panel top
+    --session x > /tmp/log`, run by hand for debugging, and a test. That case has always
+    laid out at the stated default and must keep doing so, because there is no rectangle
+    for the frame to be wrong about. A pane that IS a terminal and will not report a size
+    is a real rectangle of unknown shape — a `_PrintCapture` behind fd -1, a pty created
+    without a window size (`os.openpty`, some CI shells, a terminal attached before its
+    size is negotiated). That one gets a sentence.
+
+    **Painted per tick and never held.** A pty gets its size from a `TIOCSWINSZ` that
+    arrives moments later, and the `SIGWINCH` that follows is already a repaint reason
+    (`_tick`), so the next pass measures and draws the frame. Reaching for `_hold` here —
+    the module's other answer to "this panel cannot run" — would be permanent by
+    construction, and would wedge the pane for the one failure that routinely fixes itself.
+    """
+    if not pane.is_tty() or pane.size() is not None:
+        return None
+    return _UNMEASURED
 
 
 def _paint(slot: str, fid: str) -> None:
@@ -186,8 +246,12 @@ def _paint(slot: str, fid: str) -> None:
     COUNT to the pane's HEIGHT is what this function adds on top, because `render`'s
     contract (one string) carries no notion of height at all — see the module
     docstring's "Height is this module's job" section.
+
+    A pane that could not be measured is told so instead (:func:`_unmeasured`), and
+    `slots.render` is not called at all: every line of it would be clamped to a width this
+    pane has not agreed to.
     """
-    _write(slots.render(slot, fid))
+    _write(_unmeasured() or slots.render(slot, fid))
 
 
 def _component_painter(reg, cid: str):
@@ -203,9 +267,14 @@ def _component_painter(reg, cid: str):
     with, and what this draws was decided once, when `run` resolved that name. Taking the
     argument and not reading it keeps one signature for both painters rather than a second
     shape for `_tick` to know about.
+
+    An unmeasurable pane is reported here exactly as :func:`_paint` reports one, and for a
+    reason stronger than symmetry: `ctx.build` hands a component a `width` and a `height`
+    it is entitled to draw to the edge of, so a guess passed through this door is a guess a
+    stranger's code has already been told is a measurement.
     """
     def paint(_name: str, fid: str) -> None:
-        _write(_component_text(reg, cid, fid))
+        _write(_unmeasured() or _component_text(reg, cid, fid))
     return paint
 
 
@@ -462,9 +531,37 @@ def _watch(slot: str, fid: str, *, once: bool, paint=None) -> int:
 
 
 def run(slot: str, fid: str, *, once: bool = False) -> int:
-    """Run one panel: refuse a name nothing can draw, then paint on every version bump or
-    resize until killed (`once=True` — never passed by `charter panel` itself, only by
-    tests — paints exactly once and returns).
+    """Run one panel, on the pane this process was given.
+
+    **The claim is the first thing that happens and it is the whole of #606.** Everything
+    below paints and measures through `frame/pane.py`, and what that module answers is
+    decided here, once — above :func:`_run`'s `builtins.build()`, which is where
+    `registry.Registry.place` runs `importlib.import_module` on a provider's module and so
+    the first instant anything a stranger wrote can execute in this process. A library that
+    rebinds `sys.stdout` after that (Textual's `redirect_stdout`, `rich`, `click`, `tqdm`,
+    a logging handler installed at import) moves the global and does not move the pane.
+
+    Restored in a `finally` rather than left set, for `_watch`'s reason one question over:
+    `run(once=True)` is called in-process by tests, not only as a subprocess's whole life,
+    and a claim outliving its panel would leave the next caller in that process measuring a
+    rectangle that stopped existing — the same leak `_install_sigwinch` hands back a
+    handler to avoid. A HELD panel never reaches it, which is correct: `_hold` does not
+    return because the pane it painted into is still that process's pane.
+    """
+    held = pane.claim()
+    try:
+        return _run(slot, fid, once=once)
+    finally:
+        pane.release(held)
+
+
+def _run(slot: str, fid: str, *, once: bool = False) -> int:
+    """Refuse a name nothing can draw, then paint on every version bump or resize until
+    killed (`once=True` — never passed by `charter panel` itself, only by tests — paints
+    exactly once and returns).
+
+    Split out of :func:`run` so the pane claimed there is released by that function's own
+    `finally`, whichever of the several ways below this one returns.
 
     **`slot` is a component NAME, and this is the link Phase 1 could not build.** A panel
     process builds no registry and knows no providers, so `charter panel acme.metrics` was

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -22,15 +22,23 @@ which runs precisely when something has already gone wrong — painted a 400-col
 into a 24-column pane. :data:`_DEFAULT_COLS` is what it answers instead, beside
 :data:`_DEFAULT_ROWS`, which has always been a constant for exactly this reason. Both
 halves of a pane's size now come from the same place and neither comes from the shell.
+
+**And the pane is CLAIMED rather than looked up** (#606). Measuring "the descriptor this
+process is writing to" was written as `sys.stdout.fileno()`, which is a mutable global any
+library the process imports may replace: with Textual's `redirect_stdout` installed, a real
+150x10 pane measured 80x24 here and nothing raised. `frame/pane.py` is the one place that
+answers which rectangle this process was given, and both halves below take one reading of
+it — see that module for the property, and for why a size that cannot be taken is `None`
+rather than a plausible number.
 """
 
 from __future__ import annotations
 
 import os
-import sys
 import time
 
 from .. import tui
+from . import pane
 
 #: The spinner's own frames, and how long each is held. Ten braille cells, each one
 #: column wide (`unicodedata.east_asian_width` is `N` for U+2800–U+28FF, so `tui.width`
@@ -183,21 +191,27 @@ _DEFAULT_COLS = 80
 def _width() -> int:
     """The pane's own width in columns — measured, never read out of the environment.
 
-    `os.get_terminal_size(sys.stdout.fileno())` asks the file descriptor this process is
-    actually writing to, which for a panel launched as a tmux pane command IS the pane —
-    not a pipe, not the launching terminal. Only when that raises (stdout redirected to
-    something with no tty behind it at all, e.g. a test, or a panel run for debugging with
-    its output piped to a file) does this answer :data:`_DEFAULT_COLS`, the way
-    :func:`_height` has always answered :data:`_DEFAULT_ROWS`. The measured value is
-    returned as reported, with no artificial floor clamped over it: a pane that really is
-    10 columns wide getting reported as 20 would be exactly the theorising this function
-    exists to avoid — it would tell every caller here there is room that the real pane does
-    not have.
+    `pane.size()` asks the descriptor this process CLAIMED, which for a panel launched as
+    a tmux pane command IS the pane — not a pipe, not the launching terminal, and (since
+    #606) not whatever a provider's library has since rebound `sys.stdout` to. Only when
+    that answers `None` — a pane charter has no usable measurement of, which `frame/pane.py`
+    defines and this function does not second-guess — does this fall through to
+    :data:`_DEFAULT_COLS`, the way :func:`_height` has always answered
+    :data:`_DEFAULT_ROWS`. The measured value is returned as reported, with no artificial
+    floor clamped over it: a pane that really is 10 columns wide getting reported as 20
+    would be exactly the theorising this function exists to avoid — it would tell every
+    caller here there is room that the real pane does not have.
+
+    **The fallback is this caller's stated default and nothing infers it was taken**, which
+    is the half #606 is about. `panel._unmeasured` is where a pane that could not be
+    measured stops being indistinguishable from a real 80x24 one, because that is the
+    caller with something to do about it; this is the half that has to hand a renderer a
+    number whatever happened. The same two-function split `commands_frame._measure_window`
+    (answers `None`, so `cmd_resize` can refuse) and `_window_size` (takes
+    `_FALLBACK_SIZE`, because `cmd_launch` must draw) already draw between them.
     """
-    try:
-        return os.get_terminal_size(sys.stdout.fileno()).columns
-    except OSError:
-        return _DEFAULT_COLS
+    measured = pane.size()
+    return _DEFAULT_COLS if measured is None else measured.columns
 
 
 #: Rows a renderer assumes when this pane's own tty cannot be measured at all — the same
@@ -218,11 +232,17 @@ def _height() -> int:
     prevent (its own docstring: thirteen clean repos shown and the dirty one hidden).
     So the budget is measured before anything is composed, and `panel._paint`'s clamp
     goes back to being the safety net it is elsewhere rather than the mechanism.
+
+    **The same descriptor and the same judgement as :func:`_width`.** Both halves ask
+    `pane.size()` rather than each running its own `os.get_terminal_size` with its own
+    fallback, so a pane charter could not measure can never come back 150 columns wide and
+    24 rows tall — which is what two independent asks of a moving `sys.stdout` could
+    produce, and did (#606). They are still two calls, one per question: a pane that is
+    resized between them answers honestly twice, and `_tick`'s SIGWINCH repaint is what
+    reconciles the frame.
     """
-    try:
-        return os.get_terminal_size(sys.stdout.fileno()).lines
-    except OSError:
-        return _DEFAULT_ROWS
+    measured = pane.size()
+    return _DEFAULT_ROWS if measured is None else measured.lines
 
 
 def _top(fid: str) -> str:

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -94,6 +94,16 @@ changed.
 shell's environment whole, so trusting `$COLUMNS` there would lay a panel out at the outer
 terminal's width and wrap inside its own much narrower one.
 
+The pane a panel measures is the descriptor its process was **given**, taken once at start.
+A panel paints to `sys.stdout` and measures from that same descriptor, so a component's
+library that replaces that global — a logging handler, a progress bar, a framework's output
+capture — would otherwise have the panel painting into the library's log and laying the
+frame out for a rectangle nobody has, silently. And when the pane genuinely cannot be
+measured, the panel says so (`charter: pane size unknown`) rather than assuming 80x24: if
+your output is a file or a pipe there is no rectangle to be wrong about and the panel draws
+at that default as before, but a real terminal that will not report its size gets a
+sentence until it does.
+
 **The frame animates only while work is in flight.** Work that is still running puts a
 spinner and a count on the bottom row — `⠙ 2 running` — and the panel repaints often
 enough for it to turn. Only the bottom row moves; the other panels repaint when something

--- a/docs/news/unreleased-a-provider-cannot-take-your-pane.md
+++ b/docs/news/unreleased-a-provider-cannot-take-your-pane.md
@@ -1,0 +1,62 @@
+---
+version: unreleased
+headline: A provider's library cannot take your pane, and a size charter cannot read is not 80x24
+---
+
+A charter panel paints by writing to `sys.stdout`, and it measures its own rectangle from
+that same descriptor. So in a panel process `sys.stdout` is not an output stream — **it is
+the pane**. Which meant that any library a provider's component imported and that touched
+that global took the pane away from charter, and nothing said so.
+
+```
+$ python3 -c "... sys.stdout = a stream answering isatty()=True, fileno()=-1 ..."
+  slots._width()  = 80        # the real pane was 150x10
+  slots._height() = 24
+```
+
+Measured in a real 150x10 pane: **a correct first paint, then blank on every repaint.
+Nothing raised, nothing logged.** The panel went on painting five times a second into the
+library's in-memory log while laying the frame out for a rectangle nobody had, and because
+nothing went wrong, none of charter's own containment fired: a provider's component is
+supposed to cost its own pane when it breaks, and this evaded that promise rather than
+violating it.
+
+It is not about any one library. `textual.redirect_stdout` is where it was found, but
+`rich`, `click`, `tqdm`, `colorama`, a progress bar and a logging handler installed at
+import all reach for the same name.
+
+## The pane is claimed once, before a provider's module is imported
+
+`charter panel` now takes the descriptor it was given at its first line — above the point
+where charter imports anything a provider supplies — and everything downstream paints,
+measures and asks about colour through that claim. A library that rebinds `sys.stdout`
+afterwards moves the global and does not move your pane.
+
+Three things were reading the global and all three follow the pane now: the paint, the
+`_width`/`_height` a renderer lays itself out from, and the `isatty` behind `NO_COLOR`'s
+sibling question — which had been told a pane was a terminal by a stand-in that was not
+one.
+
+## And "charter could not measure this" no longer looks like a real 80x24 pane
+
+The fallback was silent, so a pane that could not be measured was indistinguishable from a
+pane that had been measured and was 80 by 24. Two halves, told apart by the thing that
+actually differs rather than by whether the measurement raised:
+
+- **Your output is not a terminal** — `charter panel bottom --session x > /tmp/log`, run
+  by hand for debugging, or a test. There is no rectangle to be wrong about, so charter
+  draws at the stated default exactly as it always has.
+- **It IS a terminal and will not report a size.** That is a real rectangle of unknown
+  shape, and the pane now says `charter: pane size unknown` instead of a frame laid out
+  from a guess. It is painted per redraw and never held: a pty that has not been given a
+  window size yet gets one moments later, and the resize that follows draws the frame.
+
+The second case is more ordinary than it sounds — a pty created without a window size
+reports zero columns until something sets one, which is what `os.openpty`, some CI shells
+and a terminal attached before its size is negotiated all hand you. A zero got through the
+panel's measurement as a width, which is the same defect the status line's own width
+already had one function over.
+
+## To adopt
+
+Nothing. Upgrading is the whole of it.

--- a/tests/test_a_panes_descriptor_is_not_a_mutable_global.py
+++ b/tests/test_a_panes_descriptor_is_not_a_mutable_global.py
@@ -1,0 +1,436 @@
+"""#606 — a panel's pane IS `sys.stdout`, so a library that rebinds that global takes the
+pane away from charter without anything raising.
+
+**The failure is the SECOND paint, and it is silent.** A test that patches `sys.stdout`
+and asserts a width is not this defect: on `main` the first paint was correct, and only
+once a provider's library had rebound the global did the panel start painting into that
+library's in-memory log while measuring fd -1 and laying the frame out 80x24 in a 150x10
+pane. Nothing raised, so `registry.Registry.draw`'s catch never fired and §4b's "a broken
+component costs its own pane" was evaded rather than violated. So every assertion here is
+about **what is on the pane**, never about an exception, and the shape reproduced is
+paint → rebind → repaint rather than rebind → measure.
+
+Measured on `main` before the fix, in a 150x10 pane::
+
+    pane:            slots._width() = 150   slots._height() = 10
+    after a rebind:  slots._width() = 80    slots._height() = 24   colour_ok() = True
+
+`_PrintCapture` below is Textual's `redirect_stdout` stand-in as #605 measured it, but the
+defect is not about Textual: `rich`, `click`, `tqdm`, `colorama`, a progress bar and a
+logging handler installed at import all reach for the same global. What is pinned is the
+property — *the pane this process was given* — and not the one library that took it.
+"""
+
+import io
+import os
+import sys
+import unittest
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from unittest import mock
+
+from charter.frame import chrome, pane, panel, slots, state
+
+from tests._isolation import PersonaIso
+
+#: The descriptor the pane below answers with, and the only one :func:`_measuring` will
+#: measure. A real number rather than a sentinel: `os.get_terminal_size` takes an fd, and a
+#: test that measured whatever it was handed could not tell the pane's descriptor from the
+#: stand-in's.
+_PANE_FD = 1
+
+#: The rectangle #605 measured, kept as one constant so a test that asserts the pane's size
+#: and a test that asserts the frame was laid out for it cannot drift apart.
+_PANE_SIZE = os.terminal_size((150, 10))
+
+
+class _Pane(io.StringIO):
+    """A pane: a terminal, with a descriptor behind it that can be measured."""
+
+    def isatty(self) -> bool:
+        return True
+
+    def fileno(self) -> int:
+        return _PANE_FD
+
+
+class _PrintCapture(io.StringIO):
+    """What Textual's `redirect_stdout` installs, as #605 measured it: says it is a
+    terminal, and hands back a descriptor that is not one.
+
+    Both halves matter. `isatty() -> True` is what told `chrome.colour_ok` to keep emitting
+    SGR, and `fileno() -> -1` is what made `os.get_terminal_size` raise and the measurement
+    fall through to 80x24 — a stand-in answering `False` to the first would have been
+    caught by the colour gate and a stand-in with no `fileno` at all by nothing.
+    """
+
+    def isatty(self) -> bool:
+        return True
+
+    def fileno(self) -> int:
+        return -1
+
+
+class _NotAPane(io.StringIO):
+    """`charter panel bottom --session x > /tmp/log`: not a terminal, nothing to measure.
+
+    The case `slots._DEFAULT_COLS`/`_DEFAULT_ROWS` have always existed for, and the reason
+    "cannot measure" is not one state but two.
+    """
+
+    def isatty(self) -> bool:
+        return False
+
+
+def _probe(fid: str) -> str:
+    """A renderer that draws the rectangle it was told it has.
+
+    Asserting on `charter`'s own `bottom` output would pin the measurement only as far as
+    truncation happens to make it visible; this makes the number charter believes the text
+    on the pane.
+    """
+    return f"W={slots._width()} H={slots._height()}"
+
+
+def _measuring(size=_PANE_SIZE, fd: int = _PANE_FD):
+    """`os.get_terminal_size` answering for *fd* alone, raising for every other.
+
+    The suite replaces the real one with a raise (`tests/_ttyguard`), so a test that wants
+    a size states it. Stating it *per descriptor* is what makes these tests able to tell
+    "measured the pane" from "measured whatever was asked": a blanket `return_value` would
+    answer 150x10 for fd -1 too and go green on the bug.
+    """
+    def measure(fd_asked):
+        if fd_asked != fd:
+            raise OSError(f"[Errno 25] fd {fd_asked} is not a terminal")
+        return size
+    return mock.patch("os.get_terminal_size", side_effect=measure)
+
+
+@contextmanager
+def _claimed(stream):
+    """Run the body with *stream* bound to `sys.stdout` AND claimed as this process's pane
+    — what `panel.run` does at its first line, for a test that exercises something below
+    `run` directly.
+    """
+    with redirect_stdout(stream):
+        held = pane.claim()
+        try:
+            yield
+        finally:
+            pane.release(held)
+
+
+def _paints(text: str) -> list[str]:
+    """The paints in *text*, split the way four existing test call sites already split a
+    pane's transcript: on the clear-screen that starts each one."""
+    return text.split("\x1b[2J")[1:]
+
+
+class ARepaintReachesThePaneAfterALibraryTakesStdout(PersonaIso, unittest.TestCase):
+    """The reported defect, end to end and in its real shape: a correct first paint, a
+    rebind, and then a repaint.
+
+    Red on `main` in both directions at once — the second paint landed in the capture and
+    the pane kept the first frame forever, and the measurement that fed it dropped to
+    80x24. Neither raised, so this asserts on the two transcripts and never on an
+    exception. The `KeyboardInterrupt` is how the test STOPS a live panel (`_watch`'s
+    `while True`), not what it measures — `run` deliberately does not catch one, because
+    that is how a real panel is meant to end.
+    """
+
+    def test_the_second_paint_goes_to_the_pane_and_not_to_the_libraries_log(self):
+        fid = "f-rebind"
+        real, captured = _Pane(), _PrintCapture()
+        ticks = []
+
+        def sleep(_delay):
+            ticks.append(1)
+            if len(ticks) == 1:
+                # A provider's library, mid-life: `textual.redirect_stdout`, a `rich`
+                # console, a logging handler. It replaces the global and does not touch
+                # the descriptor charter was given.
+                sys.stdout = captured
+                state.bump(fid)  # and something for the next tick to repaint for
+                return
+            raise KeyboardInterrupt
+
+        with mock.patch.dict(slots.SLOTS, {"bottom": _probe}), _measuring(), \
+             mock.patch("charter.frame.panel.time.sleep", side_effect=sleep):
+            with redirect_stdout(real), redirect_stderr(io.StringIO()):
+                with self.assertRaises(KeyboardInterrupt):
+                    panel.run("bottom", fid)
+
+        painted = _paints(real.getvalue())
+        self.assertEqual(len(painted), 2,
+                         f"the pane did not get two paints: {real.getvalue()!r}")
+        self.assertEqual(captured.getvalue(), "",
+                         "a repaint went to the library's log instead of the pane")
+        self.assertIn(f"W={_PANE_SIZE.columns} H={_PANE_SIZE.lines}", painted[1],
+                      f"the repaint was laid out for a rectangle nobody has: {painted[1]!r}")
+
+    def test_the_repaint_is_not_a_blank_pane(self):
+        """The symptom as an operator sees it, stated separately from where the bytes
+        went: on `main` the pane's second paint was a clear-screen and nothing else, which
+        is what "blank on every repaint" means. Asserting only that the capture stayed
+        empty would pass on a panel that had stopped painting altogether.
+        """
+        fid = "f-blank"
+        real, captured = _Pane(), _PrintCapture()
+        ticks = []
+
+        def sleep(_delay):
+            ticks.append(1)
+            if len(ticks) == 1:
+                sys.stdout = captured
+                state.bump(fid)
+                return
+            raise KeyboardInterrupt
+
+        with _measuring(), mock.patch("charter.frame.panel.time.sleep", side_effect=sleep):
+            with redirect_stdout(real), redirect_stderr(io.StringIO()):
+                with self.assertRaises(KeyboardInterrupt):
+                    panel.run("bottom", fid)
+
+        self.assertTrue(_paints(real.getvalue())[1].strip(),
+                        "the repaint cleared the pane and wrote nothing into it")
+
+
+class ThePaneIsClaimedAboveAnythingAStrangerWrote(PersonaIso, unittest.TestCase):
+    """The ordering, which is the whole of the fix and not a detail of it.
+
+    `tests/_ttyguard` had to install ABOVE the import that pulls charter in, because
+    `util._USE_COLOR` is `sys.stderr.isatty()` evaluated at that import (#545/#546). This
+    is the same ordering one layer over: the first instant a stranger's code can run in a
+    panel process is `registry.Registry.place`'s `importlib.import_module`, reached through
+    `builtins.build()`, so the claim has to be above THAT.
+    """
+
+    def test_a_provider_rebinding_stdout_as_it_is_imported_does_not_move_the_pane(self):
+        """`builtins.build()` stands in for the import it performs: a provider's module
+        replacing `sys.stdout` at import time is exactly a logging handler or a `rich`
+        console installed at module scope, and it happens before the panel has painted
+        anything at all — so there is no correct first paint to hide behind here.
+
+        Reached through a slot name no built-in claims, which is what sends `run` down the
+        component path (`Registry.place`) rather than the four committed names.
+        """
+        real, captured = _Pane(), _PrintCapture()
+        from charter.frame import builtins as _builtins
+        real_build = _builtins.build
+
+        def build_that_rebinds():
+            sys.stdout = captured
+            return real_build()
+
+        with mock.patch.dict(slots.SLOTS, {"probe": _probe}), _measuring(), \
+             mock.patch("charter.frame.builtins.build", side_effect=build_that_rebinds):
+            with redirect_stdout(real), redirect_stderr(io.StringIO()):
+                panel.run("probe", "f-import", once=True)
+
+        painted = _paints(real.getvalue())[0]
+        self.assertEqual(captured.getvalue(), "",
+                         "the first paint went to a stream the provider installed")
+        # `Registry.place` answers a standin for an id nothing supplies, and the standin
+        # names it — so this is the component pane's own content on the pane, not merely
+        # bytes. §4b: a provider charter cannot load is a message, never a hole.
+        self.assertIn("probe", painted,
+                      f"the component's own pane never reached the pane: {painted!r}")
+
+    def test_a_claim_does_not_outlive_the_panel_that_took_it(self):
+        """`run(once=True)` is called in-process by tests, exactly as `_install_sigwinch`
+        is — so a claim left set would make the NEXT caller in this process measure a
+        rectangle that stopped existing. Pinned the way
+        `RunOnceLoop.test_once_true_restores_the_previous_sigwinch_handler` pins the
+        handler, and for the same reason.
+
+        **The outer claim is taken and then let go of as `sys.stdout`**, and both halves
+        of that are load-bearing. There must be a claim to put back, or a `run` that ended
+        by clearing the global would answer `sys.stdout` and satisfy this by accident; and
+        the outer claim must no longer BE `sys.stdout` when the assertion runs, or clearing
+        the global would answer with the very object being compared against. Found by
+        hand-mutation — `claim` returning `None` and `release` clearing instead of
+        restoring both survived a version of this test that asserted from inside
+        `redirect_stdout(outer)`.
+        """
+        outer = _NotAPane()
+        with redirect_stdout(outer):
+            held = pane.claim()
+        try:
+            with _measuring():
+                with redirect_stdout(_Pane()), redirect_stderr(io.StringIO()):
+                    panel.run("bottom", "f-claim", once=True)
+            self.assertIsNot(pane.stream(), sys.stdout)
+            self.assertIs(pane.stream(), outer)
+        finally:
+            pane.release(held)
+
+    def test_a_process_that_claimed_nothing_answers_for_its_own_stdout(self):
+        """The fallback is not a second answer to the same question: a hook, `charter
+        statusline` and a test calling `slots._width()` on its own were never given a
+        rectangle, and for them "this process's output" IS `sys.stdout`."""
+        mine = _NotAPane()
+        with redirect_stdout(mine):
+            self.assertIs(pane.stream(), mine)
+
+
+class TheMeasurementIsOfThePaneAndNotOfTheGlobal(PersonaIso, unittest.TestCase):
+    """`slots._width`/`_height` directly, so a regression in the measurement cannot hide
+    behind whatever a renderer happens to draw — the split `test_frame_slots.py::Width`
+    already makes for `$COLUMNS`.
+    """
+
+    def test_width_and_height_follow_the_pane_through_a_rebind(self):
+        with _measuring(), _claimed(_Pane()):
+            sys.stdout = _PrintCapture()
+            self.assertEqual(slots._width(), _PANE_SIZE.columns)
+            self.assertEqual(slots._height(), _PANE_SIZE.lines)
+
+    def test_both_halves_answer_for_the_same_descriptor(self):
+        """A pane cannot be 150 columns wide and 24 rows tall. Two `os.get_terminal_size`
+        calls with their own fallbacks could produce that — and did, once one of them was
+        asked of a descriptor the other was not."""
+        with _measuring(), _claimed(_Pane()):
+            sys.stdout = _PrintCapture()
+            self.assertEqual((slots._width(), slots._height()), tuple(_PANE_SIZE))
+
+
+class AnUnmeasuredPaneIsNotAnEightyByTwentyFourPane(PersonaIso, unittest.TestCase):
+    """The second half of #606, and #594's judgement one function over: what charter does
+    when it genuinely cannot measure, and how that state is told apart from a successful
+    measurement.
+    """
+
+    def test_a_tty_reporting_zero_columns_is_not_a_measurement(self):
+        """#594's own case, which `tui.term_width` closed and this path still carried: a
+        pty created without a window size reports zero until somebody calls `TIOCSWINSZ`
+        (`os.openpty`, some CI shells, a terminal attached before its size is negotiated).
+        Red before the fix at `slots._width() == 0`, which laid every table, row and panel
+        out one column wide."""
+        with _measuring(size=os.terminal_size((0, 0))), _claimed(_Pane()):
+            self.assertIsNone(pane.size())
+            self.assertEqual(slots._width(), slots._DEFAULT_COLS)
+            self.assertEqual(slots._height(), slots._DEFAULT_ROWS)
+
+    def test_either_half_being_zero_is_a_rectangle_nobody_has(self):
+        """Both halves of the judgement, separately: a size is a rectangle, and a
+        rectangle with no rows is no more a measurement than one with no columns. Asserted
+        because `(0, 0)` alone is satisfied by half the check — either comparison on its
+        own answers `None` for it, so the pair would look pinned while one of them was
+        gone."""
+        for reported in (os.terminal_size((150, 0)), os.terminal_size((0, 10))):
+            with self.subTest(reported=tuple(reported)):
+                with _measuring(size=reported), _claimed(_Pane()):
+                    self.assertIsNone(pane.size())
+                    self.assertEqual(slots._width(), slots._DEFAULT_COLS)
+                    self.assertEqual(slots._height(), slots._DEFAULT_ROWS)
+
+    def test_a_stand_in_with_no_descriptor_at_all_is_not_a_measurement(self):
+        """A library's replacement need not be a file object at all, and one with no
+        `fileno` raises `AttributeError` rather than the `OSError` a real descriptor with
+        no tty behind it raises. Real — `test_frame_chrome`'s own `_Silent` is the same
+        object one question over — and otherwise unreached here, which is exactly how
+        `colour_ok`'s identical catch came to be narrowable to `ZeroDivisionError` with
+        the whole suite still green until that test was written."""
+        class _NoDescriptor:
+            def isatty(self):
+                return True
+
+        with _measuring(), _claimed(_NoDescriptor()):
+            self.assertIsNone(pane.size())
+            self.assertEqual(slots._width(), slots._DEFAULT_COLS)
+
+    def test_a_pane_that_cannot_be_measured_says_so_instead_of_being_drawn(self):
+        """The distinguishable state, on the pane rather than in a return value. A frame
+        laid out from `_DEFAULT_COLS` in a rectangle that is very probably not that shape
+        is the destructive move `_measure_window` already refuses for a window (#501)."""
+        real = _Pane()
+        with mock.patch.dict(slots.SLOTS, {"bottom": _probe}), \
+             mock.patch("os.get_terminal_size", side_effect=OSError("no size")):
+            with redirect_stdout(real), redirect_stderr(io.StringIO()):
+                panel.run("bottom", "f-unmeasured", once=True)
+        painted = _paints(real.getvalue())[0]
+        self.assertIn("pane size unknown", painted)
+        self.assertNotIn(f"W={slots._DEFAULT_COLS}", painted,
+                         f"a guess was drawn as if it were a measurement: {painted!r}")
+
+    def test_a_provider_component_is_not_handed_a_guessed_rectangle_either(self):
+        """The other painter, and the reason it is not symmetry for its own sake:
+        `ctx.build` hands a component a `width` and a `height` it may draw to the edge of,
+        so a fallback that reached a component would be a guess a stranger's code had
+        already been told was a measurement. Reached through a name no built-in claims,
+        which is what sends `run` down the `Registry.place` path."""
+        real = _Pane()
+        with mock.patch.dict(slots.SLOTS, {"probe": _probe}), \
+             mock.patch("os.get_terminal_size", side_effect=OSError("no size")):
+            with redirect_stdout(real), redirect_stderr(io.StringIO()):
+                panel.run("probe", "f-component", once=True)
+        painted = _paints(real.getvalue())[0]
+        self.assertIn("pane size unknown", painted)
+        self.assertNotIn("probe", painted,
+                         f"the component drew into a rectangle nobody measured: {painted!r}")
+
+    def test_a_pane_that_is_not_a_terminal_still_draws_at_the_stated_default(self):
+        """`charter panel bottom --session x > /tmp/log`, run by hand for debugging, and
+        every test in this suite. There is no rectangle for the frame to be wrong about,
+        so the stated default is the right answer and always was — telling the two halves
+        of "cannot measure" apart by the TTY is the property; "did the measurement raise"
+        is the spelling, and it cannot separate them."""
+        out = _NotAPane()
+        with mock.patch.dict(slots.SLOTS, {"bottom": _probe}), \
+             mock.patch("os.get_terminal_size", side_effect=OSError("no size")):
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                panel.run("bottom", "f-piped", once=True)
+        painted = _paints(out.getvalue())[0]
+        self.assertIn(f"W={slots._DEFAULT_COLS} H={slots._DEFAULT_ROWS}", painted)
+        self.assertNotIn("pane size unknown", painted)
+
+    def test_a_size_that_arrives_late_is_drawn_on_the_next_pass(self):
+        """A pty gets its size from a `TIOCSWINSZ` that lands moments later, and the
+        `SIGWINCH` after it is already a repaint reason. So the notice is painted per tick
+        and never held: `_hold` would be permanent by construction, and would wedge the
+        pane for the one failure that routinely fixes itself."""
+        real = _Pane()
+        with mock.patch.dict(slots.SLOTS, {"bottom": _probe}), _claimed(real):
+            with mock.patch("os.get_terminal_size", side_effect=OSError("not yet")):
+                panel._paint("bottom", "f-late")
+            with _measuring():
+                panel._paint("bottom", "f-late")
+        first, second = _paints(real.getvalue())
+        self.assertIn("pane size unknown", first)
+        self.assertIn(f"W={_PANE_SIZE.columns} H={_PANE_SIZE.lines}", second)
+
+    def test_a_refusal_is_still_readable_in_a_pane_nobody_can_measure(self):
+        """`_hold` is the module's other paint and it deliberately does NOT take the
+        notice: a panel that has already failed has something to say, and replacing its
+        reason with "pane size unknown" would lose the only trace of why the pane is
+        empty. It takes the stated fallback for its one truncation, which is
+        `_window_size`'s half of the same split."""
+        real = _Pane()
+        with mock.patch("os.get_terminal_size", side_effect=OSError("no size")):
+            with redirect_stdout(real), redirect_stderr(io.StringIO()):
+                rc = panel.run("sideways", "f-refused", once=True)
+        self.assertNotEqual(rc, 0)
+        self.assertIn("sideways", _paints(real.getvalue())[0])
+
+
+class ColourIsAskedOfThePane(PersonaIso, unittest.TestCase):
+    """The third consequence of one rebind, and the quietest: `chrome.colour_ok` was told
+    the pane is a terminal by a stand-in that is not one.
+    """
+
+    def test_a_stand_in_claiming_to_be_a_terminal_does_not_decide(self):
+        with mock.patch.dict(os.environ, {}, clear=True), _claimed(_NotAPane()):
+            sys.stdout = _PrintCapture()
+            self.assertFalse(chrome.colour_ok(),
+                             "SGR was written into a pane on a library's say-so")
+
+    def test_the_panes_own_answer_is_what_decides(self):
+        """The other direction, which a test of the first alone is satisfied by a
+        `colour_ok` that answers `False` always."""
+        with mock.patch.dict(os.environ, {}, clear=True), _claimed(_Pane()):
+            sys.stdout = _NotAPane()
+            self.assertTrue(chrome.colour_ok())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #606.

## The property

**The pane this process was given.** Not "whatever `sys.stdout` is bound to at the instant
of the ask" — which is what `panel._out`, `slots._width`/`_height` and `chrome.colour_ok`
were all asking, three times, about a mutable global. That is the ninth instance this month
of matching a spelling instead of a property (#547, #558, #537, #498, #577, #594), and the
only silent one: `Registry.draw`'s catch never fires because nothing goes wrong.

A panel paints to `sys.stdout` and measures its rectangle from that same descriptor, so in
a panel process `sys.stdout` **is** the pane. The moment a provider's library rebinds it —
Textual's `redirect_stdout`, but equally `rich`, `click`, `tqdm`, `colorama`, a logging
handler installed at import — charter paints into that library's log and measures fd -1.

## Measured, in a real 150x10 tmux pane (tmux 3.7c)

```
main:  REAL=150x10  BEFORE=150x10  AFTER_REBIND=80x24   colour_ok: True
this:  REAL=150x10  CLAIMED=150x10 AFTER_REBIND=150x10  colour_ok: True
```

And through `panel.run` with a real repaint, as the operator sees it (paint → rebind →
repaint):

```
main:  paints that reached the pane: 1   pane[0]='W=150 H=10'
       library's log: '\x1b[m\x1b[H\x1b[2JW=80 H=24'
this:  paints that reached the pane: 2   pane[0]='W=150 H=10'  pane[1]='W=150 H=10'
       library's log: ''
```

**#602 closed #594 in `tui.term_width` this morning, and `slots._width` was the same value
one function over — still live.** Measured on `origin/main` at c64dcc6, which contains
#602: a tty reporting zero columns gave `slots._width() == 0` and `slots._height() == 0`,
so a panel laid itself out one column wide. That generalisation is taken here rather than
re-derived: a source answers a number or nothing, and the judgement is made in the one
place there is exactly one of.

## What changed

**1. The pane is claimed, once, above anything a stranger wrote.** New
`charter/frame/pane.py` holds the answer to "which rectangle is this process's pane";
`panel.run` claims it at its first line — above `_run`'s `builtins.build()`, which is where
`Registry.place` runs `importlib.import_module` on a provider's module and so the first
instant third-party code can execute in a panel process. That is `tests/_ttyguard`'s
ordering one layer over (#545/#546): it installs *above* the import that pulls charter in,
because `util._USE_COLOR` is evaluated at that import. Released in `run`'s own `finally`,
for `_watch`'s reason — `run(once=True)` is called in-process by tests, and a claim
outliving its panel is the leak `_install_sigwinch` already hands a handler back to avoid.

A claim holds the stream *object*, so a rebind of the global cannot move the pane. A
`dup2` over fd 1 or a closed stream genuinely takes the descriptor away and is stated as
out of scope in the module docstring — those failures are loud, and this one was not.

**2. A size charter cannot take is no longer spelled the way a real 80x24 pane is.**
`pane.size()` answers `None` for a pane it could not measure *and* for one that reports a
zero — #594's judgement, made in the one place with a single source to make it about.
`slots._width`/`_height` keep the stated fallback for a caller that must hand a renderer a
number; the new `panel._unmeasured` is the caller that can do something about it. Exactly
the split `commands_frame._measure_window` (answers `None`, so `cmd_resize` refuses) and
`_window_size` (takes `_FALLBACK_SIZE`, because `cmd_launch` must draw) already make.

And the two halves of "cannot measure" are told apart by the **tty**, not by whether the
measurement raised:

- not a terminal → there is no rectangle to be wrong about (`charter panel bottom
  --session x > /tmp/log`, and every test): draws at the stated default, unchanged;
- a terminal that will not report a size → a real rectangle of unknown shape: the pane
  says `charter: pane size unknown`, per redraw and never held, because a pty gets its
  size from a `TIOCSWINSZ` moments later and `SIGWINCH` is already a repaint reason.

### The exact lines outside `panel.py`

- `charter/frame/slots.py:213-214` — `_width`: `pane.size()`, then `_DEFAULT_COLS` when it
  is `None`. Was two lines: `os.get_terminal_size(sys.stdout.fileno()).columns` in a
  `try`, `_DEFAULT_COLS` in an `except OSError`.
- `charter/frame/slots.py:244-245` — `_height`, the same shape, was the same shape.
- `charter/frame/slots.py` imports — `sys` dropped (now unused), `pane` added.
- `charter/frame/chrome.py:155` — `colour_ok`'s second question is `pane.is_tty()`; the
  `try/except (AttributeError, ValueError)` it used to spell moved into `pane.is_tty` so
  there is one answer. `NO_COLOR` and the rest of the function are untouched, and no
  rendering in that file was touched.

## The test

`tests/test_a_panes_descriptor_is_not_a_mutable_global.py` (17 tests), and a paragraph
in `docs/frame.md` beside the one that already says panels measure their own pane. The failure is the
**second** paint, so the tests reproduce paint → rebind → repaint through `panel.run`'s
real loop, and every assertion is **on the pane's content** — nothing here asserts an
exception, because on `main` there was none. `os.get_terminal_size` is patched *per
descriptor*, so "measured the pane" is distinguishable from "measured whatever was asked";
a blanket `return_value` would have gone green on the bug.

Verified red on `main` before the fix: the repaint in the library's log, the 80x24
measurement, `slots._width() == 0` on a zero-column tty, and `colour_ok()` returning `True`
for a non-tty pane behind a lying stand-in.

## Verification

- Full suite, two environments: **7116 tests OK** on python 3.14, and 7116 OK on
  python 3.12 with `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset. `$COLUMNS` set
  explicitly in both.
- Real tmux 3.7c for the pane measurement (numbers above); server killed and socket
  unlinked in one cleanup, 0 left behind.
- CI green at head `0de5939`, checked with `gh api .../commits/<sha>/check-runs` (#561):
  `test (3.11)`, `test (3.12)`, `test (3.13)`, `test (3.14)` all `completed success`.
- `tools/sweep.py --base origin/main`: baseline 7116 tests OK unmutated, then **11
  mutations applied, 11 pinned, 0 SURVIVED, 0 UNRESOLVED** (14.9 min). Every one of the
  four it reached is a line this PR's own argument turns on — `stream`'s
  `sys.stdout if _CLAIMED is None else _CLAIMED`, `size`'s zero judgement, both
  `_CANNOT_SAY` catches, `_unmeasured`'s two questions, and each of `slots._width`/
  `_height`'s fallbacks.
- **27 hand-mutations, 27 killed**, for what the sweep has no operator for (#569) — the
  `_UNMEASURED` string, the `_CANNOT_SAY` exception set member by member, the `and`/`>`/
  `is not None` in the size judgement and the notice's two questions, and each of
  `claim`/`release`/`stream`/`_out`/`_paint`/`_component_painter`/`colour_ok`/`run`'s
  claim. Unmutated baseline green first (#579), and every mutation asserts its edit
  actually applied before the suite runs (#585/#586).

  Two survived the first pass and both were real: `claim()` returning `None` and
  `release()` clearing instead of restoring. The restore test had been asserting from
  inside `redirect_stdout(outer)`, so `pane.stream()` falling back to `sys.stdout`
  answered with the very object it was compared against. The test now takes the outer
  claim and then lets go of it as `sys.stdout`, and both mutations die.

## A second instance, found and not fixed here

`commands_frame.cmd_palette` builds its action registry — which imports every installed
provider — **before** `palette.own_the_tty`, whose `out` defaults to `sys.stdout` and whose
`size()` reads `out.fileno()`. That is the same property in the other pane-owning process,
and closing it means claiming there too. Filed as #611 rather than widened into this PR,
which is scoped to the panel — the claim has to sit above the registry build while
`cmd_palette`'s existing `try` starts below it, so closing it is a decision about
`commands_frame`'s structure rather than a detail of this one.
