### PR TITLE
Recover #630's final commit, lost to a merge race

### DIFF
--- a/docs/news/unreleased-a-green-sweep-is-not-no-survivors.md
+++ b/docs/news/unreleased-a-green-sweep-is-not-no-survivors.md
@@ -91,7 +91,7 @@ kind of pass.
 
 ## The sweep swept the gate that reports it
 
-119 mutations, against a change whose whole subject is the sweep. It found two lines of
+127 mutations, against a change whose whole subject is the sweep. It found four lines of
 its own that no test went red without.
 
 **The unsharded path had stopped being tested.** Forcing `if shard is not None` to
@@ -105,7 +105,20 @@ zero. Deleting it changed no answer with today's constants and would have made t
 job raise with tomorrow's — no plan, no shards, no numbers, which is the failure this
 whole change exists to prevent, arriving out of the arithmetic written to prevent it.
 
-Both are pinned now. A third survivor is not a finding about this code at all: it is a
+**And the annotation escaping was asserted by absence.** The tests checked that a newline
+was *gone* from a workflow command, never that it had become `%0A` — so retuning `%0D` or
+`%0A` or `%25` left the suite green. A wrong encoding there does not break anything
+visibly: the runner prints a mangled message, which is the kind of wrong nobody files and
+nobody can read either. The bytes are pinned now, and pinning them pins the order too,
+because `%` has to be escaped first or the `%` of `%0A` gets escaped a second time.
+
+**And the reserved annotation slot had no case on its boundary.** When a level is over
+budget the tenth slot goes to the line that says how many were not drawn — otherwise that
+line is the first thing the cap eats. Every test had either far fewer than ten findings or
+far more, so "always ten" and "always nine" both passed, and "always ten" is the one that
+loses the note. There is a case at nine, ten and eleven now.
+
+All four are pinned now. A fifth survivor is not a finding about this code at all: it is a
 string inside a *type annotation*, which `from __future__ import annotations` means the
 interpreter never evaluates, so no test can ever go red without it. That is a blind spot
 in the string operator's scoping rather than a guard, and it is filed as one (#632)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -2387,6 +2387,25 @@ class EverySurvivorLandsOnTheLineItIsAbout(unittest.TestCase):
         self.assertIn("5 of these 14 are not shown", said[-1])
         self.assertIn("all 14", said[-1])
 
+    def test_exactly_the_cap_is_drawn_whole_and_one_more_costs_a_slot(self):
+        """The boundary the reserved slot turns on, found unpinned by the sweep.
+
+        At exactly ten there is nothing to announce, so all ten are findings. At eleven
+        the note has to fit inside the same ten, so nine are. Without a case sitting on
+        the boundary, "always ten" and "always nine" both pass — and "always ten" is the
+        one that loses the note, which is the only line that distinguishes *these ten*
+        from *these ten of twenty-two*.
+        """
+        def drawn(n):
+            gate = sweep.classify([_result("survived", path=f"charter/{i}.py")
+                                   for i in range(n)])
+            said = sweep.annotations(gate)
+            return sum(1 for s in said if "file=" in s), len(said)
+
+        self.assertEqual(drawn(9), (9, 9))       # under the cap: no note
+        self.assertEqual(drawn(10), (10, 10))    # exactly the cap: still no note
+        self.assertEqual(drawn(11), (9, 10))     # one over: nine findings and the note
+
     def test_the_cap_is_a_levels_budget_and_not_one_kind_of_findings(self):
         """Masked clusters, lone survivors and unmeasured mutations are all warnings, so
         they share one budget of ten. Capping each family at ten instead would emit thirty
@@ -2431,6 +2450,18 @@ class EverySurvivorLandsOnTheLineItIsAbout(unittest.TestCase):
         said = sweep.annotations(gate)
         self.assertEqual(len(said), 1)
         self.assertNotIn("\n", said[0])
+
+    def test_the_escaping_is_the_encoding_the_runner_decodes_and_not_merely_removal(self):
+        """Found by the sweep on this branch: retuning `"%0D"` left every test green.
+
+        Asserting that the newline is *gone* is not asserting that it became `%0A`. A
+        wrong encoding does not break the command — the runner prints a mangled message,
+        which is the kind of wrong nobody files and nobody can read either. So the bytes
+        are pinned, and pinning them pins the ORDER too: `%` has to be escaped first, or
+        the `%` of `%0A` gets escaped again and `a\\nb` comes out as `a%250Ab`.
+        """
+        self.assertEqual(sweep._escape("100% done\r\nnext"), "100%25 done%0D%0Anext")
+        self.assertEqual(sweep._property("a,b:c%d\ne"), "a%2Cb%3Ac%25d%0Ae")
 
     def test_an_annotation_is_not_a_failure(self):
         gate = sweep.classify([_result("survived"), _result("unapplied",


### PR DESCRIPTION
**My error, twice over.** I merged #630 at head `72f58ff` while its author was still working; `bc8b724` landed afterwards and never reached `main`. This is the same mistake I made with #604 earlier — and #613 was that recovery.

## What was missing

```
 tests/test_sweep.py                                | 31 +++++++++++++++
 docs/news/unreleased-a-green-sweep-is-not-no-...md | 17 ++++++--
```

Four lines the sweep found unpinned **in the gate's own new code**, each hand-checked against a green unmutated baseline with a sha256-verified restore, under `PYTHONDONTWRITEBYTECODE=1` — plus the news entry saying what they were.

## Why losing these in particular would have been bad

The gate exists to make "this branch has unpinned guards" visible. Merging it with four unpinned lines of its own, reporting `no survivors`, is precisely the failure it was built to prevent — and it would have said so about itself, wrongly, on every PR from then on.

## The rule I keep relearning

**A PR head is not a finished state until its author says so.** Green checks are not the signal; the author's "done" is. I have now paid for that twice in one session, so I am writing it here rather than in a summary that scrolls away.

`tests.test_sweep` — 273 tests, OK.