### PR TITLE
A change spanning several repos is a record charter keeps, and its ordering is derived (Phase 4, Tasks 1-4)

### DIFF
--- a/charter/change.py
+++ b/charter/change.py
@@ -1,0 +1,513 @@
+"""The cross-repo **change** — one intent, N repositories, stored as intent only.
+
+A change is one JSON file, ``workspaces/<ws>/changes/<slug>.json``, holding the six things
+git and the forge cannot know: what this work is called, what it is *for*, which
+repositories are meant to be part of it, which branch in each is *this change's* branch as
+against the eleven others in that clone, which member must land before which, and which
+repository was considered and deliberately left out — with the reason somebody wrote down
+while they still knew it.
+
+**There is no state field.** No request number, no CI result, no branch position, no
+``landed`` flag. Those are all things git or the forge already knows, and ADR 0011 says
+what caching one costs: *"The moment a derivable fact is cached for convenience, this ADR
+has been reversed whether or not anyone says so."* Ordering is the case worth naming twice,
+because it looks like state and is not: ``needs`` is **declared** (only a human knows that
+repo B's change needs repo A's merged), and *blocked* is **derived** at read time from that
+declaration plus a fresh reading of what has landed — see :func:`blocked_members`, which
+writes nothing anywhere.
+
+**The key set is closed, at both ends, and an unknown key is refused by name.** #503's rule,
+for #503's reason: a key charter does not read reads as nothing at all, so ``need`` where
+``needs`` was meant is an ordering constraint that silently ceased to exist. The check runs
+on :func:`write` as well as :func:`read`, because a validator only the reader consults is
+one a caller can walk around by holding the record in memory.
+
+**Membership is committed. Destination is local.** The record carries bare repository
+names — never a URL, a host, a remote name, a forge kind or a base branch. A remote in a
+committed file is a *destination* that arrives from someone else's machine, which is
+``charter.toml``'s own rule (*"Arrangement is committed. Execution is local."*) applied to
+a different committed file. Where a member's work is pushed is resolved from that clone's
+own ``origin``, by the caller, at the time it pushes.
+
+A committed record is also **untrusted input**, and two of its fields cross out of this
+module into places where a string is not just a string:
+
+* a **branch** reaches ``git`` as argv, and ref grammar is not argv safety —
+  ``git check-ref-format`` accepts ``refs/heads/-b`` (measured on git 2.50.1), so a
+  ``{"branch": "-b"}`` in a record somebody else wrote is a flag. :func:`branch_refusal`
+  is the boundary half of that guard; every git invocation carrying one places it after
+  ``--`` as the other half, and neither substitutes for the other.
+* a **slug**, a **repo name**, a **why** and a **branch** all reach a report line somebody
+  reads, so every printing site sends them through :func:`contain.one_line` *before* any
+  width arithmetic.
+
+Vocabulary, because the noun is already taken: :mod:`charter.forge.base` calls **one pull
+or merge request** a change (``open_change``, ``change_sigil``). Here a **change** is the
+cross-repo object, a **member** is one repository's part of it, and a member's pull or
+merge request is a **request**. Neither name is renamed; both are shipped.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from . import config, contain, instance, workspace
+
+
+class RecordError(Exception):
+    """A change record charter will not act on, with the reason in the message.
+
+    Raised rather than answered with ``{}``, and that is the whole point of the class.
+    :func:`add_member`-shaped callers are read-modify-write, so a read that degraded to an
+    empty record would write back a record holding only the new member and drop every
+    sibling it never saw. That is not hypothetical: ``onepassword._fields`` returned ``{}``
+    for every non-zero ``op item get``, a rate-limited vault reported "has no secrets"
+    (#322), and the read-modify-write behind it piped back a template holding one key.
+    """
+
+
+#: The directory, relative to the workspace, that holds the records.
+DIRNAME = "changes"
+
+#: The landing log's directory, inside it. A separate name because it is a separate
+#: lifetime: the records are committed when the workspace is LIVE and the log is committed
+#: **never**, exactly as ``pieces/`` is never committed. It holds the past-tense
+#: declaration git cannot make — *charter merged this commit, for this change* — and the
+#: present tense is reconstructed by asking git, not by reading a flag.
+LOG_DIRNAME = "log"
+
+#: The whole top-level key set, matched exactly. Six keys, no seventh, none missing.
+KEYS = ("change", "why", "created", "by", "members", "excluded")
+
+#: One member's keys. ``needs`` is the ordering *declaration*; there is no ``state``,
+#: ``landed``, ``pr`` or ``ci``, and the closed set is what makes them unrepresentable
+#: rather than merely unwritten.
+MEMBER_KEYS = ("repo", "branch", "needs")
+
+#: One exclusion's keys — a repository considered and deliberately left out. ``why`` is
+#: required by the same rule that requires the change's own: the exclusion is the only
+#: artifact that makes a permanently partial world explicable six months later.
+EXCLUSION_KEYS = ("repo", "why", "at")
+
+
+def changes_dir(ws: str) -> Path:
+    """``workspaces/<ws>/changes/`` — a *sibling* of ``memory/``, ``todos/`` and
+    ``pieces/``, never a child.
+
+    **Not created by** :func:`workspace.scaffold`, and that is a decision with a failure
+    behind it rather than laziness. ``commands_workspace._ws_meta_paths`` filters its list
+    by existence, and that existence filter is doing double duty as a *non-emptiness*
+    filter: the paths go to git as literal arguments, and ``git rm --cached`` on one that
+    was never tracked fails the whole call. An always-present, always-empty ``changes/``
+    would break ``charter workspace live --off`` whole — untracking nothing, and leaving
+    the manifest and the memory committed on a workspace the operator has just made
+    private. So it is created by the first ``charter change create``, and ``changes/log/``
+    by the first landing, for the same reason ``todos/`` is created by the first todo.
+    """
+    return workspace.workspace_dir(ws) / DIRNAME
+
+
+def log_dir(ws: str) -> Path:
+    """``workspaces/<ws>/changes/log/`` — never committed. See :data:`LOG_DIRNAME`."""
+    return changes_dir(ws) / LOG_DIRNAME
+
+
+def path_for(ws: str, slug: str) -> Path:
+    """The record's path, or :class:`RecordError` when *slug* is not a change name.
+
+    The name is asked of :func:`instance.change_name_ok` — one rule, in one place, where
+    ``workspace_name_ok`` already lives — and it is asked *here* rather than only at
+    creation because a record can arrive from a hand edit, from an older charter, or from
+    somebody else's machine. Creation-time validation and containment answer different
+    questions, and #442 and #503 are both what happens when one is mistaken for the other.
+    """
+    if not instance.change_name_ok(slug):
+        raise RecordError(
+            f"{contain.readable(slug)} is not a change name (letters, digits, '.', '_', "
+            "'-'; must not start with a dot or a dash). This names a file in the plane and "
+            "a branch in every member, so it is refused rather than rewritten.")
+    return changes_dir(ws) / f"{slug}.json"
+
+
+def exists(ws: str, slug: str) -> bool:
+    """Is there a record for *slug*? False for a name that is not a change name."""
+    try:
+        return path_for(ws, slug).exists()
+    except RecordError:
+        return False
+
+
+def has_records(ws: str) -> bool:
+    """Does this workspace hold at least one change record — i.e. is there anything under
+    ``changes/`` that a LIVE workspace could have committed?
+
+    A sharper question than "does the directory exist", and it has to be, because that is
+    what ``commands_workspace._ws_meta_paths`` really needs and its existence filter is
+    only a *proxy* for. ``todos/`` can rely on the proxy: it is created with its index and
+    is never empty afterwards. ``changes/`` can be emptied — ``charter change forget`` on
+    the last record leaves the directory behind, and a directory holding nothing but the
+    never-committed ``log/`` is the same case. Either way ``git rm --cached`` on a path
+    with nothing tracked under it fails the **whole** call, taking the manifest and the
+    memory down with it on a ``workspace live --off`` the operator ran to make a workspace
+    private. Asking the sharp question here keeps that knowledge in the module that owns
+    the record's shape.
+    """
+    try:
+        return any(p.name.endswith(".json") for p in changes_dir(ws).iterdir())
+    except OSError:
+        return False
+
+
+def read(ws: str, slug: str) -> dict:
+    """The record for *slug*, validated — or :class:`RecordError` saying what is wrong.
+
+    **Both refusals, not one** (#336). ``file_refusal`` cannot see the variant where the
+    *directory* is the link: every file inside a symlinked ``changes/`` is an ordinary
+    regular file with nothing to object to, and only ``dir_refusal`` — which resolves —
+    catches it.
+    """
+    p = path_for(ws, slug)
+    refusal = contain.dir_refusal(p.parent) or contain.file_refusal(p)
+    if refusal:
+        raise RecordError(refusal)
+    try:
+        raw = p.read_text()
+    except OSError as exc:
+        raise RecordError(f"change {contain.readable(slug)}: cannot be read ({exc})") from exc
+    try:
+        rec = json.loads(raw)
+    except ValueError as exc:
+        raise RecordError(
+            f"change {contain.readable(slug)}: the record is not JSON ({exc})") from exc
+    validate(rec, slug)
+    return rec
+
+
+def write(ws: str, slug: str, rec: dict) -> Path:
+    """Write *rec* as the record for *slug*, validated first. Returns the path.
+
+    The validation is not a courtesy to the next reader: without it, the closed key set is
+    a rule only the read path enforces, and anything that hangs a derived value off the
+    in-memory record — a cached ``blocked`` set, a remembered request number — serialises
+    it here and it is a stored state field from that moment on.
+    """
+    validate(rec, slug)
+    p = contain.writable(path_for(ws, slug))
+    config.mkdir_for(p.parent)
+    config.write_for(p, _serialise(rec))
+    return p
+
+
+def forget(ws: str, slug: str) -> Path | None:
+    """Delete the record for *slug*; return the path removed, or ``None`` if there was
+    none. Deletes **no** landing-log line and no branch: the log is a past-tense
+    declaration, and deleting history to tidy a list is how a store starts lying."""
+    p = path_for(ws, slug)
+    if contain.write_refusal(p) or not p.exists():
+        return None
+    p.unlink()
+    return p
+
+
+def all_for(ws: str) -> tuple[list[dict], list[tuple[str, str]]]:
+    """Every record in the workspace, as ``(records, refused)``.
+
+    Two lists rather than one, in ``workspace.merge_repo_rows``' shape and for its reason:
+    a record charter could not read is something the caller **reports**, never something
+    it silently passes off as absent. One bad file must not take the listing down, and it
+    must not disappear either — those are the two failure modes, and returning only the
+    good half picks one of them by accident.
+    """
+    records: list[dict] = []
+    refused: list[tuple[str, str]] = []
+    d = changes_dir(ws)
+    complaint = contain.dir_refusal(d)
+    if complaint:
+        return records, [(DIRNAME, complaint)]
+    try:
+        names = sorted(p.name for p in d.iterdir())
+    except OSError:
+        return records, refused          # no changes/ yet: the lazy-creation case
+    for name in names:
+        if not name.endswith(".json"):
+            continue                     # changes/log/, and anything else that is not one
+        slug = name[: -len(".json")]
+        try:
+            records.append(read(ws, slug))
+        except RecordError as exc:
+            refused.append((slug, str(exc)))
+    return records, refused
+
+
+# --------------------------------------------------------------------------- #
+# validation — the closed key set, the containment, and the ordering            #
+# --------------------------------------------------------------------------- #
+
+def validate(rec, slug: str) -> None:
+    """Raise :class:`RecordError` unless *rec* is a change record for *slug*."""
+    if not isinstance(rec, dict):
+        raise RecordError(f"change {contain.readable(slug)}: the record is not an object")
+    _closed(rec, KEYS, f"change {contain.readable(slug)}")
+
+    if rec["change"] != slug:
+        raise RecordError(
+            f"change {contain.readable(slug)}: the record calls itself "
+            f"{contain.readable(rec['change'])}. The filename and the name are one "
+            "identity — the name is what a merge commit's trailer carries, so a record "
+            "that disagrees with its own file has two of them.")
+    if not instance.change_name_ok(rec["change"]):
+        raise RecordError(f"{contain.readable(rec['change'])} is not a change name")
+    for key in ("why", "created", "by"):
+        _one_line(rec[key], f"change {contain.readable(slug)}: {key}")
+
+    if not isinstance(rec["members"], list):
+        raise RecordError(f"change {contain.readable(slug)}: 'members' is not a list")
+    seen: set[str] = set()
+    for m in rec["members"]:
+        if not isinstance(m, dict):
+            raise RecordError(f"change {contain.readable(slug)}: a member is not an object")
+        _closed(m, MEMBER_KEYS, f"change {contain.readable(slug)}: member")
+        repo = _repo_name(m["repo"], f"change {contain.readable(slug)}: member")
+        if repo in seen:
+            raise RecordError(
+                f"change {contain.readable(slug)}: '{repo}' is a member twice")
+        seen.add(repo)
+        complaint = branch_refusal(m["branch"])
+        if complaint:
+            raise RecordError(f"change {contain.readable(slug)}: member '{repo}': {complaint}")
+        if not isinstance(m["needs"], list):
+            raise RecordError(
+                f"change {contain.readable(slug)}: member '{repo}': 'needs' is not a list")
+        for n in m["needs"]:
+            _repo_name(n, f"change {contain.readable(slug)}: member '{repo}': needs")
+
+    if not isinstance(rec["excluded"], list):
+        raise RecordError(f"change {contain.readable(slug)}: 'excluded' is not a list")
+    for e in rec["excluded"]:
+        if not isinstance(e, dict):
+            raise RecordError(
+                f"change {contain.readable(slug)}: an exclusion is not an object")
+        _closed(e, EXCLUSION_KEYS, f"change {contain.readable(slug)}: exclusion")
+        repo = _repo_name(e["repo"], f"change {contain.readable(slug)}: exclusion")
+        if repo in seen:
+            raise RecordError(
+                f"change {contain.readable(slug)}: '{repo}' is both a member and excluded")
+        for key in ("why", "at"):
+            _one_line(e[key], f"change {contain.readable(slug)}: exclusion '{repo}': {key}")
+
+    complaint = order_refusal(rec)
+    if complaint:
+        raise RecordError(f"change {contain.readable(slug)}: {complaint}")
+
+
+def _closed(obj: dict, keys: tuple[str, ...], where: str) -> None:
+    """The closed key set, both directions, refused **by name**.
+
+    Unknown *and* missing, because they are the same defect seen from two sides: a record
+    with ``need`` where ``needs`` was meant has an unknown key and a missing one, and
+    naming only the first would leave a reader hunting for the typo they already made.
+    """
+    unknown = sorted(k for k in obj if k not in keys)
+    if unknown:
+        raise RecordError(
+            f"{where}: unknown key "
+            + ", ".join(contain.readable(k) for k in unknown)
+            + f". The key set is closed — {', '.join(keys)} — and a key charter does not "
+            "read reads as nothing at all, so it is named rather than ignored.")
+    missing = [k for k in keys if k not in obj]
+    if missing:
+        raise RecordError(f"{where}: missing key {', '.join(missing)}")
+
+
+def _one_line(value, where: str) -> str:
+    """*value* when it is a non-empty single line, else :class:`RecordError`.
+
+    A ``why`` that cannot be one line is a ``why`` that belongs in ``workspace.md``, which
+    is where this plane keeps prose. Refusing it here is the boundary half; every printing
+    site still calls :func:`contain.one_line`, because this cannot see what a *future*
+    reader's terminal does with U+2028 and that function can.
+    """
+    if not isinstance(value, str) or not value.strip():
+        raise RecordError(f"{where}: expected a non-empty string, got {contain.readable(value)}")
+    if contain.one_line(value) != value:
+        raise RecordError(
+            f"{where}: {contain.readable(value)} is not one plain line. This is repeated "
+            "back on a report row and written into a pull request body, where a newline "
+            "forges a second row.")
+    return value
+
+
+def _repo_name(value, where: str) -> str:
+    """A member's (or a blocker's, or an exclusion's) repository name.
+
+    :func:`contain.segment_ok` and deliberately **not** ``workspace.valid_name``: the name
+    comes from a forge rather than from charter, and ``.github`` is a real and common
+    repository that ``valid_name`` rejects for starting with a dot. That distinction has
+    already cost this project once. What is being asked is containment — could this string
+    name one entry inside the workspace directory — and nothing more.
+    """
+    if not isinstance(value, str) or not contain.segment_ok(value):
+        # `readable` inside `refusal`, not instead of it: the sentence tells somebody to go
+        # and fix this name in a file, and a name they cannot read off the row is a name
+        # they cannot find (#579). `refusal` bounds the result to one line either way.
+        raise RecordError(f"{where}: {contain.refusal(contain.readable(value))}")
+    return value
+
+
+def branch_refusal(branch) -> str | None:
+    """Why this branch name must not be handed to git, or ``None``.
+
+    ``git check-ref-format`` **accepts** ``refs/heads/-b`` — measured on git 2.50.1 — so
+    ref grammar answers a different question from the one being asked here. The value is
+    read out of a committed file and reaches ``git`` as argv, where a leading dash is a
+    flag. This is one of the two mechanisms; the other is that every invocation carrying a
+    branch places it after ``--``, and either alone has already been enough to ship a bug
+    in this repository.
+    """
+    if not isinstance(branch, str) or not branch:
+        return f"{contain.readable(branch)} is not a branch name (a non-empty string)"
+    if branch.startswith("-"):
+        return (f"branch {contain.readable(branch)} begins with '-', so it reaches git as a "
+                "FLAG rather than as a branch. `git check-ref-format` accepts "
+                "`refs/heads/-b`, so ref grammar does not answer this.")
+    if contain.one_line(branch) != branch:
+        return (f"branch {contain.readable(branch)} is not one plain line — it carries a "
+                "character with no glyph, or is longer than a report row.")
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# ordering — declared per member, derived at read time, stored never            #
+# --------------------------------------------------------------------------- #
+
+def order_refusal(rec: dict) -> str | None:
+    """Why this record's ``needs`` cannot be true, or ``None``.
+
+    Three ways, and each is a record rather than a state: a member that blocks itself, a
+    ``needs`` naming a repository that is not a member of this change (so nothing will ever
+    land it *for this change*, and the member waits for ever), and a cycle. A cycle is not
+    a condition to render — it is an ordering no sequence satisfies — so it is refused at
+    write time with the members in it named, rather than reported at read time.
+    """
+    graph = {m["repo"]: list(m["needs"]) for m in rec["members"]}
+    for repo, needs in graph.items():
+        for n in needs:
+            if n == repo:
+                return (f"member '{repo}' declares itself as its own blocker — it would "
+                        "wait for its own landing")
+            if n not in graph:
+                return (f"member '{repo}' needs '{n}', which is not a member of this "
+                        "change. Add it first (charter change add), or drop the need — a "
+                        "blocker nothing will land is a member that never becomes ready.")
+    cycle = _cycle(graph)
+    if cycle:
+        return ("ordering cycle: " + " → ".join(f"'{r}'" for r in cycle)
+                + " — no member can go first, so this is a record that cannot be true")
+    return None
+
+
+def _cycle(graph: dict[str, list[str]]) -> list[str] | None:
+    """One cycle in the ``needs`` graph as a path that returns to its start, or ``None``.
+
+    The whole path, not the pair that closed it: with A → B → C → A, naming only C and A
+    sends the reader to edit the one edge that is hardest to see is wrong.
+    """
+    state: dict[str, int] = {}          # 1 = on the current path, 2 = fully explored
+    path: list[str] = []
+
+    def walk(node: str) -> list[str] | None:
+        state[node] = 1
+        path.append(node)
+        for nxt in graph[node]:
+            if state.get(nxt) == 1:
+                return path[path.index(nxt):] + [nxt]
+            if state.get(nxt) is None:
+                found = walk(nxt)
+                if found:
+                    return found
+        path.pop()
+        state[node] = 2
+        return None
+
+    for repo in graph:
+        if state.get(repo) is None:
+            found = walk(repo)
+            if found:
+                return found
+    return None
+
+
+def blocked_members(rec: dict, landed) -> dict[str, list[str]]:
+    """``{member: the blockers of that member that have NOT landed}`` — derived, never stored.
+
+    A pure function of the record plus a landing map, so it is verified by construction
+    and disappears the moment either changes. Nothing writes ``blocked`` anywhere: ADR
+    0011 forbids recording a state charter cannot verify, and this is the alternative
+    rather than an exception to it.
+
+    Iterating or membership-testing the result gives the *set* of blocked members; the
+    values are what a refusal has to name, because "blocked" without the blocker sends the
+    reader looking through five repositories for the one that has not gone in.
+
+    Computed for **every** member, including one that has already landed — deliberately.
+    ``set(blocked_members(rec, landed)) & set(landed)`` is then exactly §3.2's out-of-order
+    landing: a member that went in while a blocker had not. Charter cannot stop a human
+    merging in a browser, and the honest half of that guard is naming it when it happens.
+    """
+    have = set(landed or ())
+    out: dict[str, list[str]] = {}
+    for m in rec["members"]:
+        pending = [n for n in m["needs"] if n not in have]
+        if pending:
+            out[m["repo"]] = pending
+    return out
+
+
+def dependents(rec: dict, repo: str) -> list[str]:
+    """The members that declare *repo* as a blocker. What ``drop`` has to name."""
+    return [m["repo"] for m in rec["members"] if repo in m["needs"]]
+
+
+def member(rec: dict, repo: str) -> dict | None:
+    """The member row for *repo*, or ``None``."""
+    for m in rec["members"]:
+        if m["repo"] == repo:
+            return m
+    return None
+
+
+def exclusion(rec: dict, repo: str) -> dict | None:
+    """The exclusion row for *repo*, or ``None``."""
+    for e in rec["excluded"]:
+        if e["repo"] == repo:
+            return e
+    return None
+
+
+def new_record(slug: str, why: str, by: str, created: str) -> dict:
+    """A change with no members and no exclusions yet."""
+    return {"change": slug, "why": why, "created": created, "by": by,
+            "members": [], "excluded": []}
+
+
+def default_branch(slug: str) -> str:
+    """The branch name ``charter change add`` offers. Stored in the record, never derived
+    from a convention afterwards — a convention breaks the moment somebody names one
+    differently, and git can tell you a branch exists but never that it is *this
+    change's*."""
+    return f"change/{slug}"
+
+
+def _serialise(rec: dict) -> str:
+    """The record's bytes: the keys in :data:`KEYS` order, two-space indent, one trailing
+    newline — ``workspace.write_manifest``'s shape.
+
+    Canonical rather than insertion-ordered so that a record read and written back is
+    byte-identical whatever order it happened to be typed in, which is what makes "nothing
+    derived reached disk" an assertion a test can make on the file itself.
+    """
+    ordered = {k: rec[k] for k in KEYS}
+    ordered["members"] = [{k: m[k] for k in MEMBER_KEYS} for m in rec["members"]]
+    ordered["excluded"] = [{k: e[k] for k in EXCLUSION_KEYS} for e in rec["excluded"]]
+    return json.dumps(ordered, indent=2) + "\n"

--- a/charter/change.py
+++ b/charter/change.py
@@ -353,7 +353,10 @@ def _one_line(value, where: str) -> str:
     site still calls :func:`contain.one_line`, because this cannot see what a *future*
     reader's terminal does with U+2028 and that function can.
     """
-    if not isinstance(value, str) or not value.strip():
+    # `not value or value.isspace()` rather than `not value.strip()`: inside a truthiness
+    # test `strip`, `lstrip` and `rstrip` give the same answer, so that spelling is three
+    # interchangeable lines and no test can say which one is meant.
+    if not isinstance(value, str) or not value or value.isspace():
         raise RecordError(f"{where}: expected a non-empty string, got {contain.readable(value)}")
     if contain.one_line(value, limit=TEXT_LIMIT) != value:
         raise RecordError(

--- a/charter/change.py
+++ b/charter/change.py
@@ -85,6 +85,15 @@ KEYS = ("change", "why", "created", "by", "members", "excluded")
 #: rather than merely unwritten.
 MEMBER_KEYS = ("repo", "branch", "needs")
 
+#: How long a record's own text may be. `contain`'s PATH budget rather than its ROW budget,
+#: and the difference is load-bearing in both directions: a `why` a little over one row is a
+#: legitimate `why` and refusing it would send somebody to hand-edit the file, while the row
+#: budget still applies where rows are drawn — `contain.one_line` clips to `DISPLAY_LIMIT` at
+#: every printing site, and that clipping is a thing a test can see precisely because this
+#: bound is the looser one. What is refused here is a character with no glyph, which is a
+#: question about the value's shape rather than its length.
+TEXT_LIMIT = contain.PATH_DISPLAY_LIMIT
+
 #: One exclusion's keys — a repository considered and deliberately left out. ``why`` is
 #: required by the same rule that requires the change's own: the exclusion is the only
 #: artifact that makes a permanently partial world explicable six months later.
@@ -247,60 +256,74 @@ def all_for(ws: str) -> tuple[list[dict], list[tuple[str, str]]]:
 # --------------------------------------------------------------------------- #
 
 def validate(rec, slug: str) -> None:
-    """Raise :class:`RecordError` unless *rec* is a change record for *slug*."""
-    if not isinstance(rec, dict):
-        raise RecordError(f"change {contain.readable(slug)}: the record is not an object")
-    _closed(rec, KEYS, f"change {contain.readable(slug)}")
+    """Raise :class:`RecordError` unless *rec* is a change record for *slug*.
 
+    **The slug is asked about first, and that is what lets every sentence below name it
+    plainly.** From the second line down, *slug* is `[A-Za-z0-9][A-Za-z0-9._-]*` — a value
+    no report row can be forged out of — so containing it again at each of the fourteen
+    messages would be fourteen calls no test could redden. :func:`read` has already asked
+    this through :func:`path_for`; :func:`write` has not, because it validates the record
+    before it resolves the path, so the invariant belongs here rather than in an order the
+    callers have to keep.
+
+    A record that calls *itself* something else is a different question, and that one IS
+    contained: the record is the untrusted half.
+    """
+    if not instance.change_name_ok(slug):
+        raise RecordError(f"{contain.readable(slug)} is not a change name")
+    if not isinstance(rec, dict):
+        raise RecordError(f"change '{slug}': the record is not an object")
+    _closed(rec, KEYS, f"change '{slug}'")
+
+    # No second `change_name_ok`, on `rec["change"]`: the line above has just established
+    # that it EQUALS *slug*, which the first line established is a change name.
     if rec["change"] != slug:
         raise RecordError(
-            f"change {contain.readable(slug)}: the record calls itself "
+            f"change '{slug}': the record calls itself "
             f"{contain.readable(rec['change'])}. The filename and the name are one "
             "identity — the name is what a merge commit's trailer carries, so a record "
             "that disagrees with its own file has two of them.")
-    if not instance.change_name_ok(rec["change"]):
-        raise RecordError(f"{contain.readable(rec['change'])} is not a change name")
     for key in ("why", "created", "by"):
-        _one_line(rec[key], f"change {contain.readable(slug)}: {key}")
+        _one_line(rec[key], f"change '{slug}': {key}")
 
     if not isinstance(rec["members"], list):
-        raise RecordError(f"change {contain.readable(slug)}: 'members' is not a list")
+        raise RecordError(f"change '{slug}': 'members' is not a list")
     seen: set[str] = set()
     for m in rec["members"]:
         if not isinstance(m, dict):
-            raise RecordError(f"change {contain.readable(slug)}: a member is not an object")
-        _closed(m, MEMBER_KEYS, f"change {contain.readable(slug)}: member")
-        repo = _repo_name(m["repo"], f"change {contain.readable(slug)}: member")
+            raise RecordError(f"change '{slug}': a member is not an object")
+        _closed(m, MEMBER_KEYS, f"change '{slug}': member")
+        repo = _repo_name(m["repo"], f"change '{slug}': member")
         if repo in seen:
             raise RecordError(
-                f"change {contain.readable(slug)}: '{repo}' is a member twice")
+                f"change '{slug}': '{repo}' is a member twice")
         seen.add(repo)
         complaint = branch_refusal(m["branch"])
         if complaint:
-            raise RecordError(f"change {contain.readable(slug)}: member '{repo}': {complaint}")
+            raise RecordError(f"change '{slug}': member '{repo}': {complaint}")
         if not isinstance(m["needs"], list):
             raise RecordError(
-                f"change {contain.readable(slug)}: member '{repo}': 'needs' is not a list")
+                f"change '{slug}': member '{repo}': 'needs' is not a list")
         for n in m["needs"]:
-            _repo_name(n, f"change {contain.readable(slug)}: member '{repo}': needs")
+            _repo_name(n, f"change '{slug}': member '{repo}': needs")
 
     if not isinstance(rec["excluded"], list):
-        raise RecordError(f"change {contain.readable(slug)}: 'excluded' is not a list")
+        raise RecordError(f"change '{slug}': 'excluded' is not a list")
     for e in rec["excluded"]:
         if not isinstance(e, dict):
             raise RecordError(
-                f"change {contain.readable(slug)}: an exclusion is not an object")
-        _closed(e, EXCLUSION_KEYS, f"change {contain.readable(slug)}: exclusion")
-        repo = _repo_name(e["repo"], f"change {contain.readable(slug)}: exclusion")
+                f"change '{slug}': an exclusion is not an object")
+        _closed(e, EXCLUSION_KEYS, f"change '{slug}': exclusion")
+        repo = _repo_name(e["repo"], f"change '{slug}': exclusion")
         if repo in seen:
             raise RecordError(
-                f"change {contain.readable(slug)}: '{repo}' is both a member and excluded")
+                f"change '{slug}': '{repo}' is both a member and excluded")
         for key in ("why", "at"):
-            _one_line(e[key], f"change {contain.readable(slug)}: exclusion '{repo}': {key}")
+            _one_line(e[key], f"change '{slug}': exclusion '{repo}': {key}")
 
     complaint = order_refusal(rec)
     if complaint:
-        raise RecordError(f"change {contain.readable(slug)}: {complaint}")
+        raise RecordError(f"change '{slug}': {complaint}")
 
 
 def _closed(obj: dict, keys: tuple[str, ...], where: str) -> None:
@@ -332,7 +355,7 @@ def _one_line(value, where: str) -> str:
     """
     if not isinstance(value, str) or not value.strip():
         raise RecordError(f"{where}: expected a non-empty string, got {contain.readable(value)}")
-    if contain.one_line(value) != value:
+    if contain.one_line(value, limit=TEXT_LIMIT) != value:
         raise RecordError(
             f"{where}: {contain.readable(value)} is not one plain line. This is repeated "
             "back on a report row and written into a pull request body, where a newline "
@@ -373,9 +396,9 @@ def branch_refusal(branch) -> str | None:
         return (f"branch {contain.readable(branch)} begins with '-', so it reaches git as a "
                 "FLAG rather than as a branch. `git check-ref-format` accepts "
                 "`refs/heads/-b`, so ref grammar does not answer this.")
-    if contain.one_line(branch) != branch:
+    if contain.one_line(branch, limit=TEXT_LIMIT) != branch:
         return (f"branch {contain.readable(branch)} is not one plain line — it carries a "
-                "character with no glyph, or is longer than a report row.")
+                "character with no glyph, or is longer than a committed value may be.")
     return None
 
 

--- a/charter/change.py
+++ b/charter/change.py
@@ -167,6 +167,9 @@ def read(ws: str, slug: str) -> dict:
     regular file with nothing to object to, and only ``dir_refusal`` — which resolves —
     catches it.
     """
+    # `path_for` refuses anything that is not a change name, so `slug` is
+    # `[A-Za-z0-9][A-Za-z0-9._-]*` from here down and the messages below need no further
+    # containment — `validate` does contain it, because `write` calls that one FIRST.
     p = path_for(ws, slug)
     refusal = contain.dir_refusal(p.parent) or contain.file_refusal(p)
     if refusal:
@@ -174,12 +177,11 @@ def read(ws: str, slug: str) -> dict:
     try:
         raw = p.read_text()
     except OSError as exc:
-        raise RecordError(f"change {contain.readable(slug)}: cannot be read ({exc})") from exc
+        raise RecordError(f"change '{slug}': cannot be read ({exc})") from exc
     try:
         rec = json.loads(raw)
     except ValueError as exc:
-        raise RecordError(
-            f"change {contain.readable(slug)}: the record is not JSON ({exc})") from exc
+        raise RecordError(f"change '{slug}': the record is not JSON ({exc})") from exc
     validate(rec, slug)
     return rec
 

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -9,6 +9,7 @@ import sys
 from . import (
     commands_update,
     commands,
+    commands_change,
     commands_frame,
     commands_harness,
     commands_persona,
@@ -360,6 +361,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_harness_parser(sub)
     _add_workspace_parser(sub)
     _add_worktree_parser(sub)
+    _add_change_parser(sub)
     _add_vault_parser(sub)
     _add_secret_parser(sub)
     _add_persona_parser(sub)
@@ -991,6 +993,72 @@ def _add_worktree_parser(sub) -> None:
                     help="Also delete the piece's branch.")
     rm.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
     rm.set_defaults(func=commands_worktree.cmd_worktree_remove)
+
+
+def _add_change_parser(sub) -> None:
+    """`charter change` — one intent, N repositories, as a per-workspace record.
+
+    Records only: nothing under this command reaches a network, and there is deliberately
+    **no expansion** anywhere in it — no glob, no pattern, no `--all-repos`, no "every repo
+    in the workspace". Membership is enumerated by hand, one literal repo name per
+    invocation, because in a LIVE workspace the record is committed and a record that could
+    grow itself is a committed file that names repositories nobody typed.
+    """
+    c = sub.add_parser("change",
+                       help="A change spanning several repos in one workspace: what it is "
+                            "for, which repos are in it, which must land first "
+                            "(workspaces/<ws>/changes/<slug>.json).")
+    csub = c.add_subparsers(dest="change_cmd", required=True)
+
+    cr = csub.add_parser("create", help="Create a change: a name and the reason for it.")
+    cr.add_argument("change", help="The change's slug — also its default branch name, and "
+                                   "the `Charter-Change:` trailer on every landing commit.")
+    # Required, and the handler refuses an empty one too. A change with no stated reason is
+    # unreadable six months later, which is the one job the record has that git cannot do.
+    cr.add_argument("--why", required=True,
+                    help="One line: what this work is for. Required.")
+    cr.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
+    cr.set_defaults(func=commands_change.cmd_change_create)
+
+    ad = csub.add_parser("add", help="Add one repo to the change, by literal name.")
+    ad.add_argument("change")
+    ad.add_argument("repo", help="A repo already cloned in this workspace. One name; there "
+                                 "is no pattern and no expansion.")
+    ad.add_argument("--branch", help="This member's branch (default: change/<slug>). Stored "
+                                     "in the record: git knows a branch exists, it cannot "
+                                     "know the branch is this change's.")
+    ad.add_argument("--needs", action="append", metavar="REPO",
+                    help="A member that must LAND before this one. Repeatable. Declared, "
+                         "because no amount of reading either repository reveals it.")
+    ad.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
+    ad.set_defaults(func=commands_change.cmd_change_add)
+
+    dr = csub.add_parser("drop", help="Take a repo out of the change (or record one that "
+                                      "was never in it), with the reason.")
+    dr.add_argument("change")
+    dr.add_argument("repo")
+    dr.add_argument("--why", required=True,
+                    help="One line: why this repo is out. Required — if members already "
+                         "landed, this is the only thing that makes the resulting partial "
+                         "world explicable.")
+    dr.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
+    dr.set_defaults(func=commands_change.cmd_change_drop)
+
+    ls = csub.add_parser("list", help="The workspace's changes, one row each.")
+    ls.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
+    ls.set_defaults(func=commands_change.cmd_change_list)
+
+    sh = csub.add_parser("show", help="One change whole: why, members, branches, blockers, "
+                                      "exclusions.")
+    sh.add_argument("change")
+    sh.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
+    sh.set_defaults(func=commands_change.cmd_change_show)
+
+    fg = csub.add_parser("forget", help="Delete the change record. Branches, requests and "
+                                        "the landing log are untouched.")
+    fg.add_argument("change")
+    fg.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
+    fg.set_defaults(func=commands_change.cmd_change_forget)
 
 
 def _add_vault_parser(sub) -> None:

--- a/charter/commands_change.py
+++ b/charter/commands_change.py
@@ -231,12 +231,11 @@ def cmd_change_drop(args) -> int:
     why = _why(args, "why this repo is out")
     if why is None:
         return 1
-    # Asked of every name, not only of one that is not already a member: a member's name
-    # came out of a validated record and passes by construction, so the unconditional form
-    # is the same rule with one fewer way to be wrong.
-    if not contain.segment_ok(repo):
-        util.err(contain.refusal(contain.readable(repo)))
-        return REFUSED
+    # No `segment_ok` gate here, deliberately, and it was measured rather than reasoned:
+    # `..` reaches `change.write` below, `_repo_name` refuses the exclusion it would have
+    # written, and the operator gets the same exit code and the same sentence — so a gate
+    # here is a line no test can redden. `add` is the opposite case and keeps its own: there
+    # the resolver has to answer *before* a name is joined onto a directory.
     if change.exclusion(rec, repo) is not None:
         util.err(f"'{repo}' is already excluded from '{slug}'.")
         return REFUSED
@@ -277,11 +276,10 @@ def cmd_change_forget(args) -> int:
     if not change.exists(ws, slug):
         util.err(f"no change {contain.readable(slug)} in workspace '{ws}'.")
         return REFUSED
-    try:
-        removed = change.forget(ws, slug)
-    except change.RecordError as exc:
-        util.err(str(exc))
-        return 1
+    # No `RecordError` handler: `exists` above has already put this slug through
+    # `path_for`, so the only way out of `forget` is a path charter must not write — a
+    # committed link at the record's own name — which is the `None` below.
+    removed = change.forget(ws, slug)
     if removed is None:
         util.err(f"could not delete the record for {contain.readable(slug)}.")
         return 1

--- a/charter/commands_change.py
+++ b/charter/commands_change.py
@@ -70,7 +70,10 @@ def _why(args, tail: str) -> str | None:
     if not why:
         util.err(f"--why is required: one line saying {tail}.")
         return None
-    if contain.one_line(why) != why:
+    # `change.TEXT_LIMIT`, not `contain`'s row budget: the record's own bound and this one
+    # have to be the same number, or a `why` charter accepts here is a record charter then
+    # refuses to read back. Where it is drawn, `contain.one_line` clips it to a row.
+    if contain.one_line(why, limit=change.TEXT_LIMIT) != why:
         util.err("--why must be one plain line — it is repeated back on a report row and "
                  "written into a pull request body. Longer reasoning belongs in "
                  "workspace.md, which is where this plane keeps prose.")
@@ -181,10 +184,11 @@ def cmd_change_add(args) -> int:
         util.info(f"Clone it first: charter clone {contain.readable(repo)} -w {ws}")
         return REFUSED
     if change.member(rec, repo) is not None:
-        util.err(f"'{repo}' is already a member of '{slug}'.")
+        shown = contain.readable(repo)
+        util.err(f"'{shown}' is already a member of '{slug}'.")
         util.info(f"Change its branch or blockers by editing "
                   f"workspaces/{ws}/changes/{slug}.json, or drop it first: "
-                  f"charter change drop {slug} {repo} --why \"…\"")
+                  f"charter change drop {slug} {shown} --why \"…\"")
         return REFUSED
 
     branch = getattr(args, "branch", None) or change.default_branch(slug)
@@ -209,7 +213,7 @@ def cmd_change_add(args) -> int:
         util.warn(f"the exclusion recorded on {contain.one_line(lifted['at'])} is lifted: "
                   f"{contain.one_line(lifted['why'])}")
     print(_member_line(rec, {"repo": repo, "branch": branch, "needs": needs}))
-    util.ok(f"'{repo}' is a member of '{slug}'")
+    util.ok(f"'{contain.readable(repo)}' is a member of '{slug}'")
     return 0
 
 
@@ -237,13 +241,13 @@ def cmd_change_drop(args) -> int:
     # here is a line no test can redden. `add` is the opposite case and keeps its own: there
     # the resolver has to answer *before* a name is joined onto a directory.
     if change.exclusion(rec, repo) is not None:
-        util.err(f"'{repo}' is already excluded from '{slug}'.")
+        util.err(f"'{contain.readable(repo)}' is already excluded from '{slug}'.")
         return REFUSED
     was_member = change.member(rec, repo) is not None
     blocked = change.dependents(rec, repo)
     if blocked:
-        util.err(f"'{repo}' cannot be dropped from '{slug}': "
-                 + ", ".join(f"'{b}'" for b in blocked) + " still need"
+        util.err(f"'{contain.readable(repo)}' cannot be dropped from '{slug}': "
+                 + ", ".join(f"'{contain.readable(b)}'" for b in blocked) + " still need"
                  + ("" if len(blocked) > 1 else "s") + " it to land first.")
         util.info("Drop those members first, or edit their `needs` — a blocker nothing "
                   "will land is a member that never becomes ready.")
@@ -255,10 +259,11 @@ def cmd_change_drop(args) -> int:
     code = _save(ws, slug, rec)
     if code:
         return code
+    shown = contain.readable(repo)
     if was_member:
-        util.ok(f"'{repo}' excluded — {len(rec['members'])} member(s) left")
+        util.ok(f"'{shown}' excluded — {len(rec['members'])} member(s) left")
     else:
-        util.ok(f"'{repo}' excluded (never a member)")
+        util.ok(f"'{shown}' excluded (never a member)")
     return 0
 
 

--- a/charter/commands_change.py
+++ b/charter/commands_change.py
@@ -1,0 +1,364 @@
+"""`charter change` — the cross-repo change, as records. **No forge, no network.**
+
+Six verbs over :mod:`charter.change`: ``create``, ``add``, ``drop``, ``list``, ``show`` and
+``forget``. Everything here is a file read, a file write and a directory listing; nothing in
+this module opens a socket, runs a forge CLI or pushes a branch. The forge half — push,
+gate, land, revert — is a later phase, and keeping the record surface separable from it is
+what makes "what did the operator declare" answerable without asking anybody's API.
+
+**Membership is enumerated by hand, and that is the containment property.** There is no
+glob, no pattern, no ``--all-repos``, no "every repo in the workspace", and nothing here
+calls ``inventory.list_repos``. Every member in a record was typed by somebody, and a member
+must resolve to a clone the operator already put in this workspace — so the reach of a
+change is bounded by what is already on the disk in front of you, and by nothing that
+travelled in a committed file. A record can name a repository you do not have; it is refused
+for that, by name, and it can never name a *place*.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+from pathlib import Path
+
+from . import change, contain, instance, tui, util, workspace
+
+#: Exit code for a **named refusal** — the request was understood and charter will not do
+#: it — as distinct from the generic 1 that means something went wrong. `commands_worktree`
+#: spends its 2 the same way (``CLAIM_TAKEN``) and for the same reason: a caller must not
+#: have to parse English to tell "you asked for something I refuse" from "the disk is full".
+#:
+#: Four conditions share the code and **none shares a message**: a repo with no clone, a
+#: change that does not exist, a member added twice, and an ordering that cannot be true.
+#: Three gates in sequence mask each other, and an exit-code assertion cannot tell them
+#: apart — so every refusal test here asserts *which* one fired.
+REFUSED = 2
+
+
+def _workspace(args) -> str:
+    ws = workspace.resolve(getattr(args, "workspace", None))
+    workspace.banner(ws, getattr(args, "workspace", None))
+    return ws
+
+
+def _now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
+
+
+def _author() -> str:
+    """Who is recorded as having created this change.
+
+    First line only, and contained: the value comes out of ``git config``, which is a file
+    on this machine that charter did not write, and it lands in a record that a LIVE
+    workspace commits and that every ``show`` prints back.
+    """
+    out = util.run(["git", "config", "user.name"], check=False).stdout or ""
+    name = contain.one_line((out.splitlines() or [""])[0].strip())
+    return name or os.environ.get("USER") or "unknown"
+
+
+def _why(args, tail: str) -> str | None:
+    """The ``--why`` this command was given, or ``None`` with the refusal printed.
+
+    Two checks, and argparse can make neither. ``required=True`` cannot see ``--why ""``,
+    and it cannot see a newline — which is the one that matters, because this value is
+    repeated back on report rows and, later, written into pull request bodies where a
+    newline forges a second row. A ``why`` that cannot be one line is prose, and prose
+    belongs in ``workspace.md``.
+    """
+    why = (getattr(args, "why", None) or "").strip()
+    if not why:
+        util.err(f"--why is required: one line saying {tail}.")
+        return None
+    if contain.one_line(why) != why:
+        util.err("--why must be one plain line — it is repeated back on a report row and "
+                 "written into a pull request body. Longer reasoning belongs in "
+                 "workspace.md, which is where this plane keeps prose.")
+        return None
+    return why
+
+
+def _load(ws: str, slug: str) -> tuple[dict | None, int]:
+    """``(record, 0)``, or ``(None, code)`` with the refusal already printed.
+
+    Two different failures, two different codes. *No such change* is a refusal of what was
+    asked (:data:`REFUSED`); a record that exists and does not parse is a defect in a file
+    somebody has to go and fix, which is an error (1). Collapsing them would tell an agent
+    to create a change that is already there.
+    """
+    if not change.exists(ws, slug):
+        util.err(f"no change {contain.readable(slug)} in workspace '{ws}'.")
+        util.info("List them: charter change list"
+                  f"  ·  create it: charter change create {contain.readable(slug)} --why \"…\"")
+        return None, REFUSED
+    try:
+        return change.read(ws, slug), 0
+    except change.RecordError as exc:
+        util.err(str(exc))
+        return None, 1
+
+
+def _save(ws: str, slug: str, rec: dict) -> int:
+    """Write *rec* back, turning either refusal into an exit code.
+
+    :class:`change.RecordError` here is an ordering that cannot be true — the cycle gate —
+    and it is a refusal of the request. :class:`contain.Refused` is a path charter must not
+    write, which is an error about the plane rather than about the request.
+    """
+    try:
+        change.write(ws, slug, rec)
+    except change.RecordError as exc:
+        util.err(str(exc))
+        return REFUSED
+    except contain.Refused as exc:
+        util.err(str(exc))
+        return 1
+    return 0
+
+
+def _clone_for(ws: str, repo: str) -> Path | None:
+    """The clone this member resolves to, or ``None``.
+
+    :func:`contain.child` is the single gate, and it refuses rather than sanitises —
+    *"silently rewriting a name invents a second identity"*. It is what makes ``..``, an
+    absolute path, a drive-qualified name and a NUL unable to name a member at all. The
+    rule underneath it is :func:`contain.segment_ok` and deliberately **not**
+    ``workspace.valid_name``: ``.github`` is a real repository name, it comes from a forge
+    rather than from charter, and ``valid_name`` rejects it for the leading dot.
+
+    ``is_clone`` is the second half and answers a different question — git itself draws
+    that line, since a clone's ``.git`` is a directory — so a symlink pointing out of the
+    workspace, a plain file, or a directory that is not a checkout are all refused here
+    rather than becoming a member charter would later try to push.
+    """
+    path = contain.child(workspace.workspace_dir(ws), repo)
+    if path is None or not workspace.is_clone(path):
+        return None
+    return path
+
+
+def cmd_change_create(args) -> int:
+    """Create a change: a name, a reason, and no members yet."""
+    ws = _workspace(args)
+    slug = args.change
+    if not instance.change_name_ok(slug):
+        util.err(f"{contain.readable(slug)} is not a change name (letters, digits, '.', "
+                 "'_', '-'; must not start with a dot or a dash).")
+        util.info("The slug names a file in this plane, a branch in every member, and the "
+                  "`Charter-Change:` trailer on each landing commit — so it is refused "
+                  "rather than rewritten.")
+        return 1
+    # `required=True` on the parser as well. Both, because a change with no stated reason
+    # is unreadable six months later — the one job the record has that git cannot do — and
+    # argparse can see neither an empty value nor a newline in one.
+    why = _why(args, "what this work is for")
+    if why is None:
+        return 1
+    if change.exists(ws, slug):
+        util.err(f"change '{slug}' already exists in workspace '{ws}'.")
+        util.info(f"Show it: charter change show {slug}")
+        return REFUSED
+    rec = change.new_record(slug, why, _author(), _now())
+    code = _save(ws, slug, rec)
+    if code:
+        return code
+    util.ok(f"change '{slug}' created")
+    util.info(f"Add its repos: charter change add {slug} <repo>")
+    return 0
+
+
+def cmd_change_add(args) -> int:
+    """Add one member — one repository's part of the change — by literal name."""
+    ws = _workspace(args)
+    slug = args.change
+    rec, code = _load(ws, slug)
+    if rec is None:
+        return code
+
+    repo = args.repo
+    if _clone_for(ws, repo) is None:
+        util.err(f"{contain.readable(repo)}: no clone in workspace '{ws}'.")
+        util.info(f"Clone it first: charter clone {contain.readable(repo)} -w {ws}")
+        return REFUSED
+    if change.member(rec, repo) is not None:
+        util.err(f"'{repo}' is already a member of '{slug}'.")
+        util.info(f"Change its branch or blockers by editing "
+                  f"workspaces/{ws}/changes/{slug}.json, or drop it first: "
+                  f"charter change drop {slug} {repo} --why \"…\"")
+        return REFUSED
+
+    branch = getattr(args, "branch", None) or change.default_branch(slug)
+    complaint = change.branch_refusal(branch)
+    if complaint:
+        util.err(complaint)
+        return 1
+    needs = list(getattr(args, "needs", None) or ())
+
+    rec = dict(rec)
+    rec["members"] = rec["members"] + [{"repo": repo, "branch": branch, "needs": needs}]
+    # A repo cannot be a member and excluded at once, so re-adding one lifts its exclusion —
+    # loudly, because the exclusion carried a reason somebody wrote down and its removal is
+    # a decision rather than bookkeeping.
+    lifted = change.exclusion(rec, repo)
+    if lifted is not None:
+        rec["excluded"] = [e for e in rec["excluded"] if e["repo"] != repo]
+    code = _save(ws, slug, rec)
+    if code:
+        return code
+    if lifted is not None:
+        util.warn(f"the exclusion recorded on {contain.one_line(lifted['at'])} is lifted: "
+                  f"{contain.one_line(lifted['why'])}")
+    print(_member_line(rec, {"repo": repo, "branch": branch, "needs": needs}))
+    util.ok(f"'{repo}' is a member of '{slug}'")
+    return 0
+
+
+def cmd_change_drop(args) -> int:
+    """Drop a member (or record a repo that was never one) into ``excluded``, with a reason.
+
+    ``--why`` is required and it is the cheapest line in this design: if members have
+    already landed, the world stays partially changed permanently, and the only thing that
+    makes that readable six months later is that somebody wrote down the reason at the
+    moment they still knew it.
+    """
+    ws = _workspace(args)
+    slug = args.change
+    rec, code = _load(ws, slug)
+    if rec is None:
+        return code
+
+    repo = args.repo
+    why = _why(args, "why this repo is out")
+    if why is None:
+        return 1
+    # Asked of every name, not only of one that is not already a member: a member's name
+    # came out of a validated record and passes by construction, so the unconditional form
+    # is the same rule with one fewer way to be wrong.
+    if not contain.segment_ok(repo):
+        util.err(contain.refusal(contain.readable(repo)))
+        return REFUSED
+    if change.exclusion(rec, repo) is not None:
+        util.err(f"'{repo}' is already excluded from '{slug}'.")
+        return REFUSED
+    was_member = change.member(rec, repo) is not None
+    blocked = change.dependents(rec, repo)
+    if blocked:
+        util.err(f"'{repo}' cannot be dropped from '{slug}': "
+                 + ", ".join(f"'{b}'" for b in blocked) + " still need"
+                 + ("" if len(blocked) > 1 else "s") + " it to land first.")
+        util.info("Drop those members first, or edit their `needs` — a blocker nothing "
+                  "will land is a member that never becomes ready.")
+        return REFUSED
+
+    rec = dict(rec)
+    rec["members"] = [m for m in rec["members"] if m["repo"] != repo]
+    rec["excluded"] = rec["excluded"] + [{"repo": repo, "why": why, "at": _now()}]
+    code = _save(ws, slug, rec)
+    if code:
+        return code
+    if was_member:
+        util.ok(f"'{repo}' excluded — {len(rec['members'])} member(s) left")
+    else:
+        util.ok(f"'{repo}' excluded (never a member)")
+    return 0
+
+
+def cmd_change_forget(args) -> int:
+    """Delete a change record by slug.
+
+    A store with no way to end an entry grows without bound — ADR 0004's argument for
+    ``charter workspace forget``, one noun out. It deletes the record and **nothing else**:
+    no landing-log line, no branch, no request. The log is a past-tense declaration of
+    something that happened, and deleting history to tidy a list is how a store starts
+    lying; the branches are the repositories' business.
+    """
+    ws = _workspace(args)
+    slug = args.change
+    if not change.exists(ws, slug):
+        util.err(f"no change {contain.readable(slug)} in workspace '{ws}'.")
+        return REFUSED
+    try:
+        removed = change.forget(ws, slug)
+    except change.RecordError as exc:
+        util.err(str(exc))
+        return 1
+    if removed is None:
+        util.err(f"could not delete the record for {contain.readable(slug)}.")
+        return 1
+    util.ok(f"change '{slug}' forgotten — the record is gone; branches, requests and the "
+            "landing log are untouched.")
+    return 0
+
+
+def cmd_change_list(args) -> int:
+    """Every change in the workspace, one row each."""
+    ws = _workspace(args)
+    records, refused = change.all_for(ws)
+    if not records and not refused:
+        util.info(f"No changes in workspace '{ws}'. "
+                  "Create one: charter change create <slug> --why \"…\"")
+        return 0
+    names = [contain.one_line(r["change"]) for r in records]
+    # gap=0: the gutter is the two literal spaces in the row below, so the width
+    # is the widest cell and nothing else. `tui.column` never `len()` — a name whose
+    # glyphs are two cells wide is two cells wide (#472).
+    w = tui.column("", names, gap=0)
+    for rec, name in zip(records, names):
+        counts = f"{len(rec['members'])} member(s)"
+        if rec["excluded"]:
+            counts += f", {len(rec['excluded'])} excluded"
+        print(f"{tui.pad(name, w)}  {counts}  ·  {contain.one_line(rec['why'])}")
+    for slug, complaint in refused:
+        util.err(f"{contain.readable(slug)}: {complaint}")
+    return 1 if refused else 0
+
+
+def cmd_change_show(args) -> int:
+    """One change, whole: what it is for, who is in it, and what must go first.
+
+    §3.4 calls this the monorepo view, and being a *view* is what makes it correct — the
+    clones are already siblings under one workspace directory, so ``rg`` already spans the
+    change; what was missing is knowing which of those subdirectories are one piece of
+    work. Every derived column (request numbers, check state, landing dates) belongs to the
+    forge-reading phase; what prints here is the record and nothing else, so it is true
+    without asking anybody.
+    """
+    ws = _workspace(args)
+    slug = args.change
+    rec, code = _load(ws, slug)
+    if rec is None:
+        return code
+
+    print(f"{contain.one_line(rec['change'])} · {len(rec['members'])} member(s)"
+          + (f" · {len(rec['excluded'])} excluded" if rec["excluded"] else ""))
+    print(f"  why: {contain.one_line(rec['why'])}")
+    print(f"  created {contain.one_line(rec['created'])} by {contain.one_line(rec['by'])}")
+
+    if rec["members"]:
+        print("")
+        for m in rec["members"]:
+            print(_member_line(rec, m))
+    if rec["excluded"]:
+        print("")
+        print("  excluded:")
+        w = tui.column("", [contain.one_line(e["repo"]) for e in rec["excluded"]], gap=0)
+        for e in rec["excluded"]:
+            print(f"  {tui.pad(contain.one_line(e['repo']), w)}  "
+                  f"{contain.one_line(e['why'])}  ({contain.one_line(e['at'])})")
+    return 0
+
+
+def _member_line(rec: dict, m: dict) -> str:
+    """One member's row. Every field is contained **before** the width arithmetic.
+
+    That order is #472: `tui.pad` measures the string it is handed, so escaping a value
+    after padding it pads it to the wrong width, and the column stops lining up at exactly
+    the row whose content came out of a committed file. `contain.one_line` is the bound
+    here, and it holds only what that function holds — line structure, not trustworthiness.
+    """
+    w = tui.column("", [contain.one_line(x["repo"]) for x in rec["members"]], gap=0)
+    row = (f"  {tui.pad(contain.one_line(m['repo']), w)}  "
+           f"branch {contain.one_line(m['branch'])}")
+    if m["needs"]:
+        row += "   needs: " + ", ".join(contain.one_line(n) for n in m["needs"])
+    return row

--- a/charter/commands_change.py
+++ b/charter/commands_change.py
@@ -286,7 +286,7 @@ def cmd_change_forget(args) -> int:
     # committed link at the record's own name — which is the `None` below.
     removed = change.forget(ws, slug)
     if removed is None:
-        util.err(f"could not delete the record for {contain.readable(slug)}.")
+        util.err(f"could not delete the record for '{slug}'.")
         return 1
     util.ok(f"change '{slug}' forgotten — the record is gone; branches, requests and the "
             "landing log are untouched.")

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -16,7 +16,7 @@ import sys
 import time
 from types import SimpleNamespace
 
-from . import config, contain, gitpolicy, planegit, tui, util, workspace, worktree
+from . import change, config, contain, gitpolicy, planegit, tui, util, workspace, worktree
 from .commands import (_cred_flag, _git, _origin_https, cmd_clone, commit_memory_reactive,
                        commit_push)
 
@@ -679,11 +679,21 @@ def _ws_meta_paths(name: str) -> list[str]:
     Filtered by existence deliberately: these go to git as literal paths, and `git rm
     --cached` on one that was never tracked fails the whole call — taking the manifest and
     memory down with a workspace that simply had no todos.
+
+    `changes/` is asked a sharper question than the others, because for it the existence
+    filter is not a safe proxy for the one being asked. `todos/` is born with its index and
+    is never empty afterwards; a `changes/` can be emptied by `charter change forget`, and
+    one holding nothing but the never-committed `changes/log/` is the same case with a
+    directory in the way. Both are "exists, nothing tracked", which is exactly the shape
+    that fails the whole call. `change.has_records` answers what this list means to ask.
     """
     wd = workspace.workspace_dir(name)
-    return [str(p.relative_to(config.ROOT))
-            for p in (wd / "workspace.json", wd / "workspace.md", wd / "memory",
-                      wd / "todos") if p.exists()]
+    rel = [str(p.relative_to(config.ROOT))
+           for p in (wd / "workspace.json", wd / "workspace.md", wd / "memory",
+                     wd / "todos") if p.exists()]
+    if change.has_records(name):
+        rel.append(str((wd / change.DIRNAME).relative_to(config.ROOT)))
+    return rel
 
 
 def _spawn_pushbg(root) -> None:

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -111,6 +111,26 @@ def workspace_name_ok(name) -> bool:
             and WORKSPACE_NAME_RE.fullmatch(name) is not None)
 
 
+#: The alphabet a cross-repo change's slug is minted in — :data:`WORKSPACE_NAME_RE`'s
+#: shape, and its own object rather than an alias, because the two names travel to
+#: different places and widening one must not widen the other by accident. A workspace name
+#: is a directory here; a change slug is a directory entry here **and** a branch name in
+#: every member repository **and** the value of a ``Charter-Change:`` trailer in somebody
+#: else's merge commit forever. The leading-character rule is what keeps a slug out of
+#: argv's flag position, which is the same guard `change.branch_refusal` makes explicit one
+#: field over.
+CHANGE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def change_name_ok(name) -> bool:
+    """Can *name* name a cross-repo change? Asked in :func:`workspace_name_ok`'s two
+    halves, for its reasons: containment first (:func:`contain.segment_ok` — could this
+    string name one entry in a directory at all), then the alphabet, which is the right
+    rule here because charter mints these names itself."""
+    return (isinstance(name, str) and contain.segment_ok(name)
+            and CHANGE_NAME_RE.fullmatch(name) is not None)
+
+
 def default_workspace_of(cfg: dict, fallback: str) -> str:
     """The workspace this plane lands on when nothing else decided — ``[workspace] default``.
 

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -123,12 +123,18 @@ CHANGE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 def change_name_ok(name) -> bool:
-    """Can *name* name a cross-repo change? Asked in :func:`workspace_name_ok`'s two
-    halves, for its reasons: containment first (:func:`contain.segment_ok` — could this
-    string name one entry in a directory at all), then the alphabet, which is the right
-    rule here because charter mints these names itself."""
-    return (isinstance(name, str) and contain.segment_ok(name)
-            and CHANGE_NAME_RE.fullmatch(name) is not None)
+    """Can *name* name a cross-repo change?
+
+    One rule and not two, which is where this differs from :func:`workspace_name_ok` next
+    door. That one asks :func:`contain.segment_ok` first and says why: it is the half that
+    still holds if the alphabet is ever widened. Here the alphabet *is* the containment —
+    :data:`CHANGE_NAME_RE` admits no separator, no leading dot, no NUL and nothing
+    absolute — so a `segment_ok` call in front of it is an answer the regex has already
+    given, and a line no test can go red without. The property it stood for is pinned
+    directly instead, on this function, against `..`, `a/b`, `a\\b`, a NUL and a leading
+    dot.
+    """
+    return isinstance(name, str) and CHANGE_NAME_RE.fullmatch(name) is not None
 
 
 def default_workspace_of(cfg: dict, fallback: str) -> str:

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -764,12 +764,30 @@ def _live_block(names) -> str:
     ``todos`` needs the same pair: a shared task list is one of the better reasons to make
     a workspace LIVE at all, and without a line here the list would simply never travel,
     which is the quietest way this could fail.
+
+    ``changes`` needs the pair **and a third line that re-ignores ``changes/log``**, and
+    that asymmetry is the whole design of the store rather than an exception to it. A
+    change record holds intent — which repositories, which branch in each, which must land
+    first, which was excluded and why — and intent is exactly what a teammate needs and git
+    cannot derive. ``changes/log/<host>.jsonl`` holds the opposite: a past-tense
+    declaration carrying merge shas, per host, appended without a lock, and it is committed
+    **never**, for the same reason ``pieces/`` is not. Re-ignoring works only because its
+    parent was re-included two lines above — git cannot re-include a file whose parent
+    directory is excluded — which is why the three lines are written together here rather
+    than as a rule someone reconstructs.
+
+    The names are literals rather than ``change.DIRNAME``/``LOG_DIRNAME`` because
+    :mod:`charter.change` imports this module; ``tests/test_todos_are_committed.py`` pins
+    them against those constants, which is the same job an import would have done and the
+    one that also catches ``_ws_meta_paths`` drifting away from this list.
     """
     lines = [_LIVE_BEGIN]
     for n in sorted(names):
         lines += [f"!/workspaces/{n}/workspace.json", f"!/workspaces/{n}/workspace.md",
                   f"!/workspaces/{n}/memory", f"!/workspaces/{n}/memory/**",
-                  f"!/workspaces/{n}/todos", f"!/workspaces/{n}/todos/**"]
+                  f"!/workspaces/{n}/todos", f"!/workspaces/{n}/todos/**",
+                  f"!/workspaces/{n}/changes", f"!/workspaces/{n}/changes/**",
+                  f"/workspaces/{n}/changes/log/"]
     lines.append(_LIVE_END)
     return "\n".join(lines)
 
@@ -1181,7 +1199,16 @@ def read_vision(name: str) -> str:
 # scaffold/restore), never committed.                                              #
 # --------------------------------------------------------------------------- #
 
-STRUCTURE_VERSION = 2  # v2: memory is a per-file DB (MEMORY.md index), not a lone notes.md
+# v3 creates no directory, and that is deliberate. `changes/` is created lazily by the
+# first `charter change create` — an always-present, always-empty one would break
+# `charter workspace live --off`, whose path list is filtered by existence and relies on
+# that filter doubling as a non-emptiness filter. The bump exists so every workspace made
+# by an older charter flags itself, `reinit` runs `refresh_live_block()`, and a LIVE
+# workspace picks up the three new un-ignore lines. Without it a plane that went LIVE
+# before this version keeps a block that never mentions `changes`, and the records simply
+# never travel — the same silent half-failure `todos/` had.
+STRUCTURE_VERSION = 3  # v2: memory is a per-file DB (MEMORY.md index), not a lone notes.md
+                       # v3: the managed .gitignore block shares `changes/` (not its log)
 _STRUCTURE_MARKER = ".charter-structure"
 _LEGACY_STRUCTURE_MARKER = ".edm-structure"   # pre-rename; migrated in place on read
 

--- a/docs/news/unreleased-cross-repo-change-records.md
+++ b/docs/news/unreleased-cross-repo-change-records.md
@@ -1,0 +1,69 @@
+---
+version: unreleased
+headline: A change spanning several repos is now a record charter keeps — intent only, with the ordering derived and never stored
+adopt: workspace reinit --all
+---
+
+`charter change` gives one piece of work that spans several repositories a name, a reason,
+a member list and an ordering — as a file, per workspace:
+
+```
+$ charter change create component-api-2 --why "component.API_VERSION 1 -> 2"
+$ charter change add component-api-2 charter
+$ charter change add component-api-2 charter-metrics --needs charter
+$ charter change drop component-api-2 charter-slack --why "no components; only an action provider"
+$ charter change show component-api-2
+```
+
+`create`, `add`, `drop`, `list`, `show`, `forget`. **Records only** — nothing under this
+command reaches a network, pushes a branch or opens a request; the forge half is a later
+phase.
+
+## What the record holds, and what it refuses to
+
+`workspaces/<ws>/changes/<slug>.json` holds six keys and no seventh: the name, the `why`,
+when and by whom, the members (each with its repo, its branch and what must land before it),
+and the repositories considered and deliberately excluded, with reasons and dates.
+
+**There is no state field, and none is representable.** No request number, no CI result, no
+branch position, no `landed` flag — the key set is closed at both ends and an unknown key
+stops the read and is *named*, rather than being ignored. `need` where `needs` was meant is
+an ordering constraint that would otherwise have silently ceased to exist.
+
+Ordering is the case worth naming twice, because it looks like state and is not. `needs` is
+**declared**, because only a human knows that repo B's change needs repo A's merged. Blocked
+is **derived** at read time from that declaration and a fresh reading of what has landed, and
+nothing writes it anywhere. A cycle is refused at write time with every member in it named:
+that is not a condition to render, it is a record that cannot be true.
+
+## Membership is committed. Destination is local.
+
+The record carries bare repository names — never a URL, a host, a remote, a forge kind or a
+base branch. A remote in a committed file is a *destination* that arrives from someone
+else's machine, which is `charter.toml`'s own rule about command strings, one file over.
+
+There is also **no expansion**: no glob, no pattern, no `--all-repos`, and nothing in the
+change surface enumerates repositories. Every member was typed by somebody, one literal name
+per invocation, and it must resolve to a clone already in this workspace. A record can name
+a repository you do not have and be refused for that; it can never name a place.
+
+Two committed fields cross out of the record into somewhere a string is not just a string,
+and each gets its own boundary. A **branch** reaches git as argv — and `git check-ref-format`
+*accepts* `refs/heads/-b`, measured on git 2.50.1, so ref grammar answers a different
+question — so a branch beginning with `-` is refused where the record is read. A **slug**, a
+**repo name**, a **why** and a **branch** all reach a report row, so each is contained before
+any width arithmetic.
+
+## What `workspace reinit --all` is for
+
+The store is the workspace's fourth, beside `memory/`, `todos/` and `pieces/`, and a LIVE
+workspace commits it — so the managed `.gitignore` block grew three lines per workspace: two
+that share `changes/`, and one that keeps `changes/log/` ignored. That log is the landing
+declaration, per host, and it is committed **never**, exactly as `pieces/` is not.
+
+Nothing re-runs `workspace live` on its own, so a plane that went LIVE before this version
+keeps a block that never mentions `changes` — and the records would simply never travel.
+`STRUCTURE_VERSION` goes 2 → 3 so every existing workspace flags itself, and one command
+repairs them all. It creates no directory: `changes/` is created by the first
+`charter change create`, because a path that exists with nothing tracked under it is exactly
+what makes `charter workspace live --off` fail whole.

--- a/docs/superpowers/specs/2026-08-28-phase4-cross-repo-change.md
+++ b/docs/superpowers/specs/2026-08-28-phase4-cross-repo-change.md
@@ -1240,7 +1240,9 @@ plan in `plans/` reads as ready to execute, and this phase is not approved.)*
 - Run the suite in **two environments** and say which; they must agree. **The count is
   deliberately not pinned here**: Phase 2's 5880 is stale by the time this phase starts, and a
   number carried forward from another branch is a fixture, not a baseline. Measure it at this
-  branch's head as Task 1 Step 0 and write it into this line then.
+  branch's head as Task 1 Step 0 and write it into this line then. **Measured at
+  `2fe663a` (the merge-base for Tasks 1–4): 7385 tests, OK, in both — CPython 3.14.4, and
+  CPython 3.12 with `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset.**
 - `PersonaIso`; new `patch.dict(os.environ, …)` MUST pass `clear=True`.
 - `tui.width()` never `len()`. `contain.one_line` **before** width arithmetic.
 - Repo names use `contain.segment_ok`, **never** `workspace.valid_name` — `org/.github` is a

--- a/tests/test_change_record.py
+++ b/tests/test_change_record.py
@@ -262,9 +262,16 @@ class TestABranchNameIsArgv(ChangeIso):
                 self.assertIsNotNone(change.branch_refusal(branch))
 
     def test_a_branch_that_is_not_one_line_is_refused(self):
-        for branch in ("a\nb", "a b", "a\rb", "a\x1b[31mb", "x" * 300):
+        for branch in ("a\nb", "a\u2028b", "a\rb", "a\x1b[31mb",
+                       "x" * (change.TEXT_LIMIT + 1)):
             with self.subTest(branch=repr(branch)):
                 self.assertIsNotNone(change.branch_refusal(branch))
+
+    def test_a_branch_a_little_longer_than_a_report_row_is_accepted(self):
+        """The record's bound is `contain`'s PATH budget, not its ROW budget. Refusing a
+        value for being one row long would send somebody to hand-edit the file; the row
+        budget still applies where rows are drawn, and is measured there."""
+        self.assertIsNone(change.branch_refusal("x" * (contain.DISPLAY_LIMIT + 20)))
 
     def test_an_ordinary_branch_is_accepted(self):
         self.assertIsNone(change.branch_refusal("change/component-api-2"))
@@ -287,6 +294,19 @@ class TestWhyIsOneLineAndRequired(ChangeIso):
         with self.assertRaises(change.RecordError) as cm:
             change.read("ws", "component-api-2")
         self.assertIn("why", str(cm.exception))
+
+    def test_a_why_a_little_longer_than_a_report_row_is_kept_whole(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["why"] = "w" * (contain.DISPLAY_LIMIT + 40)
+        change.write("ws", "component-api-2", rec)
+        self.assertEqual(change.read("ws", "component-api-2")["why"], rec["why"])
+
+    def test_a_why_longer_than_a_committed_value_may_be_is_refused(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["why"] = "w" * (change.TEXT_LIMIT + 1)
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError):
+            change.read("ws", "component-api-2")
 
     def test_a_why_that_cannot_be_one_line_is_refused(self):
         """It belongs in `workspace.md`, which is where this plane keeps prose. A newline
@@ -592,6 +612,7 @@ class TestEveryRefusalIsOneLineWhateverItNames(ChangeIso):
             # `write` validates BEFORE it resolves the path, so the slug reaching these
             # messages has been through nothing at all.
             self._refusal(change.write, "ws", self.HOSTILE, json.loads(json.dumps(GOOD))),
+            self._refusal(change.validate, json.loads(json.dumps(GOOD)), self.HOSTILE),
         ]
         hostile_name = json.loads(json.dumps(GOOD))
         hostile_name["change"] = self.HOSTILE
@@ -628,6 +649,15 @@ class TestEveryRefusalIsOneLineWhateverItNames(ChangeIso):
                 msg = change.branch_refusal(branch)
                 self.assertEqual(len(msg.splitlines()), 1, msg)
                 self.assertNotIn(self.ESC, msg)
+
+    def test_the_slug_is_asked_about_before_anything_else_is(self):
+        """The words, not the exit. With `validate`'s own slug check deleted a hostile slug
+        is still refused — by `path_for`, one line later in `write` — but only after every
+        sentence in `validate` has already named it, and those sentences name it plainly."""
+        with self.assertRaises(change.RecordError) as cm:
+            change.write("ws", self.HOSTILE, json.loads(json.dumps(GOOD)))
+        self.assertIn("is not a change name", str(cm.exception))
+        self.assertNotIn("calls itself", str(cm.exception))
 
     def test_there_are_refusals_to_measure(self):
         """The control. A helper that raised on its own first line would make every

--- a/tests/test_change_record.py
+++ b/tests/test_change_record.py
@@ -675,6 +675,73 @@ class TestEveryRefusalIsOneLineWhateverItNames(ChangeIso):
                 self.assertNotIn(self.ESC, msg)
 
 
+class TestTheRecordsOwnEdges(ChangeIso):
+    """The half of each guard that is not the refusal itself: which order names come back
+    in, what a value that is not a string does to a sentence, and what an absent argument
+    does to a derivation. Each of these was a line the deletion sweep could remove in
+    silence."""
+
+    ESC = "\x1b"
+
+    def test_unknown_keys_are_named_in_a_settled_order(self):
+        """Dict order is the order of the FILE, so without sorting the same defect reads
+        differently depending on how somebody typed it."""
+        self.put("component-api-2", json.dumps(
+            {"zeta": 1, "alpha": 1, **json.loads(json.dumps(GOOD))}))
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        msg = str(cm.exception)
+        self.assertLess(msg.index("alpha"), msg.index("zeta"))
+
+    def test_a_value_that_is_not_a_string_is_still_readable_in_the_refusal(self):
+        """The branch that says "expected a non-empty string" is a printing site too, and
+        the interesting failure there is #498's rather than #453's: `str()` of a list
+        escapes a newline for you, so no row is forged — and it hands the invisibles
+        straight through, so `['\u3164']` reads as `['']` and names nothing anybody can go
+        and fix. `contain.readable` is the function that can say which value it was."""
+        rec = json.loads(json.dumps(GOOD))
+        rec["why"] = ["\u3164\u3164"]
+        with self.assertRaises(change.RecordError) as cm:
+            change.validate(rec, "component-api-2")
+        self.assertIn("3164", str(cm.exception))
+
+    def test_a_branch_that_is_not_a_string_is_still_readable_in_the_refusal(self):
+        for branch in (["\u3164"], {"\u3164": 1}, 3164):
+            with self.subTest(branch=branch):
+                msg = change.branch_refusal(branch)
+                self.assertEqual(len(msg.splitlines()), 1, msg)
+                self.assertIn("3164", msg)
+
+    def test_a_repo_made_only_of_invisibles_is_still_named(self):
+        """#498 exactly: U+3164 HANGUL FILLER is `Lo`, so `contain.one_line` returns it
+        unchanged and correct — it forges no row — and a refusal built on that alone names
+        no repository at all. `contain.readable` is the function that can say which one."""
+        rec = json.loads(json.dumps(GOOD))
+        rec["members"] = [{"repo": "\u3164\u3164/x", "branch": "b", "needs": []}]
+        rec["excluded"] = []
+        with self.assertRaises(change.RecordError) as cm:
+            change.validate(rec, "component-api-2")
+        self.assertIn("3164", str(cm.exception))
+
+    def test_blocked_members_treats_no_landing_map_as_nothing_landed(self):
+        """`None` is what a caller with no reading yet has, and `set(None)` raises."""
+        rec = json.loads(json.dumps(GOOD))
+        self.assertEqual(change.blocked_members(rec, None), {"charter-metrics": ["charter"]})
+
+    def test_the_name_rule_is_the_whole_containment(self):
+        """`change_name_ok` carries no separate `segment_ok` call, so this is what says the
+        containment property is still there — asked of the function rather than of the
+        line that used to answer it."""
+        from charter import instance
+        for bad in ("..", ".", "a/b", "a\\b", "x\x00y", ".hidden", "-b", "", "/abs",
+                    "a\nb", "C:x", None, 3, ["a"]):
+            with self.subTest(name=bad):
+                self.assertFalse(instance.change_name_ok(bad))
+        for good in ("component-api-2", "a", "A.b_c-d", "0"):
+            with self.subTest(name=good):
+                self.assertTrue(instance.change_name_ok(good))
+
+
 def _args(**kw):
     from types import SimpleNamespace
     kw.setdefault("workspace", "ws")

--- a/tests/test_change_record.py
+++ b/tests/test_change_record.py
@@ -1,0 +1,472 @@
+"""The cross-repo change record: a closed key set, contained names, derived ordering.
+
+The record holds **intent only** — which repositories, which branch in each, which must
+land first, which was excluded and why. Everything a test here pins is one of two claims:
+
+* a value charter does not read must be **named**, not ignored (#503). ``need`` where
+  ``needs`` was meant is an ordering constraint that silently ceased to exist, and a record
+  charter half-understands is worse than one it refuses;
+* a value the record carries reaches somewhere a string is not just a string — argv, a
+  report row, a path — and the boundary that reads it is where that is answered.
+
+The ordering half is the same claim about *state*: ``needs`` is declared, "blocked" is
+derived, and the round-trip test is what says nobody cached the derivation on the way past.
+"""
+from __future__ import annotations
+
+import json
+import os
+import unittest
+
+from charter import change, config, contain, workspace
+from tests._isolation import PersonaIso
+
+GOOD = {
+    "change": "component-api-2",
+    "why": "component.API_VERSION 1 -> 2; providers declare the new integer",
+    "created": "2026-08-28T09:14:02+00:00",
+    "by": "Aaron Yordanyan",
+    "members": [
+        {"repo": "charter", "branch": "change/component-api-2", "needs": []},
+        {"repo": "charter-metrics", "branch": "change/component-api-2", "needs": ["charter"]},
+    ],
+    "excluded": [
+        {"repo": "charter-slack", "why": "no components; only an action provider",
+         "at": "2026-08-28T09:20:11+00:00"},
+    ],
+}
+
+
+class ChangeIso(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("ws")
+
+    def put(self, slug: str, text: str) -> None:
+        """Write raw bytes as a record, bypassing `change.write` — the hand edit, the older
+        charter, the record that arrived in somebody else's commit."""
+        d = change.changes_dir("ws")
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{slug}.json").write_text(text)
+
+    def put_record(self, slug: str, rec: dict) -> None:
+        self.put(slug, json.dumps(rec))
+
+
+class TestTheKeySetIsClosed(ChangeIso):
+    def test_the_key_set_is_closed_and_an_unknown_key_is_named(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["members"][0]["need"] = ["web"]
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("need", str(cm.exception))
+
+    def test_a_top_level_unknown_key_is_named(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["owner"] = "someone"
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("owner", str(cm.exception))
+
+    def test_a_missing_key_is_named_too(self):
+        rec = json.loads(json.dumps(GOOD))
+        del rec["excluded"]
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("excluded", str(cm.exception))
+
+    def test_no_state_field_is_representable(self):
+        """`state`, `landed`, `pr` and `ci` are all things git or the forge already knows.
+        Each is tested by name rather than as a class, because the closed set is what makes
+        them unrepresentable and a test over a loop would pass against a set that happened
+        to allow the one nobody listed."""
+        for key, value in (("state", "open"), ("landed", True), ("pr", 601), ("ci", "passed")):
+            with self.subTest(key=key):
+                rec = json.loads(json.dumps(GOOD))
+                rec[key] = value
+                self.put_record("component-api-2", rec)
+                with self.assertRaises(change.RecordError) as cm:
+                    change.read("ws", "component-api-2")
+                self.assertIn(key, str(cm.exception))
+
+    def test_a_per_member_state_field_is_refused_too(self):
+        for key, value in (("state", "open"), ("landed", True), ("pr", 601), ("ci", "passed")):
+            with self.subTest(key=key):
+                rec = json.loads(json.dumps(GOOD))
+                rec["members"][0][key] = value
+                self.put_record("component-api-2", rec)
+                with self.assertRaises(change.RecordError) as cm:
+                    change.read("ws", "component-api-2")
+                self.assertIn(key, str(cm.exception))
+
+    def test_a_good_record_reads(self):
+        """Positive control. Without it every assertion above would still pass against a
+        `read` that refused everything."""
+        self.put_record("component-api-2", GOOD)
+        self.assertEqual(change.read("ws", "component-api-2"), GOOD)
+
+
+class TestTheNameIsAName(ChangeIso):
+    def test_a_slug_that_is_a_path_is_refused_rather_than_sanitised(self):
+        for slug in ("..", "a/b", "a\\b", ".hidden", "-b", "x\x00y", ""):
+            with self.subTest(slug=slug):
+                with self.assertRaises(change.RecordError):
+                    change.path_for("ws", slug)
+
+    def test_a_traversing_slug_never_reaches_the_filesystem(self):
+        """The refusal is about the string, not about what is on the disk — asking the
+        filesystem would make a traversal succeed exactly when the target happens to
+        exist."""
+        outside = config.ROOT / "outside.json"
+        outside.write_text(json.dumps(GOOD))
+        with self.assertRaises(change.RecordError):
+            change.read("ws", "../../outside")
+        self.assertTrue(outside.exists())
+
+    def test_a_record_that_disagrees_with_its_filename_is_refused(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["change"] = "something-else"
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("something-else", str(cm.exception))
+
+
+class TestBothRefusalsAreAsked(ChangeIso):
+    """#336: `file_refusal` structurally cannot see the variant where the *directory* is
+    the link — every file inside it is an ordinary regular file with nothing to object to.
+    Only `dir_refusal`, which resolves, catches that one."""
+
+    def test_a_record_that_is_a_link_out_of_the_plane_is_refused(self):
+        target = self.tmp / "elsewhere.json"
+        target.write_text(json.dumps(GOOD))
+        d = change.changes_dir("ws")
+        d.mkdir(parents=True, exist_ok=True)
+        os.symlink(target, d / "component-api-2.json")
+        with self.assertRaises(change.RecordError):
+            change.read("ws", "component-api-2")
+
+    def test_a_changes_directory_that_is_a_link_out_of_the_plane_is_refused(self):
+        elsewhere = self.tmp / "elsewhere"
+        elsewhere.mkdir()
+        (elsewhere / "component-api-2.json").write_text(json.dumps(GOOD))
+        os.symlink(elsewhere, change.changes_dir("ws"))
+        with self.assertRaises(change.RecordError):
+            change.read("ws", "component-api-2")
+
+    def test_the_listing_refuses_a_linked_directory_and_says_so(self):
+        elsewhere = self.tmp / "elsewhere"
+        elsewhere.mkdir()
+        (elsewhere / "component-api-2.json").write_text(json.dumps(GOOD))
+        os.symlink(elsewhere, change.changes_dir("ws"))
+        records, refused = change.all_for("ws")
+        self.assertEqual(records, [])
+        self.assertTrue(refused)
+
+
+class TestAFailedReadRaises(ChangeIso):
+    """A read that degraded to `{}` would make every read-modify-write a truncation.
+
+    `onepassword._fields` returned `{}` for every non-zero `op item get`, a rate-limited
+    vault reported "has no secrets" (#322), and the read-modify-write behind it piped back
+    a template holding one key. `add` here is exactly that shape."""
+
+    def test_unparseable_json_raises_rather_than_answering_an_empty_record(self):
+        self.put("component-api-2", "{not json")
+        with self.assertRaises(change.RecordError):
+            change.read("ws", "component-api-2")
+
+    def test_a_missing_record_raises(self):
+        with self.assertRaises(change.RecordError):
+            change.read("ws", "never-created")
+
+    def test_an_unreadable_record_then_add_writes_nothing(self):
+        from charter import commands_change
+
+        self.put("component-api-2", "{not json")
+        before = (change.changes_dir("ws") / "component-api-2.json").read_text()
+        (workspace.workspace_dir("ws") / "api" / ".git").mkdir(parents=True)
+        code = commands_change.cmd_change_add(_args(change="component-api-2", repo="api"))
+        self.assertEqual(code, 1)
+        after = (change.changes_dir("ws") / "component-api-2.json").read_text()
+        self.assertEqual(before, after)
+
+
+class TestARepoNameIsASegmentNotAWorkspaceName(ChangeIso):
+    def test_dot_github_is_a_real_repository_and_is_accepted(self):
+        """`workspace.valid_name` rejects a leading dot; `org/.github` is a real and common
+        repository whose name comes from a forge rather than from charter. That distinction
+        has already cost this project once."""
+        rec = json.loads(json.dumps(GOOD))
+        rec["members"] = [{"repo": ".github", "branch": "change/x", "needs": []}]
+        rec["excluded"] = []
+        self.put_record("component-api-2", rec)
+        got = change.read("ws", "component-api-2")
+        self.assertEqual(got["members"][0]["repo"], ".github")
+        self.assertFalse(workspace.valid_name(".github"))   # the rule that would have failed
+
+    def test_a_member_naming_a_path_is_refused(self):
+        for repo in ("..", "a/b", "a\\b", "x\x00y", ""):
+            with self.subTest(repo=repo):
+                rec = json.loads(json.dumps(GOOD))
+                rec["members"] = [{"repo": repo, "branch": "change/x", "needs": []}]
+                rec["excluded"] = []
+                self.put_record("component-api-2", rec)
+                with self.assertRaises(change.RecordError):
+                    change.read("ws", "component-api-2")
+
+    def test_the_same_repo_twice_is_refused(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["members"] = [{"repo": "api", "branch": "a", "needs": []},
+                          {"repo": "api", "branch": "b", "needs": []}]
+        rec["excluded"] = []
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("api", str(cm.exception))
+
+    def test_a_member_that_is_also_excluded_is_refused(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["members"] = [{"repo": "api", "branch": "a", "needs": []}]
+        rec["excluded"] = [{"repo": "api", "why": "no", "at": "2026-08-28T00:00:00+00:00"}]
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError):
+            change.read("ws", "component-api-2")
+
+
+class TestABranchNameIsArgv(ChangeIso):
+    """`git check-ref-format` **accepts** `refs/heads/-b` — measured on git 2.50.1 — so ref
+    grammar proves nothing about the position this value lands in. The record boundary is
+    one of the two mechanisms; `--` in the argv is the other, and neither substitutes."""
+
+    def test_git_itself_accepts_the_ref_this_refuses(self):
+        """The measurement the refusal rests on, taken rather than asserted. Skipped where
+        git is absent, because then there is nothing to measure."""
+        import shutil
+        import subprocess
+        if not shutil.which("git"):
+            self.skipTest("no git")
+        rc = subprocess.run(["git", "check-ref-format", "refs/heads/-b"],
+                            capture_output=True).returncode
+        self.assertEqual(rc, 0, "git no longer accepts refs/heads/-b — re-read the guard")
+
+    def test_a_branch_that_reaches_git_as_a_flag_is_refused(self):
+        for branch in ("-b", "--upload-pack=touch /tmp/x", "-"):
+            with self.subTest(branch=branch):
+                self.assertIsNotNone(change.branch_refusal(branch))
+
+    def test_a_branch_that_is_not_one_line_is_refused(self):
+        for branch in ("a\nb", "a b", "a\rb", "a\x1b[31mb", "x" * 300):
+            with self.subTest(branch=repr(branch)):
+                self.assertIsNotNone(change.branch_refusal(branch))
+
+    def test_an_ordinary_branch_is_accepted(self):
+        self.assertIsNone(change.branch_refusal("change/component-api-2"))
+
+    def test_the_refusal_is_reached_through_the_record(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["members"] = [{"repo": "api", "branch": "-b", "needs": []}]
+        rec["excluded"] = []
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("FLAG", str(cm.exception))
+
+
+class TestWhyIsOneLineAndRequired(ChangeIso):
+    def test_an_empty_why_is_refused(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["why"] = "   "
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("why", str(cm.exception))
+
+    def test_a_why_that_cannot_be_one_line_is_refused(self):
+        """It belongs in `workspace.md`, which is where this plane keeps prose. A newline
+        in a value charter repeats back on a row writes a second row that looks exactly as
+        much like charter's own output as the first."""
+        rec = json.loads(json.dumps(GOOD))
+        rec["why"] = "line one\n✓ everything landed"
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError):
+            change.read("ws", "component-api-2")
+
+    def test_an_exclusion_needs_its_reason_too(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["excluded"][0]["why"] = ""
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError):
+            change.read("ws", "component-api-2")
+
+
+class TestTheWriteSideValidatesToo(ChangeIso):
+    """Without this, the closed key set is a rule only the reader enforces, and anything
+    holding a record in memory can hang a derived value off it and serialise it."""
+
+    def test_write_refuses_an_unknown_key(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["blocked"] = ["charter-metrics"]
+        with self.assertRaises(change.RecordError) as cm:
+            change.write("ws", "component-api-2", rec)
+        self.assertIn("blocked", str(cm.exception))
+        self.assertFalse(change.exists("ws", "component-api-2"))
+
+    def test_write_refuses_a_derived_value_cached_on_a_member(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["members"][1]["blocked"] = True
+        with self.assertRaises(change.RecordError) as cm:
+            change.write("ws", "component-api-2", rec)
+        self.assertIn("blocked", str(cm.exception))
+
+    def test_a_record_read_and_written_back_is_byte_identical(self):
+        """The round trip *is* the assertion that ADR 0011 has not been reversed by
+        convenience: if anything derived were cached on the record on the way through, the
+        bytes would differ."""
+        change.write("ws", "component-api-2", json.loads(json.dumps(GOOD)))
+        first = change.path_for("ws", "component-api-2").read_bytes()
+        rec = change.read("ws", "component-api-2")
+        change.blocked_members(rec, [])          # render it — the operation under suspicion
+        change.write("ws", "component-api-2", rec)
+        self.assertEqual(first, change.path_for("ws", "component-api-2").read_bytes())
+
+    def test_the_bytes_are_two_space_indented_with_a_trailing_newline(self):
+        change.write("ws", "component-api-2", json.loads(json.dumps(GOOD)))
+        text = change.path_for("ws", "component-api-2").read_text()
+        self.assertTrue(text.endswith("}\n"))
+        self.assertIn('\n  "why": ', text)
+
+
+class TestOrderingIsDeclaredAndDerived(ChangeIso):
+    def _with_needs(self, graph: dict[str, list[str]]) -> dict:
+        rec = json.loads(json.dumps(GOOD))
+        rec["members"] = [{"repo": r, "branch": f"change/{r}", "needs": n}
+                          for r, n in graph.items()]
+        rec["excluded"] = []
+        return rec
+
+    def test_a_cycle_is_refused_at_write_time_naming_both_members(self):
+        rec = self._with_needs({"api": ["web"], "web": ["api"]})
+        with self.assertRaises(change.RecordError) as cm:
+            change.write("ws", "component-api-2", rec)
+        self.assertIn("api", str(cm.exception))
+        self.assertIn("web", str(cm.exception))
+        self.assertIn("cycle", str(cm.exception))
+
+    def test_a_longer_cycle_names_every_member_in_it(self):
+        rec = self._with_needs({"a": ["c"], "b": ["a"], "c": ["b"]})
+        with self.assertRaises(change.RecordError) as cm:
+            change.write("ws", "component-api-2", rec)
+        for repo in ("a", "b", "c"):
+            self.assertIn(f"'{repo}'", str(cm.exception))
+
+    def test_a_member_cannot_block_itself(self):
+        rec = self._with_needs({"api": ["api"]})
+        with self.assertRaises(change.RecordError) as cm:
+            change.write("ws", "component-api-2", rec)
+        self.assertIn("its own blocker", str(cm.exception))
+
+    def test_needs_may_only_name_a_member_of_this_change(self):
+        rec = self._with_needs({"api": ["web"]})
+        with self.assertRaises(change.RecordError) as cm:
+            change.write("ws", "component-api-2", rec)
+        self.assertIn("web", str(cm.exception))
+        self.assertIn("not a member", str(cm.exception))
+
+    def test_a_diamond_is_not_a_cycle(self):
+        """Positive control: without it, "refuse everything" would pass every test above."""
+        rec = self._with_needs({"base": [], "left": ["base"], "right": ["base"],
+                                "top": ["left", "right"]})
+        change.write("ws", "component-api-2", rec)
+        self.assertTrue(change.exists("ws", "component-api-2"))
+
+    def test_blocked_is_derived_from_the_declaration_and_a_landing_map(self):
+        rec = self._with_needs({"api": [], "web": ["api"], "docs": ["web"]})
+        self.assertEqual(change.blocked_members(rec, []), {"web": ["api"], "docs": ["web"]})
+        self.assertEqual(change.blocked_members(rec, ["api"]), {"docs": ["web"]})
+        self.assertEqual(change.blocked_members(rec, ["api", "web"]), {})
+
+    def test_the_derivation_writes_nothing(self):
+        rec = self._with_needs({"api": [], "web": ["api"]})
+        change.write("ws", "component-api-2", rec)
+        before = change.path_for("ws", "component-api-2").read_bytes()
+        change.blocked_members(change.read("ws", "component-api-2"), [])
+        self.assertEqual(before, change.path_for("ws", "component-api-2").read_bytes())
+        self.assertNotIn("blocked", before.decode())
+
+    def test_a_member_landed_with_an_unlanded_blocker_is_still_reported_blocked(self):
+        """§3.2's out-of-order landing, which is `blocked & landed`. Computing `blocked`
+        only for members that have NOT landed would make that intersection empty by
+        construction and the divergence unnameable."""
+        rec = self._with_needs({"api": [], "web": ["api"]})
+        blocked = change.blocked_members(rec, ["web"])
+        self.assertEqual(set(blocked) & {"web"}, {"web"})
+
+    def test_the_blocker_is_named_not_merely_counted(self):
+        rec = self._with_needs({"api": [], "b": [], "web": ["api", "b"]})
+        self.assertEqual(change.blocked_members(rec, ["api"]), {"web": ["b"]})
+
+
+class TestTheListing(ChangeIso):
+    def test_records_and_refusals_come_back_separately(self):
+        change.write("ws", "good-one", dict(GOOD, change="good-one"))
+        self.put("bad-one", "{not json")
+        records, refused = change.all_for("ws")
+        self.assertEqual([r["change"] for r in records], ["good-one"])
+        self.assertEqual([slug for slug, _ in refused], ["bad-one"])
+
+    def test_a_workspace_with_no_changes_directory_lists_nothing_and_refuses_nothing(self):
+        self.assertEqual(change.all_for("ws"), ([], []))
+
+    def test_the_log_directory_is_not_a_record(self):
+        change.write("ws", "good-one", dict(GOOD, change="good-one"))
+        change.log_dir("ws").mkdir(parents=True)
+        (change.log_dir("ws") / "host.jsonl").write_text('{"ts": "x"}\n')
+        records, refused = change.all_for("ws")
+        self.assertEqual([r["change"] for r in records], ["good-one"])
+        self.assertEqual(refused, [])
+
+
+class TestTheStoreIsCreatedLazily(ChangeIso):
+    def test_scaffold_creates_no_changes_directory(self):
+        """`_ws_meta_paths` filters by existence and that filter doubles as a
+        non-emptiness filter — `git rm --cached` on a path with nothing tracked under it
+        fails the whole call. An always-present, always-empty `changes/` breaks
+        `charter workspace live --off` whole."""
+        workspace.scaffold("ws")
+        self.assertFalse(change.changes_dir("ws").exists())
+
+    def test_the_first_write_creates_it(self):
+        change.write("ws", "component-api-2", json.loads(json.dumps(GOOD)))
+        self.assertTrue(change.changes_dir("ws").exists())
+
+    def test_has_records_is_false_for_a_directory_holding_only_the_log(self):
+        change.log_dir("ws").mkdir(parents=True)
+        (change.log_dir("ws") / "host.jsonl").write_text("{}\n")
+        self.assertTrue(change.changes_dir("ws").exists())
+        self.assertFalse(change.has_records("ws"))
+
+    def test_forget_removes_the_record_and_nothing_else(self):
+        change.write("ws", "component-api-2", json.loads(json.dumps(GOOD)))
+        change.log_dir("ws").mkdir(parents=True)
+        log = change.log_dir("ws") / "host.jsonl"
+        log.write_text('{"change": "component-api-2"}\n')
+        change.forget("ws", "component-api-2")
+        self.assertFalse(change.exists("ws", "component-api-2"))
+        self.assertTrue(log.exists())
+
+
+def _args(**kw):
+    from types import SimpleNamespace
+    kw.setdefault("workspace", "ws")
+    kw.setdefault("branch", None)
+    kw.setdefault("needs", None)
+    kw.setdefault("why", None)
+    return SimpleNamespace(**kw)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_change_record.py
+++ b/tests/test_change_record.py
@@ -164,7 +164,10 @@ class TestBothRefusalsAreAsked(ChangeIso):
         os.symlink(elsewhere, change.changes_dir("ws"))
         records, refused = change.all_for("ws")
         self.assertEqual(records, [])
-        self.assertTrue(refused)
+        # The DIRECTORY is what was refused, named as such. Without the directory check the
+        # listing still refuses every file inside it one at a time — same exit, same empty
+        # `records`, and a report that blames five records for a link on their parent.
+        self.assertEqual([slug for slug, _ in refused], [change.DIRNAME])
 
 
 class TestAFailedReadRaises(ChangeIso):
@@ -421,6 +424,27 @@ class TestTheListing(ChangeIso):
     def test_a_workspace_with_no_changes_directory_lists_nothing_and_refuses_nothing(self):
         self.assertEqual(change.all_for("ws"), ([], []))
 
+    def test_records_come_back_in_slug_order(self):
+        """The listing IS the order — there is no rank field and nothing to disagree with
+        the name, which is only true while the read is sorted."""
+        for slug in ("zeta", "alpha", "middle"):
+            change.write("ws", slug, dict(GOOD, change=slug))
+        records, _ = change.all_for("ws")
+        self.assertEqual([r["change"] for r in records], ["alpha", "middle", "zeta"])
+
+    def test_an_emptied_changes_directory_holds_no_records(self):
+        """`any`, not `all`: an empty directory satisfies `all` vacuously, and the answer
+        that matters to `_ws_meta_paths` is "is there something git could untrack here"."""
+        change.write("ws", "only-one", dict(GOOD, change="only-one"))
+        change.forget("ws", "only-one")
+        self.assertTrue(change.changes_dir("ws").exists())
+        self.assertFalse(change.has_records("ws"))
+
+    def test_a_directory_holding_a_record_and_something_else_still_holds_a_record(self):
+        change.write("ws", "only-one", dict(GOOD, change="only-one"))
+        (change.changes_dir("ws") / "README.txt").write_text("notes\n")
+        self.assertTrue(change.has_records("ws"))
+
     def test_the_log_directory_is_not_a_record(self):
         change.write("ws", "good-one", dict(GOOD, change="good-one"))
         change.log_dir("ws").mkdir(parents=True)
@@ -457,6 +481,168 @@ class TestTheStoreIsCreatedLazily(ChangeIso):
         change.forget("ws", "component-api-2")
         self.assertFalse(change.exists("ws", "component-api-2"))
         self.assertTrue(log.exists())
+
+
+class TestTheShapeIsAskedNotAssumed(ChangeIso):
+    """Every `isinstance` in `validate` is a guard, and a record arriving from a hand edit
+    or an older charter is where the wrong shape comes from. Without these, a JSON list
+    where an object belongs reaches the loop below it as an `AttributeError` — a traceback
+    where the record was supposed to be named."""
+
+    def test_a_record_that_is_not_an_object_is_refused(self):
+        self.put("component-api-2", "[1, 2, 3]")
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("not an object", str(cm.exception))
+
+    def test_members_must_be_a_list(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["members"] = {"repo": "charter"}
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("'members' is not a list", str(cm.exception))
+
+    def test_a_member_must_be_an_object(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["members"] = ["charter"]
+        rec["excluded"] = []
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("member is not an object", str(cm.exception))
+
+    def test_needs_must_be_a_list(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["members"] = [{"repo": "charter", "branch": "b", "needs": "charter-metrics"}]
+        rec["excluded"] = []
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("'needs' is not a list", str(cm.exception))
+
+    def test_excluded_must_be_a_list(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["excluded"] = {"repo": "charter-slack"}
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("'excluded' is not a list", str(cm.exception))
+
+    def test_an_exclusion_must_be_an_object(self):
+        rec = json.loads(json.dumps(GOOD))
+        rec["excluded"] = ["charter-slack"]
+        self.put_record("component-api-2", rec)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("exclusion is not an object", str(cm.exception))
+
+    def test_a_why_that_is_not_a_string_is_refused(self):
+        for value in (12, None, ["a"], {"a": 1}):
+            with self.subTest(value=value):
+                rec = json.loads(json.dumps(GOOD))
+                rec["why"] = value
+                self.put_record("component-api-2", rec)
+                with self.assertRaises(change.RecordError):
+                    change.read("ws", "component-api-2")
+
+    def test_a_branch_that_is_not_a_non_empty_string_is_refused(self):
+        for branch in (None, "", 3, ["x"], {}):
+            with self.subTest(branch=branch):
+                self.assertIsNotNone(change.branch_refusal(branch))
+
+    def test_a_record_charter_may_not_open_raises_rather_than_answering_empty(self):
+        """`file_refusal` asks one `lstat` — is this a link, is it a regular file, how big
+        is it — and a file the process may not READ passes all three. The `OSError` handler
+        is what keeps that arriving as a named refusal instead of a traceback, and it is
+        the same "never answers `{}`" property one layer down."""
+        if os.geteuid() == 0:
+            self.skipTest("root reads anything, so there is nothing to measure")
+        change.write("ws", "component-api-2", json.loads(json.dumps(GOOD)))
+        p = change.path_for("ws", "component-api-2")
+        p.chmod(0o000)
+        self.addCleanup(p.chmod, 0o600)
+        with self.assertRaises(change.RecordError) as cm:
+            change.read("ws", "component-api-2")
+        self.assertIn("cannot be read", str(cm.exception))
+
+
+class TestEveryRefusalIsOneLineWhateverItNames(ChangeIso):
+    """A refusal is a report line **about** a value charter would not accept — and that
+    value is exactly the one that must not be able to write a second line into the report.
+
+    Asked as a property over every refusing entry point rather than site by site, because
+    the containment call at each site is invisible in its own output: a test that only
+    checks `assertRaises` stays green with every `contain.readable` deleted, which is how
+    ninety of them come to be a comment with a runtime cost.
+    """
+
+    ESC = "\x1b"
+    HOSTILE = "ok\n  charter  branch main  landed"
+
+    def _refusal(self, fn, *a) -> str:
+        with self.assertRaises(change.RecordError) as cm:
+            fn(*a)
+        return str(cm.exception)
+
+    def _messages(self) -> list[str]:
+        out = [
+            self._refusal(change.path_for, "ws", self.HOSTILE),
+            self._refusal(change.path_for, "ws", f"api{self.ESC}[2K"),
+            # `write` validates BEFORE it resolves the path, so the slug reaching these
+            # messages has been through nothing at all.
+            self._refusal(change.write, "ws", self.HOSTILE, json.loads(json.dumps(GOOD))),
+        ]
+        hostile_name = json.loads(json.dumps(GOOD))
+        hostile_name["change"] = self.HOSTILE
+        out.append(self._refusal(change.validate, hostile_name, "component-api-2"))
+        for field, value in (("repo", f"api{self.ESC}[2K/../x"),
+                             ("branch", f"b{self.ESC}[2K"),
+                             ("needs", [f"api{self.ESC}[2K/x"])):
+            rec = json.loads(json.dumps(GOOD))
+            rec["members"] = [{"repo": "api", "branch": "b", "needs": []}]
+            rec["excluded"] = []
+            rec["members"][0][field] = value
+            out.append(self._refusal(change.validate, rec, "component-api-2"))
+        rec = json.loads(json.dumps(GOOD))
+        rec["excluded"] = [{"repo": f"x{self.ESC}[2K/y", "why": "w", "at": "t"}]
+        out.append(self._refusal(change.validate, rec, "component-api-2"))
+        rec = json.loads(json.dumps(GOOD))
+        rec[f"sneaky{self.ESC}[2K"] = 1
+        out.append(self._refusal(change.validate, rec, "component-api-2"))
+        for key in ("why", "created", "by"):
+            rec = json.loads(json.dumps(GOOD))
+            rec[key] = self.HOSTILE
+            out.append(self._refusal(change.validate, rec, "component-api-2"))
+        rec = json.loads(json.dumps(GOOD))
+        rec["excluded"] = [{"repo": "x", "why": self.HOSTILE, "at": "t"}]
+        out.append(self._refusal(change.validate, rec, "component-api-2"))
+        return out
+
+    def test_a_branch_refusal_cannot_forge_a_second_line_either(self):
+        """`branch_refusal` answers a sentence rather than raising, and the leading-dash
+        arm is reached BEFORE the one-line arm — so that message carries a value nothing
+        else has looked at yet."""
+        for branch in (f"-b\n  charter  branch main  landed", f"-{self.ESC}[2K"):
+            with self.subTest(branch=branch):
+                msg = change.branch_refusal(branch)
+                self.assertEqual(len(msg.splitlines()), 1, msg)
+                self.assertNotIn(self.ESC, msg)
+
+    def test_there_are_refusals_to_measure(self):
+        """The control. A helper that raised on its own first line would make every
+        assertion below pass over an empty list."""
+        self.assertGreaterEqual(len(self._messages()), 8)
+
+    def test_no_refusal_can_forge_a_second_line(self):
+        for msg in self._messages():
+            with self.subTest(msg=msg[:60]):
+                self.assertEqual(len(msg.splitlines()), 1, msg)
+
+    def test_no_refusal_carries_an_escape_through(self):
+        for msg in self._messages():
+            with self.subTest(msg=msg[:60]):
+                self.assertNotIn(self.ESC, msg)
 
 
 def _args(**kw):

--- a/tests/test_commands_change.py
+++ b/tests/test_commands_change.py
@@ -827,13 +827,27 @@ class TestTheCommandSurfacesOwnEdges(ChangeCommands):
         self.assertEqual(len(hostile.strip().splitlines()),
                          len(benign.strip().splitlines()))
 
-    def test_the_lifted_exclusion_warning_cannot_be_as_long_as_the_reason(self):
+    def test_the_lifted_exclusion_warning_cannot_be_as_long_as_what_it_quotes(self):
+        """**Both** fields it quotes, one case each. The reason is the operator's; the
+        timestamp is charter's own — until the record is hand-edited, which is the only
+        state this store ever assumes about a file it did not write this second."""
         long = "w" * (change.TEXT_LIMIT - 1)
         self.create()
         self.call(commands_change.cmd_change_drop, change="component-api-2",
                   repo="charter", why=long)
         _, _, err = self.call(commands_change.cmd_change_add,
                               change="component-api-2", repo="charter")
+        self.assertIn("lifted", err)
+        for line in err.splitlines():
+            self.assertLess(len(line), change.TEXT_LIMIT, line[:80])
+
+        d = change.changes_dir("ws")
+        (d / "stamped.json").write_text(json.dumps(
+            {"change": "stamped", "why": "w", "created": "t", "by": "t", "members": [],
+             "excluded": [{"repo": "charter", "why": "short", "at": long}]}))
+        _, _, err = self.call(commands_change.cmd_change_add,
+                              change="stamped", repo="charter")
+        self.assertIn("lifted", err)
         for line in err.splitlines():
             self.assertLess(len(line), change.TEXT_LIMIT, line[:80])
 

--- a/tests/test_commands_change.py
+++ b/tests/test_commands_change.py
@@ -1,0 +1,544 @@
+"""`charter change create | add | drop | list | show | forget` — records only, no forge.
+
+Two properties run through every case here.
+
+**Which refusal fired, never merely that one did.** `charter change add` has three gates in
+sequence — the change exists, the repo resolves to a clone, the repo is not already a
+member — and an exit-code assertion cannot tell them apart. On #558, deleting a refusal
+still exited 1, for a worse reason, and the test stayed green over a real deletion. So every
+refusal below asserts its own message *and*, where a neighbouring gate could have produced
+the same code, the absence of that neighbour's words.
+
+**The containment property, stated as a property.** A member resolves through
+`contain.child(workspace_dir, name)` and must be a clone the operator already put there. So
+the reach of a change is bounded by what is on this disk, never by anything that travelled
+in a committed file — and a record can name a repository you do not have, be refused for
+that by name, and never name a *place*.
+"""
+from __future__ import annotations
+
+import ast
+import io
+import json
+import os
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import change, commands_change, workspace
+from tests._isolation import PersonaIso
+
+
+def args(**kw) -> SimpleNamespace:
+    kw.setdefault("workspace", "ws")
+    for k in ("change", "repo", "branch", "needs", "why"):
+        kw.setdefault(k, None)
+    return SimpleNamespace(**kw)
+
+
+class ChangeCommands(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("ws")
+        for repo in ("charter", "charter-metrics", ".github"):
+            self.clone(repo)
+
+    def clone(self, name: str) -> None:
+        """A clone, by git's own definition: a directory whose `.git` is a DIRECTORY."""
+        (workspace.workspace_dir("ws") / name / ".git").mkdir(parents=True)
+
+    def call(self, fn, **kw) -> tuple[int, str, str]:
+        """Call a handler, returning ``(code, stdout, stderr)``."""
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            code = fn(args(**kw))
+        return code, out.getvalue(), err.getvalue()
+
+    def create(self, slug="component-api-2", why="API 1 -> 2") -> None:
+        code, _, err = self.call(commands_change.cmd_change_create, change=slug, why=why)
+        self.assertEqual(code, 0, err)
+
+
+class TestTheHappyPath(ChangeCommands):
+    def test_create_then_add_then_show_prints_the_member(self):
+        self.create()
+        code, _, err = self.call(commands_change.cmd_change_add,
+                                change="component-api-2", repo="charter")
+        self.assertEqual(code, 0, err)
+        code, out, _ = self.call(commands_change.cmd_change_show, change="component-api-2")
+        self.assertEqual(code, 0)
+        self.assertIn("charter", out)
+        self.assertIn("change/component-api-2", out)
+        self.assertIn("API 1 -> 2", out)
+
+    def test_the_default_branch_is_the_slug_and_it_is_stored(self):
+        """Stored, not derived by convention afterwards: a convention breaks the moment
+        somebody names one differently, and git can say a branch exists but never that it
+        is *this change's*."""
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2", repo="charter")
+        rec = change.read("ws", "component-api-2")
+        self.assertEqual(rec["members"][0]["branch"], "change/component-api-2")
+
+    def test_an_explicit_branch_is_kept(self):
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2",
+                 repo="charter", branch="feature/other-name")
+        rec = change.read("ws", "component-api-2")
+        self.assertEqual(rec["members"][0]["branch"], "feature/other-name")
+
+    def test_needs_is_recorded_and_shown(self):
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2", repo="charter")
+        self.call(commands_change.cmd_change_add, change="component-api-2",
+                 repo="charter-metrics", needs=["charter"])
+        code, out, _ = self.call(commands_change.cmd_change_show, change="component-api-2")
+        self.assertEqual(code, 0)
+        self.assertIn("needs: charter", out)
+
+    def test_list_shows_every_change(self):
+        self.create("one", "first")
+        self.create("two", "second")
+        code, out, _ = self.call(commands_change.cmd_change_list)
+        self.assertEqual(code, 0)
+        self.assertIn("one", out)
+        self.assertIn("two", out)
+        self.assertIn("second", out)
+
+    def test_the_record_holds_no_state(self):
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2", repo="charter")
+        text = change.path_for("ws", "component-api-2").read_text()
+        for word in ("state", "landed", "pr", "number", "ci", "checks", "url", "remote"):
+            self.assertNotIn(f'"{word}"', text)
+
+
+class TestTheContainmentProperty(ChangeCommands):
+    def test_a_repo_with_no_clone_is_refused_and_names_charter_clone(self):
+        self.create()
+        code, _, err = self.call(commands_change.cmd_change_add,
+                                change="component-api-2", repo="charter-slack")
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("no clone in workspace", err)
+        self.assertIn("charter clone charter-slack -w ws", err)
+        self.assertNotIn("already a member", err)      # and not the gate below it
+        self.assertNotIn("no change", err)             # nor the gate above it
+
+    def test_dot_github_is_accepted_because_segment_ok_is_the_rule(self):
+        """`workspace.valid_name` rejects a leading dot and `org/.github` is a real
+        repository whose name comes from a forge rather than from charter."""
+        self.create()
+        code, _, err = self.call(commands_change.cmd_change_add,
+                                change="component-api-2", repo=".github")
+        self.assertEqual(code, 0, err)
+        self.assertFalse(workspace.valid_name(".github"))
+
+    def test_a_member_that_is_a_path_is_refused(self):
+        self.create()
+        for repo in ("..", "../charter", "/etc", "a/b", "a\\b", "x\x00y", ""):
+            with self.subTest(repo=repo):
+                code, _, err = self.call(commands_change.cmd_change_add,
+                                        change="component-api-2", repo=repo)
+                self.assertEqual(code, commands_change.REFUSED)
+                self.assertIn("no clone in workspace", err)
+
+    def test_a_traversing_member_never_resolves_even_when_the_target_exists(self):
+        """The refusal is about the string. Asking the filesystem would make a traversal
+        succeed exactly when the attacker's target happens to exist."""
+        self.create()
+        outside = self.tmp / "outside"
+        (outside / ".git").mkdir(parents=True)
+        code, _, _ = self.call(commands_change.cmd_change_add,
+                              change="component-api-2", repo="../../outside")
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIsNone(change.member(change.read("ws", "component-api-2"), "../../outside"))
+
+    def test_a_member_that_is_a_symlink_out_of_the_workspace_is_refused(self):
+        """The name passes `segment_ok` — it is the *target* that leaves. `is_clone` is
+        what answers this: git draws the line, since a clone's `.git` is a directory."""
+        self.create()
+        elsewhere = self.tmp / "elsewhere"
+        elsewhere.mkdir()
+        os.symlink(elsewhere, workspace.workspace_dir("ws") / "sneaky")
+        code, _, err = self.call(commands_change.cmd_change_add,
+                                change="component-api-2", repo="sneaky")
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("no clone in workspace", err)
+
+    def test_a_directory_that_is_not_a_checkout_is_not_a_member(self):
+        self.create()
+        (workspace.workspace_dir("ws") / "refs-like").mkdir()
+        code, _, _ = self.call(commands_change.cmd_change_add,
+                              change="component-api-2", repo="refs-like")
+        self.assertEqual(code, commands_change.REFUSED)
+
+
+class TestEachRefusalIsItsOwn(ChangeCommands):
+    def test_an_unknown_change_is_named_as_such(self):
+        code, _, err = self.call(commands_change.cmd_change_add,
+                                change="never-created", repo="charter")
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("no change", err)
+        self.assertNotIn("no clone", err)
+
+    def test_a_duplicate_member_is_named_as_such(self):
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2", repo="charter")
+        code, _, err = self.call(commands_change.cmd_change_add,
+                                change="component-api-2", repo="charter")
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("already a member", err)
+        self.assertNotIn("no clone", err)
+
+    def test_a_cycle_is_named_as_such_and_nothing_is_written(self):
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2", repo="charter")
+        self.call(commands_change.cmd_change_add, change="component-api-2",
+                 repo="charter-metrics", needs=["charter"])
+        before = change.path_for("ws", "component-api-2").read_bytes()
+        # `.github` needs charter-metrics, which needs charter — fine. Now make charter
+        # need `.github` and the three of them close a loop.
+        self.call(commands_change.cmd_change_add, change="component-api-2",
+                 repo=".github", needs=["charter-metrics"])
+        rec = change.read("ws", "component-api-2")
+        rec["members"][0]["needs"] = [".github"]
+        with self.assertRaises(change.RecordError) as cm:
+            change.write("ws", "component-api-2", rec)
+        self.assertIn("cycle", str(cm.exception))
+        del before
+
+    def test_needs_naming_a_non_member_is_refused_by_the_command(self):
+        self.create()
+        code, _, err = self.call(commands_change.cmd_change_add, change="component-api-2",
+                                repo="charter", needs=["nobody"])
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("not a member", err)
+        self.assertNotIn("no clone", err)
+        self.assertEqual(change.read("ws", "component-api-2")["members"], [])
+
+    def test_creating_a_change_twice_is_refused(self):
+        self.create()
+        code, _, err = self.call(commands_change.cmd_change_create,
+                                change="component-api-2", why="again")
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("already exists", err)
+        self.assertEqual(change.read("ws", "component-api-2")["why"], "API 1 -> 2")
+
+    def test_a_slug_that_is_not_a_name_is_refused(self):
+        for slug in ("..", "a/b", ".hidden", "-b", "x\x00y"):
+            with self.subTest(slug=slug):
+                code, _, err = self.call(commands_change.cmd_change_create,
+                                        change=slug, why="x")
+                self.assertEqual(code, 1)
+                self.assertIn("is not a change name", err)
+
+
+class TestWhyIsRequired(ChangeCommands):
+    def test_create_without_why_does_not_parse(self):
+        from charter import cli
+        with self.assertRaises(SystemExit):
+            cli.build_parser().parse_args(["change", "create", "component-api-2"])
+
+    def test_create_with_an_empty_why_is_refused_by_the_handler(self):
+        """argparse cannot see `--why ""`. A change with no stated reason is unreadable six
+        months later, which is the one job the record has that git cannot do."""
+        code, _, err = self.call(commands_change.cmd_change_create,
+                                change="component-api-2", why="   ")
+        self.assertEqual(code, 1)
+        self.assertIn("--why", err)
+        self.assertFalse(change.exists("ws", "component-api-2"))
+
+    def test_drop_without_why_does_not_parse(self):
+        from charter import cli
+        with self.assertRaises(SystemExit):
+            cli.build_parser().parse_args(["change", "drop", "component-api-2", "charter"])
+
+    def test_drop_with_an_empty_why_is_refused_by_the_handler(self):
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2", repo="charter")
+        code, _, err = self.call(commands_change.cmd_change_drop,
+                                change="component-api-2", repo="charter", why="")
+        self.assertEqual(code, 1)
+        self.assertIn("--why", err)
+        self.assertIsNotNone(change.member(change.read("ws", "component-api-2"), "charter"))
+
+
+class TestDrop(ChangeCommands):
+    def test_a_dropped_member_joins_excluded_with_its_reason_and_a_timestamp(self):
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2", repo="charter")
+        code, _, err = self.call(commands_change.cmd_change_drop, change="component-api-2",
+                                repo="charter", why="maintainer pins API 1")
+        self.assertEqual(code, 0, err)
+        rec = change.read("ws", "component-api-2")
+        self.assertEqual(rec["members"], [])
+        self.assertEqual(rec["excluded"][0]["repo"], "charter")
+        self.assertEqual(rec["excluded"][0]["why"], "maintainer pins API 1")
+        self.assertTrue(rec["excluded"][0]["at"])
+
+    def test_a_repo_that_was_never_a_member_can_be_excluded(self):
+        """§4's own step: the operator decides a repo is out of scope and records that, so
+        the record says it was considered rather than forgotten."""
+        self.create()
+        code, _, err = self.call(commands_change.cmd_change_drop, change="component-api-2",
+                                repo="charter-slack", why="no components")
+        self.assertEqual(code, 0, err)
+        self.assertIn("never a member", err)
+        self.assertEqual(change.read("ws", "component-api-2")["excluded"][0]["repo"],
+                         "charter-slack")
+
+    def test_dropping_a_blocker_is_refused_and_names_its_dependents(self):
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2", repo="charter")
+        self.call(commands_change.cmd_change_add, change="component-api-2",
+                 repo="charter-metrics", needs=["charter"])
+        code, _, err = self.call(commands_change.cmd_change_drop, change="component-api-2",
+                                repo="charter", why="out")
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("charter-metrics", err)
+        self.assertIsNotNone(change.member(change.read("ws", "component-api-2"), "charter"))
+
+    def test_dropping_the_same_repo_twice_is_refused(self):
+        self.create()
+        self.call(commands_change.cmd_change_drop, change="component-api-2",
+                 repo="charter-slack", why="no components")
+        code, _, err = self.call(commands_change.cmd_change_drop, change="component-api-2",
+                                repo="charter-slack", why="again")
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("already excluded", err)
+
+    def test_a_dropped_repo_is_never_silently_gone(self):
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2", repo="charter")
+        self.call(commands_change.cmd_change_drop, change="component-api-2",
+                 repo="charter", why="reason kept")
+        code, out, _ = self.call(commands_change.cmd_change_show, change="component-api-2")
+        self.assertEqual(code, 0)
+        self.assertIn("excluded", out)
+        self.assertIn("reason kept", out)
+
+    def test_re_adding_an_excluded_repo_lifts_the_exclusion_loudly(self):
+        self.create()
+        self.call(commands_change.cmd_change_drop, change="component-api-2",
+                 repo="charter", why="changed my mind later")
+        code, _, err = self.call(commands_change.cmd_change_add,
+                                change="component-api-2", repo="charter")
+        self.assertEqual(code, 0, err)
+        self.assertIn("lifted", err)
+        self.assertIn("changed my mind later", err)
+        rec = change.read("ws", "component-api-2")
+        self.assertEqual(rec["excluded"], [])
+        self.assertIsNotNone(change.member(rec, "charter"))
+
+
+class TestForget(ChangeCommands):
+    def test_forget_deletes_the_record(self):
+        self.create()
+        code, _, err = self.call(commands_change.cmd_change_forget, change="component-api-2")
+        self.assertEqual(code, 0, err)
+        self.assertFalse(change.exists("ws", "component-api-2"))
+
+    def test_forget_deletes_no_landing_log_line(self):
+        """The log is a past-tense declaration of what happened. Deleting history to tidy a
+        list is how a store starts lying."""
+        self.create()
+        change.log_dir("ws").mkdir(parents=True)
+        log = change.log_dir("ws") / "host.jsonl"
+        log.write_text('{"change": "component-api-2", "merge": "e0c9d13"}\n')
+        self.call(commands_change.cmd_change_forget, change="component-api-2")
+        self.assertIn("e0c9d13", log.read_text())
+
+    def test_forgetting_what_is_not_there_is_refused(self):
+        code, _, err = self.call(commands_change.cmd_change_forget, change="never-created")
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("no change", err)
+
+    def test_a_slug_that_is_a_path_forgets_nothing(self):
+        self.create()
+        code, _, _ = self.call(commands_change.cmd_change_forget, change="../../etc/passwd")
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertTrue(change.exists("ws", "component-api-2"))
+
+
+class TestABranchNameIsArgvNotARef(ChangeCommands):
+    def test_a_branch_beginning_with_a_dash_is_refused(self):
+        self.create()
+        for branch in ("-b", "--upload-pack=touch /tmp/pwn"):
+            with self.subTest(branch=branch):
+                code, _, err = self.call(commands_change.cmd_change_add,
+                                        change="component-api-2", repo="charter",
+                                        branch=branch)
+                self.assertEqual(code, 1)
+                self.assertIn("FLAG", err)
+                self.assertEqual(change.read("ws", "component-api-2")["members"], [])
+
+    def test_a_branch_carrying_a_newline_is_refused(self):
+        self.create()
+        code, _, err = self.call(commands_change.cmd_change_add, change="component-api-2",
+                                repo="charter", branch="ok\n✓ merged everything")
+        self.assertEqual(code, 1)
+        self.assertIn("one plain line", err)
+
+    def test_the_argv_form_reaches_the_same_refusal(self):
+        """`--branch=-b` is how a dash-led value gets past argparse at all, so the guard has
+        to be charter's rather than the parser's."""
+        from charter import cli
+        ns = cli.build_parser().parse_args(
+            ["change", "add", "component-api-2", "charter", "--branch=-b", "-w", "ws"])
+        self.create()
+        code, _, err = self.call(commands_change.cmd_change_add, change=ns.change,
+                                repo=ns.repo, branch=ns.branch)
+        self.assertEqual(code, 1)
+        self.assertIn("FLAG", err)
+
+
+class TestHostileValuesRenderAsOneRow(ChangeCommands):
+    """A change slug, a `why`, a repo name and a branch name are all committed values that
+    reach a report line. #453's mechanism one surface over: a value crossing into a format
+    with structure without being escaped for it. Tested with hostile values rather than
+    reasoned about."""
+
+    ESC = "\x1b"
+
+    def _hand_write(self, rec: dict) -> None:
+        d = change.changes_dir("ws")
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{rec['change']}.json").write_text(json.dumps(rec))
+
+    def test_a_why_that_would_forge_a_row_never_reaches_the_record(self):
+        code, _, err = self.call(commands_change.cmd_change_create, change="hostile",
+                                 why="ok\n✓ everything landed  #601")
+        self.assertEqual(code, 1)
+        self.assertIn("--why", err)
+        self.assertFalse(change.exists("ws", "hostile"))
+
+    def test_a_why_that_cannot_be_one_line_never_reaches_the_record_at_all(self):
+        """The boundary half. `contain.segment_ok` deliberately does NOT constrain a repo
+        name this way — see the two cases below, which are why the display half is still
+        load-bearing rather than belt and braces."""
+        self._hand_write({"change": "hostile", "why": f"plain {self.ESC}[2K{self.ESC}[1G x",
+                          "created": "t", "by": "t", "members": [], "excluded": []})
+        code, _, err = self.call(commands_change.cmd_change_show, change="hostile")
+        self.assertEqual(code, 1)
+        self.assertIn("not one plain line", err)
+
+    def test_a_repo_name_carrying_an_escape_sequence_is_escaped_on_the_row(self):
+        """`segment_ok` asks about separators, `..` and NUL — not about control characters
+        — so a repo name out of a committed record reaches the row with its ESC intact
+        unless the row escapes it. That is the display half doing work nothing else does."""
+        self._hand_write({"change": "hostile", "why": "w", "created": "t", "by": "t",
+                          "members": [{"repo": f"api{self.ESC}[2K{self.ESC}[1Gsneaky",
+                                       "branch": "x", "needs": []}],
+                          "excluded": []})
+        code, out, _ = self.call(commands_change.cmd_change_show, change="hostile")
+        self.assertEqual(code, 0)
+        self.assertNotIn(self.ESC, out)
+
+    def test_a_repo_name_carrying_a_newline_renders_as_exactly_one_row(self):
+        self._hand_write({"change": "hostile", "why": "w", "created": "t", "by": "t",
+                          "members": [{"repo": "api\n  charter  branch main  landed",
+                                       "branch": "x", "needs": []}],
+                          "excluded": []})
+        code, out, _ = self.call(commands_change.cmd_change_show, change="hostile")
+        self.assertEqual(code, 0)
+        self.assertEqual(len([ln for ln in out.splitlines() if "branch " in ln]), 1)
+
+    def test_a_member_name_never_widens_a_row_past_its_column(self):
+        """`contain.one_line` BEFORE the width arithmetic (#472): `tui.pad` measures what it
+        is given, so a value escaped afterwards is padded to the wrong width and the column
+        stops lining up at exactly the row somebody else controls."""
+        self._hand_write({"change": "hostile", "why": "w", "created": "t", "by": "t",
+                          "members": [{"repo": "a\x07b", "branch": "x", "needs": []},
+                                      {"repo": "short", "branch": "y", "needs": []}],
+                          "excluded": []})
+        code, out, _ = self.call(commands_change.cmd_change_show, change="hostile")
+        self.assertEqual(code, 0)
+        rows = [ln for ln in out.splitlines() if "branch " in ln]
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(len({ln.index("branch ") for ln in rows}), 1)
+
+    def test_a_refused_record_is_named_in_the_listing_without_forging_a_row(self):
+        self._hand_write({"change": "hostile", "why": "w\nx", "created": "t", "by": "t",
+                          "members": [], "excluded": []})
+        code, _, err = self.call(commands_change.cmd_change_list)
+        self.assertEqual(code, 1)
+        self.assertIn("hostile", err)
+
+
+class TestThereIsNoExpansionAndNoForge(unittest.TestCase):
+    """§6.1 rule 2. Every member in a record was typed by somebody, and in a LIVE workspace
+    the record is committed — so it is reviewable in a diff. A surface that could expand a
+    pattern into members is a committed file naming repositories nobody typed.
+
+    Asserted against the module's own syntax tree rather than its text, because the property
+    is *absence* and a substring search over a file that also documents the property finds
+    the documentation. A behavioural test cannot answer it at all: it can only try the
+    patterns somebody thought of."""
+
+    def _tree(self) -> ast.AST:
+        from charter import commands_change as m
+        return ast.parse(Path(m.__file__).read_text(encoding="utf-8"))
+
+    def _imports(self) -> set[str]:
+        names: set[str] = set()
+        for node in ast.walk(self._tree()):
+            if isinstance(node, ast.Import):
+                names |= {a.name.split(".")[0] for a in node.names}
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    names.add(node.module.split(".")[0])
+                names |= {a.name for a in node.names}
+        return names
+
+    def _called(self) -> set[str]:
+        out: set[str] = set()
+        for node in ast.walk(self._tree()):
+            if isinstance(node, ast.Call):
+                f = node.func
+                if isinstance(f, ast.Name):
+                    out.add(f.id)
+                elif isinstance(f, ast.Attribute):
+                    out.add(f.attr)
+        return out
+
+    def test_nothing_here_enumerates_repos(self):
+        for name in ("list_repos", "repos", "glob", "rglob", "iterdir", "walk", "scandir"):
+            self.assertNotIn(name, self._called(),
+                             f"{name}() would let a change enumerate rather than be typed")
+
+    def test_the_inventory_is_not_even_imported(self):
+        self.assertNotIn("inventory", self._imports())
+
+    def test_no_change_subcommand_takes_a_pattern_or_an_all_flag(self):
+        from charter import cli
+        top = cli.build_parser()._subparsers._group_actions[0].choices["change"]
+        for name, sub in top._subparsers._group_actions[0].choices.items():
+            for action in sub._actions:
+                for opt in action.option_strings:
+                    self.assertNotIn(opt, ("--all", "--all-repos", "--pattern", "--glob",
+                                           "--match", "--every"), f"change {name} {opt}")
+
+    def test_no_forge_module_and_no_network_module_is_imported(self):
+        """Records only. The forge half is a later phase, and keeping the record surface
+        separable from it is what makes "what did the operator declare" answerable without
+        asking anybody's API."""
+        for name in ("forge", "gitpolicy", "planegit", "glstate", "report", "inventory",
+                     "socket", "urllib", "http", "ssl", "subprocess"):
+            self.assertNotIn(name, self._imports())
+
+    def test_the_only_child_process_this_module_can_start_is_a_local_config_read(self):
+        """`util.run` is a general subprocess runner, so "no network" is a claim about the
+        argv rather than about the import. Every command this module can hand it is listed
+        here, in full: one read of `git config`, which touches no remote."""
+        spawned = []
+        for node in ast.walk(self._tree()):
+            if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                    and node.func.attr in ("run", "Popen", "call", "check_output",
+                                           "check_call", "system", "popen")):
+                spawned.append(ast.literal_eval(node.args[0]) if node.args else None)
+        self.assertEqual(spawned, [["git", "config", "user.name"]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_commands_change.py
+++ b/tests/test_commands_change.py
@@ -145,13 +145,22 @@ class TestTheContainmentProperty(ChangeCommands):
 
     def test_a_traversing_member_never_resolves_even_when_the_target_exists(self):
         """The refusal is about the string. Asking the filesystem would make a traversal
-        succeed exactly when the attacker's target happens to exist."""
+        succeed exactly when the attacker's target happens to exist — and here it does: the
+        target below is a real clone, one `..` above the workspace.
+
+        **Which refusal fires is the assertion, not that one did.** The record boundary in
+        `change.py` refuses this name too, so an exit-code test stays green with
+        `contain.child` deleted from the resolver — and the deleted version has already
+        `lstat`ed a path of somebody else's choosing outside the workspace by then, and
+        reports a malformed record rather than a member that does not resolve."""
         self.create()
         outside = self.tmp / "outside"
         (outside / ".git").mkdir(parents=True)
-        code, _, _ = self.call(commands_change.cmd_change_add,
-                              change="component-api-2", repo="../../outside")
+        code, _, err = self.call(commands_change.cmd_change_add,
+                                 change="component-api-2", repo="../../outside")
         self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("no clone in workspace", err)
+        self.assertNotIn("is not a name", err)      # not the boundary one layer down
         self.assertIsNone(change.member(change.read("ws", "component-api-2"), "../../outside"))
 
     def test_a_member_that_is_a_symlink_out_of_the_workspace_is_refused(self):
@@ -294,9 +303,16 @@ class TestDrop(ChangeCommands):
         self.call(commands_change.cmd_change_add, change="component-api-2",
                  repo="charter-metrics", needs=["charter"])
         code, _, err = self.call(commands_change.cmd_change_drop, change="component-api-2",
-                                repo="charter", why="out")
+                                 repo="charter", why="out")
         self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("cannot be dropped", err)
         self.assertIn("charter-metrics", err)
+        self.assertIn("to land first", err)
+        # And not the record boundary's own sentence, which refuses the same write for a
+        # different reason ("needs 'charter', which is not a member") and would leave an
+        # exit-code test green over this gate's deletion — while telling the operator their
+        # record is malformed rather than which member is still waiting on this one.
+        self.assertNotIn("not a member of this change", err)
         self.assertIsNotNone(change.member(change.read("ws", "component-api-2"), "charter"))
 
     def test_dropping_the_same_repo_twice_is_refused(self):

--- a/tests/test_commands_change.py
+++ b/tests/test_commands_change.py
@@ -26,7 +26,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
 
-from charter import change, commands_change, workspace
+from charter import change, commands_change, contain, workspace
 from tests._isolation import PersonaIso
 
 
@@ -540,7 +540,7 @@ class TestHostileValuesRenderAsOneRow(ChangeCommands):
         is given, so a value escaped afterwards is padded to the wrong width and the column
         stops lining up at exactly the row somebody else controls."""
         self._hand_write({"change": "hostile", "why": "w", "created": "t", "by": "t",
-                          "members": [{"repo": "a\x07b", "branch": "x", "needs": []},
+                          "members": [{"repo": "a\u2028b", "branch": "x", "needs": []},
                                       {"repo": "short", "branch": "y", "needs": []}],
                           "excluded": []})
         code, out, _ = self.call(commands_change.cmd_change_show, change="hostile")
@@ -549,12 +549,167 @@ class TestHostileValuesRenderAsOneRow(ChangeCommands):
         self.assertEqual(len(rows), 2)
         self.assertEqual(len({ln.index("branch ") for ln in rows}), 1)
 
+    def test_an_excluded_repo_is_named_on_its_row_rather_than_silently_shortened(self):
+        """The exclusion rows are a second table over the same untrusted names, and this is
+        the half `tui` cannot supply. `tui.sanitize` *removes* a character with no glyph, so
+        a raw cell renders `x<U+2028>b` as `xb` — a row naming a repository that is not the
+        one in the record, which is #498's finding exactly. `contain.one_line` escapes it
+        instead, so the reader sees which repository it is."""
+        self._hand_write({"change": "hostile", "why": "w", "created": "t", "by": "t",
+                          "members": [],
+                          "excluded": [{"repo": "x\u2028b", "why": "no components",
+                                        "at": "t"}]})
+        code, out, _ = self.call(commands_change.cmd_change_show, change="hostile")
+        self.assertEqual(code, 0)
+        self.assertIn("\\u2028", out)
+        self.assertEqual(len([ln for ln in out.splitlines()
+                              if "no components" in ln]), 1)
+
     def test_a_refused_record_is_named_in_the_listing_without_forging_a_row(self):
         self._hand_write({"change": "hostile", "why": "w\nx", "created": "t", "by": "t",
                           "members": [], "excluded": []})
         code, _, err = self.call(commands_change.cmd_change_list)
         self.assertEqual(code, 1)
         self.assertIn("hostile", err)
+
+
+class TestNoRefusalCanForgeARowEither(ChangeCommands):
+    """The command surface's half of the same property. A repo name and a change slug both
+    arrive as **argv**, so they reach a refusal without having passed through the record at
+    all — and a refusal is a line of charter's own output that a value must not be able to
+    write a second one of.
+
+    Measured as a **comparison** with the same refusal over a benign value, rather than
+    against a literal count: the count includes the workspace banner and whatever tips the
+    command prints, and a test that hard-codes those measures the tips instead of the
+    property. Each case asserts the benign refusal printed something first, so a command
+    that fell silent cannot pass by printing nothing twice."""
+
+    HOSTILE = "api\n  charter  branch main  landed"
+
+    def _lines(self, fn, **kw) -> int:
+        _, _, err = self.call(fn, **kw)
+        return len(err.strip().splitlines())
+
+    def _same(self, fn, benign: dict, hostile: dict) -> None:
+        want = self._lines(fn, **benign)
+        self.assertGreaterEqual(want, 2, "the benign refusal printed nothing to compare")
+        self.assertEqual(self._lines(fn, **hostile), want)
+
+    def test_the_no_clone_refusal_does_not_grow_for_a_hostile_repo(self):
+        self.create()
+        self._same(commands_change.cmd_change_add,
+                   {"change": "component-api-2", "repo": "charter-slack"},
+                   {"change": "component-api-2", "repo": self.HOSTILE})
+
+    def test_the_unknown_change_refusal_does_not_grow_for_a_hostile_slug(self):
+        self._same(commands_change.cmd_change_add,
+                   {"change": "never-created", "repo": "charter"},
+                   {"change": self.HOSTILE, "repo": "charter"})
+
+    def test_the_bad_slug_refusal_does_not_grow_for_a_hostile_slug(self):
+        self._same(commands_change.cmd_change_create,
+                   {"change": "..", "why": "x"},
+                   {"change": self.HOSTILE, "why": "x"})
+
+    def test_the_forget_refusal_does_not_grow_for_a_hostile_slug(self):
+        self.create()
+        self._same(commands_change.cmd_change_forget,
+                   {"change": "never-created"}, {"change": self.HOSTILE})
+
+    def test_the_already_excluded_refusal_does_not_grow_for_a_hostile_repo(self):
+        self.create()
+        for repo in ("gone", self.HOSTILE):
+            self.call(commands_change.cmd_change_drop, change="component-api-2",
+                      repo=repo, why="first")
+        self._same(commands_change.cmd_change_drop,
+                   {"change": "component-api-2", "repo": "gone", "why": "again"},
+                   {"change": "component-api-2", "repo": self.HOSTILE, "why": "again"})
+
+    def test_the_duplicate_member_refusal_does_not_grow_for_a_hostile_repo(self):
+        """A repo name is `segment_ok`, which asks about separators, `..` and NUL and
+        nothing else — so a line break is a legal repository name and a legal directory
+        name, and this member is a real clone with one in it."""
+        self.clone(self.HOSTILE)
+        self.create()
+        for repo in ("charter", self.HOSTILE):
+            self.call(commands_change.cmd_change_add, change="component-api-2", repo=repo)
+        self._same(commands_change.cmd_change_add,
+                   {"change": "component-api-2", "repo": "charter"},
+                   {"change": "component-api-2", "repo": self.HOSTILE})
+
+    def test_a_hostile_blocker_name_cannot_forge_the_drop_refusal(self):
+        d = change.changes_dir("ws")
+        d.mkdir(parents=True, exist_ok=True)
+        for slug, blocker in (("benign", "web"), ("hostile", "we\nb  charter  landed")):
+            (d / f"{slug}.json").write_text(json.dumps({
+                "change": slug, "why": "w", "created": "t", "by": "t",
+                "members": [{"repo": "api", "branch": "b", "needs": []},
+                            {"repo": blocker, "branch": "b", "needs": ["api"]}],
+                "excluded": []}))
+        self._same(commands_change.cmd_change_drop,
+                   {"change": "benign", "repo": "api", "why": "out"},
+                   {"change": "hostile", "repo": "api", "why": "out"})
+
+
+class TestALongValueIsClippedWhereTheRowIs(ChangeCommands):
+
+    def _hand_write(self, rec: dict) -> None:
+        d = change.changes_dir("ws")
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{rec['change']}.json").write_text(json.dumps(rec))
+
+    """The record's own bound is `contain`'s PATH budget, so a `why` a little longer than a
+    row is a legitimate record — and the ROW budget is then doing real work at the printing
+    site rather than being belt over a brace."""
+
+    def test_a_long_why_is_clipped_on_the_row(self):
+        long = "w" * (contain.DISPLAY_LIMIT + 60)
+        self.create(why=long)
+        code, out, _ = self.call(commands_change.cmd_change_show, change="component-api-2")
+        self.assertEqual(code, 0)
+        row = [ln for ln in out.splitlines() if ln.startswith("  why:")][0]
+        self.assertLess(len(row), len(long))
+        self.assertTrue(row.endswith("…"))
+
+    def test_the_command_and_the_record_hold_a_why_to_the_same_bound(self):
+        """Two bounds that disagree is a `why` charter accepts and then refuses to read
+        back — a record it wrote and cannot open."""
+        self.create(why="w" * change.TEXT_LIMIT)
+        self.assertEqual(len(change.read("ws", "component-api-2")["why"]),
+                         change.TEXT_LIMIT)
+
+    def test_no_printed_row_can_be_as_long_as_the_value_behind_it(self):
+        """The record's bound is `TEXT_LIMIT`; a ROW's is `DISPLAY_LIMIT`, and the gap
+        between them is exactly what every `contain.one_line` at a printing site is for.
+        Asked of every line of both commands at once, with every text field of the record
+        set to the longest value the record will hold — so a cell somebody forgets to
+        contain fails this without anybody adding a case for it."""
+        long = "v" * (change.TEXT_LIMIT - 1)
+        self._hand_write({
+            "change": "component-api-2", "why": long, "created": long, "by": long,
+            "members": [{"repo": "m" * 300, "branch": long, "needs": []},
+                        {"repo": "n" * 300, "branch": long, "needs": ["m" * 300]}],
+            "excluded": [{"repo": "x" * 300, "why": long, "at": long}]})
+        for fn in (commands_change.cmd_change_show, commands_change.cmd_change_list):
+            kw = {"change": "component-api-2"} if fn is commands_change.cmd_change_show else {}
+            code, out, _ = self.call(fn, **kw)
+            self.assertEqual(code, 0)
+            self.assertTrue(out.strip())
+            for line in out.splitlines():
+                with self.subTest(fn=fn.__name__, line=line[:40]):
+                    self.assertLess(len(line), change.TEXT_LIMIT, line[:120])
+
+    def test_a_long_branch_is_clipped_on_the_row(self):
+        long = "b" * (contain.DISPLAY_LIMIT + 60)
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2",
+                  repo="charter", branch=long)
+        code, out, _ = self.call(commands_change.cmd_change_show, change="component-api-2")
+        self.assertEqual(code, 0)
+        row = [ln for ln in out.splitlines() if "branch " in ln][0]
+        self.assertLess(len(row), len(long))
+        self.assertTrue(row.endswith("…"))
 
 
 class TestThereIsNoExpansionAndNoForge(unittest.TestCase):

--- a/tests/test_commands_change.py
+++ b/tests/test_commands_change.py
@@ -712,6 +712,213 @@ class TestALongValueIsClippedWhereTheRowIs(ChangeCommands):
         self.assertTrue(row.endswith("…"))
 
 
+class TestTheCommandSurfacesOwnEdges(ChangeCommands):
+    """What each command does at the edge of a guard rather than in the middle of it: an
+    absent value, a fallback nobody exercises, a plural, a success line. Every case here
+    was a line the deletion sweep could delete in silence."""
+
+    ESC = "\x1b"
+    HOSTILE = "api\n  charter  branch main  landed"
+
+    def test_the_refusal_exit_code_is_two_and_that_is_the_contract(self):
+        """The NUMBER, not the name. A caller branches on it — `commands_worktree` spends
+        its own 2 the same way — and 1 is what every other failure returns, so a change of
+        value here is a change of interface even though every test that uses the constant
+        keeps passing."""
+        self.assertEqual(commands_change.REFUSED, 2)
+
+    def test_the_banner_says_the_workspace_came_from_the_flag(self):
+        """The banner is how an agent knows which plane it is acting on. `-w` is the
+        loudest of the rungs and it has to be the one reported."""
+        self.create()
+        _, _, err = self.call(commands_change.cmd_change_show, change="component-api-2")
+        self.assertIn("workspace: ws", err)
+        self.assertIn("--workspace", err)
+
+    def test_an_absent_why_is_refused_rather_than_crashing(self):
+        code, _, err = self.call(commands_change.cmd_change_create,
+                                 change="component-api-2", why=None)
+        self.assertEqual(code, 1)
+        self.assertIn("--why", err)
+
+    def test_dropping_from_a_change_that_does_not_exist_is_refused(self):
+        code, _, err = self.call(commands_change.cmd_change_drop,
+                                 change="never-created", repo="charter", why="out")
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("no change", err)
+
+    def test_one_blocker_reads_as_one_and_two_read_as_two(self):
+        self.create()
+        for repo in ("charter", "charter-metrics", ".github"):
+            self.call(commands_change.cmd_change_add, change="component-api-2", repo=repo)
+        rec = change.read("ws", "component-api-2")
+        rec["members"][1]["needs"] = ["charter"]
+        change.write("ws", "component-api-2", rec)
+        _, _, err = self.call(commands_change.cmd_change_drop, change="component-api-2",
+                              repo="charter", why="out")
+        self.assertIn("still needs it", err)
+        rec = change.read("ws", "component-api-2")
+        rec["members"][2]["needs"] = ["charter"]
+        change.write("ws", "component-api-2", rec)
+        _, _, err = self.call(commands_change.cmd_change_drop, change="component-api-2",
+                              repo="charter", why="out")
+        self.assertIn("still need it", err)
+        self.assertNotIn("still needs it", err)
+
+    def test_a_dropped_member_does_not_read_as_never_a_member(self):
+        """The two sentences say different things about the record, and the one that is
+        wrong sends a reader looking for a member that was there all along."""
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2", repo="charter")
+        _, _, err = self.call(commands_change.cmd_change_drop, change="component-api-2",
+                              repo="charter", why="out")
+        self.assertNotIn("never a member", err)
+        self.assertIn("member(s) left", err)
+
+    def test_a_change_with_exclusions_says_how_many_in_both_commands(self):
+        self.create()
+        self.call(commands_change.cmd_change_drop, change="component-api-2",
+                  repo="charter-slack", why="no components")
+        _, show, _ = self.call(commands_change.cmd_change_show, change="component-api-2")
+        _, listing, _ = self.call(commands_change.cmd_change_list)
+        self.assertIn("1 excluded", show)
+        self.assertIn("1 excluded", listing)
+
+    def test_a_change_with_no_exclusions_counts_none_in_the_listing(self):
+        self.create()
+        _, listing, _ = self.call(commands_change.cmd_change_list)
+        self.assertNotIn("excluded", listing)
+
+    def test_a_record_file_whose_NAME_forges_a_row_is_named_safely_in_the_listing(self):
+        """The refused half of the listing takes its slug from the FILESYSTEM, so it has
+        been through nothing at all — and a file named with a line break is a file somebody
+        can create. Compared against the same refusal over an ordinary name, so the count
+        of tips and banners is not what is being measured."""
+        self.create()
+        d = change.changes_dir("ws")
+        (d / "benign.json").write_text("{")
+        _, _, one = self.call(commands_change.cmd_change_list)
+        (d / "benign.json").unlink()
+        (d / "hos\ntile.json").write_text("{")
+        _, _, two = self.call(commands_change.cmd_change_list)
+        self.assertGreaterEqual(len(one.strip().splitlines()), 2)
+        self.assertEqual(len(two.strip().splitlines()), len(one.strip().splitlines()))
+
+    def test_a_hostile_member_name_is_named_on_the_success_line_too(self):
+        """A repo name is `segment_ok`, which admits a line break — and this is the line
+        charter prints when it *accepts* the member, which is the one nobody thinks of."""
+        self.clone(self.HOSTILE)
+        self.create()
+        _, _, benign = self.call(commands_change.cmd_change_add,
+                                 change="component-api-2", repo="charter")
+        _, _, hostile = self.call(commands_change.cmd_change_add,
+                                  change="component-api-2", repo=self.HOSTILE)
+        self.assertGreaterEqual(len(benign.strip().splitlines()), 2)
+        self.assertEqual(len(hostile.strip().splitlines()),
+                         len(benign.strip().splitlines()))
+
+    def test_a_hostile_name_is_named_on_the_exclusion_success_line_too(self):
+        self.create()
+        _, _, benign = self.call(commands_change.cmd_change_drop,
+                                 change="component-api-2", repo="gone", why="out")
+        _, _, hostile = self.call(commands_change.cmd_change_drop,
+                                  change="component-api-2", repo=self.HOSTILE, why="out")
+        self.assertGreaterEqual(len(benign.strip().splitlines()), 2)
+        self.assertEqual(len(hostile.strip().splitlines()),
+                         len(benign.strip().splitlines()))
+
+    def test_the_lifted_exclusion_warning_cannot_be_as_long_as_the_reason(self):
+        long = "w" * (change.TEXT_LIMIT - 1)
+        self.create()
+        self.call(commands_change.cmd_change_drop, change="component-api-2",
+                  repo="charter", why=long)
+        _, _, err = self.call(commands_change.cmd_change_add,
+                              change="component-api-2", repo="charter")
+        for line in err.splitlines():
+            self.assertLess(len(line), change.TEXT_LIMIT, line[:80])
+
+    def test_the_blocker_refusal_does_not_grow_for_a_hostile_member(self):
+        """The refusal names the repo being dropped, and that name comes from argv — so
+        this is the drop gate's own printing site, distinct from the blockers it lists."""
+        d = change.changes_dir("ws")
+        d.mkdir(parents=True, exist_ok=True)
+        for slug, blocked in (("benign", "api"), ("hostile", self.HOSTILE)):
+            (d / f"{slug}.json").write_text(json.dumps({
+                "change": slug, "why": "w", "created": "t", "by": "t",
+                "members": [{"repo": blocked, "branch": "b", "needs": []},
+                            {"repo": "web", "branch": "b", "needs": [blocked]}],
+                "excluded": []}))
+        counts = []
+        for slug, repo in (("benign", "api"), ("hostile", self.HOSTILE)):
+            _, _, err = self.call(commands_change.cmd_change_drop, change=slug,
+                                  repo=repo, why="out")
+            counts.append(len(err.strip().splitlines()))
+        self.assertGreaterEqual(counts[0], 3)
+        self.assertEqual(counts[1], counts[0])
+
+    def test_a_member_name_is_shown_rather_than_silently_shortened(self):
+        """`tui.sanitize` REMOVES a character with no glyph, so a raw cell renders
+        `a<U+2028>b` as `ab` — a row naming a repository that is not the one in the record
+        (#498). `contain.one_line` escapes it instead, and the escape has to survive the
+        column's own truncation, which is why the width is computed from the escaped cell —
+        measuring the raw one gives a column 21 wide for a cell that needs 27, and the
+        escape is exactly what falls off the end."""
+        d = change.changes_dir("ws")
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "hostile.json").write_text(json.dumps({
+            "change": "hostile", "why": "w", "created": "t", "by": "t",
+            "members": [{"repo": "b" * 20 + "\u2028a", "branch": "x", "needs": []},
+                        {"repo": "s", "branch": "y",
+                         "needs": ["b" * 20 + "\u2028a"]}],
+            "excluded": []}))
+        code, out, _ = self.call(commands_change.cmd_change_show, change="hostile")
+        self.assertEqual(code, 0)
+        self.assertEqual(out.count("\\u2028"), 2)   # the member row AND its `needs` cell
+
+    def test_a_very_long_slug_is_clipped_on_both_rows(self):
+        """`change_name_ok` puts no ceiling on a slug's length — the filesystem does, at a
+        good deal more than a row."""
+        slug = "s" * 200
+        d = change.changes_dir("ws")
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{slug}.json").write_text(json.dumps(
+            {"change": slug, "why": "w", "created": "t", "by": "t",
+             "members": [], "excluded": []}))
+        _, show, _ = self.call(commands_change.cmd_change_show, change=slug)
+        _, listing, _ = self.call(commands_change.cmd_change_list)
+        for out in (show, listing):
+            self.assertTrue(out.strip())
+            for line in out.splitlines():
+                self.assertLess(len(line), 200, line[:60])
+
+
+class TestTheAuthorsOwnEdges(ChangeCommands):
+    """`by` comes out of `git config` — a file on this machine charter did not write — and
+    lands in a record a LIVE workspace commits and every `show` prints back."""
+
+    ESC = "\x1b"
+
+    def _author_with(self, stdout) -> str:
+        from unittest import mock
+        with mock.patch.object(commands_change.util, "run",
+                               return_value=SimpleNamespace(stdout=stdout)):
+            return commands_change._author()
+
+    def test_surrounding_whitespace_is_trimmed_from_both_ends(self):
+        self.assertEqual(self._author_with("  Real Name  \n"), "Real Name")
+
+    def test_a_name_carrying_an_escape_is_contained(self):
+        self.assertNotIn(self.ESC, self._author_with(f"Real{self.ESC}[2KName\n"))
+
+    def test_no_stdout_at_all_is_not_a_crash(self):
+        self.assertTrue(self._author_with(None))
+
+    def test_the_fallback_is_the_shell_the_operator_is_in(self):
+        from unittest import mock
+        with mock.patch.dict(os.environ, {"USER": "operator-name"}, clear=True):
+            self.assertEqual(self._author_with(""), "operator-name")
+
+
 class TestThereIsNoExpansionAndNoForge(unittest.TestCase):
     """§6.1 rule 2. Every member in a record was typed by somebody, and in a LIVE workspace
     the record is committed — so it is reviewable in a diff. A surface that could expand a

--- a/tests/test_commands_change.py
+++ b/tests/test_commands_change.py
@@ -113,6 +113,27 @@ class TestTheHappyPath(ChangeCommands):
         for word in ("state", "landed", "pr", "number", "ci", "checks", "url", "remote"):
             self.assertNotIn(f'"{word}"', text)
 
+    def test_a_member_with_no_blockers_shows_no_needs(self):
+        """The negative half of `test_needs_is_recorded_and_shown`: without it, printing an
+        empty `needs:` on every row would pass both."""
+        self.create()
+        self.call(commands_change.cmd_change_add, change="component-api-2", repo="charter")
+        code, out, _ = self.call(commands_change.cmd_change_show, change="component-api-2")
+        self.assertEqual(code, 0)
+        self.assertNotIn("needs:", out)
+
+    def test_a_change_with_no_exclusions_prints_no_excluded_section(self):
+        self.create()
+        code, out, _ = self.call(commands_change.cmd_change_show, change="component-api-2")
+        self.assertEqual(code, 0)
+        self.assertNotIn("excluded", out)
+
+    def test_an_empty_workspace_lists_nothing_and_says_how_to_start(self):
+        code, out, err = self.call(commands_change.cmd_change_list)
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
+        self.assertIn("charter change create", err)
+
 
 class TestTheContainmentProperty(ChangeCommands):
     def test_a_repo_with_no_clone_is_refused_and_names_charter_clone(self):
@@ -347,6 +368,16 @@ class TestDrop(ChangeCommands):
         self.assertEqual(rec["excluded"], [])
         self.assertIsNotNone(change.member(rec, "charter"))
 
+    def test_dropping_a_name_that_is_a_path_is_refused(self):
+        self.create()
+        for repo in ("..", "a/b", "x\\x00y"):
+            with self.subTest(repo=repo):
+                code, _, err = self.call(commands_change.cmd_change_drop,
+                                         change="component-api-2", repo=repo, why="out")
+                self.assertEqual(code, commands_change.REFUSED)
+                self.assertIn("is not a name", err)
+                self.assertEqual(change.read("ws", "component-api-2")["excluded"], [])
+
 
 class TestForget(ChangeCommands):
     def test_forget_deletes_the_record(self):
@@ -407,6 +438,50 @@ class TestABranchNameIsArgvNotARef(ChangeCommands):
                                 repo=ns.repo, branch=ns.branch)
         self.assertEqual(code, 1)
         self.assertIn("FLAG", err)
+
+
+class TestTheWritePathIsContainedToo(ChangeCommands):
+    """`create` is the one verb that writes without reading first, so it is the one where
+    `contain.writable` is the gate rather than a second opinion. A committed link at
+    `changes/` would otherwise relocate every record written under it — `mkdir(exist_ok=
+    True)` accepts a symlink to a directory without complaint."""
+
+    def test_creating_into_a_changes_directory_that_links_out_of_the_plane_is_refused(self):
+        elsewhere = self.tmp / "elsewhere"
+        elsewhere.mkdir()
+        os.symlink(elsewhere, change.changes_dir("ws"))
+        code, _, err = self.call(commands_change.cmd_change_create,
+                                 change="component-api-2", why="x")
+        self.assertEqual(code, 1)
+        self.assertIn("control plane", err)
+        self.assertEqual(list(elsewhere.iterdir()), [])
+
+    def test_forget_declines_a_record_that_is_a_link_out_of_the_plane(self):
+        elsewhere = self.tmp / "elsewhere.json"
+        elsewhere.write_text("{}")
+        change.changes_dir("ws").mkdir(parents=True)
+        os.symlink(elsewhere, change.changes_dir("ws") / "component-api-2.json")
+        code, _, err = self.call(commands_change.cmd_change_forget, change="component-api-2")
+        self.assertEqual(code, 1)
+        self.assertIn("could not delete", err)
+        self.assertTrue(elsewhere.exists())
+
+
+class TestTheAuthorIsOneLine(ChangeCommands):
+    """`by` comes out of `git config`, a file on this machine charter did not write, and it
+    lands in a record a LIVE workspace commits and every `show` prints back."""
+
+    def _author_with(self, stdout: str) -> str:
+        from unittest import mock
+        with mock.patch.object(commands_change.util, "run",
+                               return_value=SimpleNamespace(stdout=stdout)):
+            return commands_change._author()
+
+    def test_only_the_first_line_is_taken(self):
+        self.assertEqual(self._author_with("Real Name\n✓ merged everything\n"), "Real Name")
+
+    def test_an_unset_git_identity_still_produces_a_name(self):
+        self.assertTrue(self._author_with(""))
 
 
 class TestHostileValuesRenderAsOneRow(ChangeCommands):

--- a/tests/test_the_end_of_a_name_is_the_end_of_the_string.py
+++ b/tests/test_the_end_of_a_name_is_the_end_of_the_string.py
@@ -190,6 +190,7 @@ def _owning_constant(base: ast.AST, here: str, aliases: dict[str, str]) -> str |
 ADMITTERS: dict[str, str] = {
     "persona._NAME_RE": "evil",
     "instance.WORKSPACE_NAME_RE": "Evil",
+    "instance.CHANGE_NAME_RE": "component-api-2",
     "docsrc._TOPIC": "guide",
     "plugincache._PLUGIN_ID_RE": "charter@charter-cp",
     "plugincache._MARKETPLACE_RE": "charter-cp",

--- a/tests/test_todos_are_committed.py
+++ b/tests/test_todos_are_committed.py
@@ -1,4 +1,5 @@
-"""A LIVE workspace's todos are actually **committed**, not merely un-ignored.
+"""A LIVE workspace's todos — and now its changes — are actually **committed**, not merely
+un-ignored.
 
 Ticket 05 added `todos/` to the managed `.gitignore` block, which is only half the job.
 Un-ignoring a path tells git it *may* be tracked; something still has to stage it. The
@@ -11,11 +12,17 @@ That is the exact failure ADR 0004 predicted for this feature and the one the ti
 """
 from __future__ import annotations
 
+import re
+import subprocess
 import unittest
 
+from charter import change, config
 from charter import commands_workspace as cw
 from charter import todos, workspace
 from tests._isolation import PersonaIso
+
+_A_CHANGE = {"change": "one", "why": "because", "created": "2026-08-28T00:00:00+00:00",
+             "by": "t", "members": [], "excluded": []}
 
 
 class TestTheSharedPathSet(PersonaIso):
@@ -72,11 +79,163 @@ class TestUnIgnoringAndCommittingAgree(PersonaIso):
         workspace.set_live("alpha", True)
 
     def test_everything_committed_is_also_un_ignored(self):
-        from charter import config
         gitignore = (config.ROOT / ".gitignore").read_text()
         for rel in cw._ws_meta_paths("alpha"):
             self.assertIn(f"!/{rel}", gitignore,
                           f"{rel} is staged for commit but still git-ignored")
+
+
+def _un_ignored(name: str) -> set[str]:
+    """The repo-relative paths the managed block un-ignores for one workspace.
+
+    Normalised, because the two lists cannot be compared as sets in the shape they are
+    written: `_live_block` emits `!/`-prefixed lines and a `/**` half for each directory,
+    while `_ws_meta_paths` emits bare repo-relative paths. Only the `!` lines count — the
+    block also carries a plain *exclusion* line for `changes/log`, which is the one path it
+    deliberately keeps ignored.
+    """
+    out = set()
+    for line in workspace._live_block([name]).splitlines():
+        m = re.fullmatch(rf"!/(workspaces/{re.escape(name)}/[^ ]+)", line.strip())
+        if m:
+            out.add(re.sub(r"/\*\*$", "", m.group(1)))
+    return out
+
+
+class TestChangesTravelWithTheWorkspace(PersonaIso):
+    """The fourth store. `changes/` is the same two-sided question `todos/` was — a path
+    that is un-ignored and staged by nothing never travels, which is the quietest way this
+    can fail — plus one asymmetry `todos/` does not have: `changes/log/` must be committed
+    **never**, because it holds merge shas per host, appended without a lock, exactly as
+    `pieces/` does."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+        workspace.scaffold("alpha")
+        workspace.write_manifest("alpha", {"repos": []})
+        todos.add("alpha", "something")
+        change.write("alpha", "one", dict(_A_CHANGE))
+        workspace.set_live("alpha", True)
+
+    def test_changes_are_in_the_set_of_paths_that_get_committed(self):
+        self.assertIn("workspaces/alpha/changes", cw._ws_meta_paths("alpha"))
+
+    def test_changes_are_un_ignored(self):
+        self.assertIn("workspaces/alpha/changes", _un_ignored("alpha"))
+
+    def test_everything_un_ignored_is_also_committable(self):
+        """The direction the shipped test never asserted. Without it, adding a path to the
+        gitignore block and forgetting `_ws_meta_paths` stays green — which is precisely
+        how `todos/` came to be un-ignored and committed by nothing."""
+        self.assertEqual(_un_ignored("alpha"), set(cw._ws_meta_paths("alpha")))
+
+    def test_the_landing_log_is_in_neither_list(self):
+        log = "workspaces/alpha/changes/log"
+        self.assertNotIn(log, _un_ignored("alpha"))
+        self.assertNotIn(log, cw._ws_meta_paths("alpha"))
+
+    def test_git_itself_still_ignores_the_landing_log_inside_a_shared_changes_dir(self):
+        """Asked of git rather than of the block's text: re-including `changes/` and then
+        re-excluding `changes/log/` is a rule about *order*, and a rule about order is one
+        a reader can get right in prose and wrong in the file."""
+        if not _have_git():
+            self.skipTest("no git")
+        _git_init(config.ROOT)
+        change.log_dir("alpha").mkdir(parents=True)
+        (change.log_dir("alpha") / "h.jsonl").write_text('{"ts": "x"}\n')
+        self.assertEqual(_check_ignore("workspaces/alpha/changes/one.json"), 1)   # tracked
+        self.assertEqual(_check_ignore("workspaces/alpha/changes/log/h.jsonl"), 0)  # ignored
+
+    def test_an_emptied_changes_directory_is_not_handed_to_git(self):
+        """`charter change forget` on the last record leaves the directory behind, and one
+        holding nothing but the never-committed `log/` is the same case. Either way `git rm
+        --cached` on a path with nothing tracked under it fails the WHOLE call — untracking
+        nothing, and leaving the manifest and memory committed on a workspace the operator
+        just made private."""
+        change.log_dir("alpha").mkdir(parents=True)
+        (change.log_dir("alpha") / "h.jsonl").write_text("{}\n")
+        change.forget("alpha", "one")
+        self.assertTrue(change.changes_dir("alpha").exists())
+        self.assertNotIn("workspaces/alpha/changes", cw._ws_meta_paths("alpha"))
+
+    def test_live_off_untracks_the_whole_set_with_an_emptied_changes_dir(self):
+        """The failure above, measured through git rather than argued about. One pathspec
+        matching nothing is enough to make `git rm --cached` exit non-zero and untrack
+        none of the others."""
+        if not _have_git():
+            self.skipTest("no git")
+        _git_init(config.ROOT)
+        subprocess.run(["git", "add", "-f", "--", *cw._ws_meta_paths("alpha")],
+                       cwd=config.ROOT, check=True, capture_output=True)
+        change.forget("alpha", "one")            # leaves changes/ behind, empty
+        proc = subprocess.run(["git", "rm", "-r", "--cached", "-q", "--",
+                               *cw._ws_meta_paths("alpha")],
+                              cwd=config.ROOT, capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        tracked = subprocess.run(["git", "ls-files"], cwd=config.ROOT,
+                                 capture_output=True, text=True).stdout
+        self.assertNotIn("workspaces/alpha/memory", tracked)
+
+
+class TestTheStructureBumpFlagsEveryOlderWorkspace(PersonaIso):
+    """v3 creates no directory — `changes/` is lazy on purpose. The bump exists so a plane
+    that went LIVE before this version re-runs `refresh_live_block()` and picks up the new
+    lines; without it the records simply never travel, and nothing re-runs `set_live` on
+    its own."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+        workspace.scaffold("alpha")
+        workspace.set_live("alpha", True)
+
+    def _pin_to_v2(self) -> None:
+        (workspace.workspace_dir("alpha") / ".charter-structure").write_text("2\n")
+        # The block as a v2 charter wrote it: no `changes` lines at all.
+        gi = config.ROOT / ".gitignore"
+        gi.write_text(re.sub(r"^!?/workspaces/alpha/changes.*\n", "", gi.read_text(),
+                             flags=re.MULTILINE))
+
+    def test_a_v2_workspace_reports_needs_reinit(self):
+        self._pin_to_v2()
+        self.assertTrue(workspace.needs_reinit("alpha"))
+
+    def test_reinit_adds_the_new_un_ignore_lines(self):
+        self._pin_to_v2()
+        self.assertNotIn("!/workspaces/alpha/changes",
+                         (config.ROOT / ".gitignore").read_text())
+        workspace.reinit("alpha")
+        text = (config.ROOT / ".gitignore").read_text()
+        self.assertIn("!/workspaces/alpha/changes", text)
+        self.assertIn("/workspaces/alpha/changes/log/", text)
+
+    def test_reinit_creates_no_changes_directory(self):
+        self._pin_to_v2()
+        workspace.reinit("alpha")
+        self.assertFalse(change.changes_dir("alpha").exists())
+
+    def test_a_fresh_workspace_is_current(self):
+        """Positive control: the bump must flag OLD workspaces, not every workspace."""
+        self.assertFalse(workspace.needs_reinit("alpha"))
+
+
+def _have_git() -> bool:
+    import shutil
+    return shutil.which("git") is not None
+
+
+def _git_init(path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "config", "maintenance.auto", "false"], cwd=path,
+                   check=True, capture_output=True)
+
+
+def _check_ignore(rel: str) -> int:
+    """git's own verdict: 0 = ignored, 1 = not ignored."""
+    return subprocess.run(["git", "check-ignore", "-q", "--", rel],
+                          cwd=config.ROOT, capture_output=True).returncode
 
 
 if __name__ == "__main__":

--- a/tests/test_todos_are_committed.py
+++ b/tests/test_todos_are_committed.py
@@ -223,6 +223,13 @@ class TestTheStructureBumpFlagsEveryOlderWorkspace(PersonaIso):
         workspace.reinit("alpha")
         self.assertFalse(change.changes_dir("alpha").exists())
 
+    def test_the_version_this_layout_stamps_is_three(self):
+        """The NUMBER, not merely that it moved. The marker file records this value on
+        every machine that scaffolds a workspace, and `structure_status` compares against
+        it — so it is the plane's upgrade anchor rather than a counter, and changing it is
+        a deliberate act that belongs in the same commit as the layout it describes."""
+        self.assertEqual(workspace.STRUCTURE_VERSION, 3)
+
     def test_a_fresh_workspace_is_current(self):
         """Positive control: the bump must flag OLD workspaces, not every workspace."""
         self.assertFalse(workspace.needs_reinit("alpha"))

--- a/tests/test_todos_are_committed.py
+++ b/tests/test_todos_are_committed.py
@@ -131,9 +131,17 @@ class TestChangesTravelWithTheWorkspace(PersonaIso):
         self.assertEqual(_un_ignored("alpha"), set(cw._ws_meta_paths("alpha")))
 
     def test_the_landing_log_is_in_neither_list(self):
-        log = "workspaces/alpha/changes/log"
+        log = f"workspaces/alpha/{change.DIRNAME}/{change.LOG_DIRNAME}"
         self.assertNotIn(log, _un_ignored("alpha"))
         self.assertNotIn(log, cw._ws_meta_paths("alpha"))
+
+    def test_the_block_re_ignores_the_directory_change_itself_calls_the_log(self):
+        """The block spells the two names as literals — `charter.change` imports this
+        module, so it cannot import back — and this is what keeps the literal and the
+        constant one name. Renaming `LOG_DIRNAME` without touching the block would
+        otherwise leave the log un-ignored, which is a merge sha per host in a commit."""
+        self.assertIn(f"/workspaces/alpha/{change.DIRNAME}/{change.LOG_DIRNAME}/",
+                      workspace._live_block(["alpha"]).splitlines())
 
     def test_git_itself_still_ignores_the_landing_log_inside_a_shared_changes_dir(self):
         """Asked of git rather than of the block's text: re-including `changes/` and then


### PR DESCRIPTION
Phase 4 of the cross-repo change work, Tasks 1–4 of
`docs/superpowers/specs/2026-08-28-phase4-cross-repo-change.md` §10. **Records only —
nothing here reaches a network, pushes a branch or opens a request.** Tasks 5–14 (the
forge, push, land, revert, the surface, the floors, the docs) are not in this PR.

## What lands

**Task 1 — the change record.** New `charter/change.py`. A change is one JSON file,
`workspaces/<ws>/changes/<slug>.json`, holding **intent only**: name, why, created, by,
members (repo + branch + `needs`), exclusions (repo + why + at). Six keys, matched exactly;
an unknown key stops the read and is *named* (#503's rule — `need` where `needs` was meant
is an ordering constraint that silently ceased to exist), and so is a missing one. `state`,
`landed`, `pr` and `ci` are each tested by name as unrepresentable. Reads go through
`dir_refusal(parent)` **and** `file_refusal(path)` (#336). A failed read raises; it never
answers `{}` — `add` is read-modify-write, and #322's shape is what that costs.

**Task 2 — the workspace grows a fourth store.** `changes/` joins `workspace._live_block`
and `commands_workspace._ws_meta_paths`; `changes/log/` joins **neither** and is re-ignored
by a third block line. `STRUCTURE_VERSION` 2 → 3 so every older workspace flags itself and
`reinit` runs `refresh_live_block()`. `scaffold()` creates nothing: `changes/` is lazy.

**Task 3 — `charter change create | add | drop | list | show | forget`.** New
`charter/commands_change.py`, a new `_add_change_parser` in `cli.py`, and
`instance.change_name_ok`. A member resolves through `contain.child(workspace_dir, name)`
and must satisfy `workspace.is_clone`; the rule is `segment_ok`, never `valid_name`, so
`.github` is accepted. Exit 2 is a *named* refusal and each of the four has its own message.

**Task 4 — ordering, declared and derived.** `needs` may name only a member of this change;
a cycle is refused at write time with every member in it named; `blocked_members(rec,
landed)` is a pure function and writes nothing. `write` validates the closed key set too —
without that, caching a derived value on the in-memory record leaves the bytes identical.

## `instance.py` is contended — here is exactly what changed

One block added after `workspace_name_ok`, nothing else touched:

- `CHANGE_NAME_RE` — its own compiled object, not an alias of `WORKSPACE_NAME_RE`: the two
  names travel to different places, and a change slug also becomes a branch name and a
  `Charter-Change:` trailer.
- `change_name_ok(name)` — `isinstance` then the alphabet. **One rule and not two**, which
  is where it differs from its neighbour: `workspace_name_ok` asks `contain.segment_ok`
  first and documents it as the half that survives a widening, but here the alphabet *is*
  the containment (no separator, no leading dot, no NUL, nothing absolute), so a
  `segment_ok` call in front of it is an answer the regex has already given — and the
  deletion sweep proved it, by deleting it with the suite still green. The property it
  stood for is pinned directly on the function instead.

`tests/test_the_end_of_a_name_is_the_end_of_the_string.py` gains one line: the new pattern
is classified as an ADMITTER with a sample, which is what that file requires of a new `^…$`.
`commands_workspace.py` gains one import and six lines inside `_ws_meta_paths`.
`workspace.py` gains three lines in `_live_block` and the version bump.

## Two things the spec got wrong, said rather than worked around

**Task 2 Step 1 contradicts Step 3.** Step 1 asks for a failing test that "a fresh workspace
has `changes/`"; Step 3 says it must **not** be created by `scaffold()` and gives the reason.
Step 3 is right and Step 1 is stale. Implemented as Step 3, and the test asserts the
opposite of Step 1.

**The existence filter is not a safe proxy for `changes/`, and Step 3's own argument shows
why.** `todos/` is born with its index and is never empty afterwards. A `changes/` **can** be
emptied — `charter change forget` on the last record — and one holding nothing but the
never-committed `log/` is the same case. Both are "exists, nothing tracked", which is exactly
the shape that fails the whole `git rm --cached` call. So `_ws_meta_paths` asks
`change.has_records(name)` rather than `.exists()`, and
`test_live_off_untracks_the_whole_set_with_an_emptied_changes_dir` measures it through real
git rather than arguing about it.

## Verification

**Suite, two environments, both green and agreeing.**

| | baseline at `2fe663a` | at this head |
|---|---|---|
| CPython 3.14.4 | 7385 OK | 7556 OK |
| CPython 3.12, `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset | 7385 OK | 7556 OK |

The baseline is measured, not carried forward, and is written into the spec's Global
constraints line as Task 1 Step 0 asks.

**CI green at the head sha, read the way #561 says to read it** — `gh api
repos/diazoxide/charter/commits/<sha>/check-runs`, not `gh pr checks`. At `54581df` all four
matrix jobs and the deletion-sweep gate ("Every guard this branch adds is a line a test goes
red without") came back `success`; `f7d290e` adds one test and one docstring on top.

**Mutation testing: 68 mutations run by hand, every one RED.** Each was applied, asserted to
have changed the file's sha256, run, restored, and asserted to have restored to the original
sha256; every run ends by re-running the suite unmutated to prove nothing was left behind. A
crashed script that leaves a mutant behind is how the next run reads it as its "original".
All 23 the plan names are there, and 45 more the sweep found.

**The deletion sweep, run three times, and it changed the branch three times.** Round one
(38 mutations before I stopped it) returned 16 survivors; round two returned 34 in this
branch's own files; round three returned one. What they found, in three classes:

1. **Two refusals were masked by a second pinned guard one layer down.** Deleting the
   resolver's `contain.child` and deleting `drop`'s dependents check both left the command
   exiting 2, for a worse reason. Fixed by asserting **which** refusal fired and the absence
   of its neighbour's words — the constraint this phase sets for itself.
2. **A whole class of containment calls survived, because `assertRaises` alone stays green
   with every one of them deleted.** Fixed structurally rather than site by site:
   `validate` now asks about the slug on its **first line**, so the fourteen sentences below
   it name it plainly and the one call that can be reddened is the one that has to be; and
   the record's own text bound became `contain`'s **path** budget, not its **row** budget,
   which is what makes the `contain.one_line` at each printing site a line a test can see —
   a `why` a little longer than a row is now a legitimate record, clipped where it is drawn.
   Two new property tests carry the rest: every refusal is one line whatever it names, and
   no printed row can be as long as the value behind it.
3. **Five lines were genuinely equivalent and are deleted, not suppressed** —
   `contain.child` inside `path_for`, the `RecordError` handler in `cmd_change_forget`,
   `drop`'s own `segment_ok` gate, the re-containment of an already-validated slug in two
   `read` messages, and `contain.segment_ok` in `change_name_ok`. Each was measured (same
   exit, same sentence, nothing written), and what makes it unreachable is itself pinned.

**One survivor is left standing, knowingly, and here it is.** Removing the `^…$` anchors
from `CHANGE_NAME_RE` keeps the suite green — because the pattern is asked with `fullmatch`,
which anchors by itself. That redundancy is the repository's own convention and
`tests/test_the_end_of_a_name_is_the_end_of_the_string.py` exists to make it the *safe*
state: its inventory is built by finding anchored constants, and unanchoring this one would
take it out of the table that asserts every admitter refuses a trailing newline. The
neighbouring `instance.WORKSPACE_NAME_RE` has the identical property. Trading real
cross-cutting coverage for a mutation score is the wrong way round, so the line stays and
this paragraph is the reason.

**And one mutation the sweep cannot resolve, resolved by hand.** `instance.py:122` — the
`CHANGE_NAME_RE` pattern itself — selects 262 test modules and times out, which the tool
reports as `UNRESOLVED`, and exit 3 is not a pass. Run by hand against the full suite:
widening the alphabet to admit `/` and a leading dot is **RED** (10 failures), and so is
dropping the `isinstance` in front of it (2 failures).

**Survivors this branch did not create.** The local runs used `--base origin/main`, which has
moved since the merge-base, so they also swept `secrets/reference.py`, `secrets/plain_file.py`,
`persona.py`, `contain.py`, `news.py` and `commands_update.py` — 18 survivors in files this
PR does not touch. They are reported here and left alone; the CI gate, which scopes to this
branch's own diff, passed.

## What this deliberately does not do

No forge, no network, no push, no land, no revert, no `changes` component, no floor entries
(`hooks._PUBLISH_FORGE`, `toolgate._DANGEROUS`), no ADR 0020, no `docs/changes.md`. Those are
Tasks 5–14. `docs/news/unreleased-cross-repo-change-records.md` is `version: unreleased` with
`adopt: workspace reinit --all` and no `check:`. **No version bump, no stamp, no tag.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
