### PR TITLE
This plane writes its arrangement out, because slots cannot carry bg, pad or key

### DIFF
--- a/charter.toml
+++ b/charter.toml
@@ -42,6 +42,63 @@ slots = ["top", "bottom", "repos", "right"]
 # like. Three words: `off`, `dark`, `light`.
 chrome = "dark"
 
+# The arrangement, written out. `[[frame.component]]` supersedes `slots` above when it is
+# usable, and each table keeps its component's SHIPPED rectangle — omitting `edge`/`size`
+# is what asks for the default rather than overriding it. An arrangement is refused WHOLE
+# (#535): one value charter cannot read drops all four tables back to `slots`, because a
+# frame with one panel silently missing reads as a plane with no clones.
+#
+# `bg` is a WORD, never a style string — a tmux style value is format-expanded, so the
+# word is only ever a key into `FRAME_PANE_BG` and the value handed to tmux is charter's
+# own constant. Seventeen words: `default`, the eight ANSI names, their eight `bright`
+# forms. Sixteen names and not 256 is a decision: a committed `bg` is read on a machine
+# whose theme its author never saw, so it resolves against the OPERATOR's palette.
+#
+# Every pane charter draws is `brightblack` and the harness pane is left alone, which is
+# the whole look: charter's chrome is grey, the work area is the terminal's own. The pair
+# inverts on focus (`brightblack` active is `black`), so the focused panel is the one that
+# differs from its neighbours rather than the one that lights up.
+#
+# `pad` is horizontal only and comes OUT of the content budget, not on top of it: a
+# renderer composes narrower rather than composing wide and being pushed off its own edge.
+# Pinned as an equality — a 120-column `repos` at `pad = 2` composes byte-identical rows
+# to a 116-column one with none. `FRAME_PANE_PAD_MAX` is 5, derived as the largest inset
+# the 22-column sidebar can afford.
+#
+# ORDER IS THE GEOMETRY (#488/#500), and it is the same rule the `slots` list above
+# carries: `repos` is split BEFORE `sidebar`, so its table gets the full window width and
+# draws from 95 columns up. Reversed, it is split off a harness the sidebar has already
+# narrowed and needs 118 columns before it is drawn at all. `test_frame_config` asserts
+# this plane's committed order against what the geometry wants — it caught the reversal.
+#
+# `key` toggles that one component live. `F2` (palette) and `F12` (escape hatch) are
+# refused by name — measured: a component could otherwise take `F12` and tmux would read
+# back one binding with the operator's silently gone.
+
+[[frame.component]]
+use = "identity"
+bg  = "brightblack"
+pad = 1
+key = "F5"
+
+[[frame.component]]
+use = "attention"
+bg  = "brightblack"
+pad = 1
+key = "F6"
+
+[[frame.component]]
+use = "repos"
+bg  = "brightblack"
+pad = 2
+key = "F8"
+
+[[frame.component]]
+use = "sidebar"
+bg  = "brightblack"
+pad = 1
+key = "F7"
+
 [update]
 # Track main instead of the last release. `charter update` installs straight from git;
 # nothing is published, and PEP 610 gives `charter --version` the exact commit.

--- a/tests/test_component_id_is_the_currency.py
+++ b/tests/test_component_id_is_the_currency.py
@@ -473,11 +473,28 @@ class CharterOwnConfigIsUnchanged(unittest.TestCase):
         self.assertEqual(instance.frame_of(self.cfg)["slots"],
                          ["top", "bottom", "repos", "right"])
 
-    def test_it_declares_no_arrangement_so_nothing_extra_is_placed(self):
-        """`slots` is the shorthand this plane is written in, so there are no
-        `[[frame.component]]` tables and `layout` has no per-plane rectangle to read."""
-        self.assertIsNone(instance.component_tables(self.cfg.get("frame")))
-        self.assertEqual(instance.frame_of(self.cfg)["components"], [])
+    def test_the_arrangement_it_declares_resolves_to_the_frame_it_always_drew(self):
+        """This plane writes its arrangement out, and the tables must still answer the
+        shipped rectangle for every component.
+
+        It used to write `slots` and declare no tables, and this case asserted exactly
+        that. The vocabulary changed when the plane took `bg`/`pad`/`key`, which `slots`
+        cannot express — so the case now asserts the thing that was always the point:
+        **a new vocabulary has to keep answering in the old one.** The frame is
+        unchanged, and the three cases either side of this one are what say so.
+
+        The order is asserted here too, because the list is the SPLIT order and therefore
+        the geometry (#488/#500): `repos` before `right` draws the table at the full
+        window width from 95 columns up; reversed, it is split off a harness the sidebar
+        has already narrowed and needs 118. That reversal is exactly what this class
+        caught when the tables were first written."""
+        got = instance.component_tables(self.cfg.get("frame"))
+        self.assertIsNotNone(got, "this plane declares its arrangement")
+        self.assertEqual([c["slot"] for c in got], ["top", "bottom", "repos", "right"])
+        for c in got:
+            with self.subTest(use=c["use"]):
+                self.assertEqual(c["edge"], layout.SLOT_EDGE[c["slot"]])
+                self.assertEqual(c["visible"], True)
 
     def test_every_placement_is_the_built_in_it_always_was(self):
         got = instance.frame_components(self.cfg)


### PR DESCRIPTION
The operator asked for per-pane customisation to try in a later session. `[[frame.component]]` (#610) is where `bg`, `pad` and `key` live; `slots` cannot express any of them.

## What this plane now declares

```toml
[[frame.component]]   use = "identity"   bg = "brightblack"  pad = 1  key = "F5"
[[frame.component]]   use = "attention"  bg = "brightblack"  pad = 1  key = "F6"
[[frame.component]]   use = "repos"      bg = "brightblack"  pad = 2  key = "F8"
[[frame.component]]   use = "sidebar"    bg = "brightblack"  pad = 1  key = "F7"
```

Every pane charter draws is `brightblack` and the harness pane is left alone — **charter's chrome is grey, the work area is the terminal's own.** The pair inverts on focus (`brightblack` active is `black`), so the focused panel differs from its neighbours rather than lighting up.

`bg` is a word, never a style string: a tmux style value is format-expanded, so the word is only a key into `FRAME_PANE_BG` and the value handed to tmux is charter's own constant.

## The test that changed, and why it is not weakened

`CharterOwnConfigIsUnchanged` exists because *"#535 removed the repo table from charter's own plane and a reviewer caught it, not a test."* Its other three cases pin the resolved frame — the slot list, every placement's built-in identity, and the launch argv byte for byte — and **all three still pass untouched.**

The fourth asserted the *vocabulary*: "there are no `[[frame.component]]` tables". That was true and is now deliberately not. It is re-pointed at the property the class's own docstring names — **a new vocabulary has to keep answering in the old one** — asserting that the tables resolve to the shipped rectangle for every component, plus the order.

## The canary fired on its first real outing

I wrote `sidebar` before `repos`. This class caught it:

```
AssertionError: Lists differ: ['top','bottom','right','repos'] != ['top','bottom','repos','right']
```

The list is the **split order**, so it is the geometry (#488/#500). `repos` split second comes off a harness the sidebar has already narrowed — the table needs a **118-column terminal instead of 95**, and below that it is dropped entirely. A silent regression in the operator's own frame, caught by a test written for exactly this after a reviewer had to catch the last one.

That is now asserted explicitly rather than implied, and said in the config's comments.

## Verification

Full suite **7380 tests, OK**. The config change was briefly on `main` via `charter save` and reverted within minutes once the test caught it — this PR carries the pair together, which is how it should have gone the first time.