### PR TITLE
A green sweep says "no survivors", and one too big to finish says that instead (#617)

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -5,6 +5,13 @@ on:
 
 # Read-only, declared rather than inherited. This job runs the repository's own code
 # against mutated copies of it, which is the last place to hold a writable token.
+#
+# It is also the reason the answer below is carried by a check's NAME rather than by its
+# conclusion. GitHub gives a `run:`-driven job two conclusions, `success` and `failure`;
+# the third one this sweep needs — `neutral`, meaning "I looked, here is the count, this
+# is not a pass or a fail" — exists only on the Checks API, which needs `checks: write`
+# and a check run created by hand. That is a writable token, in this job, for a prettier
+# icon. Not a trade worth making, so `verdict` below is a job whose name is the answer.
 permissions:
   contents: read
 
@@ -19,23 +26,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sweep:
-    name: Every guard this branch adds is a line a test goes red without
+  # ------------------------------------------------------------------------------------
+  # 1. How big is this? Answered before anything is spent on answering it.
+  # ------------------------------------------------------------------------------------
+  plan:
+    name: Size the sweep
     runs-on: ubuntu-latest
     # Stage C of `docs/superpowers/specs/2026-08-27-deletion-sweep-harness.md`.
     #
     # **Scoped to the lines this branch ADDED**, never to the tree. The whole-tree number
     # is stage B — roughly 5,672 mutations and fourteen hours — and it is not a
-    # pull-request check and never will be. Measured on real branches from this phase: 30
-    # to 52 mutations each, a 262 s unmutated baseline, and about 24 s a mutation, so a
-    # gate run is twenty-odd minutes.
+    # pull-request check and never will be.
     #
-    # **It reports and blocks nothing.** `--enforce` is the flag that changes that and it
-    # is deliberately absent here. The spec's staging argument — a gate whose baseline
-    # nobody has seen gets disabled the first time it is inconvenient — applies to this
-    # job's own credibility too. Turn it on by adding `--enforce` to the step below, once
-    # the numbers on a few real branches have been read and believed.
-    timeout-minutes: 60
+    # This job used to be the whole workflow, sized against the 30 to 52 mutations Phase 2
+    # produced. #608 brought 62 and #626 brought 78, and five runs across the two were
+    # cancelled at the cap having measured about two thirds of the plan (#617). So the
+    # count is now measured rather than assumed: one `ast` pass over the diff, no test
+    # runs, and `tools/sweep.py` decides how many jobs it needs from the real number.
+    #
+    # **Nothing is dropped to make it fit.** A cap on the mutations would read, to every
+    # reader downstream, as "covered everything" — the spec says exactly that about silent
+    # truncation. What is capped is the fan-out, and when a diff is past even that the
+    # plan says so out loud instead of quietly measuring less.
+    timeout-minutes: 30
+    outputs:
+      mutations: ${{ steps.size.outputs.mutations }}
+      shards: ${{ steps.size.outputs.shards }}
+      matrix: ${{ steps.size.outputs.matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -52,7 +69,19 @@ jobs:
           # #508's entire defect, out of the sweep's reach. `sweep.reach()` says so in the
           # report rather than letting a smaller sweep read like a clean one.
           python-version: "3.12"
-      - name: Sweep the guards this branch adds
+      # The selection map is one trace of the whole suite — 350 s measured, and the
+      # largest fixed cost a shard pays. It is content-addressed on the tree it measured,
+      # so this step saves it once here and every shard below restores it instead of
+      # measuring it again. A fork's pull request cannot write this cache and will simply
+      # measure its own; `SHARD_FIXED` in `sweep.py` is the no-cache figure for that
+      # reason, because a budget that only holds when the cache hits is a budget that
+      # fails on exactly the runs nobody is watching.
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/sweep/cache
+          key: sweep-map-${{ hashFiles('charter/**/*.py', 'tests/**/*.py') }}
+      - name: How many mutations, and how many jobs they need
+        id: size
         env:
           # Through the environment and not interpolated into the script. A `${{ }}` inside
           # `run:` is textual substitution before bash ever sees it, which is how a value
@@ -67,13 +96,161 @@ jobs:
           else
             set --
           fi
+          python3 tools/sweep.py --plan --warm-map --jobs 4 \
+            --workdir "$RUNNER_TEMP/sweep" \
+            --github-output "$GITHUB_OUTPUT" "$@"
+
+  # ------------------------------------------------------------------------------------
+  # 2. The sweep itself, on as many machines as the plan asked for.
+  # ------------------------------------------------------------------------------------
+  sweep:
+    name: Sweep shard ${{ matrix.shard }} of ${{ needs.plan.outputs.shards }}
+    needs: plan
+    runs-on: ubuntu-latest
+    # The backstop and not the budget. `sweep.py` sizes a shard for forty minutes; this is
+    # what catches a box that turned out to be slower than that, and it is deliberately
+    # the same hour the unsharded job had — the fix for running out of time is more
+    # machines, not a longer rope, because a shard cancelled here reports nothing at all
+    # and a longer rope only moves where that happens.
+    timeout-minutes: 60
+    strategy:
+      # One shard's trouble must not cancel the others: three quarters of an answer, said
+      # to be three quarters of an answer, beats none of one.
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/sweep/cache
+          key: sweep-map-${{ hashFiles('charter/**/*.py', 'tests/**/*.py') }}
+      # No --summary and no --annotate here, deliberately. A shard has a slice of the
+      # answer and must never write a page that looks like the answer: five partial
+      # tables on one pull request is the same defect #617 is about, arriving five times.
+      # The merge step below is the only thing that tells this branch anything.
+      - name: Sweep the guards this branch adds
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SHARD: ${{ matrix.shard }}
+          SHARDS: ${{ needs.plan.outputs.shards }}
+        run: |
+          set -euo pipefail
+          if [ -n "${BASE_SHA:-}" ]; then
+            set -- --base "$BASE_SHA"
+          else
+            set --
+          fi
           python3 tools/sweep.py --gate --jobs 4 \
-            --json sweep-results.json \
-            --summary "$GITHUB_STEP_SUMMARY" "$@"
+            --shard "$SHARD/$SHARDS" \
+            --workdir "$RUNNER_TEMP/sweep" \
+            --json "sweep-results-$SHARD.json" "$@"
       - name: Keep the result set, whatever the sweep said
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: deletion-sweep
-          path: sweep-results.json
+          name: deletion-sweep-${{ matrix.shard }}
+          path: sweep-results-${{ matrix.shard }}.json
           if-no-files-found: ignore
+
+  # ------------------------------------------------------------------------------------
+  # 3. One answer, from however many shards came back.
+  # ------------------------------------------------------------------------------------
+  collect:
+    name: Add up what the shards found
+    needs: [plan, sweep]
+    # `always()`, because the case this exists for is the one where a shard did NOT
+    # finish. A merge step that only runs when every shard succeeded can never say "two
+    # of three shards did not report", which is precisely the sentence #617 asks for.
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      headline: ${{ steps.say.outputs.headline }}
+      conclusion: ${{ steps.say.outputs.conclusion }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      # `continue-on-error`, because "no artifacts at all" is an answer this step has to
+      # be able to reach the next line with. Every shard being cancelled is exactly the
+      # #626 failure, and it must produce `no verdict` rather than a second red job with
+      # a download error in it.
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        continue-on-error: true
+        with:
+          path: shards
+          pattern: deletion-sweep-*
+          merge-multiple: true
+      - name: One answer for the whole sweep
+        id: say
+        env:
+          # Empty when the plan job never finished — which `expected_shards` reads as "the
+          # sweep never sized itself", not as "no shards were needed". Those two are the
+          # whole distinction, so the empty string is handled there and not with a `||`
+          # default here that would quietly turn one into the other.
+          SHARDS: ${{ needs.plan.outputs.shards }}
+          # `github.sha` and NOT the pull request's head: on a `pull_request` event this
+          # is the merge commit, which is what `actions/checkout` gave the shards and so
+          # is the tree they actually swept. Naming the branch head on a page about the
+          # merge result would be one sha out on every run with a moving base.
+          SWEPT_SHA: ${{ github.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # `--enforce` is the one flag that makes any of this block a merge, and it is
+          # deliberately absent. The spec's staging argument — a gate whose baseline
+          # nobody has seen gets disabled the first time it is inconvenient — applies to
+          # this job's own credibility. Add it here, once the numbers on a few real
+          # branches have been read and believed. Nothing else in this file changes.
+          python3 tools/sweep.py --verdict shards \
+            --shards "${SHARDS:-}" \
+            --ref "$SWEPT_SHA" \
+            --base "${BASE_SHA:-}" \
+            --annotate \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --github-output "$GITHUB_OUTPUT"
+
+  # ------------------------------------------------------------------------------------
+  # 4. The answer, spelled where it can be read without opening anything.
+  # ------------------------------------------------------------------------------------
+  #
+  # This job does nothing. Its NAME is the deliverable: a job name may interpolate
+  # `needs.<job>.outputs.*`, so the pull request's check list reads
+  # `deletion sweep / 8 survivors` — or `no survivors`, or `no verdict: 2 of 3 shards
+  # did not report`. A green tick beside a silent name is what reported eight survivors as
+  # a clean branch (#617), and a conclusion cannot carry the difference: see the note at
+  # the top of this file for why `neutral` is not available to a job like this one.
+  #
+  # It stays green in all three cases. Distinguishing the states is not the same as
+  # failing on them, and this workflow still blocks nothing.
+  #
+  # **This job is not the one to make required, later.** Branch protection matches a check
+  # by NAME, and this one's name is the answer — it is different on every branch, which is
+  # the entire point and also what makes it useless as a required check. The job to require
+  # is `collect`, whose name never moves and whose exit code is what `--enforce` changes.
+  # Requiring this one instead would protect a branch against a string.
+  verdict:
+    # Quoted, because the fallback carries a `: ` and an unquoted plain scalar with one
+    # in it is a mapping to YAML rather than a string. The runtime value carries one too
+    # ("no verdict: 2 of 3 shards did not report"), but that arrives after parsing.
+    name: "${{ needs.collect.outputs.headline || 'no verdict: the sweep did not report' }}"
+    needs: collect
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Say it in the log as well as in the name
+        env:
+          HEADLINE: "${{ needs.collect.outputs.headline || 'no verdict: the sweep did not report' }}"
+          CONCLUSION: ${{ needs.collect.outputs.conclusion || 'no-verdict' }}
+        run: |
+          set -euo pipefail
+          printf 'deletion sweep: %s (%s)\n' "$HEADLINE" "$CONCLUSION"
+          printf 'This check reports and blocks nothing. The run summary has the table.\n'

--- a/docs/news/unreleased-a-green-sweep-is-not-no-survivors.md
+++ b/docs/news/unreleased-a-green-sweep-is-not-no-survivors.md
@@ -1,0 +1,115 @@
+---
+version: unreleased
+headline: A green deletion sweep now means no survivors, and a sweep too big to finish says so
+---
+
+The deletion sweep has run on every pull request since August. Two things about it were
+wrong, and the quieter one was worse.
+
+## A green check was not "no survivors"
+
+The gate is reporting-only — `--enforce` is deliberately absent, and that is still the
+design. But a job that blocks nothing still has to *say* something, and this one said
+`success` whatever it found. One branch went green with **eight survivors** under it.
+
+To anyone who did not open the run summary, that read as "this branch is clean." It is
+the opposite of what the job exists to say.
+
+There are three answers, not two, and the check now tells them apart:
+
+```
+deletion sweep / no survivors
+deletion sweep / 8 survivors
+deletion sweep / no verdict: 2 of 3 shards did not report
+```
+
+All three are **green**. Distinguishing the states is not the same as failing on them, and
+nothing here blocks a merge; `--enforce` is still the one flag that changes that.
+
+The answer is carried by the check's *name* rather than its conclusion because GitHub's
+conclusions cannot carry it. A job driven by a shell step concludes `success` or `failure`
+and nothing else. The one conclusion that means *I looked, here is the count, this is not
+a pass or a fail* — `neutral` — exists only on the Checks API, which needs a writable
+token in the job that runs mutated copies of this repository's own code. That is the last
+place in the repository that should hold one, so the sweep spends a job name instead.
+
+**And every survivor is now an annotation on the line it is about.** A warning in the
+margin of the guard itself, on the Files-changed tab, where a reviewer is already looking
+— with the question it failed and what the covering tests actually assert. Platform-
+deferred survivors arrive as notices rather than warnings, because the gate never fails on
+one of those and should not shout about one either.
+
+## A sweep too big for one machine now runs on several
+
+Two of the last three substantial branches could not finish the gate at all. #608's guard
+tables produced 62 mutations and were cancelled at the hour twice; #626's `gitconfig.py`
+produced 78 and was cancelled three times, each run reaching about two thirds of its plan.
+The job had been sized against the 30 to 52 mutations Phase 2's branches produced, and the
+`retune-string` operator roughly doubles the count on any diff that touches string
+constants — which a guard table and a config reader are made of almost nothing else.
+
+A run that is cancelled produces **no numbers at all**, so the gate was reporting nothing
+on exactly the branches least likely to be fully pinned.
+
+**Nothing is dropped to make a branch fit.** A cap on the mutation count would read, to
+every reader downstream, as "covered everything" — which is the silent truncation the
+harness exists to refuse. What is capped is the fan-out. A first job counts the mutations
+in one `ast` pass over the diff, sizes the sweep from the real number, and the sweep runs
+on as many machines as that number needs. Past even the fan-out ceiling the plan says so
+out loud instead of quietly measuring less.
+
+**Dealt one mutation at a time, and not split by file.** Sharding by file was the obvious
+answer and it does nothing here: both diffs that ran out of time were dominated by a
+*single new file*, so a job-per-file hands one job all 78 of `gitconfig.py`'s mutations and
+the others nothing. Round-robin also spreads the expensive ones, which arrive in clumps — a
+survivor costs a full suite run where a red costs seconds, and survivors cluster in the
+function that has no test.
+
+The selection map — one trace of the whole suite, **250 s on a GitHub runner** — is now
+warmed once and restored by every shard in seconds, so a second machine costs its own
+baseline and not its own trace. That the map was cached was the premise for sharding, and
+it was not true before: the workflow had no cache step at all, so every run rebuilt it.
+
+The budget is written for the case where the cache misses anyway, because a fork's pull
+request cannot write one and a budget that only holds on a hit fails on exactly the runs
+nobody is watching. Measured end to end on the runner: a shard pays about 8½ minutes
+before its first mutation with no cache and about 4½ with one, and roughly a minute a
+mutation after that.
+
+## And a shard that vanishes cannot look like a clean one
+
+Everything above turns on one distinction the tool did not previously make: **a sweep that
+ran and found nothing, and a sweep that did not run, are different answers.**
+
+So a branch with nothing under the swept paths now writes an empty result set rather than
+no result set — because a file that is absent is indistinguishable from a job that was
+cancelled. A results file that will not parse counts as a shard that did not report; there
+is no third reading of a truncated upload. And when the job that sizes the sweep fails, its
+empty output is read as *the sweep never sized itself* rather than as *no shards were
+needed*, which would have turned the loudest failure the workflow has into the quietest
+kind of pass.
+
+## The sweep swept the gate that reports it
+
+119 mutations, against a change whose whole subject is the sweep. It found two lines of
+its own that no test went red without.
+
+**The unsharded path had stopped being tested.** Forcing `if shard is not None` to
+always-true left every test green — because once the shard tests existed, nothing in the
+suite ran a sweep *without* a shard any more. That is the ordinary way anyone uses
+`tools/sweep.py` from a terminal, and it had quietly become the path no test walked.
+
+**And the sizing arithmetic could divide by zero.** The `max(1, …)` in `per_shard` is
+what stops a fixed cost that grew past the budget from making the mutations-per-shard
+zero. Deleting it changed no answer with today's constants and would have made the plan
+job raise with tomorrow's — no plan, no shards, no numbers, which is the failure this
+whole change exists to prevent, arriving out of the arithmetic written to prevent it.
+
+Both are pinned now. A third survivor is not a finding about this code at all: it is a
+string inside a *type annotation*, which `from __future__ import annotations` means the
+interpreter never evaluates, so no test can ever go red without it. That is a blind spot
+in the string operator's scoping rather than a guard, and it is filed as one (#632)
+instead of being worked around here.
+
+Nothing to adopt — this is CI, not the CLI. The gate still reports and still blocks
+nothing.

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -14,6 +14,7 @@ import contextlib
 import dataclasses
 import hashlib
 import io
+import json
 import os
 import subprocess
 import sys
@@ -2088,6 +2089,893 @@ class TheGateSaysWhatTheCoveringTestsAssert(unittest.TestCase):
         text = sweep.gate_summary(sweep.classify([_result("pinned")]),
                                   "a" * 40, "b" * 40, 60.0, enforce=False)
         self.assertIn("Nothing added here is a line the suite would not miss", text)
+
+
+class TheGateSaysWhichOfThreeThingsItFound(unittest.TestCase):
+    """#617's urgent half: a green gate is not "no survivors".
+
+    The sweep reported `success` on a branch with **eight survivors** under it, which to
+    anyone who does not open the run summary reads as "this branch is clean" — the
+    opposite of what the job exists to say. A conclusion cannot carry the difference, so
+    the answer is a sentence, and the sentence is what the check is named with. There are
+    exactly three things it may say, and no two of them may collapse into one.
+    """
+
+    def test_a_branch_with_nothing_surviving_says_no_survivors(self):
+        gate = sweep.classify([_result("pinned"), _result("pinned")])
+        self.assertEqual(sweep.gate_conclusion(gate), sweep.CLEAN)
+        self.assertEqual(sweep.headline(gate), "no survivors")
+
+    def test_a_branch_with_survivors_says_how_many(self):
+        """The whole finding. `success` with eight under it said nothing; this says 8."""
+        gate = sweep.classify([_result("survived", path=f"charter/{n}.py")
+                               for n in range(8)])
+        self.assertEqual(sweep.gate_conclusion(gate), sweep.SURVIVORS)
+        self.assertEqual(sweep.headline(gate), "8 survivors")
+
+    def test_one_survivor_is_not_called_survivors(self):
+        gate = sweep.classify([_result("survived")])
+        self.assertEqual(sweep.headline(gate), "1 survivor")
+
+    def test_a_shard_that_never_reported_is_no_verdict_and_not_no_survivors(self):
+        """The regression that matters most. Every mutation that DID report went red, so
+        every count on the page is zero — and reading that as a clean branch is exactly
+        the mistake, because the shard that vanished is the one with the answer in it."""
+        gate = sweep.classify([_result("pinned")])
+        self.assertEqual(sweep.gate_conclusion(gate, missing=2), sweep.NO_VERDICT)
+        self.assertEqual(sweep.headline(gate, missing=2, shards=3),
+                         "no verdict: 2 of 3 shards did not report")
+        self.assertNotIn("no survivors", sweep.headline(gate, missing=2, shards=3))
+
+    def test_a_run_that_never_sized_itself_does_not_invent_a_denominator(self):
+        """"1 of 1 shard did not report" describes a sweep that was planned and then lost
+        one. A plan job that failed before it counted anything is a different fact, and a
+        denominator nobody computed is not a denominator."""
+        gate = sweep.classify([])
+        self.assertEqual(sweep.headline(gate, missing=1, shards=0),
+                         "no verdict: the sweep never sized itself")
+        self.assertEqual(sweep.headline(gate, missing=1, shards=1),
+                         "no verdict: 1 of 1 shard did not report")
+        page = sweep.gate_summary(gate, "a" * 40, "b" * 40, None, False, 1, 0)
+        self.assertIn("never said how many shards it needed", page)
+        self.assertNotIn("1 of 1", page)
+
+    def test_a_mutation_nobody_measured_is_no_verdict_too(self):
+        gate = sweep.classify([_result("unresolved"), _result("pinned")])
+        self.assertEqual(sweep.gate_conclusion(gate), sweep.NO_VERDICT)
+        self.assertEqual(sweep.headline(gate), "no verdict: 1 not measured")
+
+    def test_a_mutation_that_never_applied_is_no_verdict(self):
+        gate = sweep.classify([_result("unapplied"), _result("pinned")])
+        self.assertEqual(sweep.gate_conclusion(gate), sweep.NO_VERDICT)
+        self.assertEqual(sweep.headline(gate), "no verdict: 1 mutation never applied")
+
+    def test_survivors_outrank_an_unmeasured_mutation_and_both_are_said(self):
+        """"8 survivors, 1 not measured" is a true statement about 8 real findings, and
+        burying them under "no verdict" would lose the only actionable thing on the page.
+        Precedence is `gate_exit_code`'s — 4 over 1 over 3 — because the two answers are
+        one answer in two vocabularies."""
+        gate = sweep.classify([_result("survived", path=f"charter/{n}.py")
+                               for n in range(8)] + [_result("unresolved",
+                                                             path="charter/z.py")])
+        self.assertEqual(sweep.gate_conclusion(gate), sweep.SURVIVORS)
+        self.assertEqual(sweep.headline(gate), "8 survivors, 1 not measured")
+
+    def test_a_missing_shard_outranks_survivors_and_still_names_them(self):
+        """A count taken from two thirds of a plan is a number nobody should quote, so the
+        conclusion is `no verdict` — but the survivors that DID arrive are real and stay
+        on the line."""
+        gate = sweep.classify([_result("survived", path="charter/a.py"),
+                               _result("survived", path="charter/b.py")])
+        self.assertEqual(sweep.gate_conclusion(gate, missing=1), sweep.NO_VERDICT)
+        self.assertEqual(sweep.headline(gate, missing=1, shards=3),
+                         "no verdict: 2 survivors so far, 1 of 3 shards did not report")
+
+    def test_a_platform_survivor_does_not_make_the_headline_say_survivor(self):
+        """The gate never fails on one of these and it must not shout about one either:
+        a check named "1 survivor" for a clause the runner's kernel cannot reach is the
+        noise that gets a gate muted."""
+        gate = sweep.classify([_result("survived", operator="narrow-except",
+                                       before="OSError")])
+        self.assertEqual(sweep.gate_conclusion(gate), sweep.CLEAN)
+        self.assertEqual(sweep.headline(gate), "no survivors")
+
+    def test_the_headline_is_one_line_because_it_is_a_checks_name(self):
+        for gate, missing in ((sweep.classify([_result("pinned")]), 0),
+                              (sweep.classify([_result("survived")]), 0),
+                              (sweep.classify([_result("unapplied")]), 2)):
+            said = sweep.headline(gate, missing, 3)
+            self.assertNotIn("\n", said)
+            self.assertLess(len(said), 90, said)
+
+    def test_the_page_is_headed_with_the_same_sentence_the_check_is_named_with(self):
+        """One sentence, both readers. A summary whose title disagreed with the row on the
+        pull request would be worse than either of them alone."""
+        gate = sweep.classify([_result("survived", path="charter/a.py"),
+                               _result("survived", path="charter/b.py")])
+        text = sweep.gate_summary(gate, "a" * 40, "b" * 40, 60.0, enforce=False)
+        self.assertIn("## Deletion sweep — 2 survivors", text)
+
+    def test_a_page_missing_a_shard_refuses_to_call_the_branch_clean(self):
+        gate = sweep.classify([_result("pinned")])
+        text = sweep.gate_summary(gate, "a" * 40, "b" * 40, 60.0, enforce=False,
+                                  missing=2, shards=3)
+        self.assertIn("did not report", text)
+        self.assertNotIn("Nothing added here is a line the suite would not miss", text)
+
+    def test_a_page_with_every_shard_in_still_says_the_branch_is_clean(self):
+        text = sweep.gate_summary(sweep.classify([_result("pinned")]),
+                                  "a" * 40, "b" * 40, 60.0, enforce=False)
+        self.assertIn("Nothing added here is a line the suite would not miss", text)
+
+    def test_saying_it_is_not_failing_on_it(self):
+        """"Distinguish the three states" and "block on two of them" are different asks,
+        and only the first one is #617. `--enforce` remains the single flag that decides."""
+        for results in ([_result("survived")], [_result("unresolved")],
+                        [_result("unapplied")]):
+            gate = sweep.classify(results)
+            self.assertEqual(sweep.verdict_exit_code(gate, missing=2, enforce=False), 0)
+
+    def test_a_shard_that_never_reported_exits_three_once_the_gate_enforces(self):
+        """The same code an unresolved mutation gets, for the same reason: the run has not
+        shown the branch to be clean, and "I could not look" is not "nothing to see"."""
+        gate = sweep.classify([_result("pinned")])
+        self.assertEqual(sweep.verdict_exit_code(gate, missing=1, enforce=True), 3)
+        self.assertEqual(sweep.verdict_exit_code(gate, missing=0, enforce=True), 0)
+
+    def test_a_missing_shard_does_not_downgrade_a_worse_answer(self):
+        gate = sweep.classify([_result("unapplied")])
+        self.assertEqual(sweep.verdict_exit_code(gate, missing=1, enforce=True), 4)
+        gate = sweep.classify([_result("survived")])
+        self.assertEqual(sweep.verdict_exit_code(gate, missing=1, enforce=True), 1)
+
+
+class TheSweepIsSplitAcrossMachinesAndNothingIsDropped(unittest.TestCase):
+    """#617's other half: five runs cancelled at `timeout-minutes: 60` across two branches.
+
+    The answer is more machines and never fewer questions. A cap on the mutation count
+    reads as "covered everything" to every reader downstream — the spec says so about
+    silent truncation — so the tests below are mostly one property said several ways:
+    **every mutation lands in exactly one shard.**
+    """
+
+    @staticmethod
+    def _plan(n):
+        return [sweep.Mutation(f"charter/f{i // 7}.py", i, i, "drop-if", "q?",
+                               f"if x{i}: pass", "", "f") for i in range(n)]
+
+    def test_the_shards_partition_the_plan(self):
+        for total in (0, 1, 7, 62, 78, 82, 225):
+            plan = self._plan(total)
+            for count in (1, 2, 3, 8):
+                dealt = [m for i in range(1, count + 1)
+                         for m in sweep.shard_of(plan, i, count)]
+                self.assertEqual(sorted(m.line for m in dealt),
+                                 sorted(m.line for m in plan),
+                                 f"{total} mutations across {count} shard(s)")
+                self.assertEqual(len(dealt), total)
+
+    def test_no_shard_carries_more_than_one_extra_mutation(self):
+        """Round-robin, so the slowest shard decides the wall clock and the slowest shard
+        is within one mutation of the fastest."""
+        plan = self._plan(82)
+        sizes = [len(sweep.shard_of(plan, i, 3)) for i in (1, 2, 3)]
+        self.assertEqual(sorted(sizes), [27, 27, 28])
+
+    def test_a_shard_number_outside_its_count_is_refused_rather_than_clamped(self):
+        """Off-by-one here does not fail loudly: it sweeps one slice twice and another
+        never, and the merge step then reports a complete sweep of an incomplete plan."""
+        plan = self._plan(9)
+        for index, count in ((0, 3), (4, 3), (-1, 3), (1, 0)):
+            with self.assertRaises(ValueError):
+                sweep.shard_of(plan, index, count)
+
+    def test_the_shard_argument_is_parsed_strictly(self):
+        self.assertEqual(sweep.parse_shard("2/3"), (2, 3))
+        for bad in ("2", "2/", "/3", "0/3", "4/3", "", "two/three", "2/3/4"):
+            with self.assertRaises(ValueError, msg=bad):
+                sweep.parse_shard(bad)
+
+    def test_one_shard_measures_what_it_can_finish_in_its_budget(self):
+        """Forty minutes a shard, eleven of which are gone before the first mutation — the
+        checkout, the sandbox clone, the selection map and the unmutated baseline. The
+        literal is here rather than the arithmetic on purpose: a test that recomputed it
+        from the constants would pass whatever the constants became."""
+        self.assertEqual(sweep.per_shard(), 28)
+
+    def test_a_budget_smaller_than_its_own_fixed_cost_still_measures_something(self):
+        """`max(1, …)`, found unpinned by the sweep on this very branch.
+
+        Raise the fixed cost past the budget — a slower runner, a longer suite, a map that
+        stops being cached — and the subtraction goes to zero or below. Without the clamp
+        the division in :func:`shards_for` is by zero, the plan job raises, and the
+        workflow gets an empty shard count: no plan, no shards, no numbers. Which is the
+        #617 failure exactly, arriving out of the arithmetic written to prevent it.
+        """
+        real = sweep.SHARD_FIXED
+        self.addCleanup(lambda: setattr(sweep, "SHARD_FIXED", real))
+        for fixed in (sweep.SHARD_BUDGET, sweep.SHARD_BUDGET + 3600):
+            sweep.SHARD_FIXED = fixed
+            self.assertEqual(sweep.per_shard(), 1, fixed)
+            self.assertEqual(sweep.shards_for(50), 8, fixed)   # capped, and not a crash
+
+    def test_the_two_diffs_that_ran_out_of_time_now_fit(self):
+        """#608's 62 mutations were cancelled twice and #626's 78 three times, at
+        `timeout-minutes: 60`, each run reaching about two thirds of its plan."""
+        self.assertEqual(sweep.shards_for(62), 3)
+        self.assertEqual(sweep.shards_for(78), 3)
+        for total in (62, 78):
+            biggest = max(len(sweep.shard_of(self._plan(total), i, 3))
+                          for i in (1, 2, 3))
+            self.assertLessEqual(biggest, sweep.per_shard())
+
+    def test_a_branch_phase_two_would_have_produced_still_gets_one_job(self):
+        self.assertEqual(sweep.shards_for(1), 1)
+        self.assertEqual(sweep.shards_for(28), 1)
+        self.assertEqual(sweep.shards_for(29), 2)
+
+    def test_a_branch_with_nothing_to_sweep_still_gets_a_job(self):
+        """"The sweep ran and found nothing to do" and "the sweep did not run" are the two
+        answers this whole change is about. A plan of zero shards would make them one."""
+        self.assertEqual(sweep.shards_for(0), 1)
+
+    def test_the_fan_out_is_capped_and_the_sweep_is_not(self):
+        """`MAX_SHARDS` limits how much of the runner pool one branch may hold. It does
+        not limit what gets asked: past the ceiling the shards simply carry more."""
+        self.assertEqual(sweep.shards_for(10_000), 8)
+        plan = self._plan(400)
+        dealt = [m for i in range(1, 9) for m in sweep.shard_of(plan, i, 8)]
+        self.assertEqual(len(dealt), 400)
+
+    def test_a_diff_past_the_ceiling_says_so_out_loud(self):
+        """The spec is explicit that a cap the reader cannot see is worse than the cap."""
+        self.assertEqual(sweep.over_budget(224), "")
+        loud = sweep.over_budget(225)
+        self.assertIn("225 mutations", loud)
+        self.assertIn("still swept", loud)
+        self.assertIn("nothing here is dropped", loud)
+
+
+class EverySurvivorLandsOnTheLineItIsAbout(unittest.TestCase):
+    """The other half of "without failing": the finding goes where the reviewer is looking.
+
+    An annotation renders in the margin of the diff, on the guard itself, and changes
+    nothing about the job's conclusion — which is the shape #617 asks for. The check's
+    name says how many; this says where.
+    """
+
+    def test_an_unpinned_survivor_is_a_warning_on_its_own_file_and_line(self):
+        gate = sweep.classify([_result("survived", path="charter/gitconfig.py", line=42)])
+        said = sweep.annotations(gate)
+        self.assertEqual(len(said), 1)
+        self.assertTrue(said[0].startswith("::warning file=charter/gitconfig.py,line=42,"),
+                        said[0])
+        self.assertIn("Unpinned guard", said[0])
+
+    def test_a_platform_survivor_is_a_notice_and_never_a_warning(self):
+        """The gate never fails on one of these, so it never shouts about one either."""
+        gate = sweep.classify([_result("survived", operator="narrow-except",
+                                       before="OSError")])
+        said = sweep.annotations(gate)
+        self.assertEqual(len(said), 1)
+        self.assertTrue(said[0].startswith("::notice "), said[0])
+
+    def test_a_mutation_that_never_applied_is_an_error_because_it_is_a_defect_here(self):
+        gate = sweep.classify([_result("unapplied")])
+        self.assertTrue(sweep.annotations(gate)[0].startswith("::error "))
+
+    def test_a_masked_cluster_says_so_rather_than_reading_as_two_lone_survivors(self):
+        gate = sweep.classify([_result("survived", line=1), _result("survived", line=9)])
+        self.assertEqual(len(gate.masked), 2)
+        for line in sweep.annotations(gate):
+            self.assertIn("Masked cluster", line)
+
+    def test_an_unmeasured_mutation_is_annotated_too(self):
+        gate = sweep.classify([_result("unresolved", path="charter/z.py", line=3)])
+        said = sweep.annotations(gate)
+        self.assertIn("::warning file=charter/z.py,line=3,", said[0])
+        self.assertIn("No verdict", said[0])
+
+    def test_past_the_cap_the_ones_not_drawn_are_counted_out_loud(self):
+        """GitHub draws ten annotations of a level and then stops, with no error and no
+        warning. Silence there is the silent-truncation shape again."""
+        gate = sweep.classify([_result("survived", path=f"charter/{n}.py")
+                               for n in range(14)])
+        said = sweep.annotations(gate)
+        self.assertEqual(len(said), 10)                     # nine findings and the note
+        self.assertEqual(sum(1 for s in said if "file=" in s), 9)
+        self.assertIn("5 of these 14 are not shown", said[-1])
+        self.assertIn("all 14", said[-1])
+
+    def test_the_cap_is_a_levels_budget_and_not_one_kind_of_findings(self):
+        """Masked clusters, lone survivors and unmeasured mutations are all warnings, so
+        they share one budget of ten. Capping each family at ten instead would emit thirty
+        and have GitHub silently draw the first ten of them."""
+        gate = sweep.classify(
+            [_result("survived", path="charter/m.py", line=n) for n in (1, 9)]
+            + [_result("survived", path=f"charter/u{n}.py") for n in range(9)]
+            + [_result("unresolved", path=f"charter/z{n}.py") for n in range(9)])
+        said = sweep.annotations(gate)
+        self.assertEqual(sum(1 for s in said if s.startswith("::warning file=")), 9)
+        self.assertEqual(len(said), 10)
+
+    def test_the_urgent_families_are_the_ones_that_survive_the_cap(self):
+        """A masked cluster is the finding a reviewer is least able to reach alone, and an
+        unmeasured mutation is a fact about the runner rather than about the branch. When
+        only nine of twenty fit, that is the order they go in."""
+        gate = sweep.classify(
+            [_result("survived", path="charter/m.py", line=n) for n in (1, 9)]
+            + [_result("unresolved", path=f"charter/z{n}.py") for n in range(20)])
+        drawn = [s for s in sweep.annotations(gate) if "file=" in s]
+        self.assertEqual(sum(1 for s in drawn if "Masked cluster" in s), 2)
+        self.assertEqual(sum(1 for s in drawn if "No verdict" in s), 7)
+
+    def test_a_notice_does_not_spend_a_warnings_budget(self):
+        """Platform-deferred survivors are notices, which is a separate ten."""
+        gate = sweep.classify(
+            [_result("survived", path=f"charter/u{n}.py") for n in range(9)]
+            + [_result("survived", path=f"charter/p{n}.py", operator="narrow-except",
+                       before="OSError") for n in range(4)])
+        said = sweep.annotations(gate)
+        self.assertEqual(sum(1 for s in said if s.startswith("::warning ")), 9)
+        self.assertEqual(sum(1 for s in said if s.startswith("::notice ")), 4)
+
+    def test_a_path_with_a_comma_or_a_colon_in_it_cannot_move_the_annotation(self):
+        """A `,` starts the next property and a `:` can close the list early, so an
+        unescaped one annotates the wrong place or nothing at all."""
+        gate = sweep.classify([_result("survived", path="charter/a,b:c.py")])
+        self.assertIn("file=charter/a%2Cb%3Ac.py,line=1,", sweep.annotations(gate)[0])
+
+    def test_a_newline_in_the_message_cannot_end_the_command_early(self):
+        gate = sweep.classify([_result("survived", before="if x:\n    return 100%")])
+        said = sweep.annotations(gate)
+        self.assertEqual(len(said), 1)
+        self.assertNotIn("\n", said[0])
+
+    def test_an_annotation_is_not_a_failure(self):
+        gate = sweep.classify([_result("survived"), _result("unapplied",
+                                                            path="charter/b.py")])
+        self.assertTrue(sweep.annotations(gate))
+        self.assertEqual(sweep.gate_exit_code(gate, enforce=False), 0)
+
+
+class TheAnswerSurvivesTheTripThroughAFile(unittest.TestCase):
+    """One question, several machines, one answer — which means a round trip through JSON.
+
+    Everything `classify` and the summary read has to survive it, not merely the verdict
+    string. The strongest form of that is the one asserted first: the page a merge writes
+    is the page a single run would have written, character for character.
+    """
+
+    @staticmethod
+    def _mixed():
+        ev = sweep.Evidence(["tests.test_a"],
+                            [("tests.test_a", "test_it_refuses",
+                              ["self.assertEqual(f(None), [])"])])
+        return [_result("survived", path="charter/a.py", evidence=ev),
+                _result("survived", path="charter/b.py", line=1),
+                _result("survived", path="charter/b.py", line=9),
+                _result("survived", path="charter/c.py", operator="narrow-except",
+                        before="OSError"),
+                _result("unresolved", path="charter/d.py"),
+                _result("pinned", path="charter/e.py")]
+
+    def test_the_merged_page_is_the_page_one_machine_would_have_written(self):
+        results = self._mixed()
+        here = sweep.gate_summary(sweep.classify(results), "a" * 40, "b" * 40, 60.0, False)
+        there = sweep.gate_summary(
+            sweep.classify(sweep.results_from_json(sweep.as_json(results))),
+            "a" * 40, "b" * 40, 60.0, False)
+        self.assertEqual(here, there)
+        self.assertIn("self.assertEqual(f(None), [])", there)
+
+    def test_a_survivors_own_platform_is_recomputed_and_not_read_from_the_file(self):
+        """The shard that measured it and the machine that merges it are two computers.
+        Trusting the shard's answer would let one platform's verdict be reported as
+        another's."""
+        back = sweep.results_from_json(sweep.as_json(self._mixed()))
+        self.assertEqual(len(sweep.classify(back).platform), 1)
+
+    def test_a_file_nothing_executes_does_not_come_back_as_a_file_that_ignores_it(self):
+        """The absence that has to survive the trip. "Nothing measured executes this file"
+        and "one module executes it and does not name the symbol" are different findings
+        and different next moves, and an evidence pass that never ran must not arrive
+        looking like one that ran and found nothing."""
+        never = _result("survived", path="charter/a.py")          # evidence pass not run
+        ran = _result("survived", path="charter/b.py",
+                      evidence=sweep.Evidence(["tests.test_a"], []))
+        back = sweep.results_from_json(sweep.as_json([never, ran]))
+        self.assertIsNone(back[0].evidence)
+        self.assertEqual(back[1].evidence, sweep.Evidence(["tests.test_a"], []))
+        page = sweep.gate_summary(sweep.classify(back), "a" * 40, "b" * 40, 60.0, False)
+        self.assertIn("nothing measured executes this file", page)
+        self.assertIn("**not one names `f`**", page)
+
+    def test_the_shards_add_up_to_the_whole_sweep(self):
+        results = self._mixed()
+        with tempfile.TemporaryDirectory() as tmp:
+            for i in range(3):
+                (Path(tmp) / f"sweep-results-{i + 1}.json").write_text(
+                    sweep.as_json(results[i::3]))
+            merged, missing = sweep.merge(Path(tmp), 3)
+        self.assertEqual(missing, 0)
+        self.assertEqual(len(merged), len(results))
+        self.assertEqual(sorted(r.mutation.path for r in merged),
+                         sorted(r.mutation.path for r in results))
+
+    def test_a_masked_cluster_split_across_two_machines_is_still_a_masked_cluster(self):
+        """The reason the sorting happens at the merge and not in the shard.
+
+        Two guards in sequence mask each other, and the round-robin deal puts neighbours
+        in *different* shards on purpose — so neither shard can see the pair. Classify one
+        shard at a time and a masked cluster reads as two lone survivors in two jobs, each
+        of which looks equivalent on its own, which is the exact reading the bucket exists
+        to prevent.
+        """
+        pair = [_result("survived", path="charter/a.py", line=1, symbol="close"),
+                _result("survived", path="charter/a.py", line=9, symbol="close")]
+        for one in pair:                       # one shard at a time sees a lone survivor
+            self.assertEqual(len(sweep.classify([one]).unpinned), 1)
+        with tempfile.TemporaryDirectory() as tmp:
+            for i, r in enumerate(pair, start=1):
+                (Path(tmp) / f"sweep-results-{i}.json").write_text(sweep.as_json([r]))
+            merged, missing = sweep.merge(Path(tmp), 2)
+        gate = sweep.classify(merged)
+        self.assertEqual((missing, len(gate.masked), gate.unpinned), (0, 2, []))
+        self.assertIn("### Masked cluster",
+                      sweep.gate_summary(gate, "a" * 40, "b" * 40, None, False))
+
+    def test_a_shard_that_wrote_nothing_is_counted_as_a_shard_that_did_not_report(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "sweep-results-1.json").write_text(sweep.as_json([]))
+            merged, missing = sweep.merge(Path(tmp), 3)
+        self.assertEqual((len(merged), missing), (0, 2))
+
+    def test_a_result_file_that_will_not_parse_is_not_a_shard_that_answered(self):
+        """There is no third reading of a truncated upload."""
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "a.json").write_text(sweep.as_json([]))
+            (Path(tmp) / "b.json").write_text('[{"path": "charter/a.py"')
+            (Path(tmp) / "c.json").write_text('[{"path": "charter/a.py"}]')
+            merged, missing = sweep.merge(Path(tmp), 3)
+        self.assertEqual((len(merged), missing), (0, 2))
+
+    def test_an_empty_sweep_that_ran_is_not_a_sweep_that_did_not(self):
+        """A shard with nothing to do writes `[]`, and `[]` is an answer. The directory
+        being empty is the other thing entirely."""
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "sweep-results-1.json").write_text(sweep.as_json([]))
+            ran, ran_missing = sweep.merge(Path(tmp), 1)
+        with tempfile.TemporaryDirectory() as tmp:
+            gone, gone_missing = sweep.merge(Path(tmp), 1)
+        self.assertEqual((ran, ran_missing), ([], 0))
+        self.assertEqual(gone_missing, 1)
+        self.assertEqual(sweep.gate_conclusion(sweep.classify(ran), ran_missing),
+                         sweep.CLEAN)
+        self.assertEqual(sweep.gate_conclusion(sweep.classify(gone), gone_missing),
+                         sweep.NO_VERDICT)
+
+    def test_a_directory_that_is_not_there_is_no_verdict_and_not_a_clean_one(self):
+        merged, missing = sweep.merge(Path("/nonexistent-sweep-shards"), 2)
+        self.assertEqual((merged, missing), ([], 2))
+
+    def test_a_plan_that_never_said_how_many_shards_is_not_no_shards(self):
+        """A plan job that fails leaves the output empty. Reading an empty string as zero
+        would turn the loudest failure this workflow has into the quietest kind of pass."""
+        self.assertEqual(sweep.expected_shards("3"), 3)
+        self.assertEqual(sweep.expected_shards(" 3 "), 3)
+        for nothing in ("", None, "0", "-1", "many", "3.5", []):
+            self.assertEqual(sweep.expected_shards(nothing), 0, repr(nothing))
+
+
+class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
+    """The three commands `.github/workflows/sweep.yml` runs, run.
+
+    Every decision the workflow makes now lives here rather than in YAML — how many jobs,
+    which slice, what the check is called — for #572's reason: a rule inside a `run:`
+    block is not reachable from a test, so it cannot be swept, so it is a guard the
+    harness is structurally unable to hold itself to. What is left in the YAML is which
+    values are passed, and these cases run the commands that consume them.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="sweep-gate-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull,
+                   GIT_CONFIG_SYSTEM=os.devnull, GIT_CONFIG_NOSYSTEM="1",
+                   GIT_TERMINAL_PROMPT="0")
+
+        def run(*a):
+            subprocess.run(("git", "-c", "core.hooksPath=", "-c", "commit.gpgsign=false")
+                           + a, cwd=self.tmp, check=True, env=env, timeout=60,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        run("init", "-q", "-b", "main")
+        run("config", "user.email", "sweep@example.invalid")
+        run("config", "user.name", "sweep")
+        (self.tmp / "charter").mkdir()
+        (self.tmp / "charter" / "m.py").write_text("a = 1\n")
+        run("add", "-A")
+        run("commit", "-qm", "one")
+        self.base = sweep.git("rev-parse", "HEAD", cwd=self.tmp).strip()
+        run("checkout", "-q", "-b", "side")
+        (self.tmp / "charter" / "m.py").write_text(textwrap.dedent("""
+            def close(arm, pane):
+                if arm is None:
+                    return []
+                if pane is None:
+                    return []
+                return [arm, pane]
+        """).lstrip())
+        run("add", "-A")
+        run("commit", "-qm", "two")
+        self.workdir = self.tmp / "wd"
+        self.outputs = self.tmp / "outputs.txt"
+        self.summary = self.tmp / "summary.md"
+
+    def _cli(self, *args):
+        said = io.StringIO()
+        cwd = os.getcwd()
+        os.chdir(self.tmp)
+        try:
+            with contextlib.redirect_stdout(said):
+                code = sweep.main(list(args))
+        finally:
+            os.chdir(cwd)
+        return code, said.getvalue()
+
+    def _read_outputs(self):
+        return dict(line.split("=", 1)
+                    for line in self.outputs.read_text().splitlines() if line)
+
+    def test_the_plan_costs_no_test_runs_and_says_how_many_jobs_it_needs(self):
+        """The number the job used to guess. It was sized against 30 to 52 mutations and
+        met 78, five times, and every one of those runs was cancelled at the cap."""
+        code, said = self._cli("--plan", "--base", self.base,
+                               "--workdir", str(self.workdir),
+                               "--github-output", str(self.outputs))
+        self.assertEqual(code, 0, said)
+        out = self._read_outputs()
+        self.assertEqual(int(out["mutations"]), 2)      # the two refusals added above
+        self.assertEqual(out["shards"], "1")
+        self.assertEqual(out["matrix"], "[1]")
+
+    def test_a_diff_past_the_fan_out_ceiling_warns_on_the_pull_request(self):
+        """A log line is not loud. `over_budget` reaching the plan's stdout as a workflow
+        command is what puts it in the run's annotations instead of in a fold, and the
+        spec's rule is that a cap the reader cannot see is worse than the cap."""
+        plan = [sweep.Mutation("charter/m.py", n, n, "drop-if", "q?", "if x: pass",
+                               "", "f") for n in range(300)]
+        real = sweep.plan_for
+        sweep.plan_for = lambda *a: (plan, {})
+        self.addCleanup(lambda: setattr(sweep, "plan_for", real))
+        code, said = self._cli("--plan", "--base", self.base,
+                               "--workdir", str(self.workdir),
+                               "--github-output", str(self.outputs))
+        self.assertEqual(code, 0, said)
+        self.assertIn("::warning title=The deletion sweep is over its budget::", said)
+        self.assertIn("nothing here is dropped", said)
+        # And it still asks about all three hundred, on the eight machines it is allowed.
+        self.assertEqual(self._read_outputs()["shards"], "8")
+        self.assertEqual(len([m for i in range(1, 9)
+                              for m in sweep.shard_of(plan, i, 8)]), 300)
+
+    def test_a_diff_inside_the_ceiling_says_nothing_about_the_ceiling(self):
+        code, said = self._cli("--plan", "--base", self.base,
+                               "--workdir", str(self.workdir),
+                               "--github-output", str(self.outputs))
+        self.assertEqual(code, 0, said)
+        self.assertNotIn("::warning", said)
+
+    def test_the_matrix_names_every_shard_the_plan_asked_for(self):
+        """The workflow fans out over exactly this list, so a plan of three shards that
+        emitted two entries would sweep two thirds of the branch and say nothing.
+
+        Driven through the CLI rather than by recomputing `shards_for` here: a test that
+        rebuilds the answer out of the same function it is checking agrees with that
+        function whatever it says, which is the shape that survives its own mutation.
+        """
+        real = sweep.plan_for
+        self.addCleanup(lambda: setattr(sweep, "plan_for", real))
+        for total, shards, matrix in ((0, "1", "[1]"), (28, "1", "[1]"),
+                                      (29, "2", "[1, 2]"), (78, "3", "[1, 2, 3]")):
+            plan = [sweep.Mutation("charter/m.py", n, n, "drop-if", "q?", "if x: pass",
+                                   "", "f") for n in range(total)]
+            sweep.plan_for = lambda *a, _p=plan: (_p, {})
+            self.outputs.unlink(missing_ok=True)
+            code, said = self._cli("--plan", "--base", self.base,
+                                   "--workdir", str(self.workdir),
+                                   "--github-output", str(self.outputs))
+            self.assertEqual(code, 0, said)
+            out = self._read_outputs()
+            self.assertEqual((out["mutations"], out["shards"], out["matrix"]),
+                             (str(total), shards, matrix), f"{total} mutations")
+
+    def test_the_shard_the_workflow_names_is_the_shard_the_sweep_runs(self):
+        """`--shard "$SHARD/$SHARDS"` is a string assembled in YAML, and the one thing it
+        must not do is arrive as something else. A slice that is silently wrong does not
+        fail — it sweeps some mutations twice and others never, and the merge then reports
+        a complete sweep of an incomplete plan."""
+        seen = []
+        for name, stub in (("sweep", lambda *a, **k: (seen.append(a[-1]), ([], []))[1]),
+                           ("load_map", lambda *a, **k: {})):
+            real = getattr(sweep, name)
+            setattr(sweep, name, stub)
+            self.addCleanup(setattr, sweep, name, real)
+        code, said = self._cli("--gate", "--jobs", "1", "--base", self.base,
+                               "--shard", "2/3", "--no-baseline",
+                               "--workdir", str(self.workdir))
+        self.assertEqual(code, 0, said)
+        self.assertEqual(seen, [(2, 3)])
+
+    def test_the_slice_a_shard_takes_is_the_slice_it_says_it_took(self):
+        """The log line a cancelled run leaves behind is the only trace of what it was
+        doing, so it names the shard and how much of the plan the shard was given."""
+        said = io.StringIO()
+        plan = [sweep.Mutation("charter/m.py", n, n, "drop-if", "q?", "if x: pass",
+                               "", "close") for n in range(1, 6)]
+        real = sweep.plan_for
+        sweep.plan_for = lambda *a: (plan, {})
+        self.addCleanup(lambda: setattr(sweep, "plan_for", real))
+        with contextlib.redirect_stdout(said):
+            results, _ = sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {},
+                                     self.workdir, 1, {}, 0, print, 60.0, (2, 3))
+        self.assertIn("5 mutations across 1 file(s); shard 2 of 3 takes 2 of them",
+                      said.getvalue())
+        self.assertEqual([r.mutation.line for r in results], [2, 5])
+
+    def test_no_shard_at_all_still_means_the_whole_plan(self):
+        """Found by the sweep, on this branch, against this file: forcing `if shard is not
+        None` to always-true left every test green, because nothing in the suite ran an
+        UNSHARDED sweep any more. A local `tools/sweep.py --gate` is the ordinary way this
+        tool is used, and it had quietly become the path no test walked."""
+        said = io.StringIO()
+        plan = [sweep.Mutation("charter/m.py", n, n, "drop-if", "q?", "if x: pass",
+                               "", "close") for n in range(1, 6)]
+        real = sweep.plan_for
+        sweep.plan_for = lambda *a: (plan, {})
+        self.addCleanup(lambda: setattr(sweep, "plan_for", real))
+        with contextlib.redirect_stdout(said):
+            results, _ = sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {},
+                                     self.workdir, 1, {}, 0, print, 60.0, None)
+        self.assertEqual([r.mutation.line for r in results], [1, 2, 3, 4, 5])
+        self.assertIn("5 mutations across 1 file(s)\n", said.getvalue())
+        self.assertNotIn("shard", said.getvalue())
+
+    def test_a_branch_with_nothing_to_sweep_writes_an_empty_answer_and_not_no_answer(self):
+        """A shard that writes nothing is indistinguishable from a shard that was
+        cancelled, which is the whole of #617 arriving one level down."""
+        code, said = self._cli("--gate", "--base", "HEAD", "--path", "charter",
+                               "--workdir", str(self.workdir),
+                               "--json", str(self.tmp / "r.json"))
+        self.assertEqual(code, 0, said)
+        self.assertEqual((self.tmp / "r.json").read_text(), "[]")
+        merged, missing = sweep.merge(self.tmp, 1)
+        self.assertEqual((merged, missing), ([], 0))
+
+    def _shards(self, *payloads):
+        where = self.tmp / "shards"
+        where.mkdir(exist_ok=True)
+        for i, results in enumerate(payloads, start=1):
+            (where / f"sweep-results-{i}.json").write_text(sweep.as_json(results))
+        return where
+
+    def test_the_merge_names_the_branch_with_its_own_answer(self):
+        where = self._shards([_result("survived", path="charter/a.py")],
+                             [_result("pinned", path="charter/b.py")])
+        code, said = self._cli("--verdict", str(where), "--shards", "2",
+                               "--ref", "a" * 40, "--base", "b" * 40, "--annotate",
+                               "--summary", str(self.summary),
+                               "--github-output", str(self.outputs))
+        self.assertEqual(code, 0, said)
+        self.assertEqual(self._read_outputs(),
+                         {"conclusion": "survivors", "headline": "1 survivor"})
+        self.assertIn("## Deletion sweep — 1 survivor", self.summary.read_text())
+        self.assertIn("::warning file=charter/a.py,line=1,", said)
+
+    def test_a_shard_that_never_reported_reaches_the_check_as_no_verdict(self):
+        where = self._shards([_result("pinned", path="charter/b.py")])
+        code, said = self._cli("--verdict", str(where), "--shards", "3",
+                               "--summary", str(self.summary),
+                               "--github-output", str(self.outputs))
+        self.assertEqual(code, 0, said)
+        self.assertEqual(self._read_outputs()["conclusion"], "no-verdict")
+        self.assertEqual(self._read_outputs()["headline"],
+                         "no verdict: 2 of 3 shards did not report")
+        self.assertIn("did not report", self.summary.read_text())
+
+    def test_a_plan_that_never_ran_is_no_verdict_and_says_which_job_failed(self):
+        """`needs.plan.outputs.shards` is the empty string when that job failed. An empty
+        string is not zero shards."""
+        code, said = self._cli("--verdict", str(self._shards()), "--shards", "",
+                               "--summary", str(self.summary),
+                               "--github-output", str(self.outputs))
+        self.assertEqual(code, 0, said)
+        self.assertEqual(self._read_outputs(),
+                         {"conclusion": "no-verdict",
+                          "headline": "no verdict: the sweep never sized itself"})
+        self.assertIn("never said how many shards it needed", self.summary.read_text())
+        self.assertIn("an unknown number of shard(s)", said)
+
+    def test_a_complete_merge_of_a_clean_branch_says_no_survivors(self):
+        where = self._shards([_result("pinned", path="charter/a.py")],
+                             [_result("pinned", path="charter/b.py")])
+        code, said = self._cli("--verdict", str(where), "--shards", "2",
+                               "--summary", str(self.summary),
+                               "--github-output", str(self.outputs))
+        self.assertEqual(code, 0, said)
+        self.assertEqual(self._read_outputs(),
+                         {"conclusion": "clean", "headline": "no survivors"})
+
+    def test_the_merge_blocks_nothing_until_it_is_told_to(self):
+        where = self._shards([_result("survived", path="charter/a.py")])
+        self.assertEqual(self._cli("--verdict", str(where), "--shards", "3")[0], 0)
+        self.assertEqual(
+            self._cli("--verdict", str(where), "--shards", "3", "--enforce")[0], 1)
+
+
+class TheCheckIsNamedWithTheAnswer(unittest.TestCase):
+    """`$GITHUB_OUTPUT` is the whole mechanism, so what goes into it is load-bearing."""
+
+    def test_the_conclusion_and_the_headline_are_written_where_a_job_name_can_read_them(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "out.txt"
+            sweep._write_output(str(out), conclusion="survivors", headline="8 survivors")
+            self.assertEqual(out.read_text(), "conclusion=survivors\nheadline=8 survivors\n")
+
+    def test_a_value_with_a_line_break_of_either_spelling_is_refused(self):
+        """`key=value` is one line. A value carrying a break would not set an output, it
+        would inject the next one — and a bare `\\r` ends a line for the runner's parser
+        just as `\\n` does, so both are refused rather than only the one that is easy to
+        picture."""
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "out.txt"
+            for injected in ("8 survivors\nheadline=none", "8 survivors\rheadline=none"):
+                with self.assertRaises(ValueError, msg=repr(injected)):
+                    sweep._write_output(str(out), headline=injected)
+            self.assertFalse(out.exists())
+
+    def test_nothing_is_written_when_there_is_nowhere_to_write_it(self):
+        sweep._write_output(None, headline="8 survivors")
+
+
+class TheWorkflowSaysTheAnswerWhereItCanBeSeen(unittest.TestCase):
+    """`.github/workflows/sweep.yml`, read as a tree rather than grepped.
+
+    Everything above is about what `sweep.py` can say. These are about whether anything
+    ever hears it — which is the half #617 was actually about, and the half no unit test
+    of this module can reach. The reader is `tests/test_workflows.py`'s, because a second
+    YAML parser in this repository would be a second thing to be wrong.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        from tests import test_workflows
+        root = Path(__file__).resolve().parent.parent
+        cls.wf = test_workflows.load(
+            (root / ".github/workflows/sweep.yml").read_text(encoding="utf-8"))
+        cls.jobs = cls.wf["jobs"]
+
+    def _run(self, job, step_name):
+        for step in self.jobs[job]["steps"]:
+            if step.get("name") == step_name:
+                return step["run"]
+        self.fail(f"{job} has no step named {step_name!r}")
+
+    def test_the_check_a_reviewer_sees_is_named_with_the_sweeps_own_answer(self):
+        """The whole fix. A job name may interpolate `needs.<job>.outputs.*`, so the row
+        on the pull request reads `deletion sweep / 8 survivors` instead of a tick beside
+        a name that says the same thing on every branch."""
+        name = self.jobs["verdict"]["name"]
+        self.assertIn("needs.collect.outputs.headline", name)
+        self.assertIn("no verdict", name)          # when collect itself did not answer
+        self.assertEqual(self.jobs["verdict"]["needs"], "collect")
+
+    def test_the_job_whose_exit_code_would_block_has_a_name_that_never_moves(self):
+        """Branch protection matches a check by name, and the answering job's name IS the
+        answer — different on every branch, which is the point and also what makes it
+        useless as a required check. `collect` is the one to require, because it is where
+        `--enforce` would land and its name is a constant."""
+        self.assertNotIn("${{", self.jobs["collect"]["name"])
+        self.assertIn("${{", self.jobs["verdict"]["name"])
+
+    def test_the_job_that_carries_the_answer_runs_even_when_the_sweep_did_not(self):
+        """`always()` on both, because the state this exists to report is the one where a
+        shard was cancelled. A chain that only runs on success can never say so."""
+        for job in ("collect", "verdict"):
+            self.assertEqual(self.jobs[job]["if"], "always()", job)
+
+    def test_one_shards_trouble_does_not_cancel_the_others(self):
+        self.assertEqual(self.jobs["sweep"]["strategy"]["fail-fast"], "false")
+
+    def _commands(self):
+        """Every line of every `run:` body that is a command rather than a comment.
+
+        The comments matter here: the merge step's own comment SAYS `--enforce`, at length
+        and on purpose, because that is where somebody will come looking to turn the gate
+        on. Grepping the file would find it and pass, which would make this check the
+        thing it is meant to catch — a guard that is satisfied by prose.
+        """
+        return [line for job in self.jobs.values() for step in job["steps"]
+                for line in step.get("run", "").splitlines()
+                if line.strip() and not line.strip().startswith("#")]
+
+    def test_the_gate_still_blocks_nothing(self):
+        """`--enforce` is the single flag, and it is absent. The spec's staging argument
+        applies to this job's own credibility: a gate whose numbers nobody has read gets
+        disabled the first time it is inconvenient."""
+        self.assertEqual([line for line in self._commands() if "--enforce" in line], [])
+
+    def test_the_gate_never_charges_the_whole_tree_from_ci_either(self):
+        """Stage B is fourteen hours. It is not a pull-request check and never will be."""
+        self.assertEqual([line for line in self._commands() if "--all" in line], [])
+
+    def test_a_shard_is_told_which_slice_it_is_and_where_to_write_it(self):
+        run = self._run("sweep", "Sweep the guards this branch adds")
+        self.assertIn('--shard "$SHARD/$SHARDS"', run)
+        self.assertIn('--json "sweep-results-$SHARD.json"', run)
+        # And nothing that would have it write a page of its own: a slice of the answer
+        # must never render as the answer.
+        self.assertNotIn("--summary", run)
+        self.assertNotIn("--annotate", run)
+
+    def test_the_merge_is_the_only_step_that_tells_the_branch_anything(self):
+        run = self._run("collect", "One answer for the whole sweep")
+        for flag in ("--verdict shards", '--shards "${SHARDS:-}"', "--annotate",
+                     '--summary "$GITHUB_STEP_SUMMARY"',
+                     '--github-output "$GITHUB_OUTPUT"'):
+            self.assertIn(flag, run)
+
+    def test_the_shard_count_is_passed_through_without_a_default_that_hides_a_failure(self):
+        """`${SHARDS:-}` and not `${SHARDS:-1}`. An empty value means the plan job never
+        answered, and defaulting it to a number here would turn the loudest failure this
+        workflow has into a complete-looking sweep of one shard."""
+        run = self._run("collect", "One answer for the whole sweep")
+        self.assertIn('--shards "${SHARDS:-}"', run)
+        self.assertNotIn('${SHARDS:-1}', run)
+
+    def test_the_plan_sizes_the_run_and_leaves_the_map_for_the_shards(self):
+        run = self._run("plan", "How many mutations, and how many jobs they need")
+        self.assertIn("--plan", run)
+        self.assertIn("--warm-map", run)
+        self.assertIn('--github-output "$GITHUB_OUTPUT"', run)
+        self.assertEqual(self.jobs["sweep"]["strategy"]["matrix"]["shard"],
+                         "${{ fromJSON(needs.plan.outputs.matrix) }}")
+
+    def test_the_shards_restore_the_map_the_plan_measured(self):
+        """Otherwise a second machine costs a whole trace, which is the largest fixed cost
+        there is and the reason sharding looked affordable in the first place."""
+        keys = [step["with"]["key"] for job in ("plan", "sweep")
+                for step in self.jobs[job]["steps"]
+                if "cache@" in step.get("uses", "")]
+        self.assertEqual(len(keys), 2)
+        self.assertEqual(keys[0], keys[1])
+        # And keyed on the tree the map was measured on, the way `tree_hash` is. A key
+        # that did not move with the sources would hand a shard a map of another tree,
+        # which is a selection that certifies guards it never ran.
+        self.assertIn("hashFiles('charter/**/*.py', 'tests/**/*.py')", keys[0])
+        # And the directory that is cached has to be the one the tool writes into. Two
+        # spellings of the same path in two languages is where this silently becomes a
+        # cache of an empty directory that always misses and never says so.
+        paths = [step["with"]["path"] for job in ("plan", "sweep")
+                 for step in self.jobs[job]["steps"] if "cache@" in step.get("uses", "")]
+        self.assertEqual(set(paths), {"${{ runner.temp }}/sweep/cache"})
+        for job, step in (("plan", "How many mutations, and how many jobs they need"),
+                          ("sweep", "Sweep the guards this branch adds")):
+            self.assertIn('--workdir "$RUNNER_TEMP/sweep"', self._run(job, step))
+        with tempfile.TemporaryDirectory() as tmp:
+            here = Path(tmp) / "sweep"
+            # `Path.resolve` and not `sweep.resolved`: comparing the tool against its own
+            # spelling of a path would agree with whatever that spelling became, and the
+            # bug this pins is the two languages disagreeing (#572 was that, on macOS,
+            # where `$TMPDIR` goes through `/var -> /private/var`).
+            self.assertEqual(sweep.workdir_for(Path(tmp), str(here)), here.resolve())
+
+    def test_nothing_the_sweep_writes_needs_more_than_a_read_only_token(self):
+        """The reason the answer is a name and not a `neutral` conclusion: `neutral` needs
+        `checks: write`, in the job that runs this repository's own code against mutated
+        copies of it."""
+        self.assertEqual(self.wf["permissions"], {"contents": "read"})
 
 
 class TheGateNeverChargesTheWholeTree(unittest.TestCase):

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -50,11 +50,20 @@ question should be "did my test look closely enough", not "can I suppress this".
 
 Stdlib only. `pyproject.toml` says ``dependencies = []`` and that is load-bearing.
 
+**And it says which of three things it found.** A gate that blocks nothing still has to
+say something, and reporting `success` on a branch with eight survivors under it says the
+opposite of what the job exists for. Completed-and-clean, completed-with-N-survivors, and
+*did not complete* are three answers, they are not two, and the last of them is what a
+sweep spread over several machines has to be able to report when one of them is cancelled.
+
     python3 tools/sweep.py                      # this branch, against its merge-base
     python3 tools/sweep.py --ref 5b02b3f        # some other commit
     python3 tools/sweep.py --path tools         # sweep the sweep
     python3 tools/sweep.py --all                # the whole tree, as a number
     python3 tools/sweep.py --gate               # as CI runs it (stage C)
+    python3 tools/sweep.py --plan               # how many mutations, how many jobs
+    python3 tools/sweep.py --gate --shard 2/3   # one job's slice of that plan
+    python3 tools/sweep.py --verdict shards/ --shards 3      # all of them, added up
 """
 from __future__ import annotations
 
@@ -1584,11 +1593,21 @@ def decide(box, mutation: Mutation, modules: list[str]) -> tuple[str, Outcome, O
     return ("survived" if full.green else "pinned"), subset, full
 
 
-def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str, list[str]],
-          workdir: Path, jobs: int, dirty: dict[str, bytes], second_order: int = 0,
-          log=print, full_timeout: float = FULL_TIMEOUT
-          ) -> tuple[list[Result], list["Pair"]]:
-    """Every mutation, run; every survivor, re-run against the whole suite."""
+def plan_for(root: Path, ref: str, scope: dict[str, set[int]], dirty: dict[str, bytes]
+             ) -> tuple[list[Mutation], dict[str, bytes]]:
+    """Every mutation this branch offers, and the sources they were read from.
+
+    Split out of :func:`sweep` so that the gate can ask *how big is this going to be*
+    without paying for a single test run — the whole answer is `ast`, and it costs a
+    second. #617's plan job runs exactly this and nothing else, which is what lets the
+    job that measures decide how many jobs the measuring needs.
+
+    Extracted for the second reason too, the structural one #572 taught: a rule that
+    lives inside a caller is not reachable from a test, so it cannot be swept, so it is a
+    guard this harness is unable to hold itself to. The order is load-bearing now that
+    more than one machine walks this list — see :func:`shard_of` — so it is a property
+    something has to be able to assert.
+    """
     plan: list[Mutation] = []
     sources: dict[str, bytes] = {}
     for rel, lines in sorted(scope.items()):
@@ -1597,7 +1616,23 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
             continue
         sources[rel] = blob
         plan.extend(mutations_for(rel, blob, lines))
-    log(f"  {len(plan)} mutations across {len(scope)} file(s)")
+    return plan, sources
+
+
+def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str, list[str]],
+          workdir: Path, jobs: int, dirty: dict[str, bytes], second_order: int = 0,
+          log=print, full_timeout: float = FULL_TIMEOUT,
+          shard: tuple[int, int] | None = None
+          ) -> tuple[list[Result], list["Pair"]]:
+    """Every mutation, run; every survivor, re-run against the whole suite."""
+    plan, sources = plan_for(root, ref, scope, dirty)
+    whole = len(plan)
+    if shard is not None:
+        plan = shard_of(plan, *shard)
+        log(f"  {whole} mutations across {len(scope)} file(s); "
+            f"shard {shard[0]} of {shard[1]} takes {len(plan)} of them")
+    else:
+        log(f"  {whole} mutations across {len(scope)} file(s)")
     if not plan:
         return [], []
 
@@ -1894,7 +1929,12 @@ def as_json(results: list[Result]) -> str:
         "modules": r.modules,
         "platform": sys.platform,
         "platform_caveat": platform_caveat(r.mutation),
-        "naming": [] if not r.evidence else [
+        # `null` and not `[]` when the evidence pass never ran, because the two say
+        # different things and the report prints them differently: "nothing measured
+        # executes this file" against "N modules execute it and not one names the symbol".
+        # A shard writes this file and another machine reads it (#617), so an absence that
+        # arrives as an empty list is an absence that arrives as the wrong answer.
+        "naming": None if r.evidence is None else [
             {"module": m, "test": t, "asserts": a} for m, t, a in r.evidence.naming],
     } for r in results], indent=1)
 
@@ -1991,6 +2031,303 @@ def gate_exit_code(gate: Gate, enforce: bool) -> int:
     return 3 if gate.unresolved else 0
 
 
+# --------------------------------------------------------------------------------------
+# 8a. Sizing the gate — how many jobs this branch's mutations need (#617)
+# --------------------------------------------------------------------------------------
+#
+# Two of the last three substantial branches could not finish the gate at all: #608's 62
+# mutations were cancelled at `timeout-minutes: 60` twice, and #626's 78 were cancelled
+# three times, each run reaching roughly 53 of them. The job had been sized against the
+# 30–52 that Phase 2's branches produced, and `retune-string` roughly doubles the count on
+# any diff that touches string constants — which a guard table and a config reader are
+# made of almost nothing else.
+#
+# The one answer that was never available is "sweep fewer of them". A cap on the mutation
+# count reads, to everyone downstream, as "covered everything" — the spec says so about
+# silent truncation and it is the same lie the whole harness exists to refuse. So NOTHING
+# below drops a mutation. The numbers here size the *fan-out*: how many machines the same
+# complete question is spread across.
+
+#: What one shard is allowed to spend on mutations and fixed costs together, in seconds.
+#: Deliberately under `sweep.yml`'s `timeout-minutes`, because the two failures are not
+#: symmetrical: a shard that finishes with time to spare costs a few runner-minutes, and a
+#: shard cancelled at the cap reports *nothing at all* — not a partial answer, not the
+#: survivors it had already printed, nothing the merge step can read.
+SHARD_BUDGET = 40 * 60
+
+#: What a shard pays before it measures its first mutation. Measured on `ubuntu-latest`
+#: and not on a workstation, because that is where the budget has to hold:
+#:
+#: * checkout at ``fetch-depth: 0`` and the interpreter — 3 s;
+#: * the selection map, traced — **250 s**, and restored from cache — under 5 s;
+#: * the sandbox clone — about 15 s;
+#: * the unmutated baseline — about 240 s, the same 7,693 tests `test.yml` runs in 4 min.
+#:
+#: The baseline is the expensive half and it is not negotiable: a shard that skips it
+#: cannot tell a survivor from a tree that was already red, which is the spec's second way
+#: a sweep lies. So every shard buys its own — the marginal cost of a machine.
+#:
+#: The map is the half that CAN be shared, and `sweep.yml` warms it once for all of them.
+#: This constant is deliberately the NO-CACHE figure anyway, and rounded up past even
+#: that: a pull request from a fork cannot write that cache, and a budget that only holds
+#: when the cache hits is a budget that fails on exactly the runs nobody is watching.
+SHARD_FIXED = 12 * 60
+
+#: What one mutation costs a shard. Read off the runs that ran out of time rather than off
+#: a workstation: #626 reached about 53 of its 78 inside the hour, and the fixed cost of a
+#: run with no map cache was about 515 s, which leaves **58 s** each. A workstation
+#: measures 24 s at `--jobs 3`; CI is slower and the gate must be sized against CI.
+#:
+#: Together: 78 mutations over the three shards this sizing asks for is 26 each, so
+#: 515 + 26×58 ≈ 34 min with no cache and under 30 with one — inside the budget, and well
+#: inside `sweep.yml`'s hour.
+SECONDS_A_MUTATION = 60
+
+#: The most jobs one pull request may fan out to. Not a limit on what gets swept — every
+#: mutation is still dealt to a shard past this point, they just get more each — but a
+#: limit on how much of the runner pool one branch may hold at once.
+MAX_SHARDS = 8
+
+
+def per_shard() -> int:
+    """How many mutations one shard can measure inside :data:`SHARD_BUDGET`."""
+    return max(1, (SHARD_BUDGET - SHARD_FIXED) // SECONDS_A_MUTATION)
+
+
+def shards_for(mutations: int) -> int:
+    """How many jobs *mutations* of them need, so that none of them runs out of time.
+
+    At least one, always: a branch with nothing to sweep still gets a job, because "the
+    sweep ran and found nothing to do" and "the sweep did not run" are the two answers
+    #617 is about and they must not arrive as the same silence.
+    """
+    return max(1, min(MAX_SHARDS, -(-mutations // per_shard())))
+
+
+def over_budget(mutations: int) -> str:
+    """Why this diff will be slow, said out loud, or ``""`` when it will not be.
+
+    :data:`MAX_SHARDS` is a ceiling on machines and never on questions, so a diff past it
+    is still swept whole — its shards simply carry more than the budget and some of them
+    may be cancelled. That is a real risk to the run and it gets said here rather than
+    discovered in a cancelled job: the spec's rule about silent truncation is that a cap
+    the reader cannot see is worse than the cap.
+    """
+    ceiling = MAX_SHARDS * per_shard()
+    if mutations <= ceiling:
+        return ""
+    return (f"{mutations} mutations is past the {ceiling} that {MAX_SHARDS} shards can "
+            f"measure inside {SHARD_BUDGET // 60} minutes each. Every one of them is "
+            f"still swept — nothing here is dropped — but a shard may be cancelled at "
+            f"the job timeout, and a cancelled shard reports no verdict rather than a "
+            f"short one.")
+
+
+def shard_of(plan: list[Mutation], index: int, count: int) -> list[Mutation]:
+    """Slice *index* of *count*, dealt one mutation at a time across the whole plan.
+
+    **Dealt, and not cut by file** — which is the correction the numbers forced on #617's
+    own proposal. Sharding by file sounds right and does nothing here: both diffs that ran
+    out of time were dominated by a *single new file*, so a job-per-file hands one job all
+    78 of `gitconfig.py`'s mutations and the other jobs nothing. Round-robin also spreads
+    the expensive ones, and they arrive in clumps — a survivor costs a full suite run
+    where a red costs seconds, and survivors cluster inside the function that has no test.
+
+    *index* is 1-based because it is a job number a person reads on a check ("shard 2 of
+    3"), and off-by-one here does not fail loudly: it silently sweeps one slice twice and
+    another not at all, and the merge step would report a complete sweep of an incomplete
+    plan. So it is refused rather than clamped.
+    """
+    # One comparison and not two: `count < 1` as a separate clause is unreachable, because
+    # no *index* can satisfy `1 <= index <= 0` either. A second guard that can never be the
+    # one that fires is a line the suite would not miss, and this file's own rule is that
+    # such a line gets deleted rather than kept for shape.
+    if not 1 <= index <= count:
+        raise ValueError(f"shard {index} of {count} is not a shard")
+    return plan[index - 1::count]
+
+
+# --------------------------------------------------------------------------------------
+# 8b. The conclusion — the three things a gate run can have found (#617)
+# --------------------------------------------------------------------------------------
+#
+# A gate that blocks nothing still has to SAY something, and until #617 this one did not.
+# It reported `success` on a branch with eight survivors under it, which to anyone who
+# does not open the run summary reads as "this branch is clean" — the exact opposite of
+# what the job exists to say. A run that was cancelled at the timeout reported `cancelled`,
+# which reads as infrastructure noise rather than as a missing answer.
+#
+# **GitHub's vocabulary cannot express this, and that is why the answer is not a
+# conclusion.** A job driven by a `run:` step concludes `success` or `failure` and nothing
+# else; `neutral` — the one conclusion that means "I looked, here is what I found, this is
+# not a pass/fail" — exists only on the Checks API, which needs `checks: write` and a
+# check run created by hand. `sweep.yml`'s header refuses that in as many words: this job
+# runs the repository's own code against mutated copies of it, and is the last place in
+# the repository to hold a writable token. Trading that for a prettier icon is not a trade
+# worth making.
+#
+# So the conclusion stays `success` and the *check's name* carries the answer. A job name
+# can interpolate `needs.<job>.outputs.*`, so a one-step job that does nothing but exist
+# renders on the pull request as `deletion sweep / 8 survivors` — green, blocking nothing,
+# and no longer silent. The survivors additionally arrive as annotations on the lines they
+# are about, which is where a reviewer is already looking.
+
+#: Completed, and every mutation this branch offered goes red.
+CLEAN = "clean"
+#: Completed, and N of them do not. The interesting case, and the one that was
+#: indistinguishable from `CLEAN` on the pull request until #617.
+SURVIVORS = "survivors"
+#: Did not complete. A shard that never reported, a mutation that timed out, or an edit
+#: that never reached the tree — three spellings of the same thing, which is that the
+#: numbers on this page are not an answer about this branch.
+NO_VERDICT = "no-verdict"
+
+
+def gate_conclusion(gate: Gate, missing: int = 0) -> str:
+    """Which of the three a run found. *missing* is shards that never reported.
+
+    The precedence is :func:`gate_exit_code`'s, deliberately — 4 outranks 1 outranks 3 —
+    because the two answers are the same answer in two vocabularies and a branch that
+    disagreed with itself about which would be worse than either. A shard that never
+    reported joins `unapplied` at the top: both mean the counts below are not evidence.
+
+    Survivors outrank an unresolved mutation and do not outrank a missing shard. That is
+    not a severity ranking, it is what each one licenses a reader to believe: "8
+    survivors, 2 not measured" is still a true statement about 8 real findings, whereas
+    "8 survivors" from two thirds of a plan is a number nobody should quote.
+    """
+    if missing or gate.unapplied:
+        return NO_VERDICT
+    if gate.actionable:
+        return SURVIVORS
+    return NO_VERDICT if gate.unresolved else CLEAN
+
+
+def _plural(n: int, one: str, many: str) -> str:
+    return f"{n} {one if n == 1 else many}"
+
+
+def headline(gate: Gate, missing: int = 0, shards: int = 1) -> str:
+    """The answer in one line, short enough to be a check's NAME.
+
+    This string is the whole fix for "a green gate is not no survivors": it is what the
+    pull request's check list says next to the tick, so the count is readable without
+    opening a run summary, downloading an artifact, or knowing the job exists.
+
+    *shards* below one means the run never got as far as deciding how many it needed, and
+    that is said as itself rather than as "1 of 1 did not report" — a denominator nobody
+    computed is not a denominator, and inventing one here would describe a sweep that was
+    never planned as a sweep that was planned and lost.
+    """
+    conclusion = gate_conclusion(gate, missing)
+    if conclusion == CLEAN:
+        return "no survivors"
+    found = _plural(len(gate.actionable), "survivor", "survivors")
+    unsure = []
+    if missing:
+        unsure.append(f"{missing} of {_plural(shards, 'shard', 'shards')} did not report"
+                      if shards >= 1 else "the sweep never sized itself")
+    if gate.unapplied:
+        unsure.append(f"{_plural(len(gate.unapplied), 'mutation', 'mutations')} never "
+                      "applied")
+    if gate.unresolved:
+        unsure.append(f"{len(gate.unresolved)} not measured")
+    if conclusion == SURVIVORS:
+        return f"{found}, {'; '.join(unsure)}" if unsure else found
+    if gate.actionable:
+        return f"no verdict: {found} so far, {'; '.join(unsure)}"
+    return f"no verdict: {'; '.join(unsure)}"
+
+
+#: How many annotations of one LEVEL, per step, GitHub will draw before it stops. Not per
+#: kind of finding — three of the families below are all warnings, and they share this one
+#: budget. Going past it is not an error and produces no warning: the extras are simply
+#: not there, which is the silent-truncation shape again, so the cap announces itself in
+#: the annotation stream — and reserves one of its own slots to do it, because the note
+#: saying "and eleven more" is otherwise the first thing the cap eats.
+ANNOTATION_CAP = 10
+
+
+def _escape(text: str) -> str:
+    """A workflow command's message, with the three characters that would end it early."""
+    return text.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _property(text: str) -> str:
+    """A workflow command's *property* value — two more characters than a message.
+
+    A `,` starts the next property and a `:` can close the property list early, so a file
+    path with either in it would silently annotate the wrong place, or nothing. Escaped
+    rather than trusted: these are paths and questions out of the tree, not constants.
+    """
+    return _escape(text).replace(":", "%3A").replace(",", "%2C")
+
+
+def _annotation(level: str, r: Result, title: str, body: str) -> str:
+    m = r.mutation
+    return (f"::{level} file={_property(m.path)},line={m.line},endLine={m.end_line},"
+            f"title={_property(title)}::{_escape(body)}")
+
+
+def annotations(gate: Gate) -> list[str]:
+    """One workflow command per finding, so a survivor lands ON THE LINE it is about.
+
+    The check's name says how many there are; this says where. A reviewer reading the
+    diff sees the marker in the margin of the guard itself, which is the one place the
+    question "did my test look closely enough" can actually be answered — and none of it
+    changes the job's conclusion, so the gate goes on blocking nothing.
+
+    The families are in the order they should survive :data:`ANNOTATION_CAP`, because they
+    share a level's budget and the ones past it are not drawn: a masked cluster before a
+    lone survivor, because two guards hiding each other is the finding a reviewer is least
+    able to reach on their own; both before an unmeasured mutation, which is a fact about
+    the runner rather than about the branch.
+    """
+    families = (
+        ("error", gate.unapplied, "Sweep defect — the mutation never applied",
+         "The edit never reached the tree, so the run that followed measured the "
+         "UNMUTATED file and would have called this a survivor. Every number on this "
+         "sweep is suspect until it is zero."),
+        ("warning", gate.masked, "Masked cluster — two guards hiding each other",
+         "Another survivor shares this function. Two guards in sequence each look "
+         "equivalent alone, so neither is pinned and they are read together."),
+        ("warning", gate.unpinned, "Unpinned guard — no test goes red without this line",
+         "Deleting it leaves the suite green. Write the test, or delete the line — "
+         "\"equivalent mutant\" and \"dead code\" are one finding."),
+        ("warning", gate.unresolved, "No verdict — this mutation was never measured",
+         "The run timed out rather than failing. That is not a red and it is not a pin; "
+         "nothing here has been shown to be tested."),
+        ("notice", gate.platform, "Platform-deferred — never fails this gate",
+         f"A narrowed catch on an exception the operating system decides. On "
+         f"{sys.platform} the clause may be unreachable rather than untested, and one "
+         f"machine cannot tell those apart."),
+    )
+    total: dict[str, int] = {}
+    for level, results, _, _ in families:
+        total[level] = total.get(level, 0) + len(results)
+    # One slot back when a level is over budget, for the note that says so. Spending all
+    # ten on findings and adding the note as an eleventh loses the note — which is the
+    # one line that has to arrive, because it is the difference between "these ten" and
+    # "these ten of twenty-two".
+    room = {level: ANNOTATION_CAP - 1 if n > ANNOTATION_CAP else ANNOTATION_CAP
+            for level, n in total.items()}
+    out: list[str] = []
+    drawn: dict[str, int] = {}
+    for level, results, title, body in families:
+        for r in sorted(results, key=lambda r: (r.mutation.path, r.mutation.line)):
+            if drawn.get(level, 0) >= room[level]:
+                break
+            drawn[level] = drawn.get(level, 0) + 1
+            out.append(_annotation(level, r, title, f"{r.mutation.question} — {body}"))
+    for level, n in total.items():
+        if n > ANNOTATION_CAP:
+            out.append(f"::{level} title=Not every finding is drawn here::" + _escape(
+                f"{n - room[level]} of these {n} are not shown — GitHub draws "
+                f"{ANNOTATION_CAP} annotations of one level per step and then stops "
+                f"without saying so. The run summary lists all {n}."))
+    return out
+
+
 def _summary_rows(results: list[Result]) -> list[str]:
     """One markdown bullet per survivor, carrying WHAT THE COVERING TESTS ASSERT.
 
@@ -2023,21 +2360,32 @@ def _summary_rows(results: list[Result]) -> list[str]:
     return out
 
 
-def gate_summary(gate: Gate, ref: str, base: str, elapsed: float,
-                 enforce: bool) -> str:
+def gate_summary(gate: Gate, ref: str, base: str, elapsed: float | None,
+                 enforce: bool, missing: int = 0, shards: int = 1) -> str:
     """The markdown a reviewer reads on the pull request."""
     out: list[str] = []
     w = out.append
     verdict = ("**would fail**" if gate.actionable or gate.unapplied
                else "**would pass**")
-    w(f"## Deletion sweep — {len(gate.actionable)} actionable survivor(s)")
+    # The headline and not the count, and the same string the check is NAMED with. A page
+    # whose title disagreed with the row on the pull request would be worse than either of
+    # them alone, so there is one sentence and both readers get it.
+    w(f"## Deletion sweep — {headline(gate, missing, shards)}")
     w("")
+    # No wall clock when the answer was merged rather than measured: the step that adds
+    # up several machines' results took a second and did not spend the sweep's time, and
+    # printing its own second there would understate a forty-minute run by two orders of
+    # magnitude on the one line a reader skims.
+    took = f"{elapsed / 60:.1f} min" if elapsed is not None else "merged from its shards"
     w(f"`{ref[:12]}` against `{base[:12]}`, added lines only, "
-      f"{elapsed / 60:.1f} min on {sys.platform} / CPython "
+      f"{took} on {sys.platform} / CPython "
       f"{'.'.join(str(n) for n in sys.version_info[:3])}.")
     w("")
     w("| outcome | n | what it means |")
     w("|---|---:|---|")
+    if missing:
+        w(f"| **did not report** | {f'{missing} of {shards}' if shards >= 1 else '?'} | "
+          "a shard that never wrote a result — read nothing below as a count |")
     w(f"| pinned | {gate.pinned} | a test goes red without the line |")
     w(f"| **unpinned** | {len(gate.unpinned)} | a guard with no test behind it |")
     w(f"| **masked cluster** | {len(gate.masked)} | two or more in one function; "
@@ -2054,6 +2402,21 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float,
         w(f"> **Reporting only.** This job blocks nothing; it {verdict} with `--enforce`. "
           "The spec's own staging argument says a gate whose numbers nobody has seen gets "
           "disabled the first time it is inconvenient, so the numbers come first.")
+        w("")
+    if missing:
+        w("### Did not report — this page is not a count")
+        w("")
+        if shards >= 1:
+            w(f"{missing} of {shards} shard(s) wrote no result. A shard is cancelled at "
+              "the job timeout rather than stopping short, so what it had already "
+              "measured is gone with it — the tables below are the shards that *did* "
+              "answer, and a branch with survivors in the missing slice looks exactly "
+              "like this one. Re-run the sweep; do not read it as clean.")
+        else:
+            w("The sweep **never said how many shards it needed**, so nothing here knows "
+              "how much of this branch was measured, or whether any of it was. That is "
+              "the job that sizes the sweep failing before it sized anything — and it is "
+              "**no verdict**, not a clean one.")
         w("")
     if gate.unapplied:
         w("### Not applied — read nothing else on this page until this is zero")
@@ -2095,10 +2458,77 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float,
         for r in gate.unresolved:
             w(f"- `{r.mutation.tag}` in `{r.mutation.symbol}`")
         w("")
-    if not gate.actionable and not gate.unapplied and not gate.unresolved:
+    if gate_conclusion(gate, missing) == CLEAN:
         w("Every mutation this branch offered goes red. Nothing added here is a line the "
           "suite would not miss.")
     return "\n".join(out)
+
+
+# --------------------------------------------------------------------------------------
+# 8c. Merging shards back into one answer (#617)
+# --------------------------------------------------------------------------------------
+
+def results_from_json(payload: str) -> list[Result]:
+    """A shard's results, read back from what :func:`as_json` wrote.
+
+    The gate is one question answered on several machines, so the answer has to survive a
+    round trip through a file — and everything :func:`classify` and :func:`_summary_rows`
+    read has to survive it, not merely the verdict string. `platform_caveat` is recomputed
+    from the operator and the shipped source rather than trusted from the file, so a shard
+    that ran on a different platform than the merge cannot smuggle its own answer in.
+    """
+    def outcome(o: dict | None) -> Outcome | None:
+        return None if not o else Outcome(o["green"], o["ran"], o["detail"])
+
+    out: list[Result] = []
+    for row in json.loads(payload):
+        m = Mutation(path=row["path"], line=row["line"], end_line=row["end_line"],
+                     operator=row["operator"], question=row["question"],
+                     before=row["before"], after=row["after"], symbol=row["symbol"])
+        # `null` means the evidence pass never ran, which is not the same as running and
+        # finding nothing: `_summary_rows` tells "nothing measured executes this file"
+        # from "N modules execute it and not one names the symbol" by exactly that field,
+        # and a round trip that flattened the two would report the wrong one.
+        evidence = None
+        if row["naming"] is not None:
+            evidence = Evidence(row["modules"],
+                                [(n["module"], n["test"], n["asserts"])
+                                 for n in row["naming"]])
+        out.append(Result(m, row["verdict"], outcome(row["subset"]), outcome(row["full"]),
+                          row["modules"], evidence))
+    return out
+
+
+def merge(directory: Path, shards: int) -> tuple[list[Result], int]:
+    """Every shard's results, and how many shards did not report.
+
+    Counted, not named: the merge asks *how many of the answers arrived*, and answering
+    that by parsing shard numbers out of filenames would put the workflow's shell quoting
+    and this function's regex in a position to disagree — which is a way to report a
+    complete sweep of an incomplete plan. A file is one shard's answer if it parses, and
+    a file that will not parse is a shard that did not report; there is no third reading
+    of a truncated upload.
+    """
+    results: list[Result] = []
+    reported = 0
+    for f in sorted(Path(directory).glob("*.json")) if Path(directory).is_dir() else []:
+        try:
+            results.extend(results_from_json(f.read_text(encoding="utf-8")))
+        except (OSError, ValueError, KeyError, TypeError):
+            continue
+        reported += 1
+    return results, max(0, shards - reported)
+
+
+def verdict_exit_code(gate: Gate, missing: int, enforce: bool) -> int:
+    """What the merge step exits with. **Zero until somebody turns it on**, as before.
+
+    A shard that never reported is the same answer as a mutation that never resolved —
+    *no verdict*, exit 3 — and for the same reason: the run has not shown the branch to
+    be clean, and "I could not look" must not render as "nothing to see".
+    """
+    code = gate_exit_code(gate, enforce)
+    return 3 if enforce and missing and code == 0 else code
 
 
 # --------------------------------------------------------------------------------------
@@ -2175,6 +2605,37 @@ def timeout_for(measured: float) -> float:
     return max(FULL_TIMEOUT, measured * 6)
 
 
+def parse_shard(text: str) -> tuple[int, int]:
+    """``"2/3"`` as ``(2, 3)``. Anything else is refused rather than guessed at.
+
+    A shard argument that parses loosely is a shard that runs the wrong slice, and a
+    wrong slice does not fail: it sweeps some mutations twice and others never, and the
+    merge step reports a whole plan. So `2`, `2/`, `0/3` and `4/3` are all errors here,
+    where they would all be survivable further in.
+    """
+    index, sep, count = str(text).partition("/")
+    if not sep or not index.strip().isdigit() or not count.strip().isdigit():
+        raise ValueError(f"--shard wants N/M, not {text!r}")
+    pair = (int(index), int(count))
+    if not 1 <= pair[0] <= pair[1]:
+        raise ValueError(f"--shard {text} is not a shard of anything")
+    return pair
+
+
+def expected_shards(text: str | None) -> int:
+    """How many shards the plan asked for, or ``0`` when the plan never said.
+
+    An empty value is not "no shards were needed" — it is a plan job that never got as
+    far as sizing itself, which is the loudest failure this workflow has. Reading it as
+    zero would turn that into the quietest kind of pass, which is the whole of #617.
+    """
+    try:
+        n = int(str(text).strip())
+    except (TypeError, ValueError, AttributeError):
+        return 0
+    return n if n > 0 else 0
+
+
 def exit_code(results: list[Result]) -> int:
     """What a plain (non-gate) run exits with.
 
@@ -2227,7 +2688,34 @@ def main(argv: list[str] | None = None) -> int:
                    help="Append the gate's markdown to this file — $GITHUB_STEP_SUMMARY "
                         "on CI, so the numbers are on the pull request rather than in a "
                         "log nobody opens.")
+    p.add_argument("--plan", action="store_true",
+                   help="Say how many mutations this branch offers and how many jobs "
+                        "they need, then stop. Costs one `ast` pass and no test runs.")
+    p.add_argument("--warm-map", action="store_true", dest="warm_map",
+                   help="Measure the selection map into --workdir and stop, so that the "
+                        "shards restore it instead of each measuring it again.")
+    p.add_argument("--shard", default=None, metavar="N/M",
+                   help="Sweep only slice N of M, dealt one mutation at a time across "
+                        "the whole plan. Nothing is dropped: the other slices are other "
+                        "jobs. --second-order sees only its own slice and is weaker "
+                        "under it; the masked-cluster BUCKET is not, because --verdict "
+                        "classifies the merged results and not one shard's.")
+    p.add_argument("--verdict", default=None, metavar="DIR",
+                   help="Merge every shard's --json from DIR into one answer, and say "
+                        "which of the three a run found. Needs --shards.")
+    p.add_argument("--shards", default=None, metavar="N",
+                   help="How many shards --verdict should have heard from. An empty or "
+                        "unreadable value is a sweep that never sized itself, which is "
+                        "no verdict and not a clean one.")
+    p.add_argument("--annotate", action="store_true",
+                   help="Print each finding as a GitHub workflow command, so a survivor "
+                        "lands on the line of the diff it is about.")
+    p.add_argument("--github-output", default=None, metavar="PATH", dest="github_output",
+                   help="Append `key=value` lines here — $GITHUB_OUTPUT on CI, which is "
+                        "how the check that carries the answer gets its NAME.")
     args = p.parse_args(argv)
+    if args.verdict:
+        return _merge_step(args)
     if args.gate and args.all:
         p.error("--gate charges the lines a branch added; --all charges the whole tree. "
                 "The gate never sweeps the whole tree — that is stage B, and it is a "
@@ -2259,11 +2747,19 @@ def main(argv: list[str] | None = None) -> int:
         scope = added_lines(root, base, ref, paths)
         log(f"  diff against {base[:12]}: {len(scope)} file(s), "
             f"{sum(len(v) for v in scope.values())} added line(s)")
+    if args.plan or args.warm_map:
+        return _plan_step(args, root, ref, scope, dirty, workdir, cache_dir, log)
     if not scope:
         log("  nothing under the swept paths changed. Nothing to do.")
         if args.summary:
             _append(args.summary, "## Deletion sweep\n\nNothing under the swept paths "
                                   "changed on this branch, so there was nothing to sweep.\n")
+        # An empty result set and not a missing file. Downstream — the merge step, and
+        # anyone reading the artifact — "the sweep ran and found nothing to do" and "the
+        # sweep never reported" are the two answers #617 is about, and a shard that
+        # writes nothing here is indistinguishable from a shard that was cancelled.
+        if args.json:
+            Path(args.json).write_text(as_json([]))
         return 0
 
     # The map is measured on a clean checkout of the ref, so that a mutation is the only
@@ -2301,7 +2797,8 @@ def main(argv: list[str] | None = None) -> int:
             return 2 if args.enforce or not args.gate else 0
 
     results, pairs = sweep(root, ref, scope, selection, workdir, args.jobs, dirty,
-                           args.second_order, log, full_timeout)
+                           args.second_order, log, full_timeout,
+                           parse_shard(args.shard) if args.shard else None)
     elapsed = time.time() - started
     text = report(results, root, ref, base, baseline, elapsed, pairs)
     log("")
@@ -2318,13 +2815,114 @@ def main(argv: list[str] | None = None) -> int:
     gate = classify(results)
     if args.summary:
         _append(args.summary, gate_summary(gate, ref, base, elapsed, args.enforce))
+    _say(args, gate, log)
+    return gate_exit_code(gate, args.enforce)
+
+
+def _say(args, gate: Gate, log, missing: int = 0, shards: int = 1) -> None:
+    """The counts, the one-line answer, and the annotations — in that order.
+
+    The headline is printed on every gate run and not only the sharded one. A local
+    `--gate` and CI are answering the same question, and the value of one sentence that
+    means the same thing everywhere is that nobody has to learn two vocabularies to read
+    the same sweep twice.
+    """
     log("")
     log(f"gate: {len(gate.unpinned)} unpinned, {len(gate.masked)} in masked cluster(s), "
         f"{len(gate.platform)} platform-deferred, {len(gate.unresolved)} unresolved, "
         f"{len(gate.unapplied)} not applied, {gate.pinned} pinned")
+    log(f"gate: {headline(gate, missing, shards)}")
     if not args.enforce:
         log("gate: reporting only — nothing here blocks. Pass --enforce to make it.")
-    return gate_exit_code(gate, args.enforce)
+    if args.annotate:
+        for line in annotations(gate):
+            log(line)
+    _write_output(args.github_output,
+                  conclusion=gate_conclusion(gate, missing),
+                  headline=headline(gate, missing, shards))
+
+
+def _write_output(path: str | None, **values: str) -> None:
+    """`key=value` into `$GITHUB_OUTPUT`, one line each.
+
+    Single-line values only, and every value here is one by construction — :func:`headline`
+    exists to be short. A value with a newline in it would need the heredoc form, and a
+    caller that got that wrong would inject workflow outputs rather than set one, so a
+    newline is refused instead of encoded.
+    """
+    if not path:
+        return
+    lines = []
+    for key, value in values.items():
+        if "\n" in value or "\r" in value:
+            raise ValueError(f"{key} is not a single line: {value!r}")
+        lines.append(f"{key}={value}")
+    _append(path, "\n".join(lines))
+
+
+def _plan_step(args, root: Path, ref: str, scope: dict[str, set[int]],
+               dirty: dict[str, bytes], workdir: Path, cache_dir: Path,
+               log) -> int:
+    """Size the sweep, and optionally leave the selection map where the shards will find it.
+
+    This is the job that decides how many jobs the gate needs, and it is cheap on purpose:
+    the mutation count is an `ast` pass over the diff, so the decision costs a second and
+    is made from the real number rather than from a guess about how big branches get. The
+    guess is exactly what ran out — the job was sized against Phase 2's 30–52 mutations
+    and met 78.
+    """
+    plan, _ = plan_for(root, ref, scope, dirty)
+    shards = shards_for(len(plan))
+    log(f"  {len(plan)} mutations → {shards} shard(s) of at most {per_shard()} each")
+    loud = over_budget(len(plan))
+    if loud:
+        # An annotation and not a log line. A cap nobody can see is the failure the spec
+        # names about silent truncation, and a warning in a fold nobody opens is a cap
+        # nobody can see.
+        log(f"::warning title={_property('The deletion sweep is over its budget')}::"
+            + _escape(loud))
+    _write_output(args.github_output, mutations=str(len(plan)), shards=str(shards),
+                  matrix=json.dumps(list(range(1, shards + 1))))
+    if args.warm_map:
+        # From a sandbox, for the reason `main` builds it from one: the map is measured on
+        # a clean checkout of the ref so that a mutation is the only thing that ever
+        # differs from what was traced. The cache is keyed on the tree's own hash, so the
+        # shards find this one only if they are asking about the very same tree.
+        log("  warming the selection map for the shards…")
+        box = Sandbox(root, run_dir(workdir) / "map", ref, dirty)
+        load_map(box.path, tuple(args.paths or DEFAULT_PATHS), cache_dir, args.jobs,
+                 args.refresh_map, log)
+        shutil.rmtree(run_dir(workdir), ignore_errors=True)
+    return 0
+
+
+def _merge_step(args) -> int:
+    """One answer for a sweep that ran on several machines.
+
+    The merge and not the shards is where the pull request gets told anything, and that
+    is the point: a shard writes a result file and says nothing, so there is exactly one
+    place that decides what this branch is told and exactly one sentence it says. Before
+    #617 there were N step summaries and no sentence at all.
+    """
+    shards = expected_shards(args.shards)
+    results, missing = merge(Path(args.verdict), max(shards, 1))
+    # `shards` stays 0 when the plan never answered, and travels that way: everything
+    # downstream renders "how many did not report" differently from "how many there were
+    # supposed to be is not known", and flattening the second into `1 of 1` would report
+    # a sweep that was never planned as a sweep that was planned and lost one shard.
+    if not shards:
+        missing = max(missing, 1)
+    gate = classify(results)
+    if args.summary:
+        # "merge-base" and not "the merge-base": the header shortens a sha to twelve
+        # characters, and a fallback longer than that comes out clipped mid-word.
+        _append(args.summary, gate_summary(gate, args.ref, args.base or "merge-base",
+                                           None, args.enforce, missing, shards))
+    print(f"merged {len(results)} result(s) from "
+          f"{f'{shards - missing} of {shards}' if shards else 'an unknown number of'} "
+          f"shard(s)")
+    _say(args, gate, print, missing, shards)
+    return verdict_exit_code(gate, missing, args.enforce)
 
 
 def _append(path: str, text: str) -> None:


### PR DESCRIPTION
Closes #617.

The sweep gate had two defects. The quieter one was worse.

## 1. A green check was not "no survivors"

The gate reports and blocks nothing — `--enforce` is deliberately absent and **stays absent** — but a job that blocks nothing still has to *say* something, and this one concluded `success` whatever it found. #621's branch went green with **eight survivors** under it.

**GitHub's conclusion vocabulary cannot express the difference, so the answer is not a conclusion.** A `run:`-driven job concludes `success` or `failure` and nothing else. The one conclusion that means *I looked, here is the count, this is not a pass or a fail* — `neutral` — exists only on the Checks API, which needs `checks: write` and a check run created by hand. `sweep.yml`'s header already refuses that in as many words: this job runs the repository's own code against mutated copies of it and is the last place to hold a writable token. Trading that for a prettier icon is not a trade worth making.

So the **check's name** carries it. A job name may interpolate `needs.<job>.outputs.*`, so a final one-step job renders on the pull request as one of:

```
deletion sweep / no survivors
deletion sweep / 8 survivors
deletion sweep / no verdict: 2 of 3 shards did not report
deletion sweep / no verdict: the sweep never sized itself
```

**All of them green.** Distinguishing the states is not the same as failing on them. This is live on this pull request already — the check below is literally named `no survivors`.

Every survivor is also an **annotation on the line it is about** — in the margin of the guard, on the Files-changed tab, carrying the question it failed. Platform-deferred survivors are `::notice` rather than `::warning`, because the gate never fails on one of those and should not shout about one either. GitHub draws ten annotations of a level per step and then stops silently, so the tenth slot is reserved for the line that says how many were not drawn.

## 2. It ran out of time

#608's 62 mutations were cancelled at the hour twice; #626's 78 three times, each reaching about two thirds of its plan. The job was sized against Phase 2's 30–52, and `retune-string` roughly doubles the count on a diff full of string constants.

**Nothing is dropped to make a branch fit.** A cap on the mutation count would read, downstream, as "covered everything" — the silent truncation the spec refuses. What is capped is the **fan-out**. A `plan` job counts the mutations in one `ast` pass over the diff (no test runs), sizes the sweep from the real number, and the shards run in parallel. Past even the ceiling the plan emits a warning annotation and still sweeps every mutation.

**Dealt one mutation at a time, and not split by file** — the correction the numbers force on the issue's own proposal. Both over-budget diffs were dominated by a *single new file*, so a job-per-file hands one job all 78 of `gitconfig.py`'s mutations and the others nothing. The masked-cluster bucket survives round-robin because `--verdict` classifies the **merged** results, not one shard's; there is a test for exactly that.

### Measured on `ubuntu-latest`, not on a workstation

| | measured |
|---|---|
| checkout at `fetch-depth: 0` + interpreter | 3 s |
| selection map, traced | **250 s** (`Size the sweep` step, 4 m 13 s end to end) |
| selection map, restored from cache | under 5 s |
| sandbox clone | ~15 s |
| unmutated baseline | ~240 s — the same 7,693 tests `test.yml` runs in 4 min |
| per mutation | **58 s**, read off #626: ~53 of 78 inside the hour, over a 515 s no-cache fixed cost |

`SHARD_BUDGET` 40 min, `SHARD_FIXED` 12 min → **28 mutations a shard**. 62 → 3 shards, 78 → 3 shards, 28 → 1. `MAX_SHARDS` 8, so the ceiling is 224 and past it the plan says so out loud. 78 over three shards is 26 each: 515 + 26×58 ≈ **34 min** with no cache, under 30 with one — inside the budget and well inside the hour backstop.

The map is warmed once by `plan` and restored by every shard through `actions/cache`. That the map was cached was the issue's premise for sharding, and it **was not true**: `sweep.yml` had no cache step at all, so every run rebuilt it. `SHARD_FIXED` is still the no-cache figure and rounded up past it, because a fork's pull request cannot write that cache and a budget that only holds on a hit fails on exactly the runs nobody is watching.

## What this rests on

One distinction the tool did not make: **a sweep that ran and found nothing, and a sweep that did not run, are different answers.**

- A branch with nothing under the swept paths now writes an **empty** result set rather than none — a file that is absent is indistinguishable from a job that was cancelled. (This branch is that case, which is why its check says `no survivors` and not `no verdict`.)
- A result file that will not parse is a shard that did not report. There is no third reading of a truncated upload.
- An empty shard count from a failed `plan` job reads as *the sweep never sized itself*, not *no shards were needed* — and not as `1 of 1 did not report` either, because a denominator nobody computed is not a denominator.
- `as_json` now writes `"naming": null` rather than `[]` when the evidence pass never ran. Caught by the round-trip test: "nothing measured executes this file" and "one module executes it and does not name the symbol" are different findings, and flattening them reported the wrong one.

## The sweep swept the gate that reports it

119 mutations against `tools/sweep.py`. It found two lines of its own that no test went red without, both now pinned and both hand-checked against a green baseline with a sha256-verified restore:

- **The unsharded path had stopped being tested.** Forcing `if shard is not None` to always-true left every test green — once the shard tests existed, nothing in the suite ran a sweep *without* one. That is how anyone uses `tools/sweep.py` from a terminal.
- **The sizing arithmetic could divide by zero.** The `max(1, …)` in `per_shard` is what stops a fixed cost that outgrew the budget from making mutations-per-shard zero. Deleting it changed no answer today and would have made the plan job raise tomorrow — no plan, no shards, no numbers, which is the #617 failure arriving out of the arithmetic written to prevent it.

A third survivor is not a finding about this code: it is a string inside a **type annotation**, which `from __future__ import annotations` means the interpreter never evaluates, so no test can ever go red without it. That is a blind spot in `retune-string`'s scoping rather than a guard, and it is filed as **#632** instead of being worked around here.

## Not regressed

Survivors still sort into unpinned / masked cluster / platform-deferred / unresolved / not-applied; platform-deferred still never fails; `UNRESOLVED` is still its own outcome; a survivor still reports what the covering tests assert; every mutation still asserts it applied; sandboxes are still private per run. `--enforce` is still the single flag, now on the `collect` step, and a test refuses it in any non-comment line of the workflow.

## Verification

- **270 cases in `tests/test_sweep.py`** (from 193), literals pinned rather than recomputed from the constants under test. Eleven of them read `.github/workflows/sweep.yml` as a tree through `tests/test_workflows.py`'s own loader, because the half #617 was about is whether anything ever hears the answer.
- **Full suite in two environments** — reported in a comment below.
- `actionlint` clean. `tests/test_workflows.py` parses the new four-job graph; it caught an unquoted `: ` in a job name.
- **This pull request is its own end-to-end test.** The workflow it changes runs on it: `Size the sweep` → `Sweep shard 1 of 1` → `Add up what the shards found` → a check named `no survivors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
