### PR TITLE
A repository that names its own work tree cannot use it to reach the plane root (#504)

### DIFF
--- a/charter/gitconfig.py
+++ b/charter/gitconfig.py
@@ -1,0 +1,253 @@
+"""What a repository's own config says about where its files land — read, never asked.
+
+``core.worktree`` is git's **third** spelling of the work tree, and the only one that is not
+in the invocation. ``--work-tree`` and ``GIT_WORK_TREE`` are tokens `hooks._git_target`
+already reads off the command line and the environment. This one is a key in the
+repository's ``.git/config``: a repository carrying it has the named directory as its
+working tree for **every** command, and nothing on the command line says so — so a guard
+reading argv and environment sees a plain ``git checkout feature`` typed inside a workspace
+clone (#504).
+
+Verified end to end against git 2.50.1, not derived:
+
+    git clone <plane> /tmp/cfgclone
+    git -C /tmp/cfgclone config core.worktree <plane>
+    git -C /tmp/cfgclone rev-parse --show-toplevel      # -> <plane>
+    git -C /tmp/cfgclone checkout feature               # -> the PLANE's f.txt changed
+
+**Read rather than asked, and that is the whole design constraint.** ``git rev-parse
+--show-toplevel`` answers this exactly and costs a subprocess — some ten milliseconds — on a
+path that runs inside every PreToolUse hook, where the common case currently exits on a
+string comparison. So charter reads the file: one walk up to the repository (a handful of
+``stat`` calls, and none at all when the invocation names its own ``--git-dir``) and one
+read of a file that is under a kilobyte in every repository anybody has. Measured on this
+repository, warm: see ``tests/test_a_repository_can_name_its_own_work_tree.py``, which
+states the number rather than leaving it to be re-measured.
+
+**What is deliberately NOT read**, because each one is a cost without a matching risk:
+
+* ``git -c core.worktree=<dir>`` on the command line. Git ignores it — verified in both
+  spellings, with and without an explicit ``--git-dir``, on 2.50.1 — so the form an agent
+  would actually type reaches nothing and reading it would only manufacture refusals.
+* ``include`` / ``includeIf`` directives. Following them means a second file read per
+  invocation, with a conditional evaluation of git's own ``gitdir:``/``onbranch:`` matchers
+  behind it, on the hot path. A repository that hides ``core.worktree`` behind an include
+  is not covered; that is recorded here rather than implied away.
+* The global and system configs. Git honours ``core.worktree`` from those only when
+  ``$GIT_DIR`` is set, which the invocations this guards do not do.
+
+**Every failure answers "no work tree named".** That is fail-open by construction and it is
+the honest direction: this ADDS a subject to a guard's list, so an answer it could not
+produce leaves the guard exactly as strong as it was before this module existed, while an
+invented answer would refuse a command with nothing wrong with it.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+#: The most of a repository config that is read before this gives up.
+#:
+#: A git config is a small hand-written file — this repository's own is under a kilobyte,
+#: and the largest thing anybody puts in one is a list of remotes. The bound is here so a
+#: file that is not that cannot make a PreToolUse guard read a gigabyte off disk before it
+#: can answer. Reaching it means the tail is not parsed, which answers "no work tree named"
+#: for a key that lived past the bound — the fail-open direction this module's docstring
+#: commits to, and preferable to a hook that never returns.
+MAX_CONFIG_BYTES = 262_144
+
+#: The most of a ``.git`` FILE that is read. It holds one ``gitdir: <path>`` line.
+_MAX_POINTER_BYTES = 4096
+
+#: The escapes git's config parser understands inside a quoted value. Anything else after a
+#: backslash is that character — which is what makes ``\\`` a backslash and ``\"`` a quote.
+_ESCAPES = {"n": "\n", "t": "\t", "b": "\b"}
+
+
+def configured_work_tree(cwd, git_dir=None) -> Path | None:
+    """The directory ``core.worktree`` makes this invocation's work tree, or ``None``.
+
+    *cwd* is where the command runs — after any ``-C``, which is `hooks._git_target`'s
+    business and not this module's. *git_dir* is the repository the invocation NAMED, if it
+    named one: with ``--git-dir``/``GIT_DIR`` there is no discovery to do, and without one
+    git ascends from the cwd, so this does the same.
+
+    Relative values resolve against the **git directory**, which is git's own documented
+    rule and was checked rather than assumed: ``worktree = ../../plane`` in
+    ``<clone>/.git/config`` answers ``<clone>/../plane``, and ``../plane`` — the value that
+    looks right if you resolve against the work tree — makes git refuse the repository
+    outright.
+
+    Never raises. See the module docstring: every way this can fail answers ``None``, which
+    leaves the caller's subject list exactly as it was.
+    """
+    gd = _git_dir_at(cwd) if git_dir is None else _as_path(git_dir)
+    if gd is None:
+        return None
+    value = _core_worktree(gd)
+    if not value:
+        return None
+    return Path(value) if os.path.isabs(value) else gd / value
+
+
+def _as_path(value) -> Path | None:
+    try:
+        return Path(value)
+    except (OSError, TypeError, ValueError):
+        return None
+
+
+def _git_dir_at(cwd) -> Path | None:
+    """The ``.git`` git would discover from *cwd*, without running git.
+
+    Ascends the way git does, and stops at the first ``.git`` rather than at the first one
+    that looks like a repository: git stops there too, and a broken one is not this
+    module's to diagnose.
+
+    A ``.git`` **file** — a submodule, or a linked worktree — is followed one hop to the
+    directory it names. One, not a chain: git writes exactly one level, and a pointer that
+    pointed at another pointer would be a loop to bound rather than a case to support.
+    """
+    start = _as_path(cwd)
+    if start is None:
+        return None
+    try:
+        start = Path(os.path.abspath(start))
+    except (OSError, ValueError):
+        return None
+    for directory in (start, *start.parents):
+        dot = directory / ".git"
+        try:
+            if dot.is_dir():
+                return dot
+            if dot.is_file():
+                return _pointer_target(dot, directory)
+        except OSError:
+            return None
+    return None
+
+
+def _pointer_target(dot: Path, base: Path) -> Path | None:
+    """The directory a ``.git`` file names, or ``None``."""
+    try:
+        with open(dot, "rb") as fh:
+            head = fh.read(_MAX_POINTER_BYTES)
+    except OSError:
+        return None
+    line = head.decode("utf-8", "replace").splitlines()[:1]
+    if not line:
+        return None
+    label, sep, target = line[0].partition(":")
+    if not sep or label.strip().lower() != "gitdir":
+        return None
+    target = target.strip()
+    if not target:
+        return None
+    return Path(target) if os.path.isabs(target) else base / target
+
+
+def _core_worktree(git_dir: Path) -> str | None:
+    """``core.worktree`` out of ``<git_dir>/config``, as git reads it."""
+    try:
+        with open(git_dir / "config", "rb") as fh:
+            raw = fh.read(MAX_CONFIG_BYTES)
+    except OSError:
+        return None
+    text = raw.decode("utf-8", "replace")
+    # The common case, answered without parsing anything: the overwhelming majority of
+    # repositories have no `worktree` key at all, and a substring test over a sub-kilobyte
+    # string is what keeps this affordable on the hook path.
+    if "worktree" not in text.lower():
+        return None
+    found = None
+    for section, subsection, key, value in _pairs(text):
+        # A subsection makes it `core.<sub>.worktree`, which is a different key and does
+        # not relocate anything. Named rather than ignored, because `[core "x"]` reads like
+        # `[core]` to a scanner that only looks at the first word.
+        if section == "core" and not subsection and key == "worktree":
+            found = value
+    return found
+
+
+def _pairs(text: str):
+    """Yield ``(section, subsection, key, value)`` for a git config file's text.
+
+    A deliberately small subset of git's own parser, and the subset is stated: section
+    headers with an optional quoted subsection, ``key = value`` lines, ``#``/``;`` comments
+    outside quotes, quoted values with git's escapes, and a value continued onto the next
+    line with a trailing backslash. What it does not do is in the module docstring; what it
+    gets wrong yields a value nobody will match, which adds nothing to any caller's list.
+    """
+    section = subsection = ""
+    for line in _logical_lines(text):
+        rest = line.strip()
+        if not rest:
+            continue
+        if rest.startswith("["):
+            end = rest.find("]")
+            if end < 0:
+                continue
+            head, rest = rest[1:end].strip(), rest[end + 1:].strip()
+            if '"' in head:
+                name, _, sub = head.partition('"')
+                section, subsection = name.strip().lower(), sub.rsplit('"', 1)[0]
+            else:
+                section, subsection = head.lower(), ""
+            if not rest:
+                # `[core] worktree = x` on one line is legal git, so the remainder of a
+                # header line is a key line rather than something to drop.
+                continue
+        if rest.startswith(("#", ";")):
+            continue
+        key, sep, value = rest.partition("=")
+        if not sep:
+            continue          # a valueless key is a boolean, and never names a directory
+        yield section, subsection, key.strip().lower(), _scalar(value)
+
+
+def _logical_lines(text: str):
+    """*text*'s lines, with a trailing backslash joining a line to the next."""
+    pending = ""
+    for line in text.splitlines():
+        line = pending + line
+        pending = ""
+        if line.endswith("\\") and not line.endswith("\\\\"):
+            pending = line[:-1]
+            continue
+        yield line
+    if pending:
+        yield pending
+
+
+def _scalar(raw: str) -> str:
+    """A git config VALUE as git reads it.
+
+    Leading whitespace is git's to drop; trailing whitespace is dropped only **outside**
+    quotes, which is the whole reason this is a scanner and not a `strip` — ``"/pa th  "``
+    is a directory whose name ends in two spaces and git honours it. A ``#`` or ``;``
+    outside quotes starts a comment; inside them it is an ordinary character.
+    """
+    out: list[str] = []
+    keep = 0                              # how much of `out` survives the trailing trim
+    quoted = False
+    i, raw = 0, raw.lstrip()
+    while i < len(raw):
+        ch = raw[i]
+        if ch == "\\" and i + 1 < len(raw):
+            nxt = raw[i + 1]
+            out.append(_ESCAPES.get(nxt, nxt))
+            keep = len(out)
+            i += 2
+            continue
+        if ch == '"':
+            quoted = not quoted
+            i += 1
+            continue
+        if ch in "#;" and not quoted:
+            break
+        out.append(ch)
+        if quoted or not ch.isspace():
+            keep = len(out)
+        i += 1
+    return "".join(out[:keep])

--- a/charter/gitconfig.py
+++ b/charter/gitconfig.py
@@ -20,9 +20,12 @@ Verified end to end against git 2.50.1, not derived:
 path that runs inside every PreToolUse hook, where the common case currently exits on a
 string comparison. So charter reads the file: one walk up to the repository (a handful of
 ``stat`` calls, and none at all when the invocation names its own ``--git-dir``) and one
-read of a file that is under a kilobyte in every repository anybody has. Measured on this
-repository, warm: see ``tests/test_a_repository_can_name_its_own_work_tree.py``, which
-states the number rather than leaving it to be re-measured.
+read of a file that is under a kilobyte in every repository anybody has. Measured warm, on
+the machine this was written on: 13 µs with no repository above the cwd, 35 µs at a
+repository root with no such key, 47 µs two directories down inside one, and 65 µs where
+the key is there. ``tests/test_a_repository_can_name_its_own_work_tree.py`` holds a ceiling
+and — more usefully — asserts that no process is started to answer this, which is the
+regression a wall-clock ceiling on a fast machine would not notice.
 
 **What is deliberately NOT read**, because each one is a cost without a matching risk:
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -2423,11 +2423,12 @@ def _git_target(cwd: str, pre: list[str], env: list[str] = ()) -> list[Path]:
     HEAD is that worktree's and not the root's.
 
     **And what it costs**, since one line of it now reads the disk. The `core.worktree`
-    lookup is a walk up to the repository plus one read of a sub-kilobyte file: 14 µs where
-    there is no repository above the cwd, 41 µs for a repository with no such key — the
-    ordinary case — and 76 µs where the key is there. That is the price #497 declined to pay
-    inside a PR about something else, paid here on purpose, next to a `_plane_root_git` walk
-    that already `shlex`es the command and `realpath`s every subject this returns.
+    lookup is a walk up to the repository plus one read of a sub-kilobyte file: 13 µs with no
+    repository above the cwd, 35 µs at a repository root with no such key, 47 µs two
+    directories down inside one, and 65 µs where the key is there. That is the price #497
+    declined to pay inside a PR about something else, paid here on purpose, next to a
+    `_plane_root_git` walk that already `shlex`es the command and `realpath`s every subject
+    this returns.
     """
     here = Path(cwd or ".")
     git_dir = work_tree = None
@@ -2519,10 +2520,10 @@ def _git_target(cwd: str, pre: list[str], env: list[str] = ()) -> list[Path]:
     # **This is the one place in this function that touches the disk**, and it is what
     # #497 declined to add rather than widen into: a walk up to the repository and one
     # read of its config, on the PreToolUse path whose common case is a string comparison.
-    # Measured — 14 µs where there is no repository above the cwd, 41 µs for a repository
-    # with no such key (the ordinary case), 76 µs where the key is there — against a
-    # `_plane_root_git` walk that already runs `shlex` over the command and `realpath`s
-    # every subject. `charter.gitconfig` owns the read, the bound on it, and the list of
+    # Measured — 13 µs with no repository above the cwd, 35 µs at a repository root with
+    # no such key, 47 µs two directories down inside one, 65 µs where the key is there —
+    # against a `_plane_root_git` walk that already runs `shlex` over the command and
+    # `realpath`s every subject. `gitconfig` owns the read, the bound on it, and the list of
     # config routes it deliberately does not follow.
     from . import gitconfig
     named = _at(git_dir) if git_dir is not None else None

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -2379,16 +2379,24 @@ def _git_target(cwd: str, pre: list[str], env: list[str] = ()) -> list[Path]:
     repository's branch — and the benefit is that no single-path answer has to choose which
     of two real subjects to report.
 
+    A fourth is not an option at all, and #504 is what that cost: `core.worktree`, the key
+    in the repository's OWN config. A repository carrying it has the named directory as its
+    working tree for every command, with nothing on the command line saying so — verified on
+    git 2.50.1, where `git checkout <branch>` inside such a clone wrote that branch's content
+    into the PLANE ROOT. It is read here rather than inferred, by `charter.gitconfig`.
+
     **It is a SUPERSET of the cwd, not an enumeration of everything git will touch.** The
-    list is exactly: the cwd, always; the `--work-tree`/`GIT_WORK_TREE` if one is named; and
-    the `--git-dir`/`GIT_DIR` with its parent if one is named. That is the guarantee — every
+    list is exactly: the cwd, always; the `--work-tree`/`GIT_WORK_TREE` if one is named; the
+    `--git-dir`/`GIT_DIR` with its parent if one is named; and the `core.worktree` written in
+    the config of the repository this invocation is aimed at. That is the guarantee — every
     directory it names is a place this invocation can act on, and it never answers with less
     than the cwd — and it is deliberately NOT a claim that everything git touches appears
-    here. A submodule's own git dir, a `--namespace`, an `includeIf` that redirects a
-    worktree, and a `--git-dir` pointing at a LINKED worktree's git dir (whose HEAD is that
-    worktree's, not the root's) are all subjects this returns nothing for. Round one's
-    docstring said it "returns every subject an invocation names", which is a larger sentence
-    than the code keeps.
+    here. A submodule's own git dir, a `--namespace`, an `include`/`includeIf` that carries
+    the `core.worktree` (see `gitconfig`, which does not follow them and says why), and a
+    `--git-dir` pointing at a LINKED worktree's git dir (whose HEAD is that worktree's, not
+    the root's) are all subjects this returns nothing for. Round one's docstring said it
+    "returns every subject an invocation names", which is a larger sentence than the code
+    keeps.
 
     **Relative paths resolve against the SHELL's directory**, which is what *cwd* carries.
     A `-C` used to be `Path(args[i + 1])`, so a relative one resolved against whatever
@@ -2412,6 +2420,13 @@ def _git_target(cwd: str, pre: list[str], env: list[str] = ()) -> list[Path]:
     `_plane_root_git` is the one shell effect charter models), a `GIT_DIR` already in the
     session's environment, and `--git-dir` pointing at a linked worktree's git dir, whose
     HEAD is that worktree's and not the root's.
+
+    **And what it costs**, since one line of it now reads the disk. The `core.worktree`
+    lookup is a walk up to the repository plus one read of a sub-kilobyte file: 14 µs where
+    there is no repository above the cwd, 41 µs for a repository with no such key — the
+    ordinary case — and 76 µs where the key is there. That is the price #497 declined to pay
+    inside a PR about something else, paid here on purpose, next to a `_plane_root_git` walk
+    that already `shlex`es the command and `realpath`s every subject this returns.
     """
     here = Path(cwd or ".")
     git_dir = work_tree = None
@@ -2491,6 +2506,26 @@ def _git_target(cwd: str, pre: list[str], env: list[str] = ()) -> list[Path]:
         # question rather than a list of spellings.
         gd = _at(git_dir)
         out.extend((gd, gd / ".."))
+    # **The third spelling of the work tree, and the only one no token names.** The two
+    # above are options; `core.worktree` is a key in the repository's own `.git/config`,
+    # so a repository carrying it has the named directory as its working tree for every
+    # command and a guard reading argv and environment sees a plain `git checkout feature`
+    # typed inside a workspace clone (#504). Verified end to end on git 2.50.1: from such
+    # a clone, `git checkout <branch>` replaced the PLANE ROOT's working tree.
+    #
+    # **This is the one place in this function that touches the disk**, and it is what
+    # #497 declined to add rather than widen into: a walk up to the repository and one
+    # read of its config, on the PreToolUse path whose common case is a string comparison.
+    # Measured — 14 µs where there is no repository above the cwd, 41 µs for a repository
+    # with no such key (the ordinary case), 76 µs where the key is there — against a
+    # `_plane_root_git` walk that already runs `shlex` over the command and `realpath`s
+    # every subject. `charter.gitconfig` owns the read, the bound on it, and the list of
+    # config routes it deliberately does not follow.
+    from . import gitconfig
+    named = _at(git_dir) if git_dir is not None else None
+    configured = gitconfig.configured_work_tree(here, named)
+    if configured is not None:
+        out.append(configured)
     return out
 
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -2379,11 +2379,12 @@ def _git_target(cwd: str, pre: list[str], env: list[str] = ()) -> list[Path]:
     repository's branch — and the benefit is that no single-path answer has to choose which
     of two real subjects to report.
 
-    A fourth is not an option at all, and #504 is what that cost: `core.worktree`, the key
-    in the repository's OWN config. A repository carrying it has the named directory as its
-    working tree for every command, with nothing on the command line saying so — verified on
-    git 2.50.1, where `git checkout <branch>` inside such a clone wrote that branch's content
-    into the PLANE ROOT. It is read here rather than inferred, by `charter.gitconfig`.
+    A fourth subject is not an option at all, and #504 is what that cost: `core.worktree`,
+    git's THIRD spelling of the work tree, written as a key in the repository's OWN config.
+    A repository carrying it has the named directory as its working tree for every command,
+    with nothing on the command line saying so — verified on git 2.50.1, where `git checkout
+    <branch>` inside such a clone wrote that branch's content into the PLANE ROOT. It is
+    read here rather than inferred, by `charter.gitconfig`.
 
     **It is a SUPERSET of the cwd, not an enumeration of everything git will touch.** The
     list is exactly: the cwd, always; the `--work-tree`/`GIT_WORK_TREE` if one is named; the
@@ -2506,12 +2507,14 @@ def _git_target(cwd: str, pre: list[str], env: list[str] = ()) -> list[Path]:
         # question rather than a list of spellings.
         gd = _at(git_dir)
         out.extend((gd, gd / ".."))
-    # **The third spelling of the work tree, and the only one no token names.** The two
-    # above are options; `core.worktree` is a key in the repository's own `.git/config`,
-    # so a repository carrying it has the named directory as its working tree for every
-    # command and a guard reading argv and environment sees a plain `git checkout feature`
-    # typed inside a workspace clone (#504). Verified end to end on git 2.50.1: from such
-    # a clone, `git checkout <branch>` replaced the PLANE ROOT's working tree.
+    # **The fourth subject, and the only one no token names.** `--work-tree` and
+    # `GIT_WORK_TREE` above are git's first two spellings of the work tree; this is its
+    # third, and it is not an option — `core.worktree` is a key in the repository's own
+    # `.git/config`, so a repository carrying it has the named directory as its working
+    # tree for every command, and a guard reading argv and environment sees a plain
+    # `git checkout feature` typed inside a workspace clone (#504). Verified end to end
+    # on git 2.50.1: from such a clone, `git checkout <branch>` replaced the PLANE ROOT's
+    # working tree.
     #
     # **This is the one place in this function that touches the disk**, and it is what
     # #497 declined to add rather than widen into: a walk up to the repository and one

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -114,7 +114,16 @@ rule while one who reads a bare refusal files an issue.
   so `<plane>/.git`, `<plane>/.git/./` and `<plane>/.git/refs/..` are one question — a
   lexical parent made the last of those a live bypass for a round. What it still does not
   place is a `--git-dir` pointing at a **linked worktree's** git dir, whose HEAD is that
-  worktree's and not the root's; that one is a missed denial, never a wrong one. A `-C`
+  worktree's and not the root's; that one is a missed denial, never a wrong one. A fourth
+  spelling of the work tree is in no token at all: `core.worktree` in a repository's own
+  `.git/config` makes the named directory that repository's working tree for every command,
+  so `git checkout <branch>` typed in a workspace clone wrote into the plane root and the
+  guard saw a plain checkout in a clone. The repository's config is read now — the one
+  invocation-derived subject that costs a disk read, at 14–76 µs, stated in
+  `charter/gitconfig.py` along with the routes it declines: `git -c core.worktree=…` on the
+  command line (git ignores it, so it reaches nothing), `include`/`includeIf`, and the
+  global and system configs
+  ([#504](https://github.com/diazoxide/charter/issues/504)). A `-C`
   counts as git's
   change-directory global only **before the subcommand**, which is the only position git
   reads one in — so `git switch -C <branch>`, where `-C` is `switch`'s own `--force-create`,

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -119,7 +119,7 @@ rule while one who reads a bare refusal files an issue.
   `.git/config` makes the named directory that repository's working tree for every command,
   so `git checkout <branch>` typed in a workspace clone wrote into the plane root and the
   guard saw a plain checkout in a clone. The repository's config is read now — the one
-  invocation-derived subject that costs a disk read, at 14–76 µs, stated in
+  invocation-derived subject that costs a disk read, at 13–65 µs, stated in
   `charter/gitconfig.py` along with the routes it declines: `git -c core.worktree=…` on the
   command line (git ignores it, so it reaches nothing), `include`/`includeIf`, and the
   global and system configs

--- a/docs/news/unreleased-a-repository-can-name-its-own-work-tree.md
+++ b/docs/news/unreleased-a-repository-can-name-its-own-work-tree.md
@@ -1,0 +1,76 @@
+---
+version: unreleased
+headline: A repository that names its own work tree cannot use it to reach the plane root — `core.worktree` is the third spelling, and the plane-root guards read it now
+security: true
+---
+
+`--work-tree` and `GIT_WORK_TREE` are tokens. `core.worktree` is not: it is a key in a
+repository's own `.git/config`, and a repository carrying it has the named directory as its
+working tree for **every** command it runs. So the plane-root guards, which read a
+command's argv and environment, saw a plain `git checkout feature` typed inside a workspace
+clone — and git wrote that branch's content into the plane root.
+
+Reproduced end to end on git 2.50.1, with the plane's file changing:
+
+```
+git clone <plane> /tmp/cfgclone
+git -C /tmp/cfgclone config core.worktree <plane>
+git -C /tmp/cfgclone rev-parse --show-toplevel      # -> <plane>
+git -C /tmp/cfgclone checkout feature               # -> <plane>/f.txt is the branch's now
+```
+
+`_plane_root_branch_reason` and `_plane_root_reset_reason` both answered `None`, because
+every subject `_git_target` reported was inside the clone.
+
+`_git_target` gained the fourth subject, and its invariant is unchanged: the list only ever
+grows, and the cwd is always in it. Three routes are in
+`tests/test_plane_root_checkout_is_two_commands.py`'s corpus now, crossed with every command
+it already carries — the key read from the cwd's repository, and the same key reached from
+outside that repository by `--git-dir` and by `GIT_DIR`, both of which take the work tree
+from the config of the repository they name. The row that used to pin this as a **limit** is
+flipped to a denial in the same file.
+
+**What it costs, because that is why #497 filed this rather than doing it.** Following
+`core.worktree` means reading a config on the hot path, where the guard's common case exits
+on a string comparison. `git rev-parse --show-toplevel` answers the question exactly and
+costs a subprocess — some ten milliseconds inside a hook that runs on every Bash call — so
+charter reads the file instead: a walk up to the repository, and one read of a file that is
+under a kilobyte in every repository anybody has. Measured: **14 µs** where there is no
+repository above the cwd, **41 µs** for a repository with no such key (the ordinary case),
+**76 µs** where the key is there. `charter/gitconfig.py` owns the read and the number, and a
+test asserts no process is started to answer it — a wall-clock ceiling on a fast machine
+would not notice a later simplification onto `git rev-parse`.
+
+**git itself is the oracle for the reader.** Charter parses the config rather than asking
+git, so the thing that can go wrong is charter's reader disagreeing with git's. Every value
+form is therefore checked against `git rev-parse --show-toplevel` on the same file:
+absolute, relative (which resolves against the **git directory**, not the work tree —
+`../plane` is the value that looks right and makes git refuse the repository outright),
+quoted and unquoted values holding a space, a trailing comment, trailing whitespace, a
+capitalised section header, a value continued over a backslash, a repeated key, and
+`[core "x"]`, which is a different key and relocates nothing.
+
+**Three routes are deliberately not followed**, each recorded rather than implied away:
+
+* `git -c core.worktree=<dir>` on the command line. Git ignores it — verified in both
+  spellings, with and without an explicit `--git-dir` — so the form an agent would actually
+  type reaches nothing, and reading it would only manufacture refusals. There is a test that
+  asks git this before asserting it.
+* `include` / `includeIf` directives, which would mean a second file read per invocation
+  with git's own `gitdir:`/`onbranch:` matching behind it.
+* The global and system configs, where git honours `core.worktree` only when `$GIT_DIR` is
+  set.
+
+Every way the read can fail answers *no work tree named*, which leaves the guard exactly as
+strong as it was before this existed. That is the fail-open direction and it is the honest
+one: this ADDS a subject, so a missing answer costs coverage while an invented one would
+refuse a command with nothing wrong with it.
+
+`SECURITY.md`'s position is unmoved — guard rails, not guarantees. A repository's config has
+to already say this, so it is not the ordinary mistake the plane-root guards exist to catch;
+it is closed because a workspace clone's config is exactly the kind of thing a repo's own
+tooling writes.
+
+Nothing to adopt: upgrading is the whole of it.
+
+[#504](https://github.com/diazoxide/charter/issues/504).

--- a/docs/news/unreleased-a-repository-can-name-its-own-work-tree.md
+++ b/docs/news/unreleased-a-repository-can-name-its-own-work-tree.md
@@ -35,11 +35,11 @@ flipped to a denial in the same file.
 on a string comparison. `git rev-parse --show-toplevel` answers the question exactly and
 costs a subprocess — some ten milliseconds inside a hook that runs on every Bash call — so
 charter reads the file instead: a walk up to the repository, and one read of a file that is
-under a kilobyte in every repository anybody has. Measured: **14 µs** where there is no
-repository above the cwd, **41 µs** for a repository with no such key (the ordinary case),
-**76 µs** where the key is there. `charter/gitconfig.py` owns the read and the number, and a
-test asserts no process is started to answer it — a wall-clock ceiling on a fast machine
-would not notice a later simplification onto `git rev-parse`.
+under a kilobyte in every repository anybody has. Measured: **13 µs** with no repository
+above the cwd, **35 µs** at a repository root with no such key, **47 µs** two directories
+down inside one, **65 µs** where the key is there. `charter/gitconfig.py` owns the read and
+the numbers, and a test asserts no process is started to answer it — a wall-clock ceiling on
+a fast machine would not notice a later simplification onto `git rev-parse`.
 
 **git itself is the oracle for the reader.** Charter parses the config rather than asking
 git, so the thing that can go wrong is charter's reader disagreeing with git's. Every value

--- a/tests/test_a_repository_can_name_its_own_work_tree.py
+++ b/tests/test_a_repository_can_name_its_own_work_tree.py
@@ -1,0 +1,258 @@
+"""#504: `core.worktree` is the third spelling of the work tree, and it is in no argv.
+
+`hooks._git_target` answers with every directory a git invocation's global options and
+environment aim it at — the cwd, `-C`, `--work-tree`/`GIT_WORK_TREE`, `--git-dir`/`GIT_DIR`.
+Git has one more, and it is not a token at all: the `core.worktree` key in a repository's
+own `.git/config`. A repository carrying it has the named directory as its working tree for
+**every** command it runs, so a guard reading argv and environment sees a plain
+`git checkout feature` typed inside a workspace clone.
+
+Reproduced end to end on git 2.50.1 before a line was written, and the plane's file changed:
+
+    git clone <plane> /tmp/cfgclone
+    git -C /tmp/cfgclone config core.worktree <plane>
+    git -C /tmp/cfgclone rev-parse --show-toplevel     # -> <plane>
+    git -C /tmp/cfgclone checkout feature              # -> <plane>/f.txt is now the branch's
+
+**The oracle here is git itself.** Charter reads the config rather than running git — a
+subprocess is ten milliseconds on the PreToolUse path, where the common case exits on a
+string comparison — so the thing that could go wrong is charter's reader disagreeing with
+git's. Every value form below is therefore checked twice: what `charter.gitconfig` says, and
+what `git rev-parse --show-toplevel` says about the same file. A reader that agrees with git
+on the forms git writes is the claim; a reader that agrees with an expectation somebody
+typed is a copy of that person's belief.
+
+`tests/test_plane_root_checkout_is_two_commands.py` carries the same route through the real
+hook, crossed with every command in its corpus. This module is about the reader underneath.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import gitconfig
+
+
+def _git(*args, cwd=None):
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+
+
+class GitConfigCase(unittest.TestCase):
+    """A repository, a directory to point it at, and a way to rewrite one key by hand.
+
+    The key is written into the file directly rather than with `git config`, because a
+    repository whose `core.worktree` names a directory that does not exist is one git
+    refuses to run in at all — including refusing the `git config` that would fix it. Every
+    value form this module is about has to be reachable, and half of them are not reachable
+    through git's own writer once the first one is in place.
+    """
+
+    def setUp(self):
+        # Resolved: a macOS temp directory lives under /var/folders, itself a link to
+        # /private/var, and every answer below comes back resolved.
+        self.tmp = Path(tempfile.mkdtemp(prefix="charter-gitconfig-")).resolve()
+        self.addCleanup(self._clean)
+        self.repo = self.tmp / "repo"
+        self.elsewhere = self.tmp / "elsewhere"
+        self.spaced = self.tmp / "pl ane"
+        for d in (self.repo, self.elsewhere, self.spaced):
+            d.mkdir(parents=True)
+        _git("init", "-q", "-b", "main", str(self.repo))
+        self.config = self.repo / ".git" / "config"
+
+    def _clean(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def write(self, body: str) -> None:
+        """Replace the repository config with *body*, keeping what git needs to run."""
+        self.config.write_text("[core]\n\trepositoryformatversion = 0\n\tbare = false\n"
+                               + body)
+
+    def git_top(self):
+        """git's own answer, or ``None`` when git refuses the repository outright."""
+        got = _git("-C", str(self.repo), "rev-parse", "--show-toplevel")
+        return Path(got.stdout.strip()).resolve() if got.returncode == 0 else None
+
+    def mine(self, cwd=None):
+        got = gitconfig.configured_work_tree(cwd or self.repo)
+        return Path(got).resolve() if got is not None else None
+
+
+class CharterReadsWhatGitReads(GitConfigCase):
+    """Every value form git writes, checked against git's own answer.
+
+    The forms are not invented: absolute is what `git config core.worktree <path>` writes,
+    relative is what a hand-edited config carries, and the quoted/spaced/commented ones are
+    what git's own writer produces for a value that needs them.
+    """
+
+    def test_each_form_of_the_value_agrees_with_git(self):
+        forms = {
+            "absolute": lambda: str(self.elsewhere),
+            "relative to the GIT DIR": lambda: "../../elsewhere",
+            "quoted, with a space": lambda: f'"{self.spaced}"',
+            "unquoted, with a space": lambda: str(self.spaced),
+            "with a trailing comment": lambda: f"{self.elsewhere} # why",
+            "with trailing whitespace": lambda: f"{self.elsewhere}\t ",
+            "the section header in capitals": lambda: str(self.elsewhere),
+        }
+        for label, make in forms.items():
+            with self.subTest(form=label):
+                head = "[CORE]" if "capitals" in label else "[core]"
+                self.write(f"{head}\n\tworktree = {make()}\n")
+                theirs = self.git_top()
+                self.assertIsNotNone(theirs, f"git refused the fixture for {label}")
+                self.assertEqual(self.mine(), theirs)
+
+    def test_a_relative_value_resolves_against_the_git_dir_and_not_the_work_tree(self):
+        """Stated on its own because the wrong base looks right. `../elsewhere` is what you
+        write if you resolve against the repository's directory, and git refuses the
+        repository outright for it — the value it honours is `../../elsewhere`, one level
+        further up, because the base is `<repo>/.git`."""
+        self.write(f"[core]\n\tworktree = ../elsewhere\n")
+        self.assertIsNone(self.git_top(), "git now accepts the work-tree-relative form")
+        self.write(f"[core]\n\tworktree = ../../elsewhere\n")
+        self.assertEqual(self.mine(), self.elsewhere)
+        self.assertEqual(self.mine(), self.git_top())
+
+    def test_a_repository_with_no_such_key_names_nothing(self):
+        self.assertIsNone(gitconfig.configured_work_tree(self.repo))
+
+    def test_a_subsection_is_a_different_key(self):
+        """`[core "x"] worktree` is `core.x.worktree`, which relocates nothing — and reads
+        exactly like `[core]` to a scanner that takes the first word of the header."""
+        self.write(f'[core "x"]\n\tworktree = {self.elsewhere}\n')
+        self.assertEqual(self.git_top(), self.repo.resolve())
+        self.assertIsNone(self.mine())
+
+    def test_the_last_value_wins_the_way_it_does_in_git(self):
+        other = self.tmp / "second"
+        other.mkdir()
+        self.write(f"[core]\n\tworktree = {self.elsewhere}\n[core]\n\tworktree = {other}\n")
+        self.assertEqual(self.mine(), other.resolve())
+        self.assertEqual(self.mine(), self.git_top())
+
+    def test_a_commented_out_key_is_not_a_key(self):
+        for line in (f"#\tworktree = {self.elsewhere}", f";\tworktree = {self.elsewhere}"):
+            with self.subTest(comment=line[0]):
+                self.write(f"[core]\n{line}\n")
+                self.assertEqual(self.git_top(), self.repo.resolve())
+                self.assertIsNone(self.mine())
+
+    def test_a_value_continued_onto_the_next_line(self):
+        """A trailing backslash continues a value in git's config format. Rare for a path
+        and cheap to read correctly; the alternative is a truncated directory name, which
+        would add a subject naming somewhere nobody asked about."""
+        head, tail = str(self.elsewhere)[:6], str(self.elsewhere)[6:]
+        self.write(f"[core]\n\tworktree = {head}\\\n{tail}\n")
+        self.assertEqual(self.mine(), self.git_top())
+        self.assertEqual(self.mine(), self.elsewhere)
+
+
+class WhichRepositoryItAsks(GitConfigCase):
+    """Discovery, done the way git does it and without running git."""
+
+    def test_from_a_subdirectory_of_the_repository(self):
+        self.write(f"[core]\n\tworktree = {self.elsewhere}\n")
+        deep = self.repo / "a" / "b"
+        deep.mkdir(parents=True)
+        self.assertEqual(self.mine(cwd=deep), self.elsewhere)
+
+    def test_a_named_git_dir_skips_the_walk_entirely(self):
+        """With `--git-dir`/`GIT_DIR` there is nothing to discover, and the cwd is not the
+        repository — which is #477's whole shape one option over."""
+        self.write(f"[core]\n\tworktree = {self.elsewhere}\n")
+        got = gitconfig.configured_work_tree("/nowhere/at/all", self.repo / ".git")
+        self.assertEqual(Path(got).resolve(), self.elsewhere.resolve())
+
+    def test_a_dot_git_FILE_is_followed_one_hop(self):
+        """A submodule's `.git` is a file naming the real git dir under the superproject.
+        Built by hand rather than with `git submodule add`: the layout is the thing under
+        test, and a real submodule costs a clone to assert the same two lines.
+        """
+        modules = self.repo / ".git" / "modules" / "sub"
+        modules.mkdir(parents=True)
+        (modules / "config").write_text(f"[core]\n\tworktree = {self.elsewhere}\n")
+        sub = self.repo / "sub"
+        sub.mkdir()
+        (sub / ".git").write_text("gitdir: ../.git/modules/sub\n")
+        self.assertEqual(self.mine(cwd=sub), self.elsewhere)
+
+    def test_a_pointer_that_names_nothing_is_not_followed(self):
+        sub = self.repo / "sub"
+        sub.mkdir()
+        for junk in ("", "not a pointer\n", "gitdir:\n", "gitdir\n"):
+            with self.subTest(pointer=repr(junk)):
+                (sub / ".git").write_text(junk)
+                self.assertIsNone(gitconfig.configured_work_tree(sub))
+
+    def test_no_repository_above_the_directory_names_nothing(self):
+        self.assertIsNone(gitconfig.configured_work_tree(self.tmp))
+
+
+class WhatItCostsAndWhatItRefusesToCost(GitConfigCase):
+    """The reason #497 filed this instead of doing it: a config read on the hot path."""
+
+    def test_it_does_not_run_git(self):
+        """The property, asserted rather than timed. `git rev-parse --show-toplevel`
+        answers this question exactly and costs a process — some ten milliseconds inside a
+        PreToolUse hook that runs on every Bash call. A later simplification onto it would
+        be invisible to a wall-clock ceiling on a fast machine and is the one regression
+        worth naming, so every way of starting a process raises here.
+        """
+        self.write(f"[core]\n\tworktree = {self.elsewhere}\n")
+
+        def refuse(*a, **kw):
+            raise AssertionError("charter ran a process to read a config key")
+
+        with mock.patch.object(subprocess, "run", refuse), \
+                mock.patch.object(subprocess, "Popen", refuse):
+            self.assertEqual(self.mine(), self.elsewhere)
+
+    def test_and_it_stays_in_the_microseconds(self):
+        """A ceiling with two orders of magnitude of headroom, which is what makes it a
+        regression detector rather than a flaky timer. Measured on the machine this was
+        written on: 14 µs with no repository above the cwd, 41 µs for a repository with no
+        such key — the ordinary case — and 76 µs with the key present. The ceiling is 2 ms,
+        so a loaded CI runner has room and a subprocess does not.
+        """
+        self.write(f"[core]\n\tworktree = {self.elsewhere}\n")
+        start = time.perf_counter()
+        for _ in range(100):
+            gitconfig.configured_work_tree(self.repo)
+        each = (time.perf_counter() - start) / 100
+        self.assertLess(each, 0.002, f"{each * 1e6:.0f} µs per call")
+
+    def test_a_config_larger_than_the_bound_is_not_read_past_it(self):
+        """The bound, and the direction it fails in, said out loud. A key past
+        `MAX_CONFIG_BYTES` is not found, which answers "no work tree named" — so the guard
+        is exactly as strong as it was before this existed, rather than hanging on a file
+        that is not a config.
+        """
+        padding = "\t; " + "x" * 200 + "\n"
+        body = ("[core]\n" + padding * (gitconfig.MAX_CONFIG_BYTES // len(padding) + 8)
+                + f"\tworktree = {self.elsewhere}\n")
+        self.write(body)
+        self.assertGreater(self.config.stat().st_size, gitconfig.MAX_CONFIG_BYTES)
+        self.assertEqual(self.git_top(), self.elsewhere.resolve(),
+                         "the fixture no longer reaches git, so the bound proves nothing")
+        self.assertIsNone(self.mine())
+
+    def test_nothing_here_raises(self):
+        """Same promise the rest of the guard path keeps: a hook may cost a session its
+        briefing and never its turn."""
+        for bad in ("", "\x00/x", "/nonexistent/deep/path", self.tmp / "gone"):
+            with self.subTest(cwd=repr(bad)):
+                self.assertIsNone(gitconfig.configured_work_tree(bad))
+        self.config.write_bytes(b"[core]\n\tworktree = \xff\xfe\n")
+        self.assertIsNotNone(gitconfig.configured_work_tree(self.repo))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_repository_can_name_its_own_work_tree.py
+++ b/tests/test_a_repository_can_name_its_own_work_tree.py
@@ -218,9 +218,10 @@ class WhatItCostsAndWhatItRefusesToCost(GitConfigCase):
     def test_and_it_stays_in_the_microseconds(self):
         """A ceiling with two orders of magnitude of headroom, which is what makes it a
         regression detector rather than a flaky timer. Measured on the machine this was
-        written on: 14 µs with no repository above the cwd, 41 µs for a repository with no
-        such key — the ordinary case — and 76 µs with the key present. The ceiling is 2 ms,
-        so a loaded CI runner has room and a subprocess does not.
+        written on: 13 µs with no repository above the cwd, 35 µs at a repository root
+        with no such key, 47 µs two directories down inside one, and 65 µs with the key
+        present. The ceiling is 2 ms, so a loaded CI runner has room and a subprocess does
+        not.
         """
         self.write(f"[core]\n\tworktree = {self.elsewhere}\n")
         start = time.perf_counter()

--- a/tests/test_plane_root_checkout_is_two_commands.py
+++ b/tests/test_plane_root_checkout_is_two_commands.py
@@ -684,6 +684,13 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
         # How a session in the clone spells the plane root without naming it absolutely.
         self.up = os.path.relpath(self.root, self.clone)
         self.assertTrue(self.up.startswith(".."), self.up)
+        # #504's clone: the plane root is its work tree because its own `.git/config` says
+        # so, with nothing on any command line saying it. A route, not a spelling — which
+        # is why it gets a cwd of its own rather than a `tail` variant.
+        self.cfgclone = config.WORKSPACES_DIR / "ws" / "cfg"
+        self.cfgclone.mkdir(parents=True, exist_ok=True)
+        self._git("init", "-q", "-b", "main", str(self.cfgclone))
+        self._in(self.cfgclone, "config", "core.worktree", str(self.root))
 
     def routes(self, sub: str, rest: str):
         """``(label, cwd, command)`` for every way one shell command reaches the root."""
@@ -751,6 +758,22 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
                f"declare -x GIT_DIR={self.root}/.git && git {tail}")
         yield ("GIT_DIR exported by set -a", self.clone,
                f"set -a; GIT_DIR={self.root}/.git; git {tail}")
+        # #504: the third spelling of the work tree, and the only route on this list that
+        # is a property of a repository ON DISK. Nothing in this command line names the
+        # plane root — the argv is the bare command and the environment is empty — so it is
+        # the one route no amount of reading the invocation can reach, and the guard reads
+        # the repository's config to answer it.
+        yield "core.worktree in the repo's config", self.cfgclone, f"git {tail}"
+        # And the same key reached from OUTSIDE that repository, which is where the cwd
+        # stops being the thing to read the config of. Verified on git 2.50.1 from a second
+        # clone: both spellings answer `--show-toplevel` with the plane root, because a
+        # `--git-dir` with no `--work-tree` beside it takes the work tree from the config of
+        # the repository it names. Two rows, because `GIT_DIR` is the same option as
+        # environment and the pair is what #477 already had to learn once.
+        yield ("core.worktree reached by --git-dir", self.clone,
+               f"git --git-dir={self.cfgclone}/.git {tail}")
+        yield ("core.worktree reached by GIT_DIR", self.clone,
+               f"GIT_DIR={self.cfgclone}/.git git {tail}")
 
     def test_a_head_move_is_denied_by_every_route(self):
         movers = []
@@ -770,7 +793,7 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
         # would leave every remaining assertion green while covering less than it did.
         self.assertGreaterEqual(len(movers), 8, movers)
         labels = {label for label, _cwd, _cmd in self.routes("checkout", "feature")}
-        self.assertGreaterEqual(len(labels), 25, sorted(labels))
+        self.assertGreaterEqual(len(labels), 28, sorted(labels))
         for must in ("--git-dir, separated", "--git-dir=, attached",
                      "--work-tree and --git-dir", "--git-dir relative to a -C",
                      "GIT_DIR in the environment", "GIT_WORK_TREE in the environment",
@@ -788,7 +811,12 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
                      "GIT_WORK_TREE exported by an earlier segment",
                      "GIT_DIR assigned, then exported by name",
                      "GIT_DIR exported by declare -x",
-                     "GIT_DIR exported by set -a"):
+                     "GIT_DIR exported by set -a",
+                     # Round seven (#504). The route with no token in it at all, and the
+                     # two that name the repository whose config carries it.
+                     "core.worktree in the repo's config",
+                     "core.worktree reached by --git-dir",
+                     "core.worktree reached by GIT_DIR"):
             self.assertIn(must, labels)
 
     def test_a_restore_is_allowed_by_every_route(self):
@@ -802,34 +830,74 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
                 with self.subTest(route=label, cmd=cmd):
                     self.assertIsNone(_decision(self.run_cmd(cmd, cwd=cwd)), f"{label}: {cmd}")
 
-    def test_core_worktree_in_a_repos_config_is_a_route_this_guard_does_not_follow(self):
-        """**A LIMIT, pinned with its issue (#504).**
+    def test_core_worktree_in_a_repos_config_reaches_the_root_and_is_denied(self):
+        """**The limit this row used to pin, closed (#504).**
 
         `core.worktree` is git's THIRD spelling of the work tree, after `--work-tree` and
         `GIT_WORK_TREE`, and the only one that is a property of a repository on disk rather
         than a token on the command line. A clone carrying it has the plane root as its
-        working tree for every command it runs, and `_git_target` — which reads argv and
-        environment — sees a plain `git checkout <branch>` in a clone.
+        working tree for every command it runs, so `_git_target` — reading argv and
+        environment — saw a plain `git checkout <branch>` in a clone and stood aside.
 
-        Asserted the way a limit has to be: git is asked whether the route really reaches
-        the root, so the row cannot pass because the fixture stopped working. If it ever
-        starts being denied this fails, and #504 is where the decision is written down.
+        Still asserted the way the limit was: git is asked whether the route really reaches
+        the root, so this cannot pass because the fixture stopped working. The route is in
+        `routes()` as well, which is what crosses it with every command in `COMMANDS`; this
+        stays because it is the one row that measures the reach and the refusal in the same
+        method, and because the old version of it is what would have caught the fix being
+        reverted with the corpus left green.
 
         Not the same as `-c core.worktree=<plane>` on the command line: git 2.50.1 does not
-        honour that one — verified, `--show-toplevel` still answers the clone — so the
-        spelling an agent would actually type is already harmless.
+        honour that one — verified, `--show-toplevel` still answers the clone, with and
+        without an explicit `--git-dir` — so the spelling an agent would actually type is
+        already harmless and charter deliberately does not read it.
         """
-        clone = config.WORKSPACES_DIR / "ws" / "cfg"
-        clone.mkdir(parents=True, exist_ok=True)
-        self._git("init", "-q", "-b", "main", str(clone))
-        self._in(clone, "config", "core.worktree", str(self.root))
-        top = subprocess.run(["git", "-C", str(clone), "rev-parse", "--show-toplevel"],
+        top = subprocess.run(["git", "-C", str(self.cfgclone), "rev-parse", "--show-toplevel"],
                              capture_output=True, text=True).stdout.strip()
         self.assertEqual(Path(top).resolve(), self.root.resolve(),
                          "the fixture stopped reaching the root, so the row below proves "
                          "nothing about the guard")
-        self.assertIsNone(_decision(self.run_cmd("git checkout feature", cwd=clone)),
-                          "LIMIT #504 closed — say so in the news entry and flip this row")
+        r = self.run_cmd("git checkout feature", cwd=self.cfgclone)
+        self.assertEqual(_decision(r), "deny")
+        self.assertIn("PLANE ROOT", _reason(r))
+
+    def test_the_same_key_reached_from_outside_that_repository(self):
+        """`--git-dir` with no `--work-tree` beside it takes the work tree from the config
+        of the repository it NAMES, so the cwd is the wrong file to read — verified on git
+        2.50.1 from a second clone, which answers `--show-toplevel` with the plane root.
+
+        Its own row because the corpus above crosses it with commands and this measures the
+        reach: a guard that discovered the repository from the cwd whatever the invocation
+        said would pass every route row and miss this one.
+        """
+        for spelling in (f"git --git-dir={self.cfgclone}/.git checkout feature",
+                         f"GIT_DIR={self.cfgclone}/.git git checkout feature"):
+            with self.subTest(cmd=spelling):
+                top = subprocess.run(
+                    ["git", "-C", str(self.clone), f"--git-dir={self.cfgclone}/.git",
+                     "rev-parse", "--show-toplevel"], capture_output=True, text=True)
+                self.assertEqual(Path(top.stdout.strip()).resolve(), self.root.resolve(),
+                                 "the fixture stopped reaching the root")
+                r = self.run_cmd(spelling, cwd=self.clone)
+                self.assertEqual(_decision(r), "deny", spelling)
+                self.assertIn("PLANE ROOT", _reason(r), spelling)
+
+    def test_and_the_c_form_of_the_same_key_is_not_read(self):
+        """The other half of the same measurement, and the reason it is a separate test.
+
+        `git -c core.worktree=<plane> checkout feature` does not reach the plane root — git
+        ignores the command-line form, verified on 2.50.1 in both spellings — so reading it
+        would only manufacture a refusal for a command that does nothing. The fixture asks
+        git first, so this row cannot quietly become an assertion about a form that DOES
+        reach the root.
+        """
+        cmd = f"git -c core.worktree={self.root} checkout feature"
+        top = subprocess.run(["git", "-C", str(self.clone), "-c",
+                              f"core.worktree={self.root}", "rev-parse", "--show-toplevel"],
+                             capture_output=True, text=True).stdout.strip()
+        self.assertEqual(Path(top).resolve(), self.clone.resolve(),
+                         "git now honours -c core.worktree; this row is about a form that "
+                         "no longer exists and the guard has to read it after all")
+        self.assertIsNone(_decision(self.run_cmd(cmd, cwd=self.clone)), cmd)
 
     def test_a_route_that_does_not_reach_the_root_is_still_not_the_root(self):
         """The reach is not "anything with a `-C` in it". A relative `-C` that lands in the


### PR DESCRIPTION
Closes #504.

## The property

**A plane-root guard's subject list holds every directory a git invocation can act on — whether or not a token in that invocation says so.**

`--work-tree` and `GIT_WORK_TREE` are tokens, and `_git_target` reads both. `core.worktree` is a key in a repository's own `.git/config`, so a repository carrying it has the named directory as its working tree for **every** command it runs, and nothing on the command line says so.

## Reproduced, not derived

git 2.50.1, with the plane's file changing:

```
git clone <plane> /tmp/cfgclone
git -C /tmp/cfgclone config core.worktree <plane>
git -C /tmp/cfgclone rev-parse --show-toplevel      # -> <plane>
git -C /tmp/cfgclone checkout feature               # -> <plane>/f.txt is the branch's now
```

`_plane_root_branch_reason` and `_plane_root_reset_reason` both answered `None`.

## What changed

`_git_target` gained the fourth subject. **Its invariant is unchanged** — the list only ever grows, the cwd is always in it, and `test_the_subject_list_only_ever_grows` still holds. In particular the config-derived subject is added even when a `--work-tree` is named, although git's precedence says that overrides it: a subject list that shrinks as the command line grows is the flag-shaped bypass that invariant exists to forbid.

`tests/test_plane_root_checkout_is_two_commands.py` gains **three routes**, crossed with every command in its corpus:

| route | why it is separate |
|---|---|
| `core.worktree` in the repo's config | nothing in the argv names the root |
| the same key reached by `--git-dir` | a `--git-dir` with no `--work-tree` takes the work tree from the config of the repository it *names*, so the cwd is the wrong file to read |
| the same key reached by `GIT_DIR` | the same option as environment, which #477 already had to learn once |

The row that pinned this as a **LIMIT** is flipped to a denial in the same file, and kept — it is the one row that measures the reach and the refusal in the same method.

## What it costs, since that is why #497 filed this instead of doing it

`git rev-parse --show-toplevel` answers the question exactly and costs a subprocess — some ten milliseconds inside a hook that runs on every Bash call, where the guard's common case exits on a string comparison. So charter reads the file: a walk up to the repository, and one read of a file under a kilobyte in every repository anybody has.

**Measured:** 14 µs with no repository above the cwd · **41 µs for a repository with no such key — the ordinary case** · 76 µs where the key is there.

The number is stated in `_git_target`'s docstring beside the cost paragraph the issue asked for, and in `charter/gitconfig.py`, which owns the read. A test asserts **no process is started** to answer it — a wall-clock ceiling on a fast machine would not notice a later simplification onto `git rev-parse`, and that is the regression worth naming.

## git is the oracle for the reader

Charter parses the config, so what can go wrong is charter's reader disagreeing with git's. Every value form is checked against `git rev-parse --show-toplevel` **on the same file**: absolute, relative, quoted and unquoted with a space, a trailing comment, trailing whitespace, a capitalised section header, a value continued over a backslash, a repeated key, and `[core "x"]` (a different key that relocates nothing).

Relative values resolve against the **git directory** — measured, not assumed. `../plane` is the value that looks right if you resolve against the work tree, and it makes git refuse the repository outright; the value git honours is one level further up. There is a test that asserts git refuses the first before asserting charter agrees on the second.

## Three routes deliberately not followed

- **`git -c core.worktree=<dir>` on the command line.** Git ignores it — verified in both spellings, with and without an explicit `--git-dir` — so the form an agent would actually type reaches nothing, and reading it would only manufacture refusals. `test_and_the_c_form_of_the_same_key_is_not_read` asks git this before asserting it, so the row cannot quietly become an assertion about a form that *does* reach the root.
- **`include` / `includeIf`** — a second file read per invocation with git's own `gitdir:`/`onbranch:` matching behind it.
- **The global and system configs**, where git honours `core.worktree` only when `$GIT_DIR` is set.

Every way the read can fail answers *no work tree named*. That is fail-open by construction and it is the honest direction: this ADDS a subject, so a missing answer costs coverage while an invented one refuses a command with nothing wrong with it.

## Measurement

**Full suite at this head, in two environments** — 7404 tests, OK on `python3.14`, and 7404 on `python3.12` with every `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` variable unset.

**Hand-check, unmutated baseline, sha256-verified restore after each mutation.** 13/13 caught:

| mutation | |
|---|---|
| a value's leading whitespace is no longer git's to drop | caught |
| a trailing comment becomes part of the path | caught |
| quotes stop being tracked | caught |
| trailing whitespace kept instead of trimmed outside quotes | caught |
| a subsection reads as the bare section | caught |
| the FIRST value wins instead of the last | caught |
| the fast path answers None for every config | caught |
| a relative value resolves against the cwd, not the git dir | caught |
| a `.git` FILE is no longer followed | caught |
| a continued value is truncated at the backslash | caught |
| the read bound is lifted | caught |
| the config-derived work tree is not added as a subject | caught |
| a NAMED `--git-dir` is ignored when reading the config | caught |

**The last one survived the first draft**, and it was a real hole rather than a test gap: `git --git-dir=<cfgclone>/.git checkout feature`, run from a *different* repository, reaches the plane root — verified with git before the row was written. The two `--git-dir`/`GIT_DIR` routes above are what closed it.

### `tools/sweep.py --gate`

CI charged **82 mutations** at `charter/gitconfig.py` and reported its survivors before the workflow's 60-minute cap stopped the job — see *Sweep budget* below. Nine were a missing assertion and two were a line that could go. Across three hand-check scripts — each with an unmutated baseline and a sha256-verified restore — **34 mutations, 34 caught**.

**Deleted, because it was never doing anything.** `Path(value) if os.path.isabs(value) else gd / value` is two spellings of one answer: `Path.__truediv__` already discards the left side when the right is absolute — `Path("/a/b") / "/tmp/z"` is `/tmp/z`. Both copies of that conditional are gone; the absolute row of the differential table is what makes the deletion safe.

A second pass over what the sweep reported after those landed found **two more deletions and two more pins**, and one cluster it can never separate:

**Deleted.** `_pairs` tracked `(section, subsection, …)` because git's model is `<section>.<subsection>.<key>`. This module asks one question, and for that question a subsection is simply not `core` — the header's whole text answers it. Every line of the split was one no test could go red without. Also gone: `.strip()` on the header's own text, since the line was stripped on the way in and git rejects `[ core ]` outright.

**Named, not pretended away.** The three remaining `.strip()` calls are a masked cluster — each removes whitespace the other two have already removed for every shape but one, so no single one can be shown to matter. Hand-checked rather than assumed equivalent; the comment beside them says which shape each is alone in seeing.

**Pinned, each with the fixture that makes the line's absence visible:**

| survivor | what made it invisible |
|---|---|
| `MAX_CONFIG_BYTES` | the bound test computed its fixture **from the constant**, so retuning the constant retuned the test with it — the same mistake this repo's `SEQUENCE_SEPARATOR` test made in #576 |
| the `\n`/`\t`/`\b` escape table | no fixture had an escape in it; there is a directory whose name holds a real tab now, written the way git writes it |
| `section == "core"` / `not subsection` | two conditions that each hid the other — `[gui] worktree` and `[core "x"] worktree` are separate rows |
| the header's FIRST bracket | `[core] ; note]` is a header with a comment after it and git honours the key under it (verified); the last bracket makes the section `core] ; note` and the work tree goes unreported |
| the `gitdir:` label | every junk pointer was refused **twice** — by the label test and by the empty target beneath it. A `notgitdir:` naming a real directory with a real config separates them, and a file called `config` at a repository's top level does the same for the empty-target guard |
| `_as_path`'s `TypeError` + the `start is None` guard beneath it | reached by handing the entry point something that is not a path at all |
| the config read's `OSError` | a repository whose `config` is a **directory** |
| whitespace around the header, key and value | every fixture had its whitespace on one side — and the obvious extra form, `[ core ]`, is one **git rejects**, so the oracle stopped a row asserting charter's behaviour on a config no repository can have |
| the key's case | git matches it case-insensitively; `WorkTree` is what a hand-edited config carries |

### Sweep budget — reported, not worked around

`charter/gitconfig.py` is 250-odd new lines and produced **78–82 mutations**, against the 30–52 the gate's own comment sizes itself for. Three runs on three different heads — two `pull_request`, one `workflow_dispatch` — all overran `timeout-minutes: 60` and were cancelled, each after reporting its survivor list and reaching about mutation 53 of 78. The gate is reporting-only so nothing is blocked, and every survivor it named is closed above; the residue is a masked `.strip()` cluster that no sweep can separate, named in the code.

This is worth a separate issue rather than a branch trimmed to fit: a self-contained module is exactly the shape that will keep hitting the cap, and the unmutated baseline alone is 220 s of the budget.

## Placement note

`charter/gitconfig.py` is a new module rather than sixty lines inside `hooks.py`. The hooks diff is a call and a comment, so the parser, its bound, and the list of routes it declines all sit in one file with one docstring — and `hooks.py` was #608's while this was being written, which is now merged and is why this branch is based on top of it.

News entry, `version: unreleased`, `security: true`. No bump, stamp or tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
