### PR TITLE
A chat is a window with a name charter allocated, and its panels follow it (Phase 5 spec)

### DIFF
--- a/docs/superpowers/plans/2026-08-28-phase5-workspace-and-chat-tabs.md
+++ b/docs/superpowers/plans/2026-08-28-phase5-workspace-and-chat-tabs.md
@@ -1,0 +1,360 @@
+# Phase 5 — workspace tabs, chat tabs, and many harnesses in parallel
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development`.
+
+**Goal:** a workspace holds several chats, a chat picks its harness when it starts, and switching
+between either loses nothing. A frame stops being a tmux session and becomes a tmux window; a
+tmux session becomes a workspace. Two new components draw the readout; the palette stays the
+mechanism.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-phase5-workspace-and-chat-tabs.md`.
+**It overrides `2026-08-25-agentic-ide-foundation.md` §4j in three places** and says which.
+**Measurements:** that spec's §7 — every number, with the command that produced it.
+
+## What the measurements already decided
+
+- **`window-resized` does not exist on tmux 3.2** (`invalid option`, rc=1) and a background
+  window keeps stale geometry on both 3.2 and 3.7c. **So the switch reasserts the layout itself
+  and never relies on a hook.**
+- **Panels follow the active chat; they do not duplicate.** 32 panel processes at 23.7 MB
+  resident each, rendering the same `gather.json` at widths that are wrong, is what the
+  alternative buys. Panels created *after* the switch are born at the true width.
+- **The name is allocated, not hashed.** A hash collides silently into a shared
+  `.charter/frame/<fid>/`, and a `-{ordinal}` tail makes `state._launcher_pid` read `2` as a
+  live pid, so every dead chat looks live forever. `{workspace}.{n}` makes `_launcher_pid`
+  return `None`, and that `None` is the version discriminator.
+- **Per-window `-e` overrides a session-wide `set-environment`**, on 3.7c and on 3.2. That is
+  how `$CHARTER_SESSION_ID` becomes per-chat, and it is the whole identity mechanism.
+- **`tmuxctl.chain` is worth 3.3× on the switch path** — four `split-window` go from 22.2 ms to
+  6.7 ms, four `kill-pane` from 19.3 ms to 4.9 ms.
+- **A tmux window name is not an identity.** `automatic-rename` is on by default and follows the
+  foreground process; `allow-rename on` lets the pane's own output set it; and `rename-window`
+  refuses a newline on 3.7c and accepts it on 3.2. The bars read charter's record.
+- **The harness is the cost.** 19 live `claude` processes on the measuring machine: 4.29 GB,
+  mean 226 MB. A panel is noise beside it.
+
+## Global constraints
+
+- `dependencies = []`, stdlib only. stdlib `unittest`, never pytest.
+- Run the suite in **two environments** and say which; they must agree.
+- `PersonaIso`; new `patch.dict(os.environ, …)` MUST pass `clear=True`.
+- `tui.width()` never `len()`. `contain.one_line` **before** width arithmetic (#472).
+- Every state write goes through `config.write_for` / `config.private_mkdir`, or
+  `tests/_statedirscan.py` fails the build (#505/#603/#581/#582).
+- **A chat's id and a chat's label are two strings with two alphabets.** The id is
+  `_UNSAFE`-sanitised and may reach tmux. The label is open and may reach only the palette and
+  the bars. A test that lets a label reach a tmux argv is a failing test.
+- **Nothing is added to `layout.CARRIABLE` without an argument for it.** A tmux `-e` becomes
+  world-readable argv.
+- Mutation-test every guard: apply, RED, restore, GREEN, `__pycache__` cleared. **Report the
+  mutation actually run and its actual result.**
+- No version bump, no stamping, no tag. **Implement, PR, merge — never release alone.**
+
+## The deletion sweep — required before any PR in this phase
+
+`tools/sweep.py` is in the tree and `.github/workflows/sweep.yml` runs it on every pull request:
+
+```
+python3 tools/sweep.py --gate --jobs 4 --json sweep-results.json --summary "$GITHUB_STEP_SUMMARY" [--base "$BASE_SHA"]
+```
+
+The job reports and blocks nothing — `--enforce` is deliberately absent — so **the branch author
+still runs it and still reads it.** Run it locally before submitting:
+
+```
+python3 tools/sweep.py                    # this branch, against its merge-base
+```
+
+`classify()` buckets survivors as `unpinned`, `masked` (≥2 survivors in one `(path, symbol)` —
+*more* urgent, read together), `platform`, `unresolved` and `pinned`. **A timeout is
+`unresolved`, neither green nor red.** There is no suppression list: "equivalent mutant" and
+"dead code" are the same finding.
+
+**So: for every `if` you add that refuses, clamps, contains or falls back, write the test that
+goes RED when that line is deleted** — and assert **which** refusal fired, not just that
+something did. Two guards in sequence mask each other, and an exit-code assertion cannot tell
+them apart.
+
+Phase 5 has four guards where a masked survivor would be expensive, and each gets a named test:
+
+1. the ordinal allocator's `FileExistsError` claim,
+2. the `pane-died` teardown running `kill-window` and not `kill-session`,
+3. the label containment before width arithmetic,
+4. the live-chat cap's refusal.
+
+---
+
+## Stage 5a — a frame is a window
+
+Nothing visible changes. Everything underneath does.
+
+### Task 1: A chat id is allocated, not computed
+
+- [ ] **Step 1:** write the failing test — `state.new_chat_id("api")` returns `api.1`, then
+      `api.2`; two allocators racing the same workspace never return the same id; and a
+      workspace named `api.2` does not collide with workspace `api` chat 2.
+- [ ] **Step 2:** run it, confirm it fails.
+- [ ] **Step 3:** implement. Allocation is a bare `os.mkdir(d, 0o700)` plus an explicit
+      `os.chmod(d, 0o700)` — **not** `config.private_mkdir`, which swallows `FileExistsError` on
+      a directory (#331) and is therefore idempotent, which is exactly wrong for an allocator.
+      `FileExistsError` means "taken, try `n+1`".
+- [ ] **Step 4:** `state._launcher_pid("api.3")` returns `None`, and that is the discriminator.
+      Test that an old-shape `api-12345` still parses, still reports liveness by pid, and is
+      still reaped by the old rule.
+- [ ] **Step 5:** **the id is never parsed for meaning.** Test: rename a workspace under two
+      live chats; both still resolve, both keep their old-prefixed ids, and the bar shows the
+      workspace `frame_workspace(fid)` names.
+- [ ] **Step 6:** mutations — make the allocator scan-then-create instead of claiming by
+      `mkdir`; use `private_mkdir` so `FileExistsError` is swallowed; let `_launcher_pid` parse
+      a dot id. Each RED.
+- [ ] **Step 7:** commit.
+
+### Task 2: The private server grows windows, and liveness moves
+
+- [ ] **Step 1:** write the failing test — two chats in one workspace are two windows on one
+      tmux session named after the workspace, and `state.reap` keeps both while their windows
+      exist and neither launcher process does.
+- [ ] **Step 2:** run it, confirm it fails.
+- [ ] **Step 3:** implement. `list-windows -a -F '#{window_name}'` is the live set for a chat, as
+      `_live_windows` already does on the guest path. **This makes the private path work the way
+      the guest path already works** — do not invent a third shape.
+- [ ] **Step 4:** **`set -w -t <window> @charter_chat <chat id>`** at creation, so a lookup asks
+      the window what chat it is rather than parsing a name. The same window-option mechanism
+      `@charter_hatch` already uses, and the reason `F12` works per chat with no new code.
+- [ ] **Step 5:** **the `pane-died` teardown runs `kill-window`, not `kill-session`.** This is
+      the single most dangerous line in the port: unchanged, one chat's harness dying takes
+      every other chat in that workspace with it, mid-turn. Test it with two chats and kill one.
+- [ ] **Step 6:** `state.clear_shape` still unlinks `session` at launch (#413).
+- [ ] **Step 7:** mutations — restore `kill-session` in the teardown hook; take liveness from the
+      launcher pid for a dot id; drop `@charter_chat`. Each RED.
+- [ ] **Step 8:** commit.
+
+### Task 3: Identity is per chat
+
+- [ ] **Step 1:** write the failing test — two windows on one session, created with different
+      `-e CHARTER_SESSION_ID` and `-e CHARTER_HARNESS`, each report their own values from inside
+      the pane, over a session-wide `set-environment` that says something else.
+- [ ] **Step 2:** run it, confirm it fails.
+- [ ] **Step 3:** implement through `layout._env_argv`, which already raises on any name outside
+      `CARRIABLE`. **Add nothing to `CARRIABLE`.**
+- [ ] **Step 4:** assert the consequence: `.charter/sessions/<chat id>.persona`, `.workspace`,
+      `.tools` and `.gate` become per-chat with no new code, because `session.current()` reads
+      `$CHARTER_SESSION_ID`. Two chats, two personas, two tool ceilings, each enforced in its own
+      process.
+- [ ] **Step 5:** mutation — carry the identity session-wide instead of per window; confirm two
+      chats then share a persona pointer, and confirm RED.
+- [ ] **Step 6:** commit.
+
+**Stage 5a exit criteria**
+
+- Two chats run in one workspace on one tmux session, each with its own frame directory, its own
+  `$CHARTER_SESSION_ID`, its own persona pointer and its own tool ceiling.
+- Killing one chat's harness leaves the other running.
+- `state.reap` removes a chat whose window is gone and keeps one whose window is not, with no
+  launcher process alive for either.
+- Old `{workspace}-{pid}` frames still launch, still report liveness, still reap. No migration
+  ran.
+
+---
+
+## Stage 5b — switching, and the surface
+
+### Task 4: The switch action
+
+- [ ] **Step 1:** write the failing test — switching to a chat selects its window, tears down the
+      previous chat's panels, splits panels into the new one, and bumps so they paint.
+- [ ] **Step 2:** run it, confirm it fails.
+- [ ] **Step 3:** implement over `_apply_arrangement(fid, want=[])` then
+      `_apply_arrangement(fid, want=<arrangement>)` — the one live pane-mutation funnel, not a
+      second path.
+- [ ] **Step 4:** **one `tmuxctl.chain` per group.** Measured: 6.7 ms chained against 22.2 ms
+      unchained for four splits. `chain` returns `None` when the servers disagree; a `None` is a
+      refusal, not a fallback to N invocations.
+- [ ] **Step 5:** **the switch reasserts the layout; it does not rely on `window-resized`.** Test
+      the whole path with the hook removed — it must produce the same layout, because on tmux 3.2
+      the hook does not exist.
+- [ ] **Step 6:** **bump, do not just write a pointer** (#411/#412). A pointer some panels may
+      read is the bug those issues were filed for.
+- [ ] **Step 7:** actions are fire-and-report, never blocking (§4g). A switch returns having
+      started, and a failure surfaces rather than hanging the palette.
+- [ ] **Step 8:** mutations — drop the teardown so panels accumulate; write the pointer without
+      bumping; replace the chained invocation with N invocations and assert the *behaviour* that
+      changes, not the timing; make the switch depend on `window-resized`. Each RED.
+- [ ] **Step 9:** commit.
+
+### Task 5: Harness selection at chat creation
+
+- [ ] **Step 1:** write the failing test — `F2` → `pick:harness` lists the registered harnesses,
+      choosing one creates a chat running it, and a harness whose `binary` is not on `PATH` is
+      listed **with its reason**, not hidden.
+- [ ] **Step 2:** run it, confirm it fails.
+- [ ] **Step 3:** implement over `choose.py` as a third noun. **This is the first place charter
+      asks rather than detects** (§4j) — so the row source is `harness.all()` in registration
+      order, and `harness.current()` marks the default.
+- [ ] **Step 4:** a harness's `deficits` appear as the row's note. An operator choosing `codex`
+      should see `session-lock` before they choose it, not after.
+- [ ] **Step 5:** mutations — hide an unavailable harness; drop the deficit note. Each RED.
+- [ ] **Step 6:** commit.
+
+### Task 6: The chat picker, and the containment that matters
+
+- [ ] **Step 1:** write the failing test — a chat picker lists the workspace's chats, choosing
+      one switches to it, and a chat whose label contains a newline, U+2028, an escape sequence,
+      a quote or a `#` renders as **one row** and runs nothing.
+- [ ] **Step 2:** run it, confirm it fails.
+- [ ] **Step 3:** implement as `choose.CHAT`, a third entry in `NOUNS`, over the same
+      `overlay.Surface` with `OPEN_ID`/`NAME_ID` unchanged. A chat's row id is `chat:<chat id>`;
+      the `:` is what keeps it out of the action namespace `component._ID_RE` governs, and out of
+      `palette.matches`' id filter.
+- [ ] **Step 4:** **containment.** `contain.one_line` **before** width arithmetic (#472). **Test
+      with hostile labels; do not reason about them.** And assert the stronger property: a label
+      never reaches a tmux argv or a tmux format string at all — measured, a name routed through
+      `rename-window` is stored already expanded, and `#{E:@opt}` expands a `#{...}` in an
+      option's value.
+- [ ] **Step 5:** a refused switch — the live-chat cap, or a chat whose window is gone — **says
+      so on screen**, with which refusal fired.
+- [ ] **Step 6:** mutations — skip containment; let a label reach `new-window -n`; swallow the
+      refusal. Each RED.
+- [ ] **Step 7:** commit.
+
+### Task 7: The two bars
+
+- [ ] **Step 1:** write the failing test — `workspaces` and `chats` are components in the Phase 1
+      registry, `chats` **hides itself when there is one chat** showing only "add chat", and both
+      drop before `top` when rows are short.
+- [ ] **Step 2:** run it, confirm it fails.
+- [ ] **Step 3:** implement as `edge="top"`, `size=Fixed(1)`, registered in `builtins.build()` in
+      split order, and add both to `layout._DROP_ORDER` above `top`:
+      `("right", "repos", "chats", "workspaces", "top")`.
+- [ ] **Step 4:** **degradation inside the row.** The active chat's label in full, the others as
+      marks and a count; never wraps, never scrolls, never truncates a name below
+      `slots._NAME_MIN_W` (12 cells) — below that, marks only. Test at 200, 80 and 40 columns.
+- [ ] **Step 5:** the marks come from `charter/inflight.py` where the harness reports, and from
+      `#{window_activity_flag}` / `#{window_bell_flag}` where it does not — one
+      `display-message -p -F` over the session's windows, the shape `_measure_window` already
+      uses. **`monitor-activity on` per chat window; `bell-action` left alone**, because it is
+      the operator's terminal preference and charter's conf is session-scoped.
+      **The activity flag is a hint** — "bytes moved" includes a spinner — and the docstring says
+      so.
+- [ ] **Step 6:** mutations — draw the chat bar with one chat; drop it from `_DROP_ORDER`; let a
+      name truncate below the minimum. Each RED.
+- [ ] **Step 7:** commit.
+
+**Stage 5b exit criteria**
+
+- Every chat is reachable in **≤2 keystrokes** at 200, 80 and 40 columns, and at 40 columns
+  where the bars cannot be drawn.
+- A hostile chat label renders as one row, runs nothing, and never appears in a tmux argv.
+- The switch produces the correct layout **with the `window-resized` hook removed**.
+- `F12` returns to the harness from any chat, including one whose palette is deliberately hung.
+- The chat bar is absent with one chat and present with two.
+
+---
+
+## Stage 5c — the cost, and the honesty
+
+### Task 8: The cap, the history limit, and the cost readout
+
+- [ ] **Step 1:** write the failing test — creating a chat past `[frame] max_chats` is refused
+      **with its reason and the name of the coldest live chat**, and the value is refused rather
+      than clamped at the config boundary, as `FRAME_PANE_PAD_MAX` already is.
+- [ ] **Step 2:** run it, confirm it fails.
+- [ ] **Step 3:** implement. Default **6** — see the spec §6.1 for the arithmetic. Per plane,
+      not per workspace, because the memory is the machine's.
+- [ ] **Step 4:** **`history-limit` for chat windows.** Charter ships 50,000, and one 200-column
+      pane filling it took the shared tmux server from 3.8 MB to 130.6 MB. Operator decision
+      §6.2 recommends 20,000. Whatever the answer, it is one committed value, validated at the
+      boundary, and `docs/frame.md` states the measured cost beside it.
+- [ ] **Step 5:** **the cost readout.** Every chat's token gauge on the bar, not just the one in
+      front of you — extend `slots.py`'s existing gauge, which already reads
+      `state.harness_session(fid)`, to every chat in the workspace. A chat burning tokens behind
+      your back says so.
+- [ ] **Step 6:** mutations — clamp the cap instead of refusing; drop the coldest-chat name from
+      the refusal; show the gauge only for the active chat. Each RED.
+- [ ] **Step 7:** commit.
+
+### Task 9: Cold chats, and the sentence that admits what is lost
+
+- [ ] **Step 1:** write the failing test — closing a chat kills its window and keeps its record;
+      reopening restores the workspace, the persona, the harness and the cwd, **starts a fresh
+      harness session**, and says so **before** the relaunch.
+- [ ] **Step 2:** run it, confirm it fails.
+- [ ] **Step 3:** implement. `state.clear_shape` already unlinks `session` for this reason
+      (#413) — the reopened chat must not inherit the closed one's token gauge.
+- [ ] **Step 4:** **do not add a resume member to `Harness`.** `harness/base.py`'s docstring sets
+      the bar — *"A fifth member needs the same kind of argument, not just a use."* Charter can
+      verify resume for one of three harnesses; a resume that silently starts a new conversation
+      is worse than a sentence saying it will.
+- [ ] **Step 5:** mutation — reopen without clearing `session`, and confirm the stale gauge is
+      caught RED. Second mutation: drop the message and confirm the test asserting **which**
+      sentence appears goes RED.
+- [ ] **Step 6:** commit.
+
+### Task 10: Measure at 5 and 10 chats — §4j's instruction, discharged
+
+- [ ] **Step 1:** the spec's §7.9 says this is **not** discharged by the spec. Every scale figure
+      there used `sleep` processes standing in for harnesses. Run six real harnesses in six real
+      tabs.
+- [ ] **Step 2:** measure, with the command quoted: tmux server RSS and fd count; each panel
+      process's RSS and `phys_footprint`; each harness's RSS; wall-clock switch latency from
+      keypress to first painted panel.
+- [ ] **Step 3:** compare against the spec's extrapolation and **write down where it was wrong**.
+      An extrapolation nobody checked is a guess with a table around it.
+- [ ] **Step 4:** if the paint lag is visible, the fallback is keeping the previous chat's panels
+      alive for one switch — **and only then**, because building that cache now, unmeasured, is
+      §4d's layout engine arriving through the back door for the third time.
+- [ ] **Step 5:** append the results to the spec's §7. Do not open a new document.
+- [ ] **Step 6:** commit.
+
+### Task 11: The docs, and the sentence about boundaries
+
+- [ ] **Step 1:** `docs/frame.md` — what a chat is, how the bars degrade, what `max_chats` and
+      the chat `history-limit` cost, and that `bell-action` is deliberately untouched.
+- [ ] **Step 2:** **`SECURITY.md` and `docs/frame.md` both carry the sentence**: *a chat tab is a
+      container, not a boundary. Two chats in one plane run as the same user, under the same
+      plane, with the same vaults, and can read each other's files. A second tab does not add
+      that risk — it multiplies the number of processes that hold it.* A tab looks like a
+      boundary, which is exactly why the text has to say it is not.
+- [ ] **Step 3:** `docs/harnesses.md` — two chats on the same harness share that harness's
+      credentials, and charter does not separate them.
+- [ ] **Step 4:** the per-persona grant, spelled out for two tabs: each chat's `toolgate.decide`
+      grants `effective_tools(its persona) ∩ frozen_tools(its persona, its chat id)`, the
+      intersection means narrowing lands at once and widening never, and **a persona can only
+      widen a chat, never restrict it below the plane's own guards**.
+- [ ] **Step 5:** a news entry. **No version bump, no stamping, no tag.**
+- [ ] **Step 6:** commit.
+
+**Stage 5c exit criteria**
+
+- The cap refuses with a reason and a name, and the value is refused rather than clamped.
+- Every chat's cost is visible from the chat you are looking at.
+- Reopening a cold chat says what it will not restore, before it does not restore it.
+- Six real harnesses have been run in six real tabs and the numbers are written down beside the
+  extrapolation they test.
+- The word "boundary" appears in `SECURITY.md` next to the word "not".
+
+---
+
+## Exit criteria for the phase
+
+- **A workspace holds several chats and switching between them loses nothing** — measured, with
+  two real harnesses, across a terminal resize, on tmux 3.7c **and on tmux 3.2**.
+- **Every chat is reachable in ≤2 keystrokes at every width**, including widths where neither bar
+  can be drawn.
+- **A hostile chat label renders as one row and never reaches tmux.**
+- **One chat's harness dying does not touch another chat.**
+- **`state.reap` bounds `.charter/frame/` under the new id shape**, and old-shape frames still
+  launch, report liveness and reap with no migration.
+- **The switch works with `window-resized` removed**, because on `tmuxctl.FLOOR` it does not
+  exist.
+- **Nothing was added to `layout.CARRIABLE`.**
+- **`SECURITY.md` says a tab is not a boundary.**
+- The suite gives the same answer in two environments **and CI is green at the head sha under
+  review**. Two local environments cannot see a CI-only failure: #554's overlay module passed
+  12/12 locally while CI was red at that exact head, and `gh pr checks` reports "no checks
+  reported" and `mergeStateStatus: CLEAN` identically when no run was ever created (#561). Read
+  `gh api repos/diazoxide/charter/commits/<HEAD_SHA>/check-runs`, which cannot confuse the two.
+- **The deletion sweep is run by the repository, not promised by whoever wrote the branch** —
+  `.github/workflows/sweep.yml` on every PR, and `python3 tools/sweep.py` locally before
+  submitting. Four named guards in this phase, four named tests.
+- **Implement, PR, merge — never release alone.** No version bump, no stamping, no tag.

--- a/docs/superpowers/specs/2026-08-25-agentic-ide-foundation.md
+++ b/docs/superpowers/specs/2026-08-25-agentic-ide-foundation.md
@@ -615,6 +615,12 @@ gather grows.
 
 ## 4j. Many chats, many workspaces, many harnesses — settled 2026-08-26
 
+> **Superseded in three places by `docs/superpowers/specs/2026-08-28-phase5-workspace-and-chat-tabs.md`.**
+> The name is `{workspace}.{n}`, allocated, not `{workspace}-{hash}`; panels **follow the active
+> chat** rather than duplicating per chat; and the switch reasserts the layout rather than
+> leaving it to `select-window`. Each was changed by a measurement, quoted there. Everything
+> else below stands.
+
 The IDE holds **workspace tabs**, and under them **chat tabs**. Switching a workspace does not
 lose the chats open in it. Each chat picks its harness when it starts, so several harnesses run
 in parallel in one IDE.
@@ -804,8 +810,21 @@ naming, the harness-session record and tmux's own persistence already exist; wha
 holding several frames per workspace and the two tab bars, both of which are Phase 1 components
 and Phase 2 actions.
 
-**Exit test:** ten chats across three workspaces, switching between any two in one keystroke,
+**Specified in full, 2026-08-28:**
+`docs/superpowers/specs/2026-08-28-phase5-workspace-and-chat-tabs.md`, with the plan at
+`docs/superpowers/plans/2026-08-28-phase5-workspace-and-chat-tabs.md`. **That spec overrides §4j
+in three places**, each because a measurement on this machine said so: the name is allocated
+rather than hashed, panels follow the active chat rather than duplicating per chat, and the
+switch reasserts the layout rather than relying on a `window-resized` hook that does not exist
+at `tmuxctl.FLOOR`.
+
+**Exit test:** ten chats across three workspaces, switching between any two in **≤2 keystrokes**,
 nothing torn down, and the panel cost measured at 5 and 10 rather than assumed.
+
+**"One keystroke" was wrong and is corrected here.** A single dedicated key means `bind -n`,
+which is server-wide and takes that key from every harness in every window — the same reason
+`[frame] component` ships no default toggle key. Two keystrokes is the Phase 2 criterion and it
+is the right one.
 
 ### Phase 4 — the cross-repo change
 *The IDE's actual subject.*

--- a/docs/superpowers/specs/2026-08-28-phase5-workspace-and-chat-tabs.md
+++ b/docs/superpowers/specs/2026-08-28-phase5-workspace-and-chat-tabs.md
@@ -1,0 +1,1007 @@
+# Phase 5 — workspace tabs, chat tabs, and many harnesses in parallel
+
+**Date:** 2026-08-28 · **Status:** specified, unimplemented
+**Settles:** `docs/superpowers/specs/2026-08-25-agentic-ide-foundation.md` §4j and §6's Phase 5
+**Overrides §4j where they disagree**, and they disagree in three places — each one because a
+measurement on this machine said so. The three are marked **OVERRIDES §4j** in the text.
+
+---
+
+## 1. What this is, in the operator's own words
+
+> I have an idea — I want to make our IDEA have a workspace selector, user can switch between
+> workspaces but not lose open sessions. User opening a workspace — and in one workspace he can
+> add chat sessions (tabs). We can use session name — e.g. claude has a session name, we can on
+> creating a new session make some deterministic name e.g. `{workspace}-{some-hash}`. And user
+> can on starting a session select harness. So in one IDEA session user can use many harnesses
+> in parallel.
+
+Recorded as §4j of the foundation spec, settled 2026-08-26.
+
+### The sentence that makes the rest coherent
+
+**Charter is not adding tabs. It is adding many chats. The tab bar is a readout.**
+
+That distinction is load-bearing and it comes out of a measurement (§7.9): a 200-column row
+holds about twelve chat names at charter's own minimum name width of 12 cells
+(`slots._NAME_MIN_W`); an 80-column row holds four. A design in which the bar *is* the
+mechanism breaks at 80 columns. A design in which the bar is a readout and the **palette** is
+the mechanism works at every width, because Phase 2 already reaches every action in ≤2
+keystrokes and does not care how wide the window is.
+
+So: the chat bar and the workspace bar are two new components in the Phase 1 registry, they
+join the existing degradation ladder, and when they cannot be drawn nothing is lost but the
+reminder.
+
+---
+
+## 2. What is already true, and what is not
+
+Facts checked in the tree at `27da88e`, not remembered.
+
+**Already exists and is reused unchanged.**
+
+- `state.frame_id(workspace, pid)` mints `{sanitised workspace}-{pid}`; `_UNSAFE =
+  re.compile(r"[^A-Za-z0-9._-]")` is the alphabet.
+- `state.record_harness_session(fid, sid)` / `state.harness_session(fid)` — charter already
+  records which harness session belongs to which frame, in `.charter/frame/<fid>/session`, at
+  mode 0600. The only process holding both ids at once is `statusline.py:2816`.
+- `.charter/frame/<fid>/` already holds twelve files per frame: `version`, `exit`, `harness`,
+  `session`, `server`, `workspace`, `density`, `chrome`, `hidden`, `identity`, `panes`,
+  `respawn/`.
+- `frame/choose.py` already renders a picker as rows over one `overlay.Surface`, with
+  `OPEN_ID = "pick:{}"` and `NAME_ID = "{}:n{}"`.
+- `palette.own_the_tty(surface, then=…)` is already an N-surface mechanism in one pane. The
+  two-level tree is charter's restraint, not a structural limit.
+- `_split_panels(...)` is the one funnel every panel pane comes out of, and
+  `_apply_arrangement(fid, *, where, want, window=None)` is the one live pane-mutation path.
+- `tmuxctl.chain(argvs)` collapses many tmux commands into one invocation. §7.7 shows this is
+  worth 3.3× on the switch path.
+- **The guest path already treats a frame as a window.** `_launch_in_operator_tmux` creates a
+  `new-window -n <fid>`, and `_live_windows` reads liveness from `list-windows -a -F
+  '#{window_name}'`. Phase 5 makes the private path work the way the guest path already does.
+
+**Does not exist.**
+
+- `grep -rn "tab" charter/frame/` is empty. There is no tab concept anywhere.
+- `switch-client` is not used anywhere in the tree.
+- `new-window` is used on the guest path only; nothing ever creates a second window on
+  charter's private server.
+- The `Harness` interface has `name`, `deficits`, `cli_name`, `binary`, `launch_argv(extra)`,
+  `detect()` and the wiring/rule methods. There is **no session flag, no resume flag, no
+  session-id flag, no cwd field and no auth field** anywhere under `charter/harness/`.
+
+---
+
+## 3. The seven questions, decided
+
+### 3.1 What a chat tab is, concretely
+
+**A chat is a charter frame. A frame is a tmux window. The window is where the chat is drawn;
+the frame directory is what the chat is.**
+
+Precisely: a chat is a directory `.charter/frame/<chat id>/` whose panes live in one tmux
+window on the workspace's tmux session. Identity lives on disk. The window is a rendering.
+
+This changes two words in charter's vocabulary and nothing else:
+
+| today | Phase 5 |
+|---|---|
+| a frame is a tmux **session** on `-L charter` | a frame is a tmux **window** |
+| a tmux session is a frame | a tmux session is a **workspace** |
+
+Switching chats is `select-window`; switching workspaces is `switch-client -t`. Measured
+(§7.6): both preserve every pane and neither reattaches or kills the client.
+
+#### The adversary: *"tmux already has windows and sessions. What is charter adding that `tmux new-window` is not?"*
+
+Five things, each measured or read out of the tree, and the last one is the answer on its own.
+
+1. **`new-window` cannot say which harness with which identity.** Measured (§7.5): `new-window
+   -e CHARTER_SESSION_ID=chat-A -e CHARTER_HARNESS=claude-code` works on 3.7c and on 3.2 and
+   overrides a session-wide `set-environment`. Somebody still has to compose that argv, hold it
+   to `layout.CARRIABLE` (which raises on any other name), and mint the id. That is charter.
+2. **A tmux window name is not an identity, and it is not even one thing.** Measured (§7.3):
+   `automatic-rename` is **on** by default and renamed my eight test windows to `zsh`, `tmux`,
+   `bash` and `kernel_task`, following whatever ran in them. `allow-rename` is **off** by
+   default, and with it on, `printf '\033kPWNED\033\\'` from inside the pane set the window
+   name to `PWNED` — the harness's own output naming charter's tab. And `rename-window` with a
+   newline is **refused on 3.7c** (`invalid window name`, rc=1) and **accepted on 3.2**, stored
+   escaped as the four characters `a\nb`. Three mechanisms, two versions, four answers. The tab
+   bar therefore reads charter's own record and never `#{window_name}`.
+3. **The panels.** `new-window` gives one pane. A chat is a harness pane plus the panel panes
+   `_split_panels` creates — sized by `layout`, styled per component through
+   `instance.pane_bg_options`, with `remain-on-exit` set and two `pane-died` hooks armed before
+   anything can die.
+4. **The record.** Twelve files per frame that tmux has no place for, at modes charter chose
+   rather than the umask (#505/#603).
+5. **The switch is not `select-window`, and cannot be.** Measured (§7.4): a background window
+   keeps its stale geometry. With the client resized 200×50 → 100×30, the active window followed
+   and the background window stayed at 200×50 until `select-window`, which resized it *then*.
+   On 3.7c that fires `window-resized` (2 events measured). On **tmux 3.2 — `tmuxctl.FLOOR` —
+   `set-hook -w window-resized` returns `invalid option: window-resized`, rc=1.** The hook does
+   not exist. So on the floor charter promises to run on, a bare `tmux select-window` leaves a
+   chat's panels laid out for a window size that is no longer true, with nothing to repair it.
+   Charter's switch must reassert the layout itself. **That is not a convenience over tmux; it
+   is a correction of it.**
+
+### 3.2 The deterministic name
+
+The operator wrote `{workspace}-{some-hash}`. **The word doing the work in that sentence is
+"deterministic", and it has two readings.** Reading it as *reproducible from inputs* produces a
+design that collides and breaks reaping. Reading it as *charter chooses it, nobody is prompted*
+produces a clean one. Phase 5 takes the second reading, and here is why the first fails.
+
+**Decision: a chat's id is `{workspace}.{n}` — the sanitised workspace name, a dot, and an
+ordinal. It is allocated, not computed. Nothing is hashed.** **OVERRIDES §4j**, which repeats
+the operator's `{workspace}-{hash}`.
+
+**What would be hashed, and why that is the problem.** The only inputs available at creation are
+the workspace, the chosen harness, the wall clock and a sequence number. Hashing the clock or
+the sequence produces a random-looking string carrying no more information than the counter it
+hides. Hashing (workspace, harness) is *not unique by construction* — two Claude chats in the
+same workspace hash the same. So the only hash that works is a hash of a counter, which is a
+counter wearing a disguise.
+
+**Collisions are silent and expensive.** A truncated hash collides at √(2^b): six hex characters
+is ~4,000 chats before a coin-flip. That is comfortably beyond one person's use, and the failure
+mode is what makes it unacceptable rather than the probability. Two chats sharing
+`.charter/frame/<fid>/` share `session`, `panes`, `version` and `workspace` — one chat's token
+gauge, pane map and repaint clock overwrite the other's, and nothing reports it. A counter
+cannot collide because it is **allocated**, not computed.
+
+**Allocation is a `mkdir`, not a scan.** The ordinal is the smallest positive integer whose
+directory does not exist. Charter claims it with a bare `os.mkdir(d, 0o700)` followed by an
+explicit `os.chmod(d, 0o700)` — *not* `config.private_mkdir`, which swallows `FileExistsError`
+on a directory (#331) and is therefore idempotent, which is precisely wrong for an allocator.
+`FileExistsError` is the claim failing; try `n+1`. Two racing allocators cannot both win.
+
+**Why the dot, and why it is not cosmetic.** `state._launcher_pid(name)` does
+`name.rpartition("-")` and requires a non-empty head and a digit tail; `is_live` and `reap` both
+depend on it, and `reap` is the only thing that bounds `.charter/frame/`. An id ending
+`-{ordinal}` would read `2` as a pid — and pid 2 is alive on every Unix, so every dead chat
+would look live forever. `{workspace}.{n}` makes `_launcher_pid` return `None`, and **that
+`None` is the version discriminator**: an id it can parse is an old `{workspace}-{pid}` frame
+and keeps the pid liveness rule; an id it cannot parse is a chat and takes liveness from
+`list-windows`, exactly as the guest path already does. No flag day, no migration, no new
+field.
+
+**It is legible.** `api.3` is a thing a person says out loud. `api-9f3a1c` is not, and the tab
+bar is a readout.
+
+#### What reaches tmux, and what does not
+
+A chat has **two strings and they have different alphabets**, and conflating them is how the
+`[frame] hotkey` class of bug happens.
+
+| | alphabet | where it goes |
+|---|---|---|
+| **id** — `api.3` | `_UNSAFE`-sanitised workspace + `.` + digits. Closed. | `new-window -n`, `split-window` argv, `-e CHARTER_SESSION_ID=`, the directory name |
+| **label** — whatever the operator or the harness calls it | open | the tab bar and the palette row, and **nowhere else** |
+
+The label is `contain.one_line`'d **before width arithmetic** (#472), in `Surface.render` and in
+the `chats` component, and never reaches a tmux argv or a tmux format string. That last clause
+is not caution, it is measured: §7.3 shows `rename-window 'chat#{pane_pid}X'` stores the name
+**already expanded** as `chat4327X`, and `#{E:@charter_chat}` expands a `#{...}` in a user
+option's value (`#{pane_pid}` → `4327`). A name routed through a tmux format is a format
+injection on the first hop.
+
+A chat's palette row id is `chat:<chat id>`. The `:` puts it in `choose.py`'s picker namespace,
+which `component._ID_RE` forbids for action ids and component ids — so a provider shipping an
+action called `chat` cannot steal the keypress, and the row is correctly excluded from
+`palette.matches`' id filter, the same way workspace and persona name rows already are.
+
+#### The adversary: *"what happens when the operator renames a workspace?"*
+
+Nothing, and that is a property rather than an accident. **The id is a name, not a pointer, and
+it is never parsed for meaning.** `frame_workspace(fid)` reads the workspace from
+`.charter/frame/<fid>/workspace`, name-checked through `workspace.valid_name`, and that file can
+be repointed. A renamed workspace's chats keep ids spelling the old name and keep working; the
+tab bar shows the workspace the file names, not the prefix of the id. Pin it with a test that
+renames a workspace under two live chats and asserts both still resolve.
+
+The one place a rename does cost something: allocation scans `.charter/frame/` for
+`{new name}.*`, so chat 1 in the renamed workspace may be `newname.1` while a sibling is
+`oldname.2`. That is ugly and harmless, and rewriting ids to fix it would break every
+`$CHARTER_SESSION_ID` already exported into a live process. **Do not fix it.**
+
+### 3.3 "Switch without losing sessions" — and what it costs
+
+**What keeps a session alive is tmux, and it costs almost nothing. What keeps a *harness* alive
+is the harness, and it costs 226 MB.** Everything below is measured on this machine; commands
+are in §7.
+
+Per chat, at rest:
+
+| | measured | note |
+|---|---|---|
+| tmux window structure | **~4.5 KB**, **1 fd** | §7.1 — 7 extra windows moved the server 3,792 → 3,824 KB and 15 → 22 fds |
+| tmux scrollback | **up to 127 MB** | §7.2 — one 200-column pane filling charter's shipped `history_limit = 50000` took the server 3,776 → 130,624 KB |
+| charter panel process | **23.7 MB RSS / 15.4 MB phys_footprint** idle, **36.8 MB peak RSS** through a full paint | §7.8 — ×4 per chat as things stand |
+| the harness | **226 MB mean, 660 MB max** | §7.8 — 19 live `claude` processes on this machine right now sum to 4.29 GB |
+
+Eight workspaces with two chats each, extrapolated honestly and with the panels-per-chat model
+§4j proposed:
+
+- 64 panel processes → **1.5 GB resident / 986 MB dirty**
+- 16 harnesses → **3.6 GB**
+- tmux structure → ~4 MB. fds → ~94, against a soft limit of 1,048,576 and a
+  `kern.maxfilesperproc` of 184,320. **File descriptors are not a constraint and will not
+  become one.**
+- scrollback → unbounded in practice, and it lives in **one process's heap**, not spread across
+  processes the kernel can page independently.
+
+**Total ≈ 5.1 GB before scrollback, and scrollback can exceed everything else combined.**
+
+Two decisions fall straight out of that.
+
+**Decision: a chat has three states, not two.**
+
+- **live** — the tmux window exists, the harness is running, the record is current.
+- **cold** — the record exists, the window does not, the harness is not running. Reopening is a
+  relaunch (§3.4 says exactly what that does and does not restore).
+- **gone** — reaped.
+
+The distinction matters because "switching away does not lose the chat" and "switching away
+keeps 226 MB and a token meter running" are two different promises and only the first is what
+the operator asked for.
+
+**Decision: charter caps live chats per plane, and refuses past the cap with a reason and a
+name.** The cap is per plane, not per workspace, because the memory is the machine's, not the
+workspace's. Recommended default **6** — six harnesses at the measured mean is ~1.4 GB plus
+~370 MB of panels, which a laptop survives; sixteen is 5 GB, which it does not. The refusal
+follows the palette rule from Phase 2: it appears **with its reason**, and it names the coldest
+live chat so the operator has one thing to do rather than a lecture.
+
+#### The adversary: *"eight live harnesses is eight times the memory and eight agents burning tokens while you look at one of them. Who pays for that, and does the operator know?"*
+
+The operator pays, and **today charter does not tell them**. That is the actual defect this
+question exposes, and it is not fixed by capping. So:
+
+**Decision: the `chats` component shows cost, not just names.** Charter already records
+`harness_session(fid)` and `slots.py:384` already draws a token-usage gauge from it for the
+frame in front of you. Phase 5 draws that gauge for **every** chat in the workspace, on the one
+row you are looking at. A chat burning tokens behind your back says so on the tab.
+
+And running is distinguished from idle, because an idle chat costs memory and no tokens while a
+running one costs both. Two sources, both existing: `charter/inflight.py`, which the `attention`
+component already reads; and tmux's own per-window flags — measured (§7.3), a background window
+with `monitor-activity on` sets `#{window_activity_flag}` on any output and
+`#{window_bell_flag}` on a BEL, and both read back through one `display-message -p -F` over the
+session's windows, the same shape as the existing `_measure_window`.
+
+**Charter sets `monitor-activity on` per chat window and reads those flags. It does not touch
+`bell-action`.** Measured defaults are `monitor-activity off`, `monitor-bell on`,
+`activity-action other`, `bell-action any`. `bell-action any` means a background chat's bell
+reaches the operator's terminal — which is arguably exactly right and arguably a nuisance, and
+charter's conf is session-scoped (`set -t <session>`), so charter would be overriding a personal
+preference for a benefit it cannot measure. Leave it alone and say so in `docs/frame.md`.
+
+The activity flag is a **hint, not a truth**: "bytes moved" includes a spinner. The
+`inflight` reading is the one charter states; the tmux flag is what it falls back to for a
+harness that reports nothing.
+
+#### The adversary: *"if a session survives switching away, what happens when it finishes, fails, or asks a question nobody is looking at?"*
+
+Three answers, one per case, and the first two already have machinery.
+
+- **It fails.** `remain-on-exit on` is already set on every charter pane, and two pane-scoped
+  `pane-died` hooks are already armed on the harness pane before it can die. Today the teardown
+  hook runs `kill-session`. **Under tabs it must run `kill-window`**, or one chat's harness dying
+  takes the whole workspace with it, including the other chats — including chats mid-turn. This
+  is the single most dangerous line in the port and it gets its own task and its own test.
+- **It finishes.** The pane goes dead, `remain-on-exit` keeps it, `#{pane_dead}` reads true, and
+  the chat's mark on the tab bar changes. Nothing is reaped while the window exists.
+- **It asks a question.** This is the one with no machinery, and it is why the tab bar is a
+  readout rather than decoration: a background chat has no panels of its own (§3.7), so its
+  attention row is by definition not on screen. The active chat's `chats` row carries every
+  chat's state. That is strictly better than the alternative, in which the row that would tell
+  you is in the window you are not looking at.
+
+### 3.4 Many harnesses in parallel — what charter owns
+
+**Charter owns the container, the identity and the record. It owns nothing inside the harness.**
+ADR 0018 — charter may run the harness but never draws it — is the same rule seen from the other
+side.
+
+**Charter owns:**
+
+1. **The window**, and every pane in it except the harness pane.
+2. **The identity carried in at creation**: `-e CHARTER_SESSION_ID=<chat id>`, `-e
+   CHARTER_HARNESS=<name>`, and the rest of `layout.CARRIABLE` — `CHARTER_ROOT`,
+   `CHARTER_WORKSPACE`, `CHARTER_PERSONA`, `PATH`. **Nothing else, ever**, because
+   `layout._env_argv` raises on any other name and because a tmux `-e` becomes world-readable
+   argv (already measured on this repo at 138 argv elements, 7,696 bytes, and two live
+   service-account tokens — which is why `_frame_identity_env` exists).
+3. **The record**, `.charter/frame/<chat id>/`, including `session` — the harness's own session
+   id, as the harness's own hook reports it to charter. Charter writes down what it was told.
+4. **The working directory** it starts the harness in. cwd is the frame launcher's business
+   today and stays so; the `Harness` interface has no cwd field and does not need one.
+
+**Charter does not own, and must not touch:**
+
+1. **The harness's session store.** Charter never enumerates it. §4j settled this and the tree
+   confirms why: Claude Code's id arrives as `$CLAUDE_CODE_SESSION_ID` and in the statusLine
+   payload; opencode's plugin reads `input.sessionID` off `shell.env` **per invocation** because
+   one server hosts many sessions and nothing may be cached; codex has only the payload
+   `session_id`. Three stores, three shapes, and asking each "what sessions do you have" is
+   harness-specific work that fights the point of being harness-agnostic.
+2. **The harness's auth.** Every harness authenticates itself, entirely outside the abstraction.
+   Two chats on the same harness share that harness's credentials. Charter cannot separate them
+   and does not pretend to (§4).
+3. **Anything drawn in the harness pane.** ADR 0018, enforced by construction: `_surface_argvs`
+   never takes the harness pane as an argument.
+
+#### The consequence nobody will like, stated up front
+
+**A cold chat cannot be resumed. Reopening one starts a fresh harness session.**
+
+Charter records the harness's session id and has nowhere to send it back: there is no resume
+member on `Harness`. `state.clear_shape(fid)` already unlinks `session` at launch for exactly
+this reason (#413) — a new frame claiming a recycled id must not inherit another chat's gauge.
+
+Adding `resume_argv` to `Harness` means charter shipping a claim it can verify for one of three
+harnesses. `harness/base.py`'s own docstring sets the bar — *"A fifth member needs the same kind
+of argument, not just a use."* **Phase 5 does not add it.** It ships the honest behaviour: the
+chat id, the workspace, the persona and the cwd all come back; the conversation does not, and
+the message says so before the relaunch, not after. Resume is a Phase 6 question with a real
+design cost, and a resume that silently starts a new conversation is worse than a sentence
+admitting it will.
+
+### 3.5 Where the state lives
+
+`.charter/frame/<chat id>/`, in the shape that already exists, at the modes charter chose.
+
+- Directories 0700 through `config._mkdir_0700`, which does an explicit `os.chmod` **after**
+  `mkdir` because mkdir's mode is umask-masked (#470).
+- Files 0600 through `config.write_for` → `_private_fd`: `os.open(..., O_CREAT,
+  STATE_FILE_MODE)` then `os.fchmod`, deliberately **without** `O_TRUNC` because truncating
+  first would empty the file at its old mode (#437/#505/#603). Every writer is
+  temp-then-`os.replace`, and the temp file's mode is what settles the destination's.
+- Anything new that writes must go through `write_for` or `tests/_statedirscan.py` fails the
+  build — it follows a path through one level of indirection, cross-module, and through a
+  function's return value (#581/#582).
+
+**Two new files per chat, and no index.**
+
+- `.charter/frame/<chat id>/label` — the display name. Open alphabet, contained at render.
+- `.charter/frame/<chat id>/created` — the allocation stamp, so tab order and the ordinal
+  allocator do not depend on directory mtime.
+
+**Decision: there is no per-workspace index of chats. The directory is the list.** An index
+would make "which chats does this workspace have" one read instead of an `os.scandir` over
+~30 entries — and it would be a second source of truth for a fact the directory already holds,
+free to disagree with it. That is the #411 shape: writing a pointer some readers may not read.
+The scan is cheap and `gather` already caches a plane snapshot per frame.
+
+**What stops one chat writing another's state.** `state.frame_dir(fid, create=True)` resolves
+through `contain.child(_root(), fid)` and returns `None` for a hostile id — every Phase 5 writer
+goes through it. Around that: `contain.write_refusal`/`writable` refuse writes outside the data
+roots; `hooks._state_write_reason` denies a Write or Edit whose target resolves under
+`config.STATE_DIR`; `toolgate._control_surface_paths` holds both the declared and the `realpath`
+spelling of `STATE_DIR`, `VAULTS_DIR` and every registered vault file.
+
+And the limit, said plainly because the assessment insists on it: **the chat id is an identity,
+not a capability.** A process that can set `$CHARTER_SESSION_ID` to another chat's id writes
+that chat's directory, because the env var *is* the identity. That is not a hole Phase 5 opens;
+it is what identity means. These are guard rails against a mistake, not a boundary against an
+attacker with shell access as your user (`SECURITY.md:43-46`).
+
+### 3.6 The surface
+
+**Decision: no new chrome for choosing. Two new components for showing. Everything stays within
+Phase 2's ≤2-keystroke criterion.**
+
+**Choosing reuses Phase 2 exactly.** `choose.py` gains `CHAT` as a third noun in `NOUNS`, with
+`OPEN_ID`/`NAME_ID` unchanged; the palette grows two doorway rows, `pick:chat` and
+`pick:harness`, beside `pick:workspace` and `pick:persona`. `F2` then a filter or an arrow and
+Enter — two keystrokes, the same as switching workspace today. `palette.own_the_tty`'s `then=`
+seam runs the second surface in the same pane without leaving raw mode; the chat picker is a
+third row source over one `Surface`, so there is no new input loop, no new modal and no second
+escape hatch.
+
+`F12` keeps working per chat with no new mechanism, and this is the neat part: the hatch is a
+**window** option, `@charter_hatch`, resolved by `run-shell -C '#{@charter_hatch}'` in the
+presser's own window. One chat per window means one hatch per chat, for free. `F2` likewise
+carries no frame identity in its bind text — it resolves `$CHARTER_SESSION_ID` at fire time —
+and per-window `-e` (§7.5) is what makes that variable per-chat.
+
+**No default key for next-chat or previous-chat.** `bind -n` is server-wide and would take a key
+from every harness in every window. `[frame] component` already validates an operator-chosen
+`key` per component through `instance.toggle_key` / `_HOTKEY_RE`, and
+`instance.component_tables` already refuses a key that collides with `[frame] hotkey`. Same rule,
+same validator, and the same deliberate absence of a default.
+
+**Showing needs two components**, both in the Phase 1 registry, both `edge="top"`,
+`size=Fixed(1)`:
+
+- `workspaces` — the workspace bar.
+- `chats` — the chat bar. It **hides itself when there is one chat**, showing only the "add
+  chat" affordance (§4j). A bar earns its row only when there is something to choose between.
+
+Both join `layout._DROP_ORDER`, **above `top`**: `("right", "repos", "chats", "workspaces",
+"top")`. On a short window the bars are the first things to go, because the palette still
+reaches every chat at every size and the bars are a readout.
+
+**Degradation within the row, which is where the GUI metaphor is actually tested.** The chat bar
+shows the active chat's label in full and the others as their state marks plus a count. It never
+wraps, never scrolls, and never truncates a name below `slots._NAME_MIN_W` (12 cells) — below
+that it shows marks only. `contain.one_line` runs before any of that arithmetic (#472).
+
+#### The adversary: *"this is an IDE feature borrowed from GUI editors. Does it survive contact with a terminal, or is it a metaphor that breaks?"*
+
+**The bar breaks. The feature does not, because the bar is not the feature.**
+
+Measured against charter's own minimum: a 200-column row holds about twelve names at 12 cells
+plus a mark; an 80-column row holds four; a 40-column pane holds one. A design that made the bar
+the way you switch chats would work on the author's monitor and fail on a laptop in a split. So
+the bar degrades to a status indicator and the palette — which is a **full pane** by §4k, sized
+to whatever it is given, with no row cap since Phase 2 — is the mechanism. On a 40-column window
+you cannot see the tabs and you can still reach all six chats in two keystrokes.
+
+The metaphor that genuinely does not survive, and Phase 5 does not attempt it: **dragging a tab,
+tearing one off into its own window, or moving a chat between workspaces.** §4j settled the
+last one — a chat belongs to its workspace for life, because the harness's own context is its
+cwd, its files and its history, and moving it makes all three about a different plane. A
+conversation wanted elsewhere is a new chat.
+
+### 3.7 What happens to the frame
+
+§4j said: panels duplicate per chat, measure at 5 and 10, then decide. **The measurements are
+in, and the decision changes.**
+
+**Decision: panels do not duplicate per chat. Panels follow the active chat.** **OVERRIDES §4j.**
+
+Three measurements force it:
+
+1. **Cost.** 4 panel processes per chat × 8 chats = 32 processes at 23.7 MB resident /
+   15.4 MB dirty = **758 MB resident**, all rendering the same `gather.json` at the same
+   `state.version`, of which the operator can see four.
+2. **Correctness.** A background window **does not resize** (§7.4, measured identically on 3.7c
+   and 3.2). Background panels are not merely idle; they are rendering at a width that is wrong.
+   That is exactly `panel._component_text`'s `width=slots._width()` guard — the one the deletion
+   sweep found, where a constant width made a provider's output wrap and destroy the frame in a
+   40-column pane.
+3. **Repairability.** On tmux 3.2 there is no `window-resized` hook at all (`invalid option`,
+   rc=1). The repair path charter would rely on does not exist at `tmuxctl.FLOOR`.
+
+Under "panels follow the active chat" all three vanish at once, and the third is the elegant
+part: **panels are created after the switch, in a window tmux has just resized, so they are born
+at the right width.** There is nothing stale to repair, so the missing 3.2 hook stops mattering
+for panels. (The harness pane in a background window is still stale-width and is resized by tmux
+at `select-window`; how it redraws on SIGWINCH is the harness's business — ADR 0018.)
+
+**The switch, mechanically**, and every step is an existing path:
+
+1. `select-window -t <window id>` on the workspace's session.
+2. `_apply_arrangement(old chat, want=[])` — tear down the previous chat's panels. This is the
+   same funnel a density change or a component toggle already uses.
+3. `_apply_arrangement(new chat, want=<arrangement>)` — split them into the now-active window
+   via `_split_panels`, the one funnel every panel pane comes out of.
+4. `state.bump(new chat)` so the panels paint. **Bump, not just write a pointer** — #411/#412.
+
+**The cost, measured (§7.7):** `select-window` 4.4 ms; four `kill-pane` chained through
+`tmuxctl.chain` 4.9 ms; four `split-window` chained 6.7 ms. **~16 ms of tmux work per switch**,
+against 41.5 ms if each command were its own invocation — chaining is worth 3.3× here and is not
+optional. The panels then paint about 90 ms later, which is one `charter panel … --once`
+process start (`/usr/bin/time` real 0.08–0.09 s, of which `import charter.frame` is 26 ms warm).
+
+Nothing is lost in the teardown, and this is a real property of the current design rather than a
+hope: a panel is a pure renderer over `gather.json` plus `state.version`. `panel.run` claims a
+pane, watches a version file, and paints. **No state lives in a panel process.**
+
+#### Two alternatives, rejected in writing
+
+- **Chats as panes in one window, the active one zoomed.** Tempting — `resize-pane -Z` is
+  already in charter's command surface for the palette, and it would give one set of panels per
+  *workspace*, cutting 128 processes to 32 at eight workspaces. It fails on the thing the frame
+  exists for: tmux's zoom is a whole-window takeover, so a zoomed chat hides the panels. A frame
+  whose panels disappear whenever you look at a chat is not a frame.
+- **`join-pane` the panels into the target window on each switch.** Four `join-pane` calls that
+  mutate the pane tree of two windows at once, against a `_relayout` that is explicitly *not*
+  transactional. A failure halfway leaves the panels in neither window.
+
+#### The adversary: *"you just made switching four times slower than `select-window`"*
+
+Yes — 16 ms instead of 4.4 ms, both comfortably inside the band where a terminal reads as
+instant, with a ~90 ms lag before the panels have text in them. In exchange: 758 MB of processes
+not started, and no panel anywhere rendering at a width that is not its window's. If measurement
+later shows the paint lag is visible, the fallback is to keep the *previous* chat's panels alive
+for one switch — but that is a cache, and building it now, unmeasured, is §4d's layout engine
+arriving through the back door for the third time.
+
+---
+
+## 4. Security
+
+Priority one on this project, and the honest answer here is smaller than the feature looks.
+
+### The property
+
+**Two chats in one plane hold the same authority. Charter's only real separation is that each
+chat's *record* is its own. Phase 5 must not claim more, and — because a tab looks like a
+boundary — it must say so where an operator reads it.**
+
+That is the property, not a list, and it follows from what charter is. Two harness processes run
+as the same uid, under the same `CHARTER_ROOT`, with the same vaults, on the same filesystem.
+Nothing in POSIX separates them without a sandbox charter does not have and has never claimed.
+`SECURITY.md:43-46` already says the shape of it: *"Guard rails, not guarantees… a guard against
+mistakes, not an attacker with shell access as your user."*
+
+**So the deliverable here is a sentence in `docs/frame.md` and `SECURITY.md`, not a mechanism:**
+*a chat tab is a container, not a boundary; two chats in one plane can read each other's files
+and each other's vaults, and the second tab does not add that risk — it multiplies the number of
+processes that hold it.* Writing a mechanism that half-separates them would be the exact defect
+the security assessment's headline names: a claim that is false in a reachable configuration is
+worse than no claim.
+
+### What Phase 5 does give, and it is real
+
+**Per-chat identity makes per-chat policy work with no new code.** `session.current()` reads
+`$CHARTER_SESSION_ID`, which under tabs is the chat id, so every per-session pointer becomes
+per-chat automatically: `.charter/sessions/<chat id>.persona`, `.workspace`, `.tools` and
+`.gate`. Two chats can therefore run different personas with different tool ceilings, each
+enforced in its own process by its own `toolgate.decide`.
+
+**The narrowing property carries.** `toolgate.frozen_tools` intersects — `tools &= frozen` — so
+narrowing takes effect at once and widening never does. A chat that starts under a narrow
+persona cannot widen itself mid-session by switching persona.
+
+### If two tabs run different personas, exactly what each may do
+
+- Each chat's `toolgate.decide` reads `persona.resolve_active()` from **that chat's own**
+  pointer, and grants exactly `persona.effective_tools(that persona) ∩ frozen_tools(that
+  persona, that chat id)`.
+- `effective_tools(name)` is that persona's own `tools:` ∪ the `tools:` of everything in its
+  `borrows:` — or, when `borrows:` is absent, everything in its `uses:`. Per-persona, computed
+  per name; `toolgate.snapshot()` writes `{persona: [tools]}` for **every** persona at
+  SessionStart, keyed separately, so opting one persona in never alters another's.
+- A chat under `release` may auto-approve the binaries `release`'s own charter names, and
+  nothing `forge`'s charter names unless `release` borrows `forge`.
+- **Neither may deny.** `toolgate.decide` returns `None` or an allow and never a denial
+  (`toolgate.py:10-11`), and the leak guard runs before it (`hooks.py:1293` before `:1339`). A
+  persona cannot restrict a chat below the plane's own guards; it can only widen it. An operator
+  who reads a narrow persona as a sandbox has misread it, in one tab or in six.
+- **The grant is per-persona and #575 closed four fail-opens there this week** — a miscased
+  `Borrows:`, a miscased `Extends:`, and duplicate declarations of either, each of which handed
+  back the wider legacy grant. `persona._borrows_unreadable` now asks the **whole lineage**, and
+  `borrows_of` returns `[]` rather than `None` when it cannot read, failing narrow. Phase 5 adds
+  no new grant path, which is the point: **every chat resolves its persona through the same
+  ladder, so there is exactly one place for the fifth fail-open to be found.**
+
+### What Phase 5 must not do
+
+- **No new environment variable.** `layout.CARRIABLE` is a hard funnel and `-e` becomes
+  world-readable argv. A per-chat secret, token or vault handle passed this way would be visible
+  in `ps` to every user on the machine.
+- **No index file naming chats outside the frame directory** (§3.5) — a second writable surface
+  for no gain.
+- **No claim that a chat isolates anything.**
+
+### The standing rule
+
+**Implement, PR, merge — never release alone.** No version bump, no stamping, no tag anywhere in
+Phase 5. The release is the operator's, and autonomy stops at it.
+
+---
+
+## 5. One real session, end to end
+
+Workspace `charter`, two chats, two harnesses, switch away, come back. This is the sequence, and
+every named function is one that exists today unless marked **new**.
+
+**1. Open the workspace.** `charter claude` in the operator's shell.
+`cmd_launch` resolves the harness, `_choose_workspace` returns `charter`, and — **new** —
+instead of `state.frame_id(ws, os.getpid())` it calls `state.new_chat_id("charter")`, which
+`os.mkdir`s `.charter/frame/charter.1` at 0700 and returns `charter.1`.
+
+`layout.session_argv` creates the tmux session **named after the workspace**, not the frame:
+
+```
+tmux -L charter -f <conf> new-session -d -s charter -x 200 -y 50 \
+  -P -F '#{pane_id}' -e CHARTER_SESSION_ID=charter.1 -e CHARTER_HARNESS=claude-code \
+  -e CHARTER_ROOT=… -e CHARTER_WORKSPACE=charter -e PATH=… -- claude
+```
+
+Then, as today: `source-file <conf>`, four `set-environment -t charter`, `arm_hatch_argv` on the
+harness pane, two pane-scoped `pane-died` hooks — **whose teardown now runs `kill-window`, not
+`kill-session`** — `_split_panels` for the four panels, `select-pane`, and `attach -t charter`.
+
+**New, and one line:** `set -w -t <window> monitor-activity on`, and
+`set -w -t <window> @charter_chat charter.1`. The second is why every later lookup can ask the
+window what chat it is without parsing anything.
+
+**2. Add a second chat, on a different harness.** `F2` → `pick:harness` → `codex`. Two
+keystrokes plus a pick.
+
+`builtin_actions._spawn` fires and reports (actions are fire-and-report, never blocking — §4g),
+and the spawned process: allocates `charter.2` by `mkdir`; runs one chained invocation —
+
+```
+tmux -L charter new-window -d -t charter -n charter.2 \
+  -e CHARTER_SESSION_ID=charter.2 -e CHARTER_HARNESS=codex -e CHARTER_WORKSPACE=charter … \
+  -P -F '#{window_id} #{pane_id}' -- codex \
+  ';' set -w -t <window id> @charter_chat charter.2 \
+  ';' set -w -t <window id> monitor-activity on
+```
+
+— records `harness_pane`, `workspace` and `server`, arms the hatch and the two `pane-died` hooks
+on the new harness pane, and hands off to the switch (step 3) to make it active.
+
+The old chat's `chats` component repaints on the next `state.bump` and now draws two entries, so
+the bar appears for the first time — it hid itself while there was one chat.
+
+**3. Switch to chat 2.** The switch action, ~16 ms of tmux:
+
+```
+tmux -L charter select-window -t <window id of charter.2>
+tmux -L charter kill-pane -t %5 ';' kill-pane -t %6 ';' kill-pane -t %7 ';' kill-pane -t %8
+tmux -L charter split-window … ';' split-window … ';' split-window … ';' split-window …
+```
+
+then `state.record_panes(charter.2, …)` and `state.bump(charter.2)`. tmux resized
+`charter.2`'s window at `select-window`, so the four new panels are born at the true width. The
+first paint lands ~90 ms later.
+
+**4. Switch away — to another workspace.** `F2` → `pick:workspace` → `api`. Measured (§7.6):
+`switch-client -c <tty> -t api` moves the client without killing it and without killing a pane;
+both `charter`'s windows and both harnesses stay alive with the same pids.
+
+Charter's own bookkeeping on the way out: `state.bump` the chat now becoming active in `api`,
+and leave `charter.1` and `charter.2` alone. **The panels of `charter.2` are torn down** — the
+same `_apply_arrangement(want=[])` — because no chat in a background workspace has panels.
+
+`charter.1` and `charter.2` are now what §3.3 calls **live**: harnesses running, tokens
+possibly burning, no panels, one tmux window each holding one pane.
+
+**5. Come back.** `F2` → `pick:workspace` → `charter`. `switch-client -t charter` puts the
+client back on the session; tmux restores its last active window, `charter.2`. The switch action
+splits `charter.2`'s panels into the freshly-resized window and bumps.
+
+If the operator resized the terminal while away, this is the case that would have been broken by
+a bare `select-window` on tmux 3.2 — no `window-resized` hook, stale geometry, panels laid out
+for a window that no longer exists at that size. It is not broken here because the panels did
+not exist to be stale: they are created after the resize, by the switch, on every tmux version.
+
+**6. What the operator sees.** Row 0: the workspace bar, `charter` marked. Row 1: the chat bar —
+`charter.2` in full with its harness and its token gauge, `charter.1` as a mark plus its gauge,
+and if `charter.1` produced output while nobody was looking, its activity mark. Below that,
+today's frame exactly: identity, the harness pane, the sidebar, repos, attention.
+
+---
+
+## 6. Decisions that need the operator
+
+Each is answerable in one word. Each has a recommendation and the reasoning behind it.
+
+**6.1 The live-chat cap. Recommend 6.**
+Six harnesses at the measured mean of 226 MB is ~1.4 GB, plus ~370 MB of panels — a laptop
+survives it. Sixteen is 5.1 GB before scrollback and it does not. The number is a default, not a
+law: `[frame] max_chats`, validated at the config boundary, refused rather than clamped, the way
+`FRAME_PANE_PAD_MAX` already is.
+
+**6.2 A lower `history-limit` for chat windows. Recommend yes — 20,000.**
+Charter ships `history_limit = 50000`, which is 25× tmux's default, and it is set per session,
+so under tabs it applies to every chat in a workspace. Measured: one 200-column pane filling
+50,000 lines took the shared tmux server from 3.8 MB to **130.6 MB**. That is one pane, in the
+one process that holds every chat in every workspace on the machine. 20,000 lines is still 10×
+tmux's default and caps the same pane near 50 MB.
+
+**6.3 Reopening a cold chat starts a fresh harness session. Recommend yes, with a message.**
+There is no resume member on `Harness` and adding one means a claim charter can verify for one
+of three harnesses (§3.4). The alternative — refusing to reopen at all — is worse: it makes
+"cold" mean "gone" and deletes the workspace, persona and cwd charter *can* restore. The message
+goes before the relaunch, not after.
+
+---
+
+## 7. Measurements
+
+Every command was run on this machine, 2026-08-28, macOS (Darwin 25.2.0), Apple silicon, Python
+3.14.4. tmux 3.7c is `/opt/homebrew/bin/tmux`; tmux 3.2 is the binary built from source for the
+Phase 3.5 work, at
+`…/scratchpad/task7-a6e19896/tmux-3.2/tmux`. Every test server ran on its own `-L` socket and
+none of them was charter's own `-L charter`.
+
+Context for the 3.2 column: Phase 3.5 rebuilt 3.2 from the release tarball and re-ran the whole
+of the visual design spec's §1 and §4 against it — **sixty-six of sixty-eight answers were
+byte-identical to 3.7c**, and the two that were not were the measuring harness's own batching.
+The divergences below are therefore worth reading as genuine, not as noise.
+
+### 7.1 A tmux window costs 4.5 KB and one file descriptor
+
+```
+$ tmux -L p5spec -f /dev/null new-session -d -s w1 -x 200 -y 50 'sleep 600'
+$ ps -o rss= -p $(pgrep -f "tmux -L p5spec" | head -1)   →  3792     (KB)
+$ lsof -p <server> | wc -l                                →  15
+$ for i in 2 3 4 5 6 7 8; do tmux -L p5spec new-window -t w1 -d 'sleep 600'; done
+$ ps -o rss= -p <server>                                  →  3824     (KB)
+$ lsof -p <server> | wc -l                                →  22
+```
+
+**7 windows: +32 KB, +7 fds.** ~4.5 KB and exactly one descriptor each.
+
+At scale — 8 sessions × 4 windows × 5 panes = **160 panes** in one server:
+
+```
+$ tmux -L p5scale list-sessions | wc -l   →  8
+$ tmux -L p5scale list-windows -a | wc -l →  32
+$ tmux -L p5scale list-panes -a | wc -l   →  160
+$ ps -o rss= -p <server>                  →  4656   (KB)
+$ lsof -p <server> | wc -l                →  174
+$ ulimit -n                               →  1048576
+$ sysctl -n kern.maxfilesperproc          →  184320
+```
+
+**File descriptors are not a constraint at any plausible scale.**
+
+### 7.2 Scrollback is the constraint, and it is charter's own default
+
+`charter/instance.py:914` ships `"history_limit": (50000, "history-limit")`.
+
+```
+$ tmux -L p5hist -f /dev/null new-session -d -s h -x 200 -y 50 'sleep 900'
+$ tmux -L p5hist set -t h history-limit 50000
+$ ps -o rss= -p <server>                                     →    3776  (KB)
+# one pane writes 51,000 lines of 199 columns
+$ ps -o rss= -p <server>                                     →  130624  (KB)
+$ tmux -L p5hist display -p -t h:0 '#{history_size}'         →   45951
+# a second such pane, in the same window
+$ ps -o rss= -p <server>                                     →  180624  (KB)
+```
+
+**One 200-column pane at charter's shipped history-limit: +127 MB, inside the single shared
+`tmux -L charter` server process.** At tmux's own default of 2,000 lines the same fill costs
+~2.2 MB per pane (measured separately: 8 windows × 3,000 lines took the server 3,824 →
+21,648 KB).
+
+### 7.3 Window names, activity flags, and format expansion
+
+```
+$ tmux -L p5spec show -g automatic-rename   →  automatic-rename on
+$ tmux -L p5spec show -g allow-rename       →  allow-rename off
+$ tmux -L p5spec show -g monitor-activity   →  monitor-activity off
+$ tmux -L p5spec show -g monitor-bell       →  monitor-bell on
+$ tmux -L p5spec show -g monitor-silence    →  monitor-silence 0
+$ tmux -L p5spec show -g activity-action    →  activity-action other
+$ tmux -L p5spec show -g bell-action        →  bell-action any
+$ tmux -L p5spec show -g window-size        →  window-size latest
+$ tmux -L p5spec show -g aggressive-resize  →  aggressive-resize off
+```
+
+Identical on 3.2, every line.
+
+**`automatic-rename` renames windows out from under you.** The eight windows created in §7.1
+listed as `zsh`, `tmux`, `tmux`, `kernel_task`, `tmux`, `tmux`, `tmux`, `tmux` — the name follows
+whatever the pane's foreground process is.
+
+**With `allow-rename on`, the pane's own output names the window:**
+
+```
+$ tmux -L p5spec set -w -t ws1:1 allow-rename on
+$ tmux -L p5spec respawn-window -k -t ws1:1 "sh -c 'printf \"\\033kPWNED\\033\\\\\"; sleep 900'"
+$ tmux -L p5spec display -p -t ws1:1 '#{window_name}'   →  PWNED
+```
+
+With the default `allow-rename off` the same sequence left the name as `bash`.
+
+**A window name is contained differently on the two versions:**
+
+| | 3.7c | 3.2 |
+|---|---|---|
+| `rename-window "$(printf 'a\nb')"` | `invalid window name: a\nb`, **rc=1** | **rc=0**, stored as the four characters `a\nb` |
+| `rename-window "$(printf 'a\033[31mR')"` | `invalid window name`, **rc=1** | **rc=0**, stored as `a\033[31mR` (escaped, 10 chars) |
+
+Two versions, two answers, neither of them "what charter asked for".
+
+**Formats.** `rename-window 'chat#{pane_pid}X'` stores the name **already expanded** —
+`chat4327X` on 3.7c, `chat49359X` on 3.2. A user option is *not* expanded on set but *is* under
+`#{E:}`:
+
+```
+$ tmux -L p5spec set -w -t ws1:1 @evil '#{pane_pid}'
+$ tmux -L p5spec display -p -t ws1:1 '#{@evil}'      →  #{pane_pid}
+$ tmux -L p5spec display -p -t ws1:1 '#{E:@evil}'    →  4327
+```
+
+Same on 3.2 (`49359`). A user option also accepts a newline where `rename-window` refuses one, so
+tmux's containment of the two is not the same containment.
+
+**Activity and bell flags on a genuinely background window:**
+
+```
+$ tmux -L p5spec new-window -d -t ws1: "sh -c 'sleep 5; printf HELLO; sleep 3; printf \"\\a\"; sleep 900'"
+$ tmux -L p5spec select-window -t ws1:0
+$ tmux -L p5spec set -w -t ws1:1 monitor-activity on
+# t+7
+  w0 active=1 activity=0 bell=0
+  w1 active=0 activity=1 bell=0
+# t+11
+  w1 active=0 activity=1 bell=1
+```
+
+Note in passing: `respawn-window -k -t <w>` **makes that window active**, which cost two attempts
+before this measurement was valid.
+
+### 7.4 A background window keeps stale geometry — on both versions
+
+The client is a real attached tmux client in a pty whose size the harness changes with
+`TIOCSWINSZ`.
+
+**3.7c:**
+```
+client 200x50, window 1 active
+  w0 active=0 200x50
+  w1 active=1 200x50
+client resized to 100x30
+  w0 active=0 200x50     ← background: STALE
+  w1 active=1 100x30
+tmux -L p5spec select-window -t ws1:0
+  w0 active=1 100x30     ← resized AT the switch
+  w1 active=0 100x30
+```
+
+**3.2, identical:**
+```
+client 200x50, window 0 active
+  w0 active=1 200x49
+  w1 active=0 200x50
+client resized to 100x30
+  w0 active=1 100x29
+  w1 active=0 200x50     ← background: STALE
+select-window -t ws1:1
+  w0 active=0 100x29
+  w1 active=1 100x29
+```
+
+**And the divergence that changes a decision:**
+
+```
+# 3.7c — a window-resized hook on each window, appending to a log
+$ tmux -L p5spec set-hook -w -t ws1:0 window-resized "run-shell 'date >> …'"
+  client resize while w0 active                → 1 event
+  select-window to the stale w1                → 2 events total
+
+# 3.2
+$ ./tmux-3.2/tmux -L p5v32 set-hook -w -t ws1:0 window-resized "run-shell 'true'"
+  invalid option: window-resized
+  rc=1
+```
+
+**`window-resized` does not exist at `tmuxctl.FLOOR`.** `tmuxctl.RESIZE_HOOK_FLOOR = (3, 3)`
+already says so; this is what it means for tabs.
+
+### 7.5 Per-window `-e` overrides a session-wide `set-environment`
+
+```
+$ tmux -L p5env-X -f /dev/null new-session -d -s s -x 100 -y 30 'sleep 60'
+$ tmux -L p5env-X set-environment -t s CHARTER_SESSION_ID "session-wide"
+$ tmux -L p5env-X new-window -d -t s -e CHARTER_SESSION_ID=chat-A -e CHARTER_HARNESS=claude-code \
+      "sh -c 'printenv CHARTER_SESSION_ID > …; printenv CHARTER_HARNESS >> …; sleep 60'"
+$ tmux -L p5env-X new-window -d -t s -e CHARTER_SESSION_ID=chat-B -e CHARTER_HARNESS=codex  …
+```
+
+| | 3.7c | 3.2 |
+|---|---|---|
+| window A | `chat-A claude-code` | `chat-A claude-code` |
+| window B | `chat-B codex` | `chat-B codex` |
+
+**This is the mechanism that makes identity per-chat**, and it is available at
+`tmuxctl.PANE_ENV_FLOOR = (3, 0)`, below the floor charter warns at.
+
+### 7.6 Switching loses nothing
+
+```
+$ tmux -L p5spec switch-client -c /dev/ttys058 -t ws2
+  client session: ws1 → ws2
+  attach process still alive: yes
+$ tmux -L p5spec list-panes -a -F '#{session_name}:#{window_index} … dead=#{pane_dead} pid=#{pane_pid}'
+  ws1:0 100x30 dead=0 pid=4152
+  ws1:1 100x30 dead=0 pid=4327
+  ws2:0 100x30 dead=0 pid=23812
+  ws2:1 100x30 dead=0 pid=23815
+$ tmux -L p5spec switch-client -c /dev/ttys058 -t ws1     → back, attach still alive
+```
+
+No pane died, no pid changed, the client was never reattached.
+
+### 7.7 The switch is cheap, and chaining is worth 3.3×
+
+100 iterations each, `subprocess.run` around the whole tmux invocation:
+
+```
+select-window       : min 4.1  median 4.4  p95 4.9  ms
+switch-client       : min 4.1  median 4.4  p95 4.8  ms
+list-windows -a     : min 3.9  median 4.3  p95 4.8  ms      ← the baseline: spawning tmux at all
+```
+
+**The switch itself is free; the round trip is the cost.** Twenty iterations of the panel
+teardown and re-split, four panes each:
+
+| | one invocation per command | chained through one invocation |
+|---|---|---|
+| 4 × `split-window` | median **22.2 ms** | median **6.7 ms** |
+| 4 × `kill-pane` | median **19.3 ms** | median **4.9 ms** |
+
+`tmuxctl.chain` already exists and returns `None` when the servers disagree. Phase 5's switch
+must use it.
+
+### 7.8 What a panel costs, and what a harness costs
+
+```
+$ python3 -X importtime -c "import charter.frame" 2>&1 | tail -1
+  import time:  153 | 24147 | charter.frame          ← 26 ms cumulative warm, 48 ms cold
+$ /usr/bin/time -l python3 -c "pass"                       → 15171584   max RSS  (15.2 MB)
+$ /usr/bin/time -l python3 -c "import charter.frame.panel" → 24379392   (24.4 MB)
+$ /usr/bin/time -l python3 -m charter panel identity --session testfid-1 --once
+  0.09 real   36880384 max RSS  (36.8 MB)
+```
+
+Four component ids measured: `identity` 36.9 MB, `repos` 36.8, `personas` 37.1, `todos` 36.7,
+each 0.08–0.09 s real.
+
+Eight concurrent processes that have imported `charter.frame.panel` and built the registry:
+
+```
+$ ps -o rss= -p <8 pids> | awk '{s+=$1} END {print s}'   →  190848 KB  (186 MB)
+$ footprint -f bytes -p <one>
+    15401416 B   dirty
+     4931584 B   clean
+    phys_footprint: 15434184 B                            →  15.4 MB
+```
+
+**A panel is 23.7 MB resident / 15.4 MB dirty idle, and peaks at 36.8 MB through a paint.** The
+brief's working figure of ~13 MB is in the right neighbourhood for the *dirty* number and
+understates the resident one; the multiplication in §3.3 uses the larger.
+
+The harness, sampled from what is actually running on this machine right now:
+
+```
+$ ps -eo pid=,rss=,comm= | awk '$3=="claude"{…}'
+  claude processes: 19 | sum RSS: 4389216 KB = 4286 MiB | min: 48992 KB | max: 676192 KB | mean: 231011 KB
+```
+
+**19 live harnesses, 4.29 GB, mean 226 MB, max 660 MB.** A panel is noise. The harness is the
+cost, by an order of magnitude, and no amount of panel sharing changes the shape of the bill.
+
+### 7.9 What I could not measure
+
+Stated rather than assumed, because a spec that hides its gaps is worse than one with fewer
+claims.
+
+- **Whether `#(shell)` command substitution executes through `#{E:@option}`.** I proved
+  `#{E:}` expands nested `#{format}` references (`#{pane_pid}` → `4327`). I could not get a
+  `#(touch …)` inside a user option to run — not through `display -p '#{E:@evil}'`, not through
+  `#{E:#{E:@evil}}`, and not through `status-left` with `status on`, because I could not attach
+  an interactive client with a rendering status line from a non-interactive shell. **The `#{}`
+  expansion alone is enough to reject routing a name through a tmux format**, so the design does
+  not depend on the unmeasured half — but do not repeat the stronger claim.
+- **Panel cost under real repaint load.** Every panel figure is an idle process or a single
+  `--once` paint. Nobody has run four panels against a plane bumping its version at speed.
+  §4j's `_right` at 4.8 ms is that spec's number, not one re-measured here.
+- **Anything above two chats, live.** Every scale figure above is `sleep` processes standing in
+  for harnesses, plus a separately-measured real-harness distribution. Nobody has run six real
+  agents in six tabs. **§4j's instruction to measure at 5 and 10 chats is not discharged by this
+  document** and is a task in the plan.
+- **Whether the tab bar looks right.** No screenshot was taken and nobody looked at a screen.
+- **tmux 3.3 through 3.6.** Untested, here as in Phase 3.5. The two floors that matter
+  (`RESIZE_HOOK_FLOOR`, `PANE_ENV_FLOOR`) are read from tmux's own CHANGES, and only their
+  endpoints were run.
+
+---
+
+## 8. What this spec deliberately does not do
+
+- **No resume.** §3.4. A cold chat reopens as a fresh harness session, and says so.
+- **No moving a chat between workspaces.** §4j settled it; §3.6 repeats why.
+- **No per-chat sandbox, jail, uid or container.** §4. Charter would be claiming a boundary it
+  does not have.
+- **No chat-level cross-repo query.** "Show me the chats working on this change" needs Phase 4's
+  change object and this phase's chats to both exist. Phase 5 makes it askable, not answerable —
+  §4j says the same.
+- **No shared-panel cache.** §3.7 rejects it as unmeasured, and would reject building it now for
+  the same reason it rejected duplicating them.
+- **No new ADR.** Phase 5 changes what a frame *is* without changing any decision an ADR
+  records: 0015 (the boundary moves with the harness), 0018 (charter may run the harness but
+  never draws it) and 0019 (the frame owns the surface) all hold verbatim under tabs, and 0018
+  is what forbids the one shortcut this design might have taken.


### PR DESCRIPTION
Specifies **Phase 5** of the agentic-IDE work — workspace tabs, chat tabs under them, and many
harnesses in parallel. **Docs only. No production code. Do not merge without the operator.**

- `docs/superpowers/specs/2026-08-28-phase5-workspace-and-chat-tabs.md`
- `docs/superpowers/plans/2026-08-28-phase5-workspace-and-chat-tabs.md`
- two pointers added to the foundation spec so a reader landing on §4j or §6 sees what moved

## Three of §4j's four decisions changed, and a measurement changed each one

**The name is `{workspace}.{n}`, allocated, not `{workspace}-{hash}`.** A truncated hash
collides silently into a shared `.charter/frame/<fid>/`, where two chats then overwrite each
other's `session`, `panes` and `version`. And a `-{ordinal}` tail makes
`state._launcher_pid` read `2` as a pid — alive on every Unix — so every dead chat would look
live forever and `reap` would stop bounding the directory. The dot makes `_launcher_pid` return
`None`, and that `None` is the version discriminator: an id it can parse is an old
`{workspace}-{pid}` frame and keeps the pid rule. No flag day, no migration.

**Panels follow the active chat; they do not duplicate.** Measured: a background window keeps
stale geometry — with the client resized 200×50 → 100×30 the active window followed and the
background one stayed at 200×50, on 3.7c *and* on 3.2 — so duplicated panels are not idle, they
are rendering at a width that is wrong. That is `panel._component_text`'s `width=slots._width()`
guard, the one the deletion sweep already found. And it costs 758 MB resident in 32 processes
drawing the same `gather.json`, four of which are on screen. Panels created *after* the switch
are born at the true width, so there is nothing stale to repair.

**The switch reasserts the layout; it does not rely on `window-resized`.** On tmux 3.2 —
`tmuxctl.FLOOR` — `set-hook -w window-resized` returns `invalid option: window-resized`, rc=1.
The hook does not exist at the floor charter promises to run on. A bare `tmux select-window`
would leave a chat's panels laid out for a window size that is no longer true, with nothing to
fix it.

## Every tmux claim is measured, with the command

On this machine, 2026-08-28, on 3.7c and on the 3.2 binary built for Phase 3.5. Highlights:

| | measured |
|---|---|
| a tmux window | ~4.5 KB, 1 fd (3,792 → 3,824 KB and 15 → 22 fds for 7 windows) |
| 160 panes in one server | 4,656 KB, 174 fds — against `ulimit -n` 1,048,576 |
| **one pane at charter's shipped `history_limit = 50000`** | **3,776 → 130,624 KB — +127 MB in the one shared server process** |
| a charter panel | 23.7 MB RSS / 15.4 MB `phys_footprint` idle, 36.8 MB peak; `import charter.frame` 26 ms warm |
| **the harness** | **19 live `claude` processes right now: 4.29 GB, mean 226 MB, max 660 MB** |
| the switch | `select-window` 4.4 ms; 4 × `split-window` **22.2 ms → 6.7 ms** chained; 4 × `kill-pane` **19.3 ms → 4.9 ms** chained |
| per-window `-e` over a session-wide `set-environment` | works on 3.7c and 3.2 — the whole identity mechanism |
| `rename-window` with a newline | **refused rc=1 on 3.7c, accepted rc=0 on 3.2** (stored escaped) |
| `allow-rename on` | `printf '\033kPWNED\033\\'` from inside the pane renames the window |
| `#{E:@option}` | expands a `#{...}` in the value — a name routed through a tmux format is an injection on the first hop |

§7.9 says what could **not** be measured — `#(shell)` through `#{E:}`, panel cost under real
repaint load, and anything above two live chats. §4j's "measure at 5 and 10" is explicitly **not**
discharged by this document and is Task 10.

## Security

The section states a **property**, not a list: two chats in one plane hold the same authority,
and charter's only real separation is that each chat's *record* is its own. Two harness processes
run as the same uid, under the same `CHARTER_ROOT`, with the same vaults. Nothing in POSIX
separates them without a sandbox charter does not have and has never claimed.

So the deliverable is a sentence in `SECURITY.md` and `docs/frame.md`, not a mechanism — *a chat
tab is a container, not a boundary* — because a tab **looks** like one, and a claim that is false
in a reachable configuration is worse than no claim.

What Phase 5 does give is real and needs no new code: `session.current()` reads
`$CHARTER_SESSION_ID`, which under tabs is the chat id, so `.charter/sessions/<chat id>.persona`,
`.workspace`, `.tools` and `.gate` become per-chat automatically. Two tabs, two personas: each
grants `effective_tools(its persona) ∩ frozen_tools(its persona, its chat id)`, the intersection
means narrowing lands at once and widening never does, and **neither may deny** — `toolgate.decide`
returns `None` or an allow, so a persona widens a chat and never restricts it below the plane's
own guards. #575 closed four fail-opens in that grant this week; Phase 5 adds no new grant path,
which is the point.

## Three questions for the operator, each answerable in one word

1. **Live-chat cap — recommend 6.** Six harnesses at the measured mean is ~1.4 GB plus ~370 MB of
   panels. Sixteen is 5.1 GB before scrollback.
2. **Lower `history-limit` for chat windows — recommend yes, 20,000.** 50,000 lines cost 127 MB
   per pane, in one process that holds every chat in every workspace on the machine.
3. **Reopening a cold chat starts a fresh harness session — recommend yes, with a message.**
   There is no resume member on `Harness`, and `base.py`'s own docstring sets the bar: *"A fifth
   member needs the same kind of argument, not just a use."*

## Also in the spec

- A **walk-through of one real session** end to end (§5) — open the workspace, add a codex chat
  beside a claude one, switch to another workspace, come back — with the actual tmux argvs and
  the named functions that already exist.
- The single most dangerous line in the port, called out with its own task and test: the
  `pane-died` teardown currently runs `kill-session`, and under tabs that takes every other chat
  in the workspace down with the one that died.
- Counter-arguments answered in the text, including *"tmux already has windows — what is charter
  adding?"* and *"is this a GUI metaphor that breaks in a terminal?"* (it does break — the bar
  degrades to a status indicator at 80 columns and the palette stays the mechanism at every
  width).

Docs only; `python3 -m unittest tests.test_docs tests.test_docs_claims_carry_their_residual
tests.test_docs_show` → 34 tests, OK. `docs/superpowers/` is internal record and is not
force-included in the wheel, so nothing ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
