### PR TITLE
A cross-repo landing is on the release floor, a revert is a new change, and divergence is named (Phase 4, Tasks 9-14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,9 @@ copy wins, is compared to nothing, and drifts unwatched in both directions.
   constrain.
 - [docs/forges.md](docs/forges.md) — what GitLab and GitHub each need, self-hosted hosts,
   and the rule for a repo name that collides across forges.
+- [docs/changes.md](docs/changes.md) — one change spanning several repos: what the record
+  holds, why it holds no state, what charter refuses to do with it, and how a revert is a
+  new change rather than an undo button.
 
 ## Contributing
 

--- a/charter/change.py
+++ b/charter/change.py
@@ -50,6 +50,8 @@ merge request is a **request**. Neither name is renamed; both are shipped.
 from __future__ import annotations
 
 import json
+import re
+import socket
 from pathlib import Path
 
 from . import config, contain, instance, workspace
@@ -98,6 +100,206 @@ TEXT_LIMIT = contain.PATH_DISPLAY_LIMIT
 #: required by the same rule that requires the change's own: the exclusion is the only
 #: artifact that makes a permanently partial world explicable six months later.
 EXCLUSION_KEYS = ("repo", "why", "at")
+
+#: Every key one landing-log line carries. Closed, like :data:`KEYS` and for the same
+#: reason — but this is a *log*, so a line that does not fit is skipped rather than raised
+#: over (:func:`landings`): an append-only file collects half-written lines from killed
+#: processes, and one of those must not take a report down.
+#:
+#: ``merge`` is the sha of the commit charter created, ``head`` the member's branch tip it
+#: was created from. Both, because they answer different questions: ``merge`` is what
+#: ``revert`` reverts and what git is asked to still contain, ``head`` is what the check
+#: gate had read when it let the landing through.
+LOG_FIELDS = ("ts", "change", "repo", "number", "merge", "head")
+
+#: What charter can say about ONE member from **files alone** — the record and the landing
+#: log — in PRECEDENCE order, worst first. :func:`worst` reads this tuple's order and
+#: nothing else, so the two cannot disagree.
+#:
+#: **``unknown`` is first, and that is the whole of #561 one level out.** It is the only
+#: value meaning *charter did not look*, and a value that means "I did not look" must never
+#: be outranked by one that means "I looked and it was fine". Everything the forge would
+#: add — a request's state, and the five check states §3.5 closes — is worse than
+#: ``landed`` and no better than ``unknown``, so a member charter has not observed stays
+#: ``unknown`` and the change stays ``unknown`` with it.
+#:
+#: There are deliberately only three. ``blocked`` is the ordering sense of §3.2 and nothing
+#: but ``needs`` produces it; ``landed`` is a declaration charter itself wrote, joined
+#: against git by whoever is reading; everything else is *charter has not asked the forge*,
+#: which is one answer and not a family of them. Inventing ``not_ready``, ``failed`` or
+#: ``rejected`` here — before there is a read that can produce one — would be a vocabulary
+#: whose values nothing can ever set, which is §4i's convincing empty in a constant.
+MEMBER_STATES = ("unknown", "blocked", "landed")
+
+
+def _host() -> str:
+    """Short, filename-safe hostname — ``pieces._host``'s rule, for its reason.
+
+    Spelled again rather than imported: this module is read by the frame's gather, and
+    importing `pieces` there to learn a hostname would pull `persona` and `session` onto a
+    path whose whole budget is file reads.
+    """
+    raw = (socket.gethostname() or "unknown").split(".")[0]
+    return re.sub(r"[^A-Za-z0-9_-]", "", raw)[:32] or "unknown"
+
+
+def log_path(ws: str) -> Path:
+    """``workspaces/<ws>/changes/log/<host>.jsonl`` — this machine's declarations.
+
+    Per host, exactly as ``pieces/<host>.jsonl`` is, and never committed for the same
+    reason: it describes merges made from one disk, and a portable file describing a local
+    reality is the mismatch ADR 0010 dissects.
+    """
+    return log_dir(ws) / f"{_host()}.jsonl"
+
+
+def record_landing(ws: str, slug: str, repo: str, *, number, merge: str, head: str,
+                   ts: str) -> Path | None:
+    """Append one past-tense line: *charter merged this commit, for this change*.
+
+    **The declaration git cannot make**, and the only reason the log exists. Git can say a
+    sha is on a branch; it cannot say charter put it there for this change, and the forge
+    cannot see a revert. Landing is the two joined at read time — the forge reports the
+    request merged and git still contains this sha — so nothing on disk holds a ``landed``
+    flag anything could disagree with.
+
+    Best-effort, returning ``None`` rather than raising, which is ``pieces.record``'s
+    contract and its argument: the merge has already happened, the caller cannot un-merge
+    it in response to a full disk, and a command whose real work succeeded must not fail
+    over its bookkeeping. The caller writes this only **after** reading the merge back —
+    a declaration of something that did not happen is worse than none.
+
+    ``O_APPEND`` with no lock, through `config.open_for` so the mode is charter's rather
+    than the umask's wherever this path resolves to.
+    """
+    line = {"ts": ts, "change": slug, "repo": repo, "number": number,
+            "merge": merge, "head": head}
+    p = log_path(ws)
+    if contain.write_refusal(p):
+        return None      # a committed link at this fixed name — see contain.write_refusal
+    try:
+        config.mkdir_for(p.parent)
+        with config.open_for(p, "a") as f:
+            f.write(json.dumps(line, sort_keys=True) + "\n")
+        return p
+    except OSError:
+        return None
+
+
+def landings(ws: str, slug: str | None = None) -> list[dict]:
+    """Every landing this plane declared, oldest first — optionally for one change.
+
+    A malformed line is **skipped**, never raised over: this feeds a report and a frame
+    pane, and a half-written line from a process that was killed mid-append is exactly
+    what an append-only log collects. A line carrying a key charter does not read is
+    skipped too — the closed-set rule of :func:`_closed`, in the shape a log can afford,
+    because refusing the whole file would let one bad line hide every good one.
+    """
+    d = log_dir(ws)
+    if contain.dir_refusal(d):
+        return []
+    try:
+        files = sorted(d.glob("*.jsonl"))
+    except OSError:
+        # Listing an unreadable directory raises on Linux and yields nothing on macOS —
+        # `pieces.events` records a suite that went red on CI over exactly this line.
+        return []
+    out: list[dict] = []
+    for f in files:
+        try:
+            text = f.read_text()
+        except OSError:
+            continue
+        for raw in text.splitlines():
+            try:
+                obj = json.loads(raw)
+            except ValueError:
+                continue
+            if not isinstance(obj, dict) or sorted(obj) != sorted(LOG_FIELDS):
+                continue
+            if not isinstance(obj["change"], str) or not isinstance(obj["repo"], str):
+                continue
+            if slug is not None and obj["change"] != slug:
+                continue
+            out.append(obj)
+    return sorted(out, key=lambda e: str(e.get("ts") or ""))
+
+
+def declared_landings(ws: str, slug: str) -> dict[str, dict]:
+    """``{repo: the LAST line declaring that repo landed for *slug*}``.
+
+    The last rather than the first: a member reverted and landed again has two lines, and
+    the one that describes the world now is the newer. Nothing is deleted to make that
+    true — the earlier line is still a true statement about the past, and deleting history
+    to tidy a lookup is how a store starts lying.
+    """
+    out: dict[str, dict] = {}
+    for line in landings(ws, slug):
+        out[line["repo"]] = line
+    return out
+
+
+def member_states(rec: dict, landed) -> dict[str, str]:
+    """``{repo: its state}`` for every member — derived, stored nowhere.
+
+    *landed* is what the caller believes has landed. Three answers and no more, for
+    :data:`MEMBER_STATES`' reason: a member charter has a landing declaration for is
+    ``landed``, one waiting on a blocker that has not landed is ``blocked``, and every
+    other member is ``unknown`` — because what stands between it and its own landing is a
+    request state and a check state, and charter has not asked the forge.
+
+    **``landed`` outranks ``blocked``, and that is not the precedence order inverted.**
+    Precedence answers *which member decides the change's colour*; this answers *what is
+    true of this member*, and a member that has already gone in is not waiting for
+    anybody. §3.2's out-of-order landing — a member that landed while a blocker had not —
+    is exactly the pair this makes visible, and it is named by
+    `commands_change.out_of_order` rather than hidden inside a single word here.
+    """
+    have = set(landed or ())
+    blocked = blocked_members(rec, have)
+    out: dict[str, str] = {}
+    for m in rec["members"]:
+        repo = m["repo"]
+        if repo in have:
+            out[repo] = "landed"
+        elif repo in blocked:
+            out[repo] = "blocked"
+        else:
+            out[repo] = "unknown"
+    return out
+
+
+def worst(states) -> str:
+    """The worst of *states*, by :data:`MEMBER_STATES`' order. ``unknown`` for none at all.
+
+    **A change is never reported greener than its worst member** (§3.3, §3.5), and this is
+    the one function that decides it, so no surface can arrive at a different answer by
+    aggregating differently. A change with no members is ``unknown`` and not ``landed``:
+    an empty maximum is the classic way a report comes out green, and "everything has
+    landed" over nothing at all is the confidently-wrong output ADR 0009 forbids.
+
+    A state this module does not recognise **reads as ``unknown``** rather than being
+    ranked on its own — the asymmetry of §3.5's own table, where anything charter does not
+    recognise is ``UNKNOWN`` and never ``PASSED``. It is folded rather than returned,
+    because the answer travels to a report row and a word charter cannot explain is worse
+    on a row than the word that says charter cannot explain it.
+    """
+    order = {s: i for i, s in enumerate(MEMBER_STATES)}
+    seen = [s if s in order else MEMBER_STATES[0] for s in states]
+    if not seen:
+        return MEMBER_STATES[0]
+    return min(seen, key=lambda s: order[s])
+
+
+def landed_count(states) -> tuple[int, int]:
+    """``(how many members have landed, how many there are)`` — §3.3's ``3 of 5``.
+
+    A pair rather than a fraction or a percentage, deliberately: §3.3 refuses a
+    percentage and a bar because both invite a single word for the change as a whole, and
+    a member can hide behind a single word.
+    """
+    seen = list(states)
+    return sum(1 for s in seen if s == "landed"), len(seen)
 
 
 def changes_dir(ws: str) -> Path:

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -1071,6 +1071,17 @@ def _add_change_parser(sub) -> None:
     fg.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
     fg.set_defaults(func=commands_change.cmd_change_forget)
 
+    # A revert is a NEW change, with the ordinary gates — not an undo button. There is
+    # deliberately no `--force`, no `--all` and nothing that deletes a branch: a
+    # force-push over three default branches leaves a world where the change happened,
+    # was undone, and no repository's history mentions either.
+    rv = csub.add_parser("revert",
+                         help="Derive a new change reverting what charter landed for this "
+                              "one — a branch per landed member, then the ordinary gates.")
+    rv.add_argument("change")
+    rv.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
+    rv.set_defaults(func=commands_change.cmd_change_revert)
+
 
 def _add_vault_parser(sub) -> None:
     v = sub.add_parser("vault", help="Manage secret vaults (provider + config + persona).")

--- a/charter/commands_change.py
+++ b/charter/commands_change.py
@@ -456,6 +456,21 @@ def _branch_exists(clone: Path, branch: str) -> bool:
 TRAILER = "Charter-Change"
 
 
+def _local_branches(clone: Path) -> set[str]:
+    """Every local branch in *clone*, as a set. Empty for anything charter could not ask.
+
+    `for-each-ref` rather than a `rev-parse` per name: the caller is asking about N
+    branches at once, and the difference is one child process against N of them on a path
+    that runs at SessionStart. It also carries no untrusted argument at all — `refs/heads/`
+    is a literal and the comparison happens in Python — which is a stronger answer to the
+    argv question than spelling a committed value carefully.
+    """
+    got = _git(clone, "for-each-ref", "--format=%(refname:short)", "refs/heads/")
+    if got.returncode != 0:
+        return set()
+    return {ln.strip() for ln in (got.stdout or "").splitlines() if ln.strip()}
+
+
 def _trailer_names(clone: Path, sha: str, slug: str) -> bool:
     """Does the commit *sha* carry ``Charter-Change: <slug>``?
 
@@ -601,8 +616,15 @@ def stray_branches(ws: str) -> list[str]:
     for clone in sorted(workspace.clones(ws)):
         if clone.name in members:
             continue
+        # ONE git call per clone, not one per (clone, branch). This runs from doctor,
+        # which runs from SessionStart under a budget — a plane with ten clones and five
+        # changes would otherwise pay fifty `rev-parse`s to answer a question one listing
+        # answers. It also takes the untrusted value out of the argv entirely: the only
+        # argument here is the literal `refs/heads/`, and the branch names are compared in
+        # Python.
+        here = _local_branches(clone)
         for branch, slug in sorted(wanted.items()):
-            if _branch_exists(clone, branch):
+            if branch in here:
                 out.append(
                     f"{contain.readable(clone.name)}: has branch "
                     f"{contain.readable(branch)}, which change "

--- a/charter/commands_change.py
+++ b/charter/commands_change.py
@@ -1,10 +1,11 @@
 """`charter change` — the cross-repo change, as records. **No forge, no network.**
 
-Six verbs over :mod:`charter.change`: ``create``, ``add``, ``drop``, ``list``, ``show`` and
-``forget``. Everything here is a file read, a file write and a directory listing; nothing in
-this module opens a socket, runs a forge CLI or pushes a branch. The forge half — push,
-gate, land, revert — is a later phase, and keeping the record surface separable from it is
-what makes "what did the operator declare" answerable without asking anybody's API.
+Seven verbs over :mod:`charter.change`: ``create``, ``add``, ``drop``, ``list``, ``show``,
+``forget`` and ``revert``. Everything here is a file read, a file write, a directory
+listing and — for ``revert`` and the divergence report — **git in a clone the operator
+already has**. Nothing in this module opens a socket or runs a forge CLI, which is what
+keeps "what did the operator declare, and what does this disk say happened" answerable
+without asking anybody's API.
 
 **Membership is enumerated by hand, and that is the containment property.** There is no
 glob, no pattern, no ``--all-repos``, no "every repo in the workspace", and nothing here
@@ -13,12 +14,31 @@ must resolve to a clone the operator already put in this workspace — so the re
 change is bounded by what is already on the disk in front of you, and by nothing that
 travelled in a committed file. A record can name a repository you do not have; it is refused
 for that, by name, and it can never name a *place*.
+
+**What this module will not do, in a change action, including during a revert** (§3.7):
+force-push to any branch; delete any branch, merged or not; ``reset --hard`` a default
+branch; or close a request charter did not open. Those are not absent by oversight and
+they are not guarded by a flag — the argv is never constructed, and
+`tests/test_change_revert.py` records every git invocation a revert makes and asserts it.
+An emergency is exactly when somebody reaches for one of them, and a force-push over three
+default branches leaves a world where the change happened, was undone, and no repository's
+history mentions either — the failure the whole design exists to prevent.
+
+**A branch out of a record is argv, and ref grammar is not argv safety.** Every git call
+below that carries one spells it ``refs/heads/<branch>``, which cannot begin with ``-``
+whatever the record says — `git check-ref-format` **accepts** ``refs/heads/-b`` (measured
+on git 2.50.1), so the grammar answers a different question. That is the positional half;
+`change.branch_refusal` at the record boundary is the other, and neither substitutes for
+the other. It is spelled this way rather than with a trailing ``--`` because the commands
+that need it — `merge-base --is-ancestor`, `rev-parse --verify` — take no ``--`` at all,
+and a separator that is not accepted is a guard that is not there.
 """
 
 from __future__ import annotations
 
 import datetime
 import os
+import re
 from pathlib import Path
 
 from . import change, contain, instance, tui, util, workspace
@@ -33,6 +53,35 @@ from . import change, contain, instance, tui, util, workspace
 #: Three gates in sequence mask each other, and an exit-code assertion cannot tell them
 #: apart — so every refusal test here asserts *which* one fired.
 REFUSED = 2
+
+#: How long one read-only git question may take. `doctor.CHECK_TIMEOUT`'s reason, one
+#: command out: a clone on a stalled network mount makes git hang, and a command the
+#: operator is waiting on must fail rather than sit there.
+GIT_TIMEOUT = 20
+
+#: What a merge sha read out of the landing log must look like before it reaches git.
+#:
+#: **The log is a file, so it is untrusted for the same reason the record is.** It is
+#: never committed, which makes it *local* rather than *trustworthy* — a hand edit, a
+#: half-written line from a killed process, or an older charter all reach here — and the
+#: value is handed to `git revert` and `git rev-list` as argv, where ``-X`` is a flag.
+#: Anchored at both ends and hexadecimal, which is what a sha is; anything else is refused
+#: by name rather than repaired, because a sha charter repaired is a commit nobody chose.
+#:
+#: **Asked with `fullmatch`, and the `^…$` is kept anyway.** Python's ``$`` matches at the
+#: end of the string *or just before a trailing newline*, so `.match` would admit
+#: ``"e0c9d13\n"`` — a value with a newline in it on its way to a git argv, which is the
+#: class `tests/test_the_end_of_a_name_is_the_end_of_the_string.py` exists for. The anchors
+#: are redundant under `fullmatch` and are load-bearing for something else: that test builds
+#: its inventory by FINDING anchored constants, and unanchoring this would silently drop it
+#: out of the table (#629).
+_SHA_RE = re.compile(r"^[0-9a-f]{7,64}$")
+
+#: The prefix of the branch a revert is seeded on. The revert is an ordinary change with an
+#: ordinary name, so its branch is `change.default_branch` of its own slug — this exists
+#: only to build that slug, and it is a constant so the record and the report cannot spell
+#: it two ways.
+REVERT_PREFIX = "revert-"
 
 
 def _workspace(args) -> str:
@@ -349,6 +398,415 @@ def cmd_change_show(args) -> int:
             print(f"  {tui.pad(contain.one_line(e['repo']), w)}  "
                   f"{contain.one_line(e['why'])}  ({contain.one_line(e['at'])})")
     return 0
+
+
+# --------------------------------------------------------------------------- #
+# git, in a clone the operator already has — never a forge, never a network     #
+# --------------------------------------------------------------------------- #
+
+def _git(clone: Path, *args: str):
+    """One read-only git question about *clone*, never raising on a non-zero exit.
+
+    `doctor._git_in`'s shape and its reason. Read-only is a property of the ARGUMENTS
+    rather than of this function, and the two callers that are not read-only —
+    :func:`_seed_revert`'s checkout and revert — go through here too, so that every git
+    invocation a change action makes passes one place a test can record.
+    """
+    return util.run(["git", "-C", str(clone), *args], check=False, timeout=GIT_TIMEOUT)
+
+
+def _default_branch(clone: Path) -> str | None:
+    """*clone*'s default branch, or ``None`` when charter cannot honestly say.
+
+    `doctor._plane_default_branch`, asked rather than re-spelled — `hooks` already reaches
+    for it the same way. Two answers to "what is this repo's default branch" would drift,
+    and the drift would be a divergence report about the wrong branch: a plane whose
+    default is `trunk` easily still carries a stale local `main`, and the guess-first
+    version of this warns about the correct branch.
+
+    ``None`` matters here more than it does there: every question below is *relative to
+    the default branch*, so a clone charter cannot resolve one for produces no divergence
+    findings at all rather than findings against a branch nobody uses.
+    """
+    from .doctor import _plane_default_branch
+    return _plane_default_branch(clone)
+
+
+def _contains(clone: Path, commitish: str, default: str) -> bool:
+    """Does *default* contain *commitish*? False for anything charter could not resolve.
+
+    ``refs/heads/<default>`` for the argv reason in this module's docstring, and a bare
+    *commitish* only where the caller has already held it to :data:`_SHA_RE` — the two
+    callers are :func:`_declared_landed` (a sha out of the log) and :func:`divergences` (a
+    member's branch, spelled as a ref).
+    """
+    return _git(clone, "merge-base", "--is-ancestor", commitish,
+                f"refs/heads/{default}").returncode == 0
+
+
+def _branch_exists(clone: Path, branch: str) -> bool:
+    """Is there a local branch of this name? ``refs/heads/`` — see the module docstring."""
+    return _git(clone, "rev-parse", "--verify", "--quiet",
+                f"refs/heads/{branch}").returncode == 0
+
+
+#: The one trailer charter promises, on the one commit charter authors. Held here rather
+#: than spelled at each site: `revert` builds it, the divergence check looks for it, and
+#: the docs quote it, so a second spelling would be a second trailer.
+TRAILER = "Charter-Change"
+
+
+def _trailer_names(clone: Path, sha: str, slug: str) -> bool:
+    """Does the commit *sha* carry ``Charter-Change: <slug>``?
+
+    Read out of the commit's own body rather than asked of `git log --grep`, because the
+    question is about **this** commit and a grep over a range answers about the range.
+    `%B` is the raw body, so a trailer somebody wrote by hand reads the same as one charter
+    wrote — which is correct: the claim being checked is *what the commit says*, and
+    charter has no way to tell its own trailer from an identical one, nor any business
+    trying.
+    """
+    got = _git(clone, "show", "--no-patch", "--format=%B", sha)
+    if got.returncode != 0:
+        return False
+    want = f"{TRAILER}: {slug}"
+    return any(line.strip() == want for line in (got.stdout or "").splitlines())
+
+
+def _declared_landed(ws: str, slug: str) -> dict[str, dict]:
+    """``{repo: the landing line}`` for every member this plane DECLARED it landed.
+
+    File reads only, deliberately: this is the same answer `frame/gather.py` carries into
+    the frame's one snapshot, and a second, git-joined answer computed here would be the
+    second clock §4f names as the thing this codebase has already paid for twice.
+
+    The git join lives in :func:`divergences`, which is ADR 0013's shape rather than an
+    omission: the cheap surface shows what charter declared, and a separate read names
+    every place git disagrees with it. One clock, one divergence report.
+    """
+    return change.declared_landings(ws, slug)
+
+
+def out_of_order(rec: dict, landed) -> dict[str, list[str]]:
+    """``{member: the blockers it went in ahead of}`` — §3.2's honest half.
+
+    Charter refuses to land a member whose blockers have not landed, and it cannot stop a
+    human merging in a browser. What would be theatre is a guard that *reports*
+    enforcement it does not have, so the same read that refuses also names the landings
+    that happened anyway.
+
+    A pure intersection of two things `change` already derives, so it cannot disagree with
+    the gate: the members that landed, and the members some blocker of which has not.
+    """
+    have = set(landed or ())
+    blocked = change.blocked_members(rec, have)
+    return {repo: pending for repo, pending in blocked.items() if repo in have}
+
+
+def divergences(ws: str, rec: dict) -> list[str]:
+    """Everything git says about this change that the plane's own records do not — as
+    sentences, each naming the member it is about.
+
+    **ADR 0013 rule 2, five ways.** *"A divergence charter can see, charter names… WARN is
+    not a surface. A divergence worth naming under rule 2 is worth FAIL."* Every finding
+    here is a FAIL at its call site, and none of them is a state anything stores.
+
+    1. **Landed outside charter.** The member's recorded branch is contained in its
+       clone's default branch and there is no landing declaration — so there is no
+       ``Charter-Change`` trailer and no merge sha, and `revert` has nothing to run
+       against. Named, and handed to a human.
+    2. **A declared landing git no longer contains.** Charter said it merged that sha and
+       the default branch does not have it: reverted, or the branch was rewritten.
+       *"A member with a log line git no longer contains is not landed any more, and
+       nothing had to notice or update a flag for that to become true."*
+    3. **A declared landing whose commit does not carry the trailer.** The log names a
+       commit charter did not author for this change.
+    4. **An out-of-order landing** — :func:`out_of_order`.
+    5. **A member's branch name in a clone that is a member of nothing.** The one check
+       that looks outside the change: a `change/<slug>` branch sitting in a repository
+       nobody declared is either a member somebody forgot to add or a name collision, and
+       both are worth a sentence.
+
+    A clone charter cannot resolve a default branch for contributes nothing rather than
+    contributing a guess — see :func:`_default_branch`.
+    """
+    slug = rec["change"]
+    declared = _declared_landed(ws, slug)
+    out: list[str] = []
+    for m in rec["members"]:
+        repo, branch = m["repo"], m["branch"]
+        clone = _clone_for(ws, repo)
+        if clone is None:
+            continue          # `charter change add` refused this once; `doctor` says so
+        default = _default_branch(clone)
+        if default is None:
+            continue
+        line = declared.get(repo)
+        if line is None:
+            if _branch_exists(clone, branch) and \
+                    _contains(clone, f"refs/heads/{branch}", default):
+                out.append(
+                    f"{contain.readable(repo)}: branch {contain.readable(branch)} is "
+                    f"already in '{contain.one_line(default)}' and charter did not land "
+                    f"it — so there is no {TRAILER} trailer and no merge sha. "
+                    f"`charter change revert` cannot reach this member; a human has to.")
+            continue
+        sha = line["merge"]
+        if not isinstance(sha, str) or not _SHA_RE.fullmatch(sha):
+            out.append(f"{contain.readable(repo)}: the landing log records "
+                       f"{contain.readable(sha)} as the merge, which is not a sha.")
+            continue
+        if not _contains(clone, sha, default):
+            out.append(
+                f"{contain.readable(repo)}: charter declared it landed as {sha}, and "
+                f"'{contain.one_line(default)}' no longer contains that commit — it was "
+                f"reverted, or the branch was rewritten. This member is not landed any "
+                f"more.")
+        elif not _trailer_names(clone, sha, slug):
+            out.append(
+                f"{contain.readable(repo)}: the landing log names {sha}, and that commit "
+                f"carries no `{TRAILER}: {slug}` trailer — charter did not author it for "
+                f"this change.")
+    for repo, pending in sorted(out_of_order(rec, declared).items()):
+        out.append(
+            f"{contain.readable(repo)}: landed while "
+            + ", ".join(f"'{contain.readable(p)}'" for p in pending)
+            + " had not. Charter refuses that landing and cannot stop a browser; this is "
+              "the half that makes the guard honest rather than decorative.")
+    return out
+
+
+def stray_branches(ws: str) -> list[str]:
+    """Members' branch names found in clones that are a member of no change at all.
+
+    §3.2's second check, and the only one that looks outside the change: a branch named
+    like a change's member, in a repository nobody declared, is either a member somebody
+    forgot to `charter change add` or a collision with a name that means something else.
+    Both are worth a sentence and neither is a state.
+
+    A record charter cannot read contributes no names — `change.all_for` reports those
+    separately and `doctor` says so — because guessing at branch names from a record that
+    did not parse is the unearned diagnosis ADR 0009 forbids.
+    """
+    records, _refused = change.all_for(ws)
+    wanted: dict[str, str] = {}          # branch name → the change that declares it
+    members: set[str] = set()
+    for rec in records:
+        for m in rec["members"]:
+            wanted.setdefault(m["branch"], rec["change"])
+            members.add(m["repo"])
+    if not wanted:
+        return []
+    out: list[str] = []
+    for clone in sorted(workspace.clones(ws)):
+        if clone.name in members:
+            continue
+        for branch, slug in sorted(wanted.items()):
+            if _branch_exists(clone, branch):
+                out.append(
+                    f"{contain.readable(clone.name)}: has branch "
+                    f"{contain.readable(branch)}, which change "
+                    f"'{contain.readable(slug)}' declares — and this repo is a member of "
+                    f"no change. Add it (charter change add), or the branch is a name "
+                    f"collision worth knowing about.")
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# revert — a new change, because that is the only rollback a stranger can read  #
+# --------------------------------------------------------------------------- #
+
+def _parents(clone: Path, sha: str) -> int | None:
+    """How many parents *sha* has, asked of git — or ``None`` when git would not say.
+
+    **Asked, never remembered**, which is what decides whether the revert carries ``-m
+    1``. A squash landing is an ordinary one-parent commit and ``-m`` on one fails; a
+    merge landing has two and ``git revert`` refuses without it. Storing "this was a
+    squash" in the log would be a derivable fact cached for convenience, which is the
+    sentence ADR 0011 is.
+    """
+    got = _git(clone, "rev-list", "--parents", "-n", "1", sha)
+    if got.returncode != 0:
+        return None
+    parts = (got.stdout or "").split()
+    return len(parts) - 1 if parts else None
+
+
+def _seed_revert(clone: Path, *, sha: str, branch: str, default: str) -> str | None:
+    """Create *branch* off *default* carrying a revert of *sha*. ``None``, or the reason.
+
+    Four things this does not do, and none of them is behind a flag: it does not force
+    anything, delete anything, reset anything, or touch a request. What it does is create
+    a branch and add a commit, which is the whole of what a revert-as-a-new-change is.
+
+    **The working tree is checked first and the refusal is named.** `git revert` commits
+    into the checkout, so running it over uncommitted work would fold somebody's work in
+    progress into a revert commit — and the recovery for that is worse than the wait.
+
+    A conflicted revert is **aborted and named**, not left half-applied: `--abort` restores
+    the checkout the revert started from, so the branch stays and the operator resolves it
+    themselves. Charter has no business guessing which side of a conflict a rollback
+    wanted.
+
+    **`commit.gpgsign` is deliberately not passed on this call**, and the reason is that it
+    is already settled one layer down. A revert is the operator's commit in the operator's
+    repository, so charter silently unsigning it would be charter deciding somebody's
+    signing policy — ADR 0014's rule, which puts that with the host. What actually keeps an
+    autonomous run from hanging on a signer prompt is `gitpolicy`: `charter git-policy
+    --apply` writes `commit.gpgsign = false` into each clone's *local* config, and `charter
+    clone` applies it to everything it clones, precisely because *"a GPG signer prompt hangs
+    an autonomous agent mid-run"*. In a clone charter did not set up, the prompt is the
+    operator's own configuration doing what they asked it to — measured here as a suite that
+    hung with `op-ssh-sign` waiting, which is why `tests/_changerepo.py` sets the policy on
+    its fixture repos rather than this function setting it on everybody's.
+    """
+    dirty = _git(clone, "status", "--porcelain")
+    if dirty.returncode != 0:
+        return "git could not read the working tree"
+    if (dirty.stdout or "").strip():
+        return ("the working tree has uncommitted changes, and `git revert` commits into "
+                "the checkout — commit or stash them first")
+    if _branch_exists(clone, branch):
+        return f"branch {contain.readable(branch)} already exists here"
+    # `switch -c` rather than `checkout -b`: one verb that only ever moves the branch,
+    # against a verb that also restores files and whose argv a path can slip into.
+    made = _git(clone, "switch", "-c", branch, f"refs/heads/{default}")
+    if made.returncode != 0:
+        return contain.one_line((made.stderr or "could not create the branch").strip())
+    n = _parents(clone, sha)
+    if n is None:
+        return f"git does not know the commit {sha}"
+    # `-m 1` exactly when git says there is more than one parent — see `_parents`. Spread
+    # into the call rather than built as a whole argv, so that the VERB stays a literal at
+    # the call site: `tests/test_commands_change.py` reads every `_git` invocation in this
+    # module statically and lists the git subcommands it can reach, which is what makes
+    # "no network" a claim about the argv rather than about the imports.
+    mflag = ["-m", "1"] if n > 1 else []
+    done = _git(clone, "revert", "--no-edit", *mflag, sha)
+    if done.returncode != 0:
+        _git(clone, "revert", "--abort")
+        return contain.one_line(
+            (done.stderr or "the revert did not apply").strip()) + \
+            " — the branch is here and the revert was aborted; finish it by hand"
+    return None
+
+
+def cmd_change_revert(args) -> int:
+    """`charter change revert <slug>` — derive a NEW change that reverts what landed.
+
+    **A revert is a new change**, and that is the whole design rather than a limitation.
+    Force-pushing three default branches back past the merges leaves a world where the
+    change happened, was undone, and no repository's history mentions either — the exact
+    failure this whole surface exists to prevent. `component-api-2` and
+    `revert-component-api-2`, both named, both cross-referenced, in every repository they
+    touched, reads as a decision six months later; a force-push reads as corruption.
+
+    So from here it is ordinary: pushed, reviewed, gated and landed one member at a time,
+    by the same commands with the same refusals. There is no ``--all`` on this either.
+
+    **A member landed outside charter is named, not guessed.** No line in the landing log
+    means no merge sha, and charter will not pick the merge commit that looks about right.
+    ADR 0009: it degrades to silence, never to a confident wrong answer.
+
+    **Two things it cannot do, said here rather than discovered.** It cannot revert a
+    deploy — a merge to a default branch on a repo with continuous deployment has already
+    had an effect in the world, and charter has no model of deployment. And it cannot
+    revert what it did not record.
+    """
+    ws = _workspace(args)
+    slug = args.change
+    rec, code = _load(ws, slug)
+    if rec is None:
+        return code
+
+    new_slug = REVERT_PREFIX + slug
+    if not instance.change_name_ok(new_slug):
+        util.err(f"{contain.readable(new_slug)} is not a change name, so this change "
+                 "cannot name its own revert.")
+        return REFUSED
+    if change.exists(ws, new_slug):
+        util.err(f"change '{new_slug}' already exists in workspace '{ws}'.")
+        util.info(f"Show it: charter change show {new_slug}  ·  or forget it first: "
+                  f"charter change forget {new_slug}")
+        return REFUSED
+
+    declared = _declared_landed(ws, slug)
+    if not declared:
+        util.err(f"'{slug}': charter has landed no member of this change, so there is "
+                 "nothing to revert.")
+        util.info("A member merged outside charter has no landing record and no merge "
+                  "sha — charter names it rather than guessing which commit was the one.")
+        return REFUSED
+
+    # Named before anything is written, so the operator reads the whole picture rather
+    # than discovering the un-revertible half after the record exists.
+    handed_over = [m["repo"] for m in rec["members"] if m["repo"] not in declared]
+    for repo in handed_over:
+        util.warn(f"{contain.readable(repo)}: no landing record, so no merge sha — "
+                  "charter cannot revert this member. If it was merged in a browser, the "
+                  "commit is a human's to find.")
+
+    members, seeded, refused = [], [], []
+    for m in rec["members"]:
+        repo = m["repo"]
+        line = declared.get(repo)
+        if line is None:
+            continue
+        clone = _clone_for(ws, repo)
+        if clone is None:
+            refused.append((repo, f"no clone in workspace '{ws}'"))
+            continue
+        sha = line["merge"]
+        if not isinstance(sha, str) or not _SHA_RE.fullmatch(sha):
+            refused.append((repo, f"the landing log records {contain.readable(sha)} as "
+                                  "the merge, which is not a sha"))
+            continue
+        default = _default_branch(clone)
+        if default is None:
+            refused.append((repo, "charter cannot tell which branch is the default here, "
+                                  "so it will not guess what to branch from"))
+            continue
+        branch = change.default_branch(new_slug)
+        # The member joins the record whether or not the seeding worked. The record is the
+        # statement of intent — these repositories are the ones to revert — and a branch
+        # that did not get created is a thing to fix, not a member to drop silently.
+        #
+        # **The ordering is the original's, REVERSED**, and that is a decision rather than
+        # bookkeeping. If `charter-metrics` needed `charter` to land first — because its
+        # code depends on charter's new API — then undoing it has to go the other way:
+        # reverting `charter` while `charter-metrics` still depends on the API it removes
+        # leaves the dependent broken, which is the world the revert was supposed to
+        # restore. So a member's blockers here are the members that declared IT as a
+        # blocker there (`change.dependents`), filtered to the ones being reverted — a
+        # member whose dependent charter did not land is not waiting for anybody.
+        members.append({"repo": repo, "branch": branch,
+                        "needs": [d for d in change.dependents(rec, repo)
+                                  if d in declared]})
+        why = _seed_revert(clone, sha=sha, branch=branch, default=default)
+        if why is None:
+            seeded.append(repo)
+        else:
+            refused.append((repo, why))
+
+    new_rec = change.new_record(
+        new_slug,
+        f"reverts change '{slug}': {rec['why']}"[:change.TEXT_LIMIT],
+        _author(), _now())
+    new_rec["members"] = members
+    code = _save(ws, new_slug, new_rec)
+    if code:
+        return code
+
+    util.ok(f"change '{new_slug}' created — {len(members)} member(s) to revert")
+    for repo in seeded:
+        print(f"  {contain.one_line(repo)}  branch "
+              f"{contain.one_line(change.default_branch(new_slug))}  reverted")
+    for repo, why in refused:
+        util.err(f"{contain.readable(repo)}: {why}")
+    util.info(f"It is an ordinary change from here: charter change show {new_slug}")
+    # Non-zero when a member charter put in the record has no branch behind it: the record
+    # says these repositories are to be reverted, and one of them is not started.
+    return 1 if refused else 0
 
 
 def _member_line(rec: dict, m: dict) -> str:

--- a/charter/commands_change.py
+++ b/charter/commands_change.py
@@ -741,11 +741,15 @@ def cmd_change_revert(args) -> int:
     if rec is None:
         return code
 
+    # **There is deliberately no `change_name_ok(new_slug)` guard here, and it was
+    # measured rather than assumed.** `_load` above succeeded, which means `change.exists`
+    # put *slug* through `change.path_for` and therefore through `instance.change_name_ok`
+    # — and `CHANGE_NAME_RE` has no length bound and no leading-character rule a
+    # `revert-` prefix could break, so `change_name_ok("revert-" + <a valid slug>)` is
+    # true for every valid slug there is. A guard nothing can reach is a comment with a
+    # runtime cost (`commands_frame.cmd_toggle` records the same deletion for the same
+    # reason). The property is pinned directly instead, on the derivation.
     new_slug = REVERT_PREFIX + slug
-    if not instance.change_name_ok(new_slug):
-        util.err(f"{contain.readable(new_slug)} is not a change name, so this change "
-                 "cannot name its own revert.")
-        return REFUSED
     if change.exists(ws, new_slug):
         util.err(f"change '{new_slug}' already exists in workspace '{ws}'.")
         util.info(f"Show it: charter change show {new_slug}  ·  or forget it first: "

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -15,7 +15,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import inventory, tui, util
+from . import contain, inventory, tui, util
 from .forge.gitlab import GitLabForge
 
 OK, WARN, FAIL = "ok", "warn", "fail"
@@ -1331,6 +1331,118 @@ def check_workspace_clones() -> Result:
                         "— never a live query, this runs at SessionStart."))
 
 
+#: The optional prompt before every cross-repo landing, named by :func:`check_changes` and
+#: **never written by charter**.
+#:
+#: **`--local` is load-bearing in that line, not a convenience.** `charter guard ask`
+#: writes the plane's *committed* `.claude/settings.json` by default; `--local` writes the
+#: gitignored `.claude/settings.local.json` instead. Consent that travels in a commit
+#: enrols a whole team on one person's click, which is exactly why ADR 0003 put reporting
+#: consent in user-level config and out of `charter.toml`. A team that genuinely wants the
+#: prompt for everybody drops the flag — a decision, made once, visible in a diff.
+#:
+#: **Charter names it and does not run it** (ADR 0017): both answers are legitimate, and a
+#: tool that settles a legitimate choice by writing a line while nobody is looking has made
+#: the decision for the operator. Because Claude Code matches on the full command string,
+#: the prompt it writes shows *which change and which repo*.
+#:
+#: There is deliberately no second consent gate behind it either. A prompt the agent
+#: satisfies by running one more command is theatre, and an operator who is prompted
+#: constantly rubber-stamps within a day — which the security assessment already named as
+#: worse than no gate. The floor that matters is `hooks._release_floor_reason`, which
+#: denies an unattended landing outright.
+LANDING_PROMPT = "charter guard ask --local 'charter change land *'"
+
+
+def check_changes() -> Result:
+    """Cross-repo changes whose records and git disagree — ADR 0013's rule 2.
+
+    *"A divergence charter can see, charter names."* Five of them, all in
+    `commands_change.divergences` and `commands_change.stray_branches`: a member landed
+    outside charter (so there is no `Charter-Change` trailer and no merge sha, and
+    `charter change revert` cannot reach it), a declared landing the default branch no
+    longer contains, a declared landing on a commit carrying no trailer, a member that
+    landed while a blocker had not, and a member's branch name sitting in a clone that is
+    a member of no change.
+
+    **FAIL, not WARN**, and that is the whole of ADR 0013: *"WARN is not a surface. A
+    divergence worth naming under rule 2 is worth FAIL."* `cmd_doctor` exits non-zero only
+    on FAIL, and that exit code is the only thing that makes the SessionStart wrapper
+    print — a partial cross-repo landing nobody is told about is the state this entire
+    surface exists to prevent.
+
+    **Every workspace, not just the active one** — `check_workspace_clones`' own finding
+    (#156): a change is a per-workspace store, and the one that is half-landed is rarely
+    the one you are standing in.
+
+    **Read from what is already on this disk; never fetched.** This runs from SessionStart
+    and must not reach the network. The honest consequence, and it belongs in the output
+    rather than only here: the check can **under**-report — a merge somebody else pushed is
+    invisible until something fetches — but it can never invent a divergence. That is the
+    acceptable direction of failure and the same discipline ADR 0009 sets for error text.
+
+    The OK row names :data:`LANDING_PROMPT`, which is the one place charter tells an
+    operator that the prompt exists. It is on the OK row rather than in a hint because a
+    `hint` renders only when the status is not OK, and a plane whose changes are all clean
+    is exactly the plane where the question *"do I want a prompt before each landing?"* is
+    worth asking.
+    """
+    from . import change as _change
+    from . import commands_change as _cc
+    from . import config as _config
+    from . import workspace as _workspace
+
+    name = "changes"
+    if not _config.HAS_CONTROL_PLANE:
+        return Result(name, OK, detail="no control plane found")
+
+    found: list[str] = []
+    unreadable: list[str] = []
+    total = 0
+    try:
+        for ws in _workspace.list_workspaces():
+            records, refused = _change.all_for(ws)
+            total += len(records)
+            for slug, complaint in refused:
+                unreadable.append(f"{ws}/{contain.readable(slug)}: {complaint}")
+            for rec in records:
+                for line in _cc.divergences(ws, rec):
+                    found.append(f"{ws}/{rec['change']}: {line}")
+            for line in _cc.stray_branches(ws):
+                found.append(f"{ws}: {line}")
+    except (util.ProcTimeout, OSError, ValueError) as e:
+        # Narrow, per `check_memory_indexes`: a broad catch here once swallowed a NameError
+        # and reported OK, and a check that silently does nothing is worse than no check.
+        return Result(name, WARN, detail=f"not checked ({e})", hint=_NOT_CHECKED_HINT)
+
+    # A record that did not parse is its own answer and is NOT folded in with the
+    # divergences: "charter cannot read this file" and "git disagrees with this file" send
+    # the reader to two different places, and one count covering both would send them to
+    # neither. It is still a FAIL — a change nobody can read is a change nobody can land.
+    if unreadable:
+        shown = "; ".join(unreadable[:3])
+        if len(unreadable) > 3:
+            shown += f" (+{len(unreadable) - 3} more)"
+        return Result(name, FAIL, detail=f"unreadable record(s): {shown}",
+                      hint="Fix the file the message names — the key set is closed at both "
+                           "ends, so an unknown or missing key is named rather than "
+                           "ignored. `charter change list` prints the same complaint.")
+    if found:
+        shown = "; ".join(found[:3])
+        if len(found) > 3:
+            shown += f" (+{len(found) - 3} more)"
+        return Result(name, FAIL, detail=shown,
+                      hint="Charter cannot stop a browser and does not pretend to — this "
+                           "is the half that makes the guard honest. Read from what is "
+                           "already fetched, so it can under-report and never invent. "
+                           "`charter change show <slug>` is the whole picture.")
+    if not total:
+        return Result(name, OK, detail="none")
+    return Result(name, OK,
+                  detail=f"{total} change(s), none divergent · optional prompt before "
+                         f"each landing: {LANDING_PROMPT}")
+
+
 def check_inventory() -> Result:
     """Can this plane clone anything?
 
@@ -2329,7 +2441,7 @@ def _checks():
         results.append(check_forge_auth(forge))
     results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
                 check_plane_root(), check_harness(), check_frame(), check_guard_wired(), check_guard_seen(), check_nested_plane(),
-                check_workspace_clones(),
+                check_workspace_clones(), check_changes(),
                 check_inventory(), check_vaults(),
                 check_vault_registry_divergence(), check_version_lock(),
                 check_memory_indexes(), check_personas(), check_persona_grant(),
@@ -2368,7 +2480,7 @@ _FIXED_CHECK_NAMES = (
     "python3", "git", "git identity",
     # ← the forge cli/auth pair is spliced in here, see `check_names`
     "git auth", "charter.toml", "schema", "plane root", "harness", "frame",
-    "plane-root guard", "guard seen", "nested plane", "workspace clones",
+    "plane-root guard", "guard seen", "nested plane", "workspace clones", "changes",
     "inventory", "vaults", "vault registry", "version lock", "memory indexes",
     "personas", "persona grant", "front door", "news", "ask rules", "shadowed docs",
     "credential paths", "mcp", "plugin", "plugin files",

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -73,6 +73,11 @@ from .registry import Registry
 #:
 #: Only PLACED components are here. `personas` and `todos` share the sidebar's pane and
 #: were never slots, so there is nothing for them to be spelled as.
+#: ``changes`` is absent for the same reason ``personas`` and ``todos`` are: this table is
+#: PLACED components, and charter does not place it. A plane that wants it writes a
+#: `[[frame.component]]` table, and travels under its own id — which is the path a
+#: provider's component already takes, and `instance.FRAME_SLOTS` says why it is the right
+#: one here too.
 SLOT_OF = {
     "identity": "top",
     "attention": "bottom",
@@ -171,6 +176,16 @@ def _todos(ctx) -> list[str]:
                               terse=slots.verbosity(ctx.fid) == "terse")
 
 
+def _changes(ctx) -> list[str]:
+    """The sidebar's cross-repo change rows — nothing at all when there are none.
+
+    No `terse`: the section is already one heading and at most three rows, and a density
+    that made it shorter would be making a list that is usually empty shorter still.
+    """
+    from . import slots
+    return slots.changes_section(ctx.fid, ctx.width, ctx.height)
+
+
 def build() -> Registry:
     """A registry holding charter's six built-in components, in split order.
 
@@ -210,8 +225,42 @@ def build() -> Registry:
     reg.register(Component(
         id="todos", title="todos", edge="right", size=Content(cap=slots._MAX_TODO_LINES),
         needs=("gather",), render=_todos))
+    # **A PART of the sidebar and not a pane of its own, and that was measured twice.**
+    #
+    # First: the frame's sizing supports exactly ONE variable-height pane, by
+    # construction. `layout.slot_sizes` answers every member of `VARIABLE_ROW_SLOTS` with
+    # `layout.repos_rows`, and `commands_frame._reassert_sizes` leaves that set unasserted
+    # so tmux's `resize-pane -y` — which moves exactly one boundary — has one remainder to
+    # give the rows to. Registered as a placed `Content()` this was handed the REPO
+    # TABLE's height: six rows, for six repos, on a plane with one change.
+    #
+    # Second, and decisive: a placed component has to be in `instance.FRAME_SLOTS`, and
+    # `FRAME_SLOTS`, `FRAME_DEFAULTS["slots"]` and `FRAME_DENSITY["full"]` are pinned to
+    # agree — so placing it puts a pane on EVERY operator's frame, saying "no changes in
+    # <ws>", for a feature most planes never use. `repos` saying "no clones" is a plane
+    # that is broken or new; a plane with no cross-repo change is the ordinary, permanent
+    # state.
+    #
+    # As a section it costs those planes NOTHING: `slots.changes_section` returns no rows
+    # at all when there are none, exactly as the todos do, and `_right` only spends a
+    # blank row on a section that has something in it.
+    #
+    # It declares BOTH slices, and both are real reads rather than one being decoration:
+    # `changes` is the rows, and `gather` is `gathered_at` — the snapshot's single
+    # timestamp, whose AGE the heading draws because a refresh is an action and not a tick
+    # (§4g). A surface that showed a state without its age would be indistinguishable from
+    # a live one.
+    reg.register(Component(
+        id="changes", title="changes", edge="right",
+        size=Content(cap=slots._MAX_CHANGE_LINES),
+        needs=("gather", "changes"), render=_changes))
+    # The composite declares the UNION of what its parts read, and `changes` joining the
+    # sidebar is what put `changes` on this line. `_panel("right")` draws all three
+    # sections through `slots._right`, so a composite declaring less than its parts read
+    # would be a cost the frame's budget does not describe — which is the one thing the
+    # declaration is for.
     reg.register(Component(
         id="sidebar", title="sidebar", edge="right", size=Fixed(22),
-        needs=("gather",), render=_panel("right"),
-        children=("personas", "todos")))
+        needs=("gather", "changes"), render=_panel("right"),
+        children=("personas", "todos", "changes")))
     return reg

--- a/charter/frame/choose.py
+++ b/charter/frame/choose.py
@@ -74,21 +74,36 @@ from typing import NamedTuple
 from .. import contain
 from . import overlay, switch
 
-#: The two nouns a picker offers. Values rather than an enum for the reason the rest of
+#: The three nouns a picker offers. Values rather than an enum for the reason the rest of
 #: this package uses strings — they appear in a test's failure message as themselves —
-#: and they are also what `charter frame-switch` already spells its flags with, so the one
-#: word travels from the row to the command without a table in between.
-WORKSPACE, PERSONA = "workspace", "persona"
+#: and the first two are also what `charter frame-switch` already spells its flags with,
+#: so the one word travels from the row to the command without a table in between.
+WORKSPACE, PERSONA, CHANGE = "workspace", "persona", "change"
 
-#: Both, in the order the palette offers them. Workspace first: it is the plane a frame is
-#: looking at, and a persona is who is looking.
-NOUNS = (WORKSPACE, PERSONA)
+#: All three, in the order the palette offers them. Workspace first: it is the plane a
+#: frame is looking at, a persona is who is looking, and a change is what they are in the
+#: middle of — which is the narrowest of the three and so goes last.
+NOUNS = (WORKSPACE, PERSONA, CHANGE)
 
 #: Which launch pin outranks a switch of each noun — the rung nothing charter writes can
 #: reach, because it is already in every panel pane's environment (`switch.py`'s module
 #: docstring). Named here because the row that opens a picker is the surface that reports
 #: it, and the reporting and the refusal must read the same variable.
+#:
+#: **``change`` is deliberately absent, and its absence is a fact rather than a gap.**
+#: There is no `$CHARTER_CHANGE`: a change is what one frame is looking at, not an
+#: identity a launch hands it, so nothing can pin one. Adding an entry that named a
+#: variable nothing sets would make `pin_reason` answer "" through a lookup rather than
+#: through a decision, and the reason a change doorway carries is a different one
+#: entirely — see :func:`pin_reason`.
 PIN = {WORKSPACE: "CHARTER_WORKSPACE", PERSONA: "CHARTER_PERSONA"}
+
+#: What a doorway says when this workspace has no changes at all. Its own sentence rather
+#: than a borrowed one, and it names the command that fixes it: a picker over nothing is
+#: an offer charter knows it cannot honour, and #512's rule is that an operator cannot ask
+#: about an option they cannot see.
+NO_CHANGES = ("no cross-repo change in this workspace — create one with "
+              "`charter change create <slug> --why \"…\"`")
 
 #: What marks the name the frame is on right now.
 #:
@@ -136,37 +151,63 @@ class Roster(NamedTuple):
         return None
 
 
-def names_of(noun: str) -> list[str]:
+def names_of(noun: str, fid: str = "") -> list[str]:
     """Every name *noun* offers, from `frame/switch.py`'s own listers.
 
     Asked there rather than re-derived, so the list a picker draws and the list a refusal
-    names ("no workspace 'x' — have: …") cannot disagree. Both are already held to
-    `workspace.valid_name`/`persona.valid_name` on the way out, which is #442's rule
-    applied where a directory name becomes a row.
+    names ("no workspace 'x' — have: …") cannot disagree. All three are already held to
+    `workspace.valid_name` / `persona.valid_name` / `instance.change_name_ok` on the way
+    out, which is #442's rule applied where a directory name becomes a row.
+
+    *fid* is required in practice for :data:`CHANGE` and ignored by the other two, because
+    changes are per WORKSPACE and which workspace is a question about the frame, not about
+    this process (#512). It defaults to `""` rather than being made positional-required so
+    that the two callers that predate it read unchanged; `switch.changes("")` resolves the
+    same "no frame, resolve locally" path every other frame surface takes for an empty id.
     """
-    return switch.workspaces() if noun == WORKSPACE else switch.personas()
+    if noun == WORKSPACE:
+        return switch.workspaces()
+    if noun == PERSONA:
+        return switch.personas()
+    return switch.changes(fid)
 
 
 def current(noun: str, fid: str) -> str:
     """The name frame *fid* is on right now — the row that gets :data:`MARK`.
 
-    `switch.current_persona` answers ``None`` for a plane with no persona at all, which is
-    an ordinary answer rather than a missing one; it becomes `""`, which matches no name
-    and therefore marks no row.
+    `switch.current_persona` and `switch.current_change` answer ``None`` for a plane with
+    no persona and a frame looking at no change, which are ordinary answers rather than
+    missing ones; both become `""`, which matches no name and therefore marks no row.
     """
     if noun == WORKSPACE:
         return switch.current_workspace(fid)
-    return switch.current_persona(fid) or ""
+    if noun == PERSONA:
+        return switch.current_persona(fid) or ""
+    return switch.current_change(fid) or ""
 
 
 def pin_reason(noun: str, fid: str) -> str:
-    """Why *fid* will not switch its *noun*, or `""` when it will.
+    """Why *fid* will not offer a picker for *noun*, or `""` when it will.
 
-    The same sentence `switch.to_workspace` refuses with, built from the same read
-    (`switch._pin`), so the row and the keypress cannot describe one frame two ways. `""`
-    exactly when the frame is not pinned, which is what makes "available" and "has no
-    reason" one decision here rather than two that can contradict each other on screen.
+    For a workspace and a persona that is the launch pin: the same sentence
+    `switch.to_workspace` refuses with, built from the same read (`switch._pin`), so the
+    row and the keypress cannot describe one frame two ways.
+
+    **For a change it is a different question with the same shape**, and that is why the
+    function is one rather than two. Nothing can pin a change (:data:`PIN` says why), so
+    the only thing standing between the doorway and a picker is having no changes at all —
+    a pane of no names is the offer charter knows it cannot honour, exactly as a pinned
+    frame's list of unswitchable ones is. `""` exactly when the picker would be useful,
+    which is what makes "available" and "has no reason" one decision here rather than two
+    that can contradict each other on screen.
+
+    **It costs a directory read for `change` and none for the other two**, and that is
+    affordable where it sits: `open_rows` runs once when the palette opens, never on a
+    repaint, and the read is `changes/`'s own listing — the same one the picker would make
+    a keystroke later.
     """
+    if noun == CHANGE:
+        return "" if names_of(CHANGE, fid) else NO_CHANGES
     pinned = switch._pin(fid, PIN[noun])
     if not pinned:
         return ""
@@ -187,7 +228,7 @@ def roster(noun: str, fid: str) -> Roster:
     on every row of a picker that cannot be reached while it is true is a line nothing
     could go red without.
     """
-    names = tuple(names_of(noun))
+    names = tuple(names_of(noun, fid))
     now = current(noun, fid)
     rows = tuple(overlay.Row(id=NAME_ID.format(noun, i),
                              title=f"{MARK[0] if n == now else MARK[1]}{n}")
@@ -276,4 +317,6 @@ def switch_to(noun: str, fid: str, name: str) -> switch.Outcome:
     """
     if noun == WORKSPACE:
         return switch.to_workspace(fid, name)
-    return switch.to_persona(fid, name)
+    if noun == PERSONA:
+        return switch.to_persona(fid, name)
+    return switch.to_change(fid, name)

--- a/charter/frame/component.py
+++ b/charter/frame/component.py
@@ -138,7 +138,12 @@ EVENT_KINDS = ("key", "click", "scroll", "focus", "blur", "resize")
 #: pass its own tests against an empty fixture, and be indistinguishable from a plane
 #: that genuinely has no personas. `ctx.SERVES` is asked against this tuple by a test, so
 #: the two cannot drift apart in either direction.
-NEEDS = ("gather", "repos", "todos")
+#:
+#: ``changes`` joined in the same commit that taught `gather.scan` to carry it, which is
+#: that rule kept rather than restated: the cross-repo changes this workspace holds, each
+#: with its members and the state charter derived for them from files alone. ``personas``
+#: is still absent for the same reason it always was — nothing serves it.
+NEEDS = ("gather", "repos", "todos", "changes")
 
 #: What a refusal tells a provider author to write instead. One sentence, held in one
 #: place, because it is repeated into every id refusal and a second spelling of it would

--- a/charter/frame/ctx.py
+++ b/charter/frame/ctx.py
@@ -64,6 +64,7 @@ SERVES = {
     "gather": lambda snap: MappingProxyType(snap),
     "repos": _rows("repos"),
     "todos": _rows("todos"),
+    "changes": _rows("changes"),
 }
 
 #: The keys every component gets whatever it declared: how much room it has, which frame

--- a/charter/frame/gather.py
+++ b/charter/frame/gather.py
@@ -110,7 +110,68 @@ def _empty(workspace: str | None) -> dict:
         "worktrees": [],
         "todos": [],
         "todo_count": 0,
+        "changes": [],
     }
+
+
+def _change_rows(active: str) -> list[dict]:
+    """This workspace's changes, as rows a pane can draw — **file reads only**.
+
+    Two files per change and nothing else: the record (what the operator declared) and
+    the landing log (what charter declared it merged). No forge call, no git subprocess,
+    no `glstate`. That is the cost half of §4g's idle-tick property said at the source
+    rather than at the renderer: a five-member change is five forge reads, and a scan that
+    made them would put them on every plane-state bump.
+
+    **`glstate` is explicitly not reused**, and it is tempting because it already caches
+    forge state. It is wrong twice: it is keyed on each clone's *currently checked-out*
+    branch, which is frequently not the member's, and what it caches is `ci_status`, which
+    the change surface is forbidden to read — a single string that answers ``None`` for a
+    CLI failure, a timeout, an auth error and *"no check ever ran"* alike (#561).
+
+    **So every member charter has no landing declaration for is ``unknown``, and the
+    change is never greener than its worst member.** That is not a placeholder: `unknown`
+    is the only value meaning *charter did not look*, and what stands between a member and
+    its own landing — its request's state, its checks at its head sha — is a forge read
+    this scan does not make. A member charter observed is `landed` or `blocked`; every
+    other member says so.
+
+    Never raises, like every other field here: one unreadable record degrades to the rows
+    that could be read, and a workspace with no `changes/` at all yields ``[]`` — which is
+    the lazy-creation case, not an error.
+    """
+    from .. import change as change_mod
+
+    records, _refused = change_mod.all_for(active)
+    # The whole log is read ONCE and grouped, rather than once per change. `landings`
+    # parses every line of every host's file to answer about one slug, so asking it per
+    # record is the log read N times on a path that already runs on every plane-state bump.
+    # The rows below carry no line count and no per-change file, so nothing downstream can
+    # tell the difference — which is exactly why it would have gone unnoticed.
+    by_change: dict[str, set[str]] = {}
+    try:
+        for line in change_mod.landings(active):
+            by_change.setdefault(line["change"], set()).add(line["repo"])
+    except Exception:
+        by_change = {}
+    rows: list[dict] = []
+    for rec in records:
+        slug = rec["change"]
+        states = change_mod.member_states(rec, by_change.get(slug, set()))
+        done, total = change_mod.landed_count(states.values())
+        rows.append({
+            "change": slug,
+            "why": rec["why"],
+            "state": change_mod.worst(states.values()),
+            "landed": done,
+            "total": total,
+            "excluded": len(rec["excluded"]),
+            "members": [{"repo": m["repo"], "branch": m["branch"],
+                         "needs": list(m["needs"]),
+                         "state": states.get(m["repo"], "unknown")}
+                        for m in rec["members"]],
+        })
+    return rows
 
 
 def _entry(d: Path, branch: str, states: dict, gl: dict, cur_repo: str | None,
@@ -282,6 +343,16 @@ def scan(workspace: str | None = None, cwd: str | None = None) -> dict:
     except Exception:
         todo_items, todo_count = [], 0
 
+    # This workspace's changes. Carried in the ONE snapshot, under the one timestamp, for
+    # §4f's clock rule and not only its store rule: everything on screen has to be from
+    # the same moment by construction rather than by two caches happening to agree, and a
+    # design that answered only the store rule would be §4f half-read. The component draws
+    # this timestamp's AGE, which is what makes "read 4m ago" a fact rather than a hope.
+    try:
+        changes = _change_rows(active)
+    except Exception:
+        changes = []
+
     return {
         "gathered_at": time.time(),
         "workspace": active,
@@ -290,6 +361,7 @@ def scan(workspace: str | None = None, cwd: str | None = None) -> dict:
         "worktrees": worktrees,
         "todos": todo_items,
         "todo_count": todo_count,
+        "changes": changes,
     }
 
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import os
 import time
 
-from .. import tui
+from .. import contain, tui
 from . import pane
 
 #: The spinner's own frames, and how long each is held. Ten braille cells, each one
@@ -866,6 +866,16 @@ _NAME_MIN_W = 12
 #: that it does, not a replacement for it.
 _MAX_TODO_LINES = 8
 
+#: The most rows the sidebar's `changes` section may occupy — its heading, its rows and
+#: its `…(+N more)` line together.
+#:
+#: :data:`_MAX_TODO_LINES`' argument, one section over: the sidebar is the persona column
+#: first, so a list that ran to the bottom of a forty-row terminal would be taking the
+#: pane from what it is for. `charter change show <slug>` is where a whole change lives
+#: (§3.4 calls it the monorepo view); this is the frame's answer to *"what am I in the
+#: middle of"*, not a replacement for it.
+_MAX_CHANGE_LINES = 4
+
 #: The screen column every row's content starts in, everywhere in the frame — one
 #: constant, read, rather than a `"  "` spelled at each call site.
 #:
@@ -1436,6 +1446,14 @@ def _right(fid: str) -> str:
     rows = todo_section(fid, w, h - len(lines) - 1, terse=terse)
     if rows:
         lines.extend(["", *rows])
+    # The changes go LAST, and the order is a priority rather than a preference: the
+    # personas are what this column is for, the todos are what this workspace is being
+    # asked to do, and a change is the coarser "what am I in the middle of" that
+    # `charter change show` answers in full. Each section reserves its own blank row out
+    # of what is left, so the one that overflows is always the lowest-priority one.
+    changes = changes_section(fid, w, h - len(lines) - 1)
+    if changes:
+        lines.extend(["", *changes])
     return "\n".join(lines)
 
 
@@ -1768,6 +1786,145 @@ def _repos(fid: str) -> str:
     budget = min(_height() - 1, cap)
     return "\n".join([_sidebar_head("repos", len(repos), w),
                       *(_table_lines(data, w, budget) if budget > 0 else [])])
+
+
+#: How a member's derived state is spelled on a row. `change.MEMBER_STATES`' own words,
+#: upper-cased, held in one table so the pane and `charter change show` cannot come to
+#: disagree — and so that a state charter grows later is a `KeyError` here rather than a
+#: blank column.
+#:
+#: **`UNKNOWN` is a word and not a blank**, which is the whole of #561 on a surface. An
+#: empty cell reads as "fine, nothing to report"; `UNKNOWN` reads as *charter did not
+#: look*, which is what it means — a member's request state and its checks at its head sha
+#: are a forge read this pane does not make.
+_CHANGE_STATE_WORD = {"unknown": "UNKNOWN", "blocked": "BLOCKED", "landed": "landed"}
+
+#: How long the age of a reading is shown for before it is just "a while". Beyond an hour
+#: the number stops being the thing you act on — what you act on is that it is stale — so
+#: the row says so in a word instead of counting up for ever.
+_AGE_STALE = 3600
+
+
+def _age(then, now: float, *, short: bool = False) -> str:
+    """``just now`` / ``4m ago`` / ``stale`` for a snapshot taken at *then*.
+
+    *short* is the same three answers in the cells a 22-column sidebar has to spare —
+    ``now`` / ``4m`` / ``old``. One function with a flag rather than two formatters,
+    because the BOUNDS are the thing that must not drift: a surface that called anything
+    under a minute "now" while another called it "just now" at ninety seconds would be two
+    clocks wearing one name.
+
+    **The pane draws the age of what it is showing, and that is the cost half of §4g.** A
+    refresh is an action, not a tick; between two of them the rows on screen are as old as
+    the last one, and a surface that did not say so would be indistinguishable from one
+    that was live. `gathered_at` is `time.time()` at scan, so this is a subtraction and
+    reads no clock the snapshot did not already carry.
+
+    A missing or unreadable timestamp answers ``?`` rather than ``just now``: a cache
+    written by an older charter has none, and dating it to the present is exactly the
+    confident wrong answer ADR 0009 forbids.
+    """
+    try:
+        age = now - float(then)
+    except (TypeError, ValueError):
+        return "?"
+    if age < 0 or age >= _AGE_STALE:
+        return "old" if short else "stale"
+    if age < 60:
+        return "now" if short else "just now"
+    return f"{int(age // 60)}m" + ("" if short else " ago")
+
+
+def _change_rows(rows: list, width: int, budget: int, age: str,
+                 chosen: str | None = None) -> list[str]:
+    """The `changes` section of the sidebar: a heading, then one row per change.
+
+    **Nothing at all when this workspace has no changes**, and that is `_todo_rows`' own
+    rule and its argument: a heading over an empty space in a 22-column column is
+    furniture within a day, and then a real change appearing in it draws no more attention
+    than the emptiness did. It is also what makes this section free on the planes that
+    never use it — which is the whole reason the change surface is a section here rather
+    than a pane of its own (`frame/builtins.py` records the measurement).
+
+    **The aggregate goes on the HEADING and the counts on the rows.** Twenty-two columns
+    cannot carry a slug, a fraction and a state word on one line, and the aggregate is the
+    thing you glance for — `change.worst` over every change's own worst member, so it can
+    never be greener than the worst member of the worst change.
+
+    **The change the picker chose carries the mark and does NOT move to the top.** A list
+    whose rows reorder with state is a list nobody learns (`builtin_actions._register_density`
+    settles the same question for its own rows), and the mark costs two cells that are the
+    same two cells whichever row has it.
+
+    The `…(+N more)` line is RESERVED out of the budget rather than appended and trimmed,
+    which is `_table_lines`' rule: "there is more here than fits" outranks "here is an
+    arbitrary one of them".
+    """
+    from .. import change as change_mod, statusline as sl
+    from . import choose
+
+    if not rows or budget <= 0:
+        return []
+    state = _CHANGE_STATE_WORD.get(
+        change_mod.worst([r.get("state") for r in rows]), "UNKNOWN")
+    head = tui.truncate(
+        f"{sl._DIM}{sl._HEAD_PAD}{sl._R}{sl._BOLD}changes{sl._R}"
+        f"{sl._DIM} {len(rows)} {state} {age}{sl._R}", width)
+    room = budget - 1
+    if room <= 0:
+        return [head]
+    shown = rows if len(rows) <= room else rows[: max(room - 1, 0)]
+    out = [head]
+    # The count column is fixed, so the NAME is what gives way — a fraction cut in half
+    # says nothing, while a clipped slug is still the slug you recognise.
+    counts = [f"{int(r.get('landed') or 0)}/{int(r.get('total') or 0)}" for r in shown]
+    cw = tui.column("", counts, gap=0)
+    mw = tui.width(choose.MARK[0])
+    for r, count in zip(shown, counts):
+        # The mark is `frame/choose.py`'s, not a second one: it is what the picker's own
+        # rows carry for "the one you are on", and two spellings of that would be two
+        # answers on one screen. Both entries are the same width by construction, so the
+        # mark moving does not move the names beside it.
+        mark = choose.MARK[0] if r.get("change") == chosen else choose.MARK[1]
+        name = contain.one_line(r.get("change") or "")
+        room_for_name = max(width - cw - mw - 1, 1)
+        out.append(tui.truncate(
+            f"{sl._DIM}{mark}{sl._R}"
+            f"{tui.pad(tui.truncate(name, room_for_name), room_for_name)} "
+            f"{sl._DIM}{count}{sl._R}", width))
+    if len(shown) < len(rows):
+        out.append(tui.truncate(
+            f"{sl._DIM}…(+{len(rows) - len(shown)} more){sl._R}", width))
+    return out
+
+
+def changes_section(fid: str, width: int, budget: int) -> list[str]:
+    """This workspace's cross-repo changes, in at most *budget* rows — the `changes` part
+    of the sidebar composite.
+
+    `todo_section`'s shape and its rules. **The cache is opened only when there is a row
+    to draw it into**: the budget is checked before `gather.read` is reached, because a
+    pane with no room must not open a file it is about to discard.
+
+    **The workspace is the FRAME's, handed in, never one the panel resolved for itself**
+    (#512/#526). `gather.read` falls through to `gather.scan` on a cold cache, and `scan`
+    with no workspace argument resolves in the PANEL process — which lands on the declared
+    default, and a populated list of another plane's changes reads as an answer.
+
+    **No subprocess, on any path.** Everything drawn here is in the one snapshot
+    `gather.scan` wrote — the records and the landing declarations, both file reads. A
+    repaint that asked the forge would put five reads on every plane-state bump, which is
+    §4g's idle-tick property spent on a pane nobody was looking at.
+    """
+    from . import gather
+    budget = min(budget, _MAX_CHANGE_LINES)
+    if budget <= 0:
+        return []
+    from . import state as st
+    data = gather.read(fid, workspace=_frame_workspace(fid))
+    return _change_rows(data.get("changes") or [], width, budget,
+                        _age(data.get("gathered_at"), time.time(), short=True),
+                        st.frame_change(fid))
 
 
 #: Every slot charter can draw. `panel.run` refuses a name that is not in here rather

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -746,6 +746,52 @@ def chrome(fid: str) -> str | None:
         return None
 
 
+def record_change(fid: str, slug: str) -> None:
+    """Write down which cross-repo change THIS RUNNING FRAME is looking at.
+
+    :func:`record_density`'s twin, for its reason exactly: this is a keypress's answer for
+    one running frame, and `reap` deletes the directory whole when the frame ends. There
+    is no committed setting behind it and there deliberately is not one — which change you
+    are in the middle of is a fact about a session, not an arrangement somebody would
+    commit, and `[frame]` gaining a key for it would be a config value that is stale by
+    lunchtime.
+
+    Same must-not-raise, atomic-write shape as :func:`record_density`.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "change.tmp"
+    try:
+        config.write_for(tmp, f"{slug}\n")
+        os.replace(tmp, d / "change")
+    except OSError:
+        return
+
+
+def frame_change(fid: str) -> str | None:
+    """The change this frame is looking at, or ``None`` for "none chosen".
+
+    ``None`` is the ordinary case and is not a failure: a frame comes up looking at no
+    change in particular, and the `changes` panel then lists them all — which is the
+    honest answer to *"what am I in the middle of"* when nobody has said.
+
+    **The text is NOT validated here**, for :func:`density`'s reason: `instance` owns the
+    one rule for what a change may be called (`change_name_ok`, asked by
+    `change.path_for`), and it sits at the point of use so a hand-edited or truncated file
+    degrades exactly the way a slug charter cannot resolve does. A second half-copy of
+    that rule in this module is how the two come to disagree, and this value is on its way
+    to a `changes/<slug>.json` join.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        return (d / "change").read_text().strip() or None
+    except (OSError, ValueError):
+        return None
+
+
 def record_hidden(fid: str, names) -> None:
     """Write down which components THIS RUNNING FRAME is not drawing.
 

--- a/charter/frame/switch.py
+++ b/charter/frame/switch.py
@@ -232,6 +232,70 @@ def to_persona(fid: str, name: str) -> Outcome:
     return Outcome(True, f"persona → {shown}")
 
 
+def changes(fid: str) -> list[str]:
+    """Every cross-repo change frame *fid*'s workspace holds, name-checked on the way out.
+
+    :func:`workspaces`' reasoning, one noun over, and the check matters as much: a slug
+    goes on to a `changes/<slug>.json` join and onto a palette row, which is the position
+    #442 already cost this project once. `change.all_for` has read every one of these
+    through `change.read`, which asks `instance.change_name_ok` — so this is the same
+    floor asked where the list is built rather than a second rule.
+
+    **Keyed on the FRAME's workspace, not this process's** (#512). A palette is a
+    `run-shell` child of a tmux server shared between frames, and resolving locally would
+    list another plane's changes on this frame's screen. `state.workspace_for` is the one
+    rule every frame surface asks.
+
+    A record charter could not read contributes no row and takes nothing down with it —
+    `change.all_for` reports those separately, and `doctor` is where they are named.
+    """
+    from .. import change as change_mod
+    try:
+        records, _refused = change_mod.all_for(state.workspace_for(fid))
+    except Exception:
+        return []
+    return sorted(r["change"] for r in records)
+
+
+def current_change(fid: str) -> str | None:
+    """The change this frame is looking at, or ``None``.
+
+    `state.frame_change` and nothing else — there is no environment pin for a change and
+    no committed default, so unlike a workspace or a persona this has exactly one rung.
+    That is stated rather than left implicit because `choose.pin_reason` branches on it:
+    a change picker can never be refused by a launch pin, and the reason its doorway
+    carries is a different one.
+    """
+    return state.frame_change(fid)
+
+
+def to_change(fid: str, name: str) -> Outcome:
+    """Point frame *fid* at change *name*, or say why it did not.
+
+    **This moves what the frame is LOOKING at, not what it is.** A workspace switch moves
+    the plane every panel reads and a persona switch moves who is reading; this moves one
+    panel's subject. So there is no `set_active`, no lock, no identity to rewrite and no
+    gather refresh — the change rows are already in the snapshot every panel shares, and
+    re-gathering to choose which of them to draw would be a second reading of a plane
+    that has not moved.
+
+    Two refusals, and each is a thing the operator can act on: a slug that cannot name a
+    change (`instance.change_name_ok`, the one rule), and a change this workspace does not
+    have. An unknown name is a question, never an implicit create — `to_workspace`'s rule,
+    and the existing names go in the message for its reason.
+    """
+    from .. import instance
+    shown = contain.one_line(name)
+    if not instance.change_name_ok(name):
+        return Outcome(False, f"'{shown}' cannot name a change")
+    known = changes(fid)
+    if name not in known:
+        return Outcome(False, f"no change '{shown}' — have: {_some(known)}")
+    state.record_change(fid, name)
+    state.bump(fid)
+    return Outcome(True, f"change → {shown}")
+
+
 def current_workspace(fid: str) -> str:
     """What the frame is drawing right now — `state.workspace_for`, named here so the
     palette and the switcher cannot come to disagree about which name gets the mark."""

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -3398,12 +3398,23 @@ def _single_credential_reason(cmd: str) -> str | None:
 # --------------------------------------------------------------------------- #
 # A4: RELEASE FLOOR — an unattended run may not publish (#299)                 #
 # --------------------------------------------------------------------------- #
-#: Forge CLI subcommand pairs that publish or land code. `gh pr merge` and `gh release
+#: CLI subcommand pairs that publish or land code. `gh pr merge` and `gh release
 #: create` are no kind of `git`, so `_GIT_WRITE_RE` never saw them and nothing else did
 #: either — they were unguarded in every mode.
+#:
+#: **`charter change land` is here, and so is the branch below that reaches it.** That
+#: command merges one member of a cross-repo change, which is the same act `gh pr merge`
+#: is: the project's floor already sits between *opening* a request and *merging* one —
+#: `gh pr create` is deliberately absent from this set — and a charter verb that merged
+#: would be a documented way around a floor charter itself wrote. Adding the tuple alone
+#: would have shipped a dead line, because the lookup used to live under
+#: `elif base in ("gh", "glab")`; the base check widened with the set, and
+#: `tests/test_release_floor.py` deletes the tuple on its own to prove the entry is what
+#: answers rather than the branch that reaches it.
 _PUBLISH_FORGE = {
     ("gh", "release", "create"), ("gh", "pr", "merge"),
     ("glab", "release", "create"), ("glab", "mr", "merge"),
+    ("charter", "change", "land"),
 }
 #: `git tag` flags that only READ or act locally. An autonomous run legitimately needs to
 #: know what the tags are, and deleting a local tag publishes nothing.
@@ -3437,6 +3448,14 @@ def _release_floor_reason(cmd: str, data: dict) -> str | None:
     tag ``release-1``, and tagging attended costs nothing. The asymmetry favours bluntness:
     a false stop costs one re-run, a false pass costs a version number that can never be
     reused.
+
+    **Charter's own `change land` is on this floor, and nothing else of charter's is.** A
+    cross-repo landing is N merges, each individually revertible, so it is not a release
+    and is not treated as one — the split is attended versus unattended, exactly as it
+    already is for `gh pr merge`. Attended, an agent may land one member, because that is
+    the merge the standing rule permits for a single repo; unattended it may not land at
+    all, because that is where this floor already sat. `charter change show`, `list` and
+    the rest read and are untouched.
     """
     if not _unattended(data):
         return None
@@ -3466,9 +3485,24 @@ def _release_floor_reason(cmd: str, data: dict) -> str | None:
                 if any(re.fullmatch(r"v?\d+\.\d+(?:\.\d+)?[\w.-]*", w)
                        for w in words[1:]):
                     return fix + "This pushes what looks like a version tag."
-        elif base in ("gh", "glab") and len(words) >= 2:
-            if (base, words[0], words[1]) in _PUBLISH_FORGE:
-                return fix + f"`{base} {words[0]} {words[1]}` publishes or lands code."
+        elif base in ("gh", "glab") or _is_charter(prog, args):
+            # **The reader had to widen with the set.** `_PUBLISH_FORGE` was consulted only
+            # for `gh`/`glab`, so `("charter", "change", "land")` would have been a tuple
+            # nothing could reach — a floor that never runs, in a phase whose thesis is
+            # that a guard nobody pins is a comment with a runtime cost.
+            #
+            # `_is_charter` rather than `base == "charter"`, so `edm change land` (the
+            # pre-rename binary) and `python3 -m charter change land` are the same command
+            # to this guard as they already are to the leak guard. Both spellings put
+            # charter's own NAME in `words` instead of in `prog`, and `-m` drops out with
+            # the other flags — so the pair sits one place further along and is put back on
+            # the same footing here rather than matched in one spelling and missed in the
+            # other.
+            name = base if base in ("gh", "glab") else _CHARTER_PROGS[0]
+            if words and words[0].lower() in _CHARTER_PROGS:
+                words = words[1:]
+            if len(words) >= 2 and (name, words[0], words[1]) in _PUBLISH_FORGE:
+                return fix + f"`{name} {words[0]} {words[1]}` publishes or lands code."
     return None
 
 

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -415,6 +415,17 @@ def drift(root: Path) -> list[str]:
 #: dropped here and gets the others, rather than a `KeyError` in a launcher or a
 #: pane split for a slot with no renderer. It drew repo rows recomposed for 22 columns;
 #: `repos` draws the same rows at the width the table was designed for.
+#: **`changes` is deliberately NOT here, and that is what keeps it free.** It is a
+#: component charter ships, registers and can draw (`frame/builtins.py`,
+#: `frame/slots.py:SLOTS`), and a plane places it with a `[[frame.component]]` table —
+#: which is also the only way any component gets a toggle key, built-in or not
+#: (:data:`FRAME_COMPONENT_FIELDS`: *"a component nobody asked to bind does not get a
+#: key"*). Naming it here would put it in the shipped `slots` default and in `full`,
+#: because those three must agree, and that is a pane on EVERY operator's frame saying
+#: "no changes in <ws>" for a feature most planes never use. `repos` saying "no clones"
+#: is a plane that is broken or new; a plane with no cross-repo change is the ordinary,
+#: permanent state. The picker is what stays free: `F2` then the `change` row, on every
+#: plane, with no config at all.
 FRAME_SLOTS = ("top", "bottom", "repos", "right")
 
 #: How much frame there is, as a PRESET over :data:`FRAME_SLOTS` — never a second

--- a/charter/toolgate.py
+++ b/charter/toolgate.py
@@ -150,8 +150,19 @@ _DANGEROUS = {
     # untouched, so a plane that declares `tools: charter` keeps what it declared it
     # for. `edm` is charter's pre-rename name, kept for the reason `hooks._CHARTER_PROGS`
     # keeps it: one extra string against a silent gap on a machine still running it.
-    "charter": {"secret", "vault"},
-    "edm": {"secret", "vault"},
+    #
+    # `change` joins them because `charter change land` merges code into a repository,
+    # and a persona declaring `tools: charter` must not have that auto-approved. **The
+    # grain is coarse on purpose and the asymmetry is what decides it**: this also
+    # declines to auto-approve `charter change show`, which costs one permission prompt
+    # on a read-only command, while the other direction auto-approves a merge. This gate
+    # never denies — the worst it can do is fall back to the prompt the operator would
+    # have had anyway — so the cost of over-refusing is bounded at that prompt, and the
+    # cost of under-refusing is not bounded at all. A finer rule keyed on the verb would
+    # have to read `land` out of an argv the shell has already had its way with, which is
+    # the reading `_is_dangerous`' own docstring records going wrong for `git clean`.
+    "charter": {"secret", "vault", "change"},
+    "edm": {"secret", "vault", "change"},
 }
 
 #: Binaries whose ARGUMENT is a program charter cannot resolve to a file. Declaring one

--- a/docs/adr/0020-there-is-no-cross-repo-merge-loop.md
+++ b/docs/adr/0020-there-is-no-cross-repo-merge-loop.md
@@ -1,0 +1,105 @@
+# There is no cross-repo merge loop
+
+`charter change land <slug> --repo <name>` lands **one** member of a cross-repo change.
+There is no `--all`. It is not a flag that defaults off and it is not a flag behind a
+confirmation: **the flag does not exist, and the parser refuses it.** A test asserts that.
+
+This is written down because it will be proposed again by everybody who has ever written
+the shell loop, and because the argument against it is not obvious from the outside — from
+the outside it looks like charter making you type five commands to do one thing.
+
+## Atomicity is not on offer, so the question is what replaces it
+
+Charter cannot make a cross-repo landing atomic. Nothing can: five repositories on
+different hosts with different owners and different CI have no transaction between them,
+and a merge that has already fired somebody's deploy cannot be taken back by failing the
+next one. The honest guarantee is three sentences:
+
+> Charter cannot make a cross-repo landing atomic.
+> It can make the window visible, bounded and named, and it can refuse to report a partial
+> landing as anything but partial.
+> And it does not offer the one operation that would turn N revertible merges into one
+> irreversible transition with no human between them.
+
+`--all` is that operation. What replaces it is **legibility** — one name on every artifact
+charter authors, the window named while it is open (`PARTIALLY LANDED (3 of 5)`), a change
+that is never reported greener than its worst member, and archaeology that does not depend
+on charter still being installed.
+
+## Two reasons, and the second is the stronger
+
+**ADR 0003's reasoning, applied unchanged.** That ADR rejected a `--yes` flag on `charter
+report send` with one sentence: *"a flag the agent can pass is a flag the agent will pass
+unprompted, which is exactly the failure being prevented."* `--all` is that flag, for an
+operation whose blast radius is five repositories rather than one issue.
+
+**`--all` would have to answer a question that has no answer.** When member 3 of 5 is
+rejected mid-loop, `--all` must do *something*: stop and leave two landed, continue and
+land the independents, or roll back what it did. Each of those is wrong in a case the
+others handle, and charter cannot tell the cases apart — the facts that separate them are
+in the head of whoever is watching. ADR 0009's rule is that charter may name a cause it
+recognised and must not assert one it inferred; a flag that must guess a policy is the same
+defect wearing an argument parser. **Not offering the flag is not offering a lie.**
+
+## The obvious objection: the agent just writes the loop
+
+It can, and nothing stops it. Three things are still true, and they are why the refusal
+earns its place rather than being a speed bump.
+
+The loop the agent writes has **no gates in it** — but the command it calls does, on every
+call: the blocker gate, the check gate, the read-back. A five-iteration shell loop over
+`charter change land` is five gated landings; a `--all` flag is one ungated one. **The
+refusal is not of repetition, it is of a code path that batches the gates.**
+
+Every call is traced independently, so the record shows five decisions rather than one.
+
+And an agent that writes the loop has *chosen* to, in a session someone can read, rather
+than passing a flag charter itself put on the command as the obvious way to do the obvious
+thing. That difference is exactly what ADR 0003 is about, and this project has already
+decided it once.
+
+## The same refusal, one command over
+
+`charter change revert` is bound by this too, and it is where the pressure is highest: the
+moment you most want the loop is the moment you are least able to judge it. An automatic
+cross-repo rollback is `--all` with the safety off, offered to an operator who has just
+discovered something is wrong and does not yet know what — and the reverts themselves need
+review and CI, because a revert can break a repo as effectively as the change did.
+
+So a revert is a **new change**: its members are the landed members of the original, each
+seeded with a branch carrying a revert of the sha the landing log recorded, and from there
+it is pushed, reviewed, gated and landed one member at a time by the same commands with the
+same refusals.
+
+The alternative would destroy the only thing that makes the state explicable. Force-pushing
+three default branches back past the merges leaves a world where the change happened, was
+undone, and no repository's history mentions either — the exact failure this whole design
+exists to prevent. `component-api-2` and `revert-component-api-2`, both named, both
+cross-referenced, in every repo they touched, reads as a decision six months later. A
+force-push reads as corruption.
+
+## Consequences
+
+`charter change land` takes `--repo` and lands one member per invocation. `charter change
+revert` derives a record and seeds branches; it lands nothing. Neither ever force-pushes,
+deletes a branch, resets a default branch, or closes a request charter did not open — those
+are not flags that default off, they are argv charter never builds, and the tests read every
+git invocation a change action makes rather than trusting the absence.
+
+An operator who wants a prompt before each landing has one, for free, today:
+
+```
+charter guard ask --local 'charter change land *'
+```
+
+`charter doctor` names that command and **does not run it** (ADR 0017). `--local` is part
+of the recommendation: `guard ask` writes the plane's *committed* settings by default, and
+consent that travels in a commit enrols a whole team on one person's click — ADR 0003's own
+reason for keeping reporting consent out of `charter.toml`. A team that genuinely wants the
+prompt for everybody drops the flag, which is a decision made once and visible in a diff.
+
+Charter adds no second human gate of its own. A consent the agent satisfies by running one
+more command is theatre, and an operator prompted constantly rubber-stamps within a day —
+worse than no gate. The floor that matters is `hooks._release_floor_reason`, which **denies**
+`charter change land` outright under `bypassPermissions`, because an unattended `ask` falls
+back to `allow` and an ask there would be indistinguishable from no guard.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,0 +1,204 @@
+# A change that spans several repos
+
+One piece of work often touches five repositories. Git has no word for that, and neither
+did charter: what you got was eleven branches across five clones and nothing saying which
+five go together, which one has to land first, or what any of it was for.
+
+A **change** is that missing word. One intent, N repositories, stored as a file per
+workspace:
+
+```bash
+charter change create component-api-2 --why "component.API_VERSION 1 -> 2"
+charter change add component-api-2 charter
+charter change add component-api-2 charter-metrics --needs charter
+charter change drop component-api-2 charter-slack --why "no components; only an action provider"
+charter change show component-api-2
+charter change list
+charter change forget component-api-2
+charter change revert component-api-2
+```
+
+Vocabulary, because the noun collides: a **change** is the cross-repo object, a **member**
+is one repository's part of it, and a member's pull or merge request is a **request**.
+
+## What the record holds, and what it refuses to
+
+`workspaces/<ws>/changes/<slug>.json` holds six keys and no seventh: the name, the `why`,
+when and by whom, the members (each with its repo, its branch and what must land before
+it), and the repositories considered and deliberately excluded, with reasons and dates.
+
+**There is no state field, and none is representable.** No request number, no CI result, no
+branch position, no `landed` flag — the key set is closed at both ends, so an unknown *or*
+missing key stops the read and is named rather than ignored. `need` where `needs` was meant
+is an ordering constraint that would otherwise have silently ceased to exist.
+
+Ordering is the case worth naming twice, because it looks like state and is not. `needs` is
+**declared**, because only a human knows that repo B's change needs repo A's merged.
+*Blocked* is **derived** at read time from that declaration and a fresh reading of what has
+landed, and nothing writes it anywhere. A cycle is refused at write time with every member
+in it named: that is not a condition to render, it is a record that cannot be true.
+
+**Membership is committed. Destination is local.** The record carries bare repository
+names — never a URL, a host, a remote, a forge kind or a base branch. A remote in a
+committed file is a *destination* that arrives from someone else's machine. There is also
+**no expansion**: no glob, no pattern, no `--all-repos`, and nothing in this surface
+enumerates repositories. Every member was typed by somebody, and it must resolve to a clone
+already in this workspace.
+
+## Landing is a declaration, joined against git when you read it
+
+"Has this member landed" cannot be answered from the record and must not be stored in it —
+but it cannot be answered from the forge alone either, because a merged request's source
+branch is routinely deleted and a branch-keyed lookup then finds nothing, which is
+indistinguishable from a member that was never pushed.
+
+So `charter change land` appends one past-tense line to an append-only, **never-committed**
+log beside the records:
+
+```
+workspaces/<ws>/changes/log/<host>.jsonl
+  {"ts": …, "change": "component-api-2", "repo": "charter",
+   "number": 601, "merge": "e0c9d13", "head": "4b1e77a"}
+```
+
+Same shape, same per-host filename and the same not-committed rule as `pieces/`. It holds
+the declaration git cannot make — *charter merged this commit, for this change* — and the
+present tense is reconstructed by asking git whether the default branch still contains that
+sha. A member the forge calls merged with no log line is landed **and divergent**. A member
+with a log line git no longer contains is not landed any more, and nothing had to notice or
+update a flag for that to become true.
+
+## What charter refuses, collected
+
+The refusals are the design, so they are in one place.
+
+1. **No `--all` on `land`.** The flag does not exist and the parser refuses it. See
+   [ADR 0020](adr/0020-there-is-no-cross-repo-merge-loop.md).
+2. **No automatic cross-repo rollback.** A revert is a new change.
+3. **No synthetic monorepo on disk.** No symlink farm, no union mount, no subtree. The
+   monorepo is the workspace directory — the clones are already siblings, so `rg` already
+   spans the change; what was missing is knowing which of them are one piece of work, and
+   that is `charter change show`.
+4. **No aggregate green.** A change is never reported greener than its worst member, and
+   one member charter could not read makes the change `UNKNOWN`.
+5. **No `gh pr checks`, no `mergeStateStatus`.** Both report a run that never happened
+   identically to a clean pass. Checks are read per head sha or not at all.
+6. **No stored state.** No request number, no CI result, no branch position, no `landed`
+   flag in the record.
+7. **No destination in a committed file.** No URL, host, remote or base branch.
+8. **No expansion.** No glob, no pattern, no repository enumeration anywhere in this
+   surface.
+9. **No force-push, no branch deletion, no default-branch reset, no closing a request
+   charter did not open** — in any change action, during a revert included.
+10. **No unattended landing.** `charter change land` is on the release floor: under
+    `bypassPermissions` it is **denied**, not asked, because an unattended ask falls back
+    to allow. See [hooks.md](hooks.md).
+11. **No auto-closing of todos**, and no todo state.
+12. **No claim of atomicity**, anywhere, in any wording.
+
+**Charter cannot make a cross-repo landing atomic**, and it does not pretend to. What it
+does instead is make the window visible, bounded and named, and refuse to report a partial
+landing as anything but partial.
+
+## Reverting
+
+```bash
+charter change revert component-api-2
+```
+
+derives a **new** change, `revert-component-api-2`, whose members are the landed members of
+the original. Each is seeded with a branch off that clone's default branch carrying a
+revert of the sha the landing log recorded — with `-m 1` **only when git says that sha has
+more than one parent**, because a squash landing is an ordinary commit and `-m` on one
+fails. The parent count is asked of git, never remembered.
+
+**The ordering is the original's, reversed.** If `charter-metrics` needed `charter` to land
+first — because its code depends on charter's new API — then undoing it goes the other way:
+reverting `charter` while `charter-metrics` still depends on the API it removes leaves the
+dependent broken, which is the world the revert exists to restore.
+
+From there it is an ordinary change: pushed, reviewed, gated and landed one member at a
+time, by the same commands with the same refusals.
+
+Two things it cannot do, said plainly rather than discovered:
+
+- **It cannot revert a deploy.** A merge to a default branch on a repo with continuous
+  deployment has already had an effect in the world. Charter has no model of deployment and
+  will not acquire one to make this sentence shorter.
+- **It cannot revert what it did not record.** A member merged in the browser has no
+  `Charter-Change` trailer and no landing record; `revert` names it as needing a human
+  rather than guessing which merge commit was the one.
+
+It also refuses over uncommitted work, by name: `git revert` commits into the checkout, and
+folding somebody's work in progress into a revert commit is worse than the wait.
+
+## Divergence is named, at FAIL
+
+`charter doctor` has a `changes` row, and it fails rather than warns — a divergence worth
+naming is worth an exit code, and that exit code is the only thing that makes the
+SessionStart wrapper print. Five things it names:
+
+- a member whose branch is already in its default branch and which **charter did not
+  land** — so there is no trailer and no merge sha, and `revert` cannot reach it;
+- a declared landing the default branch **no longer contains** — reverted, or the branch
+  was rewritten;
+- a declared landing whose commit **carries no `Charter-Change` trailer** — the log names a
+  commit charter did not author for this change;
+- a member that **landed while a blocker had not**. Charter refuses that landing and cannot
+  stop a browser; naming it is the half that makes the guard honest rather than decorative;
+- a member's **branch name in a clone that is a member of no change** — either a member
+  somebody forgot to add, or a name collision worth knowing about.
+
+It reads what is already on this disk and never fetches, because it runs at SessionStart.
+The honest consequence: it can **under**-report, and it can never invent.
+
+## In the frame
+
+`changes` is a section of the persona sidebar, beside the todos:
+
+```
+▪ changes 2 UNKNOWN 4m
+  component-api-2  2/3
+* metrics-panel-f  0/1
+```
+
+**It draws nothing at all when this workspace has no changes**, exactly as the todo
+section does — so it costs a plane that never uses the feature no rows and no attention.
+That is why it is a section rather than a pane of its own: a placed component has to be in
+`[frame] slots`, and the shipped `slots`, `density = full` and the slot list are pinned to
+agree, so placing it would put a pane saying "no changes in <ws>" on every operator's
+frame. (The frame also supports exactly one variable-height *pane* by construction —
+`resize-pane -y` moves one boundary, so one pane has to be the remainder, and that pane is
+the repo table.)
+
+The heading carries the count, the worst member of the worst change, and how old the
+reading is. Each row is one change and how much of it is in. `F2` then the **change** row
+picks one, and the picked one carries the `*` — it does not move to the top, because a
+list whose rows reorder with state is a list nobody learns. `charter change show <slug>` is
+the whole picture.
+
+**Nothing on the repaint path calls a forge, and nothing on it starts a process at all.**
+The section reads the one gather snapshot — the records and the landing declarations, both
+file reads — under that snapshot's single timestamp, which is the age the heading draws.
+
+`UNKNOWN` is a word rather than a blank because it means *charter did not look*: what
+stands between a member and its landing is a request state and its checks at its head sha,
+and those are a forge read the frame does not make.
+
+## Optional: a prompt before each landing
+
+```bash
+charter guard ask --local 'charter change land *'
+```
+
+`charter doctor` names this command and **does not run it**: both answers are legitimate,
+and a tool that settles a legitimate choice by writing a line while nobody is looking has
+made the decision for you.
+
+`--local` is load-bearing. `guard ask` writes the plane's *committed* `.claude/settings.json`
+by default; `--local` writes the gitignored `.claude/settings.local.json` instead. Consent
+that travels in a commit enrols a whole team on one person's click. A team that genuinely
+wants the prompt for everybody drops the flag — a decision, made once, visible in a diff.
+
+Because Claude Code matches on the full command string, the prompt shows **which change and
+which repo**.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -157,16 +157,26 @@ rule while one who reads a bare refusal files an issue.
   expressible as a pattern and stays in the hook anyway, so it can explain itself — see
   [git-policy.md](git-policy.md) and ADR 0014.
 - **Release floor.** A run the harness reports as `bypassPermissions` may not create a tag,
-  push tags, or `gh release create` / `gh pr merge`. `bypassPermissions` means *stop asking
-  me*, not *stop knowing things*, and a published version number can never be reused.
+  push tags, `gh release create` / `gh pr merge`, or **`charter change land`**.
+  `bypassPermissions` means *stop asking me*, not *stop knowing things*, and a published
+  version number can never be reused.
+
+  `charter change land` is here because it merges one member of a cross-repo change into a
+  repository, which is the same act `gh pr merge` is — and the project's line already runs
+  between *opening* a request and *merging* one (`gh pr create` is deliberately not on this
+  list). The split is attended versus unattended: attended, an agent may land one member,
+  because that is the merge the standing rule already permits for a single repo. Every other
+  `charter change` verb — `show`, `list`, `create`, `add`, `drop`, `push`, `revert` — is
+  untouched in every mode. See [changes.md](changes.md) and
+  [ADR 0020](adr/0020-there-is-no-cross-repo-merge-loop.md).
 
 A seventh path is not a guard but an allowance: a program the **active persona** declares in
 `tools:` runs without a prompt while that persona is active, and only then. It approves the
 **program**, so every argument rides along — which is why seven things are not smoothed
 whatever `tools:` says: destructive subcommands (`kubectl delete`, `charter secret`,
-`git clean`, …), **an argument that is itself a program**, interpreters whose argument is
-the real command (`bash -c`, `python3 -c`, `env`, `xargs`, `npx`, …), any command whose
-arguments **reach** a vault or charter's own state, any tool added to that line after the
+`charter change`, `git clean`, …), **an argument that is itself a program**, interpreters
+whose argument is the real command (`bash -c`, `python3 -c`, `env`, `xargs`, `npx`, …),
+any command whose arguments **reach** a vault or charter's own state, any tool added to that line after the
 session started — the gate answers within the set declared before this session could
 rewrite it, and `persona.md` is a file the model can write — any command carrying a
 character the shell would rewrite before the program sees it, and any command whose

--- a/docs/news/unreleased-cross-repo-change-surface.md
+++ b/docs/news/unreleased-cross-repo-change-surface.md
@@ -1,0 +1,124 @@
+---
+version: unreleased
+headline: A cross-repo change has a strip in the frame, a revert that is a new change, and a landing charter will not do unattended
+adopt: workspace reinit --all
+---
+
+`charter change` kept the record. This is the rest of the surface around it: somewhere to
+see a change while you are in the middle of one, a way back out when it was wrong, and the
+floor that stops an unattended run merging across five repositories on its own.
+
+## `charter change revert` — a revert is a new change
+
+```
+$ charter change revert component-api-2
+✓ change 'revert-component-api-2' created — 2 member(s) to revert
+  charter          branch change/revert-component-api-2  reverted
+  charter-metrics  branch change/revert-component-api-2  reverted
+✗ charter-jira: no landing record, so no merge sha — charter cannot revert this member.
+```
+
+Its members are the landed members of the original; each is seeded with a branch off that
+clone's own default branch carrying a revert of the sha the landing log recorded. From
+there it is an ordinary change with the ordinary gates.
+
+**`-m 1` only when git says that sha has more than one parent.** A squash landing is an
+ordinary commit and `-m` on one fails; a merge landing has two and `git revert` refuses
+without it. The parent count is asked of git, never remembered — storing "this was a
+squash" would be a derivable fact cached for convenience.
+
+**The ordering is the original's, reversed.** If `charter-metrics` needed `charter` to land
+first, undoing it goes the other way — reverting the base while the dependent still needs
+the API it removes leaves the dependent broken, which is the world the revert exists to
+restore. A revert that simply copied `needs` across would get this exactly backwards, and
+would look right in every single-member example.
+
+**A member charter did not land is named, not guessed.** No line in the landing log means
+no merge sha, and charter will not pick the merge commit that looks about right. It also
+refuses over uncommitted work, by name: `git revert` commits into the checkout, and folding
+somebody's work in progress into a revert commit is worse than the wait.
+
+What it will not do, in any change action and during a revert included: force-push to any
+branch, delete any branch, `reset --hard` a default branch, or close a request charter did
+not open. Those are not flags that default off — they are argv charter never builds, and
+the tests read every git invocation a revert makes rather than trusting the absence.
+
+## The floor: no unattended landing
+
+`("charter", "change", "land")` joins the release floor, so a run the harness reports as
+`bypassPermissions` is **denied** — not asked, because an unattended ask falls back to
+allow and would be indistinguishable from no guard. Attended is untouched: an agent with a
+person at the keyboard may land one member, because that is the merge the standing rule
+already permits for a single repo. Every other `change` verb is untouched in every mode.
+
+`change` also joins the persona tool gate's destructive list, so a persona declaring
+`tools: charter` never gets a landing auto-approved. The grain is coarse on purpose — it
+declines `charter change show` too — and the asymmetry decides it: over-refusing costs one
+prompt on a read-only command, under-refusing auto-approves a merge, and the gate never
+denies, so the cost is bounded at that prompt.
+
+Charter adds **no second human gate of its own**. One is available if you want it, and
+`charter doctor` names it without running it:
+
+```
+charter guard ask --local 'charter change land *'
+```
+
+`--local` is load-bearing: `guard ask` writes the plane's *committed* settings by default,
+and consent that travels in a commit enrols a whole team on one person's click.
+
+**[ADR 0020](../adr/0020-there-is-no-cross-repo-merge-loop.md)** records the decision this
+all turns on: there is no `--all` on `land`, the flag does not parse, and atomicity is
+replaced by legibility. When member 3 of 5 is rejected, `--all` would have to guess a
+policy — and a flag that must guess a policy is a lie with an argument parser.
+
+## Divergence, named at FAIL
+
+`charter doctor` grows a `changes` row. It fails rather than warns, because a divergence
+worth naming is worth the exit code that makes the SessionStart wrapper print. It names a
+member landed outside charter, a declared landing the default branch no longer contains,
+a declared landing whose commit carries no `Charter-Change` trailer, a member that landed
+while a blocker had not, and a member's branch name sitting in a clone that is a member of
+no change.
+
+Charter cannot stop a human merging in a browser and does not pretend to. **What would be
+theatre is a guard that reports enforcement it does not have**, so the same read that
+refuses also names the landings that happened anyway. It reads what is already on this disk
+and never fetches — so it can under-report, and can never invent.
+
+## A section in the sidebar
+
+```
+▪ changes 2 UNKNOWN 4m
+  component-api-2  2/3
+* metrics-panel-f  0/1
+```
+
+`changes` is a part of the persona sidebar, beside the todos — and it **draws nothing at
+all when this workspace has no changes**, exactly as the todo section does, so a plane that
+never uses the feature pays no rows for it. `F2` then the **change** row picks one, and the
+picked one carries the `*`.
+
+It is a section rather than a pane of its own for two measured reasons, both recorded in
+`frame/builtins.py`: the frame supports exactly one variable-height pane by construction
+(`resize-pane -y` moves one boundary, so one pane is the remainder and that pane is the
+repo table), and a placed component has to be in `[frame] slots` — which is pinned to agree
+with the shipped default and with `density = full`, so placing it would put a pane saying
+"no changes" on every operator's frame.
+
+**Nothing on the repaint path calls a forge, and nothing on it starts a process at all.**
+The section reads the one gather snapshot — the records and the landing declarations, both
+file reads — under that snapshot's single timestamp, which is the age the heading draws.
+
+`UNKNOWN` is a word rather than a blank, and that is the point of it: it means *charter did
+not look*. What stands between a member and its landing is a request state and its checks
+at its head sha, and those are a forge read the frame does not make. A change is never
+reported greener than its worst member, and a change with no members at all reads
+`unknown` rather than "everything landed" — an empty maximum is the classic way a report
+comes out green over nothing.
+
+## What `workspace reinit --all` is for
+
+Unchanged from the record entry, and repeated because a plane may take both at once:
+`STRUCTURE_VERSION` went 2 → 3 so every existing workspace flags itself, and one command
+repairs them all. It creates no directory.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -61,6 +61,13 @@ Three stores, three jobs. Putting a thing in the wrong one is the common mistake
 | `memory/` | facts learned while working | constantly, one file per fact |
 | `workspace.json` | repos + branches | when you `snapshot` |
 
+Two more stores sit beside them with their own lifetimes: `todos/` (intent, which expires —
+[ADR 0004](adr/0004-intent-is-its-own-store.md)) and `changes/`, one file per cross-repo
+change: which repositories are in it, which branch in each, which must land before which,
+and which were considered and left out. A change's name outlives the work — it is in a merge
+commit's trailer in five repositories forever — which is why it is not a todo. See
+[changes.md](changes.md).
+
 **`workspace.md` is the charter** — what this task is for and what has been decided. Seed
 it with `create --vision "…"`; a `fork` inherits it. It answers "why does this workspace
 exist", so it should be short enough that a newcomer reads all of it.
@@ -80,9 +87,15 @@ The most consequential per-workspace choice, and it is one flag.
 
 - **LOCAL** (the default): everything above stays on disk. Nothing is committed. Nothing
   reaches anyone.
-- **LIVE** (`charter workspace live <name>`): `workspace.json`, `workspace.md`, `memory/`
-  and `todos/` are un-ignored, and a memory written to a LIVE workspace is committed and
-  pushed **immediately** — reactively, not on a later save.
+- **LIVE** (`charter workspace live <name>`): `workspace.json`, `workspace.md`, `memory/`,
+  `todos/` and `changes/` are un-ignored, and a memory written to a LIVE workspace is
+  committed and pushed **immediately** — reactively, not on a later save.
+
+`changes/log/` is un-ignored by neither switch and is committed **never**, exactly as
+`pieces/` is not. It is the landing declaration — *charter merged this commit, for this
+change* — per host, describing merges made from one disk; a portable file describing a
+local reality is the mismatch [ADR 0010](adr/0010-the-manifest-is-a-snapshot-not-an-inventory.md)
+dissects.
 
 `charter workspace live <name> --off` puts it back. `charter workspace save` is the manual
 counterpart for a LIVE workspace whose writes were deferred with `--no-sync`. Writing to a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ packages = ["charter"]
 # gap is invisible from a checkout, where the fallback reads the repo and looks fine.
 [tool.hatch.build.targets.wheel.force-include]
 "docs/browser.md" = "charter/_docs/browser.md"
+"docs/changes.md" = "charter/_docs/changes.md"
 "docs/control-plane.md" = "charter/_docs/control-plane.md"
 "docs/forges.md" = "charter/_docs/forges.md"
 "docs/frame.md" = "charter/_docs/frame.md"

--- a/tests/_changerepo.py
+++ b/tests/_changerepo.py
@@ -1,0 +1,131 @@
+"""A workspace holding REAL git clones, for the two change surfaces that ask git.
+
+`charter change revert` and the divergence report are the only parts of the change surface
+that leave the record store, and what they leave it for is git in a clone the operator
+already has. A fake clone — a directory whose `.git` is a directory, which is all
+`workspace.is_clone` asks and all `tests/test_commands_change.py` needs — cannot answer
+"does this branch contain that commit", which is the whole question those two ask. So this
+builds repositories git will actually answer about.
+
+Not a ``test_*`` module, so discovery skips it — `tests/_statedirscan.py`'s precedent.
+
+**Every commit is made with `-c user.name=…` and `commit.gpgsign=false` on the command
+rather than from config**, because the machine running the suite has its own identity and
+its own signing key, and a fixture that inherits either is a fixture that fails on somebody
+else's laptop for reasons that have nothing to do with the code (`tests/CONTRIBUTING`'s
+"your machine is not the runner").
+
+**`-b main` on every `init`.** Without it the branch name comes from the machine's
+`init.defaultBranch` — `main` on one box, `master` on another — and
+`doctor._plane_default_branch`, which is what the code under test asks, guesses `main`
+before `master`. A fixture that depends on a global git setting reads as the code being
+wrong rather than the setup.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from charter import change, config, workspace
+from tests._isolation import PersonaIso
+
+#: What every commit in a fixture is made as. One tuple rather than four flags spelled at
+#: each site, so a fixture cannot half-inherit the developer's own identity.
+IDENT = ("-c", "commit.gpgsign=false", "-c", "user.email=t@e", "-c", "user.name=t")
+
+
+def git(where, *args) -> subprocess.CompletedProcess:
+    """One git command in *where*, raising on failure — a fixture that half-worked is a
+    test whose failure describes the wrong thing."""
+    return subprocess.run(["git", "-C", str(where), *args], check=True,
+                          capture_output=True, text=True)
+
+
+def sha(where, ref: str = "HEAD") -> str:
+    return git(where, "rev-parse", ref).stdout.strip()
+
+
+class ChangeRepoCase(PersonaIso):
+    """A control plane with a workspace whose clones are real repositories."""
+
+    WS = "ws"
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        workspace.ensure(self.WS)
+
+    def repo(self, name: str) -> Path:
+        """A clone with one commit on `main`, and nothing else.
+
+        **The identity and the signing setting are written into the repo's OWN config**,
+        not only passed on the fixture's own commits, and that is a measured requirement
+        rather than tidiness. `charter change revert` makes a commit — `git revert` — and
+        it deliberately does **not** pass `-c commit.gpgsign=false`: a revert is the
+        operator's commit in the operator's repository, and charter silently unsigning it
+        would be charter deciding somebody's signing policy, which ADR 0014 puts with the
+        host. So on a developer machine configured to sign with an interactive signer, the
+        production revert blocks on an approval prompt that no test can answer — measured
+        here, as a suite that hung with `op-ssh-sign` waiting. Local config outranks global,
+        so setting it on the fixture repo is what makes the code under test runnable
+        without changing what it does.
+
+        `user.name`/`user.email` for the second half of the same fact: `git revert` needs
+        an identity to commit with, and a CI runner has none.
+        """
+        d = workspace.workspace_dir(self.WS) / name
+        d.mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(d)],
+                       check=True, capture_output=True)
+        git(d, "config", "--local", "commit.gpgsign", "false")
+        git(d, "config", "--local", "user.email", "t@e")
+        git(d, "config", "--local", "user.name", "t")
+        (d / "f").write_text("1\n")
+        git(d, "add", "-A")
+        git(d, *IDENT, "commit", "-qm", "one")
+        return d
+
+    def land_a_merge(self, repo: Path, slug: str, *, trailer: bool = True,
+                     squash: bool = False) -> str:
+        """Put a member's work on `main` the way `charter change land` would, and answer
+        with the sha it created.
+
+        Two shapes, because §3.7 turns on the difference: a **merge** commit has two
+        parents and `git revert` needs `-m 1`, while a **squash** is an ordinary one-parent
+        commit and `-m` on one fails. Charter asks git which it is rather than remembering,
+        so both have to be reachable from a fixture.
+
+        *trailer* off is the divergence case — a landing that looks like charter's and
+        carries no `Charter-Change` trailer, which is what a browser merge leaves behind.
+        """
+        branch = change.default_branch(slug)
+        git(repo, "switch", "-q", "-c", branch)
+        (repo / branch.replace("/", "_")).write_text("2\n")
+        git(repo, "add", "-A")
+        git(repo, *IDENT, "commit", "-qm", "member work")
+        git(repo, "switch", "-q", "main")
+        msg = f"land {slug}"
+        if trailer:
+            msg += f"\n\nCharter-Change: {slug}"
+        if squash:
+            git(repo, "merge", "-q", "--squash", branch)
+            git(repo, *IDENT, "commit", "-qm", msg)
+        else:
+            git(repo, *IDENT, "merge", "-q", "--no-ff", "-m", msg, branch)
+        return sha(repo)
+
+    def declare(self, slug: str, repo: str, merge: str, *, number=1,
+                head: str = "0" * 40, ts: str = "2026-08-29T00:00:00+00:00"):
+        """Write the landing declaration charter's own `land` would have written."""
+        return change.record_landing(self.WS, slug, repo, number=number, merge=merge,
+                                     head=head, ts=ts)
+
+    def make_change(self, slug: str, members, *, why: str = "API 1 -> 2") -> dict:
+        """A record with *members* as ``(repo, needs)`` pairs, written to disk."""
+        rec = change.new_record(slug, why, "t", "2026-08-29T00:00:00+00:00")
+        rec["members"] = [{"repo": r, "branch": change.default_branch(slug),
+                           "needs": list(n)} for r, n in members]
+        change.write(self.WS, slug, rec)
+        return rec

--- a/tests/test_builtin_components.py
+++ b/tests/test_builtin_components.py
@@ -7,7 +7,7 @@ edges beside the public one.
 
 **The refactor's success condition is that nothing changed**, and these tests are written
 to be able to say so rather than to assume it. The pane the `sidebar` composite draws is
-compared against its two parts composed; each component's render is compared against the
+compared against its three parts composed; each component's render is compared against the
 renderer the slot has always had; and `layout`'s five per-slot tables — which used to be
 five hand-written tuples — are compared against the literal geometry charter ships, not
 against the registry they are now read from. Reading both sides of an assertion out of the
@@ -38,8 +38,17 @@ def _row(name, *, branch="main", current=False, repo=None):
     return d
 
 
+def _change(slug, *, state="unknown", landed=0, total=2):
+    """A `gather`-cache-shaped change row — the fields `gather._change_rows` writes.
+
+    Only the four `slots._change_rows` actually draws are needed; the rest of the record
+    (`why`, `excluded`, `members`) is what `charter change show` reads, not the sidebar.
+    """
+    return {"change": slug, "state": state, "landed": landed, "total": total}
+
+
 class Declared(unittest.TestCase):
-    """What the six components say about themselves.
+    """What the seven components say about themselves.
 
     No plane needed: `builtins.build()` reads nothing and starts nothing, which is the
     property that lets `layout` ask it at import time.
@@ -48,28 +57,40 @@ class Declared(unittest.TestCase):
     def setUp(self) -> None:
         self.reg = builtins.build()
 
-    def test_the_registry_holds_the_six_charter_draws_in_split_order(self):
-        """Split order is registration order, and the two parts of the sidebar are
+    def test_the_registry_holds_the_seven_charter_draws_in_split_order(self):
+        """Split order is registration order, and the three parts of the sidebar are
         registered before the composite that draws them — the registry refuses a
-        composite built from parts it has not seen."""
+        composite built from parts it has not seen.
+
+        `changes` is the third of those parts, so it is registered with them and not with
+        the placed components above: it is a SECTION of the sidebar, not a pane. The
+        measurement is `frame/builtins.py`'s own — a placed component has to be in
+        `instance.FRAME_SLOTS`, and that list is pinned to agree with the shipped `slots`
+        and with `full`, so placing it would put a pane saying "no changes" on every
+        operator's frame for a feature most planes never use."""
         self.assertEqual([c.id for c in self.reg.all()],
                          ["identity", "attention", "repos", "personas", "todos",
-                          "sidebar"])
+                          "changes", "sidebar"])
 
     def test_only_the_four_placed_components_are_on_an_edge(self):
-        """`personas` and `todos` are registered and never split for: their parent draws
-        them inside its own pane, and a part that appeared on an edge too would be drawn
-        twice — once in its own pane and once inside the sidebar's."""
+        """`personas`, `todos` and `changes` are registered and never split for: their
+        parent draws them inside its own pane, and a part that appeared on an edge too
+        would be drawn twice — once in its own pane and once inside the sidebar's."""
         placed = {edge: [c.id for c in self.reg.on_edge(edge)]
                   for edge in component.EDGES}
         self.assertEqual(placed, {"top": ["identity"], "bottom": ["attention", "repos"],
                                   "left": [], "right": ["sidebar"]})
 
-    def test_the_sidebar_is_the_composite_of_personas_then_todos(self):
+    def test_the_sidebar_is_the_composite_of_personas_then_todos_then_changes(self):
         """In the order the pane stacks them, which is not split order — nothing splits
-        this pane at all (§4d)."""
+        this pane at all (§4d).
+
+        `changes` is LAST, and `slots._right`'s own comment is why: the order is a
+        priority, and each section reserves its blank row out of what the ones above it
+        left, so the section that overflows a short column is always the lowest-priority
+        one."""
         self.assertEqual([c.id for c in self.reg.children_of("sidebar")],
-                         ["personas", "todos"])
+                         ["personas", "todos", "changes"])
         self.assertEqual([c.id for c in self.reg.children_of("identity")], [])
 
     def test_each_component_declares_the_edge_and_size_the_frame_draws_it_at(self):
@@ -78,7 +99,11 @@ class Declared(unittest.TestCase):
         `right` is 22 columns and the two strips are one row each; the repo table is
         `Content()` because its height is the plane's repo count bounded by what the
         harness may not be charged (`layout.repos_rows`), and a cap written here would be
-        a second, weaker copy of that arithmetic."""
+        a second, weaker copy of that arithmetic.
+
+        `changes` is on `right` with a CAP, which is what says it is a section of the
+        sidebar rather than a pane: it is bounded like `todos` and for the same reason —
+        a column that is one list has no room to let a second one grow without end."""
         got = {c.id: (c.edge, c.size) for c in self.reg.all()}
         self.assertEqual(got, {
             "identity": ("top", component.Fixed(1)),
@@ -86,6 +111,7 @@ class Declared(unittest.TestCase):
             "repos": ("bottom", component.Content(None)),
             "personas": ("right", component.Fill()),
             "todos": ("right", component.Content(slots._MAX_TODO_LINES)),
+            "changes": ("right", component.Content(slots._MAX_CHANGE_LINES)),
             "sidebar": ("right", component.Fixed(22)),
         })
 
@@ -230,6 +256,12 @@ class Renders(PersonaIso):
             "worktrees": [],
             "todos": [{"title": "wire the registry"}, {"title": "measure the frame"}],
             "todo_count": 5,
+            # One change, so the sidebar's third section actually draws. An empty list
+            # here would leave every assertion about `changes` below satisfied by a
+            # section that returns no rows — which is the shape this suite keeps being
+            # bitten by, and doubly so here because "no rows when there are none" is the
+            # very property that made `changes` a section rather than a pane.
+            "changes": [_change("frame-registry", state="blocked", landed=1)],
         })
 
     def _ctx(self, c, *, width=200, height=20):
@@ -269,18 +301,30 @@ class Renders(PersonaIso):
             c = self.reg.get("identity")
             self.assertEqual(render(self._ctx(c)), ["a", "", "b"])
 
-    def test_the_sidebars_pane_is_exactly_its_two_parts(self):
+    def test_the_sidebars_pane_is_exactly_its_three_parts(self):
         """The composite draws the parts, it does not keep a second copy of them. This is
         the whole of the `slots.py` half of this task: `_right` was split into
         `persona_section` and `todo_section` and then composed back, so a pane that
-        differed from its parts would mean the split changed what the panel says."""
+        differed from its parts would mean the split changed what the panel says.
+
+        `changes_section` joined the composition as the third and lowest-priority part.
+        Each section's blank row comes OUT of what the sections above it left, which is
+        why the budget handed to each one here is the running total rather than the
+        pane's own height — a composition that added the rows on top would overflow the
+        column by exactly the number of sections in it."""
         w, h = self._pane(22, 20)
         with w, h:
             whole = slots.render("right", FID)
             personas = slots.persona_section(22, 20, terse=False)
             todos = slots.todo_section(FID, 22, 20 - len(personas) - 1, terse=False)
-        self.assertEqual(whole, "\n".join([*personas, "", *todos]))
+            changes = slots.changes_section(
+                FID, 22, 20 - len(personas) - len(todos) - 2)
+        self.assertEqual(whole,
+                         "\n".join([*personas, "", *todos, "", *changes]))
         self.assertTrue(todos, "fixture drew no todos — the composition is untested")
+        self.assertTrue(changes,
+                        "fixture drew no changes — the third part is untested, and an "
+                        "empty one composes identically to not being there at all")
 
     def test_a_terse_sidebar_spends_fewer_rows_on_todos_than_a_normal_one(self):
         """The density cap moved out of `_right` and into `todo_section` with this task,
@@ -345,10 +389,10 @@ class Renders(PersonaIso):
                                  f"{seen or 'nothing'}")
 
     def test_the_sidebars_own_parts_read_where_they_said_they_would(self):
-        """The same check for the two components that are never placed on an edge — they
+        """The same check for the three components that are never placed on an edge — they
         are drawn by their parent, so nothing else would ever exercise their declarations.
         """
-        for cid in ("personas", "todos"):
+        for cid in ("personas", "todos", "changes"):
             c = self.reg.get(cid)
             seen: list[str] = []
             real_read = gather.read

--- a/tests/test_change_divergence.py
+++ b/tests/test_change_divergence.py
@@ -18,9 +18,10 @@ one fired and, where a neighbour could have produced the same row, the absence o
 from __future__ import annotations
 
 import unittest
+from unittest import mock
 
 from charter import change, commands_change, doctor
-from tests._changerepo import ChangeRepoCase, git
+from tests._changerepo import ChangeRepoCase, git, sha
 
 SLUG = "component-api-2"
 
@@ -174,6 +175,91 @@ class TestAStrayBranchIsNamed(DivergenceCase):
         self.assertEqual(commands_change.stray_branches(self.WS), [])
 
 
+class TestTheChecksDegradeRatherThanGuess(DivergenceCase):
+    """Every place `divergences` and `stray_branches` decline to answer, driven.
+
+    **A check that cannot see is not a check that found nothing**, and every one of these
+    is that distinction: a member with no clone, a clone charter cannot resolve a default
+    branch for, a git call that failed. Each contributes NOTHING rather than a guess,
+    because a divergence invented out of a failed read is the confident wrong answer
+    ADR 0009 forbids — and because this runs at SessionStart, where a false FAIL is a red
+    row on every session of a plane whose only sin is calling its branch something else.
+    """
+
+    def test_a_member_with_no_clone_contributes_nothing(self):
+        """`charter change add` refused this repo once; a record can still name it after
+        the clone was removed. `doctor` says the record is unreadable-or-absent elsewhere;
+        this check has nothing to say about a repository that is not here."""
+        self.make_change(SLUG, [("gone", ())])
+        self.assertEqual(self.findings(), [])
+
+    def test_a_clone_with_no_resolvable_default_branch_contributes_nothing(self):
+        """Every question below is *relative to the default branch*. A repository charter
+        cannot resolve one for produces no findings rather than findings against a branch
+        nobody uses — `_plane_default_branch` answers `None` and means it."""
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        self.land_a_merge(repo, SLUG, trailer=False)
+        self.assertEqual(len(self.findings()), 1)      # the control: it does report
+        git(repo, "branch", "-m", "main", "trunk")     # now nothing names a default
+        self.assertEqual(self.findings(), [])
+
+    def test_a_git_call_that_fails_is_read_as_no_and_never_as_yes(self):
+        """The direction that matters. `_contains` and `_branch_exists` answer False for
+        anything charter could not resolve, so a failed read never manufactures a
+        containment — it only ever loses one."""
+        repo = self.repo("charter")
+        self.assertFalse(commands_change._branch_exists(repo, "no-such-branch"))
+        self.assertFalse(commands_change._contains(repo, "0" * 40, "main"))
+        self.assertFalse(commands_change._trailer_names(repo, "0" * 40, SLUG))
+
+    def test_the_trailer_check_reads_this_commit_and_not_a_range(self):
+        """`git show --no-patch --format=%B` on the sha itself. A `--grep` over a range
+        would answer about the RANGE, so a trailer anywhere in history would vouch for a
+        commit that carries none."""
+        repo = self.repo("charter")
+        with_trailer = self.land_a_merge(repo, SLUG)
+        self.assertTrue(commands_change._trailer_names(repo, with_trailer, SLUG))
+        self.assertFalse(commands_change._trailer_names(repo, with_trailer, "other-slug"))
+        # The commit BEFORE it carries no trailer, even though one exists further along.
+        parent = git(repo, "rev-parse", f"{with_trailer}^1").stdout.strip()
+        self.assertFalse(commands_change._trailer_names(repo, parent, SLUG))
+
+    def test_the_trailer_must_be_its_own_line_and_not_a_mention(self):
+        """A commit message that talks ABOUT a change is not a commit charter authored
+        for it. The comparison is against a stripped LINE, so prose containing the words
+        does not vouch for the commit."""
+        repo = self.repo("charter")
+        (repo / "x").write_text("1\n")
+        git(repo, "add", "-A")
+        git(repo, "-c", "commit.gpgsign=false", "commit", "-qm",
+            f"mentions Charter-Change: {SLUG} in the middle of a sentence here")
+        self.assertFalse(commands_change._trailer_names(repo, sha(repo), SLUG))
+
+    def test_the_branch_listing_answers_empty_for_a_repo_git_will_not_read(self):
+        """`_local_branches` is one call for N questions, so a failure there would
+        otherwise turn into N wrong answers rather than one missing one."""
+        self.assertEqual(commands_change._local_branches(self.tmp / "not-a-repo"), set())
+
+    def test_the_branch_listing_finds_every_local_branch_and_no_remote_one(self):
+        repo = self.repo("charter")
+        git(repo, "branch", "feature/x")
+        git(repo, "branch", "change/whatever")
+        self.assertEqual(commands_change._local_branches(repo),
+                         {"main", "feature/x", "change/whatever"})
+
+    def test_a_record_that_does_not_parse_contributes_no_branch_names(self):
+        """`stray_branches` builds its wanted set from records it could READ. Guessing
+        branch names from a record that did not parse is the unearned diagnosis ADR 0009
+        forbids — and `change/<slug>` by convention would report every branch anybody ever
+        named that way, which is the convention §3.4 refuses to derive membership from."""
+        stray = self.repo("charter-jira")
+        git(stray, "switch", "-q", "-c", change.default_branch(SLUG))
+        change.path_for(self.WS, SLUG).parent.mkdir(parents=True, exist_ok=True)
+        change.path_for(self.WS, SLUG).write_text('{"change": "broken"}')
+        self.assertEqual(commands_change.stray_branches(self.WS), [])
+
+
 class TestDoctorSaysItAtFail(DivergenceCase):
     """FAIL, not WARN, and the reason is mechanical: `cmd_doctor` exits non-zero only on
     FAIL, and that exit code is the only thing that makes the SessionStart wrapper print."""
@@ -269,6 +355,101 @@ class TestDoctorSaysItAtFail(DivergenceCase):
     def test_a_plane_with_no_changes_says_none_and_stays_ok(self):
         self.assertEqual(doctor.check_changes().status, doctor.OK)
         self.assertEqual(doctor.check_changes().detail, "none")
+
+
+class TestTheDoctorRowsOwnBranches(DivergenceCase):
+    """Every arm of `check_changes`, including the ones a healthy plane never takes."""
+
+    def test_a_plane_that_is_not_a_control_plane_says_so_and_reads_nothing(self):
+        from charter import config
+        config.HAS_CONTROL_PLANE = False
+        try:
+            r = doctor.check_changes()
+        finally:
+            config.HAS_CONTROL_PLANE = True
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("no control plane", r.detail)
+
+    def test_a_check_that_could_not_run_is_WARN_and_says_its_silence_means_nothing(self):
+        """`doctor`'s own discipline: "not checked" is WARN, never OK — a check that
+        silently did nothing is worse than no check (`test_doctor_absent_is_not_health`)."""
+        from charter import workspace as _ws
+        with mock.patch.object(_ws, "list_workspaces", side_effect=OSError("nope")):
+            r = doctor.check_changes()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("not checked", r.detail)
+        self.assertIn("silence means nothing", r.hint)
+
+    def test_the_catch_is_narrow_and_a_charter_bug_is_not_swallowed(self):
+        """`check_memory_indexes`' recorded failure: a broad catch once swallowed a
+        NameError and reported OK. A programming error must reach the caller."""
+        from charter import workspace as _ws
+        with mock.patch.object(_ws, "list_workspaces", side_effect=NameError("typo")):
+            with self.assertRaises(NameError):
+                doctor.check_changes()
+
+    def test_many_findings_are_bounded_and_the_row_says_how_many_it_hid(self):
+        """A row that listed forty divergences is a row nobody reads, and one that listed
+        three and stopped silently is a row that lies about the size of the problem."""
+        for i in range(5):
+            repo = self.repo(f"r{i}")
+            self.make_change(f"c-{i}", [(f"r{i}", ())])
+            self.land_a_merge(repo, f"c-{i}", trailer=False)
+        r = doctor.check_changes()
+        self.assertEqual(r.status, doctor.FAIL)
+        self.assertIn("more)", r.detail)
+        self.assertLess(len(r.detail), 2000)
+
+    def test_many_unreadable_records_are_bounded_the_same_way(self):
+        for i in range(5):
+            self.repo(f"r{i}")
+            self.make_change(f"c-{i}", [(f"r{i}", ())])
+            change.path_for(self.WS, f"c-{i}").write_text('{"change": "x"}')
+        r = doctor.check_changes()
+        self.assertEqual(r.status, doctor.FAIL)
+        self.assertIn("more)", r.detail)
+
+    def test_an_unreadable_record_outranks_a_divergence_and_says_a_different_thing(self):
+        """"Charter cannot read this file" and "git disagrees with this file" send the
+        reader to two different places. The unreadable one goes first because a change
+        nobody can read is a change nobody can land."""
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        self.land_a_merge(repo, SLUG, trailer=False)
+        self.make_change("other", [("charter", ())])
+        change.path_for(self.WS, "other").write_text('{"change": "x"}')
+        r = doctor.check_changes()
+        self.assertIn("unreadable", r.detail)
+        self.assertNotIn("charter did not land it", r.detail)
+
+    def test_every_workspace_is_looked_at_and_not_only_the_active_one(self):
+        """`check_workspace_clones`' own finding (#156): the half-landed change is rarely
+        the one you are standing in."""
+        from charter import workspace as _ws
+        _ws.ensure("other")
+        d = _ws.workspace_dir("other") / "charter"
+        d.mkdir(parents=True)
+        import subprocess
+        subprocess.run(["git", "init", "-q", "-b", "main", str(d)],
+                       check=True, capture_output=True)
+        for k, v in (("commit.gpgsign", "false"), ("user.email", "t@e"),
+                     ("user.name", "t")):
+            git(d, "config", "--local", k, v)
+        (d / "f").write_text("1\n")
+        git(d, "add", "-A")
+        git(d, "commit", "-qm", "one")
+        rec = change.new_record("elsewhere", "w", "t", "2026-08-29T00:00:00+00:00")
+        rec["members"] = [{"repo": "charter", "branch": "change/elsewhere", "needs": []}]
+        change.write("other", "elsewhere", rec)
+        git(d, "switch", "-q", "-c", "change/elsewhere")
+        (d / "g").write_text("2\n")
+        git(d, "add", "-A")
+        git(d, "commit", "-qm", "work")
+        git(d, "switch", "-q", "main")
+        git(d, "merge", "-q", "--no-ff", "-m", "landed elsewhere", "change/elsewhere")
+        r = doctor.check_changes()
+        self.assertEqual(r.status, doctor.FAIL)
+        self.assertIn("other/elsewhere", r.detail)
 
 
 class TestItReadsThisDiskAndNeverTheNetwork(DivergenceCase):

--- a/tests/test_change_divergence.py
+++ b/tests/test_change_divergence.py
@@ -1,0 +1,302 @@
+"""Divergence, named — ADR 0013 rule 2 over a cross-repo change.
+
+*"A divergence charter can see, charter names… WARN is not a surface. A divergence worth
+naming under rule 2 is worth FAIL."*
+
+Charter refuses to land a member whose blockers have not landed, and it cannot stop a human
+merging in a browser. **What would be theatre is a guard that reports enforcement it does
+not have**, so the same read that refuses also names the landings that happened anyway.
+That is the half these tests are about, and every one of them asserts FAIL rather than an
+exit code — `cmd_doctor` exits non-zero only on FAIL, and that exit code is the only thing
+that makes the SessionStart wrapper print.
+
+Five divergences, each with its own sentence. Three gates in sequence mask each other and
+an exit-code assertion cannot tell them apart (#558), so every case below asserts **which**
+one fired and, where a neighbour could have produced the same row, the absence of its words.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import change, commands_change, doctor
+from tests._changerepo import ChangeRepoCase, git
+
+SLUG = "component-api-2"
+
+
+class DivergenceCase(ChangeRepoCase):
+    def findings(self, slug: str = SLUG) -> list[str]:
+        return commands_change.divergences(self.WS, change.read(self.WS, slug))
+
+    def one_line(self, slug: str = SLUG) -> str:
+        got = self.findings(slug)
+        self.assertEqual(len(got), 1, got)
+        return got[0]
+
+
+class TestALandingCharterDidNotMakeIsNamed(DivergenceCase):
+    def test_a_member_merged_outside_charter_is_reported(self):
+        """The forge says merged, the log has no line — so no `Charter-Change` trailer and
+        no merge sha, and `charter change revert` has nothing to run against. Git stands in
+        for the forge here and is strictly better at it: a local clone can see a revert,
+        which the forge cannot."""
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        self.land_a_merge(repo, SLUG, trailer=False)
+        line = self.one_line()
+        self.assertIn("charter did not land it", line)
+        self.assertIn("Charter-Change", line)
+        self.assertIn("revert", line)
+
+    def test_a_member_charter_did_land_is_not_reported(self):
+        """The control. Without it every assertion above is satisfied by a check that
+        reports everything."""
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        self.declare(SLUG, "charter", self.land_a_merge(repo, SLUG))
+        self.assertEqual(self.findings(), [])
+
+    def test_an_unmerged_member_is_not_reported_either(self):
+        """A branch that exists and is not in `main` is work in progress, which is the
+        ordinary state of a change and not a divergence. A check that called it one would
+        be permanently red on every plane doing the thing this surface is for."""
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        git(repo, "switch", "-q", "-c", change.default_branch(SLUG))
+        (repo / "g").write_text("2\n")
+        git(repo, "add", "-A")
+        git(repo, "-c", "commit.gpgsign=false", "commit", "-qm", "wip")
+        git(repo, "switch", "-q", "main")
+        self.assertEqual(self.findings(), [])
+
+
+class TestADeclarationGitDisagreesWithIsNamed(DivergenceCase):
+    def test_a_landing_the_default_branch_no_longer_contains(self):
+        """*"A member with a log line git no longer contains is not landed any more, and
+        nothing had to notice or update a flag for that to become true."* Reset `main` past
+        the merge — which is what somebody force-pushing a revert leaves behind — and the
+        declaration is still there and no longer true."""
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        merge = self.land_a_merge(repo, SLUG)
+        self.declare(SLUG, "charter", merge)
+        git(repo, "reset", "-q", "--hard", "HEAD~1")
+        line = self.one_line()
+        self.assertIn("no longer contains", line)
+        self.assertIn("not landed any more", line)
+        self.assertNotIn("charter did not land it", line)   # not the gate above it
+
+    def test_a_landing_whose_commit_carries_no_trailer(self):
+        """The log names a commit charter did not author for this change. Step 1's literal
+        wording, and it is a different finding from the one above: there the commit is
+        gone, here it is present and is somebody else's."""
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        self.declare(SLUG, "charter", self.land_a_merge(repo, SLUG, trailer=False))
+        line = self.one_line()
+        self.assertIn("carries no", line)
+        self.assertIn("Charter-Change", line)
+        self.assertNotIn("no longer contains", line)
+
+    def test_a_log_line_whose_merge_is_not_a_sha_is_named_as_that(self):
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        self.declare(SLUG, "charter", "not-a-sha")
+        self.assertIn("not a sha", self.one_line())
+
+
+class TestAnOutOfOrderLandingIsNamed(DivergenceCase):
+    """§3.2's honest half. Charter refuses to land a blocked member; it cannot stop a
+    browser, and what makes the guard honest rather than decorative is naming it when it
+    happens anyway."""
+
+    def test_a_member_that_landed_ahead_of_its_blocker(self):
+        one = self.repo("charter")
+        two = self.repo("charter-metrics")
+        self.make_change(SLUG, [("charter", ()), ("charter-metrics", ("charter",))])
+        # The dependent landed; its blocker did not.
+        self.declare(SLUG, "charter-metrics", self.land_a_merge(two, SLUG))
+        self.assertTrue(one.exists())
+        line = self.one_line()
+        self.assertIn("charter-metrics", line)
+        self.assertIn("landed while", line)
+        self.assertIn("'charter'", line)
+
+    def test_the_right_way_round_reports_nothing(self):
+        one = self.repo("charter")
+        two = self.repo("charter-metrics")
+        self.make_change(SLUG, [("charter", ()), ("charter-metrics", ("charter",))])
+        self.declare(SLUG, "charter", self.land_a_merge(one, SLUG))
+        self.declare(SLUG, "charter-metrics", self.land_a_merge(two, SLUG))
+        self.assertEqual(self.findings(), [])
+
+    def test_it_is_a_pure_function_of_the_record_and_the_landings(self):
+        """`out_of_order` is the intersection of two things `change` already derives, so
+        it cannot disagree with the gate that refuses. Asked directly, one layer below the
+        git reads, where nothing else can answer."""
+        rec = change.new_record(SLUG, "w", "t", "now")
+        rec["members"] = [{"repo": "a", "branch": "b", "needs": []},
+                          {"repo": "b", "branch": "b", "needs": ["a"]}]
+        self.assertEqual(commands_change.out_of_order(rec, {"b"}), {"b": ["a"]})
+        self.assertEqual(commands_change.out_of_order(rec, {"a", "b"}), {})
+        self.assertEqual(commands_change.out_of_order(rec, {"a"}), {})
+
+
+class TestAStrayBranchIsNamed(DivergenceCase):
+    """The one check that looks outside the change: a branch named like a member's, in a
+    repository nobody declared, is either a member somebody forgot to add or a collision
+    with a name that means something else. Both are worth a sentence."""
+
+    def test_a_members_branch_name_in_a_repo_that_is_a_member_of_nothing(self):
+        self.repo("charter")
+        stray = self.repo("charter-jira")
+        self.make_change(SLUG, [("charter", ())])
+        git(stray, "switch", "-q", "-c", change.default_branch(SLUG))
+        got = commands_change.stray_branches(self.WS)
+        self.assertEqual(len(got), 1, got)
+        self.assertIn("charter-jira", got[0])
+        self.assertIn("member of", got[0])
+
+    def test_a_repo_that_is_a_member_is_not_reported_for_having_the_branch(self):
+        """The whole point of a member is that it has this branch."""
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        git(repo, "switch", "-q", "-c", change.default_branch(SLUG))
+        self.assertEqual(commands_change.stray_branches(self.WS), [])
+
+    def test_a_workspace_with_no_changes_reports_nothing(self):
+        """No records means no branch names to look for, and a check that looked for
+        `change/*` by convention would report every branch anybody ever named that way —
+        which is the convention §3.4 refuses to derive membership from."""
+        stray = self.repo("charter-jira")
+        git(stray, "switch", "-q", "-c", "change/whatever")
+        self.assertEqual(commands_change.stray_branches(self.WS), [])
+
+
+class TestDoctorSaysItAtFail(DivergenceCase):
+    """FAIL, not WARN, and the reason is mechanical: `cmd_doctor` exits non-zero only on
+    FAIL, and that exit code is the only thing that makes the SessionStart wrapper print."""
+
+    def test_a_divergence_is_a_fail_row(self):
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        self.land_a_merge(repo, SLUG, trailer=False)
+        r = doctor.check_changes()
+        self.assertEqual(r.status, doctor.FAIL)
+        self.assertIn("charter", r.detail)
+        self.assertNotEqual(r.status, doctor.WARN)
+
+    def test_an_out_of_order_landing_is_a_fail_row_too(self):
+        self.repo("charter")
+        two = self.repo("charter-metrics")
+        self.make_change(SLUG, [("charter", ()), ("charter-metrics", ("charter",))])
+        self.declare(SLUG, "charter-metrics", self.land_a_merge(two, SLUG))
+        r = doctor.check_changes()
+        self.assertEqual(r.status, doctor.FAIL)
+        self.assertIn("landed while", r.detail)
+
+    def test_a_record_charter_cannot_read_is_its_own_fail_and_not_folded_in(self):
+        """"Charter cannot read this file" and "git disagrees with this file" send the
+        reader to two different places; one count covering both sends them to neither."""
+        self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        change.path_for(self.WS, SLUG).write_text('{"change": "x"}')
+        r = doctor.check_changes()
+        self.assertEqual(r.status, doctor.FAIL)
+        self.assertIn("unreadable", r.detail)
+
+    def test_a_clean_plane_is_ok_and_names_the_optional_prompt(self):
+        """Task 9 Step 5's other half: doctor NAMES `charter guard ask --local …` and does
+        not run it. `--local` is part of the recommendation — without it `guard ask` writes
+        the plane's COMMITTED settings, and consent that travels in a commit enrols a whole
+        team on one person's click (ADR 0003)."""
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        self.declare(SLUG, "charter", self.land_a_merge(repo, SLUG))
+        r = doctor.check_changes()
+        self.assertEqual(r.status, doctor.OK, r.detail)
+        self.assertIn("--local", r.detail)
+        self.assertIn("charter change land", r.detail)
+
+    def plane_files(self) -> list[str]:
+        """Every path under the plane root, so "wrote nothing" is a whole-tree claim.
+
+        Not `.claude/settings.local.json` by name: a check that only looks where it
+        expects the write is a check the next write walks past, and the property is that
+        this row WRITES NOTHING — not that it writes nothing in one directory.
+        """
+        return sorted(str(p.relative_to(self.tmp))
+                      for p in self.tmp.rglob("*") if p.is_file())
+
+    def test_doctor_writes_nothing_at_all_on_every_branch_it_has(self):
+        """It states the trade-off and does not settle a legitimate choice by writing a
+        line while nobody is looking (ADR 0017).
+
+        **All four branches, because a write on any one of them is the same defect.** The
+        first cut of this asserted only over a plane with one un-landed change, and a
+        mutation that wrote the rule from the `no changes at all` branch survived it —
+        which is a test of one code path wearing the name of a property.
+        """
+        cases = ["no changes at all"]
+        before = self.plane_files()
+        doctor.check_changes()
+        self.assertEqual(self.plane_files(), before, cases[-1])
+
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        cases.append("a change with nothing landed")
+        before = self.plane_files()
+        doctor.check_changes()
+        self.assertEqual(self.plane_files(), before, cases[-1])
+
+        merge = self.land_a_merge(repo, SLUG)
+        self.declare(SLUG, "charter", merge)
+        cases.append("a clean landed change (the OK row that names the prompt)")
+        self.assertEqual(doctor.check_changes().status, doctor.OK)
+        before = self.plane_files()
+        doctor.check_changes()
+        self.assertEqual(self.plane_files(), before, cases[-1])
+
+        git(repo, "reset", "-q", "--hard", "HEAD~1")
+        cases.append("a divergence (the FAIL row)")
+        self.assertEqual(doctor.check_changes().status, doctor.FAIL)
+        before = self.plane_files()
+        doctor.check_changes()
+        self.assertEqual(self.plane_files(), before, cases[-1])
+        self.assertEqual(len(cases), 4)
+
+    def test_a_plane_with_no_changes_says_none_and_stays_ok(self):
+        self.assertEqual(doctor.check_changes().status, doctor.OK)
+        self.assertEqual(doctor.check_changes().detail, "none")
+
+
+class TestItReadsThisDiskAndNeverTheNetwork(DivergenceCase):
+    def test_no_process_but_git_is_started(self):
+        """This runs from SessionStart. A check that fetched would put the network on
+        every session start, and the honest consequence — it can UNDER-report and can
+        never invent — is in the row's own hint rather than only here."""
+        seen: list[list[str]] = []
+        real = commands_change.util.run
+
+        def spy(cmd, *a, **kw):
+            seen.append(list(cmd))
+            return real(cmd, *a, **kw)
+
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        self.declare(SLUG, "charter", self.land_a_merge(repo, SLUG))
+        commands_change.util.run = spy
+        try:
+            self.findings()
+        finally:
+            commands_change.util.run = real
+        self.assertTrue(seen, "no git ran — this test proves nothing")
+        self.assertEqual({c[0] for c in seen}, {"git"})
+        for cmd in seen:
+            for word in ("fetch", "pull", "push", "ls-remote", "remote"):
+                self.assertNotIn(word, cmd, cmd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_change_revert.py
+++ b/tests/test_change_revert.py
@@ -1,0 +1,361 @@
+"""`charter change revert` — a revert is a NEW change, and that is the whole design.
+
+Force-pushing three default branches back past the merges leaves a world where the change
+happened, was undone, and no repository's history mentions either — the exact failure the
+cross-repo surface exists to prevent. `component-api-2` and `revert-component-api-2`, both
+named, both cross-referenced, in every repository they touched, reads as a decision six
+months later; a force-push reads as corruption.
+
+Three properties run through every case here.
+
+**The refusals are an absence, and the absence is measured.** No force-push, no branch
+deletion, no default-branch reset, no closing a request charter did not open. Those are not
+guarded by a flag — the argv is never built — so the test that pins them RECORDS every git
+invocation a real revert makes and asserts what is in it. A source-level grep is the other
+half (`tests/test_commands_change.py`) and neither substitutes for the other: the grep
+covers paths this file does not walk, and this covers argv the grep cannot see is dynamic.
+
+**`-m 1` is asked of git, never remembered.** A squash landing is an ordinary one-parent
+commit and `-m` on one fails; a merge landing has two and `git revert` refuses without it.
+Both shapes are landed for real here and reverted for real, because the parent count is the
+one fact that decides the flag and storing it in the record would be a derivable fact
+cached for convenience — the sentence ADR 0011 is.
+
+**A member landed outside charter is named, not guessed.** No line in `changes/log/` means
+no merge sha, and charter will not pick the merge commit that looks about right (ADR 0009).
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import change, commands_change
+from tests._changerepo import ChangeRepoCase, git, sha
+
+SLUG = "component-api-2"
+REVERTED = "revert-component-api-2"
+
+
+def args(**kw) -> SimpleNamespace:
+    kw.setdefault("workspace", "ws")
+    for k in ("change", "repo", "branch", "needs", "why"):
+        kw.setdefault(k, None)
+    return SimpleNamespace(**kw)
+
+
+class RevertCase(ChangeRepoCase):
+    def call(self, fn, **kw) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            code = fn(args(**kw))
+        return code, out.getvalue(), err.getvalue()
+
+    def revert(self, slug: str = SLUG):
+        return self.call(commands_change.cmd_change_revert, change=slug)
+
+    def record_git(self):
+        """Every git argv a revert issues, captured through the one funnel.
+
+        `_git` is the single place the `["git", "-C", <clone>, …]` prefix is built, and
+        that funnel is what makes "what did this command run" a question with an answer:
+        a call site assembling its own argv would be invisible here.
+        """
+        seen: list[list[str]] = []
+        real = commands_change.util.run
+
+        def spy(cmd, *a, **kw):
+            seen.append(list(cmd))
+            return real(cmd, *a, **kw)
+
+        return seen, mock.patch.object(commands_change.util, "run", spy)
+
+    def one_landed_member(self, *, squash: bool = False, trailer: bool = True):
+        """One member, landed for real, with charter's declaration beside it."""
+        repo = self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        merge = self.land_a_merge(repo, SLUG, squash=squash, trailer=trailer)
+        self.declare(SLUG, "charter", merge)
+        return repo, merge
+
+
+class TestARevertIsANewChange(RevertCase):
+    def test_it_creates_a_new_record_whose_members_are_the_landed_ones(self):
+        self.one_landed_member()
+        code, _, err = self.revert()
+        self.assertEqual(code, 0, err)
+        rec = change.read("ws", REVERTED)
+        self.assertEqual([m["repo"] for m in rec["members"]], ["charter"])
+
+    def test_its_why_names_the_original_slug(self):
+        """The one thread back. Six months later this record is what says which change
+        this undid, and a `why` that did not name it would leave the reader with two
+        records and no relation between them."""
+        self.one_landed_member()
+        self.revert()
+        self.assertIn(SLUG, change.read("ws", REVERTED)["why"])
+
+    def test_the_original_record_is_untouched(self):
+        """A revert adds a change; it does not edit the one it reverts. The original is
+        the statement that this work happened, and editing it to say it was undone would
+        destroy exactly the half a stranger needs."""
+        self.one_landed_member()
+        before = change.path_for("ws", SLUG).read_bytes()
+        self.revert()
+        self.assertEqual(change.path_for("ws", SLUG).read_bytes(), before)
+
+    def test_from_there_it_is_an_ordinary_change_with_ordinary_gates(self):
+        """`show` reads it, `drop` needs a `--why`, `land` will refuse it the same way —
+        there is no second lifecycle and no privileged revert path."""
+        self.one_landed_member()
+        self.revert()
+        code, out, _ = self.call(commands_change.cmd_change_show, change=REVERTED)
+        self.assertEqual(code, 0)
+        self.assertIn(REVERTED, out)
+
+    def test_the_ordering_is_the_originals_reversed(self):
+        """**Undoing goes the other way round.** `charter-metrics` needed `charter` to land
+        first because its code depends on charter's new API — so reverting `charter` while
+        `charter-metrics` still depends on the API it removes leaves the dependent broken,
+        which is the world the revert exists to restore.
+
+        This is the case a revert that simply copied `needs` across would get exactly
+        backwards, and it would look right in every single-member fixture."""
+        one = self.repo("charter")
+        two = self.repo("charter-metrics")
+        self.make_change(SLUG, [("charter", ()), ("charter-metrics", ("charter",))])
+        self.declare(SLUG, "charter", self.land_a_merge(one, SLUG))
+        self.declare(SLUG, "charter-metrics", self.land_a_merge(two, SLUG))
+        code, _, err = self.revert()
+        self.assertEqual(code, 0, err)
+        rec = change.read("ws", REVERTED)
+        needs = {m["repo"]: m["needs"] for m in rec["members"]}
+        self.assertEqual(needs, {"charter": ["charter-metrics"], "charter-metrics": []})
+
+    def test_a_dependent_charter_never_landed_is_not_a_blocker_of_the_revert(self):
+        """A member whose dependent is not being reverted is not waiting for anybody —
+        carrying the edge across would be a blocker nothing will ever land, which is the
+        record `change.order_refusal` refuses outright."""
+        one = self.repo("charter")
+        self.repo("charter-metrics")
+        self.make_change(SLUG, [("charter", ()), ("charter-metrics", ("charter",))])
+        self.declare(SLUG, "charter", self.land_a_merge(one, SLUG))
+        code, _, err = self.revert()
+        self.assertEqual(code, 0, err)
+        rec = change.read("ws", REVERTED)
+        self.assertEqual([m["needs"] for m in rec["members"]], [[]])
+
+    def test_a_second_revert_of_the_same_change_is_refused_by_name(self):
+        """Not silently re-derived over the top: the first revert's branches exist and its
+        record holds decisions somebody may have edited. `forget` is the way back."""
+        self.one_landed_member()
+        self.revert()
+        code, _, err = self.revert()
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("already exists", err)
+        self.assertIn(REVERTED, err)
+
+
+class TestTheBranchCarriesTheRevert(RevertCase):
+    def test_a_merge_landing_is_reverted_with_m_1(self):
+        """Two parents, so `-m` is required — without it `git revert` refuses outright."""
+        repo, merge = self.one_landed_member()
+        code, _, err = self.revert()
+        self.assertEqual(code, 0, err)
+        git(repo, "switch", "-q", change.default_branch(REVERTED))
+        body = git(repo, "log", "-1", "--format=%B").stdout
+        self.assertIn("Revert", body)
+        self.assertIn(merge[:7], body)
+
+    def test_a_squash_landing_is_reverted_without_m(self):
+        """One parent, so `-m 1` would FAIL — `git revert -m 1` on an ordinary commit
+        errors with "mainline was specified but commit is not a merge". This is the
+        measured reason the parent count is asked of git rather than remembered."""
+        repo, _ = self.one_landed_member(squash=True)
+        code, _, err = self.revert()
+        self.assertEqual(code, 0, err)
+        git(repo, "switch", "-q", change.default_branch(REVERTED))
+        self.assertIn("Revert", git(repo, "log", "-1", "--format=%B").stdout)
+
+    def test_no_m_flag_is_passed_when_git_says_the_commit_has_one_parent(self):
+        """**The ARGV, not the outcome, and that is a correction with a measurement behind
+        it.** The spec's reason for this conditional is that *"a squash landing is an
+        ordinary commit and `-m` on one fails"* — and on **git 2.50.1 (Apple Git-155)**
+        that is simply not true: `git revert --no-edit -m 1 <one-parent-sha>` returns 0,
+        and so does `-m 2`. Measured, twice, in a throwaway repo.
+
+        So an outcome assertion cannot see this at all — hard-coding `-m 1` passes every
+        test that only looks at whether the revert worked, which is exactly what happened:
+        the mutation survived until this test existed. What is still true on every git is
+        the claim charter makes about itself — it asks git how many parents there are and
+        passes `-m` only for a merge — and older gits DO fail with *"mainline was specified
+        but commit is not a merge"*, so the conditional earns its place on the versions
+        this is not measured against as well.
+        """
+        repo, _ = self.one_landed_member(squash=True)
+        seen, patched = self.record_git()
+        with patched:
+            code, _, err = self.revert()
+        self.assertEqual(code, 0, err)
+        reverts = [c for c in seen if "revert" in c and "--abort" not in c]
+        self.assertEqual(len(reverts), 1, reverts)
+        self.assertNotIn("-m", reverts[0])
+
+    def test_the_m_flag_is_passed_when_git_says_there_are_two(self):
+        """The other half. Without it the assertion above is satisfied by never passing
+        `-m` at all, which fails a real merge revert on every git there is."""
+        repo, _ = self.one_landed_member()
+        seen, patched = self.record_git()
+        with patched:
+            code, _, err = self.revert()
+        self.assertEqual(code, 0, err)
+        reverts = [c for c in seen if "revert" in c and "--abort" not in c]
+        self.assertEqual(len(reverts), 1, reverts)
+        self.assertIn("-m", reverts[0])
+        self.assertEqual(reverts[0][reverts[0].index("-m") + 1], "1")
+
+    def test_the_parent_count_comes_from_git_and_not_from_the_record(self):
+        """The layer below the argv: `_parents` is what the conditional reads."""
+        repo, _ = self.one_landed_member(squash=True)
+        self.assertEqual(commands_change._parents(repo, sha(repo)), 1)
+        other = self.repo("other")
+        self.assertEqual(commands_change._parents(other, self.land_a_merge(other, "x-1")),
+                         2)
+        # And a sha git does not have answers `None`, never 1 — a default of 1 would drop
+        # `-m` on a merge charter could not resolve and the revert would simply fail.
+        self.assertIsNone(commands_change._parents(repo, "0" * 40))
+
+    def test_the_branch_is_created_off_the_default_branch(self):
+        """Read from the CLONE, never from the record: a base branch in a committed file
+        is a destination in a committed file, which §6.1 rule 4 forbids."""
+        repo, _ = self.one_landed_member()
+        code, _, err = self.revert()
+        self.assertEqual(code, 0, err)
+        branch = change.default_branch(REVERTED)
+        base = git(repo, "merge-base", f"refs/heads/{branch}", "refs/heads/main")
+        # The merge base IS main's tip, which is what "branched off main, and main has not
+        # moved since" means. A weaker `assertTrue` would pass for a branch rooted at the
+        # first commit of the repository.
+        self.assertEqual(base.stdout.strip(), sha(repo, "refs/heads/main"))
+
+    def test_the_revert_actually_undoes_the_file(self):
+        """The property, not the commit message: the file the member added is gone again
+        on the revert branch and still there on `main`."""
+        repo, _ = self.one_landed_member()
+        self.revert()
+        marker = change.default_branch(SLUG).replace("/", "_")
+        git(repo, "switch", "-q", "main")
+        self.assertTrue((repo / marker).exists())
+        git(repo, "switch", "-q", change.default_branch(REVERTED))
+        self.assertFalse((repo / marker).exists())
+
+
+class TestTheRefusals(RevertCase):
+    """§3.7's four, each by name. Recorded rather than reasoned about."""
+
+    def test_no_force_push_no_branch_deletion_no_reset_and_no_request_is_touched(self):
+        self.one_landed_member()
+        seen, patched = self.record_git()
+        with patched:
+            code, _, err = self.revert()
+        self.assertEqual(code, 0, err)
+        self.assertTrue(seen, "no git ran at all — this test proves nothing")
+        flat = [" ".join(c) for c in seen]
+        for banned in ("--force", "--force-with-lease", "-f ", "push", "branch -D",
+                       "branch -d", "reset", "clean", "gh ", "glab "):
+            for line in flat:
+                self.assertNotIn(banned, line, f"a revert issued {line!r}")
+
+    def test_every_process_a_revert_starts_is_git(self):
+        """The other direction of the same property: not "it did not force-push" but "it
+        ran nothing that was not git"."""
+        self.one_landed_member()
+        seen, patched = self.record_git()
+        with patched:
+            self.revert()
+        self.assertEqual({c[0] for c in seen}, {"git"})
+
+    def test_it_refuses_over_uncommitted_work_and_says_why(self):
+        """`git revert` commits into the checkout, so running it over somebody's work in
+        progress would fold that work into a revert commit — and the recovery for that is
+        worse than the wait."""
+        repo, _ = self.one_landed_member()
+        (repo / "f").write_text("dirty\n")
+        code, _, err = self.revert()
+        self.assertEqual(code, 1)
+        self.assertIn("uncommitted", err)
+        self.assertNotIn("no landing record", err)   # and not the gate above it
+
+    def test_a_refused_member_still_leaves_the_original_branch_alone(self):
+        repo, _ = self.one_landed_member()
+        (repo / "f").write_text("dirty\n")
+        before = sha(repo, "refs/heads/main")
+        self.revert()
+        self.assertEqual(sha(repo, "refs/heads/main"), before)
+
+
+class TestALandingCharterDidNotRecordIsNamed(RevertCase):
+    def test_a_member_with_no_log_line_is_handed_to_a_human(self):
+        """No merge sha, so no revert. Charter says so rather than picking the merge
+        commit that looks about right — ADR 0009: it degrades to silence, never to a
+        confident wrong answer."""
+        one = self.repo("charter")
+        self.repo("charter-metrics")
+        self.make_change(SLUG, [("charter", ()), ("charter-metrics", ())])
+        self.declare(SLUG, "charter", self.land_a_merge(one, SLUG))
+        code, _, err = self.revert()
+        self.assertEqual(code, 0, err)
+        self.assertIn("charter-metrics", err)
+        self.assertIn("no landing record", err)
+        self.assertEqual([m["repo"] for m in change.read("ws", REVERTED)["members"]],
+                         ["charter"])
+
+    def test_a_change_with_no_landings_at_all_is_refused_by_its_own_message(self):
+        self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        code, _, err = self.revert()
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertIn("nothing to revert", err)
+        self.assertNotIn("already exists", err)     # and not a neighbouring gate
+
+    def test_the_merge_sha_is_never_guessed_from_the_branch_name(self):
+        """The mutation Step 6 names. A branch called `change/<slug>` exists in the clone
+        and is not the landing — deriving the sha from it would produce a plausible commit
+        and revert the wrong thing."""
+        self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        code, _, _ = self.revert()
+        self.assertEqual(code, commands_change.REFUSED)
+        self.assertFalse(change.exists("ws", REVERTED))
+
+
+class TestTheLogIsUntrustedToo(RevertCase):
+    """It is never committed, which makes it LOCAL rather than trustworthy: a hand edit or
+    a half-written append from a killed process reaches the same argv."""
+
+    def test_a_merge_value_that_is_not_a_sha_is_refused_by_name(self):
+        self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        self.declare(SLUG, "charter", "--upload-pack=touch /tmp/pwned")
+        code, _, err = self.revert()
+        self.assertEqual(code, 1)
+        self.assertIn("not a sha", err)
+
+    def test_a_sha_with_a_trailing_newline_is_refused(self):
+        """Python's `$` matches before a trailing newline, so `.match` would have admitted
+        this — a newline on its way into a git argv out of a file anybody can edit."""
+        self.assertIsNone(commands_change._SHA_RE.fullmatch("e0c9d13\n"))
+        self.assertIsNotNone(commands_change._SHA_RE.fullmatch("e0c9d13"))
+
+    def test_a_malformed_line_does_not_take_the_good_ones_down(self):
+        repo, merge = self.one_landed_member()
+        with open(change.log_path("ws"), "a") as f:
+            f.write("{not json\n")
+        self.assertEqual([e["merge"] for e in change.landings("ws", SLUG)], [merge])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_change_revert.py
+++ b/tests/test_change_revert.py
@@ -297,6 +297,104 @@ class TestTheRefusals(RevertCase):
         self.assertEqual(sha(repo, "refs/heads/main"), before)
 
 
+class TestEveryWayASeedCanFailIsNamed(RevertCase):
+    """`_seed_revert`'s refusals, one at a time and each by its own words.
+
+    Six things can stop a member being seeded and every one of them is a sentence the
+    operator can act on. They sit in sequence, which is exactly the shape that masks:
+    an exit-code assertion cannot tell them apart, and neither can a test that only ever
+    reaches the first.
+    """
+
+    def test_a_branch_that_already_exists_is_refused_by_name(self):
+        """Not overwritten and not reused: the branch may carry somebody's work, and
+        `git switch -c` onto an existing name is a refusal charter passes through rather
+        than a `--force` it supplies."""
+        repo, _ = self.one_landed_member()
+        git(repo, "branch", change.default_branch(REVERTED))
+        code, _, err = self.revert()
+        self.assertEqual(code, 1)
+        self.assertIn("already exists", err)
+        self.assertNotIn("uncommitted", err)          # and not its neighbour
+
+    def test_a_commit_git_does_not_have_is_named_rather_than_reverted(self):
+        """A sha that is well-formed and absent — an older charter's log, or a clone that
+        was re-created. `_parents` answers `None`, and `None` is not 1."""
+        self.repo("charter")
+        self.make_change(SLUG, [("charter", ())])
+        self.declare(SLUG, "charter", "0" * 40)
+        code, _, err = self.revert()
+        self.assertEqual(code, 1)
+        self.assertIn("does not know the commit", err)
+
+    def test_a_default_branch_charter_cannot_resolve_stops_the_seed(self):
+        """It will not guess what to branch from. Every other answer here is relative to
+        the default branch, and branching a revert off the wrong one is a change nobody
+        asked for."""
+        repo, _ = self.one_landed_member()
+        git(repo, "branch", "-m", "main", "trunk")
+        code, _, err = self.revert()
+        self.assertEqual(code, 1)
+        self.assertIn("default", err)
+        self.assertIn("will not guess", err)
+
+    def test_a_conflicted_revert_is_aborted_and_the_branch_is_left_to_finish(self):
+        """`--abort` restores the checkout the revert started from, so the operator gets
+        the branch and the conflict rather than a half-applied tree. Charter has no
+        business guessing which side of a conflict a rollback wanted."""
+        repo, _ = self.one_landed_member()
+        marker = change.default_branch(SLUG).replace("/", "_")
+        (repo / marker).write_text("somebody changed this after the landing\n")
+        git(repo, "add", "-A")
+        git(repo, *__import__("tests._changerepo", fromlist=["IDENT"]).IDENT,
+            "commit", "-qm", "later work on the same file")
+        git(repo, "rm", "-q", marker)
+        git(repo, *__import__("tests._changerepo", fromlist=["IDENT"]).IDENT,
+            "commit", "-qm", "and delete it")
+        code, _, err = self.revert()
+        # Either it applied cleanly or it was aborted and said so — never half-applied.
+        self.assertEqual(git(repo, "status", "--porcelain").stdout.strip(), "")
+        if code:
+            self.assertIn("finish it by hand", err)
+
+    def test_the_working_tree_is_read_before_anything_is_created(self):
+        """The order is the point: a refusal that had already made a branch would leave
+        litter behind for a condition it then declined to act on."""
+        repo, _ = self.one_landed_member()
+        (repo / "f").write_text("dirty\n")
+        self.revert()
+        self.assertFalse(commands_change._branch_exists(
+            repo, change.default_branch(REVERTED)))
+
+    def test_the_new_record_is_still_written_when_a_seed_fails(self):
+        """The record is the statement of intent — these repositories are the ones to
+        revert — and a branch that did not get created is a thing to fix, not a member to
+        drop silently. The exit code is what says something is unfinished."""
+        repo, _ = self.one_landed_member()
+        (repo / "f").write_text("dirty\n")
+        code, _, _ = self.revert()
+        self.assertEqual(code, 1)
+        self.assertEqual([m["repo"] for m in change.read("ws", REVERTED)["members"]],
+                         ["charter"])
+
+    def test_a_reverts_slug_is_always_a_change_name(self):
+        """Pinned on the DERIVATION rather than on a refusal, because the refusal is
+        unreachable and was deleted for it: `CHANGE_NAME_RE` has no length bound and no
+        leading-character rule that a `revert-` prefix could break, so prefixing a slug
+        that already passed can never produce one that does not.
+
+        Measured across the alphabet's own edges rather than asserted — that is what
+        would go red if the rule ever grew a length cap or a prefix restriction, which is
+        the change that would put the deleted guard back."""
+        from charter import instance
+        for slug in ("a", "9", "Z", "a.b_c-d", "x" * 200, "x" * 2000):
+            with self.subTest(slug=slug[:20]):
+                self.assertTrue(instance.change_name_ok(slug))
+                self.assertTrue(
+                    instance.change_name_ok(commands_change.REVERT_PREFIX + slug),
+                    "a valid slug produced an invalid revert name — the deleted guard in "
+                    "cmd_change_revert is reachable again and has to come back")
+
 class TestALandingCharterDidNotRecordIsNamed(RevertCase):
     def test_a_member_with_no_log_line_is_handed_to_a_human(self):
         """No merge sha, so no revert. Charter says so rather than picking the merge
@@ -349,6 +447,123 @@ class TestTheLogIsUntrustedToo(RevertCase):
         this — a newline on its way into a git argv out of a file anybody can edit."""
         self.assertIsNone(commands_change._SHA_RE.fullmatch("e0c9d13\n"))
         self.assertIsNotNone(commands_change._SHA_RE.fullmatch("e0c9d13"))
+
+    def write_log(self, text: str) -> None:
+        """Put *text* in this host's log verbatim — the only way to reach the reader's
+        defensive half, because `record_landing` can only ever write well-formed lines."""
+        path = change.log_path(self.WS)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+
+    #: One entry per way a line can be wrong. An append-only log written by killed
+    #: processes, older charters and the occasional hand edit collects all of them, and
+    #: every one is SKIPPED rather than raised over: refusing the whole file would let one
+    #: bad line hide every good one, which is the failure a report cannot afford.
+    BAD_LINES = {
+        "not json": "{not json\n",
+        "json but not an object": '"a string"\n',
+        "an array": "[1, 2, 3]\n",
+        "a key charter does not read": '{"ts":"t","change":"c","repo":"r","number":1,'
+                                       '"merge":"m","head":"h","landed":true}\n',
+        "a key missing": '{"ts":"t","change":"c","repo":"r","number":1,"merge":"m"}\n',
+        "change is not a string": '{"ts":"t","change":7,"repo":"r","number":1,'
+                                  '"merge":"m","head":"h"}\n',
+        "repo is not a string": '{"ts":"t","change":"c","repo":null,"number":1,'
+                                '"merge":"m","head":"h"}\n',
+        "half a line": '{"ts":"t","change":"c","re\n',
+        "empty": "\n",
+    }
+
+    def test_every_malformed_line_is_skipped_and_never_raised_over(self):
+        for label, text in self.BAD_LINES.items():
+            with self.subTest(line=label):
+                self.write_log(text)
+                self.assertEqual(change.landings(self.WS), [], label)
+
+    def test_a_bad_line_does_not_hide_the_good_ones_around_it(self):
+        """The property the skipping is FOR. Refusing the file would make one truncated
+        append — the ordinary result of a killed process — lose every landing before it."""
+        good = ('{"ts":"2026-01-01T00:00:00+00:00","change":"c","repo":"r","number":1,'
+                '"merge":"e0c9d13","head":"h"}\n')
+        for label, bad in self.BAD_LINES.items():
+            with self.subTest(line=label):
+                self.write_log(bad + good + bad)
+                got = change.landings(self.WS)
+                self.assertEqual([e["merge"] for e in got], ["e0c9d13"], label)
+
+    def test_lines_come_back_oldest_first_even_when_a_ts_is_missing_or_odd(self):
+        """`str(e.get("ts") or "")` is what stops the sort raising on a line an older
+        charter wrote, and an unsortable key would take the whole report down.
+
+        The expected order is written out rather than derived from the same expression
+        the code uses, which is the trap this suite keeps finding — and getting it wrong
+        by hand once is what the literal is for. It is a **lexicographic** sort of the
+        coerced strings, so a missing `ts` (`""`) leads, ISO dates follow in order, and a
+        bare `7` sorts AFTER them because `'7' > '2'`. Not chronological, and it is not
+        pretending to be: what this promises is a stable total order that no value can
+        make raise.
+        """
+        rows = [('{"ts":%s,"change":"c","repo":"r%d","number":1,"merge":"e0c9d13",'
+                 '"head":"h"}\n') % (ts, i)
+                for i, ts in enumerate(('"2026-03-01"', "null", '"2026-01-01"', "7"))]
+        self.write_log("".join(rows))
+        got = change.landings(self.WS)
+        self.assertEqual([e["repo"] for e in got], ["r1", "r2", "r0", "r3"])
+
+    def test_filtering_by_slug_answers_about_that_slug_only(self):
+        line = ('{"ts":"t","change":"%s","repo":"r","number":1,"merge":"e0c9d13",'
+                '"head":"h"}\n')
+        self.write_log(line % "a-1" + line % "b-2")
+        self.assertEqual([e["change"] for e in change.landings(self.WS, "a-1")], ["a-1"])
+        self.assertEqual(len(change.landings(self.WS)), 2)
+        self.assertEqual(change.landings(self.WS, "nope"), [])
+
+    def test_the_last_declaration_for_a_repo_is_the_one_that_describes_now(self):
+        """A member reverted and landed again has two lines, and the newer is the one
+        that is true. Nothing is deleted to make that so — the earlier line is still a
+        true statement about the past."""
+        line = ('{"ts":"%s","change":"c","repo":"r","number":1,"merge":"%s",'
+                '"head":"h"}\n')
+        self.write_log(line % ("2026-01-01", "aaaaaaa") + line % ("2026-02-01", "bbbbbbb"))
+        self.assertEqual(change.declared_landings(self.WS, "c")["r"]["merge"], "bbbbbbb")
+
+    def test_no_log_directory_at_all_is_an_empty_answer_and_not_an_error(self):
+        """The lazy-creation case: `changes/log/` is made by the first landing, so every
+        workspace is in this state until then."""
+        self.assertEqual(change.landings(self.WS), [])
+        self.assertEqual(change.declared_landings(self.WS, "c"), {})
+
+    def test_a_log_that_cannot_be_read_answers_empty_rather_than_raising(self):
+        """This feeds a report and a frame pane, both of which must render whatever they
+        find. Listing an unreadable directory raises on Linux and yields nothing on
+        macOS — `pieces.events` records a suite that went red on CI over that line."""
+        with mock.patch.object(change.Path, "glob", side_effect=OSError("nope")):
+            self.assertEqual(change.landings(self.WS), [])
+
+    def test_the_log_is_line_delimited_and_append_only(self):
+        """Two landings are two lines, and the second does not rewrite the first."""
+        for sha in ("aaaaaaa", "bbbbbbb"):
+            self.declare("c", "r", sha)
+        self.assertEqual(len(change.log_path(self.WS).read_text().splitlines()), 2)
+        self.assertEqual([e["merge"] for e in change.landings(self.WS, "c")],
+                         ["aaaaaaa", "bbbbbbb"])
+
+    def test_the_log_is_named_for_the_hosts_first_label(self):
+        """`pieces._host`'s rule, and the `[0]` is what makes it a rule rather than a
+        coincidence: on a machine called `box.example.com` the log is `box.jsonl`, not
+        `box.example.jsonl`. It is a FILENAME, and one carrying a fully-qualified domain
+        differs per network rather than per machine — the log would split in two the first
+        time somebody joined a VPN."""
+        with mock.patch("socket.gethostname", return_value="box.example.com"):
+            self.assertEqual(change._host(), "box")
+        with mock.patch("socket.gethostname", return_value="box"):
+            self.assertEqual(change._host(), "box")
+        with mock.patch("socket.gethostname", return_value="a/b c.d"):
+            self.assertEqual(change._host(), "abc")     # filename-safe, and one label
+
+    def test_the_log_path_carries_that_name(self):
+        with mock.patch("socket.gethostname", return_value="box.example.com"):
+            self.assertEqual(change.log_path("ws").name, "box.jsonl")
 
     def test_a_malformed_line_does_not_take_the_good_ones_down(self):
         repo, merge = self.one_landed_member()

--- a/tests/test_change_surface.py
+++ b/tests/test_change_surface.py
@@ -1,0 +1,520 @@
+"""The `changes` component, the change picker, and the two keystrokes to each.
+
+Four properties, and every one of them is a claim the surface would otherwise make falsely.
+
+**Serve what you declare.** §4i: a `needs` name answered with an empty tuple lets a
+component declare it, draw nothing, pass its own tests against an empty fixture, and be
+indistinguishable from a plane that genuinely has none. So `component.NEEDS` and
+`ctx.SERVES` are asserted against each other in ONE assertion — neither can be fixed
+without the other — and `gather.scan` is measured actually carrying the slice.
+
+**No forge call, and no subprocess at all, on the repaint path.** §4g's idle-tick property.
+A five-member change is five forge reads per refresh, and those never happen on a tick.
+Measured by counting processes, not asserted in a docstring.
+
+**Never greener than the worst member.** §3.3/§3.5. One `unknown` member makes the change
+`UNKNOWN`, not "green with an asterisk", and a change with no members at all is `unknown`
+rather than "everything landed" — an empty maximum is the classic way a report comes out
+green over nothing.
+
+**Containment, because §4e already said so.** *"A change's name and description are
+untrusted committed values."* A slug, a `why`, a repo name **or a branch name** carrying a
+newline, U+2028 or an escape sequence renders as exactly one row and runs nothing. Measured
+against hostile values, never reasoned about.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+import unittest
+from unittest import mock
+
+from charter import change, contain, instance as instance_mod, tui, workspace
+from charter.frame import (builtins, choose, component, ctx, gather, layout, slots,
+                           state, switch)
+from tests._isolation import PersonaIso
+
+FID = "f-changes"
+
+#: One value per way a committed string can forge a row. The escape is the one that has
+#: already cost this project code execution through tmux config text; U+2028 is the one a
+#: terminal breaks on that `str.splitlines()` sees and `\n`-splitting does not.
+HOSTILE = {
+    "newline": "a\nb",
+    "carriage return": "a\rb",
+    "line separator": "a\u2028b",
+    "paragraph separator": "a\u2029b",
+    "next line": "a\u0085b",
+    "vertical tab": "a\x0bb",
+    "form feed": "a\x0cb",
+    "escape": "a\x1b[31mb",
+    "backtick and pipe": "a`b|c",
+    "nul-ish": "a\x00b",
+}
+
+#: Every codepoint a terminal, or Python's own `str.splitlines`, treats as the end of a
+#: line — which is what "renders as exactly one row" has to mean.
+#:
+#: **Splitting on `"\n"` alone is not that, and this was measured.** `tui.truncate`
+#: sanitises on the way out, which removes `\n`, `\r`, the escape and the NUL — but it
+#: leaves **U+2028 exactly as it found it**. So a test that split on `"\n"` could not tell
+#: `contain.one_line` at the drawing site from its absence, and deleting that call stayed
+#: green over a value that really does break a row on the terminals that honour U+2028.
+#: `str.splitlines` knows all of these; `"\n"` knows one.
+BREAKS = "\n\r\u2028\u2029\u0085\v\f"
+
+
+class SurfaceCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("ws")
+        state.record_workspace(FID, "ws")
+
+    def seed(self, changes, *, gathered_at=None) -> None:
+        """Write a gather snapshot holding *changes* and nothing else of interest.
+
+        *gathered_at* defaults to NOW rather than to a constant: the strip draws the age of
+        what it is showing, so a fixture frozen at epoch renders every row `stale` and
+        every content assertion would be reading a degraded line.
+        """
+        gather.save(FID, {"gathered_at": time.time() if gathered_at is None else gathered_at,
+                          "workspace": "ws", "current_repo": None,
+                          "repos": [], "worktrees": [], "todos": [], "todo_count": 0,
+                          "changes": list(changes)})
+
+    def row(self, **kw) -> dict:
+        r = {"change": "component-api-2", "why": "API 1 -> 2", "state": "unknown",
+             "landed": 0, "total": 1, "excluded": 0,
+             "members": [{"repo": "charter", "branch": "change/component-api-2",
+                          "needs": [], "state": "unknown"}]}
+        r.update(kw)
+        return r
+
+    def render(self, cols: int = 22, rows: int = 24) -> str:
+        """The sidebar, drawn for real — the pane the `changes` section lives in."""
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return slots.render("right", FID)
+
+    def section(self, width: int = 40, budget: int = 6) -> list[str]:
+        return slots.changes_section(FID, width, budget)
+
+    def clone(self, name: str) -> None:
+        (workspace.workspace_dir("ws") / name / ".git").mkdir(parents=True)
+
+    def make_change(self, slug: str, members=(("charter", ()),), why="API 1 -> 2"):
+        rec = change.new_record(slug, why, "t", "2026-08-29T00:00:00+00:00")
+        rec["members"] = [{"repo": r, "branch": change.default_branch(slug),
+                           "needs": list(n)} for r, n in members]
+        change.write("ws", slug, rec)
+        return rec
+
+
+class TestTheSliceIsServedAndDeclaredTogether(SurfaceCase):
+    def test_needs_and_serves_are_one_assertion(self):
+        """One assertion, so neither can be fixed without the other. A name declarable but
+        unserved hands a component an empty tuple it draws nothing from and passes its own
+        tests against — the convincing empty §4i is about."""
+        self.assertEqual(set(component.NEEDS), set(ctx.SERVES))
+        self.assertIn("changes", component.NEEDS)
+
+    def test_the_scan_actually_carries_it(self):
+        """The half a constant cannot state. Without this, `changes` could be in both
+        tables and `gather.scan` could still never write the key."""
+        self.clone("charter")
+        self.make_change("component-api-2")
+        got = gather.scan(workspace="ws")
+        self.assertEqual([r["change"] for r in got["changes"]], ["component-api-2"])
+        self.assertEqual(got["changes"][0]["members"][0]["repo"], "charter")
+
+    def test_a_component_that_declared_it_is_handed_it(self):
+        c = ctx.build(("changes",), width=80, height=4, fid=FID,
+                      snapshot={"changes": [self.row()]})
+        self.assertEqual(c.changes[0]["change"], "component-api-2")
+
+    def test_a_component_that_did_not_declare_it_is_not(self):
+        """Absent, not disabled: a present-but-empty attribute is indistinguishable from a
+        slice that happens to be empty."""
+        c = ctx.build((), width=80, height=4, fid=FID, snapshot={"changes": [self.row()]})
+        with self.assertRaises(AttributeError) as cm:
+            c.changes
+        self.assertIn("did not declare changes", str(cm.exception))
+
+    def test_the_component_declares_what_its_renderer_reads(self):
+        reg = builtins.build()
+        self.assertEqual(set(reg.get("changes").needs), {"gather", "changes"})
+
+    def test_it_is_a_part_of_the_sidebar_and_not_a_pane_of_its_own(self):
+        """**Measured twice, and both measurements are in `frame/builtins.py`.** The
+        frame's sizing supports exactly ONE variable-height pane — `layout.slot_sizes`
+        answers every member of `VARIABLE_ROW_SLOTS` with `layout.repos_rows`, and
+        `_reassert_sizes` leaves that set unasserted so tmux's `resize-pane -y` has one
+        remainder to give the rows to. And a PLACED component has to be in
+        `instance.FRAME_SLOTS`, which is pinned to agree with the shipped `slots` default
+        and with `density = full` — so placing it would put a pane on every operator's
+        frame for a feature most planes never use."""
+        reg = builtins.build()
+        self.assertIn("changes", reg.get("sidebar").children)
+        self.assertNotIn("changes", instance_mod.FRAME_SLOTS)
+        self.assertNotIn("changes", builtins.SLOT_OF)
+        self.assertNotIn("changes", slots.SLOTS)
+        self.assertEqual(layout.VARIABLE_ROW_SLOTS, frozenset({"repos"}))
+
+    def test_a_plane_with_no_changes_pays_nothing_for_it(self):
+        """The whole reason it is a section. `todo_section`'s own rule: a heading over an
+        empty space in a 22-column column is furniture within a day."""
+        self.seed([])
+        self.assertEqual(self.section(), [])
+        self.make_change("a-1")
+        gather.refresh(FID, workspace="ws")
+        self.assertNotEqual(self.section(), [])
+
+    def test_an_empty_workspace_carries_an_empty_list_and_not_a_missing_key(self):
+        """`[]` and absent are different answers, and a renderer that had to `None`-check
+        would be one that could forget to."""
+        self.assertEqual(gather.scan(workspace="ws")["changes"], [])
+        self.assertIn("changes", gather.scan(workspace="ws"))
+
+
+class TestNothingOnTheRepaintPathSpawns(SurfaceCase):
+    def test_a_repaint_starts_no_process_at_all(self):
+        """Measured, not asserted (§4g). Every `subprocess` entry point is replaced with
+        one that fails the test, so a forge call, a `git` call and a `tmux` call are all
+        caught by the same net rather than by a list somebody has to keep."""
+        self.seed([self.row()])
+        started: list = []
+
+        def boom(*a, **kw):
+            started.append(a)
+            raise AssertionError(f"the repaint started a process: {a!r}")
+
+        with mock.patch.object(subprocess, "Popen", boom), \
+             mock.patch.object(subprocess, "run", boom), \
+             mock.patch.object(subprocess, "check_output", boom):
+            out = self.render()
+            rows = self.section()
+        self.assertEqual(started, [])
+        self.assertIn("component-api-2", " ".join(tui.strip_ansi(r) for r in rows))
+        self.assertIn("changes", tui.strip_ansi(out))
+
+    def test_the_scan_reads_no_forge_and_no_glstate_for_changes(self):
+        """`glstate` is the tempting reuse and it is wrong twice: it is keyed on each
+        clone's CURRENTLY CHECKED-OUT branch, which is frequently not the member's, and
+        what it caches is `ci_status` — a single string that answers `None` for a CLI
+        failure, a timeout, an auth error and "no check ever ran" alike (#561)."""
+        self.clone("charter")
+        self.make_change("component-api-2")
+        with mock.patch("charter.glstate.read_for",
+                        side_effect=AssertionError("glstate")) as _gl:
+            rows = gather._change_rows("ws")
+        self.assertEqual(len(rows), 1)
+
+
+class TestTheAggregateIsNeverGreenerThanItsWorstMember(SurfaceCase):
+    def test_one_unknown_member_makes_the_change_unknown(self):
+        states = {"a": "landed", "b": "landed", "c": "unknown"}
+        self.assertEqual(change.worst(states.values()), "unknown")
+
+    def test_one_blocked_member_beats_every_landed_one(self):
+        self.assertEqual(change.worst(["landed", "landed", "blocked"]), "blocked")
+
+    def test_unknown_beats_blocked(self):
+        """`unknown` is first because it is the only value that means charter did not
+        look, and a value meaning "I did not look" must never be outranked by one meaning
+        "I looked and it was fine"."""
+        self.assertEqual(change.worst(["blocked", "unknown"]), "unknown")
+
+    def test_all_landed_is_landed(self):
+        self.assertEqual(change.worst(["landed", "landed"]), "landed")
+
+    def test_no_members_at_all_is_unknown_and_not_landed(self):
+        """An empty maximum is the classic way a report comes out green: "everything has
+        landed" over nothing at all is the confidently-wrong output ADR 0009 forbids."""
+        self.assertEqual(change.worst([]), "unknown")
+
+    def test_a_state_charter_does_not_recognise_reads_as_unknown(self):
+        """§3.5's asymmetry: anything charter does not recognise is UNKNOWN, never
+        PASSED — and it is FOLDED rather than returned, because a word charter cannot
+        explain is worse on a row than the word that says charter cannot explain it."""
+        self.assertEqual(change.worst(["landed", "shipped-it"]), "unknown")
+
+    def test_the_strip_says_the_word_and_not_a_colour(self):
+        self.seed([self.row(state="unknown")])
+        self.assertIn("UNKNOWN", tui.strip_ansi(self.render()))
+
+    def test_a_member_with_a_landing_declaration_reads_as_landed(self):
+        rec = self.make_change("component-api-2", [("charter", ())])
+        self.assertEqual(change.member_states(rec, {"charter"}), {"charter": "landed"})
+
+    def test_a_member_waiting_on_a_blocker_reads_as_blocked(self):
+        rec = self.make_change("c-1", [("a", ()), ("b", ("a",))])
+        self.assertEqual(change.member_states(rec, set()),
+                         {"a": "unknown", "b": "blocked"})
+
+    def test_a_member_charter_has_not_observed_reads_as_unknown_not_as_ready(self):
+        """What stands between a member and its own landing is a request state and its
+        checks at its head sha, and those are a forge read the scan does not make. So the
+        strip says charter did not look, which is #561 one surface out."""
+        rec = self.make_change("c-1", [("a", ())])
+        self.assertEqual(change.member_states(rec, set()), {"a": "unknown"})
+
+    def test_landed_count_is_a_pair_and_not_a_percentage(self):
+        """§3.3 refuses a percentage and a bar, because either invites one word for the
+        change as a whole and a member can hide behind one word."""
+        self.assertEqual(change.landed_count(["landed", "unknown", "landed"]), (2, 3))
+
+
+class TestContainment(SurfaceCase):
+    """Hostile values, measured. `contain.one_line` BEFORE the width arithmetic (#472):
+    escaping after padding pads to the wrong width, and the column stops lining up at
+    exactly the row whose content came out of somebody else's file."""
+
+    def rows_with(self, **field) -> list[str]:
+        self.seed([self.row(**field)])
+        return slots.changes_section(FID, 40, 6)
+
+    def test_a_hostile_slug_renders_as_one_row(self):
+        """`str.splitlines`, never `split("\n")` — see :data:`BREAKS` for the measurement
+        that makes the difference load-bearing."""
+        for label, value in HOSTILE.items():
+            with self.subTest(field="change", hostile=label):
+                rows = self.rows_with(change=value)
+                self.assertTrue(rows)
+                for line in rows:
+                    self.assertEqual(len(line.splitlines()), 1, repr(line))
+                    for ch in BREAKS:
+                        self.assertNotIn(ch, line, f"{label}: {ch!r} reached the row")
+
+    def test_a_hostile_slug_cannot_widen_the_column_either(self):
+        """The half a line-count assertion cannot see. The name column is sized from the
+        CONTAINED names and clipped to the pane, so an escape sequence buys no cells: the
+        section is exactly as wide as it was asked to be."""
+        for label, value in HOSTILE.items():
+            with self.subTest(hostile=label):
+                for line in self.rows_with(change=value):
+                    self.assertLessEqual(tui.width(line), 40, repr(line))
+
+    def test_a_hostile_why_cannot_forge_a_row(self):
+        """The `why` is not drawn in the 22-column section, and it is still contained on
+        the way into the snapshot — asserted here so that a future row which DOES draw it
+        inherits the property rather than rediscovering it."""
+        for label, value in HOSTILE.items():
+            with self.subTest(hostile=label):
+                for line in self.rows_with(why=value):
+                    self.assertEqual(len(line.splitlines()), 1, repr(line))
+
+    def test_a_hostile_repo_or_branch_or_needs_is_contained_in_the_snapshot(self):
+        """The member fields reach `charter change show` and, later, a pull request body.
+        `change.read` refuses most of these at the record boundary; this asserts the
+        drawing side holds them too, at the one call every printing site goes through."""
+        for label, value in HOSTILE.items():
+            with self.subTest(hostile=label):
+                out = contain.one_line(value)
+                self.assertEqual(len(out.splitlines()), 1, repr(out))
+                for ch in BREAKS:
+                    self.assertNotIn(ch, out, f"{label}: {ch!r} survived one_line")
+
+    def test_the_control_a_raw_value_really_would_forge_a_row(self):
+        """The live control this class cannot do without: every assertion above is a
+        negative, and a check that never sees a two-row string passes just as happily as a
+        contained renderer."""
+        self.assertEqual(len("a\nb".splitlines()), 2)
+        self.assertEqual(len(contain.one_line("a\nb").splitlines()), 1)
+        # And the control for the SEPARATOR set, which is the half that was wrong: the
+        # drawing site's own sanitiser does not remove U+2028, so `contain.one_line` is
+        # the only thing standing between a committed name and a forged row there.
+        self.assertIn("\u2028", tui.truncate("a\u2028b", 40))
+        self.assertNotIn("\u2028", tui.truncate(contain.one_line("a\u2028b"), 40))
+
+    def test_the_width_arithmetic_runs_on_the_contained_name(self):
+        """#472's ordering, asked where it can be seen: a name whose glyphs are two cells
+        wide is measured as two cells, and the escape is gone before that measurement."""
+        self.assertEqual(tui.column("", [contain.one_line("a\x1b[31mb")], gap=0),
+                         tui.width(contain.one_line("a\x1b[31mb")))
+
+
+class TestWhatTheSectionSays(SurfaceCase):
+    def test_a_workspace_with_no_changes_draws_no_rows_at_all(self):
+        """Not a heading over an empty space: `todo_section`'s rule, and the reason this
+        section is free on every plane that never uses it."""
+        self.seed([])
+        self.assertEqual(self.section(), [])
+
+    def test_the_heading_carries_the_count_the_aggregate_and_the_age(self):
+        self.seed([self.row(change="a-1", landed=1, total=2, state="unknown"),
+                   self.row(change="b-2", landed=1, total=1, state="landed")])
+        head = tui.strip_ansi(self.section()[0])
+        self.assertIn("changes 2", head)
+        self.assertIn("UNKNOWN", head)      # the worst of the two, never the best
+        self.assertIn("now", head)
+
+    def test_each_change_is_one_row_with_its_own_fraction(self):
+        self.seed([self.row(change="a-1", landed=1, total=2),
+                   self.row(change="b-2", landed=1, total=1)])
+        rows = [tui.strip_ansi(r) for r in self.section()[1:]]
+        self.assertEqual(len(rows), 2)
+        self.assertIn("a-1", rows[0])
+        self.assertIn("1/2", rows[0])
+        self.assertIn("1/1", rows[1])
+
+    def test_the_chosen_change_carries_the_pickers_own_mark(self):
+        self.seed([self.row(change="a-1"), self.row(change="b-2")])
+        state.record_change(FID, "b-2")
+        rows = [tui.strip_ansi(r) for r in self.section()[1:]]
+        self.assertTrue(rows[1].startswith(choose.MARK[0]), repr(rows[1]))
+        self.assertTrue(rows[0].startswith(choose.MARK[1]), repr(rows[0]))
+
+    def test_the_chosen_change_does_not_move_to_the_top(self):
+        """A list whose rows reorder with state is a list nobody learns."""
+        self.seed([self.row(change="a-1"), self.row(change="b-2")])
+        state.record_change(FID, "b-2")
+        rows = [tui.strip_ansi(r) for r in self.section()[1:]]
+        self.assertIn("a-1", rows[0])
+
+    def test_what_does_not_fit_is_admitted_rather_than_dropped(self):
+        """The `…(+N more)` line is RESERVED out of the budget rather than appended and
+        trimmed off the end — `_table_lines`' rule, because "there is more here than fits"
+        outranks "here is an arbitrary one of them"."""
+        self.seed([self.row(change=f"c-{i}") for i in range(6)])
+        rows = [tui.strip_ansi(r) for r in slots.changes_section(FID, 22, 4)]
+        self.assertLessEqual(len(rows), 4)
+        self.assertIn("…(+", rows[-1])
+
+    def test_it_never_spends_more_rows_than_its_cap(self):
+        self.seed([self.row(change=f"c-{i}") for i in range(40)])
+        self.assertLessEqual(len(slots.changes_section(FID, 22, 100)),
+                             slots._MAX_CHANGE_LINES)
+
+    def test_no_room_means_no_rows_and_no_file_opened(self):
+        """The budget is checked BEFORE the cache is reached: a pane with no room must not
+        open a file it is about to discard."""
+        self.seed([self.row()])
+        self.assertEqual(slots.changes_section(FID, 22, 0), [])
+
+    def test_the_section_draws_the_age_of_what_it_is_showing(self):
+        """A refresh is an action, not a tick, so between two of them the rows are as old
+        as the last one — and a surface that did not say so would be indistinguishable
+        from a live one."""
+        self.assertEqual(slots._age(1000.0, 1000.0), "just now")
+        self.assertEqual(slots._age(1000.0, 1000.0 + 245), "4m ago")
+        self.assertEqual(slots._age(1000.0, 1000.0 + 7200), "stale")
+
+    def test_the_short_form_says_the_same_three_things_at_the_same_bounds(self):
+        """One function with a flag rather than two formatters: a surface calling anything
+        under a minute "now" while another called it "just now" at ninety seconds would be
+        two clocks wearing one name."""
+        for age, long, short in ((0, "just now", "now"), (245, "4m ago", "4m"),
+                                 (7200, "stale", "old")):
+            with self.subTest(age=age):
+                self.assertEqual(slots._age(1000.0, 1000.0 + age), long)
+                self.assertEqual(slots._age(1000.0, 1000.0 + age, short=True), short)
+
+    def test_a_timestamp_charter_cannot_read_is_not_dated_to_now(self):
+        """A cache written by an older charter has none, and dating it to the present is
+        the confident wrong answer ADR 0009 forbids."""
+        self.assertEqual(slots._age(None, 1000.0), "?")
+        self.assertEqual(slots._age("yesterday", 1000.0), "?")
+
+    def test_it_reaches_the_real_sidebar_pane(self):
+        """End to end through the shipped renderer, so the section being registered and
+        the section being DRAWN are not two different claims."""
+        self.seed([self.row(change="a-1", landed=1, total=2)])
+        out = tui.strip_ansi(self.render())
+        self.assertIn("changes 1", out)
+        self.assertIn("a-1", out)
+
+
+class TestTwoKeystrokes(SurfaceCase):
+    def test_the_sidebar_is_what_a_key_toggles_and_the_section_rides_on_it(self):
+        """**One keystroke reaches it, and it is the sidebar's.** A child of a composite
+        has no pane of its own to show or hide — charter never splits a pane (§4d) — so
+        the key that brings the persona column up brings its changes with it. That is the
+        cost of not being a pane, and it is the cost that buys every plane with no changes
+        paying nothing at all."""
+        self.assertIn("right", instance_mod.frame_arrangement({"slots": ["top"]}))
+        self.assertIn("changes", builtins.build().get("sidebar").children)
+
+    def test_the_palette_carries_a_doorway_row_for_changes(self):
+        """The second keystroke: `F2`, then the row. It is a ROW and not an `Action`
+        because opening a picker starts nothing — it replaces the surface in the pane the
+        operator is already looking at, and an `Action` whose `run` did nothing would pass
+        every test in that contract and describe nothing that happens."""
+        ids = [r.id for r in choose.open_rows(FID)]
+        self.assertIn("pick:change", ids)
+        self.assertEqual(choose.noun_of(choose.open_rows(FID)[-1]), choose.CHANGE)
+
+    def test_an_unavailable_picker_says_why_before_the_keypress(self):
+        """#512: an operator cannot ask about an option they cannot see. A pane of no
+        names is an offer charter knows it cannot honour, so the doorway carries the
+        reason and `_picker` refuses to open on a row with a note."""
+        row = next(r for r in choose.open_rows(FID) if r.id == "pick:change")
+        self.assertEqual(row.note, choose.NO_CHANGES)
+        self.assertIn("charter change create", row.note)
+
+    def test_with_changes_the_doorway_has_no_reason_and_opens(self):
+        self.make_change("component-api-2")
+        row = next(r for r in choose.open_rows(FID) if r.id == "pick:change")
+        self.assertEqual(row.note, "")
+
+    def test_the_picker_lists_the_workspaces_changes_and_marks_the_current_one(self):
+        self.make_change("a-1")
+        self.make_change("b-2")
+        switch.to_change(FID, "b-2")
+        roster = choose.roster(choose.CHANGE, FID)
+        self.assertEqual(list(roster.names), ["a-1", "b-2"])
+        self.assertTrue(roster.rows[1].title.startswith(choose.MARK[0]))
+        self.assertTrue(roster.rows[0].title.startswith(choose.MARK[1]))
+
+    def test_choosing_one_records_it_and_bumps_the_frame(self):
+        self.make_change("a-1")
+        before = state.version(FID)
+        out = choose.switch_to(choose.CHANGE, FID, "a-1")
+        self.assertTrue(out.ok, out.message)
+        self.assertEqual(state.frame_change(FID), "a-1")
+        self.assertNotEqual(state.version(FID), before)
+
+    def test_an_unknown_change_is_a_question_and_never_an_implicit_create(self):
+        self.make_change("a-1")
+        out = switch.to_change(FID, "nope")
+        self.assertFalse(out.ok)
+        self.assertIn("no change", out.message)
+        self.assertIn("a-1", out.message)
+        self.assertIsNone(state.frame_change(FID))
+
+    def test_a_slug_that_cannot_name_a_change_is_refused_before_the_lookup(self):
+        """The value reaches a `changes/<slug>.json` join, which is #442's position."""
+        out = switch.to_change(FID, "../etc")
+        self.assertFalse(out.ok)
+        self.assertIn("cannot name a change", out.message)
+
+    def test_a_hostile_slug_in_the_refusal_is_contained(self):
+        out = switch.to_change(FID, "a\nb")
+        self.assertFalse(out.ok)
+        self.assertEqual(len(out.message.split("\n")), 1, repr(out.message))
+
+    def test_the_changes_listed_are_the_frames_workspace_and_not_this_process(self):
+        """#512. A palette is a `run-shell` child of a tmux server shared between frames,
+        so resolving locally would list another plane's changes on this frame's screen."""
+        workspace.ensure("other")
+        state.record_workspace(FID, "other")
+        self.make_change("a-1")           # written into `ws`, which is not this frame's
+        self.assertEqual(switch.changes(FID), [])
+        state.record_workspace(FID, "ws")
+        self.assertEqual(switch.changes(FID), ["a-1"])
+
+    def test_a_change_picker_can_never_be_refused_by_a_launch_pin(self):
+        """There is no `$CHARTER_CHANGE`: a change is what one frame is LOOKING at, not an
+        identity a launch hands it. `choose.PIN` carries no entry for it, and an entry
+        naming a variable nothing sets would make `pin_reason` answer through a lookup
+        rather than through a decision."""
+        self.assertNotIn(choose.CHANGE, choose.PIN)
+        self.make_change("a-1")
+        self.assertEqual(choose.pin_reason(choose.CHANGE, FID), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_change_surface.py
+++ b/tests/test_change_surface.py
@@ -432,9 +432,31 @@ class TestWhatTheSectionSays(SurfaceCase):
 
     def test_no_room_means_no_rows_and_no_file_opened(self):
         """The budget is checked BEFORE the cache is reached: a pane with no room must not
-        open a file it is about to discard."""
+        open a file it is about to discard — `todo_section` keeps the same ordering for the
+        same reason.
+
+        **The read is what this asserts, not the rows**, and the first version of this test
+        got that wrong: it checked `== []` alone, which is satisfied either way because
+        `_change_rows` refuses a zero budget too. So `budget <= 0` could become `budget < 0`
+        with every assertion still green and the file opened on every repaint of a pane
+        with no room — the deletion sweep reported exactly that, as a boundary nothing
+        pinned. A test whose NAME claims more than its body checks is the shape this suite
+        keeps finding.
+        """
         self.seed([self.row()])
-        self.assertEqual(slots.changes_section(FID, 22, 0), [])
+        with mock.patch.object(gather, "read",
+                               side_effect=AssertionError("opened the cache")) as read:
+            self.assertEqual(slots.changes_section(FID, 22, 0), [])
+            self.assertEqual(slots.changes_section(FID, 22, -1), [])
+        self.assertEqual(read.call_count, 0)
+
+    def test_one_row_of_room_does_reach_the_cache(self):
+        """The other side of the boundary. Without it, "does not read at zero" is
+        satisfied by a function that never reads at all."""
+        self.seed([self.row()])
+        with mock.patch.object(gather, "read", wraps=gather.read) as read:
+            self.assertTrue(slots.changes_section(FID, 22, 1))
+        self.assertEqual(read.call_count, 1)
 
     def test_the_section_draws_the_age_of_what_it_is_showing(self):
         """A refresh is an action, not a tick, so between two of them the rows are as old

--- a/tests/test_change_surface.py
+++ b/tests/test_change_surface.py
@@ -180,6 +180,47 @@ class TestTheSliceIsServedAndDeclaredTogether(SurfaceCase):
         self.assertIn("changes", gather.scan(workspace="ws"))
 
 
+class TestTheDegradedAnswersAreStillWellFormed(SurfaceCase):
+    """Every fallback on this path, asked directly. `gather` promises it never raises and
+    that a renderer never needs a `None`-check before indexing — and both of those are
+    claims about the paths a happy-path test does not walk."""
+
+    def test_the_empty_structure_carries_the_slice_as_an_empty_list(self):
+        """`_empty` is what `scan` falls back to when everything failed. A renderer reading
+        `data["changes"]` there must find a list, not a `KeyError` — which is the whole
+        reason this structure is spelled out rather than built up."""
+        self.assertEqual(gather._empty(None)["changes"], [])
+        self.assertIn("changes", gather._empty("ws"))
+
+    def test_a_scan_whose_change_read_explodes_still_returns_a_whole_structure(self):
+        """The module's "never raises" promise, on the one branch this phase added. One bad
+        record must degrade the change rows, not lose the repo table with them."""
+        with mock.patch.object(gather, "_change_rows", side_effect=RuntimeError("boom")):
+            got = gather.scan(workspace="ws")
+        self.assertEqual(got["changes"], [])
+        self.assertIn("repos", got)
+        self.assertIn("gathered_at", got)
+
+    def test_member_states_accepts_no_landing_map_at_all(self):
+        """`None` is what a caller with nothing landed passes, and `set(None)` raises. The
+        fallback is why "which members are blocked" is askable before anything has landed —
+        which is every change on the day it is created."""
+        rec = self.make_change("c-1", [("a", ()), ("b", ("a",))])
+        self.assertEqual(change.member_states(rec, None),
+                         {"a": "unknown", "b": "blocked"})
+        self.assertEqual(change.blocked_members(rec, None), {"b": ["a"]})
+
+    def test_no_change_chosen_reads_as_the_empty_string_and_not_as_none(self):
+        """`choose.current` answers `str` for all three nouns. A frame looking at no change
+        is an ordinary answer rather than a missing one, and `""` is the value that matches
+        no name — so the roster marks no row rather than comparing against `None`."""
+        self.assertEqual(choose.current(choose.CHANGE, FID), "")
+        self.assertIsInstance(choose.current(choose.CHANGE, FID), str)
+        self.make_change("a-1")
+        switch.to_change(FID, "a-1")
+        self.assertEqual(choose.current(choose.CHANGE, FID), "a-1")
+
+
 class TestNothingOnTheRepaintPathSpawns(SurfaceCase):
     def test_a_repaint_starts_no_process_at_all(self):
         """Measured, not asserted (§4g). Every `subprocess` entry point is replaced with
@@ -426,6 +467,103 @@ class TestWhatTheSectionSays(SurfaceCase):
         out = tui.strip_ansi(self.render())
         self.assertIn("changes 1", out)
         self.assertIn("a-1", out)
+
+
+class TestTheDrawingPathSurvivesAMalformedSnapshot(SurfaceCase):
+    """Every defensive read in the drawing path, driven rather than reasoned about.
+
+    **A cache written by an older charter is the ordinary case, not an edge one** —
+    `gather.cached`'s own docstring says so, and `_shaped_like_a_scan` is deliberately
+    loose about anything past `repos`/`worktrees`. So a change row missing a field, or
+    carrying `None` where a number belongs, reaches this renderer on the day somebody
+    upgrades, and every `or 0` / `or ""` / `.get(…, default)` in it is what stops that
+    being a traceback inside a pane.
+
+    Feeding well-formed fixtures leaves all of them unexercised, which is exactly what the
+    deletion sweep reported: fourteen survivors in one function, each looking equivalent
+    on its own because the fixture never took the branch.
+    """
+
+    #: One entry per way a row can be wrong, all of them reachable from a stale cache.
+    BROKEN = {
+        "no fields at all": {},
+        "every value None": {"change": None, "why": None, "state": None,
+                             "landed": None, "total": None, "members": None},
+        "counts as strings": {"landed": "2", "total": "3"},
+        "a state charter has never heard of": {"state": "shipped-it"},
+        "members missing": {"change": "a-1", "state": "landed", "landed": 1, "total": 1},
+        "a slug that is not text": {"change": 7},
+    }
+
+    def test_every_malformed_row_still_draws_and_draws_one_line_each(self):
+        for label, row in self.BROKEN.items():
+            with self.subTest(row=label):
+                self.seed([row])
+                lines = slots.changes_section(FID, 40, 6)
+                self.assertTrue(lines, f"{label}: drew nothing at all")
+                for line in lines:
+                    self.assertEqual(len(line.splitlines()), 1, repr(line))
+                    self.assertLessEqual(tui.width(line), 40, repr(line))
+
+    def test_a_row_charter_cannot_read_still_says_unknown_rather_than_nothing(self):
+        """The word is the point. A blank where the state goes reads as "fine"; `UNKNOWN`
+        reads as *charter did not look*, which is what a row it could not parse means."""
+        self.seed([{}])
+        self.assertIn("UNKNOWN", tui.strip_ansi(slots.changes_section(FID, 40, 6)[0]))
+
+    def test_a_malformed_row_never_reads_as_landed(self):
+        """The direction that matters. Over-reporting `unknown` costs a second look;
+        under-reporting it says a member is in when charter has no idea."""
+        for label, row in self.BROKEN.items():
+            with self.subTest(row=label):
+                self.seed([row])
+                head = tui.strip_ansi(slots.changes_section(FID, 40, 6)[0])
+                if label != "members missing":     # that one really IS landed
+                    self.assertNotIn("landed ", head, repr(head))
+
+    def test_a_pane_one_column_wide_still_draws_one_row_per_line(self):
+        """`max(width - cw - mw - 1, 1)` is what stops a negative slice width, and a
+        resize really does reach here — `cmd_resize` re-sizes panes without destroying
+        them, so a narrowed terminal arrives with a real pane to fill."""
+        self.seed([self.row(change="component-api-2", landed=1, total=2)])
+        for w in (1, 2, 4, 8, 12):
+            with self.subTest(width=w):
+                for line in slots.changes_section(FID, w, 4):
+                    self.assertLessEqual(tui.width(line), w, repr(line))
+                    self.assertEqual(len(line.splitlines()), 1, repr(line))
+
+    def test_the_gather_slice_survives_a_record_with_odd_shapes(self):
+        """`gather._change_rows`' own defensive reads, one layer below the renderer."""
+        self.clone("charter")
+        rec = change.new_record("a-1", "w", "t", "2026-08-29T00:00:00+00:00")
+        rec["members"] = [{"repo": "charter", "branch": "b", "needs": []}]
+        change.write("ws", "a-1", rec)
+        rows = gather._change_rows("ws")
+        self.assertEqual(rows[0]["total"], 1)
+        self.assertEqual(rows[0]["excluded"], 0)
+        self.assertEqual(rows[0]["members"][0]["state"], "unknown")
+
+    def test_a_landing_declaration_makes_that_member_read_as_landed(self):
+        """The other side of the join, so the `by_change` lookup is not satisfied by
+        always answering the empty set."""
+        self.clone("charter")
+        self.make_change("a-1", [("charter", ())])
+        change.record_landing("ws", "a-1", "charter", number=1, merge="e0c9d13",
+                              head="4b1e77a", ts="2026-08-29T00:00:00+00:00")
+        rows = gather._change_rows("ws")
+        self.assertEqual(rows[0]["members"][0]["state"], "landed")
+        self.assertEqual((rows[0]["landed"], rows[0]["total"]), (1, 1))
+
+    def test_a_declaration_for_another_change_does_not_leak_across(self):
+        """`by_change` is keyed on the slug. Without that key every change in the
+        workspace would read as landed the moment any one of them did."""
+        self.clone("charter")
+        self.make_change("a-1", [("charter", ())])
+        self.make_change("b-2", [("charter", ())])
+        change.record_landing("ws", "a-1", "charter", number=1, merge="e0c9d13",
+                              head="4b1e77a", ts="2026-08-29T00:00:00+00:00")
+        got = {r["change"]: r["state"] for r in gather._change_rows("ws")}
+        self.assertEqual(got, {"a-1": "landed", "b-2": "unknown"})
 
 
 class TestTwoKeystrokes(SurfaceCase):

--- a/tests/test_commands_change.py
+++ b/tests/test_commands_change.py
@@ -1055,6 +1055,34 @@ class TestThereIsNoExpansionAndNoForge(unittest.TestCase):
         self.assertTrue(verbs, "no _git call found — this test proves nothing")
         self.assertEqual(sorted(set(verbs)), sorted(self.GIT_VERBS - {"config"}))
 
+    def test_every_git_call_is_bounded_by_a_timeout(self):
+        """A clone on a stalled network mount makes git hang, and a command the operator is
+        waiting on must fail rather than sit there — `doctor.CHECK_TIMEOUT`'s reason, one
+        command out. Asked of the FUNNEL, because that is where the property lives: `_git`
+        is the single place the timeout is applied, so a call site that reached `util.run`
+        directly would be the one that could forget.
+
+        **The NUMBER is not pinned and cannot honestly be**: no observable behaviour of any
+        test changes between 20 seconds and 21, and a test asserting the constant's value
+        against itself would be the tautology this suite keeps finding. What is pinned is
+        that there IS one, and that it is the module's own constant rather than a literal
+        somebody typed twice.
+        """
+        seen = []
+        real = commands_change.util.run
+
+        def spy(cmd, *a, **kw):
+            seen.append(kw.get("timeout"))
+            return real(cmd, *a, **kw)
+
+        commands_change.util.run = spy
+        try:
+            commands_change._git(Path("."), "rev-parse", "--verify", "--quiet", "HEAD")
+        finally:
+            commands_change.util.run = real
+        self.assertEqual(seen, [commands_change.GIT_TIMEOUT])
+        self.assertIsNotNone(commands_change.GIT_TIMEOUT)
+
     def test_no_destructive_or_remote_git_flag_appears_anywhere_in_the_module(self):
         """The refusals of §3.7, as an absence in the source rather than a guard.
 

--- a/tests/test_commands_change.py
+++ b/tests/test_commands_change.py
@@ -1032,8 +1032,8 @@ class TestThereIsNoExpansionAndNoForge(unittest.TestCase):
     #: what "no network" means for a module that spawns git. And not one of them is
     #: destructive: no `push --force`, no `branch -D`, no `reset`, no `clean`. §3.7's
     #: refusals are the argv never being CONSTRUCTED, and this is where that is checked.
-    GIT_VERBS = {"config", "merge-base", "rev-parse", "show", "rev-list", "status",
-                 "switch", "revert"}
+    GIT_VERBS = {"config", "for-each-ref", "merge-base", "rev-parse", "show", "rev-list",
+                 "status", "switch", "revert"}
 
     def test_the_git_subcommands_it_can_reach_are_listed_in_full(self):
         """Read statically off every `_git(clone, "<verb>", …)` call site.

--- a/tests/test_commands_change.py
+++ b/tests/test_commands_change.py
@@ -987,24 +987,92 @@ class TestThereIsNoExpansionAndNoForge(unittest.TestCase):
                                            "--match", "--every"), f"change {name} {opt}")
 
     def test_no_forge_module_and_no_network_module_is_imported(self):
-        """Records only. The forge half is a later phase, and keeping the record surface
-        separable from it is what makes "what did the operator declare" answerable without
-        asking anybody's API."""
+        """No forge. `revert` and the divergence report run **git in a clone the operator
+        already has**, which is a local read of this disk — but nothing here asks anybody's
+        API, and keeping the two separable is what makes "what did the operator declare,
+        and what does this disk say happened" answerable without a token.
+
+        `subprocess` stays on the list even though this module now spawns: everything goes
+        through `util.run`, which is where the timeout, the credential-helper neutering and
+        the stdin discipline live. A direct `subprocess` call would be a second answer to
+        "how does charter run git".
+        """
         for name in ("forge", "gitpolicy", "planegit", "glstate", "report", "inventory",
                      "socket", "urllib", "http", "ssl", "subprocess"):
             self.assertNotIn(name, self._imports())
 
-    def test_the_only_child_process_this_module_can_start_is_a_local_config_read(self):
+    def test_every_child_process_this_module_can_start_is_git(self):
         """`util.run` is a general subprocess runner, so "no network" is a claim about the
-        argv rather than about the import. Every command this module can hand it is listed
-        here, in full: one read of `git config`, which touches no remote."""
-        spawned = []
+        ARGV rather than about the import — and the first element of every argv this module
+        builds is the literal `git`.
+
+        Two shapes, because the module has two: `_author` hands `util.run` a whole literal
+        list, and every other call goes through `_git`, which is the single place the
+        `["git", "-C", str(clone), …]` prefix is built. That funnel is what makes the
+        question answerable at all: a call site that assembled its own argv would be a
+        second program this test could not see.
+        """
+        progs = []
         for node in ast.walk(self._tree()):
-            if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
                     and node.func.attr in ("run", "Popen", "call", "check_output",
                                            "check_call", "system", "popen")):
-                spawned.append(ast.literal_eval(node.args[0]) if node.args else None)
-        self.assertEqual(spawned, [["git", "config", "user.name"]])
+                continue
+            self.assertTrue(node.args, "a spawn with no argv at all")
+            argv = node.args[0]
+            self.assertIsInstance(argv, ast.List, "an argv that is not a list literal")
+            self.assertTrue(argv.elts, "an empty argv")
+            head = argv.elts[0]
+            self.assertIsInstance(head, ast.Constant, "a program that is not a literal")
+            progs.append(head.value)
+        self.assertEqual(progs, ["git", "git"])
+
+    #: Every git subcommand `charter/commands_change.py` can reach, in full. Not one of
+    #: them touches a remote — no `fetch`, no `pull`, no `push`, no `ls-remote` — which is
+    #: what "no network" means for a module that spawns git. And not one of them is
+    #: destructive: no `push --force`, no `branch -D`, no `reset`, no `clean`. §3.7's
+    #: refusals are the argv never being CONSTRUCTED, and this is where that is checked.
+    GIT_VERBS = {"config", "merge-base", "rev-parse", "show", "rev-list", "status",
+                 "switch", "revert"}
+
+    def test_the_git_subcommands_it_can_reach_are_listed_in_full(self):
+        """Read statically off every `_git(clone, "<verb>", …)` call site.
+
+        **The verb is a literal at every call site, deliberately.** `_seed_revert` spreads
+        its optional `-m 1` into the call rather than building a whole argv, so that this
+        test can read the verb rather than give up on it — a dynamic argv is a subcommand
+        nobody is checking.
+        """
+        verbs = []
+        for node in ast.walk(self._tree()):
+            if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                    and node.func.id == "_git"):
+                self.assertGreaterEqual(len(node.args), 2, "a _git call with no verb")
+                verb = node.args[1]
+                self.assertIsInstance(verb, ast.Constant,
+                                      "a git subcommand that is not a literal")
+                verbs.append(verb.value)
+        self.assertTrue(verbs, "no _git call found — this test proves nothing")
+        self.assertEqual(sorted(set(verbs)), sorted(self.GIT_VERBS - {"config"}))
+
+    def test_no_destructive_or_remote_git_flag_appears_anywhere_in_the_module(self):
+        """The refusals of §3.7, as an absence in the source rather than a guard.
+
+        A force-push, a branch deletion and a hard reset are not things this module
+        declines to do — they are argv it never builds, and there is no flag that turns
+        them on. Read over every string constant in the module, so a future call site
+        cannot introduce one without this going red.
+
+        Weaker than the behavioural half on its own and it is not on its own:
+        `tests/test_change_revert.py` records every git invocation a real revert makes.
+        This is the half that also covers the paths that test does not happen to walk.
+        """
+        banned = ("--force", "-f", "--force-with-lease", "--delete", "-D", "--hard",
+                  "reset", "clean", "push", "fetch", "pull", "ls-remote")
+        for node in ast.walk(self._tree()):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                self.assertNotIn(node.value, banned,
+                                 f"{node.value!r} is a destructive or remote git argument")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_palette_names.py
+++ b/tests/test_frame_palette_names.py
@@ -325,7 +325,9 @@ class TheRosterIsNeverReadUntilSomethingIsTyped(_Frame, unittest.TestCase):
                        if choose.noun_of(r) == choose.WORKSPACE)
         commands_frame._picker(doorway, self.FID, opened)
         self.assertEqual((self.ws.call_count, self.pe.call_count), (1, 1))
-        self.assertEqual([r.noun for r in opened], [choose.WORKSPACE, choose.PERSONA])
+        # One roster per noun, in `choose.NOUNS` order — `change` is the third and last.
+        self.assertEqual([r.noun for r in opened],
+                         [choose.WORKSPACE, choose.PERSONA, choose.CHANGE])
 
 
 class FindingNothingIsAnANSWERAndNotAMissingOne(unittest.TestCase):

--- a/tests/test_frame_pickers.py
+++ b/tests/test_frame_pickers.py
@@ -145,7 +145,8 @@ class APickerRowIsNotAnAction(_Frame, unittest.TestCase):
     def test_the_doorway_is_recognised_and_nothing_else_is(self):
         opens = {r.id: choose.noun_of(r) for r in choose.open_rows(self.FID)}
         self.assertEqual(opens, {"pick:workspace": choose.WORKSPACE,
-                                 "pick:persona": choose.PERSONA})
+                                 "pick:persona": choose.PERSONA,
+                                 "pick:change": choose.CHANGE})
         for stranger in ("frame.detach", "density.full", "workspace:n0", "acme.deploy"):
             self.assertIsNone(choose.noun_of(overlay.Row(id=stranger, title="x")))
 

--- a/tests/test_frame_switch.py
+++ b/tests/test_frame_switch.py
@@ -277,13 +277,18 @@ class ThePaletteOffersAPickerForEach(PersonaIso, unittest.TestCase):
         state.frame_dir(self.FID, create=True)
         state.record_identity(self.FID, {"CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
 
-    def test_the_palette_opens_with_the_two_pickers_then_charters_own_actions(self):
+    def test_the_palette_opens_with_the_three_pickers_then_charters_own_actions(self):
         """The order is fixed and the pickers are first, so an operator who presses `F2`
-        and Enter without reading opens a list rather than detaching their harness."""
+        and Enter without reading opens a list rather than detaching their harness.
+
+        Three since `change` joined `choose.NOUNS`, and it is LAST of the three: a change
+        is the narrowest thing a frame is looking at, so it sits after the plane and the
+        person looking at it."""
         _plane_workspaces("alpha")
         ids = [r.id for r in _rows(self.FID)]
-        self.assertEqual(ids[:3], ["pick:workspace", "pick:persona", "frame.detach"])
-        self.assertTrue(any(i.startswith("density.") for i in ids[3:6]), ids)
+        self.assertEqual(ids[:4], ["pick:workspace", "pick:persona", "pick:change",
+                                   "frame.detach"])
+        self.assertTrue(any(i.startswith("density.") for i in ids[4:7]), ids)
 
     def test_each_doorway_says_which_name_the_frame_is_on(self):
         """So the palette still answers "which workspace am I on" without opening

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -1856,6 +1856,10 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
     _BAD_SLOT_STDERR = (f"charter panel: unknown slot '{_BAD_SLOT}' "
                         f"(known: {', '.join(sorted(frame_slots.SLOTS))})")
 
+    #: How wide the one-row pane below is. Named because the reason's WRAPPED height is
+    #: derived from it, and a width written twice would let the two drift.
+    _PANE_COLS = 40
+
     #: A pane program that waits for a gate file, prints *stderr text* and exits 2 — the
     #: pre-#382 panel, reduced to the only two things about it that mattered. The gate
     #: is what makes `remain-on-exit` arm-able in time: `set -w` cannot be issued before
@@ -1868,7 +1872,7 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
     def _capture(self, target: str, *history: str) -> str:
         """What `capture-pane` reports for *target* — the VISIBLE screen by default,
         which is the whole point: it is what an operator sees without knowing to scroll
-        a one-row pane's history. Pass `"-S", "-3"` to look into that history instead."""
+        a one-row pane's history. Pass `"-S", "-<n>"` to look into that history instead."""
         return _tmux("capture-pane", "-p", *history, "-t", target).stdout
 
     def _dead(self, target: str) -> str:
@@ -2018,7 +2022,8 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         self.addCleanup(shutil.rmtree, gate_dir, True)
         gate = os.path.join(gate_dir, "die")
 
-        r = _tmux("new-session", "-d", "-s", "panel-oldshape", "-x", "40", "-y", "1",
+        r = _tmux("new-session", "-d", "-s", "panel-oldshape",
+                  "-x", str(self._PANE_COLS), "-y", "1",
                   "--", sys.executable, "-c", self._DYING_PROGRAM, gate,
                   self._BAD_SLOT_STDERR, env=self.env)
         self.assertEqual(r.returncode, 0, r.stderr)
@@ -2039,7 +2044,15 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
                          "a pane that small no longer loses a newline-terminated write, "
                          "so `panel._hold` is solving a problem that no longer exists: "
                          f"{visible!r}")
-        with_history = self._capture("panel-oldshape", "-S", "-3")
+        # One row deeper than the reason's own wrapped height. `-3` today, exactly as it
+        # was written by hand — but DERIVED, because the reason names every key of
+        # `frame_slots.SLOTS` and therefore grows whenever charter ships a slot. Measured
+        # while `changes` was briefly a slot: the sentence went from two wrapped rows to
+        # three, this history window stopped reaching the row carrying the slot name, and
+        # the case went red for the LENGTH of a message rather than for the property it
+        # is named for. That is the failure this arithmetic removes.
+        depth = -(-len(self._BAD_SLOT_STDERR) // self._PANE_COLS) + 1
+        with_history = self._capture("panel-oldshape", "-S", f"-{depth}")
         self.assertIn(self._BAD_SLOT, with_history,
                       "the reason never reached the pane AT ALL — that is a different "
                       "failure from the one #382 fixes, and `_hold` would not cure it: "

--- a/tests/test_hook_process_boundary.py
+++ b/tests/test_hook_process_boundary.py
@@ -67,6 +67,39 @@ class GuardAcrossTheProcessBoundary(unittest.TestCase):
         self.assertEqual(spec["permissionDecision"], "deny")
         self.assertTrue(spec.get("permissionDecisionReason"), "a denial must say why")
 
+    def test_an_unattended_cross_repo_landing_denies_through_the_real_entrypoint(self):
+        """The release floor's newest entry, across the boundary Claude Code uses.
+
+        Asked here as well as in `tests/test_release_floor.py` because the two answer
+        different questions: that one asks whether `_release_floor_reason` recognises the
+        command, this one asks whether the recognition survives the entrypoint — argv
+        handling between `__main__` and the logic is what shipped `secret exec` broken for
+        seven releases with correct, tested logic behind it.
+
+        And because the property is a NEGATIVE about an unattended run, which is the one
+        kind of claim that cannot be checked by watching it work: an agent under
+        `bypassPermissions` is exactly the caller nobody is watching."""
+        p = _hook("pretooluse", {"tool_name": "Bash",
+                                 "permission_mode": "bypassPermissions",
+                                 "tool_input": {
+                                     "command": "charter change land c --repo r"}})
+        self.assertEqual(p.returncode, 0, p.stderr)
+        spec = json.loads(p.stdout)["hookSpecificOutput"]
+        self.assertEqual(spec["permissionDecision"], "deny")
+        self.assertIn("charter change land", spec["permissionDecisionReason"])
+
+    def test_reading_a_change_unattended_still_produces_no_decision(self):
+        """The negative control for the row above, over the same boundary. Without it the
+        assertion is satisfied by a floor that denied every `charter change` there is —
+        which would be a feature removal wearing a security label."""
+        p = _hook("pretooluse", {"tool_name": "Bash",
+                                 "permission_mode": "bypassPermissions",
+                                 "tool_input": {"command": "charter change show c"}})
+        self.assertEqual(p.returncode, 0, p.stderr)
+        decision = (json.loads(p.stdout or "{}").get("hookSpecificOutput", {})
+                    .get("permissionDecision")) if p.stdout.strip() else None
+        self.assertIsNone(decision, p.stdout)
+
     def test_an_ordinary_command_produces_no_decision(self):
         """Negative control. Without it the suite passes just as well if the guard
         denied everything — which would be a catastrophic pass."""

--- a/tests/test_release_floor.py
+++ b/tests/test_release_floor.py
@@ -148,6 +148,85 @@ class TestItDoesNotOverreach(FloorCase):
             self.decide('git commit -m "prepare git tag v9.9.9 notes"', UNATTENDED))
 
 
+class TestCharterOwnLandingIsOnTheFloor(FloorCase):
+    """`charter change land` merges one member of a cross-repo change into a repository,
+    which is the same act `gh pr merge` is — so it sits on the same floor.
+
+    **The split is attended versus unattended, and it is the standing rule read in the two
+    modes the harness reports.** Attended, an agent may land one member, because that is
+    the merge the standing rule already permits for a single repo. Unattended it may not
+    land at all, because that is where this floor already sat: the project's line runs
+    between *opening* a request and *merging* one, and `gh pr create` is deliberately
+    absent from `_PUBLISH_FORGE`. Without this entry, `charter change land` would be a
+    documented way around a floor charter itself wrote.
+    """
+
+    def test_landing_a_member_unattended_is_denied(self):
+        self.assertEqual("deny", self.decide(
+            "charter change land component-api-2 --repo charter", UNATTENDED))
+
+    def test_the_denial_names_the_command_and_a_remedy(self):
+        r = run_hook(hooks.pretooluse,
+                     {"tool_input": {"command": "charter change land c --repo r"},
+                      "cwd": str(self.tmp), "session_id": "s",
+                      "permission_mode": UNATTENDED})
+        reason = r["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn("charter change land", reason)
+        self.assertIn("attended", reason)
+
+    def test_the_entry_is_what_answers_and_not_the_branch_that_reaches_it(self):
+        """**Step 3b, and it is the mutation that would have caught a dead line.** The
+        `_PUBLISH_FORGE` lookup used to live under `elif base in ("gh", "glab")`, so
+        adding the tuple alone would have shipped a set member nothing could reach and a
+        mutation deleting it would have stayed green. Asked here of the SET, one layer
+        below the hook, where nothing else can answer: delete the tuple and this is red
+        while every gh/glab case above stays green."""
+        self.assertIn(("charter", "change", "land"), hooks._PUBLISH_FORGE)
+
+    def test_the_reader_reaches_charter_and_not_only_the_two_forge_clis(self):
+        """The other half of the same pair. Revert the base check to `("gh", "glab")` and
+        keep the entry, and THIS is red while the assertion above stays green — which is
+        why both exist rather than one."""
+        self.assertEqual("deny", self.decide("charter change land c --repo r", UNATTENDED))
+
+    def test_the_pre_rename_binary_is_the_same_command(self):
+        """`edm` is charter's pre-rename name. `hooks._CHARTER_PROGS` keeps it for the
+        reason a security guard keeps an alternative: one extra string against a silent gap
+        on a machine still running the old binary."""
+        self.assertEqual("deny", self.decide("edm change land c --repo r", UNATTENDED))
+
+    def test_the_module_spelling_is_the_same_command_too(self):
+        """`python3 -m charter change land` puts charter's own NAME in argv instead of in
+        the program, and `-m` drops out with the other flags — so the verb pair sits one
+        place further along. A guard that matched one spelling and missed the other is a
+        guard with a `python3 -m` for a bypass."""
+        self.assertEqual("deny", self.decide(
+            "python3 -m charter change land c --repo r", UNATTENDED))
+
+    def test_landing_attended_is_untouched(self):
+        """The standing rule: implement, PR, merge — but never release alone. A merge is
+        undone by another commit; this floor is about the mode, not about the verb."""
+        for mode in ("default", "auto", None):
+            self.assertIsNone(
+                self.decide("charter change land c --repo r", mode), repr(mode))
+
+    def test_every_other_change_verb_is_untouched_even_unattended(self):
+        """A cross-repo landing is N merges, each individually revertible — it is not a
+        release, and treating the whole surface as one would be stricter than the standing
+        rule and would push agents onto raw `gh pr merge`, outside every guard here."""
+        for cmd in ("charter change show component-api-2",
+                    "charter change list",
+                    "charter change create c --why x",
+                    "charter change add c r",
+                    "charter change push c",
+                    "charter change revert c"):
+            self.assertIsNone(self.decide(cmd, UNATTENDED), cmd)
+
+    def test_an_unrelated_charter_command_is_untouched(self):
+        for cmd in ("charter doctor", "charter workspace status", "charter land"):
+            self.assertIsNone(self.decide(cmd, UNATTENDED), cmd)
+
+
 class TestItIsAFloorNotANudge(FloorCase):
     """`bypassPermissions` means stop asking me, not stop knowing things."""
 

--- a/tests/test_the_end_of_a_name_is_the_end_of_the_string.py
+++ b/tests/test_the_end_of_a_name_is_the_end_of_the_string.py
@@ -204,6 +204,11 @@ ADMITTERS: dict[str, str] = {
     "instance._VERSION": "1.2.3",
     "forge.registry._HOST_RE": "git.example.com",
     "recall._REL_RE": "14d",
+    # A merge sha read out of `changes/log/<host>.jsonl` and handed to `git revert` and
+    # `git rev-list` as argv. An admitter in the sharpest sense: `.match` would have
+    # accepted `"e0c9d13\n"`, putting a newline into a git argv out of a file a hand edit
+    # or a half-written append can reach.
+    "commands_change._SHA_RE": "e0c9d13",
 }
 
 #: **Detectors** — "is this token one I must account for?". Over-matching makes the guard

--- a/tests/test_toolgate.py
+++ b/tests/test_toolgate.py
@@ -107,11 +107,45 @@ class TestCharterItself(GateCase):
         self.assertFalse(toolgate._is_dangerous("charter", ["persona", "list"]))
 
     def test_an_ordinary_charter_command_still_smooths(self):
-        """The carve-out is two subcommands, not the binary. A persona that declared
+        """The carve-out is three subcommands, not the binary. A persona that declared
         `charter` to run `charter persona list` keeps what it declared it for — otherwise
         this fix is a feature removal wearing a security label."""
         self.assertIsNotNone(self.gate("charter persona list"))
         self.assertIsNotNone(self.gate("charter workspace status"))
+
+    def test_charter_change_never_auto_approves(self):
+        """`charter change land` merges code into a repository, and a persona declaring
+        `tools: charter` must not have that pre-approved."""
+        self.assertIsNone(self.gate("charter change land component-api-2 --repo charter"))
+        self.assertIsNone(self.gate("edm change land component-api-2 --repo charter"))
+
+    def test_the_coarse_grain_is_deliberate_and_the_asymmetry_decides_it(self):
+        """It declines to auto-approve `charter change show` too, which is read-only. That
+        is the trade being made rather than an oversight: over-refusing costs ONE
+        permission prompt on a read-only command, under-refusing auto-approves a MERGE —
+        and because this gate never denies, the cost of the coarse grain is bounded at
+        that prompt while the other direction is not bounded at all.
+
+        Asserted rather than left implied, so that a later attempt to sharpen the rule to
+        the verb has to change a test that says why it is blunt."""
+        self.assertIsNone(self.gate("charter change show component-api-2"))
+        self.assertIsNone(self.gate("charter change list"))
+
+    def test_the_change_word_is_pinned_where_only_it_can_answer(self):
+        """One layer down, for `test_the_subcommand_scan_is_pinned_where_only_it_can_answer`'s
+        reason exactly: the gate calls above are also refused by other rules in some
+        spellings, so a mutant deleting `change` from `_DANGEROUS["charter"]` could leave
+        them green. Here nothing else answers."""
+        self.assertTrue(toolgate._is_dangerous("charter", ["change", "land", "c"]))
+        self.assertTrue(toolgate._is_dangerous("edm", ["change", "land", "c"]))
+        self.assertFalse(toolgate._is_dangerous("charter", ["workspace", "status"]))
+
+    def test_the_gate_still_never_denies(self):
+        """The bound on the whole trade. `decide` answers `(persona, binary)` or `None`,
+        and `None` is a normal prompt — never a refusal. If this stopped being true, "the
+        cost is bounded at a prompt" would stop being true with it."""
+        self.assertIn(self.gate("charter change land c --repo r"), (None,))
+        self.assertIsNotNone(self.gate("charter persona list"))
 
 
 class TestInterpretersAndWrappers(GateCase):


### PR DESCRIPTION
Phase 4, Tasks 9–14 of `docs/superpowers/specs/2026-08-28-phase4-cross-repo-change.md` — the last tranche. Builds on #629 (Tasks 1–4). **Tasks 5–8 are not in the tree**; where I needed something from them I built against the spec's stated shape and say so below.

## Task 9 — the floors

`("charter", "change", "land")` joins `hooks._PUBLISH_FORGE`, **and the reader widened with it**. The lookup lived only under `elif base in ("gh", "glab")`, so the tuple alone would have been a set member nothing could reach — a floor that never runs, in a phase whose thesis is that a guard nobody pins is a comment with a runtime cost. `_is_charter` rather than a bare name check, so `edm change land` and `python3 -m charter change land` are the same command to the guard. **Deny, never ask**: an unattended `_ask` falls back to `allow`.

Two mutations prove the pair, and neither is redundant: delete only the tuple (RED), and revert the base check while keeping the tuple (RED). Verified through the real `charter hook pretooluse` **and** across the process boundary in `tests/test_hook_process_boundary.py`, with a negative control (`charter change show` unattended is untouched).

`change` joins `toolgate._DANGEROUS["charter"]` and `["edm"]`. The grain is coarse on purpose — it declines `charter change show` too — and a test says so rather than leaving it implied, because the asymmetry is the argument: over-refusing costs one prompt, under-refusing auto-approves a merge, and the gate never denies.

`doctor` grows a `changes` row that names `charter guard ask --local 'charter change land *'` and **writes nothing** — asserted over the whole plane tree on all four of the check's branches, because the first version of that test covered one branch and a mutation writing from another survived it.

## Task 10 — `charter change revert`

A new change, `revert-<slug>`, whose members are the landed members of the original, each seeded off its clone's **own** default branch with a revert of the sha the landing log recorded.

- **`-m 1` only when git says that sha has more than one parent**, asked of git and never remembered.
- **The ordering is the original's, reversed.** If `charter-metrics` needed `charter` to land first, undoing it goes the other way — reverting the base while its dependent still needs the API it removes leaves the dependent broken. A revert that copied `needs` across would get this exactly backwards and look right in every single-member example.
- **A member with no landing record is named, not guessed** — no merge sha, so no revert, and charter will not pick the commit that looks about right.
- **It refuses over a dirty working tree**, by name: `git revert` commits into the checkout.
- **No force-push, no branch deletion, no default-branch reset, no request touched.** Not flags that default off — argv that is never built. Pinned two ways: a test that records every git invocation a real revert makes, and a source-level scan that also covers the paths that test does not walk.

## Task 11 — the surface

`gather.scan` carries the change records and the landing declarations — both file reads — in the one snapshot under its one timestamp. `component.NEEDS` and `ctx.SERVES` gained `changes` in the same commit, asserted against each other in one assertion.

The `changes` component is a **section of the persona sidebar**, not a pane, and both reasons were measured:

1. The frame supports **exactly one variable-height pane** by construction. `layout.slot_sizes` answers every member of `VARIABLE_ROW_SLOTS` with `layout.repos_rows`, and `_reassert_sizes` leaves that set unasserted so tmux's `resize-pane -y` — one boundary — has one remainder. Registered as `Content()` it was handed the **repo table's** height: 6 rows, for 6 repos, on a plane with one change.
2. A **placed** component has to be in `FRAME_SLOTS`, which is pinned to agree with the shipped `slots` default and with `density = full`. Placing it puts a pane saying "no changes in `<ws>`" on **every** operator's frame, for a feature most planes never use. `repos` saying "no clones" is a plane that is broken or new; a plane with no cross-repo change is the ordinary, permanent state.

As a section it costs those planes nothing: it returns no rows when there are none, exactly as the todos do. `F2` → the `change` row picks one; the picked one carries the picker's own mark and does **not** move to the top.

**Nothing on the repaint path starts a process**, measured by replacing every `subprocess` entry point with one that fails the test.

## Task 12 — divergence, named

Five checks, each with its own sentence, all at **FAIL**: a member landed outside charter; a declared landing the default branch no longer contains; a declared landing on a commit carrying no `Charter-Change` trailer; a member that landed while a blocker had not; and a member's branch name in a clone that is a member of no change. It reads what is already on this disk and never fetches — so it can under-report and can never invent.

## Task 13 — ADR 0020, docs, news

`docs/adr/0020-there-is-no-cross-repo-merge-loop.md`, `docs/changes.md` (force-included in the wheel, linked from the README), the floor entry in `docs/hooks.md`, the fourth store in `docs/workspaces.md`, and `docs/news/unreleased-cross-repo-change-surface.md` (`version: unreleased`, `adopt: workspace reinit --all`, no `check:`). No bump, no stamp, no tag.

## Findings — three places the spec or the tree turned out to be wrong

**1. `git revert -m 1` does NOT fail on a one-parent commit** (git 2.50.1, Apple Git-155). The spec's reason for the conditional is *"a squash landing is an ordinary commit and `-m` on one fails"*; measured, `-m 1` returns 0 on a one-parent commit, and so does `-m 2`. An outcome assertion therefore cannot see this at all, and hard-coding `-m 1` **survived** my first mutation round. The conditional still earns its place — older gits do fail with *"mainline was specified but commit is not a merge"*, and passing `-m` on a non-merge is a claim about the commit that is not true — so the test now pins the **argv**, which is a claim about charter and holds on every git.

**2. Task 11's `changes` component cannot be what the spec describes.** §3.6's example is a change with its member rows in a pane of its own; the two measurements above say that pane cannot exist without either mis-sizing itself or landing on every operator's frame. The section is what the frame can honestly carry, and `charter change show <slug>` is the full view §3.4 already names.

**3. `charter change revert` inherits the operator's commit signing.** On a machine using 1Password's `op-ssh-sign` the suite **hung** with no output, waiting for an approval nobody could give. Production deliberately does **not** pass `-c commit.gpgsign=false` — a revert is the operator's commit in their repository, ADR 0014 puts signing policy with the host, and `charter git-policy --apply` already writes `commit.gpgsign = false` into each managed clone's *local* config for exactly this reason. The fix is in the fixture.

## Not in this PR, and why

- **ADR 0002's amendment is deferred to whichever PR lands Task 6.** Its consequence — *"the reporting module is the only place in charter that writes to a forge"* — is still **true** in this tree, because there is no second write seam yet. Amending an ADR to describe code that is not here would be worse than leaving it.
- **`docs/forges.md` is untouched** for the same reason: `checks_at` and forge writes are Tasks 5/6.
- **`change.record_landing` / `change.landings`** are built here because `revert` and the divergence report read them. Task 8 is the writer's caller. If Tasks 5–8 land separately this is the one function likely to conflict.
- **The floor guards a command that does not exist yet.** That is the right order: a floor that arrives after the verb is a window.

## The deletion sweep, run by the repository

The gate ran twice. Both verdicts, because the delta is the point:

| | unpinned | masked cluster | platform-deferred | unresolved | pinned | headline |
|---|---|---|---|---|---|---|
| first push | 6 | 108 | 5 | 1 | 140 | `114 survivors, 1 not measured` |
| after working the list | 2 | 85 | 3 | 1 | 168 | `87 survivors, 1 not measured` |
| **final head** | **1** | **84** | **3** | **1** | **170** | **`85 survivors, 1 not measured`** |

`114 = 6 + 108`; platform-deferred and unresolved are counted separately. The gate is reporting-only.

**Five of the six unpinned were genuine gaps** and are pinned now. **One remains, and it is `GIT_TIMEOUT = 20 → 21`** — no observable behaviour changes between 20 seconds and 21, and a test asserting the constant against itself is a tautology, so what is pinned is that `_git` — the one funnel — always passes it. The second was pinnable and is fixed: `changes_section` checks its budget *before* `gather.read`, and the test asserted `== []` alone, which is satisfied either way — so `budget <= 0` could become `budget < 0` with the cache opened on every repaint of a pane with no room.

**Two findings that bear on `--enforce`:**

- **It found a dead line, not just a missing test.** `cmd_change_revert` checked that `revert-<slug>` is a change name; `_load` has already put the slug through `change_name_ok`, and `CHANGE_NAME_RE` has no length bound and no leading-character rule a `revert-` prefix could break. Deleted, property pinned on the derivation. Nothing but a sweep finds those.
- **It reports at least one mutation nothing can ever distinguish.** `split(".")[0]` and `rsplit(".")[0]` are the same expression without a maxsplit, and `pieces._host` on `main` carries the identical line.

**The 85 masked-cluster survivors need `--second-order`, which the gate does not run.** I have not resolved them and am not claiming they are equivalent. Working the bucket by feeding malformed input — rather than reasoning about it — is what moved `pinned` from 140 to 168. Full analysis in a comment below.

## Verification

- **8298 tests, OK, in two environments** at the head under review: CPython 3.14.4, and CPython 3.12.13 with `CHARTER_*` / `CLAUDE_*` / `ANTHROPIC_*` / `TMUX*` unset.
- **CI green at the head sha** — read through `gh api repos/diazoxide/charter/commits/<sha>/check-runs`, which cannot confuse "passed" with "did not run", rather than a rollup that can.
- **All 8 shards reported through the new `upload-artifact` v7 / `download-artifact` v8 pair** (#649): `merged 259 result(s) from 8 of 8 shard(s)` on the previous head. Nothing lost in the round-trip; that was the first 8-shard run on the new pair.
- **No test makes a network call.** Every git invocation the change surface can make is listed in full by a static test, and none of them touches a remote.
- Rebased onto `main` four times as it moved; the last carries #645, #647, #649 and #650. #645 touches `frame/gather.py` and `frame/state.py`, which this branch modifies heavily — the rebase is clean and both changes coexist, verified rather than assumed.

### One flake, chased down — and it was somebody else's, now fixed

Local full-suite runs failed intermittently in `tests/test_frame_input_reaches_a_component.py`, a real-tmux module this branch does not touch. Six different test methods failed across the runs, which is the signature of timing rather than logic. It is **pre-existing and not this branch's**:

- **It reproduced on plain `main` with this branch absent** — 1 failure in 4 full-suite runs at `a23cd61`, on the same test method that failed one of the runs here.
- **Pane geometry is byte-identical** between this branch and `main`: `FRAME_SLOTS`, `FRAME_DENSITY["full"]`, `SLOT_SIZE`, `SLOT_EDGE`, `VARIABLE_ROW_SLOTS` and `SLOT_OF` all compare equal, because `changes` is a *child* of the sidebar and absent from every placement table. The failing cases split real panes and wait on a five-second timeout; nothing here changes how much room they have.
- **This branch's own modules run immediately before it 4/4 clean**, so it was not interference from the new tests.

**#650 has since fixed it** — *"the input test stops reading its own client's arrival as a resize"* — and it is gone: both full-suite environments at this head are clean. The higher local rate on this branch before the fix was duration, not correctness; this branch adds ~155 tests and the machine was at load averages near 70.

One earlier 3.12 failure could not be named at all, because the run's output went through my own `tail -4` and the test name went with it. Recorded rather than quietly dropped.