### PR TITLE
A string the interpreter never evaluates is not a read position (#632)

### DIFF
--- a/docs/news/unreleased-the-sweep-stops-asking-about-a-string-nothing-reads.md
+++ b/docs/news/unreleased-the-sweep-stops-asking-about-a-string-nothing-reads.md
@@ -1,0 +1,132 @@
+---
+version: unreleased
+headline: The deletion sweep stops asking about a string nothing reads, and its own report grows tests
+---
+
+#630's self-sweep — the gate run against the change that built the gate — reported this:
+
+```
+[8/119] SURVIVED  tools/sweep.py:1626 [retune-string] "Pair"   (1 module(s), then all 7692)
+```
+
+Line 1626 is a return annotation:
+
+```python
+def sweep(...) -> tuple[list[Result], list["Pair"]]:
+```
+
+Every module in this repository begins `from __future__ import annotations`, so that
+annotation is never evaluated. It is stored as the string
+`"tuple[list[Result], list['Pair']]"` and nothing reads it. Re-spelling `"Pair"` changes
+the contents of a string the interpreter never looks at, so **no test can ever go red
+without it** — not a test anybody has failed to write, a test that cannot exist.
+
+That is worse than a wrong finding. The gate's whole argument is that a survivor is worth
+a reviewer's minute, and there is deliberately no suppression list to put an exception on.
+One survivor that provably cannot be pinned teaches the reader to skim the list, and a
+skimmed gate is a gate somebody switches off — which is the failure the harness's own spec
+names as the one that ends adoption.
+
+**And it is the one defect that would make `--enforce` unusable the day it is switched on.**
+The gate blocks nothing today. When it does, a branch that adds a signature
+forward-referencing a class defined below it would be blocked *with no move available to
+its author*: there is no test to write, because no test can go red without that string, and
+there is no suppression list to reach for, because charter refuses one on principle — a
+config key it could read is a config key a committed file could flip. A gate that blocks
+with no remedy is a gate somebody turns off, and they would be right to.
+
+## Fixed as a property, not as a line
+
+The cause is scoping. `retune-string` only mutates strings the program *reads*, and it
+counted a `Subscript` slice as one — right for `d["components"]`, wrong for `list["Pair"]`,
+and those two are the same shape.
+
+The rule now is the general one: **a position whose value is never evaluated at runtime is
+not a read position.** Under PEP 563 a function's return annotation, an argument's, and a
+variable's are all source text the interpreter never runs, so nothing inside one is a
+value any test could hold.
+
+Unquoting that one forward reference would have fixed one line. This fixes the shape:
+every signature in the tree that forward-references a class defined below it, and every
+one a future branch adds.
+
+**Narrowly, and only where it is provable.** Without the future import an annotation *is*
+an evaluated expression, and what becomes of a string inside one depends on what evaluates
+it — `typing.List["Pair"]` compiles the text into a `ForwardRef` right there at import,
+while `list["Pair"]` merely stores it. So the rule asks for the future import, which is the
+version of it with no judgement in it.
+
+Measured over the paths the sweep actually runs on, `charter/` and `tools/`: 15 string
+constants sit inside a deferred annotation, three of them were being offered as mutations,
+and the read positions go from 3,492 to 3,489. That is a small number and it is the honest
+one — the other twelve are whole annotations (`x: "Path"`), which were never in a read
+position and were never offered. All three were in `tools/sweep.py` itself. The case for
+the change is not the volume; it is that each of the three was a finding nobody could ever
+close.
+
+**The neighbours were checked one at a time**, because "looks like typing" is not the rule
+and evaluation is: `typing.cast("Pair", v)` and `TypeVar(bound="Pair")` were never offered
+(the string is an ordinary argument that the callee throws away), `NamedTuple` and
+`TypedDict` fields written as class annotations are deferred like any other, and
+`TypedDict("Cfg", {"slot": str})` — the same type spelled as a call — keeps its field names
+mutable, because at runtime that dictionary really is read.
+
+## And the report the gate prints grew tests of its own
+
+Stage A's self-sweep put "report renderer + CLI" at roughly **0 of 49** pinned, and the
+defence at the time was that the renderer decides no verdict. #630 took that argument away:
+the gate's answer is now carried by the *name of a check* and by the page a reviewer reads,
+so a renderer that prints the wrong count is a gate that says the wrong thing.
+
+Re-measured on this branch, over the 274 mutations from `report()` to the end of the file:
+**99 survived.** The ones that changed what an operator is told are pinned now.
+
+**The report's five header numbers were computed and never read back.** Every one of
+`mutations applied`, `pinned`, `SURVIVED`, `UNRESOLVED` and `NOT APPLIED` comes out of a
+comprehension filtering on the verdict, and forcing any of those filters to always-true —
+so that four pinned mutations are counted as four survivors — left the whole suite green.
+A report that makes up the finding it exists to find is the worst thing in this file.
+
+**The baseline line could have said `OK` on a red tree.** It is the first thing a reader
+has to be able to check, because a tree that was red before any mutation makes every
+mutation look pinned.
+
+**And the `covered:` field's three shapes were one shape as far as the suite knew.**
+"Nothing measured executes this file", "eleven modules execute it and not one names the
+symbol", and "two tests name it, here is what they assert" are three different claims and
+the difference between a survivor somebody can act on and a line number. Either branch
+could be forced either way with everything still green. The truncation note under it —
+three are printed and the rest were simply *absent* — was unasserted too, which is the
+silent truncation the harness exists to refuse, in the harness.
+
+**The artifact a shard writes did not round-trip its outcomes.** `as_json` writes each
+run's `green`, `ran` and `detail`; `results_from_json` reads them on another machine.
+Re-spelling any of those keys, or collapsing either outcome to `null`, left the suite
+green, because nothing had ever written one and read it back.
+
+**And nothing ran the merge step at all.** `main --verdict` is the last thing a sharded
+gate does and the only place the pull request is told anything, and every rule inside it —
+the clamp that stops "did not report" going negative, the one that keeps a plan that never
+sized itself from rendering as `1 of 1` — was a rule no mutation could be caught by. That
+is #572's structural lesson again, and `default_jobs()` came out of `main()`'s argument
+list for the same reason: `(os.cpu_count() or 4) // 2` is **zero** on a one-core runner,
+and zero sandboxes is a sweep that measures nothing while reporting that it ran.
+
+**One survivor was not a survivor at all — it was a hang.** The test for "`--gate` and
+`--all` together are refused" called `main()` and checked stderr, which pins the refusal
+only while the refusal is there: delete it and `main()` does not fail, it sweeps the whole
+tree, in the test process, for fourteen hours. The sweep reported that one as *unresolved*
+rather than pinned, exactly as its own rule says it must. There is a tripwire on the first
+thing `main()` reaches for now, so the same deletion is a red in milliseconds — and the
+other half of the conjunction is asserted too, because nothing in the suite had ever run
+`--all` on its own.
+
+**43 of those 274 still survive**, and here is what they are. Sixteen cannot be killed by
+anybody: `split(".")[-1]` against `rsplit(".")[-1]`, a `.get(k, 0)` whose default is
+unreachable because the table is built from the very list being walked, a `max()` made
+redundant by a guard two lines below it, and the `if __name__ == "__main__"` entry point.
+Twenty-seven are real. Seventeen of those are inside `main()`'s own body — which is where
+this row has always been thin, and it is the same lesson: a rule that lives inside `main()`
+cannot be reached from a test, so it cannot be swept, so the harness cannot hold itself to
+it until somebody moves it out. The other ten are detail in the report's prose — an
+ellipsis after the fourth module name, the wording beside a second-order pair.

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -564,6 +564,168 @@ class TheStringShape(unittest.TestCase):
         self.assertEqual(_afters(muts, "retune-string"), ["b'\\x03r'"])
 
 
+class TheUnevaluatedPosition(unittest.TestCase):
+    """#632: a position the interpreter never evaluates is not a read position.
+
+    `sweep(...) -> tuple[list[Result], list["Pair"]]` came back a SURVIVOR on #630's own
+    gate, and it is a survivor **no test can ever kill**: every module in this tree begins
+    `from __future__ import annotations`, so that annotation is the string
+    `"tuple[list[Result], list['Pair']]"` and nothing reads it. There is deliberately no
+    suppression list to put such a thing on, so the operator must not offer it — an
+    unkillable finding is the false positive the spec names as what gets a gate switched
+    off.
+
+    The rule is the PROPERTY and not the line: `"Pair"` is a `Subscript` slice, which is
+    a read position for `d["components"]` and is not one for `list["Pair"]`. Every case
+    below asserts one half — either that a deferred position really is skipped, or that
+    something next door to it really is not.
+    """
+
+    def test_a_forward_reference_in_a_return_annotation_is_not_offered(self):
+        """#632's own line, and the whole point: PEP 563 stores the annotation as source
+        text, so retuning `"Pair"` changes the contents of a string nothing evaluates."""
+        muts = _mutations("""
+            from __future__ import annotations
+
+            def sweep(root) -> tuple[list[Result], list["Pair"]]:
+                return ([], [])
+        """)
+        self.assertEqual(_by(muts, "retune-string"), [])
+
+    def test_an_argument_annotation_is_deferred_too_and_so_is_a_variable_one(self):
+        """`returns` is one of three annotation positions and skipping only that one
+        would leave `def _second_order(boxes: list["Sandbox"])` — a real line of this
+        file — reporting a survivor nothing can kill."""
+        muts = _mutations("""
+            from __future__ import annotations
+
+            def f(box: "Sandbox", xs: list["Pair"]) -> None:
+                seen: dict[str, "Pair"] = {}
+                return None
+        """)
+        self.assertEqual(_by(muts, "retune-string"), [])
+
+    def test_the_value_beside_a_deferred_annotation_is_still_read(self):
+        """An `AnnAssign`'s VALUE is evaluated exactly as any other assignment's is. Only
+        the annotation is deferred, so `"Pair"` goes and `"left"` stays."""
+        muts = _mutations("""
+            from __future__ import annotations
+
+            SLOT: dict[str, "Pair"] = {"left": 1}
+        """)
+        self.assertEqual(_afters(muts, "retune-string"), ["'mfgu'"])
+
+    def test_a_subscript_that_really_is_a_lookup_is_untouched(self):
+        """The narrowness that keeps this a scoping fix rather than a deletion. Dropping
+        the `Subscript` arm of `read_positions` would silence the phantom AND `d["k"]`
+        with it, which is the operator's single most common real position."""
+        muts = _mutations("""
+            from __future__ import annotations
+
+            def f(d):
+                return d["components"]
+        """)
+        self.assertEqual(_afters(muts, "retune-string"), ["'dpnqpofout'"])
+
+    def test_without_the_future_import_the_annotation_is_an_evaluated_expression(self):
+        """The narrow rule, and the reason it is narrow. Without PEP 563 the annotation
+        IS evaluated where it is written, and what happens to a string inside it depends
+        on what evaluates it — `typing.List["Pair"]` compiles the text into a `ForwardRef`
+        right there at import. So here the string is live: a test that exercises whatever
+        resolves the hint goes red without it, and the author of a branch the gate stopped
+        has the ordinary move available. That is the whole line the predicate is drawn on
+        — under `--enforce`, "unpinnable" means "blocked with nothing to do about it"."""
+        muts = _mutations("""
+            def sweep(root) -> tuple[list[Result], list["Pair"]]:
+                return ([], [])
+        """)
+        self.assertEqual(_afters(muts, "retune-string"), ["'Qbjs'"])
+
+    def test_only_the_annotations_future_defers_anything(self):
+        """`from __future__ import division` is a `__future__` import and is not this
+        one. A predicate that matched the module and not the name would silence a real
+        read position in any file that imports a different future."""
+        self.assertIs(sweep.defers_annotations(
+            ast.parse("from __future__ import annotations\n")), True)
+        self.assertIs(sweep.defers_annotations(
+            ast.parse("from __future__ import division\n")), False)
+        self.assertIs(sweep.defers_annotations(ast.parse("import __future__\n")), False)
+        self.assertIs(sweep.defers_annotations(ast.parse("x = 1\n")), False)
+        # One of several names on the one line still defers.
+        self.assertIs(sweep.defers_annotations(
+            ast.parse("from __future__ import division, annotations\n")), True)
+
+    def test_the_neighbours_a_forward_reference_hides_among_are_checked_one_by_one(self):
+        """The cases next door, each answered on whether the interpreter evaluates it.
+
+        * `typing.cast("Pair", v)` — evaluated as an ordinary argument and then *thrown
+          away*; `cast` returns its second argument and never reads the first.
+        * `TypeVar(bound="Pair")` — the same, one keyword along.
+        * a `NamedTuple` / `TypedDict` field written as a class annotation — deferred.
+        * a `dataclasses.field` line — the annotation is deferred, the `field(...)` call
+          beside it is not, and `"factory"` below is there to prove the difference.
+        * `Literal["a", "b"]` — deferred, while the `== "a"` that reads the value is not.
+
+        Asserted as one exact set rather than five absences, so that a rule which stopped
+        deferring annotations fails here by producing MORE than this list.
+        """
+        muts = _mutations('''
+            from __future__ import annotations
+
+            import dataclasses
+            import typing
+
+            T = typing.TypeVar("T", bound="Pair")
+
+            class Row(typing.NamedTuple):
+                kids: list["Row"]
+
+            class Cfg(typing.TypedDict):
+                slot: "Slot"
+
+            @dataclasses.dataclass
+            class Held:
+                pairs: list["Pair"] = dataclasses.field(default_factory=dict)
+                mode: typing.Literal["a", "b"] = "a"
+
+            def f(v, mode):
+                return typing.cast("Pair", v), mode == "a", {"factory": 1}
+        ''')
+        self.assertEqual(_afters(muts, "retune-string"), ["'b'", "'gbdupsz'"])
+
+    def test_a_typed_dict_spelled_as_a_call_keeps_its_field_names(self):
+        """The boundary the rule is drawn on is EVALUATION and not "looks like typing".
+        `TypedDict("Cfg", {"slot": str})` is an ordinary call in an ordinary expression:
+        `"slot"` becomes a field name at runtime, so it is read and stays mutable."""
+        muts = _mutations("""
+            from __future__ import annotations
+
+            import typing
+
+            Cfg = typing.TypedDict("Cfg", {"slot": str})
+        """)
+        self.assertEqual(_afters(muts, "retune-string"), ["'tmpu'"])
+
+    def test_the_deferred_ids_are_the_annotation_and_nothing_around_it(self):
+        """`unevaluated` walks the annotation subtree only. Widened by one step it would
+        swallow the `AnnAssign`'s value, the argument's default and the function body."""
+        tree = ast.parse(textwrap.dedent("""
+            from __future__ import annotations
+
+            def f(x: list["A"] = ["B"]) -> "C":
+                y: "D" = "E"
+                return y
+        """))
+        deferred = sweep.unevaluated(tree)
+        inside = sorted(n.value for n in ast.walk(tree)
+                        if isinstance(n, ast.Constant) and isinstance(n.value, str)
+                        and id(n) in deferred)
+        self.assertEqual(inside, ["A", "C", "D"])
+
+    def test_a_module_that_defers_nothing_defers_nothing(self):
+        self.assertEqual(sweep.unevaluated(ast.parse('def f() -> "C": return 1\n')), set())
+
+
 class TheBoundaryShape(unittest.TestCase):
     """`shift-boundary` (#569): `<` against `<=`, and nothing else moved.
 
@@ -3064,13 +3226,50 @@ class TheWorkflowSaysTheAnswerWhereItCanBeSeen(unittest.TestCase):
 
 
 class TheGateNeverChargesTheWholeTree(unittest.TestCase):
-    def test_gate_and_all_together_are_refused(self):
+    """The refusal, and — as of the self-sweep — the fact that it comes FIRST.
+
+    This case used to call `main(["--gate", "--all"])` and check stderr, which pins the
+    refusal only as long as the refusal is there. Delete it and `main()` does not fail:
+    it goes on and sweeps the whole tree, in the test process, for fourteen hours. The
+    sweep reported that mutation as *unresolved* rather than pinned — a hang is not a red
+    — so the line had no verdict behind it at all.
+
+    `repo_root` is the first thing `main()` reaches for after the argument check, so
+    standing a tripwire there turns "the refusal is gone" from a hang into a red in
+    milliseconds. That is the same rule the tool applies to itself: a run that wedges has
+    not passed.
+    """
+
+    def setUp(self):
+        original = sweep.repo_root
+        self.addCleanup(setattr, sweep, "repo_root", original)
+        self.reached = []
+
+        def tripwire(start):
+            self.reached.append(start)
+            raise RuntimeError("main() got past the argument check and started working")
+
+        sweep.repo_root = tripwire
+
+    def test_gate_and_all_together_are_refused_before_any_work(self):
         """Stage B is a fourteen-hour job and stage C is a pull-request check. Letting the
         two be asked for at once is how the gate becomes the reason nobody runs either."""
         said = io.StringIO()
         with contextlib.redirect_stderr(said), self.assertRaises(SystemExit):
             sweep.main(["--gate", "--all"])
         self.assertIn("never sweeps the whole tree", said.getvalue())
+        self.assertEqual(self.reached, [])
+
+    def test_all_on_its_own_is_the_supported_way_to_charge_the_whole_tree(self):
+        """The other half of `args.gate and args.all`, and the half that makes it a
+        conjunction. Dropping either name from the condition refuses a flag the tool
+        documents — `--all` is stage B, and it is how the number in `docs` was measured —
+        and nothing in the suite ran `--all` at all."""
+        said = io.StringIO()
+        with contextlib.redirect_stderr(said), self.assertRaises(RuntimeError):
+            sweep.main(["--all"])
+        self.assertEqual(said.getvalue(), "")
+        self.assertEqual(len(self.reached), 1)
 
 
 # ======================================================================================
@@ -3439,6 +3638,416 @@ class TheScopeReaderHoldsItsOwnEdges(unittest.TestCase):
         (self.tmp / "charter" / "fresh.txt").write_text("not python\n")
         dirty = sweep.dirty_files(self.tmp, ("charter",))
         self.assertEqual(set(dirty), {"charter/fresh.py"})
+
+
+# ======================================================================================
+# The report renderer's own guards — #569's thin row, measured again
+# ======================================================================================
+#
+# Stage A's self-sweep put "report renderer + CLI" at roughly 0 of 49 pinned, and the
+# reason it was allowed to stay thin was that the renderer decides no verdict. #630 took
+# that argument away: the gate's answer is now carried by the check's NAME and by the page
+# a reviewer reads, so a renderer that prints the wrong count is a gate that says the wrong
+# thing. Re-measured on this branch over the 274 mutations from `report()` to the end of
+# the file: 99 survived. The cases below are the ones whose survival changes what an
+# operator is told, and `docs/news` says plainly what was left.
+
+def _outcome(green=True, ran=10, detail="OK"):
+    return sweep.Outcome(green, ran, detail)
+
+
+def _survivor(line=291, symbol="_placed_here", evidence=None, full=None, subset=None,
+              operator="drop-conjunct", before="isinstance(n, str) and n not in SLOTS"):
+    m = sweep.Mutation(path="charter/frame/layout.py", line=line, end_line=line,
+                       operator=operator, question="is the half pinned?", before=before,
+                       after="isinstance(n, str)", symbol=symbol)
+    return sweep.Result(m, "survived", subset, full, ["tests.test_a"], evidence)
+
+
+class TheReportCountsWhatItFound(unittest.TestCase):
+    """The header of the terminal report: five numbers, and nothing asserted them.
+
+    Every one is computed by a comprehension filtering on `r.verdict`, and forcing any of
+    those filters to `True` — which is what `drop-comprehension-if` does — left the whole
+    suite green. A report that calls four pinned mutations four survivors is worse than no
+    report: it is the tool making the finding it exists to find.
+    """
+
+    def _mixed(self):
+        return [_result("pinned"), _result("pinned"), _result("survived", line=1),
+                _result("survived", line=9), _result("survived", line=17),
+                _result("unresolved"), _result("unapplied")]
+
+    def test_each_count_in_the_header_is_its_own_verdict(self):
+        text = sweep.report(self._mixed(), Path("."), "a" * 12, "b" * 12, None, 60.0)
+        self.assertIn("mutations applied : 7", text)
+        self.assertIn("pinned            : 2", text)
+        self.assertIn("SURVIVED          : 3", text)
+        self.assertIn("UNRESOLVED        : 1", text)
+        self.assertIn("NOT APPLIED       : 1", text)
+
+    def test_a_sweep_with_nothing_unapplied_does_not_print_that_row_at_all(self):
+        """The row is the loudest thing the report can say — "every number above is
+        suspect" — so it appears only when it is true."""
+        text = sweep.report([_result("pinned")], Path("."), "a" * 12, "b" * 12, None, 1.0)
+        self.assertNotIn("NOT APPLIED", text)
+
+    def test_the_baseline_line_carries_ok_or_carries_what_went_wrong(self):
+        """A tree that was red before any mutation makes every mutation look pinned, so
+        the baseline is the first thing the reader has to be able to check. Both arms
+        matter: collapsing the conditional to `'OK'` reports a red baseline as a green
+        one, which is the sweep's second way of lying with a straight face."""
+        green = sweep.report([], Path("."), "a" * 12, "b" * 12,
+                             _outcome(True, 7909, "OK"), 1.0)
+        self.assertIn("baseline          : Ran 7909 tests — OK", green)
+        red = sweep.report([], Path("."), "a" * 12, "b" * 12,
+                           _outcome(False, 7909, "tests.test_a.T.test_x"), 1.0)
+        self.assertIn("baseline          : Ran 7909 tests — tests.test_a.T.test_x", red)
+        # `--no-baseline` measured nothing, and silence is the honest rendering of that.
+        self.assertNotIn("baseline  ", sweep.report([], Path("."), "a" * 12, "b" * 12,
+                                                    None, 1.0))
+
+    def test_the_wall_clock_is_minutes_to_one_decimal(self):
+        """1236 s is 20.6 minutes and `.2g` calls it 21. A run that took twenty minutes
+        forty and reports "21 min" is a number nobody can check against a job's own
+        clock."""
+        text = sweep.report([], Path("."), "a" * 12, "b" * 12, None, 1236.0)
+        self.assertIn("wall clock        : 20.6 min", text)
+
+    def test_a_shape_this_interpreter_cannot_reach_is_named_on_both_pages(self):
+        """`reach()` is empty on 3.12 and later, so on a modern interpreter both of these
+        lines are dead and deleting either changed nothing — which is exactly how the
+        sweep reported them. The claim is not about this machine's version: it is that
+        when there IS something out of reach, both pages say so. A sweep that asks fewer
+        questions and does not mention it reads precisely like a clean one.
+        """
+        original = sweep.reach
+        sweep.reach = lambda: "f-string literals"
+        self.addCleanup(setattr, sweep, "reach", original)
+        text = sweep.report([], Path("."), "a" * 12, "b" * 12, None, 1.0)
+        self.assertIn("NOT ASKED ABOUT  : f-string literals", text)
+        page = sweep.gate_summary(sweep.classify([_result("pinned")]),
+                                  "a" * 40, "b" * 40, 60.0, enforce=False)
+        self.assertIn("| not asked about | — | f-string literals |", page)
+        sweep.reach = lambda: ""
+        self.assertNotIn("NOT ASKED ABOUT",
+                         sweep.report([], Path("."), "a" * 12, "b" * 12, None, 1.0))
+        self.assertNotIn("not asked about", sweep.gate_summary(
+            sweep.classify([_result("pinned")]), "a" * 40, "b" * 40, 60.0, enforce=False))
+
+    def test_a_survivor_carries_the_full_run_that_measured_it(self):
+        """"Survived" means the WHOLE suite stayed green, and the count of tests that ran
+        is how a reader tells that from a subset that never covered the file."""
+        text = sweep.report([_survivor(full=_outcome(True, 7909, "OK"))],
+                            Path("."), "a" * 12, "b" * 12, None, 1.0)
+        self.assertIn("full    : Ran 7909 tests — OK, with the line gone", text)
+
+
+class TheReportTellsThreeKindsOfSilenceApart(unittest.TestCase):
+    """The `covered:` field — the one that made 82 survivors triageable.
+
+    Its three shapes are three different claims and the suite asserted none of them, so
+    forcing either branch of the chain in either direction left everything green. "Nothing
+    measured executes this file", "eleven modules execute it and not one names the
+    symbol", and "two tests name it, here is what they assert" are the difference between
+    a survivor a reviewer can act on and a line number.
+    """
+
+    def _rendered(self, evidence):
+        return sweep.report([_survivor(evidence=evidence)], Path("."), "a" * 12,
+                            "b" * 12, None, 1.0)
+
+    def test_no_evidence_at_all_prints_no_claim_about_coverage(self):
+        """`evidence=None` is the shard-merge shape (#617): the evidence pass never ran,
+        which is not the same as running and finding nothing. Dropping the guard that
+        says so reaches for `.modules` on `None`."""
+        text = self._rendered(None)
+        self.assertIn("charter/frame/layout.py:291", text)
+        self.assertNotIn("covered :", text)
+
+    def test_nothing_executing_the_file_is_said_in_those_words(self):
+        self.assertIn("covered : nothing measured executes this file at all",
+                      self._rendered(sweep.Evidence([], [])))
+
+    def test_modules_that_execute_it_and_never_name_it_are_counted(self):
+        text = self._rendered(sweep.Evidence(["tests.test_a", "tests.test_b"], []))
+        self.assertIn("covered : 2 module(s) execute this file and NOT ONE", text)
+        self.assertIn("names `_placed_here` — tests.test_a, tests.test_b", text)
+
+    def test_tests_that_do_name_it_arrive_with_their_assertions(self):
+        text = self._rendered(sweep.Evidence(
+            ["tests.test_a"],
+            [("tests.test_a", "test_window", ["assertEqual(_window(8), (0, 6))"])]))
+        self.assertIn("covered : 1 test(s) name `_placed_here`; what they assert:", text)
+        self.assertIn("test_a.test_window", text)
+        self.assertIn("assertEqual(_window(8), (0, 6))", text)
+
+    def test_a_list_longer_than_three_says_how_many_it_did_not_show(self):
+        """Silent truncation, in the tool that exists to refuse it. Three are printed and
+        the rest were simply absent — and "three tests name this" reads as the whole
+        answer. The boundary is asserted at three and at four, because `> 3` and `>= 3`
+        both passed while the only case was a list of one."""
+        naming = [("tests.test_a", f"test_{n}", ["assertTrue(x)"]) for n in range(5)]
+        text = self._rendered(sweep.Evidence(["tests.test_a"], naming))
+        self.assertIn("… and 2 more", text)
+        exactly_three = self._rendered(sweep.Evidence(["tests.test_a"], naming[:3]))
+        self.assertNotIn("… and", exactly_three)
+
+
+class TheArtifactAShardWritesIsReadBackWhole(unittest.TestCase):
+    """`as_json` and `results_from_json` are one contract across two machines (#617).
+
+    Everything `classify` and `gate_summary` read has to survive the trip, not merely the
+    verdict string — and the outcomes did not: re-spelling `"green"`, `"ran"` or
+    `"detail"` on the writing side, or collapsing either outcome to `null`, left the suite
+    green because nothing ever round-tripped one.
+    """
+
+    def test_every_field_the_merge_reads_survives_the_file(self):
+        written = sweep.as_json([_survivor(
+            subset=_outcome(True, 12, "OK"),
+            full=_outcome(False, 7909, "tests.test_a.T.test_x"),
+            evidence=sweep.Evidence(["tests.test_a"],
+                                    [("tests.test_a", "test_x", ["assertTrue(x)"])]))])
+        row = json.loads(written)[0]
+        self.assertEqual(row["subset"], {"green": True, "ran": 12, "detail": "OK"})
+        self.assertEqual(row["full"], {"green": False, "ran": 7909,
+                                       "detail": "tests.test_a.T.test_x"})
+        back = sweep.results_from_json(written)[0]
+        self.assertEqual((back.subset.green, back.subset.ran, back.subset.detail),
+                         (True, 12, "OK"))
+        self.assertEqual((back.full.green, back.full.ran, back.full.detail),
+                         (False, 7909, "tests.test_a.T.test_x"))
+
+    def test_an_outcome_that_was_never_measured_arrives_as_nothing(self):
+        row = json.loads(sweep.as_json([_survivor()]))[0]
+        self.assertIsNone(row["subset"])
+        self.assertIsNone(row["full"])
+        self.assertIsNone(sweep.results_from_json(sweep.as_json([_survivor()]))[0].full)
+
+    def test_the_row_carries_the_platform_it_was_measured_on(self):
+        """Named keys and not a shape: the merge recomputes `platform_caveat` from the
+        operator rather than trusting the file, and the field is still written so that a
+        person reading the artifact can see which machine said what."""
+        row = json.loads(sweep.as_json([_survivor(operator="narrow-except",
+                                                  before="OSError")]))[0]
+        self.assertEqual(row["platform"], sys.platform)
+        self.assertEqual(row["platform_caveat"], "OSError")
+
+
+class TheGatePageSaysWhatItWouldDoAndWhatItCouldNotSee(unittest.TestCase):
+    def test_the_page_says_whether_this_branch_would_fail_under_enforce(self):
+        """The one sentence on a reporting-only page that tells a reviewer whether the
+        gate is about to start blocking them. Both arms survived: the page could have said
+        "would fail" on every branch, or "would pass" on every branch, and nothing in the
+        suite would have noticed."""
+        survivors = sweep.gate_summary(sweep.classify([_result("survived")]),
+                                       "a" * 40, "b" * 40, 60.0, enforce=False)
+        self.assertIn("it **would fail** with `--enforce`", survivors)
+        clean = sweep.gate_summary(sweep.classify([_result("pinned")]),
+                                   "a" * 40, "b" * 40, 60.0, enforce=False)
+        self.assertIn("it **would pass** with `--enforce`", clean)
+
+    def test_a_lost_shard_and_a_sweep_that_never_sized_itself_read_differently(self):
+        """#617's own distinction, in the paragraph that explains the row. "1 of 3 did not
+        report" is a number; "the plan job died before it sized anything" is the absence
+        of one, and rendering the second as `1 of 0` would describe a sweep that was never
+        planned as a sweep that was planned and lost."""
+        gate = sweep.classify([_result("pinned")])
+        many = sweep.gate_summary(gate, "a" * 40, "b" * 40, None, False,
+                                  missing=1, shards=3)
+        self.assertIn("1 of 3 shard(s) wrote no result", many)
+        # `shards >= 1` and not `> 1`: the one-shard plan whose only shard vanished is the
+        # ordinary shape for a small diff, and it is the case the boundary turns on.
+        lone = sweep.gate_summary(gate, "a" * 40, "b" * 40, None, False,
+                                  missing=1, shards=1)
+        self.assertIn("1 of 1 shard(s) wrote no result", lone)
+        unsized = sweep.gate_summary(gate, "a" * 40, "b" * 40, None, False,
+                                     missing=1, shards=0)
+        self.assertIn("never said how many shards it needed", unsized)
+        self.assertNotIn("wrote no result", unsized)
+
+
+class TheMergeStepHoldsItsOwnEdges(unittest.TestCase):
+    """`merge`, `_merge_step` and `_append` — the last thing that runs on a sharded gate.
+
+    Nothing in the suite ran `main --verdict` at all, so every rule inside `_merge_step`
+    was a rule no mutation could be caught by. That is #572's structural lesson again: a
+    rule reachable only from a `main()` nobody calls is a guard the harness cannot hold
+    itself to.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="sweep-merge-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp,
+                                                            ignore_errors=True))
+        self.shards = self.tmp / "shards"
+        self.shards.mkdir()
+
+    def _shard(self, name, results):
+        (self.shards / name).write_text(sweep.as_json(results), encoding="utf-8")
+
+    def test_more_answers_than_the_plan_asked_for_is_not_a_negative_absence(self):
+        """A count of shards that did not report can only be zero or more. Without the
+        clamp, four answers against a plan of three make `missing` negative — which is
+        truthy, so the page would announce "-1 of 3 did not report" and refuse to call a
+        complete sweep complete."""
+        for n in (1, 2, 3, 4):
+            self._shard(f"s{n}.json", [_result("pinned")])
+        results, missing = sweep.merge(self.shards, 3)
+        self.assertEqual((len(results), missing), (4, 0))
+
+    def test_a_file_that_will_not_parse_is_a_shard_that_did_not_report(self):
+        """There is no third reading of a truncated upload."""
+        self._shard("good.json", [_result("pinned")])
+        (self.shards / "torn.json").write_text("[{\"path\":", encoding="utf-8")
+        results, missing = sweep.merge(self.shards, 2)
+        self.assertEqual((len(results), missing), (1, 1))
+
+    def test_the_merge_step_says_how_many_of_how_many_answered(self):
+        self._shard("s1.json", [_result("survived")])
+        out = self.tmp / "out.txt"
+        said = io.StringIO()
+        with contextlib.redirect_stdout(said):
+            code = sweep.main(["--verdict", str(self.shards), "--shards", "3",
+                               "--gate", "--github-output", str(out)])
+        self.assertEqual(code, 0)
+        self.assertIn("merged 1 result(s) from 1 of 3 shard(s)", said.getvalue())
+        self.assertIn("gate: reporting only — nothing here blocks.", said.getvalue())
+        self.assertIn("conclusion=no-verdict", out.read_text())
+        self.assertIn("headline=no verdict: 1 survivor so far, 2 of 3 shards did not "
+                      "report", out.read_text())
+
+    def test_a_sweep_that_never_sized_itself_is_missing_a_shard_it_cannot_count(self):
+        """An empty `--shards` is the plan job failing before it sized anything, and that
+        has to travel as *no denominator* rather than as `1 of 1`. Without the guard the
+        loudest failure the workflow has arrives as the quietest kind of pass."""
+        self._shard("s1.json", [_result("pinned")])
+        said = io.StringIO()
+        with contextlib.redirect_stdout(said):
+            sweep.main(["--verdict", str(self.shards), "--shards", "", "--gate"])
+        self.assertIn("merged 1 result(s) from an unknown number of shard(s)",
+                      said.getvalue())
+        self.assertIn("gate: no verdict: the sweep never sized itself", said.getvalue())
+
+    def test_appending_to_the_summary_adds_to_it_and_ends_it_once(self):
+        """`$GITHUB_STEP_SUMMARY` is shared by every step of a job, so this appends. The
+        trailing newline is normalised from the RIGHT: stripping the other end leaves the
+        blank lines a markdown block ends with and pushes the next step's heading down
+        the page."""
+        page = self.tmp / "summary.md"
+        sweep._append(str(page), "## one\n\n")
+        sweep._append(str(page), "## two")
+        self.assertEqual(page.read_text(), "## one\n## two\n")
+
+
+class TheCLIsOwnArithmeticIsReachable(unittest.TestCase):
+    """The rules `main()` used to hold in-line, pulled out so a mutation can reach them."""
+
+    def test_the_exit_code_reads_every_result_and_not_only_one(self):
+        """`any` against `all`: every existing case passed a single-element list, where
+        the two are the same function. A real sweep is one survivor among forty pins."""
+        pinned, survived = _result("pinned"), _result("survived")
+        unresolved, unapplied = _result("unresolved"), _result("unapplied")
+        self.assertEqual(sweep.exit_code([pinned, survived]), 1)
+        self.assertEqual(sweep.exit_code([pinned, unresolved]), 3)
+        self.assertEqual(sweep.exit_code([pinned, survived, unapplied]), 4)
+        self.assertEqual(sweep.exit_code([pinned, pinned]), 0)
+
+    def test_the_default_job_count_is_half_the_machine_and_never_zero(self):
+        """`(os.cpu_count() or 4) // 2` is zero on a one-core runner, and zero sandboxes
+        is a sweep that measures nothing while reporting that it ran. The clamp was
+        written inside `main()`'s argument list, where no mutation could reach it."""
+        original = os.cpu_count
+        self.addCleanup(setattr, os, "cpu_count", original)
+        os.cpu_count = lambda: 1
+        self.assertEqual(sweep.default_jobs(), 1)
+        os.cpu_count = lambda: 8
+        self.assertEqual(sweep.default_jobs(), 4)
+        # `os.cpu_count()` is documented to be able to return None.
+        os.cpu_count = lambda: None
+        self.assertEqual(sweep.default_jobs(), 2)
+
+    def test_a_shard_argument_is_read_exactly_or_refused(self):
+        """A shard argument that parses loosely does not fail: it sweeps one slice twice
+        and another never, and the merge reports a complete sweep of an incomplete plan.
+        Both ends of `1 <= index <= count` are asserted, because shard 1 of 3 and shard 3
+        of 3 are the two the boundary drops."""
+        self.assertEqual(sweep.parse_shard("1/3"), (1, 3))
+        self.assertEqual(sweep.parse_shard("3/3"), (3, 3))
+        self.assertEqual(sweep.parse_shard("2/3"), (2, 3))
+        # Whitespace either side of either number — a workflow's `$SHARD/$SHARDS` is a
+        # shell expansion, and both ends of both numbers get the same treatment.
+        self.assertEqual(sweep.parse_shard(" 2 / 3 "), (2, 3))
+        for bad in ("2", "2/", "/2", "0/3", "4/3", "a/3", "2/b", ""):
+            with self.assertRaises(ValueError, msg=bad):
+                sweep.parse_shard(bad)
+        # `+2` is what the refusal itself catches and nothing else does: `int()` accepts a
+        # signed number happily, so without the `isdigit()` check `"+2/3"` parses to shard
+        # 2 of 3 and the guard is a line every remaining case would redden anyway.
+        for signed in ("+2/3", "2/+3"):
+            with self.assertRaises(ValueError, msg=signed):
+                sweep.parse_shard(signed)
+
+
+class TheBranchIsChargedAgainstItsUpstream(unittest.TestCase):
+    """`base_for`'s two spellings of upstream, told apart by a repo that has each."""
+
+    def _repo(self, name):
+        tmp = Path(tempfile.mkdtemp(prefix=f"sweep-base-{name}-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(tmp, ignore_errors=True))
+        env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull,
+                   GIT_CONFIG_SYSTEM=os.devnull, GIT_CONFIG_NOSYSTEM="1",
+                   GIT_TERMINAL_PROMPT="0")
+
+        def run(*a):
+            subprocess.run(("git", "-c", "core.hooksPath=", "-c", "commit.gpgsign=false")
+                           + a, cwd=tmp, check=True, env=env, timeout=60,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        run("init", "-q", "-b", "main")
+        run("config", "user.email", "sweep@example.invalid")
+        run("config", "user.name", "sweep")
+        (tmp / "charter").mkdir()
+        (tmp / "charter" / "m.py").write_text("a = 1\n")
+        run("add", "-A")
+        run("commit", "-qm", "one")
+        return tmp, run
+
+    def test_with_no_remote_the_local_main_is_the_upstream(self):
+        tmp, run = self._repo("local")
+        first = sweep.git("rev-parse", "HEAD", cwd=tmp).strip()
+        run("checkout", "-q", "-b", "side")
+        (tmp / "charter" / "m.py").write_text("a = 1\nb = 2\n")
+        run("add", "-A")
+        run("commit", "-qm", "two")
+        side = sweep.git("rev-parse", "HEAD", cwd=tmp).strip()
+        self.assertEqual(sweep.base_for(tmp, side, None), first)
+
+    def test_when_origin_main_exists_it_is_the_one_that_counts(self):
+        """A fresh clone, a linked worktree and CI disagree about which of the two names
+        is there, and picking the wrong one does not fail — it is a different merge-base,
+        so the branch is charged for lines it did not add.
+
+        The two are made to disagree on purpose: `origin/main` is left at the first commit
+        while local `main` moves on, and the branch is cut from the LATER one. Reading
+        `main` gives the second commit and reading `origin/main` gives the first, so the
+        answer says which name was consulted rather than passing either way.
+        """
+        tmp, run = self._repo("remote")
+        first = sweep.git("rev-parse", "HEAD", cwd=tmp).strip()
+        run("update-ref", "refs/remotes/origin/main", first)
+        (tmp / "charter" / "other.py").write_text("z = 9\n")
+        run("add", "-A")
+        run("commit", "-qm", "main moved on, the remote did not")
+        second = sweep.git("rev-parse", "HEAD", cwd=tmp).strip()
+        run("checkout", "-q", "-b", "side")
+        (tmp / "charter" / "m.py").write_text("a = 1\nb = 2\n")
+        run("add", "-A")
+        run("commit", "-qm", "two")
+        side = sweep.git("rev-parse", "HEAD", cwd=tmp).strip()
+        self.assertNotEqual(first, second)
+        self.assertEqual(sweep.base_for(tmp, side, None), first)
 
 
 if __name__ == "__main__":      # pragma: no cover

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -477,6 +477,86 @@ READERS = frozenset({
 })
 
 
+def defers_annotations(tree: ast.AST) -> bool:
+    """Does this module carry ``from __future__ import annotations``?
+
+    PEP 563. With it, **every** annotation in the file — a function's `returns`, an
+    argument's, an `AnnAssign`'s — is stored as source text and never evaluated. Without
+    it every one of them is an ordinary expression, evaluated where it is written.
+
+    A `__future__` import is only legal at the top of a module, so `tree.body` is the
+    whole search and a walk would only be able to find an illegal one.
+    """
+    return any(
+        isinstance(stmt, ast.ImportFrom) and stmt.module == "__future__"
+        and any(alias.name == "annotations" for alias in stmt.names)
+        for stmt in getattr(tree, "body", []))
+
+
+def unevaluated(tree: ast.AST) -> set[int]:
+    """The ids of every node the interpreter never evaluates: #632's property.
+
+    **A position whose value is never evaluated at runtime is not a read position.** That
+    is the whole rule, and it is the general form of the defect rather than the one line
+    that found it. `sweep(...) -> tuple[list[Result], list["Pair"]]` reported `"Pair"` as
+    a survivor on #630's own gate, and it is a survivor **no test can ever kill** — under
+    PEP 563 that annotation is the string `"tuple[list[Result], list['Pair']]"` and
+    nothing reads it. `tools/sweep.py` carries four of these on its own, and any branch
+    that adds a function forward-referencing a class defined below it grows another.
+
+    An unkillable survivor is not a finding, it is the false positive the spec (#565)
+    names as the thing that gets a gate switched off. **Under `--enforce` it is worse than
+    noise: it is a blocked branch whose author has no move to make.** They cannot write the
+    test, because there is no test to write; they cannot suppress it, because #370 refuses
+    a suppression list on principle — a config key charter could read is a config key a
+    committed file could flip. A gate that blocks with no remedy available is a gate
+    somebody turns off, and they are right to. So the operator must not offer this at all.
+
+    **Only under the future import**, which is the version of the rule with no judgement
+    in it — and the version where "no remedy" is actually true. Without PEP 563 an
+    annotation is an evaluated expression, and what happens to a string inside one depends
+    on what evaluates it: `typing.List["Pair"]` compiles the text into a `ForwardRef` right
+    there at import, while `list["Pair"]` stores it. So there the string is live, a test
+    that exercises whatever resolves the hint can go red without it, and the author of a
+    blocked branch has the ordinary move available. "Never evaluated" is provable for the
+    deferred case and an argument for the other, and this predicate claims only the half it
+    can prove.
+
+    The one thing that *does* re-evaluate a deferred annotation is a program that asks it
+    to — `typing.get_type_hints`, or a library that calls it. Measured on this tree:
+    there are none, in `charter/`, `tools/` or `tests/`. If one arrives, the cost of this
+    rule is a question not asked rather than a guard wrongly certified, which is the
+    direction this file errs in everywhere else.
+
+    **The one sibling shape this deliberately does not cover, named so it is not
+    rediscovered:** the body of `if typing.TYPE_CHECKING:` never runs either, so a read
+    position inside one would be unkillable in exactly the same way. It is not here for
+    two reasons. Measured on `charter/`, `tools/` and `tests/`: **zero** occurrences, and
+    this file's rule is that a widening carries a measurement. And `TYPE_CHECKING` is a
+    NAME, which a module may rebind or import under an alias, so an `ast` pass can only
+    guess at it — where `from __future__ import annotations` is a statement the language
+    defines. The proof is what makes the rule above have no judgement in it. If such a
+    block ever appears in this tree, it belongs in this function and nowhere else.
+    """
+    if not defers_annotations(tree):
+        return set()
+    out: set[int] = set()
+    for node in ast.walk(tree):
+        annotation = None
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            annotation = node.returns
+        elif isinstance(node, (ast.arg, ast.AnnAssign)):
+            annotation = node.annotation
+        if annotation is None:
+            continue
+        # The annotation only. An `AnnAssign`'s VALUE is evaluated exactly as any other
+        # assignment's is, so `SLOT: dict[str, "Pair"] = {"left": …}` loses the `"Pair"`
+        # and keeps the `"left"`.
+        for part in ast.walk(annotation):
+            out.add(id(part))
+    return out
+
+
 def read_positions(tree: ast.AST) -> set[int]:
     """The ids of the string constants whose **value the program reads**.
 
@@ -499,11 +579,30 @@ def read_positions(tree: ast.AST) -> set[int]:
 
     Every position below is a property of Python, not of this project. Nothing here was
     chosen because a finding happened to have that shape.
+
+    **The one subtraction, and the same measurement behind it (#632):** a position the
+    interpreter never evaluates is not a read position, however read-shaped it looks. A
+    forward reference in an annotation is a `Subscript` slice, which is right for
+    `d["components"]` and wrong for `list["Pair"]` — see :func:`unevaluated`.
+
+    **Measured over the swept paths, `charter/` and `tools/`:** 15 string constants sit
+    inside a deferred annotation. Three of them were read positions, and the subtraction
+    takes the read positions from 3,492 to 3,489 and the mutation count from 10,412 to
+    10,409. That is a small number and it is the honest one — the other twelve are whole
+    annotations (`x: "Path"`), which were never `Subscript` slices and were never offered.
+    All three are in this file, and `charter/` has none today.
+
+    So the case for it is not the volume, it is the KIND: each of the three was a
+    survivor that no test could ever have killed, and one of those in a report teaches
+    the reader to skim the rest. It costs nothing to remove and it is one predicate that
+    stops every future signature forward-referencing a class below it from growing one.
     """
     out: set[int] = set()
+    inert = unevaluated(tree)
 
     def take(node: ast.AST | None) -> None:
-        if isinstance(node, ast.Constant) and isinstance(node.value, (str, bytes)):
+        if isinstance(node, ast.Constant) and isinstance(node.value, (str, bytes)) \
+                and id(node) not in inert:
             out.add(id(node))
 
     for node in ast.walk(tree):
@@ -2636,6 +2735,22 @@ def expected_shards(text: str | None) -> int:
     return n if n > 0 else 0
 
 
+def default_jobs() -> int:
+    """How many sandboxes a run uses when nobody says: half the machine, never none.
+
+    Out of `main()`'s argument list for #572's reason, which is the same one `base_for`
+    and `timeout_for` are out here for: a rule written inside `main()` is not reachable
+    from a test, so it cannot be swept, so it is a guard this harness is unable to hold
+    itself to. The self-sweep found this exact line unpinned in both directions.
+
+    Half, because a sandbox runs the suite and the suite starts real tmux servers, so the
+    machine is doing about two things per job. Never zero, which is what the floor is for:
+    `os.cpu_count()` is 1 on a small runner and `1 // 2` is a sweep that measures nothing
+    while reporting that it ran.
+    """
+    return max(1, (os.cpu_count() or 4) // 2)
+
+
 def exit_code(results: list[Result]) -> int:
     """What a plain (non-gate) run exits with.
 
@@ -2664,7 +2779,7 @@ def main(argv: list[str] | None = None) -> int:
                    help="Directory to sweep, repeatable (default: charter).")
     p.add_argument("--all", action="store_true",
                    help="Charge the whole tree instead of the diff — a number, not a gate.")
-    p.add_argument("--jobs", type=int, default=max(1, (os.cpu_count() or 4) // 2),
+    p.add_argument("--jobs", type=int, default=default_jobs(),
                    help="Sandboxes to run at once.")
     p.add_argument("--workdir", default=None, help="Where sandboxes and the cache live.")
     p.add_argument("--refresh-map", action="store_true", help="Re-trace the selection map.")


### PR DESCRIPTION
Closes #632, and takes the next bite out of #569's tail.

## #632 — a mutation no test can ever kill

`retune-string` mutated string constants inside **annotations**. Every module in this tree
begins `from __future__ import annotations`, so an annotation is never evaluated — it is
stored as source text — and `"Pair"` in

```python
def sweep(...) -> tuple[list[Result], list["Pair"]]:
```

is a forward reference nothing at runtime reads. #630's own gate reported it as a
SURVIVOR. It is not a guard with no test behind it; it is a finding **no test could ever
close**, and there is deliberately no suppression list to put one on.

**Fixed as the property, not as the line.** `read_positions` counted a `Subscript` slice as
a read position, which is right for `d["components"]` and wrong for `list["Pair"]` — the
same shape. The rule now is *a position whose value is never evaluated at runtime is not a
read position* (`unevaluated`), so every signature in the tree that forward-references a
class defined below it is covered, and so is every one a future branch adds. Unquoting the
one forward reference would have fixed one line.

**Narrow on purpose.** Only under the future import. Without PEP 563 an annotation *is* an
evaluated expression, and what happens to a string inside one depends on what evaluates it
— `typing.List["Pair"]` compiles the text into a `ForwardRef` at import while
`list["Pair"]` stores it. "Never evaluated" is provable in the first case and an argument
in the second, and the predicate only claims the half it can prove.

**Measured**, as `read_positions`' docstring demands of any change to its predicate, over
the paths the sweep runs on (`charter/` and `tools/`): 15 string constants sit inside a
deferred annotation, **3** of them were read positions, read positions go 3,492 → 3,489 and
mutations 10,412 → 10,409. Small, and honest: the other twelve are whole annotations
(`x: "Path"`), which were never `Subscript` slices and were never offered. All three were
in `tools/sweep.py`; `charter/` has none today. The case is the kind, not the volume.

**The neighbours, checked one at a time** — the boundary is *evaluation*, not "looks like
typing":

| shape | offered? | why |
|---|---|---|
| `typing.cast("Pair", v)` | no, and never was | an ordinary argument the callee throws away |
| `TypeVar(bound="Pair")` | no, and never was | same, one keyword along |
| `NamedTuple` / `TypedDict` class fields | no, now | `AnnAssign` annotations, deferred |
| `dataclasses.field` line | annotation no, `field(...)` yes | only the annotation is deferred |
| `Literal["a", "b"]` vs `== "a"` beside it | annotation no, comparison yes | one is read, one is not |
| `TypedDict("Cfg", {"slot": str})` | **yes** | at runtime that dict really is read |
| a string annotation with no future import | **yes** | the annotation is evaluated where it is written |

## #569's tail — the report renderer and the CLI

Stage A put that row at roughly 0 of 49 pinned and the defence was that the renderer
decides no verdict. #630 removed that defence: the answer is now carried by a check's
*name* and by the page a reviewer reads.

Re-measured on this branch over the **274** mutations from `report()` to the end of the
file. Method, because a hand-check without a baseline is not a verdict: `tools/sweep.py`'s
own `Sandbox`, one unmutated `tests.test_sweep` baseline per sandbox, every mutation
asserting it applied (sha256 of the file it was read from) and that its restore landed.
The subset stands in for the full suite because `tests/test_sweep.py` is the only module in
the repository that imports `tools.sweep`.

**Before: 99 survived, 174 pinned, 1 unresolved. After: 43 survive, 231 pinned, 0 unresolved.**

What is pinned now:

- **the report's five header counts** — `mutations applied`, `pinned`, `SURVIVED`,
  `UNRESOLVED`, `NOT APPLIED`. Each is a comprehension filtering on the verdict, and
  forcing any filter to always-true (four pins reported as four survivors) left the whole
  suite green;
- **the baseline line**, which could have said `OK` on a red tree — the one thing a reader
  has to check first, because a red tree makes every mutation look pinned;
- **the wall clock**, to one decimal (`.2g` calls 20.6 minutes "21");
- **`NOT ASKED ABOUT` / `not asked about`** on both pages, pinned with `reach()` stubbed so
  the claim holds on every interpreter rather than only on 3.11;
- **the `covered:` field's three shapes** — "nothing measured executes this file", "N
  modules execute it and not one names the symbol", "N tests name it, here is what they
  assert" — plus the `… and N more` note under it, which is silent truncation inside the
  tool that exists to refuse it;
- **the survivor's `full: Ran N tests` line**, which is how a reader tells a whole-suite
  green from a subset that never covered the file;
- **the shard artifact's round trip** — `as_json` writes each run's `green`/`ran`/`detail`
  and `results_from_json` reads them on another machine; re-spelling any key or collapsing
  either outcome to `null` was invisible;
- **`would fail` / `would pass`** on the reporting-only page;
- **a lost shard against a sweep that never sized itself**, at 3 shards, at 1, and at none;
- **the merge step, through `main --verdict`** — nothing had run it at all, so the clamp
  that stops "did not report" going negative and the guard that keeps an unsized plan from
  rendering as `1 of 1` were rules no mutation could be caught by;
- **`parse_shard`'s two boundaries** — shard 1 of 3 and shard 3 of 3 are exactly the two a
  one-notch move drops — and whitespace on both ends of both numbers;
- **`base_for`'s two spellings of upstream**, told apart by a repo where `main` and
  `origin/main` point at different commits, so only one answer can be right;
- **`_append`'s trailing newline**, normalised from the right because `$GITHUB_STEP_SUMMARY`
  is shared by every step of a job;
- **`exit_code` read across a list**, since every existing case passed a single element,
  where `any` and `all` are the same function.

Two structural moves, both #572's lesson (*a rule inside `main()` is not reachable from a
test, so it cannot be swept*):

- **`default_jobs()` came out of `main()`'s argument list.** `(os.cpu_count() or 4) // 2`
  is **zero** on a one-core runner, and zero sandboxes is a sweep that measures nothing
  while reporting that it ran. The clamp was unpinned in both directions.
- **`--gate --all` was pinned by a test that HANGS on the mutant.** Delete the refusal and
  `main()` does not fail — it sweeps the whole tree, in the test process, for fourteen
  hours. The sweep called that one *unresolved* rather than pinned, exactly as its own rule
  says it must. There is a tripwire on the first thing `main()` reaches for now, so the
  deletion is a red in milliseconds, and the other half of the conjunction is asserted too
  — nothing in the suite had ever run `--all` on its own.

### What is left, and it is 43 of 274

Named rather than rounded.

**Sixteen no test can kill** — equivalent mutants and the entry point, listed so nobody
re-derives them:

| line | mutation | why it is equivalent |
|---|---|---|
| `report` | `pairs or []` → `pairs` | the `if pairs:` below treats `None` and `[]` alike |
| `report` | `'OK' if baseline.green else baseline.detail` → `baseline.detail` | a green `Outcome` from `_verdict` carries `"OK"` |
| `report`, `classify` | `crowded.get(k, 0)` → `crowded[k]` | the table is built from the very survivors being walked, so the default is unreachable |
| `report`, `_summary_rows` | `split(".")[-1]` → `rsplit(".")[-1]` | identical for `[-1]` |
| `merge` | `… if Path(directory).is_dir() else []` | `Path.glob` on a missing directory yields nothing anyway — the same finding as `all_lines`' deleted `if base.exists()` |
| `base_for` | `git(…).strip()` → `.lstrip()` | only the truthiness of the output is read |
| `parse_shard` | `partition("/")` → `rpartition("/")` | every malformed input is refused either way |
| `expected_shards` | `.strip()` → `.lstrip()`, `n > 0` → `n >= 0` | `int()` strips for itself; both spellings give `0` at zero |
| `_merge_step` | `max(shards, 1)`, `max(missing, 1)` | both made redundant by the `if not shards` guard between them |
| module scope | `if __name__ == "__main__"` ×2 | `# pragma: no cover` — the entry point |

**Twenty-seven are real**, and seventeen of them are inside `main()`'s own body: the
`if args.json:` write, both `if args.summary:` writes, `if not args.keep:`,
`if not args.gate: return exit_code(...)`, the red-baseline exit code, the raised-timeout
log and its boundary, `if dirty:`, `parse_shard(args.shard) if args.shard else None`, and
`--all`'s own branch. Reaching any of them from a test means running a whole sweep, or
moving the rule out of `main()` — which is what `base_for`, `workdir_for`, `timeout_for`,
`exit_code` and now `default_jobs` are, one at a time. I moved one this round rather than
claiming a row I had not measured.

The other ten are detail in what the report prints: the ellipsis after the fourth module
name and its boundary, the wording beside a second-order pair, the `sorted()` that fixes
the order files appear in, and the `detail if … else ''` fallbacks in the unresolved and
unapplied lists.

## Why this one was worth doing first

Not for the three mutations. **Under `--enforce` an unpinnable survivor is a blocked branch
whose author has no move to make** — there is no test to write, because no test can go red
without that string, and there is no suppression list to reach for, because #370 refuses
one on principle (a config key charter could read is one a committed file could flip). A
gate that blocks with no remedy is the gate people turn off.

That is also exactly why the rule stops at the future import. Without PEP 563 the string
*is* live, so a test that exercises whatever resolves the hint goes red without it and the
author of a blocked branch has the ordinary move available. The predicate draws the line
where "no remedy" stops being true.

One sibling shape is named in `unevaluated`'s docstring rather than implemented: the body of
`if typing.TYPE_CHECKING:` never runs either. It is not covered because there are **zero**
occurrences in `charter/`, `tools/` or `tests/`, and because `TYPE_CHECKING` is a name a
module can rebind or alias — so an `ast` pass can only guess at it, where
`from __future__ import annotations` is a statement the language defines. The proof is what
keeps the rule above free of judgement. If one ever lands in this tree, the docstring says
where it goes.

## Verification

- **Full suite, two interpreters.** 3.14, in a clean clone of this head: **7,988 tests, OK**.
  3.12, with `CHARTER_*` / `CLAUDE_*` / `ANTHROPIC_*` / `TMUX*` unset: **7,988 tests, one
  failure** — and the failure is not this branch's. It is
  `test_frame_input_reaches_a_component.test_a_focus_change_reaches_only_the_pane_it_is_about`,
  a real-tmux focus test, and **`origin/main` fails the identical case on the same machine**
  (7,951 tests, same one failure). Differenced against its own baseline, exactly as the
  harness insists on for a mutant: a red subset only proves a red branch when the unmutated
  tree is measured too. CI's `test (3.12)` is green at this head. An earlier 3.12 run of this
  branch, on a quieter machine, was 7,987 / OK — so it is load, and it is worth somebody
  who owns that file knowing about.
- **Self-sweep of this branch's own added lines**, real tool, real baseline:
  `python3 tools/sweep.py --gate --path tools` — baseline `Ran 7988 tests — OK`,
  **14 mutations, 14 pinned, 0 survivors, 0 unresolved**. `gate: no survivors`.
- **CI green at head `92b7d69`** — `test (3.11)`, `(3.12)`, `(3.13)`, `(3.14)`,
  `Size the sweep`, `Sweep shard 1 of 1`, `Add up what the shards found`, and the gate's
  verdict check reporting as **`no survivors`**.
- News entry, `version: unreleased`. No bump, no stamp, no tag; `release.yml` untouched.

Not merged. Say the word and I will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
