### PR TITLE
A report line is contained as it is assembled, in one place (#576)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2589,7 +2589,7 @@ def cmd_news(args) -> int:
                 # silence would be read as "nothing to adopt" — the shape ADR 0013 and
                 # `doctor`'s not-checked hint both exist to refuse.
                 # The slug is the committed filename with its version prefix cut off, and
-                # `why` already carries the entry's `check:` contained (`news._report`).
+                # `why` already carries the entry's `check:` contained (`contain.sentence`).
                 util.warn(f"{contain.one_line(e.slug)}: {why}")
                 unchecked += 1
         if not shown:

--- a/charter/contain.py
+++ b/charter/contain.py
@@ -65,11 +65,13 @@ only that doing half of this while claiming all of it would be worse than filing
 **One assembler for report lines, because two of them drifted.** :func:`sentence` and its
 path-budget twin :func:`path_sentence` are where a line of charter's own output gets its
 untrusted spans contained, and they are here rather than in each module that reports.
-`news` grew a private copy of exactly this (#573) while this module's copy was closed for
-#498, and within one version the two disagreed about the budget and about what to do with
-a field holding several things — the second drift being invisible from either side, since
-neither copy could see the other. That is the argument this module's own opening paragraph
-makes about `valid_name`, turned on this module. A third reporting surface —
+`news` grew a private copy of exactly this (#573) rather than import the one here, which
+was private and carried the wrong budget for a frontmatter value — and, proximately,
+because #498 was open on this module at the time. Within one version the two disagreed
+about the budget and about what to do with a field holding several things — the second
+drift invisible from either side, since neither copy could see the other. That is the
+argument this module's own opening paragraph makes about `valid_name`, turned on this
+module. A third reporting surface —
 `commands_persona`'s tables, `frame/registry`'s entry-point errors, `mcpseen` — now picks
 one of two written-down budgets instead of inventing a third (#576).
 

--- a/charter/contain.py
+++ b/charter/contain.py
@@ -62,6 +62,17 @@ and break a plane that legitimately links a persona directory. Resolving keeps t
 working, and #342's reason for staying lexical was never that symlinks are acceptable —
 only that doing half of this while claiming all of it would be worse than filing it.
 
+**One assembler for report lines, because two of them drifted.** :func:`sentence` and its
+path-budget twin :func:`path_sentence` are where a line of charter's own output gets its
+untrusted spans contained, and they are here rather than in each module that reports.
+`news` grew a private copy of exactly this (#573) while this module's copy was closed for
+#498, and within one version the two disagreed about the budget and about what to do with
+a field holding several things — the second drift being invisible from either side, since
+neither copy could see the other. That is the argument this module's own opening paragraph
+makes about `valid_name`, turned on this module. A third reporting surface —
+`commands_persona`'s tables, `frame/registry`'s entry-point errors, `mcpseen` — now picks
+one of two written-down budgets instead of inventing a third (#576).
+
 **No refusal function here raises.** These checks sit under `doctor`, the status line and
 SessionStart, where the rule is that a hook may cost a session its briefing and never its
 turn. The single exception is :func:`writable`, which exists to raise and says so: a write
@@ -142,7 +153,7 @@ def child(base, name: str) -> Path | None:
 
 def refusal(name: str) -> str:
     """The one sentence every site uses to say why *name* was refused."""
-    return _sentence(NOT_A_SEGMENT, name=name)
+    return path_sentence(NOT_A_SEGMENT, name=name)
 
 
 # --------------------------------------------------------------------------- #
@@ -328,20 +339,98 @@ def readable(value, limit: int = DISPLAY_LIMIT) -> str:
 PATH_DISPLAY_LIMIT = 1024
 
 
-def _sentence(template: str, **fields) -> str:
-    """One refusal sentence, with every field bounded to one line.
+#: What :func:`sentence` writes BETWEEN the elements of a field holding several things.
+#:
+#: Charter's own separator, for the same reason the template is charter's own text: a line
+#: naming several committed things is a line with structure, and a separator taken from one
+#: of the things would let that thing restructure the line. Written once, so two report
+#: surfaces cannot separate their lists differently.
+SEQUENCE_SEPARATOR = ", "
 
-    A refusal is a report line **about** a value charter would not accept, and that value is
-    exactly the thing that must not be able to write a second line into the report. It is
-    also, on every path through this module, a value out of a committed file or a filesystem
-    somebody else's commit created.
+
+def _slots(fields: dict, limit: int) -> dict:
+    """Every field bounded to one line, ready to be substituted into a template.
+
+    The **budget** is the caller's, and it is the only thing :func:`sentence` and
+    :func:`path_sentence` differ by. Everything else — that a field is contained at all,
+    and that a field holding several things is contained element by element rather than
+    after the join — is the same question wherever a report line is assembled, so it is
+    answered here and cannot be answered twice.
+
+    **Containing the elements and not the join, because the join is the sentence.** A
+    sentence that names a list exists to name every entry in it; clipping the joined string
+    drops the last entries and leaves a line that reads as though those entries were never
+    there. Per element, a long entry is clipped and its neighbours still arrive.
+
+    **"Several things" is a property, not a type.** The test is *is this one string, or is
+    it something that can be iterated* — not a list of the container classes somebody
+    happened to pass. ``(list, tuple)`` is a spelling: a caller handing a `set`, a
+    `frozenset`, a `dict_keys` or a generator to a sentence naming several files falls off
+    the end of it and gets Python's own `repr` of the container printed into charter's
+    prose, brackets and quotes and all. `str` and `bytes` are iterable and are one thing,
+    which is why they are named as the exception rather than the containers being named as
+    the rule.
+    """
+    shown = {}
+    for key, value in fields.items():
+        if isinstance(value, (str, bytes)) or not hasattr(value, "__iter__"):
+            shown[key] = one_line(value, limit=limit)
+        else:
+            shown[key] = SEQUENCE_SEPARATOR.join(one_line(v, limit=limit) for v in value)
+    return shown
+
+
+def sentence(template: str, **fields) -> str:
+    """One line of charter's own report, with **every** field in it bounded to one line.
+
+    *template* is a literal in charter's own source — charter's sentence, with ``{}`` slots.
+    Everything substituted into it is treated as a value out of a committed file or off a
+    filesystem somebody else's commit created, and goes through :func:`one_line`.
+
+    **The containment is at the assembly, not at the slots.** A report line is charter's
+    own output and the fields in it are not; a newline in one of them writes a second line
+    that looks exactly as much like charter's output as the first. `news.entry_errors`
+    contained the ordering *value* and interpolated the committed *filename* three inches
+    away raw, so an entry named ``0.60.0-a\\nEVIL: charter says nothing is wrong.md``
+    printed two lines where charter emitted one, the second being the author's sentence in
+    charter's voice (#502). The value was contained because the value was what that commit
+    was about — not because the filename had been judged safe.
+
+    Wrapping each span individually fixes the spans somebody enumerated and leaves the door
+    open at the shape #502 predicted: a further untrusted span turning up in one of these
+    sentences. A field added to a template tomorrow is contained by having been passed
+    here, which is a property a reviewer checks by reading the call site rather than one
+    they have to remember.
+
+    **Two functions rather than one with a ``limit=`` keyword, and the reason is this
+    signature.** ``**fields`` makes the template's slot names and this function's own
+    parameter names one namespace, so a template that ever grows a ``{limit}`` slot would
+    have its value silently eaten as the budget and then raise ``KeyError`` out of
+    `str.format` — inside the module whose rule is that nothing here raises. The budget is
+    named by which function you call instead, so no slot name can collide with it, and the
+    two budgets charter has are written down where each other can see them.
+
+    What this does not reach is a call site that builds its sentence with an f-string
+    instead of calling this. Nothing in the language stops that, so
+    `tests/test_a_news_entry_cannot_forge_a_report_line.py` plants a line break in every
+    field a news entry owns and asserts each report is still the number of lines charter
+    meant to write.
+    """
+    return template.format(**_slots(fields, DISPLAY_LIMIT))
+
+
+def path_sentence(template: str, **fields) -> str:
+    """:func:`sentence` at :data:`PATH_DISPLAY_LIMIT` — a sentence that names a PATH.
+
+    The refusals in this module name resolved paths, and a plane's paths are legitimately
+    long: at :data:`DISPLAY_LIMIT` the reader gets a clipped path they cannot act on, which
+    is the one thing a refusal exists to give them. Everything else is :func:`sentence`.
 
     Formatted here rather than at the twelve `.format` calls it replaces, because twelve is
     how many places the thirteenth gets forgotten in — the same argument that put the name
     bound inside `persona.mcp_servers` instead of at each of its consumers (#453).
     """
-    return template.format(
-        **{k: one_line(v, limit=PATH_DISPLAY_LIMIT) for k, v in fields.items()})
+    return template.format(**_slots(fields, PATH_DISPLAY_LIMIT))
 
 
 def json_line(obj, *, sort_keys: bool = False) -> str:
@@ -502,12 +591,16 @@ def within_data(path) -> bool:
 
 
 def _not_plane_data(path, verb: str = "read") -> str:
-    roots = ", ".join(sorted(Path(r).name for r in data_roots()))
+    # The names go in as a SEQUENCE, not as a string this function joined: joining first
+    # and containing second bounds the whole list at one budget, so the last root drops out
+    # of a sentence whose job is to say which directories are the plane's. The join is
+    # `path_sentence`'s (:data:`SEQUENCE_SEPARATOR`), and the rendering is unchanged.
+    roots = sorted(Path(r).name for r in data_roots())
     try:
         target = os.path.realpath(path)
     except (OSError, ValueError):
         target = path            # unresolvable — say what was asked for, never raise here
-    return _sentence(NOT_PLANE_DATA, name=path, target=target, roots=roots, verb=verb)
+    return path_sentence(NOT_PLANE_DATA, name=path, target=target, roots=roots, verb=verb)
 
 
 #: Said once, like the two above. Names the resolved target because that is the whole
@@ -564,7 +657,7 @@ def plane_adjacent_refusal(root, declared) -> str | None:
         target = os.path.realpath(p)
     except (OSError, ValueError):
         target = str(p)
-    return _sentence(NOT_PLANE_ADJACENT, name=declared, target=target, root=root)
+    return path_sentence(NOT_PLANE_ADJACENT, name=declared, target=target, root=root)
 
 
 def dir_refusal(directory, verb: str = "read") -> str | None:
@@ -677,20 +770,20 @@ def _path_refusal(path, *, missing_ok: bool, verb: str) -> str | None:
         # the empty path never can. Without this the write side answered "nothing to
         # object to" for it and handed the caller an unhandled `OSError` one line later —
         # a refusal turned back into a crash, which is the bug #348 shipped and fixed.
-        return _sentence(UNREADABLE, name=path, error="empty path")
+        return path_sentence(UNREADABLE, name=path, error="empty path")
     try:
         st = os.lstat(path)
     except FileNotFoundError:
         if missing_ok:
             return None       # about to be created — there is nothing there to object to
-        return _sentence(UNREADABLE, name=path, error="No such file or directory")
+        return path_sentence(UNREADABLE, name=path, error="No such file or directory")
     except OSError as e:
-        return _sentence(UNREADABLE, name=path, error=e.strerror or e)
+        return path_sentence(UNREADABLE, name=path, error=e.strerror or e)
     except ValueError as e:
         # `os.lstat` raises ValueError, NOT OSError, on a path holding a NUL — the one
         # input shaped to get past a check (`segment_ok` refuses it for the same reason).
         # "Nothing here raises" is this module's promise; catching only OSError broke it.
-        return _sentence(UNREADABLE, name=path, error=e)
+        return path_sentence(UNREADABLE, name=path, error=e)
     if stat.S_ISLNK(st.st_mode):
         # Asked BEFORE `os.stat`, and that order is load-bearing on the write side: a
         # dangling link has no target to stat, so a containment check placed after the
@@ -704,14 +797,14 @@ def _path_refusal(path, *, missing_ok: bool, verb: str) -> str | None:
         except FileNotFoundError:
             if missing_ok:
                 return None   # a contained link naming a file charter is about to create
-            return _sentence(UNREADABLE, name=path, error="No such file or directory")
+            return path_sentence(UNREADABLE, name=path, error="No such file or directory")
         except OSError as e:
-            return _sentence(UNREADABLE, name=path, error=e.strerror or e)
+            return path_sentence(UNREADABLE, name=path, error=e.strerror or e)
         except ValueError as e:
-            return _sentence(UNREADABLE, name=path, error=e)
+            return path_sentence(UNREADABLE, name=path, error=e)
     if not stat.S_ISREG(st.st_mode):
         kind = next((k for test, k in _KINDS if test(st.st_mode)), "not a file")
-        return _sentence(NOT_A_FILE, name=path, kind=kind, verb=verb)
+        return path_sentence(NOT_A_FILE, name=path, kind=kind, verb=verb)
     if st.st_size > MAX_BYTES:
-        return _sentence(TOO_LARGE, name=path, size=st.st_size, cap=MAX_BYTES)
+        return path_sentence(TOO_LARGE, name=path, size=st.st_size, cap=MAX_BYTES)
     return None

--- a/charter/news.py
+++ b/charter/news.py
@@ -26,7 +26,7 @@ exited 0 with an empty stderr (#503). :data:`_KNOWN_FIELDS` closes the key half,
 its `Entry` altogether and no per-entry check can be asked about it.
 
 And the report saying so is charter's own output, so every span in it is contained as the
-sentence is assembled (:func:`_report`) rather than at the spans somebody was thinking
+sentence is assembled (`contain.sentence`) rather than at the spans somebody was thinking
 about: the ordering VALUE was contained and the committed FILENAME beside it was not, so a
 filename holding a newline forged an extra line of charter's report (#502).
 
@@ -376,48 +376,6 @@ def marker(e: Entry) -> str:
     return "security: " if e.security else ""
 
 
-def _report(template: str, **fields) -> str:
-    """One line of charter's own report, with **every** field in it bounded to one line.
-
-    *template* is a literal in this module — charter's own sentence, with ``{}`` slots.
-    Everything substituted into it comes out of a committed file and goes through
-    :func:`contain.one_line`; a sequence is contained element by element and then joined
-    with charter's own comma, so the separator cannot come from the data either.
-
-    **Why the containment is here and not at the slots.** A news entry is a committed file
-    and so is its NAME: whoever writes the commit chooses both, and both land in a line a
-    release engineer reads out of CI. `entry_errors` contained the ordering *value* and
-    interpolated the *filename* three inches away raw, so an entry named
-    ``0.60.0-a\\nEVIL: charter says nothing is wrong.md`` printed two lines where charter
-    emitted one, the second being the attacker's sentence in charter's own voice (#502).
-    The value was contained because the value was what that commit was about — not because
-    the filename half had been judged safe.
-
-    Wrapping each span individually would have fixed the four call sites #502 named and
-    left the door open at the shape it predicted: a THIRD untrusted span turning up in one
-    of these sentences. There were three of those already. The ``{version}`` in the
-    duplicate-`lead:` message is frontmatter; the ``{check}`` in a probe's reason is
-    frontmatter; the pair of filenames in `stamp`'s SUCCESS line is the same pair its
-    refusals carry, on the path that runs at every release. So the message is contained as
-    it is ASSEMBLED, and a field added to one of these templates tomorrow is contained by
-    having been passed here — which is a property a reviewer can check by reading the call
-    site, rather than one they have to remember.
-
-    What this does not reach is a call site that builds its sentence with an f-string
-    instead of calling this. Nothing in the language stops that, so
-    `tests/test_a_news_entry_cannot_forge_a_report_line.py` plants a newline in every field
-    a news entry owns and asserts each of these reports is still the number of lines
-    charter meant to write.
-    """
-    shown = {}
-    for key, value in fields.items():
-        if isinstance(value, (list, tuple)):
-            shown[key] = ", ".join(contain.one_line(v) for v in value)
-        else:
-            shown[key] = contain.one_line(value)
-    return template.format(**shown)
-
-
 #: An ordering field whose value charter could not read, quoted back to its author.
 _BAD_VALUE = ("{name}: `{field}: {raw}` is not a value charter reads — a news ordering "
               "field is `true` or `false`. Left unread, this entry sorts as though it "
@@ -487,28 +445,29 @@ def entry_errors(entries: list[Entry]) -> list[str]:
 
     Callers rather than this function decide the consequence: `charter news --for`, which
     IS the release workflow's publish gate, refuses; the range view warns and prints on.
-    Every sentence is assembled through :func:`_report`, so a committed filename in one
-    cannot write a second line into the report it appears in (#502).
+    Every sentence is assembled through `contain.sentence`, so a committed filename in
+    one cannot write a second line into the report it appears in (#502).
     """
     out: list[str] = []
     for e in sorted(entries, key=lambda e: e.path.name):
         for field, raw in e.bad:
             template = _EMPTY_VALUE if raw == "" else _BAD_VALUE
-            out.append(_report(template, name=e.path.name, field=field, raw=raw))
+            out.append(contain.sentence(template, name=e.path.name, field=field, raw=raw))
         for key in e.unknown:
             known = next((f for f in _KNOWN_FIELDS if f == key.casefold()), None)
             if known is not None:
-                out.append(_report(_MISCASED_KEY, name=e.path.name, key=key, known=known))
+                out.append(contain.sentence(_MISCASED_KEY, name=e.path.name,
+                                            key=key, known=known))
             else:
-                out.append(_report(_UNKNOWN_KEY, name=e.path.name, key=key))
+                out.append(contain.sentence(_UNKNOWN_KEY, name=e.path.name, key=key))
     leads: dict[str, list[Entry]] = {}
     for e in entries:
         if e.lead:
             leads.setdefault(e.version, []).append(e)
     for version, claimants in sorted(leads.items()):
         if len(claimants) > 1:
-            out.append(_report(_TWO_LEADS, version=version, count=len(claimants),
-                               names=sorted(c.path.name for c in claimants)))
+            out.append(contain.sentence(_TWO_LEADS, version=version, count=len(claimants),
+                                        names=sorted(c.path.name for c in claimants)))
     return out
 
 
@@ -552,16 +511,17 @@ def _not_an_entry(p: Path) -> str:
     try:
         text = p.read_text()
     except (OSError, UnicodeDecodeError) as exc:
-        return _report(_UNREADABLE_FILE, name=p.name, error=f"{type(exc).__name__}: {exc}")
+        return contain.sentence(_UNREADABLE_FILE, name=p.name,
+                                error=f"{type(exc).__name__}: {exc}")
     meta, _body = persona.parse(text)
     if not meta:
-        return _report(_NO_FRONTMATTER, name=p.name)
+        return contain.sentence(_NO_FRONTMATTER, name=p.name)
     miscased = next((k for k in meta if k != "version" and k.casefold() == "version"), None)
     if miscased is not None:
-        return _report(_MISCASED_VERSION, name=p.name, key=miscased)
+        return contain.sentence(_MISCASED_VERSION, name=p.name, key=miscased)
     if not (meta.get("version") or "").strip():
-        return _report(_NO_VERSION, name=p.name)
-    return _report(_NOT_AN_ENTRY, name=p.name)
+        return contain.sentence(_NO_VERSION, name=p.name)
+    return contain.sentence(_NOT_AN_ENTRY, name=p.name)
 
 
 def unreadable() -> list[str]:
@@ -1063,13 +1023,13 @@ def probe(entry: Entry) -> tuple[str, str]:
     code = _dispatch(entry.check)
     if code is None:
         why = _IN_FLIGHT if in_flight else (_refused or _NOT_RUN)
-        # Through `_report` rather than `.format` directly: `check:` is frontmatter, this
-        # sentence is printed as a line of `charter news --pending`'s own report, and the
-        # five templates above are the third untrusted span #502 predicted would turn up in
-        # one of these messages. `_tokens` refuses `\n` as shell syntax and never sees
-        # U+2028 or an ANSI escape, and in any case a guard that decides whether a probe
-        # RUNS is not a guard on what the report PRINTS.
-        return UNKNOWN, _report(why, check=entry.check)
+        # Through `contain.sentence` rather than `.format` directly: `check:` is
+        # frontmatter, this sentence is printed as a line of `charter news --pending`'s
+        # own report, and the five templates above are the third untrusted span #502
+        # predicted would turn up in one of these messages. `_tokens` refuses `\n` as
+        # shell syntax and never sees U+2028 or an ANSI escape, and in any case a guard
+        # that decides whether a probe RUNS is not a guard on what the report PRINTS.
+        return UNKNOWN, contain.sentence(why, check=entry.check)
     return (ADOPTED if code == 0 else PENDING), ""
 
 
@@ -1142,7 +1102,7 @@ def _restamp(text: str, version: str) -> str | None:
     return "".join(out) if found else None
 
 
-#: Why a stamp was refused, one sentence each. Through :func:`_report` for the reason
+#: Why a stamp was refused, one sentence each. Through `contain.sentence` for the reason
 #: `entry_errors`' sentences are: these name FILES, a filename is chosen by whoever wrote
 #: the commit, and this text is read out of a release engineer's terminal at the one moment
 #: nobody re-derives it (#502). `{version}` is argv rather than a committed file and is
@@ -1167,7 +1127,7 @@ def stamp(version: str) -> tuple[list[tuple[Path, Path]], list[str]]:
     leaves every entry staged, which fails loudly at the next catch.
     """
     if not _is_version(version):
-        return [], [_report(_NOT_A_VERSION, version=version)]
+        return [], [contain.sentence(_NOT_A_VERSION, version=version)]
     d = checkout_dir()
     if d is None:
         return [], ["news entries are stamped in the repo, and this is not a charter "
@@ -1179,11 +1139,11 @@ def stamp(version: str) -> tuple[list[tuple[Path, Path]], list[str]]:
         slug = src.stem.split("-", 1)[1]
         dst = d / f"{version}-{slug}.md"
         if dst.exists():
-            blocked.append(_report(_NAME_TAKEN, src=src.name, dst=dst.name))
+            blocked.append(contain.sentence(_NAME_TAKEN, src=src.name, dst=dst.name))
             continue
         text = _restamp(src.read_text(), version)
         if text is None:
-            blocked.append(_report(_NOTHING_TO_STAMP, src=src.name))
+            blocked.append(contain.sentence(_NOTHING_TO_STAMP, src=src.name))
             continue
         plan.append((src, dst, text))
     if blocked:

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -115,7 +115,7 @@ def reference_refusal(ref: str) -> str | None:
         return contain.refusal(ref)
     if not valid_name(ref):
         # `contain.readable`, for the reason the branch above goes through
-        # `contain._sentence`: this sentence NAMES the offender, so the offender must not
+        # `contain.path_sentence`: this sentence NAMES the offender, so the offender must not
         # be able to write a second line of it. Newly load-bearing as of #577 — while `$`
         # admitted a trailing newline this branch was unreachable for the one character
         # that could, and the raw `.format` was safe by accident (#453, #498).

--- a/docs/news/unreleased-one-report-sentence-is-assembled-in-one-place.md
+++ b/docs/news/unreleased-one-report-sentence-is-assembled-in-one-place.md
@@ -1,0 +1,61 @@
+---
+version: unreleased
+headline: A report line is contained as it is assembled — in one place, not two that had already drifted
+---
+
+Charter had two private implementations of "contain the sentence as it is assembled", the
+argument #502 ended on. `contain._sentence` bounded every field at `PATH_DISPLAY_LIMIT`.
+`news._report`, added one version later, bounded every field at `DISPLAY_LIMIT` and joined
+a field holding several things element by element so the separator could not come from the
+data. Both were correct. Both were tested. Neither could see the other.
+
+So the two things they differed by — the budget, and what happens to a field holding
+several things — had been decided twice and written down nowhere the other copy could
+read. That is not a hypothetical: it had already happened, in one version, in the module
+whose own opening paragraph argues that a guard covering "the sites we thought of" grows a
+new hole every time a noun is added.
+
+There is one assembler now, and two public spellings of the budget:
+
+* `contain.sentence(template, **fields)` — `DISPLAY_LIMIT`, for a line that names a
+  filename, a frontmatter value, a config key.
+* `contain.path_sentence(template, **fields)` — `PATH_DISPLAY_LIMIT`, for a refusal that
+  names a resolved path, because a clipped path is one the reader cannot act on.
+
+`news`'s thirteen reports and `contain`'s thirteen refusals are call sites of those two.
+`charter/news.py` now contains no `str.format` call at all, and `charter/contain.py`
+contains exactly the assembler's own two — asserted by an AST walk over both modules, so a
+sentence assembled at a call site with an f-string is a red test rather than a review
+comment.
+
+**Two things the merge decided rather than copied.**
+
+*The sequence handling is shared, because it was never news-specific.* A sentence naming
+several committed things is what "a list of untrusted things in one line" always needs, and
+containing the *joined* string is the bug it avoids — it clips the last entries out of a
+sentence whose purpose is to name every one of them. `contain._not_plane_data` stops
+joining the plane's data-root names by hand and hands them over as a sequence.
+
+*"Several things" is now a property rather than a type.* `news._report` asked
+`isinstance(value, (list, tuple))`, which is a spelling: a caller handing a `set`, a
+`frozenset`, a `dict`'s keys or a generator fell off the end of it and got Python's own
+`repr` of the container — brackets, quotes and all — printed into charter's prose. The test
+is "is this one string, or is it something that can be iterated", with `str` and `bytes`
+named as the exception. That is the same finding as
+[#547](https://github.com/diazoxide/charter/issues/547) and
+[#558](https://github.com/diazoxide/charter/issues/558) one surface over: a check matching
+a spelling instead of the property it is about.
+
+**And two functions rather than one with a `limit=` keyword**, which is a smaller point
+worth writing down because the obvious shape is the wrong one. `**fields` makes the
+template's slot names and the function's own parameter names one namespace, so a template
+that ever grew a `{limit}` slot would have its value silently eaten as the budget and then
+raise `KeyError` out of `str.format` — inside the module whose stated rule is that nothing
+in it raises. Naming the budget by which function you call is what makes a slot name unable
+to collide with it.
+
+Nothing to adopt: no output changes. The value of the change is what the third reporting
+surface gets — `commands_persona`'s tables, `frame/registry`'s entry-point errors,
+`mcpseen` — which is one of two written-down budgets instead of a third invented one.
+
+[#576](https://github.com/diazoxide/charter/issues/576).

--- a/tests/test_a_news_entry_cannot_forge_a_report_line.py
+++ b/tests/test_a_news_entry_cannot_forge_a_report_line.py
@@ -18,7 +18,7 @@ not judged safe, it was not judged.
 **So the property is not "the filename is contained".** It is *every untrusted span in a
 report line is contained, including the ones nobody was thinking about* — and the way to
 have that is to contain the sentence as it is ASSEMBLED rather than at the spans somebody
-enumerated. `news._report` does that, and this module is what says so about spans that
+enumerated. `contain.sentence` does that, and this module is what says so about spans that
 were not enumerated: the `{version}` in the duplicate-`lead:` message is frontmatter, the
 `{check}` in a probe's reason is frontmatter, a slug is a filename with its prefix cut off,
 and the two filenames in `news stamp`'s SUCCESS line are the same pair its refusal carries.
@@ -44,7 +44,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import commands, news
+from charter import commands, contain, news
 
 _V = "0.60.0"
 
@@ -458,7 +458,7 @@ class TheGuardIsAtTheAssemblyNotAtTheSpans(unittest.TestCase):
     """
 
     def test_every_field_handed_to_report_is_contained(self):
-        said = news._report("{a} {b}", a=f"x{_LF}y", b=f"p{_LINE_SEP}q")
+        said = contain.sentence("{a} {b}", a=f"x{_LF}y", b=f"p{_LINE_SEP}q")
         self.assertEqual(len(said.splitlines()), 1, said)
 
     def test_a_sequence_is_contained_element_by_element(self):
@@ -472,16 +472,16 @@ class TheGuardIsAtTheAssemblyNotAtTheSpans(unittest.TestCase):
         repr, with the brackets and quotes of a data structure, in a sentence a person
         reads.
         """
-        said = news._report("{names}", names=[f"a{_LF}b", f"c{_LF}d"])
+        said = contain.sentence("{names}", names=[f"a{_LF}b", f"c{_LF}d"])
         self.assertEqual(said, "a\\x0ab, c\\x0ad")
 
     def test_a_sequence_is_joined_by_charter_and_not_by_python(self):
-        said = news._report("{names}", names=["one.md", "two.md"])
+        said = contain.sentence("{names}", names=["one.md", "two.md"])
         self.assertEqual(said, "one.md, two.md")
 
     def test_the_templates_are_charters_own_text(self):
         """`str.format` reads the TEMPLATE for `{}` slots and never the values, so a
         committed value holding braces is data. Asserted rather than assumed, because it
         is the reason this helper can take a template at all."""
-        said = news._report("{a}", a="{b} {0} {}")
+        said = contain.sentence("{a}", a="{b} {0} {}")
         self.assertEqual(said, "{b} {0} {}")

--- a/tests/test_a_report_line_is_assembled_in_one_place.py
+++ b/tests/test_a_report_line_is_assembled_in_one_place.py
@@ -1,0 +1,235 @@
+"""#576: "contain the sentence as it is assembled" had two private implementations.
+
+`contain._sentence` bounded every field at `PATH_DISPLAY_LIMIT`. `news._report`, added a
+version later (#573), bounded every field at `DISPLAY_LIMIT` and joined a field holding
+several things element by element. Both were correct and both were tested; neither could
+see the other, so the two differences — the budget and the sequence — were decided twice
+and written down nowhere the other copy could read.
+
+That is the argument `contain.py`'s own opening paragraph makes about `valid_name`, and
+the one `marker()`, `_shell_syntax` and `tests/_planeguard.py` were each collapsed by:
+**two lists for one concept drift, and the drift is the defect.** The third reporting
+surface is what made it concrete — `commands_persona`'s tables, `frame/registry`'s
+entry-point errors, `mcpseen` — because each one that writes its own gets a third budget
+and a third answer to "what about a list?".
+
+So there is one assembler, `contain._slots`, and two public spellings of the budget:
+:func:`contain.sentence` at `DISPLAY_LIMIT` and :func:`contain.path_sentence` at
+`PATH_DISPLAY_LIMIT`. This module states what that is supposed to buy.
+
+**Why two functions and not one with `limit=`.** ``**fields`` puts the template's slot
+names and the function's own parameter names in one namespace. A template that ever grew a
+``{limit}`` slot would have its value eaten as the budget and then raise `KeyError` out of
+`str.format`, inside the module whose stated rule is that nothing in it raises. Naming the
+budget by which function you call is what makes a slot name unable to collide with it —
+`test_no_slot_name_can_become_the_budget` is the check, and it is the same shape as every
+other finding this month: a guard matching a spelling instead of a property.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import unittest
+from pathlib import Path
+
+from charter import contain, news
+
+#: One of every way to end a line, plus one that ends no line and repaints the terminal —
+#: the payload `tests/test_a_news_entry_cannot_forge_a_report_line.py` uses, for the same
+#: reason: "newline" is four different characters depending on who is reading.
+_BREAKS = ("\n", "\r", "\x85", " ", " ", "\x1b[31m")
+
+
+class TheBudgetIsTheOnlyDifference(unittest.TestCase):
+    """Two names for one implementation. If they diverge in anything but the clip, the
+    merge did not happen and #576 is back with different function names."""
+
+    #: Values that fit inside BOTH budgets, so the two functions must agree byte for byte.
+    SHORT = ("plain", "", "with space", "a/b", "0.60.0-x.md", "\n\r ", "é", "\x00",
+             ["one.md", "two.md"], (), 7, None, Path("/tmp/x"))
+
+    def test_below_both_budgets_the_two_agree_byte_for_byte(self):
+        for value in self.SHORT:
+            with self.subTest(value=value):
+                self.assertEqual(contain.sentence("{v}", v=value),
+                                 contain.path_sentence("{v}", v=value))
+
+    def test_and_they_disagree_where_the_budgets_do(self):
+        """A path is legitimately long and a refusal that clips it is unactionable, which
+        is the whole reason `PATH_DISPLAY_LIMIT` exists. Asserted at a length between the
+        two so this fails if either budget moves onto the other."""
+        long = "x" * (contain.DISPLAY_LIMIT + 40)
+        self.assertLess(len(long), contain.PATH_DISPLAY_LIMIT)
+        self.assertEqual(contain.path_sentence("{v}", v=long), long)
+        self.assertNotEqual(contain.sentence("{v}", v=long), long)
+        self.assertEqual(len(contain.sentence("{v}", v=long)), contain.DISPLAY_LIMIT + 1)
+
+    def test_the_two_budgets_are_different_numbers(self):
+        """The premise of having two. A change that quietly made them equal would leave
+        every assertion above still passing on one of them."""
+        self.assertGreater(contain.PATH_DISPLAY_LIMIT, contain.DISPLAY_LIMIT)
+
+    def test_no_slot_name_can_become_the_budget(self):
+        """The reason the budget is a function name and not a keyword argument.
+
+        `{limit}` is an ordinary slot in charter's own template here. With a
+        ``limit=DISPLAY_LIMIT`` parameter in the signature this call binds the parameter,
+        substitutes nothing, and raises `KeyError` out of `str.format` — a refusal turned
+        back into a crash, which is the bug `_path_refusal`'s empty-path branch already
+        records once.
+        """
+        self.assertEqual(contain.sentence("{limit} is the cap", limit="160"),
+                         "160 is the cap")
+        self.assertEqual(contain.path_sentence("{limit}", limit="1024"), "1024")
+
+
+class SeveralThingsIsAPropertyNotAType(unittest.TestCase):
+    """`news._report` asked ``isinstance(value, (list, tuple))``, which is a spelling.
+
+    A caller handing a `set`, a `frozenset`, a `dict`'s keys or a generator to a sentence
+    that names several files fell off the end of that test and got Python's own `repr` of
+    the container printed into charter's prose — brackets, quotes and all — which is the
+    exact failure `test_a_sequence_is_contained_element_by_element` was written to catch
+    for a `list` and could not see one container class over.
+    """
+
+    def test_every_container_a_caller_can_reach_for_is_joined_by_charter(self):
+        for label, value in (
+            ("list", ["a.md", "b.md"]),
+            ("tuple", ("a.md", "b.md")),
+            ("set", {"a.md"}),                 # one element: a set has no order to pin
+            ("frozenset", frozenset({"a.md"})),
+            ("generator", (n for n in ("a.md", "b.md"))),
+            ("dict keys", {"a.md": 1, "b.md": 2}.keys()),
+            ("a dict itself", {"a.md": 1, "b.md": 2}),
+            ("sorted()", sorted(("b.md", "a.md"))),
+        ):
+            with self.subTest(container=label):
+                said = contain.sentence("{names}", names=value)
+                self.assertNotIn("[", said, said)
+                self.assertNotIn("'", said, said)
+                self.assertIn("a.md", said, said)
+
+    def test_a_string_is_one_thing_however_iterable_it_is(self):
+        """`str` and `bytes` are iterable and are not several things. Named as the
+        exception, so the rule can stay "can this be iterated" rather than growing into a
+        list of the container classes somebody has passed so far."""
+        self.assertEqual(contain.sentence("{v}", v="abc"), "abc")
+        self.assertEqual(contain.sentence("{v}", v=b"ab"), "b'ab'")
+
+    def test_and_the_things_that_are_not_containers_are_unchanged(self):
+        self.assertEqual(contain.sentence("{v}", v=7), "7")
+        self.assertEqual(contain.sentence("{v}", v=None), "None")
+        self.assertEqual(contain.path_sentence("{v}", v=Path("/tmp/x")), "/tmp/x")
+
+    def test_the_separator_is_charters_own(self):
+        """The literal, not `contain.SEQUENCE_SEPARATOR` interpolated into the expectation.
+
+        Written the second way first, and it survived changing the constant — a test that
+        reads the value it is checking asserts that the code equals itself. The constant
+        exists so two report surfaces cannot separate their lists differently; what pins it
+        is a rendering somebody read.
+        """
+        self.assertEqual(contain.sentence("{n}", n=["one.md", "two.md"]), "one.md, two.md")
+        self.assertEqual(contain.SEQUENCE_SEPARATOR, ", ")
+
+
+class ContainmentIsPerElementAndNotAfterTheJoin(unittest.TestCase):
+    """A sentence that names a list exists to name every entry in it.
+
+    Containing the joined string clips the tail off, so the last entries read as though
+    they were never there — which is the one thing that sentence was written to say.
+    """
+
+    def test_a_long_first_entry_does_not_cost_the_last_one(self):
+        names = ["x" * (contain.DISPLAY_LIMIT * 2), "last.md"]
+        said = contain.sentence("{n}", n=names)
+        self.assertTrue(said.endswith("last.md"), said[-40:])
+
+    def test_and_the_long_one_is_still_bounded(self):
+        """Per element, so a list of N is bounded at N budgets rather than at one — which
+        is the cost of the paragraph above and is stated rather than hidden."""
+        said = contain.sentence("{n}", n=["x" * 500])
+        self.assertEqual(len(said), contain.DISPLAY_LIMIT + 1)
+
+    def test_a_line_break_in_any_element_still_writes_one_line(self):
+        for brk in _BREAKS:
+            with self.subTest(payload=repr(brk)):
+                said = contain.sentence("{n}", n=[f"a{brk}b", "c.md"])
+                self.assertEqual(len(said.splitlines()), 1, repr(said))
+                self.assertNotIn("\x1b", said)
+
+    def test_the_template_is_read_for_slots_and_the_values_are_not(self):
+        """`str.format` reads the TEMPLATE and never the substituted values, which is what
+        lets this helper take a template at all. Held for both budgets, because a second
+        format pass added to one of them would be invisible from the other."""
+        for fn in (contain.sentence, contain.path_sentence):
+            with self.subTest(fn=fn.__name__):
+                self.assertEqual(fn("{a}", a="{b} {0} {}"), "{b} {0} {}")
+
+
+class ThereIsNoSecondCopy(unittest.TestCase):
+    """The merge is only worth anything while it stays merged."""
+
+    def test_news_no_longer_carries_its_own(self):
+        self.assertFalse(hasattr(news, "_report"),
+                         "news grew a second assembler again — it belongs in contain")
+
+    def test_every_format_call_in_these_two_modules_is_the_assemblers_own(self):
+        """The structural half, and the reason it is worth an AST walk rather than a grep.
+
+        A report sentence built with `.format` at a call site is exactly the shape #502
+        closed: the spans somebody enumerated get contained and the next one does not. So
+        in the two modules that assemble charter's report lines, the only `str.format`
+        calls that may exist are the assembler's own two.
+
+        Scoped to these two modules on purpose. Elsewhere in `charter/` a `.format` is
+        ordinary — it builds an argv element, a URL, a label out of charter's own data —
+        and a repo-wide ban would be a rule people route around rather than one they keep.
+        """
+        allowed = {"sentence", "path_sentence"}
+        for module in (contain, news):
+            source = Path(inspect.getsourcefile(module)).read_text()
+            tree = ast.parse(source)
+            # The enclosing function of every node, so a `.format` can be attributed to the
+            # `def` it sits in rather than to the line it sits on.
+            holder: dict[int, str] = {}
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    for child in ast.walk(node):
+                        holder.setdefault(id(child), node.name)
+            for node in ast.walk(tree):
+                if (isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr == "format"):
+                    where = holder.get(id(node), "<module level>")
+                    self.assertIn(
+                        where, allowed,
+                        f"{module.__name__}:{node.lineno} formats a template inside "
+                        f"{where}() — a report line is assembled in contain.sentence")
+
+
+class TheSentencesThemselvesStillSayWhatTheySaid(unittest.TestCase):
+    """End to end through the real refusals, because the paragraphs above all talk to the
+    assembler directly and a merge that broke a caller would not show up in any of them."""
+
+    def test_a_refused_name_is_one_line_that_names_the_value(self):
+        said = contain.refusal("a\nb/c")
+        self.assertEqual(len(said.splitlines()), 1, said)
+        self.assertIn("a\\x0ab/c", said)
+
+    def test_a_refused_read_names_every_directory_a_plane_keeps_data_in(self):
+        """`_not_plane_data` used to join the root names itself and hand the assembler one
+        string, so the whole list shared one budget. It hands over the names now, and the
+        thing that would go wrong — a root dropping out of the sentence that exists to say
+        which directories are the plane's — is what this asserts against.
+        """
+        said = contain._not_plane_data("/nonexistent/elsewhere")
+        for root in contain.data_roots():
+            self.assertIn(Path(root).name, said, said)
+        self.assertEqual(len(said.splitlines()), 1, said)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_report_line_is_assembled_in_one_place.py
+++ b/tests/test_a_report_line_is_assembled_in_one_place.py
@@ -230,6 +230,16 @@ class TheSentencesThemselvesStillSayWhatTheySaid(unittest.TestCase):
             self.assertIn(Path(root).name, said, said)
         self.assertEqual(len(said.splitlines()), 1, said)
 
+    def test_and_it_lists_them_alphabetically_rather_than_in_tuple_order(self):
+        """`sorted`, doing work: `data_roots()` answers personas, workspaces, persona-state
+        — which is not alphabetical — and two refusals read side by side should not differ
+        by the order a tuple happens to be written in."""
+        names = [Path(r).name for r in contain.data_roots()]
+        self.assertNotEqual(names, sorted(names),
+                            "the roots are already in order, so this proves nothing")
+        said = contain._not_plane_data("/nonexistent/elsewhere")
+        self.assertIn("(" + ", ".join(sorted(names)) + ")", said, said)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_a_server_name_cannot_declare_a_server.py
+++ b/tests/test_a_server_name_cannot_declare_a_server.py
@@ -504,7 +504,7 @@ class TestARefusalSentenceIsOneLine(unittest.TestCase):
     an untrusted value, so the value gets one line and no more.
 
     This is the surface the whole #453 audit is reported ON. Every message in `contain` is
-    formatted through `_sentence` for the same reason `mcp_servers` holds the name bound
+    formatted through `contain.path_sentence` for the same reason `mcp_servers` holds the name bound
     for all its consumers: twelve `.format` calls are twelve chances to forget the
     thirteenth.
     """

--- a/tests/test_news_ordering.py
+++ b/tests/test_news_ordering.py
@@ -384,6 +384,28 @@ class TheReleaseGateRefusesAContradiction(NewsDir):
         self.assertIn("z-important", err)
         self.assertIn("a-ordinary", err)
 
+    def test_the_claimants_are_named_in_a_stable_order(self):
+        """`sorted`, doing work — found by `tools/sweep.py`, which could delete it with the
+        suite green because the row above asserts only that both names appear.
+
+        **Asked of `entry_errors` directly, and that is the point.** Through `cmd_news` the
+        entries arrive already in name order, so the sentence comes out alphabetical whether
+        this sort is there or not — the first version of this test asserted the right thing
+        and was masked by a sort three functions upstream. Handed the claimants in the other
+        order, the sentence a release engineer reads out of CI names the same two files
+        either way round unless this sort holds, and two runs of one tree print two
+        different refusals.
+        """
+        entries = [self.entry("z-important"), self.entry("a-ordinary")]
+        said = news.entry_errors(entries)
+        self.assertEqual(len(said), 1, said)
+        self.assertLess(said[0].index("a-ordinary"), said[0].index("z-important"), said[0])
+
+    def entry(self, slug: str) -> news.Entry:
+        """A claimant, named by its file the way a real entry is."""
+        return news.Entry(version=_V, slug=slug, headline="h", check="", adopt="",
+                          body="", path=Path(f"{_V}-{slug}.md"), lead=True)
+
     def test_and_publishes_no_partial_body_while_refusing(self):
         """The announce job redirects this stdout into the notes file. A refusal that
         still printed the entries would put un-ordered notes on the Release anyway."""

--- a/tests/test_plane_writes_are_contained.py
+++ b/tests/test_plane_writes_are_contained.py
@@ -669,5 +669,47 @@ class FixedNameWritesAreContained(WriteFixtures):
         self.assertEqual("task", (config.WORKSPACES_DIR / ".default").read_text().strip())
 
 
+class TheEmptyPathIsRefusedRatherThanCreated(WriteFixtures):
+    """`_path_refusal`'s first branch, which the module's own comment records and no test
+    held (found by `tools/sweep.py`, which could delete the branch with the suite green).
+
+    ENOENT on a write means *about to be created*, and the empty path never can be. Without
+    the branch the write side answers "nothing to object to" and hands its caller an
+    unhandled `OSError` one line later — a refusal turned back into a crash, which is the
+    bug #348 shipped and fixed.
+
+    **The cwd is inside a data root here, and that is the whole fixture.** `Path("")` is
+    `Path(".")`, so `write_refusal` asks `dir_refusal` about the current directory first —
+    and from anywhere outside the plane that check refuses on its own and masks the branch
+    entirely. A test written from the suite's own directory passes whether the branch is
+    there or not, which is what "check whether a second line hides the consequence" means
+    in practice.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        config.PERSONAS_DIR.mkdir(parents=True, exist_ok=True)
+        here = os.getcwd()
+        os.chdir(config.PERSONAS_DIR)
+        self.addCleanup(os.chdir, here)
+
+    def test_the_directory_check_above_it_would_have_allowed_this(self):
+        """Non-vacuity: if the cwd stopped being plane data, the assertions below would
+        pass on the strength of `dir_refusal` and prove nothing about the branch."""
+        self.assertIsNone(contain.dir_refusal(Path("").parent, "write"))
+
+    def test_a_write_to_the_empty_path_is_refused(self):
+        said = contain.write_refusal("")
+        self.assertIsNotNone(said, "the empty path answered 'nothing to object to'")
+        self.assertIn("cannot be examined", said)
+
+    def test_and_the_raising_form_raises_rather_than_handing_back_a_path(self):
+        with self.assertRaises(contain.Refused):
+            contain.writable("")
+
+    def test_the_read_side_refuses_it_too(self):
+        self.assertIsNotNone(contain.file_refusal(""))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_the_end_of_a_name_is_the_end_of_the_string.py
+++ b/tests/test_the_end_of_a_name_is_the_end_of_the_string.py
@@ -567,7 +567,7 @@ class TestTheRefusalsThisFixMadeReachable(unittest.TestCase):
 
     `persona.reference_refusal` is fixed in this change: it is the sentence #577 quotes
     `mcpseen.label` about, `contain` was already imported, and the branch three lines above
-    it already went through `contain._sentence`.
+    it already went through `contain.path_sentence`.
 
     **The version refusals are NOT fixed here, and that is recorded rather than hidden.**
     `instance.NOT_A_VERSION` and `browser.NOT_A_VERSION` are `.format`-ed at six sites


### PR DESCRIPTION
Closes #576.

## The property

**A report line's untrusted spans are contained by one implementation, at the assembly, and the budget is the only thing a caller chooses.**

Everything below is written against that sentence rather than against the two functions that happened to exist.

## What was there

Two private copies of the argument #502 ended on — *contain the message as it is assembled, not at the spans somebody enumerated*:

| | budget | a field holding several things |
|---|---|---|
| `contain._sentence` | `PATH_DISPLAY_LIMIT` (1024) | no case for it |
| `news._report` (#573) | `DISPLAY_LIMIT` (160) | contained element by element, joined with charter's comma |

Both correct, both tested, neither able to see the other. So the two differences had been decided twice and written down nowhere the other copy could read — which is exactly what `contain.py`'s own opening paragraph says about a guard covering "the sites we thought of", and what `marker()`, `_shell_syntax` and `tests/_planeguard.py` were each collapsed to avoid.

## What is there now

One assembler, `contain._slots`, and two public spellings of the budget:

- `contain.sentence(template, **fields)` — `DISPLAY_LIMIT`; a filename, a frontmatter value, a config key.
- `contain.path_sentence(template, **fields)` — `PATH_DISPLAY_LIMIT`; a refusal naming a resolved path, because a clipped path is one the reader cannot act on.

`news._report` is gone and its thirteen call sites call `contain.sentence`. `contain._sentence` is now `path_sentence` at its thirteen.

### Two functions, not one with `limit=`

The issue offered both shapes. I took the second, and the reason is in the signature: `**fields` makes the template's slot names and the function's own parameter names **one namespace**. A template that ever grew a `{limit}` slot would have its value eaten as the budget and then raise `KeyError` out of `str.format` — inside the module whose stated rule is that no refusal function in it raises. Naming the budget by *which function you call* is what makes a slot name unable to collide with it. `test_no_slot_name_can_become_the_budget` is the check.

### The sequence handling moved into the shared one

Not a news-specific need: it is what "a list of untrusted things in one line" always requires, and containing the **joined** string is the bug it avoids — it clips the last entries out of a sentence whose purpose is to name every one of them. `contain._not_plane_data` stops joining the plane's data-root names by hand and hands them over.

### "Several things" is a property, not a type

`isinstance(value, (list, tuple))` is a spelling. A caller handing a `set`, a `frozenset`, a `dict`'s keys or a generator fell off the end of it and got Python's own `repr` of the container — brackets, quotes and all — printed into charter's prose. The test is now *is this one string, or is it something that can be iterated*, with `str` and `bytes` named as the exception. Same finding as #547 and #558 one surface over.

## The structural half

`charter/news.py` now contains **no `str.format` call at all**, and `charter/contain.py` contains exactly the assembler's own two. `test_every_format_call_in_these_two_modules_is_the_assemblers_own` walks the AST of both and attributes every `.format` to its enclosing `def`, so a sentence assembled at a call site with an f-string is a red test rather than a review comment. Scoped to those two modules deliberately — elsewhere a `.format` builds an argv element or a label, and a repo-wide ban is a rule people route around.

## Measurement

**Full suite at this head, in two environments** — 7402 tests, OK on `python3.14`, and 7402 on `python3.12` with every `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` variable unset.

**Hand-check, with an unmutated baseline and a verified restore after every mutation** (sha256 of the file compared back). 7/7 caught:

| mutation | |
|---|---|
| the sequence test back to the `(list, tuple)` spelling | caught |
| contain the **join** instead of the elements | caught |
| `path_sentence` collapses onto the display budget | caught |
| `sentence` collapses onto the path budget | caught |
| the separator comes from Python's repr, not charter | caught |
| a news report line assembled with `.format` at the call site | caught |
| a second private assembler comes back in `news` | caught |

The separator row **survived the first draft**: the test read `contain.SEQUENCE_SEPARATOR` into its own expectation, which asserts that the code equals itself. It pins the rendering now.

**`tools/sweep.py --gate`**, run locally and then on CI, found **three** survivors across two runs. Each is a line that could be deleted with the whole suite green, and each got an assertion rather than an explanation:

1. *`sorted` in `_not_plane_data`.* `data_roots()` is not in alphabetical order, so the sort does work — two refusals read side by side should not differ by the order a tuple happens to be written in.
2. *`_path_refusal`'s empty-path branch.* The module's own comment records what it is for; no test held it. The fixture is the interesting half: `Path("")` is `Path(".")`, so `write_refusal` asks `dir_refusal` about the cwd first, and from anywhere outside the plane that refuses on its own and **masks the branch entirely**. The test chdirs into the plane's own data first and carries a non-vacuity row that fails if the cwd stops being plane data.
3. *`entry_errors` sorting the two `lead:` claimants.* The existing row asserts both filenames appear and not their order.

Number 3 is worth a sentence, because **the first pin for it passed while the mutation was applied**: through `cmd_news` the entries arrive already in name order, so a sort three functions upstream produced the right answer either way. It is asked of `entry_errors` directly now, with the claimants handed over in the other order. That is the "check whether a second unpinned line hides the consequence" rule catching a test I had just written.

Each of the three is hand-checked with an unmutated baseline and a sha256-verified restore. CI's gate at this head: **0 unpinned, 0 masked, 26 pinned.**

## Behaviour

None. No output changes on any path; the roots line renders byte-identically. The value is what the third reporting surface gets — `commands_persona`'s tables, `frame/registry`'s entry-point errors, `mcpseen` — which is one of two written-down budgets instead of a third invented one.

News entry, `version: unreleased`. No bump, stamp or tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
