### PR TITLE
The sweep runs on every pull request, and a string is a value it can move (#569)

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1,0 +1,73 @@
+name: deletion sweep
+on:
+  pull_request:
+  workflow_dispatch:      # so a branch can be re-swept without a noise commit
+
+# Read-only, declared rather than inherited. This job runs the repository's own code
+# against mutated copies of it, which is the last place to hold a writable token.
+permissions:
+  contents: read
+
+# Every `uses:` is pinned to a full commit SHA with its tag in a trailing comment, for the
+# reason `release.yml`'s header gives at length and `tests/test_workflows.py` enforces.
+# Dependabot moves these (`.github/dependabot.yml`).
+
+# A pull request that gets three pushes should pay for one sweep, not three. Twenty-odd
+# minutes of runner time per push is the whole reason this is affordable at all.
+concurrency:
+  group: sweep-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sweep:
+    name: Every guard this branch adds is a line a test goes red without
+    runs-on: ubuntu-latest
+    # Stage C of `docs/superpowers/specs/2026-08-27-deletion-sweep-harness.md`.
+    #
+    # **Scoped to the lines this branch ADDED**, never to the tree. The whole-tree number
+    # is stage B — roughly 5,672 mutations and fourteen hours — and it is not a
+    # pull-request check and never will be. Measured on real branches from this phase: 30
+    # to 52 mutations each, a 262 s unmutated baseline, and about 24 s a mutation, so a
+    # gate run is twenty-odd minutes.
+    #
+    # **It reports and blocks nothing.** `--enforce` is the flag that changes that and it
+    # is deliberately absent here. The spec's staging argument — a gate whose baseline
+    # nobody has seen gets disabled the first time it is inconvenient — applies to this
+    # job's own credibility too. Turn it on by adding `--enforce` to the step below, once
+    # the numbers on a few real branches have been read and believed.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The whole history, because the sweep charges a branch against its MERGE-BASE
+          # and a shallow clone has no such commit. It also clones this checkout into its
+          # sandboxes, so a graft point here becomes a broken sandbox there.
+          fetch-depth: 0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Sweep the guards this branch adds
+        env:
+          # Through the environment and not interpolated into the script. A `${{ }}` inside
+          # `run:` is textual substitution before bash ever sees it, which is how a value
+          # somebody else controls becomes a command; the same rule `release.yml` follows.
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # No --base on a manual dispatch: with no pull request there is no base sha, and
+          # the tool's own default (the merge-base with origin/main) is the right answer.
+          if [ -n "${BASE_SHA:-}" ]; then
+            set -- --base "$BASE_SHA"
+          else
+            set --
+          fi
+          python3 tools/sweep.py --gate --jobs 4 \
+            --json sweep-results.json \
+            --summary "$GITHUB_STEP_SUMMARY" "$@"
+      - name: Keep the result set, whatever the sweep said
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: deletion-sweep
+          path: sweep-results.json
+          if-no-files-found: ignore

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -45,6 +45,12 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
+          # 3.12 at the earliest, and that is a floor rather than a preference. Before PEP
+          # 701 (3.12) `ast` gives an f-string's internal nodes approximate positions, so
+          # `retune-string` cannot vouch for the bytes it would splice and refuses — which
+          # puts `f"{name:<28}"`, where a width literal actually lives in this tree and
+          # #508's entire defect, out of the sweep's reach. `sweep.reach()` says so in the
+          # report rather than letting a smaller sweep read like a clean one.
           python-version: "3.12"
       - name: Sweep the guards this branch adds
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,7 @@ the diff with your merge-base:
 python3 tools/sweep.py                  # this branch, against origin/main
 python3 tools/sweep.py --second-order 24 # survivors in one function, applied together
 python3 tools/sweep.py --all             # the standing debt across the tree, as a number
+python3 tools/sweep.py --gate            # exactly what CI runs on your pull request
 ```
 
 It deletes one guard at a time, runs only the test modules measured to execute that
@@ -195,8 +196,20 @@ A survivor is a line you can delete with the suite still green. There is no supp
 list, on purpose: if deleting a line genuinely changes nothing observable, delete the line
 — "equivalent mutant" and "dead code" are the same finding.
 
-It is not a CI gate yet. It is stdlib-only, it makes its own clones, and it never writes to
-your checkout.
+It is stdlib-only, it makes its own clones, and it never writes to your checkout.
+
+**CI runs it on every pull request** (`.github/workflows/sweep.yml`), scoped to the lines
+your branch added, and writes the result onto the run's summary page — the survivors, what
+the covering tests assert about each one, and the categories it keeps apart: *unpinned*, a
+*masked cluster* (two survivors in one function, which hide each other and have to be read
+together), *platform-deferred* (a catch the runner's kernel may never reach), *unresolved*
+(the run timed out, so there is no verdict) and *not applied* (a bug in the sweep, not a
+finding about your branch).
+
+**It blocks nothing yet, on purpose.** A gate whose numbers nobody has read gets switched
+off the first time it is inconvenient, so it reports first. Adding `--enforce` to that
+workflow's step is what makes it blocking, and that is a decision to take once the numbers
+on real branches have been looked at and believed.
 
 ## Architecture decisions
 

--- a/docs/news/unreleased-the-sweep-runs-on-every-pull-request.md
+++ b/docs/news/unreleased-the-sweep-runs-on-every-pull-request.md
@@ -11,15 +11,18 @@ in the diff, which is why it kept being *reported* rather than *run*.
 `tools/sweep.py` made that mechanical in August. **Now CI runs it**, on every pull request,
 scoped to the lines the branch added.
 
-```
-Deletion sweep — 2 actionable survivor(s)
+The summary it writes onto the run has one row per outcome — the shape, not a run:
 
-| outcome            |  n | what it means                                        |
-| pinned             | 34 | a test goes red without the line                     |
-| unpinned           |  1 | a guard with no test behind it                       |
-| masked cluster     |  0 | two or more in one function; none is safe alone      |
-| platform-deferred  |  1 | may be unreachable on linux; never fails this gate   |
-| unresolved         |  0 | no verdict — timed out, not measured                 |
+```
+Deletion sweep — N actionable survivor(s)
+
+| outcome            | what it means                                        |
+| pinned             | a test goes red without the line                     |
+| unpinned           | a guard with no test behind it                       |
+| masked cluster     | two or more in one function; none is safe alone      |
+| platform-deferred  | may be unreachable here; never fails this gate       |
+| unresolved         | no verdict — timed out, not measured                 |
+| not applied        | the edit never reached the tree — a bug in the sweep |
 ```
 
 **It blocks nothing yet, and that is the design.** A gate whose numbers nobody has read

--- a/docs/news/unreleased-the-sweep-runs-on-every-pull-request.md
+++ b/docs/news/unreleased-the-sweep-runs-on-every-pull-request.md
@@ -1,0 +1,77 @@
+---
+version: unreleased
+headline: The deletion sweep runs on every pull request, and it can now see a string
+---
+
+For three review rounds the same defect kept arriving: **a guard with no test behind it.**
+Correct code, shipped, that a later refactor could delete in silence. Every one was found
+by deleting the line and running the suite — a step that is mechanical, slow and invisible
+in the diff, which is why it kept being *reported* rather than *run*.
+
+`tools/sweep.py` made that mechanical in August. **Now CI runs it**, on every pull request,
+scoped to the lines the branch added.
+
+```
+Deletion sweep — 2 actionable survivor(s)
+
+| outcome            |  n | what it means                                        |
+| pinned             | 34 | a test goes red without the line                     |
+| unpinned           |  1 | a guard with no test behind it                       |
+| masked cluster     |  0 | two or more in one function; none is safe alone      |
+| platform-deferred  |  1 | may be unreachable on linux; never fails this gate   |
+| unresolved         |  0 | no verdict — timed out, not measured                 |
+```
+
+**It blocks nothing yet, and that is the design.** A gate whose numbers nobody has read
+gets switched off the first time it is inconvenient, so it reports first and says on the
+page what it *would* have done. One flag turns it on, once the numbers have been believed.
+
+**A survivor comes with the assertions that were supposed to hold it.** Not "line 291 is
+unpinned" but the covering tests, by name, and what each one actually asserts about the
+symbol. That field is the difference between a report somebody triages and a report
+somebody mutes — because most "that mutant is equivalent" claims turn out to be "the test
+asserts too little", and you cannot tell which from a line number.
+
+**And it keeps three kinds of survivor apart.** A *masked cluster* is two survivors inside
+one function: two guards in sequence hide each other, so neither looks like it matters on
+its own and neither is tested. *Platform-deferred* is a catch on an error the operating
+system decides — `except OSError` around a pty read is dead code on macOS and live on
+Linux — and the gate never fails on one, because a check that fails a branch for a clause
+the runner's kernel cannot reach is a check people are right to disable. *Unresolved* is
+its own answer too: a run that timed out is not a pass and not a failure, it is no verdict,
+and machine load must never be allowed to certify a guard as tested.
+
+## Two shapes it could not see before
+
+The sweep mutates by statement shape, and two families had no shape at all — between them,
+nearly every finding the last round had to check by hand.
+
+**A string is now a value the sweep can move.** The old objection was that strings have no
+honest perturbation: picking `1003` over `1000` for a mouse-tracking escape is fitting the
+answer key, not recognising a shape. The answer is to move the *value* while holding
+everything structural — same length, same character classes, escapes untouched. So
+`"\x1b[?1000h"` becomes `"\x1b[?2111i"` and is still an escape sequence, `{:<28}` becomes
+`{:<39}` and is still a format spec, and a regex stays a regex. It is derived from the
+constant and nothing else, so it cannot fit an answer key it never reads.
+
+It applies where the program *reads* the string — a key, a comparison, a pattern, a
+separator, a width — and not to prose. That line is drawn from a measurement rather than a
+preference: mutating every string in `charter/` took the tree from 7,006 mutations to
+14,801 and spent the difference on log lines.
+
+**And a near-synonym is now a mutation.** `<` against `<=`, so a guard written one notch
+out is caught by something other than luck; `.lower()` against `.upper()`,
+`startswith` against `endswith`, `sorted` against `list`; and `p.resolve()` dropped to `p`
+— which is the exact shape of the bug that made the sweep itself unusable on macOS, where
+one path was normalised and the one it was compared against was not.
+
+Both were checked against a defect already known and already fixed: run over the commit
+before the roster-column fix, the sweep now finds the `{:<28}` width literal on its own —
+the finding that had to be hand-written last time because no operator could see it.
+
+## The sweep swept itself again
+
+It found 123 of its own 198 mutations survived, deleted two of its own lines that turned
+out to guard nothing, and the operator table — the half that decides every verdict — now
+holds. The report renderer is still thin, and the number in the pull request says so
+rather than rounding it up.

--- a/docs/news/unreleased-the-sweep-runs-on-every-pull-request.md
+++ b/docs/news/unreleased-the-sweep-runs-on-every-pull-request.md
@@ -72,9 +72,23 @@ Both were checked against a defect already known and already fixed: run over the
 before the roster-column fix, the sweep now finds the `{:<28}` width literal on its own —
 the finding that had to be hand-written last time because no operator could see it.
 
+## And every mutation now proves it happened
+
+A mutation whose edit never lands runs the *unmutated* tree, passes, and gets reported as a
+survivor — which sends somebody to write a test for a line that is already covered. So each
+one carries a fingerprint of the file it was read from, and refuses if the tree it is handed
+is a different one.
+
+That check earned its place within a day of being written. Two sweeps of the same checkout
+were running at once and quietly sharing sandboxes, each applying mutations to the other's
+files. **486 of 489 mutations refused to answer.** Without the check the same run would have
+printed a confident table of pinned guards and survivors, about bytes neither sweep chose.
+Sandboxes are now private to a run; the trace cache, which is content-addressed, is still
+shared.
+
 ## The sweep swept itself again
 
-It found 123 of its own 198 mutations survived, deleted two of its own lines that turned
-out to guard nothing, and the operator table — the half that decides every verdict — now
-holds. The report renderer is still thin, and the number in the pull request says so
-rather than rounding it up.
+It deleted three of its own lines that turned out to guard nothing — including one guarding
+a loop over the very list it was testing for emptiness — and closed the operator table, the
+half that decides every verdict. The report renderer is thinner, and the number in the pull
+request says so rather than rounding it up.

--- a/docs/superpowers/specs/2026-08-27-deletion-sweep-harness.md
+++ b/docs/superpowers/specs/2026-08-27-deletion-sweep-harness.md
@@ -181,14 +181,26 @@ final word in the *other* direction: a survivor of a subset is not yet a survivo
 
 **A. The harness** — `tools/sweep.py`, stdlib only. Trace-based selection map, the mutation
 operators above, survivors re-confirmed against the full suite. Runs standalone and prints a
-report a human can act on. Not wired to CI yet.
+report a human can act on. **Shipped** (#565).
 
 **B. The baseline** — run `--all` against `main` and write the number down. This is the first
-honest count of the repo's unpinned guards, and it sets what B→C has to hold flat.
+honest count of the repo's unpinned guards, and it sets what B→C has to hold flat. **Not run**:
+measured at roughly 5,672 mutations and fourteen hours, which is a background job somebody
+schedules, not a step on the way to anything.
 
 **C. The gate** — a CI job on pull requests, scoped to added lines, that fails on a survivor.
 Wire it only after A and B, because a gate whose baseline nobody has seen gets disabled the first
 time it is inconvenient.
+
+**Shipped before B, and the ordering above was the thing re-examined rather than ignored.** Its
+stated reason is credibility, not a technical dependency — and the gate never sweeps the whole
+tree, so B is not on C's critical path at all. What the reason actually asks for is that the
+gate's numbers be *seen* before it can block a branch, and B is a poor way to get that: it
+measures `main`'s standing debt, which is not the number a gate run produces. So the gate ships
+**reporting only** — it prints its table on every pull request, says what it *would* have done,
+and blocks nothing until `--enforce` is added to `.github/workflows/sweep.yml`. That makes the
+gate's own baseline visible on real branches, which is what the ordering was protecting. B
+remains worth doing, as a number, whenever a machine is free.
 
 ## How this gets verified
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -551,6 +551,9 @@ class TheStringShape(unittest.TestCase):
         text = sweep.report([], Path("."), "a" * 12, "b" * 12, None, 1.0)
         self.assertEqual("f-string" in text, sys.version_info < (3, 12))
         self.assertIn(".".join(str(n) for n in sys.version_info[:3]), text)
+        # And on the pull request too, which is the page anybody will actually read.
+        summary = sweep.gate_summary(sweep.classify([]), "a" * 40, "b" * 40, 1.0, False)
+        self.assertEqual("f-string" in summary, sys.version_info < (3, 12))
 
     def test_a_bytes_constant_is_retuned_as_bytes(self):
         muts = _mutations("""
@@ -1875,8 +1878,7 @@ class AMutationThatNeverAppliedIsNotASurvivor(unittest.TestCase):
 
     def test_decide_calls_it_unapplied_and_never_survived(self):
         box = _Refusing()
-        verdict, subset, full = sweep.decide(box, _mutations("x = 1\n")[0] if False
-                                             else self._mutation(), ["tests.test_a"])
+        verdict, subset, full = sweep.decide(box, self._mutation(), ["tests.test_a"])
         self.assertEqual(verdict, "unapplied")
         self.assertIsNone(full)
         self.assertFalse(subset.conclusive)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1906,6 +1906,25 @@ class AMutationThatNeverAppliedIsNotASurvivor(unittest.TestCase):
         self.assertIn("this edit did not happen", text)
         self.assertNotIn("Every mutation this diff offered goes red", text)
 
+    def test_two_sweeps_of_one_checkout_do_not_share_a_sandbox(self):
+        """The collision that produced the assertion's first real catch.
+
+        `workdir_for` gives one workdir per checkout, which is right for the trace cache
+        and wrong for the sandboxes: two sweeps of the same tree — two agents on one box,
+        or one person who forgot the first run was still going — would apply mutations to
+        each other's files. Measured on `tools/sweep.py` by accident: two overlapping runs
+        and 486 of 489 mutations came back `unapplied`, which is the digest check refusing
+        to answer about a tree it did not recognise. Before that check the same run would
+        have printed a plausible table of pins and survivors.
+        """
+        self.assertIn(str(os.getpid()), str(sweep.run_dir(Path("/w"))))
+        self.assertEqual(sweep.run_dir(Path("/w")).parent, Path("/w"))
+
+    def test_the_cache_is_still_shared_between_runs(self):
+        """Keyed by a hash of the tree, so two runs of one checkout want the same map and
+        paying for it twice is pure loss. Only the sandboxes are private."""
+        self.assertNotIn(str(os.getpid()), str(sweep.workdir_for(Path.cwd(), None)))
+
     def test_a_run_with_one_is_not_a_clean_exit(self):
         m = self._mutation()
         clean = [sweep.Result(m, "pinned", None, None, [])]

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -10,6 +10,10 @@ still passes has kept the property those rounds actually measured.
 from __future__ import annotations
 
 import ast
+import contextlib
+import dataclasses
+import hashlib
+import io
 import os
 import subprocess
 import sys
@@ -400,6 +404,291 @@ class TheConstantShape(unittest.TestCase):
 # ======================================================================================
 # Splicing — line numbers are the whole output of this tool
 # ======================================================================================
+
+class TheStringShape(unittest.TestCase):
+    """`retune-string` (#569): the value moved, every structural property held.
+
+    The spec declared this family a gap on the grounds that a string has no honest general
+    perturbation — "picking `1003` over `1000` for `MOUSE_ON` is fitting the answer key".
+    :func:`sweep.retune` is the answer: same length, same character classes, different
+    value, derived from the constant and from nothing else. Every case below asserts one
+    half of that — either that the value really moved, or that some structure really did
+    not.
+    """
+
+    def test_a_string_the_program_compares_is_retuned(self):
+        muts = _mutations("""
+            def f(answer):
+                if answer == "yes":
+                    return 1
+        """)
+        self.assertEqual(_afters(muts, "retune-string"), ["'zft'"])
+
+    def test_the_mutant_is_the_same_length_and_the_same_character_classes(self):
+        """The whole justification for the operator. A perturbation that changed the
+        length, or turned a digit into a letter, would break f-string specs, regexes and
+        escape sequences — and a mutation that reddens the suite because the mutant no
+        longer *parses as its own kind of string* is a false pin."""
+        for shipped in ("\x1b[?1000h", "components", "{:<28}", "%s says", "a-b_c.d"):
+            moved = sweep.retune(shipped)
+            self.assertNotEqual(moved, shipped)
+            self.assertEqual(len(moved), len(shipped))
+            for a, b in zip(shipped, moved):
+                self.assertEqual((a.isdigit(), a.isupper(), a.islower(), a.isalnum()),
+                                 (b.isdigit(), b.isupper(), b.islower(), b.isalnum()),
+                                 f"{shipped!r} -> {moved!r} changed a character's class")
+
+    def test_the_terminal_escape_stays_a_terminal_escape(self):
+        """`MOUSE_ON` is the spec's own example of the string it could not mutate."""
+        self.assertEqual(sweep.retune("\x1b[?1000h"), "\x1b[?2111i")
+
+    def test_a_character_behind_a_backslash_is_left_alone(self):
+        """A raw `\\d` is one escape, not a backslash next to a letter. Shifting the `d`
+        makes `re.error: bad escape \\e`, which reddens the suite for a reason that has
+        nothing to do with the property — the definition of a false pin."""
+        self.assertEqual(sweep.retune(r"^Ran (\d+) tests?"), r"^Sbo (\d+) uftut?")
+
+    def test_a_string_with_nothing_to_move_offers_no_mutation(self):
+        muts = _mutations("""
+            def f(x):
+                return x.split("/")
+        """)
+        self.assertEqual(_by(muts, "retune-string"), [])
+
+    def test_a_docstring_is_prose_and_is_never_mutated(self):
+        muts = _mutations('''
+            MARK = "the mark"
+
+            def f():
+                """A docstring naming the mark, which is not a value anybody tests."""
+                return MARK
+        ''')
+        self.assertEqual(_afters(muts, "retune-string"), ["'uif nbsl'"])
+
+    def test_a_message_nobody_reads_back_is_not_a_read_position(self):
+        """The scoping half, and the honest one. A key, a pattern and a separator decide
+        what the program *does*; a log line decides what it *says*, and nothing in a suite
+        is obliged to assert it. Measured on `charter/`: mutating every string took the
+        tree from 7,006 mutations to 14,801 and spent the difference on prose."""
+        muts = _mutations("""
+            def f(log, d):
+                log("could not reach the vault")
+                return d["session"]
+        """)
+        self.assertEqual(_afters(muts, "retune-string"), ["'tfttjpo'"])
+
+    def test_a_member_of_a_module_table_is_read_through_the_lookup_and_not_at_the_table(self):
+        """The value of a module-level `NAME = "…"` is a claim — `MOUSE_ON` and `_MARK` are
+        two of round two's five findings and both are scalars. Every string inside a
+        container assigned to an upper-case name is not: measured on `charter/`, walking
+        into containers takes the read positions from 2,826 to 4,065, and what those 1,239
+        extra mutations ask for is a test per member of every membership table in the tree.
+        Where a member genuinely decides something, the lookup that reads it is a read
+        position on its own."""
+        muts = _mutations("""
+            MARK = "seen"
+            NAMES = ("alpha", "beta")
+
+            def f(x):
+                return x in NAMES
+        """)
+        self.assertEqual(_afters(muts, "retune-string"), ["'tffo'"])
+
+    def test_every_read_position_is_reached(self):
+        muts = _mutations("""
+            MARK = "alpha"
+
+            def f(d, s, name):
+                a = d["key"]
+                b = d.get("other")
+                c = {"third": 1}
+                e = s.startswith("pre")
+                g = " and ".join(name)
+                h = "%s!" % name
+                return a, b, c, e, g, h, MARK
+        """)
+        self.assertEqual(
+            sorted(_afters(muts, "retune-string")),
+            sorted(["'bmqib'", "'lfz'", "'puifs'", "'uijse'", "'qsf'", "' boe '",
+                    "'%t!'"]))
+
+    def test_the_width_literal_inside_an_fstring_is_reached(self):
+        """#508's defect exactly: `f"{name:<28}"`, a layout claim with nothing measuring
+        it, which had to be hand-checked because this operator did not exist. The segment's
+        span carries no quotes, so the splice is raw text and `span_is_sound` proves the
+        round-trip a different way — the bytes at the span ARE the characters of the value.
+        """
+        muts = _mutations("""
+            def f(name):
+                return f"{name:<28}"
+        """)
+        self.assertEqual(_afters(muts, "retune-string"), ["<39"])
+
+    def test_an_fstring_segment_whose_source_is_not_its_value_is_refused(self):
+        """`{{` is two source characters and one value character, so a raw splice at that
+        span would replace bytes the mutation cannot describe. Refused rather than guessed
+        at — the same rule as every other unsound span."""
+        muts = _mutations("""
+            MARK = f"a{{b}}c{0:<28}"
+        """)
+        self.assertEqual(_afters(muts, "retune-string"), ["<39"])
+
+    def test_a_bytes_constant_is_retuned_as_bytes(self):
+        muts = _mutations("""
+            def f(ch):
+                return ch == b"\\x03q"
+        """)
+        self.assertEqual(_afters(muts, "retune-string"), ["b'\\x03r'"])
+
+
+class TheBoundaryShape(unittest.TestCase):
+    """`shift-boundary` (#569): `<` against `<=`, and nothing else moved.
+
+    The general half of the near-synonym family. Two comparisons that accept the same
+    values one number apart, so the mutant always runs and asks exactly one question — is
+    the EDGE pinned, or only the direction? `drop-if` cannot ask it: a test that never
+    approaches the edge answers "yes, the refusal exists" perfectly well.
+    """
+
+    def test_a_strict_comparison_is_offered_one_notch_wider(self):
+        muts = _mutations("""
+            def _window(sel, top):
+                if sel < top:
+                    return sel
+                return top
+        """)
+        self.assertEqual(_afters(muts, "shift-boundary"), ["(sel) <= (top)"])
+
+    def test_an_inclusive_comparison_is_offered_one_notch_narrower(self):
+        muts = _mutations("""
+            def f(n, cap):
+                return n <= cap
+        """)
+        self.assertEqual(_afters(muts, "shift-boundary"), ["(n) < (cap)"])
+
+    def test_a_chain_moves_one_link_and_respells_the_rest(self):
+        """`0 <= i < n` is ONE node. Moving one link means writing the whole chain back
+        out, and a link this tool could not spell would vanish from the mutant — an edit
+        that is not the edit the report describes."""
+        muts = _mutations("""
+            def f(i, n):
+                return 0 <= i < n
+        """)
+        self.assertEqual(sorted(_afters(muts, "shift-boundary")),
+                         ["(0) < (i) < (n)", "(0) <= (i) <= (n)"])
+
+    def test_a_link_that_is_not_a_boundary_is_carried_through_untouched(self):
+        muts = _mutations("""
+            def f(a, b, c):
+                return a < b == c
+        """)
+        self.assertEqual(_afters(muts, "shift-boundary"), ["(a) <= (b) == (c)"])
+
+    def test_every_comparison_operator_python_has_is_spelled(self):
+        """`CMP_TEXT` is subscripted directly, with no fallback, so an operator missing
+        from it would be a `KeyError` in the middle of a sweep. There is no runtime guard
+        for that — a guard nothing can reach is a line this tool would delete — so the
+        completeness lives here, where it fails on the day Python grows an eleventh
+        comparison rather than the day somebody's sweep crashes."""
+        self.assertEqual(set(ast.cmpop.__subclasses__()), set(sweep.CMP_TEXT))
+
+    def test_equality_is_not_a_boundary(self):
+        """`!=` is the negation of `==`, not a near-synonym of it, and inverting a whole
+        condition is a coarser question this table does not ask."""
+        muts = _mutations("""
+            def f(a):
+                return a == 3
+        """)
+        self.assertEqual(_by(muts, "shift-boundary"), [])
+
+
+class TheSynonymShape(unittest.TestCase):
+    """`swap-synonym` and `drop-normalise` (#569): one documented axis, moved.
+
+    Each pair in :data:`sweep.SYNONYMS` is two standard-library names that do the same job
+    and differ along exactly one axis, so the mutant is type-correct by construction and a
+    red means a test noticed the AXIS rather than a test noticing a crash. Nothing
+    charter-specific is in the table — the same discipline as `NARROW_TO`.
+    """
+
+    def test_a_case_fold_is_swapped_for_its_opposite(self):
+        muts = _mutations("""
+            def f(name):
+                return name.lower()
+        """)
+        self.assertEqual(_afters(muts, "swap-synonym"), ["name.upper"])
+
+    def test_an_anchor_is_swapped_end_for_end(self):
+        muts = _mutations("""
+            def f(name):
+                return name.startswith("x")
+        """)
+        self.assertEqual(_afters(muts, "swap-synonym"), ["name.endswith"])
+
+    def test_an_ordering_is_asked_about_by_dropping_it(self):
+        muts = _mutations("""
+            def f(xs):
+                return sorted(xs)
+        """)
+        self.assertEqual(_afters(muts, "swap-synonym"), ["list"])
+
+    def test_a_call_whose_swap_would_be_a_type_error_is_not_offered(self):
+        """`sorted(xs, key=f)` -> `list(xs, key=f)` raises `TypeError`, which reddens the
+        suite for a reason that has nothing to do with the ordering. That is a FALSE PIN,
+        and a false pin is the failure this whole file exists to prevent — so the operator
+        declines rather than scoring a point it did not earn."""
+        muts = _mutations("""
+            def f(xs, key):
+                return sorted(xs, key=key)
+        """)
+        self.assertEqual(_by(muts, "swap-synonym"), [])
+
+    def test_a_normalisation_is_dropped_to_its_receiver(self):
+        """#572's own shape: the map keys were `resolve()`d on both sides and the prefix
+        that chose them was not. A test whose paths carry no symlink cannot tell the
+        mutant from the shipped line, which is exactly what the sweep should say."""
+        muts = _mutations("""
+            def f(p):
+                return p.resolve()
+        """)
+        self.assertEqual(_afters(muts, "drop-normalise"), ["p"])
+
+    def test_a_normalisation_with_arguments_is_left_alone(self):
+        muts = _mutations("""
+            def f(p):
+                return p.resolve(strict=True)
+        """)
+        self.assertEqual(_by(muts, "drop-normalise"), [])
+
+    def test_every_pair_in_the_table_names_the_one_axis_it_moves(self):
+        """The table is the justification. A pair with no axis written down is a swap
+        somebody liked the look of, and that is how this becomes a general-purpose mutation
+        engine that reddens code for reasons nobody can read."""
+        for name, (other, axis) in sweep.SYNONYMS.items():
+            self.assertTrue(axis and isinstance(axis, str), name)
+            self.assertNotEqual(name, other)
+
+
+class TheNonDecimalConstantShape(unittest.TestCase):
+    """An integer written in base 8 or 16 was written that way because its digits matter."""
+
+    def test_a_permission_is_moved_by_one_and_stays_octal(self):
+        muts = _mutations("""
+            def f(p):
+                p.chmod(0o600)
+        """)
+        self.assertEqual(_afters(muts, "retune-constant"), ["0o601"])
+
+    def test_a_decimal_literal_in_the_same_position_is_not_retuned(self):
+        """Every `0`, `1` and `2` index in the tree would otherwise become a mutation. The
+        thresholds that matter are reached by `shift-boundary` instead, which asks the same
+        question of `x > 28` without asking it of `xs[0]`."""
+        muts = _mutations("""
+            def f(p):
+                p.chmod(384)
+        """)
+        self.assertEqual(_by(muts, "retune-constant"), [])
+
 
 class TheSplicePreservesEveryLineNumber(unittest.TestCase):
     def test_a_deleted_multi_line_statement_leaves_the_rest_where_it_was(self):
@@ -1447,6 +1736,650 @@ class ThereIsNoSuppressionList(unittest.TestCase):
         for forbidden in ("suppress", "ignore_list", "allowlist", "equivalent",
                           "nosweep", "skip_mutation", "exclusions"):
             self.assertNotIn(forbidden, names, f"a suppression hatch named {forbidden}")
+
+
+class _Refusing:
+    """A sandbox whose `apply` refuses, so `decide` can be asked what it does about it."""
+
+    def __init__(self, why="the mutant is byte-identical to the tree it replaces"):
+        self.why = why
+        self.subset_calls = 0
+        self.full_calls = 0
+
+    def clean_failures(self, modules):
+        return frozenset()
+
+    def apply(self, m):
+        raise sweep.NotApplied(self.why)
+
+    def restore(self):
+        pass
+
+    def subset(self, modules):        # pragma: no cover - never reached, and that is the point
+        self.subset_calls += 1
+        return sweep.Outcome(True, 9, "OK")
+
+    def full(self):                   # pragma: no cover - same
+        self.full_calls += 1
+        return sweep.Outcome(True, 9, "OK")
+
+
+class AMutationThatNeverAppliedIsNotASurvivor(unittest.TestCase):
+    """The fifth way a sweep lies (#586), closed by construction.
+
+    The edit does not match, so the "mutant" tree is the UNMUTATED tree, the suite passes,
+    and the guard is reported as a survivor. It is the only one of the five that errs
+    toward *more* work rather than less, and it is the one that ends adoption: somebody
+    writes a test for a line already covered, finds out, and stops believing the tool.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="sweep-applied-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp,
+                                                            ignore_errors=True))
+        (self.tmp / "charter").mkdir()
+        (self.tmp / "charter" / "m.py").write_bytes(b"def f(x):\n    if x:\n        return 1\n")
+        self.box = sweep.Sandbox.__new__(sweep.Sandbox)
+        self.box.path = self.tmp
+        self.box._pristine = {}
+        self.box._clean_failures = {}
+
+    def _mutation(self, **over):
+        source = (self.tmp / "charter" / "m.py").read_bytes()
+        m = _mutations(source.decode())[0]
+        return dataclasses.replace(m, path="charter/m.py", **over)
+
+    def test_a_mutant_identical_to_the_tree_is_refused_rather_than_run(self):
+        pristine = (self.tmp / "charter" / "m.py").read_bytes()
+        m = self._mutation(source=pristine,
+                           origin=hashlib.sha256(pristine).hexdigest())
+        with self.assertRaises(sweep.NotApplied):
+            self.box.apply(m)
+
+    def test_a_sandbox_holding_a_different_file_is_refused(self):
+        """A mutation carries a digest of the file it was READ FROM. A sandbox at another
+        ref, or one an earlier restore did not undo, fails here rather than producing a
+        verdict about bytes nobody looked at."""
+        m = self._mutation(source=b"x = 1\n", origin="0" * 64)
+        with self.assertRaises(sweep.NotApplied) as caught:
+            self.box.apply(m)
+        self.assertIn("not the file the mutation was read from", str(caught.exception))
+
+    def test_the_mutation_that_does_apply_is_written_and_can_be_undone(self):
+        pristine = (self.tmp / "charter" / "m.py").read_bytes()
+        m = self._mutation(source=b"def f(x):\n    pass\n",
+                           origin=hashlib.sha256(pristine).hexdigest())
+        self.box.apply(m)
+        self.assertEqual((self.tmp / "charter" / "m.py").read_bytes(),
+                         b"def f(x):\n    pass\n")
+        self.box.restore()
+        self.assertEqual((self.tmp / "charter" / "m.py").read_bytes(), pristine)
+
+    def test_every_mutation_this_tool_offers_carries_the_digest_of_its_own_source(self):
+        source = b"def f(x):\n    if x:\n        return 1\n"
+        for m in sweep.mutations_for("charter/m.py", source, {1, 2, 3}):
+            self.assertEqual(m.origin, hashlib.sha256(source).hexdigest())
+
+    def test_decide_calls_it_unapplied_and_never_survived(self):
+        box = _Refusing()
+        verdict, subset, full = sweep.decide(box, _mutations("x = 1\n")[0] if False
+                                             else self._mutation(), ["tests.test_a"])
+        self.assertEqual(verdict, "unapplied")
+        self.assertIsNone(full)
+        self.assertFalse(subset.conclusive)
+        self.assertEqual(box.full_calls, 0)
+
+    def test_the_report_says_so_in_its_own_section(self):
+        m = self._mutation()
+        r = sweep.Result(m, "unapplied",
+                         sweep.Outcome(False, 0, "this edit did not happen",
+                                       conclusive=False), None, [])
+        text = sweep.report([r], self.tmp, "a" * 12, "b" * 12, None, 1.0)
+        self.assertIn("NOT APPLIED", text)
+        self.assertIn("this edit did not happen", text)
+        self.assertNotIn("Every mutation this diff offered goes red", text)
+
+    def test_a_run_with_one_is_not_a_clean_exit(self):
+        m = self._mutation()
+        clean = [sweep.Result(m, "pinned", None, None, [])]
+        self.assertEqual(sweep.exit_code(clean), 0)
+        self.assertEqual(sweep.exit_code(clean + [sweep.Result(m, "unapplied", None,
+                                                               None, [])]), 4)
+
+
+# ======================================================================================
+# Stage C — the gate
+# ======================================================================================
+
+def _result(verdict, path="charter/a.py", line=1, symbol="f", operator="drop-if",
+            before="if x:\n    return", evidence=None):
+    m = sweep.Mutation(path=path, line=line, end_line=line, operator=operator,
+                       question="is the refusal pinned?", before=before, after="",
+                       symbol=symbol)
+    return sweep.Result(m, verdict, None, sweep.Outcome(True, 10, "OK"), ["tests.test_a"],
+                        evidence)
+
+
+class TheGateSortsSurvivorsIntoWhatItMayActOn(unittest.TestCase):
+    """Three categories stage A already knows, kept apart because the responses differ.
+
+    Collapsing any two of them is how this gate gets switched off inside a week — most of
+    all the platform one, because a gate that fails a pull request for a clause the
+    runner's kernel cannot reach deserves to be disabled.
+    """
+
+    def test_a_lone_survivor_is_unpinned_and_actionable(self):
+        gate = sweep.classify([_result("survived")])
+        self.assertEqual(len(gate.unpinned), 1)
+        self.assertEqual(gate.masked, [])
+        self.assertEqual(len(gate.actionable), 1)
+
+    def test_two_survivors_in_one_function_are_a_masked_cluster(self):
+        """Two guards in sequence mask each other, so neither is safe to call equivalent
+        on its own. Still actionable — more so — but read together, which is why it is its
+        own bucket rather than a note on a row."""
+        gate = sweep.classify([_result("survived", line=1), _result("survived", line=9)])
+        self.assertEqual(gate.unpinned, [])
+        self.assertEqual(len(gate.masked), 2)
+        self.assertEqual(len(gate.actionable), 2)
+
+    def test_a_platform_survivor_is_deferred_and_never_actionable(self):
+        gate = sweep.classify([_result("survived", operator="narrow-except",
+                                       before="OSError")])
+        self.assertEqual(len(gate.platform), 1)
+        self.assertEqual(gate.actionable, [])
+
+    def test_two_platform_survivors_in_one_function_stay_platform(self):
+        """The platform question is asked first, and it has to be: a clause the kernel
+        never enters is unreachable whether or not a second one sits beside it, and
+        promoting the pair to a masked cluster would fail the gate on exactly the finding
+        it is not allowed to fail on."""
+        gate = sweep.classify([_result("survived", operator="narrow-except",
+                                       before="OSError", line=n) for n in (1, 9)])
+        self.assertEqual(len(gate.platform), 2)
+        self.assertEqual(gate.actionable, [])
+
+    def test_unresolved_and_unapplied_and_pinned_are_their_own_answers(self):
+        gate = sweep.classify([_result("unresolved"), _result("unapplied"),
+                               _result("pinned"), _result("pinned")])
+        self.assertEqual((len(gate.unresolved), len(gate.unapplied), gate.pinned),
+                         (1, 1, 2))
+        self.assertEqual(gate.actionable, [])
+
+
+class TheGateBlocksNothingUntilItIsToldTo(unittest.TestCase):
+    """The spec's staging argument, applied to the gate's own credibility.
+
+    "A gate whose baseline nobody has seen gets disabled the first time it is
+    inconvenient." So the first version of this job reports its numbers and blocks
+    nothing, and `--enforce` is the single flag that changes that.
+    """
+
+    def test_a_survivor_does_not_fail_a_reporting_run(self):
+        gate = sweep.classify([_result("survived")])
+        self.assertEqual(sweep.gate_exit_code(gate, enforce=False), 0)
+
+    def test_the_same_survivor_fails_an_enforcing_run(self):
+        gate = sweep.classify([_result("survived")])
+        self.assertEqual(sweep.gate_exit_code(gate, enforce=True), 1)
+
+    def test_a_platform_survivor_passes_even_when_enforcing(self):
+        gate = sweep.classify([_result("survived", operator="narrow-except",
+                                       before="OSError")])
+        self.assertEqual(sweep.gate_exit_code(gate, enforce=True), 0)
+
+    def test_an_unmeasured_mutation_is_its_own_exit_code_and_not_a_pass(self):
+        """A timeout is not a red and not a survivor. Under load this repository hits it
+        repeatedly, and "I could not look" must never render as "nothing to see"."""
+        gate = sweep.classify([_result("unresolved"), _result("pinned")])
+        self.assertEqual(sweep.gate_exit_code(gate, enforce=True), 3)
+
+    def test_a_mutation_that_never_applied_outranks_everything(self):
+        gate = sweep.classify([_result("unapplied"), _result("survived"),
+                               _result("unresolved")])
+        self.assertEqual(sweep.gate_exit_code(gate, enforce=True), 4)
+
+    def test_a_clean_branch_passes_either_way(self):
+        gate = sweep.classify([_result("pinned")])
+        self.assertEqual(sweep.gate_exit_code(gate, enforce=False), 0)
+        self.assertEqual(sweep.gate_exit_code(gate, enforce=True), 0)
+
+
+class TheGateSaysWhatTheCoveringTestsAssert(unittest.TestCase):
+    """The field that made 82 survivors triageable rather than merely alarming.
+
+    `release.yml`'s `-z "$claimed"` refusal (#558) is why: deleting it left the run still
+    exiting 1, for a different reason. So the honest first question about a survivor is
+    "did my test look closely enough", and nobody can answer that from a line number.
+    """
+
+    def test_a_survivor_carries_the_assertions_that_were_supposed_to_hold_it(self):
+        ev = sweep.Evidence(["tests.test_a"],
+                            [("tests.test_a", "test_it_refuses",
+                              ["self.assertEqual(f(None), [])"])])
+        gate = sweep.classify([_result("survived", evidence=ev)])
+        text = sweep.gate_summary(gate, "a" * 40, "b" * 40, 60.0, enforce=False)
+        self.assertIn("test_it_refuses", text)
+        self.assertIn("self.assertEqual(f(None), [])", text)
+
+    def test_a_symbol_no_covering_test_names_is_said_plainly(self):
+        ev = sweep.Evidence(["tests.test_a", "tests.test_b"], [])
+        gate = sweep.classify([_result("survived", evidence=ev)])
+        text = sweep.gate_summary(gate, "a" * 40, "b" * 40, 60.0, enforce=False)
+        self.assertIn("not one names", text)
+
+    def test_a_file_nothing_executes_is_said_plainly_too(self):
+        gate = sweep.classify([_result("survived", evidence=sweep.Evidence([], []))])
+        text = sweep.gate_summary(gate, "a" * 40, "b" * 40, 60.0, enforce=False)
+        self.assertIn("nothing measured executes this file", text)
+
+    def test_the_three_categories_are_headed_separately(self):
+        gate = sweep.classify([
+            _result("survived", path="charter/a.py"),
+            _result("survived", path="charter/b.py", line=1),
+            _result("survived", path="charter/b.py", line=9),
+            _result("survived", path="charter/c.py", operator="narrow-except",
+                    before="OSError"),
+            _result("unresolved", path="charter/d.py")])
+        text = sweep.gate_summary(gate, "a" * 40, "b" * 40, 60.0, enforce=False)
+        for heading in ("### Unpinned", "### Masked cluster",
+                        "### Platform-deferred", "### Unresolved"):
+            self.assertIn(heading, text)
+
+    def test_a_reporting_run_says_on_the_page_that_it_blocks_nothing(self):
+        gate = sweep.classify([_result("survived")])
+        self.assertIn("Reporting only",
+                      sweep.gate_summary(gate, "a" * 40, "b" * 40, 60.0, enforce=False))
+        self.assertNotIn("Reporting only",
+                         sweep.gate_summary(gate, "a" * 40, "b" * 40, 60.0, enforce=True))
+
+    def test_a_run_with_an_unapplied_mutation_says_to_read_nothing_else(self):
+        gate = sweep.classify([_result("unapplied"), _result("survived")])
+        text = sweep.gate_summary(gate, "a" * 40, "b" * 40, 60.0, enforce=False)
+        self.assertIn("until this is zero", text)
+
+    def test_a_clean_branch_says_so(self):
+        text = sweep.gate_summary(sweep.classify([_result("pinned")]),
+                                  "a" * 40, "b" * 40, 60.0, enforce=False)
+        self.assertIn("Nothing added here is a line the suite would not miss", text)
+
+
+class TheGateNeverChargesTheWholeTree(unittest.TestCase):
+    def test_gate_and_all_together_are_refused(self):
+        """Stage B is a fourteen-hour job and stage C is a pull-request check. Letting the
+        two be asked for at once is how the gate becomes the reason nobody runs either."""
+        said = io.StringIO()
+        with contextlib.redirect_stderr(said), self.assertRaises(SystemExit):
+            sweep.main(["--gate", "--all"])
+        self.assertIn("never sweeps the whole tree", said.getvalue())
+
+
+# ======================================================================================
+# The CLI's own rules — extracted so they can be swept at all
+# ======================================================================================
+
+class ARuleInsideMainCannotBeSwept(unittest.TestCase):
+    """#572's structural lesson, applied to the rest of the CLI.
+
+    `workdir_for` had to come out of `main()` before the bug that made this tool unusable
+    on macOS could be pinned: a rule inside `main()` is not reachable from a test, so it
+    cannot be swept, so it is a guard the harness is structurally unable to hold itself to.
+    The self-sweep's "renderer + CLI, ~0 of 49" row is what that hazard looks like at scale.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="sweep-cli-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp,
+                                                            ignore_errors=True))
+        env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull,
+                   GIT_CONFIG_SYSTEM=os.devnull, GIT_CONFIG_NOSYSTEM="1",
+                   GIT_TERMINAL_PROMPT="0")
+
+        def run(*a):
+            subprocess.run(("git", "-c", "core.hooksPath=", "-c", "commit.gpgsign=false")
+                           + a, cwd=self.tmp, check=True, env=env, timeout=60,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        self.run = run
+        run("init", "-q", "-b", "main")
+        run("config", "user.email", "sweep@example.invalid")
+        run("config", "user.name", "sweep")
+        (self.tmp / "charter").mkdir()
+        (self.tmp / "charter" / "m.py").write_text("a = 1\n")
+        run("add", "-A")
+        run("commit", "-qm", "one")
+        self.first = sweep.git("rev-parse", "HEAD", cwd=self.tmp).strip()
+        run("checkout", "-q", "-b", "side")
+        (self.tmp / "charter" / "m.py").write_text("a = 1\nb = 2\n")
+        run("add", "-A")
+        run("commit", "-qm", "two")
+        self.side = sweep.git("rev-parse", "HEAD", cwd=self.tmp).strip()
+        run("checkout", "-q", "main")
+        (self.tmp / "charter" / "other.py").write_text("z = 9\n")
+        run("add", "-A")
+        run("commit", "-qm", "main moved on")
+        self.main_tip = sweep.git("rev-parse", "HEAD", cwd=self.tmp).strip()
+
+    def test_a_branch_is_charged_against_the_merge_base_and_not_the_tip(self):
+        """A branch is answerable for what IT added, never for what main gained while it
+        was open. Charging against the tip would hand every long-lived branch a diff full
+        of somebody else's lines."""
+        self.assertEqual(sweep.base_for(self.tmp, self.side, None), self.first)
+
+    def test_an_explicit_base_is_resolved_to_a_commit(self):
+        self.assertEqual(sweep.base_for(self.tmp, self.side, "main"), self.main_tip)
+
+    def test_uncommitted_work_is_carried_only_when_the_sweep_is_about_the_working_tree(self):
+        """`--ref HEAD` means "what I have here". Any other ref names a specific historical
+        tree, and pouring today's uncommitted files into it would sweep a tree that has
+        never existed."""
+        (self.tmp / "charter" / "dirty.py").write_text("q = 1\n")
+        self.assertIn("charter/dirty.py", sweep.dirty_for(self.tmp, ("charter",), "HEAD"))
+        self.assertEqual(sweep.dirty_for(self.tmp, ("charter",), self.first), {})
+
+    def test_the_full_suite_cap_is_taken_from_this_machines_own_baseline(self):
+        """Measured at a load average of 100: a five-minute suite ran past the fixed
+        forty-minute cap and two known-unpinned guards came back "pinned" on the strength
+        of a stopwatch. Six times the measured run, and never below the floor."""
+        self.assertEqual(sweep.timeout_for(1.0), sweep.FULL_TIMEOUT)
+        self.assertEqual(sweep.timeout_for(sweep.FULL_TIMEOUT), sweep.FULL_TIMEOUT * 6)
+
+    def test_the_exit_code_separates_a_survivor_from_a_mutation_nobody_measured(self):
+        m = sweep.Mutation("charter/a.py", 1, 1, "drop-if", "q?", "if x: pass", "", "f")
+        self.assertEqual(sweep.exit_code([sweep.Result(m, "pinned", None, None, [])]), 0)
+        self.assertEqual(sweep.exit_code([sweep.Result(m, "survived", None, None, [])]), 1)
+        self.assertEqual(sweep.exit_code([sweep.Result(m, "unresolved", None, None, [])]),
+                         3)
+
+
+# ======================================================================================
+# The operator table's own guards
+# ======================================================================================
+
+class TheOperatorTableHoldsItsOwnEdges(unittest.TestCase):
+    """The rows the self-sweep found unpinned in `_iter_operators` and its helpers.
+
+    "The operator table decides verdicts" — an unpinned line here does not mislead a
+    reviewer about one guard, it silently changes which questions the tool asks of every
+    branch that follows.
+    """
+
+    def test_a_statement_that_is_not_alone_in_its_block_is_deleted_and_not_passed(self):
+        """`_drop_statement` chooses between deleting and `pass`, and BOTH arms have to be
+        held: collapsing it to `"pass"` leaves a mutant that still refuses (a false pin),
+        and collapsing it to `""` is caught only by a fallback two functions away."""
+        muts = _mutations("""
+            def f(x):
+                if x:
+                    return 1
+                return 2
+        """)
+        self.assertEqual(_afters(muts, "drop-if"), [""])
+
+    def test_a_refusal_inside_an_else_block_is_found_through_the_orelse(self):
+        """`_body_of` looks in `body`, `orelse` AND `finalbody`. A version that knew only
+        `body` would call this the sole statement of its block and replace it with `pass`
+        — a mutant that still refuses, reported as a deletion."""
+        muts = _mutations("""
+            def f(x, y):
+                if x:
+                    y = 1
+                else:
+                    if y:
+                        return 3
+                    return 4
+        """)
+        self.assertEqual(_afters(muts, "drop-if"), [""])
+
+    def test_a_refusal_in_a_block_this_tool_cannot_name_is_still_offered(self):
+        """`_body_of` returns `None` for a block shape it does not know — a `match` case is
+        one — and the `or []` behind it is what stops that being a `TypeError` in the
+        middle of somebody's sweep. Without the fallback this file does not even mutate."""
+        muts = _mutations("""
+            def f(x, y):
+                match x:
+                    case 1:
+                        if y:
+                            return 3
+        """)
+        self.assertEqual(_afters(muts, "drop-if"), ["pass"])
+
+    def test_the_innermost_enclosing_function_is_the_one_reported(self):
+        """`_enclosing` picks the SMALLEST span containing the node, and the symbol is what
+        the selection map is keyed by. Reporting the outer name sends the mutation to the
+        modules that exercise the wrapper and not the ones that exercise the helper."""
+        muts = _mutations("""
+            def outer(x):
+                def inner(y):
+                    if y:
+                        return 1
+                return inner(x)
+        """)
+        self.assertEqual([m.symbol for m in _by(muts, "drop-if")], ["inner"])
+
+    def test_a_statement_at_module_scope_is_not_attributed_to_a_function(self):
+        muts = _mutations("""
+            def f(y):
+                return y
+
+            if f:
+                pass
+        """)
+        self.assertEqual([m.symbol for m in _by(muts, "drop-if")], ["<module>"])
+
+    def test_an_annotated_module_constant_is_retuned_like_any_other(self):
+        muts = _mutations("""
+            WIDTH: int = 28
+        """)
+        self.assertEqual(_afters(muts, "retune-constant"), ["29"])
+
+    def test_a_constant_built_with_anything_but_addition_offers_no_term_to_drop(self):
+        """`drop-term` asks "is every term pinned?", which only means something for a sum.
+        Dropping a factor of a product is a different and much larger question."""
+        muts = _mutations("""
+            SPAN = ROWS * COLS
+        """)
+        self.assertEqual(_by(muts, "drop-term"), [])
+
+    def test_a_get_with_no_default_and_no_fallback_is_left_alone(self):
+        """`d.get(k)` on its own is not a fallback this tool knows how to remove — the
+        two spellings it does know are `d.get(k) or ()` and `d.get(k, v)`. Mutating the
+        bare form would report a question the operator table never asked."""
+        muts = _mutations("""
+            def f(d, k):
+                d.get(k)
+                return 1
+        """)
+        self.assertEqual(_by(muts, "no-fallback"), [])
+
+    def test_an_empty_dict_is_an_empty_literal_like_the_other_three(self):
+        muts = _mutations("""
+            def f(a):
+                return a or {}
+        """)
+        self.assertEqual(_afters(muts, "no-fallback"), ["a"])
+
+    def test_a_file_that_does_not_parse_offers_nothing_rather_than_raising(self):
+        """A sweep runs over whatever the branch contains, including a file mid-edit."""
+        self.assertEqual(sweep.mutations_for("charter/x.py", b"def (:\n", {1}), [])
+
+    def test_a_mutation_whose_result_would_not_parse_is_dropped(self):
+        """`disable-branch` rewrites a test to `True`/`False`, and the parse check is what
+        stops a shape whose replacement is not a legal expression from being offered."""
+        muts = _mutations("""
+            def f(x):
+                if x:
+                    return 1
+                elif x > 2:
+                    return 2
+                else:
+                    return 3
+        """)
+        for m in muts:
+            ast.parse(m.source)
+
+    def test_an_elif_is_never_offered_for_deletion_because_its_span_is_not_a_statement(self):
+        """The `elif` keyword is part of the enclosing `if`'s source, so an `elif` node's
+        span does not re-parse into itself. `span_is_sound` refuses it and the branch is
+        asked about with `disable-branch` instead — which is the same question, spelled so
+        that the mutant is still a legal file."""
+        muts = _mutations("""
+            def f(x):
+                if x == 1:
+                    return 1
+                elif x == 2:
+                    return 2
+                else:
+                    return 3
+        """)
+        self.assertEqual([m.line for m in _by(muts, "drop-if")], [])
+        self.assertIn(4, [m.line for m in _by(muts, "disable-branch")])
+
+    def test_the_same_edit_offered_twice_is_reported_once(self):
+        """Several rows of the table recognise the same node, and a mutation listed twice
+        is a run paid for twice and a survivor a reviewer reads as two findings."""
+        muts = _mutations("""
+            def f(a, b):
+                if isinstance(a, str) and b:
+                    return 1
+        """)
+        keys = [(m.line, m.operator, m.after) for m in muts]
+        self.assertEqual(len(keys), len(set(keys)))
+
+    def test_a_replacement_identical_to_what_is_there_is_not_a_mutation(self):
+        muts = _mutations("""
+            def f(a):
+                try:
+                    return a
+                except ZeroDivisionError:
+                    return None
+        """)
+        self.assertEqual(_by(muts, "narrow-except"), [])
+
+    def test_a_splice_that_adds_lines_does_not_lose_the_ones_below_it(self):
+        """`max(0, lost)` in `_Spans.splice`: a replacement with MORE newlines than the
+        span it replaces has nothing to pad, and padding by a negative count would be a
+        `bytes * -1` — silently the empty string, and every line below renumbered."""
+        source = b"a = 1\nb = (2)\nc = 3\n"
+        sp = sweep._Spans(source)
+        tree = ast.parse(source)
+        node = tree.body[1].value
+        spliced = sp.splice(node, "(\n4\n)")
+        self.assertEqual(spliced.decode().splitlines()[-1], "c = 3")
+        self.assertEqual(ast.parse(spliced).body[-1].lineno, 5)
+
+    def test_two_mutations_that_add_lines_still_compose(self):
+        source = b"def f(a, b):\n    x = (a)\n    y = (b)\n    return x, y\n"
+        sp = sweep._Spans(source)
+        tree = ast.parse(source)
+        first, second = tree.body[0].body[0].value, tree.body[0].body[1].value
+        pair = (sweep.Mutation("m.py", 2, 2, "t", "q", "(a)", "(\na\n)", "f",
+                               span=sp.span(first)),
+                sweep.Mutation("m.py", 3, 3, "t", "q", "(b)", "(\nb\n)", "f",
+                               span=sp.span(second)))
+        out = sweep.compose(source, pair)
+        self.assertIsNotNone(out)
+        self.assertIn("return x, y", out.decode())
+
+    def test_a_composed_pair_that_would_not_parse_is_refused(self):
+        source = b"x = (1)\n"
+        sp = sweep._Spans(source)
+        node = ast.parse(source).body[0].value
+        pair = (sweep.Mutation("m.py", 1, 1, "t", "q", "(1)", "(", "f",
+                               span=sp.span(node)),
+                sweep.Mutation("m.py", 1, 1, "t", "q", "(1)", "(", "f", span=(0, 0)))
+        self.assertIsNone(sweep.compose(source, pair))
+
+    def test_a_test_module_that_does_not_parse_is_skipped_by_the_evidence_pass(self):
+        tmp = Path(tempfile.mkdtemp(prefix="sweep-ev-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(tmp, ignore_errors=True))
+        (tmp / "tests").mkdir()
+        (tmp / "tests" / "test_broken.py").write_text("def test_window(:\n")
+        m = sweep.Mutation("charter/a.py", 1, 1, "drop-if", "q", "if x: pass", "",
+                           "_window")
+        ev = sweep.evidence_for(tmp, m, ["tests.test_broken"])
+        self.assertEqual(ev.naming, [])
+
+    def test_a_shortened_line_is_marked_and_a_short_one_is_left_alone(self):
+        self.assertEqual(sweep._oneline("abc def"), "abc def")
+        self.assertTrue(sweep._oneline("x" * 200).endswith("…"))
+        self.assertEqual(len(sweep._oneline("x" * 200)), 96)
+
+
+class TheScopeReaderHoldsItsOwnEdges(unittest.TestCase):
+    """`git`, `_blob_at` and `added_lines` — the rows the self-sweep found unpinned."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="sweep-scope-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp,
+                                                            ignore_errors=True))
+        env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull,
+                   GIT_CONFIG_SYSTEM=os.devnull, GIT_CONFIG_NOSYSTEM="1",
+                   GIT_TERMINAL_PROMPT="0")
+
+        def run(*a):
+            subprocess.run(("git", "-c", "core.hooksPath=", "-c", "commit.gpgsign=false")
+                           + a, cwd=self.tmp, check=True, env=env, timeout=60,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        run("init", "-q", "-b", "main")
+        run("config", "user.email", "sweep@example.invalid")
+        run("config", "user.name", "sweep")
+        (self.tmp / "charter").mkdir()
+        (self.tmp / "charter" / "m.py").write_text("a = 1\n")
+        (self.tmp / "charter" / "gone.py").write_text("b = 2\n")
+        (self.tmp / "charter" / "notes.txt").write_text("hello\n")
+        run("add", "-A")
+        run("commit", "-qm", "one")
+        self.base = sweep.git("rev-parse", "HEAD", cwd=self.tmp).strip()
+        (self.tmp / "charter" / "gone.py").unlink()
+        (self.tmp / "charter" / "m.py").write_text("a = 1\nc = 3\n")
+        (self.tmp / "charter" / "notes.txt").write_text("hello\nagain\n")
+        run("add", "-A")
+        run("commit", "-qm", "two")
+        self.head = sweep.git("rev-parse", "HEAD", cwd=self.tmp).strip()
+
+    def test_a_failing_git_command_raises_with_what_git_said(self):
+        """The `check` half of `git()`. Without it a broken invocation returns empty
+        output, and a sweep quietly charges an empty diff — a green report for a question
+        never asked."""
+        with self.assertRaises(RuntimeError) as caught:
+            sweep.git("rev-parse", "--verify", "no/such/ref", cwd=self.tmp)
+        self.assertIn("no/such/ref", str(caught.exception))
+
+    def test_the_same_command_can_be_asked_without_raising(self):
+        self.assertEqual(
+            sweep.git("rev-parse", "--verify", "--quiet", "no/such/ref",
+                      cwd=self.tmp, check=False).strip(), "")
+
+    def test_a_blob_that_is_not_there_is_empty_bytes_and_not_a_crash(self):
+        self.assertEqual(sweep._blob_at(self.tmp, self.base, "charter/nope.py"), b"")
+        self.assertEqual(sweep._blob_at(self.tmp, self.base, "charter/m.py"), b"a = 1\n")
+
+    def test_a_deleted_file_is_not_charged_to_the_branch(self):
+        """A deletion's hunk header names `/dev/null` on the `+` side. Read as a path, it
+        would put the deleted file's line numbers into the scope and every mutation of it
+        would come back with no source at all."""
+        found = sweep.added_lines(self.tmp, self.base, self.head, ("charter",))
+        self.assertEqual(found, {"charter/m.py": {2}})
+
+    def test_a_file_that_is_not_python_is_not_charged_either(self):
+        found = sweep.added_lines(self.tmp, self.base, self.head, ("charter",))
+        self.assertNotIn("charter/notes.txt", found)
+
+    def test_a_path_that_is_not_in_the_tree_charges_nothing_rather_than_raising(self):
+        """`all_lines` has no `if base.exists()` — the sweep deleted it and the suite
+        stayed green, because `rglob` on a missing directory yields nothing anyway. §4:
+        an equivalent mutant and a dead line are one finding, so it went."""
+        self.assertEqual(sweep.all_lines(self.tmp, ("nowhere",)), {})
+        self.assertEqual(sweep.tree_hash(self.tmp, ("nowhere",)),
+                         sweep.tree_hash(self.tmp, ("nowhere",)))
+
+    def test_uncommitted_work_under_the_swept_paths_is_collected(self):
+        (self.tmp / "charter" / "fresh.py").write_text("d = 4\n")
+        (self.tmp / "charter" / "fresh.txt").write_text("not python\n")
+        dirty = sweep.dirty_files(self.tmp, ("charter",))
+        self.assertEqual(set(dirty), {"charter/fresh.py"})
 
 
 if __name__ == "__main__":      # pragma: no cover

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -660,6 +660,18 @@ class TheSynonymShape(unittest.TestCase):
         """)
         self.assertEqual(_by(muts, "drop-normalise"), [])
 
+    def test_a_swap_that_is_not_type_correct_everywhere_is_not_in_the_table(self):
+        """`index` is on `list`, `tuple` and `str`; `rindex` is on `str` alone. Swapping
+        it would turn `args.index("-m")` into an `AttributeError` — a red for a reason that
+        has nothing to do with which end was searched, which is a false pin. Measured
+        before the pair was dropped: all five `.index(` calls in `charter/` are on lists."""
+        self.assertNotIn("index", sweep.SYNONYMS)
+        muts = _mutations("""
+            def f(args):
+                return args.index("-m")
+        """)
+        self.assertEqual(_by(muts, "swap-synonym"), [])
+
     def test_every_pair_in_the_table_names_the_one_axis_it_moves(self):
         """The table is the justification. A pair with no axis written down is a swap
         somebody liked the look of, and that is how this becomes a general-purpose mutation

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1774,6 +1774,18 @@ class ASurvivorIsASurvivorOnTHISPlatform(unittest.TestCase):
                             Path("."), "a", "b", None, 1.0)
         self.assertNotIn("    PLATFORM:", text)
 
+    def test_a_clause_naming_two_os_level_types_names_one_of_them_the_same_way_twice(self):
+        """`sorted(...)[0]` and not `next(iter(...))`: a set's iteration order is not the
+        set's, so an unsorted pick would name `OSError` on one run and `TimeoutError` on
+        the next for the same clause — and a caveat that changes between runs is one nobody
+        can act on or diff. Found by the sweep on this file: `swap-synonym` turned the
+        `sorted` into a `list` and every case still passed."""
+        m = sweep.Mutation("charter/a.py", 1, 1, "narrow-except", "q?",
+                           "(TimeoutError, OSError, PermissionError)", "ZeroDivisionError",
+                           "f")
+        self.assertEqual(sweep.platform_caveat(m), "OSError")
+        self.assertEqual(sweep.platform_caveat(m), sweep.platform_caveat(m))
+
     def test_the_report_says_which_platform_it_measured_on(self):
         text = sweep.report([], Path("."), "a", "b", None, 1.0)
         self.assertIn(sys.platform, text)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -512,17 +512,26 @@ class TheStringShape(unittest.TestCase):
             sorted(["'bmqib'", "'lfz'", "'puifs'", "'uijse'", "'qsf'", "' boe '",
                     "'%t!'"]))
 
-    def test_the_width_literal_inside_an_fstring_is_reached(self):
+    def test_the_width_literal_inside_an_fstring_is_reached_where_positions_are_exact(self):
         """#508's defect exactly: `f"{name:<28}"`, a layout claim with nothing measuring
         it, which had to be hand-checked because this operator did not exist. The segment's
         span carries no quotes, so the splice is raw text and `span_is_sound` proves the
         round-trip a different way — the bytes at the span ARE the characters of the value.
+
+        BOTH arms are asserted, because the interesting one is the older interpreter. PEP
+        701 landed in 3.12; before it `ast` gives an f-string's internal nodes approximate
+        positions, the bytes at the span are not the value, and the check refuses. That is
+        the tool asking one fewer question rather than making an edit it cannot describe —
+        and :func:`sweep.reach` is what stops it being a silent difference.
         """
         muts = _mutations("""
             def f(name):
                 return f"{name:<28}"
         """)
-        self.assertEqual(_afters(muts, "retune-string"), ["<39"])
+        if sys.version_info >= (3, 12):
+            self.assertEqual(_afters(muts, "retune-string"), ["<39"])
+        else:
+            self.assertEqual(_by(muts, "retune-string"), [])
 
     def test_an_fstring_segment_whose_source_is_not_its_value_is_refused(self):
         """`{{` is two source characters and one value character, so a raw splice at that
@@ -531,7 +540,17 @@ class TheStringShape(unittest.TestCase):
         muts = _mutations("""
             MARK = f"a{{b}}c{0:<28}"
         """)
-        self.assertEqual(_afters(muts, "retune-string"), ["<39"])
+        self.assertEqual(_afters(muts, "retune-string"),
+                         ["<39"] if sys.version_info >= (3, 12) else [])
+
+    def test_the_report_says_when_the_interpreter_puts_a_shape_out_of_reach(self):
+        """A sweep that asks fewer questions than it could, and does not say so, is the
+        quietest way this tool can mislead: the report reads exactly like a clean one. So
+        the header names the shapes this interpreter cannot reach, next to the platform it
+        measured on and for the same reason."""
+        text = sweep.report([], Path("."), "a" * 12, "b" * 12, None, 1.0)
+        self.assertEqual("f-string" in text, sys.version_info < (3, 12))
+        self.assertIn(".".join(str(n) for n in sys.version_info[:3]), text)
 
     def test_a_bytes_constant_is_retuned_as_bytes(self):
         muts = _mutations("""
@@ -669,6 +688,28 @@ class TheSynonymShape(unittest.TestCase):
         muts = _mutations("""
             def f(args):
                 return args.index("-m")
+        """)
+        self.assertEqual(_by(muts, "swap-synonym"), [])
+
+    def test_a_function_in_a_module_is_not_a_method_on_a_type(self):
+        """`shlex.split` and `re.split` live in a namespace with no `rsplit` in it at all,
+        so the swap is an `AttributeError` rather than a question about which end was
+        searched. The pair is justified by two methods on one TYPE, and a module is not an
+        instance of anything. Measured on `charter/`: eight such call sites."""
+        muts = _mutations("""
+            import shlex
+
+            def f(command, name):
+                return shlex.split(command), name.split(",")
+        """)
+        self.assertEqual(_afters(muts, "swap-synonym"), ["name.rsplit"])
+
+    def test_a_module_reached_through_a_package_is_recognised_too(self):
+        muts = _mutations("""
+            import os
+
+            def f(p):
+                return os.path.split(p)
         """)
         self.assertEqual(_by(muts, "swap-synonym"), [])
 

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -368,7 +368,13 @@ SYNONYMS = {
     "partition": ("rpartition", "which end"),
     "rpartition": ("partition", "which end"),
     "find": ("rfind", "which end"),    "rfind": ("find", "which end"),
-    "index": ("rindex", "which end"),
+    # `index`/`rindex` is deliberately NOT here, and the reason is the rule the table is
+    # built on. A pair belongs only if the swap is type-correct wherever the name appears,
+    # and `index` is on `list`, `tuple` and `str` while `rindex` is on `str` alone — so
+    # `args.index("-m")` would mutate into an `AttributeError`. That reddens the suite for
+    # a reason that has nothing to do with which end was searched, which is a FALSE PIN,
+    # which is the failure this whole file exists to prevent. Checked against the tree
+    # before dropping it: all five `.index(` calls in `charter/` are on lists.
     "min": ("max", "which extreme"),   "max": ("min", "which extreme"),
     "any": ("all", "how many"),        "all": ("any", "how many"),
     "sorted": ("list", "ordering"),

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -104,6 +104,26 @@ PLATFORM_SENSITIVE = frozenset({
 })
 
 
+def reach() -> str:
+    """What this interpreter puts out of the sweep's reach, or "" when nothing does.
+
+    A sweep that asks fewer questions than it could, and does not say so, is the quietest
+    way this tool can mislead: fewer mutations, no survivors among them, and a report that
+    reads exactly like a clean one.
+
+    PEP 701 is the one case measured so far. Before 3.12, `ast` gives an f-string's
+    internal nodes approximate positions, so `retune-string` cannot prove that the bytes at
+    a segment's span are the segment's value — and it refuses rather than splicing over a
+    position it cannot vouch for. The consequence is concrete: `f"{name:<28}"` is where a
+    width literal lives in this tree, it is #508's whole defect, and on 3.11 the sweep
+    cannot see it. CI's gate job pins 3.12 for exactly this reason.
+    """
+    if sys.version_info < (3, 12):
+        return ("literals inside an f-string (positions are approximate before PEP 701; "
+                "run the sweep on 3.12+ to reach them)")
+    return ""
+
+
 def platform_caveat(mutation: "Mutation") -> str:
     """Why this survivor might be a platform artefact rather than a missing test."""
     if mutation.operator != "narrow-except":
@@ -533,6 +553,35 @@ def read_positions(tree: ast.AST) -> set[int]:
     return out
 
 
+def module_names(tree: ast.AST) -> set[str]:
+    """Every name this file binds by importing something.
+
+    A near-synonym pair is justified by two methods living on the same *type*, and a
+    module is not an instance of anything. `shlex.split` and `re.split` are functions in a
+    namespace that has no `rsplit` at all, so swapping them raises `AttributeError` —
+    a red for a reason that has nothing to do with which end was searched, which is a
+    false pin, which is the failure this file exists to prevent. Measured on `charter/`:
+    eight call sites, all of them `shlex.split` or `re.split`.
+
+    `from x import y` counts too. `y` may be a module or it may be a class, and this side
+    cannot tell; skipping a swap that would have been fine costs one mutation, and offering
+    one that crashes costs a guard wrongly certified as tested.
+    """
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                out.add(alias.asname or alias.name.split(".")[0])
+    return out
+
+
+def _receiver_root(node: ast.AST) -> str:
+    """The leftmost name of an attribute chain — `os` in `os.path.split`."""
+    while isinstance(node, ast.Attribute):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else ""
+
+
 def _docstrings(tree: ast.AST) -> set[int]:
     """The ids of every docstring constant — prose, not a value, and never mutated."""
     out: set[int] = set()
@@ -557,6 +606,7 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
     parents = _parents(tree)
     docstrings = _docstrings(tree)
     reads = read_positions(tree)
+    modules = module_names(tree)
     in_fstring = {id(part) for node in ast.walk(tree) if isinstance(node, ast.JoinedStr)
                   for part in ast.walk(node) if part is not node}
 
@@ -771,7 +821,8 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
         # :data:`SYNONYMS`. The mutant is type-correct by construction, so a red here is a
         # test noticing the AXIS rather than a test noticing a crash.
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
-                and node.func.attr in SYNONYMS:
+                and node.func.attr in SYNONYMS \
+                and _receiver_root(node.func.value) not in modules:
             other, axis = SYNONYMS[node.func.attr]
             yield (node.func, f"{sp.text(node.func.value)}.{other}", "swap-synonym",
                    f"is `{axis}` pinned, or does `{other}` pass the same tests?")
@@ -791,7 +842,9 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
         # missing at another, where the two spellings agree on every path a test happens
         # to use and disagree on the one the operator's machine actually has.
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
-                and node.func.attr in NORMALISERS and not node.args and not node.keywords:
+                and node.func.attr in NORMALISERS and not node.args \
+                and not node.keywords \
+                and _receiver_root(node.func.value) not in modules:
             yield (node, sp.text(node.func.value), "drop-normalise",
                    f"is `{node.func.attr}()` pinned, or does every test use a path that "
                    "needs no normalising?")
@@ -1670,6 +1723,8 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
     w("=" * 86)
     w(f"measured on      : {sys.platform}, CPython "
       f"{'.'.join(str(n) for n in sys.version_info[:3])}")
+    if reach():
+        w(f"NOT ASKED ABOUT  : {reach()}")
     if baseline is not None:
         w(f"baseline          : Ran {baseline.ran} tests — {'OK' if baseline.green else baseline.detail}")
     w(f"mutations applied : {len(results)}")
@@ -1968,6 +2023,8 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float,
     w(f"| platform-deferred | {len(gate.platform)} | the clause may be unreachable on "
       f"{sys.platform}; never fails this gate |")
     w(f"| unresolved | {len(gate.unresolved)} | no verdict — timed out, not measured |")
+    if reach():
+        w(f"| not asked about | — | {reach()} |")
     w(f"| not applied | {len(gate.unapplied)} | the edit never reached the tree — a bug "
       "in the sweep |")
     w("")

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -1978,7 +1978,7 @@ def _summary_rows(results: list[Result]) -> list[str]:
     different reason, so the honest first question about a survivor is "did my test look
     closely enough" — which nobody can answer from a line number alone.
     """
-    out: list[str] = []
+    out: list[str] = [""]
     for r in sorted(results, key=lambda r: (r.mutation.path, r.mutation.line)):
         m = r.mutation
         out.append(f"- **`{m.path}:{m.line}`** in `{m.symbol}` — _{m.question}_")

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -54,6 +54,7 @@ Stdlib only. `pyproject.toml` says ``dependencies = []`` and that is load-bearin
     python3 tools/sweep.py --ref 5b02b3f        # some other commit
     python3 tools/sweep.py --path tools         # sweep the sweep
     python3 tools/sweep.py --all                # the whole tree, as a number
+    python3 tools/sweep.py --gate               # as CI runs it (stage C)
 """
 from __future__ import annotations
 
@@ -189,12 +190,17 @@ def added_lines(repo: Path, base: str, ref: str, paths: tuple[str, ...]
 
 
 def all_lines(root: Path, paths: tuple[str, ...]) -> dict[str, set[int]]:
-    """Every line of every swept file — what ``--all`` charges instead of a diff."""
+    """Every line of every swept file — what ``--all`` charges instead of a diff.
+
+    There is no ``if base.exists()`` here, and its absence is a finding rather than an
+    oversight. It was written, the sweep deleted it, and the suite stayed green on 3.12
+    and 3.14: `rglob` on a directory that is not there yields nothing, so the guard
+    refused a loop that was already empty. Per §4 of the spec that makes it dead code and
+    dead code gets deleted — "equivalent mutant" and "unreachable line" are one finding.
+    """
     found: dict[str, set[int]] = {}
     for p in paths:
         base = root / p
-        if not base.exists():
-            continue
         for f in sorted(base.rglob("*.py")):
             rel = f.relative_to(root).as_posix()
             n = len(f.read_bytes().splitlines())
@@ -220,6 +226,13 @@ class Mutation:
     symbol: str         #: enclosing def/class, for the evidence pass
     source: bytes = b""  #: the whole mutated file
     span: tuple[int, int] = (0, 0)   #: byte span replaced, so two can be composed
+    #: A digest of the file this mutation was READ FROM. The sandbox refuses to apply a
+    #: mutation to anything else, which is the fifth way a sweep lies (#586) closed by
+    #: construction: a mutant tree that is really the pristine tree passes its tests and is
+    #: reported SURVIVED, and a false survivor is the failure that ends adoption — it sends
+    #: somebody to write a test for a line that is already covered, and the first person
+    #: who chases one and finds that out stops believing the tool.
+    origin: str = ""
 
     @property
     def tag(self) -> str:
@@ -314,6 +327,220 @@ def _body_of(parent: ast.AST, node: ast.AST) -> list[ast.stmt] | None:
     return None
 
 
+#: The two comparisons that differ by their boundary and by nothing else. `<` and `<=`
+#: accept the same values but one number apart, so a mutant is always type-correct, always
+#: runs, and asks exactly one question: **is the edge pinned, or only the direction?**
+#: `==` is deliberately absent — `!=` is not a near-synonym of `==`, it is its negation,
+#: and a whole-condition inversion is a different (and much coarser) question.
+BOUNDARY = {ast.Lt: ("<", "<="), ast.LtE: ("<=", "<"),
+            ast.Gt: (">", ">="), ast.GtE: (">=", ">")}
+
+#: Every comparison operator, spelled. A chained comparison (`0 <= i < n`) is one node, so
+#: moving the boundary of ONE link means re-spelling the whole chain, and a link this table
+#: could not spell would be silently dropped — a mutation that is not the mutation the
+#: report describes.
+#:
+#: Subscripted directly, with no `.get` and no skip-if-missing guard, because the guard
+#: would be a line nothing can reach: `ast` has exactly these ten comparison operators and
+#: they are all here. `TheBoundaryShape` asserts that completeness against
+#: `ast.cmpop.__subclasses__()` instead, which is the same protection moved to the one
+#: place that can actually fail — the suite, on the day Python grows an eleventh.
+
+CMP_TEXT = {ast.Eq: "==", ast.NotEq: "!=", ast.Lt: "<", ast.LtE: "<=", ast.Gt: ">",
+            ast.GtE: ">=", ast.Is: "is", ast.IsNot: "is not", ast.In: "in",
+            ast.NotIn: "not in"}
+
+#: Near-synonyms: two names from the **standard library** documented as doing the same job
+#: and differing along exactly one axis. The axis is written down for each pair because it
+#: is the whole justification — a swap along one axis produces a mutant that is still
+#: type-correct, still runs, and asks one question rather than "does this code work at all".
+#:
+#: Nothing charter-specific is in this table and nothing may be added to it from a finding.
+#: That is the same discipline as :data:`NARROW_TO`: the perturbation is chosen from what
+#: Python guarantees, never from what this project's answer key happened to contain. A
+#: table drawn from findings is a table that scores well on the findings it was drawn from.
+SYNONYMS = {
+    "lower": ("upper", "case"),        "upper": ("lower", "case"),
+    "startswith": ("endswith", "which end"), "endswith": ("startswith", "which end"),
+    "lstrip": ("rstrip", "which side"), "rstrip": ("lstrip", "which side"),
+    "strip": ("lstrip", "how much"),
+    "split": ("rsplit", "which end"),  "rsplit": ("split", "which end"),
+    "partition": ("rpartition", "which end"),
+    "rpartition": ("partition", "which end"),
+    "find": ("rfind", "which end"),    "rfind": ("find", "which end"),
+    "index": ("rindex", "which end"),
+    "min": ("max", "which extreme"),   "max": ("min", "which extreme"),
+    "any": ("all", "how many"),        "all": ("any", "how many"),
+    "sorted": ("list", "ordering"),
+}
+
+#: Calls that only ever *normalise* their receiver and return the same kind of thing, so
+#: dropping one is a mutation that always parses and always runs. This is #572's own shape:
+#: the map keys were `resolve()`d on both sides and the prefix that chose them was not, and
+#: "a normalisation applied at one site and missing at another" is the bug that hid behind
+#: the double `resolve()` two lines away. A test that never sees a symlink, a relative path
+#: or a trailing separator cannot tell the mutant from the shipped line.
+NORMALISERS = ("resolve", "absolute", "expanduser", "casefold")
+
+
+def _shift_char(ch: str) -> str:
+    """A different character of the same class, or *ch* when it has no class.
+
+    Letters rotate within their case, digits within the digits. Everything else — the
+    punctuation, the whitespace, the escapes, the control bytes, the non-ASCII — is left
+    exactly where it was, because that is the string's *shape* and this operator asks
+    about its *value*.
+    """
+    if "a" <= ch <= "z":
+        return "a" if ch == "z" else chr(ord(ch) + 1)
+    if "A" <= ch <= "Z":
+        return "A" if ch == "Z" else chr(ord(ch) + 1)
+    if "0" <= ch <= "9":
+        return "0" if ch == "9" else chr(ord(ch) + 1)
+    return ch
+
+
+def retune(text: str) -> str:
+    """*text*, re-spelled: same length, same character classes, a different value.
+
+    **This is the principled general form the spec said a string constant did not have,
+    and the argument for it is that it perturbs the value while holding every structural
+    property the surrounding code can depend on.** Same type, same length, same
+    punctuation, same escapes, same case pattern, same digits-are-digits. So a format
+    string is still a format string (`{:<28}` -> `{:<39}`), a regex is still a regex, a
+    terminal escape is still an escape (`\\x1b[?1000h` -> `\\x1b[?2111i`), a path is still
+    a path. It is the string analogue of :data:`retune-constant`'s ``n + 1``: the smallest
+    edit guaranteed to be a *different value of the same kind*.
+
+    It is derived from the constant and from nothing else. There is no table of "the other
+    mouse-tracking mode" and no list of colour names — the objection to fitting the answer
+    key is what this form answers, because it cannot fit an answer key it never reads.
+
+    A character **immediately after a backslash** is left alone. In a raw string that
+    backslash and its neighbour are one escape — `\\d` in a regex, `\\1` in a replacement —
+    and shifting the neighbour turns a working pattern into `re.error: bad escape \\e`.
+    That is a red for a reason that has nothing to do with the property, which is the one
+    outcome this whole file exists to refuse.
+    """
+    out: list[str] = []
+    escaped = False
+    for ch in text:
+        out.append(ch if escaped else _shift_char(ch))
+        escaped = ch == "\\" and not escaped
+    return "".join(out)
+
+
+#: Calls whose string argument — or whose string *receiver* — is read by the program
+#: rather than shown to a person. A key, a pattern, a separator, a prefix. Standard-library
+#: names only, so this is a statement about Python and not about charter.
+READERS = frozenset({
+    "get", "setdefault", "pop", "getattr", "setattr", "hasattr", "delattr", "getenv",
+    "startswith", "endswith", "removeprefix", "removesuffix", "split", "rsplit",
+    "partition", "rpartition", "replace", "count", "find", "rfind", "index", "join",
+    "compile", "match", "search", "fullmatch", "sub", "subn", "findall", "finditer",
+    "glob", "rglob", "encode", "decode", "format",
+})
+
+
+def read_positions(tree: ast.AST) -> set[int]:
+    """The ids of the string constants whose **value the program reads**.
+
+    `retune-string` is scoped to these, and the scoping is the honest half of the operator.
+    A string is a claim in two different ways, and only one of them is a claim a test can
+    hold. A key, a comparison operand, a pattern, a separator, a format spec, a table entry
+    — those decide what the program *does*, and a test that does not notice one changing is
+    a test with a hole in it. A log line decides what the program *says*, and nothing in a
+    suite is obliged to assert it.
+
+    **Measured on `charter/` before choosing:** 8,471 string constants are mutable at all,
+    of which 2,458 sit in a read position. Mutating all 8,471 took the tree's mutation
+    count from 7,006 to 14,801 — more than double, and the difference spent almost entirely
+    on prose (2,328 f-string fragments alone). Scoped as below it is 9,319, and on real
+    pull requests from this phase the gate goes from 15–35 mutations to roughly 30–50,
+    which is still the twenty-odd minutes the cost model was built around. A gate that
+    doubles in price to report unasserted log messages is a gate somebody switches off, and
+    the spec's own staging argument says the credibility is the deliverable. Widening this
+    is one predicate; it should be done with a measurement behind it, as this was.
+
+    Every position below is a property of Python, not of this project. Nothing here was
+    chosen because a finding happened to have that shape.
+    """
+    out: set[int] = set()
+
+    def take(node: ast.AST | None) -> None:
+        if isinstance(node, ast.Constant) and isinstance(node.value, (str, bytes)):
+            out.add(id(node))
+
+    for node in ast.walk(tree):
+        # `x == "yes"`, `k in ("a", "b")` — the value decides a branch.
+        if isinstance(node, ast.Compare) and all(
+                isinstance(o, (ast.Eq, ast.NotEq, ast.In, ast.NotIn, ast.Is, ast.IsNot))
+                for o in node.ops):
+            for operand in (node.left, *node.comparators):
+                take(operand)
+                for elt in getattr(operand, "elts", []):
+                    take(elt)
+        # `{"components": …}` and `d["components"]` — the value selects the data.
+        if isinstance(node, ast.Dict):
+            for key in node.keys:
+                take(key)
+        if isinstance(node, ast.Subscript):
+            take(node.slice)
+        # `d.get("k")`, `re.compile(p)`, `"-".join(xs)`, `"{:<12}".format(n)`.
+        if isinstance(node, ast.Call):
+            name = node.func.attr if isinstance(node.func, ast.Attribute) else (
+                node.func.id if isinstance(node.func, ast.Name) else "")
+            if name in READERS:
+                for arg in node.args:
+                    take(arg)
+                if isinstance(node.func, ast.Attribute):
+                    take(node.func.value)
+        # `"%s says" % x` — the template is machinery, however prose-like it reads.
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mod):
+            take(node.left)
+        # The `<28` of `f"{name:<28}"`. A width is a layout claim and #508 is what one
+        # costs when nothing measures it.
+        if isinstance(node, ast.FormattedValue) and node.format_spec is not None:
+            for part in ast.walk(node.format_spec):
+                take(part)
+
+    # A module-level `NAME = "…"`: a constant with a docstring making a specific claim for
+    # its value and nothing measuring it. `MOUSE_ON` and `_MARK` are two of round two's
+    # five, and both are scalars — as are `_CHROME_ROWS`, `_SPLIT_ROWS` and `_MIN_TITLE`,
+    # the three the integer operator already covers.
+    #
+    # The VALUE only, deliberately, and not every string inside a container assigned to an
+    # upper-case name. Measured on `charter/`: walking into containers takes the read
+    # positions from 2,826 to 4,065, and what those 1,239 extra mutations ask for is a test
+    # per member of every membership table in the tree. A member is read through the
+    # container, not at the assignment — so where one genuinely decides something, the
+    # lookup that reads it is a read position on its own and is already covered above.
+    for stmt in getattr(tree, "body", []):
+        target = None
+        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 \
+                and isinstance(stmt.targets[0], ast.Name):
+            target = stmt.targets[0].id
+        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            target = stmt.target.id
+        if target and target.lstrip("_").isupper():
+            take(stmt.value)
+    return out
+
+
+def _docstrings(tree: ast.AST) -> set[int]:
+    """The ids of every docstring constant — prose, not a value, and never mutated."""
+    out: set[int] = set()
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef,
+                             ast.AsyncFunctionDef)) and isinstance(body, list) and body \
+                and isinstance(body[0], ast.Expr) \
+                and isinstance(body[0].value, ast.Constant) \
+                and isinstance(body[0].value.value, str):
+            out.add(id(body[0].value))
+    return out
+
+
 def _iter_operators(tree: ast.Module, sp: _Spans):
     """Yield ``(node, replacement, operator, question)`` for every recognised shape.
 
@@ -322,16 +549,19 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
     engine: a shape earns a place by having caught a real unpinned line.
     """
     parents = _parents(tree)
+    docstrings = _docstrings(tree)
+    reads = read_positions(tree)
+    in_fstring = {id(part) for node in ast.walk(tree) if isinstance(node, ast.JoinedStr)
+                  for part in ast.walk(node) if part is not node}
 
     # A module-level constant is a guard too, and the spec's shape table has no row for
     # one. Five of round two's eighteen overlay findings are exactly this — `_CHROME_ROWS`,
     # `_SPLIT_ROWS`, `_MIN_TITLE`, `MOUSE_ON`, `_MARK` — a number or a string with a
-    # docstring making a specific claim for the value, and nothing measuring it. Only the
-    # two forms with a principled general perturbation are mutated here: an integer, moved
-    # by one, and a sum of named parts, dropped to each part. A string constant has no
-    # honest general perturbation — picking `1003` over `1000` for `MOUSE_ON` is fitting
-    # the answer key, not recognising a shape — so it stays a known gap and is reported
-    # as one rather than faked.
+    # docstring making a specific claim for the value, and nothing measuring it. An integer
+    # is moved by one and a sum of named parts is dropped to each part; the STRING half of
+    # this shape used to be a declared gap ("picking 1003 over 1000 for MOUSE_ON is fitting
+    # the answer key") and is now `retune-string` below, whose general form is stated at
+    # :func:`retune` — the value moved, every structural property held.
     for stmt in tree.body:
         target = None
         if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 \
@@ -379,7 +609,11 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
         # first finding, `harness_rows`' `if _edge_of(slot) not in _COLUMN_EDGES`, lives
         # inside a `sum(...)` generator, and a shape table that only knows the statement
         # spelling of `if` cannot see it at all.
-        if isinstance(node, ast.comprehension) and node.ifs:
+        # No `and node.ifs` on this line, and its absence is a finding of this tool against
+        # itself. It was written, the self-sweep deleted it, and `tests.test_sweep` stayed
+        # green: the guard refused to enter a loop over the very list it was testing for
+        # emptiness. §4 again — an equivalent mutant and a dead line are one finding.
+        if isinstance(node, ast.comprehension):
             for cond in node.ifs:
                 # `True` rather than excising the `if` keyword: the filter is gone either
                 # way, and this keeps the splice inside one expression's span, so every
@@ -458,6 +692,104 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
             yield (node, sp.text(node.orelse), "collapse-ifexp",
                    "is this branch pinned?")
 
+        # ------------------------------------------------------------------------------
+        # String and regex constants (#569). The general form is :func:`retune`.
+        # ------------------------------------------------------------------------------
+        if isinstance(node, ast.Constant) and isinstance(node.value, (str, bytes)) \
+                and id(node) in reads and id(node) not in docstrings:
+            raw = node.value if isinstance(node.value, str) \
+                else node.value.decode("latin-1")
+            moved = retune(raw)
+            if moved != raw:
+                if id(node) in in_fstring:
+                    # A literal segment of an f-string, including a `{x:<28}` FORMAT SPEC,
+                    # which is where a width literal actually lives in this tree. Its span
+                    # holds no quotes, so the replacement is raw text and not a repr — but
+                    # only when the source and the value are the same bytes. If the segment
+                    # spells anything with an escape, a brace or a quote, the two disagree
+                    # and splicing raw text is a guess; those are dropped rather than
+                    # guessed at. Below 3.12 the positions themselves are approximate, and
+                    # `span_is_sound` cannot vet an unquoted fragment, so this check is the
+                    # only thing standing between the tool and an edit it cannot describe.
+                    if isinstance(node.value, str) and sp.text(node) == node.value:
+                        yield (node, moved, "retune-string",
+                               "is this literal pinned, or would any spelling do?")
+                else:
+                    rep = repr(moved) if isinstance(node.value, str) \
+                        else repr(moved.encode("latin-1"))
+                    yield (node, rep, "retune-string",
+                           "is this literal pinned, or would any spelling do?")
+
+        # An integer written in a base other than ten was written that way because its
+        # digits are the point: `0o600` is a permission, `0x1b` is a byte. So the spelling
+        # is the evidence that the value is deliberate, and a deliberate value is a claim.
+        # Decimal literals are deliberately NOT mutated here — every `0`, `1` and `2` index
+        # in the tree would become a mutation, and the thresholds that matter are reached
+        # instead by `shift-boundary`, which asks the same question of `x > 28` without
+        # asking it of `xs[0]`.
+        if isinstance(node, ast.Constant) and isinstance(node.value, int) \
+                and not isinstance(node.value, bool) \
+                and sp.text(node)[:2].lower() in ("0o", "0x", "0b"):
+            # Re-spelled in its own base, because the report is read by a person: a
+            # permission that came back `385` instead of `0o601` is a mutation nobody can
+            # check at a glance.
+            base = {"0o": oct, "0x": hex, "0b": bin}[sp.text(node)[:2].lower()]
+            yield (node, base(node.value + 1), "retune-constant",
+                   "is this value pinned, or would any number do?")
+
+        # ------------------------------------------------------------------------------
+        # Semantic near-synonyms (#569): one axis moved, everything else held.
+        # ------------------------------------------------------------------------------
+
+        # `a < b` -> `a <= b`. The boundary, and only the boundary. A guard written one
+        # notch out is the defect this catches, and the whole-condition operators above
+        # cannot see it: `drop-if` asks whether the refusal exists at all, which a test
+        # that never approaches the edge answers perfectly well.
+        if isinstance(node, ast.Compare):
+            operands = [node.left, *node.comparators]
+            for i, op in enumerate(node.ops):
+                swap = BOUNDARY.get(type(op))
+                if not swap:
+                    continue
+                spelled = [f"({sp.text(x)})" for x in operands]
+                ops = [CMP_TEXT[type(o)] for o in node.ops]
+                ops[i] = swap[1]
+                parts = [spelled[0]]
+                for o, right in zip(ops, spelled[1:]):
+                    parts += [o, right]
+                yield (node, " ".join(parts), "shift-boundary",
+                       f"is the boundary pinned, or only the direction ({swap[0]} vs "
+                       f"{swap[1]})?")
+
+        # `x.lower()` -> `x.upper()`, `sorted(xs)` -> `list(xs)`, and the rest of
+        # :data:`SYNONYMS`. The mutant is type-correct by construction, so a red here is a
+        # test noticing the AXIS rather than a test noticing a crash.
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
+                and node.func.attr in SYNONYMS:
+            other, axis = SYNONYMS[node.func.attr]
+            yield (node.func, f"{sp.text(node.func.value)}.{other}", "swap-synonym",
+                   f"is `{axis}` pinned, or does `{other}` pass the same tests?")
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                and node.func.id in SYNONYMS and not node.keywords \
+                and len(node.args) == 1 and not any(
+                    isinstance(a, ast.Starred) for a in node.args):
+            # One positional argument and no keywords, deliberately. `sorted(xs, key=f)`
+            # -> `list(xs, key=f)` is a `TypeError`, which reddens the suite for a reason
+            # that has nothing to do with the ordering — a false pin, and the false pin is
+            # the failure this file exists to prevent.
+            other, axis = SYNONYMS[node.func.id]
+            yield (node.func, other, "swap-synonym",
+                   f"is `{axis}` pinned, or does `{other}` pass the same tests?")
+
+        # `p.resolve()` -> `p`. #572's own shape: a normalisation applied at one site and
+        # missing at another, where the two spellings agree on every path a test happens
+        # to use and disagree on the one the operator's machine actually has.
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
+                and node.func.attr in NORMALISERS and not node.args and not node.keywords:
+            yield (node, sp.text(node.func.value), "drop-normalise",
+                   f"is `{node.func.attr}()` pinned, or does every test use a path that "
+                   "needs no normalising?")
+
 
 def span_is_sound(sp: _Spans, node: ast.AST) -> bool:
     """Does the source at *node*'s span actually parse back into *node*?
@@ -475,6 +807,16 @@ def span_is_sound(sp: _Spans, node: ast.AST) -> bool:
     change is worse than one not offered.
     """
     text = sp.text(node)
+    # An f-string's literal segment — ` ok` in `f"{n} ok"`, and the `<28` of a `{n:<28}`
+    # format spec, which is where a width literal actually lives in this tree. Its span
+    # holds no quotes, so it cannot be re-parsed as an expression, and the arms below would
+    # refuse every one of them. The round-trip is proved a different way and a stronger
+    # one: the bytes at the span ARE the characters of the value, so a splice here replaces
+    # exactly the text the mutation claims to replace. A quoted literal never satisfies
+    # this — its span includes the quotes and its value does not.
+    if isinstance(node, ast.Constant) and isinstance(node.value, str) \
+            and text == node.value:
+        return True
     try:
         if isinstance(node, ast.stmt):
             reparsed = ast.parse(text).body
@@ -547,7 +889,8 @@ def mutations_for(path: str, source: bytes, lines: set[int]) -> list[Mutation]:
         out.append(Mutation(
             path=path, line=node.lineno, end_line=node.end_lineno or node.lineno,
             operator=operator, question=question, before=before, after=replacement,
-            symbol=_enclosing(tree, node), source=mutated, span=sp.span(node)))
+            symbol=_enclosing(tree, node), source=mutated, span=sp.span(node),
+            origin=hashlib.sha256(source).hexdigest()))
     out.sort(key=lambda m: (m.path, m.line, m.operator, m.after))
     return out
 
@@ -655,8 +998,9 @@ def tree_hash(root: Path, paths: tuple[str, ...]) -> str:
     h = hashlib.sha256()
     for top in sorted(set(paths) | {"tests"}):
         base = root / top
-        if not base.exists():
-            continue
+        # No `if base.exists()`: see :func:`all_lines`. Measured on 3.12.13 and 3.14.4 —
+        # deleting the guard left the suite green, because the `rglob` it guarded yields
+        # nothing for a directory that is not there.
         for f in sorted(base.rglob("*.py")):
             h.update(f.relative_to(root).as_posix().encode())
             h.update(hashlib.sha256(f.read_bytes()).digest())
@@ -843,6 +1187,10 @@ def _named(ids) -> str:
     return "; ".join(short[:3]) + (f" (+{len(short) - 3} more)" if len(short) > 3 else "")
 
 
+class NotApplied(Exception):
+    """The mutant tree is not a mutant. See :meth:`Sandbox.apply`."""
+
+
 class Sandbox:
     """A private clone of the tree. The operator's checkout is never written to."""
 
@@ -877,12 +1225,36 @@ class Sandbox:
         self._clean_failures: dict[tuple[str, ...], frozenset] = {}
 
     def apply(self, mutation: Mutation) -> None:
+        """Write the mutant, having first proved this IS the tree the mutation came from.
+
+        The fifth way a sweep lies (#586): the edit does not match — a quoting difference,
+        an anchor that moved, a sandbox at the wrong ref — so the "mutant" tree is the
+        **unmutated** tree, the suite passes, and the guard is reported as a SURVIVOR. That
+        is the only one of the five that errs toward *more* work rather than less, and it
+        is the one that ends adoption: somebody writes a test for a line already covered,
+        discovers it, and never trusts the tool again.
+
+        Two assertions, and they are different questions. The digest says *this is the file
+        I read* — a sandbox at another ref, or a file some earlier restore did not undo,
+        fails here rather than producing a verdict about the wrong bytes. The inequality
+        says *and the bytes really changed*. Neither is expensive and neither is optional:
+        a verdict from an edit that did not happen is not a verdict.
+        """
+        current = (self.path / mutation.path).read_bytes()
+        if mutation.origin and hashlib.sha256(current).hexdigest() != mutation.origin:
+            raise NotApplied(
+                f"{mutation.path} in this sandbox is not the file the mutation was read "
+                f"from, so nothing here would be a verdict about {mutation.tag}")
         self.apply_source(mutation.path, mutation.source)
 
     def apply_source(self, rel: str, blob: bytes) -> None:
         """Write one file, remembering what was there so :meth:`restore` can undo it."""
         target = self.path / rel
-        self._pristine.setdefault(rel, target.read_bytes())
+        was = target.read_bytes()
+        if was == blob:
+            raise NotApplied(f"the mutant of {rel} is byte-identical to the tree it "
+                             f"replaces — this edit did not happen")
+        self._pristine.setdefault(rel, was)
         target.write_bytes(blob)
 
     def restore(self) -> None:
@@ -1073,7 +1445,12 @@ def decide(box, mutation: Mutation, modules: list[str]) -> tuple[str, Outcome, O
     """
     # Measured BEFORE the mutation goes anywhere near the tree.
     clean = box.clean_failures(modules) if modules else frozenset()
-    box.apply(mutation)
+    try:
+        box.apply(mutation)
+    except NotApplied as why:
+        # Its own outcome, not a survivor and not a pin. This is a defect in the TOOL, and
+        # the one thing it must never do is quietly become a finding about the code.
+        return "unapplied", Outcome(False, 0, str(why), conclusive=False), None
     if modules:
         subset = box.subset(modules)
         if not subset.conclusive:
@@ -1182,7 +1559,7 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
         if full is not None:
             how += f", then all {full.ran or '?'}"
         label = {"survived": "SURVIVED", "pinned": "pinned  ",
-                 "unresolved": "UNRESOLVED"}[verdict]
+                 "unresolved": "UNRESOLVED", "unapplied": "NOT APPLIED"}[verdict]
         log(f"    [{n}/{len(plan)}] {label}  {mutation}   ({how})")
         return Result(mutation, verdict, subset, full, modules)
 
@@ -1254,7 +1631,10 @@ def _second_order(results: list[Result], boxes: list["Sandbox"],
                     break
             time.sleep(0.05)
         try:
-            box.apply_source(pair[0].path, combined)
+            try:
+                box.apply_source(pair[0].path, combined)
+            except NotApplied:
+                return None
             outcome = box.full()
         finally:
             box.restore()
@@ -1275,6 +1655,7 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
     survivors = [r for r in results if r.verdict == "survived"]
     unresolved = [r for r in results if r.verdict == "unresolved"]
     pinned = [r for r in results if r.verdict == "pinned"]
+    unapplied = [r for r in results if r.verdict == "unapplied"]
     pairs = pairs or []
     out: list[str] = []
     w = out.append
@@ -1289,8 +1670,25 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
     w(f"pinned            : {len(pinned)}")
     w(f"SURVIVED          : {len(survivors)}")
     w(f"UNRESOLVED        : {len(unresolved)}")
+    if unapplied:
+        w(f"NOT APPLIED       : {len(unapplied)}  (a defect in this tool, not a finding)")
     w(f"wall clock        : {elapsed / 60:.1f} min")
     w("")
+
+    if unapplied:
+        w("-" * 86)
+        w("NOT APPLIED — these mutations never reached the tree")
+        w("-" * 86)
+        w("The mutant was byte-identical to the tree it replaced, or the sandbox held a")
+        w("different file from the one the mutation was read from. Either way the run that")
+        w("followed would have measured the UNMUTATED tree and reported a survivor for a")
+        w("line that is already covered. That is a bug here, not a finding about the code,")
+        w("and the sweep is not complete until it is zero.")
+        for r in sorted(unapplied, key=lambda r: (r.mutation.path, r.mutation.line)):
+            m = r.mutation
+            w(f"  {m.path}:{m.line}  [{m.operator}]  "
+              f"{r.subset.detail if r.subset else ''}")
+        w("")
 
     if unresolved:
         w("-" * 86)
@@ -1307,8 +1705,12 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
         w("")
 
     if not survivors:
-        w("Every mutation this diff offered goes red. Nothing added here is a line the")
-        w("suite would not miss.")
+        if unresolved or unapplied:
+            w("No survivor — but see above: not every mutation was measured, so this is")
+            w("not the same claim as a clean sweep.")
+        else:
+            w("Every mutation this diff offered goes red. Nothing added here is a line the")
+            w("suite would not miss.")
         return "\n".join(out)
 
     w("A survivor is a line you can delete with the whole suite still green")
@@ -1415,7 +1817,207 @@ def as_json(results: list[Result]) -> str:
 
 
 # --------------------------------------------------------------------------------------
-# 8. CLI
+# 8. The gate — stage C
+# --------------------------------------------------------------------------------------
+
+@dataclasses.dataclass
+class Gate:
+    """One sweep, sorted into the outcomes a gate is allowed to act on differently.
+
+    The buckets are not cosmetic and they are not a severity ranking. Each one is a
+    different *kind of claim*, and collapsing any two of them is a way this gate gets
+    switched off within a week:
+
+    * ``unpinned`` — a guard with no test behind it. The finding. Actionable.
+    * ``masked`` — two or more survivors inside one function. Also actionable, and MORE
+      urgent, not less: two guards in sequence mask each other, so none of them can be
+      called equivalent on its own. Separated because the advice differs — these are read
+      together or not at all.
+    * ``platform`` — a narrowed catch on an exception type the operating system decides.
+      Measured on this project: `except OSError` around a pty read is dead code on macOS
+      and live on Linux. **The gate never fails on one of these.** A gate that fails a pull
+      request for a clause the runner's kernel cannot reach is a gate somebody disables,
+      and they will be right to.
+    * ``unresolved`` — no verdict. A timeout is not a red and not a survivor. Under load
+      this repository hits it repeatedly, and "I could not look" must never render as
+      "nothing to see".
+    * ``unapplied`` — the mutation never reached the tree (#586). A defect in the tool.
+    """
+
+    unpinned: list[Result] = dataclasses.field(default_factory=list)
+    masked: list[Result] = dataclasses.field(default_factory=list)
+    platform: list[Result] = dataclasses.field(default_factory=list)
+    unresolved: list[Result] = dataclasses.field(default_factory=list)
+    unapplied: list[Result] = dataclasses.field(default_factory=list)
+    pinned: int = 0
+
+    @property
+    def actionable(self) -> list[Result]:
+        """Survivors a person should act on. Platform-deferred ones are not among them."""
+        return self.unpinned + self.masked
+
+
+def classify(results: list[Result]) -> Gate:
+    """Sort a sweep into :class:`Gate`'s buckets."""
+    gate = Gate()
+    crowded: dict[tuple[str, str], int] = {}
+    for r in results:
+        if r.verdict == "survived":
+            key = (r.mutation.path, r.mutation.symbol)
+            crowded[key] = crowded.get(key, 0) + 1
+    for r in results:
+        if r.verdict == "pinned":
+            gate.pinned += 1
+        elif r.verdict == "unresolved":
+            gate.unresolved.append(r)
+        elif r.verdict == "unapplied":
+            gate.unapplied.append(r)
+        elif r.verdict == "survived":
+            if platform_caveat(r.mutation):
+                gate.platform.append(r)
+            elif crowded.get((r.mutation.path, r.mutation.symbol), 0) > 1:
+                gate.masked.append(r)
+            else:
+                gate.unpinned.append(r)
+    return gate
+
+
+def gate_exit_code(gate: Gate, enforce: bool) -> int:
+    """What a gate run exits with. **Zero until somebody turns it on.**
+
+    The spec's staging argument — "a gate whose baseline nobody has seen gets disabled the
+    first time it is inconvenient" — applies to the gate's own credibility as much as to
+    the tree's. So the first version of this job reports its numbers on every pull request
+    and blocks nothing; `--enforce` is the one flag that changes that, and it should be set
+    only once the numbers on real branches have been looked at and believed.
+
+    When it does enforce, the codes are distinct because the responses are:
+
+    * **1** — an actionable survivor. Write the test, or delete the line.
+    * **3** — nothing actionable, but something could not be measured. Re-run it; do not
+      read it as clean.
+    * **4** — a mutation never applied. The tool is wrong, and its numbers are not
+      evidence about this branch either way.
+    """
+    if not enforce:
+        return 0
+    if gate.unapplied:
+        return 4
+    if gate.actionable:
+        return 1
+    return 3 if gate.unresolved else 0
+
+
+def _summary_rows(results: list[Result]) -> list[str]:
+    """One markdown bullet per survivor, carrying WHAT THE COVERING TESTS ASSERT.
+
+    That field is what made 82 survivors triageable rather than merely alarming, and it is
+    the difference between a gate that gets read and a gate that gets muted. `release.yml`'s
+    `-z "$claimed"` refusal (#558) is why: deleting it left the run still exiting 1, for a
+    different reason, so the honest first question about a survivor is "did my test look
+    closely enough" — which nobody can answer from a line number alone.
+    """
+    out: list[str] = []
+    for r in sorted(results, key=lambda r: (r.mutation.path, r.mutation.line)):
+        m = r.mutation
+        out.append(f"- **`{m.path}:{m.line}`** in `{m.symbol}` — _{m.question}_")
+        out.append(f"  - shipped: `{_oneline(m.before, 100)}`")
+        out.append(f"  - mutant `[{m.operator}]`: "
+                   f"`{_oneline(m.after, 100) or '(the statement, deleted)'}`")
+        ev = r.evidence
+        if ev is None or not ev.modules:
+            out.append("  - covered by: **nothing measured executes this file**")
+        elif ev.nothing_names_it:
+            out.append(f"  - covered by: {len(ev.modules)} module(s) execute this file and "
+                       f"**not one names `{m.symbol}`**")
+        else:
+            asserted = [a for _, _, asserts in ev.naming for a in asserts]
+            out.append(f"  - covered by: {len(ev.naming)} test(s) naming `{m.symbol}` — "
+                       + ", ".join(f"`{module.split('.')[-1]}.{name}`"
+                                   for module, name, _ in ev.naming[:3]))
+            for a in asserted[:3]:
+                out.append(f"    - asserts `{a}`")
+    return out
+
+
+def gate_summary(gate: Gate, ref: str, base: str, elapsed: float,
+                 enforce: bool) -> str:
+    """The markdown a reviewer reads on the pull request."""
+    out: list[str] = []
+    w = out.append
+    verdict = ("**would fail**" if gate.actionable or gate.unapplied
+               else "**would pass**")
+    w(f"## Deletion sweep — {len(gate.actionable)} actionable survivor(s)")
+    w("")
+    w(f"`{ref[:12]}` against `{base[:12]}`, added lines only, "
+      f"{elapsed / 60:.1f} min on {sys.platform} / CPython "
+      f"{'.'.join(str(n) for n in sys.version_info[:3])}.")
+    w("")
+    w("| outcome | n | what it means |")
+    w("|---|---:|---|")
+    w(f"| pinned | {gate.pinned} | a test goes red without the line |")
+    w(f"| **unpinned** | {len(gate.unpinned)} | a guard with no test behind it |")
+    w(f"| **masked cluster** | {len(gate.masked)} | two or more in one function; "
+      "none is safe to call equivalent alone |")
+    w(f"| platform-deferred | {len(gate.platform)} | the clause may be unreachable on "
+      f"{sys.platform}; never fails this gate |")
+    w(f"| unresolved | {len(gate.unresolved)} | no verdict — timed out, not measured |")
+    w(f"| not applied | {len(gate.unapplied)} | the edit never reached the tree — a bug "
+      "in the sweep |")
+    w("")
+    if not enforce:
+        w(f"> **Reporting only.** This job blocks nothing; it {verdict} with `--enforce`. "
+          "The spec's own staging argument says a gate whose numbers nobody has seen gets "
+          "disabled the first time it is inconvenient, so the numbers come first.")
+        w("")
+    if gate.unapplied:
+        w("### Not applied — read nothing else on this page until this is zero")
+        w("")
+        w("A mutation whose edit never landed runs the **unmutated** tree, passes, and is "
+          "reported as a survivor. Every number above is suspect while this is non-zero.")
+        for r in gate.unapplied:
+            w(f"- `{r.mutation.tag}` — {r.subset.detail if r.subset else ''}")
+        w("")
+    if gate.masked:
+        w("### Masked cluster")
+        w("")
+        w("Two guards in sequence hide each other, so each one looks equivalent on its "
+          "own and neither is pinned. Read these together.")
+        out.extend(_summary_rows(gate.masked))
+        w("")
+    if gate.unpinned:
+        w("### Unpinned")
+        w("")
+        w("Delete the line and the suite stays green. Either write the test, or delete the "
+          "line — there is no suppression list, and \"equivalent mutant\" and \"dead code\" "
+          "are one finding.")
+        out.extend(_summary_rows(gate.unpinned))
+        w("")
+    if gate.platform:
+        w("### Platform-deferred (not a gate failure)")
+        w("")
+        w(f"A narrowed catch on an exception the operating system decides. On "
+          f"{sys.platform} the clause may never be entered at all, which is *unreachable* "
+          "rather than *untested*, and the two are indistinguishable from one machine.")
+        out.extend(_summary_rows(gate.platform))
+        w("")
+    if gate.unresolved:
+        w("### Unresolved — no verdict")
+        w("")
+        w("The run timed out rather than failing, twice. That is not a red and it is "
+          "emphatically not a pin. Re-run on a quieter machine before reading this sweep "
+          "as clean.")
+        for r in gate.unresolved:
+            w(f"- `{r.mutation.tag}` in `{r.mutation.symbol}`")
+        w("")
+    if not gate.actionable and not gate.unapplied and not gate.unresolved:
+        w("Every mutation this branch offered goes red. Nothing added here is a line the "
+          "suite would not miss.")
+    return "\n".join(out)
+
+
+# --------------------------------------------------------------------------------------
+# 9. CLI
 # --------------------------------------------------------------------------------------
 
 def repo_root(start: Path) -> Path:
@@ -1441,6 +2043,66 @@ def workdir_for(root: Path, override: str | None) -> Path:
         return resolved(override)
     digest = hashlib.sha256(str(resolved(root)).encode()).hexdigest()[:12]
     return resolved(Path(tempfile.gettempdir()) / f"charter-sweep-{digest}")
+
+
+def base_for(root: Path, ref: str, override: str | None) -> str:
+    """What the branch is charged against: the merge-base, not the tip.
+
+    Extracted from `main()` for the reason #572 taught: **a rule that lives inside
+    `main()` is not reachable from a test, so it cannot be swept, so it is a guard the
+    harness is structurally unable to hold itself to.** `workdir_for` had to come out of
+    `main()` before the bug that made this tool unusable on macOS could be pinned. This
+    function, `dirty_for`, `timeout_for` and `exit_code` are the same move applied to the
+    rest of the CLI, and the self-sweep's "renderer + CLI, ~0 of 49" row is what that
+    hazard looks like when nobody applies it.
+
+    `origin/main` when the remote is there, `main` when it is not — a fresh clone, a
+    worktree, and CI all differ on that. The merge-base and not the tip, because a branch
+    is answerable for what IT added and not for what main gained while it was open.
+    """
+    if override:
+        return git("rev-parse", override, cwd=root).strip()
+    upstream = "origin/main" if git("rev-parse", "--verify", "--quiet", "origin/main",
+                                    cwd=root, check=False).strip() else "main"
+    return git("merge-base", ref, upstream, cwd=root).strip()
+
+
+def dirty_for(root: Path, paths: tuple[str, ...], ref_arg: str) -> dict[str, bytes]:
+    """Uncommitted work, but only when the sweep is about the working tree.
+
+    `--ref HEAD` means "what I have here", so the sandboxes carry what is not committed
+    yet — that is what makes the tool usable before a commit. Any other ref names a
+    specific historical tree, and pouring today's uncommitted files into it would sweep a
+    tree that has never existed and report findings against it.
+    """
+    return dirty_files(root, paths) if ref_arg == "HEAD" else {}
+
+
+def timeout_for(measured: float) -> float:
+    """The full-suite cap, taken from THIS machine's own baseline rather than a constant.
+
+    Six times what the suite just took, never below the floor. A fixed forty minutes is
+    generous on an idle box and far too tight on a shared one: measured at a load average
+    of 100, a five-minute suite ran past 2400 s and two known-unpinned guards came back
+    "pinned" on the strength of a stopwatch. Six, and not two, because the mutants that
+    matter most are exactly the ones that make the suite slow.
+    """
+    return max(FULL_TIMEOUT, measured * 6)
+
+
+def exit_code(results: list[Result]) -> int:
+    """What a plain (non-gate) run exits with.
+
+    3 and not 0 for an unmeasured mutation: a sweep that could not measure some of its
+    mutations has not shown the branch to be clean, and anything reading this code must
+    not treat "I could not look" as "nothing to see". 4 outranks both, because a mutation
+    that never applied means the other numbers are not evidence either.
+    """
+    if any(r.verdict == "unapplied" for r in results):
+        return 4
+    if any(r.verdict == "survived" for r in results):
+        return 1
+    return 3 if any(r.verdict == "unresolved" for r in results) else 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1469,17 +2131,27 @@ def main(argv: list[str] | None = None) -> int:
                         "enclosing function, together. Two guards in sequence mask each "
                         "other, and a masked mutant looks equivalent one at a time.")
     p.add_argument("--keep", action="store_true", help="Leave the sandboxes behind.")
+    p.add_argument("--gate", action="store_true",
+                   help="Report as a CI gate: sort the survivors into unpinned, masked "
+                        "cluster and platform-deferred, and exit by the gate's rules.")
+    p.add_argument("--enforce", action="store_true",
+                   help="Make --gate blocking. Off by default and deliberately: a gate "
+                        "whose numbers nobody has seen gets disabled the first time it is "
+                        "inconvenient.")
+    p.add_argument("--summary", default=None, metavar="PATH",
+                   help="Append the gate's markdown to this file — $GITHUB_STEP_SUMMARY "
+                        "on CI, so the numbers are on the pull request rather than in a "
+                        "log nobody opens.")
     args = p.parse_args(argv)
+    if args.gate and args.all:
+        p.error("--gate charges the lines a branch added; --all charges the whole tree. "
+                "The gate never sweeps the whole tree — that is stage B, and it is a "
+                "14-hour job, not a pull-request check.")
 
     root = repo_root(Path.cwd())
     paths = tuple(args.paths or DEFAULT_PATHS)
     ref = git("rev-parse", args.ref, cwd=root).strip()
-    if args.base:
-        base = git("rev-parse", args.base, cwd=root).strip()
-    else:
-        upstream = "origin/main" if git("rev-parse", "--verify", "--quiet", "origin/main",
-                                        cwd=root, check=False).strip() else "main"
-        base = git("merge-base", ref, upstream, cwd=root).strip()
+    base = base_for(root, ref, args.base)
 
     workdir = workdir_for(root, args.workdir)
     workdir.mkdir(parents=True, exist_ok=True)
@@ -1491,7 +2163,7 @@ def main(argv: list[str] | None = None) -> int:
     log(f"  workdir: {workdir}")
     started = time.time()
     log(f"sweeping {ref[:12]} (paths: {', '.join(paths)})")
-    dirty = dirty_files(root, paths) if args.ref == "HEAD" else {}
+    dirty = dirty_for(root, paths, args.ref)
     if dirty:
         log(f"  carrying {len(dirty)} uncommitted file(s) into the sandboxes")
 
@@ -1504,6 +2176,9 @@ def main(argv: list[str] | None = None) -> int:
             f"{sum(len(v) for v in scope.values())} added line(s)")
     if not scope:
         log("  nothing under the swept paths changed. Nothing to do.")
+        if args.summary:
+            _append(args.summary, "## Deletion sweep\n\nNothing under the swept paths "
+                                  "changed on this branch, so there was nothing to sweep.\n")
         return 0
 
     # The map is measured on a clean checkout of the ref, so that a mutation is the only
@@ -1521,16 +2196,24 @@ def main(argv: list[str] | None = None) -> int:
         took = time.time() - started_baseline
         log(f"    Ran {baseline.ran} tests — {'OK' if baseline.green else baseline.detail}"
             f" in {took:.0f}s")
-        # Six times what this machine, right now, took to run the suite once — and never
-        # below the floor. The mutants that matter are the ones that make the suite SLOW,
-        # and the sweep may be sharing the box with itself.
-        full_timeout = max(FULL_TIMEOUT, took * 6)
+        full_timeout = timeout_for(took)
         if full_timeout > FULL_TIMEOUT:
             log(f"    full-suite timeout raised to {full_timeout / 60:.0f} min for this box")
         if not baseline.green:
             log("  ! the tree is RED before any mutation. Every mutation below will look")
             log("  ! pinned for a reason that has nothing to do with the guard. Fix first.")
-            return 2
+            if args.summary:
+                _append(args.summary,
+                        "## Deletion sweep — not run\n\nThe tree is **red before any "
+                        "mutation**, so every mutation would have looked pinned for a "
+                        f"reason that has nothing to do with any guard: {baseline.detail}\n")
+            # A reporting gate blocks nothing, and that has to include this. A red baseline
+            # is a real problem and the summary above says so in the loudest terms the page
+            # has — but failing a pull request over it, on a job whose numbers nobody has
+            # read yet, is precisely the "inconvenient the first time" that gets a gate
+            # switched off. `--enforce` is the flag that decides, for this and everything
+            # else, and it decides once.
+            return 2 if args.enforce or not args.gate else 0
 
     results, pairs = sweep(root, ref, scope, selection, workdir, args.jobs, dirty,
                            args.second_order, log, full_timeout)
@@ -1544,12 +2227,28 @@ def main(argv: list[str] | None = None) -> int:
         for child in workdir.glob("w*"):
             shutil.rmtree(child, ignore_errors=True)
         shutil.rmtree(workdir / "ref", ignore_errors=True)
-    if any(r.verdict == "survived" for r in results):
-        return 1
-    # 3, not 0: a sweep that could not measure some of its mutations has not shown the
-    # branch to be clean, and a gate reading this must not treat "I could not look" as
-    # "nothing to see".
-    return 3 if any(r.verdict == "unresolved" for r in results) else 0
+    if not args.gate:
+        return exit_code(results)
+    gate = classify(results)
+    if args.summary:
+        _append(args.summary, gate_summary(gate, ref, base, elapsed, args.enforce))
+    log("")
+    log(f"gate: {len(gate.unpinned)} unpinned, {len(gate.masked)} in masked cluster(s), "
+        f"{len(gate.platform)} platform-deferred, {len(gate.unresolved)} unresolved, "
+        f"{len(gate.unapplied)} not applied, {gate.pinned} pinned")
+    if not args.enforce:
+        log("gate: reporting only — nothing here blocks. Pass --enforce to make it.")
+    return gate_exit_code(gate, args.enforce)
+
+
+def _append(path: str, text: str) -> None:
+    """Add to a file rather than replacing it — `$GITHUB_STEP_SUMMARY` is shared.
+
+    Every step of a job writes to the same file, so a `write_text` here would silently
+    delete whatever an earlier step put on the pull request.
+    """
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(text.rstrip("\n") + "\n")
 
 
 if __name__ == "__main__":       # pragma: no cover - entry point

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -1246,6 +1246,28 @@ def _named(ids) -> str:
     return "; ".join(short[:3]) + (f" (+{len(short) - 3} more)" if len(short) > 3 else "")
 
 
+def run_dir(workdir: Path) -> Path:
+    """Where THIS run's sandboxes live — one directory per process.
+
+    :func:`workdir_for` gives one workdir per checkout, which is right for the trace cache
+    (content-addressed, so sharing it is the whole point) and wrong for the sandboxes. Two
+    sweeps of the same checkout — two agents on one box, or one person who forgot the first
+    run was still going — would otherwise apply mutations to each other's trees: each one
+    restoring a file the other was about to run against, and each one's verdicts about
+    bytes neither of them chose.
+
+    **Measured, on this file, by accident.** Two sweeps overlapped and 486 of 489 mutations
+    came back `unapplied` — the digest check refusing to produce a verdict from a tree it
+    did not recognise. That refusal is what made the collision visible at all; before it,
+    the same run would have printed a plausible table of pins and survivors. This is the
+    other half of that fix: the collision should not happen in the first place.
+
+    The cache stays shared. It is keyed by a hash of the tree, so two runs of one checkout
+    want exactly the same map and paying for it twice is pure loss.
+    """
+    return workdir / f"run-{os.getpid()}"
+
+
 class NotApplied(Exception):
     """The mutant tree is not a mutant. See :meth:`Sandbox.apply`."""
 
@@ -1580,7 +1602,7 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
         return [], []
 
     log(f"  building {jobs} sandbox(es)…")
-    boxes = [Sandbox(root, workdir / f"w{i}", ref, dirty) for i in range(jobs)]
+    boxes = [Sandbox(root, run_dir(workdir) / f"w{i}", ref, dirty) for i in range(jobs)]
     for box in boxes:
         box.full_timeout = full_timeout
     free: list[Sandbox] = list(boxes)
@@ -2247,7 +2269,7 @@ def main(argv: list[str] | None = None) -> int:
     # The map is measured on a clean checkout of the ref, so that a mutation is the only
     # thing that ever differs from what was traced.
     log("  preparing the reference sandbox…")
-    ref_box = Sandbox(root, workdir / "ref", ref, dirty)
+    ref_box = Sandbox(root, run_dir(workdir) / "ref", ref, dirty)
     selection = load_map(ref_box.path, paths, cache_dir, args.jobs, args.refresh_map, log)
 
     baseline = None
@@ -2287,9 +2309,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         Path(args.json).write_text(as_json(results))
     if not args.keep:
-        for child in workdir.glob("w*"):
-            shutil.rmtree(child, ignore_errors=True)
-        shutil.rmtree(workdir / "ref", ignore_errors=True)
+        # This run's sandboxes and no others. A `workdir.glob("w*")` here would delete a
+        # concurrent sweep's trees out from under it — the same collision `run_dir` exists
+        # to prevent, arriving at the end instead of the beginning.
+        shutil.rmtree(run_dir(workdir), ignore_errors=True)
     if not args.gate:
         return exit_code(results)
     gate = classify(results)


### PR DESCRIPTION
Stage C of the deletion-sweep spec, the two operator families stage A declined to fake,
and the harness's own unpinned guards.

## Stage C — the gate

`.github/workflows/sweep.yml`, on every pull request, **scoped to the lines the branch
added**. It writes onto the run's summary page rather than into a log nobody opens, and
every survivor carries **what the covering tests assert about the mutated symbol** — the
field that made 82 survivors triageable rather than merely alarming.

**It blocks nothing.** `--enforce` is the one flag that changes that and it is deliberately
absent. The spec's staging argument — *a gate whose baseline nobody has seen gets disabled
the first time it is inconvenient* — applies to the gate's own credibility as much as to
the tree's, so the numbers come first and the page says what it *would* have done.

### On shipping C before B

The spec orders C after B, and I re-read the ordering rather than ignoring it. Its stated
reason is credibility, not a technical dependency — and **the gate never sweeps the whole
tree**, so B is not on C's critical path at all. What the reason actually asks for is that
the gate's numbers be *seen* before it can block a branch, and B is a poor way to get that:
it measures `main`'s standing debt, which is not the number a gate run produces. A
reporting-only gate produces exactly that number, on real branches, every day. `docs/…/
deletion-sweep-harness.md`'s Delivery section now records this.

### Five outcomes, kept apart

| outcome | why it is its own bucket |
|---|---|
| **unpinned** | a guard with no test behind it. The finding. |
| **masked cluster** | two or more survivors in one function. They hide each other, so none is safe to call equivalent alone — read together, and separated because the advice differs. |
| **platform-deferred** | a narrowed catch on an OS-decided type. **Never fails the gate**, even when enforcing. `except OSError` around a pty read is dead code on macOS and live on Linux; a gate that fails a branch for a clause the runner's kernel cannot reach is one people are right to switch off. |
| **unresolved** | no verdict. A timeout is not a red and not a survivor, and under load this repo hits it constantly. Exit code 3, distinct from 1. |
| **not applied** | the edit never reached the tree. A bug in the sweep, not a finding about the branch. Exit code 4, and the summary says to read nothing else until it is zero. |

### Measured end to end, not asserted

Run for real against a probe branch that adds three guards to `charter/tui.py`, with the
sweep's own CLI and its own workflow arguments:

```
selection map    345 test modules traced in 171s (cold; cached after)
baseline         Ran 7066 tests — OK in 371s
mutations        4
  [1/4] SURVIVED  charter/tui.py:201 [drop-if]        if not name: return "-"
  [2/4] SURVIVED  charter/tui.py:203 [shift-boundary] width(name) > cap
  [3/4] SURVIVED  charter/tui.py:205 [swap-synonym]   name.lower
  [4/4] SURVIVED  charter/tui.py:203 [drop-if]        if width(name) > cap: …
                  (46 module(s) each, then all 7066)
gate: 0 unpinned, 4 in masked cluster(s), 0 platform-deferred,
      0 unresolved, 0 not applied, 0 pinned
gate: reporting only — nothing here blocks. Pass --enforce to make it.
exit 0
```

All four correct — nothing tests the probe — and all four show the escalation the cost model
rests on: the mapped subset first, the **whole** suite before anything is called a survivor.
They land in the **masked cluster** bucket rather than as four unrelated findings, because
they share a function. And each one carries its evidence line, which here is the loudest
form of it: *46 modules execute this file and not one names `gate_probe`*.

The summary it wrote is what a reviewer sees on the run:

> ## Deletion sweep — 4 actionable survivor(s)
>
> `23c1ff7ec8b2` against `2277288d2363`, added lines only, 20.0 min on darwin / CPython 3.14.4.
>
> | outcome | n | what it means |
> |---|---:|---|
> | pinned | 0 | a test goes red without the line |
> | **unpinned** | 0 | a guard with no test behind it |
> | **masked cluster** | 4 | two or more in one function; none is safe to call equivalent alone |
> | platform-deferred | 0 | the clause may be unreachable on darwin; never fails this gate |
> | unresolved | 0 | no verdict — timed out, not measured |
> | not applied | 0 | the edit never reached the tree — a bug in the sweep |
>
> **Reporting only.** This job blocks nothing; it **would fail** with `--enforce`.

**One honest cost caveat the run surfaced.** The "24 s a mutation" model assumes the mutated
symbol is in the trace map. A brand-new function is not — no test executed it, so nothing
maps to it — and selection widens to the *file*, which for `charter/tui.py` is 46 modules
rather than the median 1. That is the design working (it widens on doubt, never narrows).
The dominant cost is unchanged either way: every survivor buys a full-suite run, and this
probe was four survivors out of four, which is the worst case rather than the typical one.

## The two missing operator families

Both were declared gaps by stage A rather than fitted to the answer key. The brief was to
find a principled general form **or say precisely why not**.

### `retune-string` — same length, same character classes, a different value

The objection was that a string has no honest general perturbation: *picking `1003` over
`1000` for `MOUSE_ON` is fitting the answer key, not recognising a shape.* The answer is to
move the **value** while holding every structural property the surrounding code can depend
on — type, length, punctuation, escapes, case pattern, digits-are-digits:

```
"\x1b[?1000h"  ->  "\x1b[?2111i"     still an escape sequence
"{:<28}"       ->  "{:<39}"          still a format spec
r"^Ran (\d+)"  ->  r"^Sbo (\d+)"     still a regex — a character behind a backslash
                                     is left alone, or `\d` becomes `re.error:
                                     bad escape \e`, which is a false pin
```

It is derived from the constant and from nothing else, so it **cannot fit an answer key it
never reads**. It is the string analogue of `retune-constant`'s `n + 1`: the smallest edit
guaranteed to be a different value of the same kind.

**Scoped to read positions, and that scope is measured rather than preferred.** A string is
a claim in two ways and only one is a claim a test can hold: a key, a comparison operand, a
pattern, a separator and a width decide what the program *does*; a log line decides what it
*says*. On `charter/`: 8,471 mutable string constants, 2,458 in a read position. Mutating
all of them took the tree from 7,006 mutations to 14,801 and spent the difference on prose
(2,328 f-string fragments alone). Scoped, it is 9,319, and real pull requests from this
phase go from 15–35 mutations to roughly 30–50 — still the twenty-odd minutes the cost
model was built on. Widening it is one predicate, and should carry a measurement the way
this does.

Same reasoning drew a second line: a module-level `NAME = "…"` is mutated (that is
`MOUSE_ON`'s and `_MARK`'s shape, two of round two's five), a string *inside a container*
assigned to an upper-case name is not. Walking into containers takes read positions from
2,826 to 4,065, and what those 1,239 ask for is a test per member of every membership table
in the tree. A member is read through the container, and where one genuinely decides
something the lookup that reads it is already a read position.

### `shift-boundary`, `swap-synonym`, `drop-normalise` — one documented axis, moved

- `<` against `<=`. Fully general, domain-free, minimal. `drop-if` cannot ask this: a test
  that never approaches the edge answers "the refusal exists" perfectly well.
- A closed table of **standard-library** pairs differing on exactly one documented axis —
  `lower`/`upper`, `startswith`/`endswith`, `lstrip`/`rstrip`, `sorted`/`list`, `min`/`max`,
  `any`/`all`. Nothing charter-specific, so it cannot be fitting this project's findings;
  the same discipline as `NARROW_TO = ZeroDivisionError`.
- `p.resolve()` dropped to `p` — **#572's own shape**: a normalisation applied at one site
  and missing at the one it is compared against.

**Where the honest limit is.** `shift-boundary` has a principled *general* form. The synonym
table has a principled *rule* — two names on one type, one axis — but not a principled
*closure*: it is finite and hand-built, and a pair nobody wrote down is a shape the sweep
cannot see. Stated rather than papered over.

Two type-correctness rules came out of checking the table against the tree rather than
trusting it. Both close a **false pin**, which is the failure that ends adoption:

- `index`/`rindex` is **not** in the table. `index` is on `list`, `tuple` and `str`;
  `rindex` is on `str` alone, so `args.index("-m")` would mutate into an `AttributeError`.
  All five `.index(` call sites in `charter/` are on lists.
- A receiver bound by an `import` is skipped. `shlex.split` and `re.split` live in a
  namespace with no `rsplit` in it — eight such call sites in `charter/`.

### Acceptance: it rediscovers a finding it could not see before

Run over the commit *before* #508 was fixed, with no list supplied, the sweep now finds the
`{:<28}` width literal in `cmd_persona_stats` on its own — twice, once per format string.
That is the exact finding #585 had to hand-write a mutation for, because no operator could
see it.

## A sweep that asks fewer questions says so

PEP 701 is 3.12. Before it, `ast` gives an f-string's internal nodes approximate positions,
so `retune-string` cannot vouch for the bytes it would splice and refuses — which puts
`f"{name:<28}"`, #508's whole defect, out of reach on 3.11. `reach()` names that in the
report header and in the gate summary, next to the platform line and for the same reason:
**a sweep that asks fewer questions and does not say so reads exactly like a clean one.**
The gate job pins 3.12 for that reason and says so where the pin is.

## Every mutation asserts it applied (#586), and it caught something within the day

`Mutation.origin` is a digest of the file the mutation was **read from**, and `apply`
refuses two different ways: *this is not the file I read*, and *the bytes did not change*.
Either raises `NotApplied`, `decide` returns the verdict `unapplied`, and the report and
the gate summary both say to read nothing else until it is zero. A verdict from an edit that
did not happen is not a verdict — and a false survivor is the failure that ends adoption,
because it sends somebody to write a test for a line that is already covered.

**It earned its place immediately, and by accident.** A self-sweep run came back
`489 mutations, 486 unapplied, 2 survived, 1 pinned`. Two sweeps of the same checkout were
running at once and sharing sandboxes — each applying mutations to the other's tree, each
restoring a file the other was about to run against. The digest check refused to answer 486
times rather than reporting verdicts about bytes neither sweep chose.

**Without it, that run would have printed a plausible table and I would have reported it.**
Nothing else in the run looked wrong: no crash, no timeout, no empty baseline. That is the
whole argument of #586 arriving unprompted, in the tool, on its own numbers.

So the collision is fixed at the other end too. `workdir_for` gives one workdir per
checkout, which is right for the trace cache — content-addressed, so sharing it is the
point — and wrong for the sandboxes. `run_dir` puts a run's trees under its own pid, and
cleanup removes that directory rather than globbing `w*`, which would have deleted a
concurrent sweep's trees at the far end of the same mistake. Three other agents run sweeps
on this box, so it is not a hypothetical.

## The harness's own guards

`tools/sweep.py --path tools --all`, the harness swept by itself, both runs on this box.
`tools/sweep.py` grew by about 70% on this branch and the operator set widened by two and a
half times, so the denominators are not comparable — the rate per area is:

| area | before | after |
|---|---|---|
| **operator table** | 31 / 59 (53%) | **98 / 156 (63%)** |
| verdict logic | 26 / 57 (46%) | 37 / 87 (43%) |
| trace map | 10 / 11 (91%) | 18 / 27 (67%) |
| scoping | 3 / 14 (21%) | **15 / 24 (63%)** |
| report + CLI | 5 / 54 (9%) | **62 / 168 (37%)** |
| module scope | 0 / 3 | 8 / 26 |
| **total** | 75 / 198 (38%) | **238 / 488 (49%)** |

**Like for like**, on the operator families that existed before this branch:
**169 / 304 (56%), up from 75 / 198 (38%)**. The three new families account for the rest —
**69 / 184 (38%)** — which is what a new operator family is *supposed* to look like on its
first run: it asks questions nothing was written to answer.

| new family | pinned |
|---|---|
| `retune-string` | 50 / 118 |
| `swap-synonym` | 12 / 43 |
| `shift-boundary` | 6 / 22 |
| `drop-normalise` | 1 / 1 |

**Nought unresolved and nought not-applied** — that is the run being measurable, which the
first attempt at it was not.

**The report renderer is still the thin row and this PR does not pretend otherwise.** It
went from 9% to 37% as a side-effect of extracting the CLI's rules, and 106 of its 168
mutations still survive. That is the honest number; the operator table was the priority
because it decides every verdict, and the renderer is cosmetic by comparison.

One caveat on the count: the run was interrupted after 488 of the 489 mutations, so the
last one has no verdict. Everything above is 488.

The operator table was the priority and is where the work went: it decides every verdict, so
an unpinned line there does not mislead a reviewer about one guard, it silently changes
which questions the tool asks of every branch that follows.

### Three lines deleted, because §4 says so

- `tree_hash`'s `if not base.exists(): continue` — the measured equivalent mutant from
  #574's comment.
- `all_lines`' identical guard, found by the same sweep in the same run.
- `_iter_operators`' `and node.ifs` — a guard refusing to enter a loop over the very list it
  was testing for emptiness.

All three guard an iteration that yields nothing anyway. "Equivalent mutant" and "dead code"
are one finding.

There is a fourth of the same shape that is **not** deleted but moved: `shift-boundary` used
to skip a chained comparison containing an operator it could not spell, and `ast` has exactly
ten comparison operators, all of which it spells. So the guard was a line nothing could
reach. It is now a test — `assertEqual(set(ast.cmpop.__subclasses__()), set(CMP_TEXT))` —
which fails on the day Python grows an eleventh rather than on the day somebody's sweep
crashes.

### A rule inside `main()` cannot be swept

#572's structural lesson, applied to the rest of the CLI. `workdir_for` had to come out of
`main()` before the bug that made this tool unusable on macOS could be pinned, and the
self-sweep's "report + CLI, 5 of 54" row is what that hazard looks like at scale. So
`base_for`, `dirty_for`, `timeout_for` and `exit_code` are functions now, each with the test
that goes red without it.

## Verification

**Full suite in two environments, both at the branch head**, both green:

```
CPython 3.14.4                                     Ran 7066 tests in 457s — OK
CPython 3.12, with CHARTER_* / CLAUDE_* /
  ANTHROPIC_* / TMUX* unset                        Ran 7066 tests in 459s — OK
```

**CI**, read through `gh api repos/diazoxide/charter/commits/<sha>/check-runs` and not
`gh pr checks` (#561): green on 3.11, 3.12, 3.13 and 3.14.

**`tools/sweep.py --path tools --all`** — the numbers above.

Stdlib only, `unittest`, no new dependency. No version bump, no stamp, no tag, and
`release.yml` is untouched.

Closes #569
