### PR TITLE
Two more lines the sweep found unpinned in the gate it reports (#617)

### DIFF
--- a/docs/news/unreleased-a-green-sweep-is-not-no-survivors.md
+++ b/docs/news/unreleased-a-green-sweep-is-not-no-survivors.md
@@ -91,7 +91,7 @@ kind of pass.
 
 ## The sweep swept the gate that reports it
 
-127 mutations, against a change whose whole subject is the sweep. It found five lines of
+127 mutations, against a change whose whole subject is the sweep. It found six lines of
 its own that no test went red without.
 
 **The unsharded path had stopped being tested.** Forcing `if shard is not None` to
@@ -124,7 +124,13 @@ instead, because a merge takes a second and printing that second would understat
 forty-minute run by two orders of magnitude. Nothing asserted the minutes, so collapsing
 the whole thing to "merged from its shards" left the suite green and every page saying it.
 
-All five are pinned now. A sixth survivor is not a finding about this code at all: it is a
+**And the row that counts the missing shards was asserted by a phrase that appears
+twice.** The test looked for "did not report" anywhere on the page — and the section
+heading below carries the same words, so deleting the table row outright left it green,
+and so did collapsing the cell that holds "2 of 3". A row is a number; the number is
+asserted now, in each of the three shapes it takes.
+
+All six are pinned now. A seventh survivor is not a finding about this code at all: it is a
 string inside a *type annotation*, which `from __future__ import annotations` means the
 interpreter never evaluates, so no test can ever go red without it. That is a blind spot
 in the string operator's scoping rather than a guard, and it is filed as one (#632)

--- a/docs/news/unreleased-a-green-sweep-is-not-no-survivors.md
+++ b/docs/news/unreleased-a-green-sweep-is-not-no-survivors.md
@@ -91,7 +91,7 @@ kind of pass.
 
 ## The sweep swept the gate that reports it
 
-127 mutations, against a change whose whole subject is the sweep. It found four lines of
+127 mutations, against a change whose whole subject is the sweep. It found five lines of
 its own that no test went red without.
 
 **The unsharded path had stopped being tested.** Forcing `if shard is not None` to
@@ -118,7 +118,13 @@ line is the first thing the cap eats. Every test had either far fewer than ten f
 far more, so "always ten" and "always nine" both passed, and "always ten" is the one that
 loses the note. There is a case at nine, ten and eleven now.
 
-All four are pinned now. A fifth survivor is not a finding about this code at all: it is a
+**And the wall clock was never read back.** The summary prints how long the sweep took,
+or — when the answer was added up from several machines rather than measured — says that
+instead, because a merge takes a second and printing that second would understate a
+forty-minute run by two orders of magnitude. Nothing asserted the minutes, so collapsing
+the whole thing to "merged from its shards" left the suite green and every page saying it.
+
+All five are pinned now. A sixth survivor is not a finding about this code at all: it is a
 string inside a *type annotation*, which `from __future__ import annotations` means the
 interpreter never evaluates, so no test can ever go red without it. That is a blind spot
 in the string operator's scoping rather than a guard, and it is filed as one (#632)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -2196,6 +2196,22 @@ class TheGateSaysWhichOfThreeThingsItFound(unittest.TestCase):
         text = sweep.gate_summary(gate, "a" * 40, "b" * 40, 60.0, enforce=False)
         self.assertIn("## Deletion sweep — 2 survivors", text)
 
+    def test_the_page_says_how_long_it_took_or_that_it_did_not_measure_that(self):
+        """`elapsed is None`, found unpinned by the sweep on the branch that added it.
+
+        A merge adds up several machines' results in about a second, and printing that
+        second as the sweep's wall clock would understate a forty-minute run by two orders
+        of magnitude, on the one line a reader skims. So the merged page says where its
+        number came from instead — and the *measured* page has to actually carry the
+        minutes, or "says so instead" is the only thing either page ever says.
+        """
+        gate = sweep.classify([_result("pinned")])
+        measured = sweep.gate_summary(gate, "a" * 40, "b" * 40, 1234.0, enforce=False)
+        merged = sweep.gate_summary(gate, "a" * 40, "b" * 40, None, enforce=False)
+        self.assertIn("20.6 min on ", measured)
+        self.assertNotIn("merged from its shards", measured)
+        self.assertIn("merged from its shards on ", merged)
+
     def test_a_page_missing_a_shard_refuses_to_call_the_branch_clean(self):
         gate = sweep.classify([_result("pinned")])
         text = sweep.gate_summary(gate, "a" * 40, "b" * 40, 60.0, enforce=False,

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -2219,6 +2219,27 @@ class TheGateSaysWhichOfThreeThingsItFound(unittest.TestCase):
         self.assertIn("did not report", text)
         self.assertNotIn("Nothing added here is a line the suite would not miss", text)
 
+    def test_the_table_carries_the_missing_shards_as_a_row_with_a_count_in_it(self):
+        """`[59]` and `[60]` from the self-sweep, and both are one mistake.
+
+        The test above looks for "did not report" *anywhere on the page* — and the section
+        further down carries that phrase in its heading, so deleting the table row
+        outright left the suite green, and so did collapsing the cell that holds the
+        count. A row is a number; assert the number, in both of the shapes it has.
+        """
+        gate = sweep.classify([_result("pinned")])
+        counted = sweep.gate_summary(gate, "a" * 40, "b" * 40, None, False,
+                                     missing=2, shards=3)
+        self.assertIn("| **did not report** | 2 of 3 |", counted)
+        # One shard, and it was the one that vanished — the ordinary shape for a small
+        # diff, and the edge `shards >= 1` actually turns on.
+        lone = sweep.gate_summary(gate, "a" * 40, "b" * 40, None, False,
+                                  missing=1, shards=1)
+        self.assertIn("| **did not report** | 1 of 1 |", lone)
+        unsized = sweep.gate_summary(gate, "a" * 40, "b" * 40, None, False,
+                                     missing=1, shards=0)
+        self.assertIn("| **did not report** | ? |", unsized)
+
     def test_a_page_with_every_shard_in_still_says_the_branch_is_clean(self):
         text = sweep.gate_summary(sweep.classify([_result("pinned")]),
                                   "a" * 40, "b" * 40, 60.0, enforce=False)


### PR DESCRIPTION
Follow-up to #630 and #635. **These two commits were pushed to `recover/617-final` after #635 had already been merged**, so they are on that branch but not on `main` — a second merge race, same shape as the first. Rebased onto current `main` here.

`main` already has the escaping fix and the annotation-cap boundary case. It does not have these.

## `[56]` / `[58]` — the wall clock was never read back

```python
took = f"{elapsed / 60:.1f} min" if elapsed is not None else "merged from its shards"
```

Collapsing that to the second arm left **all 273 tests green**. Nothing asserted the minutes, so every page — measured or merged — could have said "merged from its shards" and no test would have noticed. The `.1f` retune survived for the same reason.

The conditional earns its place: a merge adds up several machines' results in about a second, and printing that second as the sweep's wall clock understates a forty-minute run by two orders of magnitude, on the one line a reader skims. But *"says so instead"* only means something if the other arm carries a number.

## `[59]` / `[60]` / `[61]` — the row that counts the missing shards

```python
if missing:
    w(f"| **did not report** | {f'{missing} of {shards}' if shards >= 1 else '?'} | "
      "a shard that never wrote a result — read nothing below as a count |")
```

Deleting the row outright left the suite green, and so did collapsing the cell in either direction — because the test looked for `"did not report"` **anywhere on the page**, and the section heading below carries the same three words. The phrase survived with the count gone.

Asserted now in each of the three shapes the cell takes: `2 of 3`, `1 of 1` for the one-shard plan whose only shard vanished, and `?` when the sweep never sized itself. The middle one is the case `shards >= 1` actually turns on — without it the boundary shifted to `shards > 1` and survived too.

## The pattern

Three findings in a row, and all one mistake: **an assertion about the absence of something standing in for one about its value.** A newline that was gone rather than encoded; a cap with no case on its edge; a phrase that appears twice. Which is the harness's own thesis, arriving about the harness.

## Verification

Every mutant hand-checked against a **green unmutated baseline** with a **sha256-verified restore**, under `PYTHONDONTWRITEBYTECODE=1`, in a worktree no verification run was reading:

```
BASELINE TheGateSaysWhichOfThreeThingsItFound: rc=0 Ran 18 tests  OK
   collapse -> always "merged from its shards"  rc=1 FAILED (failures=1)  PINNED
   collapse -> always the minutes               rc=1 FAILED (errors=2)    PINNED
   retune the minutes format                    rc=1 FAILED (failures=1)  PINNED

BASELINE (with the row cases): rc=0 Ran 19 tests  OK
   [59] drop the whole row                rc=1 FAILED (failures=1)  PINNED
   [60] collapse the cell -> count        rc=1 FAILED (failures=1)  PINNED
   [60] collapse the cell -> '?'          rc=1 FAILED (failures=1)  PINNED
   boundary shards >= 1 -> shards > 1     rc=1 FAILED (failures=1)  PINNED
   boundary shards >= 1 -> shards >= 0    rc=1 FAILED (failures=1)  PINNED
```

Both conditions in that sentence are load-bearing, and each cost me a wrong answer first:

- **`PYTHONDONTWRITEBYTECODE=1`** — `retune-string` preserves length by construction, so a same-second restore of an equal-length mutation is byte-different and `(mtime, size)`-identical, which is all CPython validates a `.pyc` on. My first hand-check called a mutant green while the file on disk was provably correct, because the interpreter was running the previous mutant's bytecode. `Sandbox.run` already sets this and documents the measurement; only my ad-hoc script was missing it.
- **A worktree no suite is reading** — a later full-suite run came back `FAILED (errors=6)` on CPython 3.14 while CI's Linux 3.14 was green at the same sha. All six were my own tests, and the traceback was one of my hand-check mutants mid-flight. I had mutated the tree the suite was reading.

`tests.test_sweep` + `test_workflows` + `test_news`: **341 tests, OK.**

## Where the sweep stands

`tools/sweep.py --gate --path tools --base bcc1228` is running again on the fixed tree. Twelve survivors found so far across the earlier runs, every one accounted for: three escaping, three annotation-cap boundary, two wall-clock, three table-row — all pinned — and `"Pair"`, which is an annotation string under PEP 563 and can never be pinned (#632).

It has not finished, and I am not offering it as a complete verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
