### PR TITLE
The rule between two panes is a cell in neither of them, so it takes their colour (#627)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1574,6 +1574,13 @@ _CHROME_STYLE = "fg=default,dim"
 #: `pane-border-format` is deliberately NOT here: it is inert while `pane-border-status`
 #: is `off`, and pinning a format nothing renders would be pinning a spelling rather than
 #: the property.
+#:
+#: **The two style entries are where the frame's SURFACE joins its rules**, and the value
+#: written here is the one they carry when there is no surface. `_chrome_argvs` appends
+#: `instance.border_bg`'s background clause to whichever entries are pinned to
+#: `_CHROME_STYLE` — derived from this table the way `instance.chrome_option_names`
+#: derives its own, so a sixth border-style option added here is not the one rule left
+#: with a seam through it.
 _CHROME: tuple[tuple[str, str], ...] = (
     ("pane-border-style", _CHROME_STYLE),
     ("pane-active-border-style", _CHROME_STYLE),
@@ -1583,7 +1590,8 @@ _CHROME: tuple[tuple[str, str], ...] = (
 )
 
 
-def _chrome_argvs(*, socket: str, harness_pane: str) -> list[list[str]]:
+def _chrome_argvs(*, socket: str, harness_pane: str,
+                  surface: str | None = None) -> list[list[str]]:
     """`set-option -w`: charter's own answer for every option tmux draws a border from.
 
     **Charter owns the frame's chrome, and tmux draws all of it.** #514 named two
@@ -1616,9 +1624,50 @@ def _chrome_argvs(*, socket: str, harness_pane: str) -> list[list[str]]:
     fifteen tmux calls a launch already makes. Nothing here runs on a panel's repaint —
     the idle tick this must not touch is `panel.py`'s one `stat`, and these are issued at
     launch and at a density change, never per paint.
+
+    ***surface* is `instance.border_bg`'s background clause, and it closes the SEAM.**
+    `window-style` paints a pane's interior and the rule between two panes is not in any
+    pane, so a frame with every panel painted grey came out as grey rectangles separated
+    by a one-cell strip of the terminal's own black — reported off a screenshot, and read
+    back off an attached client's wire as an `\\x1b[49m` in the middle of two `\\x1b[100m`
+    runs. Appending the same background to the rule removes that `\\x1b[49m` and the
+    surface runs straight through (measured on 3.7c and on `tmuxctl.FLOOR`; both accept
+    the combined value and read it back verbatim). `instance.border_bg` decides WHICH
+    colour and argues why; this decides only that the rule is drawn in it.
+
+    **Both styles, again, and for #514's reason rather than by symmetry.** The whole
+    defect that put these two options here is a rule that changed colour where it passed
+    the active pane's corner, and a BACKGROUND that changed there would be the same defect
+    an order of magnitude more visible. So the surface goes on both or on neither, and the
+    active-pane indication tmux's own default carries — `pane-active-border-style`
+    defaults to the format expression
+    ``#{?pane_in_mode,fg=yellow,#{?synchronize-panes,fg=red,fg=green}}``, measured — stays
+    discarded, as it has been since #514. Focus is drawn where it cannot run past a
+    corner: on the pane's own rectangle, by `window-active-style`
+    (`instance.FRAME_PANE_BG` pairs every colour with its focused shade).
+
+    **Which options carry it is derived, not listed**: the ones already pinned to
+    `_CHROME_STYLE` are exactly the styles, which is `instance.chrome_option_names`'
+    discipline said about this table. `pane-border-lines` and the rest are not styles and
+    take no colour.
+
+    ``None`` is the frame that had no surface, and then every value here is `_CHROME`'s
+    own — byte-identical to what charter emitted before this parameter existed, which is
+    what makes `chrome = "off"` a REMOVAL on the live path too: `cmd_chrome` re-issues
+    these `set-option`s and the coloured value is replaced by the uncoloured one. These
+    two options are charter's at every level (#514 pins them with or without a surface),
+    so there is nothing here to `-u`.
+
+    **`NO_COLOR` refuses the surface and keeps the rules**, which is the split that
+    matters: `_CHROME_STYLE` is an attribute over the terminal's own foreground and never
+    a colour charter chose, so it is not what `NO_COLOR` is about, while a background is
+    exactly what it is about. Asked through `chrome.no_colour` so there is one reading of
+    the variable (#547), the same way `_surface_argvs` asks.
     """
+    rule = (f"{_CHROME_STYLE},{surface}"
+            if surface and not chrome_mod.no_colour() else _CHROME_STYLE)
     return [tmuxctl.server_argv(socket, "set-option", "-w", "-t", harness_pane, name,
-                                value)
+                                rule if value == _CHROME_STYLE else value)
             for name, value in _CHROME]
 
 
@@ -2227,21 +2276,6 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     tmuxctl.run("keeping the frame's own dead panes long enough to bring them back",
                 _panel_remain_on_exit_argv(socket=socket, harness_pane=harness_pane),
                 env=env)
-    # And the chrome those panes will be bordered with, armed at the same moment and for
-    # the same reason: this is the one funnel both launch paths and every density change
-    # reach panels through, so a rule cannot come out styled one way on charter's own
-    # server and another way on the operator's (#514, `_chrome_argvs`). Reported but not
-    # fatal, like the splits themselves — a frame whose borders kept tmux's own colours
-    # is a frame that looks wrong, not one that fails.
-    for chrome in _chrome_argvs(socket=socket, harness_pane=harness_pane):
-        tmuxctl.run("styling the frame's own rules", chrome, env=env)
-    panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=socket,
-                                    harness_pane=harness_pane, env=pane_env,
-                                    sizes=sizes)
-    # Zipped with `slots`, not just iterated: `_resize_hook_argv` needs to know WHICH slot
-    # each successfully-created pane belongs to (for its size and its resize-pane flag),
-    # and `panel_argvs` returns exactly one command per slot, in the same order (see its
-    # own docstring).
     # The word, resolved once for the whole batch, through `_current_chrome` rather than
     # off `config.FRAME` — which is the difference a live `charter frame-chrome` makes.
     # The configured value says what a frame STARTS at; a frame the operator has since
@@ -2252,6 +2286,29 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     # styles, so a value charter does not know produces no commands at all, which is
     # `off`.
     chrome = _current_chrome(fid)
+    # And the chrome those panes will be bordered with, armed at the same moment and for
+    # the same reason: this is the one funnel both launch paths and every density change
+    # reach panels through, so a rule cannot come out styled one way on charter's own
+    # server and another way on the operator's (#514, `_chrome_argvs`). Reported but not
+    # fatal, like the splits themselves — a frame whose borders kept tmux's own colours
+    # is a frame that looks wrong, not one that fails.
+    #
+    # The rules carry the frame's SURFACE, from the arrangement rather than from `slots`:
+    # this function is handed only the slots being split, which on a density change is the
+    # ones being ADDED (`_relayout` passes `missing`), so a rule colour derived from that
+    # list would change every time a panel appeared. `instance.border_bg` reads
+    # `config.FRAME`, which is the same thing `cmd_chrome` reads on the live path — the
+    # agreement #610 is about, made by construction rather than by two call sites matching.
+    for argv in _chrome_argvs(socket=socket, harness_pane=harness_pane,
+                              surface=instance.border_bg(config.FRAME, chrome)):
+        tmuxctl.run("styling the frame's own rules", argv, env=env)
+    panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=socket,
+                                    harness_pane=harness_pane, env=pane_env,
+                                    sizes=sizes)
+    # Zipped with `slots`, not just iterated: `_resize_hook_argv` needs to know WHICH slot
+    # each successfully-created pane belongs to (for its size and its resize-pane flag),
+    # and `panel_argvs` returns exactly one command per slot, in the same order (see its
+    # own docstring).
     panes: dict[str, str] = {}
     for slot, cmd in zip(slots, panel_cmds):
         # Reported by `tmuxctl.run` but not fatal: one decorative panel failing to draw
@@ -3910,8 +3967,10 @@ def cmd_chrome(args) -> int:
     * a *level* outside `instance.FRAME_CHROME` — a closed set of three words charter
       wrote itself, so this can only be a hand-typed argument;
     * a frame with no recorded pane map — nothing to resurface. Unlike `cmd_density` this
-      needs no harness pane and no tmux version: it splits nothing, so `_relayout_target`'s
-      refusals are not this function's.
+      needs no tmux version: it splits nothing, so `_relayout_target`'s refusals are not
+      this function's. It reads the harness pane, but does not REFUSE without one — that
+      is only the window selector for the frame's rules (`_chrome_argvs`), and a frame
+      that has no record of it still gets every pane repainted.
 
     The word is recorded BEFORE the panes are touched, so a frame whose options fail
     halfway still splits its NEXT pane into the surface the operator asked for
@@ -3943,6 +4002,24 @@ def cmd_chrome(args) -> int:
         for argv in _resurface_argvs(socket=socket, pane_id=pane_id, chrome=level,
                                      bg=bg):
             tmuxctl.run("painting a panel's surface", argv)
+    # And the frame's RULES, which are the surface's other half and are not any pane's
+    # (`instance.border_bg`): a level change that repainted the panes and left the borders
+    # would leave the seam this closed running between them — or, going the other way,
+    # leave a grey rule around panes that had just gone back to the terminal's own colour.
+    # `off` is the removal here too, and it needs no `-u`: these two options are charter's
+    # own at every level (#514), so re-issuing them with no surface IS the removal.
+    #
+    # The harness pane is only the WINDOW selector — `-w -t <a pane id>` resolves to that
+    # pane's window — and nothing is set on it, which is `_chrome_argvs`' own boundary.
+    # Skipped rather than refused when the frame has no readable record of it: a frame
+    # launched by a charter that predates `record_harness_pane` has none, and its panes are
+    # already repainted above. `_PANE_ID_RE` is #475's rule about a value off disk that is
+    # about to be a tmux argv, made here exactly as the loop above makes it.
+    harness = state.harness_pane(fid) or ""
+    if _PANE_ID_RE.fullmatch(harness):
+        for argv in _chrome_argvs(socket=socket, harness_pane=harness,
+                                  surface=instance.border_bg(config.FRAME, level)):
+            tmuxctl.run("styling the frame's own rules", argv)
     return 0
 
 

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -805,6 +805,84 @@ def chrome_option_names() -> tuple[str, ...]:
                                for name, _value in pairs))
 
 
+def border_bg(frame: dict, chrome) -> str | None:
+    """The background clause every rule in *frame* is drawn over, or ``None`` for a frame
+    whose rules keep the terminal's own — `commands_frame._chrome_argvs`' *surface*.
+
+    **A pane border is the one cell that belongs to no pane, and that is the whole
+    problem.** :func:`chrome_options` and :func:`pane_bg_options` paint a pane's INTERIOR
+    (``window-style``); the rule between two panes is drawn from `pane-border-style`, a
+    different option, and charter has pinned it to `commands_frame._CHROME_STYLE` — an
+    ``fg`` and an attribute, no ``bg`` — since #514. So a frame whose panes are all painted
+    grey came out as grey rectangles separated by a one-cell strip of the terminal's own
+    black. Measured on 3.7c, the same three panes with `bg = "brightblack"` on each, read
+    off an attached client's wire::
+
+        before  '\\x1b[100m … \\x1b[2m\\x1b[49m│\\x1b[0m\\x1b[100m'   <- ESC[49m: the seam
+        after   '\\x1b[100m … \\x1b[2m│\\x1b[0m\\x1b[100m'            <- the surface runs through
+
+    **Which colour, when the two sides of a rule may be different colours.** There is no
+    "panel side" to match: tmux draws ONE border, not two half-borders. (On 3.7c it will
+    take a pane-scoped `pane-border-style` from the pane above or left of the rule and
+    ignore the other side's entirely; at `tmuxctl.FLOOR` that option has no pane scope at
+    all and ``set -p`` silently writes the WINDOW's — measured both ways. A per-side design
+    is therefore unavailable, one-sided where it exists, and silently window-wide where it
+    does not.)
+
+    So the rule takes the surface the frame's own components AGREE on, and the frame-wide
+    `[frame] chrome` surface when they do not agree. A gutter in the frame's own colour
+    between two differently-coloured panels is what an application looks like; a gutter in
+    NO colour between two identically-coloured panels is a seam, and the seam is the whole
+    report.
+
+    **Resolved by the same expression every pane resolves itself with** —
+    ``pane_bg_options(bg) or chrome_options(chrome)``, `commands_frame._surface_argvs`'
+    own — asked of every placement at once instead of one at a time. That is what makes
+    "they agree" mean the thing an operator can see rather than "they wrote the same word":
+    a component that names no ``bg`` takes the frame-wide surface, and agrees with one that
+    named the colour that surface already is.
+
+    **The universe is the ARRANGEMENT, not the panes on screen**, and that is deliberate
+    twice over. It is what makes the launch path and the live path (`cmd_chrome`) answer
+    identically by construction — both read `config.FRAME` and neither needs a pane map,
+    which is the disagreement #610 cost — and it is what stops the frame's rules changing
+    colour when a toggle key hides a panel or a narrow terminal drops one. A plane that
+    wrote no ``[[frame.component]]`` at all has no per-pane colours to agree about, so the
+    set is empty and the frame-wide word is the answer, which is what it was before this
+    key existed.
+
+    ``None`` where `[frame] chrome` is ``off`` and nothing named a colour, and it is the
+    same ``None`` a frame got before any of this: `_chrome_argvs` then emits
+    `_CHROME_STYLE` unchanged, so `off` is the REMOVAL of the surface from the rule rather
+    than a third style of it. The two border options are charter's own at every level
+    (#514 pins them whether or not there is a surface), which is why this needs no unset
+    where :func:`chrome_option_names` needs one — the option is always set, and what
+    changes is whether it carries a colour.
+
+    **What comes back is charter's own constant, never the operator's word.** It is a
+    value out of :data:`FRAME_PANE_BG` or :data:`FRAME_CHROME` — those tables' own
+    ``window-style`` entries, indexed by a word that was only ever a key — and the two
+    reasons that rule exists were both re-measured on 3.7c against *this* option rather
+    than assumed from `window-style`'s own:
+
+    * ``set -w pane-border-style 'bg=#{?#{==:1,1},colour196,colour46}'`` is **rc 0** and
+      reads back verbatim. A border style is FORMAT-EXPANDED at draw time exactly as a
+      window style is, so a free string in a committed `charter.toml` would be a
+      stranger's value reaching a tmux evaluator here too.
+    * ``bg=chartreuse`` is **rc 0** as well — tmux knows the X11 colour names, and
+      ``chartreuse`` is a fixed RGB point no theme moves, which is the hazard
+      :data:`FRAME_PANE_COLOURS` refuses ``colour24`` for. tmux refusing a value
+      (``bg=notacolour`` is rc 1, ``invalid style:``) is therefore not the boundary
+      charter needs, and is not asked to be.
+    """
+    surfaces = {dict(pane_bg_options(placed.get("bg"))
+                     or chrome_options(chrome)).get("window-style")
+                for placed in frame.get("components") or ()}
+    if len(surfaces) == 1:
+        return surfaces.pop()
+    return dict(chrome_options(chrome)).get("window-style")
+
+
 def verbosity_for(level) -> str:
     """How much each panel says at *level*. :data:`DEFAULT_VERBOSITY` for anything else.
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -213,7 +213,12 @@ the sentence above:
   the frame is one colour and the frame looks the same in your tmux as in charter's own.
   With `[frame] chrome` left at its default this is the only place charter overrides a
   preference of yours rather than deferring to it; setting `chrome` adds a second, on
-  charter's own panel panes and never on the pane your harness runs in. The reason for
+  charter's own panel panes and never on the pane your harness runs in — and it also puts
+  that colour BEHIND the frame's rules, because the cell between two panes is in neither
+  of them and would otherwise stay your terminal's own background: a one-cell seam running
+  between panels that are all the same colour. The rules take the colour the frame's
+  components agree on, and the frame-wide `chrome` colour when they name different ones.
+  Still window-scoped, still both border styles set to one value. The reason for
   the borders is that two of those options make one rule differ from its neighbour:
   the active-pane colour and the arrow indicators mark some borders and not others, and
   `pane-border-status top` writes your hostname into every rule and takes a row the
@@ -716,6 +721,27 @@ back to `slots`, which is visible, rather than one pane quietly losing its colou
 `bg` does not need `chrome` to be on. `chrome`'s default is `off` because a background
 charter chose is wrong on somebody's terminal; a `bg` is a line you wrote by hand about one
 pane, so it applies either way.
+
+**The rules between the panes are painted too, and you do not configure them.** A pane
+background fills that pane's rectangle, and the one-cell rule tmux draws between two panes
+is in neither rectangle — so a frame whose panels were all `brightblack` came out as grey
+boxes with your terminal's own black running between them, which reads as seams rather than
+as an application. Charter puts a background behind the rules as well.
+
+Which colour, given a rule has a pane on each side and they may be different colours: the
+one your components **agree** on when they all resolve to the same background, and the
+frame-wide `chrome` colour when they do not. A gutter in the frame's own colour between two
+differently-coloured panels is what an application looks like; a gutter in no colour between
+two identically-coloured panels is a seam. A plane that sets no `bg` at all is unchanged —
+every pane is the frame-wide colour, so the rules are too.
+
+There is one rule colour and not two, and that is deliberate: tmux draws the border of the
+active pane from a second option, and letting the two differ is exactly the defect that put
+charter in charge of these options in the first place — a rule that changes colour halfway
+along, where it passes the active pane's corner. Which pane is live is shown on the pane
+itself (its background is one shade off the others), never on the border. `chrome = "off"`
+with no `bg` anywhere puts the rules back to your terminal's own, and `NO_COLOR` takes the
+background off them while leaving the frame's rules drawn.
 
 `pad` is how many cells that pane leaves empty at its **left and right edges** — one number,
 both sides. Charter draws this one: tmux paints backgrounds and insets nothing.

--- a/docs/news/unreleased-the-frames-rules-stop-being-seams.md
+++ b/docs/news/unreleased-the-frames-rules-stop-being-seams.md
@@ -1,0 +1,63 @@
+---
+version: unreleased
+headline: The frame's rules stop being seams between the panels
+---
+
+A plane that painted all four panels — `chrome = "dark"` with `bg = "brightblack"` on every
+component — got four grey rectangles with a **one-cell dark strip running between every pair
+of them**, and around the sidebar. Reported off a screenshot: the frame read as coloured
+boxes separated by seams rather than as one application.
+
+The cause is a boundary, not a colour. `window-style` fills a **pane's** rectangle, and the
+rule tmux draws between two panes is in neither rectangle — it comes from
+`pane-border-style`, which charter has pinned to `fg=default,dim` since the frame started
+drawing its own chrome. An `fg` and an attribute, and no background at all, so the cell
+stayed whatever your terminal already was. Read off an attached client's wire, through a
+nested tmux, three panes each `bg = "brightblack"`:
+
+```
+before  '\x1b[100m … \x1b[2m\x1b[49m│\x1b[0m\x1b[100m'   <- ESC[49m: the seam
+after   '\x1b[100m … \x1b[2m│\x1b[0m\x1b[100m'            <- the surface runs through
+```
+
+Charter now puts a background behind the frame's rules as well, and **you configure
+nothing** — it is derived from the colours you already wrote.
+
+**Which colour, when a rule has a different pane on each side.** There is no "panel side" to
+match: tmux draws one border, not two half-borders. So the rule takes the surface your
+components **agree** on when they all resolve to the same background, and the frame-wide
+`chrome` colour when they name different ones. A gutter in the frame's own colour between two
+differently-coloured panels is what an application looks like; a gutter in *no* colour
+between two identically-coloured panels is a seam. A plane that never set a `bg` sees the
+rules take the `chrome` colour, which is what every pane in it was already wearing — and a
+plane at `chrome = "off"` with no `bg` anywhere gets exactly the frame it got before, byte
+for byte.
+
+**One rule colour and not two.** tmux draws the active pane's border from a second option
+whose default is a format expression (`#{?pane_in_mode,fg=yellow,…}`), and letting the two
+differ is the defect that put charter in charge of these options in the first place: a rule
+that changes colour halfway along, where it passes the active pane's corner. A *background*
+that changed there would be that defect an order of magnitude more visible, so both options
+get the same value or neither does. Which pane is live is still shown on the pane itself —
+its background is one shade off the others — never on the border.
+
+**Window-scoped, and that was measured rather than assumed.** `pane-border-style` is a pane
+option on tmux 3.7c, where tmux draws each border cell from the pane above or left of it and
+ignores the other side's outright. At charter's floor, tmux 3.2, it is not a pane option at
+all: `set -p` returns 0 but writes the **window's** value, and `set -p -u` would remove
+charter's own pin for the whole window. So per-side border colours are unavailable at the
+floor, silently window-wide there, and one-sided where they exist. Both border options
+accept the combined value and read it back verbatim on 3.7c and on 3.2 alike, and a tmux
+that refuses one of these settings is reported and not fatal, as it already was.
+
+`NO_COLOR` takes the background off the rules and leaves the rules drawn: the dim
+foreground is an attribute over your own palette rather than a colour charter chose, and a
+background is exactly what that variable is about — including one charter asked tmux to
+paint on its behalf.
+
+`F2`'s `chrome:` rows and `charter frame-chrome <level>` repaint the rules along with the
+panes, so a live change cannot leave grey borders around panes that just went back to your
+terminal's colour, or the seam running between panes that just went grey. As before, a
+`chrome` level never erases a colour a component wrote.
+
+Nothing to adopt: upgrading is the whole of it.

--- a/tests/test_frame_border_surface.py
+++ b/tests/test_frame_border_surface.py
@@ -43,11 +43,28 @@ _STYLES = ("pane-border-style", "pane-active-border-style")
 
 
 def _frame(*bgs, **rest) -> dict:
-    """A resolved `[frame]` mapping whose arrangement names one component per *bgs*
-    entry — `None` for a component that names no background of its own."""
+    """A `[frame]` mapping whose arrangement names one component per *bgs* entry — `None`
+    for a component that names no background of its own.
+
+    Built by hand, and only for `instance.border_bg`, which reads a placement's `bg` and
+    nothing else. Anything that goes near `frame/layout.py` needs :func:`_resolved`, whose
+    placements carry the `edge` and `size` a split is computed from.
+    """
     return {"components": [{"slot": f"s{i}", "use": f"s{i}",
                             **({} if bg is None else {"bg": bg})}
                            for i, bg in enumerate(bgs)], **rest}
+
+
+def _resolved(*bgs, **rest) -> dict:
+    """A frame `instance.frame_of` really produced, for the tests that drive a launch.
+
+    Resolved rather than assembled: what these then patch into `config.FRAME` is what a
+    real `charter.toml` would have produced, refusals included — the same trade
+    `tests/test_frame_pane_style.py`'s own `_arrangement` makes.
+    """
+    tables = [{"use": cid, **({} if bg is None else {"bg": bg})}
+              for cid, bg in zip(("identity", "attention", "repos", "sidebar"), bgs)]
+    return {**instance.frame_of({"frame": {"component": tables}}), **rest}
 
 
 class TheRuleTakesTheSurfaceTheComponentsAgreeOn(unittest.TestCase):
@@ -296,15 +313,8 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         return {a[-2]: a[-1] for a in issued
                 if "set-option" in a and "-w" in a and a[-2] in dict(commands_frame._CHROME)}
 
-    def _frame(self, **style) -> dict:
-        tables = [{"use": cid, **style.get(cid, {})}
-                  for cid in ("identity", "attention", "repos", "sidebar")]
-        return instance.frame_of({"frame": {"component": tables}, })
-
     def test_a_launch_draws_its_rules_in_the_colour_its_panels_agree_on(self):
-        frame = {**self._frame(**{c: {"bg": "brightblack"} for c in
-                                  ("identity", "attention", "repos", "sidebar")}),
-                 "chrome": "dark"}
+        frame = _resolved(*["brightblack"] * 4, chrome="dark")
         rules = self._rules(self._issued(frame, ["top", "bottom", "repos", "right"]))
         self.assertEqual(rules["pane-border-style"],
                          f"{commands_frame._CHROME_STYLE},bg=brightblack")
@@ -319,9 +329,7 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         derived from the *slots* argument would change every time a density level brought
         a panel back — and would be wrong for the panels already on screen. It is derived
         from `config.FRAME` instead, which is the same thing `cmd_chrome` reads."""
-        frame = {**self._frame(**{c: {"bg": "blue"} for c in
-                                  ("identity", "attention", "repos", "sidebar")}),
-                 "chrome": "dark"}
+        frame = _resolved(*["blue"] * 4, chrome="dark")
         whole = self._rules(self._issued(frame, ["top", "bottom", "repos", "right"]))
         one = self._rules(self._issued(frame, ["right"]))
         self.assertEqual(one, whole)
@@ -333,7 +341,7 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         into a frame the operator has since surfaced from the palette is bordered with the
         surface the frame IS rather than the one it launched with — the same resolver the
         pane's own background already goes through."""
-        frame = {**self._frame(), "chrome": "off"}
+        frame = _resolved(None, None, None, None, chrome="off")
         state.record_chrome("f-live", "dark")
         rules = self._rules(self._issued(frame, ["top"], fid="f-live"))
         self.assertEqual(rules["pane-border-style"],
@@ -353,17 +361,28 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
     FID = "fr-border"
 
     def _launch_value(self, frame, level):
+        """What `_split_panels` — the funnel both launch paths and every density change
+        come through — actually issues, with the frame's live word recorded rather than
+        the resolver stubbed out. A reconstruction of the expression would agree with the
+        live path by being written twice, which is the thing #610 is about."""
+        calls: list[list[str]] = []
+        state.record_chrome(self.FID, level)
+
+        def fake_run(_why, argv, **_kw):
+            calls.append(list(argv))
+            return subprocess.CompletedProcess(argv, 0, stdout="%9\n", stderr="")
+
         with mock.patch.object(config, "FRAME", frame), \
-                mock.patch.object(commands_frame, "_current_chrome",
-                                  lambda _fid: level):
-            chrome = commands_frame._current_chrome(self.FID)
-            return {a[-2]: a[-1] for a in commands_frame._chrome_argvs(
-                socket="s", harness_pane="%1",
-                surface=instance.border_bg(config.FRAME, chrome))}
+                mock.patch.object(commands_frame.tmuxctl, "run", fake_run), \
+                mock.patch.dict(os.environ, {}, clear=True):
+            commands_frame._split_panels("s", slots=["top"], fid=self.FID,
+                                         harness_pane="%1", env=None, pane_env=None)
+        return {a[-2]: a[-1] for a in calls
+                if "-w" in a and a[-2] in dict(commands_frame._CHROME)}
 
     def _live_value(self, frame, level):
         calls: list[list[str]] = []
-        state.record_panes(self.FID, panels={"s0": "%2"})
+        state.record_panes(self.FID, panels={"top": "%2"})
         state.record_harness_pane(self.FID, "%1")
         with mock.patch.object(config, "FRAME", frame), \
                 mock.patch.object(commands_frame.tmuxctl, "run",
@@ -376,7 +395,7 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
     def test_every_level_crossed_with_every_colour_lands_on_one_value(self):
         for level in instance.FRAME_CHROME:
             for word in (None, *instance.FRAME_PANE_BG):
-                frame = _frame(word, word)
+                frame = _resolved(word, word, word, word)
                 with self.subTest(level=level, bg=word):
                     self.assertEqual(self._launch_value(frame, level),
                                      self._live_value(frame, level))
@@ -384,13 +403,14 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
     def test_a_committed_colour_survives_the_level_that_used_to_erase_it(self):
         """`chrome: off` is a removal of the FRAME'S surface, never of a colour a
         component wrote. The rules stay the panels' colour, because the panels do."""
-        frame = _frame(*["brightblack"] * 4)
+        frame = _resolved(*["brightblack"] * 4)
         self.assertEqual(
             self._live_value(frame, "off")["pane-border-style"],
             f"{commands_frame._CHROME_STYLE},bg=brightblack")
 
     def test_off_on_a_plane_that_named_no_colour_puts_the_rules_back(self):
-        self.assertEqual(self._live_value({}, "off"), dict(commands_frame._CHROME))
+        self.assertEqual(self._live_value({"slots": ["top"]}, "off"),
+                         dict(commands_frame._CHROME))
 
     def test_a_frame_with_no_harness_pane_still_repaints_its_panes(self):
         """Skipped rather than refused: a frame launched by a charter that predates

--- a/tests/test_frame_border_surface.py
+++ b/tests/test_frame_border_surface.py
@@ -1,0 +1,430 @@
+"""The frame's RULES carry the frame's surface — `instance.border_bg` and the two
+`_CHROME` style options it reaches.
+
+**The defect, as it was reported.** With `chrome = "dark"` and `bg = "brightblack"` on all
+four components, every panel came out grey and a one-cell DARK STRIP ran between each pair
+of them and around the sidebar — the frame read as coloured rectangles separated by seams
+rather than as an application. `window-style` paints a pane's INTERIOR; the cell between
+two panes is in neither pane, and tmux draws it from `pane-border-style`, which charter has
+pinned to `commands_frame._CHROME_STYLE` (an `fg` and an attribute, no `bg`) since #514.
+
+Measured on 3.7c, three panes each `bg = "brightblack"`, read off an attached client's
+wire through a nested tmux::
+
+    before  '\\x1b[100m … \\x1b[2m\\x1b[49m│\\x1b[0m\\x1b[100m'   <- ESC[49m: the seam
+    after   '\\x1b[100m … \\x1b[2m│\\x1b[0m\\x1b[100m'            <- the surface runs through
+
+The rendered half of that lives in `tests/test_frame_tmux_integration.py`'s
+`ChromeIsOneColour`, which already owns the nested-tmux screenshot harness. This file is
+the argv and the table — what charter decides, before any tmux is asked.
+
+**Window-scoped, and that is a measurement rather than a preference.** `pane-border-style`
+IS a pane option on 3.7c, and tmux there draws each border cell from the pane ABOVE or LEFT
+of it and ignores the other side's outright (window blue + left pane red + right pane green
+renders red). At `tmuxctl.FLOOR` it is not a pane option at all: `set -p` is rc 0 but
+writes the WINDOW's value, `show -p` on a pane nobody set answers the window's, and
+`set -p -u` removes charter's own #514 pin for the whole window. So a per-side design is
+unavailable at the floor, silently window-wide there, and one-sided where it exists — the
+rule takes ONE colour, set `-w`, exactly as `_chrome_argvs` already sets the other four.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from unittest import mock
+
+from charter import commands_frame, config, instance
+from charter.frame import state
+from tests._isolation import PersonaIso
+
+_STYLES = ("pane-border-style", "pane-active-border-style")
+
+
+def _frame(*bgs, **rest) -> dict:
+    """A resolved `[frame]` mapping whose arrangement names one component per *bgs*
+    entry — `None` for a component that names no background of its own."""
+    return {"components": [{"slot": f"s{i}", "use": f"s{i}",
+                            **({} if bg is None else {"bg": bg})}
+                           for i, bg in enumerate(bgs)], **rest}
+
+
+class TheRuleTakesTheSurfaceTheComponentsAgreeOn(unittest.TestCase):
+    """`instance.border_bg` — which colour, and why that one.
+
+    A border sits BETWEEN two panes, so with per-component `bg` the two sides may be
+    different colours and no single value matches both. The rule takes the surface the
+    components agree on, and the frame-wide `[frame] chrome` surface when they do not: a
+    gutter in the frame's own colour between two differently-coloured panels is what an
+    application looks like, while a gutter in NO colour between two identically-coloured
+    panels is the seam this exists to close.
+    """
+
+    def test_components_that_all_name_one_colour_give_the_rule_that_colour(self):
+        """The reported case. Four panels, one word, and the rule is that word's own
+        `window-style` value — not the frame-wide `chrome`'s, which is a colour nothing
+        else on the screen is wearing."""
+        self.assertEqual(
+            instance.border_bg(_frame(*["brightblack"] * 4), "dark"), "bg=brightblack")
+
+    def test_components_that_disagree_leave_the_rule_the_frame_wide_surface(self):
+        """No colour matches both sides, so the rule stops trying to and becomes the
+        frame's own gutter — which is the colour every pane that named nothing is already
+        wearing."""
+        self.assertEqual(instance.border_bg(_frame("blue", "brightblack"), "dark"),
+                         dict(instance.FRAME_CHROME["dark"])["window-style"])
+
+    def test_naming_no_colour_agrees_with_naming_the_colour_chrome_already_is(self):
+        """"They agree" is resolved through the same expression a PANE is resolved
+        through — `pane_bg_options(bg) or chrome_options(chrome)` — so it means what an
+        operator can see rather than "they wrote the same word". A component with no `bg`
+        takes the frame-wide surface, and a component that named that surface's own colour
+        is the same colour as it."""
+        self.assertEqual(instance.border_bg(_frame("black", None), "dark"), "bg=black")
+        self.assertEqual(instance.border_bg(_frame("brightblack", None), "dark"),
+                         dict(instance.FRAME_CHROME["dark"])["window-style"],
+                         "a `brightblack` panel beside an unpainted one is two colours, "
+                         "and the rule must not claim to match both")
+
+    def test_a_plane_with_no_arrangement_takes_the_frame_wide_surface(self):
+        """`[frame] slots` and no `[[frame.component]]`: there are no per-pane colours to
+        agree about, every pane is the frame-wide word, and so is the rule."""
+        for level in instance.FRAME_CHROME:
+            with self.subTest(level=level):
+                self.assertEqual(instance.border_bg({}, level),
+                                 dict(instance.FRAME_CHROME[level]).get("window-style"))
+
+    def test_off_with_nothing_named_is_no_background_at_all(self):
+        """The frame charter shipped before any of this, unchanged: `_chrome_argvs` then
+        emits `_CHROME_STYLE` itself and the rule is the terminal's own."""
+        self.assertIsNone(instance.border_bg({}, "off"))
+        self.assertIsNone(instance.border_bg(_frame("blue", "red"), "off"))
+
+    def test_a_colour_does_not_need_chrome_to_be_on(self):
+        """`_surface_argvs`' rule, one option over: a `bg` is not a default, it is a line
+        somebody wrote by hand about one pane. A plane that painted every panel and left
+        `chrome = "off"` gets rules that match its panels."""
+        self.assertEqual(instance.border_bg(_frame("blue", "blue"), "off"), "bg=blue")
+
+    def test_the_word_default_is_carried_as_the_terminal_s_own(self):
+        """`default` is the seventeenth word and not a colour. Panels that all opted out
+        of the frame's surface get a rule that opted out with them."""
+        self.assertEqual(instance.border_bg(_frame("default", "default"), "dark"),
+                         "bg=default")
+
+    def test_a_word_charter_does_not_know_falls_back_and_never_reaches_the_answer(self):
+        """The containment, on this key. A committed `bg` is only ever a KEY into
+        `FRAME_PANE_BG`; a word charter does not know indexes nothing, so that component
+        resolves to the frame-wide surface exactly as a component with no `bg` does."""
+        for hostile in ("bg=#{?#{==:1,1},colour196,colour46}", "colour236", "chartreuse",
+                        "", None, ["blue"], {"a": 1}, 3, True):
+            with self.subTest(value=hostile):
+                self.assertEqual(instance.border_bg(_frame(hostile, None), "dark"),
+                                 "bg=black")
+
+    def test_every_answer_is_a_value_out_of_charters_own_two_tables(self):
+        """Not "no `#` in it" — the stronger form: what comes back is a value charter
+        wrote, identically to `chrome_options` and `pane_bg_options`, so nothing assembled
+        from an operator's word can leave through here whatever the word was."""
+        ours = {v for pairs in instance.FRAME_PANE_BG.values() for _n, v in pairs}
+        ours |= {v for pairs in instance.FRAME_CHROME.values() for _n, v in pairs}
+        for level in (*instance.FRAME_CHROME, "bg=red", None):
+            for word in (*instance.FRAME_PANE_BG, "colour236", "#00ff00", None):
+                with self.subTest(level=level, bg=word):
+                    got = instance.border_bg(_frame(word, word), level)
+                    self.assertTrue(got is None or got in ours, got)
+
+    def test_the_rule_names_a_palette_slot_and_never_an_index_or_a_triple(self):
+        """`FRAME_PANE_COLOURS`' rule reaching the border: sixteen names and `default`,
+        because a colour resolves against the OPERATOR's own palette. `colour24` is a
+        fixed point in the xterm cube that no theme moves, and a committed one is a
+        black-on-black rule on somebody else's machine."""
+        allowed = {f"bg={n}" for n in instance.FRAME_PANE_BG} | {"bg=default"}
+        for level in instance.FRAME_CHROME:
+            for word in instance.FRAME_PANE_BG:
+                with self.subTest(level=level, bg=word):
+                    got = instance.border_bg(_frame(word, word), level)
+                    self.assertIn(got, allowed)
+                    self.assertNotRegex(got, r"colour\d|#[0-9a-fA-F]{6}|\d{1,3},\d")
+
+    def test_it_reads_the_arrangement_and_never_a_pane_map(self):
+        """The universe is what the plane WROTE, not what is on screen — which is what
+        makes the launch path and `cmd_chrome` answer identically without either of them
+        holding a pane map (#610's disagreement, removed by construction), and what stops
+        the rules changing colour when a toggle key hides a panel or a narrow terminal
+        drops one."""
+        frame = _frame(*["brightblack"] * 4, slots=["s0"])
+        self.assertEqual(instance.border_bg(frame, "dark"), "bg=brightblack")
+        self.assertEqual(instance.border_bg({**frame, "slots": []}, "dark"),
+                         "bg=brightblack")
+
+    def test_this_planes_own_committed_frame_answers_the_report(self):
+        """The operator's charter.toml, asked directly. Four components, one word, and
+        their own comment for it: "charter's chrome is grey, the work area is the
+        terminal's own". Grey is `brightblack`, and until this key existed the rules
+        between those grey panes were the terminal's black."""
+        if not (config.FRAME.get("components") or ()):
+            self.skipTest("this plane's charter.toml writes no arrangement")
+        self.assertEqual(instance.border_bg(config.FRAME, config.FRAME.get("chrome")),
+                         "bg=brightblack")
+
+
+class TheRuleIsDrawnInIt(unittest.TestCase):
+    """`commands_frame._chrome_argvs` — the five `set-option -w`s, with the surface in
+    the two that are styles."""
+
+    def _tails(self, surface=None):
+        return [a[a.index("set-option"):]
+                for a in commands_frame._chrome_argvs(socket="s", harness_pane="%1",
+                                                      surface=surface)]
+
+    def _values(self, surface=None):
+        return {a[-2]: a[-1] for a in self._tails(surface)}
+
+    def test_no_surface_is_byte_identical_to_the_frame_charter_shipped(self):
+        """The `off` invariant, and the reason the border needs no `-u` where the pane
+        surface does: these two options are charter's own at EVERY level (#514 pins them
+        with or without a surface), so "no surface" is a value rather than an absence, and
+        it is the value that was there before this parameter existed."""
+        self.assertEqual(self._values(), dict(commands_frame._CHROME))
+
+    def test_the_surface_is_appended_to_the_styles_and_to_nothing_else(self):
+        got = self._values("bg=brightblack")
+        for name in _STYLES:
+            with self.subTest(option=name):
+                self.assertEqual(got[name],
+                                 f"{commands_frame._CHROME_STYLE},bg=brightblack")
+        for name, value in commands_frame._CHROME:
+            if name not in _STYLES:
+                with self.subTest(option=name):
+                    self.assertEqual(got[name], value,
+                                     "a background was appended to an option that is "
+                                     "not a style")
+
+    def test_both_styles_get_it_or_neither_does(self):
+        """#514, restated where it would break. That defect was a rule that changed
+        colour where it ran past the ACTIVE pane's corner; a BACKGROUND that changed there
+        is the same defect an order of magnitude more visible. tmux's own
+        `pane-active-border-style` default is the format expression
+        `#{?pane_in_mode,fg=yellow,#{?synchronize-panes,fg=red,fg=green}}` (measured on
+        3.7c) — charter has replaced it since #514, and focus is drawn where it cannot run
+        past a corner, on the pane's own rectangle by `window-active-style`."""
+        for surface in (None, "bg=brightblack", "bg=default"):
+            with self.subTest(surface=surface):
+                got = self._values(surface)
+                self.assertEqual(got["pane-border-style"],
+                                 got["pane-active-border-style"])
+
+    def test_which_options_carry_it_is_derived_from_the_table(self):
+        """`instance.chrome_option_names`' discipline said about `_CHROME`: the options a
+        surface belongs in are the ones already pinned to `_CHROME_STYLE`, so a sixth
+        border-style option added to that table is not the one rule left with a seam
+        through it."""
+        with mock.patch.object(
+                commands_frame, "_CHROME",
+                commands_frame._CHROME + (("pane-border-status-style",
+                                           commands_frame._CHROME_STYLE),)):
+            self.assertEqual(self._values("bg=blue")["pane-border-status-style"],
+                             f"{commands_frame._CHROME_STYLE},bg=blue")
+
+    def test_the_option_names_and_the_scope_are_unchanged(self):
+        """Every one of these is set `-w` and targets a pane only to name its WINDOW.
+        Nothing is written on the pane itself, which is how ADR 0018's boundary holds here
+        by construction rather than by care."""
+        for tail in self._tails("bg=blue"):
+            with self.subTest(argv=tail):
+                self.assertEqual(tail[:4], ["set-option", "-w", "-t", "%1"])
+
+    def test_no_colour_drops_the_surface_and_keeps_the_rules(self):
+        """The split that matters: `_CHROME_STYLE` is an attribute over the terminal's own
+        foreground and never a colour charter chose, so it is not what `NO_COLOR` is
+        about — a background is exactly what it is about, and charter asking tmux to paint
+        one is still charter putting colour on their screen."""
+        with mock.patch.dict(os.environ, {"NO_COLOR": ""}, clear=True):
+            self.assertEqual(self._values("bg=brightblack"),
+                             dict(commands_frame._CHROME))
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertNotEqual(self._values("bg=brightblack"),
+                                dict(commands_frame._CHROME))
+
+    def test_no_operator_string_reaches_a_style_value(self):
+        """The boundary asserted end to end rather than at the table: whatever a committed
+        `bg` says, the value that reaches a `set-option` is `_CHROME_STYLE` plus a clause
+        charter wrote. A tmux style is format-expanded at draw time — measured on this
+        very option: `set -w pane-border-style 'bg=#{?#{==:1,1},colour196,colour46}'` is
+        rc 0 and reads back verbatim — so this cannot be tmux's job."""
+        hostile = "bg=#{?#{==:1,1},colour196,colour46}"
+        for level in ("dark", hostile):
+            argvs = commands_frame._chrome_argvs(
+                socket="s", harness_pane="%1",
+                surface=instance.border_bg(_frame(hostile, hostile), level))
+            for argv in argvs:
+                for word in argv:
+                    self.assertNotIn("#", word)
+
+
+class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
+    """**The wiring, which every `_chrome_argvs` test above takes as given.**
+
+    `TheLauncherActuallyAsksForEachPanesColour` in `tests/test_frame_pane_style.py` was
+    written because a hand-check replaced `_split_panels`' one resolving line with
+    ``bg = None`` and the whole suite stayed green — a per-pane colour that production
+    never resolves is a feature that does nothing on a real frame and a test file that
+    says it works. The *surface* argument has exactly that shape, so it is driven through
+    exactly that funnel: `_split_panels`, which both launch paths and every density change
+    come through, with only `tmuxctl.run` faked.
+    """
+
+    def _issued(self, frame: dict, slots: list[str], *, fid="f-1") -> list[list[str]]:
+        seen: list[list[str]] = []
+        panes = iter(f"%{n}" for n in range(10, 99))
+
+        def fake_run(_why, argv, **_kw):
+            seen.append(list(argv))
+            out = next(panes) if "split-window" in argv else ""
+            return subprocess.CompletedProcess(argv, 0, stdout=out + "\n", stderr="")
+
+        with mock.patch.dict(config.FRAME, frame), \
+                mock.patch.object(commands_frame.tmuxctl, "run", fake_run), \
+                mock.patch.dict(os.environ, {}, clear=True):
+            commands_frame._split_panels("sock", slots=slots, fid=fid,
+                                         harness_pane="%1", env=None, pane_env=None)
+        return seen
+
+    def _rules(self, issued: list[list[str]]) -> dict[str, str]:
+        return {a[-2]: a[-1] for a in issued
+                if "set-option" in a and "-w" in a and a[-2] in dict(commands_frame._CHROME)}
+
+    def _frame(self, **style) -> dict:
+        tables = [{"use": cid, **style.get(cid, {})}
+                  for cid in ("identity", "attention", "repos", "sidebar")]
+        return instance.frame_of({"frame": {"component": tables}, })
+
+    def test_a_launch_draws_its_rules_in_the_colour_its_panels_agree_on(self):
+        frame = {**self._frame(**{c: {"bg": "brightblack"} for c in
+                                  ("identity", "attention", "repos", "sidebar")}),
+                 "chrome": "dark"}
+        rules = self._rules(self._issued(frame, ["top", "bottom", "repos", "right"]))
+        self.assertEqual(rules["pane-border-style"],
+                         f"{commands_frame._CHROME_STYLE},bg=brightblack")
+        self.assertEqual(rules["pane-active-border-style"], rules["pane-border-style"])
+
+    def test_a_launch_that_names_no_colour_arms_exactly_what_it_always_did(self):
+        self.assertEqual(self._rules(self._issued({}, ["top", "bottom"])),
+                         dict(commands_frame._CHROME))
+
+    def test_a_relayout_that_adds_one_pane_still_arms_the_WHOLE_frames_surface(self):
+        """`_relayout` calls this funnel with only the slots being ADDED, so a rule colour
+        derived from the *slots* argument would change every time a density level brought
+        a panel back — and would be wrong for the panels already on screen. It is derived
+        from `config.FRAME` instead, which is the same thing `cmd_chrome` reads."""
+        frame = {**self._frame(**{c: {"bg": "blue"} for c in
+                                  ("identity", "attention", "repos", "sidebar")}),
+                 "chrome": "dark"}
+        whole = self._rules(self._issued(frame, ["top", "bottom", "repos", "right"]))
+        one = self._rules(self._issued(frame, ["right"]))
+        self.assertEqual(one, whole)
+        self.assertEqual(one["pane-border-style"],
+                         f"{commands_frame._CHROME_STYLE},bg=blue")
+
+    def test_the_live_word_and_not_the_committed_one_decides_the_rules(self):
+        """`_split_panels` resolves the level through `_current_chrome`, so a pane split
+        into a frame the operator has since surfaced from the palette is bordered with the
+        surface the frame IS rather than the one it launched with — the same resolver the
+        pane's own background already goes through."""
+        frame = {**self._frame(), "chrome": "off"}
+        state.record_chrome("f-live", "dark")
+        rules = self._rules(self._issued(frame, ["top"], fid="f-live"))
+        self.assertEqual(rules["pane-border-style"],
+                         f"{commands_frame._CHROME_STYLE},"
+                         f"{dict(instance.FRAME_CHROME['dark'])['window-style']}")
+
+
+class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
+    """#610's pin, on the border: what a frame LAUNCHES with and what a keypress leaves it
+    with must be the same value, at every level and for every colour.
+
+    The defect that rule exists for is specific and was paid for once already: a component
+    with `bg = "brightblack"` repainted in the frame-wide colour by `chrome: light`, and
+    ERASED by `chrome: off`, with nothing to bring it back until relaunch.
+    """
+
+    FID = "fr-border"
+
+    def _launch_value(self, frame, level):
+        with mock.patch.object(config, "FRAME", frame), \
+                mock.patch.object(commands_frame, "_current_chrome",
+                                  lambda _fid: level):
+            chrome = commands_frame._current_chrome(self.FID)
+            return {a[-2]: a[-1] for a in commands_frame._chrome_argvs(
+                socket="s", harness_pane="%1",
+                surface=instance.border_bg(config.FRAME, chrome))}
+
+    def _live_value(self, frame, level):
+        calls: list[list[str]] = []
+        state.record_panes(self.FID, panels={"s0": "%2"})
+        state.record_harness_pane(self.FID, "%1")
+        with mock.patch.object(config, "FRAME", frame), \
+                mock.patch.object(commands_frame.tmuxctl, "run",
+                                  lambda _w, argv, **kw: calls.append(argv)), \
+                mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID},
+                                clear=True):
+            commands_frame.cmd_chrome(type("A", (), {"level": level})())
+        return {a[-2]: a[-1] for a in calls if a[-2] in dict(commands_frame._CHROME)}
+
+    def test_every_level_crossed_with_every_colour_lands_on_one_value(self):
+        for level in instance.FRAME_CHROME:
+            for word in (None, *instance.FRAME_PANE_BG):
+                frame = _frame(word, word)
+                with self.subTest(level=level, bg=word):
+                    self.assertEqual(self._launch_value(frame, level),
+                                     self._live_value(frame, level))
+
+    def test_a_committed_colour_survives_the_level_that_used_to_erase_it(self):
+        """`chrome: off` is a removal of the FRAME'S surface, never of a colour a
+        component wrote. The rules stay the panels' colour, because the panels do."""
+        frame = _frame(*["brightblack"] * 4)
+        self.assertEqual(
+            self._live_value(frame, "off")["pane-border-style"],
+            f"{commands_frame._CHROME_STYLE},bg=brightblack")
+
+    def test_off_on_a_plane_that_named_no_colour_puts_the_rules_back(self):
+        self.assertEqual(self._live_value({}, "off"), dict(commands_frame._CHROME))
+
+    def test_a_frame_with_no_harness_pane_still_repaints_its_panes(self):
+        """Skipped rather than refused: a frame launched by a charter that predates
+        `record_harness_pane` has no record of one, and its panes are repainted above the
+        rules. The harness pane is only the window SELECTOR here."""
+        calls: list[list[str]] = []
+        state.record_panes(self.FID, panels={"s0": "%2"})
+        with mock.patch.object(config, "FRAME", _frame("brightblack")), \
+                mock.patch.object(commands_frame.tmuxctl, "run",
+                                  lambda _w, argv, **kw: calls.append(argv)), \
+                mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID},
+                                clear=True):
+            self.assertEqual(
+                commands_frame.cmd_chrome(type("A", (), {"level": "dark"})()), 0)
+        self.assertEqual([a[-2] for a in calls if a[-2] in dict(commands_frame._CHROME)],
+                         [])
+        self.assertTrue([a for a in calls if "window-style" in a],
+                        "the panes were not repainted either")
+
+    def test_a_harness_pane_that_is_not_tmuxs_own_is_not_handed_to_tmux(self):
+        """#475's rule about a value that arrived off DISK and is about to be a tmux argv,
+        made here exactly as `cmd_chrome` already makes it of each panel's."""
+        calls: list[list[str]] = []
+        state.record_panes(self.FID, panels={"s0": "%2"})
+        state.record_harness_pane(self.FID, "; kill-server")
+        with mock.patch.object(config, "FRAME", _frame("brightblack")), \
+                mock.patch.object(commands_frame.tmuxctl, "run",
+                                  lambda _w, argv, **kw: calls.append(argv)), \
+                mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID},
+                                clear=True):
+            commands_frame.cmd_chrome(type("A", (), {"level": "dark"})())
+        for argv in calls:
+            self.assertNotIn("; kill-server", argv)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -3811,7 +3811,7 @@ _RULE_GLYPHS = frozenset(chr(c) for c in range(0x2500, 0x2580))
 _SGR_RE = re.compile("\x1b\\[([0-9;]*)m")
 
 
-def _sgr_runs(text: str) -> list[tuple[frozenset, str]]:
+def _sgr_runs(text: str, *, carry: bool = False) -> list[tuple[frozenset, str]]:
     """`(appearance, character)` for every printable cell of *text*.
 
     The appearance is NORMALISED, not the raw escape bytes, because two spellings of one
@@ -3821,14 +3821,25 @@ def _sgr_runs(text: str) -> list[tuple[frozenset, str]]:
     is the spelling-versus-property trap this repo keeps paying for, so the property
     (what a cell LOOKS like) is what gets compared.
 
-    Line-scoped: `capture-pane -e` re-states a line's attributes at its start, and a run
-    carried across a newline would attribute one row's colour to the next.
+    Line-scoped by default: `capture-pane -e` re-states a line's attributes at its start,
+    and a run carried across a newline would attribute one row's colour to the next.
+
+    ***carry* turns that off, and it is needed for a BACKGROUND.** The re-statement is
+    tmux's optimiser, not a rule: a row whose background is already what the previous row
+    ended on gets no SGR at all, so a horizontal rule drawn over the frame's surface comes
+    back looking like a rule over the terminal's own — measured on 3.7c, where the vertical
+    rules carry `ESC[100m` and the horizontal ones carry nothing because the painted panel
+    above them already left the terminal there. A real terminal carries attributes across a
+    newline, so this is the faithful reading; the line-scoped default is the conservative
+    one and #514's tests keep it.
     """
     out: list[tuple[frozenset, str]] = []
+    fg: object = "default"
+    bg: object = "default"
+    attrs: set[int] = set()
     for line in text.split("\n"):
-        fg: object = "default"
-        bg: object = "default"
-        attrs: set[int] = set()
+        if not carry:
+            fg, bg, attrs = "default", "default", set()
         i = 0
         while i < len(line):
             m = _SGR_RE.match(line, i)
@@ -3872,12 +3883,17 @@ def _sgr_runs(text: str) -> list[tuple[frozenset, str]]:
     return out
 
 
-def _rule_states(text: str) -> set:
+def _rule_states(text: str, *, carry: bool = False) -> set:
     """The distinct appearances every pane-border cell in *text* is drawn with.
 
     One entry means every rule in the frame looks the same, which IS #514's property.
+
+    *carry* is `_sgr_runs`' own, and a frame with a SURFACE needs it: tmux does not
+    re-state a background a row already inherits, so the horizontal rules read as the
+    terminal's own default while the vertical ones read as the surface, and the property
+    would come back false on a frame that renders perfectly uniform.
     """
-    return {state for state, ch in _sgr_runs(text) if ch in _RULE_GLYPHS}
+    return {state for state, ch in _sgr_runs(text, carry=carry) if ch in _RULE_GLYPHS}
 
 
 def _rule_glyphs(text: str) -> set:
@@ -3949,10 +3965,20 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
                             ("pane-border-status", "top")):
             self.assertEqual(self._srv("set", "-wg", name, value).returncode, 0)
 
-    def _screenshot(self, *, arm: bool, hostile: bool = False) -> str:
+    def _screenshot(self, *, arm: bool, hostile: bool = False,
+                    surface: str | None = None, rules_too: bool = True) -> str:
         """Build the frame on the inner server, show it through the outer one, and return
-        what the outer pane holds — the frame's whole screen, escapes and all."""
-        session = f"f{int(arm)}{int(hostile)}-{self._pane_counter}"
+        what the outer pane holds — the frame's whole screen, escapes and all.
+
+        *surface* paints the three PANELS the way `_surface_argvs` paints them (pane-scoped
+        `window-style`, harness pane untouched). *rules_too* decides whether
+        `_chrome_argvs` is handed the matching background as well, and the two together are
+        what make the seam a measurement instead of a claim: painted panes with unpainted
+        rules is the frame the operator reported, and it is this class's own "render the
+        defect first" discipline applied to a defect that is a background rather than a
+        foreground."""
+        session = (f"f{int(arm)}{int(hostile)}{int(bool(surface))}{int(rules_too)}"
+                   f"-{self._pane_counter}")
         self._pane_counter += 1
         r = self._srv("new-session", "-d", "-s", session, "-x", "100", "-y", "24",
                       "-P", "-F", "#{pane_id}", "--", "cat")
@@ -3971,15 +3997,26 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
             self._hostile()
         if arm:
             # The production argv, never a hand-retyped `set-option` — see `_run`.
-            for cmd in commands_frame._chrome_argvs(socket=self.SOCKET_NAME,
-                                                    harness_pane=harness):
+            for cmd in commands_frame._chrome_argvs(
+                    socket=self.SOCKET_NAME, harness_pane=harness,
+                    surface=surface if rules_too else None):
                 self.assertEqual(_run(cmd).returncode, 0, cmd)
         for direction, before, size in self._SPLITS:
-            args = ["split-window", "-t", harness, direction]
+            args = ["split-window", "-t", harness, direction, "-P", "-F", "#{pane_id}"]
             if before:
-                args.append(before)
+                args.insert(4, before)
             args += ["-l", size, "--", "cat"]
-            self.assertEqual(self._srv(*args).returncode, 0, args)
+            r = self._srv(*args)
+            self.assertEqual(r.returncode, 0, args)
+            if surface:
+                # The production argv again, and pane-scoped exactly as production is —
+                # so the harness pane is never an argument here, which is the boundary
+                # ADR 0018 draws and the reason the frame's rules cannot borrow its
+                # colour from a pane it is not allowed to paint.
+                for cmd in commands_frame._surface_argvs(
+                        socket=self.SOCKET_NAME, pane_id=r.stdout.strip(), chrome="off",
+                        bg=surface.removeprefix("bg=")):
+                    self.assertEqual(_run(cmd).returncode, 0, cmd)
         self.assertEqual(self._srv("select-pane", "-t", harness).returncode, 0)
         host = f"host-{session}"
         r = self._outer("new-session", "-d", "-s", host, "-x", "100", "-y", "24",
@@ -3997,7 +4034,13 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         deadline = time.time() + 10
         shot = ""
         while time.time() < deadline:
-            got = self._outer("capture-pane", "-p", "-e", "-t", host)
+            # `-N` keeps the trailing spaces on each row, and without it a SURFACE is
+            # invisible to this harness: every pane here runs `cat` and writes nothing, so
+            # a painted pane is a rectangle of spaces and `capture-pane` trims the whole
+            # of it, leaving the background SGR with no cell to describe. It adds no
+            # glyph, so `_rule_states` and `_rule_glyphs` see exactly what they saw
+            # before. Available at `tmuxctl.FLOOR` as well as on 3.7c (measured).
+            got = self._outer("capture-pane", "-p", "-e", "-N", "-t", host)
             if got.returncode == 0:
                 shot = got.stdout
             if _rule_states(shot):
@@ -4068,6 +4111,68 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
                          (_rule_glyphs(own), _rule_states(own)),
                          "charter's frame is drawn differently on the operator's server "
                          "than on charter's own")
+
+    #: The colour every panel in a surfaced screenshot is painted, and the only
+    #: non-default background on the screen — the harness pane is never painted, and every
+    #: pane runs `cat` and writes nothing.
+    _SURFACE = "bg=brightblack"
+
+    def _backgrounds(self, shot: str) -> tuple[set, set]:
+        """`(what the rules are drawn over, what the painted panes are drawn over)`.
+
+        Read out of ONE capture rather than compared against an SGR constant this test
+        would have to know: the surfaced panes are the only cells on the screen with a
+        background at all, so "the rule matches the panels" is answerable without this
+        file knowing what `brightblack` is spelled as on the wire.
+        """
+        cells = _sgr_runs(shot, carry=True)
+        rules = {dict(s)["bg"] for s, ch in cells if ch in _RULE_GLYPHS}
+        panes = {dict(s)["bg"] for s, _ch in cells} - {"default"}
+        return rules, panes
+
+    def _seam(self) -> tuple[set, set]:
+        """The defect, rendered — this class's `_control` for a background rather than a
+        foreground. Panels painted, rules left as `_CHROME_STYLE` alone: every border cell
+        comes back over the terminal's own background while the panes on both sides of it
+        are over another, which is the one-cell strip the operator reported.
+
+        Skips rather than fails on a machine that cannot render it, for `_control`'s
+        reason: a harness that cannot see the seam cannot testify about its absence.
+        """
+        rules, panes = self._backgrounds(
+            self._screenshot(arm=True, surface=self._SURFACE, rules_too=False))
+        if not rules:
+            raise unittest.SkipTest("this machine rendered no pane borders at all")
+        if not panes:
+            raise unittest.SkipTest(
+                "this tmux painted no pane background through a nested client, so there "
+                "is no surface here for a rule to fail to match")
+        return rules, panes
+
+    def test_a_surfaced_frame_really_does_render_a_seam_between_its_panes(self):
+        """The defect itself, named rather than only used as a control."""
+        rules, panes = self._seam()
+        self.assertEqual(rules, {"default"},
+                         "the rules already carry a background before charter puts one "
+                         f"there, so the seam does not reproduce here: {rules}")
+        self.assertNotEqual(rules, panes)
+
+    def test_the_frames_rules_are_drawn_over_the_frames_own_surface(self):
+        """The fix, on the screen the operator judges it by. Every border cell is drawn
+        over the same background as the panes it runs between, so there is no strip left
+        between them — and #514's property survives it: still ONE appearance for every
+        rule in the frame, including the ones running past the active pane's corner."""
+        self._seam()
+        shot = self._screenshot(arm=True, surface=self._SURFACE)
+        rules, panes = self._backgrounds(shot)
+        self.assertEqual(len(panes), 1,
+                         f"the panels came out more than one colour: {panes}")
+        self.assertEqual(rules, panes,
+                         "a rule is still drawn over a different background than the "
+                         f"panes it separates: rules={rules} panes={panes}")
+        self.assertEqual(len(_rule_states(shot, carry=True)), 1,
+                         "the surfaced frame draws its rules two ways — #514, reopened "
+                         "on the background instead of the foreground")
 
     def test_charters_chrome_reaches_charters_own_window_and_no_other(self):
         """The boundary the `-w` scope is for, measured on a real server rather than


### PR DESCRIPTION
Closes #627.

`window-style` paints a **pane's** rectangle. The one-cell rule tmux draws between two
panes is in neither rectangle — it comes from `pane-border-style`, pinned to
`fg=default,dim` since #514: a foreground and an attribute, and no background. So a plane
that painted all four panels got grey boxes with the terminal's own black running between
them.

## Show it

Real `capture-pane -p -e`, escapes visible (`ESC` for `\x1b`), through a nested tmux so the
outer pane's content **is** the frame's whole screen, borders included. Both runs use
charter's production argvs (`_chrome_argvs`, `_surface_argvs`), three panes at
`bg = "brightblack"`, `chrome = "dark"`, tmux 3.7c. `-N` keeps the trailing spaces, without
which a painted pane full of them is trimmed away and its background has no cell to
describe.

**Before** — `pane-border-style` = `fg=default,dim`:

```
$ tmux show -wv -t s pane-border-style
fg=default,dim
$ tmux show -wv -t s pane-active-border-style
fg=default,dim
$ tmux -L outer capture-pane -p -e -N -t %0
ESC[100m
ESC[2mESC[49m─────────────────────────────────────────────────────────┬────────────────────
ESC[0m                                                         ESC[2m│ESC[0mESC[100m
ESC[49m                                                         ESC[2m│ESC[0mESC[100m
ESC[49m                                                         ESC[2m│ESC[0mESC[100m
```

`ESC[49m` — the terminal's own background — for the whole horizontal rule, and for the
`│` between two `ESC[100m` panes. That is the seam.

**After** — `pane-border-style` = `fg=default,dim,bg=brightblack`:

```
$ tmux show -wv -t s pane-border-style
fg=default,dim,bg=brightblack
$ tmux show -wv -t s pane-active-border-style
fg=default,dim,bg=brightblack
$ tmux -L outer capture-pane -p -e -N -t %0
ESC[100m
ESC[2m─────────────────────────────────────────────────────────┬────────────────────
ESC[0m                                                         ESC[2mESC[100m│ESC[0mESC[100m
ESC[49m                                                         ESC[2mESC[100m│ESC[0mESC[100m
ESC[49m                                                         ESC[2mESC[100m│ESC[0mESC[100m
```

The `ESC[49m` in front of the rule is gone. The horizontal rule now carries no SGR at all —
tmux does not re-state a background the row already inherits, so it is drawn over the
`ESC[100m` the panel above it left behind — and the vertical rule carries `ESC[100m`
explicitly. Same frame at the floor: no `ESC[49m` on a rule row there either.

## The design question, answered

**A border has a different pane on each side, and tmux draws one border rather than two
half-borders.** So "match the panel side" is not a thing that exists — and where a
per-side value does exist it is worse than not existing:

| | tmux 3.7c | tmux 3.2 (`tmuxctl.FLOOR`) |
|---|---|---|
| `set -p pane-border-style bg=red` | rc 0, stored on the pane | rc 0, **written to the WINDOW** |
| `show -p` on a pane nobody set | `''` | the window's value |
| rule between L=red and R=green | **red** — the pane above/left wins, the other side is ignored | whatever was written last, window-wide |
| `set -p -u` | removes the pane's | removes **charter's own #514 pin** for the whole window |

A per-side design is therefore unavailable at the floor, silently window-wide there, and
one-sided where it exists. **Window-scoped, `-w`, exactly as the other four `_CHROME`
options already are** — the operator's instinct, with the mechanism behind it.

**Which colour, then.** Not the frame-wide `chrome` alone: this plane sets
`chrome = "dark"` (surface `bg=black`) and `bg = "brightblack"` on every component, so the
frame-wide word is a colour that **nothing on the screen is wearing** — and it cannot be
made to match, because `chrome` is a closed enum of three and none of them means
"brightblack". A rule painted from it would still be a dark strip between grey panes. The
operator's own comment in `charter.toml` states the intent in words: *"charter's chrome is
grey, the work area is the terminal's own."*

So `instance.border_bg` takes **the surface the components agree on, and the frame-wide
`chrome` surface when they do not.** A gutter in the frame's own colour between two
differently-coloured panels is what an application looks like; a gutter in *no* colour
between two identically-coloured panels is a seam, and the seam is the whole report.

"Agree" is resolved through the same expression a pane resolves itself through —
`pane_bg_options(bg) or chrome_options(chrome)`, `_surface_argvs`' own — so it means what
an operator can see rather than "they wrote the same word": a component with no `bg` takes
the frame-wide surface and agrees with one that named the colour that surface already is.

## `pane-active-border-style`

tmux's default for it **is** the format expression
`#{?pane_in_mode,fg=yellow,#{?synchronize-panes,fg=red,fg=green}}` (measured). Charter has
replaced it wholesale since #514 — that is the fix, not a side effect — so the active-pane
and copy-mode indication was already discarded and is unchanged here. It gets the identical
value including the background, and the reason is #514 said about a background: the defect
was a rule that changed colour where it passed the active pane's **corner**, and a
background changing there is that defect an order of magnitude more visible. Focus is drawn
where it cannot run past a corner — on the pane's own rectangle, by `window-active-style`,
which `FRAME_PANE_BG` already pairs with every colour.

## The constraints, kept

* **No operator string reaches a style value.** The word is only ever a key; what comes
  back is a value out of `FRAME_PANE_BG` or `FRAME_CHROME`, asserted as membership of those
  tables rather than as "no `#` in it". Re-measured against *this* option rather than
  inherited from `window-style`'s: `set -w pane-border-style 'bg=#{?#{==:1,1},colour196,colour46}'`
  is **rc 0 and reads back verbatim**, and `bg=chartreuse` is rc 0 too (tmux knows the X11
  names, and `chartreuse` is a fixed RGB point no theme moves — `FRAME_PANE_COLOURS`' own
  hazard). tmux refusing a value is not the boundary charter needs.
* **Sixteen names, no cube index, no 24-bit triple.** Pinned over the level × colour cross
  product.
* **`off` is a removal, not a third style** — and it needs no `-u`: these two options are
  charter's own at *every* level (#514 pins them with or without a surface), so re-issuing
  them without a background *is* the removal, and `_chrome_argvs(surface=None)` is asserted
  byte-identical to `dict(_CHROME)`. Which options carry a background is derived from the
  table (the entries pinned to `_CHROME_STYLE`), never listed beside it.
* **Live application works, and cannot disagree with the launch path.** Both read
  `config.FRAME`; neither needs a pane map. Pinned across the level × colour cross product
  (#610), plus the case that cost #610: `chrome: off` on a plane whose components named a
  colour keeps that colour on the rules, because it keeps it on the panes.
* **Zero runtime dependencies**, stdlib, `unittest`.

## Verification

* **Full suite, two environments**: 7415 tests, `OK` on CPython 3.14.4, and `OK` on
  CPython 3.12.13 with all 16 `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` variables
  dropped (the child's own `os.environ` checked empty of them first).
* **`tools/sweep.py`**: 11 mutations, **11 pinned, 0 survived, 0 unresolved**, 8.9 min —
  well inside #617's ceiling.
* **Hand-check, ten mutations, from an unmutated baseline** (#579). Every mutation asserted
  it applied (old text present *and* the file's hash changed), every restore verified
  against a hash taken before anything was touched, `finally` restores on a crash, and the
  post-restore run re-confirmed green. **All ten killed, zero survivors** — including the
  agreement branch, the fallback, resolving a no-`bg` component through `chrome`, which
  options are styles (both `== → nothing` and `== → !=`), the `NO_COLOR` gate, the launch
  path resolving a surface at all, the live path arming the rules at all, the `_PANE_ID_RE`
  check on the harness pane read off disk, and the live path using the level it just
  recorded. Separately confirmed that the **rendered** test alone kills the central one, so
  the screen assertion is load-bearing and not decoration.
* **Real tmux for every claim**, on 3.7c and on `tmuxctl.FLOOR` 3.2 built from source here.
  Charter's production argvs at the floor: both border styles rc 0 and read back verbatim;
  `pane-border-indicators` rc 1 `invalid option:` — pre-existing, reported and not fatal, as
  `test_a_chrome_setting_tmux_refuses_is_reported_but_not_fatal` already requires. Sockets
  killed and unlinked in one cleanup on every path, including the failing ones; nothing left
  in `/private/tmp/tmux-$(id -u)/`.

## What is new in the tests

`tests/test_frame_border_surface.py` (28 tests) is the table and the argv. The **screen** is
in `tests/test_frame_tmux_integration.py`'s existing `ChromeIsOneColour`, which already owns
the nested-tmux harness, and it keeps that class's own discipline: the seam is **rendered
first as a control**, and a machine that cannot reproduce it skips rather than passing
quietly.

Two shared helpers there gained an opt-in `carry` flag, default off so #514's tests are
byte-identical. It is needed for a *background*: tmux does not re-state one a row already
inherits, so a horizontal rule drawn over the surface reads as the terminal's own default
under a line-scoped parser and the property would come back false on a frame that renders
perfectly uniform. `capture-pane` gained `-N` for the same class of reason — every pane here
runs `cat`, so a painted pane is a rectangle of trailing spaces and the capture trimmed the
whole of it.

## Diff surface

`commands_frame.py` is contended, so the functional change there is four places:

* `_chrome_argvs` — signature (`surface=None`) and two body lines (`rule = …`, and
  `rule if value == _CHROME_STYLE else value`).
* `_CHROME` — doc comment only, no entries changed.
* `_split_panels` — `chrome = _current_chrome(fid)` moved above the arming loop (a pure
  read, previously below it), and `surface=instance.border_bg(config.FRAME, chrome)` passed.
* `cmd_chrome` — four lines at the end, arming the rules after the panes.

Everything else is `instance.border_bg` (new, `instance.py`), docs and tests.

## Not done

No version bump, no stamp, no tag. News entry at `version: unreleased`.
