### PR TITLE
A reference vault reports the directory it is listed in, and a withheld credential is still reported after the run (#491, #489)

### DIFF
--- a/charter/mcpseen.py
+++ b/charter/mcpseen.py
@@ -143,6 +143,33 @@ def path() -> Path:
     return Path(config.STATE_DIR) / FILE_NAME
 
 
+def declares_credential(entry: dict) -> bool:
+    """Does *entry* ask for a vault value at all — through ``secrets`` OR ``secret_files``?
+
+    The vault-free half of :func:`needs_consent`, split out because a second caller asks
+    this exact question about a persona that has **no** vault, where `needs_consent` is
+    False by construction and therefore cannot be that caller's answer.
+
+    `persona.lint` was that caller, and it asked with ``entry.get("secrets")`` alone. The
+    two keys are two MECHANISMS for one thing — `secrets` puts a value in the environment,
+    `secret_files` materialises a 0600 file and puts its path there (#190) — and every
+    other reader treats them as one: `needs_consent` here, `persona.mcp_render_entry` when
+    it decides whether to wrap the command, and `charter secret exec`'s own `--env`/`--file`
+    pair. `lint` was the odd one out, so a server declaring only `secret_files` against a
+    persona naming no vault rendered with no credential and no finding on any surface —
+    and `secret_files` is not the exotic half: it is what Google ADC needs, which is the
+    very declaration #489's own reproduction uses.
+
+    One function, so the next key of this kind is added in one place rather than in the
+    three that happen to be remembered.
+    """
+    if not isinstance(entry, dict):
+        return False
+    secrets, files = entry.get("secrets"), entry.get("secret_files")
+    return bool((isinstance(secrets, dict) and secrets)
+                or (isinstance(files, dict) and files))
+
+
 def needs_consent(vault: str | None, entry: dict) -> bool:
     """Would rendering *entry* hand *vault*'s value to the command a committed file names?
 
@@ -152,11 +179,7 @@ def needs_consent(vault: str | None, entry: dict) -> bool:
     ``None`` now means "no approval can exist", which includes entries that ARE in scope
     and must still be reported.
     """
-    if not vault or not isinstance(entry, dict):
-        return False
-    secrets, files = entry.get("secrets"), entry.get("secret_files")
-    return bool((isinstance(secrets, dict) and secrets)
-                or (isinstance(files, dict) and files))
+    return bool(vault) and declares_credential(entry)
 
 
 def fingerprint(vault: str | None, entry: dict) -> str | None:

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -639,6 +639,47 @@ def _mcp_declared(name: str) -> tuple[dict, list[str]]:
     return out, refused
 
 
+def mcp_vault(vault) -> str | None:
+    """The vault an MCP entry would actually be wrapped with — ``None`` for :data:`NO_VAULT`.
+
+    ``vault: none`` is charter's reserved way of saying *this persona deliberately holds no
+    credentials* (:func:`declares_no_vault`), and :func:`vault_of` has always returned
+    ``None`` for it so that no caller goes looking for a vault literally named ``none``.
+    The MCP path read ``meta["vault"]`` raw and therefore did not. Measured against 0.53.0,
+    on a persona whose charter says ``vault: none``:
+
+        consent line   run uvx analytics-mcp  secrets "T"="k"  vault "none"
+        rendered       charter secret exec none --env T=k --exec -- uvx analytics-mcp
+
+    So charter asked the operator to approve spending the value of a vault named ``none``,
+    recorded the consent, and wrote a launcher into the generated agent that can never
+    work — while `lint` was separately, correctly, calling the same persona one that names
+    no vault. One sentinel, two readings.
+
+    Applied in :func:`mcp_render_entry` and :func:`mcp_credentialed` — the render and the
+    consent list — because those two must agree about which servers carry a credential or
+    the operator is asked about a server the file does not wrap, and vice versa.
+    """
+    v = vault.strip() if isinstance(vault, str) else ""
+    return None if not v or v == NO_VAULT else v
+
+
+def vault_for_mcp(name: str) -> str | None:
+    """The vault *name*'s MCP entries would actually be wrapped with, or ``None``.
+
+    :func:`mcp_vault` applied to the resolved ``vault:``, in ONE place. Both readers that
+    have to agree — :func:`mcp_credentialed`, which decides what the operator is asked
+    about, and :func:`lint`, which decides what they are told — spelled this chain out
+    themselves, and a chain written twice is the thing `file_path` and `loose_dirs` are
+    both about in this same commit.
+
+    The ``or {}`` is load-bearing here and not in the callers' old copies: `resolve` returns
+    ``None`` for a persona whose ``persona.md`` does not load, and `_approve_mcp` reaches
+    `mcp_credentialed` for every name `list_personas` globbed, without asking first.
+    """
+    return mcp_vault((resolve(name) or {}).get("meta", {}).get("vault"))
+
+
 def mcp_render_entry(name: str, vault: str | None, entry: dict) -> dict:
     """One declared server, as the generated agent should carry it.
 
@@ -657,6 +698,9 @@ def mcp_render_entry(name: str, vault: str | None, entry: dict) -> dict:
     server through charter would buy nothing and add a process.
     """
     out = {k: v for k, v in entry.items() if k not in ("secrets", "secret_files")}
+    # `vault: none` is the declared ABSENCE of a vault, not the name of one — see
+    # :func:`mcp_vault` for what this line was emitting before it was normalised here.
+    vault = mcp_vault(vault)
     secrets = entry.get("secrets") or {}
     # A separate key, not a marker inside `secrets`, because these are different MECHANISMS
     # rather than two spellings of one: `secrets` puts a VALUE in the environment,
@@ -726,7 +770,10 @@ def mcp_credentialed(name: str) -> list[tuple[str, dict, str, str]]:
     than by the digest, so such an entry is still REPORTED as withheld instead of
     vanishing from both lists at once.
     """
-    vault = (resolve(name) or {}).get("meta", {}).get("vault")
+    # `vault_for_mcp`, which is `mcp_render_entry`'s own normalisation: a persona declaring
+    # `vault: none` holds no credential to withhold, and a consent prompt about one is a
+    # prompt about nothing that records an approval for a command that cannot run.
+    vault = vault_for_mcp(name)
     out = []
     for server, entry in sorted(mcp_servers(name).items()):
         if mcpseen.needs_consent(vault, entry):
@@ -1639,12 +1686,69 @@ def lint(name: str, deep: bool = True) -> list[tuple[str, str]]:
                        f"letters, digits, '_', '.' and '-' (64 max). Rename it in "
                        f"`{MCP_FILE}`"))
     if servers:
-        vault = (resolve(name) or {}).get("meta", {}).get("vault")
-        needs_secrets = sorted(s for s, e in servers.items() if (e or {}).get("secrets"))
-        if needs_secrets and (not vault or vault == "none"):
+        # `vault_for_mcp`, so this row and the render agree about what "has a vault" means.
+        # It was `not vault or vault == "none"` — a second spelling of the sentinel, written
+        # out beside a `NO_VAULT` constant that exists to stop exactly that, and one that
+        # reads a whitespace-only `vault:  ` as a vault name.
+        vault = vault_for_mcp(name)
+        # `mcpseen.declares_credential`, not `entry.get("secrets")`. `secrets` and
+        # `secret_files` are two mechanisms for one thing and every other reader treats
+        # them as one — `needs_consent`, `mcp_render_entry`, `secret exec --env/--file`.
+        # This line was the odd one out, so a server declaring only `secret_files` against
+        # a persona naming no vault rendered without its credential and was reported by
+        # NOTHING: not here, because the key was not read, and not by `mcp_withheld`,
+        # because with no vault there is no consent to withhold. `secret_files` is what
+        # Google ADC needs (#190) — the exact declaration #489's reproduction carries.
+        # `e`, not `e or {}`. A committed `{"mcpServers": {"x": null}}` puts `None` here,
+        # and `declares_credential` answers that with False by construction — its
+        # `isinstance(entry, dict)` is the guard, and it is pinned. A second guard in front
+        # of a pinned one is a line no test can go red without, which the sweep reported and
+        # which this file's own rule says to delete rather than to leave looking careful.
+        wants = sorted(s for s, e in servers.items() if mcpseen.declares_credential(e))
+        if wants and not vault:
             issues.append(("error",
-                           f"mcp: server(s) {', '.join(needs_secrets)} declare `secrets` but "
-                           f"this persona names no vault — add `vault:` or drop the secrets"))
+                           f"mcp: server(s) {', '.join(wants)} declare `secrets` or "
+                           f"`secret_files` but this persona names no vault — add `vault:` "
+                           f"or drop the declaration"))
+    # The credential this persona declares and is NOT running with (#489). Standing state,
+    # said by the command you run BECAUSE a persona is misbehaving — which is the whole
+    # finding: `mcp_withheld` had exactly one caller, `sync-agents`, on the run that wrote
+    # the file. That warning is correct and it is said once. After it scrolls, a persona
+    # running without the credential it declares is byte-identical in
+    # `.claude/agents/<name>.md` to one that never declared a vault at all, and the failure
+    # it produces arrives three layers away as an MCP server failing to authenticate.
+    #
+    # A WARNING, not an error, and that is a decision rather than a default. Withholding is
+    # the #330 gate working: the operator may have read the command and declined it, and
+    # charter must not overrule that with an exit code — `charter persona lint` returning 1
+    # forever would make the finding something planes turn off. What charter owes is that
+    # the state stays VISIBLE, which is what this row is. `doctor` reports it without a
+    # second sentence of its own: `check_personas` already counts these issues and names
+    # the persona, and one fact with two wordings is the drift this file keeps recording.
+    #
+    # Nothing is re-derived here. `mcp_withheld` computes the list `sync-agents` prints, so
+    # the two surfaces cannot disagree about which servers are withheld — the failure mode
+    # of a report that recomputes its own answer.
+    for server, line in mcp_withheld(name):
+        if line:
+            issues.append((
+                "warn",
+                f"mcp: '{mcpseen.label(server)}' declares a credential this machine has "
+                f"not approved, so the generated sub-agent runs it WITHOUT the vault and "
+                f"it will fail to authenticate. Read the command and approve it with "
+                f"`charter persona sync-agents --approve-mcp`, or drop `secrets`/"
+                f"`secret_files` from `{MCP_FILE}` if it should hold no credential"))
+        else:
+            # `describe` cannot render this entry, so it can never be approved (#427) and
+            # `--approve-mcp` refuses it by name. Telling the operator to run that command
+            # would be a nudge that cannot work, which is the one thing a nudge may not be
+            # (#371) — so this is a different sentence AND a different level: the entry has
+            # to change before any answer to the consent question exists.
+            issues.append((
+                "error",
+                f"mcp: '{mcpseen.label(server)}' declares a credential and "
+                f"{mcpseen.UNRENDERABLE} — it can never be approved, so the vault is "
+                f"withheld permanently. Fix the entry in `{MCP_FILE}`"))
 
     return issues
 

--- a/charter/secrets/base.py
+++ b/charter/secrets/base.py
@@ -160,6 +160,12 @@ def loose_dirs(leaf, stop) -> list:
     return out
 
 
+#: :func:`loose_dirs` under a name that reads as what it does from inside a class that also
+#: has a ``loose_dirs`` method. Same object; `plain_file` imported it under this name for
+#: the same reason, and :meth:`VaultProvider.loose_dirs` calls it.
+_dirs_up_to = loose_dirs
+
+
 def _same(p, resolved) -> bool:
     from pathlib import Path
 
@@ -203,6 +209,39 @@ def loose_dir_note(loose) -> str:
         return ""
     named = ", ".join(f"{short_path(d)} {oct(m)[-3:]}" for d, m in loose)
     return f"listed by other accounts: {named} (want 700 — chmod 700)"
+
+
+def mode_note(p) -> str:
+    """``perms 644 (want 600)`` for a vault file that is not 0600, or ``""``.
+
+    The FILE half of :func:`loose_dir_note`, extracted here for the same reason that one
+    exists: `plain-file` rendered this sentence inline inside `health` and `reference`
+    rendered nothing at all, so a vault file another account can read said so on one
+    provider and stayed silent on the other (#491). Both providers write 0600, and both
+    hold something worth not publishing — a reference file is not a secret, but it names
+    every item and field this plane reaches (see :mod:`charter.secrets.reference`).
+
+    Reports, never repairs, which is the posture the read-only paths already take: `health`,
+    `keys` and `ages` NAME a loose mode rather than quietly chmod-ing it, because a health
+    check that writes is the defect whatever it writes to — `doctor` calls this from the
+    SessionStart hook, and a vault's ``file`` may name any path on this machine (#331,
+    :meth:`PlainFileProvider._tighten`).
+
+    Never raises. A health line that can throw is a `doctor` that cannot run, and the empty
+    string is the honest answer for a mode charter could not read: the file's own existence
+    is reported by the branch above every caller's, so silence here is never the only thing
+    said about a file. The catch is `Exception` and not `BaseException`, deliberately —
+    `tests/_planeguard.py` signals a test reaching the real ``.charter/`` with a
+    `BaseException` precisely so a fallback like this cannot turn it into a quiet "".
+    """
+    import os
+    import stat as _stat
+
+    try:
+        mode = _stat.S_IMODE(os.stat(p).st_mode)
+    except Exception:
+        return ""
+    return "" if mode == 0o600 else f"perms {oct(mode)[-3:]} (want 600)"
 
 
 class VaultProvider(ABC):
@@ -353,8 +392,34 @@ class VaultProvider(ABC):
         A provider that stores its data somewhere else entirely (1Password, Vault) has no
         directory of charter's to report, so the honest answer is an empty list rather than
         a guess about a backend charter does not own.
+
+        **Which providers those are is decided by** :attr:`file_path`, **not by a second
+        list somebody keeps in step.** This used to live on `PlainFileProvider` alone, and
+        the base default was a bare ``return []`` — honest for 1Password and *false* for
+        `reference`, which writes a file under ``.charter/vaults/`` through the same private
+        walk and reported nothing about the directory holding it, on `vault list` and on
+        `doctor` alike (#491). A reference file is not a secret; the DIRECTORY still lists
+        every vault name on the plane, which is the exposure this report exists for.
+
+        Two copies of the same eight lines was the wrong number for the same reason
+        :attr:`file_path` gives about the two byte-identical ``path`` properties it
+        replaced: the second copy is how one provider quietly keeps answering the old way.
+        So the question is asked of the one place that already knows where a vault's file
+        is. A provider with no ``file`` in its config — 1Password today, anything backed by
+        a real service tomorrow — makes :attr:`file_path` raise, and the answer is the
+        empty list it always was, without a new attribute for a new provider to forget.
+
+        Never raises: a health line that can throw is a `doctor` that cannot run. The catch
+        is `Exception`, not `BaseException`, deliberately — `tests/_planeguard.py` signals a
+        test reaching the real ``.charter/`` with a `BaseException` precisely so that a
+        fallback like this one cannot turn it into a quiet empty answer.
         """
-        return []
+        from .. import config as _config
+
+        try:
+            return _dirs_up_to(self.file_path.parent, _config.STATE_DIR)
+        except Exception:
+            return []
 
 
 def redact(text: str, secrets: list[str]) -> str:

--- a/charter/secrets/plain_file.py
+++ b/charter/secrets/plain_file.py
@@ -14,7 +14,7 @@ import stat
 from pathlib import Path
 
 from .base import (SecretNotFound, VaultError, VaultProvider, loose_dir_note,
-                   loose_dirs as _dirs_up_to, make_private_dir, short_path as _short)
+                   make_private_dir, mode_note, short_path as _short)
 
 
 class PlainFileProvider(VaultProvider):
@@ -210,44 +210,15 @@ class PlainFileProvider(VaultProvider):
             count = len(self._load())
         except VaultError as e:
             return False, str(e)
-        mode = stat.S_IMODE(pp.stat().st_mode)
-        perms = "" if mode == 0o600 else f", perms {oct(mode)[-3:]} (want 600)"
-        return True, f"{count} secret(s){perms}" + (f", {note}" if note else "")
+        # `base.mode_note`, not a second `oct(...)[-3:]` here. `reference` had no sentence
+        # about its file's mode at all, and the fix for that (#491) is one wording for both
+        # providers rather than a copy that goes stale in the same way `loose_dirs` did.
+        return True, ", ".join(
+            [f"{count} secret(s)"] + [s for s in (mode_note(pp), note) if s])
 
-    def loose_dirs(self) -> list:
-        """The other-readable directories holding this vault, named — never chmod-ed.
-
-        Every directory charter creates on the way here is 0700: the vault writers walk
-        each level (:func:`base.make_private_dir`), and since #470 so does whatever creates
-        ``.charter/`` first, which on the ``charter vault add`` flow is the registry write
-        rather than any vault writer.
-
-        A directory that was already there when charter arrived keeps whatever mode it
-        has, and that is the case this exists for: a ``.charter/vaults/`` created before
-        0.51.x, or by ``mkdir -p`` at the umask default, sits at 0755 and lists every vault
-        name on the plane to every account on the machine. `set` does not fix it, because a
-        vault's ``file`` can name any path on this machine and charter chmod-ing a
-        directory it did not create — a home directory, a shared team directory — is the
-        #331 defect over again.
-
-        So it is REPORTED, and reported as a *list* rather than as prose inside `health`'s
-        string: `charter vault list` renders it into its STATUS column and `charter doctor`
-        puts it on the vaults line, both through :func:`base.loose_dir_note` (#471).
-
-        This is the same posture the file mode already takes on the read-only paths:
-        `health`, `keys` and `ages` name a loose mode rather than silently fixing it,
-        because a health check that writes is the defect regardless of what it writes.
-
-        Never raises: a health line that can throw is a `doctor` that cannot run. The catch
-        is `Exception`, not `BaseException`, deliberately — `tests/_planeguard.py` signals
-        a test reaching the real ``.charter/`` with a `BaseException` precisely so that
-        fallbacks like this one cannot turn it into a quiet empty answer.
-        """
-        from .. import config
-
-        try:
-            if not self.config.get("file"):
-                return []
-            return _dirs_up_to(self.file_path.parent, config.STATE_DIR)
-        except Exception:
-            return []
+    # `loose_dirs` is INHERITED — the implementation lives on `base.VaultProvider` and is
+    # keyed on `file_path`, so `reference` answers it too (#491). The eight lines that used
+    # to sit here reported the directory for the one provider that had them; the argument
+    # for why they are not copied per provider is `VaultProvider.loose_dirs`'s, and it is
+    # the same argument `VaultProvider.file_path` makes about the two byte-identical `path`
+    # properties it replaced.

--- a/charter/secrets/reference.py
+++ b/charter/secrets/reference.py
@@ -42,7 +42,8 @@ from pathlib import Path
 from urllib.parse import urlsplit
 
 from .. import util
-from .base import SecretNotFound, VaultError, VaultProvider, make_private_dir
+from .base import (SecretNotFound, VaultError, VaultProvider, loose_dir_note,
+                   make_private_dir, mode_note, short_path as _short)
 
 
 def _op_argv(uri: str, config: dict) -> tuple[list[str], str]:
@@ -126,10 +127,41 @@ _RESOLVERS = {"op": _op_argv, "vault": _vault_argv, "browser": _browser_argv}
 RESOLVE_TIMEOUT = 60.0
 
 
-def scheme_of(value: str) -> str | None:
-    """The reference scheme of *value*, or None if it isn't a supported reference."""
-    scheme = urlsplit(value or "").scheme
+def scheme_of(value) -> str | None:
+    """The reference scheme of *value*, or None if it isn't a supported reference.
+
+    **TOTAL, over anything JSON can hold, and that is not defensive programming.** The
+    vault file is hand-editable and — for this provider especially — *committed*: the whole
+    argument for reference vaults is that a team commits the wiring and a fresh clone
+    inherits it. So the values here are arbitrary JSON, and `_load` checks only that the
+    document is an object. A committed ``{"K": 123}`` reached `urlsplit`, which raised
+    ``AttributeError: 'int' object has no attribute 'decode'`` straight out of
+    :meth:`ReferenceProvider.health` — and `health` is called by `charter vault list` and by
+    `charter doctor`, which catch `VaultError` and nothing else, from the SessionStart hook.
+    The command whose entire job is reporting on this file was the thing the file could
+    crash. Anything that is not a string is not a supported reference, which is the same
+    answer this already gave a string that is not one.
+    """
+    if not isinstance(value, str):
+        return None
+    scheme = urlsplit(value).scheme
     return scheme if scheme in _RESOLVERS else None
+
+
+def _cli_for(scheme: str, data: dict, config: dict) -> str:
+    """The CLI name *scheme*'s resolver would invoke, for the entries in *data*.
+
+    The argv builder is what knows its CLI, and it needs a URI to build one — so the URI
+    handed to it has to be one of *this* scheme's. `health` asked the same question twice,
+    once to decide whether the CLI is on PATH and once to name it, and each spelled the
+    ``next(v for v in data.values() if scheme_of(v) == s)`` search out again. The filter is
+    the whole search: without it the first call gets whichever entry happens to be first,
+    and `_vault_argv` handed an ``op://`` URI raises "malformed Vault reference" out of a
+    health check. One implementation, so the two questions cannot disagree about which
+    entry they are asking about.
+    """
+    return _RESOLVERS[scheme](
+        next(v for v in data.values() if scheme_of(v) == scheme), config)[1]
 
 
 class ReferenceProvider(VaultProvider):
@@ -259,20 +291,98 @@ class ReferenceProvider(VaultProvider):
 
         ``vault list`` and ``doctor`` call this routinely; resolving here would hit
         1Password/Vault on every listing and could prompt for re-auth.
+
+        **What this line says about the FILE, which for three releases was nothing (#491).**
+        A reference vault keeps a file under ``.charter/vaults/`` exactly as a plain-file
+        vault does, and said nothing about the directory holding it or about its own mode.
+        The values in it are not secrets — that is the provider's whole point — but the
+        file lists every item and field this plane reaches and the directory lists the
+        vault NAMES, which is precisely the exposure the report exists for. So three
+        clauses, in the same wording `plain-file` uses because they come from the same two
+        functions in :mod:`charter.secrets.base`:
+
+        * the file is not there at all — ``not created yet (<path>)``, which used to render
+          as ``no references yet``. A vault registered against a mistyped ``--file`` is a
+          failed read, and a failed read must never come out as a benign state: "no
+          references yet" is what an empty vault says, and the operator cannot tell the two
+          apart. `statusline` reads exactly this phrase to mark such a vault ``◦``, so a
+          reference vault was also the one provider whose never-written state was invisible
+          there;
+        * the file's mode, when charter did not write it (:func:`base.mode_note`);
+        * the directories above it that another account can list
+          (:func:`base.loose_dir_note`) — and `doctor` gets that one from
+          :meth:`loose_dirs` rather than from this string, so both surfaces render one list
+          (#471);
+        * an entry that is **not a supported reference at all**. :meth:`set` refuses one,
+          but entries arrive here by hand and by commit as well, and this counted them and
+          named only the schemes that work: every entry unsupported printed a green ``1
+          reference(s) via `` trailing off after the word "via", and one good entry beside
+          one dead one printed ``2 reference(s) via op``. Both read as a healthy vault, and
+          the failure waited for a `get` the operator was doing for another reason.
+
+        Nothing here chmods anything. `_save` writes 0600 and `make_private_dir` walks the
+        parents it creates at 0700; a file or directory that was already there is REPORTED,
+        because a vault's ``file`` may name any path on this machine and tightening one
+        charter did not create is #331 (see :meth:`PlainFileProvider._tighten`).
         """
+        if not self.config.get("file"):
+            # Ahead of `_load`, which reaches the same conclusion through a raise. Said in
+            # `plain-file`'s words rather than `file_path`'s longer sentence, because the
+            # two providers print into the same STATUS column of the same table.
+            return False, "no 'file' configured"
+        p = self.file_path
+        # Collected before the branches and appended by every one of them. This is the
+        # `check_vaults` lesson at provider scale (#471): a note that rides only the branch
+        # where nothing else is wrong is reported in exactly the conditions nobody is in —
+        # and what another account can list is the DIRECTORY, which is just as listable
+        # before this vault's file exists as after.
+        note = loose_dir_note(self.loose_dirs())
+
+        def _line(text: str) -> str:
+            return ", ".join([text] + [s for s in (mode_note(p), note) if s])
+
+        if not p.exists():
+            return True, _line(f"not created yet ({_short(p)})")
         try:
             data = self._load()
         except VaultError as e:
-            return False, str(e)
+            # `_line` here too. `check_vaults` records the rule one level up — the note goes
+            # on EVERY return, not only the green one — and a directory does not stop being
+            # listable because the file inside it is also unparseable.
+            return False, _line(str(e))
         if not data:
-            return True, "no references yet"
+            return True, _line("no references yet")
         needed = sorted({s for s in (scheme_of(v) for v in data.values()) if s})
-        missing = [s for s in needed if not shutil.which(_RESOLVERS[s](
-            next(v for v in data.values() if scheme_of(v) == s), self.config)[1])]
+        missing = [s for s in needed if not shutil.which(_cli_for(s, data, self.config))]
         n = len(data)
-        if missing:
-            clis = ", ".join(sorted({_RESOLVERS[s](
-                next(v for v in data.values() if scheme_of(v) == s), self.config)[1]
-                for s in missing}))
-            return False, f"{n} reference(s), but not on PATH: {clis}"
-        return True, f"{n} reference(s) via {', '.join(needed)}"
+        # An entry `set` would have refused, arriving the way entries actually arrive here:
+        # by hand, or by commit. It resolves to nothing, and the line said nothing about it
+        # — a vault whose every entry was unsupported printed a green ``1 reference(s) via
+        # `` with the sentence trailing off after the word "via", and a vault with one good
+        # entry and one dead one printed ``2 reference(s) via op``, counting the dead one
+        # and naming only the scheme that works. Both read as a healthy vault; the failure
+        # waited for `get`, which is a read the operator is doing for another reason.
+        #
+        # The COUNT here and the names in `charter vault verify`, which already prints
+        # ``<key>: <error>`` per failing reference and exits non-zero. A key comes out of a
+        # committed JSON object, so it is a value charter did not mint landing in a table
+        # row — and the row that carries what is wrong and what to type is the shape
+        # `loose_dir_note` settled on for the surface right beside this one.
+        unsupported = [k for k, v in data.items() if not scheme_of(v)]
+        if unsupported or missing:
+            problems = []
+            if unsupported:
+                problems.append(f"{len(unsupported)} not a supported URI "
+                                f"(charter vault verify names them)")
+            if missing:
+                # Ordered by SCHEME, which `needed` already sorted and `missing` preserves
+                # — not by collecting the CLI names into a set and sorting that. A set of
+                # short strings iterates in hash order, and `str` hashing is randomised per
+                # process, so the old spelling leaned on `sorted` to undo a randomness it
+                # had just introduced; drop the set and the order is a property of the data
+                # rather than of `$PYTHONHASHSEED`. A health line that reorders between runs
+                # is one nobody can diff, and `vault list` output gets pasted into issues.
+                problems.append("not on PATH: " + ", ".join(_cli_for(s, data, self.config)
+                                                            for s in missing))
+            return False, _line(f"{n} reference(s), but " + "; ".join(problems))
+        return True, _line(f"{n} reference(s) via {', '.join(needed)}")

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -152,6 +152,17 @@ vault wrapper — so the persona keeps working and the server fails at authentic
 than silently running with a credential nobody sanctioned. `sync-agents` prints the exact
 command it withheld from, which is the thing worth looking at.
 
+**And it keeps saying so after that run scrolls.** The generated agent carries no trace of
+what was withheld — an entry with its vault withheld renders byte-identically to one that
+declared no `secrets` at all, in a file you are told never to hand-edit, so it reads as
+intended output ([#489](https://github.com/diazoxide/charter/issues/489)). `charter persona
+lint` names each withheld server and both ways out (approve it, or drop the declaration),
+and `charter doctor` reaches it through the personas line. It is a **warning**, not an
+error: declining a server is a decision you are allowed to make, and charter's job is to
+keep it visible rather than to overrule it with an exit code. The one case that *is* an
+error is an entry charter cannot show in full — no approval can ever exist for it, so
+"approve it" is advice that cannot work and the committed entry has to change.
+
 `--approve-mcp` asks **per server**, and prints the entry before it asks:
 
 ```

--- a/docs/news/unreleased-a-reference-vault-says-where-it-lives.md
+++ b/docs/news/unreleased-a-reference-vault-says-where-it-lives.md
@@ -1,0 +1,75 @@
+---
+version: unreleased
+headline: a reference vault reports the directory it is listed in, the mode of its own file, and whether that file is there at all
+security: true
+---
+
+`charter vault list` and `charter doctor` name a state directory another account on the
+machine can list, and print the `chmod` — charter will not tighten a directory it did not
+create, so saying it is the remedy
+([#470](https://github.com/diazoxide/charter/issues/470),
+[#471](https://github.com/diazoxide/charter/issues/471)). On a plane whose `.charter/` was
+made by hand, by `mkdir -p`, or by a charter older than 0.52.1, two vaults sitting in that
+one directory disagreed about whether there was anything to say:
+
+```
+devops   plain-file   —   local   1 secret(s), listed by other accounts: .charter 755 (want 700 — chmod 700)
+refs     reference    —   local   no references yet
+```
+
+Same directory. Same 0755. One line about it
+([#491](https://github.com/diazoxide/charter/issues/491)).
+
+A reference vault stores `op://Eng/deploy/token`, not a token, and that is the provider's
+whole point — but it stores it in a file under `.charter/vaults/`, written through the same
+private walk as a plain-file vault. The values are not secrets; the file lists every item
+and field this plane reaches, and the directory lists the **vault names** on the machine,
+which is exactly the exposure the report exists for.
+
+**The fix is not "give `reference` a `loose_dirs()` too."** That is the second copy of eight
+lines, and this file already knows how that ends: `VaultProvider.file_path` exists because
+`plain-file` and `reference` once had byte-identical `path` properties, and the reason two
+implementations of "where is this vault's file" is the wrong number is that one of them
+quietly keeps answering the old way. `loose_dirs()` was that same mistake one method over.
+
+So the question moved onto `VaultProvider` and is keyed on `file_path`. Every provider that
+reaches a file answers it; a provider with no `file` — 1Password today, anything backed by a
+real service tomorrow — makes `file_path` raise and gets the honest empty list it always
+had. No new attribute for a new provider to forget, and no third copy the next time.
+
+Three neighbours came with it, all on the same line and all the same shape — charter
+knowing something and not saying it:
+
+* **the file's own mode.** `plain-file` prints `perms 644 (want 600)`; `reference` printed
+  nothing, though `_save` writes 0600 for a stated reason and a hand-authored file inherits
+  the umask.
+* **whether the file exists.** A missing file rendered as `no references yet` — the wording
+  for an empty vault — so a mistyped `--file` was indistinguishable from a vault nobody had
+  filled in yet. It now says `not created yet (<path>)`, the same phrase `plain-file` uses,
+  which is also the phrase the status line matches to mark such a vault `◦`. A reference
+  vault was the one provider whose never-written state was invisible there as well.
+* **an entry that is not a supported reference at all.** `charter secret set` refuses one,
+  but entries reach this file by hand and — for this provider above all — **by commit**,
+  since the argument for reference vaults is that a team commits the wiring and a fresh
+  clone inherits it. A vault whose every entry was unsupported printed a green
+  `1 reference(s) via `, the sentence trailing off after the word "via" because there was
+  no scheme to name; one live entry beside one dead one printed `2 reference(s) via op`,
+  counting the dead one and naming only the scheme that works. Both read as healthy, and
+  the failure waited for a `get` you were doing for another reason. The row now says how
+  many cannot resolve and points at `charter vault verify`, which already names each key.
+
+And the one that took the reporting command with it: a committed `{"K": 123}` reached
+`urlsplit` and raised `AttributeError` straight out of `health()`. `charter vault list` and
+`charter doctor` catch `VaultError` and nothing else, and `doctor` runs from the
+SessionStart hook — so the command whose entire job is reporting on this file was the thing
+this file could take down. `scheme_of` is total over anything JSON can hold now: what is not
+a string is not a supported reference, the same answer it always gave a string that is not
+one.
+
+Nothing here chmods anything, on either surface. charter tightens what it creates and
+reports what it did not — a health check that writes is the defect whatever it writes to,
+and a vault's `file` may name any path on this machine
+([#331](https://github.com/diazoxide/charter/issues/331)).
+
+If a row about a reference vault has grown a `listed by other accounts:` clause, it was
+true before this and unsaid: one `chmod 700` on the directory it names clears it.

--- a/docs/news/unreleased-a-withheld-credential-is-still-reported.md
+++ b/docs/news/unreleased-a-withheld-credential-is-still-reported.md
@@ -1,0 +1,77 @@
+---
+version: unreleased
+headline: `persona lint` and `doctor` report a persona running without the credential it declares, instead of it being said once and lost
+security: true
+---
+
+When `charter persona sync-agents` withholds a vault from an MCP server, it says so, and it
+names the command that would restore it. That warning is correct and it was the **only**
+place it was ever said ([#489](https://github.com/diazoxide/charter/issues/489)).
+
+`persona.mcp_withheld` had exactly one caller — `sync-agents`, on the run that wrote the
+file. Once the terminal scrolled, a persona running without its credential was
+indistinguishable from one that never declared one:
+
+```
+$ cat .claude/agents/ws.md | grep ga4
+  - {"ga4": {"command": "uvx", "args": ["analytics-mcp==0.7.0"]}}
+$ charter persona lint          # nothing
+$ charter doctor                # nothing
+```
+
+That rendering is **byte-identical** to what an entry with no `secrets` at all produces —
+in a generated file people are told never to hand-edit, so it reads as intended output.
+The failure it produces arrives three layers away, as an MCP server that will not
+authenticate. This matters most in exactly the transition it was reported from: a plane
+upgrading past the consent gate rewrites every credentialed server in every persona on the
+first `sync-agents`, while the operator's attention is on whatever they actually ran the
+command for.
+
+**`charter persona lint` now names each one**, with both ways out — approve the command, or
+drop the `secrets`/`secret_files` declaration if the server should hold no credential.
+`charter doctor` reaches it through the personas line, which already runs `lint` across the
+roster; a `doctor` row of its own would be a second sentence about one fact, and two
+sentences about one fact is how the pair comes to disagree.
+
+**A warning, not an error, and that is a decision.** Withholding is the gate *working*: you
+may have read the command and declined it, and a lint that exits 1 forever is a lint planes
+turn off. What charter owes is that the state stays visible, not that it overrules your
+answer. The one case that *is* an error is an entry charter cannot show in full — no
+approval can ever exist for it, `--approve-mcp` refuses it by name, so "approve it" is
+advice that cannot work and the committed entry has to change.
+
+**The generated agent deliberately gains no comment of its own**, which the issue floats.
+The consent record has learned across four rounds that this class closes by *not* keeping a
+second representation — the fingerprint is the SHA-256 of the line itself precisely so
+there is nothing left to fall out of step with. A comment in a wholesale-regenerated file is
+exactly a second representation: it goes stale the moment you approve without re-syncing,
+and a reader who trusts it then reads a false statement about a live credential. The file is
+where the question gets asked; the record is where it is answered, and `lint` asks the
+record.
+
+**Two siblings, found by enumerating the surfaces rather than by being filed.**
+
+`lint`'s "declares `secrets` but names no vault" error read `secrets` and not
+`secret_files`, while `mcpseen.needs_consent`, `mcp_render_entry` and `charter secret exec`'s
+own `--env`/`--file` pair all treat the two as one mechanism. So a server declaring only
+`secret_files` against a persona with no vault rendered with no credential and was reported
+by **nothing**: not by that error, because the key was not read, and not as withheld,
+because with no vault there is nothing to withhold. `secret_files` is not the exotic half —
+it is what Google ADC needs, and it is the declaration the issue's own reproduction carries.
+Both keys now go through one function.
+
+And `vault: none` — charter's reserved way of saying *this persona deliberately holds no
+credentials* — was read as the name of a vault by the MCP path, though `persona.vault_of`
+has always returned `None` for it. Measured against 0.53.0:
+
+```
+consent line   run uvx analytics-mcp  secrets "T"="k"  vault "none"
+rendered       charter secret exec none --env T=k --exec -- uvx analytics-mcp
+```
+
+So `--approve-mcp` asked you to approve spending a vault named `none`, recorded the
+consent, and wrote a launcher into the generated agent that cannot run — while `lint` was
+separately and correctly calling the same persona one that names no vault. One sentinel,
+two readings, and the consent record was on the wrong side of it. The render and the consent
+list now normalise it in one place, because those two disagreeing is an operator asked about
+a server the file does not wrap.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -43,6 +43,17 @@ directory and the `chmod` to run. It stays a **green** line rather than a warnin
 will not fix this one for you, so saying it is the remedy, and a warning at every session
 start about a directory you have decided to leave alone is a check nobody reads twice.
 
+**Every vault charter keeps a file for says this, not only `plain-file`.** A `reference`
+vault sits in the same `.charter/vaults/` and used to report nothing at all about it, so
+two vaults side by side in one loose directory disagreed about whether there was anything
+to say ([#491](https://github.com/diazoxide/charter/issues/491)). Its health line now
+carries the same three facts a plain-file one does, in the same words: the loose directory,
+the file's own mode when charter did not write it (`perms 644 (want 600)`), and whether the
+file is there at all — `not created yet (<path>)`, which used to read as `no references
+yet` and made a mistyped `--file` indistinguishable from a vault nobody had filled in. The
+values in a reference file are not secrets, but the file lists every item and field this
+plane reaches and the directory lists the vault names, which is what the report is for.
+
 **The files in it are a different answer, and on purpose.** Every file charter writes under
 `.charter/` — the vault registry, `guard-seen.json`, the trace log, the ephemeral persona
 store, the session and workspace pointers, the caches — is **0600**, whatever your umask

--- a/tests/test_a_withheld_credential_is_still_reported.py
+++ b/tests/test_a_withheld_credential_is_still_reported.py
@@ -1,0 +1,513 @@
+"""A persona running without the credential it declares is reported by something STANDING.
+
+#489, split out of #452. The #330 consent gate is working as designed and the run that
+withholds a vault is **not** silent: `sync-agents` names every server it withheld and the
+command that would restore it. That warning is the only place it was ever said.
+
+`persona.mcp_withheld` had exactly one caller — `cmd_persona_sync_agents`, on the run that
+wrote the file — and nothing that reports standing state. So once the terminal scrolls, a
+persona running without its credential is indistinguishable from one that never declared
+one:
+
+* ``.claude/agents/<name>.md`` renders ``{"command": "uvx", "args": [...]}``, byte-identical
+  to what an entry with no ``secrets`` at all produces. `TheGeneratedFileCannotSayIt`
+  asserts that equality rather than describing it, because it is the whole finding: **the
+  damage lands in a GENERATED file people are told never to hand-edit, so it reads as
+  intended output.**
+* `charter persona lint` said nothing.
+* `charter doctor` said nothing.
+
+The failure it produces is the one `mcpseen`'s own module docstring warns about — an MCP
+server failing to authenticate, three layers away — except that after the run it *is*
+silent, because the only thing that was ever going to say it has already been printed once
+and lost.
+
+**Where it is reported, and why not somewhere else.**
+
+`persona lint` is the home: it already reports per-persona defects and it is the command
+you run *because* a persona is misbehaving. `doctor` gets it for free, because
+`check_personas` runs `persona.lint` across the roster and names the personas with
+findings — one line, which is that check's stated design, and one WORDING, which is this
+repo's repeated lesson. A dedicated `doctor` row would be a second sentence about one fact,
+and two sentences about one fact is how the pair comes to disagree (`base.loose_dir_note`
+records the same argument for the surface next door).
+
+**A warning, not an error, and that is a decision.** Withholding is the gate WORKING: the
+operator may have read the command and declined it, and `charter persona lint` exiting 1
+forever would make this the finding planes learn to turn off. What charter owes is that the
+state stays visible, not that it overrules the answer. `TheLevelIsAChoice` pins both
+directions, including the one case that *is* an error — an entry `describe` cannot render,
+which can never be approved by anybody, so the only way out is an edit and "approve it" is
+advice that cannot work (#371: a prompt is worth its interruption only if it names what to
+do next).
+
+**The generated file deliberately carries no trace of its own**, which the issue floats and
+this rejects. `mcpseen` learned across four rounds that the way to close this class is to
+stop keeping a second representation of consent — *"there is nothing left to fall out of
+step"*. A comment in a wholesale-regenerated file is exactly a second representation: it
+goes stale the moment the operator approves without re-syncing, and a reader who trusts it
+then reads a false statement about a live credential. The artefact is where the question
+gets asked; the RECORD is where it gets answered, and `lint` asks the record.
+
+**The sibling, found by enumerating rather than by being filed.** `lint`'s "declares
+secrets but names no vault" error read ``entry.get("secrets")`` and not ``secret_files`` —
+while `mcpseen.needs_consent`, `persona.mcp_render_entry` and `charter secret exec`'s own
+``--env``/``--file`` pair all treat the two as one mechanism. A server declaring only
+``secret_files`` against a persona with no vault therefore rendered with no credential and
+was reported by NOTHING: not by that error, because the key was not read, and not as
+withheld, because with no vault there is no consent to withhold. `secret_files` is not the
+exotic half — it is what Google ADC needs, and it is the declaration #489's own
+reproduction carries. See `SecretFilesIsNotTheForgottenHalf`.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_persona, config, doctor, mcpseen, persona
+from tests._isolation import PersonaIso
+
+VAULT = "wsvault"
+
+#: Charter's own colour codes, which `util` adds and a terminal does not print.
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+#: The declaration from #489's reproduction, field for field: `secret_files`, because
+#: `GOOGLE_APPLICATION_CREDENTIALS` takes a PATH and not a value (#190).
+GA4 = {
+    "command": "uvx",
+    "args": ["analytics-mcp==0.7.0"],
+    "secret_files": {"GOOGLE_APPLICATION_CREDENTIALS": "GOOGLE_SERVICE_ACCOUNT"},
+}
+
+#: The other mechanism, same shape: a value straight into the environment.
+ENVVAR = {
+    "command": "uvx",
+    "args": ["some-mcp"],
+    "secrets": {"API_TOKEN": "api-token"},
+}
+
+
+class WithheldBase(PersonaIso):
+    def _persona(self, servers=None, name="ws", vault=VAULT):
+        meta = {"role": "R", "delegate-when": "things"}
+        if vault is not None:
+            meta["vault"] = vault
+        self.make_persona(name, **meta)
+        if servers is not None:
+            self._write(name, servers)
+        return name
+
+    def _write(self, name, servers) -> None:
+        (persona.dir_of(name) / persona.MCP_FILE).write_text(
+            json.dumps({"mcpServers": servers}))
+
+    def _approve(self, name="ws") -> None:
+        mcpseen.approve(name, [fp for _s, _e, fp, _l in persona.mcp_credentialed(name) if fp])
+
+    def _sync(self, name=None):
+        """A real `sync-agents` run — no `--approve-mcp`, the shape #489 describes: the
+        operator ran it for something else entirely."""
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(persona=name, approve_mcp=False, yes=False, dry_run=False)
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = commands_persona.cmd_persona_sync_agents(args)
+        return rc, _ANSI.sub("", err.getvalue())
+
+    def _lint(self, name=None):
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(name=name, only=None)
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = commands_persona.cmd_persona_lint(args)
+        return rc, _ANSI.sub("", err.getvalue() + out.getvalue())
+
+    def _rows(self, name="ws", level=None):
+        return [m for lvl, m in persona.lint(name)
+                if "declares a credential" in m and (level is None or lvl == level)]
+
+    def _agent(self, name="ws") -> str:
+        return (Path(config.ROOT) / ".claude" / "agents" / f"{name}.md").read_text()
+
+
+class TheGeneratedFileCannotSayIt(WithheldBase):
+    """#452's sharpest sentence, asserted rather than quoted. This is why a standing report
+    is needed at all: the artefact the operator actually reads cannot tell them."""
+
+    def test_a_withheld_server_renders_exactly_like_one_that_declares_no_credential(self):
+        name = self._persona({"ga4": dict(GA4)})
+        self._sync()
+        withheld = self._agent()
+
+        bare = {k: v for k, v in GA4.items() if k != "secret_files"}
+        self._write(name, {"ga4": bare})
+        self._sync()
+        self.assertEqual(withheld, self._agent(),
+                         "the generated agent is byte-identical whether the credential was "
+                         "withheld or never declared — which is the finding")
+
+    def test_the_run_that_wrote_it_does_say_so(self):
+        """The half that was never broken, pinned so the fix cannot be mistaken for it."""
+        self._persona({"ga4": dict(GA4)})
+        _rc, err = self._sync()
+        self.assertIn("Withheld the vault", err)
+        self.assertIn("--approve-mcp", err)
+
+
+class LintReportsTheStandingState(WithheldBase):
+    def test_it_names_the_server(self):
+        self._persona({"ga4": dict(GA4)})
+        rows = self._rows()
+        self.assertEqual(len(rows), 1, rows)
+        self.assertIn("ga4", rows[0])
+
+    def test_it_names_what_to_do_next(self):
+        """#371/PR 379: a prompt is worth its interruption only if it names the next move.
+        Both moves — this is a decision the operator may legitimately make either way."""
+        self._persona({"ga4": dict(GA4)})
+        row = self._rows()[0]
+        self.assertIn("charter persona sync-agents --approve-mcp", row)
+        self.assertIn("secret_files", row, "and the other way out: drop the declaration")
+
+    def test_it_says_what_actually_happens(self):
+        """Not "unapproved" — the consequence. The failure this exists to pre-empt arrives
+        three layers away as a server that will not authenticate."""
+        self._persona({"ga4": dict(GA4)})
+        row = self._rows()[0]
+        self.assertIn("WITHOUT the vault", row)
+        self.assertIn("authenticate", row)
+
+    def test_approving_it_silences_the_row(self):
+        """The complaint has to be caused by the state. A finding that is always there is
+        one people learn to scroll past, and it takes the rest of the report with it."""
+        name = self._persona({"ga4": dict(GA4)})
+        self.assertTrue(self._rows(), "precondition: withheld")
+        self._approve(name)
+        self.assertEqual(self._rows(), [])
+
+    def test_a_committed_edit_brings_the_row_back(self):
+        """The approval is of a LINE, so an edited entry is a new destination — and the
+        report has to follow the record rather than remember its own answer."""
+        name = self._persona({"ga4": dict(GA4)})
+        self._approve(name)
+        self.assertEqual(self._rows(), [], "precondition: approved")
+        self._write(name, {"ga4": dict(GA4, args=["analytics-mcp==0.7.0", "--write"])})
+        self.assertTrue(self._rows(), "a changed command is not the approved one")
+
+    def test_a_credential_free_server_produces_nothing(self):
+        self._persona({"docs": {"command": "uvx", "args": ["docs-mcp"]}})
+        self.assertEqual(persona.lint("ws"), [], "nothing is at stake, so nothing is said")
+
+    def test_a_persona_with_no_mcp_json_produces_nothing(self):
+        self._persona()
+        self.assertEqual(persona.lint("ws"), [])
+
+    def test_both_mechanisms_are_reported(self):
+        """`secrets` and `secret_files` are two mechanisms for one thing, and the report
+        may not know only the one that happened to be tested.
+
+        A persona per case rather than a re-run `setUp`: `PersonaIso` snapshots the real
+        config once and restores it on cleanup, so calling `setUp` twice discards the first
+        snapshot and leaves the suite pointing at a tmp root for every module after this
+        one — measured, as 26 unrelated failures in `_planeguard`'s own tests."""
+        for label, entry in (("secret_files", GA4), ("secrets", ENVVAR)):
+            with self.subTest(mechanism=label):
+                name = self._persona({"srv": dict(entry)}, name=f"ws-{label}")
+                self.assertTrue(self._rows(name), f"{label} was not reported")
+
+
+class TheReportsCannotDisagree(WithheldBase):
+    """`lint` and `sync-agents` both ask `persona.mcp_withheld`. The property, not the
+    prose: a report that recomputes its own answer is one that drifts from the run."""
+
+    def test_the_two_surfaces_name_the_same_servers(self):
+        name = self._persona({"ga4": dict(GA4), "envs": dict(ENVVAR),
+                              "docs": {"command": "uvx", "args": ["docs-mcp"]}})
+        _rc, sync_err = self._sync()
+        rows = self._rows(name)
+        withheld = {s for s, _line in persona.mcp_withheld(name)}
+        self.assertEqual(withheld, {"ga4", "envs"}, "precondition: two of the three")
+        for server in withheld:
+            self.assertTrue(any(server in r for r in rows), f"lint missed {server}")
+            self.assertIn(server, sync_err, f"sync-agents missed {server}")
+        self.assertFalse(any("docs" in r for r in rows),
+                         "a server with nothing at stake is in neither report")
+
+    def test_approving_one_of_two_leaves_the_other_in_both(self):
+        name = self._persona({"ga4": dict(GA4), "envs": dict(ENVVAR)})
+        keep = [fp for s, _e, fp, _l in persona.mcp_credentialed(name) if s == "envs" and fp]
+        mcpseen.approve(name, keep)
+        _rc, sync_err = self._sync()
+        rows = " | ".join(self._rows(name))
+        self.assertIn("ga4", rows)
+        self.assertNotIn("envs", rows)
+        self.assertIn("ga4", sync_err.split("Withheld the vault")[1])
+
+
+class TheLevelIsAChoice(WithheldBase):
+    def test_a_withheld_credential_is_a_warning(self):
+        """Withholding is the gate working, and the operator may have declined on purpose.
+        An exit code here would overrule an answer charter asked for."""
+        self._persona({"ga4": dict(GA4)})
+        self.assertEqual([lvl for lvl, m in persona.lint("ws")
+                          if "declares a credential" in m], ["warn"])
+        rc, out = self._lint("ws")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("ga4", out)
+
+    def test_an_entry_nobody_can_be_shown_is_an_error(self):
+        """#427: `describe` cannot render it, so `fingerprint` is None and no approval can
+        ever exist — `--approve-mcp` refuses it by name. Telling the operator to run that
+        command would be a nudge that cannot work, so it is a different sentence AND a
+        different level: the committed entry has to change."""
+        self._persona({"ga4": dict(GA4, args=["evil"] + ["ㅤ" * 200] * 9)})
+        rows = self._rows(level="error")
+        self.assertEqual(len(rows), 1, persona.lint("ws"))
+        self.assertIn(mcpseen.UNRENDERABLE, rows[0])
+        self.assertNotIn("--approve-mcp", rows[0],
+                         "advice that cannot work is worse than none")
+        rc, _out = self._lint("ws")
+        self.assertEqual(rc, 1, "an entry no answer exists for is an error")
+
+    def test_the_row_names_the_persona_and_the_server(self):
+        """Every lint row ends in "go and fix this", so it has to say WHICH."""
+        self._persona({"ga4": dict(GA4)})
+        rc, out = self._lint()
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("ws:" in ln and "ga4" in ln for ln in out.splitlines()), out)
+
+    def test_a_name_that_could_forge_a_row_never_reaches_this_one(self):
+        """The name is a key of a committed `mcp.json`, and the boundary is upstream:
+        `mcp_servers` refuses anything outside `mcp_name_ok`, so a server named with
+        HANGUL FILLERs is not declared at all and is reported by the refusal row instead
+        (#453). This asserts the two findings do not overlap — the withheld row can only
+        ever be about a server that survived the bound."""
+        self._persona({"ㅤㅤ": dict(GA4)})
+        issues = persona.lint("ws")
+        self.assertEqual(self._rows(), [], "a refused name declares no server to withhold")
+        self.assertTrue([m for lvl, m in issues if lvl == "error" and "is refused" in m],
+                        issues)
+
+    def test_a_legal_but_long_name_is_bounded_on_the_row(self):
+        """Defence in depth, and the layer that holds if that boundary is ever widened.
+        `mcp_name_ok` bounds the ALPHABET at 64 characters; `mcpseen.label` is what keeps
+        the row a row, and it is the same escape the sibling findings in this report use."""
+        long_name = "a" * 64
+        self.assertTrue(persona.mcp_name_ok(long_name), "precondition: a legal name")
+        self._persona({long_name: dict(GA4)})
+        rows = self._rows()
+        self.assertEqual(len(rows), 1, rows)
+        self.assertNotIn(long_name, rows[0], "the row carries `label`'s clip, not the key")
+        self.assertIn("a" * 32 + "...", rows[0])
+        self.assertEqual(len(rows[0].splitlines()), 1, "one finding is one row")
+
+
+class DoctorCarriesIt(WithheldBase):
+    """`doctor` has the standing-health role and reaches this through `check_personas`,
+    which already runs `persona.lint` across the roster. One wording, two commands."""
+
+    def test_the_personas_line_is_not_green(self):
+        self._persona({"ga4": dict(GA4)})
+        res = doctor.check_personas()
+        self.assertEqual(res.status, doctor.WARN)
+        self.assertIn("ws", res.detail)
+        self.assertIn("charter persona lint", res.hint,
+                      "the summary names the command with room to explain")
+
+    def test_it_goes_green_once_the_credential_is_approved(self):
+        name = self._persona({"ga4": dict(GA4)})
+        self.assertEqual(doctor.check_personas().status, doctor.WARN, "precondition")
+        self._approve(name)
+        self.assertEqual(doctor.check_personas().status, doctor.OK,
+                         "nothing else about this persona is wrong")
+
+    def test_doctor_does_not_reach_a_vault_to_say_it(self):
+        """This runs from the SessionStart hook. The finding is about the RECORD, not about
+        whether the credential resolves — no provider is opened and no CLI is spawned."""
+        self._persona({"ga4": dict(GA4)})
+        with mock.patch("charter.secrets.registry.provider_for",
+                        side_effect=AssertionError("check_personas opened a vault")):
+            self.assertEqual(doctor.check_personas().status, doctor.WARN)
+
+
+class SecretFilesIsNotTheForgottenHalf(WithheldBase):
+    """The sibling. `lint`'s "declares secrets but names no vault" error read one of the two
+    keys, so the OTHER one fell through every surface at once."""
+
+    def _no_vault_rows(self, name="ws"):
+        return [m for _lvl, m in persona.lint(name) if "names no vault" in m]
+
+    def test_a_secret_files_server_with_no_vault_is_reported(self):
+        self._persona({"ga4": dict(GA4)}, vault=None)
+        rows = self._no_vault_rows()
+        self.assertEqual(len(rows), 1, persona.lint("ws"))
+        self.assertIn("ga4", rows[0])
+
+    def test_a_secrets_server_with_no_vault_is_still_reported(self):
+        """The half that always worked, pinned beside the half that did not."""
+        self._persona({"envs": dict(ENVVAR)}, vault=None)
+        self.assertTrue(self._no_vault_rows())
+
+    def test_the_servers_are_named_in_a_stable_order(self):
+        """One row, several servers, and a report people diff. The sort is what makes the
+        row the same row on two machines; without it the order is `mcp.json`'s and a
+        re-serialised file rewrites a finding that has not changed."""
+        self._persona({"zeta": dict(GA4), "alpha": dict(ENVVAR)}, vault=None)
+        rows = self._no_vault_rows()
+        self.assertEqual(len(rows), 1, rows)
+        self.assertIn("alpha, zeta", rows[0])
+
+    def test_the_reserved_no_vault_value_counts_as_no_vault(self):
+        self._persona({"ga4": dict(GA4)}, vault=persona.NO_VAULT)
+        self.assertTrue(self._no_vault_rows())
+
+    def test_a_credential_free_server_with_no_vault_is_not_reported(self):
+        self._persona({"docs": {"command": "uvx", "args": ["docs-mcp"]}}, vault=None)
+        self.assertEqual(self._no_vault_rows(), [])
+
+    def test_no_persona_falls_between_the_two_reports(self):
+        """The gap was structural: with no vault there is nothing to withhold, so a server
+        the "no vault" error did not read was reported by neither surface. Asserted as the
+        disjunction over both mechanisms and both vault states, which is the property —
+        every declared credential is named by exactly one of the two."""
+        for mech, entry in (("secret_files", GA4), ("secrets", ENVVAR)):
+            for vault in (VAULT, None, persona.NO_VAULT):
+                with self.subTest(mechanism=mech, vault=vault):
+                    name = self._persona({"srv": dict(entry)}, vault=vault,
+                                         name=f"ws-{mech}-{vault or 'unset'}")
+                    said = [m for _l, m in persona.lint(name)
+                            if "names no vault" in m or "declares a credential" in m]
+                    self.assertEqual(len(said), 1,
+                                     f"a declared credential must be named exactly once: "
+                                     f"{persona.lint(name)}")
+                    self.assertIn("srv", said[0])
+
+
+class TheNoVaultSentinelIsNotAVaultName(WithheldBase):
+    """The third instance, found by enumerating the surfaces rather than by being filed.
+
+    ``vault: none`` is charter's reserved way of saying *this persona deliberately holds no
+    credentials*, and `persona.vault_of` has always returned ``None`` for it. The MCP path
+    read ``meta["vault"]`` raw. Measured against 0.53.0 on such a persona, before the fix::
+
+        consent line   run uvx analytics-mcp  secrets "T"="k"  vault "none"
+        rendered       charter secret exec none --env T=k --exec -- uvx analytics-mcp
+
+    So `--approve-mcp` asked the operator to approve spending a vault named ``none``,
+    recorded the consent, and wrote into the generated agent a launcher that cannot run —
+    while `lint` was separately and correctly calling the same persona one that names no
+    vault. One sentinel, two readings, and the consent record was on the wrong side of it.
+    """
+
+    def test_it_is_not_offered_for_approval(self):
+        self._persona({"srv": dict(ENVVAR)}, vault=persona.NO_VAULT)
+        self.assertEqual(persona.mcp_credentialed("ws"), [],
+                         "there is no credential here to consent to")
+        self.assertEqual(persona.mcp_withheld("ws"), [])
+
+    def test_the_generated_agent_does_not_launch_a_vault_named_none(self):
+        name = self._persona({"srv": dict(ENVVAR)}, vault=persona.NO_VAULT)
+        mcpseen.approve(name, [mcpseen.fingerprint(persona.NO_VAULT,
+                                                   persona.mcp_servers(name)["srv"]) or "x"])
+        out = persona.mcp_render_entry(name, persona.NO_VAULT,
+                                       persona.mcp_servers(name)["srv"])
+        self.assertEqual(out.get("command"), "uvx", "passed through, not wrapped")
+        self.assertNotIn("none", out.get("args") or [])
+        self._sync()
+        self.assertNotIn("secret exec none", self._agent(name).replace('", "', " "))
+
+    def test_lint_says_it_once_and_says_the_right_thing(self):
+        """The double report this fix also removes: "names no vault" is the finding, and
+        "your credential is withheld" is not, because nothing was withheld."""
+        self._persona({"srv": dict(ENVVAR)}, vault=persona.NO_VAULT)
+        said = [m for _l, m in persona.lint("ws")
+                if "names no vault" in m or "declares a credential" in m]
+        self.assertEqual(len(said), 1, persona.lint("ws"))
+        self.assertIn("names no vault", said[0])
+
+    def test_the_sentinel_resolves_to_none_and_not_to_a_falsy_string(self):
+        """``-> str | None`` is the contract, and every caller reads the result for
+        truthiness — so ``""`` would pass every behavioural test here while breaking the
+        one thing the annotation promises. Asserted directly, because nothing downstream
+        can tell the two apart."""
+        for absent in (None, "", "  ", persona.NO_VAULT, f"  {persona.NO_VAULT}  ", 7):
+            with self.subTest(vault=repr(absent)):
+                self.assertIsNone(persona.mcp_vault(absent))
+        self.assertEqual(persona.mcp_vault(f"  {VAULT} "), VAULT)
+
+    def test_a_persona_that_does_not_load_is_asked_about_rather_than_crashed_on(self):
+        """`resolve` answers `None` for a persona whose `persona.md` does not load, and
+        `_approve_mcp` reaches `mcp_credentialed` for every name `list_personas` globbed
+        without asking first — so the fallback in `vault_for_mcp` is on a live path, not a
+        decoration. `lint` reports the unloadable persona; nothing here may raise."""
+        # A directory `list_personas` globs with no `persona.md` in it — the shape #336 is
+        # about, and what `_approve_mcp` walks straight into: it takes every name the glob
+        # returned and asks `mcp_credentialed` about each, loadable or not.
+        d = config.PERSONAS_DIR / "broken"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / persona.MCP_FILE).write_text(json.dumps({"mcpServers": {"srv": dict(ENVVAR)}}))
+        self.assertIsNone(persona.resolve("broken"), "precondition: it does not load")
+        self.assertIsNone(persona.vault_for_mcp("broken"))
+        self.assertEqual(persona.mcp_credentialed("broken"), [])
+        self.assertEqual(persona.mcp_withheld("broken"), [])
+        self.assertTrue([m for _l, m in persona.lint("broken") if "does not load" in m],
+                        persona.lint("broken"))
+
+    def test_the_render_and_the_consent_list_agree(self):
+        """Why one normalisation and not two: these are the two readers, and a persona the
+        consent list thinks is credentialed while the render passes it through is an
+        operator asked about a server the file does not wrap."""
+        for i, vault in enumerate((VAULT, None, persona.NO_VAULT, "  ",
+                                   f"  {persona.NO_VAULT}  ")):
+            with self.subTest(vault=repr(vault)):
+                name = self._persona({"srv": dict(ENVVAR)}, vault=vault, name=f"ws-{i}")
+                self._approve(name)
+                wrapped = persona.mcp_render_entry(
+                    name, vault, persona.mcp_servers(name)["srv"]).get("command") == "charter"
+                self.assertEqual(bool(persona.mcp_credentialed(name)), wrapped,
+                                 "consent was asked for exactly when the vault is spent")
+
+
+class OneQuestionAboutTheTwoKeys(PersonaIso):
+    """`mcpseen.declares_credential` is the shared answer. Asserted over the relation
+    between the two functions rather than over one call of each, because the failure was
+    two readers disagreeing about the same entry."""
+
+    def test_the_two_mechanisms_answer_identically(self):
+        for entry in ({"secrets": {"A": "k"}}, {"secret_files": {"A": "k"}},
+                      {"secrets": {"A": "k"}, "secret_files": {"B": "k"}}):
+            with self.subTest(entry=entry):
+                self.assertTrue(mcpseen.declares_credential(entry))
+                self.assertTrue(mcpseen.needs_consent("v", entry))
+
+    def test_nothing_declared_is_nothing_to_consent_to(self):
+        """Both keys, and both ways of being wrong. The non-dict cases are the ones the
+        `isinstance` halves are for, and they have to be TRUTHY non-dicts to test anything:
+        `mcp.json` is committed, so ``"secret_files": "GOOGLE_SERVICE_ACCOUNT"`` — the map
+        written as the bare key somebody meant — is a plausible hand-edit, and without the
+        type check `mcp_render_entry` would reach `.items()` on a string and take
+        `sync-agents` down with it."""
+        for entry in ({}, {"command": "uvx"}, {"secrets": {}}, {"secret_files": {}},
+                      {"secrets": "not-a-map"}, {"secret_files": "not-a-map"},
+                      {"secrets": ["A"]}, {"secret_files": ["A"]}, "not-an-entry"):
+            with self.subTest(entry=entry):
+                self.assertFalse(mcpseen.declares_credential(entry))
+                self.assertFalse(mcpseen.needs_consent("v", entry))
+
+    def test_consent_needs_a_vault_and_the_declaration_does_not(self):
+        """The reason they are two functions: `lint` asks about a persona with NO vault,
+        where `needs_consent` is False by construction and cannot be its answer."""
+        entry = {"secret_files": {"A": "k"}}
+        self.assertTrue(mcpseen.declares_credential(entry))
+        self.assertFalse(mcpseen.needs_consent(None, entry))
+        self.assertFalse(mcpseen.needs_consent("", entry))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_doctor_names_a_loose_state_directory.py
+++ b/tests/test_doctor_names_a_loose_state_directory.py
@@ -25,12 +25,14 @@ state directory anywhere — so reporting *is* the remedy, and a WARN at every s
 about a directory the operator has decided to leave alone is a check crying wolf. The note
 is on the ✓ line, in the same posture as the "points outside the plane" note beside it.
 
-The next spelling: a provider whose data lives in a directory charter creates and whose
-`loose_dirs()` still answers ``[]``. `reference` is exactly that today — it writes a file
-under ``.charter/vaults/`` through the same private walk, and reports nothing about a
-directory that predates it, on either surface. That is a real gap and it is not this
-file's: it is filed upstream, and the base class's default is the honest ``[]`` rather than
-a guess.
+The next spelling was: a provider whose data lives in a directory charter creates and whose
+`loose_dirs()` still answers ``[]``. `reference` was exactly that — it writes a file under
+``.charter/vaults/`` through the same private walk, and reported nothing about a directory
+that predates it, on either surface. **Closed in #491**, and not by giving `reference` a
+copy of the eight lines: the question moved onto `VaultProvider` and is keyed on
+`file_path`, so every file-backed provider answers it and a provider with no ``file`` still
+gets the honest ``[]``. `tests/test_reference_vault_reports_its_directory.py` holds that
+side, including the assertion that neither provider overrides the method any more.
 """
 
 from __future__ import annotations

--- a/tests/test_reference_vault_reports_its_directory.py
+++ b/tests/test_reference_vault_reports_its_directory.py
@@ -1,0 +1,492 @@
+"""A reference vault says where it lives — the directory, the mode, and whether it is there.
+
+#491. A `reference` vault keeps a file under ``.charter/vaults/`` exactly as a plain-file
+vault does, through the same private walk, and reported **nothing** about it. On a plane
+whose ``.charter/`` predates charter — made by hand, by ``mkdir -p``, or by a charter older
+than #470 — a plain-file vault named the loose directory and printed the ``chmod``, and a
+reference vault beside it stayed silent, on `charter vault list` and on `charter doctor`
+alike::
+
+    devops   plain-file   —   local   1 secret(s), listed by other accounts: .charter 755 (want 700 — chmod 700)
+    refs     reference    —   local   no references yet
+
+The values in a reference file are not secrets — that is the whole point of the provider —
+but the file lists every item and field this plane reaches, and the DIRECTORY lists the
+vault names on the machine, which is exactly the exposure the report exists for.
+
+**The shape of the fix is not "give `reference` a `loose_dirs` too".** That is the second
+copy of eight lines, and `VaultProvider.file_path` already records what happens next: it
+replaced two byte-identical ``path`` properties, and the reason it had to is that the
+second copy is how one provider quietly keeps answering the old way. So the question is
+asked once, on the base class, of the one thing that already knows where a vault's file is
+— and a provider with no ``file`` (1Password today) makes `file_path` raise and gets the
+empty list it always had, with no new attribute for a new provider to forget.
+
+Three findings, one family, and the family is the one this repo keeps filing: **charter
+knowing something and not saying it.**
+
+* the directory another account can list — the filed defect;
+* the FILE's mode. `plain-file` prints ``perms 644 (want 600)``; `reference` printed
+  nothing, though it writes 0600 for a stated reason and a hand-authored or pre-existing
+  file inherits the umask;
+* the file not being there **at all**, which rendered as ``no references yet`` — the
+  wording for an empty vault. A ``--file`` pointing at a path that does not exist is a
+  failed read, and *a failed read must never render as a benign state*. `statusline` reads
+  the phrase ``not created yet`` to mark such a vault ``◦``, so this was also the one
+  provider whose never-written state was invisible there.
+
+Nothing here chmods anything, and that is #331: a vault's ``file`` may name any path on
+this machine, so charter tightens what it creates and REPORTS what it did not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import stat
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from charter import config, doctor
+from charter.commands_secrets import cmd_vault_list, cmd_vault_verify
+from charter.secrets import base, reference, registry
+from charter.secrets.plain_file import PlainFileProvider
+from charter.secrets.reference import ReferenceProvider
+
+from tests._isolation import PersonaIso
+
+#: The same list `test_doctor_names_a_loose_state_directory` sweeps, and for the reason it
+#: gives: 0755 is the mode everybody thinks of, and 0705, 0701, 0711 and 0730 list or
+#: traverse just as well. A report written against a literal set of bad values is the
+#: defect `base._OTHERS` exists to avoid.
+LOOSE_MODES = (0o755, 0o750, 0o705, 0o701, 0o711, 0o730, 0o707)
+
+REF = "op://Eng/deploy/token"
+
+
+class ReferencePlane(PersonaIso):
+    """A plane whose `.charter/` was made by hand at the umask default, holding one
+    reference vault — the configuration in #491's reproduction."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.sd = Path(config.STATE_DIR)
+        self.sd.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.sd, 0o755)
+        self.vf = self.sd / "vaults" / "refs.json"
+        registry.add_vault("refs", "reference", {"file": str(self.vf)})
+        # Both resolvers present, always. Whether `op` happens to be installed on the
+        # machine running the suite is not a fact about this fix, and a test that reads it
+        # passes for the wrong reason on one of the two kinds of machine. Nothing is
+        # spawned: `health` only ever asks `which`.
+        self.enterContext(mock.patch.object(reference.shutil, "which",
+                                            lambda c: f"/usr/local/bin/{c}"))
+        self.assertEqual(stat.S_IMODE(self.sd.stat().st_mode), 0o755,
+                         "precondition: there is something to report")
+
+    def provider(self) -> ReferenceProvider:
+        return registry.provider_for("refs")
+
+    def write_refs(self, data=None) -> None:
+        """The vault file, as charter's own writer leaves it: 0600, parents at 0700."""
+        self.provider().set("TOKEN", REF)
+        if data is not None:
+            self.vf.write_text(json.dumps(data))
+            os.chmod(self.vf, 0o600)
+
+    def vault_list(self) -> str:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cmd_vault_list(argparse.Namespace())
+        return buf.getvalue()
+
+    def status_row(self) -> str:
+        """The one printed row about `refs`, STATUS column and all."""
+        rows = [ln for ln in self.vault_list().splitlines() if ln.startswith("refs")]
+        self.assertEqual(len(rows), 1, self.vault_list())
+        return rows[0]
+
+
+class TheDirectoryIsNamedOnBothSurfaces(ReferencePlane):
+    def test_vault_list_names_the_directory_and_the_chmod(self) -> None:
+        self.write_refs()
+        row = self.status_row()
+        self.assertIn("listed by other accounts", row)
+        self.assertIn(".charter 755", row,
+                      f"the row must name the level that is loose, not merely that one "
+                      f"is: {row!r}")
+        self.assertIn("chmod 700", row, "and what to type about it")
+
+    def test_doctor_names_it_too(self) -> None:
+        """The half #471 is about: `doctor` keeps `health()`'s boolean and drops its
+        string, so a note that lives only in the sentence never reaches this command."""
+        self.write_refs()
+        rendered = doctor.check_vaults().render()
+        self.assertIn("listed by other accounts", rendered)
+        self.assertIn(".charter 755", rendered)
+
+    def test_it_reaches_the_json(self) -> None:
+        """`doctor --json` is what a script reads. `cmd_doctor` builds its objects out of
+        ``r.detail``, so a note that appeared only in `render()` would leave the machine
+        readable surface exactly as silent as before."""
+        self.write_refs()
+        res = doctor.check_vaults()
+        payload = json.dumps({"name": res.name, "status": res.status,
+                              "detail": res.detail, "hint": res.hint})
+        self.assertIn("listed by other accounts", payload)
+
+    def test_both_surfaces_render_the_same_list(self) -> None:
+        """The property rather than the prose: the two commands agree because they render
+        one structured answer, not because two sentences are kept in step by hand."""
+        self.write_refs()
+        note = base.loose_dir_note(self.provider().loose_dirs())
+        self.assertTrue(note, "precondition: the provider reports the directory")
+        self.assertIn(note, self.status_row())
+        self.assertIn(note, doctor.check_vaults().render())
+
+    def test_reference_and_plain_file_say_the_same_thing_about_one_directory(self) -> None:
+        """The defect was an ASYMMETRY: two vaults in one directory, one reporting it.
+
+        Asserted as "the same rendering", not as two greps for the same words — the point
+        of #471's structured answer is that neither provider owns a sentence."""
+        self.write_refs()
+        pf = self.sd / "vaults" / "devops.json"
+        registry.add_vault("devops", "plain-file", {"file": str(pf)})
+        PlainFileProvider("devops", {"file": str(pf)}).set("K", "value-one")
+        self.assertEqual(base.loose_dir_note(registry.provider_for("refs").loose_dirs()),
+                         base.loose_dir_note(registry.provider_for("devops").loose_dirs()),
+                         "one directory, one chmod, one sentence")
+
+    def test_every_loose_mode_is_reported_not_just_0755(self) -> None:
+        self.write_refs()
+        for mode in LOOSE_MODES:
+            with self.subTest(mode=oct(mode)):
+                os.chmod(self.sd, mode)
+                self.assertIn("listed by other accounts", self.status_row(),
+                              f"{oct(mode)[-3:]} lets another account in and was not named")
+
+    def test_a_private_directory_says_nothing(self) -> None:
+        """The complaint has to be caused by the mode. A note that is always there is a
+        line people learn to skip, and it takes the rest of the report with it."""
+        self.write_refs()
+        os.chmod(self.sd, 0o700)
+        os.chmod(self.sd / "vaults", 0o700)
+        self.assertNotIn("listed by other accounts", self.status_row())
+        self.assertNotIn("listed by other accounts", doctor.check_vaults().render())
+
+
+class TheNoteRidesEveryBranch(ReferencePlane):
+    """`reference.health` returns from five places, and a directory does not stop being
+    listable because something else about the vault is also wrong. `check_vaults` records
+    the same lesson one level up: a note that rides only the branch where nothing else has
+    gone wrong is reported in exactly the conditions nobody is in."""
+
+    def test_before_the_file_exists(self) -> None:
+        self.assertFalse(self.vf.exists(), "precondition: nothing written yet")
+        _ok, detail = self.provider().health()
+        self.assertIn("listed by other accounts", detail)
+
+    def test_with_no_references_in_it(self) -> None:
+        self.vf.parent.mkdir(parents=True, exist_ok=True)
+        self.vf.write_text("{}\n")
+        os.chmod(self.vf, 0o600)
+        _ok, detail = self.provider().health()
+        self.assertIn("no references yet", detail)
+        self.assertIn("listed by other accounts", detail)
+
+    def test_with_references(self) -> None:
+        self.write_refs()
+        ok, detail = self.provider().health()
+        self.assertTrue(ok)
+        self.assertIn("1 reference(s)", detail)
+        self.assertIn("listed by other accounts", detail)
+
+    def test_when_the_resolver_cli_is_missing(self) -> None:
+        self.write_refs()
+        with mock.patch.object(reference.shutil, "which", lambda c: None):
+            ok, detail = self.provider().health()
+        self.assertFalse(ok, "precondition: an unreachable resolver")
+        self.assertIn("not on PATH", detail)
+        self.assertIn("listed by other accounts", detail,
+                      "the directory did not stop being loose because `op` is missing")
+
+    def test_when_the_file_is_not_valid_json(self) -> None:
+        self.vf.parent.mkdir(parents=True, exist_ok=True)
+        self.vf.write_text("{ not json")
+        ok, detail = self.provider().health()
+        self.assertFalse(ok, "precondition: unparseable")
+        self.assertIn("not valid JSON", detail)
+        self.assertIn("listed by other accounts", detail,
+                      "the directory did not stop being loose because the file is broken")
+
+    def test_two_missing_clis_are_named_in_a_stable_order(self) -> None:
+        """More than one scheme, which the single-scheme cases above cannot see.
+
+        Two things live on this line and neither shows up with one scheme present. The CLI
+        names come back in SCHEME order, derived from the sorted `needed` list rather than
+        from a set — a set of short strings iterates in hash order and `str` hashing is
+        randomised per process, so a health line built from one reorders between runs and
+        cannot be diffed. And the search that finds a URI for each scheme is FILTERED: hand
+        `_vault_argv` the `op://` entry because it happened to be first and it raises
+        "malformed Vault reference" out of a health check.
+        """
+        self.vf.parent.mkdir(parents=True, exist_ok=True)
+        self.vf.write_text(json.dumps({"A": REF, "B": "vault://secret/data/app#TOKEN"}))
+        os.chmod(self.vf, 0o600)
+        with mock.patch.object(reference.shutil, "which", lambda c: None):
+            ok, detail = self.provider().health()
+        self.assertFalse(ok)
+        self.assertIn("not on PATH: op, vault", detail)
+
+    def test_the_cli_lookup_asks_about_the_scheme_it_was_given(self) -> None:
+        """The filter as a property, independent of which entry `dict` happens to yield
+        first — `_cli_for` is asked for each scheme against a vault holding both."""
+        data = {"A": REF, "B": "vault://secret/data/app#TOKEN"}
+        self.assertEqual(reference._cli_for("op", data, {}), "op")
+        self.assertEqual(reference._cli_for("vault", data, {}), "vault")
+
+    def test_an_unreachable_reference_vault_does_not_take_the_note_out_of_doctor(self) -> None:
+        self.vf.parent.mkdir(parents=True, exist_ok=True)
+        self.vf.write_text("{ not json")
+        res = doctor.check_vaults()
+        self.assertEqual(res.status, doctor.WARN, "precondition: a vault must be broken")
+        self.assertIn("not reachable", res.render())
+        self.assertIn("listed by other accounts", res.render())
+
+
+class TheFileSaysItsOwnMode(ReferencePlane):
+    """`plain-file` prints ``perms 644 (want 600)``; `reference` printed nothing at all.
+
+    The file is not a secret and it is still worth not publishing — it names every item
+    and field this plane reaches. Reported, never repaired: this is a read path, and a
+    health check that writes is the defect whatever it writes to (#331)."""
+
+    def _write_at(self, mode: int) -> None:
+        self.vf.parent.mkdir(parents=True, exist_ok=True)
+        self.vf.write_text(json.dumps({"TOKEN": REF}))
+        os.chmod(self.vf, mode)
+
+    def test_a_hand_authored_0644_file_is_named(self) -> None:
+        self._write_at(0o644)
+        _ok, detail = self.provider().health()
+        self.assertIn("perms 644 (want 600)", detail)
+
+    def test_charter_s_own_0600_file_says_nothing(self) -> None:
+        self.write_refs()
+        self.assertEqual(stat.S_IMODE(self.vf.stat().st_mode), 0o600,
+                         "precondition: `_save` chose this mode")
+        _ok, detail = self.provider().health()
+        self.assertNotIn("perms", detail)
+
+    def test_the_report_does_not_repair_the_mode(self) -> None:
+        """`health` runs from the SessionStart hook and a vault's `file` may name any path
+        on this machine. Naming it IS the remedy — chmod-ing it is #331."""
+        self._write_at(0o644)
+        self.provider().health()
+        self.assertEqual(stat.S_IMODE(self.vf.stat().st_mode), 0o644,
+                         "health() must not write")
+
+    def test_a_clean_vault_says_only_what_is_true(self) -> None:
+        """Exact, because the clauses are ASSEMBLED now. A health line built by joining
+        three parts has to drop the ones with nothing to say, or every healthy row on every
+        plane grows a trailing ``, ,`` that no substring assertion in this file would ever
+        notice. Both providers, because both were rewritten to the same join."""
+        self.write_refs()
+        pf = self.sd / "vaults" / "devops.json"
+        registry.add_vault("devops", "plain-file", {"file": str(pf)})
+        PlainFileProvider("devops", {"file": str(pf)}).set("K", "v")
+        os.chmod(self.sd, 0o700)
+        os.chmod(self.sd / "vaults", 0o700)
+        self.assertEqual(self.provider().health(), (True, "1 reference(s) via op"))
+        self.assertEqual(registry.provider_for("devops").health(), (True, "1 secret(s)"))
+
+    def test_both_providers_use_one_wording(self) -> None:
+        self._write_at(0o644)
+        pf = self.sd / "vaults" / "devops.json"
+        pf.write_text(json.dumps({"K": "v"}))
+        os.chmod(pf, 0o644)
+        registry.add_vault("devops", "plain-file", {"file": str(pf)})
+        self.assertIn(base.mode_note(pf), registry.provider_for("devops").health()[1])
+        self.assertIn(base.mode_note(self.vf), self.provider().health()[1])
+
+
+class AMissingFileIsNotAnEmptyVault(ReferencePlane):
+    """*A failed read must never render as a benign state.* ``no references yet`` is what
+    an empty vault says; a vault registered against a path that is not there said the same
+    thing, and the operator could not tell a typo in ``--file`` from a vault nobody had
+    filled in."""
+
+    def test_a_file_that_does_not_exist_says_so_and_names_the_path(self) -> None:
+        self.assertFalse(self.vf.exists(), "precondition")
+        ok, detail = self.provider().health()
+        self.assertTrue(ok, "not created yet is not an unreachable vault")
+        self.assertIn("not created yet", detail)
+        self.assertIn("refs.json", detail, "and the path it looked at")
+        self.assertNotIn("no references yet", detail)
+
+    def test_an_existing_empty_file_still_says_no_references_yet(self) -> None:
+        """The other half. Both states are legitimate and they are different facts."""
+        self.vf.parent.mkdir(parents=True, exist_ok=True)
+        self.vf.write_text("{}\n")
+        os.chmod(self.vf, 0o600)
+        ok, detail = self.provider().health()
+        self.assertTrue(ok)
+        self.assertIn("no references yet", detail)
+        self.assertNotIn("not created yet", detail)
+
+    def test_the_two_providers_agree_about_a_file_that_is_not_there(self) -> None:
+        """`statusline._vault_dot` marks a vault ``◦`` by matching this exact phrase, so a
+        reference vault was the one provider whose never-written state was invisible there
+        as well. Asserted through the phrase the reader keys on, because that IS the
+        contract between the two modules."""
+        pf = self.sd / "vaults" / "devops.json"
+        registry.add_vault("devops", "plain-file", {"file": str(pf)})
+        self.assertIn("not created yet", registry.provider_for("devops").health()[1])
+        self.assertIn("not created yet", self.provider().health()[1])
+
+    def test_the_statusline_marks_it(self) -> None:
+        from charter import statusline
+        self.assertIn("◦", statusline._vault_dot("refs"))
+
+
+class AReferenceThatResolvesToNothing(ReferencePlane):
+    """The fourth instance on this line, and the one that took `doctor` with it.
+
+    `set` refuses anything that is not a supported URI — but entries arrive in this file by
+    hand and, for this provider above all, **by commit**: the argument for reference vaults
+    is that a team commits the wiring and a fresh clone inherits it. `_load` checks that
+    the document is an object and nothing about its values.
+    """
+
+    def _write_raw(self, data) -> None:
+        self.vf.parent.mkdir(parents=True, exist_ok=True)
+        self.vf.write_text(json.dumps(data))
+        os.chmod(self.vf, 0o600)
+
+    def test_a_vault_of_only_unsupported_entries_is_not_healthy(self) -> None:
+        """It read ``1 reference(s) via `` — a green line whose sentence stops after the
+        word "via" because there was no scheme to name."""
+        self._write_raw({"K": "https://example.test/x"})
+        ok, detail = self.provider().health()
+        self.assertFalse(ok)
+        self.assertIn("not a supported URI", detail)
+        self.assertFalse(detail.rstrip().endswith("via"), detail)
+
+    def test_a_dead_entry_beside_a_live_one_is_named(self) -> None:
+        """The sharper half: ``2 reference(s) via op`` counted the dead one and named only
+        the scheme that works, so the count said two and one of them could never resolve."""
+        self._write_raw({"K": "https://example.test/x", "T": REF})
+        ok, detail = self.provider().health()
+        self.assertFalse(ok)
+        self.assertIn("2 reference(s)", detail)
+        self.assertIn("1 not a supported URI", detail)
+
+    def test_it_names_the_command_that_names_the_keys(self) -> None:
+        """#371: a report is worth its row only if it says what to do next. The key itself
+        stays off this row — it is a value out of a committed JSON object landing in a
+        table — and `charter vault verify` already prints ``<key>: <error>`` per failure."""
+        self._write_raw({"K": "https://example.test/x"})
+        _ok, detail = self.provider().health()
+        self.assertIn("charter vault verify", detail)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_vault_verify(argparse.Namespace(name="refs"))
+        self.assertEqual(rc, 1, "a dead reference is a non-zero verify")
+        self.assertIn("K", buf.getvalue(), "and the command named in the row names the key")
+
+    def test_a_non_string_value_does_not_crash_the_report(self) -> None:
+        """`charter doctor` runs from the SessionStart hook and catches `VaultError` and
+        nothing else. A committed ``{"K": 123}`` reached `urlsplit` and raised
+        ``AttributeError`` out of `health`, so the command whose job is reporting on this
+        file was the thing this file could take down."""
+        self._write_raw({"K": 123})
+        ok, detail = self.provider().health()
+        self.assertFalse(ok)
+        self.assertIn("not a supported URI", detail)
+        self.assertIn("refs", self.status_row())
+        self.assertEqual(doctor.check_vaults().status, doctor.WARN)
+
+    def test_scheme_of_is_total_over_anything_json_holds(self) -> None:
+        for value in (None, 123, 1.5, True, [], {}, ["op://v/i/f"], {"op": "//v/i/f"}):
+            with self.subTest(value=value):
+                self.assertIsNone(reference.scheme_of(value))
+        self.assertEqual(reference.scheme_of(REF), "op")
+
+    def test_the_note_rides_this_branch_too(self) -> None:
+        self._write_raw({"K": "https://example.test/x"})
+        _ok, detail = self.provider().health()
+        self.assertIn("listed by other accounts", detail)
+
+
+class OneImplementationForEveryFileBackedProvider(PersonaIso):
+    """Why this is on the base class and not copied per provider.
+
+    `VaultProvider.file_path` already replaced two byte-identical ``path`` properties and
+    says why: the second copy is how one provider quietly keeps answering the old way.
+    `loose_dirs` was that same mistake one method over, and #491 is the bill for it."""
+
+    def test_it_is_not_overridden_anywhere(self) -> None:
+        """The structural claim. A provider that re-declares `loose_dirs` has reopened the
+        gap this closed, so the test is about the class dict rather than about output."""
+        for cls in (PlainFileProvider, ReferenceProvider):
+            with self.subTest(provider=cls.id):
+                self.assertNotIn("loose_dirs", vars(cls),
+                                 f"{cls.__name__} answers `loose_dirs` from the base class; "
+                                 f"a copy here is what #491 was filed about")
+
+    def test_a_provider_with_no_file_answers_empty(self) -> None:
+        """1Password keeps nothing of charter's on this disk, so there is no directory of
+        charter's to report and the honest answer is ``[]`` — not a guess about somebody
+        else's backend, and not a crash from `file_path` raising."""
+        class Nowhere(base.VaultProvider):
+            id = "nowhere"
+
+            def get(self, key):  # pragma: no cover - never called
+                raise base.SecretNotFound(key)
+
+            def set(self, key, value):  # pragma: no cover - never called
+                raise base.VaultError("read-only")
+
+            def delete(self, key):  # pragma: no cover - never called
+                raise base.VaultError("read-only")
+
+            def keys(self):
+                return []
+
+        self.assertEqual(Nowhere("v", {}).loose_dirs(), [])
+
+    def test_the_1password_provider_still_answers_empty(self) -> None:
+        from charter.secrets.onepassword import OnePasswordProvider
+        prov = OnePasswordProvider("op", {"op_vault": "Eng", "op_item": "charter"})
+        self.assertEqual(prov.loose_dirs(), [])
+        self.assertEqual(prov.health.__qualname__.split(".")[0], "OnePasswordProvider",
+                         "precondition: this provider has a health line of its own")
+
+    def test_a_reference_vault_with_no_file_configured_does_not_raise(self) -> None:
+        """A health line that can throw is a `doctor` that cannot run, and `doctor` calls
+        this from the SessionStart hook."""
+        prov = ReferenceProvider("broken", {})
+        self.assertEqual(prov.loose_dirs(), [])
+        ok, detail = prov.health()
+        self.assertFalse(ok)
+        self.assertIn("no 'file' configured", detail)
+
+    def test_a_file_outside_the_plane_reports_only_its_own_directory(self) -> None:
+        """`loose_dirs`' documented bound, now that a second provider reaches it: a vault
+        deliberately kept outside the plane must not drag ``/Users`` or ``/`` into the
+        report — those are 0755 on every machine and are nobody's defect."""
+        outside = Path(self.tmp) / "elsewhere"
+        outside.mkdir(parents=True, exist_ok=True)
+        os.chmod(outside, 0o755)
+        prov = ReferenceProvider("out", {"file": str(outside / "refs.json")})
+        found = [p for p, _m in prov.loose_dirs()]
+        self.assertEqual([Path(p).resolve() for p in found], [outside.resolve()])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secret_reference.py
+++ b/tests/test_secret_reference.py
@@ -165,6 +165,15 @@ class ReferenceVault(unittest.TestCase):
         self.assertIn("op", detail)
 
     def test_health_on_an_empty_vault(self):
+        """An empty vault FILE, which is a different fact from no file at all (#491).
+
+        This case used to be asserted with no file on disk, and both states printed
+        ``no references yet`` — so a vault registered against a mistyped ``--file`` read
+        as one somebody had simply not filled in yet. The distinction is
+        `tests/test_reference_vault_reports_its_directory.py`'s subject; what belongs here
+        is that a vault that HAS a file and no entries still says so.
+        """
+        self.f.write_text("{}\n")
         ok, detail = self.p.health()
         self.assertTrue(ok)
         self.assertIn("no references", detail)


### PR DESCRIPTION
Closes #491. Closes #489.

Both filed issues are one family: **charter knowing something and not saying it.** The
standard they are measured against is already written down — *a failed read must never
render as a benign state* — and #573's is the sharp precedent: silence that looks like
success.

## #491 — a reference vault never reported the directory it is listed in

`ReferenceProvider` writes a file under `.charter/vaults/` through the same private walk a
plain-file vault does, and answered the base class's `loose_dirs() -> []`. So on a plane
whose `.charter/` predates charter, two vaults in one 0755 directory disagreed about
whether there was anything to say:

```
devops   plain-file   —   local   1 secret(s), listed by other accounts: .charter 755 (want 700 — chmod 700)
refs     reference    —   local   no references yet
```

**Not fixed by giving `reference` a copy of the eight lines.** `VaultProvider.file_path`
already records what a second copy costs — it replaced two byte-identical `path`
properties, and the reason two implementations of "where is this vault's file" is the wrong
number is that one of them quietly keeps answering the old way. `loose_dirs()` was that
mistake one method over. It moves onto `VaultProvider`, keyed on `file_path`: every
file-backed provider answers it, and a provider with no `file` makes `file_path` raise and
gets the honest `[]` it always had — no new attribute for a new provider to forget.
`plain_file`'s override is deleted, and a test asserts neither provider re-declares it.

### Neighbours found on the same line, not filed

- **the file's own mode.** `plain-file` prints `perms 644 (want 600)`; `reference` printed
  nothing, though `_save` writes 0600 for a stated reason. Extracted as `base.mode_note`,
  so it is one wording for both providers rather than a copy.
- **whether the file exists.** A missing file rendered as `no references yet` — the wording
  for an *empty* vault — so a mistyped `--file` was indistinguishable from a vault nobody
  had filled in. Now `not created yet (<path>)`, which is also the phrase
  `statusline._vault_dot` matches to mark such a vault `◦`; a reference vault was the one
  provider whose never-written state was invisible there too.
- **an entry that is not a supported reference at all.** `set` refuses one, but entries
  reach this file by hand and — for this provider above all — *by commit*. A vault whose
  every entry was unsupported printed a green ``1 reference(s) via `` with the sentence
  trailing off after the word "via"; one live entry beside one dead one printed
  `2 reference(s) via op`, counting the dead one and naming only the scheme that works.
- **and the one that took the reporting command with it.** A committed `{"K": 123}` reached
  `urlsplit` and raised `AttributeError` straight out of `health()`. `vault list` and
  `doctor` catch `VaultError` and nothing else, and `doctor` runs from the SessionStart
  hook — so the command whose job is reporting on this file was the thing this file could
  crash. `scheme_of` is now total over anything JSON can hold.

Nothing chmods anything: charter tightens what it creates and reports what it did not
(#331). No containment is added to a vault `file` path.

## #489 — a withheld MCP credential was announced once and then invisible

`persona.mcp_withheld` had exactly one caller: `sync-agents`, on the run that wrote the
file. After that, a persona running without the credential it declares is byte-identical in
`.claude/agents/<name>.md` to one that never declared one — asserted, not described, in
`TheGeneratedFileCannotSayIt`.

**`persona lint` names each withheld server**, with both ways out (approve it, or drop the
declaration). `doctor` reaches it through `check_personas`, which already runs `lint` across
the roster — a `doctor` row of its own would be a second sentence about one fact, which is
the drift this repo keeps recording.

**A warning, not an error, and that is argued rather than defaulted.** Withholding is the
#330 gate working; the operator may have read the command and declined it, and a lint that
exits 1 forever is one planes turn off. The one *error* case is an entry `describe` cannot
render: no approval can ever exist for it, `--approve-mcp` refuses it by name, so "approve
it" would be a nudge that cannot work (#371) — it gets a different sentence and a different
level.

**The generated agent deliberately gains no comment of its own.** The issue floats it; this
declines. `mcpseen` closed this class across four rounds by *removing* the second
representation of consent — "there is nothing left to fall out of step with". A comment in a
wholesale-regenerated file is exactly a second representation, and it goes stale the moment
someone approves without re-syncing, at which point a reader who trusts it reads a false
statement about a live credential.

### Two siblings, found by enumerating

- **`lint` read `secrets` and not `secret_files`.** Every other reader treats them as one
  mechanism (`needs_consent`, `mcp_render_entry`, `secret exec --env/--file`). So a server
  declaring only `secret_files` against a persona with no vault rendered without its
  credential and was reported by **nothing** — not by that error, because the key was not
  read, and not as withheld, because with no vault there is nothing to withhold.
  `secret_files` is what Google ADC needs, and it is the declaration #489's own
  reproduction carries. Both keys now go through `mcpseen.declares_credential`.
- **`vault: none` was read as the name of a vault by the MCP path.** Measured on the
  unmutated baseline at `d08da07`'s successor:

  ```
  consent line   run uvx analytics-mcp  secrets "T"="k"  vault "none"
  rendered       charter secret exec none --env T=k --exec -- uvx analytics-mcp
  ```

  `--approve-mcp` asked the operator to approve spending a vault named `none`, recorded the
  consent, and wrote a launcher into the generated agent that cannot run — while `lint` was
  separately and correctly calling the same persona one that names no vault.
  `persona.mcp_vault` normalises it in the two places that must agree: the render and the
  consent list.

## Verification

- Full suite green in **two environments** at this head: python3.14 and python3.12 with
  every `CHARTER_*` / `CLAUDE_*` / `ANTHROPIC_*` / `TMUX*` variable unset (verified empty
  in the child, not just passed `-u`). 7450 tests each. CI green on 3.11/3.12/3.13/3.14.
- Both new test modules verified **RED against `origin/main`** before the fix — 23 of 25
  and 36 of 32 (subtests) failing — so nothing here passes both ways.
- `tools/sweep.py` on the diff, from an unmutated green baseline (7447 tests). The first
  run reported **5 survivors**; all five are addressed rather than argued away:
  - two were the *same* `(resolve(name) or {}).get("meta", {}).get("vault")` chain written
    out in `mcp_credentialed` and in `lint`. Collapsed into `persona.vault_for_mcp`, where
    the `or {}` is on a live path — `_approve_mcp` asks `mcp_credentialed` about every name
    `list_personas` globbed, loadable or not — and pinned by a test that drives exactly
    that persona;
  - `declares_credential(e or {})` was a guard in front of a pinned guard. The
    `isinstance(entry, dict)` inside `declares_credential` is what makes it dead, the sweep
    pinned that, so the `or {}` is **deleted** rather than left looking careful;
  - `sorted({...})` over the missing-CLI names leaned on `sorted` to undo a randomness it
    had just introduced — a set of short strings iterates in hash order, and `str` hashing
    is per-process. The set is gone; the order now follows the already-sorted scheme list,
    so it is a property of the data rather than of `$PYTHONHASHSEED`;
  - the `next(v for v in data.values() if scheme_of(v) == s)` filter was unpinned because
    no test had two schemes. It is real — `_vault_argv` handed an `op://` URI raises
    "malformed Vault reference" out of a health check — and it now lives once, in
    `_cli_for`, with a two-scheme test behind it.
- Plus **14 hand-mutations** for shapes the sweep's operator table cannot reach: a
  module-level alias, `return`-position `BoolOp` conjuncts, an `IfExp` condition's `or`
  halves, and the two fallbacks above. Each asserts it applied by reading the file back
  after writing, and each restore is verified against a sha256 taken before the edit.
  **14/14 killed, no survivors**, post-restore baseline green.
- The suite reaches no real vault: nothing spawns `op`/`vault`/`npx` — `health` only asks
  `which`, and an unsupported reference raises before any resolver is reached.
- Cost to `doctor`, counted rather than guessed: the new `lint` row adds **5 `read_text`
  calls per persona** (65 for a 13-persona roster) — `mcpseen.approved()` plus the entry
  walk. `check_personas`' recorded concern was a 27ms-per-persona plugin-cache walk, which
  is memoised; this is not in that class.

News: two entries, `version: unreleased`, both `security: true`. No bump, stamp or tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
