### PR TITLE
A click on a panel stays where it points, even with `[frame] mouse = true` (#634)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -374,6 +374,50 @@ def cmd_probe(args=None) -> int:
     return _report_probe(*frame_ready())
 
 
+#: The pane option that says "this rectangle is a panel charter split off", and the whole
+#: of what `conf_text`'s `MouseDown1Pane` bind asks before it decides whether a click may
+#: move the keyboard. Written by :func:`_panel_mark_argv` on every panel pane charter
+#: creates; never on the harness pane, never on the palette's, never on a pane the
+#: operator split themselves.
+#:
+#: **PANE-scoped, which is the narrowest thing tmux has, and that is why it is the marker
+#: rather than a window option holding the harness's own `%N`.** The issue that asked for
+#: this (#634) sketched the other shape — `set -w @charter_harness_pane <harness id>` plus
+#: `#{==:#{pane_id},#{@charter_harness_pane}}` in the bind — and then asked whether that id
+#: would be a second write free to drift from `overlay.HATCH_OPTION`'s. It would have been;
+#: this shape has no id in it at all, so there is nothing to drift. A pane option also dies
+#: with the pane, so nothing charter writes here outlives the frame on a server every other
+#: frame shares — the "last launched wins" trap this module's own docstrings keep naming.
+#:
+#: The value is charter's own constant and so is the name: both halves reach a tmux option
+#: that a `bind` line later FORMAT-EXPANDS, which is `_HOTKEY_RE`'s hazard one option over,
+#: and no operator string is anywhere near either.
+#:
+#: **A pane option is not inherited by a pane split off the one carrying it** — measured on
+#: 3.7c and at `tmuxctl.FLOOR`, `split-window -t <a marked panel>` producing a child whose
+#: `#{@charter_panel}` reads `''` on both. That is the answer to the sharpest form of "what
+#: about a pane the operator split themselves": even splitting one out of a PANEL leaves it
+#: tmux's pane rather than charter's, and a click on it selects it the way every pane in
+#: their own tmux does. Pinned by `test_frame_input_reaches_a_component.py`, because it is
+#: a fact about tmux and this comment would otherwise be the only thing asserting it.
+_PANEL_OPTION = "@charter_panel"
+
+#: What :data:`_PANEL_OPTION` is set to, and it is a DIGIT rather than a word for a
+#: measured reason. `if-shell -F` reads its condition the way tmux reads any format
+#: truth-value, which is not the way an operator reads `on`/`off` — probed on tmux 3.7c
+#: and at `tmuxctl.FLOOR`, identical on both::
+#:
+#:     '1' -> TRUE     '0'  -> FALSE     (unset/'') -> FALSE
+#:     '2' -> TRUE     'on' -> TRUE      'off'      -> TRUE
+#:
+#: So `off` would have marked every panel as a panel, and only the empty string and `0`
+#: are false. `1` is the shortest value that is true, it is charter's own literal rather
+#: than anything read off a config file, and the UNSET row is what makes "not a charter
+#: panel" the default answer for every pane charter never marked — the harness's, the
+#: palette's, and the operator's own.
+_PANEL_MARK = "1"
+
+
 def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
               toggles: dict | None = None) -> str:
     """The private tmux config for one frame's own settings. Never `~/.tmux.conf`.
@@ -391,6 +435,61 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
     there being no such thing as a per-session keymap, and every frame wants the
     identical binding anyway, so nothing is lost by sharing it the same way
     `remain-on-exit` is (see `_PLACEHOLDER_CONF`).
+
+    **`MouseDown1Pane` is the second such bind, and it is what keeps `click` point-to-act
+    once `[frame] mouse = true` (#634).** tmux's own default for that key is `select-pane
+    -t = \\; send-keys -M`: with its mouse on, tmux moves the keyboard to the pane under
+    the pointer *before* forwarding the click. So the flag an operator turns on precisely
+    because they want to click panels was the flag that took the property away, and the
+    wheel — which tmux forwards without selecting — never did it. Charter rebinds the key
+    to ask **whose rectangle the pointer is over** and answer separately:
+
+    * a pane charter marked as a panel (:data:`_PANEL_OPTION`) — forward and **do not**
+      select, which is exactly what `frame/events.py` delivers and what the frame is for;
+    * anything else — the harness pane, the palette's pane, a pane the operator split
+      themselves — **tmux's own two commands, unchanged**, so clicking BACK to a pane
+      still works.
+
+    That second row is the whole reason this is a conditional and not `bind -n
+    MouseDown1Pane send -M`. Measured on tmux 3.7c and at `tmuxctl.FLOOR` (3.2)
+    identically, real server, real client on a real pty, `mouse on`, three panes — a
+    marked panel, the harness, and one more split by hand standing in for the operator's
+    — with SGR reports injected as a reporting terminal sends them::
+
+        bind              click a panel        click back to harness   click own split
+        tmux's default    delivered, MOVED     works                   works
+        blanket send -M   delivered, unchanged BROKEN (stays put)      BROKEN (stays put)
+        this one          delivered, unchanged works                   works
+
+    The blanket row is not a milder version of the same thing; it takes away clicking back
+    to any pane at all, harness included, which is worse than the focus steal it fixes.
+
+    **The marker is on the PANEL, not on the harness, and that decides the third case.**
+    The issue sketched the mirror image — a window option holding the harness pane's own
+    `%N`, compared with `#{==:#{pane_id},#{@charter_harness_pane}}` — and asked first
+    whether that format parses at the floor. It does: measured on a 3.2 built from the
+    release tarball, `#{==:}` with a nested `#{pane_id}` and a nested user option
+    evaluates to `1` on the harness and `0` on a panel, and the whole `bind` line
+    `source-file`s at rc 0 and reads back byte for byte through `list-keys`. The format
+    was available and the SHAPE is what is refused: marking the harness makes every pane
+    that is not the harness un-clickable-to, so a pane the operator split inside charter's
+    window would stop taking the keyboard on a click — tmux's documented behaviour
+    removed from a pane charter has nothing to do with. Marking the panels leaves that
+    pane exactly as tmux left it, and leaves no pane id in the binding to drift from the
+    one `overlay.HATCH_OPTION` already holds.
+
+    **Bound whatever `mouse` says, like the wheel above and for a sharper reason than
+    symmetry.** A root key table is server-wide and `source-file` can only ADD a binding —
+    omitting this line on a `mouse = false` launch would not unbind what a `mouse = true`
+    frame on the same socket already bound, so gating it would buy nothing and make the
+    root table depend on launch order. It costs a `mouse = false` frame nothing either
+    way: with tmux's own mouse off tmux runs no mouse binding at all, and the reports go
+    to whichever pane the terminal was already reporting for.
+
+    `MouseDown1Pane` and `WheelUpPane` are both in `instance.component_tables`'s set of
+    keys a component may not claim, for `HATCH_KEY`'s reason exactly — both are written
+    here BEFORE the toggles, so tmux's last-wins would leave charter's mouse handling
+    silently deleted and `list-keys` reading back one line where two were meant (#566).
 
     **`focus-events` is the THIRD genuine server option here, and it is written `-g` for
     exactly `escape-time`'s reason.** Spec §4f closes the component event kinds at six,
@@ -587,8 +686,10 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
         "set -g focus-events on",
         f"bind -n {hotkey} run-shell "
         f"'\"${_CHARTER_PY_ENV}\" -m charter frame-palette \"#{{client_name}}\"'",
-        "bind -n WheelUpPane if-shell -F -t = '#{mouse_any_flag}'"
+        f"bind -n {tmuxctl.WHEEL_KEY} if-shell -F -t = '#{{mouse_any_flag}}'"
         " 'send-keys -M' 'copy-mode -e; send-keys -M'",
+        f"bind -n {tmuxctl.CLICK_KEY} if-shell -F -t = '#{{{_PANEL_OPTION}}}'"
+        " 'send-keys -M' 'select-pane -t =; send-keys -M'",
     ]
     for name, key in (toggles or {}).items():
         if not component.usable_id(name):
@@ -1805,6 +1906,47 @@ def _surface_argvs(*, socket: str, pane_id: str, chrome, bg=None,
                                                     pane_borders=pane_borders))]
 
 
+def _panel_mark_argv(*, socket: str, pane_id: str) -> list[str]:
+    """`set-option -p`: say that THIS pane is a panel charter split off, and no other.
+
+    The write half of :data:`_PANEL_OPTION`; `conf_text`'s `MouseDown1Pane` bind is the
+    read half, and between them they are the whole of why a click on a panel does not take
+    the keyboard off the harness once `[frame] mouse = true` (#634).
+
+    **Beside `_surface_argvs` and issued from the same funnel, for the same measured
+    reason** — `_split_panels` is the one place every panel pane charter creates comes out
+    of, so both launch paths and every density change mark a pane as it appears rather
+    than by a second pass that could forget one. A pane a later `_relayout` adds is marked
+    when it is created; a pane `cmd_respawn` brings back keeps the mark, because a respawn
+    reuses the same `%N` and this is a property of the rectangle rather than of the process
+    in it — the argument `_surface_argvs` already makes one option over.
+
+    **Unlike `_surface_argvs` it is NOT gated on `NO_COLOR`, and that difference is the
+    point.** A surface is something an operator can ask charter not to paint. This is
+    routing: it decides where a click goes and where the keyboard stays, and an operator
+    who set `NO_COLOR` asked for no colour, not for their clicks to start moving the
+    keyboard. Nothing here reaches a screen.
+
+    **Written on BOTH servers, and inside the operator's own tmux it marks a pane nothing
+    reads.** `conf_text` is sourced only against charter's private `SOCKET` — charter does
+    not rebind keys in a server it does not own, and `_launch_in_operator_tmux` is
+    explicit that it must not — so inside an operator's tmux this is a user option on a
+    pane charter created, carrying charter's namespace, dying with the pane, and changing
+    nothing. That is the same reach `_surface_argvs` and `_panel_remain_on_exit_argv`
+    already have there. It is written on both anyway rather than gated on which server,
+    because a mark that existed on one is a second thing for `_split_panels` to be right
+    about, and the value of getting it wrong is a focus steal that only reproduces on one
+    of two paths.
+
+    A plain `list[str]`, never ``None``: both arguments are charter's own — *pane_id* is a
+    `%N` this module just read back off `split-window` and held to `_PANE_ID_RE` before it
+    got here, and the name and value are the two constants above — so there is no value
+    this can be handed that it would have to decline.
+    """
+    return tmuxctl.server_argv(socket, "set-option", "-p", "-t", pane_id,
+                               _PANEL_OPTION, _PANEL_MARK)
+
+
 def _resurface_argvs(*, socket: str, pane_id: str, chrome, bg=None,
                      pane_borders: bool = False) -> list[list[str]]:
     """:func:`_surface_argvs` for a pane that is ALREADY DRAWN — with the unsets.
@@ -2334,6 +2476,12 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     server and bare on the other, and a pane added by a later `_relayout` is surfaced when
     it is created rather than by a second pass that could forget it.
 
+    **And the PANEL MARK, for that third time and the same reason** (`_panel_mark_argv`,
+    #634). It is the pane option `conf_text`'s `MouseDown1Pane` bind asks before it lets a
+    click move the keyboard, so a panel that reached the operator's screen without it is a
+    panel that steals focus the first time it is clicked. A funnel is the only place that
+    can promise every panel has one.
+
     Reported but not fatal, like the splits themselves: a frame whose panels cannot be
     respawned is still a frame, and the harness pane's own `remain-on-exit` was armed
     separately and earlier (`_remain_on_exit_argv`), so the exit code does not ride on
@@ -2394,6 +2542,15 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
         pane_id = p.stdout.strip()
         if pane_id and _PANE_ID_RE.fullmatch(pane_id):
             panes[slot] = pane_id
+            # This pane is a PANEL, said to tmux itself where a root-table binding can ask
+            # (#634, `_panel_mark_argv`). It goes before the surface rather than after
+            # because it is the only one of the two that decides where a click goes: a
+            # panel that came up unmarked takes the keyboard off the harness the first
+            # time it is clicked, which is the whole defect. Reported but not fatal, like
+            # the splits and the surface — a panel charter could not mark still draws and
+            # is still clicked, it just costs the operator an `F12` afterwards.
+            tmuxctl.run("marking a panel so a click on it stays where it points",
+                        _panel_mark_argv(socket=socket, pane_id=pane_id), env=env)
             # The pane surface, on the pane that was just created and on no other — the
             # one place charter has a panel's `%N` in hand. The harness pane is never an
             # argument (`_surface_argvs`), which is how ADR 0018's boundary holds by

--- a/charter/frame/events.py
+++ b/charter/frame/events.py
@@ -76,16 +76,21 @@ owed before they set it::
 
     tmux mouse on
       wheel over the panel   ->  panel receives it        active: harness   (unchanged)
-      click over the panel   ->  panel receives it        active: PANEL     (moved)
+      click over the panel   ->  panel receives it        active: harness   (unchanged)
 
-**With tmux's own mouse on, a click moves the keyboard**, because tmux's default
-``MouseDown1Pane`` binding selects the pane under the pointer before forwarding. That is
-tmux's semantics for the flag and not something this module can dissolve from inside a
-pane; charter does not rebind it here, and `docs/frame.md` says so beside the trade. The
-wheel never moves it, on either version. So point-to-act is exactly what the flag OFF
-gives, and the flag ON buys certainty about delivery with the keyboard following the
-pointer on click — which is the shape of the argument, stated, rather than a default
-quietly chosen for the operator.
+**That second row used to read `active: PANEL (moved)`, and closing it is #634.** tmux's
+default ``MouseDown1Pane`` binding selects the pane under the pointer before forwarding,
+so with its own mouse on a click moved the keyboard — the one regime in which this
+module's point-to-act delivery disagreed with what the operator actually saw, and the
+regime an operator opts into *because* they want to click panels. It is not something this
+module can dissolve from inside a pane: the fix is a root-table rebind, conditional on the
+pane under the pointer being one charter split off, and it lives in
+`commands_frame.conf_text` with its measurement. `docs/frame.md` says it beside the trade.
+
+The wheel never moved it, on either version. So point-to-act is now what the flag gives in
+both settings, and what ON still buys — and still costs — is certainty that the event
+fires at all, paid for with the terminal's own drag-select. That trade is unchanged and
+unavoidable; only the keyboard's part of it went away.
 
 **A pointer event is translated into the component's own columns before it is delivered**,
 and that is charter's subtraction rather than tmux's — :meth:`Dispatcher._on_canvas` is the

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -147,6 +147,31 @@ PANE_BORDER_FLOOR = (3, 7)
 #: `commands_frame._charter_py_env_argv` for why the value travels out of band at all.
 CHARTER_PY_ENV = "CHARTER_PY"
 
+#: The mouse wheel, and the root-table key charter rebinds so the wheel scrolls tmux's own
+#: buffer rather than the terminal's (`commands_frame.conf_text`).
+WHEEL_KEY = "WheelUpPane"
+
+#: A left click on a pane, and the root-table key charter rebinds so a click on a PANEL
+#: does not move the keyboard off the harness (#634, `commands_frame.conf_text`). tmux's
+#: own default for it is `select-pane -t = \; send-keys -M`, which is the focus steal.
+CLICK_KEY = "MouseDown1Pane"
+
+#: Both of them, as the set of mouse keys charter binds for every frame on its own server.
+#:
+#: Defined HERE for :data:`CHARTER_PY_ENV`'s reason exactly — two modules need the same
+#: names for two different jobs and neither may spell them itself.
+#: `commands_frame.conf_text` WRITES a `bind -n` for each; `instance.component_tables`
+#: REFUSES each to a component's ``key``, because both lines are emitted before the toggle
+#: binds and tmux's key tables have no notion of a conflict — a later `bind -n` simply
+#: replaces the earlier, so a component claiming one would delete charter's mouse handling
+#: for every frame on the socket and `list-keys` would read back one line where two were
+#: meant (#566). Two spellings of these names is that deletion waiting for the day they
+#: stop matching.
+#:
+#: Both names pass `instance._HOTKEY_RE` — they are alphanumerics under twenty characters —
+#: so this is a reachable claim rather than a theoretical one.
+MOUSE_KEYS = (WHEEL_KEY, CLICK_KEY)
+
 #: How long any one tmux ADMIN command may take before charter stops waiting for it.
 #: Every command the launcher issues is a local, in-process request to a server on a
 #: unix socket; none of them is supposed to take measurable time at all, so a command

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -1066,36 +1066,37 @@ FRAME_FIELDS = {
     #: The palette is the exception and does not need this flag: while it is open it is
     #: the active surface, so its own request is the one that reaches the terminal.
     #:
-    #: **And there is a SECOND cost to turning it on, measured when charter began
-    #: delivering the pointer and owed to anyone about to set this.** With tmux's own
-    #: mouse on, tmux does not merely report a click — its default `MouseDown1Pane`
-    #: binding SELECTS the pane under the pointer before forwarding it. Measured on 3.7c
-    #: and at the 3.2 floor, identically — **with the terminal already reporting in both
-    #: rows**, which off the flag is the harness's doing and not charter's, and is the
-    #: precondition the paragraph above is entirely about::
+    #: **The SECOND cost this flag used to carry is gone, and what replaced it is a
+    #: change of tmux's semantics an operator who already set it should know about
+    #: (#634).** tmux's default `MouseDown1Pane` binding is `select-pane -t = \; send-keys
+    #: -M`: with its own mouse on, tmux SELECTS the pane under the pointer before
+    #: forwarding the click, so every click on a panel took the keyboard off the harness.
+    #: Charter now rebinds that key — see `commands_frame.conf_text` for the binding, its
+    #: measurement and why it is conditional rather than blanket. Measured on 3.7c and at
+    #: the 3.2 floor, identically — **with the terminal already reporting in every row**,
+    #: which off the flag is the harness's doing and not charter's, and is the precondition
+    #: the paragraph above is entirely about::
     #:
-    #:     mouse off  click a panel  -> panel receives it,  active pane: the harness
-    #:     mouse ON   click a panel  -> panel receives it,  active pane: THE PANEL
-    #:     either     wheel a panel  -> panel receives it,  active pane: the harness
+    #:     mouse off  click a panel   -> panel receives it,  active pane: the harness
+    #:     mouse ON   click a panel   -> panel receives it,  active pane: the harness
+    #:     either     wheel a panel   -> panel receives it,  active pane: the harness
+    #:     mouse ON   click the HARNESS or a pane the operator split -> that pane, as tmux
     #:
     #: So the first row is not a promise that a click arrives with the flag off. It is the
     #: answer to a different question — *if* one arrives, does it move the keyboard — and
     #: the two must not be read as one, because with the flag off and the harness asking
     #: for nothing the terminal is never asked to report and no click happens at all.
     #:
-    #: So with this on, clicking a panel takes the keyboard off the harness until the
-    #: operator puts it back (`overlay.HATCH_KEY`, or their own prefix keys) — which is
-    #: exactly the click-to-focus charter's own delivery refuses to do, arriving from tmux
-    #: instead. The wheel never does it, on either version.
+    #: **What ON still costs is the drag-select above, and that has not changed.** The
+    #: paragraph that opens this comment is the whole of the trade and it is still
+    #: unavoidable; this only removes a second cost that was never tmux's price for
+    #: reporting, only its default for one key.
     #:
-    #: Charter does not rebind `MouseDown1Pane` to prevent it, and that is a decision
-    #: rather than an omission: `bind -n` writes tmux's ROOT key table, which is
-    #: server-wide and shared by every frame on charter's private server
-    #: (`commands_frame.conf_text` records what a bind carrying one frame's assumptions
-    #: costs the next), and dropping the `select-pane` would also take away clicking BACK
-    #: to a pane — including the harness. Point-to-act is what this flag OFF already
-    #: gives; what ON buys is certainty that the event fires at all, and the keyboard
-    #: following a click is the price of tmux's own semantics for the setting.
+    #: The rebind is charter changing a documented tmux behaviour inside its own private
+    #: server, which is why it is written down in three places rather than one: an
+    #: operator who set `mouse = true` before this release and put the keyboard back with
+    #: `overlay.HATCH_KEY` after every click will find they no longer have to, and a click
+    #: on a pane charter did not create still selects it exactly as tmux says.
     "mouse": (False, "mouse"),
     #: The pane surface, off by default — see :data:`FRAME_CHROME` for what the three
     #: words mean, why there is no fourth, and why the value is a word rather than a
@@ -1496,16 +1497,18 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
     *hotkey* is the key the frame's own palette is bound to — resolved by :func:`frame_of`
     before it calls this, because the comparison has to be against what will actually be
     bound, not against the shipped constant a plane may have moved off. It joins
-    `frame/overlay.py`'s ``HATCH_KEY`` in the set of keys charter has already taken, and a
-    component may have neither. ``None`` means the caller has no palette key to reserve,
-    which is what resolving an arrangement outside a `[frame]` section has; the hatch is
-    reserved regardless, because charter binds it for every frame on its own server.
+    `frame/overlay.py`'s ``HATCH_KEY`` and `frame/tmuxctl.py`'s ``MOUSE_KEYS`` in the set
+    of keys charter has already taken, and a component may have none of them. ``None``
+    means the caller has no palette key to reserve, which is what resolving an arrangement
+    outside a `[frame]` section has; the hatch and the two mouse keys are reserved
+    regardless, because charter binds all three for every frame on its own server.
     """
     tables = section.get(FRAME_COMPONENT_KEY) if isinstance(section, dict) else None
     if not isinstance(tables, list) or not tables:
         return None
     from .frame import builtins as _builtins
     from .frame import overlay as _overlay
+    from .frame import tmuxctl as _tmuxctl
     from .frame.component import EDGES, Fixed
     reg = _builtins.build()
     out: list[dict] = []
@@ -1515,7 +1518,22 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
     # the hatch key is an import, and this line runs only once a plane has actually
     # written `[[frame.component]]` tables — `frame_of` itself is on the path of every
     # command, `charter --version` included, and must stay as cheap as it was.
-    bound: set[str] = {k for k in (hotkey, _overlay.HATCH_KEY) if k}
+    # `frame/tmuxctl.py` costs nothing extra: `frame/overlay.py` imports it already.
+    #
+    # The two MOUSE keys are here for the hatch's reason with the sign flipped. `conf_text`
+    # writes them BEFORE the toggles, so tmux's last-wins leaves the COMPONENT's key alive
+    # and charter's mouse handling silently gone — the wheel stops entering copy-mode and,
+    # since #634, a click on a panel goes back to taking the keyboard off the harness. One
+    # dead binding, nothing anywhere saying which, and the frame still launching at rc 0.
+    # Named off `tmuxctl.MOUSE_KEYS` rather than spelled here, so the key this refuses is
+    # the same object `conf_text` binds.
+    #
+    # `if k` drops a falsy *hotkey* — ``None`` for every caller with no palette key to
+    # reserve — and it is the ONE place this set's invariant is established: `bound` holds
+    # real keys and nothing else. The collision test below leans on that rather than
+    # re-checking, so this filter is load-bearing; see the comment there for what a
+    # ``None`` in here would cost.
+    bound: set[str] = {k for k in (hotkey, _overlay.HATCH_KEY, *_tmuxctl.MOUSE_KEYS) if k}
     for table in tables:
         if not isinstance(table, dict):
             return None
@@ -1562,7 +1580,17 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
         #   order — a guard whose consequence depends on where two other lines are
         #   emitted is a guard nothing can pin (#553), which is the same trap one level
         #   up from the one this sweep exists to catch.
-        if key is not None and key in bound:
+        #
+        # **No `key is not None` in front of this, and that is what makes the `if k`
+        # filter above load-bearing rather than decorative.** *hotkey* is ``None`` for
+        # every caller resolving an arrangement outside a `[frame]` section, so without
+        # that filter ``bound`` would hold a ``None`` — and a component that simply
+        # declares no toggle key (the common case: `key` absent, so ``key is None``)
+        # would collide with it and take the WHOLE arrangement down, panels and all.
+        # Guarding here instead would have made the filter unobservable, which is exactly
+        # the shape the deletion sweep calls a survivor: a line nothing can fail without.
+        # One invariant, stated once, where it is established.
+        if key in bound:
             return None
         if key is not None:
             bound.add(key)

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -84,19 +84,28 @@ in that panel's own cells, and never selects the pane — the frame exists to ke
 harness the thing you type into, and a click that quietly moved the keyboard somewhere
 else would be the opposite of that. Measured on tmux 3.7c and 3.2 alike.
 
-**With `mouse = true`, tmux itself moves the keyboard on a click, and charter cannot stop
-it.** That is tmux's own behaviour for the setting: with its mouse on, tmux selects the
-pane under the pointer before handing the click on. So turning this on buys you clicks
-that always work, and costs you a keyboard that follows them — press `F12` to get back to
-the harness. The wheel never moves it, either way. Both measured on 3.7c and 3.2:
+**If you already set `mouse = true`, this release stops your clicks moving the keyboard —
+you no longer need `F12` after clicking a panel.** Until now, tmux's own default binding
+selected the pane under the pointer before handing the click on, so `mouse = true` bought
+you clicks that always work and cost you a keyboard that followed them. Charter now
+rebinds that one key inside its own private tmux server, and only for the panes it created
+itself: **a click on a panel acts where you pointed and leaves your keyboard on the
+harness, while a click on the harness — or on any pane you split yourself inside the frame
+— still selects it, exactly as tmux documents.** The wheel never moved the keyboard and
+still does not. Both measured on 3.7c and 3.2:
 
 | | `mouse = false` (default) | `mouse = true` |
 |---|---|---|
 | does a click reach the panel? | only while the active pane is asking your terminal to report — your harness decides | always, from the moment you attach |
-| does a click move your keyboard? | **no** | **yes**, to the panel you clicked |
+| does a click on a panel move your keyboard? | **no** | **no** |
+| does a click on the harness, or a pane you split, move your keyboard? | no — with its mouse off tmux runs no mouse binding at all | yes — tmux's own behaviour, untouched |
 | does the wheel move your keyboard? | no | no |
 | do you keep native drag-select? | while no mouse-requesting pane is active | no |
 | a click on a pane border | reaches nobody — a border is a cell in neither pane | reaches nobody |
+
+The drag-select row is the trade `mouse = true` makes, and it has not changed and will not:
+it is how tmux works, not a default charter chose. What went away was a second cost that was
+never part of that trade — one key's default behaviour, in a server charter owns.
 
 One consequence of that first column worth knowing, because it is new: a panel whose
 component declares `click` or `scroll` asks *its own* terminal to report, so if you select

--- a/docs/news/unreleased-a-click-acts-where-you-pointed.md
+++ b/docs/news/unreleased-a-click-acts-where-you-pointed.md
@@ -87,23 +87,22 @@ harness active and not asking, a click on a panel produces no bytes at all. Noth
 dropped — the event never happens. Whether it does is decided by the program you ran, which
 charter does not own. **Give every pointer affordance a key as well.**
 
-Turning it on makes reporting unconditional, and there are now two prices rather than one.
-The first was already documented: you lose your terminal's own drag-select, and no release
-will ever remove that. The second was measured for this change and is new to the docs:
+Turning it on makes reporting unconditional, and the price is that you lose your terminal's
+own drag-select. No release will ever remove that one — it is how tmux works.
 
 ```
 mouse off  click a panel  ->  panel receives it,  active pane: the harness
-mouse ON   click a panel  ->  panel receives it,  active pane: THE PANEL
+mouse ON   click a panel  ->  panel receives it,  active pane: the harness
 either     wheel a panel  ->  panel receives it,  active pane: the harness
 ```
 
-With tmux's own mouse on, tmux selects the pane under the pointer before forwarding the
-click. That is click-to-focus arriving from tmux rather than from charter, and charter does
-not rebind it away: the binding that would have to change is in tmux's root key table, which
-is server-wide and shared by every frame charter launches, and dropping it would also take
-away clicking back to a pane — including your harness. `F12` still returns you to it.
+A *second* price was measured for this change and briefly documented: with tmux's own mouse
+on, tmux's default binding selected the pane under the pointer before forwarding, so a click
+took your keyboard off the harness. **That is fixed in this same release — see *A click on a
+panel stays where it points* — so the table above reads the same in both rows.** A click on
+the harness, or on a pane you split yourself, still selects it exactly as tmux documents.
 
-Point-to-act is therefore what `mouse = false` gives you, and what `mouse = true` buys is
+Point-to-act is therefore what `mouse` gives you either way, and what `mouse = true` buys is
 certainty that the event fires at all. The wheel never moves your keyboard either way.
 
 ## What has not changed

--- a/docs/news/unreleased-a-click-on-a-panel-stays-where-it-points.md
+++ b/docs/news/unreleased-a-click-on-a-panel-stays-where-it-points.md
@@ -1,0 +1,67 @@
+---
+version: unreleased
+headline: A click on a panel stays where it points, even with `[frame] mouse = true`
+---
+
+**If you already set `[frame] mouse = true`, this is the line to act on: your clicks stop
+moving the keyboard, so you no longer need `F12` after clicking a panel. A click on the
+harness — or on a pane you split yourself inside the frame — still selects it, exactly as
+tmux documents.**
+
+`click` and `scroll` shipped point-to-act: charter delivers a pointer event to whichever
+panel it landed on, in that panel's own cells, and never selects the pane, because the
+frame exists to keep the harness the thing you type into. That property held with
+`[frame] mouse` off and broke with it on — and on is the setting an operator turns on
+*precisely because* they want to click panels. The setting that made the feature reliable
+was the setting that made it hostile.
+
+The cause was tmux's default root binding, `MouseDown1Pane  select-pane -t = \; send-keys
+-M`: with its own mouse on, tmux selects the pane under the pointer before forwarding the
+click. The wheel never did this — only the click.
+
+Charter now rebinds that one key inside its own private tmux server, **conditionally on
+which pane the pointer is over**. Every pane charter splits off for a panel is marked with
+a pane-scoped option; the binding asks for it and answers separately:
+
+| with `mouse = true`, a click on… | before | now |
+|---|---|---|
+| a charter panel | delivered — **keyboard moved to the panel** | delivered — **keyboard stays on the harness** |
+| the harness pane | selects it | selects it |
+| a pane you split yourself | selects it | selects it |
+| any of them, with the wheel | never moved the keyboard | never moves the keyboard |
+
+**The conditional is the whole design, and a blanket rebind was measured before it was
+rejected.** `bind -n MouseDown1Pane send -M` fixes the first row and breaks the next two:
+it takes away clicking back to *any* pane, the harness included, which is worse than the
+focus steal it fixes. That was measured, not reasoned about — real server, real client on
+a real pty, reports injected as a reporting terminal sends them, on **tmux 3.7c and at the
+3.2 floor built from the release tarball**, twelve cells, identical on both:
+
+| bind | click a panel | click back to the harness | click your own split |
+|---|---|---|---|
+| tmux's own default | delivered, **keyboard moved** | works | works |
+| blanket `send -M` | delivered, unchanged | **broken** — stays put | **broken** — stays put |
+| charter's, conditional | delivered, unchanged | works | works |
+
+**The open question the issue left was whether the format even parses at charter's floor,
+and it does.** `#{==:}` with nested formats evaluates correctly on tmux 3.2, and a `bind`
+line carrying it sources at rc 0 and reads back byte for byte. So the format was available
+and the *shape* was what got refused: the marker is on the panels rather than on the
+harness, because marking the harness would make every other pane un-clickable-to — taking
+tmux's documented behaviour away from a pane you split yourself, which charter has nothing
+to do with. Marking the panels leaves that pane exactly as tmux left it, and leaves no pane
+id in the binding at all to drift from the one the escape hatch already holds.
+
+**What this does not change: the trade `mouse = true` makes.** Turning it on still costs
+you your terminal's own drag-select, for as long as any mouse-requesting pane is active.
+That is how tmux works, it was measured on 3.1c, 3.2 and 3.7c, and no release will remove
+it — `mouse` still defaults to **off** for exactly that reason. What went away was a second
+cost that was never part of that trade: one key's default behaviour, in a server charter
+owns.
+
+Both mouse keys charter binds — `MouseDown1Pane` and `WheelUpPane` — join the frame's
+hotkey and the `F12` escape hatch in the set a component may not claim as its toggle key.
+Both are ordinary alphanumeric key names, so a `[[frame.component]]` could have taken
+either; tmux key tables have no notion of a conflict, so unrefused that would have deleted
+charter's mouse handling for every frame on the socket with `list-keys` reading back one
+line where two were meant, and nothing anywhere saying which.

--- a/tests/test_a_click_on_a_panel_stays_where_it_points.py
+++ b/tests/test_a_click_on_a_panel_stays_where_it_points.py
@@ -1,0 +1,292 @@
+"""`[frame] mouse = true` stops taking the keyboard off the harness on every click (#634).
+
+Charter delivers `click` and `scroll` point-to-act: it acts where the pointer is and never
+moves focus, because the frame exists to keep the harness the thing you type into. That
+held with `[frame] mouse` off and broke with it on — and on is the setting an operator
+turns on precisely *because* they want to click panels, so the setting that made the
+feature reliable was the setting that made it hostile.
+
+The cause is tmux's, and so is the fix. tmux's default root binding is
+``MouseDown1Pane  select-pane -t = \\; send-keys -M``: with its own mouse on it selects the
+pane under the pointer *before* forwarding. The wheel never does this. Charter rebinds that
+one key inside its own private server, **conditionally on the pane under the pointer being
+one charter split off**, so:
+
+* a panel — forward, do not select;
+* the harness, the palette's pane, a pane the operator split themselves — tmux's own two
+  commands, untouched.
+
+Three files hold the mechanism and this one asks about all three: the pane option
+(`commands_frame._PANEL_OPTION`), the write that puts it on every panel
+(`_panel_mark_argv`, from `_split_panels`' single funnel), and the bind that reads it
+(`conf_text`). `tests/test_frame_input_reaches_a_component.py` is the real-tmux half — it
+can say what tmux does with a real click and cannot say whether charter ever wrote the
+option; this file is the other way round.
+
+**Every expected string here is a literal.** A case that built its expectation out of
+`_PANEL_OPTION` would still pass with the constant mutated to anything at all, which is
+the survivor `commands_change.BLOCK_END` produced this week. So the option name, the value
+and the whole bind line are spelled out, and a change to any of them is a change to this
+file as well.
+
+Measured, and the measurement is what chose the conditional over the two alternatives —
+real tmux server, real client on a real pty, ``mouse on``, three panes (a marked panel, the
+harness, and one more split by hand standing in for the operator's own), SGR reports
+injected as a reporting terminal sends them. **tmux 3.7c and tmux 3.2 —
+`tmuxctl.FLOOR`, built from the release tarball — answered identically in all twelve
+cells**::
+
+    bind                      click a panel          click back to harness  click own split
+    tmux's own default        delivered, MOVED       works                  works
+    blanket `send -M`         delivered, unchanged   BROKEN, stays put      BROKEN, stays put
+    charter's (conditional)   delivered, unchanged   works                  works
+
+The blanket row is why this is not two words shorter. Dropping the `select-pane` outright
+also takes away clicking back to a pane at all — the harness included — which is worse than
+the focus steal it fixes.
+
+**The issue's own open question, settled by measurement rather than reasoning: `#{==:}`
+DOES parse and evaluate at the 3.2 floor.** On that same 3.2,
+``#{==:#{pane_id},#{@charter_harness_pane}}`` evaluated to ``1`` on the harness pane and
+``0`` on a panel, and a `bind` line carrying it returned rc 0 from `source-file` and read
+back byte for byte through `list-keys`. So the format was available and the SHAPE is what
+is refused: marking the *harness* and treating every other pane as un-clickable-to would
+take tmux's documented behaviour away from a pane charter has nothing to do with — the one
+the operator split themselves. Marking the *panels* leaves that pane exactly as tmux left
+it, and leaves no pane id in the binding at all to drift from the one
+`overlay.HATCH_OPTION` already holds.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import commands_frame, instance
+from charter.frame import overlay, tmuxctl
+
+
+def _text(*, mouse: bool = True, toggles=None) -> str:
+    return commands_frame.conf_text(hotkey="F2", mouse=mouse, history_limit=1,
+                                    session="fr-1", toggles=toggles)
+
+
+def _click_line(text: str) -> str:
+    return next(ln for ln in text.split("\n") if ln.startswith("bind -n MouseDown1Pane"))
+
+
+class TheBindCharterWrites(unittest.TestCase):
+    """What `conf_text` actually puts in the file `source-file` parses."""
+
+    def test_the_click_bind_is_the_line_that_was_measured(self):
+        """The whole line, byte for byte, as a literal — this is the string a real tmux
+        was asked to parse on 3.7c and at the floor, and a test that assembled it from
+        the same pieces the code assembles it from would agree with any of them."""
+        self.assertIn(
+            "bind -n MouseDown1Pane if-shell -F -t = '#{@charter_panel}' "
+            "'send-keys -M' 'select-pane -t =; send-keys -M'",
+            _text())
+
+    def test_a_panel_is_forwarded_to_and_never_selected(self):
+        """The true branch is `send-keys -M` ALONE. A `select-pane` that crept back into
+        it would restore the exact defect, and every other assertion in this file would
+        still pass — the line would still be present, still conditional, still last-wins
+        safe."""
+        line = _click_line(_text())
+        true_branch = line.split("'")[3]
+        self.assertEqual(true_branch, "send-keys -M")
+
+    def test_every_other_pane_keeps_tmuxs_own_two_commands(self):
+        """The false branch is tmux's default behaviour, restated. This is what keeps
+        clicking BACK to the harness — and into a pane the operator split themselves —
+        working, and it is the difference between this and `bind -n MouseDown1Pane
+        send -M`, which was measured to break both."""
+        line = _click_line(_text())
+        false_branch = line.split("'")[5]
+        self.assertEqual(false_branch, "select-pane -t =; send-keys -M")
+
+    def test_it_is_bound_whatever_the_mouse_setting_says(self):
+        """Not gated on *mouse*, and the reason is sharper than symmetry with the wheel: a
+        root key table is server-wide and `source-file` can only ADD a binding. Omitting
+        the line on a `mouse = false` launch would not unbind what a `mouse = true` frame
+        on the same socket already bound, so a gate would buy nothing and make the root
+        table depend on launch order."""
+        for mouse in (True, False):
+            with self.subTest(mouse=mouse):
+                self.assertIn("bind -n MouseDown1Pane", _text(mouse=mouse))
+
+    def test_the_click_bind_sits_between_the_palette_and_the_hatch(self):
+        """Both ends load-bearing, for the reasons `conf_text` already argues about the
+        toggles: after the palette so a colliding key would visibly steal something (which
+        is what keeps `component_tables`' refusal pinnable), and before
+        `overlay.hatch_bind()` so a tmux below `tmuxctl.FLOOR` — which cannot parse
+        `run-shell -C` — has already applied this line by the time it drops that one."""
+        lines = _text(toggles={"repos": "F7"}).split("\n")
+        palette = next(i for i, ln in enumerate(lines) if "frame-palette" in ln)
+        click = next(i for i, ln in enumerate(lines) if "MouseDown1Pane" in ln)
+        hatch = next(i for i, ln in enumerate(lines) if ln == overlay.hatch_bind())
+        self.assertLess(palette, click)
+        self.assertLess(click, hatch)
+
+    def test_the_escape_hatch_is_still_the_last_line(self):
+        """`test_component_toggle_keys.py` pins this for the toggles; asked again here
+        because this change inserted a line into the same list and the invariant is about
+        the LIST, not about who last edited it."""
+        for toggles in ({"repos": "F7"}, {}, None):
+            with self.subTest(toggles=toggles):
+                lines = [ln for ln in _text(toggles=toggles).split("\n") if ln]
+                self.assertEqual(lines[-1], overlay.hatch_bind())
+
+    def test_nothing_an_operator_wrote_is_anywhere_in_the_line(self):
+        """A `bind` line is format-expanded by tmux, so the containment rule that applies
+        to a style applies here: charter's own constants only. The hostile hotkey and the
+        hostile toggle are both refused elsewhere; what this asks is that the click bind
+        is the same eleven words whatever they were."""
+        for hotkey, toggles in (("F2", None),
+                                ("M-x", {"repos": "F7"}),
+                                ("F2", {"repos": "F7\nkill-server"})):
+            with self.subTest(hotkey=hotkey, toggles=toggles):
+                text = commands_frame.conf_text(hotkey=hotkey, mouse=True,
+                                                history_limit=1, session="fr-1",
+                                                toggles=toggles)
+                self.assertEqual(
+                    _click_line(text),
+                    "bind -n MouseDown1Pane if-shell -F -t = '#{@charter_panel}' "
+                    "'send-keys -M' 'select-pane -t =; send-keys -M'")
+
+    def test_the_wheel_bind_is_untouched(self):
+        """The control. The wheel never moved the keyboard and this change must not give
+        it a way to start: a refactor that routed both mouse binds through one builder
+        could quietly hand the wheel a `select-pane`."""
+        self.assertIn("bind -n WheelUpPane if-shell -F -t = '#{mouse_any_flag}' "
+                      "'send-keys -M' 'copy-mode -e; send-keys -M'", _text())
+
+
+class ThePaneOptionTheBindReads(unittest.TestCase):
+    """`_panel_mark_argv` — the write half, which nothing else in the suite covers."""
+
+    def test_it_sets_charters_own_name_to_charters_own_value(self):
+        argv = commands_frame._panel_mark_argv(socket="charter-x", pane_id="%11")
+        self.assertEqual(argv[-2:], ["@charter_panel", "1"])
+
+    def test_the_write_is_pane_scoped_and_targets_that_pane(self):
+        """`-p`, never `-w` and never `-g`. A window write would mark the harness pane
+        too, since it shares the window — and a click on the harness would stop selecting
+        it. A global write is the "last launched wins" trap `conf_text`'s docstring names,
+        reached through an option instead of a session setting."""
+        argv = commands_frame._panel_mark_argv(socket="charter-x", pane_id="%11")
+        self.assertIn("set-option", argv)
+        self.assertIn("-p", argv)
+        self.assertNotIn("-w", argv)
+        self.assertNotIn("-g", argv)
+        self.assertEqual(argv[argv.index("-t") + 1], "%11")
+
+    def test_it_goes_to_the_server_it_was_handed(self):
+        """Same rule as every other argv this module builds: charter's private server by
+        name, or the operator's own by socket PATH, and whichever one the caller named.
+
+        The path here is a bare absolute one rather than a real tmux socket, because
+        `tmuxctl.server_argv` discriminates on the leading `/` alone and
+        `tests/test_no_test_bakes_a_uid_into_a_socket_path.py` refuses a `tmux-<uid>` spelt
+        into a test file — this case is about the flag, not about where tmux listens."""
+        self.assertEqual(
+            commands_frame._panel_mark_argv(socket="charter-x", pane_id="%11")[:3],
+            ["tmux", "-L", "charter-x"])
+        self.assertEqual(
+            commands_frame._panel_mark_argv(socket="/nowhere/default",
+                                            pane_id="%11")[:3],
+            ["tmux", "-S", "/nowhere/default"])
+
+    def test_the_name_the_bind_reads_is_the_name_the_write_sets(self):
+        """One constant, two uses — spelled as a literal on both sides here so that a
+        rename that updated only one of them fails rather than passing quietly. This is
+        the only case in the file allowed to look at the constant at all, and it looks at
+        it to compare it against text, not to build one."""
+        self.assertEqual(commands_frame._PANEL_OPTION, "@charter_panel")
+        self.assertIn("'#{@charter_panel}'", _click_line(_text()))
+        self.assertEqual(
+            commands_frame._panel_mark_argv(socket="s", pane_id="%1")[-2],
+            "@charter_panel")
+
+
+class NeitherMouseKeyIsAComponentsToTake(unittest.TestCase):
+    """#566's hazard, in the mouse table.
+
+    tmux key tables have no notion of a conflict — a later `bind -n` replaces the earlier
+    and `list-keys` reads back one line where two were meant. `conf_text` writes both mouse
+    binds BEFORE the toggles, so a component claiming either would leave its own key alive
+    and charter's mouse handling silently gone: the wheel would stop entering copy-mode,
+    and a click on a panel would go back to taking the keyboard off the harness.
+
+    Both names pass `instance._HOTKEY_RE` — they are alphanumerics under twenty characters
+    — so this is reachable rather than theoretical, and the guard is what closes it.
+    """
+
+    def _resolve(self, key: str) -> dict:
+        return instance.frame_of(
+            {"frame": {"hotkey": "M-x", "component": [{"use": "identity", "key": key}]}})
+
+    def test_both_names_are_keys_the_alphabet_would_otherwise_allow(self):
+        """Without this the two cases below could be passing for the wrong reason — a
+        component claiming a key `_HOTKEY_RE` rejects is refused by a different guard
+        entirely, and the collision guard would never fire."""
+        for key in ("WheelUpPane", "MouseDown1Pane"):
+            with self.subTest(key=key):
+                self.assertEqual(instance.toggle_key(key), key)
+
+    def test_a_component_may_not_take_the_wheel(self):
+        frame = self._resolve("WheelUpPane")
+        self.assertEqual(frame["components"], [])
+        self.assertEqual(frame["slots"], instance.FRAME_DEFAULTS["slots"])
+
+    def test_a_component_may_not_take_the_click(self):
+        frame = self._resolve("MouseDown1Pane")
+        self.assertEqual(frame["components"], [])
+        self.assertEqual(frame["slots"], instance.FRAME_DEFAULTS["slots"])
+
+    def test_a_key_charter_has_not_taken_is_the_control(self):
+        """Without this a `component_tables` that refused every key would pass both cases
+        above. `MouseDown2Pane` is one character from a key charter binds and is nobody's."""
+        frame = self._resolve("MouseDown2Pane")
+        self.assertEqual([p["key"] for p in frame["components"]], ["MouseDown2Pane"])
+
+    def test_a_component_with_no_key_survives_an_arrangement_with_no_hotkey(self):
+        """The reserved set holds real keys and nothing else, pinned where it costs
+        something.
+
+        `component_tables` builds that set as ``{k for k in (hotkey, HATCH_KEY,
+        *MOUSE_KEYS) if k}``, and *hotkey* is ``None`` for every caller resolving an
+        arrangement outside a `[frame]` section — this function's own default. The
+        collision test is a bare ``key in bound``, so a ``None`` that got into the set
+        would match the component that declares **no** toggle key, which is the common
+        case, and refuse the whole arrangement: every panel gone because nobody named a
+        key.
+
+        The deletion sweep found this exact line unpinned when the guard read ``key is
+        not None and key in bound`` — the filter could be deleted with the suite still
+        green, because that second condition made it unobservable. This case is what the
+        filter now costs to remove.
+        """
+        got = instance.component_tables({"component": [{"use": "identity"}]})
+        self.assertEqual([t["use"] for t in got or []], ["identity"],
+                         "a component that declares no key collided with something")
+
+    def test_a_component_with_no_key_still_collides_with_nothing_when_others_do(self):
+        """The control beside it: two components, one keyed and one not, both survive —
+        so the case above is not passing because keys are ignored altogether."""
+        got = instance.component_tables(
+            {"component": [{"use": "identity", "key": "F7"}, {"use": "repos"}]},
+            hotkey="F2")
+        self.assertEqual([t["use"] for t in got or []], ["identity", "repos"])
+
+    def test_the_reserved_names_are_the_ones_actually_bound(self):
+        """The drift this reservation exists to prevent, asked directly: every key in
+        `tmuxctl.MOUSE_KEYS` must appear as a `bind -n` in `conf_text`'s output, and the
+        two spellings are pinned as literals so that renaming the constant alone is red."""
+        self.assertEqual(tuple(tmuxctl.MOUSE_KEYS), ("WheelUpPane", "MouseDown1Pane"))
+        for key in ("WheelUpPane", "MouseDown1Pane"):
+            with self.subTest(key=key):
+                self.assertIn(f"bind -n {key} ", _text())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_frame_input_reaches_a_component.py
+++ b/tests/test_frame_input_reaches_a_component.py
@@ -13,7 +13,9 @@ branches make that could be wrong is a claim about tmux:
 * that a `resize-window` reaches every pane, focused or not;
 * that tmux routes a POINTER to the pane under it by position, pane-relative, **without
   making that pane active** — which is the entire premise of delivering `click` and
-  `scroll` at all, and the one this file exists to keep true.
+  `scroll` at all, and the one this file exists to keep true;
+* that the same holds with tmux's OWN mouse on, where it does not hold by default and
+  charter's `MouseDown1Pane` bind is what makes it (`APointerWithTmuxsOwnMouseOn`, #634).
 
 The measurements this file is the standing form of, taken against **tmux 3.7c** and
 re-taken at the **3.2 floor**, both identical::
@@ -27,8 +29,11 @@ re-taken at the **3.2 floor**, both identical::
       click window col 100 (pane left=80) -> panel READ b'\\x1b[<0;20;5M'   active: harness
       click the border between them       -> nobody                       active: harness
       wheel over the panel                -> panel READ b'\\x1b[<64;20;5M'  active: harness
-    mouse ON
-      click over the panel                -> panel receives it            active: PANEL
+    mouse ON, charter's own `MouseDown1Pane` bind in place (#634)
+      click over the panel                -> panel receives it            active: harness
+      click over the HARNESS              -> harness receives it          active: harness
+      click a pane the operator split     -> that pane receives it        active: THAT pane
+      wheel over the panel                -> panel receives it            active: harness
 
 and, for the tty mode, one pane per mode painting three ``\\n``-joined rows::
 
@@ -262,12 +267,26 @@ class _AFrameWithProviderPanels(PersonaIso):
         return site
 
     def _split(self, cid: str) -> str:
-        """One panel pane running the argv charter's own launcher would run."""
+        """One panel pane running the argv charter's own launcher would run, marked the
+        way charter's own launcher marks it.
+
+        The mark is `commands_frame._panel_mark_argv`, called rather than re-spelled, for
+        the reason `conf_text` is sourced above rather than hand-written (#547): this
+        fixture must not carry its own copy of charter's answer. `_split_panels` is what
+        issues it in production and `tests/test_frame_launcher.py` is what pins that it
+        does; here it is fixture, so that the pointer cases below are asking about tmux
+        rather than about whether a pane got set up.
+        """
         argv = layout.panel_command(slot=cid, session=self.fid)
         r = _tmux("split-window", "-t", self.harness, "-v", "-l", "3",
                   "-P", "-F", "#{pane_id}", "--", *argv, env=self.env)
         self.assertEqual(r.returncode, 0, r.stderr)
-        return r.stdout.strip()
+        pane = r.stdout.strip()
+        marked = subprocess.run(
+            commands_frame._panel_mark_argv(socket=SOCKET, pane_id=pane),
+            capture_output=True, text=True, timeout=20)
+        self.assertEqual(marked.returncode, 0, marked.stderr)
+        return pane
 
     def _attach(self) -> int:
         refusals = []
@@ -577,6 +596,132 @@ class APointerReachesTheComponentItLandedOn(_AFrameWithProviderPanels):
         self._point(self.pane[POINT_CID], row=0, col=0)
         self.assertTrue(_await(lambda: "POINT-click:left:0,0:up" in self._pointed()),
                         f"the release was not the last event seen: {self._pointed()!r}")
+
+
+class APointerWithTmuxsOwnMouseOn(_AFrameWithProviderPanels):
+    """The same frame with `[frame] mouse = true`, which is the regime #634 is about.
+
+    Everything above runs at charter's default, `mouse = false`, where tmux processes no
+    mouse binding at all and the pointer reaching a panel is entirely the harness's doing.
+    This class is the other regime — the one an operator opts into *because* they want to
+    click panels — and it is where tmux's own default `MouseDown1Pane` binding used to
+    select the pane under the pointer before forwarding, so every click took the keyboard
+    off the harness until they pressed `F12`.
+
+    `conf_text` now rebinds that key, conditionally on the pane under the pointer carrying
+    `_PANEL_OPTION`. **The whole point of the conditional is the last two cases**: a
+    blanket `bind -n MouseDown1Pane send -M` passes the first two and breaks both of
+    those, measured on 3.7c and at the 3.2 floor — it takes away clicking back to any pane
+    at all, the harness included, which is worse than the focus steal it fixes.
+
+    Nothing here is stubbed and nothing is set up by the test that the launcher does not
+    set up: the config is `conf_text`'s own text and the mark is `_panel_mark_argv`'s own
+    argv.
+    """
+
+    #: The only difference from the fixture above, and the setting the whole class is about.
+    MOUSE = True
+
+    def setUp(self) -> None:
+        super().setUp()
+        # A pane the OPERATOR split, standing for what they would get by typing their own
+        # prefix-split inside charter's window. Not a charter panel: no `panel_command`,
+        # no mark, nothing charter would ever do to it. Two rows, so it fits beside four
+        # panels in a 24-row window.
+        r = _tmux("split-window", "-t", self.harness, "-v", "-l", "2",
+                  "-P", "-F", "#{pane_id}", "--", "cat", env=self.env)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.operator_pane = r.stdout.strip()
+        self._select(self.harness)
+
+    def _pointed(self) -> str:
+        return self._shown(POINT_CID)
+
+    def test_tmuxs_own_mouse_really_is_on(self):
+        """Without this every case below could be passing because tmux is ignoring the
+        mouse entirely — which is the fixture above's regime and proves nothing about this
+        one. Read off tmux rather than off `self.MOUSE`, so a `conf_text` that stopped
+        writing the line fails here instead of quietly making the rest vacuous."""
+        said = _tmux("show-options", "-t", self.fid, "-v", "mouse")
+        self.assertEqual(said.stdout.strip(), "on", said.stderr)
+
+    def test_a_click_still_reaches_the_component_whose_pane_it_landed_on(self):
+        """Delivery first, because every focus assertion below is worth nothing if the
+        click never arrived — a keyboard that did not move because nothing happened is not
+        the property being claimed."""
+        self._select(self.harness)
+        self._point(self.pane[POINT_CID], row=0, col=2)
+        self.assertTrue(_await(lambda: "POINT-click" in self._pointed()),
+                        f"a click never reached it: {self._pointed()!r}")
+
+    def test_the_keyboard_does_not_follow_the_pointer(self):
+        """#634 itself. This assertion was `active pane: THE PANEL` before the rebind, on
+        3.7c and at the 3.2 floor identically, and it is the reason `[frame] mouse = true`
+        was documented as hostile rather than recommended."""
+        self._select(self.harness)
+        self._point(self.pane[POINT_CID], row=0, col=2)
+        self.assertTrue(_await(lambda: "POINT-click" in self._pointed()),
+                        "the click never arrived, so this proves nothing about focus")
+        self.assertEqual(self._active(), self.harness,
+                         "a click on a panel took the keyboard off the harness")
+
+    def test_clicking_the_harness_still_selects_it(self):
+        """Half of what the conditional buys, and the half a blanket rebind destroys. The
+        keyboard starts on a PANEL here — put there by `select-pane`, not by a click —
+        so the assertion is that the click moved it back, not that it never moved."""
+        self._select(self.pane[POINT_CID])
+        self.assertEqual(self._active(), self.pane[POINT_CID])
+        self._point(self.harness, row=0, col=1)
+        self.assertTrue(_await(lambda: self._active() == self.harness, 5.0),
+                        "a click on the harness no longer brings the keyboard back — "
+                        "which is worse than the focus steal this rebind fixes")
+
+    def test_clicking_a_pane_the_operator_split_still_selects_it(self):
+        """The other half, and the question the issue asked third: what happens to a click
+        on a pane that is neither the harness nor a charter panel. It is not charter's, so
+        charter changes nothing about it — tmux's documented `select-pane -t = \\;
+        send-keys -M` is what runs, and the operator's own pane behaves the way every pane
+        in their own tmux does."""
+        self._select(self.harness)
+        self._point(self.operator_pane, row=0, col=1)
+        self.assertTrue(_await(lambda: self._active() == self.operator_pane, 5.0),
+                        "a pane the operator split themselves stopped taking the keyboard "
+                        "on a click — tmux's own behaviour, removed from a pane charter "
+                        "has nothing to do with")
+
+    def test_a_pane_split_out_of_a_PANEL_is_not_one(self):
+        """The sharpest form of the same question, and it rests on a fact about tmux
+        rather than about charter: a pane option is not inherited by a pane split off the
+        one carrying it. So even a pane the operator carved out of a panel is theirs, and
+        clicking it selects it.
+
+        If tmux ever started copying pane options across a split, this is the case that
+        notices — and the consequence would be an operator's own pane silently refusing
+        the keyboard, which nothing else here would catch."""
+        r = _tmux("split-window", "-t", self.pane[POINT_CID], "-v", "-l", "1",
+                  "-P", "-F", "#{pane_id}", "--", "cat", env=self.env)
+        if r.returncode != 0:
+            self.skipTest(f"no room to split a child out of a panel: {r.stderr.strip()}")
+        child = r.stdout.strip()
+        said = _tmux("display-message", "-p", "-t", child, "#{@charter_panel}")
+        self.assertEqual(said.stdout.strip(), "",
+                         "a pane split out of a panel inherited the panel's mark")
+        self._select(self.harness)
+        self._point(child, row=0, col=0)
+        self.assertTrue(_await(lambda: self._active() == child, 5.0),
+                        "a pane the operator carved out of a panel stopped taking the "
+                        "keyboard on a click")
+
+    def test_the_wheel_still_does_not_move_the_keyboard(self):
+        """The control that has always held, on both settings and both tmux versions. A
+        rebind that routed the wheel through the click's branch would break it."""
+        self._select(self.harness)
+        left, top, _w, _h = self._rect(self.pane[POINT_CID])
+        self._inject(b"\x1b[<64;%d;%dM" % (left + 1, top + 1))
+        self.assertTrue(_await(lambda: "POINT-scroll" in self._pointed()),
+                        f"the wheel never reached it: {self._pointed()!r}")
+        self.assertEqual(self._active(), self.harness,
+                         "the wheel moved the keyboard")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1437,7 +1437,8 @@ class _FakeTmux:
                 panel_pane_ids=None, pane_capture="",
                 session_rc=0, source_rc=0, env_set_rc=0, write_hook_rc=0,
                 teardown_hook_rc=0, panel_rc=0, select_rc=0, attach_rc=0, dm_rc=0,
-                kill_rc=0, arm_rc=0, hatch_rc=0, chrome_rc=0, resize_hook_rc=0,
+                kill_rc=0, arm_rc=0, hatch_rc=0, mark_rc=0, chrome_rc=0,
+                resize_hook_rc=0,
                 capture_rc=0,
                 respawn_hook_rc=0,
                 resize_hook_stderr="bad resize hook target"):
@@ -1465,6 +1466,9 @@ class _FakeTmux:
         self.kill_rc = kill_rc
         self.arm_rc = arm_rc
         self.hatch_rc = hatch_rc
+        # `set-option -p @charter_panel` — #634's pane mark, its own knob for
+        # `hatch_rc`'s reason: a test needs to fail it without failing the chrome.
+        self.mark_rc = mark_rc
         self.chrome_rc = chrome_rc
         self.resize_hook_rc = resize_hook_rc
         self.capture_rc = capture_rc
@@ -1505,6 +1509,13 @@ class _FakeTmux:
             # element would otherwise be answered by the wrong fake.
             return subprocess.CompletedProcess(cmd, self.hatch_rc, stdout="",
                                                stderr="" if self.hatch_rc == 0
+                                               else "cannot set")
+        if commands_frame._PANEL_OPTION in cmd:
+            # The panel mark (#634). Matched on the PRODUCTION constant, like the hatch
+            # option above, so a rename is answered here rather than raising "unexpected
+            # tmux command" in every test that draws a panel.
+            return subprocess.CompletedProcess(cmd, self.mark_rc, stdout="",
+                                               stderr="" if self.mark_rc == 0
                                                else "cannot set")
         if _is_chrome(cmd):
             return subprocess.CompletedProcess(cmd, self.chrome_rc, stdout="",
@@ -2397,6 +2408,65 @@ class Launch(PersonaIso, unittest.TestCase):
         by_pane = {c[c.index("-t") + 1]: c[-1] for c in hooks}
         self.assertIn("top", by_pane["%11"])
         self.assertIn("bottom", by_pane["%12"])
+
+    def test_every_drawn_panel_is_marked_as_one(self):
+        """#634 at the launcher. `conf_text`'s `MouseDown1Pane` bind lets a click through
+        without moving the keyboard only for panes carrying `@charter_panel`, so a panel
+        that reached the operator's screen unmarked is a panel that steals focus the first
+        time it is clicked — with `[frame] mouse = true`, which is the setting an operator
+        turns on in order to click panels.
+
+        Why `tests/test_a_click_on_a_panel_stays_where_it_points.py` does not cover this:
+        every case there either builds the argv directly or sets the option by hand before
+        clicking. They prove the bind's half — that tmux does the right thing once a pane
+        carries the option — and never charter's half, that anything ever writes it. A
+        test that arms the mechanism it is verifying proves the other party's half.
+
+        One mark per drawn panel, each naming the pane tmux actually reported for that
+        slot, and never the harness pane: `-p` on the harness would make a click on it
+        stop selecting it, which is the one pane the whole feature exists to protect.
+        """
+        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"})
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        marks = [c for c in fake.calls if "@charter_panel" in c]
+        self.assertEqual(sorted(c[c.index("-t") + 1] for c in marks), ["%11", "%12"],
+                         f"every drawn panel is marked, and only panels: {fake.calls}")
+        for cmd in marks:
+            self.assertIn("set-option", cmd)
+            self.assertIn("-p", cmd)
+            self.assertNotIn("-g", cmd)
+            self.assertEqual(cmd[-1], "1")
+            self.assertNotEqual(cmd[cmd.index("-t") + 1], fake.pane_id,
+                                "the harness pane was marked as a panel")
+
+    def test_a_mark_tmux_refuses_is_reported_but_not_fatal(self):
+        """The same treatment every other decorative-adjacent tmux command in this
+        launcher gets. A panel charter could not mark still draws, still repaints and
+        still receives its clicks — what it costs the operator is an `F12` after clicking
+        it, which is exactly where they were before #634. Taking down a harness pane that
+        is already running would be a far larger failure than the one being avoided."""
+        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11"}, mark_rc=1)
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("cannot set" in m for m in buf),
+                        f"the refusal was never surfaced: {buf}")
+        self.assertTrue(any("attach" in c for c in fake.calls),
+                        "a panel that could not be marked cancelled the attach")
+
+    def test_a_panel_whose_pane_id_was_never_learned_is_not_marked(self):
+        """Same guard the respawn and resize hooks already have, reached through the same
+        `_PANE_ID_RE` check in the same loop: without a valid `%<digits>` there is no pane
+        to name, and an option written against a guessed one would land somewhere charter
+        did not choose."""
+        fake = _FakeTmux(exit_code=0,
+                         panel_pane_ids={"top": "not-a-pane-id", "bottom": "%12"})
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        marks = [c for c in fake.calls if "@charter_panel" in c]
+        self.assertEqual([c[c.index("-t") + 1] for c in marks], ["%12"])
 
     def test_a_panel_whose_pane_id_was_never_learned_is_not_armed(self):
         """Same guard the resize hook already has, for the same reason: without a valid
@@ -4034,6 +4104,8 @@ class _FakeOperatorTmux:
         if "remain-on-exit" in cmd:
             return subprocess.CompletedProcess(cmd, self.arm_rc, stdout="",
                                                stderr="" if self.arm_rc == 0 else "cannot set")
+        if commands_frame._PANEL_OPTION in cmd:
+            return self._ok(cmd)
         if _is_chrome(cmd):
             return subprocess.CompletedProcess(cmd, self.chrome_rc, stdout="",
                                                stderr="" if self.chrome_rc == 0

--- a/tests/test_frame_pane_style.py
+++ b/tests/test_frame_pane_style.py
@@ -542,10 +542,19 @@ class TheLauncherActuallyAsksForEachPanesColour(PersonaIso, unittest.TestCase):
         return seen
 
     def _styles(self, issued: list[list[str]]) -> dict[str, list[str]]:
-        """`{pane id: [style values]}` out of the recorded `set-option -p` calls."""
+        """`{pane id: [style values]}` out of the recorded `set-option -p` calls.
+
+        **Filtered to the options this class is about, by the family tmux itself names
+        them with** — an option whose name ends `style` — rather than by every `-p` the
+        funnel happens to issue. `test_frame_launcher._is_chrome` makes the same call for
+        the same reason: `_split_panels` is a shared funnel, and a helper here that
+        collected whatever it issued would turn every future pane option into a failure in
+        four tests that are not about it. #634's `@charter_panel` mark was exactly that —
+        a pane option about mouse ROUTING, landing in a list of colours as a bare `'1'`.
+        """
         out: dict[str, list[str]] = {}
         for argv in issued:
-            if "set-option" in argv and "-p" in argv:
+            if "set-option" in argv and "-p" in argv and argv[-2].endswith("style"):
                 out.setdefault(argv[argv.index("-t") + 1], []).append(argv[-1])
         return out
 
@@ -576,6 +585,14 @@ class TheLauncherActuallyAsksForEachPanesColour(PersonaIso, unittest.TestCase):
         """The control that this whole mechanism is inert until somebody writes a `bg`."""
         bare = instance.frame_of({"frame": {"chrome": "dark"}})
         styles = self._styles(self._issued(bare, ["repos", "right"]))
+        # Both panes answered for, asserted before the loop rather than left to it: this
+        # case's body is a loop over what `_styles` found, so an empty answer would pass it
+        # without running an assertion at all. That became reachable when `_styles` started
+        # filtering to the style family (#634) — before, every pane had at least one `-p`
+        # to report. The two cases above would still fail, but a control that cannot fail
+        # is not one.
+        self.assertEqual(len(styles), 2,
+                         f"both panes must have been styled, not {sorted(styles)}")
         for values in styles.values():
             self.assertEqual(values, ["bg=black", "bg=brightblack"])
 


### PR DESCRIPTION
Closes #634.

`click` and `scroll` ship point-to-act: charter delivers a pointer event where the pointer
is and never moves focus, because the frame exists to keep the harness the thing you type
into. That held with `[frame] mouse` off and broke with it on — and **on is the setting an
operator turns on precisely because they want to click panels.** The setting that made the
feature reliable was the setting that made it hostile.

tmux's default root binding is `MouseDown1Pane  select-pane -t = \; send-keys -M`: with its
own mouse on it selects the pane under the pointer before forwarding. The wheel never does.

## What changed for an operator

**If you already set `mouse = true`, your clicks stop moving the keyboard — you no longer
need `F12` after clicking a panel. A click on the harness, or on a pane you split yourself,
still selects it, exactly as tmux documents.** That sentence is in the news entry and in
`docs/frame.md`. The drag-select trade `mouse = true` makes is unchanged and unavoidable,
and `mouse` still defaults to **off**.

## The shape, and why not the other two

`conf_text` gains one line, conditional on a **pane-scoped option charter writes on every
panel it splits off** (`_PANEL_OPTION`, from `_split_panels` — the single funnel both launch
paths and every density change reach panels through):

```
bind -n MouseDown1Pane if-shell -F -t = '#{@charter_panel}' \
    'send-keys -M' 'select-pane -t =; send-keys -M'
```

Measured — real server, real client on a real pty, `mouse on`, three panes (a marked panel,
the harness, and one split by hand standing in for the operator's), SGR reports injected as
a reporting terminal sends them. **tmux 3.7c and the 3.2 floor answered identically in all
twelve cells:**

| bind | click a panel | click back to the harness | click your own split |
|---|---|---|---|
| tmux's own default | delivered, **keyboard MOVED** | works | works |
| blanket `send -M` | delivered, unchanged | **BROKEN** — stays put | **BROKEN** — stays put |
| this one, conditional | delivered, unchanged | works | works |

The blanket rebind is not a milder version of the same thing: it takes away clicking back to
any pane at all, the harness included, which is worse than the focus steal it fixes.

## The open question the issue left: `#{==:}` **does** parse at the 3.2 floor

Measured on a 3.2 built from the release tarball, not reasoned about:
`#{==:#{pane_id},#{@charter_harness_pane}}` evaluated to `1` on the harness and `0` on a
panel, and the whole `bind` line returned rc 0 from `source-file` and read back byte for byte
through `list-keys`. **So the format was available and the *shape* is what is refused.**

The marker is on the **panels**, not on the harness, and that decides the issue's third
question. Marking the harness makes every pane that is not the harness un-clickable-to — so
a pane the operator split inside charter's window would stop taking the keyboard on a click,
tmux's documented behaviour removed from a pane charter has nothing to do with. Marking the
panels leaves that pane exactly as tmux left it. It also dissolves the issue's second
question outright: there is no pane id in the binding at all, so there is nothing to drift
from the one `overlay.HATCH_OPTION` already holds. And a pane option dies with its pane, so
nothing leaks to the next frame on a server every frame shares.

**A pane option is not inherited across a split** — measured on both versions — so even a
pane the operator carves out of a *panel* is theirs and selects on click. Pinned.

## Bound whatever `mouse` says

A root key table is server-wide and `source-file` can only ADD a binding, so omitting the
line on a `mouse = false` launch would not unbind what a `mouse = true` frame on the same
socket already bound. A gate would buy nothing and make the root table depend on launch
order. It costs a `mouse = false` frame nothing: with tmux's own mouse off, tmux runs no
mouse binding at all (measured — no click moves focus in that regime, either).

## #566, in the mouse table

`MouseDown1Pane` and `WheelUpPane` join the frame hotkey and the `F12` hatch in the set a
component may not claim as its toggle key. Both are ordinary alphanumerics that
`instance._HOTKEY_RE` accepts, so a `[[frame.component]]` could have taken either — and tmux
key tables have no notion of a conflict, so unrefused that deletes charter's mouse handling
for every frame on the socket, `list-keys` reading back one line where two were meant. The
wheel's absence from that set was a pre-existing hole this change would have doubled. Named
off one `tmuxctl.MOUSE_KEYS` so the key refused is the key bound.
