### PR TITLE
A panel draws its own edges, so the frame stops boxing the pane it does not own (#631)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1671,7 +1671,59 @@ def _chrome_argvs(*, socket: str, harness_pane: str,
             for name, value in _CHROME]
 
 
-def _surface_argvs(*, socket: str, pane_id: str, chrome, bg=None) -> list[list[str]]:
+def _pane_borders_wanted(v: tuple[int, int] | None) -> bool:
+    """Can this tmux give a pane its OWN edges — `tmuxctl.PANE_BORDER_FLOOR`, asked once.
+
+    ``None`` is "charter could not find out", and it answers **False** for the reason the
+    floor constant gives at length: below the line `set -p pane-border-style` is not
+    refused, it is rc 0 and writes the WINDOW. A wrong guess in that direction is not a
+    cosmetic loss but the last panel written deciding every rule in the frame, and an `off`
+    removing charter's own #514 pin window-wide. The frame-wide answer is correct on every
+    tmux; the per-pane one is correct only above the floor, so the unknown takes the one
+    that cannot be wrong.
+
+    A version and not a probe, because the failure below the line is SILENT: there is no
+    refusal to catch, and a probe would have to perform the damaging write to discover it
+    (`tmuxctl.PANE_BORDER_FLOOR`).
+    """
+    return v is not None and v >= tmuxctl.PANE_BORDER_FLOOR
+
+
+def _pane_border_pairs(*, chrome, bg, pane_borders: bool) -> tuple[tuple[str, str], ...]:
+    """This pane's own edges, in this pane's own surface — or nothing at all.
+
+    **The #631 fix in one expression, and the gate that keeps it off the floor.** A
+    window-wide border surface (`instance.border_bg`, which is what #628 shipped) reaches
+    every rule in the frame including the three around the HARNESS, so a plane whose four
+    panels were all grey came out with a grey box drawn round the operator's own session.
+    A pane-scoped one cannot: `_surface_argvs` is only ever handed a PANEL pane, so the
+    harness keeps the window's bare `_CHROME_STYLE` and the rules tmux resolves against it
+    stay the terminal's own.
+
+    Rendered, charter's real four-panel shape at 100x24 on tmux 3.7c, every panel
+    `bg = "brightblack"`, read through a nested client — the harness's three edges, and the
+    rule between two panels::
+
+        window-wide (#628)  harness top ESC[100m   right ESC[100m   panel|panel ESC[100m
+        per pane    (#631)  harness top ESC[49m    right ESC[49m    panel|panel ESC[100m
+
+    *pane_borders* is `tmuxctl.PANE_BORDER_FLOOR` already answered by the caller, which is
+    where the tmux version is known. Below it these two names are WINDOW options wearing a
+    pane's clothes: `set -p` is rc 0 and writes the window, so the last panel written would
+    decide every rule in the frame, and `set -p -u` would remove charter's #514 pin
+    window-wide. Nothing is emitted there and `_chrome_argvs` carries the frame-wide answer
+    instead — one of the two, never both, so the two designs cannot half-apply.
+
+    `instance.pane_border_options` builds the values from charter's own tables and
+    `_CHROME_STYLE`, so no operator string reaches a style here any more than it does one
+    function up.
+    """
+    return (instance.pane_border_options(bg, chrome, _CHROME_STYLE)
+            if pane_borders else ())
+
+
+def _surface_argvs(*, socket: str, pane_id: str, chrome, bg=None,
+                   pane_borders: bool = False) -> list[list[str]]:
     """`set-option -p`: the pane surface `[frame] chrome` asked for, on ONE panel pane.
 
     **tmux paints the background; charter sets an option.** `window-style` and
@@ -1747,11 +1799,14 @@ def _surface_argvs(*, socket: str, pane_id: str, chrome, bg=None) -> list[list[s
     # takes the frame's own answer". One expression, so there is no state in which a pane
     # gets one option from here and the other from there.
     return [tmuxctl.server_argv(socket, "set-option", "-p", "-t", pane_id, name, value)
-            for name, value in (instance.pane_bg_options(bg)
-                                or instance.chrome_options(chrome))]
+            for name, value in (*(instance.pane_bg_options(bg)
+                                  or instance.chrome_options(chrome)),
+                                *_pane_border_pairs(chrome=chrome, bg=bg,
+                                                    pane_borders=pane_borders))]
 
 
-def _resurface_argvs(*, socket: str, pane_id: str, chrome, bg=None) -> list[list[str]]:
+def _resurface_argvs(*, socket: str, pane_id: str, chrome, bg=None,
+                     pane_borders: bool = False) -> list[list[str]]:
     """:func:`_surface_argvs` for a pane that is ALREADY DRAWN — with the unsets.
 
     **The difference is `off`, and it is not a detail.** On a launch, `off` is free:
@@ -1803,9 +1858,19 @@ def _resurface_argvs(*, socket: str, pane_id: str, chrome, bg=None) -> list[list
     `chrome.no_colour` so there is one reading of the variable (#547).
     """
     want = dict(() if chrome_mod.no_colour()
-                else (instance.pane_bg_options(bg) or instance.chrome_options(chrome)))
+                else (*(instance.pane_bg_options(bg)
+                        or instance.chrome_options(chrome)),
+                      *_pane_border_pairs(chrome=chrome, bg=bg,
+                                          pane_borders=pane_borders)))
+    # The removal reaches the pane's own EDGES too, and only where charter ever wrote
+    # them: below `tmuxctl.PANE_BORDER_FLOOR` a `set -p -u` on these two names removes the
+    # WINDOW's value — charter's own #514 pin, for every rule in the frame — so the gate
+    # is on the unset exactly as it is on the set. `instance.PANE_BORDER_OPTIONS` is the
+    # one list both halves read.
+    removable = (*instance.chrome_option_names(),
+                 *(instance.PANE_BORDER_OPTIONS if pane_borders else ()))
     argvs = [tmuxctl.server_argv(socket, "set-option", "-p", "-u", "-t", pane_id, name)
-             for name in instance.chrome_option_names() if name not in want]
+             for name in removable if name not in want]
     argvs += [tmuxctl.server_argv(socket, "set-option", "-p", "-t", pane_id, name, value)
               for name, value in want.items()]
     return argvs
@@ -2227,7 +2292,7 @@ def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     inside an operator's tmux the cwd is the same cwd, so the hole is the same hole.
     """
     panes = _split_panels(socket, slots=slots, fid=fid, harness_pane=harness_pane,
-                          env=env, pane_env=pane_env, sizes=sizes)
+                          env=env, pane_env=pane_env, sizes=sizes, v=v)
     _install_resize_hook(socket, harness_pane=harness_pane, panes=panes, v=v, env=env,
                          fid=fid)
     # Written down, because a frame's shape can now be CHANGED while it runs (the density
@@ -2240,7 +2305,8 @@ def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
 
 def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
                   env: dict | None, pane_env: dict[str, str] | None,
-                  sizes: dict[str, int] | None = None) -> dict[str, str]:
+                  sizes: dict[str, int] | None = None,
+                  v: tuple[int, int] | None = None) -> dict[str, str]:
     """One `split-window` per slot, and the `{slot: pane id}` map that came back.
 
     The splitting half of :func:`_draw_panels`, separated from the hook-and-record half so
@@ -2299,8 +2365,16 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     # list would change every time a panel appeared. `instance.border_bg` reads
     # `config.FRAME`, which is the same thing `cmd_chrome` reads on the live path — the
     # agreement #610 is about, made by construction rather than by two call sites matching.
-    for argv in _chrome_argvs(socket=socket, harness_pane=harness_pane,
-                              surface=instance.border_bg(config.FRAME, chrome)):
+    # Above `tmuxctl.PANE_BORDER_FLOOR` the rules are each pane's own (`_pane_border_pairs`,
+    # set beside that pane's surface below) and the WINDOW's stay bare — which is the whole
+    # of #631: a frame-wide border surface reaches the three rules around the harness, and
+    # a plane whose panels were all grey drew a grey box around the operator's own session.
+    # Below the floor those two options have no pane scope at all, so the frame-wide answer
+    # is the only one that can be given and it is given here. One or the other, never both.
+    pane_borders = _pane_borders_wanted(v)
+    for argv in _chrome_argvs(
+            socket=socket, harness_pane=harness_pane,
+            surface=None if pane_borders else instance.border_bg(config.FRAME, chrome)):
         tmuxctl.run("styling the frame's own rules", argv, env=env)
     panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=socket,
                                     harness_pane=harness_pane, env=pane_env,
@@ -2333,7 +2407,7 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
             # word about this pane.
             bg = instance.component_style(config.FRAME, slot)["bg"]
             for surface in _surface_argvs(socket=socket, pane_id=pane_id, chrome=chrome,
-                                          bg=bg):
+                                          bg=bg, pane_borders=pane_borders):
                 tmuxctl.run("painting a panel's surface", surface, env=env)
     return panes
 
@@ -3342,7 +3416,7 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
         # and hand it the seven-row pane this fix exists to stop.
         keep.update(_split_panels(
             socket, slots=missing, fid=fid, harness_pane=harness_pane, env=None,
-            pane_env=pane_env,
+            pane_env=pane_env, v=v,
             sizes=layout.slot_sizes(
                 want, window_rows=window_rows,
                 content_rows=frame_slots.repos_rows_wanted(
@@ -3967,10 +4041,11 @@ def cmd_chrome(args) -> int:
     * a *level* outside `instance.FRAME_CHROME` — a closed set of three words charter
       wrote itself, so this can only be a hand-typed argument;
     * a frame with no recorded pane map — nothing to resurface. Unlike `cmd_density` this
-      needs no tmux version: it splits nothing, so `_relayout_target`'s refusals are not
-      this function's. It reads the harness pane, but does not REFUSE without one — that
-      is only the window selector for the frame's rules (`_chrome_argvs`), and a frame
-      that has no record of it still gets every pane repainted.
+      refuses on no tmux VERSION either: it splits nothing, so `_relayout_target`'s
+      refusals are not this function's. It reads the version (#631 made which design
+      applies depend on it) and the harness pane, and REFUSES on neither — an unreadable
+      version takes the frame-wide design, which is correct on every tmux, and a frame with
+      no record of its harness pane still gets every pane repainted.
 
     The word is recorded BEFORE the panes are touched, so a frame whose options fail
     halfway still splits its NEXT pane into the surface the operator asked for
@@ -3985,6 +4060,14 @@ def cmd_chrome(args) -> int:
         return 0
     state.record_chrome(fid, level)
     socket = state.frame_server(fid) or SOCKET
+    # Asked once for the whole keypress rather than per pane, and asked at all because
+    # #631 made this function version-dependent where it was not before: above
+    # `tmuxctl.PANE_BORDER_FLOOR` each panel carries its own edges and the window's stay
+    # bare, below it the frame-wide answer is the only one tmux can hold. `version()` is
+    # one `tmux -V`; this path is a keypress that already spawns a process, and it is not
+    # a refusal — an unreadable version answers the frame-wide design, which is correct on
+    # every tmux (`_pane_borders_wanted`).
+    pane_borders = _pane_borders_wanted(tmuxctl.version())
     for slot, pane_id in panes.items():
         # `_PANE_ID_RE` is #475's rule applied to a value that arrived off DISK and is
         # about to be a tmux argv — the same check `_relayout_target` makes of the harness
@@ -4000,7 +4083,7 @@ def cmd_chrome(args) -> int:
         # back until relaunch.
         bg = instance.component_style(config.FRAME, slot)["bg"]
         for argv in _resurface_argvs(socket=socket, pane_id=pane_id, chrome=level,
-                                     bg=bg):
+                                     bg=bg, pane_borders=pane_borders):
             tmuxctl.run("painting a panel's surface", argv)
     # And the frame's RULES, which are the surface's other half and are not any pane's
     # (`instance.border_bg`): a level change that repainted the panes and left the borders
@@ -4017,8 +4100,10 @@ def cmd_chrome(args) -> int:
     # about to be a tmux argv, made here exactly as the loop above makes it.
     harness = state.harness_pane(fid) or ""
     if _PANE_ID_RE.fullmatch(harness):
-        for argv in _chrome_argvs(socket=socket, harness_pane=harness,
-                                  surface=instance.border_bg(config.FRAME, level)):
+        for argv in _chrome_argvs(
+                socket=socket, harness_pane=harness,
+                surface=None if pane_borders
+                else instance.border_bg(config.FRAME, level)):
             tmuxctl.run("styling the frame's own rules", argv)
     return 0
 

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -110,6 +110,35 @@ SESSION_ENV_FLOOR = (3, 2)
 #: same reason `RESIZE_HOOK_FLOOR` is not folded into `FLOOR`.
 PANE_ENV_FLOOR = (3, 0)
 
+#: The first tmux release in which `pane-border-style` and `pane-active-border-style` are
+#: PANE options rather than only window options — so a panel can be given its own edges
+#: and the harness pane can keep the terminal's, which is what stops charter's surface
+#: drawing a box around the one rectangle it does not own (ADR 0018).
+#:
+#: **Read out of tmux's own source at every release either side of the line, and confirmed
+#: by running both sides.** `options-table.c`'s entry for `pane-border-style` is
+#: ``OPTIONS_TABLE_WINDOW`` in 3.2, 3.3a, 3.4, 3.5, 3.6 and 3.6a, and
+#: ``OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE`` in 3.7, 3.7a, 3.7c and master. Run against
+#: a real 3.7c: ``set -p -t <panel>`` stores on the pane, ``show -p`` on the sibling and on
+#: the harness both answer ``''``, and the window's own value is untouched. Run against a
+#: real 3.2 built from source on this machine: the same ``set -p`` is **rc 0 and writes the
+#: WINDOW**, ``show -p`` on a pane nobody set answers the window's value, and ``set -p -u``
+#: removes the window's.
+#:
+#: **That silent-success is the whole reason this is a version gate and not a probe.** A
+#: refused option is loud and already handled — `tmuxctl.run` reports it and the launch
+#: continues. This one is not refused: below the line every per-pane write lands on the
+#: window, so the LAST panel written would decide every rule in the frame, and an `off`
+#: would `-u` away charter's own #514 border pin for the whole window. A probe that
+#: measured it would have to perform exactly that write to find out. So the gate is on the
+#: WRITE, not on the value, and below it charter uses the frame-wide answer
+#: (`instance.border_bg`) it used before per-pane edges existed.
+#:
+#: HIGHER than `FLOOR`, and a separate constant for `RESIZE_HOOK_FLOOR`'s reason: an
+#: operator on 3.2 is explicitly still allowed to launch, and what they lose here is one
+#: shade on one row of cells, not a frame.
+PANE_BORDER_FLOOR = (3, 7)
+
 #: The session-scoped tmux environment variable carrying the interpreter that runs
 #: charter from inside a frame — `"$CHARTER_PY" -m charter …`, never a bare `charter`
 #: off `$PATH`. Defined HERE, not in either of the two modules that build text around it

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -805,9 +805,75 @@ def chrome_option_names() -> tuple[str, ...]:
                                for name, _value in pairs))
 
 
+#: The two tmux options a pane draws its OWN edges from, above `tmuxctl.PANE_BORDER_FLOOR`.
+#:
+#: Written here rather than derived from a table the way :func:`chrome_option_names` is,
+#: because there is no per-colour table for them: every colour puts its surface into the
+#: same two names, and the value is assembled by :func:`pane_border_options` out of a style
+#: constant its caller owns. One tuple, read by the setter and by the removal
+#: (`commands_frame._resurface_argvs`), so an option added to the pair cannot be set by one
+#: and left behind by the other — which is the property `chrome_option_names` exists for,
+#: kept the same way with one less indirection.
+PANE_BORDER_OPTIONS: tuple[str, ...] = ("pane-border-style", "pane-active-border-style")
+
+
+def pane_border_options(name, chrome, style: str) -> tuple[tuple[str, str], ...]:
+    """The ``(option, value)`` pairs that draw ONE panel pane's own edges in its own
+    surface — empty for a pane that has no surface to draw them in.
+
+    **A pane's edges, not the frame's rules, and that distinction is the fix for #631.**
+    `border_bg` answers one colour for the whole window, which is all tmux below
+    `tmuxctl.PANE_BORDER_FLOOR` can be told. Above it every pane carries its own, and the
+    difference is the pane charter must NOT paint: the harness. A window-wide surface
+    reaches the rules around the harness too, so a frame whose panels were all grey drew a
+    grey box around the operator's own session on three sides — reported off a screenshot,
+    and the reason this function exists beside that one rather than instead of it.
+
+    **The harness gets its dark edges by being left alone**, which is the same construction
+    ADR 0018 already rests on: `commands_frame._surface_argvs` is only ever handed a PANEL
+    pane, so the harness keeps the window's own bare `_CHROME_STYLE` and every border cell
+    tmux resolves against the harness is drawn in it. Nothing here has to name the harness
+    to protect it.
+
+    *style* is the caller's rule style — `commands_frame._CHROME_STYLE`, `fg=default,dim` —
+    passed in rather than imported so the one place that decides what a charter rule looks
+    like stays the one place. The surface is `pane_bg_options(name) or
+    chrome_options(chrome)`'s ``window-style`` value, which is the SAME expression the
+    pane's interior is painted from: a pane and its own edges cannot come out two colours,
+    because they are read off one answer.
+
+    **Both options carry the identical value**, and that is #514's rule surviving the move
+    to pane scope rather than being dropped by it. tmux picks between them per border CELL
+    — `pane-active-border-style` for a cell that touches the active pane, the other for the
+    rest — so a pane whose two differed would have edges that changed colour where they
+    passed the active pane's corner, which is the defect #514 closed. Measured on 3.7c
+    across four focus states (harness active, sidebar active, repos active, harness again):
+    with the pair identical every rule cell held its colour, and the frame did not move when
+    focus did.
+
+    Empty rather than a bare *style* for a pane with no surface: the window option is
+    already exactly that, so a pane that adds nothing must SET nothing, or `off` would
+    leave a pane-scoped copy of the window's own value behind for
+    `chrome_option_names`'s removal to miss.
+    """
+    surface = dict(pane_bg_options(name) or chrome_options(chrome)).get("window-style")
+    return tuple((n, f"{style},{surface}") for n in PANE_BORDER_OPTIONS) if surface else ()
+
+
 def border_bg(frame: dict, chrome) -> str | None:
     """The background clause every rule in *frame* is drawn over, or ``None`` for a frame
     whose rules keep the terminal's own — `commands_frame._chrome_argvs`' *surface*.
+
+    **BELOW `tmuxctl.PANE_BORDER_FLOOR` only, since #631.** One colour for every rule in
+    the window is all a tmux without pane-scoped border options can be told, and its cost
+    is the pane charter does not own: a window-wide surface paints the rules around the
+    HARNESS too, so a frame whose panels were all grey drew a grey box around the
+    operator's own session on three sides. Above the floor
+    :func:`pane_border_options` gives each panel its own edges and the harness keeps the
+    terminal's, which has no such cost. This stays because the floor cannot have that, and
+    a frame with no surface on its rules at all is the seam this whole key was written to
+    close — so below the floor the choice is between two imperfect renderings and this is
+    the one where the panels at least read as one surface.
 
     **A pane border is the one cell that belongs to no pane, and that is the whole
     problem.** :func:`chrome_options` and :func:`pane_bg_options` paint a pane's INTERIOR

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -728,20 +728,25 @@ is in neither rectangle — so a frame whose panels were all `brightblack` came 
 boxes with your terminal's own black running between them, which reads as seams rather than
 as an application. Charter puts a background behind the rules as well.
 
-Which colour, given a rule has a pane on each side and they may be different colours: the
-one your components **agree** on when they all resolve to the same background, and the
-frame-wide `chrome` colour when they do not. A gutter in the frame's own colour between two
-differently-coloured panels is what an application looks like; a gutter in no colour between
-two identically-coloured panels is a seam. A plane that sets no `bg` at all is unchanged —
-every pane is the frame-wide colour, so the rules are too.
+**Each panel's edges are its own**, so the rule between two panels is their shared colour
+and the rules around **your harness pane are left alone** — charter does not draw a box
+around the one rectangle it does not own. That needs tmux **3.7 or newer**, where
+`pane-border-style` is a per-pane option.
 
-There is one rule colour and not two, and that is deliberate: tmux draws the border of the
-active pane from a second option, and letting the two differ is exactly the defect that put
-charter in charge of these options in the first place — a rule that changes colour halfway
-along, where it passes the active pane's corner. Which pane is live is shown on the pane
-itself (its background is one shade off the others), never on the border. `chrome = "off"`
-with no `bg` anywhere puts the rules back to your terminal's own, and `NO_COLOR` takes the
-background off them while leaving the frame's rules drawn.
+On tmux 3.2 to 3.6 it is a window option only, so there is one rule colour for the whole
+frame: the one your components **agree** on when they all resolve to the same background,
+and the frame-wide `chrome` colour when they do not. That closes the seam and costs a rule
+of charter's colour on the three sides of your harness — the lesser of two imperfect
+renderings, and the reason the per-pane version exists. A plane that sets no `bg` at all is
+unchanged either way: every pane is the frame-wide colour, so the rules are too.
+
+A pane's two edge colours are always identical, and that is deliberate: tmux draws the
+border of the active pane from a second option, and letting the two differ is exactly the
+defect that put charter in charge of these options in the first place — a rule that changes
+colour halfway along, where it passes the active pane's corner. Which pane is live is shown
+on the pane itself (its background is one shade off the others), never on the border.
+`chrome = "off"` with no `bg` anywhere puts the rules back to your terminal's own, and
+`NO_COLOR` takes the background off them while leaving the frame's rules drawn.
 
 `pad` is how many cells that pane leaves empty at its **left and right edges** — one number,
 both sides. Charter draws this one: tmux paints backgrounds and insets nothing.

--- a/docs/news/unreleased-the-frame-stops-boxing-your-own-session.md
+++ b/docs/news/unreleased-the-frame-stops-boxing-your-own-session.md
@@ -1,0 +1,50 @@
+---
+version: unreleased
+headline: The frame stops drawing a box around your own session
+---
+
+The last release put a background behind the frame's rules so a surfaced frame stopped
+showing a one-cell seam between its panels. It put that background on the **window**, which
+is every rule in the frame — including the three that run between a panel and the pane your
+harness is in. A plane whose four panels were all `brightblack` got a grey box drawn round
+its own session on three sides. Reported off a screenshot, again.
+
+The cell between two panes belongs to neither, and a window-wide answer cannot tell the
+panels apart from the one pane charter does not own. **On tmux 3.7 and newer it does not
+have to.** `pane-border-style` and `pane-active-border-style` became per-pane options in
+3.7, so each panel now carries its own edges, the window's stay bare, and the harness —
+never written, which is the same construction ADR 0018 already rests on — keeps your
+terminal's own. Read back off an attached client's wire, charter's real four-panel shape at
+100x24:
+
+```
+window-wide   harness top ESC[100m   harness right ESC[100m   panel|panel ESC[100m
+per pane      harness top ESC[49m    harness right ESC[49m    panel|panel ESC[100m
+```
+
+Three edges change and nothing else does: no rule between two panels of one colour is a
+different colour, which is the seam the last release closed and this one keeps closed.
+
+**tmux 3.2 to 3.6 keeps the window-wide answer, and that is a measurement rather than
+caution.** In those releases the two options are window options only — but `set -p` does not
+say so. It returns **0 and writes the window**, so the last panel written would decide every
+rule in the frame, and turning the surface off would `set -p -u` charter's own border
+settings away for the whole window. There is no refusal to catch and a probe would have to
+perform that write to find out, so this is a version gate: `options-table.c` says
+`OPTIONS_TABLE_WINDOW` in 3.2, 3.3a, 3.4, 3.5, 3.6 and 3.6a and gains
+`OPTIONS_TABLE_PANE` in 3.7, and both sides were run — 3.7c, and a 3.2 built from source.
+A tmux charter cannot get a version out of takes the window-wide answer too, because that
+one is correct everywhere and the other is correct only above the line.
+
+Which colour a panel's edges are is unchanged and still needs no configuration: the surface
+that panel's own `bg` resolves to, or the frame-wide `chrome` colour where it names none —
+the same expression its interior is painted from, so a pane and its edges cannot come out
+two colours. Both of a pane's edge options always carry the identical value, which is the
+same rule that stops a rule changing colour at the active pane's corner; measured across
+four focus states, the frame does not move when focus does.
+
+`NO_COLOR` takes the background off the edges as well as off the panes. `chrome = "off"`
+removes them, and on tmux 3.7+ that is a real per-pane removal rather than one that would
+reach the window.
+
+Nothing to adopt: upgrading is the whole of it.

--- a/tests/test_frame_border_surface.py
+++ b/tests/test_frame_border_surface.py
@@ -36,7 +36,7 @@ import unittest
 from unittest import mock
 
 from charter import commands_frame, config, instance
-from charter.frame import state
+from charter.frame import state, tmuxctl
 from tests._isolation import PersonaIso
 
 _STYLES = ("pane-border-style", "pane-active-border-style")
@@ -281,6 +281,165 @@ class TheRuleIsDrawnInIt(unittest.TestCase):
                     self.assertNotIn("#", word)
 
 
+class APanelDrawsItsOwnEdgesAndTheHarnessKeepsItsOwn(unittest.TestCase):
+    """#631. `instance.pane_border_options` and `commands_frame._pane_border_pairs`.
+
+    #628 closed the seam by putting the surface on the WINDOW's two border options, which
+    reaches every rule in the frame — including the three around the pane charter does not
+    own. The operator's report: "the dark harness now sits inside a tan box on three
+    sides." Above `tmuxctl.PANE_BORDER_FLOOR` those options are PANE options, so each
+    panel can carry its own edges and the harness, never written, keeps the window's bare
+    style. Measured on 3.7c through a nested client, charter's real four-panel shape::
+
+        window-wide (#628)  harness top ESC[100m   right ESC[100m   panel|panel ESC[100m
+        per pane    (#631)  harness top ESC[49m    right ESC[49m    panel|panel ESC[100m
+    """
+
+    STYLE = "fg=default,dim"
+
+    def test_a_pane_with_a_colour_gets_both_of_its_edges_in_that_colour(self):
+        self.assertEqual(
+            instance.pane_border_options("brightblack", "dark", self.STYLE),
+            (("pane-border-style", "fg=default,dim,bg=brightblack"),
+             ("pane-active-border-style", "fg=default,dim,bg=brightblack")))
+
+    def test_a_pane_with_no_colour_of_its_own_takes_the_frame_wide_one(self):
+        """The same `pane_bg_options(bg) or chrome_options(chrome)` its INTERIOR is
+        painted from, so a pane and its edges cannot come out two colours."""
+        self.assertEqual(
+            [v for _n, v in instance.pane_border_options(None, "dark", self.STYLE)],
+            [f"{self.STYLE},{dict(instance.FRAME_CHROME['dark'])['window-style']}"] * 2)
+
+    def test_a_pane_with_no_surface_at_all_sets_nothing(self):
+        """Not a bare style — the window option already IS that. A pane-scoped copy of the
+        window's own value would be a value `off`'s removal has to find and remove, for a
+        pane that never needed one."""
+        self.assertEqual(instance.pane_border_options(None, "off", self.STYLE), ())
+        self.assertEqual(instance.pane_border_options("nonsense", "off", self.STYLE), ())
+
+    def test_both_edges_always_carry_the_identical_value(self):
+        """#514 surviving the move to pane scope. tmux picks between the two per border
+        CELL — the active one for a cell touching the active pane — so a pane whose two
+        differed would have edges that changed colour at the active pane's corner."""
+        for word in (None, *instance.FRAME_PANE_BG):
+            for level in instance.FRAME_CHROME:
+                with self.subTest(bg=word, chrome=level):
+                    values = {v for _n, v
+                              in instance.pane_border_options(word, level, self.STYLE)}
+                    self.assertLessEqual(len(values), 1, values)
+
+    def test_the_two_option_names_are_the_ones_the_removal_reads(self):
+        """One list, read by the setter and by `_resurface_argvs`' unset — so an option
+        added to the pair cannot be set by one half and left behind by the other."""
+        self.assertEqual(
+            tuple(n for n, _v in instance.pane_border_options("blue", "dark", self.STYLE)),
+            instance.PANE_BORDER_OPTIONS)
+
+    def test_no_operator_string_reaches_a_pane_edge(self):
+        """The containment, on the new key: the value is charter's style constant plus a
+        `window-style` value out of charter's own tables, indexed by a word that was only
+        ever a key."""
+        ours = {v for pairs in instance.FRAME_PANE_BG.values() for _n, v in pairs}
+        ours |= {v for pairs in instance.FRAME_CHROME.values() for _n, v in pairs}
+        for word in (*instance.FRAME_PANE_BG, "colour236", "chartreuse", None, 7,
+                     "bg=#{?#{==:1,1},colour196,colour46}", ["blue"], True):
+            with self.subTest(bg=word):
+                for _n, value in instance.pane_border_options(word, "dark", self.STYLE):
+                    self.assertNotIn("#", value)
+                    self.assertIn(value.removeprefix(f"{self.STYLE},"), ours)
+
+
+class TheFloorCannotHavePerPaneEdgesAndIsNotGivenThem(unittest.TestCase):
+    """`commands_frame._pane_borders_wanted` and `tmuxctl.PANE_BORDER_FLOOR`.
+
+    **The gate is on the WRITE, not on the value, and the reason is that the floor fails
+    silently.** A refused option is loud and already handled — `tmuxctl.run` reports it and
+    the launch continues. Below the floor `set -p pane-border-style` is **rc 0 and writes
+    the WINDOW** (measured against a real 3.2 built from source on this machine): the last
+    panel written would decide every rule in the frame, and an `off` would `set -p -u`
+    charter's own #514 pin away for the whole window.
+    """
+
+    def test_the_floor_is_the_version_the_option_gained_pane_scope_in(self):
+        """Read out of tmux's own `options-table.c` at every release either side of the
+        line — `OPTIONS_TABLE_WINDOW` in 3.2 through 3.6a, `…|OPTIONS_TABLE_PANE` from 3.7
+        — and run on both sides. Pinned so a floor moved without a measurement is red."""
+        self.assertEqual(tmuxctl.PANE_BORDER_FLOOR, (3, 7))
+        self.assertGreater(tmuxctl.PANE_BORDER_FLOOR, tmuxctl.FLOOR,
+                           "an operator charter still lets launch would now be issuing "
+                           "pane-scoped writes their tmux silently applies to the window")
+
+    def test_only_a_version_at_or_above_the_floor_gets_its_own_edges(self):
+        for v, want in ((None, False), ((3, 2), False), ((3, 6), False),
+                        ((3, 7), True), ((3, 9), True), ((4, 0), True)):
+            with self.subTest(v=v):
+                self.assertIs(commands_frame._pane_borders_wanted(v), want)
+
+    def test_an_unreadable_version_takes_the_design_that_cannot_be_wrong(self):
+        """`None` is "charter could not find out", and it answers the frame-wide design —
+        correct on every tmux — rather than the per-pane one, which is correct only above
+        the floor and damaging below it."""
+        self.assertIs(commands_frame._pane_borders_wanted(None), False)
+
+    def test_below_the_floor_no_border_option_is_ever_set_on_a_pane(self):
+        for v in (None, (3, 2), (3, 6)):
+            with self.subTest(v=v):
+                self.assertEqual(
+                    commands_frame._pane_border_pairs(
+                        chrome="dark", bg="brightblack",
+                        pane_borders=commands_frame._pane_borders_wanted(v)), ())
+
+    def test_below_the_floor_no_border_option_is_ever_UNSET_on_a_pane(self):
+        """The half that would be silent damage rather than a missing colour: `set -p -u`
+        on these names removes the WINDOW's value below the floor, and the window's value
+        is charter's #514 pin for every rule in the frame."""
+        for v in (None, (3, 2), (3, 6)):
+            argvs = commands_frame._resurface_argvs(
+                socket="s", pane_id="%3", chrome="off",
+                pane_borders=commands_frame._pane_borders_wanted(v))
+            with self.subTest(v=v):
+                for name in instance.PANE_BORDER_OPTIONS:
+                    self.assertNotIn(name, [a[-1] for a in argvs])
+
+    def test_above_the_floor_off_removes_the_edges_it_set(self):
+        argvs = commands_frame._resurface_argvs(socket="s", pane_id="%3", chrome="off",
+                                                pane_borders=True)
+        tails = [a[a.index("set-option"):] for a in argvs]
+        for name in instance.PANE_BORDER_OPTIONS:
+            with self.subTest(option=name):
+                self.assertIn(["set-option", "-p", "-u", "-t", "%3", name], tails)
+
+    def test_a_pane_that_keeps_its_colour_keeps_its_edges(self):
+        """`off` is the frame's removal and never a component's: a pane whose component
+        named a colour has that colour SET here, edges included, and nothing unset."""
+        argvs = commands_frame._resurface_argvs(socket="s", pane_id="%3", chrome="off",
+                                                bg="brightblack", pane_borders=True)
+        self.assertEqual([a for a in argvs if "-u" in a], [])
+        self.assertIn("fg=default,dim,bg=brightblack", [a[-1] for a in argvs])
+
+    def test_no_colour_takes_the_edges_off_too(self):
+        """The fill is tmux's paint either way, so a `NO_COLOR` that stripped the pane and
+        left its edges would be charter having asked somebody else to paint them."""
+        with mock.patch.dict(os.environ, {"NO_COLOR": ""}, clear=True):
+            self.assertEqual(
+                commands_frame._surface_argvs(socket="s", pane_id="%3", chrome="dark",
+                                              bg="brightblack", pane_borders=True), [])
+            tails = [a[a.index("set-option"):] for a in commands_frame._resurface_argvs(
+                socket="s", pane_id="%3", chrome="dark", bg="brightblack",
+                pane_borders=True)]
+            for name in instance.PANE_BORDER_OPTIONS:
+                self.assertIn(["set-option", "-p", "-u", "-t", "%3", name], tails)
+
+    def test_the_edges_are_set_on_the_pane_and_never_on_the_window(self):
+        """`-p`, which is what keeps them off the harness: `_surface_argvs` is only ever
+        handed a PANEL pane, so ADR 0018's boundary carries the new options unchanged."""
+        for argv in commands_frame._surface_argvs(socket="s", pane_id="%3", chrome="dark",
+                                                  bg="brightblack", pane_borders=True):
+            with self.subTest(argv=argv):
+                self.assertIn("-p", argv)
+                self.assertNotIn("-w", argv)
+
+
 class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
     """**The wiring, which every `_chrome_argvs` test above takes as given.**
 
@@ -293,7 +452,8 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
     come through, with only `tmuxctl.run` faked.
     """
 
-    def _issued(self, frame: dict, slots: list[str], *, fid="f-1") -> list[list[str]]:
+    def _issued(self, frame: dict, slots: list[str], *, fid="f-1",
+                v=None) -> list[list[str]]:
         seen: list[list[str]] = []
         panes = iter(f"%{n}" for n in range(10, 99))
 
@@ -306,23 +466,59 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
                 mock.patch.object(commands_frame.tmuxctl, "run", fake_run), \
                 mock.patch.dict(os.environ, {}, clear=True):
             commands_frame._split_panels("sock", slots=slots, fid=fid,
-                                         harness_pane="%1", env=None, pane_env=None)
+                                         harness_pane="%1", env=None, pane_env=None, v=v)
         return seen
 
     def _rules(self, issued: list[list[str]]) -> dict[str, str]:
         return {a[-2]: a[-1] for a in issued
                 if "set-option" in a and "-w" in a and a[-2] in dict(commands_frame._CHROME)}
 
-    def test_a_launch_draws_its_rules_in_the_colour_its_panels_agree_on(self):
+    def test_a_launch_below_the_floor_draws_its_rules_in_the_agreed_colour(self):
+        """The frame-wide design, which is all a tmux without pane-scoped border options
+        can be told. `v=None` is the default here and answers it, which is the safe
+        direction (`_pane_borders_wanted`)."""
         frame = _resolved(*["brightblack"] * 4, chrome="dark")
         rules = self._rules(self._issued(frame, ["top", "bottom", "repos", "right"]))
         self.assertEqual(rules["pane-border-style"],
                          f"{commands_frame._CHROME_STYLE},bg=brightblack")
         self.assertEqual(rules["pane-active-border-style"], rules["pane-border-style"])
 
+    def test_a_launch_above_the_floor_gives_each_panel_its_own_edges(self):
+        """#631's wiring, through the same funnel: the WINDOW keeps charter's bare #514
+        style — which is what the harness inherits and why it is not boxed — and every
+        panel pane that was actually split gets its own two options."""
+        frame = _resolved(*["brightblack"] * 4, chrome="dark")
+        issued = self._issued(frame, ["top", "bottom", "repos", "right"], v=(3, 7))
+        self.assertEqual(self._rules(issued), dict(commands_frame._CHROME),
+                         "the window still carries a surface, so the rules around the "
+                         "harness are still charter's colour")
+        want = f"{commands_frame._CHROME_STYLE},bg=brightblack"
+        per_pane = {}
+        for a in issued:
+            if "set-option" in a and "-p" in a and a[-2] in instance.PANE_BORDER_OPTIONS:
+                per_pane.setdefault(a[a.index("-t") + 1], []).append(a[-1])
+        self.assertEqual(len(per_pane), 4, f"not every panel got its edges: {per_pane}")
+        for pane, values in per_pane.items():
+            with self.subTest(pane=pane):
+                self.assertEqual(values, [want, want])
+
+    def test_no_border_option_is_written_on_the_harness_pane(self):
+        """ADR 0018's boundary, carried by construction rather than by a check: the pane
+        every split TARGETS is never the pane a surface is set on."""
+        frame = _resolved(*["brightblack"] * 4, chrome="dark")
+        for v in (None, (3, 2), (3, 7)):
+            with self.subTest(v=v):
+                for a in self._issued(frame, ["top", "right"], v=v):
+                    if "set-option" in a and "-p" in a:
+                        self.assertNotEqual(a[a.index("-t") + 1], "%1")
+
     def test_a_launch_that_names_no_colour_arms_exactly_what_it_always_did(self):
-        self.assertEqual(self._rules(self._issued({}, ["top", "bottom"])),
-                         dict(commands_frame._CHROME))
+        for v in (None, (3, 2), (3, 7)):
+            with self.subTest(v=v):
+                issued = self._issued({}, ["top", "bottom"], v=v)
+                self.assertEqual(self._rules(issued), dict(commands_frame._CHROME))
+                self.assertEqual([a for a in issued if "set-option" in a and "-p" in a
+                                  and a[-2] in instance.PANE_BORDER_OPTIONS], [])
 
     def test_a_relayout_that_adds_one_pane_still_arms_the_WHOLE_frames_surface(self):
         """`_relayout` calls this funnel with only the slots being ADDED, so a rule colour
@@ -332,6 +528,7 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         frame = _resolved(*["blue"] * 4, chrome="dark")
         whole = self._rules(self._issued(frame, ["top", "bottom", "repos", "right"]))
         one = self._rules(self._issued(frame, ["right"]))
+        self.assertEqual(one, whole)
         self.assertEqual(one, whole)
         self.assertEqual(one["pane-border-style"],
                          f"{commands_frame._CHROME_STYLE},bg=blue")
@@ -349,6 +546,74 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
                          f"{dict(instance.FRAME_CHROME['dark'])['window-style']}")
 
 
+class TheVersionReachesTheFunnelFromTheFunctionThatKnowsIt(PersonaIso, unittest.TestCase):
+    """**The deletion sweep found this one and it was a real hole.** `_split_panels` takes
+    the tmux version as an argument, and every other test here hands it one directly — so
+    replacing `_draw_panels`' own ``v=v`` with ``v=None`` left the whole suite green while
+    a real frame on a modern tmux silently took the FLOOR design and put the box back round
+    the harness. A per-pane edge production never asks for is a fix that does nothing on a
+    real frame and a test file that says it works, which is what
+    `TheLauncherActuallyAsksForEachPanesColour` in `tests/test_frame_pane_style.py` exists
+    for one key over.
+
+    `_draw_panels` and not `cmd_launch`, and that is a finding rather than a shortcut:
+    `tests/test_frame_launcher.py`'s fake reports no pane id for a `split-window`, so a
+    whole faked launch never reaches the per-pane surface AT ALL — `_surface_argvs` is not
+    called once. That is why the pane-style tests drive this function too, and a test built
+    on the launcher's fake would have passed while asserting nothing.
+    """
+
+    def _calls(self, v):
+        seen: list[list[str]] = []
+        panes = iter(f"%{n}" for n in range(20, 99))
+
+        def fake_run(_why, argv, **_kw):
+            seen.append(list(argv))
+            out = next(panes) if "split-window" in argv else ""
+            return subprocess.CompletedProcess(argv, 0, stdout=out + "\n", stderr="")
+
+        frame = _resolved(*["brightblack"] * 4, chrome="dark")
+        with mock.patch.object(config, "FRAME", frame), \
+                mock.patch.object(commands_frame.tmuxctl, "run", fake_run), \
+                mock.patch.dict(os.environ, {}, clear=True):
+            commands_frame._draw_panels("s", slots=["top", "right"], fid="f-v",
+                                        harness_pane="%1", env=None, v=v)
+        return seen
+
+    def _edges(self, calls):
+        return {a[a.index("-t") + 1]: a[-1] for a in calls
+                if "set-option" in a and "-p" in a and a[-2] == "pane-border-style"}
+
+    def _window_rule(self, calls):
+        return next(a[-1] for a in calls
+                    if "set-option" in a and "-w" in a and a[-2] == "pane-border-style")
+
+    def test_a_frame_drawn_on_a_modern_tmux_really_does_get_per_pane_edges(self):
+        calls = self._calls((3, 7))
+        edges = self._edges(calls)
+        self.assertEqual(len(edges), 2,
+                         "the version never reached `_split_panels`, so a real frame "
+                         f"above the floor took the floor's design: {edges}")
+        self.assertEqual(set(edges.values()),
+                         {f"{commands_frame._CHROME_STYLE},bg=brightblack"})
+        self.assertEqual(self._window_rule(calls), commands_frame._CHROME_STYLE,
+                         "the window kept a surface, so the harness is still boxed")
+
+    def test_a_frame_drawn_on_an_old_tmux_really_does_fall_back_to_the_window(self):
+        calls = self._calls((3, 6))
+        self.assertEqual(self._edges(calls), {},
+                         "a frame below the floor wrote a pane-scoped border option, "
+                         "which on that tmux lands on the window")
+        self.assertEqual(self._window_rule(calls),
+                         f"{commands_frame._CHROME_STYLE},bg=brightblack")
+
+    def test_the_harness_pane_is_never_among_the_panes_given_edges(self):
+        for v in ((3, 6), (3, 7)):
+            with self.subTest(v=v):
+                self.assertNotIn("%1", self._edges(self._calls(v)),
+                                 "charter wrote a border style on the harness pane")
+
+
 class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
     """#610's pin, on the border: what a frame LAUNCHES with and what a keypress leaves it
     with must be the same value, at every level and for every colour.
@@ -360,7 +625,7 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
 
     FID = "fr-border"
 
-    def _launch_value(self, frame, level):
+    def _launch_value(self, frame, level, v=None):
         """What `_split_panels` — the funnel both launch paths and every density change
         come through — actually issues, with the frame's live word recorded rather than
         the resolver stubbed out. A reconstruction of the expression would agree with the
@@ -376,41 +641,80 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
                 mock.patch.object(commands_frame.tmuxctl, "run", fake_run), \
                 mock.patch.dict(os.environ, {}, clear=True):
             commands_frame._split_panels("s", slots=["top"], fid=self.FID,
-                                         harness_pane="%1", env=None, pane_env=None)
-        return {a[-2]: a[-1] for a in calls
-                if "-w" in a and a[-2] in dict(commands_frame._CHROME)}
+                                         harness_pane="%1", env=None, pane_env=None, v=v)
+        return self._styles(calls)
 
-    def _live_value(self, frame, level):
+    def _styles(self, calls):
+        """Every border style charter set, keyed by `(scope, option)` — so a value that
+        moved from the window to the pane shows up as a difference rather than as two
+        tests that each still pass."""
+        out = {}
+        for a in calls:
+            if "set-option" not in a or a[-2] not in ("pane-border-style",
+                                                      "pane-active-border-style"):
+                continue
+            out[("-w" if "-w" in a else "-p", a[-2])] = a[-1]
+        return out
+
+    def _live_value(self, frame, level, v=None):
         calls: list[list[str]] = []
         state.record_panes(self.FID, panels={"top": "%2"})
         state.record_harness_pane(self.FID, "%1")
         with mock.patch.object(config, "FRAME", frame), \
                 mock.patch.object(commands_frame.tmuxctl, "run",
                                   lambda _w, argv, **kw: calls.append(argv)), \
+                mock.patch.object(commands_frame.tmuxctl, "version", lambda: v), \
                 mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID},
                                 clear=True):
             commands_frame.cmd_chrome(type("A", (), {"level": level})())
-        return {a[-2]: a[-1] for a in calls if a[-2] in dict(commands_frame._CHROME)}
+        return self._styles(calls)
 
     def test_every_level_crossed_with_every_colour_lands_on_one_value(self):
-        for level in instance.FRAME_CHROME:
-            for word in (None, *instance.FRAME_PANE_BG):
-                frame = _resolved(word, word, word, word)
-                with self.subTest(level=level, bg=word):
-                    self.assertEqual(self._launch_value(frame, level),
-                                     self._live_value(frame, level))
+        """And crossed with the VERSION too, since #631 made which design applies depend
+        on it — a launch above the floor and a keypress below it would be two frames."""
+        for v in (None, (3, 2), (3, 6), (3, 7), (4, 0)):
+            for level in instance.FRAME_CHROME:
+                for word in (None, *instance.FRAME_PANE_BG):
+                    frame = _resolved(word, word, word, word)
+                    with self.subTest(v=v, level=level, bg=word):
+                        self.assertEqual(self._launch_value(frame, level, v),
+                                         self._live_value(frame, level, v))
 
     def test_a_committed_colour_survives_the_level_that_used_to_erase_it(self):
         """`chrome: off` is a removal of the FRAME'S surface, never of a colour a
-        component wrote. The rules stay the panels' colour, because the panels do."""
+        component wrote. The rules stay the panels' colour, because the panels do — on the
+        window below the floor, on the pane itself above it."""
         frame = _resolved(*["brightblack"] * 4)
-        self.assertEqual(
-            self._live_value(frame, "off")["pane-border-style"],
-            f"{commands_frame._CHROME_STYLE},bg=brightblack")
+        want = f"{commands_frame._CHROME_STYLE},bg=brightblack"
+        self.assertEqual(self._live_value(frame, "off", (3, 2))[("-w", "pane-border-style")],
+                         want)
+        self.assertEqual(self._live_value(frame, "off", (3, 7))[("-p", "pane-border-style")],
+                         want)
 
     def test_off_on_a_plane_that_named_no_colour_puts_the_rules_back(self):
-        self.assertEqual(self._live_value({"slots": ["top"]}, "off"),
-                         dict(commands_frame._CHROME))
+        for v in (None, (3, 2), (3, 7)):
+            with self.subTest(v=v):
+                self.assertEqual(
+                    self._live_value({"slots": ["top"]}, "off", v),
+                    {("-w", n): commands_frame._CHROME_STYLE
+                     for n in instance.PANE_BORDER_OPTIONS})
+
+    def test_the_window_carries_the_surface_below_the_floor_and_the_pane_above_it(self):
+        """The switch itself, on the live path: never both, and never neither. A window
+        that kept the frame-wide surface above the floor would go on boxing the harness
+        the per-pane edges exist to unbox; a pane written below it would land on the
+        window anyway and the last panel would decide the frame."""
+        frame = _resolved(*["brightblack"] * 4)
+        want = f"{commands_frame._CHROME_STYLE},bg=brightblack"
+        floor = self._live_value(frame, "dark", (3, 2))
+        self.assertEqual(floor[("-w", "pane-border-style")], want)
+        self.assertNotIn(("-p", "pane-border-style"), floor)
+        above = self._live_value(frame, "dark", (3, 7))
+        self.assertEqual(above[("-p", "pane-border-style")], want)
+        self.assertEqual(above[("-w", "pane-border-style")],
+                         commands_frame._CHROME_STYLE,
+                         "the window kept a surface above the floor, so the rules around "
+                         "the harness are still charter's colour")
 
     def test_a_frame_with_no_harness_pane_still_repaints_its_panes(self):
         """Skipped rather than refused: a frame launched by a charter that predates

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -4122,19 +4122,27 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
             self.assertEqual(self._srv("set", "-wg", name, value).returncode, 0)
 
     def _screenshot(self, *, arm: bool, hostile: bool = False,
-                    surface: str | None = None, rules_too: bool = True) -> str:
+                    surface: str | None = None, design: str = "pane") -> str:
         """Build the frame on the inner server, show it through the outer one, and return
         what the outer pane holds — the frame's whole screen, escapes and all.
 
         *surface* paints the three PANELS the way `_surface_argvs` paints them (pane-scoped
-        `window-style`, harness pane untouched). *rules_too* decides whether
-        `_chrome_argvs` is handed the matching background as well, and the two together are
-        what make the seam a measurement instead of a claim: painted panes with unpainted
-        rules is the frame the operator reported, and it is this class's own "render the
-        defect first" discipline applied to a defect that is a background rather than a
-        foreground."""
-        session = (f"f{int(arm)}{int(hostile)}{int(bool(surface))}{int(rules_too)}"
-                   f"-{self._pane_counter}")
+        `window-style`, harness pane untouched), and *design* is which of charter's two
+        answers for the RULES is applied — the whole point being that all three renderings
+        come out of the production argvs and differ only in the arguments production would
+        really pass:
+
+        * ``"bare"`` — panels painted, rules left as `_CHROME_STYLE` alone. The defect the
+          operator first reported: a one-cell strip of the terminal's own between panes
+          that are all one colour. This class's "render the defect first" discipline,
+          applied to a background rather than a foreground.
+        * ``"window"`` — `_chrome_argvs` carries the frame-wide surface. What charter does
+          BELOW `tmuxctl.PANE_BORDER_FLOOR`, and what #628 shipped everywhere. Closes the
+          seam and boxes the harness, which is the second defect.
+        * ``"pane"`` — each panel carries its own edges and the window's stay bare. What
+          charter does above the floor.
+        """
+        session = f"f{int(arm)}{int(hostile)}{int(bool(surface))}{design[0]}-{self._pane_counter}"
         self._pane_counter += 1
         r = self._srv("new-session", "-d", "-s", session, "-x", "100", "-y", "24",
                       "-P", "-F", "#{pane_id}", "--", "cat")
@@ -4155,7 +4163,7 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
             # The production argv, never a hand-retyped `set-option` — see `_run`.
             for cmd in commands_frame._chrome_argvs(
                     socket=self.SOCKET_NAME, harness_pane=harness,
-                    surface=surface if rules_too else None):
+                    surface=surface if design == "window" else None):
                 self.assertEqual(_run(cmd).returncode, 0, cmd)
         for direction, before, size in self._SPLITS:
             args = ["split-window", "-t", harness, direction, "-P", "-F", "#{pane_id}"]
@@ -4171,7 +4179,8 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
                 # colour from a pane it is not allowed to paint.
                 for cmd in commands_frame._surface_argvs(
                         socket=self.SOCKET_NAME, pane_id=r.stdout.strip(), chrome="off",
-                        bg=surface.removeprefix("bg=")):
+                        bg=surface.removeprefix("bg="),
+                        pane_borders=design == "pane"):
                     self.assertEqual(_run(cmd).returncode, 0, cmd)
         self.assertEqual(self._srv("select-pane", "-t", harness).returncode, 0)
         host = f"host-{session}"
@@ -4273,90 +4282,165 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
     #: pane runs `cat` and writes nothing.
     _SURFACE = "bg=brightblack"
 
-    def _backgrounds(self, shot: str) -> tuple[set, set]:
-        """`(what the rules are drawn over, what the painted panes are drawn over)`.
+    def _grid(self, shot: str) -> list[list[tuple]]:
+        """*shot* as rows of `(appearance, character)`, so a border cell can be compared
+        with the pane cells ON EITHER SIDE OF IT.
 
-        Read out of ONE capture rather than compared against an SGR constant this test
-        would have to know: the surfaced panes are the only cells on the screen with a
-        background at all, so "the rule matches the panels" is answerable without this
-        file knowing what `brightblack` is spelled as on the wire.
+        `_sgr_runs` answers one flat list with the row breaks dropped, which is right for
+        "what colours are the rules" and useless for "does this rule match its
+        neighbours". The printable width of each line is what slices it back into rows.
+        `carry=True` for the reason that flag exists: tmux does not re-state a background a
+        row already inherits.
         """
+        lines = shot.split("\n")
         cells = _sgr_runs(shot, carry=True)
-        rules = {dict(s)["bg"] for s, ch in cells if ch in _RULE_GLYPHS}
-        panes = {dict(s)["bg"] for s, _ch in cells} - {"default"}
-        return rules, panes
+        rows, at = [], 0
+        for line in lines:
+            width = len(_SGR_RE.sub("", line))
+            rows.append(cells[at:at + width])
+            at += width
+        return rows
 
-    def _seam(self) -> tuple[set, set]:
-        """The defect, rendered — this class's `_control` for a background rather than a
-        foreground. Panels painted, rules left as `_CHROME_STYLE` alone: every border cell
-        comes back over the terminal's own background while the panes on both sides of it
-        are over another, which is the one-cell strip the operator reported.
+    def _seams(self, shot: str) -> list[tuple]:
+        """Every rule cell whose background matches NEITHER pane it separates.
 
-        Skips rather than fails on a machine that cannot render it, for `_control`'s
-        reason: a harness that cannot see the seam cannot testify about its absence.
+        The definition of the defect, and it needs no pane geometry: a `─` is compared
+        with the cell above and the cell below it, a `│` with the cells left and right.
+        Junctions are skipped — a `┬` has three neighbours and no one right answer. A
+        border cell may legitimately take either side (tmux draws one border, not two
+        half-borders); what it may never be is a THIRD colour, which is what a seam is.
         """
-        rules, panes = self._backgrounds(
-            self._screenshot(arm=True, surface=self._SURFACE, rules_too=False))
-        if not rules:
+        rows = self._grid(shot)
+        out = []
+        for y, row in enumerate(rows):
+            for x, (state, ch) in enumerate(row):
+                if ch == "\u2500":
+                    sides = [rows[y - 1][x:x + 1], rows[y + 1][x:x + 1]]
+                elif ch == "\u2502":
+                    sides = [row[x - 1:x], row[x + 1:x + 2]]
+                else:
+                    continue
+                near = [dict(c[0][0])["bg"] for c in sides if c and c[0]]
+                if len(near) == 2 and dict(state)["bg"] not in near:
+                    out.append((y, x, dict(state)["bg"], near))
+        return out
+
+    def _harness_edges(self, shot: str) -> set:
+        """The backgrounds the rules touching the UNPAINTED pane are drawn in.
+
+        The harness is the only pane charter never paints, so it is the only pane whose
+        interior cells are the terminal's own — which is how this finds its edges without
+        knowing where tmux put it.
+        """
+        rows = self._grid(shot)
+        out = set()
+        for y, row in enumerate(rows):
+            for x, (state, ch) in enumerate(row):
+                if ch == "\u2500":
+                    sides = [rows[y - 1][x:x + 1], rows[y + 1][x:x + 1]]
+                elif ch == "\u2502":
+                    sides = [row[x - 1:x], row[x + 1:x + 2]]
+                else:
+                    continue
+                near = [dict(c[0][0])["bg"] for c in sides if c and c[0]]
+                if "default" in near:
+                    out.add(dict(state)["bg"])
+        return out
+
+    def _painted(self, shot: str):
+        """The one background the panels are painted in, or a skip naming what this
+        machine could not render. `_control`'s discipline: a harness that cannot see the
+        surface cannot testify about the rules drawn over it."""
+        cells = _sgr_runs(shot, carry=True)
+        if not any(ch in _RULE_GLYPHS for _s, ch in cells):
             raise unittest.SkipTest("this machine rendered no pane borders at all")
-        if not panes:
+        painted = {dict(s)["bg"] for s, _ch in cells} - {"default"}
+        if len(painted) != 1:
             raise unittest.SkipTest(
-                "this tmux painted no pane background through a nested client, so there "
-                "is no surface here for a rule to fail to match")
-        return rules, panes
+                "this tmux did not paint the panels one colour through a nested client "
+                f"({painted}), so there is no surface here for a rule to match")
+        return painted.pop()
 
-    def test_a_surfaced_frame_really_does_render_a_seam_between_its_panes(self):
-        """The defect itself, named rather than only used as a control."""
-        rules, panes = self._seam()
-        self.assertEqual(rules, {"default"},
-                         "the rules already carry a background before charter puts one "
-                         f"there, so the seam does not reproduce here: {rules}")
-        self.assertNotEqual(rules, panes)
+    def test_an_unsurfaced_rule_really_does_leave_a_seam_between_painted_panes(self):
+        """The first defect, rendered — and the control for both tests below. Panels
+        painted, rules left as `_CHROME_STYLE` alone: border cells come back over the
+        terminal's own background while the panes on BOTH sides of them are over another.
+        That one-cell strip is what the operator reported off a screenshot."""
+        shot = self._screenshot(arm=True, surface=self._SURFACE, design="bare")
+        self._painted(shot)
+        self.assertTrue(self._seams(shot),
+                        "no rule here is drawn over a background neither of its "
+                        "neighbours has, so the seam does not reproduce on this tmux and "
+                        "a frame without one would prove nothing")
 
-    def test_the_frames_rules_are_drawn_over_the_frames_own_surface(self):
-        """The fix, on the screen the operator judges it by. Every border cell is drawn
-        over the same background as the panes it runs between, so there is no strip left
-        between them — and #514's property survives it: still ONE appearance for every
-        rule in the frame, including the ones running past the active pane's corner."""
-        self._seam()
-        shot = self._screenshot(arm=True, surface=self._SURFACE)
-        rules, panes = self._backgrounds(shot)
-        self.assertEqual(len(panes), 1,
-                         f"the panels came out more than one colour: {panes}")
-        self.assertEqual(rules, panes,
-                         "a rule is still drawn over a different background than the "
-                         f"panes it separates: rules={rules} panes={panes}")
-        self.assertEqual(len(_rule_states(shot, carry=True)), 1,
-                         "the surfaced frame draws its rules two ways — #514, reopened "
-                         "on the background instead of the foreground")
+    def test_neither_design_leaves_a_seam_between_two_panes_of_one_colour(self):
+        """The property both of charter's answers must have, asked of the screen. A rule
+        may take either side — tmux draws one border, not two half-borders — but it may
+        never be a third colour, and a third colour between two identically-painted panes
+        is exactly the strip this began with."""
+        self.assertTrue(
+            self._seams(self._screenshot(arm=True, surface=self._SURFACE, design="bare")),
+            "the control rendered no seam, so this machine cannot testify")
+        for design in ("window", "pane"):
+            with self.subTest(design=design):
+                shot = self._screenshot(arm=True, surface=self._SURFACE, design=design)
+                self._painted(shot)
+                self.assertEqual(self._seams(shot), [])
 
-    def test_charters_chrome_reaches_charters_own_window_and_no_other(self):
-        """The boundary the `-w` scope is for, measured on a real server rather than
-        argued from the flag: after charter styles its own window, a window the operator
-        already had still resolves to the value THEIR config set."""
-        theirs = self._srv("new-session", "-d", "-s", "theirs", "-x", "80", "-y", "24",
-                           "--", "cat")
-        self.assertEqual(theirs.returncode, 0, theirs.stderr)
-        self.assertEqual(self._srv("set", "-wg", "pane-border-style",
-                                   "fg=blue").returncode, 0)
-        ours = self._srv("new-session", "-d", "-s", "ours", "-x", "80", "-y", "24",
-                         "-P", "-F", "#{pane_id}", "--", "cat")
-        self.assertEqual(ours.returncode, 0, ours.stderr)
+    def test_only_the_per_pane_design_leaves_the_harness_pane_unboxed(self):
+        """#631, on the screen the operator judges it by.
+
+        A window-wide border surface reaches EVERY rule in the frame, including the three
+        around the pane charter does not own — so the frame that closed the seam drew a
+        grey box round the operator's own session. Per-pane edges cannot: `_surface_argvs`
+        is only ever handed a panel pane, so the harness keeps the window's bare style and
+        every rule cell tmux resolves against it is the terminal's own.
+
+        Asserted as a DIFFERENCE between the two designs rendered on this machine at this
+        moment, never against a remembered colour: the window-wide frame is the control
+        that proves this test can see the box.
+        """
+        boxed = self._screenshot(arm=True, surface=self._SURFACE, design="window")
+        painted = self._painted(boxed)
+        self.assertEqual(self._harness_edges(boxed), {painted},
+                         "the frame-wide design did not box the unpainted pane on this "
+                         "tmux, so there is nothing here for the per-pane one to fix")
+        unboxed = self._screenshot(arm=True, surface=self._SURFACE, design="pane")
+        self.assertEqual(self._painted(unboxed), painted)
+        self.assertEqual(self._harness_edges(unboxed), {"default"},
+                         "a rule touching the pane charter never paints is still drawn "
+                         "in charter's colour — the harness is boxed")
+
+    def test_the_harness_pane_carries_no_border_option_of_its_own(self):
+        """The other half of the same boundary, read off tmux rather than off the screen.
+        Per-pane edges are set with `set -p`, and ADR 0018's line holds here the way it
+        holds for the surface: the harness pane is never an argument, so it has nothing of
+        charter's on it and inherits the window's own."""
+        session = f"hb-{self._pane_counter}"
+        self._pane_counter += 1
+        r = self._srv("new-session", "-d", "-s", session, "-x", "80", "-y", "24",
+                      "-P", "-F", "#{pane_id}", "--", "cat")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness = r.stdout.strip()
         for cmd in commands_frame._chrome_argvs(socket=self.SOCKET_NAME,
-                                                harness_pane=ours.stdout.strip()):
+                                                harness_pane=harness):
+            _run(cmd)
+        p = self._srv("split-window", "-t", harness, "-P", "-F", "#{pane_id}", "--", "cat")
+        panel = p.stdout.strip()
+        for cmd in commands_frame._surface_argvs(socket=self.SOCKET_NAME, pane_id=panel,
+                                                 chrome="dark", bg="brightblack",
+                                                 pane_borders=True):
             self.assertEqual(_run(cmd).returncode, 0, cmd)
-        # `-A` so tmux reports the value the window RESOLVES to (inherited included), not
-        # only what was set on it locally — the second would answer "nothing" for their
-        # window whether charter had reached it or not.
-        resolved = self._srv("show-options", "-w", "-A", "-v", "-t", "theirs:0",
-                             "pane-border-style")
-        self.assertEqual(resolved.stdout.strip(), "fg=blue",
-                         "charter restyled a window that is not its own")
-        mine = self._srv("show-options", "-w", "-A", "-v", "-t", "ours:0",
-                         "pane-border-style")
-        self.assertEqual(mine.stdout.strip(),
-                         dict(commands_frame._CHROME)["pane-border-style"],
-                         "charter's own window did not take charter's own style")
+        for option in instance.PANE_BORDER_OPTIONS:
+            with self.subTest(option=option):
+                self.assertEqual(
+                    self._srv("show", "-p", "-t", harness, "-v", option).stdout.strip(),
+                    "", "charter wrote a border style on the harness pane")
+                self.assertTrue(
+                    self._srv("show", "-p", "-t", panel, "-v", option).stdout.strip(),
+                    "the panel never got its own edges, so the harness reading '' "
+                    "proves nothing")
+        self._srv("kill-session", "-t", session)
 
 
 class EveryBorderOptionThisTmuxHasIsPinned(_TmuxServerFixture, PersonaIso,

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -4277,6 +4277,53 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
                          "charter's frame is drawn differently on the operator's server "
                          "than on charter's own")
 
+    def _require_pane_scoped_borders(self) -> None:
+        """Skip unless THIS tmux really keeps `pane-border-style` per pane.
+
+        **Probed, never a version string**, per this plane's rule and this module's own
+        docstring — and here the probe is the only honest form, because the thing being
+        detected does not fail loudly. Below `tmuxctl.PANE_BORDER_FLOOR` the option is a
+        window option: `set -p` returns 0 and writes the WINDOW, so a test that assumed
+        pane scope would not error, it would assert against a frame where charter's write
+        had leaked onto the harness — which is exactly what CI's tmux 3.4 did to the first
+        version of these tests.
+
+        The probe performs that write on a throwaway session this test owns, so the only
+        thing it can damage is its own.
+        """
+        session = f"probe-{self._pane_counter}"
+        self._pane_counter += 1
+        r = self._srv("new-session", "-d", "-s", session, "-x", "40", "-y", "10",
+                      "-P", "-F", "#{pane_id}", "--", "cat")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pane = r.stdout.strip()
+        self._srv("set", "-w", "-t", pane, "pane-border-style", "fg=default")
+        self._srv("set", "-p", "-t", pane, "pane-border-style", "bg=red")
+        window = self._srv("show", "-wv", "-t", pane, "pane-border-style").stdout.strip()
+        self._srv("kill-session", "-t", session)
+        if window != "fg=default":
+            raise unittest.SkipTest(
+                "this tmux has no pane scope for `pane-border-style` — `set -p` wrote the "
+                f"window ({window!r}), which is what `tmuxctl.PANE_BORDER_FLOOR` gates")
+
+    def test_the_floor_agrees_with_what_this_tmux_actually_does(self):
+        """The version constant, checked against the binary rather than against tmux's
+        source. Where a real tmux is present its behaviour is the authority, so a
+        `PANE_BORDER_FLOOR` moved without a measurement goes red on the machine that could
+        have measured it."""
+        v = tmuxctl.version()
+        if v is None:
+            raise unittest.SkipTest("no readable tmux version to check the floor against")
+        supported = True
+        try:
+            self._require_pane_scoped_borders()
+        except unittest.SkipTest:
+            supported = False
+        self.assertEqual(supported, v >= tmuxctl.PANE_BORDER_FLOOR,
+                         f"tmux {v} {'does' if supported else 'does not'} keep "
+                         "`pane-border-style` per pane, which is not what "
+                         f"`PANE_BORDER_FLOOR` {tmuxctl.PANE_BORDER_FLOOR} says")
+
     #: The colour every panel in a surfaced screenshot is painted, and the only
     #: non-default background on the screen — the harness pane is never painted, and every
     #: pane runs `cat` and writes nothing.
@@ -4383,6 +4430,8 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
             "the control rendered no seam, so this machine cannot testify")
         for design in ("window", "pane"):
             with self.subTest(design=design):
+                if design == "pane":
+                    self._require_pane_scoped_borders()
                 shot = self._screenshot(arm=True, surface=self._SURFACE, design=design)
                 self._painted(shot)
                 self.assertEqual(self._seams(shot), [])
@@ -4400,6 +4449,7 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         moment, never against a remembered colour: the window-wide frame is the control
         that proves this test can see the box.
         """
+        self._require_pane_scoped_borders()
         boxed = self._screenshot(arm=True, surface=self._SURFACE, design="window")
         painted = self._painted(boxed)
         self.assertEqual(self._harness_edges(boxed), {painted},
@@ -4416,6 +4466,7 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         Per-pane edges are set with `set -p`, and ADR 0018's line holds here the way it
         holds for the surface: the harness pane is never an argument, so it has nothing of
         charter's on it and inherits the window's own."""
+        self._require_pane_scoped_borders()
         session = f"hb-{self._pane_counter}"
         self._pane_counter += 1
         r = self._srv("new-session", "-d", "-s", session, "-x", "80", "-y", "24",


### PR DESCRIPTION
Closes #631. Follows #628, which closed the seam and opened this.

**You were right and I was wrong.** I chose window-wide everywhere for consistency; the
render says the modern-tmux operator pays for that with a box around their own session, and
the floor's silent `set -p` is a reason the floor cannot have per-pane edges, not a reason
3.7 should not.

One correction to the model, from the render rather than from the option table: the
ownership rule is not "the pane above or left". tmux 3.2's `screen_redraw_check_cell` scans
the pane list **starting at the active pane** and returns the first pane whose border ring
contains the cell; 3.7 then resolves the style against *that pane's* options
(`screen_redraw_draw_borders_style`, `oo = w->options` in 3.2, the pane's in 3.7). So which
pane owns a rule is not derivable from geometry alone — which is why this is settled by
capture, and why I measured four focus states before believing it was stable.

It lands better than your table predicted: the harness comes out unboxed on **all three**
sides, not two. The rule under the top bar is the harness's, not the top bar's.

## Show it

Charter's real four-panel shape (`top`, `bottom`, `repos`, `right` off the harness) at
100x24, `chrome = "dark"`, every component `bg = "brightblack"`, driven by the production
argvs — `_chrome_argvs` and `_surface_argvs`, never a hand-retyped `set-option` — and read
through a nested tmux with `capture-pane -p -e -N`. `ESC` for `\x1b`.

**#628, window-wide** (`pane-border-style = fg=default,dim,bg=brightblack`):

```
 0 ESC[100m                                        <- top bar, grey
 1 ESC[2m──────────────────────────────┬─────────  <- no ESC[49m: grey, all the way across
 2 ESC[0m          ...          ESC[2mESC[100m│ESC[0mESC[100m   <- the vertical: grey
15 ESC[2m──────────────────────────────┴─────────  <- grey
```

Rows 1, 2 and 15 are the harness's three edges. All grey. That is the box.

**#631, per pane** (window stays `fg=default,dim`; each panel carries its own):

```
 0 ESC[100m                                        <- top bar, grey
 1 ESC[2mESC[49m─────────────────────────┬ESC[100m──────  <- dark over the harness, grey over the sidebar
 2 ESC[0m          ...            ESC[2m│ESC[0mESC[100m     <- the vertical: dark
15 ESC[2mESC[49m─────────────────────────┴ESC[100m──────  <- dark over the harness, grey over the sidebar
22 ESC[2m────────────────────────────────────────  <- repos|bottom, both grey: grey, no seam
```

The `ESC[49m` is back exactly where it belongs — on the three rules that touch the pane
charter does not own — and nowhere else. Every rule between two grey panels is still grey.
Read off tmux rather than off the screen: `show -p -t <harness> -v pane-border-style` is
`''`, and the panels' is `fg=default,dim,bg=brightblack`.

**Focus-stable.** Because the scan starts at the active pane, I rendered all four states —
harness active, sidebar active, repos active, harness again. Rows 1, 15 and the vertical
were byte-identical in every one. The frame does not move when focus does.

## The gate is on the write, and the floor proves why

`PANE_BORDER_FLOOR = (3, 7)`, from tmux's own `options-table.c` at every release either
side of the line, and run on both:

| release | `pane-border-style` scope |
|---|---|
| 3.2, 3.3a, 3.4, 3.5, 3.6, 3.6a | `OPTIONS_TABLE_WINDOW` |
| 3.7, 3.7a, 3.7c, master | `OPTIONS_TABLE_WINDOW\|OPTIONS_TABLE_PANE` |

Below the line the failure is **silent, not refused** — there is nothing for `tmuxctl.run`
to report. Forcing the wrong branch on the real 3.2 built from source here, with the
production argvs:

```
  v=(3, 7) pane_borders=True          # deliberately wrong for this tmux
  window pane-border-style     = 'fg=default,dim,bg=brightblack'
  harness -p pane-border-style = 'fg=default,dim,bg=brightblack'   <- the PANELS' write, on the HARNESS
```

The per-pane writes landed on the window, the harness reads them back, and the rendering
collapses to the window-wide one with the last panel written deciding it. `set -p -u` would
take charter's #514 pin with it. A probe would have to perform that write to discover this,
so it is a version gate — and `None` ("charter could not find out") takes the frame-wide
answer, which is correct on every tmux.

`pane-border-indicators` is still rc 1 `invalid option:` at the floor — pre-existing,
reported, not fatal, unchanged.

## What the floor gets, said plainly

The window-wide answer, exactly as #628 shipped it: seam closed, harness boxed. That is the
lesser of two imperfect renderings on a tmux that cannot have the good one, and
`instance.border_bg`'s docstring and `docs/frame.md` now say so rather than presenting it
as the design.

## `pane-active-border-style`

Identical value to `pane-border-style`, per pane, for #514's reason restated one scope down:
tmux picks between the two **per border cell**, so a pane whose two differed would have
edges that changed colour at the active pane's corner. Its indication was already discarded
by #514; nothing new is lost.

## Verification

- **Full suite, two environments**: 7657 tests `OK` on CPython 3.14.4, and `OK` on 3.12.13
  with all 16 `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` variables dropped.
- **`tools/sweep.py`**: 15 mutations, **15 pinned, 0 survived, 0 unresolved**, 16.2 min.
- **Hand-check, 12 mutations from an unmutated baseline** (#579) — applied-assertion on both
  text and file hash, restore verified against a pre-touch hash, `finally` restore, green
  post-restore run. **First pass left one survivor and it was real**: `_draw_panels`' own
  `v=v`. With it mutated to `v=None` the whole suite stayed green while a real frame on a
  modern tmux silently took the floor design and put the box back. Fixed by driving
  `_draw_panels` in `TheVersionReachesTheFunnelFromTheFunctionThatKnowsIt`; second pass
  **12/12 killed, 0 survivors**.
  - Worth recording: I first wrote that test on `cmd_launch` via
    `tests/test_frame_launcher.py`'s fake, and it failed — that fake reports no pane id for
    a `split-window`, so a whole faked launch never reaches the per-pane surface and
    `_surface_argvs` is not called once. A test built on it would have passed while
    asserting nothing.
- **Real tmux for every claim**, 3.7c and the 3.2 floor. Sockets killed and unlinked in one
  cleanup on every path; nothing left in `/private/tmp/tmux-$(id -u)/`.

## Tests

The rendered assertions in `ChromeIsOneColour` were rewritten, because #628's were checking
the wrong property (*"every rule is the surface"* — which is the box). They now check what
"seam" and "box" actually mean, without re-deriving tmux's pane geometry:

- `_seams` compares each `─` with the cell above and below it, each `│` with left and right,
  and flags any border drawn in a **third** colour. A rule may take either side; it may
  never be a colour neither neighbour has.
- `_harness_edges` finds the rules touching the only unpainted pane and reports their
  backgrounds — `{surface}` window-wide, `{default}` per pane.
- Both designs are rendered on the machine at that moment, so the window-wide frame is the
  live control proving the test can see the box. The unsurfaced frame is still rendered
  first as the seam control, keeping this class's own discipline.

`_screenshot` now takes `design` in `{"bare", "window", "pane"}`, all three driven by the
production argvs and differing only in what production would really pass.

## CI caught the same trap in my own tests

First push went red on 3.11 and 3.14, and it was the right kind of red. **CI runs tmux
3.4** — below the floor — and my rendered tests forced `pane_borders=True` there. They did
not error, because below the floor nothing errors: the per-pane write landed on the window,
the harness read it back, and the tests reported the box they exist to refuse. Production's
gate was correct; the tests were making no gate at all, which is the same silent-failure
shape one layer up.

Fixed by probing rather than by a version check, per this module's own rule:
`_require_pane_scoped_borders` performs the write on a throwaway session the test owns and
reads the **window** back — unchanged means real pane scope, changed means skip with the
reason. Verified both ways: the two pane-scoped tests run on 3.7c and skip on the 3.2 build
with `"set -p wrote the window ('bg=red')"`.

`test_the_floor_agrees_with_what_this_tmux_actually_does` closes the loop the other way —
where a real tmux is present its behaviour is the authority, so a `PANE_BORDER_FLOOR` moved
without a measurement goes red on the machine that could have measured it.

## Diff surface

`instance.py` (`PANE_BORDER_OPTIONS`, `pane_border_options`, a scope note on `border_bg`),
`tmuxctl.py` (one constant), and four places in the contended `commands_frame.py`:
`_pane_borders_wanted` and `_pane_border_pairs` (new, adjacent), `_surface_argvs` and
`_resurface_argvs` (one keyword and one expression each — the removal reuses the existing
unset machinery rather than adding a second), `_split_panels`/`_draw_panels`/`_relayout` (the
`v` keyword), and `cmd_chrome` (the version read and two call arguments). No file owned by
the click/scroll or sweep agents is touched.

No version bump, no stamp, no tag. News entry at `version: unreleased`. **Not merged.**
