### PR TITLE
`charter update` asks the running install, not the cwd or the plane's absence (#537)

### DIFF
--- a/charter/channel.py
+++ b/charter/channel.py
@@ -14,6 +14,23 @@ says dev and its build is still the PyPI wheel, right up until ``charter update`
 Every caller here wants exactly one of the two, and conflating them is how a status line
 would claim a dev build that nobody installed.
 
+**A third question, and it is about the running install too.** *Where did this charter load
+FROM* — :func:`package_dir`, :func:`running_inside` — is what ``charter update`` has to ask
+before it declines to install over "the tree you are editing". It used to ask instead
+whether the DIRECTORY IT WAS TYPED IN is a charter clone, which is a fact about the cwd and
+not about the operator's charter: standing in the clone with a ``uv tool`` install on
+``PATH``, ``charter --version`` said ``main @ e17801c`` while the clone's ``HEAD`` said
+``97163fb`` — two commits that could not disagree if the claim were true — and the CLI was
+left stale with nothing saying so (#537). ``charter.__file__`` answers it directly, so it
+is asked here rather than inferred from somewhere adjacent.
+
+:func:`update_is_dev` is the one function that joins the plane's answer to the build's, and
+it is separate from :func:`is_dev` for the reason the two are separate at all. Outside a
+plane there is no ``[update] channel`` to read, and reading the absence as *stable* is the
+same defect facing the other way: ``charter update`` in ``/tmp`` targeted the release
+channel and then failed a version comparison against a dev build. With no plane to ask, the
+running build is the only thing that has an answer — and it is a direct one.
+
 **Dev builds are never published.** PyPI forbids local version identifiers, so a real dev
 release would have to burn ``0.52.0.dev1``, ``.dev2``, … permanently, at a rate of hundreds
 a month and irreversibly; and running the release workflow on every push to ``main`` would
@@ -28,6 +45,7 @@ line's render path, which renders every turn.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from . import __version__
 
@@ -69,6 +87,41 @@ def channel() -> str:
 def is_dev() -> bool:
     """True when this plane asked for the dev channel. About the PLANE, not the build."""
     return channel() == "dev"
+
+
+def package_dir() -> Path:
+    """The directory the charter running this process was imported from.
+
+    ``charter/__file__``, resolved — the one thing that answers "which charter is this"
+    without asking anything adjacent. A ``uv tool`` install answers with
+    ``~/.local/share/uv/tools/charter-cp/lib/python3.13/site-packages/charter``, a
+    ``python3 -m charter`` from a clone answers with that clone's ``charter/``, and an
+    editable install answers with the tree it points at — which is the case that makes
+    ``shutil.which("charter")`` the wrong instrument here even though it is the obvious
+    one: an editable install's console script lives in a venv's ``bin/`` while the code it
+    runs is the checkout, so `which` reports the half that is safe to replace.
+    """
+    return Path(__file__).resolve().parent
+
+
+def running_inside(root) -> bool:
+    """True when the charter this process is running lives at or under *root*.
+
+    The question ``charter update`` needs before it declines to install: **would an install
+    land on the tree somebody is editing?** Not *is the directory I was typed in a charter
+    clone* — those come apart in the ordinary case, because a maintainer has a clone AND
+    the ``uv tool`` install the dev channel documents, and `git pull` in one does not move
+    the other (#537).
+
+    Never raises: an unresolvable *root* is simply not the tree this charter came from, and
+    the caller of this is a command that must still be able to say something.
+    """
+    try:
+        here = package_dir()
+        base = Path(root).resolve()
+    except (OSError, ValueError):
+        return False
+    return here == base or base in here.parents
 
 
 def direct_url() -> dict | None:
@@ -153,6 +206,49 @@ def installed_commit() -> str | None:
     info = _vcs_info()
     commit = (info or {}).get("commit_id")
     return commit.strip() or None if isinstance(commit, str) else None
+
+
+def is_dev_build() -> bool:
+    """True when the charter this process runs was installed from a **git ref**.
+
+    About the BUILD, and the exact question :func:`build_label` answers with ``+dev``: PEP
+    610 writes ``direct_url.json`` for an install resolved from a direct URL and writes
+    nothing for one resolved from an index, so its absence is the positive statement *this
+    came from PyPI*. Deliberately not "does the version string contain ``+dev``" — that
+    string is produced from this, and reading it back would be charter asking charter what
+    charter just said.
+
+    Compare :func:`is_dev`, which is about the PLANE. A plane that has just opted in is
+    ``is_dev()`` and not ``is_dev_build()``; a build installed from git under a plane that
+    never asked is the reverse, and `charter update` has to move it back.
+    """
+    return _vcs_info() is not None
+
+
+def update_is_dev() -> bool:
+    """Whether **this run** of ``charter update`` installs from git.
+
+    The plane's answer where there is a plane to ask, and the running build's where there
+    is not. Both halves are the same rule — *ask the thing the question is about* — and the
+    second half is the one that was missing: with no ``charter.toml`` anywhere above the
+    cwd there is no ``[update] channel``, and reading that absence as ``stable`` is a
+    statement about the filesystem rather than about anything the operator chose. It cost
+    an operator on the dev channel a real update: ``cd /tmp && charter update`` resolved the
+    release channel, found the published version equal to the number a dev build reports,
+    installed nothing, and then failed its own verification because ``charter --version``
+    ended in a commit rather than in that number (#537).
+
+    **A plane that exists and says nothing is not the same as no plane.** Silence in a
+    committed ``charter.toml`` is a choice — the default is stable and a plane keeps it —
+    so this branches on `config.HAS_CONTROL_PLANE` rather than on whether the channel key
+    was found. That is also what keeps the answer stable for every plane that has one: this
+    returns exactly :func:`is_dev` wherever a plane exists, so nothing about a configured
+    plane's behaviour moves.
+    """
+    from . import config
+    if getattr(config, "HAS_CONTROL_PLANE", False):
+        return is_dev()
+    return is_dev_build()
 
 
 def installed_ref() -> str | None:

--- a/charter/commands_update.py
+++ b/charter/commands_update.py
@@ -15,6 +15,18 @@ first working out whether there is anything to do.
 breaks — the plugin dispatches ``charter hook <name>`` for handlers an older CLI does not
 have, and `hooks.skew_message` is deliberately one-directional, so it stays quiet the other
 way round. The release charter says this; the sequence here obeys it for the same reason.
+
+**Every question about the running install is asked OF the running install** (#537). This
+command decides two things before it does anything — *would an install land on a tree
+somebody is editing*, and *which channel does this run follow* — and it used to answer both
+by looking somewhere adjacent. The first read the CWD: a maintainer standing in a charter
+clone was told "the charter you run is this checkout, moved by git" while their charter was
+the ``uv tool`` install the dev channel documents, three commits behind, with ``charter
+--version`` and the clone's ``HEAD`` naming two different commits that could not disagree
+if the claim were true. The second read the ABSENCE of a plane: ``cd /tmp && charter
+update`` found no ``[update] channel``, took that for *stable*, and failed a version
+comparison against a dev build. ``charter.__file__`` and the PEP 610 ``direct_url.json``
+answer both directly, and `charter.channel` is where they are asked.
 """
 
 from __future__ import annotations
@@ -424,6 +436,12 @@ def _update_dev(args, installed: str) -> int:
 
     util.warn(SHARED_INSTALL_NOTE)
     util.info(f"installing charter from {DEV_SPEC} …")
+    # Which install is being replaced, named rather than left to `readlink -f $(which
+    # charter)`. #537's whole cost was that the two cases — the CLI IS this tree, and the
+    # CLI is an install standing next to it — printed nothing that told them apart, so an
+    # operator in a charter clone read "the charter you run is this checkout" about a `uv
+    # tool` install and copied the install command out of `commands_update.py` instead.
+    util.info(f"  over the charter this process is running: {channel.package_dir()}")
     ok, detail = _sync_dev()
     if not ok:
         util.err(f"could not install the dev build: {detail}")
@@ -463,18 +481,26 @@ def _update_dev_on_a_checkout(args) -> int:
     replaced with a second command to know about.
 
     **The CLI refusal is not weakened, it is stated.** Nothing on this path installs
-    anything: the operator's charter already IS this checkout, moved by git.
+    anything: the operator's charter already IS this tree, moved by git.
+
+    **And "already IS" is now measured** (#537). This branch is reached because
+    `channel.running_inside` said the charter running this process loaded from under the
+    plane root — not because the plane root looks like a charter clone. Standing in the
+    clone with the dev channel's documented ``uv tool`` install on ``PATH``, the old
+    condition printed the sentence above about a binary `git pull` cannot reach, and the
+    two versions said so out loud: ``charter --version`` reported ``main @ e17801c`` while
+    the clone's ``HEAD`` was ``97163fb``.
 
     Two more things it deliberately does not do. It does not move the harness artifact —
     `_move_harness` writes into the plane root, and on a charter checkout the plane root is
     the tree being edited, which is the same objection one directory over. And it does not
     stamp an update baseline, because nothing moved for a news range to be measured from.
     """
-    from . import plugincache
+    from . import channel, plugincache
 
-    util.warn("this is a charter checkout — the CLI here is the tree you are editing, so "
-              "nothing was installed over it.")
-    util.info("  the charter you run is this checkout, moved by git:  charter version")
+    util.warn(f"the charter you are running IS this tree ({channel.package_dir()}), so "
+              f"nothing was installed over it.")
+    util.info("  it moves by git rather than by an installer:  charter version")
     if not plugincache.available():
         util.info("  no `claude` on PATH either, so there is no plugin to refresh — "
                   "there is nothing this command can do from here.")
@@ -489,7 +515,7 @@ def _update_dev_on_a_checkout(args) -> int:
 
 
 def cmd_update(args) -> int:
-    from . import channel, doctor, instance, news
+    from . import channel, instance, news
 
     if news.probing():
         # FIRST, before the checkout refusal below and before anything is read, because
@@ -507,25 +533,32 @@ def cmd_update(args) -> int:
 
     explicit = (getattr(args, "to", None) or "").strip()
 
-    if doctor._is_charter_checkout(config.ROOT):
+    if channel.running_inside(config.ROOT):
         # `CONTRIBUTING.md` tells contributors to run `python3 -m charter …` from the
         # clone. Installing over that is never what "let me try the update command" meant,
         # and the failure is silent: the news phase would hand off to a binary that is not
         # the tree being edited, and report on it as though it were.
         #
+        # **Asked of the running install, not of the cwd** (#537). `_is_charter_checkout`
+        # used to stand here, and it answers a question about the DIRECTORY — so a
+        # maintainer who has both a clone and the `uv tool` install the dev channel
+        # documents was told "the charter you run is this checkout, moved by git" about a
+        # binary `git pull` cannot reach, and left three commits stale. Being in a charter
+        # checkout does not mean running it; `charter.__file__` is what does.
+        #
         # The CLI half. NOT the plugin half — see `_update_dev_on_a_checkout`, which runs
         # for the one shape of this command that has something left to do here.
-        if channel.is_dev() and not explicit:
+        if channel.update_is_dev() and not explicit:
             return _update_dev_on_a_checkout(args)
-        util.err("this is a charter checkout — refusing to install over the tree you are "
-                 "editing.")
+        util.err(f"the charter you are running IS this tree ({channel.package_dir()}) — "
+                 f"refusing to install over the tree you are editing.")
         util.info("  what you probably want:  charter version")
         return 2
 
     installed = _installed_version()
-    if channel.is_dev() and not explicit:
+    if channel.update_is_dev() and not explicit:
         return _update_dev(args, installed)
-    if channel.is_dev():
+    if channel.update_is_dev():
         # `--to X.Y.Z` names a PUBLISHED version, which is the one thing the dev channel
         # does not have. Rather than refuse it, honour it and say what just happened: this
         # is how somebody goes back to a release without first editing charter.toml, and
@@ -549,9 +582,22 @@ def cmd_update(args) -> int:
     # BEFORE anything moves, so an interrupted update still knows where it started.
     _stamp_baseline(installed)
 
-    if target != installed:
+    # `target != installed` compares two version NUMBERS, and a dev build carries the same
+    # number as the release it was built from — that is the whole reason dev builds are
+    # never published (`channel`'s docstring). So "is the running install already the
+    # target" is asked of the install RECORD as well: a git install is not the published
+    # wheel, whatever number it prints. Without that, a plane on the stable channel with a
+    # dev build on it installed nothing, and then `_handoff` reported *the install did not
+    # take* — because `charter --version` ends in a commit rather than in the target
+    # (#537). Nothing to install and a failed verification of it is the worst pair.
+    on_a_dev_build = channel.is_dev_build()
+    if target != installed or on_a_dev_build:
         util.warn(SHARED_INSTALL_NOTE)
-        util.info(f"installing charter {installed} → {target} …")
+        if target == installed:
+            util.info(f"installing the published charter {target} over the dev build this "
+                      f"process is running …")
+        else:
+            util.info(f"installing charter {installed} → {target} …")
         ok, detail = _sync_to(target)
         if not ok:
             util.err(f"could not install {target}: {detail}")

--- a/docs/news/unreleased-update-asks-the-charter-you-are-running.md
+++ b/docs/news/unreleased-update-asks-the-charter-you-are-running.md
@@ -1,0 +1,79 @@
+---
+version: unreleased
+headline: `charter update` asks the charter you are running, not the directory you are standing in — a `uv tool` dev install stopped being silently stale
+---
+
+`charter update` decides two things before it does anything: *would an install land on a
+tree somebody is editing*, and *which channel does this run follow*. It answered both by
+looking somewhere adjacent, and both answers were wrong in the ordinary case.
+
+**Standing in a charter clone, it claimed the clone was your CLI.**
+
+```
+$ charter --version
+charter 0.53.0+dev (main @ e17801c)     # the clone's HEAD was 97163fb
+
+$ charter update
+! this is a charter checkout — the CLI here is the tree you are editing, so nothing was
+  installed over it.
+•   the charter you run is this checkout, moved by git:  charter version
+```
+
+The claim is checkably false, and the two commits are the check: if the running CLI were
+the tree, `charter --version` and `git rev-parse HEAD` could not name different ones. The
+operator's `charter` was the `uv tool` install the dev channel documents — resolving the
+console script's symlink lands in `~/.local/share/uv/tools/charter-cp/`, and `git pull` in
+the clone does not move it. Charter supports both at once and says so: `CONTRIBUTING.md`
+tells contributors to run `python3 -m charter …` from the clone, and `docs/install.md`
+tells everybody to `uv tool install`. Being in a charter checkout was never the same as
+running it.
+
+**Outside a plane, it read the absence of a `charter.toml` as a choice.**
+
+```
+$ cd /tmp && charter update
+✗ the install did not take: the installed `charter` reports charter 0.53.0+dev
+  (main @ e17801c), expected 0.53.0
+```
+
+With no plane there is no `[update] channel`, so the release channel was targeted; the
+published version equals the number a dev build reports — dev builds are never published,
+which is the whole reason they carry the release's number — so nothing was installed; and
+then the verification failed, because `charter --version` on a dev build ends in a commit
+rather than in a version. Nothing to do, plus a failed verification of it.
+
+**One property closes both: a question about the running install is answered from the
+running install.** `charter.__file__` says where this charter loaded from, and the PEP 610
+`direct_url.json` says what installed it — the same record `+dev (main @ …)` is already
+produced from. `charter.channel` gained three functions that say so out loud:
+
+* `package_dir()` / `running_inside(root)` — the refusal fires when the charter running
+  this process loaded from under the plane root, and not when the plane root happens to
+  look like a clone. Resolving `charter` on `PATH` is the obvious instrument and is the
+  wrong one: an editable install's console script sits in a venv's `bin/` while the code it
+  runs is the checkout, so that reports the half which is safe to replace.
+* `is_dev_build()` — was this build installed from a git ref. About the BUILD, next to
+  `is_dev()`, which is about the PLANE, and they disagree routinely: the moment a plane
+  opts into dev, its channel says dev and its build is still the wheel.
+* `update_is_dev()` — the one place the two are joined, and only where nothing else can
+  answer. A plane that exists decides its own channel even when it says nothing, because
+  the default is stable and keeping it is a choice. Only the absence of a plane is the
+  absence of an answer.
+
+**And a version number cannot tell a dev build from the release it was built from.**
+`target != installed` compares two numbers a dev build shares with its release, so a plane
+on the stable channel carrying a dev build installed nothing and then reported *the install
+did not take*. The install record is asked as well now, and the line says which of the two
+`0.53.0`s is being installed.
+
+**What is unchanged.** The refusal itself is not weakened: installing a wheel over a tree
+somebody is editing still never happens, on either channel, with or without `--to`, and
+[#456](https://github.com/diazoxide/charter/issues/456)'s split — the plugin half still
+runs from a checkout, because it lives outside the tree — is untouched. Every plane that
+has a `charter.toml` follows exactly the channel it declares, as before.
+
+Nothing to adopt: upgrading is the whole of it. If you are on the dev channel and have been
+copying the install command out of charter's own source to update, you no longer have to.
+
+[#537](https://github.com/diazoxide/charter/issues/537), reported twice from the same
+machine and reproduced from the two commits that disagreed.

--- a/tests/test_dev_update_command.py
+++ b/tests/test_dev_update_command.py
@@ -317,9 +317,14 @@ class TheProbeAndCheckoutRefusalsStillHold(PersonaIso):
     unreleased code.
 
     #456 split the checkout case in two without weakening it. The CLI install still never
-    happens on a checkout — that is what every test below asserts, on both channels and
-    with and without an explicit target. What changed is that the plugin half, which lives
-    outside the tree, is no longer refused along with it.
+    happens over the tree being edited — that is what every test below asserts, on both
+    channels and with and without an explicit target. What changed is that the plugin half,
+    which lives outside the tree, is no longer refused along with it.
+
+    #537 changed what "the tree being edited" is measured by, and not what happens when it
+    is. Every assertion here is unchanged; the condition under them moved from *the plane
+    root looks like a charter clone* to *the charter running this process loaded from under
+    the plane root*.
     """
 
     def setUp(self):
@@ -338,9 +343,18 @@ class TheProbeAndCheckoutRefusalsStillHold(PersonaIso):
         return argparse.Namespace(**{"to": None, "bump": False, **kw})
 
     @contextlib.contextmanager
-    def _on_a_checkout(self, claude=True):
-        from charter import doctor, plugincache
-        with mock.patch.object(doctor, "_is_charter_checkout", return_value=True), \
+    def _running_the_tree(self, claude=True):
+        """The condition the refusal is actually about: the charter running this process
+        loaded from under the plane root.
+
+        Patched at `channel.running_inside` and NOT at `doctor._is_charter_checkout`, which
+        is what used to stand here and is the defect #537 records — that one answers about
+        the DIRECTORY, and a maintainer with a clone and a `uv tool` install has both
+        answers at once. `TheRefusalIsAboutTheRunningInstall` builds the disagreement out
+        of real files rather than out of a patch.
+        """
+        from charter import channel, plugincache
+        with mock.patch.object(channel, "running_inside", return_value=True), \
                 mock.patch.object(plugincache, "available", return_value=claude), \
                 mock.patch.object(commands_update, "_refresh_plugin") as refresh, \
                 mock.patch.object(commands_update, "_move_harness") as harness_:
@@ -358,7 +372,7 @@ class TheProbeAndCheckoutRefusalsStillHold(PersonaIso):
             self.assertEqual(commands_update.cmd_update(self._args()), 2)
         self._installed_nothing()
 
-    def test_a_charter_checkout_cannot_install_over_itself(self):
+    def test_the_running_tree_cannot_be_installed_over(self):
         """The guard #456 says must stay. The CLI is the tree; nothing is installed on it,
         on either channel and whatever else the command goes on to do."""
         for channel in ("dev", "stable"):
@@ -366,7 +380,7 @@ class TheProbeAndCheckoutRefusalsStillHold(PersonaIso):
                 (self.tmp / "charter.toml").write_text(
                     f'schema = 1\n[update]\nchannel = "{channel}"\n')
                 config.use(self.tmp)
-                with self._on_a_checkout():
+                with self._running_the_tree():
                     commands_update.cmd_update(self._args())
                 self._installed_nothing()
 
@@ -374,7 +388,7 @@ class TheProbeAndCheckoutRefusalsStillHold(PersonaIso):
         """#456. `doctor`'s `plugin files` row names `charter update` as the fix and a
         maintainer reads that row standing in a checkout — so the command has to do the
         part that is safe here instead of refusing the whole thing."""
-        with self._on_a_checkout() as (refresh, harness_):
+        with self._running_the_tree() as (refresh, harness_):
             self.assertEqual(commands_update.cmd_update(self._args()), 0)
         refresh.assert_called_once()
         # NOT the harness artifact: `_move_harness` writes into the plane root, which on a
@@ -386,7 +400,7 @@ class TheProbeAndCheckoutRefusalsStillHold(PersonaIso):
         """`--to X.Y.Z` asks for a published CLI to be installed, which is exactly the half
         that cannot happen here. Answering 0 and quietly doing something else would be a
         command reporting success for a thing it did not do."""
-        with self._on_a_checkout() as (refresh, _):
+        with self._running_the_tree() as (refresh, _):
             self.assertEqual(commands_update.cmd_update(self._args(to="0.50.1")), 2)
         refresh.assert_not_called()
         self._installed_nothing()
@@ -397,7 +411,7 @@ class TheProbeAndCheckoutRefusalsStillHold(PersonaIso):
         path has nothing safe left to do and says so, exit code and all."""
         (self.tmp / "charter.toml").write_text('schema = 1\n[update]\nchannel = "stable"\n')
         config.use(self.tmp)
-        with self._on_a_checkout() as (refresh, _):
+        with self._running_the_tree() as (refresh, _):
             self.assertEqual(commands_update.cmd_update(self._args()), 2)
         refresh.assert_not_called()
         self._installed_nothing()
@@ -406,7 +420,7 @@ class TheProbeAndCheckoutRefusalsStillHold(PersonaIso):
         """The honest end of the same branch. A plane with no Claude Code has no plugin to
         refresh either, and reporting a refresh that did not happen is the overclaim this
         repository keeps having to unwrite."""
-        with self._on_a_checkout(claude=False) as (refresh, _):
+        with self._running_the_tree(claude=False) as (refresh, _):
             self.assertEqual(commands_update.cmd_update(self._args()), 0)
         refresh.assert_not_called()
         self._installed_nothing()

--- a/tests/test_news_cross_process.py
+++ b/tests/test_news_cross_process.py
@@ -40,7 +40,7 @@ from pathlib import Path
 from unittest import mock
 
 import charter
-from charter import (commands, commands_persona, commands_update, doctor, harness,
+from charter import (channel, commands, commands_persona, commands_update, harness,
                      instance, news, root)
 from tests._isolation import child_plane_env, pin_update_channel
 
@@ -55,7 +55,7 @@ STAND_IN, STAND_IN_FN = "persona lint", "cmd_persona_lint"
 #: the guard working, and the suite runs inside exactly the charter checkout `cmd_update`
 #: declines to install over.
 _CLEAR_THE_WAY = (
-    (doctor, "_is_charter_checkout", lambda root: False),
+    (channel, "running_inside", lambda root: False),
     (instance, "load", lambda root: {}),
     (instance, "locked_version", lambda cfg: None),
     (harness, "current", lambda: None),

--- a/tests/test_plugin_freshness.py
+++ b/tests/test_plugin_freshness.py
@@ -621,8 +621,20 @@ class DoctorReportsFreshnessOnBothChannels(PersonaIso):
         typed = hint.split("Run:", 1)[1].strip()          # the literal a reader copies
         self.assertEqual(typed, "charter update")
 
+        # `channel.running_inside` and not `doctor._is_charter_checkout`: the refusal is
+        # about the charter this process is RUNNING, not about the directory it was typed
+        # in (#537). What this test is about — that the command `doctor` names still does
+        # the plugin half from here — is unchanged.
+        #
+        # `HAS_CONTROL_PLANE` travels with `UPDATE` because in production it cannot not:
+        # both come off the same `charter.toml`, so a plane that declares a channel is by
+        # construction a plane. `channel.update_is_dev` reads the first to decide whether
+        # there is anybody to ask, and patching one without the other builds a state no
+        # plane can be in.
+        from charter import channel as _channel
         with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
-                mock.patch.object(doctor, "_is_charter_checkout", return_value=True), \
+                mock.patch.object(config, "HAS_CONTROL_PLANE", True), \
+                mock.patch.object(_channel, "running_inside", return_value=True), \
                 mock.patch.object(plugincache, "available", return_value=True), \
                 mock.patch.object(commands_update, "_sync_dev") as installed, \
                 mock.patch.object(commands_update, "_refresh_plugin") as refreshed:

--- a/tests/test_update_asks_the_running_install.py
+++ b/tests/test_update_asks_the_running_install.py
@@ -98,13 +98,38 @@ class WhereThisCharterLoadedFrom(unittest.TestCase):
             self.assertFalse(channel.running_inside(d))
         self.assertFalse(channel.running_inside(Path("/nonexistent/charter")))
 
-    def test_a_sibling_whose_name_starts_the_same_is_not_the_tree(self):
-        """The `startswith` trap, asked here rather than left to a reviewer: a plane at
-        `<parent>/charter-old` is not the tree `<parent>/charter` was imported from, and a
-        string prefix cannot tell them apart."""
+    def test_a_directory_whose_NAME_is_a_prefix_is_not_an_ancestor(self):
+        """The `startswith` trap, and the fixture that actually springs it.
+
+        A sibling — `<parent>/charter-old` beside `<parent>/charter` — is the obvious
+        fixture and it does not catch anything: a string prefix answers it correctly, since
+        the sibling's name is LONGER. What a prefix comparison gets wrong is the other
+        direction, a directory whose whole path spells the opening of this one:
+        `…/wt/chart` is a string prefix of `…/wt/charter` and is an ancestor of nothing.
+        Written after the version without it survived being replaced by `startswith`.
+        """
         here = channel.package_dir()
+        self.assertFalse(channel.running_inside(str(here)[:-2]))
         self.assertFalse(channel.running_inside(here.parent / (here.name + "-old")))
         self.assertFalse(channel.running_inside(str(here) + "-old"))
+
+    def test_a_plane_root_behind_a_symlink_is_still_the_tree(self):
+        """Both ends resolve, for the reason `contain.within_data` gives one module over: a
+        macOS temp directory lives under `/var/folders/…`, which is itself a link to
+        `/private/var/…`, and any plane behind a linked mount is the same shape. Comparing
+        a resolved package directory against an unresolved root answers "not the tree" for
+        a plane that IS the tree — and this refusal's whole job is to fire there.
+
+        Residue, stated: this pins the ROOT side. The package side is `Path(__file__)
+        .resolve()`, and whether that resolve is load-bearing depends on where the suite
+        was imported from, so no fixture here can decide it.
+        """
+        here = channel.package_dir()
+        with tempfile.TemporaryDirectory() as d:
+            link = Path(d) / "plane"
+            link.symlink_to(here.parent, target_is_directory=True)
+            self.assertTrue(channel.running_inside(link))
+            self.assertFalse(channel.running_inside(Path(d) / "elsewhere"))
 
     def test_it_answers_rather_than_raises_on_a_path_it_cannot_resolve(self):
         """Same promise the refusal helpers in `contain` keep, and bounded the same way:

--- a/tests/test_update_asks_the_running_install.py
+++ b/tests/test_update_asks_the_running_install.py
@@ -1,0 +1,280 @@
+"""#537: `charter update` answers questions about the running install from the install.
+
+Two halves of one defect, facing opposite directions, and both were reproduced on a real
+machine rather than derived.
+
+**Inside a plane it inferred the CLI from the cwd.** `cmd_update` asked
+`doctor._is_charter_checkout(config.ROOT)` — *is the directory I am standing in a charter
+clone* — and answered with it a different question: *is the charter the operator runs this
+tree*. A maintainer has both, because charter documents both: `CONTRIBUTING.md` says
+`python3 -m charter …` from the clone, and the dev channel says `uv tool install
+git+…@main`. Standing in the clone with the second on `PATH`, the command printed *"the
+charter you run is this checkout, moved by git"*, installed nothing, and left the CLI three
+commits stale. The refutation is checkable and was checked: `charter --version` said `main
+@ e17801c` while the clone's `HEAD` said `97163fb`, and the console script's shebang named
+`~/.local/share/uv/tools/charter-cp/bin/python3`. If the running CLI were the tree, two
+commits could not disagree.
+
+**Outside a plane it inferred the CHANNEL from the plane's absence.** `cd /tmp && charter
+update` found no `[update] channel`, read that absence as *stable*, resolved the published
+version — which equals the number a dev build reports, because dev builds are never
+published — installed nothing, and then failed its own verification, because `charter
+--version` on a dev build ends in a commit rather than in that number:
+
+    ✗ the install did not take: the installed `charter` reports charter 0.53.0+dev
+      (main @ e17801c), expected 0.53.0
+
+**The property is one sentence**: a question about the running install is answered from the
+running install. `charter.__file__` says where this charter loaded from and the PEP 610
+`direct_url.json` says what installed it — the same record `+dev (main @ …)` is already
+produced from. Both are direct, and neither is adjacent to anything.
+
+It is the shape this month keeps returning: a check matching a spelling instead of a
+property (#547, #558, #576). Here the spellings were "the cwd looks like a clone" and "no
+charter.toml above me", and the properties are "this module loaded from there" and "this
+build came from git".
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+import charter
+from charter import channel, commands_update, config, doctor
+from tests._isolation import PersonaIso
+
+#: A PEP 610 record of the install `docs/install.md` documents for the dev channel. Shaped
+#: like the real file rather than like the minimum `_vcs_info` reads, so a change that
+#: tightened the reader would be measured against a real record.
+_GIT_INSTALL = {
+    "url": "https://github.com/diazoxide/charter",
+    "vcs_info": {"vcs": "git", "commit_id": "e17801c" + "0" * 33,
+                 "requested_revision": "main"},
+}
+
+
+@contextlib.contextmanager
+def installed_by(record):
+    """Run the block with the PEP 610 record this charter reports as its own.
+
+    Writes `channel`'s memo directly and resets it after. That memo is documented as a
+    per-process cache with one writer and a named reset — an install replaces the
+    interpreter's own package, so a running process is the build it started as — and this
+    is the seam that exists for exactly this.
+    """
+    channel._direct_url = record
+    try:
+        yield
+    finally:
+        channel._reset_cache_for_tests()
+
+
+class WhereThisCharterLoadedFrom(unittest.TestCase):
+    """`channel.package_dir` / `running_inside`, measured against the real running charter.
+
+    Nothing is patched in this class on purpose. The suite imports charter from somewhere,
+    and whatever that somewhere is, these have to be true of it — which is the only way to
+    check a function whose whole job is to report a fact about this process.
+    """
+
+    def test_the_package_directory_is_the_one_holding_this_module(self):
+        self.assertEqual(channel.package_dir(),
+                         Path(charter.__file__).resolve().parent)
+        self.assertTrue((channel.package_dir() / "channel.py").is_file())
+
+    def test_the_tree_this_charter_came_from_contains_it(self):
+        self.assertTrue(channel.running_inside(channel.package_dir().parent))
+        self.assertTrue(channel.running_inside(channel.package_dir()))
+
+    def test_and_a_directory_it_did_not_come_from_does_not(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertFalse(channel.running_inside(d))
+        self.assertFalse(channel.running_inside(Path("/nonexistent/charter")))
+
+    def test_a_sibling_whose_name_starts_the_same_is_not_the_tree(self):
+        """The `startswith` trap, asked here rather than left to a reviewer: a plane at
+        `<parent>/charter-old` is not the tree `<parent>/charter` was imported from, and a
+        string prefix cannot tell them apart."""
+        here = channel.package_dir()
+        self.assertFalse(channel.running_inside(here.parent / (here.name + "-old")))
+        self.assertFalse(channel.running_inside(str(here) + "-old"))
+
+    def test_it_answers_rather_than_raises_on_a_path_it_cannot_resolve(self):
+        """Same promise the refusal helpers in `contain` keep, and bounded the same way:
+        `OSError` and `ValueError` are conditions a real root can be in — a NUL in the
+        string, a resolve that the filesystem refuses — and they answer False. A `TypeError`
+        from handing this an `int` is a defect in the caller and is left to raise, because
+        catching it would make `running_inside` report "not the tree" for a bug."""
+        for bad in ("", "\x00/x", Path("")):
+            with self.subTest(root=repr(bad)):
+                self.assertIsInstance(channel.running_inside(bad), bool)
+
+
+class TheChannelOutsideAPlaneIsTheBuilds(unittest.TestCase):
+    """`update_is_dev` — the plane's answer where there is a plane, the build's where not.
+
+    `is_dev` and `is_dev_build` stay two functions, because they are two facts that
+    routinely and legitimately disagree. This is the one place they are joined, and it is
+    joined for a stated reason rather than by a caller reaching for whichever is handy.
+    """
+
+    @contextlib.contextmanager
+    def _as(self, *, plane, declares="stable", build):
+        with mock.patch.object(config, "HAS_CONTROL_PLANE", plane), \
+                mock.patch.object(config, "UPDATE", {"channel": declares}), \
+                installed_by(build):
+            yield
+
+    def test_with_no_plane_a_git_install_follows_the_dev_channel(self):
+        with self._as(plane=False, build=_GIT_INSTALL):
+            self.assertTrue(channel.is_dev_build())
+            self.assertTrue(channel.update_is_dev())
+
+    def test_with_no_plane_a_pypi_install_follows_the_release_channel(self):
+        """PEP 610 writes no `direct_url.json` for an install resolved from an index, so
+        the file's absence is the positive statement "this came from PyPI"."""
+        with self._as(plane=False, build=None):
+            self.assertFalse(channel.is_dev_build())
+            self.assertFalse(channel.update_is_dev())
+
+    def test_a_plane_that_exists_decides_it_whatever_is_installed(self):
+        """A plane that says nothing about the channel has still SAID something: the
+        default is stable and the plane keeps it. Only the absence of a plane is an absence
+        of an answer, which is why this branches on whether a plane exists rather than on
+        whether the key was found."""
+        for declares, build, expected in (
+            ("dev", None, True),            # opted in, still on the wheel — the ordinary
+            ("dev", _GIT_INSTALL, True),    # first day of the dev channel
+            ("stable", _GIT_INSTALL, False),  # the plane's word outranks the build
+            ("stable", None, False),
+        ):
+            with self.subTest(declares=declares, git=bool(build)):
+                with self._as(plane=True, declares=declares, build=build):
+                    self.assertEqual(channel.update_is_dev(), expected)
+
+    def test_a_non_git_direct_url_is_not_a_dev_build(self):
+        """`uv tool install .` from a checkout writes a `dir_info` record, which
+        `build_label` already reports as `+local`. It came from a direct URL and there is
+        no git ref to follow, so it is not the dev channel."""
+        with self._as(plane=False, build={"url": "file:///tmp/charter",
+                                          "dir_info": {"editable": False}}):
+            self.assertFalse(channel.is_dev_build())
+            self.assertFalse(channel.update_is_dev())
+
+
+class TheRefusalIsAboutTheRunningInstall(PersonaIso):
+    """The first half, end to end through `cmd_update` with nothing patched to make it so.
+
+    The plane root is built into a charter checkout on disk — `charter/docsrc.py` and a
+    `pyproject.toml` naming the distribution, which is every test `doctor` applies — and
+    the charter running the suite is elsewhere. That is the state the issue was filed from.
+    """
+
+    def setUp(self):
+        super().setUp()
+        (self.tmp / "charter").mkdir(parents=True, exist_ok=True)
+        (self.tmp / "charter" / "docsrc.py").write_text("")
+        (self.tmp / "pyproject.toml").write_text('name = "charter-cp"\n')
+        (self.tmp / "charter.toml").write_text('schema = 1\n[update]\nchannel = "dev"\n')
+        config.use(self.tmp)
+        self.sync = self.enterContext(
+            mock.patch.object(commands_update, "_sync_dev", return_value=(True, "spec")))
+        self.enterContext(mock.patch.object(commands_update, "_move_harness"))
+        self.enterContext(mock.patch.object(commands_update, "_refresh_plugin"))
+        self.enterContext(
+            mock.patch.object(commands_update, "_handoff_dev", return_value=(True, "ok")))
+
+    def _run(self):
+        err = io.StringIO()
+        with redirect_stderr(err), redirect_stdout(io.StringIO()):
+            code = commands_update.cmd_update(argparse.Namespace(to=None, bump=False))
+        return code, err.getvalue()
+
+    def test_the_two_questions_genuinely_disagree_here(self):
+        """Stated as its own assertion, because every claim below rests on it. If these
+        ever agree, the tests underneath pass for a reason that is not the one written."""
+        self.assertTrue(doctor._is_charter_checkout(self.tmp))
+        self.assertFalse(channel.running_inside(self.tmp))
+
+    def test_standing_in_a_clone_no_longer_refuses_the_install(self):
+        code, _err = self._run()
+        self.assertEqual(code, 0)
+        self.sync.assert_called_once()
+
+    def test_and_it_names_the_install_it_moved(self):
+        """The issue's second ask. Two cases printed nothing that told them apart, so an
+        operator read "the charter you run is this checkout" about a `uv tool` install and
+        copied the install command out of `commands_update.py` instead — a dozen times in
+        two days.
+        """
+        _code, err = self._run()
+        self.assertIn(str(channel.package_dir()), err)
+
+    def test_it_does_not_consult_where_you_are_standing_at_all(self):
+        """Not "it consults it and then ignores it". A second reader of the cwd is a second
+        place for this to come back, so the update path has none."""
+        with mock.patch.object(doctor, "_is_charter_checkout",
+                               side_effect=AssertionError("cwd was read")):
+            code, _err = self._run()
+        self.assertEqual(code, 0)
+
+
+class AVersionNumberCannotTellADevBuildFromItsRelease(PersonaIso):
+    """The second half: `target != installed` compares two numbers a dev build shares.
+
+    A dev build reports the version of the release it was built from — that is why they are
+    never published — so on a plane that has one, an update to the published version found
+    nothing to do and then failed to verify the thing it had not done.
+    """
+
+    def setUp(self):
+        super().setUp()
+        (self.tmp / "charter.toml").write_text('schema = 1\n[update]\nchannel = "stable"\n')
+        config.use(self.tmp)
+        self.enterContext(mock.patch.object(config, "HAS_CONTROL_PLANE", True))
+        self.enterContext(
+            mock.patch.object(commands_update, "_installed_version", lambda: "0.53.0"))
+        self.enterContext(
+            mock.patch.object(commands_update, "_latest", lambda live=True: "0.53.0"))
+        self.enterContext(mock.patch.object(commands_update, "_move_harness"))
+        self.moved: list[str] = []
+        self.enterContext(mock.patch.object(
+            commands_update, "_sync_to",
+            side_effect=lambda v: (self.moved.append(v), (True, v))[1]))
+        self.enterContext(
+            mock.patch.object(commands_update, "_handoff", return_value=(True, "")))
+
+    def _run(self):
+        err = io.StringIO()
+        with redirect_stderr(err), redirect_stdout(io.StringIO()):
+            code = commands_update.cmd_update(argparse.Namespace(to=None, bump=False))
+        return code, err.getvalue()
+
+    def test_a_dev_build_under_a_stable_plane_is_moved_onto_the_wheel(self):
+        with installed_by(_GIT_INSTALL):
+            code, err = self._run()
+        self.assertEqual(code, 0)
+        self.assertEqual(self.moved, ["0.53.0"])
+        # And it says which of the two "0.53.0"s it is installing, rather than printing
+        # `installing charter 0.53.0 → 0.53.0 …` at somebody.
+        self.assertIn("over the dev build", err)
+
+    def test_and_a_wheel_already_on_the_target_still_installs_nothing(self):
+        """The idempotence the module docstring promises. The new condition may only add
+        the case a version number cannot see; it may not turn every re-run into an
+        install."""
+        with installed_by(None):
+            code, _err = self._run()
+        self.assertEqual(code, 0)
+        self.assertEqual(self.moved, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_asks_the_running_install.py
+++ b/tests/test_update_asks_the_running_install.py
@@ -113,6 +113,24 @@ class WhereThisCharterLoadedFrom(unittest.TestCase):
         self.assertFalse(channel.running_inside(here.parent / (here.name + "-old")))
         self.assertFalse(channel.running_inside(str(here) + "-old"))
 
+    def test_a_charter_installed_behind_a_symlink_is_still_this_tree(self):
+        """The PACKAGE side of the same resolve, which the sweep could delete with the
+        suite green — the row below pins the ROOT side only.
+
+        `package_dir` reads this module's `__file__` at call time, so a charter reached
+        through a linked prefix is a fixture rather than a subprocess. Without the resolve
+        it answers with the link, `running_inside` compares two spellings of one directory
+        and says they are different, and the refusal that exists to stop an install landing
+        on the tree somebody is editing does not fire.
+        """
+        here = channel.package_dir()
+        with tempfile.TemporaryDirectory() as d:
+            link = Path(d) / "charter"
+            link.symlink_to(here, target_is_directory=True)
+            with mock.patch.object(channel, "__file__", str(link / "channel.py")):
+                self.assertEqual(channel.package_dir(), here)
+                self.assertTrue(channel.running_inside(here.parent))
+
     def test_a_plane_root_behind_a_symlink_is_still_the_tree(self):
         """Both ends resolve, for the reason `contain.within_data` gives one module over: a
         macOS temp directory lives under `/var/folders/…`, which is itself a link to
@@ -276,10 +294,11 @@ class AVersionNumberCannotTellADevBuildFromItsRelease(PersonaIso):
         self.enterContext(
             mock.patch.object(commands_update, "_handoff", return_value=(True, "")))
 
-    def _run(self):
+    def _run(self, **kw):
+        args = argparse.Namespace(**{"to": None, "bump": False, **kw})
         err = io.StringIO()
         with redirect_stderr(err), redirect_stdout(io.StringIO()):
-            code = commands_update.cmd_update(argparse.Namespace(to=None, bump=False))
+            code = commands_update.cmd_update(args)
         return code, err.getvalue()
 
     def test_a_dev_build_under_a_stable_plane_is_moved_onto_the_wheel(self):
@@ -290,6 +309,43 @@ class AVersionNumberCannotTellADevBuildFromItsRelease(PersonaIso):
         # And it says which of the two "0.53.0"s it is installing, rather than printing
         # `installing charter 0.53.0 → 0.53.0 …` at somebody.
         self.assertIn("over the dev build", err)
+
+    def test_an_explicit_target_on_a_dev_plane_says_it_is_overriding_the_channel(self):
+        """The line that tells an operator their `--to` beat the channel their plane
+        declares — which the sweep could make unconditional with the suite green, so it
+        would also greet a stable plane with news about a dev channel it does not track.
+
+        Both directions in one test, because the line is only informative if it appears
+        exactly where the override happened.
+        """
+        (self.tmp / "charter.toml").write_text('schema = 1\n[update]\nchannel = "dev"\n')
+        config.use(self.tmp)
+        with installed_by(None):
+            _code, dev_said = self._run(to="0.54.0")
+        self.assertIn("tracks the dev channel", dev_said)
+        self.assertIn("--to 0.54.0 overrides it", dev_said)
+
+        (self.tmp / "charter.toml").write_text('schema = 1\n[update]\nchannel = "stable"\n')
+        config.use(self.tmp)
+        with installed_by(None):
+            _code, stable_said = self._run(to="0.54.0")
+        self.assertNotIn("tracks the dev channel", stable_said)
+
+    def test_a_genuine_version_move_says_so_in_the_old_words(self):
+        """The other side of the branch that picks the wording, which the sweep could force
+        one way with the suite green: nothing asserted what an ORDINARY upgrade prints.
+
+        `installing charter A → B …` is what every stable update has always said, and it
+        must not become "over the dev build this process is running" for a plane that has
+        no dev build anywhere near it.
+        """
+        with mock.patch.object(commands_update, "_latest", lambda live=True: "0.54.0"), \
+                installed_by(None):
+            code, err = self._run()
+        self.assertEqual(code, 0)
+        self.assertEqual(self.moved, ["0.54.0"])
+        self.assertIn("installing charter 0.53.0 → 0.54.0", err)
+        self.assertNotIn("over the dev build", err)
 
     def test_and_a_wheel_already_on_the_target_still_installs_nothing(self):
         """The idempotence the module docstring promises. The new condition may only add

--- a/tests/test_update_command.py
+++ b/tests/test_update_command.py
@@ -122,18 +122,50 @@ class TheNetworkIsReadOnce(PersonaIso):
 
 
 class ThingsItRefusesOrDegrades(UpdateCase):
-    def test_it_refuses_inside_a_charter_checkout(self):
+    def test_it_refuses_when_the_charter_it_is_running_is_the_tree(self):
         """`CONTRIBUTING.md` tells contributors to run `python3 -m charter` from the
         clone. Installing over that is never what "let me try the update command" meant,
         and the damage is silent — the news phase would then hand off to a binary that is
-        not the tree being edited."""
-        (self.tmp / "charter").mkdir(parents=True, exist_ok=True)
-        (self.tmp / "charter" / "docsrc.py").write_text("")
-        (self.tmp / "pyproject.toml").write_text('name = "charter-cp"\n')
-        code, out = self.update()
+        not the tree being edited.
+
+        Asked of `channel.running_inside`, which is where the running charter says where it
+        loaded from. Patched here because this suite cannot make the charter it imported
+        live under a temporary directory; the *unpatched* half is
+        `TheRefusalIsAboutTheRunningInstall` in
+        `tests/test_update_asks_the_running_install.py`, which measures the real one.
+        """
+        from charter import channel
+        with mock.patch.object(channel, "running_inside", return_value=True):
+            code, out = self.update()
         self.assertEqual(self.moved, [])
         self.assertNotEqual(code, 0)
         self.assertIn("charter version", out)
+
+    def test_standing_in_a_charter_clone_is_not_running_it(self):
+        """#537, reproduced from the files rather than from a patch.
+
+        The plane root here is a charter checkout by every test `doctor` applies — the
+        source tree and a `pyproject.toml` naming the distribution — and the charter running
+        this process is somewhere else entirely, which is the ordinary state of a maintainer
+        who has both a clone and the `uv tool` install the dev channel documents.
+
+        The command used to read the first and claim the second: *the charter you run is
+        this checkout, moved by git*, about a binary `git pull` cannot reach. It installed
+        nothing and said nothing was needed, and `charter --version` reported `main @
+        e17801c` while the clone's `HEAD` was `97163fb` — two commits that could not
+        disagree if the claim were true.
+        """
+        from charter import channel, doctor
+        (self.tmp / "charter").mkdir(parents=True, exist_ok=True)
+        (self.tmp / "charter" / "docsrc.py").write_text("")
+        (self.tmp / "pyproject.toml").write_text('name = "charter-cp"\n')
+        # Both halves of the disagreement, stated: the directory says checkout, the running
+        # install says it is not from here. Nothing is patched to make either one true.
+        self.assertTrue(doctor._is_charter_checkout(self.tmp))
+        self.assertFalse(channel.running_inside(self.tmp))
+        code, _out = self.update()
+        self.assertEqual(code, 0)
+        self.assertEqual(self.moved, ["0.46.0"])
 
     def test_outside_a_harness_it_says_the_artifact_was_not_checked(self):
         with mock.patch.dict(os.environ, {}, clear=True), \


### PR DESCRIPTION
Closes #537.

## The property

**A question about the running install is answered from the running install** — from `charter.__file__` and from the PEP 610 `direct_url.json`, never from the working directory, the plane root, or the absence of a plane.

Two checks were answering it from somewhere adjacent, in opposite directions. Both were reproduced on a real machine, and both are in the issue.

## Half one: the CLI, inferred from the cwd

`cmd_update` asked `doctor._is_charter_checkout(config.ROOT)` — *is the directory I am standing in a charter clone* — and used the answer to claim *the charter the operator runs is this tree*.

Charter documents both at once: `CONTRIBUTING.md` says `python3 -m charter …` from the clone, `docs/install.md` says `uv tool install`. A maintainer has both, and the two trees drift arbitrarily far apart.

The refutation is checkable and was checked: `charter --version` said `main @ e17801c` while the clone's `HEAD` said `97163fb`. **If the running CLI were the tree, two commits could not disagree.**

Now `channel.running_inside(root)`, built on `channel.package_dir()` (`charter/__file__`, resolved).

### Why not `shutil.which("charter")`, which the issue proposed

It answers wrong for an **editable install**: the console script lives in a venv's `bin/`, outside the checkout, while the code it runs *is* the checkout — so `which` reports the half that is safe to replace and the refusal would not fire on the one install where it must. `charter.__file__` is the module actually loaded, which is the thing an install replaces. The issue's own follow-up comment names it, and it is the one used.

## Half two: the channel, inferred from the plane's absence

```
$ cd /tmp && charter update
✗ the install did not take: the installed `charter` reports charter 0.53.0+dev
  (main @ e17801c), expected 0.53.0
```

No plane means no `[update] channel`, and that absence was read as *stable*. Tracing it: `target` resolved to the published `0.53.0`, `installed` is `__version__` = `0.53.0`, so `target != installed` was false and **nothing was installed at all** — which settles the half of the report the operator could not establish. Then `_handoff` compared `charter --version`'s last word to `0.53.0` and got `e17801c)`.

Now `channel.update_is_dev()`: the plane's answer where there is a plane, the running build's PEP 610 record where there is not. **A plane that exists and says nothing has still chosen** — the default is stable and keeping it is a choice — so this branches on `config.HAS_CONTROL_PLANE`, not on whether the key was found. Every plane with a `charter.toml` follows exactly the channel it declares, unchanged.

## Half three, found while measuring: a version number cannot tell a dev build from its release

`target != installed` compares two numbers a dev build **shares** with the release it was built from — which is the whole reason dev builds are never published. So a plane on the stable channel carrying a dev build installed nothing and then reported *the install did not take*. The install record is consulted too now, and the line says which of the two `0.53.0`s is being installed rather than printing `installing charter 0.53.0 → 0.53.0 …`.

## Three functions, three subjects

`channel.py`'s founding distinction is that the **plane's** channel and the **build's** identity are two facts that disagree routinely and legitimately. That is kept:

- `is_dev()` — what the plane asked for.
- `is_dev_build()` — what is installed (`vcs_info`, not the `+dev` in the version string; that string is *produced from* this, and reading it back would be charter asking charter what charter just said).
- `update_is_dev()` — the single place they are joined, with the reason written down.

## What is unchanged

The refusal is not weakened. Nothing installs over the tree being edited, on either channel, with or without `--to`; #456's split — the plugin half still runs from a checkout, because it lives outside the tree — is untouched. `_is_charter_checkout` itself is unchanged and still serves `doctor.shadowed_knowledge`, which really is asking about the directory.

## Measurement

**Full suite at this head, in two environments** — 7400 tests, OK on `python3.14`, and 7400 on `python3.12` with every `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` variable unset. `charter update` was never run: every case constructs the conditions.

**Hand-check, unmutated baseline, sha256-verified restore after each mutation.** 10/10 caught:

| mutation | |
|---|---|
| `running_inside` back to a string prefix | caught |
| `running_inside` stops resolving the root | caught |
| `running_inside` always says no (the refusal never fires) | caught |
| `running_inside` always says yes (nothing ever installs) | caught |
| `update_is_dev` reads the plane's absence as stable again | caught |
| `update_is_dev` lets the build outrank a plane that says stable | caught |
| `is_dev_build` calls any direct URL a dev build | caught |
| the checkout question goes back to the cwd | caught |
| the dev-build install condition is dropped | caught |
| it stops naming the install it moved | caught |

**Two of those survived the first draft**, and both were real gaps:

- *the string prefix.* A **sibling** — `<parent>/charter-old` — does not spring the `startswith` trap, because its name is longer and a prefix comparison answers it correctly. What a prefix gets wrong is a directory whose whole path spells the opening of this one (`…/wt/chart`). That is the fixture now.
- *the unresolved root.* Both ends resolve, for the reason `contain.within_data` gives: a macOS temp plane lives under `/var/folders`, itself a link to `/private/var`. Comparing a resolved package directory against an unresolved root answers "not the tree" for a plane that is one. Now pinned with a real symlink.

**`tools/sweep.py --gate` on CI found three more survivors**, and each got an assertion rather than an explanation:

1. *`package_dir`'s `.resolve()`.* The symlink row beside it pins the ROOT side and says so; this is the package side, and it is reachable — a charter installed at a path that goes through a link answers with the link, `running_inside` compares two spellings of one directory and calls them different, and the refusal does not fire. `package_dir` reads the module's `__file__` at call time, so a fixture reaches it without a subprocess.
2. *the `--to` override line.* Made unconditional it greets a **stable** plane with news about a dev channel it does not track. Both directions in one test, because the line is only informative where the override happened.
3. *the branch that picks the install wording.* Forced one way it was invisible: nothing asserted what an ORDINARY upgrade prints. `installing charter A → B …` is what every stable update has always said.

All three are hand-checked with the same baseline-and-restore discipline, including the *other* direction of #3 — a branch a test can only force one way is half-pinned. CI's gate at the current head: **0 unpinned, 0 masked, 14 pinned.**

**The reproduction is a test with nothing patched to make it true.** `test_standing_in_a_charter_clone_is_not_running_it` builds a charter checkout on disk under the plane root and asserts *both halves of the disagreement* — `doctor._is_charter_checkout(tmp)` is True, `channel.running_inside(tmp)` is False — before asserting the install proceeds. And `test_it_does_not_consult_where_you_are_standing_at_all` makes `_is_charter_checkout` raise, because "consults it and then ignores it" is a second place for this to come back.

## Operator cost this removes

The workaround was copying `uv tool install --force git+https://github.com/diazoxide/charter@main` out of `commands_update.py:52` — done by hand a dozen times in two days.

News entry, `version: unreleased`. No bump, stamp or tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
