### PR TITLE
A component can be told its pane was focused, blurred or resized (#607)

### DIFF
--- a/charter/frame/component.py
+++ b/charter/frame/component.py
@@ -88,6 +88,16 @@ EDGES = ("top", "bottom", "left", "right")
 #: The rule that follows, and the one thing this constant is asking of you: **degrade to
 #: "never fires", never to "fires wrongly".** A component that treats a missing ``blur``
 #: as "still focused" is correct; one that infers focus from elapsed time is not.
+#:
+#: **Which of these charter actually delivers is `frame/events.py`'s `DELIVERED`, and it
+#: is three of the six** (#607). ``focus``, ``blur`` and ``resize`` fire; ``key``,
+#: ``click`` and ``scroll`` are decoded and routed nowhere, because the harness owns the
+#: keyboard and because tmux routes a pointer by POSITION without focusing the pane it
+#: lands in — so a click would be a second focus, disagreeing with the keyboard's. Both
+#: lists are needed and neither can be the other: this one is what a provider may DECLARE
+#: and is closed by the spec, that one is what charter can carry this release. Declaring a
+#: kind charter does not deliver is not an error and does not become one — it is the
+#: paragraph above, live.
 EVENT_KINDS = ("key", "click", "scroll", "focus", "blur", "resize")
 
 #: The slices of the plane snapshot a component may declare in ``needs`` — and therefore
@@ -271,6 +281,27 @@ class Component:
     render: Callable[[Any], list[str]]
     needs: tuple[str, ...] = ()
     events: tuple[str, ...] = ()
+    #: What receives an event of a declared kind — one `frame.events.Event`, answering
+    #: truthy for "repaint me" (§4f, #607). ``None`` for a component that declares no
+    #: events, and refused alongside a non-empty ``events`` below.
+    #:
+    #: **It is handed no ``ctx``, and that is the contract rather than an omission.** A
+    #: component reads the plane at the repaint that follows, out of the one snapshot §4f
+    #: gives it; a handler that could read a second one would be the second timestamp that
+    #: doctrine exists to prevent. So a handler notes what happened and `render` draws it.
+    #:
+    #: **Nothing it returns reaches the pane.** The rows on screen are ``render``'s, which
+    #: `registry.Registry.draw` escapes, measures and clips; the return value here is read
+    #: for its truth and nothing else. That is why the containment order #472 is about
+    #: needs no second guard on this path — there is no path.
+    #:
+    #: This field was ADDED to a shipped contract without moving :data:`API_VERSION`, and
+    #: the reason is what that constant is for: it asks "can charter honour what this
+    #: provider declared", and a component built before this field existed declares nothing
+    #: charter cannot still honour. A bump would refuse every installed provider at once to
+    #: fix a class of provider — one that declared ``events`` — whose events had never
+    #: fired in the first place.
+    on_event: Callable[[Any], Any] | None = None
     #: The leaf ids this component draws inside its own pane, in the order it draws
     #: them, or ``()`` for a leaf. Charter never splits a pane (§4d), so this is how N
     #: things share one — and it is ids rather than components because the rules that
@@ -319,3 +350,27 @@ class Component:
             self, "events",
             names("events", f"component {self.id}", self.events, EVENT_KINDS))
         object.__setattr__(self, "children", tuple(self.children))
+        # After the normalisation above, so both refusals below quote the tuple charter
+        # will actually dispatch against rather than whatever shape arrived.
+        if self.on_event is not None and not callable(self.on_event):
+            raise ComponentError(
+                f"component {self.id}: on_event must be callable, not "
+                f"{contain.one_line(repr(self.on_event))}")
+        # **The pair is refused in BOTH directions, and that is this issue's whole shape.**
+        # `events` was validated here and read by nothing for two phases (#607), so a
+        # provider could declare `scroll`, pass every check, and receive nothing ever. A
+        # declaration with no handler is that defect written by the provider instead of by
+        # charter; a handler with no declaration is a callable charter would never call.
+        # Both are refused at construction, where the message names a fixable thing —
+        # which is the argument this module's docstring makes for checking anything here.
+        if self.events and self.on_event is None:
+            raise ComponentError(
+                f"component {self.id}: declares events "
+                f"{', '.join(self.events)} and supplies no on_event to receive them — "
+                f"give it one, or drop the declaration. A kind declared with nothing "
+                f"behind it is indistinguishable from one charter never fires")
+        if self.on_event is not None and not self.events:
+            raise ComponentError(
+                f"component {self.id}: supplies on_event and declares no events, so "
+                f"nothing would ever reach it — name what it handles in events "
+                f"({', '.join(EVENT_KINDS)})")

--- a/charter/frame/events.py
+++ b/charter/frame/events.py
@@ -132,7 +132,6 @@ import select
 import termios
 import time
 
-from .. import contain
 from . import overlay, pane
 from .registry import _because
 
@@ -216,27 +215,27 @@ _CANNOT_SAY = (AttributeError, OSError, TypeError, ValueError, termios.error)
 def wanted(c) -> tuple[str, ...]:
     """The kinds charter will actually deliver to component *c*, in declared order.
 
-    The intersection of what it declared and what :data:`DELIVERED` says charter carries —
-    empty for a component with no handler, which `component.Component` already refuses to
-    build alongside a non-empty ``events``, and empty for one whose every declared kind is
-    a kind charter does not fire. That second emptiness is the one that matters: a
-    component declaring only ``click`` gets no dispatcher, so its pane's terminal is left
-    exactly as it was found.
+    The intersection of what it declared and what :data:`DELIVERED` says charter carries.
+    Empty for a component whose every declared kind is one charter does not fire, and that
+    emptiness is the one that matters: a component declaring only ``click`` gets no
+    dispatcher, so its pane's terminal is left exactly as it was found.
 
-    ``c.on_event`` rather than a ``getattr`` with a default: every `Component` carries the
-    field, so a default here would be a branch nothing can reach and no test can falsify —
-    which this project deletes rather than keeps (#568). What makes it unreachable is
-    itself pinned, by the case that asks a component declaring neither for its ``on_event``
-    and gets ``None``.
+    **It does not ask whether there is a handler, and the deleted check is why this
+    docstring is long.** Two versions of that guard shipped here — a ``getattr`` default,
+    then ``c.on_event is not None`` — and the sweep proved the second one equivalent on
+    `main`. Both were: `Component` refuses ``events`` without ``on_event`` and refuses
+    ``on_event`` without ``events``, so a component with no handler has no events either
+    and the intersection below is already ``()``. A branch that cannot change an outcome is
+    not documentation of an intent — it is a second, weaker answer to a question
+    `component.Component.__post_init__` has already answered (#568's argument, and the
+    sweep's own definition of a line that should not be there).
 
-    ``is not None`` rather than truthiness, which is the same question `Component`'s own
-    validation asks one module over. A callable object defining a falsy ``__bool__`` or an
-    empty ``__len__`` — a handler written as an instance of a class rather than as a
-    function — passes construction and would silently get no dispatcher here, which is
-    #607's defect with a new spelling.
+    What makes it unreachable is itself pinned, which is the condition for deleting rather
+    than keeping: `TheDeclarationAndTheHandlerAreOneThing` asks for the refusal in both
+    directions, so the day either half is relaxed, those cases go red here rather than this
+    function silently starting to matter.
     """
-    return tuple(k for k in c.events if k in DELIVERED) \
-        if c.on_event is not None else ()
+    return tuple(k for k in c.events if k in DELIVERED)
 
 
 class Dispatcher:
@@ -514,8 +513,14 @@ class Dispatcher:
         except KeyboardInterrupt:
             raise
         except BaseException as exc:
-            self._failure = (f"{contain.one_line(self._c.id)} stopped taking events — "
-                             f"{_because(exc)}")
+            # No `contain.one_line` on the id, and that is the sweep's verdict rather than
+            # an oversight: `Component.__post_init__` holds every id to `_ID_RE`
+            # (`[a-z0-9_.]`), so there is nothing here for it to contain and the call could
+            # not change an outcome. What the exception SAID is a different matter and
+            # `_because` contains it; and `panel._component_text` contains the whole line
+            # again before any width arithmetic touches it, which is the guard that has a
+            # consequence and a case behind it.
+            self._failure = f"{self._c.id} stopped taking events — {_because(exc)}"
             self.close()
             # True, so the pane repaints and says so on the very next tick rather than
             # whenever something else happens to move the frame's version.

--- a/charter/frame/events.py
+++ b/charter/frame/events.py
@@ -115,6 +115,14 @@ not have, and it would add a new way for the `select` and the `write` on either 
 handler to fail half-way. The operator's way out is unchanged and is not charter's code:
 `overlay.HATCH_KEY` is matched in tmux's own root key table before any byte reaches this
 process.
+
+**"And nothing else" has one exception and it belongs in the sentence rather than under
+it**: a handler that never returns never reaches `panel._watch`'s ``finally`` either, so
+that pane keeps the mode :meth:`Dispatcher.open` installed — ``ICANON`` and ``ECHO`` off —
+for the life of the process. Typing into it echoes nothing. That is a WEDGED pane looking
+wedged rather than a second failure, and it is bounded to the same one pane; but a
+docstring that said the pane was simply frozen would be describing a tidier failure than
+the one this design actually has.
 """
 
 from __future__ import annotations
@@ -190,7 +198,19 @@ _CHUNK = 4096
 #: it wrong would have taken a panel with stdout piped to a file (`charter panel
 #: acme.metrics --session x > /tmp/log`) from "no focus events, which is fine" to
 #: `panel._hold`, painting a refusal for a component that had done nothing wrong.
-_CANNOT_SAY = (AttributeError, OSError, ValueError, termios.error)
+#:
+#: `TypeError` is here for the same reason and was the same miss one step further out.
+#: A stream stand-in answers `fileno()` with whatever it likes, and what it answers is
+#: handed straight to `termios.tcgetattr`::
+#:
+#:     termios.tcgetattr(None)   -> TypeError: argument must be an int, or have a fileno()
+#:     select.select([None], ..) -> TypeError: argument must be an int, or have a fileno()
+#:
+#: `frame/pane.py` never meets that case — it passes what it gets to
+#: `os.get_terminal_size`, which raises `OSError` — so its set is complete for ITS
+#: questions and this one is a superset rather than a disagreement. A `MagicMock` stdout,
+#: which is what `mock.patch("sys.stdout")` installs, reaches this exact path.
+_CANNOT_SAY = (AttributeError, OSError, TypeError, ValueError, termios.error)
 
 
 def wanted(c) -> tuple[str, ...]:
@@ -208,8 +228,15 @@ def wanted(c) -> tuple[str, ...]:
     which this project deletes rather than keeps (#568). What makes it unreachable is
     itself pinned, by the case that asks a component declaring neither for its ``on_event``
     and gets ``None``.
+
+    ``is not None`` rather than truthiness, which is the same question `Component`'s own
+    validation asks one module over. A callable object defining a falsy ``__bool__`` or an
+    empty ``__len__`` — a handler written as an instance of a class rather than as a
+    function — passes construction and would silently get no dispatcher here, which is
+    #607's defect with a new spelling.
     """
-    return tuple(k for k in c.events if k in DELIVERED) if c.on_event else ()
+    return tuple(k for k in c.events if k in DELIVERED) \
+        if c.on_event is not None else ()
 
 
 class Dispatcher:
@@ -275,6 +302,13 @@ class Dispatcher:
         self._size = pane.size()
         if not any(k in self._kinds for k in _FROM_INPUT):
             return
+        if self._fd is not None:
+            # Already open. Without this a second `open` would read the mode the FIRST one
+            # installed and keep it as `_before`, so `close` would "restore" the pane to
+            # cbreak — ECHO off, for good. `panel._run` builds one dispatcher per panel so
+            # this cannot happen there today; it is a property of the object rather than of
+            # its one caller, and the case below is what keeps it one.
+            return
         stream = pane.stream() if self._stream is None else self._stream
         try:
             fd = stream.fileno()
@@ -304,11 +338,17 @@ class Dispatcher:
     def close(self) -> None:
         """Withdraw the request and put the tty back exactly as it was found.
 
-        Idempotent and never raising, because both callers are a ``finally``: `_watch`'s,
-        which runs before `panel._hold` can paint a reason and hold the pane forever, and
-        :meth:`_deliver`'s, which runs while a stranger's exception is being turned into a
-        message. A restore that raised in either would leave the operator's pane in a mode
-        charter chose and nothing puts back.
+        Idempotent, and it does not raise for any of the ways a pane can be gone
+        (:data:`_CANNOT_SAY`) — which matters because both callers are a ``finally``:
+        `_watch`'s, which runs before `panel._hold` can paint a reason and hold the pane
+        forever, and :meth:`_deliver`'s, which runs while a stranger's exception is being
+        turned into a message.
+
+        It is not an unconditional promise, and the honest version is worth more than the
+        tidy one: something a stream stand-in raises from outside that set escapes the
+        withdrawal below. What that costs is bounded by the order — the mode is already
+        back — and `panel._watch` hands its `SIGWINCH` handler back from a nested
+        ``finally`` for exactly this case.
 
         **`TCSANOW` and never `TCSADRAIN`, and this one was measured the hard way.**
         `TCSADRAIN` waits for the terminal to consume everything already written, and on a
@@ -320,16 +360,33 @@ class Dispatcher:
         (see :meth:`open`), so a drain here protects nothing and can only wedge — and a
         wedge in the `finally` that holds the operator's tty mode is the worst place on the
         path to put one.
+
+        **The RESTORE goes first and the withdrawal second, and the order is the whole
+        function.** It was the other way round, with ``_fd``/``_before`` cleared on the very
+        first line, and that made "idempotent" mean "the second call is a guaranteed
+        no-op": anything that raised or blocked in between lost the `tcsetattr` FOREVER,
+        because the retry from `panel._watch`'s `finally` would find ``_fd`` already
+        ``None`` and return. And there is something that can block. This clears ``ICANON``
+        and ``ECHO`` and deliberately leaves the input flags alone, so ``IXON`` is still on:
+        an operator who selects this pane and presses Ctrl-S puts the pty in XOFF, and the
+        `flush` inside :meth:`_write` then waits for an XON that may never come. That
+        hazard is not new — `panel._out` flushes into the same pane on every paint and has
+        always been able to wait there — but doing it AHEAD of the mode restore would have
+        been, and it would have left the operator with a pane that echoes nothing and no
+        process left to put it back.
         """
-        fd, before, self._fd, self._before = self._fd, self._before, None, None
+        fd, before = self._fd, self._before
         if fd is None:
             return
         try:
-            self._write(FOCUS_OFF)
+            termios.tcsetattr(fd, termios.TCSANOW, before)
         except _CANNOT_SAY:
             pass
+        # Only now: the mode the operator cares about is back, so a second call has
+        # nothing left to retry and the withdrawal below may fail without costing it.
+        self._fd = self._before = None
         try:
-            termios.tcsetattr(fd, termios.TCSANOW, before)
+            self._write(FOCUS_OFF)
         except _CANNOT_SAY:
             pass
 
@@ -355,7 +412,13 @@ class Dispatcher:
         if overlay.RESIZE not in self._kinds:
             return
         was, now = self._size, pane.size()
-        self._size = now
+        if now is not None:
+            # Stored only when it IS a rectangle. Overwriting with `None` would spend the
+            # comparison: a pty answers "no size" between a resize and the `TIOCSWINSZ`
+            # that follows (`frame/pane.py` calls that ordinary, not exotic), and one such
+            # reading in the middle would leave `was` as `None` on the next tick — so the
+            # resize that actually happened would never fire at all.
+            self._size = now
         if was is not None and now is not None and was != now:
             self._deliver(Event(overlay.RESIZE))
 
@@ -396,8 +459,18 @@ class Dispatcher:
             return self._feed(b"", final=True)
         try:
             chunk = os.read(self._fd, _CHUNK)
-        except OSError:
-            chunk = b""
+        except (BlockingIOError, InterruptedError):
+            # Not end of input, and telling them apart matters because the answer here is
+            # PERMANENT. `EAGAIN` means "ready a moment ago, nothing now" — a race that
+            # exists the instant anything in a provider's import graph puts `O_NONBLOCK`
+            # on fd 1 (asyncio adding stdout to an event loop does exactly that) — and
+            # `EINTR` is a signal this process handles, `SIGWINCH` being the one it arms
+            # itself. Folding either into the branch below would retire a component's
+            # events for the life of the panel over a syscall that meant "ask again".
+            return False
+        except _CANNOT_SAY:
+            self.close()
+            return False
         if not chunk:
             self.close()
             return False

--- a/charter/frame/events.py
+++ b/charter/frame/events.py
@@ -1,0 +1,460 @@
+"""Getting an event to the component that owns a pane — the half `Component.events`
+never had.
+
+`component.EVENT_KINDS` has been a closed vocabulary since §4f and, until this module,
+nothing read it: a provider could declare ``events = ["scroll"]``, pass validation, and
+receive nothing, ever (#607). The decoder already existed — `overlay.decode` turns a
+pane's bytes into `overlay.Event` — but it was wired only to the overlay's OWN surface,
+the palette and the pickers. Nothing carried an event from a PANEL's pane to the
+component drawing in it. This is that carriage.
+
+**Three kinds are delivered and three are not, and the split is measured rather than
+chosen.** :data:`DELIVERED` is ``focus``, ``blur`` and ``resize``.
+
+* ``key`` is not delivered because the harness owns the keyboard. tmux routes typing to
+  the ACTIVE pane, which is the harness's, so a panel's pane receives keystrokes only
+  while the operator has deliberately left the harness — and a component that acted on
+  them would be acting on the few the operator typed into the wrong pane.
+* ``click`` and ``scroll`` are not delivered because charter cannot yet say what a click
+  on a NON-ACTIVE pane means. tmux routes pointer events by POSITION and a click does not
+  focus the pane (measured against tmux 3.7c, #605), so the pointer would be a second
+  focus, disagreeing with the keyboard's, with no rule anywhere saying which one a
+  component is being driven by. The trade is relocated by "only the active pane requests
+  mouse", not dissolved. `component.EVENT_KINDS` already promises a declaration is
+  "what you HANDLE, never a promise that it FIRES", so both stay declarable and simply do
+  not fire — which is the direction that constant asks for: **degrade to "never fires",
+  never to "fires wrongly"**.
+
+---
+
+**Input is read off the pane this process CLAIMED, never off `sys.stdin`.** A tmux pane
+runs its command with fds 0, 1 and 2 on one pty, so the descriptor `frame/pane.py` holds
+as the pane is the descriptor the pane's input arrives on — measured against real tmux
+3.7c with the probe's own stdin closed (``0<&-``)::
+
+    fd=1 isatty=True
+    DRIVER select probe    READ b'\\x1b[I'
+    DRIVER select other    READ b'\\x1b[O'
+    DRIVER select probe    READ b'\\x1b[I'
+
+That is #606's fix reused rather than a second one written for the other direction:
+`sys.stdin` is a mutable global any library the process imports may replace, and a panel
+that read events off a framework's stand-in while painting into the operator's rectangle
+would be the same silent split that module exists to close, one descriptor over.
+
+**The tty goes to cbreak and never to raw, and the difference is the whole paint.**
+`tty.setraw` clears ``OPOST``/``ONLCR``, and `panel._write` joins its rows with ``\\n``.
+Measured, four modes, one 40x10 pane each, read back with `capture-pane`::
+
+    cooked    -> ['AAA', 'BBB', 'CCC']
+    raw       -> ['AAA', '   BBB', '      CCC']      <- the staircase
+    cbreak    -> ['AAA', 'BBB', 'CCC']
+    explicit  -> ['AAA', 'BBB', 'CCC']
+
+So this module clears exactly ``ICANON`` and ``ECHO`` and sets ``VMIN``/``VTIME`` to zero,
+and touches no output flag. `frame/palette.py` reaches for `tty.setraw` and is right to:
+its surface joins with ``\\r\\n`` because it owns the whole pane. A panel does not, and a
+panel that adopted the palette's mode would shear every repaint by a column a row.
+``ICANON`` has to go because ``\\x1b[I`` carries no newline and the line discipline would
+hold it forever; ``ECHO`` has to go because the terminal would otherwise print the
+sequence into the rectangle the component is drawing in.
+
+**Nothing is touched for a component that declared nothing.** A panel whose component
+declares no delivered kind builds no dispatcher at all: the tty keeps its mode, no
+``\\x1b[?1004h`` is written, and `panel._watch` sleeps exactly as it did before this
+module existed. A component declaring only ``resize`` opens no input path either — a
+resize is a `SIGWINCH` this process already receives. That scoping is `slots.ANIMATED`'s
+argument one mechanism over: a feature that costs every panel is a feature every panel
+pays for.
+
+---
+
+**A handler is a notification, not a second renderer.** :data:`Component.on_event`
+receives one `Event` and answers truthy for "repaint me". Nothing it returns reaches the
+pane — the rows on screen are `render`'s, which `Registry.draw` already escapes, measures
+and clips (§4b properties 1 and 3). So the containment order #472 is about is kept by
+construction here rather than by a second guard: there is no path from a handler's return
+value to a terminal for an escape sequence to travel down.
+
+It is also why a handler is handed no ``ctx``. A component reads the plane at the repaint
+that follows, out of the one snapshot §4f gives it; a handler that could read a second one
+would be the second timestamp that doctrine exists to prevent. For the same reason a
+``resize`` event carries no size: `ctx.width` and `ctx.height` are where a component's
+rectangle is read, and a number on the event would be a second answer to that question
+which could disagree with the first.
+
+**An event reaches the screen through the repaint path that already exists.** A handler
+answering truthy is a fourth reason for `panel._tick` to paint, beside a version bump, a
+resize and the spinner — not a second way to draw. The paint that follows is the same
+`_write`, the same `Registry.draw`, the same rectangle.
+
+---
+
+**A handler that raises costs its component its events, and the pane says so** (§4b).
+`registry.Registry`'s docstring names three moments a provider can fail — on import, while
+building, and in ``render`` — and gives one answer to all three: the pane names the
+component and what it raised. ``on_event`` is the fourth, and it takes the same answer,
+because the alternative is the one this project keeps refusing: a component that quietly
+stops being interactive is indistinguishable from one nobody has clicked yet, and #512 is
+what a convincing empty costs.
+
+It is retired rather than retried. A handler that raised on one event will raise on the
+next, and delivering more would spend the operator's repaints on a loop of identical
+failures — so the input path is closed, the mode is put back, and every later event is
+dropped. The cost is stated plainly: a component whose ``render`` still works loses its
+pane to a message because its HANDLER broke. That is the smaller of the two wrongs, and it
+is reversible by relaunching the frame.
+
+**A handler that never returns wedges its own panel, and nothing else** — which is §4b's
+promise kept rather than evaded. There is no watchdog and that is deliberate: the panel is
+one process holding one pane, so a handler that loops stops that pane repainting and
+leaves every sibling pane, the harness and tmux itself untouched. It is exactly what an
+infinite loop in ``render`` already does. A `signal.setitimer` watchdog was considered and
+refused — it cannot interrupt a C-level block at all, so it would promise a bound it does
+not have, and it would add a new way for the `select` and the `write` on either side of a
+handler to fail half-way. The operator's way out is unchanged and is not charter's code:
+`overlay.HATCH_KEY` is matched in tmux's own root key table before any byte reaches this
+process.
+"""
+
+from __future__ import annotations
+
+import os
+import select
+import termios
+import time
+
+from .. import contain
+from . import overlay, pane
+from .registry import _because
+
+#: One decoded event, re-exported from the decoder that produces it so a provider can name
+#: the type it handles without importing the overlay — which is a modal surface it has
+#: nothing to do with. One class, not two: a second `Event` would be a second answer to
+#: "what did the terminal just say".
+Event = overlay.Event
+
+#: The kinds charter routes to a component today — a subset of `component.EVENT_KINDS`,
+#: and see this module's docstring for why the other three are not in it.
+#:
+#: Named here rather than in `component.py` because the two answer different questions:
+#: that tuple is the closed vocabulary a provider may DECLARE (§4f), this is what charter
+#: can currently deliver. Merging them would either refuse a component for declaring a kind
+#: charter may deliver next release, or promise delivery by the act of declaring — and the
+#: EVENT_KINDS docstring already turns down both.
+DELIVERED = (overlay.FOCUS, overlay.BLUR, overlay.RESIZE)
+
+#: The delivered kinds that need the pane's own input read. ``resize`` is not among them:
+#: a `SIGWINCH` already reaches this process and `pane.size()` already answers the
+#: rectangle, so a component that wants only that costs its pane's terminal nothing.
+_FROM_INPUT = (overlay.FOCUS, overlay.BLUR)
+
+#: What the pane writes to ask its terminal to report its own focus, and the withdrawal.
+#: `overlay.MOUSE_ON`/`MOUSE_OFF` are the same pair for the pointer, one surface over.
+#:
+#: tmux delivers ``\\x1b[I``/``\\x1b[O`` to a pane's program only when that program has
+#: asked, and only while the server's ``focus-events`` is on — both halves measured against
+#: real tmux 3.7c, two panes, a real attached client::
+#:
+#:     focus-events on   pane that asked:      READ b'\\x1b[I' / b'\\x1b[O' on every select
+#:                       pane that did not:    nothing, ever
+#:     focus-events off  pane that asked:      nothing, ever
+#:
+#: `commands_frame.conf_text` writes ``set -g focus-events on`` for every frame charter
+#: launches (#559), so these fire on charter's own server and do not inside an operator's
+#: existing tmux, where charter sources no config at all. `docs/frame.md` says that half to
+#: the operator.
+FOCUS_ON = "\x1b[?1004h"
+FOCUS_OFF = "\x1b[?1004l"
+
+#: How much of the pane is read at once. One `read` never has to return a whole sequence —
+#: `overlay.decode` holds a partial one back — so this only bounds how many events one
+#: tick can carry. `palette._CHUNK`'s number, for the same reason it is that number.
+_CHUNK = 4096
+
+#: What a descriptor that cannot be asked raises. `frame/pane.py`'s own set — a `StringIO`
+#: has no `fileno`, a closed stream raises `ValueError`, a real descriptor with no tty
+#: behind it raises `OSError`, and a library's stand-in may have no such attribute at all —
+#: **plus `termios.error`, which is not any of them.**
+#:
+#: That last one is measured rather than assumed, and the first version of this module had
+#: it wrong::
+#:
+#:     termios.error.__mro__       -> (termios.error, Exception, BaseException, object)
+#:     termios.tcgetattr(/dev/null) -> termios.error(19, 'Operation not supported by device')
+#:     isinstance(that, OSError)    -> False
+#:
+#: `frame/pane.py`'s set is complete for the questions IT asks — `fileno`, `isatty` and
+#: `os.get_terminal_size` all raise `OSError` — so this is a superset rather than a
+#: disagreement, and the extra member is named here beside the call that needs it. Getting
+#: it wrong would have taken a panel with stdout piped to a file (`charter panel
+#: acme.metrics --session x > /tmp/log`) from "no focus events, which is fine" to
+#: `panel._hold`, painting a refusal for a component that had done nothing wrong.
+_CANNOT_SAY = (AttributeError, OSError, ValueError, termios.error)
+
+
+def wanted(c) -> tuple[str, ...]:
+    """The kinds charter will actually deliver to component *c*, in declared order.
+
+    The intersection of what it declared and what :data:`DELIVERED` says charter carries —
+    empty for a component with no handler, which `component.Component` already refuses to
+    build alongside a non-empty ``events``, and empty for one whose every declared kind is
+    a kind charter does not fire. That second emptiness is the one that matters: a
+    component declaring only ``click`` gets no dispatcher, so its pane's terminal is left
+    exactly as it was found.
+
+    ``c.on_event`` rather than a ``getattr`` with a default: every `Component` carries the
+    field, so a default here would be a branch nothing can reach and no test can falsify —
+    which this project deletes rather than keeps (#568). What makes it unreachable is
+    itself pinned, by the case that asks a component declaring neither for its ``on_event``
+    and gets ``None``.
+    """
+    return tuple(k for k in c.events if k in DELIVERED) if c.on_event else ()
+
+
+class Dispatcher:
+    """The event path for one panel's one component: the pane's input, and the handler.
+
+    One instance per panel process, built by `panel._run` only when :func:`wanted` answers
+    something, and opened and closed by `panel._watch` around the loop it lives in.
+
+    An object rather than a closure because it holds four things that must be put back or
+    compared later: the tty attributes it displaced, the partial escape sequence it is
+    holding, the rectangle it last saw, and whether the handler has already failed.
+    """
+
+    def __init__(self, component, *, stream=None) -> None:
+        self._c = component
+        self._kinds = frozenset(wanted(component))
+        #: The pane, resolved once. ``None`` until :meth:`open`, and left ``None`` for a
+        #: pane whose input cannot be read at all — see :meth:`open`.
+        self._stream = stream
+        self._fd: int | None = None
+        self._before = None
+        self._tail = b""
+        self._size = None
+        self._failure: str | None = None
+
+    # -- what the panel asks ------------------------------------------------ #
+
+    @property
+    def failure(self) -> str | None:
+        """Why this component stopped taking events, or ``None`` while it still does.
+
+        Read by `panel._component_text`, which draws it INSTEAD of the component — see
+        this module's docstring for the trade that is.
+        """
+        return self._failure
+
+    @property
+    def reading(self) -> bool:
+        """Whether this dispatcher currently holds the pane's input open.
+
+        ``False`` before :meth:`open`, for a component that wants only ``resize``, for a
+        pane that is not a terminal, and after a handler failure retired it. Asked by tests
+        rather than by production, which is the point: "charter touched nothing" is the
+        promise a panel with no declared events makes, and a promise nothing can ask about
+        is a promise nothing can pin.
+        """
+        return self._fd is not None
+
+    def open(self) -> None:
+        """Take what this dispatcher needs, and nothing it does not.
+
+        Records the pane's rectangle so :meth:`note_resize` has something to compare
+        against — always, because ``resize`` needs no input path — and then, only if a kind
+        that comes from input was declared, puts the tty in cbreak and asks the terminal to
+        report focus.
+
+        **A pane that cannot be asked is left alone and reports nothing**, which is
+        `component.EVENT_KINDS`'s "degrade to never fires" rather than a failure: this is
+        `charter panel acme.metrics --session x > /tmp/log` run by hand for debugging, or a
+        test, and neither has a terminal for a focus change to happen in. It is not a
+        provider's fault and must not reach a provider's pane.
+        """
+        self._size = pane.size()
+        if not any(k in self._kinds for k in _FROM_INPUT):
+            return
+        stream = pane.stream() if self._stream is None else self._stream
+        try:
+            fd = stream.fileno()
+            before = termios.tcgetattr(fd)
+            mode = termios.tcgetattr(fd)
+            # Exactly two lflags and the two control characters, and no output flag at
+            # all — see this module's docstring for the measured staircase `tty.setraw`
+            # draws here. A second `tcgetattr` rather than a slice of the first, because
+            # `tcsetattr` takes the list apart and a shared one would leave *before*
+            # describing the mode this call installed instead of the one it displaced.
+            mode[3] = mode[3] & ~(termios.ICANON | termios.ECHO)
+            mode[6] = list(mode[6])
+            mode[6][termios.VMIN] = 0
+            mode[6][termios.VTIME] = 0
+            termios.tcsetattr(fd, termios.TCSANOW, mode)
+        except _CANNOT_SAY:
+            # Everything up to here either all happened or changed nothing: the two
+            # `tcgetattr`s are reads, and a `tcsetattr` that raised installed nothing. So
+            # there is no half-open state to unwind, and `_fd` staying `None` is what says
+            # this pane has no input path.
+            return
+        self._before = before
+        self._fd = fd
+        self._stream = stream
+        self._write(FOCUS_ON)
+
+    def close(self) -> None:
+        """Withdraw the request and put the tty back exactly as it was found.
+
+        Idempotent and never raising, because both callers are a ``finally``: `_watch`'s,
+        which runs before `panel._hold` can paint a reason and hold the pane forever, and
+        :meth:`_deliver`'s, which runs while a stranger's exception is being turned into a
+        message. A restore that raised in either would leave the operator's pane in a mode
+        charter chose and nothing puts back.
+
+        **`TCSANOW` and never `TCSADRAIN`, and this one was measured the hard way.**
+        `TCSADRAIN` waits for the terminal to consume everything already written, and on a
+        pty whose far end is not reading it simply never returns — the first version of
+        this module hung its own test suite there, in a cleanup, with the traceback
+        pointing at this line. `frame/palette.py:own_the_tty` uses `TCSADRAIN` and is right
+        to: it clears `OPOST`, so output already queued would come out under different
+        rules if the restore jumped the queue. This module changes no output flag at all
+        (see :meth:`open`), so a drain here protects nothing and can only wedge — and a
+        wedge in the `finally` that holds the operator's tty mode is the worst place on the
+        path to put one.
+        """
+        fd, before, self._fd, self._before = self._fd, self._before, None, None
+        if fd is None:
+            return
+        try:
+            self._write(FOCUS_OFF)
+        except _CANNOT_SAY:
+            pass
+        try:
+            termios.tcsetattr(fd, termios.TCSANOW, before)
+        except _CANNOT_SAY:
+            pass
+
+    def note_resize(self) -> None:
+        """Deliver a ``resize`` if this pane's rectangle has actually moved.
+
+        Called by `panel._tick` immediately BEFORE the paint, so a handler that recomputes
+        a layout has done so by the time `render` is asked for rows — one repaint, not two.
+
+        **The rectangle is what decides, never the signal.** `SIGWINCH` is how the panel
+        learns to look, and `panel._watch` seeds its resize flag ``True`` so the first pass
+        always paints; a `resize` fired off that flag would announce one before the pane
+        had ever been drawn. Comparing `pane.size()` to the last one seen answers the
+        question the event is actually about, and answers it correctly for the first tick
+        (nothing moved) without a second "have I painted yet" sentinel.
+
+        A rectangle charter could not measure is not one end of a comparison. ``None`` on
+        either side fires nothing: a pty gets its size from a `TIOCSWINSZ` that arrives
+        moments later, and `panel._unmeasured` means the component was never drawn at the
+        earlier size in the first place, so there is nothing for it to have laid out
+        against.
+        """
+        if overlay.RESIZE not in self._kinds:
+            return
+        was, now = self._size, pane.size()
+        self._size = now
+        if was is not None and now is not None and was != now:
+            self._deliver(Event(overlay.RESIZE))
+
+    def poll(self, timeout: float) -> bool:
+        """Wait up to *timeout* for the pane to say something, and answer whether what it
+        said changed what the panel should draw.
+
+        This replaces `panel._watch`'s `time.sleep` rather than being added beside it: a
+        `select` with a deadline is the same idle cost as a sleep of the same length, and
+        it wakes the moment an event arrives instead of at the next tick boundary. A panel
+        with no dispatcher still sleeps — `panel._wait` is the one place that choice is
+        made.
+
+        **"The other end is gone" has two spellings and this platform is not the one that
+        decides which** — `palette._reader`'s docstring records the measurement that cost a
+        red CI: closing a pty's far end makes the next read answer ``b""`` on macOS and
+        raise ``OSError: [Errno 5]`` on Linux. Both are end of input, both mean there will
+        never be another event, and both close the input path here rather than being
+        answered differently on two operators' machines. The panel itself is NOT ended:
+        its pane is still a rectangle it can paint into, and a panel that stopped
+        repainting because its input closed would be this module taking a pane it was only
+        ever lent.
+        """
+        if self._fd is None:
+            time.sleep(timeout)
+            return False
+        try:
+            ready = select.select([self._fd], [], [], timeout)[0]
+        except _CANNOT_SAY:
+            self.close()
+            return False
+        if not ready:
+            # A quiet period is how every terminal program tells a lone `\x1b` from the
+            # start of a sequence (`overlay.decode`'s *final*). Nothing this module
+            # delivers is spelled with a bare Escape, so what this actually buys is that a
+            # truncated sequence is dropped at the tick rather than held for the life of
+            # the panel and prepended to whatever arrives next.
+            return self._feed(b"", final=True)
+        try:
+            chunk = os.read(self._fd, _CHUNK)
+        except OSError:
+            chunk = b""
+        if not chunk:
+            self.close()
+            return False
+        return self._feed(chunk, final=False)
+
+    # -- the machinery ------------------------------------------------------ #
+
+    def _feed(self, chunk: bytes, *, final: bool) -> bool:
+        """Decode what arrived and hand each event to the component. Repaint?
+
+        The tail is `overlay.decode`'s and is kept here rather than re-derived: a pane's
+        `read` returns whatever the kernel had, which splits ``\\x1b[I`` across two reads as
+        readily as not.
+
+        ``any`` over a list rather than a generator, deliberately: a component with two
+        handlers' worth of state must see EVERY event, and short-circuiting would stop
+        delivering at the first one that asked for a repaint.
+        """
+        evs, self._tail = overlay.decode(self._tail + chunk, final=final)
+        return any([self._deliver(ev) for ev in evs])
+
+    def _deliver(self, ev) -> bool:
+        """Hand *ev* to the handler if it declared that kind. Repaint?
+
+        A kind the component did not declare is dropped here rather than never decoded, so
+        that "what the terminal said" and "what this component asked for" stay two separate
+        questions — the decoder answers the first for every panel identically, and only
+        this line knows the second.
+
+        **`except BaseException` under `except KeyboardInterrupt: raise` is the pairing
+        `Registry.draw` uses, and it means here exactly what it means there**: everything a
+        stranger's code does wrong is contained, and the operator's own interrupt is still
+        theirs. Do not read `panel._component_text`'s single `except Exception` as the same
+        thing — that clause guards charter's own code, one layer up, and #568 removed the
+        interrupt arm from it precisely because it could never have fired.
+        """
+        if self._failure is not None or ev.kind not in self._kinds:
+            return False
+        try:
+            return bool(self._c.on_event(ev))
+        except KeyboardInterrupt:
+            raise
+        except BaseException as exc:
+            self._failure = (f"{contain.one_line(self._c.id)} stopped taking events — "
+                             f"{_because(exc)}")
+            self.close()
+            # True, so the pane repaints and says so on the very next tick rather than
+            # whenever something else happens to move the frame's version.
+            return True
+
+    def _write(self, payload: str) -> None:
+        """One mode request, flushed.
+
+        Into the pane, never `sys.stdout` — `panel._out`'s reason, which is `frame/pane.py`
+        entire. Not through `panel._write`: that clears the pane and honours `NO_COLOR` by
+        stripping every CSI that is not SGR, and both would be wrong for a request that
+        draws nothing and is not colour.
+        """
+        self._stream.write(payload)
+        self._stream.flush()

--- a/charter/frame/overlay.py
+++ b/charter/frame/overlay.py
@@ -177,13 +177,26 @@ _MIN_TITLE = 8
 #: in a short frame, which is the one way this number could cost anything.
 _SPLIT_ROWS = 5
 
-#: The event kinds this surface produces. A subset of `component.EVENT_KINDS` — §4f
-#: closed that list at six, and `focus`/`blur` are not among these because they do not
-#: exist yet: `focus-events` is off by default in tmux and gates the whole path, and with
-#: it off `#{client_flags}` still reads `attached,focused`, so a guard written against
-#: that flag passes with the feature dead (§4i). Task 7 of the Phase 2 plan turns it on;
-#: until then a `focus` this module invented would fire never or wrongly.
+#: The event kinds :func:`decode` produces. A subset of `component.EVENT_KINDS` — §4f
+#: closed that list at six, and `key` is the only one of these this SURFACE acts on
+#: besides the pointer pair (:meth:`Surface.handle`).
+#:
+#: `focus`/`blur` joined the decoder with #607, and the sentence they replace said they
+#: could not exist because `focus-events` ships off in tmux and gates the whole path.
+#: Task 7 of the Phase 2 plan (#559) turned it on: `commands_frame.conf_text` writes
+#: `set -g focus-events on` for every frame charter launches, so the bytes are real on
+#: charter's own server. They are still absent inside an operator's existing tmux, where
+#: charter sources no config at all — which is "never fires", the direction
+#: `component.EVENT_KINDS` asks to degrade in, and not the `#{client_flags}` guard §4i
+#: warns about, which reads `attached,focused` with the feature dead.
+#:
+#: **This surface acts on neither**, and that is not an oversight: the overlay is the
+#: ACTIVE, zoomed pane for its whole life, so it never asks for `\x1b[?1004h` and no
+#: focus report ever reaches its decoder. `frame/events.py` is what these are decoded
+#: for, one pane over. `Surface.handle` returning `None` for them is pinned, so this
+#: addition cannot start moving a palette's selection.
 KEY, CLICK, SCROLL, RESIZE = "key", "click", "scroll", "resize"
+FOCUS, BLUR = "focus", "blur"
 
 #: What :meth:`Surface.handle` answers with. Strings rather than an enum for the reason
 #: the rest of this package uses strings: they appear in a test's failure message as
@@ -216,6 +229,23 @@ _CSI_KEYS = {b"A": "up", b"B": "down", b"C": "right", b"D": "left",
              b"H": "home", b"F": "end"}
 _TILDE_KEYS = {b"1": "home", b"4": "end", b"5": "pgup", b"6": "pgdn", b"7": "home",
                b"8": "end"}
+
+#: The two CSI sequences that are not a key at all but this pane's own focus changing.
+#: tmux's spelling, measured against real tmux 3.7c: selecting a pane whose program had
+#: written `\x1b[?1004h` delivered `b'\x1b[I'`, selecting away delivered `b'\x1b[O'`, and
+#: the client's own terminal losing and regaining focus delivered the same pair to the
+#: active pane.
+#:
+#: **Matched only with NO parameters, and that is a guard rather than tidiness.** `CSI I`
+#: is ECMA-48's CHT and `CSI O` is a private form; both take a numeric parameter in every
+#: use that is not this one, so `\x1b[3I` is a cursor movement some program echoed and not
+#: three focus events. Requiring the parameter list to be empty is
+#: `component.EVENT_KINDS`'s "degrade to never fires, never to fires wrongly" applied at
+#: the only place that can tell the two apart.
+#:
+#: Before #607 both fell through to :data:`_CSI_KEYS`, which has no name for either, and
+#: were consumed and dropped — so this changes nothing about what the palette sees.
+_CSI_FOCUS = {b"I": FOCUS, b"O": BLUR}
 
 #: One WHOLE CSI: `ESC [`, its numeric parameters, and the final byte that ends it —
 #: ECMA-48's own shape, `0x40`–`0x7e`.
@@ -322,6 +352,13 @@ def decode(buf: bytes, *, final: bool = False) -> tuple[list[Event], bytes]:
     path — otherwise Ctrl-Up types `1;5A`, F1 types `P`, and a paste types the brackets
     tmux wrapped it in. The rule is one rule; only where it is enforced was ever in
     question.
+
+    **Two of those whole sequences are not keys, and #607 gave them their names.**
+    ``\\x1b[I`` and ``\\x1b[O`` are this pane gaining and losing focus (:data:`_CSI_FOCUS`);
+    they used to be consumed and dropped, which was right while nothing could receive
+    them and wrong once `frame/events.py` could. Decoding is one question for every caller
+    — WHICH kinds a given surface acts on is the caller's, and this surface acts on
+    neither.
     """
     evs: list[Event] = []
     while buf:
@@ -361,6 +398,11 @@ def decode(buf: bytes, *, final: bool = False) -> tuple[list[Event], bytes]:
                 buf = buf[2:]
                 continue
             params, final_byte, buf = m[1], m[2], buf[m.end():]
+            if not params and final_byte in _CSI_FOCUS:
+                # This pane gained or lost focus. Not a key, and never named as one: a
+                # `focus` reaching `_CSI_KEYS` would be a keypress spelled `I`.
+                evs.append(Event(_CSI_FOCUS[final_byte]))
+                continue
             # For the `~` family the FIRST parameter names the key and the rest are
             # modifiers, exactly as the final byte names it for the others — so
             # `\x1b[5;5~` (Ctrl-PgUp) is PgUp, and one rule covers both families rather

--- a/charter/frame/overlay.py
+++ b/charter/frame/overlay.py
@@ -190,11 +190,19 @@ _SPLIT_ROWS = 5
 #: `component.EVENT_KINDS` asks to degrade in, and not the `#{client_flags}` guard §4i
 #: warns about, which reads `attached,focused` with the feature dead.
 #:
-#: **This surface acts on neither**, and that is not an oversight: the overlay is the
-#: ACTIVE, zoomed pane for its whole life, so it never asks for `\x1b[?1004h` and no
-#: focus report ever reaches its decoder. `frame/events.py` is what these are decoded
-#: for, one pane over. `Surface.handle` returning `None` for them is pinned, so this
-#: addition cannot start moving a palette's selection.
+#: **This surface acts on neither**, and that is not an oversight: the overlay runs in a
+#: pane `open_argv` splits for it moments earlier, nothing in that pane writes
+#: `\x1b[?1004h`, and tmux sends focus reports only to a pane whose program asked
+#: (measured — see `frame/events.py`). `frame/events.py` is what these are decoded for,
+#: one pane over. `Surface.handle` returning `None` for them is pinned, so this addition
+#: cannot move a palette's selection.
+#:
+#: **What it would cost if one did arrive is a repaint, and that is stated rather than
+#: waved away.** `Surface.run` sets `repaint = True` for every event its `handle` does not
+#: turn into a verdict, so a focus report would redraw the pane where before these bytes
+#: were consumed and produced nothing. A palette redraws on every keystroke already, so
+#: the cost is one the surface pays constantly by design — but "cannot reach it" and
+#: "would be free if it did" are two claims, and only the first was true.
 KEY, CLICK, SCROLL, RESIZE = "key", "click", "scroll", "resize"
 FOCUS, BLUR = "focus", "blur"
 

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -344,12 +344,26 @@ def _component_text(reg, cid: str, fid: str, *, evs=None) -> str:
     #512 is what it costs to ship.
     """
     from . import ctx as _ctx, gather
+    from .registry import _fit, _wrap
     try:
         if evs is not None and evs.failure:
-            # `contain.one_line` BEFORE the width arithmetic, as below and for the same
-            # reason: the reason quotes a stranger's exception text.
-            return tui.truncate(f" charter: {contain.one_line(evs.failure)}",
-                                slots._width())
+            # WRAPPED across the pane's rows, exactly as `Registry.draw` wraps the same
+            # class of message, and never truncated to one line. `_wrap`'s own docstring
+            # says why that is not cosmetic: "the tail of a refusal is the half that says
+            # what to do about it". Measured against this message in a 30-column `right`
+            # panel — " charter: acme.metrics stopped taking events — " is 45 characters
+            # on its own, so a single `tui.truncate` clips the exception text ALWAYS,
+            # which is the only part naming what broke.
+            #
+            # `content_width`/`inset_rows`, not `slots._width()`, so the reason sits in
+            # the same rectangle the component's own rows do and the operator's `pad`
+            # reaches it. `contain.one_line` BEFORE the width arithmetic (#472): the text
+            # quotes a stranger's exception, and `tui.width` on an unescaped escape
+            # sequence measures something the terminal is not about to draw.
+            width = slots.content_width(cid)
+            return slots.inset_rows(
+                "\n".join(_fit(_wrap(f"charter: {contain.one_line(evs.failure)}", width),
+                               width=width, height=_rows(), escape=True)), cid)
         c = reg.get(cid)
         snapshot = gather.read(fid) if c.needs else {}
         drew = reg.draw(cid, _ctx.build(c.needs, width=slots.content_width(cid),
@@ -645,9 +659,17 @@ def _watch(slot: str, fid: str, *, once: bool, paint=None, evs=None) -> int:
                 return 0
             handled = _wait(evs)
     finally:
-        if evs is not None:
-            evs.close()
-        signal.signal(signal.SIGWINCH, old_handler)
+        # Nested, so the handler goes back even if `close` raises. `signal.signal` cannot
+        # fail here and `close` can, and a flat sequence put the fallible call FIRST —
+        # which would have defeated the very guarantee this function was split out to make
+        # (`RunOnceLoop.test_once_true_restores_the_previous_sigwinch_handler`), leaving a
+        # handler waking a loop that has nothing left to repaint for the rest of a held
+        # process's life.
+        try:
+            if evs is not None:
+                evs.close()
+        finally:
+            signal.signal(signal.SIGWINCH, old_handler)
 
 
 def run(slot: str, fid: str, *, once: bool = False) -> int:

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -49,6 +49,20 @@ the directory absent, or present and empty — that is one syscall per tick, alo
 one `state.version` already pays, and the panel paints nothing. It is self-limiting by
 construction rather than by a budget: the ticking stops when the records do.
 
+**A panel can now READ its pane, and only when a component asked it to** (#607). The loop
+below is otherwise unchanged: `_wait` replaces the tick's `time.sleep` with a `select` of
+the same length when — and only when — the placed component declared an event kind charter
+delivers, so an event wakes the panel the instant it arrives instead of at the next tick
+boundary, and a panel that declared nothing pays and changes nothing at all. Charter's own
+four are in that second group, so the frame an operator has today is byte-identical and
+syscall-identical to the one they had before the dispatcher existed.
+
+The event itself never draws. A handler answers "repaint me" and `_tick` treats that as a
+fourth reason to run the paint it already had — the rows are still `render`'s, still
+escaped and clipped by `Registry.draw`, still written by `_write`. `frame/events.py` holds
+the whole mechanism and the argument for it; what lives here is the loop it hangs off and
+the `finally` that puts the operator's tty mode back.
+
 **SIGWINCH matters because a resize does not bump the frame's version.** Only charter's
 own hooks call `state.bump`; the operator resizing their terminal does not. Without a
 handler, a pane sits with content painted for the OLD size until some unrelated activity
@@ -254,7 +268,7 @@ def _paint(slot: str, fid: str) -> None:
     _write(_unmeasured() or slots.render(slot, fid))
 
 
-def _component_painter(reg, cid: str):
+def _component_painter(reg, cid: str, evs=None):
     """A paint function for *cid*, drawn out of *reg* — `_paint`'s shape for a component.
 
     **The registry is built once and closed over, not rebuilt per tick.** A panel drawing
@@ -272,13 +286,18 @@ def _component_painter(reg, cid: str):
     reason stronger than symmetry: `ctx.build` hands a component a `width` and a `height`
     it is entitled to draw to the edge of, so a guess passed through this door is a guess a
     stranger's code has already been told is a measurement.
+
+    *evs* is this component's event path (`frame/events.py`), or ``None`` for one that
+    declared nothing charter delivers. Closed over here for the same reason *reg* is: what
+    this panel draws was decided once, when `run` resolved the name, and asking per tick
+    would put the question on the repaint path.
     """
     def paint(_name: str, fid: str) -> None:
-        _write(_unmeasured() or _component_text(reg, cid, fid))
+        _write(_unmeasured() or _component_text(reg, cid, fid, evs=evs))
     return paint
 
 
-def _component_text(reg, cid: str, fid: str) -> str:
+def _component_text(reg, cid: str, fid: str, *, evs=None) -> str:
     """*cid*'s rows for this pane, as the one string `_write` takes.
 
     ``ctx`` is built from what the component DECLARED (§4e), so a component that declared
@@ -316,9 +335,21 @@ def _component_text(reg, cid: str, fid: str) -> str:
     the clause below THAT one is `except BaseException`, so there the two lines are the
     only reason an interrupt survives a stranger's renderer at all.
     `TheOperatorsInterruptIsNotAComponentFailure` pins both halves.
+
+    **A component whose event handler raised draws this message instead of its rows**
+    (#607), which is `registry.Registry`'s answer to a provider that fails on import or
+    while building, given to the fourth moment one can fail. The trade is real and
+    `frame/events.py` states it: a working ``render`` loses its pane because the HANDLER
+    broke. The alternative is a component that quietly stops being interactive, which
+    #512 is what it costs to ship.
     """
     from . import ctx as _ctx, gather
     try:
+        if evs is not None and evs.failure:
+            # `contain.one_line` BEFORE the width arithmetic, as below and for the same
+            # reason: the reason quotes a stranger's exception text.
+            return tui.truncate(f" charter: {contain.one_line(evs.failure)}",
+                                slots._width())
         c = reg.get(cid)
         snapshot = gather.read(fid) if c.needs else {}
         drew = reg.draw(cid, _ctx.build(c.needs, width=slots.content_width(cid),
@@ -332,6 +363,30 @@ def _component_text(reg, cid: str, fid: str) -> str:
         return tui.truncate(
             f" charter: {contain.one_line(cid)} unavailable ({type(e).__name__})",
             slots._width())
+
+
+def _dispatcher(reg, cid: str):
+    """*cid*'s event path, or ``None`` for a component charter delivers nothing to.
+
+    **``None`` is the whole cost promise** (#607). A panel whose component declared no
+    event kind charter fires builds no dispatcher, so `_watch` sleeps as it always has, the
+    pane's tty keeps whatever mode it was in, and nothing asks the terminal to report
+    anything. Charter's own four panels never reach this function at all — they are drawn
+    by `slots.SLOTS` off the branch above — so the frame an operator has today is
+    byte-identical and syscall-identical to the one they had before this existed.
+
+    Built from the REGISTERED component rather than from the id, so a provider that failed
+    to load gets no event path either: `Registry._stand_in` declares no events, which is
+    correct — a standin is charter's own message about somebody else's failure, and a
+    message does not handle a click.
+
+    Imported here rather than at module scope, following this module's own precedent for
+    `builtins` and `gather`: `charter panel top` is the common case and must not pay for
+    the import of a decoder it will never call.
+    """
+    from . import events as _events
+    c = reg.get(cid)
+    return _events.Dispatcher(c) if _events.wanted(c) else None
 
 
 def _hold(reason: str, *, once: bool, rc: int) -> int:
@@ -448,8 +503,28 @@ def _install_sigwinch(resized: dict) -> object:
     return signal.signal(signal.SIGWINCH, lambda *_a: resized.__setitem__("flag", True))
 
 
+def _wait(evs, timeout: float = TICK) -> bool:
+    """Wait out one tick, and answer whether an event changed what to draw.
+
+    **The one place a panel decides how it waits**, so "a panel with no declared events
+    behaves exactly as it did before this feature existed" is a property one function
+    holds rather than a claim spread across the loop. With no dispatcher this is the
+    `time.sleep` `_watch` has always ended its iteration with.
+
+    With one, a `select` of the same length replaces it (`events.Dispatcher.poll`) — the
+    same idle cost, and it wakes the instant the pane says something instead of at the
+    next tick boundary. A *second* mechanism beside the sleep is what this deliberately is
+    not: a panel that both slept and polled would have two clocks to keep in step.
+    """
+    if evs is None:
+        time.sleep(timeout)
+        return False
+    return evs.poll(timeout)
+
+
 def _tick(resized: dict, seen: str, slot: str, fid: str, *,
-          animating: bool = False, paint=None) -> str:
+          animating: bool = False, paint=None, events=None,
+          handled: bool = False) -> str:
     """One loop iteration's decision AND its effect — split out of `run` so the
     DECISION (paint now, or wait) can be exercised without also exercising `run`'s
     `while True`/`time.sleep`, which a test cannot call directly without either hanging
@@ -493,16 +568,33 @@ def _tick(resized: dict, seen: str, slot: str, fid: str, *,
     instead. A parameter rather than a branch inside the loop, because the choice is made
     once, where `run` resolves the name: asking "is this a component?" every tick would
     put an installed-distribution scan on the repaint path.
+
+    *handled* is the fourth reason, and it is the ONLY way an event reaches the screen
+    (#607): a component's handler answered truthy for "repaint me", so what this panel
+    would draw now differs from what is on it. Deliberately a reason to run the existing
+    paint rather than a second way to draw — the rows are still `render`'s, still escaped
+    and clipped by `registry.Registry.draw`, still written by `_write`. `_watch` is what
+    computes it, from `_wait`.
+
+    *events* is that component's event path, and it is asked for a ``resize`` immediately
+    BEFORE the paint. The order is the property: a handler that recomputes a layout for a
+    new rectangle has done so by the time `render` is asked for rows, so a resize costs one
+    repaint rather than one that is wrong and one that corrects it. It is asked on every
+    paint rather than only when *resized* is set, because `events.Dispatcher.note_resize`
+    answers from the pane's MEASURED rectangle — the flag is how this loop learns to look,
+    and the rectangle is what the event is about.
     """
     now = state.version(fid)
-    if resized["flag"] or now != seen or animating:
+    if resized["flag"] or now != seen or animating or handled:
+        if events is not None:
+            events.note_resize()
         resized["flag"] = False
         (paint or _paint)(slot, fid)
         return now
     return seen
 
 
-def _watch(slot: str, fid: str, *, once: bool, paint=None) -> int:
+def _watch(slot: str, fid: str, *, once: bool, paint=None, evs=None) -> int:
     """The live loop: paint on every version bump, resize, or spinner frame, until killed.
 
     The third reason is the only one that repeats on its own, and it is bounded twice over
@@ -517,6 +609,12 @@ def _watch(slot: str, fid: str, *, once: bool, paint=None) -> int:
     the rest of a held process's life would keep waking a loop that has nothing left to
     repaint, and `RunOnceLoop.test_once_true_restores_the_previous_sigwinch_handler`
     already pins that this module leaks no handler past its own work.
+
+    **The event path is opened and closed by the same `finally`, for that same reason and
+    a sharper one** (#607): what `evs.open()` displaces is the operator's own tty mode, and
+    a panel that reached `_hold` — which never returns — having left `ECHO` off would leave
+    the pane in a state nothing on the machine puts back. `evs.close()` is idempotent and
+    never raises, so it is safe to run after a handler failure has already closed it.
     """
     resized = {"flag": True}  # the first pass always paints, resized or not
     inflight_cache = _new_inflight_cache()
@@ -528,15 +626,20 @@ def _watch(slot: str, fid: str, *, once: bool, paint=None) -> int:
     # `slots.ANIMATED`).
     animates = slot in slots.ANIMATED
     old_handler = _install_sigwinch(resized)
+    if evs is not None:
+        evs.open()
     try:
-        seen = ""
+        seen, handled = "", False
         while True:
-            seen = _tick(resized, seen, slot, fid, paint=paint,
-                         animating=animates and bool(_running(inflight_cache)))
+            seen = _tick(resized, seen, slot, fid, paint=paint, events=evs,
+                         animating=animates and bool(_running(inflight_cache)),
+                         handled=handled)
             if once:
                 return 0
-            time.sleep(TICK)
+            handled = _wait(evs)
     finally:
+        if evs is not None:
+            evs.close()
         signal.signal(signal.SIGWINCH, old_handler)
 
 
@@ -614,7 +717,7 @@ def _run(slot: str, fid: str, *, once: bool = False) -> int:
     from . import builtins as _builtins
     cid = _builtins.component_id(slot)
     try:
-        painter = None
+        painter = evs = None
         if cid in _builtins.SLOT_OF:
             # One of charter's own, under either spelling: `slots.SLOTS` draws it,
             # exactly as it has since there were four names and nothing else.
@@ -628,8 +731,9 @@ def _run(slot: str, fid: str, *, once: bool = False) -> int:
             # `try` all the same — this is a stranger's distribution metadata being read,
             # and the promise this function makes is that a panel PAINTS why it stopped.
             reg.place(cid)
-            painter = _component_painter(reg, cid)
-        return _watch(slot, fid, once=once, paint=painter)
+            evs = _dispatcher(reg, cid)
+            painter = _component_painter(reg, cid, evs)
+        return _watch(slot, fid, once=once, paint=painter, evs=evs)
     except Exception as e:
         reason = f"{contain.one_line(slot)} panel stopped ({type(e).__name__}: {e})"
         print(f"charter panel: {reason}", file=sys.stderr)

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -626,9 +626,16 @@ def _watch(slot: str, fid: str, *, once: bool, paint=None, evs=None) -> int:
     # `slots.ANIMATED`).
     animates = slot in slots.ANIMATED
     old_handler = _install_sigwinch(resized)
-    if evs is not None:
-        evs.open()
     try:
+        # INSIDE the `try`, and that placement is the whole of the second paragraph
+        # above. `open` ends by writing `\x1b[?1004h` to the pane, and a write to a pane
+        # whose far end has gone raises — from OUTSIDE this block that would leak the
+        # SIGWINCH handler this function exists to hand back AND leave the tty in the mode
+        # `open` had already installed a line earlier, with nothing on the machine left to
+        # put either back. `close` is idempotent and reads `_fd`, which `open` sets before
+        # that write, so a failed `open` is still fully unwound here.
+        if evs is not None:
+            evs.open()
         seen, handled = "", False
         while True:
             seen = _tick(resized, seen, slot, fid, paint=paint, events=evs,

--- a/charter/frame/registry.py
+++ b/charter/frame/registry.py
@@ -498,6 +498,25 @@ class Registry:
                 raise ComponentError(
                     f"component {c.id} is built from {cid}, which {self._parent[cid]} "
                     f"already draws — one pane draws it, and two claims have no answer")
+            if child.events:
+                # #607's own defect, one level down, and refused for the reason that issue
+                # exists: `frame/panel.py:_dispatcher` asks `wanted()` of the component
+                # PLACED on the frame, and a part is never placed — its parent draws it
+                # (`on_edge`). So a child's declaration would pass every check, build a
+                # handler, and receive nothing, ever, with nothing anywhere saying so.
+                #
+                # The refusal rather than delivering to children as well, and the argument
+                # is `EVENT_KINDS`'s own about `drag`: widening this later costs nothing,
+                # while a provider that shipped against child delivery makes narrowing it
+                # impossible. A part that needs events says so through the composite that
+                # owns the pane, which is also the only thing that knows which of its parts
+                # a pointer would have been over.
+                raise ComponentError(
+                    f"component {c.id} is built from {cid}, which declares events "
+                    f"{', '.join(child.events)} — a part shares its parent's pane and is "
+                    f"never placed on the frame, so charter would dispatch to {c.id} and "
+                    f"nothing would ever reach {cid}. Declare the events on {c.id} and let "
+                    f"it tell its parts")
             if isinstance(child.size, Fill):
                 fills.append(cid)
         if len(fills) != 1:

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1135,9 +1135,17 @@ repaint that follows, from the one snapshot every component in that repaint shar
 
 **A handler that raises costs the component its events, and the pane says so.** It is
 retired — no further events are delivered to it — and its pane draws the reason instead of
-its rows, the same answer charter gives a provider that fails to import. A handler that
-never returns freezes that one pane and nothing else: the other panels keep painting, your
-harness is untouched, and `F12` still returns you to it.
+its rows, the same answer charter gives a provider that fails to import.
+
+A handler that never returns freezes that one pane. The other panels keep painting, your
+harness is untouched, and `F12` still returns you to it — but that pane also keeps the
+terminal mode charter set for it, so typing into it echoes nothing until you kill it.
+
+**A part of a composite cannot declare events.** A composite draws its parts inside its own
+pane, so a part is never placed on the frame and charter dispatches to the component that
+owns the pane. A part that declared events would receive nothing, which is the thing this
+release exists to stop happening — so it is refused when it registers, and the message says
+to declare them on the composite instead.
 
 ### Picking a workspace when the frame opens
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1088,6 +1088,57 @@ same property that makes `F12` work against a pane that has stopped answering. T
 palette is the one taking your keys; Escape closes it, and the first is an ordinary pane
 you can select and close the same way.
 
+### What a component can be told about
+
+A component declares which events it handles, and supplies one function to receive them:
+
+```python
+component.Component(
+    id="acme.metrics", title="Metrics", edge="right", size=component.Fixed(12),
+    events=("focus", "blur"),
+    on_event=lambda ev: remember(ev.kind),   # answer truthy to repaint
+    render=lambda ctx: [line_for(remembered())],
+)
+```
+
+The two go together or not at all. A component that declares `events` and supplies no
+`on_event` is refused when it loads, and so is one that supplies `on_event` and declares
+nothing — a declaration with nothing behind it looks exactly like a kind charter never
+fires, and that ambiguity is the thing this refusal exists to remove.
+
+**Three of the six kinds fire today.**
+
+| kind | fires |
+|---|---|
+| `resize` | Always. Your pane's rectangle changed. |
+| `focus`, `blur` | Inside a frame charter launched, on a terminal that reports focus. |
+| `key`, `click`, `scroll` | Never yet. Declarable, and delivered nowhere. |
+
+`focus` and `blur` need tmux's `focus-events`, which charter turns on for its own server
+and cannot turn on inside a tmux you already have (see *Inside a tmux you already have*) —
+and your terminal emulator has to report focus in the first place. `key` is not delivered
+because your harness owns the keyboard: tmux routes typing to the active pane, which is the
+harness's, so the only keystrokes a panel could see are the ones you typed into the wrong
+pane. `click` and `scroll` are the subject of *Mouse is off by default* above, and there is
+a second reason on top of that one: tmux routes a pointer by position and a click does not
+move focus, so a click on an unfocused panel would be a second, silent focus that disagrees
+with where your keyboard is going. Charter would rather deliver nothing than deliver that.
+
+Declaring a kind that does not fire is not an error and never becomes one. A declaration
+says what a component *handles*; it is not a promise from charter that the event happens.
+Give anything a pointer could do a key or a palette action as well.
+
+**A handler is told what happened; `render` is what draws.** Nothing `on_event` returns
+reaches your pane — the return value only says whether to repaint, and the repaint runs
+your ordinary `render`. A handler is handed no `ctx` either: the plane is read at the
+repaint that follows, from the one snapshot every component in that repaint shares.
+
+**A handler that raises costs the component its events, and the pane says so.** It is
+retired — no further events are delivered to it — and its pane draws the reason instead of
+its rows, the same answer charter gives a provider that fails to import. A handler that
+never returns freezes that one pane and nothing else: the other panels keep painting, your
+harness is untouched, and `F12` still returns you to it.
+
 ### Picking a workspace when the frame opens
 
 `charter <harness>` used to resolve a workspace silently and go straight in. If **nothing

--- a/docs/news/unreleased-a-panel-can-tell-you-it-is-the-one-you-are-looking-at.md
+++ b/docs/news/unreleased-a-panel-can-tell-you-it-is-the-one-you-are-looking-at.md
@@ -82,7 +82,17 @@ from one nothing has happened to yet.
 
 A handler that never returns freezes that one pane. The other panels keep painting, your
 harness is untouched, and `F12` still takes you back to it — the escape hatch runs in
-tmux's own key table and needs no charter code to be working.
+tmux's own key table and needs no charter code to be working. That pane also keeps the
+terminal mode charter set for it, so typing into it echoes nothing until you kill it; the
+restore runs when the panel stops, and a handler that never returns never lets it.
+
+## One more refusal
+
+A **part of a composite** cannot declare events. A composite draws its parts inside its own
+pane, so a part is never placed on the frame and charter dispatches to whatever owns the
+pane. A part that declared events would get none — this release's own defect, one level
+down — so it is refused when it registers, naming both components and saying to put the
+declaration on the composite.
 
 ## Nothing to adopt
 

--- a/docs/news/unreleased-a-panel-can-tell-you-it-is-the-one-you-are-looking-at.md
+++ b/docs/news/unreleased-a-panel-can-tell-you-it-is-the-one-you-are-looking-at.md
@@ -1,0 +1,89 @@
+---
+version: unreleased
+headline: A component can be told when its pane is focused, blurred or resized — the events it was allowed to declare and never received
+---
+
+`Component.events` has been part of the contract for two phases. A provider could write
+`events = ["scroll"]`, pass every check charter makes, and receive nothing, ever. There was
+no dispatcher. The vocabulary was validated and read by nothing.
+
+There is one now, and it delivers three of the six kinds.
+
+## What fires
+
+```python
+component.Component(
+    id="acme.metrics", title="Metrics", edge="right", size=12,
+    events=("focus", "blur"),
+    on_event=lambda ev: remember(ev.kind),   # answer truthy to repaint
+    render=lambda ctx: [line_for(remembered())],
+)
+```
+
+`focus` and `blur` when your pane becomes, or stops being, the one you are looking at.
+`resize` when its rectangle moves. That is enough for a panel to dim itself when you look
+away, to show a hint only while you are on it, or to drop a layout it cached for a width
+it no longer has.
+
+Measured against real tmux 3.7c before any of it was written — two panes, a real attached
+client, one pane asking for focus reporting and one not:
+
+```
+focus-events on    the pane that asked      READ b'\x1b[I' on select, b'\x1b[O' on leave
+                   the pane that did not    nothing, ever
+focus-events off   the pane that asked      nothing, ever
+```
+
+So this works on charter's own server, where charter writes `set -g focus-events on`, and
+does not inside a tmux you already have, where charter writes no config at all. Your
+terminal has to report focus too. That is the honest limit and it is the direction the
+contract asks you to degrade in: **never fires, rather than fires wrongly.**
+
+## What does not fire, and why it is still declarable
+
+`key`, `click` and `scroll` are decoded and routed nowhere.
+
+`key` is not delivered because your harness owns the keyboard. tmux sends typing to the
+active pane, which is the harness's, so the only keystrokes a panel could ever see are the
+ones you typed into the wrong pane — and acting on those is worse than dropping them.
+
+`click` and `scroll` are the harder one, and the answer is *not yet* rather than *no*.
+Mouse reporting comes from the active pane's own request, which is why `[frame] mouse`
+defaults to off and costs you your terminal's text selection when it is on. The experiment
+behind this work measured the rest: **tmux routes a pointer by position, and a click does
+not focus the pane it lands in.** So a click on an unfocused panel would be a second focus,
+disagreeing with where your keyboard is going, with nothing anywhere saying which one is
+driving the component. Charter would rather deliver nothing than deliver that, and the
+decision about what a click on a non-active pane should mean is written down in the pull
+request rather than guessed at here.
+
+Declaring a kind that does not fire stays legal and stays free. A declaration says what
+your component *handles*; it was never a promise from charter that the event happens.
+
+## What a declaration costs now
+
+The two halves go together. A component that declares `events` and supplies no `on_event`
+is refused when it loads, and so is one that supplies `on_event` and declares nothing. That
+is a real change for a component written against the old contract — but only for one that
+declared events it was never receiving, which is the defect this release is about.
+
+A panel whose component declares nothing charter delivers is untouched: no dispatcher is
+built, its pane's terminal keeps whatever mode it was in, and the loop sleeps exactly as it
+did. Charter's own four panels are in that group, so the frame you have today is the frame
+you had yesterday.
+
+## When a handler goes wrong
+
+A handler that raises is retired — no further events reach it — and its pane draws the
+reason instead of its rows, the same answer charter already gives a provider that fails to
+import. A working `render` does lose its pane to a message when its handler breaks, and
+that is the trade: a component that quietly stops being interactive is indistinguishable
+from one nothing has happened to yet.
+
+A handler that never returns freezes that one pane. The other panels keep painting, your
+harness is untouched, and `F12` still takes you back to it — the escape hatch runs in
+tmux's own key table and needs no charter code to be working.
+
+## Nothing to adopt
+
+If you have not written a frame component, nothing changes for you.

--- a/tests/test_a_component_event_reaches_its_handler.py
+++ b/tests/test_a_component_event_reaches_its_handler.py
@@ -181,6 +181,38 @@ class CharterDeliversThreeOfTheSixAndSaysWhich(unittest.TestCase):
         self.assertEqual(events.wanted(c), ())
 
 
+class TheWithdrawalUndoesExactlyWhatTheRequestAsked(unittest.TestCase):
+    """The two mode constants are a PAIR, and the cases that watch them being written can
+    only ever compare a constant to itself.
+
+    `FOCUS_ON`'s value is pinned for real by `tests/test_frame_focus_reaches_a_component.py`
+    — a wrong private-mode number there means tmux sends nothing and the whole integration
+    class goes red. `FOCUS_OFF` has no such witness: nothing observes a pane after charter
+    has stopped reading it. So what is asked here is the RELATIONSHIP, which is where the
+    realistic defect lives — a typo in one number of one of the two.
+
+    It is not cosmetic. A `FOCUS_OFF` that withdrew a different mode would leave tmux
+    reporting focus at a pane nobody is reading after a handler failure retired it, filling
+    that pty's input buffer for the life of the frame.
+    """
+
+    def test_off_is_on_with_the_low_letter(self):
+        self.assertTrue(events.FOCUS_ON.endswith("h"))
+        self.assertEqual(events.FOCUS_OFF, events.FOCUS_ON[:-1] + "l")
+
+    def test_it_is_a_private_mode_set_and_not_something_else(self):
+        self.assertTrue(events.FOCUS_ON.startswith("\x1b[?"))
+
+    def test_it_is_the_pair_the_overlay_does_not_already_own(self):
+        """`overlay.MOUSE_ON` is the same shape for the pointer. Asking that these are not
+        it keeps a copy-paste from arming mouse reporting on every panel that wanted to
+        know whether it was focused — which would take the operator's text selection
+        without `[frame] mouse` ever being set."""
+        self.assertNotIn(events.FOCUS_ON, overlay.MOUSE_ON)
+        self.assertNotIn("1000", events.FOCUS_ON)
+        self.assertNotIn("1006", events.FOCUS_ON)
+
+
 class TheDecoderNamesFocusAndBlur(unittest.TestCase):
     """The two sequences `overlay.decode` used to consume and drop."""
 

--- a/tests/test_a_component_event_reaches_its_handler.py
+++ b/tests/test_a_component_event_reaches_its_handler.py
@@ -138,6 +138,21 @@ class TheDeclarationAndTheHandlerAreOneThing(unittest.TestCase):
             _component(on_event="not a function")
         self.assertIn("callable", str(e.exception))
 
+    def test_the_refusal_contains_what_it_quotes_back(self):
+        """The refusal repeats the value it would not take, and a provider's object
+        answers `repr` with whatever it likes. A message is display text that reaches a
+        terminal (`component.py`'s module docstring is entirely about this), so an escape
+        sequence in that `repr` is an instruction rather than a character — and a refusal
+        that could forge a second line is worse than the value it refuses."""
+        class _Forges:
+            def __repr__(self_):
+                return "harmless\x1b[2J\x1b[Hgone"
+
+        with self.assertRaises(component.ComponentError) as e:
+            _component(on_event=_Forges())
+        self.assertNotIn("\x1b[2J", str(e.exception))
+        self.assertIn("harmless", str(e.exception))
+
     def test_the_pair_together_is_accepted(self):
         c, _seen = _component()
         self.assertEqual(c.events, ("focus", "blur"))
@@ -182,11 +197,14 @@ class CharterDeliversThreeOfTheSixAndSaysWhich(unittest.TestCase):
         self.assertEqual(events.wanted(c), ())
 
     def test_a_handler_that_is_falsy_is_still_a_handler(self):
-        """`Component` accepts any callable, and a handler written as an instance of a
-        class rather than as a function may define a falsy `__bool__` or an empty
-        `__len__`. Asking truthiness here would give it no dispatcher at all — #607's
-        defect with a new spelling — so the question is `is not None`, which is the one
-        `Component`'s own validation asks."""
+        """`wanted` asks nothing about the handler now — `Component` refuses the pair apart,
+        so a component with none has no events either and the intersection is already `()`.
+
+        This case is what stops that check coming back. A handler written as an instance
+        with a falsy `__bool__` or an empty `__len__` is a callable `Component` accepts, and
+        any `if c.on_event:` reintroduced here would silently give it no dispatcher —
+        #607's defect with a new spelling. It went red for both spellings this branch
+        shipped before the sweep proved the second equivalent."""
         class _Falsy:
             def __bool__(self_):
                 return False
@@ -357,6 +375,20 @@ class ADispatcherTakesOnlyWhatItNeeds(unittest.TestCase):
         t = threading.Thread(target=lambda: (d.close(), done.set()), daemon=True)
         t.start()
         self.assertTrue(done.wait(5.0), "close() blocked draining a pane nobody reads")
+
+    def test_closing_a_path_that_was_never_opened_writes_nothing_to_the_pane(self):
+        """`close` guards on `_fd`, and without that guard a dispatcher that never opened
+        an input path would still write `\x1b[?1004l` into a pane that never asked for
+        reporting — a resize-only component's, or one whose pane is not a terminal. The
+        mode restore is harmless there; the write is not, because it is charter putting an
+        escape sequence into a rectangle a provider is drawing in."""
+        c, _seen = _component(events=("resize",))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        self.assertFalse(d.reading)
+        d.close()
+        self.assertEqual(self.tty.sent(), b"",
+                         "close() spoke to a pane it had never opened")
 
     def test_close_is_idempotent(self):
         """Both callers are a `finally`, and one of them runs after a handler failure has
@@ -615,6 +647,40 @@ class AnEventReachesTheComponentThatOwnsThePane(unittest.TestCase):
                     self.assertFalse(d.poll(1.0))
                 self.assertTrue(d.reading, "a retryable read retired the input path")
                 self.assertIsNone(d.failure)
+
+    def test_a_descriptor_select_can_no_longer_ask_about_closes_the_path(self):
+        """`select` raises for a descriptor that has gone. Letting it escape would take the
+        exception out of `poll`, out of `_watch` and into `_run`'s catch, which paints
+        `panel stopped` and holds the pane — a refusal, for a pane that merely closed."""
+        c, _seen = _component(events=("focus",))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        self.addCleanup(d.close)
+        with mock.patch("charter.frame.events.select.select",
+                        side_effect=OSError(9, "Bad file descriptor")):
+            self.assertFalse(d.poll(0.1))
+        self.assertFalse(d.reading)
+
+    def test_the_other_spelling_of_end_of_input_is_the_same_answer(self):
+        """**"The other end is gone" has two spellings and this platform is not the one
+        that decides which.** `palette._reader`'s docstring records the measurement that
+        cost a red CI: closing a pty's far end answers `b""` on macOS and raises
+        `OSError: [Errno 5]` on Linux. The case below this one reaches the `b""` arm on a
+        macOS machine and would never reach the other, so a suite green twice over here
+        would still have been red on every Linux operator's machine.
+
+        Two survivors sat in `poll` and masked each other; this is the second of them.
+        """
+        c, _seen = _component(events=("focus",))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        self.addCleanup(d.close)
+        self.tty.deliver(b"\x1b[I")
+        with mock.patch("charter.frame.events.os.read",
+                        side_effect=OSError(5, "Input/output error")):
+            self.assertFalse(d.poll(1.0))
+        self.assertFalse(d.reading, "Linux's spelling of EOF left the path open")
+        self.assertIsNone(d.failure, "a closed pane is not a component's failure")
 
     def test_end_of_input_closes_the_path_and_does_not_end_the_panel(self):
         """The pane is still a rectangle this process can paint into. A panel that stopped
@@ -905,6 +971,38 @@ class ThePanelPaintsWhatTheEventChanged(unittest.TestCase):
              mock.patch("charter.frame.panel._rows", return_value=6):
             got = panel._component_text(object(), "acme.metrics", "f-1", evs=_Evs())
         self.assertNotIn("\x1b[2J", got)
+
+    def test_containing_after_the_width_arithmetic_silently_loses_the_reason(self):
+        """The sharp half of #472, and neither the escaping nor the width can show it —
+        which is exactly why this containment survived the sweep with two cases standing
+        over it.
+
+        `_fit` escapes every line on the way out, so "is the escape gone" is answered by
+        `_fit` whichever order the two run in. `_fit` also `tui.truncate`s every line to the
+        width, so "is any row too wide" can never fail either. What the ORDER decides is
+        where `_wrap` puts the line breaks, and getting that wrong DROPS TEXT. Measured, at
+        width 32, on `'stopped: ' + '\x1b[2J' * 3 + ' ENDMARK'`::
+
+            tui.width(raw) = 17      tui.width(contained) = 38
+            contain first  -> ('stopped: \\x1b[2J\\x1b[2J\\x1b[2J', 'ENDMARK')
+            contain second -> ('stopped: \\x1b[2J\\x1b[2J\\x1b[2J …',)
+
+        Contain second and `_wrap` sizes the escapes at nothing, packs the tail onto the
+        same row, and `_fit` then cuts what it cannot fit. `ENDMARK` is gone — and in a
+        real failure that tail is the exception's own message, the only part that says what
+        broke. `_wrap`'s own docstring makes the same argument about a word wider than the
+        pane: "the tail of a refusal is the half that says what to do about it".
+        """
+        class _Evs:
+            failure = "stopped: " + "\x1b[2J" * 3 + " ENDMARK"
+
+        with mock.patch("charter.frame.slots.content_width", return_value=32), \
+             mock.patch("charter.frame.slots.inset_rows", side_effect=lambda t, n: t), \
+             mock.patch("charter.frame.panel._rows", return_value=12):
+            got = panel._component_text(object(), "acme.metrics", "f-1", evs=_Evs())
+        self.assertNotIn("\x1b[2J", got)
+        self.assertIn("ENDMARK", got,
+                      "the tail was measured unescaped, packed onto one row, and cut")
 
     def test_a_component_still_taking_events_draws_its_own_rows(self):
         class _Evs:

--- a/tests/test_a_component_event_reaches_its_handler.py
+++ b/tests/test_a_component_event_reaches_its_handler.py
@@ -30,6 +30,7 @@ import time
 import unittest
 from unittest import mock
 
+from charter import tui
 from charter.frame import component, events, overlay, panel
 
 from tests.test_component_providers import _source
@@ -179,6 +180,22 @@ class CharterDeliversThreeOfTheSixAndSaysWhich(unittest.TestCase):
     def test_a_component_with_no_handler_wants_nothing(self):
         c, _seen = _component(events=(), on_event=None)
         self.assertEqual(events.wanted(c), ())
+
+    def test_a_handler_that_is_falsy_is_still_a_handler(self):
+        """`Component` accepts any callable, and a handler written as an instance of a
+        class rather than as a function may define a falsy `__bool__` or an empty
+        `__len__`. Asking truthiness here would give it no dispatcher at all — #607's
+        defect with a new spelling — so the question is `is not None`, which is the one
+        `Component`'s own validation asks."""
+        class _Falsy:
+            def __bool__(self_):
+                return False
+
+            def __call__(self_, ev):
+                return True
+
+        c, _seen = _component(events=("focus",), on_event=_Falsy())
+        self.assertEqual(events.wanted(c), ("focus",))
 
 
 class TheWithdrawalUndoesExactlyWhatTheRequestAsked(unittest.TestCase):
@@ -361,6 +378,29 @@ class ADispatcherTakesOnlyWhatItNeeds(unittest.TestCase):
         self.assertFalse(d.reading)
         d.close()
 
+    def test_a_stream_whose_fileno_is_not_a_descriptor_is_left_alone(self):
+        """`termios.tcgetattr(None)` raises `TypeError`, not `OSError` — measured — so a
+        guard set widened only for `termios.error` still sent this to `panel._hold`,
+        painting a refusal for a component that had done nothing wrong. A `MagicMock`
+        stdout, which `mock.patch("sys.stdout")` installs, reaches this exact path."""
+        class _Vague:
+            def fileno(self_):
+                return None
+
+            def write(self_, _s):
+                pass
+
+            def flush(self_):
+                pass
+
+        with self.assertRaises(TypeError):
+            termios.tcgetattr(None)          # the measurement this case exists for
+        c, _seen = _component(events=("focus",))
+        d = events.Dispatcher(c, stream=_Vague())
+        d.open()
+        self.assertFalse(d.reading)
+        d.close()
+
     def test_a_pane_behind_a_real_descriptor_with_no_tty_is_the_same_answer(self):
         fd = os.open(os.devnull, os.O_RDWR)
         self.addCleanup(os.close, fd)
@@ -371,6 +411,108 @@ class ADispatcherTakesOnlyWhatItNeeds(unittest.TestCase):
         d = events.Dispatcher(c, stream=stream)
         d.open()
         self.assertFalse(d.reading)
+
+
+class TheRestoreIsTheThingCloseCannotAffordToLose(unittest.TestCase):
+    """`close` runs in two `finally`s and the mode it puts back is the operator's.
+
+    These are the cases an adversarial read of the first version produced. Each one is a
+    way the restore could be skipped or lost, and each was reachable.
+    """
+
+    def setUp(self):
+        self.tty = _Pty(self)
+
+    def _open(self):
+        c, _seen = _component(events=("focus",))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        self.addCleanup(d.close)
+        self.tty.sent()
+        return d
+
+    def test_a_withdrawal_that_raises_does_not_cost_the_mode(self):
+        """The withdrawal writes to the pane and the restore does not, so the write is the
+        half that can fail — and it used to run FIRST, with `_fd` already cleared, so a
+        raise there lost the `tcsetattr` permanently: the retry from `_watch`'s `finally`
+        found `_fd` `None` and returned."""
+        before = _mode(self.tty.slave)
+        d = self._open()
+        self.assertNotEqual(_lflags(self.tty.slave), before[3])
+
+        class _Refuses:
+            def fileno(self_):
+                return self.tty.slave
+
+            def write(self_, _s):
+                raise OSError("the pane went away")
+
+            def flush(self_):
+                pass
+
+        d._stream = _Refuses()
+        d.close()
+        self.assertEqual(_mode(self.tty.slave), before,
+                         "a failing withdrawal took the mode restore with it")
+
+    def test_the_mode_is_back_before_the_withdrawal_is_even_attempted(self):
+        """The case the ordering actually exists for, and the one a raising stream cannot
+        show: a withdrawal that BLOCKS.
+
+        `open` clears `ICANON`/`ECHO` and deliberately leaves the input flags alone, so
+        `IXON` is still on — an operator who selects this pane and presses Ctrl-S puts the
+        pty in XOFF and the flush inside `_write` waits for an XON that may never come.
+        With the withdrawal ahead of the restore, `close` parks there in a `finally` with
+        the operator's pane still echoing nothing and no process left to fix it.
+
+        Run on a thread with a deadline, so a regression is red rather than a hang.
+        """
+        import threading
+
+        before = _mode(self.tty.slave)
+        d = self._open()
+        released = threading.Event()
+
+        class _Blocks:
+            def fileno(self_):
+                return self.tty.slave
+
+            def write(self_, _s):
+                released.wait(10.0)
+
+            def flush(self_):
+                pass
+
+        d._stream = _Blocks()
+        t = threading.Thread(target=d.close, daemon=True)
+        t.start()
+        try:
+            deadline = time.time() + 5.0
+            while time.time() < deadline and _mode(self.tty.slave) != before:
+                time.sleep(0.02)
+            self.assertEqual(
+                _mode(self.tty.slave), before,
+                "close() parked on the withdrawal with the operator's mode still changed")
+        finally:
+            released.set()
+            t.join(10.0)
+
+    def test_a_second_close_after_a_failed_one_is_not_a_silent_no_op(self):
+        """Whatever `close` gives up on, the mode is back before it can."""
+        before = _mode(self.tty.slave)
+        d = self._open()
+        d.close()
+        d.close()
+        self.assertEqual(_mode(self.tty.slave), before)
+
+    def test_opening_twice_does_not_capture_cbreak_as_the_mode_to_restore(self):
+        """A second `open` used to read the mode the FIRST one installed and keep it as
+        `_before`, so `close` would "restore" the pane to ECHO off, for good."""
+        before = _mode(self.tty.slave)
+        d = self._open()
+        d.open()
+        d.close()
+        self.assertEqual(_mode(self.tty.slave), before)
 
 
 class AnEventReachesTheComponentThatOwnsThePane(unittest.TestCase):
@@ -456,6 +598,24 @@ class AnEventReachesTheComponentThatOwnsThePane(unittest.TestCase):
         self.assertEqual(seen, [])
         self.assertTrue(d.reading)
 
+    def test_nothing_available_right_now_is_not_end_of_input(self):
+        """`EAGAIN` and `EINTR` mean "ask again"; the branch beside them retires the
+        component's events for the life of the panel. Folding them together means one
+        `O_NONBLOCK` race — which anything putting stdout on an asyncio loop creates — or
+        one `SIGWINCH` landing in the read costs a component every later event, silently,
+        with no `failure` to paint."""
+        for err in (BlockingIOError(11, "EAGAIN"), InterruptedError(4, "EINTR")):
+            with self.subTest(err=type(err).__name__):
+                c, _seen = _component(events=("focus",))
+                d = events.Dispatcher(c, stream=self.tty.stream)
+                d.open()
+                self.addCleanup(d.close)
+                self.tty.deliver(b"\x1b[I")
+                with mock.patch("charter.frame.events.os.read", side_effect=err):
+                    self.assertFalse(d.poll(1.0))
+                self.assertTrue(d.reading, "a retryable read retired the input path")
+                self.assertIsNone(d.failure)
+
     def test_end_of_input_closes_the_path_and_does_not_end_the_panel(self):
         """The pane is still a rectangle this process can paint into. A panel that stopped
         repainting because its input closed would be taking a pane it was only lent."""
@@ -521,6 +681,20 @@ class AResizeIsTheRectangleMovingAndNotTheSignal(unittest.TestCase):
         with mock.patch("charter.frame.pane.size", return_value=None):
             d.note_resize()
         self.assertEqual(seen, [])
+
+    def test_a_reading_charter_could_not_take_does_not_swallow_the_resize(self):
+        """A pty answers "no size" between a resize and the `TIOCSWINSZ` that follows —
+        `frame/pane.py` calls that ordinary. Storing that `None` spends the comparison: the
+        next tick sees `was is None` and the resize that really happened never fires."""
+        c, seen = _component(events=("resize",))
+        d = self._dispatcher(c, os.terminal_size((40, 8)))
+        with mock.patch("charter.frame.pane.size", return_value=None):
+            d.note_resize()
+        self.assertEqual(seen, [])
+        with mock.patch("charter.frame.pane.size",
+                        return_value=os.terminal_size((120, 8))):
+            d.note_resize()
+        self.assertEqual([e.kind for e in seen], [overlay.RESIZE])
 
     def test_a_component_that_did_not_declare_resize_gets_none(self):
         c, seen = _component(events=("focus",))
@@ -694,10 +868,31 @@ class ThePanelPaintsWhatTheEventChanged(unittest.TestCase):
         class _Evs:
             failure = "acme.metrics stopped taking events — KeyError: 'no such row'"
 
-        with mock.patch("charter.frame.slots._width", return_value=78):
+        with mock.patch("charter.frame.slots.content_width", return_value=78), \
+             mock.patch("charter.frame.slots.inset_rows", side_effect=lambda t, n: t), \
+             mock.patch("charter.frame.panel._rows", return_value=6):
             got = panel._component_text(object(), "acme.metrics", "f-1", evs=_Evs())
         self.assertIn("acme.metrics", got)
         self.assertIn("KeyError", got)
+
+    def test_the_reason_is_wrapped_across_the_pane_and_never_clipped_to_one_line(self):
+        """Every other provider failure reaches a pane through `_wrap`, and `_wrap`'s own
+        docstring says why: "the tail of a refusal is the half that says what to do about
+        it". This message names the component first and what broke last, and
+        " charter: acme.metrics stopped taking events - " is 45 characters on its own — so
+        a single `tui.truncate` in a 30-column side panel clips the exception ALWAYS."""
+        class _Evs:
+            failure = ("acme.metrics stopped taking events — "
+                       "ZeroDivisionError: division by zero")
+
+        with mock.patch("charter.frame.slots.content_width", return_value=30), \
+             mock.patch("charter.frame.slots.inset_rows", side_effect=lambda t, n: t), \
+             mock.patch("charter.frame.panel._rows", return_value=8):
+            got = panel._component_text(object(), "acme.metrics", "f-1", evs=_Evs())
+        self.assertGreater(len(got.split("\n")), 1, "the reason was clipped to one line")
+        self.assertIn("ZeroDivisionError", got)
+        for line in got.split("\n"):
+            self.assertLessEqual(tui.width(line), 30, line)
 
     def test_the_reason_is_contained_before_it_is_measured(self):
         """#472's order. The reason quotes a stranger's exception text, and an escape
@@ -705,7 +900,9 @@ class ThePanelPaintsWhatTheEventChanged(unittest.TestCase):
         class _Evs:
             failure = "acme.metrics stopped taking events — KeyError: 'a\x1b[2Jb'"
 
-        with mock.patch("charter.frame.slots._width", return_value=200):
+        with mock.patch("charter.frame.slots.content_width", return_value=200), \
+             mock.patch("charter.frame.slots.inset_rows", side_effect=lambda t, n: t), \
+             mock.patch("charter.frame.panel._rows", return_value=6):
             got = panel._component_text(object(), "acme.metrics", "f-1", evs=_Evs())
         self.assertNotIn("\x1b[2J", got)
 
@@ -775,6 +972,27 @@ class ThePanelOpensAndClosesTheEventPathAroundItsLoop(unittest.TestCase):
         self.assertEqual(evs.log, ["open", "close"])
         self.assertIs(_signal.getsignal(_signal.SIGWINCH), before)
 
+    def test_a_close_that_raises_still_hands_the_sigwinch_handler_back(self):
+        """`_watch` exists as its own function so the handler it arms is restored by its
+        own `finally` (`RunOnceLoop.test_once_true_restores_the_previous_sigwinch_handler`).
+        A flat `close(); signal.signal(...)` puts the fallible call FIRST and defeats
+        exactly that — leaving a handler waking a loop with nothing left to repaint for the
+        rest of a held process's life."""
+        import signal as _signal
+
+        class _Raises(self._Evs):
+            def close(self_):
+                self_.log.append("close")
+                raise RuntimeError("the pane went away mid-restore")
+
+        evs = _Raises()
+        before = _signal.getsignal(_signal.SIGWINCH)
+        with mock.patch("charter.frame.state.version", return_value="v1"):
+            with self.assertRaises(RuntimeError):
+                panel._watch("top", "f-1", once=True, evs=evs,
+                             paint=lambda name, fid: None)
+        self.assertIs(_signal.getsignal(_signal.SIGWINCH), before)
+
     def test_a_loop_that_raises_still_puts_the_tty_back(self):
         """`panel._hold` never returns, so a mode left changed here is a pane in a state
         nothing on the machine puts back."""
@@ -841,6 +1059,60 @@ class TheCommittedRectangleDoesNotCostAComponentItsHandler(unittest.TestCase):
         reg.register(c)
         placed = reg.place(c.id, edge="bottom", size=component.Fixed(2))
         self.assertEqual(events.wanted(placed), ("focus",))
+
+
+class ACompositesPartCannotDeclareEventsNothingWouldDeliver(unittest.TestCase):
+    """#607's own defect, one level down, refused where the message names a fixable thing.
+
+    `panel._dispatcher` asks `wanted()` of the component PLACED on the frame, and a part is
+    never placed — its parent draws it inside its own pane (`Registry.on_edge`). So a
+    child's declaration would pass every check `Component` makes, build a handler, and
+    receive nothing, ever: exactly the state this whole branch exists to end.
+    """
+
+    def _leaf(self, cid, **kw):
+        base = dict(id=cid, title=cid, edge="right", size=component.Fixed(1),
+                    render=lambda ctx: [cid])
+        base.update(kw)
+        return component.Component(**base)
+
+    def test_a_part_that_declares_events_is_refused_and_names_both(self):
+        from charter.frame import registry
+
+        reg = registry.Registry()
+        reg.register(self._leaf("acme.head", events=("focus",),
+                                on_event=lambda ev: True))
+        reg.register(self._leaf("acme.body", size=component.Fill()))
+        with self.assertRaises(component.ComponentError) as e:
+            reg.register(self._leaf("acme.side",
+                                    children=("acme.head", "acme.body")))
+        self.assertIn("acme.head", str(e.exception))
+        self.assertIn("acme.side", str(e.exception))
+        self.assertIn("focus", str(e.exception))
+
+    def test_a_composite_may_declare_them_itself(self):
+        """The refusal is about WHERE the declaration sits, not about composites. The
+        parent owns the pane, so the parent is what charter can dispatch to."""
+        from charter.frame import registry
+
+        reg = registry.Registry()
+        reg.register(self._leaf("acme.head"))
+        reg.register(self._leaf("acme.body", size=component.Fill()))
+        side = reg.register(self._leaf(
+            "acme.side", children=("acme.head", "acme.body"),
+            events=("focus",), on_event=lambda ev: True))
+        self.assertEqual(events.wanted(side), ("focus",))
+
+    def test_a_composite_of_ordinary_parts_is_untouched(self):
+        """Charter's own sidebar is this shape, so the refusal must not reach it."""
+        from charter.frame import registry
+
+        reg = registry.Registry()
+        reg.register(self._leaf("acme.head"))
+        reg.register(self._leaf("acme.body", size=component.Fill()))
+        side = reg.register(self._leaf("acme.side",
+                                       children=("acme.head", "acme.body")))
+        self.assertEqual(side.children, ("acme.head", "acme.body"))
 
 
 class AProviderCanDeclareAHandlerAndCharterBuildsIt(unittest.TestCase):

--- a/tests/test_a_component_event_reaches_its_handler.py
+++ b/tests/test_a_component_event_reaches_its_handler.py
@@ -753,6 +753,28 @@ class ThePanelOpensAndClosesTheEventPathAroundItsLoop(unittest.TestCase):
                          paint=lambda name, fid: None)
         self.assertEqual(evs.log, ["open", "close"])
 
+    def test_an_open_that_raises_leaks_neither_the_handler_nor_the_mode(self):
+        """`open` ends by writing `\\x1b[?1004h`, and a write to a pane whose far end has
+        gone raises. From outside `_watch`'s `try` that leaked the SIGWINCH handler and
+        left the tty in the mode `open` had installed a line earlier — with the panel then
+        going to `_hold`, which never returns, so nothing on the machine put either back.
+        """
+        import signal as _signal
+
+        class _Boom(self._Evs):
+            def open(self_):
+                self_.log.append("open")
+                raise OSError("the pane went away")
+
+        evs = _Boom()
+        before = _signal.getsignal(_signal.SIGWINCH)
+        with mock.patch("charter.frame.state.version", return_value="v1"):
+            with self.assertRaises(OSError):
+                panel._watch("top", "f-1", once=True, evs=evs,
+                             paint=lambda name, fid: None)
+        self.assertEqual(evs.log, ["open", "close"])
+        self.assertIs(_signal.getsignal(_signal.SIGWINCH), before)
+
     def test_a_loop_that_raises_still_puts_the_tty_back(self):
         """`panel._hold` never returns, so a mode left changed here is a pane in a state
         nothing on the machine puts back."""

--- a/tests/test_a_component_event_reaches_its_handler.py
+++ b/tests/test_a_component_event_reaches_its_handler.py
@@ -1,0 +1,826 @@
+"""`Component.events` was validated and read by nothing. These are the cases that make
+it a delivery (#607).
+
+The gap the issue names, said as a test: a provider could declare ``events = ["scroll"]``,
+pass every check `frame/component.py` makes, and receive nothing, ever. So the first
+question every case here asks is not "does the dispatcher work" but **"can this component
+tell the difference between an event that fired and one that did not"** — which is why
+each handler below records what it was handed rather than merely returning ``True``.
+
+**The tty is real everywhere it matters.** The `Dispatcher` cases open a real `pty`, put
+the real slave into the mode `frame/events.py` chooses, write the real bytes tmux writes,
+and read the real mode back with `termios.tcgetattr` — the shape `test_frame_palette.py`
+already uses for `own_the_tty`. A mocked `select` would prove the mock returns what the
+test told it to; it would not have caught `termios.error` failing to be an `OSError`,
+which is the one defect the first version of that module actually had.
+
+The real tmux half — that tmux delivers ``\\x1b[I`` to a panel's pane at all, and only to
+one that asked — is `tests/test_frame_focus_reaches_a_component.py`.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import io
+import os
+import pty
+import struct
+import termios
+import time
+import unittest
+from unittest import mock
+
+from charter.frame import component, events, overlay, panel
+
+from tests.test_component_providers import _source
+
+
+def _component(**kw):
+    """A component with a handler that records every event it is handed."""
+    seen = []
+    base = dict(id="acme.metrics", title="Metrics", edge="right",
+                size=component.Fixed(4), render=lambda ctx: ["drew"],
+                events=("focus", "blur"), on_event=lambda ev: seen.append(ev) or True)
+    base.update(kw)
+    c = component.Component(**base)
+    return c, seen
+
+
+class _Pty:
+    """One real pty, and the pane's own end of it.
+
+    *slave* is what a tmux pane's program is given — the descriptor `frame/events.py`
+    reads and sets the mode on. *master* is the terminal side: writing to it is what tmux
+    does when it delivers a focus report, and reading it is how a case sees what the pane
+    asked the terminal for.
+    """
+
+    def __init__(self, case: unittest.TestCase, *, cols: int = 40, rows: int = 8) -> None:
+        self.master, self.slave = pty.openpty()
+        fcntl.ioctl(self.slave, termios.TIOCSWINSZ,
+                    struct.pack("HHHH", rows, cols, 0, 0))
+        self.stream = os.fdopen(self.slave, "w", buffering=1, closefd=False)
+        case.addCleanup(self._close)
+
+    def sent(self) -> bytes:
+        """Whatever the pane has written to its terminal and not yet been asked about."""
+        if not _readable(self.master):
+            return b""
+        return os.read(self.master, 4096)
+
+    def deliver(self, payload: bytes) -> None:
+        """What tmux does: put bytes on the pane's input."""
+        os.write(self.master, payload)
+
+    def _close(self) -> None:
+        # The wrapper first, and before the descriptors it sits on. A `TextIOWrapper`
+        # flushes when it is finalised, and a case that closed the master to reach end of
+        # input leaves it holding bytes for a descriptor that has gone — which surfaces as
+        # `Exception ignored while finalizing file` on a later, unrelated test.
+        try:
+            self.stream.close()
+        except OSError:
+            pass
+        for fd in (self.master, self.slave):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _readable(fd: int, timeout: float = 0.5) -> bool:
+    import select
+    return bool(select.select([fd], [], [], timeout)[0])
+
+
+#: What the KERNEL sets on its own, so a case comparing two modes does not read it as a
+#: change charter made. macOS raises `PENDIN` (0x20000000) whenever input is queued for
+#: re-processing, which is exactly what these cases arrange — `tests/test_frame_palette.py`
+#: masks the same bit against `own_the_tty` for the same reason. `getattr` because it is
+#: not defined on every platform's `termios`, and a missing bit masks nothing.
+_KERNELS_OWN = getattr(termios, "PENDIN", 0)
+
+
+def _mode(fd: int) -> list:
+    """A tty's mode with the kernel's own bookkeeping bit masked out."""
+    m = termios.tcgetattr(fd)
+    return [m[0], m[1], m[2], m[3] & ~_KERNELS_OWN]
+
+
+def _lflags(fd: int) -> int:
+    return termios.tcgetattr(fd)[3] & ~_KERNELS_OWN
+
+
+class TheDeclarationAndTheHandlerAreOneThing(unittest.TestCase):
+    """#607's own shape, refused at construction where the message names a fixable thing.
+
+    A declaration with nothing behind it IS the defect this issue is about, written by the
+    provider instead of by charter — so it is refused in both directions rather than
+    accepted and quietly never delivered.
+    """
+
+    def test_declaring_events_with_no_handler_is_refused_and_names_the_kinds(self):
+        with self.assertRaises(component.ComponentError) as e:
+            _component(events=("scroll",), on_event=None)
+        self.assertIn("scroll", str(e.exception))
+        self.assertIn("on_event", str(e.exception))
+
+    def test_a_handler_with_no_declaration_is_refused(self):
+        """A callable nothing would ever call is not a component that works — it is one
+        whose author believes it is interactive."""
+        with self.assertRaises(component.ComponentError) as e:
+            _component(events=(), on_event=lambda ev: None)
+        self.assertIn("events", str(e.exception))
+
+    def test_a_handler_that_is_not_callable_is_refused(self):
+        with self.assertRaises(component.ComponentError) as e:
+            _component(on_event="not a function")
+        self.assertIn("callable", str(e.exception))
+
+    def test_the_pair_together_is_accepted(self):
+        c, _seen = _component()
+        self.assertEqual(c.events, ("focus", "blur"))
+        self.assertTrue(callable(c.on_event))
+
+    def test_a_component_without_either_is_untouched(self):
+        """Every component charter itself registers is this shape, so the refusals above
+        must not reach one."""
+        c, _seen = _component(events=(), on_event=None)
+        self.assertEqual(c.events, ())
+        self.assertIsNone(c.on_event)
+
+
+class CharterDeliversThreeOfTheSixAndSaysWhich(unittest.TestCase):
+    def test_delivered_is_a_subset_of_the_closed_vocabulary(self):
+        """`EVENT_KINDS` is what may be DECLARED and `DELIVERED` is what charter carries.
+        Two lists, and the smaller one must never contain a name the larger does not — a
+        kind charter delivered that a provider could not declare would be undeliverable."""
+        for kind in events.DELIVERED:
+            self.assertIn(kind, component.EVENT_KINDS)
+
+    def test_the_undelivered_three_are_still_declarable(self):
+        """`EVENT_KINDS`'s own rule: declaring is what you HANDLE, never a promise that it
+        FIRES. A component that declares `click` today must not be refused for it."""
+        for kind in ("key", "click", "scroll"):
+            self.assertNotIn(kind, events.DELIVERED)
+            c, _seen = _component(events=(kind,))
+            self.assertEqual(c.events, (kind,))
+
+    def test_wanted_is_the_intersection_in_declared_order(self):
+        c, _seen = _component(events=("resize", "click", "focus"))
+        self.assertEqual(events.wanted(c), ("resize", "focus"))
+
+    def test_a_component_charter_delivers_nothing_to_wants_nothing(self):
+        """The cost promise: `click` alone builds no dispatcher, so nothing touches the
+        pane's terminal."""
+        c, _seen = _component(events=("click", "scroll"))
+        self.assertEqual(events.wanted(c), ())
+
+    def test_a_component_with_no_handler_wants_nothing(self):
+        c, _seen = _component(events=(), on_event=None)
+        self.assertEqual(events.wanted(c), ())
+
+
+class TheDecoderNamesFocusAndBlur(unittest.TestCase):
+    """The two sequences `overlay.decode` used to consume and drop."""
+
+    def test_focus_in_and_out_decode_to_their_own_kinds(self):
+        evs, tail = overlay.decode(b"\x1b[I\x1b[O")
+        self.assertEqual([e.kind for e in evs], [overlay.FOCUS, overlay.BLUR])
+        self.assertEqual(tail, b"")
+
+    def test_neither_is_reported_as_a_keypress(self):
+        """Before this they fell through to `_CSI_KEYS`, which has no name for either.
+        Falling through to the SINGLE-BYTE path instead would have typed an `I`."""
+        evs, _tail = overlay.decode(b"\x1b[I")
+        self.assertNotEqual(evs[0].kind, overlay.KEY)
+
+    def test_a_parameterised_form_is_not_a_focus_report(self):
+        """`CSI 3 I` is ECMA-48's CHT, a cursor movement some program echoed. Reading it
+        as three focus events would be `EVENT_KINDS`'s "fires wrongly"."""
+        evs, tail = overlay.decode(b"\x1b[3I")
+        self.assertEqual(evs, [])
+        self.assertEqual(tail, b"")
+
+    def test_a_report_split_across_two_reads_is_still_one_event(self):
+        """A pane's `read` returns whatever the kernel had, and splits `\\x1b[I` as
+        readily as not."""
+        first, tail = overlay.decode(b"\x1b[")
+        self.assertEqual(first, [])
+        second, tail = overlay.decode(tail + b"I")
+        self.assertEqual([e.kind for e in second], [overlay.FOCUS])
+
+    def test_the_application_cursor_form_is_untouched(self):
+        """`\\x1bOA` is SS3 Up and must not be read as a blur because it contains an `O`."""
+        evs, _tail = overlay.decode(b"\x1bOA")
+        self.assertEqual([(e.kind, e.name) for e in evs], [(overlay.KEY, "up")])
+
+
+class TheOverlayIgnoresTheKindsItNeverAsksFor(unittest.TestCase):
+    """The shared-machinery guard. `overlay.py` is the palette's and the pickers'; this
+    branch added two kinds to its decoder, so a case has to prove the palette cannot start
+    acting on one. It never receives one in production — the overlay is the ACTIVE zoomed
+    pane and never writes `\\x1b[?1004h` — but "never receives" is not "would be harmless
+    if it did"."""
+
+    def _surface(self, mouse: bool) -> overlay.Surface:
+        return overlay.Surface(rows=(overlay.Row(id="a", title="A"),
+                                     overlay.Row(id="b", title="B")), mouse=mouse)
+
+    def test_a_focus_event_neither_chooses_nor_cancels_nor_moves(self):
+        for mouse in (False, True):
+            for kind in (overlay.FOCUS, overlay.BLUR):
+                with self.subTest(mouse=mouse, kind=kind):
+                    s = self._surface(mouse)
+                    self.assertIsNone(s.handle(overlay.Event(kind), 10))
+                    self.assertEqual(s.selected.id, "a")
+
+
+class ADispatcherTakesOnlyWhatItNeeds(unittest.TestCase):
+    """What a panel's pane costs, per declaration."""
+
+    def setUp(self):
+        self.tty = _Pty(self)
+
+    def test_a_resize_only_component_never_opens_the_panes_input(self):
+        """A `SIGWINCH` already reaches this process, so `resize` costs the terminal
+        nothing — no mode change and no `\\x1b[?1004h`."""
+        c, _seen = _component(events=("resize",))
+        before = _lflags(self.tty.slave)
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        self.addCleanup(d.close)
+        self.assertFalse(d.reading)
+        self.assertEqual(_lflags(self.tty.slave), before)
+        self.assertEqual(self.tty.sent(), b"")
+
+    def test_focus_opens_it_and_asks_the_terminal_to_report(self):
+        c, _seen = _component(events=("focus",))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        self.addCleanup(d.close)
+        self.assertTrue(d.reading)
+        self.assertEqual(self.tty.sent(), events.FOCUS_ON.encode())
+
+    def test_it_clears_icanon_and_echo_and_leaves_the_output_flags_alone(self):
+        """`tty.setraw` would clear `OPOST`/`ONLCR` too, and `panel._write` joins its rows
+        with `\\n` — measured in a real 40x10 tmux pane, that draws a staircase:
+        `['AAA', '   BBB', '      CCC']`."""
+        before = termios.tcgetattr(self.tty.slave)
+        c, _seen = _component(events=("focus",))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        self.addCleanup(d.close)
+        after = termios.tcgetattr(self.tty.slave)
+        self.assertFalse(after[3] & termios.ICANON)
+        self.assertFalse(after[3] & termios.ECHO)
+        self.assertEqual(after[1], before[1], "an output flag moved")
+        self.assertTrue(before[1] & termios.OPOST, "the fixture was not in cooked mode")
+        self.assertEqual(after[6][termios.VMIN], 0)
+        self.assertEqual(after[6][termios.VTIME], 0)
+
+    def test_close_puts_the_mode_back_and_withdraws_the_request(self):
+        before = _mode(self.tty.slave)
+        c, _seen = _component(events=("focus",))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        self.tty.sent()
+        d.close()
+        self.assertEqual(_mode(self.tty.slave), before)
+        self.assertEqual(self.tty.sent(), events.FOCUS_OFF.encode())
+        self.assertFalse(d.reading)
+
+    def test_close_returns_even_when_nothing_is_draining_the_pane(self):
+        """`TCSADRAIN` waits for the terminal to consume what is already written, and on a
+        pane whose far end is not reading it never returns — the first version of this
+        module hung its own suite there, in a cleanup, with the traceback on that line.
+
+        Asserted on a THREAD with a deadline rather than by calling `close` directly: a
+        regression that reinstated the drain would otherwise be a suite that hangs, and a
+        hang is an `unresolved`, not a red.
+        """
+        import threading
+
+        c, _seen = _component(events=("focus",))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()                       # writes FOCUS_ON, which nothing reads back
+        done = threading.Event()
+        t = threading.Thread(target=lambda: (d.close(), done.set()), daemon=True)
+        t.start()
+        self.assertTrue(done.wait(5.0), "close() blocked draining a pane nobody reads")
+
+    def test_close_is_idempotent(self):
+        """Both callers are a `finally`, and one of them runs after a handler failure has
+        already closed it."""
+        c, _seen = _component(events=("focus",))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        d.close()
+        d.close()
+
+    def test_a_pane_that_is_not_a_terminal_is_left_alone_rather_than_refused(self):
+        """`charter panel acme.metrics --session x > /tmp/log`, run by hand for debugging.
+        `termios.error` is not an `OSError` — measured — so a guard written against
+        `OSError` alone turns this into `panel._hold` painting a refusal for a component
+        that did nothing wrong."""
+        c, _seen = _component(events=("focus",))
+        d = events.Dispatcher(c, stream=io.StringIO())
+        d.open()
+        self.assertFalse(d.reading)
+        d.close()
+
+    def test_a_pane_behind_a_real_descriptor_with_no_tty_is_the_same_answer(self):
+        fd = os.open(os.devnull, os.O_RDWR)
+        self.addCleanup(os.close, fd)
+        stream = os.fdopen(fd, "w", closefd=False)
+        with self.assertRaises(termios.error):
+            termios.tcgetattr(fd)          # the measurement this case exists for
+        c, _seen = _component(events=("focus",))
+        d = events.Dispatcher(c, stream=stream)
+        d.open()
+        self.assertFalse(d.reading)
+
+
+class AnEventReachesTheComponentThatOwnsThePane(unittest.TestCase):
+    def setUp(self):
+        self.tty = _Pty(self)
+
+    def _open(self, c):
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        self.addCleanup(d.close)
+        self.tty.sent()
+        return d
+
+    def test_a_focus_report_on_the_pane_reaches_the_handler(self):
+        """The whole issue, in one case: bytes on the pane, an `Event` in the component."""
+        c, seen = _component(events=("focus", "blur"))
+        d = self._open(c)
+        self.tty.deliver(b"\x1b[I")
+        self.assertTrue(d.poll(1.0))
+        self.assertEqual([e.kind for e in seen], [overlay.FOCUS])
+
+    def test_blur_arrives_as_its_own_kind(self):
+        c, seen = _component(events=("focus", "blur"))
+        d = self._open(c)
+        self.tty.deliver(b"\x1b[O")
+        self.assertTrue(d.poll(1.0))
+        self.assertEqual([e.kind for e in seen], [overlay.BLUR])
+
+    def test_a_kind_the_component_did_not_declare_is_dropped(self):
+        """Decoding is one question for every panel; what a component asked for is
+        another, and only the dispatcher knows the second."""
+        c, seen = _component(events=("focus",))
+        d = self._open(c)
+        self.tty.deliver(b"\x1b[O\x1b[I")
+        self.assertTrue(d.poll(1.0))
+        self.assertEqual([e.kind for e in seen], [overlay.FOCUS])
+
+    def test_a_keypress_never_reaches_a_handler_that_asked_for_focus(self):
+        """The sharpest consequence of the declared-kind filter, and the one an operator
+        would feel.
+
+        Once a panel asks for focus reporting it is reading its pane, and a pane that is
+        ACTIVE receives whatever the operator types. `key` is not a kind charter delivers —
+        the harness owns the keyboard — so a handler that declared `focus` must not be
+        handed the characters somebody typed into the wrong pane.
+        """
+        c, seen = _component(events=("focus",))
+        d = self._open(c)
+        self.tty.deliver(b"hello\r\x1b[A\x1b[I")
+        self.assertTrue(d.poll(1.0))
+        self.assertEqual([e.kind for e in seen], [overlay.FOCUS])
+
+    def test_a_handler_that_answers_falsy_costs_no_repaint(self):
+        """A component that ignores an event must not make the panel redraw for it."""
+        c, _seen = _component(events=("focus",), on_event=lambda ev: False)
+        d = self._open(c)
+        self.tty.deliver(b"\x1b[I")
+        self.assertFalse(d.poll(1.0))
+
+    def test_every_event_in_one_read_is_delivered_even_after_one_asks_to_repaint(self):
+        """A generator with `any` would stop at the first truthy handler and drop the
+        rest, leaving a component's state describing an event that was superseded."""
+        c, seen = _component(events=("focus", "blur"))
+        d = self._open(c)
+        self.tty.deliver(b"\x1b[I\x1b[O\x1b[I")
+        self.assertTrue(d.poll(1.0))
+        self.assertEqual([e.kind for e in seen],
+                         [overlay.FOCUS, overlay.BLUR, overlay.FOCUS])
+
+    def test_a_report_split_across_two_polls_is_still_one_event(self):
+        c, seen = _component(events=("focus",))
+        d = self._open(c)
+        self.tty.deliver(b"\x1b[")
+        d.poll(0.3)
+        self.tty.deliver(b"I")
+        self.assertTrue(d.poll(1.0))
+        self.assertEqual([e.kind for e in seen], [overlay.FOCUS])
+
+    def test_a_quiet_tick_answers_no_repaint_and_holds_the_pane(self):
+        c, seen = _component(events=("focus",))
+        d = self._open(c)
+        self.assertFalse(d.poll(0.05))
+        self.assertEqual(seen, [])
+        self.assertTrue(d.reading)
+
+    def test_end_of_input_closes_the_path_and_does_not_end_the_panel(self):
+        """The pane is still a rectangle this process can paint into. A panel that stopped
+        repainting because its input closed would be taking a pane it was only lent."""
+        c, _seen = _component(events=("focus",))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        os.close(self.tty.master)
+        self.tty.master = -1
+        for _ in range(10):
+            if not d.reading:
+                break
+            d.poll(0.05)
+        self.assertFalse(d.reading)
+
+
+class AResizeIsTheRectangleMovingAndNotTheSignal(unittest.TestCase):
+    def setUp(self):
+        self.tty = _Pty(self)
+
+    def _dispatcher(self, c, size):
+        with mock.patch("charter.frame.pane.size", return_value=size):
+            d = events.Dispatcher(c, stream=self.tty.stream)
+            d.open()
+        self.addCleanup(d.close)
+        return d
+
+    def test_a_first_pass_fires_nothing(self):
+        """`panel._watch` seeds its resize flag True so the first pass always paints. A
+        `resize` fired off that flag would announce one before the pane had been drawn."""
+        c, seen = _component(events=("resize",))
+        d = self._dispatcher(c, os.terminal_size((40, 8)))
+        with mock.patch("charter.frame.pane.size",
+                        return_value=os.terminal_size((40, 8))):
+            d.note_resize()
+        self.assertEqual(seen, [])
+
+    def test_a_rectangle_that_moved_fires_one(self):
+        c, seen = _component(events=("resize",))
+        d = self._dispatcher(c, os.terminal_size((40, 8)))
+        with mock.patch("charter.frame.pane.size",
+                        return_value=os.terminal_size((60, 8))):
+            d.note_resize()
+        self.assertEqual([e.kind for e in seen], [overlay.RESIZE])
+
+    def test_it_fires_once_per_move_and_not_once_per_paint(self):
+        c, seen = _component(events=("resize",))
+        d = self._dispatcher(c, os.terminal_size((40, 8)))
+        with mock.patch("charter.frame.pane.size",
+                        return_value=os.terminal_size((60, 8))):
+            d.note_resize()
+            d.note_resize()
+        self.assertEqual(len(seen), 1)
+
+    def test_an_unmeasurable_rectangle_is_not_one_end_of_a_comparison(self):
+        """`panel._unmeasured` means the component was never drawn at the earlier size, so
+        there is nothing for it to have laid out against."""
+        c, seen = _component(events=("resize",))
+        d = self._dispatcher(c, None)
+        with mock.patch("charter.frame.pane.size",
+                        return_value=os.terminal_size((60, 8))):
+            d.note_resize()
+        self.assertEqual(seen, [])
+        with mock.patch("charter.frame.pane.size", return_value=None):
+            d.note_resize()
+        self.assertEqual(seen, [])
+
+    def test_a_component_that_did_not_declare_resize_gets_none(self):
+        c, seen = _component(events=("focus",))
+        d = self._dispatcher(c, os.terminal_size((40, 8)))
+        with mock.patch("charter.frame.pane.size",
+                        return_value=os.terminal_size((60, 8))):
+            d.note_resize()
+        self.assertEqual(seen, [])
+
+    def test_it_does_not_even_measure_the_pane_for_a_component_that_did_not_ask(self):
+        """`note_resize` runs on every paint, so its own gate has to come BEFORE the
+        measurement rather than relying on the delivery filter to drop the event.
+
+        Without this the outcome is identical and the cost is not: every paint of every
+        focus-only panel would pay an `os.get_terminal_size` for an event nothing would
+        receive. `slots.ANIMATED`'s short-circuit is the same argument — "never repaints
+        for the spinner and never even pays the `stat` that would have told it to".
+        """
+        c, _seen = _component(events=("focus",))
+        d = self._dispatcher(c, os.terminal_size((40, 8)))
+        with mock.patch("charter.frame.pane.size",
+                        return_value=os.terminal_size((60, 8))) as measured:
+            d.note_resize()
+            d.note_resize()
+        measured.assert_not_called()
+
+
+class AHandlerThatRaisesCostsItsComponentItsEvents(unittest.TestCase):
+    """§4b's fourth moment. `registry.Registry` names three — on import, while building,
+    in `render` — and gives one answer to all of them: the pane says which component
+    failed and why. `on_event` takes the same answer."""
+
+    def setUp(self):
+        self.tty = _Pty(self)
+
+    def _boom(self, events_=("focus", "blur")):
+        c, seen = _component(
+            events=events_,
+            on_event=lambda ev: (_ for _ in ()).throw(KeyError("no such row")))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        self.addCleanup(d.close)
+        self.tty.sent()
+        return c, d
+
+    def test_the_failure_names_the_component_and_what_it_raised(self):
+        _c, d = self._boom()
+        self.tty.deliver(b"\x1b[I")
+        self.assertTrue(d.poll(1.0))
+        self.assertIn("acme.metrics", d.failure)
+        self.assertIn("KeyError", d.failure)
+
+    def test_it_asks_for_a_repaint_so_the_pane_says_so_on_the_next_tick(self):
+        _c, d = self._boom()
+        self.tty.deliver(b"\x1b[I")
+        self.assertTrue(d.poll(1.0),
+                        "the pane would keep the old content until something else moved")
+
+    def test_the_input_path_is_closed_and_the_mode_put_back(self):
+        before = _mode(self.tty.slave)
+        _c, d = self._boom()
+        self.assertNotEqual(_lflags(self.tty.slave), before[3])
+        self.tty.deliver(b"\x1b[I")
+        d.poll(1.0)
+        self.assertFalse(d.reading)
+        self.assertEqual(_mode(self.tty.slave), before)
+
+    def test_no_later_event_reaches_it(self):
+        """Retired rather than retried: a handler that raised on one event will raise on
+        the next, and delivering more spends the operator's repaints on a loop."""
+        calls = []
+
+        def boom(ev):
+            calls.append(ev)
+            raise RuntimeError("still broken")
+
+        c, _seen = _component(events=("focus", "resize"), on_event=boom)
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        with mock.patch("charter.frame.pane.size",
+                        return_value=os.terminal_size((40, 8))):
+            d.open()
+        self.addCleanup(d.close)
+        self.tty.deliver(b"\x1b[I")
+        d.poll(1.0)
+        self.assertEqual(len(calls), 1)
+        with mock.patch("charter.frame.pane.size",
+                        return_value=os.terminal_size((99, 8))):
+            d.note_resize()
+        self.assertEqual(len(calls), 1)
+
+    def test_the_operators_interrupt_is_not_a_component_failure(self):
+        """`except BaseException` under `except KeyboardInterrupt: raise` — the pairing
+        `Registry.draw` uses, meaning here exactly what it means there."""
+        c, _seen = _component(
+            events=("focus",),
+            on_event=lambda ev: (_ for _ in ()).throw(KeyboardInterrupt()))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        self.addCleanup(d.close)
+        self.tty.deliver(b"\x1b[I")
+        with self.assertRaises(KeyboardInterrupt):
+            d.poll(1.0)
+        self.assertIsNone(d.failure)
+
+    def test_a_system_exit_is_contained_like_any_other_failure(self):
+        """A provider calling `sys.exit()` in a handler must not end the panel — that is
+        §4b's "costs its own pane, never the session", said for the one exception a
+        stranger is most likely to reach for by accident."""
+        c, _seen = _component(
+            events=("focus",),
+            on_event=lambda ev: (_ for _ in ()).throw(SystemExit(3)))
+        d = events.Dispatcher(c, stream=self.tty.stream)
+        d.open()
+        self.addCleanup(d.close)
+        self.tty.deliver(b"\x1b[I")
+        d.poll(1.0)
+        self.assertIn("SystemExit", d.failure)
+
+
+class ThePanelPaintsWhatTheEventChanged(unittest.TestCase):
+    """The loop half: how an event reaches the screen, and how it does not."""
+
+    def test_a_handled_event_is_a_reason_to_paint_and_the_only_new_one(self):
+        painted = []
+        with mock.patch("charter.frame.state.version", return_value="v1"):
+            seen = panel._tick({"flag": False}, "v1", "top", "f-1",
+                               paint=lambda name, fid: painted.append(name),
+                               handled=True)
+        self.assertEqual(painted, ["top"])
+        self.assertEqual(seen, "v1")
+
+    def test_nothing_handled_and_nothing_moved_paints_nothing(self):
+        painted = []
+        with mock.patch("charter.frame.state.version", return_value="v1"):
+            panel._tick({"flag": False}, "v1", "top", "f-1",
+                        paint=lambda name, fid: painted.append(name))
+        self.assertEqual(painted, [])
+
+    def test_a_resize_is_delivered_before_the_paint_and_not_after(self):
+        """One repaint, not one that is wrong and one that corrects it."""
+        order = []
+
+        class _Evs:
+            def note_resize(self_):
+                order.append("event")
+
+        panel._tick({"flag": True}, "v1", "top", "f-1", events=_Evs(),
+                    paint=lambda name, fid: order.append("paint"))
+        self.assertEqual(order, ["event", "paint"])
+
+    def test_a_panel_with_no_dispatcher_sleeps_exactly_as_it_did(self):
+        with mock.patch("charter.frame.panel.time.sleep") as slept:
+            self.assertFalse(panel._wait(None, 0.2))
+        slept.assert_called_once_with(0.2)
+
+    def test_a_panel_with_one_polls_instead_of_sleeping(self):
+        """A second mechanism beside the sleep would be two clocks to keep in step."""
+        polled = []
+
+        class _Evs:
+            def poll(self_, timeout):
+                polled.append(timeout)
+                return True
+
+        with mock.patch("charter.frame.panel.time.sleep") as slept:
+            self.assertTrue(panel._wait(_Evs(), 0.2))
+        self.assertEqual(polled, [0.2])
+        slept.assert_not_called()
+
+    def test_a_retired_handler_makes_the_pane_say_so_instead_of_drawing(self):
+        class _Evs:
+            failure = "acme.metrics stopped taking events — KeyError: 'no such row'"
+
+        with mock.patch("charter.frame.slots._width", return_value=78):
+            got = panel._component_text(object(), "acme.metrics", "f-1", evs=_Evs())
+        self.assertIn("acme.metrics", got)
+        self.assertIn("KeyError", got)
+
+    def test_the_reason_is_contained_before_it_is_measured(self):
+        """#472's order. The reason quotes a stranger's exception text, and an escape
+        sequence in it is an instruction to the terminal rather than a character."""
+        class _Evs:
+            failure = "acme.metrics stopped taking events — KeyError: 'a\x1b[2Jb'"
+
+        with mock.patch("charter.frame.slots._width", return_value=200):
+            got = panel._component_text(object(), "acme.metrics", "f-1", evs=_Evs())
+        self.assertNotIn("\x1b[2J", got)
+
+    def test_a_component_still_taking_events_draws_its_own_rows(self):
+        class _Evs:
+            failure = None
+
+        class _Reg:
+            def get(self_, cid):
+                return component.Component(
+                    id=cid, title="M", edge="right", size=component.Fixed(4),
+                    render=lambda ctx: ["metrics 42"])
+
+            def draw(self_, cid, c):
+                return ("metrics 42",)
+
+        with mock.patch("charter.frame.slots.content_width", return_value=30), \
+             mock.patch("charter.frame.slots.inset_rows", side_effect=lambda t, n: t), \
+             mock.patch("charter.frame.panel._rows", return_value=6):
+            got = panel._component_text(_Reg(), "acme.metrics", "f-1", evs=_Evs())
+        self.assertEqual(got, "metrics 42")
+
+
+class ThePanelOpensAndClosesTheEventPathAroundItsLoop(unittest.TestCase):
+    class _Evs:
+        def __init__(self):
+            self.log = []
+
+        def open(self):
+            self.log.append("open")
+
+        def close(self):
+            self.log.append("close")
+
+        def note_resize(self):
+            pass
+
+        def poll(self, timeout):
+            return False
+
+    def test_once_true_opens_and_closes(self):
+        evs = self._Evs()
+        with mock.patch("charter.frame.state.version", return_value="v1"):
+            panel._watch("top", "f-1", once=True, evs=evs,
+                         paint=lambda name, fid: None)
+        self.assertEqual(evs.log, ["open", "close"])
+
+    def test_a_loop_that_raises_still_puts_the_tty_back(self):
+        """`panel._hold` never returns, so a mode left changed here is a pane in a state
+        nothing on the machine puts back."""
+        evs = self._Evs()
+
+        def explode(_name, _fid):
+            raise RuntimeError("paint blew up")
+
+        with mock.patch("charter.frame.state.version", return_value="v1"):
+            with self.assertRaises(RuntimeError):
+                panel._watch("top", "f-1", once=True, evs=evs, paint=explode)
+        self.assertEqual(evs.log, ["open", "close"])
+
+
+class APanelBuildsNoDispatcherForAComponentThatDeclaredNothing(unittest.TestCase):
+    """The cost promise, asked of the function that decides it."""
+
+    class _Reg:
+        def __init__(self, c):
+            self._c = c
+
+        def get(self, cid):
+            return self._c
+
+    def test_a_component_with_no_events_gets_none(self):
+        c, _seen = _component(events=(), on_event=None)
+        self.assertIsNone(panel._dispatcher(self._Reg(c), c.id))
+
+    def test_a_component_declaring_only_undelivered_kinds_gets_none(self):
+        c, _seen = _component(events=("click", "scroll"))
+        self.assertIsNone(panel._dispatcher(self._Reg(c), c.id))
+
+    def test_a_component_declaring_focus_gets_one(self):
+        c, _seen = _component(events=("focus",))
+        self.assertIsInstance(panel._dispatcher(self._Reg(c), c.id),
+                              events.Dispatcher)
+
+
+class TheCommittedRectangleDoesNotCostAComponentItsHandler(unittest.TestCase):
+    """`Registry.place` re-builds a provider's component through `dataclasses.replace` to
+    apply the committed `edge` and `size` (*arrangement is committed, execution is local*).
+
+    That rebuild re-runs `__post_init__`, so the new pair of refusals runs against a
+    component nobody re-declared — and a field dropped there would turn every configured
+    provider into a load-time refusal naming a declaration its author did write.
+    """
+
+    def test_replacing_the_rectangle_keeps_both_halves(self):
+        import dataclasses
+
+        c, seen = _component(events=("focus",))
+        moved = dataclasses.replace(c, edge="bottom", size=component.Fixed(2))
+        self.assertEqual(moved.edge, "bottom")
+        self.assertEqual(moved.events, ("focus",))
+        self.assertIs(moved.on_event, c.on_event)
+        moved.on_event(overlay.Event(overlay.FOCUS))
+        self.assertEqual([e.kind for e in seen], [overlay.FOCUS])
+
+    def test_the_registry_places_one_and_the_dispatcher_still_finds_it(self):
+        from charter.frame import registry
+
+        reg = registry.Registry()
+        c, _seen = _component(events=("focus",))
+        reg.register(c)
+        placed = reg.place(c.id, edge="bottom", size=component.Fixed(2))
+        self.assertEqual(events.wanted(placed), ("focus",))
+
+
+class AProviderCanDeclareAHandlerAndCharterBuildsIt(unittest.TestCase):
+    """The provider seam, end to end through a real installed distribution's source.
+
+    `_source` is `tests.test_component_providers`'s, so what is exercised here is the
+    module text a real `.dist-info` would import — not a `Component` this file built by
+    hand, which could not catch a keyword the dataclass no longer takes.
+    """
+
+    def test_the_module_a_provider_ships_builds_a_component_with_a_handler(self):
+        ns: dict = {}
+        exec(_source(events=("focus", "blur"),
+                     on_event="lambda ev: True"), ns)
+        c = ns["metrics"]()
+        self.assertEqual(c.events, ("focus", "blur"))
+        self.assertEqual(events.wanted(c), ("focus", "blur"))
+        self.assertTrue(c.on_event(overlay.Event(overlay.FOCUS)))
+
+    def test_a_handler_can_change_what_the_next_render_draws(self):
+        """The point of the whole path: an event that changes what a component SHOWS."""
+        ns: dict = {}
+        exec(_source(
+            events=("focus", "blur"),
+            head="state = {'on': False}",
+            on_event="lambda ev: state.__setitem__('on', ev.kind == 'focus') or True",
+            render="lambda ctx: ['FOCUSED' if state['on'] else 'idle']"), ns)
+        c = ns["metrics"]()
+        self.assertEqual(c.render(None), ["idle"])
+        c.on_event(overlay.Event(overlay.FOCUS))
+        self.assertEqual(c.render(None), ["FOCUSED"])
+        c.on_event(overlay.Event(overlay.BLUR))
+        self.assertEqual(c.render(None), ["idle"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_component_contract.py
+++ b/tests/test_component_contract.py
@@ -218,7 +218,11 @@ class NeedsAreTheDeclaredCost(unittest.TestCase):
 
 class EventsAreTheClosedFive(unittest.TestCase):
     def test_every_named_kind_is_accepted(self):
-        self.assertEqual(_c(events=component.EVENT_KINDS).events,
+        """The `on_event` is not decoration here: since #607 a declaration with nothing
+        behind it is refused, so "every kind is accepted" can only be asked of a
+        component that could actually receive one."""
+        self.assertEqual(_c(events=component.EVENT_KINDS,
+                            on_event=lambda ev: None).events,
                          tuple(component.EVENT_KINDS))
 
     def test_drag_was_deliberately_excluded_and_stays_excluded(self):

--- a/tests/test_component_providers.py
+++ b/tests/test_component_providers.py
@@ -63,7 +63,8 @@ _CHARTERS = object()
 
 def _source(*, cid: str = CID, api: object = _CHARTERS,
             render: str = "lambda ctx: ['ok']", head: str = "",
-            needs: tuple[str, ...] = ()) -> str:
+            needs: tuple[str, ...] = (), events: tuple[str, ...] = (),
+            on_event: str = "None") -> str:
     """A provider module: a version, a factory, and a record of whether it ran.
 
     ``built`` is what makes "refused before the provider built anything" an assertion
@@ -75,6 +76,11 @@ def _source(*, cid: str = CID, api: object = _CHARTERS,
     on each side of that branch. A knob here rather than a second module fixture beside
     this one, for the reason `_SitePackages.install` already gives: two fixtures for one
     idea drift, and the drift is invisible from either side.
+
+    *events* and *on_event* are the same knob for §4f's other declaration (#607), and they
+    move together because `component.Component` refuses them apart. *on_event* is SOURCE
+    text, like *render*, so a case can install a handler that keeps state across events —
+    which is the only way to watch a `focus` change what the next `render` draws.
     """
     api = component.API_VERSION if api is _CHARTERS else api
     return textwrap.dedent(f"""\
@@ -89,7 +95,8 @@ def _source(*, cid: str = CID, api: object = _CHARTERS,
             built = True
             return component.Component(
                 id={cid!r}, title="Metrics", edge="right",
-                size=component.Fixed(12), needs={needs!r}, events=(),
+                size=component.Fixed(12), needs={needs!r}, events={events!r},
+                on_event={on_event},
                 render={render})
         """)
 

--- a/tests/test_frame_focus_reaches_a_component.py
+++ b/tests/test_frame_focus_reaches_a_component.py
@@ -1,0 +1,354 @@
+"""A focus change in a REAL tmux pane reaches a REAL provider component (#607).
+
+Everything here is real: a real tmux server, a real attached client on a real pty, a real
+installed distribution on `sys.path`, and three real `charter panel <component-id>`
+processes each holding their own pane. Nothing is stubbed, because every claim this branch
+makes that could be wrong is a claim about tmux:
+
+* that tmux delivers ``\\x1b[I``/``\\x1b[O`` to a pane's PROGRAM at all;
+* that it delivers them to a pane that asked and to no other;
+* that a panel can read them off the descriptor `frame/pane.py` claims (fd 1), with the
+  pane's `stdin` never consulted;
+* that the mode `frame/events.py` sets does not shear the paint that follows;
+* that a `resize-window` reaches every pane, focused or not.
+
+The measurements this file is the standing form of, taken against **tmux 3.7c** before a
+line of the dispatcher was written::
+
+    focus-events on   pane that asked      -> READ b'\\x1b[I' on select, b'\\x1b[O' on leave
+                      pane that did not    -> nothing, ever
+    focus-events off  pane that asked      -> nothing, ever
+    resize-window     every pane           -> SIGWINCH, focused or not
+
+and, for the tty mode, one pane per mode painting three ``\\n``-joined rows::
+
+    cooked  ['AAA','BBB','CCC']   raw  ['AAA','   BBB','      CCC']   cbreak  ['AAA','BBB','CCC']
+
+`tests/test_a_component_event_reaches_its_handler.py` is the unit half; it can say what
+the dispatcher does with a byte, and cannot say whether the byte ever arrives.
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import shutil
+import subprocess
+import sys
+import textwrap
+import time
+import unittest
+from pathlib import Path
+
+from charter import commands_frame, config
+from charter.frame import layout, state, tmuxctl
+
+from tests import _tmuxreap
+from tests._isolation import PersonaIso
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: The checkout, reached through `$PYTHONPATH` rather than by prepending to `sys.path` —
+#: `util.self_relaunch_argv` passes `-P` (#390) and that flag must not be weakened to make
+#: a test pass. `tests/test_frame_palette_integration.py`'s rule, one module over.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SOCKET = _tmuxreap.name("focus-integ")
+SOCKET_PATH = os.path.join(os.environ.get("TMUX_TMPDIR") or "/tmp",
+                           f"tmux-{os.getuid()}", SOCKET)
+
+#: How long a tmux state change gets before this gives up. Generous, and spent only on the
+#: way to a failure: every wait below returns the instant the state is right.
+_DEADLINE = 25.0
+
+_TERM_CANDIDATES = tuple(dict.fromkeys(
+    ([os.environ["TERM"]] if os.environ.get("TERM", "dumb") != "dumb" else [])
+    + ["xterm-256color", "screen", "vt100"]))
+
+#: The three components, one per pane. Each draws ONE line whose text is a fact about what
+#: it has been handed — so `capture-pane` can tell "the event fired" from "the event did
+#: not" without the test reading any charter state.
+#:
+#: `acme.deaf` is the negative and it is the whole reason there are three: it declares
+#: `click`, which charter does not deliver, so its pane must keep saying `DEAF-quiet` for
+#: the entire test — including while it is the ACTIVE pane, which is when a dispatcher that
+#: ignored the declaration would light it up.
+FOCUS_CID, DEAF_CID, SIZE_CID = "acme.focus", "acme.deaf", "acme.sized"
+
+_PROVIDER = textwrap.dedent("""\
+    from charter.frame import component
+
+    API_VERSION = 1
+
+    seen = {"focus": False, "click": 0, "resize": 0}
+
+
+    def _focus(ev):
+        seen["focus"] = ev.kind == "focus"
+        return True
+
+
+    def focus_component():
+        return component.Component(
+            id="acme.focus", title="Focus", edge="bottom",
+            size=component.Fixed(1), events=("focus", "blur"), on_event=_focus,
+            render=lambda ctx: ["FOCUS-" + ("on" if seen["focus"] else "off")])
+
+
+    def _click(ev):
+        seen["click"] += 1
+        return True
+
+
+    def deaf_component():
+        return component.Component(
+            id="acme.deaf", title="Deaf", edge="bottom",
+            size=component.Fixed(1), events=("click",), on_event=_click,
+            render=lambda ctx: ["DEAF-" + ("hit" if seen["click"] else "quiet")])
+
+
+    def _resize(ev):
+        seen["resize"] += 1
+        return True
+
+
+    def sized_component():
+        return component.Component(
+            id="acme.sized", title="Sized", edge="bottom",
+            size=component.Fixed(1), events=("resize",), on_event=_resize,
+            render=lambda ctx: ["SIZE-%d" % seen["resize"]])
+    """)
+
+
+def _tmux(*args: str, env=None) -> subprocess.CompletedProcess:
+    return subprocess.run(["tmux", "-L", SOCKET, *args], capture_output=True, text=True,
+                          timeout=20, env=env)
+
+
+def _await(predicate, timeout: float = _DEADLINE) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class AFocusChangeReachesTheComponentThatOwnsThePane(PersonaIso):
+    """One frame, one attached client, three provider panels."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        v = tmuxctl.version()
+        if v is None or v < tmuxctl.FLOOR:
+            self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}."
+                          f"{tmuxctl.FLOOR[1]}; this machine has {v}")
+        # Registered FIRST so it runs LAST: `addCleanup` is LIFO, and the client forked
+        # onto a pty must be reaped before the server it is attached to goes.
+        self.addCleanup(self._teardown_socket)
+        (self.tmp / "charter.toml").write_text("")
+
+        self.fid = state.frame_id("focus-integ", os.getpid())
+        state.frame_dir(self.fid, create=True)
+        site = self._install_provider()
+
+        existing = os.environ.get("PYTHONPATH", "")
+        parts = [str(_REPO_ROOT), str(site)] + ([existing] if existing else [])
+        self.env = dict(os.environ, CHARTER_ROOT=str(self.tmp),
+                        PYTHONPATH=os.pathsep.join(parts))
+        self.env.pop("CHARTER_HOME", None)
+
+        started = _tmux("-f", "/dev/null", "new-session", "-d", "-s", self.fid,
+                        "-x", "100", "-y", "24", "-P", "-F", "#{pane_id}", "cat",
+                        env=self.env)
+        self.assertEqual(started.returncode, 0, started.stderr)
+        self.harness = started.stdout.strip()
+        state.record_server(self.fid, SOCKET)
+        state.record_harness_pane(self.fid, self.harness)
+
+        # Charter's OWN frame config, sourced the way a launch sources it — never a
+        # hand-written `set -g focus-events on` standing in for it. This whole file is
+        # about whether that ONE line does what #559 says, so a test that re-spelled it
+        # would be measuring its own copy of charter's answer (#547).
+        conf = str(self.tmp / "frame.conf")
+        with open(conf, "w") as fh:
+            fh.write(commands_frame.conf_text(hotkey=config.FRAME["hotkey"], mouse=False,
+                                              history_limit=100, session=self.fid))
+        sourced = _tmux("source-file", conf)
+        self.assertEqual(sourced.returncode, 0, sourced.stderr)
+
+        self.pane = {}
+        for cid in (FOCUS_CID, DEAF_CID, SIZE_CID):
+            self.pane[cid] = self._split(cid)
+        self.fd = self._attach()
+        # Every panel has painted its first frame before any case touches focus, so a
+        # later change can only be the event.
+        for cid, expect in ((FOCUS_CID, "FOCUS-off"), (DEAF_CID, "DEAF-quiet"),
+                            (SIZE_CID, "SIZE-0")):
+            self.assertTrue(_await(lambda c=cid, e=expect: e in self._shown(c)),
+                            f"{cid} never painted {expect}: {self._shown(cid)!r}")
+
+    # -- the frame ---------------------------------------------------------- #
+
+    def _install_provider(self) -> Path:
+        """One real distribution supplying all three components.
+
+        A real `.dist-info` with a real `entry_points.txt`, which is what an installed
+        package IS as far as `importlib.metadata` is concerned — and the panel processes
+        below are separate interpreters, so nothing this process could monkey-patch would
+        reach them anyway.
+        """
+        site = self.tmp / "site"
+        site.mkdir(parents=True, exist_ok=True)
+        (site / "acme_focus.py").write_text(_PROVIDER, encoding="utf-8")
+        info = site / "acme_focus-1.0.dist-info"
+        info.mkdir(exist_ok=True)
+        (info / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: acme-focus\nVersion: 1.0\n", encoding="utf-8")
+        (info / "entry_points.txt").write_text(
+            "[charter.components]\n"
+            f"{FOCUS_CID} = acme_focus:focus_component\n"
+            f"{DEAF_CID} = acme_focus:deaf_component\n"
+            f"{SIZE_CID} = acme_focus:sized_component\n", encoding="utf-8")
+        return site
+
+    def _split(self, cid: str) -> str:
+        """One panel pane running the argv charter's own launcher would run."""
+        argv = layout.panel_command(slot=cid, session=self.fid)
+        r = _tmux("split-window", "-t", self.harness, "-v", "-l", "3",
+                  "-P", "-F", "#{pane_id}", "--", *argv, env=self.env)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        return r.stdout.strip()
+
+    def _attach(self) -> int:
+        refusals = []
+        for term in _TERM_CANDIDATES:
+            pid, fd = pty.fork()
+            if pid == 0:
+                try:
+                    os.environ["TERM"] = term
+                    os.environ["CHARTER_ROOT"] = str(self.tmp)
+                    os.execvp("tmux", ["tmux", "-L", SOCKET, "attach", "-t", self.fid])
+                finally:
+                    os._exit(127)
+            if _await(lambda: bool(_tmux("list-clients", "-t", self.fid,
+                                         "-F", "#{client_name}").stdout.strip()),
+                      timeout=10.0):
+                self.addCleanup(self._reap, pid, fd)
+                return fd
+            refusals.append(term)
+            self._reap(pid, fd)
+        self.skipTest("no tmux client will attach on this machine, and focus events need "
+                      "one — tried TERM=" + ", ".join(refusals))
+
+    @staticmethod
+    def _reap(pid: int, fd: int) -> None:
+        for call in (lambda: os.kill(pid, 9), lambda: os.waitpid(pid, 0),
+                     lambda: os.close(fd)):
+            try:
+                call()
+            except OSError:
+                pass
+
+    def _teardown_socket(self) -> None:
+        """End the server and take its socket FILE with it, in that order and in ONE
+        cleanup — `test_frame_palette_integration.py::_ThePalette._teardown_socket`'s
+        argument verbatim: `kill-server` is a signal rather than a wait, so the listening
+        socket keeps accepting for a measured fraction of a millisecond afterwards, and a
+        client that connects in that window reads EOF where a reply should be.
+        """
+        said = _tmux("display-message", "-p", "#{socket_path}")
+        was_running = said.returncode == 0
+        path = said.stdout.strip()
+        _tmux("kill-server")
+        for candidate in {SOCKET_PATH, path if path.startswith("/") else SOCKET_PATH}:
+            try:
+                os.unlink(candidate)
+            except OSError:
+                pass
+        if not was_running:
+            return
+        self.assertTrue(path.startswith("/"),
+                        f"tmux would not say where its socket is — `#{{socket_path}}` "
+                        f"gave {path!r}, so this teardown is unlinking a guess")
+        self.assertFalse(os.path.exists(path),
+                         f"{path} survived this test's teardown")
+
+    # -- reading the frame back --------------------------------------------- #
+
+    def _shown(self, cid: str) -> str:
+        return _tmux("capture-pane", "-p", "-t", self.pane[cid]).stdout
+
+    def _select(self, pane: str) -> None:
+        r = _tmux("select-pane", "-t", pane)
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    # -- the cases ---------------------------------------------------------- #
+
+    def test_selecting_a_panels_pane_reaches_its_component_and_repaints(self):
+        """The whole issue, end to end: `Component.events` is a delivery now.
+
+        Nothing here bumps the frame's version and nothing resizes anything, so the only
+        thing that can have changed what this pane shows is the event.
+        """
+        self._select(self.harness)
+        self.assertIn("FOCUS-off", self._shown(FOCUS_CID))
+        self._select(self.pane[FOCUS_CID])
+        self.assertTrue(_await(lambda: "FOCUS-on" in self._shown(FOCUS_CID)),
+                        f"a focus event never reached it: {self._shown(FOCUS_CID)!r}")
+
+    def test_leaving_the_pane_reaches_it_as_a_blur(self):
+        """`focus` and `blur` are two names because a component receives one or the
+        other, never "a focus/blur" — so the return trip has to be its own case."""
+        self._select(self.pane[FOCUS_CID])
+        self.assertTrue(_await(lambda: "FOCUS-on" in self._shown(FOCUS_CID)))
+        self._select(self.harness)
+        self.assertTrue(_await(lambda: "FOCUS-off" in self._shown(FOCUS_CID)),
+                        f"a blur never reached it: {self._shown(FOCUS_CID)!r}")
+
+    def test_a_component_that_declared_an_undelivered_kind_receives_nothing(self):
+        """`click` is declared and charter does not deliver it, so this pane must say the
+        same thing while it is the ACTIVE pane as it does while it is not.
+
+        The negative that matters: a dispatcher that opened the input path for any
+        declaration at all would light this up on the focus report tmux sends the moment
+        it is selected — which is a `click` firing on something that was not a click.
+        """
+        self._select(self.pane[DEAF_CID])
+        time.sleep(1.0)
+        self.assertIn("DEAF-quiet", self._shown(DEAF_CID))
+        self._select(self.harness)
+        time.sleep(0.5)
+        self.assertIn("DEAF-quiet", self._shown(DEAF_CID))
+
+    def test_a_focus_change_reaches_only_the_pane_it_is_about(self):
+        """Two panels ask for focus reporting at once — only one of them is selected."""
+        self._select(self.pane[FOCUS_CID])
+        self.assertTrue(_await(lambda: "FOCUS-on" in self._shown(FOCUS_CID)))
+        self.assertIn("SIZE-0", self._shown(SIZE_CID))
+        self.assertIn("DEAF-quiet", self._shown(DEAF_CID))
+
+    def test_resizing_the_window_reaches_a_component_that_asked_for_it(self):
+        """A resize does not bump the frame's version — `panel.py`'s SIGWINCH section is
+        the same fact for charter's own renderers. It reaches every pane, focused or not,
+        which is why this case never selects the pane it asserts about."""
+        self._select(self.harness)
+        r = _tmux("resize-window", "-t", self.fid, "-x", "120", "-y", "26")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertTrue(_await(lambda: "SIZE-1" in self._shown(SIZE_CID)),
+                        f"a resize never reached it: {self._shown(SIZE_CID)!r}")
+
+    def test_the_paint_that_follows_is_not_sheared_by_the_mode_charter_set(self):
+        """`tty.setraw` would clear `OPOST`/`ONLCR`, and a panel joins its rows with
+        `\\n` — measured, that draws a staircase. A one-row panel cannot show one, so this
+        asks the pane charter set the mode on to still start at column 0."""
+        self._select(self.pane[FOCUS_CID])
+        self.assertTrue(_await(lambda: "FOCUS-on" in self._shown(FOCUS_CID)))
+        first = self._shown(FOCUS_CID).split("\n")[0]
+        self.assertTrue(first.startswith("FOCUS-on"),
+                        f"the row was indented by the mode: {first!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -757,6 +757,10 @@ class NoCharterEscapesThroughTheExecFamily(unittest.TestCase):
             "The same `tmux attach` inside a `pty.fork` child, and for the same reason "
             "again: the palette's whole entry point is a `bind -n`, which only a real "
             "client with a real terminal can press. `os._exit`s in its `finally`.",
+        "tests/test_frame_focus_reaches_a_component.py:execvp":
+            "The same `tmux attach` inside a `pty.fork` child once more: tmux sends a "
+            "pane focus report only while a client is attached, so `focus`/`blur` cannot "
+            "be exercised without a real one. `os._exit`s in its `finally`.",
     }
 
     _WATCHED = ("execl", "execle", "execlp", "execlpe", "execv", "execve", "execvp",


### PR DESCRIPTION
Closes #607.

`Component.events` was validated at `component.py:320` and read by nothing. A provider could
declare `events = ["scroll"]`, pass every check, and receive nothing, ever. There was no
dispatcher. There is one now, and it delivers **three of the six kinds**: `focus`, `blur`,
`resize`.

## What a provider writes

```python
component.Component(
    id="acme.metrics", title="Metrics", edge="right", size=Fixed(12),
    events=("focus", "blur"),
    on_event=lambda ev: remember(ev.kind),   # truthy = repaint me
    render=lambda ctx: [line_for(remembered())],
)
```

The two halves are refused apart, in both directions. A declaration with nothing behind it
*is* #607's defect written by the provider instead of by charter, and a handler with no
declaration is a callable charter would never call.

## The four decisions worth reviewing

**1. Input is read off the pane charter already claimed (fd 1), never off `sys.stdin`.**
A tmux pane runs its command with fds 0/1/2 on one pty, so `frame/pane.py`'s claimed
descriptor *is* where the pane's input arrives. Measured against tmux 3.7c with the probe's
own stdin closed (`0<&-`): `fd=1 isatty=True`, then `READ b'\x1b[I'` on select. That reuses
#606's fix rather than writing a second one for the other direction — `sys.stdin` is a
mutable global a provider's library can replace exactly as it can replace `sys.stdout`.

**2. The tty goes to cbreak, never to raw.** `tty.setraw` clears `OPOST`/`ONLCR` and
`panel._write` joins rows with `\n`. Four modes, one 40x10 tmux pane each, read back with
`capture-pane`:

```
cooked    -> ['AAA', 'BBB', 'CCC']
raw       -> ['AAA', '   BBB', '      CCC']      <- every panel paint, sheared
cbreak    -> ['AAA', 'BBB', 'CCC']
explicit  -> ['AAA', 'BBB', 'CCC']
```

`frame/palette.py` reaches for `setraw` and is right to — it joins with `\r\n` because it
owns the whole pane. A panel does not.

**3. A handler is a notification, not a second renderer.** Nothing `on_event` returns
reaches the pane; the return value is read for its truth and nothing else, and the repaint
that follows is the existing one — same `_write`, same `Registry.draw`, same rectangle. So
#472's containment order is kept *by construction*: there is no path from a handler's
return value to a terminal for an escape sequence to travel down. A handler is also handed
no `ctx`, so §4f's one-snapshot-one-timestamp survives; and a `resize` carries no size,
because `ctx.width`/`ctx.height` is where a rectangle is read and a number on the event
would be a second answer that could disagree.

**4. A handler that raises is retired, and the pane says so.** `registry.py`'s docstring
names three moments a provider can fail — on import, while building, in `render` — and
gives one answer to all three: the pane names the component and why. `on_event` is the
fourth and takes the same answer. **The cost is real and I want it read rather than
skimmed:** a component whose `render` still works loses its pane to a message because its
*handler* broke. I chose that over the alternative — a component that quietly stops being
interactive, indistinguishable from one nothing has happened to yet, which is #512's shape.
Retired rather than retried, because a handler that raised on one event will raise on the
next and delivering more spends the operator's repaints on a loop of identical failures.

**A handler that never returns wedges its own panel and nothing else.** No watchdog, and
that is deliberate: the panel is one process holding one pane, so a looping handler stops
that pane repainting and leaves every sibling pane, the harness and tmux untouched — §4b's
promise kept, and exactly what an infinite loop in `render` already does. A
`signal.setitimer` watchdog cannot interrupt a C-level block, so it would promise a bound
it does not have while adding a new way for the `select` and the `write` on either side of
a handler to fail half-way. The operator's way out is unchanged and runs no charter code:
`HATCH_KEY` is matched in tmux's own root key table.

## What I did NOT ship, and why

`key`, `click` and `scroll` are decoded and routed nowhere. They stay declarable, which is
what `EVENT_KINDS` already promises ("a declaration of what you HANDLE, never a promise
that it FIRES"), and a case pins that declaring one is still not an error.

- **`key`** — the harness owns the keyboard. tmux routes typing to the active pane, which
  is the harness's, so the only keystrokes a panel could see are the ones the operator typed
  into the wrong pane. There is a case pinning that a keypress never reaches a handler that
  asked for `focus`, because once a panel is reading its pane those bytes really do arrive.
- **`click`/`scroll`** — see below. This is the one thing I could not decide alone.

## The decision I am asking for — one word

**What does a click on a non-active pane mean?**

The measurement I was given: tmux routes pointer events by POSITION, and a click does not
focus the pane. So "only the active pane requests mouse" relocates the trade rather than
dissolving it, and a click on an unfocused panel arrives at that panel without moving the
operator's keyboard. Three answers:

| | behaviour | cost |
|---|---|---|
| **(a) point-to-act** | deliver where the pointer is; never move focus | the pointer and the keyboard address different panes at once |
| (b) click-to-focus | deliver, and `select-pane` to it | a misclick mid-prompt moves your typing off the harness; F12 to get back |
| (c) active-only | drop clicks on unfocused panes | the mouse is dead in the common case, since the harness is nearly always active |

**My recommendation is (a), and this PR is what makes it defensible.** (b) is hostile — the
frame exists to keep the harness the thing you type into, and a stray click must not take
that away. (c) makes the pointer useless unless you first pay (b)'s cost by hand. (a) is
also what an operator already experiences from tmux with `mouse on`: scrolling a pane you
are not focused on works.

The reason (a) was ambiguous before and is not now: the objection to point-to-act is that
the pointer becomes a second, silent focus disagreeing with the keyboard's. **After this
PR a component can see which one it is** — `focus`/`blur` tell it whether the keyboard is
on it, so it can render "you are pointing at me" and "you are typing into me" as different
states instead of guessing. Delivering `click` on top of that is then routing, not a new
question.

Worth noting either way: `[frame] mouse` still defaults off and costs the operator their
terminal's text selection when on, so under any of the three, clicks fire only for someone
who opted in with their eyes open.

Answer **a**, **b** or **c** and I will open the follow-up.

## Coordination — `overlay.py`

`overlay.py` is shared machinery, so this only **adds** to it. Five executable lines; **no
executable line edited, none deleted**:

- `overlay.py:199` — `FOCUS, BLUR = "focus", "blur"` (beside the existing `KEY, CLICK,
  SCROLL, RESIZE`)
- `overlay.py:248` — `_CSI_FOCUS = {b"I": FOCUS, b"O": BLUR}`
- `overlay.py:401-405` — three statements (plus a two-line comment) in `decode`'s existing
  CSI branch, emitting those kinds for a parameterless `CSI I`/`CSI O`

The only deletions in that file are six lines of comment prose on the `KEY, CLICK,
SCROLL, RESIZE` constant, which said `focus`/`blur` "do not exist yet" because
`focus-events` ships off in tmux — #559 made that stale.

Both sequences were previously consumed by `_CSI` and dropped, so the palette and the
pickers see exactly what they saw. `Surface.handle` returning `None` for both, with `mouse`
on and off, is pinned so this cannot start moving a palette's selection.

Nothing here touches `charter/hooks.py` (#608).

## Measurements (real tmux 3.7c, sockets killed and unlinked in one cleanup, nothing left)

```
focus-events on    pane that asked        READ b'\x1b[I' on select, b'\x1b[O' on leave
                   pane that did NOT ask  nothing, ever
                   client's own terminal  loses/regains focus -> same pair to active pane
focus-events off   pane that asked        nothing, ever
resize-window      every pane             SIGWINCH, focused or not
```

`commands_frame.conf_text` writes `set -g focus-events on` (#559), so this works on
charter's own server and does not inside an operator's existing tmux, where charter sources
no config at all. That is the "never fires" direction `EVENT_KINDS` asks for, and
`docs/frame.md` says it to the operator.

**Two defects the measurements caught before review did:**

- `termios.error` is **not** an `OSError` (`mro: (termios.error, Exception, BaseException,
  object)`). A guard written against `frame/pane.py`'s `_CANNOT_SAY` set alone would have
  turned `charter panel acme.metrics > /tmp/log` into `panel._hold` painting a refusal for
  a component that did nothing wrong.
- `TCSADRAIN` waits for the terminal to consume what is already written, and on a pane
  whose far end is not reading it never returns — it hung this branch's own suite in a
  cleanup. `close()` uses `TCSANOW`; it changes no output flag, so a drain protects nothing
  and can only wedge, in the `finally` that holds the operator's tty mode. Pinned on a
  thread with a deadline, so a regression is red rather than a hang.

## Cost

A panel whose component declares nothing charter delivers builds **no dispatcher**: the
tty keeps its mode, no `\x1b[?1004h` is written, and `_watch` sleeps exactly as before.
Charter's own four panels are in that group. A component declaring only `resize` opens no
input path either, and does not even measure the pane — pinned, because that gate's
consequence is a syscall per paint and is otherwise masked by the delivery filter.

## Behaviour change

A component that declares `events` and supplies no `on_event` now fails to load. That is a
real break for a component written against the old contract — but only for one that
declared events it was never receiving, which is the defect being fixed.
`API_VERSION` is **not** bumped: it asks "can charter honour what this provider declared",
and a component built before this field existed declares nothing charter cannot still
honour. Bumping would refuse every installed provider at once to fix a class whose events
had never fired. The reasoning is in the field's own docstring so the next reader can
disagree with it in one place.

## What an adversarial read found afterwards

The dispatcher was written, pinned and green before it was reviewed adversarially. The
review found **nine reachable defects**, all now fixed with a case that goes red without
the fix — recording them because they are the interesting part of this branch:

1. **`close()` destroyed its own restore state on the first line**, so "idempotent" meant
   "the second call is a guaranteed no-op": anything that raised or blocked in between lost
   the `tcsetattr` for good, since `_watch`'s `finally` would find `_fd` already `None`. And
   something *can* block — `open()` leaves `IXON` on, so Ctrl-S in the pane parks the flush
   inside the withdrawal. **The restore goes first now**, pinned on a thread with a deadline
   so a regression is red rather than a hang.
2. **`_watch`'s `finally` ran the fallible `close()` ahead of the infallible
   `signal.signal()`**, so a raising close leaked the SIGWINCH handler that function was
   split out to hand back. Nested now.
3. **`_CANNOT_SAY` was missing `TypeError`** — what `termios.tcgetattr` and `select.select`
   raise for a stream stand-in whose `fileno()` is not a descriptor. Same class as the
   `termios.error` miss one step out, and it sent a piped panel to `_hold` for doing
   nothing wrong. A `MagicMock` stdout reaches it.
4. **`os.read`'s bare `except OSError` folded `BlockingIOError`/`InterruptedError` into
   end-of-input**, which is *permanent*. One `O_NONBLOCK` race — anything putting stdout on
   an asyncio loop creates one — or one `SIGWINCH` landing in the read cost a component
   every later event, silently, with no `failure` to paint.
5. **`note_resize` stored an unmeasurable reading**, spending the comparison: a pty answers
   "no size" between a resize and its `TIOCSWINSZ`, and one such reading in the middle meant
   the resize never fired at all.
6. **`open()` called twice captured cbreak as `before`**, so `close()` would "restore" the
   pane to `ECHO` off, for good.
7. **`wanted()` asked truthiness**, so a handler written as an instance with a falsy
   `__bool__` silently got no dispatcher — this issue's defect with a new spelling.
8. **The handler-failure message was truncated to one line** instead of wrapped like every
   other provider failure. `" charter: <id> stopped taking events — "` is 45 characters, so
   in a 30-column side panel the exception text was *always* what got clipped — and
   `_wrap`'s own docstring says why that is not cosmetic. It also ignored the operator's
   `pad`.
9. **A composite's PART could declare events.** A part is never placed on the frame, so
   `_dispatcher` never asks `wanted()` of it: declared, and read by nothing — #607 one level
   down. Refused at registration now, naming both components; widening to deliver to
   children later costs nothing, which is `EVENT_KINDS`'s own argument about `drag`.

Two docstring claims were also overstated and are now accurate: a wedged handler **also
leaves its pane in cbreak** (the `finally` that restores it never runs), and the overlay
does not receive focus reports because its pane is split fresh for it — not because nothing
could ever deliver one.

## Verification

- `python3 -m unittest discover -s tests` green on **3.14** and on **3.12** with
  `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset (`env -i`, all 15 such variables
  dropped). Counts in the comments below.
- `tools/sweep.py` runs as this repo's CI gate on every PR; its verdict is on this PR.
- Hand-checks ran through a harness that asserts the mutation **applied** (anchor present,
  exactly once, digest moved) and that the restore **landed** (digest back to the original),
  with the restore in a `finally` — #585/#586, and the false pin that followed a script
  crashing before its restore.
- Falsification of the integration suite before trusting it: six mutations, five killed it,
  and the sixth (`_deliver`'s declared-kind filter) survived *there* because `wanted()`
  gates it — it is killed by the unit suite, and the sharper consequence it guards (a
  keypress reaching a `focus` handler) now has its own case.
- Hand-checks in total: 6 falsifying the integration suite, 2 on guards the first pass had
  left masked, 12 on the constants and failure paths the sweep is weakest on, and 9 on the
  review fixes above — 29, all killed.

### Known limit, stated rather than left to be found

An operator switching away from their whole terminal window also blurs the focused panel —
tmux forwards the client's own focus report to the active pane, measured. That behaviour is
recorded with its measurement in `events.py` but does not yet have an automated case; adding
one is a small follow-up, not a gap in the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
