### PR TITLE
A shard's outcomes survive the trip through the file (#617, fourth recovery)

### DIFF
--- a/docs/news/unreleased-a-green-sweep-is-not-no-survivors.md
+++ b/docs/news/unreleased-a-green-sweep-is-not-no-survivors.md
@@ -91,7 +91,7 @@ kind of pass.
 
 ## The sweep swept the gate that reports it
 
-127 mutations, against a change whose whole subject is the sweep. It found six lines of
+127 mutations, against a change whose whole subject is the sweep. It found seven lines of
 its own that no test went red without.
 
 **The unsharded path had stopped being tested.** Forcing `if shard is not None` to
@@ -130,7 +130,14 @@ heading below carries the same words, so deleting the table row outright left it
 and so did collapsing the cell that holds "2 of 3". A row is a number; the number is
 asserted now, in each of the three shapes it takes.
 
-All six are pinned now. A seventh survivor is not a finding about this code at all: it is a
+**And the outcomes a shard reports did not survive the trip through the file.** The
+merge rebuilds each result from JSON, and the helper that rebuilds a run's outcome could
+be collapsed to "there was none" with every page still matching — because the one place a
+subset's detail is printed is the *not-applied* section, and nothing round-tripped a
+not-applied result. That is the case where a shard says "the edit never landed" and the
+merge has to be able to say why.
+
+All seven are pinned now. An eighth survivor is not a finding about this code at all: it is a
 string inside a *type annotation*, which `from __future__ import annotations` means the
 interpreter never evaluates, so no test can ever go red without it. That is a blind spot
 in the string operator's scoping rather than a guard, and it is filed as one (#632)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -2537,6 +2537,23 @@ class TheAnswerSurvivesTheTripThroughAFile(unittest.TestCase):
         self.assertEqual(here, there)
         self.assertIn("self.assertEqual(f(None), [])", there)
 
+    def test_the_outcome_of_a_mutation_that_never_applied_survives_the_trip(self):
+        """`[31/43]` from the sharded self-sweep, in the half no earlier run reached.
+
+        `results_from_json`'s `outcome()` collapsed to `None` and every page still
+        matched — because the one place a subset's detail is printed is the not-applied
+        section, and the round-trip fixture had no not-applied result in it. A shard
+        reporting "the edit never landed" is the case where the merge has to say WHY, and
+        it was the case nothing round-tripped.
+        """
+        r = _result("unapplied", path="charter/a.py")
+        r.subset = sweep.Outcome(False, 0, "the tree did not match the mutation's origin")
+        back = sweep.results_from_json(sweep.as_json([r]))
+        self.assertEqual(back[0].subset, r.subset)
+        self.assertEqual(back[0].full, r.full)
+        page = sweep.gate_summary(sweep.classify(back), "a" * 40, "b" * 40, None, False)
+        self.assertIn("the tree did not match the mutation's origin", page)
+
     def test_a_survivors_own_platform_is_recomputed_and_not_read_from_the_file(self):
         """The shard that measured it and the machine that merges it are two computers.
         Trusting the shard's answer would let one platform's verdict be reported as


### PR DESCRIPTION
**Fourth merge race tonight, same cause.** I merged #637 while its author was still working; `2998749` landed on the branch afterwards and never reached `main`.

## What it carries, and why losing it was the worst of the four

`results_from_json`'s `outcome()` helper could be collapsed to always-`None` — **dropping every subset and full outcome a shard reports** — and every rendered page still matched. The round-trip test compares a merged summary against a single machine's, and a subset's `detail` prints in exactly one place: the **not-applied** section, which the fixture had no result for.

So `--verdict` could silently discard the evidence behind *"the edit never landed"*. The function is on `main` (line 2480); **the test pinning it is not.** A correct line with nothing behind it, in the tool built to find exactly that.

Three mutants now pinned — collapse both ways, plus retuning the `detail` key.

## Why the shard found it and three serial retries did not

The serial self-sweep died three times, and each restart re-measured the front of the file — never reaching the back. `--shard 1/3` is 43 mutations instead of 127, short enough to survive the pressure, and because the deal is round-robin it samples the **whole** file at once. It reached line 2481 within seventeen mutations.

That is #617's own feature working on its own author's code.

## Seven, all one mistake

Running total: **seven unpinned lines in the gate's own new code**, and all seven are the same shape — *an assertion about the absence of something standing in for one about its value*.

## The rule I have now paid for four times

**A PR head is not a finished state until its author says so.** Green checks are not the signal. Recoveries: #613, #635, #637, this one.

`tests.test_sweep` — 276 tests, OK.