### PR TITLE
A workspace is a session and a chat is a window in it (Phase 5, Stage 5a — tasks 1-3)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -804,6 +804,14 @@ def _add_frame_parsers(sub) -> None:
     pal = sub.add_parser("frame-palette")
     pal.add_argument("client", nargs="?", default="")
     pal.add_argument("--pane", action="store_true")
+    # Which CHAT the key was pressed in, expanded by tmux out of the presser's own
+    # window's `@charter_chat` (`commands_frame.conf_text`). A value rather than a
+    # positional, and OPTIONAL rather than required, for `frame-respawn --frame`'s reason
+    # exactly: a bind installed by a charter that predates the option is still sitting in
+    # a running server's key table across the upgrade, and it fires this command with no
+    # `--chat` at all. Empty falls back to `$CHARTER_SESSION_ID`, which is what that frame
+    # always resolved through — see `commands_frame._pressers_chat`.
+    pal.add_argument("--chat", dest="chat", default="")
     pal.set_defaults(func=commands_frame.cmd_palette)
 
     # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
@@ -912,6 +920,9 @@ def _add_frame_parsers(sub) -> None:
     # its own frame's arrangement does not contain — one gate, where the arrangement is.
     tg = sub.add_parser("frame-toggle")
     tg.add_argument("component")
+    # Which chat the key was pressed in — `frame-palette --chat`'s twin, same source
+    # (`#{@charter_chat}` in this component's own `bind -n`), same reason it is optional.
+    tg.add_argument("--chat", dest="chat", default="")
     tg.set_defaults(func=commands_frame.cmd_toggle)
 
     # A TOP-LEVEL sibling of `frame` for a DIFFERENT reason than `frame-palette` above:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -18,9 +18,11 @@ below — the private server, `-f` versus `source-file`, both `pane-died` hooks,
 install race they close — describe the FIRST path only; the second has no hooks at all,
 for a reason `_launch_in_operator_tmux` gives.
 
-**Every frame on charter's own server shares one tmux server (`SOCKET`), told apart by
-session name (the frame id), not one server per frame.** That single choice is what makes the rest of this module
-non-obvious, and it is why the session-scoped/hook-installing config reaches tmux through
+**Every frame on charter's own server shares one tmux server (`SOCKET`), and a WORKSPACE
+is a session on it while a CHAT is one window in that session.** A frame used to BE the
+session, named by the frame id; it is now the window, named by the chat id, with the
+session named after the workspace the chats belong to. That single choice is what makes the
+rest of this module non-obvious, and it is why the session-scoped/hook-installing config reaches tmux through
 `source-file`/direct `set-hook`/`set-environment` commands rather than through the `-f`
 flag `layout.session_argv` also carries. Measured against tmux 3.7c: `-f` is read only at
 the moment a client's connection actually STARTS the server — a later `new-session -f`
@@ -30,14 +32,14 @@ own config applied at all if it relied on `-f` alone. `source-file` and direct c
 both re-apply against whatever server already answers on the socket, so they work
 identically for the first frame and the fifty-first (verified by hand against tmux 3.7c: a
 hook installed this way for a SECOND session on an already-running server fires correctly,
-and its `kill-session` tears down only that session, leaving a sibling frame untouched).
+and its teardown tears down only its own window, leaving a sibling chat untouched).
 
 **A second, narrower race survives even that fix.** `new-session` starts the harness
 running immediately; the hooks that would record its exit code and end the session are
 not installed until separate `set-hook` calls a few milliseconds later (measured
 8.2-10.5ms). A harness that dies inside that window is never caught by them — hooks do
 not fire retroactively for an event that already happened — and this is worse than
-`state.exit_code` merely reading back `None`: with nothing left to run `kill-session`, an
+`state.exit_code` merely reading back `None`: with nothing left to run the teardown, an
 `attach` against that session BLOCKS FOREVER (verified by hand against a real tmux 3.7c,
 via a Python `pty` driving the real launcher end to end — `remain-on-exit`, armed for
 exactly this reason, is legitimately keeping the dead pane's session alive; nothing else
@@ -47,7 +49,7 @@ not sufficient on its own. What actually closes the race is asking tmux directly
 `display-message -p -t <harness_pane> '#{pane_dead}:#{pane_dead_status}'`, IMMEDIATELY
 after the hooks are installed and BEFORE ever calling `attach`: if the pane is already
 dead at that point, this launcher finishes the hooks' own job itself (records the code,
-runs `kill-session`) and skips `attach` entirely, rather than block on a session that
+runs the teardown) and skips `attach` entirely, rather than block on a session that
 will never end on its own. The same query runs again as a fallback after `attach` DOES
 return, for whatever gap the eager check could not have seen yet.
 
@@ -68,10 +70,23 @@ nothing left for any path, however hostile, to corrupt (verified against tmux 3.
 a path containing a space, a literal `'`, and a `$(...)` injection attempt: the exact
 byte string reaches the file and nothing embedded in it runs).
 
+**One session now holds several chats, so that variable names the frame ROOT and the hook
+appends the chat.** It used to name one frame's own `exit` file, which was correct while a
+session held exactly one frame and is a wrong exit code the moment it holds two: a
+`set-environment` is session-scoped, so the second chat's launch would repoint it and the
+first chat's death would write its status into the second chat's file. The chat comes from
+the `@charter_chat` WINDOW option through a tmux format, `#{@charter_chat}`, expanded in
+the dying pane's own context — measured on tmux 3.7c and on tmux 3.2, a real `pane-died`
+hook wrote `42` to `$CHARTER_FRAME_EXIT/<chat>/exit` on both. The hook action stays a
+constant string, which is the property that paragraph is about: the operator-controlled
+half (the plane root) still travels out of band, and the half that is interpolated is a
+chat id in `_FRAME_ID_RE`'s closed alphabet, which holds no quote, `$`, backtick or space
+for the nested parse to trip over.
+
 **Teardown is its own hook, `pane-died[1]`, entirely separate from the write hook
-(`pane-died[0]`).** `kill-session` alone, a constant string with no interpolated data at
+(`pane-died[0]`).** `kill-window` alone, a constant string with no interpolated data at
 all. Verified by hand: even with the write hook's own action deliberately mangled, the
-teardown hook — sharing no text with it — still fired and ended the session correctly.
+teardown hook — sharing no text with it — still fired and ended the frame correctly.
 Belt and braces over the constant-action fix above: it means a *future* bug in the write
 hook's own construction can degrade to "the wrong exit code was recorded" and never
 regress all the way back to "the session never ends."
@@ -86,7 +101,7 @@ did before either hook existed. See `_pane_died_teardown_hook_argv`'s own docstr
 
 **A command that dies before the frame is drawn is reported AFTER the fact, never
 refused before it (#384).** The eager `#{pane_dead}` check above is exactly what makes
-that death total: it catches the dead pane, runs `kill-session`, and because `code is
+that death total: it catches the dead pane, runs `kill-window`, and because `code is
 not None` from that moment the entire attach branch — panels, `select-pane`, `attach` —
 is skipped, so there is no pane, no attach, and nothing drawn. Measured under a pty
 against a real tmux 3.7c: **zero bytes**, both for `charter frame -- nosuchthing` and
@@ -100,7 +115,7 @@ the wrong question of text that is not even one word; over the second it is a pr
 where a real answer arrives for free a few milliseconds later (a binary that resolves
 can still exit 127 for its own reasons, or carry a broken shebang). So nothing is
 refused, and `early_death_message` builds the report out of what tmux actually did —
-quoting the pane (`_pane_last_words`, read BEFORE `kill-session` destroys it) when the
+quoting the pane (`_pane_last_words`, read BEFORE `kill-window` destroys it) when the
 shell already said what was wrong, and answering for itself when a failed `execvp` left
 the pane empty and a bare exit 1.
 
@@ -172,10 +187,31 @@ _FALLBACK_SIZE = (80, 24)
 #: launcher's fallback query) has a pane left to learn anything from.
 _PLACEHOLDER_CONF = "set -g remain-on-exit on\n"
 
-#: The session-scoped environment variable the write hook's shell reads the exit-status
-#: path back from — see the module docstring's "constant string" section for why the
-#: path is delivered this way instead of being embedded in the hook's own action text.
+#: The session-scoped environment variable the write hook's shell reads the frame ROOT
+#: back from — see the module docstring's "constant string" section for why the path is
+#: delivered this way instead of being embedded in the hook's own action text, and
+#: `_exit_path_env_argv` for why it is the root rather than one chat's file.
 _EXIT_PATH_ENV = "CHARTER_FRAME_EXIT"
+
+#: The WINDOW option that says which chat a window is drawing — the identity, where the
+#: window's NAME is only a label.
+#:
+#: **A window name is not an identity, and that is measured rather than argued.** On tmux
+#: 3.7c and on tmux 3.2 alike: `new-window -n api.3` does pin the name (it turns that
+#: window's `automatic-rename` off), but with `allow-rename on` the pane's own output —
+#: `printf '\033kPWNED\033\\'` — renamed the window to `PWNED` on both versions while
+#: this option was untouched. `automatic-rename` is also ON by default, so any window
+#: charter did NOT name follows whatever runs in it. A liveness list read from
+#: `#{window_name}` therefore loses a chat the moment something renames its window, and
+#: `state.reap` — the only thing bounding `.charter/frame/` — would delete a running
+#: chat's state. So `_live_chats` reads this, and every lookup asks the window what chat
+#: it is rather than parsing a name.
+#:
+#: `@`-prefixed because that is tmux's own namespace for options it does not define, and
+#: `@charter_hatch` (`frame/overlay.py`) is the same mechanism one surface over — which
+#: is also why `F12` is per chat with no new code: one chat per window means one hatch
+#: per window.
+_CHAT_OPTION = "@charter_chat"
 
 #: The second value carried the same out-of-band way, for the same reason: the
 #: interpreter the hotkey bind runs charter with. Owned by `tmuxctl` so every module
@@ -556,7 +592,22 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
     `mouse`/`history-limit`, just reached through a binding instead of a session-scoped
     `set`.
 
-    `"#{client_name}"` is a SECOND thing this same bind carries, for a DIFFERENT
+    **`"#{@charter_chat}"` is what makes that resolution per CHAT, and it is not
+    decoration over the variable — it is the only thing that works.** A session holds
+    several chats now, and `set-environment` has no window scope, so
+    `$CHARTER_SESSION_ID` can only ever name one of them. Measured on tmux 3.7c and on
+    tmux 3.2, one session carrying `set-environment CHARTER_SESSION_ID session-wide` with
+    a window created `-e CHARTER_SESSION_ID=chat-A` in it: the window's own PANE reported
+    `chat-A` and a `run-shell` fired against that session reported `session-wide`. This
+    bind's action IS a `run-shell`, so the variable would hand every chat's keypress the
+    same frame. The window option does not: like `#{client_name}` beside it, it is
+    expanded in the context of whoever's keypress is firing the bind, so `F2` in chat two
+    opens chat two's palette. `cmd_palette` falls back to `$CHARTER_SESSION_ID` when the
+    option is empty, which is what a frame launched by an older charter — its window
+    carrying no such option, its bind text replaced by this one the moment a newer frame
+    launches on the shared server — still resolves through.
+
+    `"#{client_name}"` is a THIRD thing this same bind carries, for a DIFFERENT
     reason: which of possibly several clients attached to one frame should be TOLD when
     an action refuses. Format expansion resolves `#{client_name}` in the context of
     whoever's keypress is firing the bind — verified by hand with two real ptys attached
@@ -685,7 +736,8 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
         "set -g remain-on-exit on",
         "set -g focus-events on",
         f"bind -n {hotkey} run-shell "
-        f"'\"${_CHARTER_PY_ENV}\" -m charter frame-palette \"#{{client_name}}\"'",
+        f"'\"${_CHARTER_PY_ENV}\" -m charter frame-palette \"#{{client_name}}\" "
+        f"--chat \"#{{{_CHAT_OPTION}}}\"'",
         f"bind -n {tmuxctl.WHEEL_KEY} if-shell -F -t = '#{{mouse_any_flag}}'"
         " 'send-keys -M' 'copy-mode -e; send-keys -M'",
         f"bind -n {tmuxctl.CLICK_KEY} if-shell -F -t = '#{{{_PANEL_OPTION}}}'"
@@ -697,7 +749,8 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
         if instance.toggle_key(key) is None:
             continue
         lines.append(f"bind -n {key} run-shell "
-                     f"'\"${_CHARTER_PY_ENV}\" -m charter frame-toggle {name}'")
+                     f"'\"${_CHARTER_PY_ENV}\" -m charter frame-toggle {name} "
+                     f"--chat \"#{{{_CHAT_OPTION}}}\"'")
     # The escape hatch stays the LAST line, which is this file's own invariant and not
     # this loop's convenience: `frame/overlay.py`'s `hatch_bind` is the one bind that has
     # to keep working when charter's code does not, and it uses `run-shell -C`, which
@@ -763,20 +816,27 @@ def _charter_pythonsafepath_env_argv(*, socket: str, session: str) -> list[str]:
                                _PYTHONSAFEPATH_ENV, "1")
 
 
-def _exit_path_env_argv(*, socket: str, session: str, status_path: str) -> list[str]:
-    """`set-environment`: carries *status_path* to the write hook's shell out of band.
+def _exit_path_env_argv(*, socket: str, session: str, frame_root: str) -> list[str]:
+    """`set-environment`: carries the frame ROOT to the write hook's shell out of band.
 
     One argv value, no shell parsing at all on this side — the whole point (see the
     module docstring). `run-shell`'s own spawned shell later reads it back from its
     inherited environment via `$CHARTER_FRAME_EXIT`, verified by hand to work for a
     SESSION-scoped `set-environment` (no `-g`) reaching a hook fired for a pane in that
     session.
+
+    **The root, not one chat's file, and a session holding two chats is why.** This is a
+    SESSION-scoped variable and a session is now a workspace, so a value naming one
+    chat's `exit` file is a value the next chat's launch repoints — after which the first
+    chat's death writes its status into the second chat's file and that chat's launcher
+    reports a number that was never its own. The hook appends the chat itself, from the
+    window option `_chat_option_argv` writes; see `_pane_died_write_hook_argv`.
     """
     return tmuxctl.server_argv(socket, "set-environment", "-t", session, _EXIT_PATH_ENV,
-                               status_path)
+                               frame_root)
 
 
-def _session_id_env_argv(*, socket: str, session: str) -> list[str]:
+def _session_id_env_argv(*, socket: str, session: str, chat: str) -> list[str]:
     """`set-environment`: makes *session* resolvable from its own `run-shell` calls.
 
     `cmd_palette` (the hotkey bind's own action) and every action it starts read
@@ -796,13 +856,53 @@ def _session_id_env_argv(*, socket: str, session: str) -> list[str]:
     unfixed, every frame after the first would open the FIRST frame's own palette and
     run its actions against the wrong session's state.
 
-    The value IS the session's own name (`state.frame_id`'s own restricted alphabet —
-    see its docstring — so there is nothing here for this call's own text to sanitise),
-    which is why this hands the session right back to itself rather than taking a
-    separate value the way `_exit_path_env_argv` takes `status_path`.
+    **The value is the CHAT's id, and the session's name is the workspace.** Those used to
+    be one string; they are two now, and this variable means the frame rather than the
+    session it is drawn in, so it takes *chat* explicitly. `state.new_chat_id` mints it in
+    the same restricted alphabet `state.frame_id` used, so there is still nothing here for
+    this call's own text to sanitise.
+
+    **It is a FALLBACK under tabs, not the mechanism, and that is measured.** A session
+    can only hold one value of it, so with two chats it names whichever launch set it
+    last. What makes a keypress reach the RIGHT chat is `conf_text`'s bind carrying
+    `#{@charter_chat}`, expanded in the presser's own window. This is still set because a
+    `run-shell` child reads the SESSION's environment and nothing else: measured on tmux
+    3.7c and on 3.2, a window created with `-e CHARTER_SESSION_ID=chat-A` gave `chat-A` to
+    its own pane and `session-wide` to a `run-shell` fired against that session. So a
+    chat's harness gets its id from `-e` (`layout.chat_window_argv`), a keypress gets it
+    from the bind, and this is what answers for everything else that asks the session.
     """
     return tmuxctl.server_argv(socket, "set-environment", "-t", session,
-                               "CHARTER_SESSION_ID", session)
+                               "CHARTER_SESSION_ID", chat)
+
+
+def _chat_option_argv(*, socket: str, harness_pane: str, chat: str) -> list[str] | None:
+    """`set-option -w`: write which chat this window is drawing. ``None`` to refuse.
+
+    Task-critical and one line, because it is what every later lookup asks instead of
+    parsing a name (see :data:`_CHAT_OPTION` for the measurement that makes a name
+    unusable for it). `state.reap` reads it back through `_live_chats`, the `pane-died`
+    write hook expands it as `#{@charter_chat}` to find the chat's own `exit` file, and
+    `conf_text`'s binds carry it so a keypress reaches the presser's own chat.
+
+    **Window-scoped, targeting the harness PANE** — the idiom
+    `_panel_remain_on_exit_argv` and `overlay.arm_hatch_argv` already use, and for the
+    same reason: `-w -t <a pane id>` resolves to that pane's window, which is charter's
+    own on either server (measured again here on tmux 3.7c and 3.2 — the option set that
+    way reads back through `list-windows -a -F '#{@charter_chat}'`). Never `-g`, which
+    would hand every window on charter's shared private server one chat's id.
+
+    ``None`` rather than a raise for `overlay.arm_hatch_argv`'s reason — this is called
+    from inside a launch — and the check is `_FRAME_ID_RE`, the same alphabet a frame id
+    already travels to tmux under. It is asked HERE rather than trusted from
+    `state.new_chat_id` because the value goes on to be expanded by tmux inside a hook
+    action and inside a key bind, and a value that reaches two re-parsing grammars is
+    checked where it enters them, not where it was minted.
+    """
+    if not _FRAME_ID_RE.fullmatch(chat or ""):
+        return None
+    return tmuxctl.server_argv(socket, "set-option", "-w", "-t", harness_pane,
+                               _CHAT_OPTION, chat)
 
 
 def _pane_died_write_hook_argv(*, socket: str, harness_pane: str) -> list[str]:
@@ -826,18 +926,52 @@ def _pane_died_write_hook_argv(*, socket: str, harness_pane: str) -> list[str]:
     substitutes for UNSET, not empty) closes that at the point of writing, so the file
     this hook produces is always a parseable integer — `_UNKNOWN_DEATH_CODE` on a signal
     death, the real status otherwise. Verified against tmux 3.7c for both.
+
+    **The path is the frame root plus this window's own chat**, `$CHARTER_FRAME_EXIT` from
+    the session and `#{@charter_chat}` from the window, and both halves are load-bearing.
+    A session holds several chats, so the session-scoped variable cannot name one chat's
+    file without the next launch repointing it (see `_exit_path_env_argv`); and the chat
+    cannot travel in the variable for the same reason. `#{@charter_chat}` is expanded by
+    tmux in the context of the pane the hook fired for — measured against tmux 3.7c AND
+    tmux 3.2, a real `pane-died` on a window carrying `@charter_chat hooky.7`, with the
+    exit path set to a directory: both wrote `42` to `<dir>/hooky.7/exit`.
+
+    **This action is still a CONSTANT string** — the property the module docstring calls
+    the whole fix. The two things it names are resolved by tmux and by the shell at fire
+    time, not interpolated here, so a plane root with an apostrophe in it still cannot
+    corrupt the stored text. The chat id that IS interpolated by tmux is `_FRAME_ID_RE`'s
+    closed alphabet (`_chat_option_argv` refuses anything else on the way in), so it holds
+    no quote, `$`, backtick, space or `#` for either parser to trip over.
     """
     action = ('run-shell "v=#{pane_dead_status}; echo '
              f'\\"\\${{v:-{_UNKNOWN_DEATH_CODE}}}\\" > '
-             f'\\"\\${_EXIT_PATH_ENV}\\""')
+             f'\\"\\${_EXIT_PATH_ENV}/#{{{_CHAT_OPTION}}}/exit\\""')
     return tmuxctl.server_argv(socket, "set-hook", "-p", "-t", harness_pane, "pane-died",
                                action)
 
 
 def _pane_died_teardown_hook_argv(*, socket: str, harness_pane: str) -> list[str]:
-    """`pane-died[1]`: ends the session. Nothing else — see the module docstring's
+    """`pane-died[1]`: ends the CHAT's window. Nothing else — see the module docstring's
     "Teardown is its own hook" section for why this is never combined with the write
     hook above.
+
+    **`kill-window`, never `kill-session`, and this is the single most dangerous line in
+    the move to chats.** A session used to be one frame, so ending it ended exactly the
+    frame whose harness had died. A session is a WORKSPACE now and a chat is one window
+    in it, so the old spelling would take every other chat in that workspace down with the
+    one that died — including chats mid-turn, in another agent's terminal, for a death
+    that had nothing to do with them.
+
+    Measured on tmux 3.7c and on tmux 3.2, one session, a pane-scoped `pane-died[1]
+    kill-window` on a harness that exits 9: the dying chat's window is gone, every sibling
+    window is still listed, and the session is still listed. And the single-chat case is
+    unchanged where it matters — killing a session's last window destroys the session
+    (measured on both), so `attach` returns exactly as it did.
+
+    The hook is PANE-scoped (`-p -t <harness pane>`), and `kill-window` with no `-t` acts
+    on the target the hook fired for, which is that pane's own window. The same
+    pane-resolves-to-its-window rule is what `_remain_on_exit_argv` and
+    `overlay.arm_hatch_argv` already rely on for `-w -t <pane>`.
 
     **Must be installed AFTER `_pane_died_write_hook_argv`, never before — this is not
     a style preference, it is the entire fix.** Verified by hand against tmux 3.7c: an
@@ -854,7 +988,7 @@ def _pane_died_teardown_hook_argv(*, socket: str, harness_pane: str) -> list[str
     behaviour against a real server.
     """
     return tmuxctl.server_argv(socket, "set-hook", "-p", "-t", harness_pane,
-                               "pane-died[1]", "kill-session")
+                               "pane-died[1]", "kill-window")
 
 
 #: How many times one slot's panel may be brought back before charter stops trying, per
@@ -1277,16 +1411,71 @@ def _live_windows(socket: str) -> set[str] | None:
     return {line.strip() for line in out.stdout.splitlines() if line.strip()}
 
 
+def _live_chats(socket: str) -> set[str] | None:
+    """Every chat id *socket*'s server reports through the `@charter_chat` window option,
+    or ``None`` when it did not answer at all.
+
+    The liveness list for a CHAT, and the one `state.reap` has to be given for one: a
+    chat's id carries no launcher pid (`state.new_chat_id`), so this list is the only
+    thing keeping its directory, and a chat missing from it is a chat whose state is
+    deleted.
+
+    **The OPTION, not `#{window_name}`, and the difference is a running chat's state.**
+    `_live_windows` reads the name because that is what the guest path has always named a
+    frame's window; a name is not an identity. Measured on tmux 3.7c and on tmux 3.2:
+    `new-window -n api.3` pins the name and turns `automatic-rename` off for that window,
+    but with `allow-rename on` the pane's own `printf '\\033kPWNED\\033\\\\'` renamed it
+    to `PWNED` on both versions while `@charter_chat` stayed `api.3`. A liveness list read
+    from the name loses that chat, and `reap` — the only bound on `.charter/frame/` —
+    removes the state of a chat that is running.
+
+    **``None`` rather than an empty set for a non-zero return, and here it costs more
+    than it does anywhere else in this module.** `_live_windows` keeps the two apart
+    because `$TMUX` can outlive its server; this keeps them apart because a chat's
+    directory has NOTHING ELSE keeping it. An old frame that vanished from a failed
+    `list-sessions` is still held by the pid in its name (#383); a chat has no pid, so a
+    server that answers "no windows" because it was wedged rather than because it is
+    empty would take every live chat's state with it — the version file its panels poll
+    and the exit code its launcher has not read yet. Both callers refuse to reap on that
+    answer. A LIVE server with no chats on it is a different fact and answers with an
+    empty set, which reaps exactly as it should.
+
+    A window with no such option prints an empty line, which the comprehension drops.
+
+    **Stripped once, tested once.** `_live_sessions` and `_live_windows` both spell
+    ``{line.strip() for line in … if line.strip()}``, and the second call is an
+    EQUIVALENT MUTANT: ``s.strip()`` and ``s.lstrip()`` are truthy for exactly the same
+    strings, so no test can tell the guard from its own mutation. Stripping into a name
+    and asking whether the NAME is empty says the same thing once, and both halves are
+    then pinnable — `tests/test_frame_launcher.TheChatListIsParsedLineByLine` pins them.
+    """
+    out = tmuxctl.run("listing the chats already running",
+                      tmuxctl.server_argv(socket, "list-windows", "-a", "-F",
+                                          f"#{{{_CHAT_OPTION}}}"),
+                      timeout=5, report=False)
+    if out.returncode != 0:
+        return None
+    names = (line.strip() for line in out.stdout.splitlines())
+    return {name for name in names if name}
+
+
 def _frame_is_live(socket: str, fid: str) -> bool:
     """Is the frame *fid* still running on *socket*? One question, one place — #408.
 
-    A frame is a SESSION on charter's own private server and a WINDOW in the operator's,
-    so "is it still there" is two different queries and `tmuxctl.is_operator_socket` is
-    the same single discriminator that already turns a server into `-L` or `-S`.
+    A frame is a WINDOW on either server now — one of a workspace session's chats on
+    charter's own, one of the operator's own windows in theirs — and `@charter_chat` is
+    what it answers to on both, so `_live_chats` is asked either way.
+    `tmuxctl.is_operator_socket` is the same single discriminator that already turns a
+    server into `-L` or `-S`, and it still decides what the SECOND question is:
     `cmd_respawn` asked `_live_sessions(SOCKET)` unconditionally, which on the operator's
     server is a question about a server that is not theirs: it answers "no such session"
     for a frame that is on screen, so a panel that died there could never have been
     brought back even once the hook reached charter.
+
+    The second question is the old shape's, and both are asked because both can answer:
+    a frame launched by a charter that predates chats is still a session named by its id
+    on charter's server and a window named by its id in the operator's, and neither of
+    those carries `@charter_chat`.
 
     ``False`` for a server that did not answer at all (`_live_windows`'s ``None``), and
     that direction is deliberate: the only caller is about to RESPAWN something, and
@@ -1295,8 +1484,10 @@ def _frame_is_live(socket: str, fid: str) -> bool:
     """
     if tmuxctl.is_operator_socket(socket):
         live = _live_windows(socket)
-        return live is not None and fid in live
-    return fid in _live_sessions(socket)
+        if live is None:
+            return False
+        return fid in live or fid in (_live_chats(socket) or set())
+    return fid in _live_sessions(socket) or fid in (_live_chats(socket) or set())
 
 
 def _wait_for_harness(socket: str, harness_pane: str) -> int | None:
@@ -2051,8 +2242,9 @@ def _panel_remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
                                "remain-on-exit", "on")
 
 
-def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, ws: str,
-                             argv: list[str], h, v: tuple[int, int]) -> int | None:
+def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
+                             argv: list[str], h, v: tuple[int, int],
+                             picked: bool) -> int | None:
     """Build the frame as a WINDOW in the tmux the operator is already in.
 
     The same layout as the private-server path — harness in the middle, charter's panels
@@ -2134,17 +2326,37 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, ws: str,
     live_before = _live_windows(socket)
     if live_before is None:
         return None
-    state.reap(live_before, server=socket)
+    # Both lists, and the same refusal `_reap_this_server` makes: a chat's directory is
+    # kept by `@charter_chat` alone (no launcher pid abstains in its favour), so a server
+    # that answered for the window NAMES and would not answer for the chats is one
+    # charter cannot reap on.
+    chats_before = _live_chats(socket)
+    if chats_before is not None:
+        state.reap(live_before | chats_before, server=socket)
 
+    # AFTER the reap, never before it: allocation claims a directory by creating it
+    # (`state.new_chat_id`), and a `reap` that ran afterwards would see a directory with
+    # no window of its own yet and delete it out from under this very launch. The same
+    # ordering, for the same reason, as the private-server path's.
+    fid = state.new_chat_id(ws)
+    if fid is None:
+        util.err(f"charter frame: could not open a chat in workspace {ws!r} — its state "
+                 f"directory could not be created")
+        return 1
+    _pin_workspace(ws, fid, picked)
     fdir = state.frame_dir(fid, create=True)
     if fdir is None:
         util.err(f"charter frame: could not create state for frame {fid!r}")
         return 1
-    # The same recycled-pid adoption #383 fixed on the private-server path, and nothing
-    # about it is private-server-specific: `fid` is `<workspace>-<launcher pid>` on
-    # either server, `reap` keeps a directory for as long as that pid is live, and on a
-    # launch it is live because it is ours — so an earlier launcher for this workspace
-    # that landed on the same pid leaves its whole directory here to be adopted.
+    # The recycled-pid adoption #383 fixed, kept as belt and braces on both paths now
+    # that it cannot happen. A frame id WAS `<workspace>-<launcher pid>`, `reap` keeps
+    # such a directory while that pid is live, and on a launch it was live because it was
+    # ours — so an earlier launcher for this workspace that landed on the same pid left
+    # its whole directory to be adopted. `state.new_chat_id` claims its ordinal with a
+    # `mkdir` that FAILS when the name is taken, so a launch cannot land on an occupied
+    # directory at all. These four calls therefore have nothing to clear today; they are
+    # kept because Stage 5c reopens a COLD chat into its own existing directory, which is
+    # the case they are actually for (`state.clear_shape`, #413).
     #
     # `gather.json` is the one that costs something on this path: `gather.read` has no
     # freshness check by design (a panel's hot path) and a panel repaints only on a
@@ -2192,6 +2404,12 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, ws: str,
     # (ADR 0019, `state.record_harness_pane`). Recorded before the harness is started, so
     # the very first status line it spawns can already answer.
     state.record_harness_pane(fid, harness_pane)
+    # What every later lookup asks instead of parsing this window's name — the liveness
+    # list `_reap_this_server` reads, and the same option `@charter_hatch` already uses.
+    # A window name is not an identity; see `_CHAT_OPTION`.
+    named = _chat_option_argv(socket=socket, harness_pane=harness_pane, chat=fid)
+    if named is not None:
+        tmuxctl.run("naming the chat on its window", named)
 
     def _close_window() -> None:
         tmuxctl.run("closing the frame's window",
@@ -2287,10 +2505,17 @@ def _reap_this_server(socket: str) -> None:
     would delete a sibling frame's version file and recorded exit code over a question
     charter could not get an answer to. Not reaping costs a directory until the next
     launch; reaping on no information costs a running frame its state.
+
+    The chat ids are unioned in for `_live_chats`' own reason, and it matters MORE here
+    than on charter's own server rather than less: this is somebody else's tmux, where
+    `allow-rename on` is an ordinary thing to have in a `.tmux.conf`, and a frame whose
+    window the harness has renamed is a frame this function would otherwise reap while
+    the operator was looking at it.
     """
     live = _live_windows(socket)
-    if live is not None:
-        state.reap(live, server=socket)
+    chats = _live_chats(socket)
+    if live is not None and chats is not None:
+        state.reap(live | chats, server=socket)
 
 
 def _measure_window(socket: str, harness_pane: str) -> tuple[int, int] | None:
@@ -2944,6 +3169,52 @@ def _choose_workspace(args) -> tuple[str, int | None, bool]:
     return got.name, None, True
 
 
+def _pin_workspace(ws: str, fid: str, picked: bool) -> None:
+    """Write the workspace pointer for a chat the operator PICKED — and say it locked.
+
+    Lifted out of `cmd_launch` rather than copied, because both launch paths now allocate
+    their own chat id after their own reap (`state.new_chat_id` claims a directory, and a
+    reap that ran afterwards would delete it), so the pointer can only be written once the
+    id exists — which is inside each path rather than above both of them.
+
+    **Only when the operator actually picked.** A launch that resolved silently writes no
+    pointer today and must keep writing none — starting to would move every framed
+    session's workspace on a path nobody asked anything on.
+
+    *fid* is the chat, so the per-session pointer lands under the CHAT's id: inside a frame
+    the frame IS the charter session (ADR 0019), which is what makes the choice reach the
+    panels and the agent's own shell alike (`state.workspace_for` rung 1) — and what makes
+    two chats in one workspace able to hold two different pointers. `set_active` also
+    writes the pointer for the LAUNCHER's terminal, and that is the half that answers
+    #518's "must not answer a prompt every launch": the next launch from this terminal
+    finds `workspace.chosen` already answered and never asks.
+
+    `force=True` is kept, and its reason has narrowed rather than gone. It was for the
+    recycled pid: an earlier launcher for this workspace landing on this process's pid
+    minted the same id and could have left a lock under it. An allocated id cannot be a
+    previous frame's, so that case is closed by `new_chat_id` — but a lock can still be
+    standing under this id from a chat that ran, was reaped, and had its ordinal allocated
+    again, and being refused by a dead frame's lock on a name the operator just typed is
+    not a refusal worth having.
+
+    **Picking IS the confirmation that locks, and #518 asks that this be decided and
+    SAID.** `set_active`'s contract is that confirming a workspace locks the session to it,
+    and the picker is a confirmation — the alternative would be a launch that writes the
+    pointer and leaves the lock off, which is a third behaviour for `charter workspace use`
+    to disagree with. What makes it liveable is that the frame has its own way out: `F2 →
+    workspace` overrides the lock and says so (`frame/switch.py`), so the operator is not
+    sent back to the shell for a choice they just made at a prompt. Printed here rather
+    than in the picker, because it describes what the LAUNCH did with the answer, not what
+    the answer was.
+    """
+    if not picked:
+        return
+    workspace.set_active(ws, session_id=fid, force=True)
+    util.info(f"Workspace '{contain.one_line(ws)}' — 🔒 locked for this frame's "
+              f"session. F2 → workspace changes it; `charter workspace unlock` "
+              f"releases it.")
+
+
 def cmd_launch(args) -> int:
     """One launcher, shared by every registered harness and by `charter frame --`."""
     if getattr(args, "probe", False):
@@ -3015,39 +3286,6 @@ def cmd_launch(args) -> int:
     ws, rc, picked = _choose_workspace(args)
     if rc is not None:
         return rc
-    fid = state.frame_id(ws, os.getpid())
-    if picked:
-        # **Only when the operator actually picked.** A launch that resolved silently
-        # writes no pointer today and must keep writing none — starting to would move
-        # every framed session's workspace on a path nobody asked anything on.
-        #
-        # `session_id=fid`, so the per-session pointer lands under the FRAME's id: inside
-        # a frame the frame IS the charter session (ADR 0019), which is what makes the
-        # choice reach the panels and the agent's own shell alike (`state.workspace_for`
-        # rung 1). `set_active` also writes the pointer for the LAUNCHER's terminal, and
-        # that is the half that answers #518's "must not answer a prompt every launch":
-        # the next launch from this terminal finds `workspace.chosen` already answered
-        # and never asks.
-        #
-        # `force=True` because `fid` is minted from the workspace and this process's pid,
-        # so an earlier launcher with the same pid and the same workspace can have left a
-        # lock under this very id (`cmd_launch` reaps exactly that case a few lines down).
-        # Being refused by a dead frame's lock, on a name the operator just typed, is not
-        # a refusal worth having.
-        workspace.set_active(ws, session_id=fid, force=True)
-        # **Picking IS the confirmation that locks, and #518 asks that this be decided and
-        # SAID.** `set_active`'s contract is that confirming a workspace locks the session
-        # to it, and the picker is a confirmation — the alternative would be a launch that
-        # writes the pointer and leaves the lock off, which is a third behaviour for
-        # `charter workspace use` to disagree with. What makes it liveable is that the
-        # frame has its own way out: `F2 → workspace` overrides the lock and says so
-        # (`frame/switch.py`), so the operator is not sent back to the shell for a choice
-        # they just made at a prompt. Printed here rather than in the picker, because it
-        # describes what the LAUNCH did with the answer, not what the answer was.
-        util.info(f"Workspace '{contain.one_line(ws)}' — 🔒 locked for this frame's "
-                  f"session. F2 → workspace changes it; `charter workspace unlock` "
-                  f"releases it.")
-
     # Inside a tmux the operator already has, the frame is a WINDOW in THEIR server —
     # same layout, no second tmux, no second prefix key (ADR 0018 and the design spec
     # both settle this; `docs/frame.md` describes what it costs). Read from `$TMUX`,
@@ -3058,8 +3296,8 @@ def cmd_launch(args) -> int:
     # exactly that, and the private-server path below is the right one after all.
     inside = tmuxctl.operator_server()
     if inside is not None:
-        rc = _launch_in_operator_tmux(inside[0], inside[1], fid=fid, ws=ws, argv=argv,
-                                      h=h, v=v)
+        rc = _launch_in_operator_tmux(inside[0], inside[1], ws=ws, argv=argv,
+                                      h=h, v=v, picked=picked)
         if rc is not None:
             return rc
 
@@ -3070,8 +3308,21 @@ def cmd_launch(args) -> int:
     # also narrows (though does not close) the same race for a sibling frame's `exit`
     # file: less time between "session gone" and "directory removed" for a sibling's own
     # launcher to lose the read.
-    live_before = _live_sessions(SOCKET)
-    if live_before:
+    live_sessions = _live_sessions(SOCKET)
+    # Both, and neither is redundant: a CHAT's directory is kept only by the chat id its
+    # window carries (`_live_chats` — a chat's id holds no launcher pid for `reap`'s
+    # second rule to abstain in its favour), and a frame launched by a charter that
+    # predates chats is still a SESSION named by its id and is kept only by that list.
+    live_chats = _live_chats(SOCKET)
+    # A server that listed SESSIONS and then would not list its windows is a server
+    # charter cannot tell the live chats of, and reaping on that answer deletes the state
+    # of chats that are running — the version file their panels poll and the exit code
+    # their own launcher has not read yet. Not reaping costs a directory until the next
+    # launch. An EMPTY session list is the opposite fact and reaps as it always did: the
+    # server is not running, so nothing recorded against it is live.
+    can_reap = live_chats is not None or not live_sessions
+    live_before = live_sessions | (live_chats or set())
+    if live_sessions:
         # Arm `remain-on-exit` by construction here, not by coincidence. The placeholder
         # `-f` config above only takes effect if THIS `new-session` call is what starts
         # the tmux server — but a server on `SOCKET` may already be running for a reason
@@ -3085,7 +3336,28 @@ def cmd_launch(args) -> int:
         # first-frame-ever case.
         tmuxctl.run("arming remain-on-exit ahead of an already-running server",
                     tmuxctl.server_argv(SOCKET, "set", "-g", "remain-on-exit", "on"))
-    state.reap(live_before, server=SOCKET)
+    if can_reap:
+        state.reap(live_before, server=SOCKET)
+
+    # AFTER the reap, for the reason the paragraph above gives about the directory: the
+    # allocation IS a `mkdir`, so an id claimed before the reap would be a directory the
+    # reap then deleted, with this launch already holding the name.
+    #
+    # **Allocated, not computed.** `state.frame_id`'s `{workspace}-{pid}` could collide
+    # with a previous launcher's on a recycled pid, which is what `clear_exit` /
+    # `clear_shape` / `clear_respawn` below exist to survive; a claimed ordinal cannot,
+    # because `mkdir` is the exclusion. Those calls stay because Stage 5c reopens a COLD
+    # chat into its own existing directory, which is the case they are actually for.
+    fid = state.new_chat_id(ws)
+    if fid is None:
+        util.err(f"charter frame: could not open a chat in workspace {ws!r} — its state "
+                 f"directory could not be created")
+        return 1
+    _pin_workspace(ws, fid, picked)
+    # The tmux SESSION is the workspace, and the chat is one window in it. `new_chat_id`
+    # spells the id out of the same `workspace_prefix`, so the session's name is exactly
+    # the part of the chat id before the dot and the two can always be matched up by eye.
+    session = state.workspace_prefix(ws)
 
     fdir = state.frame_dir(fid, create=True)
     if fdir is None:
@@ -3094,13 +3366,16 @@ def cmd_launch(args) -> int:
         # ENAMETOOLONG) must not be treated as a Path here just because it usually is one.
         util.err(f"charter frame: could not create state for frame {fid!r}")
         return 1
-    # The pid this launch was handed may have belonged to an earlier launcher for the
-    # same workspace, which mints the SAME `fid` — and since #383 `reap` keeps that
-    # earlier directory for as long as the pid in its name is live, which right now it
-    # is, because it is ours. Everything recorded under this id therefore predates this
-    # frame, and a launch beginning is the one moment that can be certain of it.
+    # Belt and braces, and no longer the guard it was. The pid this launch was handed
+    # could belong to an earlier launcher for the same workspace, which minted the SAME
+    # `<workspace>-<pid>` id — and since #383 `reap` keeps that earlier directory while
+    # the pid in its name is live, which on a launch it is, because it is ours. An
+    # ALLOCATED id cannot be a previous frame's: `state.new_chat_id` claims by `mkdir`
+    # and a taken ordinal is skipped, so nothing is under this id to clear. Kept because
+    # Stage 5c's reopen relaunches into a cold chat's OWN directory, which is where these
+    # four become live again — `state.clear_shape` most of all (#413).
     #
-    # Three things, because three readers inherit. `state.exit_code(fid)` below would
+    # Three things, because three readers inherited. `state.exit_code(fid)` below would
     # read a dead frame's `exit` back as this launch's own return value. `gather.read(fid)`
     # (no freshness check, by design — it is a panel's hot path) would serve a dead
     # frame's scan to every panel until the session's first hook bump. And
@@ -3147,7 +3422,10 @@ def cmd_launch(args) -> int:
     state.record_identity(fid, _frame_identity_env(env))
 
     conf_path = fdir / "tmux.conf"
-    status_path = fdir / "exit"
+    # The frame ROOT, not this chat's own `exit` file: the variable is session-scoped and
+    # a session holds several chats now, so the hook appends `#{@charter_chat}` itself.
+    # See `_exit_path_env_argv` and `_pane_died_write_hook_argv`.
+    frame_root = fdir.parent
     # `config.write_for`, not `Path.write_text`: this file is under `.charter/frame/<fid>/`
     # and `write_text` creates at `0o777 & ~umask` — 0644 by default, 0666 under `umask
     # 000`. The frame's tmux config carries the session id, the hotkey and the toggles, and
@@ -3167,27 +3445,67 @@ def cmd_launch(args) -> int:
     #
     # Withheld below `SESSION_ENV_FLOOR`, where `-e` is a parse error rather than a
     # missing feature and would take the whole launch down with it.
-    session_cmd = layout.session_argv(
-        session=fid, conf=str(conf_path), socket=SOCKET, cols=cols, rows=rows,
-        harness_argv=argv,
-        env=_frame_identity_env(env) if v >= tmuxctl.SESSION_ENV_FLOOR else None)
-    proc = tmuxctl.run("starting the frame", session_cmd, env=env)
+    #
+    # **The workspace's session, or one more window in it.** A chat is a window, so the
+    # second chat of a workspace does not start a second session: it joins the one the
+    # first chat's launch created, which is what makes switching between them
+    # `select-window` rather than a reattach, and what makes a workspace something several
+    # harnesses can be open in at once. `new-window` carries the identical `-e` overlay
+    # for the identical reason, and needs no version gate for it — window `-e` is
+    # available at `tmuxctl.PANE_ENV_FLOOR` (3.0), below the floor, where `new-session -e`
+    # is a parse error below `SESSION_ENV_FLOOR` (3.2).
+    #
+    # **The one residual, stated rather than guarded.** `live_sessions` also holds the
+    # sessions of frames an OLDER charter launched, which are named `<workspace>-<pid>` —
+    # so a workspace named, say, `api-4242` would join a still-running old frame for
+    # workspace `api` whose launcher pid happened to be 4242, and that frame's own
+    # teardown hook (`kill-session`, installed before this change) would take the new chat
+    # down with it. It needs a workspace deliberately named like a frame id AND that exact
+    # frame still live across the upgrade, and it stops being reachable at all once the
+    # last pre-chat frame on the machine has ended. Telling the two apart would mean
+    # asking tmux a second question on every launch to buy a case that expires on its own.
+    if session in live_sessions:
+        start_cmd = layout.chat_window_argv(
+            socket=SOCKET, session=session, chat=fid, cwd=os.getcwd(),
+            harness_argv=argv, env=_frame_identity_env(env))
+        started_what = "adding a chat to the workspace"
+    else:
+        start_cmd = layout.session_argv(
+            session=session, conf=str(conf_path), socket=SOCKET, cols=cols, rows=rows,
+            harness_argv=argv, chat=fid,
+            env=_frame_identity_env(env) if v >= tmuxctl.SESSION_ENV_FLOOR else None)
+        started_what = "starting the frame"
+    proc = tmuxctl.run(started_what, start_cmd, env=env)
     if proc.returncode != 0:
         return 1
     harness_pane = proc.stdout.strip()
     if not harness_pane:
-        util.err("charter frame: tmux started the session but did not report a pane id "
+        util.err("charter frame: tmux started the frame but did not report a pane id "
                  "— cannot scope the exit-code hook to it")
         return 1
     # See the identical call on the operator's-tmux path: this is what lets a status line
     # tell "I am this frame's harness" from "I inherited this frame's id", which below
     # `SESSION_ENV_FLOOR` a second frame on this shared server genuinely does.
     state.record_harness_pane(fid, harness_pane)
+    # And what every later lookup asks instead of parsing the window's name: `reap`'s
+    # liveness list (`_live_chats`), the write hook's `#{@charter_chat}`, and the binds
+    # `conf_text` writes. Armed before either hook, so the hook that names it cannot fire
+    # against a window that has not been told yet.
+    named = _chat_option_argv(socket=SOCKET, harness_pane=harness_pane, chat=fid)
+    if named is None:
+        util.warn(f"charter frame: {fid!r} is not a shape tmux can carry as a window "
+                  "option — this chat's state may be reaped while it is still running")
+    else:
+        chat_set = tmuxctl.run("naming the chat on its window", named, env=env)
+        if chat_set.returncode != 0:
+            util.warn("charter frame: continuing without it — this chat's state may be "
+                      "reaped while it is still running, and its exit code may not be "
+                      "recorded")
 
     frame = config.FRAME
     config.write_for(conf_path,
                      conf_text(hotkey=frame["hotkey"], mouse=frame["mouse"],
-                               history_limit=frame["history_limit"], session=fid,
+                               history_limit=frame["history_limit"], session=session,
                                toggles=instance.frame_toggles(frame)))
     src = tmuxctl.run("loading the frame's config",
                       tmuxctl.server_argv(SOCKET, "source-file", str(conf_path)),
@@ -3198,7 +3516,8 @@ def cmd_launch(args) -> int:
 
     env_set = tmuxctl.run(
         "carrying the exit-status path",
-        _exit_path_env_argv(socket=SOCKET, session=fid, status_path=str(status_path)),
+        _exit_path_env_argv(socket=SOCKET, session=session,
+                            frame_root=str(frame_root)),
         env=env)
     if env_set.returncode != 0:
         util.warn("charter frame: continuing without it — the exit code may not be "
@@ -3211,7 +3530,8 @@ def cmd_launch(args) -> int:
     # `SOCKET` would silently resolve the FIRST frame's id instead of its own (see
     # `_session_id_env_argv`'s own docstring for what was verified by hand).
     sid_set = tmuxctl.run("carrying the frame id to its own palette",
-                          _session_id_env_argv(socket=SOCKET, session=fid), env=env)
+                          _session_id_env_argv(socket=SOCKET, session=session, chat=fid),
+                          env=env)
     if sid_set.returncode != 0:
         util.warn("charter frame: continuing without it — the palette may not find "
                   "this frame's own actions")
@@ -3221,7 +3541,7 @@ def cmd_launch(args) -> int:
     # on the tmux server's own `$PATH`, and `run-shell` reports the resulting 127 by
     # printing it INTO THE HARNESS PANE — see `conf_text`'s own docstring.
     py_set = tmuxctl.run("carrying charter's own interpreter to the palette",
-                         _charter_py_env_argv(socket=SOCKET, session=fid), env=env)
+                         _charter_py_env_argv(socket=SOCKET, session=session), env=env)
     if py_set.returncode != 0:
         util.warn("charter frame: continuing without it — the palette may not open "
                   "on this frame")
@@ -3247,7 +3567,8 @@ def cmd_launch(args) -> int:
     # the hotkey template above has no room for a per-invocation flag — see
     # `_charter_pythonsafepath_env_argv`'s own docstring.
     safepath_set = tmuxctl.run("carrying PYTHONSAFEPATH to the palette",
-                               _charter_pythonsafepath_env_argv(socket=SOCKET, session=fid),
+                               _charter_pythonsafepath_env_argv(socket=SOCKET,
+                                                               session=session),
                                env=env)
     if safepath_set.returncode != 0:
         util.warn("charter frame: continuing without it — the palette may import "
@@ -3267,7 +3588,7 @@ def cmd_launch(args) -> int:
                   "recorded for this frame")
 
     teardown_hook = tmuxctl.run(
-        "installing the session-teardown hook",
+        "installing the chat-teardown hook",
         _pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=harness_pane), env=env)
 
     # Closes the install race directly, rather than merely working around its symptom. A
@@ -3288,7 +3609,7 @@ def cmd_launch(args) -> int:
             # The one path on which NOTHING is ever drawn (#384): no panels, no
             # `select-pane`, no `attach` — the whole `if code is None:` block below is
             # skipped from here on — so this is the only chance the operator has of
-            # learning anything at all. Read the pane BEFORE `kill-session` destroys it;
+            # learning anything at all. Read the pane BEFORE `kill-window` destroys it;
             # afterwards there is nothing left to read.
             #
             # Only for a FAILURE. A command that finished cleanly before the frame came
@@ -3297,8 +3618,15 @@ def cmd_launch(args) -> int:
             # inventing output on the wrong stream. Its exit code is the whole message.
             util.err(early_death_message(argv, code,
                                          _pane_last_words(SOCKET, harness_pane)))
-        tmuxctl.run("ending the frame after an early death",
-                    tmuxctl.server_argv(SOCKET, "kill-session", "-t", fid), env=env)
+        # `kill-window` targeting the harness PANE, never `kill-session` on the workspace:
+        # this chat's window is what is over, and the workspace may hold other chats whose
+        # harnesses are mid-turn. Measured on tmux 3.7c and on tmux 3.2 that `kill-window
+        # -t <pane id>` resolves to that pane's own window, and that killing a session's
+        # LAST window destroys the session — so the ordinary one-chat case ends exactly as
+        # it did.
+        tmuxctl.run("ending the chat after an early death",
+                    tmuxctl.server_argv(SOCKET, "kill-window", "-t", harness_pane),
+                    env=env)
 
     attach = None
     attach_cmd = None
@@ -3312,11 +3640,11 @@ def cmd_launch(args) -> int:
             # harness keeps running (it was already started, detached); the operator can
             # still attach manually and accept that risk themselves.
             refused_to_attach = True
-            util.err("charter frame: refusing to attach — the session-teardown hook "
+            util.err("charter frame: refusing to attach — the chat-teardown hook "
                      "failed to install, so a crash later would block `attach` forever "
                      "with nothing to end the session. The harness is still running, "
                      f"detached; reattach manually if you must: "
-                     f"tmux -L {SOCKET} attach -t {fid}")
+                     f"tmux -L {SOCKET} attach -t {session}")
         else:
             # `pane_env` on this path too, since #411: a panel splits off a server that
             # may have been started by ANOTHER launcher, so `$CHARTER_WORKSPACE` and
@@ -3329,6 +3657,16 @@ def cmd_launch(args) -> int:
                 sizes=_launch_sizes(fid, slots, window_cols=cols,
                                     window_rows=rows))
             _arm_panel_respawn(SOCKET, fid=fid, panes=panes, env=env)
+
+            # The chat this launch just built is the one the operator asked for, so it
+            # is the one their client lands on. `new-window` created it detached (`-d`),
+            # for `layout.chat_window_argv`'s reason — a client already in this workspace
+            # must not be dragged onto a half-built window — and this is where that is
+            # paid back. A no-op for the launch that created the session, whose only
+            # window is already current.
+            tmuxctl.run("selecting the chat",
+                        tmuxctl.server_argv(SOCKET, "select-window", "-t", harness_pane),
+                        env=env)
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
             # after every slot has been drawn, the LAST panel drawn — not the harness —
@@ -3344,7 +3682,7 @@ def cmd_launch(args) -> int:
             # `tmuxctl.interact`, not `tmuxctl.run`: no capture and no timeout — this
             # IS the operator's own terminal for as long as the harness runs, not an
             # admin command whose output (or lifetime) charter should own.
-            attach_cmd = tmuxctl.server_argv(SOCKET, "attach", "-t", fid)
+            attach_cmd = tmuxctl.server_argv(SOCKET, "attach", "-t", session)
             attach = tmuxctl.interact(attach_cmd, env=env)
 
             code = state.exit_code(fid)
@@ -3355,8 +3693,11 @@ def cmd_launch(args) -> int:
                 # never actually reached the server despite reporting success).
                 code = _query_pane_dead_status(SOCKET, harness_pane)
 
-    live_after = _live_sessions(SOCKET)
-    state.reap(live_after, server=SOCKET)
+    after_sessions = _live_sessions(SOCKET)
+    after_chats = _live_chats(SOCKET)
+    live_after = after_sessions | (after_chats or set())
+    if after_chats is not None or not after_sessions:
+        state.reap(live_after, server=SOCKET)
     if code is not None:
         return code
     if refused_to_attach:
@@ -3366,12 +3707,14 @@ def cmd_launch(args) -> int:
         # quiet success an operator's own deliberate detach is allowed to be.
         return 1
     if fid in live_after:
-        # Detach, not completion — the session tmux still lists is this frame's own.
+        # Detach, not completion — the chat tmux still lists is this launch's own.
         # Silence here is exactly what the spec calls out: "an agent surviving a closed
         # lid is a feature, and returning silently to a shell with it still running is
-        # not."
+        # not." The reattach line names the WORKSPACE, because that is the session; the
+        # chat is a window inside it, and tmux puts the client back on whichever window
+        # was last current.
         util.info(f"charter frame: detached — the harness is still running.\n"
-                 f"  reattach with: tmux -L {SOCKET} attach -t {fid}")
+                 f"  reattach with: tmux -L {SOCKET} attach -t {session}")
         return 0
     if attach is not None and attach.returncode != 0:
         # Nothing was recorded, tmux is not still tracking this session, AND `attach`
@@ -3445,7 +3788,10 @@ def _relayout_pane_env(fid: str, v: tuple[int, int]) -> dict[str, str] | None:
     **`os.environ` here is not this frame's identity, and that is #411 arriving on the one
     command added since.** `cmd_density` normally runs as a `subprocess.run` child of
     `cmd_action`, which is a `run-shell` child of the tmux server. Only
-    `CHARTER_SESSION_ID` is session-scoped (`_session_id_env_argv`); `CHARTER_ROOT`,
+    `CHARTER_SESSION_ID` is session-scoped (`_session_id_env_argv`) — and under chats it
+    names ONE of the workspace's chats rather than the presser's own, which is why a
+    keypress carries `#{@charter_chat}` instead (`conf_text`, `_pressers_chat`) and why
+    *fid* arrives here as an argument rather than being read back; `CHARTER_ROOT`,
     `CHARTER_WORKSPACE`, `CHARTER_HARNESS` and `CHARTER_PERSONA` all reach that child from
     the SERVER's environment, and charter's private server is shared between every frame
     on the machine. Measured against tmux 3.7c, the second frame's `run-shell` reported
@@ -4269,9 +4615,10 @@ def cmd_toggle(args) -> int:
     """`charter frame-toggle <component>` — show or hide ONE component, live.
 
     Fired by that component's own `bind -n` (`conf_text`), and typeable by hand from
-    inside a frame. The frame is resolved from `$CHARTER_SESSION_ID` exactly as
-    `cmd_density`, `cmd_palette` and `cmd_respawn` resolve theirs, since one bind text is
-    shared by every frame on `SOCKET`.
+    inside a frame. The chat is resolved by :func:`_pressers_chat` — the `--chat` the bind
+    carries out of the presser's own window, falling back to `$CHARTER_SESSION_ID` —
+    because one bind text is shared by every frame on `SOCKET` and a session now holds
+    several chats.
 
     **charter.toml is not touched**, and every word of `cmd_density`'s argument for that
     applies unchanged: `[[frame.component]]`'s `visible` says what a frame STARTS at, this
@@ -4310,7 +4657,7 @@ def cmd_toggle(args) -> int:
     is a comment with a runtime cost. `test_outside_a_frame_it_does_nothing` pins the
     property that survives it, and names the line that carries it.
     """
-    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    fid = _pressers_chat(args)
     name = getattr(args, "component", None)
     frame = config.FRAME
     arrangement = instance.frame_arrangement(frame)
@@ -4347,6 +4694,40 @@ def cmd_toggle(args) -> int:
 #: action still inside one after two seconds has broken the contract — at which point the
 #: palette closes anyway rather than holding a pane open on a hung action, which is the
 #: escape hatch's own argument applied one layer up.
+def _pressers_chat(args) -> str:
+    """Which chat the keypress that started this process was fired in.
+
+    **One bind text is shared by every frame on `SOCKET`, and a session now holds several
+    chats, so neither half of this is optional.** `--chat` is `#{@charter_chat}` expanded
+    by tmux in the presser's own window (`conf_text`), which is the only source that can
+    tell two chats of one session apart: measured on tmux 3.7c and on 3.2, a `run-shell`
+    child — which every bind's action is — reads the SESSION's `set-environment` and never
+    the window's `-e`, so `$CHARTER_SESSION_ID` hands every chat in a workspace the same
+    id.
+
+    `$CHARTER_SESSION_ID` stays as the fallback, and it is a real one rather than
+    politeness. A frame launched by a charter that predates the option has no
+    `@charter_chat` on its window — and its bind text is REPLACED by this one the moment a
+    newer frame launches on the shared server, since a key table is server-wide — so that
+    frame's `F2` starts arriving here with an empty `--chat` and has to resolve the way it
+    always did. It is also what a hand-typed `charter frame-toggle repos` inside a frame
+    resolves through.
+
+    A value the option could not have held is not one: `_FRAME_ID_RE` is the alphabet a
+    frame id travels to tmux under, and this is the far end of the same trip, so a
+    `--chat` outside it falls back rather than being carried into a state path. Empty is
+    the ordinary case of that (a window with no such option expands to nothing).
+    """
+    chat = (getattr(args, "chat", None) or "").strip()
+    # `fullmatch` alone, with no `chat and` in front of it: `_FRAME_ID_RE` is `+`, so it
+    # already refuses the empty string, and a truthiness test would be a second guard no
+    # mutation could turn red — the shape `state.frame_workspace` names for `valid_name`
+    # and the one the deletion sweep found here.
+    if _FRAME_ID_RE.fullmatch(chat):
+        return chat
+    return os.environ.get("CHARTER_SESSION_ID", "")
+
+
 _ACTION_START_GRACE = 2.0
 
 
@@ -4423,8 +4804,14 @@ def _open_palette(args) -> int:
     A tmux charter cannot get a version out of is a quiet no-op rather than a traceback in
     the harness pane: `_relayout_pane_env` needs the version to decide whether `-e` can be
     parsed at all, and there is nothing to open a palette against either way.
+
+    The chat comes from :func:`_pressers_chat`, so `F2` in chat two opens chat two's
+    palette rather than whichever chat's id the session variable happens to hold. The
+    pane this carves is then told that id explicitly (`_relayout_pane_env`), which is what
+    makes every row the palette runs — `frame-density`, `frame-chrome`, `frame-switch` —
+    act on the chat the key was pressed in.
     """
-    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    fid = _pressers_chat(args)
     harness = state.harness_pane(fid) or ""
     socket = state.frame_server(fid) or SOCKET
     v = tmuxctl.version()

--- a/charter/config.py
+++ b/charter/config.py
@@ -274,6 +274,39 @@ def _mkdir_0700(d: "Path") -> None:
         pass
 
 
+def claim_private_dir(p) -> None:
+    """Create *p* at 0700 and **raise ``FileExistsError`` when the name is already taken.**
+
+    :func:`private_mkdir` with its one idempotence removed, and that removal is the whole
+    of it. `private_mkdir` swallows ``FileExistsError`` on a directory (#331) because
+    every caller it has is asking "make sure this exists"; an **allocator** is asking the
+    opposite question — "is this name mine?" — and for that, idempotence is not a
+    convenience, it is the bug. `frame.state.new_chat_id` claims a chat's ordinal by
+    calling this: the ``mkdir`` IS the mutual exclusion, so two launchers racing the same
+    workspace cannot both be told they won, and ``FileExistsError`` means "taken, try
+    ``n+1``" rather than "already done".
+
+    Here rather than in the caller, for the reason `private_mkdir` is here at all: the
+    umask must not decide the mode of the plane's own state, and a bare ``os.mkdir``
+    spelled at a call site is a bare ``os.mkdir`` the next call site copies.
+    ``os.mkdir``'s own *mode* is masked by the umask, so the explicit ``os.chmod``
+    afterwards is what actually names 0700 — the same pair, in the same order, as
+    :func:`_mkdir_0700`.
+
+    The parents are NOT created. An allocator that could bring the frame root into being
+    on the way past would resurrect a directory `reap` had just deleted; the caller makes
+    the root through :func:`private_mkdir` first, where creating it is the declared job.
+    """
+    p = Path(p)
+    os.mkdir(p, 0o700)
+    try:
+        os.chmod(p, 0o700)
+    except OSError:
+        # Same posture as `_mkdir_0700`: the directory exists at the mode `mkdir` managed,
+        # and a claim that succeeded must not be reported as a failure over the chmod.
+        pass
+
+
 def under_state(p) -> bool:
     """Is *p* the state directory, or a path inside it?
 

--- a/charter/frame/gather.py
+++ b/charter/frame/gather.py
@@ -434,11 +434,14 @@ def discard(fid: str) -> None:
     """Forget the cached scan under *fid*, because a NEW frame is claiming the id.
 
     The gather half of ``state.clear_exit``'s bill, and the same recycled pid
-    underneath it (#383). A frame id is ``<workspace>-<launcher pid>``; since #383
-    ``state.reap`` keeps a directory for as long as the pid in its name is live, and
-    on a launch that pid is live because it is the launcher's own — so a launcher
-    landing on a pid an earlier launcher for the same workspace already used adopts
-    that earlier frame's whole directory, ``gather.json`` included.
+    underneath it (#383). A frame id WAS ``<workspace>-<launcher pid>``; ``state.reap``
+    keeps such a directory for as long as the pid in its name is live, and on a launch
+    that pid is live because it is the launcher's own — so a launcher landing on a pid an
+    earlier launcher for the same workspace already used adopted that earlier frame's
+    whole directory, ``gather.json`` included. A chat's id is allocated
+    (``state.new_chat_id``) and cannot collide that way, so on the launch path this is
+    now belt and braces; the case it is for is Stage 5c's reopen, which relaunches into a
+    cold chat's own existing directory.
 
     :func:`read` has no freshness check and needs none — it is the hot path a panel
     polls, and the cache is kept current by ``notify.plane_changed`` — so it hands

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -703,9 +703,9 @@ def respawn_argv(*, socket: str, harness_pane: str, env: dict[str, str],
 
 
 def session_argv(*, session: str, conf: str, socket: str, cols: int, rows: int,
-                 harness_argv: list[str],
+                 harness_argv: list[str], chat: str | None = None,
                  env: dict[str, str] | None = None) -> list[str]:
-    """The `new-session` command that starts the frame's tmux server, harness inside it.
+    """The `new-session` that starts the workspace's tmux session, first chat inside it.
 
     Detached (`-d`): this is launched from a script with no tty to hand tmux, not typed
     interactively, and without `-d` tmux would attach and the call would never return.
@@ -740,11 +740,64 @@ def session_argv(*, session: str, conf: str, socket: str, cols: int, rows: int,
     ``None`` means "carry nothing", which is what a tmux below
     `tmuxctl.SESSION_ENV_FLOOR` gets: `-e` is not a flag `new-session` degrades on, it is
     one it refuses, and refusing takes the whole launch with it.
+
+    *chat* names the window, the way :func:`chat_window_argv` and :func:`window_argv`
+    name theirs — so the first chat of a workspace is legible in `tmux list-windows`
+    beside its siblings instead of showing whatever `automatic-rename` made of the
+    harness's process name. It is a READOUT and nothing reads liveness from it: measured
+    on tmux 3.7c and on 3.2, `-n` does pin the name (it turns that window's
+    `automatic-rename` off) and `allow-rename on` still lets the pane's own output take
+    it back, which is why `commands_frame._CHAT_OPTION` exists. ``None`` for a caller
+    with no chat to name, which is the only reason it is optional.
     """
-    return _tmux(socket, "-f", conf, "new-session", "-d", "-s", session,
+    named = ("-n", chat) if chat else ()
+    return _tmux(socket, "-f", conf, "new-session", "-d", "-s", session, *named,
                 "-x", str(cols), "-y", str(rows), "-P", "-F", "#{pane_id}",
                 *_env_argv(env),
                 "--", *harness_argv)
+
+
+def chat_window_argv(*, socket: str, session: str, chat: str, cwd: str,
+                     harness_argv: list[str],
+                     env: dict[str, str] | None = None) -> list[str]:
+    """The `new-window` that adds a CHAT to a workspace's session on charter's own server.
+
+    :func:`session_argv`'s sibling, for the launch that finds the workspace's session
+    already running. The session is the workspace; a chat is one window in it; the
+    harness runs in that window's first pane. Everything the two calls have in common is
+    common on purpose — the reported pane id, the `-e` overlay, the harness after `--` —
+    so a launcher does not have to know which of them started its frame.
+
+    Detached (`-d`), like :func:`window_argv` and for the same reason: a client already
+    attached to this session must not be dragged to a half-built window. The launcher
+    `select-window`s once the frame has actually been drawn.
+
+    **`-a`, and it is not decoration.** `-t <session>` resolves to that session's CURRENT
+    window, and `new-window` reads a resolved window target as the INDEX to create at — so
+    without it tmux answers `create window failed: index 0 in use` for the second chat of
+    a workspace and no chat is ever added. Measured against tmux 3.7c and tmux 3.2, which
+    is also how :func:`window_argv` came to carry it.
+
+    ``-P -F '#{pane_id}'`` and NOT the window id, deliberately: `session_argv` reports the
+    pane alone, every caller downstream scopes itself to the pane (`split-window`,
+    `set-hook -p`, `set-option -w -t <pane>`, `kill-window -t <pane>` — measured on tmux
+    3.7c and 3.2 to resolve to that pane's own window), and a second reported field would
+    be a second shape for `cmd_launch` to branch on for nothing.
+
+    *env* rides on `-e` through :func:`_env_argv`, and **this is the whole mechanism that
+    makes identity per chat.** Measured on tmux 3.7c and on tmux 3.2, one session with a
+    session-wide ``set-environment CHARTER_SESSION_ID session-wide`` under it: a window
+    created with ``-e CHARTER_SESSION_ID=chat-A -e CHARTER_HARNESS=codex`` reported
+    ``chat-A codex`` from inside its own pane on both versions. `-e` on a window is
+    available at `tmuxctl.PANE_ENV_FLOOR` (3.0), below the floor charter warns at, so
+    unlike `new-session -e` there is no version below which this has to be withheld.
+
+    *cwd* is `-c` for :func:`respawn_argv`'s reason: a new window's start directory would
+    otherwise be the SESSION's, which is wherever the launcher that created the workspace
+    happened to be — and the panels split off this pane inherit its directory in turn.
+    """
+    return _tmux(socket, "new-window", "-d", "-a", "-t", session, "-n", chat, "-c", cwd,
+                 "-P", "-F", "#{pane_id}", *_env_argv(env), "--", *harness_argv)
 
 
 #: Every environment variable name charter will ever put on a tmux command line, and the

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -1,8 +1,15 @@
 """What one frame knows about itself, on disk.
 
-Under ``<STATE_DIR>/frame/<frame-id>/`` — per frame, never global, because two frames may
-run at once (one per session, named by workspace and pid) and a shared version file would
-make each frame's panels redraw for the other's activity.
+Under ``<STATE_DIR>/frame/<frame-id>/`` — per frame, never global, because several frames
+may run at once (a chat per tmux WINDOW, several windows to a workspace's session) and a
+shared version file would make each frame's panels redraw for the other's activity.
+
+**Two id shapes live here, and which one an id is decides how its liveness is read.** A
+chat's id is ``{workspace}.{n}``, allocated by :func:`new_chat_id`, and its liveness comes
+from the tmux window it is drawn in. A frame launched by a charter old enough to predate
+that is ``{workspace}-{launcher pid}`` (:func:`frame_id`) and keeps the pid rule.
+:func:`_launcher_pid` is the discriminator — it parses the second and not the first — so
+nothing was migrated and no frame carries a version field.
 
 ``config.STATE_DIR`` is read as an attribute at call time, everywhere below, and never
 imported as a bare name (``from ..config import STATE_DIR``) — the test harness repoints
@@ -51,21 +58,139 @@ from .. import config, contain
 _UNSAFE = re.compile(r"[^A-Za-z0-9._-]")
 
 
-def frame_id(workspace: str, pid: int) -> str:
-    """A stable id for one frame: the workspace it is for, and the launcher's pid.
+def workspace_prefix(workspace: str) -> str:
+    """*workspace*, reduced to the alphabet an id may be spelled in.
 
-    The same pair the tmux session and socket are named for, so a directory on disk and a
-    session in `tmux list-sessions` can always be matched up by eye. *workspace* is a name
-    read out of ``workspace.json`` or a directory listing rather than typed by an operator
-    (#328), so it is sanitised here rather than trusted — this is the one place in the
-    module that mints an identity instead of resolving one handed to it.
+    Shared by :func:`frame_id` and :func:`new_chat_id` so the two cannot drift: a name
+    read out of ``workspace.json`` or a directory listing rather than typed by an
+    operator (#328) is sanitised rather than trusted, and both minting paths have to
+    sanitise it identically or a chat's id would stop starting with the same characters
+    the frame ids beside it do.
+
+    ``or "frame"`` is what makes the result non-empty, which :func:`_launcher_pid`
+    depends on: a name with no head before its separator is not a pid claim.
+
+    ``strip``, both ends, and the trailing end is the one that matters here: a workspace
+    called ``api.`` would otherwise mint the chat id ``api..1``, whose directory
+    :func:`frame_dir` still resolves but which no operator can say out loud and which
+    reads as an ordinal on a workspace called ``api.``. It is also what makes the result
+    of this function unable to be ``.`` or ``..`` — the two names
+    :func:`charter.contain.segment_ok` refuses — so a name built from it is a path
+    segment by construction.
     """
-    safe = _UNSAFE.sub("_", workspace).strip("._-") or "frame"
-    return f"{safe}-{int(pid)}"
+    return _UNSAFE.sub("_", workspace).strip("._-") or "frame"
+
+
+def frame_id(workspace: str, pid: int) -> str:
+    """The OLD shape of a frame id: the workspace it is for, and the launcher's pid.
+
+    The same pair the tmux session and socket were named for, so a directory on disk and
+    a session in `tmux list-sessions` could always be matched up by eye.
+
+    **Nothing mints one of these any more.** A frame is a chat now
+    (:func:`new_chat_id`), and its liveness comes from the tmux window it is drawn in
+    rather than from a pid in its name. This stays because the shape is still READ:
+    :func:`_launcher_pid` is its exact inverse, and a frame launched by an older charter
+    — running across the upgrade, or left on disk by one that was — keeps being reported
+    live and reaped by the pid rule with no migration. It is the spelling those frames
+    are in, so it is spelled once, here.
+    """
+    return f"{workspace_prefix(workspace)}-{int(pid)}"
+
+
+#: The separator between a chat's workspace and its ordinal, and it is a `.` rather than
+#: a `-` for one measured reason: `_launcher_pid` reads a `-<digits>` tail as a launcher
+#: pid, so `myws-2` answers `2` — and pid 2 is alive on every Unix, so every dead chat
+#: would look live forever and `reap` would stop bounding `.charter/frame/` at all.
+#: Measured on this tree: ``_launcher_pid("myws-2") -> 2``, ``_launcher_pid("myws.2") ->
+#: None``. That ``None`` is not a gap, it is the **version discriminator** — an id this
+#: module can parse a pid out of is an old `frame_id` frame and keeps the pid rule; one
+#: it cannot is a chat and takes liveness from tmux's own window list.
+_CHAT_SEP = "."
+
+#: How far :func:`new_chat_id` will count before it gives up on a workspace.
+#:
+#: Not a policy about how many chats an operator may have — `[frame] max_chats` is that,
+#: and it is a different question asked somewhere else. This bounds the LOOP: allocation
+#: walks upwards from 1 claiming directories, and without a ceiling a plane whose frame
+#: root somehow refuses every name would spin instead of answering. Ten thousand is far
+#: past any real plane (the scan costs one `mkdir` per taken ordinal, and a plane holds
+#: tens of frame directories, not thousands) and small enough that giving up is a
+#: refusal a caller can report rather than a hang nobody can see.
+_CHAT_ORDINAL_MAX = 10_000
 
 
 def _root() -> Path:
     return Path(config.STATE_DIR) / "frame"
+
+
+def new_chat_id(workspace: str) -> str | None:
+    """Allocate the next chat id for *workspace* — ``{workspace}.{n}`` — or ``None``.
+
+    **Allocated, not computed, and the ``mkdir`` IS the allocation.** The alternative the
+    operator's own sketch reached for was ``{workspace}-{some-hash}``, and both halves of
+    it fail. A hash of the only inputs available at creation is a hash of a counter
+    wearing a disguise — (workspace, harness) is not unique by construction, two Claude
+    chats in one workspace hash the same — and a truncated hash COLLIDES SILENTLY into a
+    shared ``.charter/frame/<fid>/``, where one chat's ``session``, ``panes`` and
+    ``version`` overwrite the other's and nothing reports it. A `-{ordinal}` tail fails
+    differently and worse: see :data:`_CHAT_SEP` for the measurement.
+
+    A counter cannot collide because it is claimed rather than computed.
+    :func:`config.claim_private_dir` is `config.private_mkdir` with its idempotence
+    removed **on purpose** — `private_mkdir` swallows ``FileExistsError`` on a directory
+    (#331), which is exactly right for "make sure this exists" and exactly wrong for "is
+    this name mine?". Here ``FileExistsError`` is the claim failing, and the answer to it
+    is ``n+1``. Two allocators racing the same workspace cannot both win, because
+    ``mkdir`` is one syscall and the kernel picks.
+
+    **A scan is not a substitute.** Reading the directory and taking ``max + 1`` gives
+    two racers the same answer, and the loser silently adopts the winner's frame
+    directory — the collision this whole design exists to make impossible, reintroduced
+    by the cheaper-looking spelling.
+
+    ``None`` for every way this can fail to allocate: a frame root that cannot be made, a
+    name :func:`contain.child` refuses, an id so long ``mkdir`` answers ``ENAMETOOLONG``,
+    a filesystem that will not take the directory, or a workspace already holding
+    :data:`_CHAT_ORDINAL_MAX` chats. One answer for all of them, because the caller does
+    the same thing with each: report that it could not open a chat, rather than launch
+    one whose state has nowhere to live.
+
+    The id is a NAME and is never parsed for meaning. Renaming a workspace leaves its
+    live chats spelling the old one and changes nothing — `frame_workspace` reads the
+    workspace out of the frame's own ``workspace`` file, which can be repointed, and the
+    bars show that rather than the prefix of the id. The one visible cost is cosmetic and
+    deliberately not fixed: after a rename, chat 1 of the renamed workspace may be
+    ``newname.1`` beside a sibling still called ``oldname.2``. Rewriting ids to tidy that
+    would break every ``$CHARTER_SESSION_ID`` already exported into a live process.
+    """
+    prefix = workspace_prefix(workspace)
+    root = _root()
+    try:
+        config.private_mkdir(root)
+    except OSError:
+        return None
+    for n in range(1, _CHAT_ORDINAL_MAX + 1):
+        # A plain join, and the containment is asserted rather than branched on — the
+        # deletion sweep is why. `contain.child` here could only ever refuse a name
+        # `workspace_prefix` cannot produce: the alphabet holds no separator and no NUL,
+        # the head is non-empty (`or "frame"`), the strip rules out `.` and `..`, and the
+        # tail is a decimal integer. So `if d is None: return None` was a branch no test
+        # could reach and no mutation could redden — the shape `record_identity`'s own
+        # unreachable `isinstance` filter was deleted for. What still refuses a bad name
+        # is `frame_dir`, which every later reader of this id goes through, and which
+        # resolves through `contain.child` on the way back.
+        d = root / f"{prefix}{_CHAT_SEP}{n}"
+        try:
+            config.claim_private_dir(d)
+        except FileExistsError:
+            continue          # taken — by a sibling chat, by a racer, or by debris
+        except OSError:
+            # ENAMETOOLONG for an id no `mkdir` will take, a full filesystem, a
+            # permission the plane does not have. None of those gets better at `n+1`.
+            return None
+        return d.name
+    return None
 
 
 def frame_dir(fid: str, *, create: bool = False) -> Path | None:
@@ -191,7 +316,7 @@ def clear_exit(fid: str) -> None:
     """Forget any exit code recorded under *fid*, because a new frame is claiming the id.
 
     The bill for #383's rule, and the reason it is only a bill and not a defect. A frame
-    id is ``<workspace>-<launcher pid>`` and pids are recycled — Linux wraps at
+    id WAS ``<workspace>-<launcher pid>`` and pids are recycled — Linux wraps at
     ``kernel.pid_max``, 32768 by default — so a launcher for the same workspace really
     does land on a pid an earlier launcher already used. Since :func:`reap` keeps a
     directory for as long as the pid in its name is live, and on a launch that pid is
@@ -201,7 +326,13 @@ def clear_exit(fid: str) -> None:
     reported as having failed with a dead frame's number.
 
     A launch beginning is the one moment that can be certain about this — whatever is
-    recorded under the id was recorded before this frame existed. Only ``exit`` is
+    recorded under the id was recorded before this frame existed.
+
+    **A CHAT's id cannot be adopted that way at all**, because :func:`new_chat_id` claims
+    its ordinal with a ``mkdir`` that fails when the name is taken, so a launch never
+    lands on an occupied directory. On the launch path this is now belt and braces; the
+    case it is still for is reopening a COLD chat, which relaunches into that chat's own
+    existing directory. Only ``exit`` is
     removed: ``version`` is a counter panels poll, and moving it is :func:`bump`'s job.
     Never raises, and never creates, for the same reasons as everything else here.
     """
@@ -683,7 +814,9 @@ def clear_shape(fid: str) -> None:
     decision about one frame, and that frame is over.
 
     The fourth and fifth lines on :func:`clear_exit`'s bill, and the same recycled pid
-    underneath them (#383). A frame id is ``<workspace>-<launcher pid>``; :func:`reap`
+    underneath them (#383) — and the same narrowing: an ALLOCATED chat id cannot be a
+    previous frame's, so what this is for now is a cold chat being reopened into its own
+    directory. A frame id WAS ``<workspace>-<launcher pid>``; :func:`reap`
     keeps a directory while the pid in its name is live, and on a launch it is live
     BECAUSE IT IS THE LAUNCHER'S OWN — so a launcher landing on a pid an earlier launcher
     for the same workspace already used adopts that earlier frame's whole directory.
@@ -963,7 +1096,8 @@ def clear_respawn(fid: str) -> None:
     """Forget every respawn count under *fid*, because a NEW frame is claiming the id.
 
     The third line on :func:`clear_exit`'s bill, and the same recycled pid underneath it
-    (#383). A frame id is ``<workspace>-<launcher pid>``; since #383 :func:`reap` keeps a
+    (#383), narrowed the same way an allocated id narrows the other two. A frame id WAS
+    ``<workspace>-<launcher pid>``; since #383 :func:`reap` keeps a
     directory for as long as the pid in its name is live, and on a launch that pid is
     live BECAUSE IT IS THE LAUNCHER'S OWN — so a launcher landing on a pid an earlier
     launcher for the SAME workspace already used adopts that earlier frame's whole
@@ -1001,6 +1135,15 @@ def _launcher_pid(name: str) -> int | None:
     ``or "frame"`` fallback guarantees it), so a name without one did not come from here
     and its digits are not a claim about any process. ``rpartition`` rather than
     ``split``, because a workspace may contain ``-`` itself (``harness-wrapper-4242``).
+
+    **The separator is also the version discriminator, and that is a load-bearing use of
+    this function rather than a happy accident.** ``-`` is `frame_id`'s and ``.`` is
+    `new_chat_id`'s, so ``myws-2`` answers ``2`` and ``myws.2`` answers ``None`` — which
+    is what lets `is_live` and `reap` apply the pid rule to an old frame and the window
+    rule to a chat with no flag, no migration and no extra field on disk. Widening this
+    to accept ``.`` would hand every chat a launcher pid that is really its ordinal:
+    ``api.1`` would read as pid 1, ``launchd``/``init``, alive on every Unix, and `reap`
+    would keep every dead chat forever.
     """
     head, sep, tail = name.rpartition("-")
     if not sep or not head or not tail.isdigit():
@@ -1079,16 +1222,30 @@ def is_live(fid: str, *, pane: str | None = None) -> bool:
     *pane* is optional because :func:`reap`'s question is the frame's existence, not any
     process's membership of it. ``None`` means "do not ask", not "assume yes".
 
+    **A CHAT has no launcher pid, and the pane record is what answers instead.** An id
+    :func:`_launcher_pid` cannot parse is a `new_chat_id` chat (see :data:`_CHAT_SEP`),
+    and there is no process in its name to signal. The honest evidence available here —
+    with no tmux subprocess, on a path Claude Code re-runs every time it repaints its
+    footer — is :func:`record_harness_pane`'s: a process running in the pane a LAUNCHER
+    wrote down is a process inside a window that still exists, which is what "this chat
+    is live" means. So for a chat the pane is not an extra check on top of liveness, it
+    IS the liveness, and a caller that offers none gets ``False`` rather than a claim
+    nothing here can support. Both callers (`statusline`, `doctor`) already pass
+    ``$TMUX_PANE``.
+
     Every unknown answers ``False``, which for the status line means "render" — a
     duplicated line is recoverable in a way a line that vanished for an invisible reason
     is not.
     """
     if frame_server(fid) is None:
         return False
+    pane_matches = pane is not None and harness_pane(fid) == pane
     pid = _launcher_pid(fid)
-    if pid is None or not _launcher_is_alive(pid):
+    if pid is None:
+        return pane_matches
+    if not _launcher_is_alive(pid):
         return False
-    if pane is not None and harness_pane(fid) != pane:
+    if pane is not None and not pane_matches:
         return False
     return True
 
@@ -1098,8 +1255,22 @@ def reap(live: set[str], *, server: str) -> list[str]:
 
     Never by age: a frame open for two days is exactly a working frame, and an age
     heuristic would delete precisely that one. *live* names what that server still
-    reports — sessions on charter's own private one, windows on an operator's — so the
-    only frames removed are ones nothing is watching any more.
+    reports — on charter's own private server that is now its sessions AND the chat ids
+    its windows carry, on an operator's it is their windows — so the only frames removed
+    are ones nothing is watching any more.
+
+    **A chat is bounded by this list alone, and that is the whole of why the id has a dot
+    in it.** A `new_chat_id` id carries no launcher pid, so the second rule below
+    (:func:`_launcher_pid`) abstains for it and *live* decides on its own. Had the
+    ordinal been spelled `-{n}`, `myws-1` would read as pid 1 — ``launchd``/``init``,
+    alive on every Unix — and every dead chat would be kept forever: this function is the
+    only thing bounding ``.charter/frame/``, so that is not litter, it is an unbounded
+    directory. `commands_frame._live_chats` is what puts the chat ids in *live*, read
+    from the ``@charter_chat`` WINDOW OPTION rather than from ``#{window_name}``, because
+    a window name is not an identity (measured: with ``allow-rename on`` a pane's own
+    output renamed a `-n`-named window to ``PWNED`` on tmux 3.7c and on 3.2, while the
+    option was untouched — and a chat whose name has been taken from it is a chat this
+    function would delete the state of while it was still running).
 
     **Scoped to one server, because "not live" is only an answer the frame's OWN server
     can give.** A frame launched inside the operator's tmux is a window on their socket

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -201,8 +201,22 @@ whose program exits is destroyed along with its hook. Charter sets that one opti
 always did.
 
 Charter never touches `~/.tmux.conf` — the frame's settings go into a private server of
-charter's own (`tmux -L charter`), one server shared by every frame on the machine, with
-each frame a session on it.
+charter's own (`tmux -L charter`), one server shared by every frame on the machine. On it,
+a **workspace is a session** and a **chat is a window** in that session: `charter claude`
+in a workspace that already has one open adds a second chat beside it rather than starting
+a second session, and the two run side by side with their own harnesses, their own personas
+and their own tool ceilings. A chat's id is `<workspace>.<n>` — allocated, so two of them
+can never land on the same state — and it is what `$CHARTER_SESSION_ID` holds inside that
+chat.
+
+One chat's harness dying ends **that chat's window** and nothing else; the other chats in
+the workspace keep running. When the last chat's window goes, so does the session, which is
+what returns `charter claude` to your shell.
+
+The cost of one session, said plainly: a tmux session has one current window, so two
+terminals attached to the same workspace look at the same chat. Opening a second chat from
+a second terminal moves both. That is what "one workspace, several chats" means — the
+chats are independent, the *view* is the session's.
 
 ## Inside a tmux you already have
 
@@ -1038,8 +1052,9 @@ frame can do, drawn by charter in a pane of its own. Type to narrow it, arrow ke
 Enter to run, Escape to leave. It exists only on charter's own server; inside a tmux you
 already have, charter binds no key at all (see above). However you detach — the palette's
 own row, or tmux's own prefix key — charter notices the session is still running and prints
-how to get back in (`tmux -L charter attach -t <frame-id>`) rather than leaving you to
-remember the flags.
+how to get back in (`tmux -L charter attach -t <workspace>`) rather than leaving you to
+remember the flags. The workspace is the session; tmux puts you back on whichever of its
+chats was last in front of you.
 
 ```
 charter · 9 to choose from

--- a/docs/news/unreleased-a-workspace-holds-several-chats.md
+++ b/docs/news/unreleased-a-workspace-holds-several-chats.md
@@ -1,0 +1,85 @@
+---
+version: unreleased
+headline: A workspace is a tmux session and a chat is a window in it, so one workspace can hold several harnesses and one dying does not take the others with it
+---
+
+Nothing on screen changes yet. Underneath, what a frame *is* has moved: a frame used to be
+a tmux session named after the workspace and the launcher's pid, and it is now a **window**
+named after a chat, in a session named after the **workspace**. `charter claude` in a
+workspace that already has a chat open adds a second one beside it instead of starting a
+second session.
+
+**A chat id is allocated, not computed.** `charter.1`, `charter.2`, and the next free
+ordinal each time — claimed with a `mkdir` that fails when the name is taken, so the claim
+*is* the mutual exclusion and two launchers racing one workspace cannot both be told they
+won. The design this replaces was `{workspace}-{some-hash}`, and both halves of it fail. A
+hash of the only inputs available at creation is a counter in disguise — (workspace,
+harness) is not unique by construction, two Claude chats in one workspace hash the same —
+and a truncated hash collides silently into a shared `.charter/frame/<id>/`, where one
+chat's token gauge, pane map and repaint clock overwrite the other's with nothing reporting
+it.
+
+**The dot is not cosmetic, and it is what keeps `.charter/frame/` bounded.** `reap` is the
+only thing that removes frame state, and it keeps any directory whose name ends in a live
+pid. Measured on this tree:
+
+```
+state._launcher_pid("myws-2")  ->  2       # the ordinal read as a process id
+state._launcher_pid("myws.2")  ->  None    # the dot makes it not a claim
+```
+
+Pid 1 is `launchd`/`init` and pid 2 is a kernel thread on every Unix, so a `-{ordinal}`
+tail would have made **every dead chat look live forever**. `None` is also the version
+discriminator: an id charter can read a pid out of is a frame an older charter launched and
+keeps the pid rule; one it cannot is a chat and takes its liveness from tmux's own windows.
+No flag day, no migration, no new field on disk — old frames still launch, still report
+liveness and still reap.
+
+**One chat's harness dying no longer takes the workspace with it.** The `pane-died`
+teardown hook ran `kill-session`; under tabs that ends every other chat in the workspace,
+mid-turn, for a death that was not theirs. It runs `kill-window` now. Measured on tmux 3.7c
+and on tmux 3.2 — charter's own floor, built from the release tarball and run: the dying
+chat's window goes, every sibling window is still listed, the session is still listed, and
+killing a session's *last* window still destroys the session, so a launcher's `attach`
+returns exactly as it did.
+
+**A window name is not an identity.** Charter names each chat's window, but liveness is
+read from a window option (`@charter_chat`), not from `#{window_name}`, and that is
+measured rather than argued. `new-window -n` does pin a name — it turns that window's
+`automatic-rename` off — but with `allow-rename on` the pane's own output takes it anyway:
+
+| tmux 3.7c and tmux 3.2 | before | after the pane prints `\033kPWNED\033\\` |
+|---|---|---|
+| `#{window_name}` | `api.3` | `PWNED` |
+| `#{@charter_chat}` | `api.3` | `api.3` |
+
+Read liveness from the name and a harness that renames its own window gets its state
+deleted while it is still running. `automatic-rename` is on by default too, so any window
+charter did not name follows whatever runs in it.
+
+**Identity is per chat, and nothing was added to the list of variables charter will put on
+a tmux command line.** A chat's window is created with `-e CHARTER_SESSION_ID=<chat>` and
+`-e CHARTER_HARNESS=<name>`, which beats a session-wide `set-environment` inside the pane —
+measured on 3.7c and 3.2. Everything charter already keys on the session id therefore
+becomes per chat with no new code: `.charter/sessions/<chat>.persona`, `.workspace`,
+`.tools` and `.gate`. Two chats, two personas, two tool ceilings, each enforced in its own
+process.
+
+The same measurement had a second half worth stating, because it decided something else: a
+`run-shell` child — which every key binding's action is — reads the **session's**
+environment and never the window's. So `F2` and the component toggle keys now carry
+`#{@charter_chat}`, expanded in the presser's own window, and the palette that opens is the
+one for the chat you pressed it in rather than for whichever chat launched last. A frame
+from an older charter, whose window carries no such option, still resolves the way it
+always did.
+
+**The exit code follows the chat.** `$CHARTER_FRAME_EXIT` used to name one frame's own
+`exit` file; a `set-environment` is session-scoped and a session holds several chats now,
+so it names the frame **root** and the hook appends `#{@charter_chat}` itself. The
+operator-controlled half of that path still travels out of band, as a single argv value
+nothing re-parses; the half that is interpolated is a chat id in a closed alphabet with no
+quote, `$`, backtick or space in it.
+
+A tab is a container, not a boundary. Two chats in one plane run as the same user, under
+the same plane, with the same vaults, and can read each other's files — a second tab does
+not add that risk, it multiplies the number of processes that hold it.

--- a/tests/_statedirscan.py
+++ b/tests/_statedirscan.py
@@ -116,14 +116,15 @@ PACKAGE = Path(__file__).resolve().parent.parent / "charter"
 #: The two routed spellings. A ``mkdir`` is never one of these — they are functions, not
 #: methods named ``mkdir`` — so this is documentation of what "routed" means rather than a
 #: filter, and is asserted against `config` so a rename cannot leave it stale.
-ROUTED = ("private_mkdir", "mkdir_for")
+ROUTED = ("private_mkdir", "mkdir_for", "claim_private_dir")
 
 #: `config`'s own walk, exempt because it **is** the routing. ``_mkdir_0700`` is the
 #: private mkdir itself; ``mkdir_for``'s bare one is the branch it takes having just
 #: decided at runtime that the path is not state. Flagging these would be asking the guard
 #: to route through itself. Named in full — ``module.function`` — so an unrelated
 #: ``_mkdir_0700`` appearing elsewhere would still be scanned.
-THE_WALK = ("config.private_mkdir", "config._mkdir_0700", "config.mkdir_for")
+THE_WALK = ("config.private_mkdir", "config._mkdir_0700", "config.mkdir_for",
+            "config.claim_private_dir")
 
 #: The routed spellings for a FILE (#505). Same shape as `ROUTED`, and the same reason it
 #: is documentation rather than a filter: none of these is named ``write_text``/``open``/

--- a/tests/test_component_toggle_keys.py
+++ b/tests/test_component_toggle_keys.py
@@ -478,7 +478,8 @@ class TheBindReachesTmuxConfigText(unittest.TestCase):
     def test_a_key_binds_the_toggle_for_its_own_component(self):
         text = self._text({"repos": "F7"})
         self.assertIn("bind -n F7 run-shell "
-                      "'\"$CHARTER_PY\" -m charter frame-toggle repos'", text)
+                      "'\"$CHARTER_PY\" -m charter frame-toggle repos "
+                      "--chat \"#{@charter_chat}\"'", text)
 
     def test_every_declared_toggle_gets_its_own_line_in_split_order(self):
         text = self._text({"top": "F5", "bottom": "F6", "repos": "F7"})

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -333,7 +333,8 @@ class Conf(unittest.TestCase):
         text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
                                         session="x")
         self.assertIn('bind -n F2 run-shell \'"$CHARTER_PY" -m charter '
-                      'frame-palette "#{client_name}"\'', text)
+                      'frame-palette "#{client_name}" --chat "#{@charter_chat}"\'',
+                      text)
         self.assertNotIn("frame palette", text)
 
     def test_the_menu_is_gone_rather_than_left_beside_the_palette(self):
@@ -545,11 +546,20 @@ class PaneDiedHooks(unittest.TestCase):
         action = cmd[-1]
         self.assertIn(f"${{v:-{commands_frame._UNKNOWN_DEATH_CODE}}}", action)
 
-    def test_the_teardown_hook_is_a_constant_kill_session_at_index_1(self):
+    def test_the_teardown_hook_is_a_constant_kill_window_at_index_1(self):
+        """`kill-window`, and the literal is the test.
+
+        A session is a WORKSPACE now and a chat is one window in it, so `kill-session`
+        here would take every other chat in the workspace down with the one whose harness
+        died — mid-turn, in another agent's terminal. Measured on tmux 3.7c and on tmux
+        3.2: a pane-scoped `pane-died[1] kill-window` on a harness that exits leaves every
+        sibling window and the session itself listed, and killing a session's LAST window
+        destroys the session, so the one-chat case ends exactly as it always did."""
         cmd = commands_frame._pane_died_teardown_hook_argv(socket="charter", harness_pane="%9")
         self.assertEqual(cmd[cmd.index("-t") + 1], "%9")
         self.assertIn("pane-died[1]", cmd)
-        self.assertEqual(cmd[-1], "kill-session")
+        self.assertEqual(cmd[-1], "kill-window")
+        self.assertNotIn("kill-session", cmd)
 
     def test_both_hooks_are_clean_argv_lists_naming_the_socket(self):
         for cmd in (commands_frame._pane_died_write_hook_argv(socket="charter", harness_pane="%0"),
@@ -559,28 +569,39 @@ class PaneDiedHooks(unittest.TestCase):
                 self.assertIsInstance(part, str)
             self.assertEqual(cmd[:3], ["tmux", "-L", "charter"])
 
-    def test_the_status_path_is_carried_out_of_band(self):
+    def test_the_frame_root_is_carried_out_of_band(self):
         """`set-environment` takes the path as ONE argv value — no shell, no tmux
         text-command parsing of it at all — verified by hand to round-trip a space, a
         literal `'`, and a `$(...)` injection attempt correctly precisely because
-        nothing here ever re-parses it as text."""
-        path = "/tmp/My Plane's exit $(touch pwned)/exit"
-        cmd = commands_frame._exit_path_env_argv(socket="charter", session="demo-1",
-                                                 status_path=path)
-        self.assertEqual(cmd, ["tmux", "-L", "charter", "set-environment", "-t", "demo-1",
-                              "CHARTER_FRAME_EXIT", path])
+        nothing here ever re-parses it as text.
+
+        The value is the frame ROOT rather than one chat's `exit` file, and that is not
+        cosmetic: this variable is SESSION-scoped and a session holds several chats, so a
+        value naming one chat's file is one the next chat's launch repoints — after which
+        the first chat's death writes its status into the second chat's file. The write
+        hook appends `#{@charter_chat}` itself."""
+        root = "/tmp/My Plane's frames $(touch pwned)"
+        cmd = commands_frame._exit_path_env_argv(socket="charter", session="demo",
+                                                 frame_root=root)
+        self.assertEqual(cmd, ["tmux", "-L", "charter", "set-environment", "-t", "demo",
+                              "CHARTER_FRAME_EXIT", root])
 
     def test_the_frame_id_is_carried_to_its_own_palette(self):
         """Without this, `run-shell` fired from a LATER frame sharing `SOCKET` falls
         back to the SERVER's own starting environment — the FIRST frame's
         `CHARTER_SESSION_ID`, not this one's (verified by hand against tmux 3.7c: a
         second session on an already-running server, `run-shell`'d with no override of
-        its own, reported the first frame's id). The value carried is the session's own
-        name — `_session_id_env_argv` hands a session its own id back, unlike
-        `_exit_path_env_argv`, which carries a SEPARATE value (`status_path`)."""
-        cmd = commands_frame._session_id_env_argv(socket="charter", session="demo-1")
-        self.assertEqual(cmd, ["tmux", "-L", "charter", "set-environment", "-t", "demo-1",
-                              "CHARTER_SESSION_ID", "demo-1"])
+        its own, reported the first frame's id).
+
+        **The TARGET is the workspace's session and the VALUE is the chat**, which used
+        to be one string and is two now. Pinned as literals that differ, so a version
+        that hands the session its own name back — which is what this call did while a
+        frame WAS a session — fails here rather than silently naming the workspace as
+        every chat's frame id."""
+        cmd = commands_frame._session_id_env_argv(socket="charter", session="demo",
+                                                  chat="demo.2")
+        self.assertEqual(cmd, ["tmux", "-L", "charter", "set-environment", "-t", "demo",
+                              "CHARTER_SESSION_ID", "demo.2"])
 
 
 class PanelRespawnHook(unittest.TestCase):
@@ -1051,7 +1072,10 @@ class Respawn(PersonaIso, unittest.TestCase):
         fake = _RespawnTmux()
         _respawn(fake, on_argv=True)
         self.assertEqual(fake.liveness[0][:3], ["tmux", "-L", commands_frame.SOCKET])
-        self.assertIn("list-sessions", fake.liveness[0])
+        # Two questions, both of charter's own server: the chat ids its windows carry
+        # (`@charter_chat`), and — for a frame launched by a charter that predates chats
+        # and is still a session named by its id — `list-sessions`.
+        self.assertTrue(any("list-sessions" in c for c in fake.liveness), fake.liveness)
         self.assertEqual(fake.respawns[0][:3], ["tmux", "-L", commands_frame.SOCKET])
 
     def test_an_operators_server_that_does_not_answer_is_not_respawned_into(self):
@@ -1434,13 +1458,14 @@ class _FakeTmux:
 
     def __init__(self, *, pane_id="%7", exit_code=None, race_death_status=None,
                 still_live=False, pre_existing_sessions=frozenset(),
+                pre_existing_chats=frozenset(), list_windows_rc=0,
                 panel_pane_ids=None, pane_capture="",
                 session_rc=0, source_rc=0, env_set_rc=0, write_hook_rc=0,
                 teardown_hook_rc=0, panel_rc=0, select_rc=0, attach_rc=0, dm_rc=0,
                 kill_rc=0, arm_rc=0, hatch_rc=0, mark_rc=0, chrome_rc=0,
                 resize_hook_rc=0,
                 capture_rc=0,
-                respawn_hook_rc=0,
+                respawn_hook_rc=0, chat_option_rc=0,
                 resize_hook_stderr="bad resize hook target"):
         self.pane_id = pane_id
         self.exit_code = exit_code
@@ -1449,6 +1474,13 @@ class _FakeTmux:
         # command that died before `attach` ever got the chance to say anything (#384).
         self.pane_capture = pane_capture
         self.still_live = still_live
+        #: Chats the server already reports through `@charter_chat` — a workspace that
+        #: already has one chat open, which is what makes a launch into it the SECOND
+        #: chat rather than the first.
+        self.pre_existing_chats = frozenset(pre_existing_chats)
+        #: A server that answers `list-sessions` and then refuses `list-windows` — the
+        #: one state in which charter cannot tell which chats are live and must not reap.
+        self.list_windows_rc = list_windows_rc
         self.pre_existing_sessions = pre_existing_sessions
         # slot -> pane id `split-window` reports for it. Empty by default (see
         # `split-window`'s own handler below for why that matters for every other test
@@ -1473,24 +1505,47 @@ class _FakeTmux:
         self.resize_hook_rc = resize_hook_rc
         self.capture_rc = capture_rc
         self.respawn_hook_rc = respawn_hook_rc
+        self.chat_option_rc = chat_option_rc
         # Distinct from every other stderr string in this fake — a test needs to
         # control it independently to exercise the "invalid option" degrade (fix
         # round 3, item 2) separately from an ordinary resize-hook failure.
         self.resize_hook_stderr = resize_hook_stderr
         self.calls: list[list[str]] = []
+        #: The CHAT id, learned from the `@charter_chat` window option the launcher
+        #: writes — never from `new-session -s`, which names the WORKSPACE now.
         self.fid = None
+        #: The tmux SESSION name, which is the workspace.
+        self.session = None
         self.sourced_conf_text = None
         self.new_session_env = None
         self.kill_session_called = False
+        self.kill_window_called = False
 
     def __call__(self, cmd, **kwargs):
         self.calls.append(list(cmd))
         if "new-session" in cmd:
-            self.fid = cmd[cmd.index("-s") + 1]
+            self.session = cmd[cmd.index("-s") + 1]
             self.new_session_env = kwargs.get("env")
             return subprocess.CompletedProcess(cmd, self.session_rc,
                                                stdout=(self.pane_id + "\n") if self.session_rc == 0 else "",
                                                stderr="" if self.session_rc == 0 else "no space for a new pane")
+        if "new-window" in cmd:
+            # A SECOND chat joining a workspace session that already exists.
+            self.session = cmd[cmd.index("-t") + 1]
+            self.new_session_env = kwargs.get("env")
+            return subprocess.CompletedProcess(cmd, self.session_rc,
+                                               stdout=(self.pane_id + "\n") if self.session_rc == 0 else "",
+                                               stderr="" if self.session_rc == 0 else "no space for a new window")
+        if commands_frame._CHAT_OPTION in cmd:
+            # Which chat this window draws — matched on the production constant, and
+            # BEFORE the `set-option`/chrome branches below for the same reason the hatch
+            # option is: the value is a plain id that another branch could answer for.
+            # This is also the one place this fake can learn the chat id at all, the
+            # session being the workspace.
+            self.fid = cmd[-1]
+            return subprocess.CompletedProcess(cmd, self.chat_option_rc, stdout="",
+                                               stderr="" if self.chat_option_rc == 0
+                                               else "cannot set")
         if "source-file" in cmd:
             conf_path = cmd[cmd.index("source-file") + 1]
             self.sourced_conf_text = Path(conf_path).read_text()
@@ -1567,15 +1622,34 @@ class _FakeTmux:
             self.kill_session_called = True
             return subprocess.CompletedProcess(cmd, self.kill_rc, stdout="",
                                                stderr="" if self.kill_rc == 0 else "no such session")
+        if "kill-window" in cmd:
+            self.kill_window_called = True
+            return subprocess.CompletedProcess(cmd, self.kill_rc, stdout="",
+                                               stderr="" if self.kill_rc == 0 else "no such window")
+        if "select-window" in cmd:
+            return subprocess.CompletedProcess(cmd, self.select_rc, stdout="",
+                                               stderr="" if self.select_rc == 0 else "no such window")
         if "attach" in cmd:
             if self.exit_code is not None and self.fid:
                 state.record_exit(self.fid, self.exit_code)
             return subprocess.CompletedProcess(cmd, self.attach_rc, stdout="", stderr="")
         if "list-sessions" in cmd:
-            if self.fid is None:
+            if self.session is None:
                 live = set(self.pre_existing_sessions)
             else:
-                live = {self.fid} if self.still_live else set()
+                live = {self.session} if self.still_live else set()
+            return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(live), stderr="")
+        if "list-windows" in cmd:
+            if self.list_windows_rc != 0:
+                return subprocess.CompletedProcess(cmd, self.list_windows_rc, stdout="",
+                                                   stderr="server exited unexpectedly")
+            # `commands_frame._live_chats`: the chat ids the server's windows carry.
+            # Empty until this launch has named its own window, `{fid}` after — the same
+            # `still_live` switch `list-sessions` reads, because a chat that is still
+            # live is a window that is still there.
+            live = set(self.pre_existing_chats)
+            if self.fid and self.still_live:
+                live.add(self.fid)
             return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(live), stderr="")
         raise AssertionError(f"unexpected tmux command in test: {cmd}")
 
@@ -1712,6 +1786,440 @@ def _launch(fake: _FakeTmux, *, cols=200, rows=50, version=(3, 7), harness="clau
         return commands_frame.cmd_launch(args)
 
 
+class PickingAWorkspaceLocksTheChatToIt(PersonaIso, unittest.TestCase):
+    """`_pin_workspace` — lifted out of `cmd_launch` because both launch paths now
+    allocate their chat id after their own reap, so the pointer can only be written once
+    the id exists.
+
+    Nothing pinned either half of it while it was inline, and both are behaviour an
+    operator sees: a launch that resolved silently must write no pointer at all (#518 —
+    starting to would move every framed session's workspace on a path nobody asked
+    anything on), and the sentence that says it locked carries a name read off disk into
+    a line an operator reads."""
+
+    def test_a_pick_writes_the_pointer_under_the_chats_own_id(self):
+        from charter import workspace
+        buf = []
+        with mock.patch("charter.util.info", side_effect=lambda m: buf.append(m)):
+            commands_frame._pin_workspace("alpha", "demo.2", True)
+        self.assertEqual(workspace.for_session("demo.2"), "alpha",
+                         "inside a frame the CHAT is the charter session (ADR 0019), so "
+                         "the pointer is what makes two chats hold two workspaces")
+        self.assertTrue(any("locked" in m for m in buf), buf)
+
+    def test_a_launch_that_picked_nothing_writes_nothing_and_says_nothing(self):
+        """The guard, and it is the whole of #518's "must not answer a prompt every
+        launch": an ordinary `charter claude` resolves its workspace silently and must
+        leave every pointer exactly as it found it."""
+        from charter import workspace
+        buf = []
+        with mock.patch("charter.util.info", side_effect=lambda m: buf.append(m)):
+            commands_frame._pin_workspace("alpha", "demo.2", False)
+        self.assertIsNone(workspace.for_session("demo.2"),
+                          "a launch nobody answered a prompt for locked the session to a "
+                          "workspace anyway")
+        self.assertEqual(buf, [])
+
+    def test_the_workspace_name_is_contained_before_it_reaches_the_line(self):
+        """The name comes off `workspace.json` or a directory listing, and this line is
+        charter's own report format (#453/#472): a newline in it writes a second line that
+        looks exactly as much like charter's output as the first."""
+        buf = []
+        with mock.patch.object(commands_frame.workspace, "set_active"), \
+             mock.patch("charter.util.info", side_effect=lambda m: buf.append(m)):
+            commands_frame._pin_workspace("alpha\n✗ Vault unlocked", "demo.2", True)
+        self.assertEqual(len(buf), 1, buf)
+        self.assertNotIn("\n✗", buf[0],
+                         "a workspace name forged a second line of charter's own output")
+        self.assertIn("alpha", buf[0])
+
+
+class AWorkspaceIsASessionAndAChatIsAWindow(PersonaIso, unittest.TestCase):
+    """Stage 5a's shape, at the launcher. The real-tmux half is
+    `tests/test_frame_tmux_integration.ChatsAreWindowsOnOneWorkspaceSession`; this is what
+    the launcher SENDS, and which of the two commands it sends."""
+
+    def test_the_session_is_the_workspace_and_the_window_is_the_chat(self):
+        fake = _FakeTmux(exit_code=0, still_live=True)
+        _launch(fake)
+        new_session = next(c for c in fake.calls if "new-session" in c)
+        self.assertEqual(new_session[new_session.index("-s") + 1], "demo",
+                         "the tmux session is the WORKSPACE — a chat is a window in it")
+        self.assertEqual(new_session[new_session.index("-n") + 1], "demo.1",
+                         "and the window is named for the chat, so `list-windows` is "
+                         "legible beside the chat ids on disk")
+
+    def test_a_second_chat_joins_the_workspaces_session_rather_than_starting_one(self):
+        """`new-window`, not `new-session`, and it is targeted at the workspace. This is
+        the whole of "a workspace holds several chats": two harnesses, two windows, one
+        session, one client."""
+        # The workspace already has a chat: its window on the server AND its directory
+        # on disk. Both, because they answer different questions — the window is what
+        # `reap` keeps the record for, the directory is what the allocator has to step
+        # over.
+        state.record_server("demo.1", commands_frame.SOCKET)
+        fake = _FakeTmux(exit_code=0, still_live=True,
+                         pre_existing_sessions=("demo",),
+                         pre_existing_chats=("demo.1",))
+        _launch(fake)
+        self.assertFalse([c for c in fake.calls if "new-session" in c],
+                         "a second chat started a second session for one workspace")
+        new_window = next(c for c in fake.calls if "new-window" in c)
+        self.assertEqual(new_window[new_window.index("-t") + 1], "demo")
+        self.assertEqual(new_window[new_window.index("-n") + 1], "demo.2")
+        self.assertEqual(fake.fid, "demo.2")
+
+    def test_the_chat_is_written_on_its_window_before_either_hook(self):
+        """`@charter_chat` is what `_live_chats`, the write hook's `#{@charter_chat}` and
+        `conf_text`'s binds all read, so it has to be there before anything can fire.
+        Ordered by index against the FIRST `set-hook`, the same way the two hooks' own
+        ordering is pinned."""
+        fake = _FakeTmux(exit_code=0, still_live=True)
+        _launch(fake)
+        chat_calls = [c for c in fake.calls if commands_frame._CHAT_OPTION in c]
+        self.assertEqual(len(chat_calls), 1,
+                         f"the chat must be named exactly once: {fake.calls}")
+        cmd = chat_calls[0]
+        self.assertEqual(cmd[cmd.index("-t") + 1], fake.pane_id,
+                         "window-scoped through the harness PANE, never `-g` — a global "
+                         "write hands every window on this shared server one chat's id")
+        self.assertIn("-w", cmd)
+        self.assertEqual(cmd[-1], "demo.1")
+        hook_idx = next(i for i, c in enumerate(fake.calls) if "set-hook" in c)
+        self.assertLess(fake.calls.index(cmd), hook_idx)
+
+    def test_the_identity_rides_on_new_session_at_the_floor_and_not_below_it(self):
+        """`new-session -e` arrived in tmux 3.2 (`tmuxctl.SESSION_ENV_FLOOR`), and `-e` is
+        not a flag `new-session` degrades on — it is one it REFUSES, which takes the whole
+        launch down. So the boundary is `>=` and both sides of it are asserted: AT the
+        floor the identity rides, one release below it does not.
+
+        `new-window -e` has no such gate and needs none: window `-e` is available at
+        `tmuxctl.PANE_ENV_FLOOR` (3.0), below the floor charter warns at."""
+        at_floor = _FakeTmux(exit_code=0, still_live=True)
+        _launch(at_floor, version=tmuxctl.SESSION_ENV_FLOOR)
+        cmd = next(c for c in at_floor.calls if "new-session" in c)
+        self.assertIn("CHARTER_SESSION_ID=demo.1", cmd,
+                      "the floor is the version this WORKS on, not the first one above it")
+
+        major, minor = tmuxctl.SESSION_ENV_FLOOR
+        below = _FakeTmux(exit_code=0, still_live=True)
+        _launch(below, version=(major, minor - 1))
+        cmd = next(c for c in below.calls if "new-session" in c)
+        self.assertNotIn("-e", cmd,
+                         "a tmux that cannot parse `-e` was handed one, and `new-session` "
+                         "refuses rather than degrades")
+
+    def test_the_reap_set_carries_the_chats_as_well_as_the_sessions(self):
+        """A chat's id holds no launcher pid, so `list-windows -F '#{@charter_chat}'` is
+        the only thing that can keep its directory — and an old frame is still a SESSION
+        named by its id, so `list-sessions` is still asked too. Both, or one of the two
+        shapes is reaped while it is running."""
+        fake = _FakeTmux(exit_code=0, still_live=True)
+        _launch(fake)
+        formats = [c[c.index("-F") + 1] for c in fake.calls
+                   if "list-windows" in c and "-F" in c]
+        self.assertIn("#{@charter_chat}", formats,
+                      "liveness was not asked of the chat option")
+        self.assertNotIn("#{window_name}", formats,
+                         "a window NAME is not an identity — a pane with "
+                         "`allow-rename on` takes it, measured on tmux 3.7c and 3.2")
+        self.assertTrue([c for c in fake.calls if "list-sessions" in c])
+
+    def test_the_attach_and_the_reattach_line_name_the_workspaces_session(self):
+        """`tmux attach -t <chat>` is not a thing: the chat is a window. Both the real
+        attach and the sentence an operator is told to retype have to say the session."""
+        fake = _FakeTmux(still_live=True)
+        buf = []
+        with mock.patch("charter.util.info", side_effect=lambda m: buf.append(m)):
+            _launch(fake)
+        attach = next(c for c in fake.calls if "attach" in c)
+        self.assertEqual(attach[attach.index("-t") + 1], "demo")
+        self.assertTrue(any(f"attach -t demo" in m for m in buf), buf)
+
+    def test_the_launched_chat_is_selected_before_the_client_attaches(self):
+        """`chat_window_argv` creates the window detached, so a client already in this
+        workspace is not dragged onto a half-built one. Selecting it afterwards is what
+        pays that back — and it targets the harness PANE, which tmux resolves to its own
+        window (measured on tmux 3.7c and 3.2)."""
+        state.record_server("demo.1", commands_frame.SOCKET)
+        fake = _FakeTmux(exit_code=0, still_live=True,
+                         pre_existing_sessions=("demo",),
+                         pre_existing_chats=("demo.1",))
+        _launch(fake)
+        select = next(c for c in fake.calls if "select-window" in c)
+        self.assertEqual(select[select.index("-t") + 1], fake.pane_id)
+        self.assertLess(fake.calls.index(select),
+                        next(i for i, c in enumerate(fake.calls) if "attach" in c))
+
+    def test_a_server_that_will_not_list_its_windows_reaps_nothing(self):
+        """The guard a chat needs and an old frame did not.
+
+        `reap` keeps an old `{workspace}-{pid}` frame's directory because the pid in its
+        name is still a live process (#383), so a `list-sessions` that came back empty
+        because the server was wedged cost nothing. A chat has no pid, so the window list
+        is the whole of what keeps its directory — and a server that answers "sessions:
+        yes, windows: no" would take every live chat's version file and unread exit code
+        with it. Not reaping costs a directory until the next launch.
+
+        The live chat here is a SIBLING's, deliberately: this launch's own id is allocated
+        after the reap, so a launcher that reaped everything would not be visible in its
+        own directory."""
+        state.record_server("demo.1", commands_frame.SOCKET)
+        state.record_exit("demo.1", 42)
+        fake = _FakeTmux(exit_code=0, still_live=True,
+                         pre_existing_sessions=("demo",), list_windows_rc=1)
+        _launch(fake)
+        self.assertEqual(state.exit_code("demo.1"), 42,
+                         "a wedged server's silence was read as `no chats are live`, and "
+                         "a running chat's state went with it")
+
+    def test_a_server_that_is_not_running_at_all_still_reaps(self):
+        """The other half, and the one that keeps the guard from being a leak: an EMPTY
+        session list is not silence, it is the answer. Nothing recorded against a server
+        that is not running is live — a reboot leaves exactly that — so the stale
+        directory goes, which is `reap`'s whole job."""
+        state.record_server("stale.1", commands_frame.SOCKET)
+        state.bump("stale.1")
+        fake = _FakeTmux(exit_code=0, still_live=True, list_windows_rc=1)
+        _launch(fake)
+        self.assertFalse(state.frame_dir("stale.1").exists(),
+                         "a directory recorded against a server that is not running was "
+                         "kept — nothing else will ever remove it")
+
+    def test_a_window_option_tmux_refused_is_reported_with_what_it_costs(self):
+        """The other way this can fail, and it fails differently: charter built a usable
+        command and tmux would not take it. Continuing is right — the harness is already
+        running — but silently is not: without the option this chat is invisible to
+        `_live_chats`, so `reap` deletes its state while it runs, and the write hook's
+        `#{@charter_chat}` expands to nothing so its exit code lands nowhere."""
+        buf = []
+        with mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
+            rc = _launch(_FakeTmux(exit_code=0, still_live=True, chat_option_rc=1))
+        self.assertEqual(rc, 0, "a refused window option must not fail the launch")
+        self.assertTrue(any("reaped while it is still running" in m for m in buf), buf)
+        self.assertTrue(any("exit code may not be" in m for m in buf), buf)
+
+    def test_a_chat_id_tmux_could_not_carry_is_reported_rather_than_silently_dropped(self):
+        """`_chat_option_argv` refuses anything outside `_FRAME_ID_RE`, and the launch
+        says what that costs — reaping while the chat is still running, and no exit code
+        — rather than carrying on as though the window had been named."""
+        buf = []
+        with mock.patch.object(commands_frame, "_chat_option_argv", return_value=None), \
+             mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
+            _launch(_FakeTmux(exit_code=0, still_live=True))
+        self.assertTrue(any("reaped while it is still running" in m for m in buf), buf)
+
+
+class TheChatOptionIsCheckedWhereItEntersTmux(unittest.TestCase):
+    """`_chat_option_argv`. The value goes on to be expanded by tmux inside a `pane-died`
+    action AND inside a key bind, so it is checked where it enters those grammars rather
+    than trusted from `state.new_chat_id` — the same rule `_PANE_ID_RE` applies to a pane
+    id that arrived off `split-window`'s stdout."""
+
+    def test_a_chat_is_written_as_a_window_option_on_the_harness_pane(self):
+        cmd = commands_frame._chat_option_argv(socket="charter", harness_pane="%9",
+                                               chat="demo.2")
+        self.assertEqual(cmd, ["tmux", "-L", "charter", "set-option", "-w", "-t", "%9",
+                               "@charter_chat", "demo.2"])
+        self.assertNotIn("-g", cmd,
+                         "a global write hands every window on this shared server one "
+                         "chat's id")
+
+    def test_a_chat_outside_the_alphabet_is_refused(self):
+        """`None`, never a sanitised spelling: rewriting a hostile value into a
+        safe-looking one invents a second identity for it, which is the failure
+        `contain.child` documents one layer down."""
+        for hostile in ("a;b", "a b", "../../etc", "a\nb", "a$b", "a#{pane_pid}b",
+                        "a'b", 'a"b'):
+            with self.subTest(hostile=hostile):
+                self.assertIsNone(commands_frame._chat_option_argv(
+                    socket="charter", harness_pane="%9", chat=hostile))
+
+    def test_no_chat_at_all_is_refused_rather_than_raising(self):
+        """`""` and `None` are both "charter has no chat to write here", and this is
+        called from inside a launch — where a `TypeError` out of a regex would take the
+        whole launch down for a bookkeeping value."""
+        for empty in ("", None):
+            with self.subTest(empty=empty):
+                self.assertIsNone(commands_frame._chat_option_argv(
+                    socket="charter", harness_pane="%9", chat=empty))
+
+
+class TheChatListIsParsedLineByLine(unittest.TestCase):
+    """`_live_chats`' own reading of what tmux printed, asked of the text rather than of a
+    server — because the two things this pins are properties of the PARSE.
+
+    A window with no `@charter_chat` prints an EMPTY line (tmux prints a format's literal
+    text whether or not anything expands into it), and an empty string in the live set is
+    a name `state.reap` would then compare every directory against. And the value is
+    stripped, so a line that arrived with an edge of whitespace still names the chat it
+    names rather than a string no directory can equal."""
+
+    def _reading(self, stdout: str):
+        done = subprocess.CompletedProcess(["tmux"], 0, stdout=stdout, stderr="")
+        with mock.patch.object(commands_frame.tmuxctl, "run", return_value=done):
+            return commands_frame._live_chats("charter")
+
+    def test_a_window_with_no_chat_contributes_nothing(self):
+        self.assertEqual(self._reading("demo.1\n\ndemo.2\n"), {"demo.1", "demo.2"})
+
+    def test_a_server_with_no_chats_at_all_is_an_empty_set_not_a_set_holding_one(self):
+        self.assertEqual(self._reading("\n\n\n"), set())
+
+    def test_each_name_is_stripped(self):
+        self.assertEqual(self._reading("  demo.1  \n\tdemo.2\t\n"),
+                         {"demo.1", "demo.2"})
+
+    def test_a_server_that_did_not_answer_is_not_an_empty_set(self):
+        """`None`, and it is the whole of the refusal both callers make: a chat has no
+        launcher pid, so "no chats" and "no answer" would otherwise reap the same."""
+        done = subprocess.CompletedProcess(["tmux"], 1, stdout="", stderr="no server")
+        with mock.patch.object(commands_frame.tmuxctl, "run", return_value=done):
+            self.assertIsNone(commands_frame._live_chats("charter"))
+
+
+class ThePresserOwnChatIsWhatTheBindCarries(unittest.TestCase):
+    """`_pressers_chat`. Measured on tmux 3.7c and on tmux 3.2: a `run-shell` child —
+    which every `bind -n` action is — reads the SESSION's `set-environment` and never the
+    window's `-e`, so `$CHARTER_SESSION_ID` hands every chat in one workspace the same
+    id. `#{@charter_chat}`, expanded in the presser's own window, is what does not."""
+
+    def test_the_argv_chat_wins_over_the_session_variable(self):
+        args = SimpleNamespace(chat="demo.2")
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "demo.1"}, clear=True):
+            self.assertEqual(commands_frame._pressers_chat(args), "demo.2")
+
+    def test_an_empty_chat_falls_back_to_the_variable(self):
+        """A window with no `@charter_chat` expands to nothing — which is every frame
+        launched by a charter that predates the option, whose bind text is REPLACED by
+        the new one the moment a newer frame launches on the shared server."""
+        for value in ("", "   ", None):
+            with self.subTest(value=value):
+                args = SimpleNamespace(chat=value)
+                with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "demo.1"},
+                                     clear=True):
+                    self.assertEqual(commands_frame._pressers_chat(args), "demo.1")
+
+    def test_a_chat_that_arrived_with_an_edge_of_whitespace_is_still_that_chat(self):
+        """Stripped, and the trailing end is the one a mutation can move: `--chat` is also
+        typeable by hand, and `_FRAME_ID_RE` holds no whitespace — so a value that kept a
+        trailing space would fail the shape check and fall back to the session variable,
+        silently resolving somebody else's chat."""
+        for spelling in ("demo.2 ", " demo.2", "  demo.2\t"):
+            with self.subTest(spelling=spelling):
+                args = SimpleNamespace(chat=spelling)
+                with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "demo.1"},
+                                     clear=True):
+                    self.assertEqual(commands_frame._pressers_chat(args), "demo.2")
+
+    def test_a_chat_outside_the_alphabet_falls_back_rather_than_being_carried(self):
+        """The far end of a trip a frame id already makes to tmux: this value came back
+        out of a tmux format, and it is on its way to a state path."""
+        for hostile in ("../../etc", "a b", "a;b", "a\nb", "a$b"):
+            with self.subTest(hostile=hostile):
+                args = SimpleNamespace(chat=hostile)
+                with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "demo.1"},
+                                     clear=True):
+                    self.assertEqual(commands_frame._pressers_chat(args), "demo.1")
+
+    def test_with_neither_it_is_the_empty_string(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(commands_frame._pressers_chat(SimpleNamespace(chat="")), "")
+
+
+class NothingIsAddedToCarriable(unittest.TestCase):
+    """Phase 5's own constraint, asserted rather than remembered. A tmux `-e` becomes
+    world-readable argv, so the funnel every `-e` charter builds goes through is a closed
+    list — and identity being per chat is a matter of WHICH of these a window is given,
+    never of adding one."""
+
+    def test_the_list_is_exactly_what_it_was(self):
+        self.assertEqual(set(layout.CARRIABLE), {
+            "CHARTER_SESSION_ID", "CHARTER_HARNESS", "CHARTER_ROOT",
+            "CHARTER_WORKSPACE", "CHARTER_PERSONA", "PATH"})
+
+    def test_a_chat_window_may_carry_only_those_names(self):
+        with self.assertRaises(ValueError) as caught:
+            layout.chat_window_argv(socket="charter", session="demo", chat="demo.2",
+                                    cwd="/tmp", harness_argv=["claude"],
+                                    env={"CHARTER_SESSION_ID": "demo.2",
+                                         "OP_SERVICE_ACCOUNT_TOKEN": "sekrit"})
+        self.assertIn("OP_SERVICE_ACCOUNT_TOKEN", str(caught.exception))
+        self.assertNotIn("sekrit", str(caught.exception),
+                         "a value that does not belong on a command line does not belong "
+                         "in a traceback either")
+
+    def test_a_chat_window_carries_the_identity_it_is_given(self):
+        cmd = layout.chat_window_argv(socket="charter", session="demo", chat="demo.2",
+                                      cwd="/tmp", harness_argv=["codex"],
+                                      env={"CHARTER_SESSION_ID": "demo.2",
+                                           "CHARTER_HARNESS": "codex"})
+        self.assertEqual(cmd[:3], ["tmux", "-L", "charter"])
+        self.assertIn("new-window", cmd)
+        self.assertEqual(cmd[cmd.index("-n") + 1], "demo.2")
+        self.assertEqual(cmd[cmd.index("-t") + 1], "demo")
+        self.assertIn("-a", cmd)
+        self.assertIn("-e", cmd)
+        self.assertIn("CHARTER_SESSION_ID=demo.2", cmd)
+        self.assertIn("CHARTER_HARNESS=codex", cmd)
+        # Every `-e` before the `--`: they are `new-window`'s options, never something to
+        # graft onto the harness's own argv.
+        self.assertTrue(all(cmd.index(x) < cmd.index("--")
+                            for x in ("-e", "CHARTER_SESSION_ID=demo.2")))
+        self.assertEqual(cmd[cmd.index("--") + 1:], ["codex"])
+
+
+class TwoChatsAreTwoCharterSessions(PersonaIso, unittest.TestCase):
+    """Task 3's consequence, and the reason it needs no new code: `session.current()`
+    reads `$CHARTER_SESSION_ID`, which under tabs is the CHAT's id, so every per-session
+    pointer charter already has becomes per chat.
+
+    Asserted through the real pointer writers rather than by spelling paths, because the
+    claim is about what those writers do with two different ids — `.persona`, `.workspace`
+    and `.tools` under `.charter/sessions/<chat id>` are the files, and there is exactly
+    one place each is keyed."""
+
+    def test_two_chats_hold_two_personas(self):
+        from charter import persona
+        persona.set_active("release", session_id="demo.1")
+        persona.set_active("forge", session_id="demo.2")
+        for chat, expected in (("demo.1", "release"), ("demo.2", "forge")):
+            with self.subTest(chat=chat):
+                with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": chat},
+                                     clear=True):
+                    self.assertEqual(persona.resolve_active(), expected)
+
+    def test_two_chats_hold_two_workspaces(self):
+        from charter import workspace
+        workspace.set_active("alpha", session_id="demo.1", force=True)
+        workspace.set_active("beta", session_id="demo.2", force=True)
+        self.assertEqual(workspace.for_session("demo.1"), "alpha")
+        self.assertEqual(workspace.for_session("demo.2"), "beta")
+
+    def test_two_chats_hold_two_tool_ceilings(self):
+        """`toolgate.snapshot` writes `.charter/sessions/<sid>.tools`, keyed on
+        `session.current()` — so two chats freeze independently and one chat widening its
+        persona's `tools:` line mid-session cannot widen the other's ceiling.
+
+        Driven through the real writer with the persona set faked at ONE seam
+        (`persona.effective_tools`), because the subject is the KEYING, not what a
+        persona happens to declare on this plane."""
+        from charter import persona, toolgate
+        with mock.patch.object(persona, "list_personas", return_value=["release"]), \
+             mock.patch.object(persona, "effective_tools", return_value={"Bash"}):
+            toolgate.snapshot(session_id="demo.1")
+        # The working tree widens between the two chats' SessionStarts — an ordinary
+        # edit, and exactly what a frozen ceiling exists to stop reaching chat one.
+        with mock.patch.object(persona, "list_personas", return_value=["release"]), \
+             mock.patch.object(persona, "effective_tools",
+                               return_value={"Bash", "Read"}):
+            toolgate.snapshot(session_id="demo.2")
+        self.assertEqual(toolgate.frozen_tools("release", "demo.1"), {"Bash"},
+                         "one chat's ceiling moved when another chat froze its own")
+        self.assertEqual(toolgate.frozen_tools("release", "demo.2"), {"Bash", "Read"})
+
+
 class Launch(PersonaIso, unittest.TestCase):
     def test_the_write_hook_targets_the_pane_tmux_actually_reported(self):
         """The regression correction 3 names directly: the hook's target must be the id
@@ -1756,7 +2264,8 @@ class Launch(PersonaIso, unittest.TestCase):
         with mock.patch.dict(config.FRAME, frame):
             _launch(fake)
         self.assertIn("bind -n F7 run-shell "
-                      "'\"$CHARTER_PY\" -m charter frame-toggle repos'",
+                      "'\"$CHARTER_PY\" -m charter frame-toggle repos "
+                      "--chat \"#{@charter_chat}\"'",
                       fake.sourced_conf_text)
 
     def test_a_plane_that_binds_no_component_keys_sources_no_toggle_binds(self):
@@ -1801,10 +2310,11 @@ class Launch(PersonaIso, unittest.TestCase):
                          "the exit-status path must be carried out of band exactly "
                          f"once: {fake.calls}")
         cmd = exit_calls[0]
-        self.assertEqual(cmd[cmd.index("-t") + 1], fake.fid)
-        self.assertEqual(cmd[-1], str(state.frame_dir(fake.fid) / "exit"),
-                         "the path carried must be THIS frame's own `exit` file — the "
-                         "one `state.exit_code` reads back")
+        self.assertEqual(cmd[cmd.index("-t") + 1], fake.session)
+        self.assertEqual(cmd[-1], str(state.frame_dir(fake.fid).parent),
+                         "the frame ROOT: the variable is session-scoped and a session "
+                         "holds several chats, so the hook appends `#{@charter_chat}` "
+                         "and this must not name one chat's file")
         hook_idx = next(i for i, c in enumerate(fake.calls)
                        if "set-hook" in c and "pane-died[1]" not in c)
         self.assertLess(fake.calls.index(cmd), hook_idx)
@@ -1820,8 +2330,11 @@ class Launch(PersonaIso, unittest.TestCase):
         sid_calls = [c for c in fake.calls if "set-environment" in c and "CHARTER_SESSION_ID" in c]
         self.assertEqual(len(sid_calls), 1,
                          "the frame's own id must be carried out of band exactly once")
-        self.assertEqual(sid_calls[0][sid_calls[0].index("-t") + 1], fake.fid)
-        self.assertEqual(sid_calls[0][-1], fake.fid)
+        self.assertEqual(sid_calls[0][sid_calls[0].index("-t") + 1], fake.session,
+                         "targeted at the workspace's session — there is no window scope "
+                         "for `set-environment`")
+        self.assertEqual(sid_calls[0][-1], fake.fid,
+                         "and the VALUE is the chat, not the session's own name")
         sid_idx = fake.calls.index(sid_calls[0])
         hook_idx = next(i for i, c in enumerate(fake.calls)
                        if "set-hook" in c and "pane-died[1]" not in c)
@@ -1841,7 +2354,7 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(len(py_calls), 1,
                          f"the interpreter must be carried exactly once: {fake.calls}")
         cmd = py_calls[0]
-        self.assertEqual(cmd[cmd.index("-t") + 1], fake.fid,
+        self.assertEqual(cmd[cmd.index("-t") + 1], fake.session,
                          "session-scoped: two planes on one laptop can be two different "
                          "charter installs, so a `-g` write would hand frame N's "
                          "interpreter to frame N-1")
@@ -1864,7 +2377,7 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(len(safepath_calls), 1,
                          f"PYTHONSAFEPATH must be carried exactly once: {fake.calls}")
         cmd = safepath_calls[0]
-        self.assertEqual(cmd[cmd.index("-t") + 1], fake.fid,
+        self.assertEqual(cmd[cmd.index("-t") + 1], fake.session,
                          "session-scoped, same reasoning as CHARTER_PY: two planes on "
                          "one laptop can be two different charter installs")
         self.assertEqual(cmd[-1], "1")
@@ -2123,18 +2636,22 @@ class Launch(PersonaIso, unittest.TestCase):
 
         The check for this is EAGER — run immediately after both hooks are installed,
         before `attach` is ever called — not merely a fallback after `attach` returns.
-        Verified by hand against a real tmux 3.7c: with nothing left to run
-        `kill-session`, `remain-on-exit` legitimately keeps the session alive forever,
-        so an `attach` reaching this state BLOCKS FOREVER rather than returning 0 early.
-        A correct launcher must therefore finish the hooks' own job itself (record the
-        code, run `kill-session`) and skip `attach` entirely — this test fails if
+        Verified by hand against a real tmux 3.7c: with nothing left to run the
+        teardown, `remain-on-exit` legitimately keeps the pane alive forever, so an
+        `attach` reaching this state BLOCKS FOREVER rather than returning 0 early. A
+        correct launcher must therefore finish the hooks' own job itself (record the
+        code, end the chat's window) and skip `attach` entirely — this test fails if
         `attach` is ever reached in this scenario, not only if the wrong code comes
-        back."""
+        back.
+
+        **`kill-window`, not `kill-session`.** A session is a workspace now and holds
+        every chat in it, so ending the session here would take a sibling chat's harness
+        down for a death that was not its own."""
         fake = _FakeTmux(race_death_status=42)
         # `state.record_exit` is asserted on directly, mid-call, rather than by reading
         # `state.exit_code` back after `_launch` returns: `reap()` legitimately deletes
         # a frame's directory once its session is truly gone (which it is here, once
-        # `kill-session` runs), and this test's own `_FakeTmux` reports nothing live —
+        # `kill-window` runs), and this test's own `_FakeTmux` reports nothing live —
         # so a post-hoc read would see the sentinel `None` regardless of whether the
         # code was ever written, for a reason that has nothing to do with this test.
         with mock.patch("charter.frame.state.record_exit",
@@ -2143,14 +2660,17 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 42)
         rec.assert_called_once_with(fake.fid, 42)
         self.assertTrue(any("display-message" in c for c in fake.calls))
-        self.assertTrue(fake.kill_session_called,
-                        "nothing else was ever going to end this session")
+        self.assertTrue(fake.kill_window_called,
+                        "nothing else was ever going to end this chat")
+        self.assertFalse(fake.kill_session_called,
+                         "a session is a WORKSPACE now — ending it takes every other "
+                         "chat in it down with this one")
         self.assertFalse(any("attach" in c for c in fake.calls),
                          "attach must never be reached against a session already known "
                          "to be over — reaching it here would hang against real tmux")
 
     def test_a_failed_teardown_after_an_early_death_is_reported(self):
-        """`kill-session`, run directly after the eager check recovers an early death,
+        """`kill-window`, run directly after the eager check recovers an early death,
         was the module's own last unchecked tmux return code — correction 2 applies to
         it too."""
         fake = _FakeTmux(race_death_status=9, kill_rc=1)
@@ -2158,7 +2678,7 @@ class Launch(PersonaIso, unittest.TestCase):
         with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
             rc = _launch(fake)
         self.assertEqual(rc, 9)
-        self.assertTrue(any("ending the frame" in m for m in buf), buf)
+        self.assertTrue(any("ending the chat" in m for m in buf), buf)
 
     def test_remain_on_exit_is_armed_before_the_pane_id_is_even_known(self):
         """The other half of Critical 1: the placeholder loaded via `new-session`'s own
@@ -2281,15 +2801,16 @@ class Launch(PersonaIso, unittest.TestCase):
         with mock.patch("charter.util.info", side_effect=lambda m: buf.append(m)):
             rc = _launch(fake)
         self.assertEqual(rc, 0)
-        self.assertTrue(any("detach" in m.lower() and fake.fid in m for m in buf),
+        # The reattach line names the SESSION, which is the workspace: the chat is a
+        # window inside it and `tmux attach -t <chat>` is not a thing an operator can
+        # type. The chat id is what the frame's own state is under, and it is asserted
+        # separately below.
+        self.assertTrue(any("detach" in m.lower() and fake.session in m for m in buf),
                         f"no reattach message was printed: {buf}")
-        # The frame's own directory must not be reaped while the session is still live.
-        # Weak evidence for the live-session rule specifically, and deliberately not
-        # dressed up as more: since #383 this directory is kept by EITHER rule, because
-        # `fid` ends in the launcher's pid and the launcher is this test process. That
-        # is inherent — a launch's own id always names a live pid — so `Reap`'s fixtures
-        # in tests/test_frame_state.py are where the live-session rule is pinned alone,
-        # deliberately named after dead pids so nothing else can keep them.
+        # The chat's own directory must not be reaped while its window is still there.
+        # Stronger evidence than it used to be, and that is the change: a chat id carries
+        # no launcher pid, so `reap`'s pid rule abstains and the LIVENESS LIST is the only
+        # thing keeping this directory. `still_live=True` is what puts the chat in it.
         self.assertTrue(state.frame_dir(fake.fid).exists())
 
     def test_refuses_to_attach_when_the_teardown_hook_fails_to_install(self):
@@ -2827,7 +3348,13 @@ class Launch(PersonaIso, unittest.TestCase):
         frame's id" (ADR 0019, `state.record_harness_pane`). Not recorded, `is_live`
         answers `None != <pane>` and no frame ever suppresses — a duplicated status line,
         which nobody reports as a bug and no other test would notice."""
-        fake = _FakeTmux(exit_code=0)
+        # `still_live=True`, and that is a real change rather than a fixture tweak. A
+        # chat id carries no launcher pid, so `reap` no longer keeps a finished frame's
+        # directory just because the launcher process that started it is still running —
+        # the launch's own closing reap removes it, which is the bounding property
+        # `state.reap`'s docstring is about. Reading the record therefore has to happen
+        # while the chat is still there.
+        fake = _FakeTmux(exit_code=0, still_live=True)
         rc = _launch(fake)
         self.assertEqual(rc, 0)
         self.assertEqual(state.harness_pane(fake.fid), fake.pane_id)
@@ -3004,32 +3531,66 @@ class Launch(PersonaIso, unittest.TestCase):
                          "alive — that launcher now returns a fabricated 0 for a "
                          "harness that exited 42")
 
-    def test_a_launch_does_not_inherit_an_exit_code_from_an_earlier_life_of_its_pid(self):
-        """The bill for #383's fix, paid here rather than left to be discovered. A frame
-        id is `<workspace>-<launcher pid>` and pids are recycled — Linux wraps at
-        `kernel.pid_max`, 32768 by default — so a launcher for the same workspace really
-        does land on a pid an earlier launcher already used. `reap` now keeps a directory
-        for as long as the pid in its name is live, and on THIS launch that pid is live
-        because it is ours: the earlier frame's directory, `exit` file and all, is still
-        there when this launch adopts the same id.
+    def test_a_launch_claims_an_id_no_directory_already_holds(self):
+        """The bill for #383's fix, no longer paid — because the id is ALLOCATED.
 
-        Read back, that stale code becomes this launch's own return value. Asserted on
-        the DETACH path, where nothing new is ever recorded and the stale file is
-        therefore the only thing `state.exit_code` can find — a harness running perfectly
-        well, detached, would be reported as having failed with a dead frame's number and
-        the reattach line would never print."""
-        stale = state.frame_id("demo", os.getpid())   # the id `_launch` is about to mint
-        state.record_exit(stale, 99)
+        A frame id used to be `<workspace>-<launcher pid>` and pids are recycled — Linux
+        wraps at `kernel.pid_max`, 32768 by default — so a launcher for the same workspace
+        really did land on a pid an earlier launcher had used, and adopted that frame's
+        whole directory: its `exit` file read back as this launch's own return value, its
+        `gather.json` drew on every panel, its spent respawn budget refused this frame's
+        first panel death. That is what `state.clear_exit` / `clear_shape` /
+        `clear_respawn` / `gather.discard` on the launch path were for.
 
-        fake = _FakeTmux(still_live=True)
+        `state.new_chat_id` claims its ordinal with a `mkdir` that FAILS when the name is
+        taken, so a launch cannot land on an occupied directory at all — the collision is
+        prevented rather than cleaned up after. Pinned as literals: workspace `demo`,
+        `demo.1` already on disk, so the launch must take `demo.2`.
+        """
+        state.record_exit("demo.1", 99)
+
+        fake = _FakeTmux(still_live=True, pre_existing_chats=("demo.1",),
+                         pre_existing_sessions=("demo",))
         buf = []
         with mock.patch("charter.util.info", side_effect=lambda m: buf.append(m)):
             rc = _launch(fake)
 
-        self.assertEqual(fake.fid, stale, "the fixture stopped colliding — proves nothing")
+        self.assertEqual(fake.fid, "demo.2",
+                         "the launch adopted an id whose directory already existed")
         self.assertEqual(rc, 0, "a previous frame's exit code was returned as this one's")
         self.assertTrue(any("detach" in m.lower() for m in buf),
-                        f"no reattach message — the stale code suppressed it: {buf}")
+                        f"no reattach message — a stale code suppressed it: {buf}")
+
+    def test_a_launch_leaves_the_record_of_the_chat_it_stepped_over(self):
+        """The other half, and the one an adopt-then-clear design cannot give.
+
+        Skipping a taken ordinal means the launch never writes in that directory — so a
+        COLD chat's record (Stage 5c reopens one) survives a sibling launching beside it,
+        where a launcher that adopted the id and cleared it would have deleted exactly
+        that. Every file a launch used to clear is asserted still there, by name, because
+        four separate clears used to be four separate defects."""
+        state.record_exit("demo.1", 99)
+        state.record_density("demo.1", "minimal")
+        state.record_panes("demo.1", panels={"left": "%98"})
+        state.record_harness_session("demo.1", "a-harness-session")
+        state.bump("demo.1")
+        for _ in range(commands_frame._RESPAWN_ATTEMPTS + 1):
+            state.respawn_attempt("demo.1", "top")
+        gather.save("demo.1", {"gathered_at": 1.0, "workspace": "a-cold-chat",
+                               "current_repo": None, "repos": [], "worktrees": []})
+
+        fake = _FakeTmux(still_live=True, pre_existing_chats=("demo.1",),
+                         pre_existing_sessions=("demo",))
+        _launch(fake)
+
+        self.assertEqual(fake.fid, "demo.2")
+        self.assertEqual(state.exit_code("demo.1"), 99)
+        self.assertEqual(state.density("demo.1"), "minimal")
+        self.assertEqual(state.panes("demo.1"), {"left": "%98"})
+        self.assertEqual(state.harness_session("demo.1"), "a-harness-session")
+        self.assertEqual(state.respawn_attempt("demo.1", "top"),
+                         commands_frame._RESPAWN_ATTEMPTS + 2)
+        self.assertEqual(gather.read("demo.1")["workspace"], "a-cold-chat")
 
     def test_a_launch_records_the_frames_own_charter_identity(self):
         """#411 on the density path. A hotkey pressed later runs as a `run-shell` child of
@@ -3052,82 +3613,42 @@ class Launch(PersonaIso, unittest.TestCase):
                          "every identity name must be recorded, including the empty ones "
                          "— an omitted name is inherited from the server, which is the bug")
 
-    def test_a_launch_does_not_inherit_a_density_from_an_earlier_life_of_its_pid(self):
-        """The third file the recycled directory carries (#387). `density` is written by
-        the palette and by nothing else — it is the "for the running frame only"
-        override — so a frame that adopts one has a keypress from a session that is over
-        silently outranking this plane's own `[frame] density`, with nothing anywhere to
-        explain why the frame came up narrower than the file says. `panes` goes with it:
-        it names tmux panes of a frame that no longer exists, and a launch that dies
-        before `_draw_panels` rewrites it would leave the next density change killing
-        whatever tmux has since reused those ids for."""
-        stale = state.frame_id("demo", os.getpid())   # the id `_launch` is about to mint
-        state.record_density(stale, "minimal")
-        state.record_panes(stale, panels={"left": "%98"})
+    def test_the_chat_the_launch_claimed_carries_none_of_a_neighbours_state(self):
+        """The consequence for the frame that DID launch, asserted at its own id.
 
-        fake = _FakeTmux(still_live=True)
+        Each of these four was its own defect when a launch could adopt a directory (#383
+        for `exit`, #387 for `density`/`panes`, #382 for the respawn budget, and the
+        panel hot path for `gather.json`), so each is asked separately rather than folded
+        into "the directory is empty" — a single assertion could not say which reader had
+        started serving a neighbour's record."""
+        state.record_exit("demo.1", 99)
+        state.record_density("demo.1", "minimal")
+        state.record_panes("demo.1", panels={"left": "%98"})
+        state.bump("demo.1")
+        for _ in range(commands_frame._RESPAWN_ATTEMPTS + 1):
+            state.respawn_attempt("demo.1", "top")
+        gather.save("demo.1", {"gathered_at": 1.0, "workspace": "from-a-dead-frame",
+                               "current_repo": None, "repos": [], "worktrees": []})
+
+        fake = _FakeTmux(still_live=True, pre_existing_chats=("demo.1",),
+                         pre_existing_sessions=("demo",))
         _launch(fake)
 
-        self.assertEqual(fake.fid, stale, "the fixture stopped colliding — proves nothing")
-        self.assertIsNone(state.density(stale),
-                          "a dead frame's density override outlived it")
-        self.assertEqual(state.panes(stale), {},
-                         "a dead frame's pane map outlived it")
-
-    def test_a_launch_does_not_inherit_a_cached_scan_from_an_earlier_life_of_its_pid(self):
-        """The second file the recycled directory carries, and the second reader that
-        inherits it. `exit` is read once, by this launcher; `gather.json` is read by
-        every PANEL, on every repaint, and `gather.read` has no freshness check by
-        design — it is a panel's hot path, kept current by `notify.plane_changed`.
-
-        So a launch adopting a dead frame's directory draws that frame's repos,
-        branches and CI, and nothing corrects it: a panel repaints only on a
-        `state.version` bump, so a scan from another day sits on screen until the
-        session's first hook fires. Before #383 this was unreachable — `reap` had
-        deleted the directory and `read` fell through to a live `scan` — and clearing
-        the file on the launch path is what puts it back on exactly that path.
-
-        `scan` is mocked to a sentinel, so this fails if the stale cache is served AND
-        distinguishes that from "a live gather happened to agree"."""
-        stale = state.frame_id("demo", os.getpid())   # the id `_launch` is about to mint
-        gather.save(stale, {"gathered_at": 1.0, "workspace": "from-a-dead-frame",
-                            "current_repo": None, "repos": [], "worktrees": []})
-
-        fake = _FakeTmux(still_live=True)
-        _launch(fake)
-
-        self.assertEqual(fake.fid, stale, "the fixture stopped colliding — proves nothing")
+        self.assertEqual(fake.fid, "demo.2")
+        self.assertIsNone(state.density(fake.fid),
+                          "a neighbour's density override outranked this plane's own")
+        self.assertEqual(state.panes(fake.fid), {},
+                         "a neighbour's pane map would name tmux panes this frame never "
+                         "split, and the next density change would kill them")
+        self.assertEqual(state.respawn_attempt(fake.fid, "top"), 1,
+                         "this frame's first panel death was charged to another chat's "
+                         "budget and would never be respawned")
         fresh = {"gathered_at": 0.0, "workspace": "sentinel", "current_repo": None,
                  "repos": [], "worktrees": []}
         with mock.patch.object(gather, "scan", return_value=fresh):
             self.assertEqual(gather.read(fake.fid), fresh,
-                             "a panel of this frame would draw a dead frame's scan "
-                             "until the session's first hook bump")
-
-    def test_a_launch_does_not_inherit_a_spent_respawn_budget_from_its_pid(self):
-        """The third thing the recycled directory carries (#382 meeting #383), and the
-        one whose inheritance is not merely stale but already exhausted.
-
-        `state.respawn_attempt` never resets — three deaths across a frame's whole life,
-        deliberately — and every panel's `pane-died` hook fires during its own frame's
-        TEARDOWN, so a directory left behind by a finished frame always has counts in it
-        and may well be at `_RESPAWN_ATTEMPTS` already. Adopted by a new frame, those
-        counts are charged to panels that have not died once: the first real death of
-        this frame's `top` panel would be refused as attempt 4, and a panel that charter
-        promises to bring back would simply stay dead, with nothing anywhere saying it
-        was another frame's budget that ran out."""
-        stale = state.frame_id("demo", os.getpid())   # the id `_launch` is about to mint
-        state.bump(stale)
-        for _ in range(commands_frame._RESPAWN_ATTEMPTS + 1):
-            state.respawn_attempt(stale, "top")
-
-        fake = _FakeTmux(still_live=True)
-        _launch(fake)
-
-        self.assertEqual(fake.fid, stale, "the fixture stopped colliding — proves nothing")
-        self.assertEqual(state.respawn_attempt(fake.fid, "top"), 1,
-                         "this frame's first panel death was charged to a dead frame's "
-                         "budget and would never be respawned")
+                             "a panel of this frame would draw a neighbour's scan until "
+                             "the session's first hook bump")
 
 
 class TheTablePaneIsSplitForWhatItCanDraw(PersonaIso, unittest.TestCase):
@@ -3298,14 +3819,14 @@ class EarlyDeathIsLegible(PersonaIso, unittest.TestCase):
                         f"the pane's own last words never reached the operator: {buf}")
 
     def test_the_pane_is_read_before_the_session_is_killed(self):
-        """Ordering, and load-bearing rather than incidental — `kill-session` destroys
+        """Ordering, and load-bearing rather than incidental — `kill-window` destroys
         the pane, so a capture issued after it can only ever come back empty. Pinned by
         comparing indices, the same way
         `test_the_write_hook_is_installed_before_the_teardown_hook` pins the other
         ordering this launcher depends on.
 
         `"set-hook" not in c` is not decoration: `_pane_died_teardown_hook_argv`'s ACTION
-        is the literal string `kill-session`, so an unfiltered search finds the hook
+        is the literal string `kill-window`, so an unfiltered search finds the hook
         INSTALL — issued long before either the capture or the real teardown — and this
         test failed against a correct implementation until it stopped matching that."""
         fake = _FakeTmux(race_death_status=127, pane_capture="boom\n")
@@ -3313,7 +3834,7 @@ class EarlyDeathIsLegible(PersonaIso, unittest.TestCase):
             _launch(fake, harness="", rest=["--", "nosuchthing-xyz"])
         capture_idx = next(i for i, c in enumerate(fake.calls) if "capture-pane" in c)
         kill_idx = next(i for i, c in enumerate(fake.calls)
-                        if "kill-session" in c and "set-hook" not in c)
+                        if "kill-window" in c and "set-hook" not in c)
         self.assertLess(capture_idx, kill_idx,
                         "the pane must be read BEFORE it is destroyed, or there is "
                         "nothing left to read")
@@ -4053,7 +4574,7 @@ class _FakeOperatorTmux:
                  pre_existing_windows=("zsh",), list_windows_rc=0,
                  new_window_rc=0, arm_rc=0, chrome_rc=0, respawn_rc=0, panel_rc=0,
                  panel_pane_ids=None, resize_hook_rc=0, select_rc=0, kill_rc=0,
-                 pane_capture="", capture_rc=0):
+                 pane_capture="", capture_rc=0, chat_option_rc=0, chat_list_rc=0):
         self.window_id = window_id
         self.pane_id = pane_id
         self.polls_alive = polls_alive
@@ -4077,6 +4598,11 @@ class _FakeOperatorTmux:
         self.resize_hook_rc = resize_hook_rc
         self.select_rc = select_rc
         self.kill_rc = kill_rc
+        self.chat_option_rc = chat_option_rc
+        #: A server that answers `list-windows` for the NAMES and refuses it for the
+        #: chats — the two questions `_reap_this_server` asks, and the one state in which
+        #: charter cannot tell which chats are live and must not reap.
+        self.chat_list_rc = chat_list_rc
         self.calls: list[list[str]] = []
         self.status_queries = 0
         self.window_killed = False
@@ -4092,10 +4618,27 @@ class _FakeOperatorTmux:
                 return subprocess.CompletedProcess(
                     cmd, self.list_windows_rc, stdout="",
                     stderr=f"error connecting to {OPERATOR_SOCKET} (No such file)")
-            live = list(self.pre_existing_windows)
+            # TWO questions share this command and they want different answers:
+            # `_live_windows` asks for `#{window_name}`, `_live_chats` for
+            # `#{@charter_chat}`. Told apart by the FORMAT charter actually sent, so a
+            # test cannot pass by having one answer stand in for the other — the whole
+            # point of `_live_chats` is that a window's name and its chat are not the
+            # same fact.
+            chats = commands_frame._CHAT_OPTION in cmd[-1]
+            if chats and self.chat_list_rc != 0:
+                return subprocess.CompletedProcess(
+                    cmd, self.chat_list_rc, stdout="",
+                    stderr=f"error connecting to {OPERATOR_SOCKET} (No such file)")
+            live = [] if chats else list(self.pre_existing_windows)
             if self.window_killed is False and any("new-window" in c for c in self.calls):
                 live.append(_frame_id())
             return self._ok(cmd, stdout="\n".join(live))
+        if commands_frame._CHAT_OPTION in cmd:
+            # Which chat this window draws. BEFORE the `set-option`/chrome branches, for
+            # the reason the hatch option is: the value is a plain id.
+            return subprocess.CompletedProcess(cmd, self.chat_option_rc, stdout="",
+                                               stderr="" if self.chat_option_rc == 0
+                                               else "cannot set")
         if "new-window" in cmd:
             if self.new_window_rc != 0:
                 return subprocess.CompletedProcess(cmd, self.new_window_rc, stdout="",
@@ -4168,7 +4711,13 @@ class _FakeOperatorTmux:
 
 
 def _frame_id():
-    return state.frame_id("demo", os.getpid())
+    """The chat id a launch for workspace `demo` allocates in a fresh plane.
+
+    A LITERAL, not `state.new_chat_id("demo")`: every test here runs against its own
+    empty state directory, so the first ordinal a launch can claim is `1`, and an
+    expectation computed from the allocator under test would follow it wherever it went.
+    """
+    return "demo.1"
 
 
 def _launch_inside(fake: _FakeOperatorTmux, *, version=(3, 7), harness="claude",
@@ -4479,6 +5028,32 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         self.assertEqual(armed[0][armed[0].index("-t") + 1], "%9")
         self.assertIn(f"--frame {_frame_id()}", armed[0][-1])
 
+    def test_a_finished_frame_leaves_no_directory_behind_on_this_path(self):
+        """The CLOSING reap, and it needs a fixture the opening one cannot satisfy.
+
+        `_launch_in_operator_tmux` reaps twice: once before it builds anything, and once
+        after `_close_window`. The test below spies on the SERVER each reap was given, so
+        deleting the closing call leaves the opening one answering for it — two guards in
+        sequence, the first masking the second, which is exactly the shape the deletion
+        sweep found here (`_reap_this_server`'s whole `if` came out and the suite stayed
+        green).
+
+        What only the closing reap can do is remove THIS frame's own directory:
+        `state.new_chat_id` creates it after the opening reap has already run, and a chat
+        id carries no launcher pid for `reap`'s second rule to keep it by. So a launch
+        that has returned must leave nothing under the frame root at all — and with the
+        closing reap gone, its own directory is still standing."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        rc = _launch_inside(fake)
+        self.assertEqual(rc, 0)
+        self.assertTrue(fake.window_killed,
+                        "the window was never closed, so the closing reap had nothing to "
+                        "notice and this test would pass on the opening one")
+        self.assertFalse(state.frame_dir(_frame_id()).exists(),
+                         "the finished frame's own directory outlived it — nothing else "
+                         "will ever remove it, because a chat id carries no pid for "
+                         "`reap`'s launcher rule to ask about")
+
     def test_the_frames_state_is_reaped_against_the_operators_server(self):
         """A frame here is a window on their socket and appears in no `tmux -L charter
         list-sessions` output at all. Reaping on the wrong server's list deletes a
@@ -4591,6 +5166,38 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         self.assertFalse([c for c in fake.calls if "split-window" in c],
                          "a 60x8 tmux window has no room for a panel")
 
+    def test_a_server_that_will_not_list_its_chats_reaps_nothing_here_either(self):
+        """The guest path's half of the same refusal, and it needs a server that answers
+        one of the two questions and not the other — `_live_windows` for the names,
+        `_live_chats` for `@charter_chat`. Both failing is already covered by
+        `test_a_server_that_stops_answering_is_not_treated_as_empty`, and that case cannot
+        tell the chat conjunct from the window one.
+
+        A chat has no launcher pid, so this list is the whole of what keeps its directory:
+        read a wedged server's silence as "no chats" and a running frame's version file
+        and unread exit code go with it."""
+        state.record_server("survivor.1", OPERATOR_SOCKET)
+        state.record_exit("survivor.1", 42)
+        fake = _FakeOperatorTmux(exit_code=0, pane_vanishes=True, chat_list_rc=1)
+        _launch_inside(fake)
+        self.assertEqual(state.exit_code("survivor.1"), 42,
+                         "a server that would not list its chats was read as having "
+                         "none, and a running chat's state went with it")
+
+    def test_the_chat_is_written_on_the_window_here_too(self):
+        """The guest path names its window for the chat and writes the option on it —
+        which is what stops `_reap_this_server` losing a frame whose window the harness
+        renamed. `allow-rename on` is an ordinary thing to have in somebody's own
+        `.tmux.conf`, which is why this matters MORE here than on charter's own server."""
+        fake = _FakeOperatorTmux(exit_code=0, pane_id="%7", pane_vanishes=True)
+        _launch_inside(fake)
+        chat_calls = [c for c in fake.calls if commands_frame._CHAT_OPTION in c]
+        self.assertEqual(len(chat_calls), 1, f"expected exactly one: {fake.calls}")
+        cmd = chat_calls[0]
+        self.assertIn("-w", cmd)
+        self.assertEqual(cmd[cmd.index("-t") + 1], "%7")
+        self.assertEqual(cmd[-1], _frame_id())
+
     def test_the_harness_pane_is_recorded_on_this_path_too(self):
         """ADR 0019's suppression asks `state.harness_pane(fid)` whether the process
         holding a frame id is actually inside that frame; a path that forgot to record it
@@ -4598,12 +5205,17 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         would report as a bug. Written down here rather than assumed shared, because the
         two launch paths capture their pane id in two different places and only one of
         them had a test."""
-        fake = _FakeOperatorTmux(exit_code=0, pane_id="%7",
+        # Read while the frame is still there. A chat id carries no launcher pid, so
+        # `reap` no longer keeps a finished frame's directory because the process that
+        # launched it is still running — this path closes its own window and then reaps,
+        # and the directory goes with it. `pane_vanishes` is the operator closing the
+        # window themselves, which is the one ending on this path that leaves the record
+        # standing (charter cannot know the code, so it kills nothing).
+        fake = _FakeOperatorTmux(exit_code=0, pane_id="%7", pane_vanishes=True,
                                  panel_pane_ids={"top": "%8", "bottom": "%9",
                                                  "right": "%11"})
         _launch_inside(fake)
-        fid = state.frame_id("demo", os.getpid())
-        self.assertEqual(state.harness_pane(fid), "%7")
+        self.assertEqual(state.harness_pane(_frame_id()), "%7")
 
     def test_the_panels_are_split_off_the_harness_pane(self):
         """The slot list is pinned here rather than left to the shipped default: this

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -42,6 +42,277 @@ class FrameId(unittest.TestCase):
         self.assertNotIn("..", fid)
 
 
+class ChatIdIsAllocated(PersonaIso, unittest.TestCase):
+    """`state.new_chat_id` — the ordinal is CLAIMED, not computed.
+
+    The operator's own sketch was `{workspace}-{some-hash}`, and both halves of it fail.
+    A hash of the only inputs available at creation is a hash of a counter in disguise,
+    and it collides silently into a shared `.charter/frame/<fid>/` where one chat's
+    `session`, `panes` and `version` overwrite the other's. A `-{ordinal}` tail fails
+    worse — see :class:`TheDotIsTheVersionDiscriminator` for the measurement.
+    """
+
+    def test_the_first_chat_of_a_workspace_is_one(self):
+        self.assertEqual(state.new_chat_id("api"), "api.1")
+
+    def test_the_next_one_is_two(self):
+        self.assertEqual(state.new_chat_id("api"), "api.1")
+        self.assertEqual(state.new_chat_id("api"), "api.2")
+
+    def test_the_claim_is_the_directory(self):
+        """The `mkdir` IS the allocation, so the id comes back with its directory already
+        on disk at 0700 — charter's mode, not the umask's (#470/#505). A scan-then-create
+        allocator would return a name nothing had claimed yet."""
+        fid = state.new_chat_id("api")
+        d = state.frame_dir(fid)
+        self.assertTrue(d.is_dir())
+        self.assertEqual(oct(d.stat().st_mode & 0o777), oct(0o700))
+
+    def test_two_allocators_racing_one_workspace_never_agree(self):
+        """The property a scan cannot give. Twenty threads on one barrier, all asking for
+        the same workspace: `mkdir` is one syscall and the kernel picks, so each gets its
+        own ordinal. Read `max + 1` off a directory listing instead and two racers get
+        the same answer, and the loser silently adopts the winner's frame directory —
+        which is exactly the silent collision a hash was rejected for."""
+        import threading
+        n = 20
+        barrier = threading.Barrier(n)
+        got: list[str | None] = []
+        lock = threading.Lock()
+
+        def claim():
+            barrier.wait()
+            fid = state.new_chat_id("race")
+            with lock:
+                got.append(fid)
+
+        threads = [threading.Thread(target=claim) for _ in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(len(got), n)
+        self.assertNotIn(None, got, "an allocator gave up while ordinals were free")
+        self.assertEqual(len(set(got)), n, f"two allocators returned one id: {got}")
+        self.assertEqual(sorted(got), sorted(f"race.{i}" for i in range(1, n + 1)))
+
+    def test_a_workspace_spelled_like_a_chat_id_does_not_collide_with_one(self):
+        """Workspace `api.2` and chat 2 of workspace `api` are two different names, and
+        the allocator has to keep them that way: `api.2`'s own chats are `api.2.1`,
+        `api.2.2`, and the directory `api.2` belongs to whichever allocator claimed it.
+        Pinned as literals, because the point is which strings come out."""
+        self.assertEqual(state.new_chat_id("api"), "api.1")
+        self.assertEqual(state.new_chat_id("api"), "api.2")
+        self.assertEqual(state.new_chat_id("api.2"), "api.2.1")
+        self.assertEqual(state.new_chat_id("api"), "api.3")
+
+    def test_a_taken_ordinal_is_skipped_rather_than_adopted(self):
+        """A directory already holding another chat's record is not an id to hand out.
+        `config.private_mkdir` would have swallowed the `FileExistsError` (#331) and
+        returned it — idempotence being exactly wrong for an allocator — so the new chat
+        would have inherited that record's `exit`, `density`, `panes` and `session`."""
+        state.record_exit("api.1", 99)
+        self.assertEqual(state.new_chat_id("api"), "api.2")
+        self.assertEqual(state.exit_code("api.1"), 99,
+                         "the allocator wrote in a directory it did not claim")
+
+    def test_a_hostile_workspace_name_cannot_escape_the_frame_root(self):
+        """The id becomes a directory name, so the same sanitisation `frame_id` does."""
+        fid = state.new_chat_id("../../etc")
+        self.assertNotIn("/", fid)
+        self.assertNotIn("..", fid)
+        self.assertTrue(state.frame_dir(fid).is_dir())
+
+    def test_a_workspace_name_that_ends_in_a_dot_does_not_double_it(self):
+        """`workspace_prefix` strips BOTH ends, and the trailing one is what this is
+        about: `api.` would otherwise mint `api..1`, which reads as chat 1 of a workspace
+        called `api.` and is not a thing anyone can say out loud. Stripping the trailing
+        end is also what stops the prefix ever being `.` or `..`, the two names
+        `contain.segment_ok` refuses."""
+        self.assertEqual(state.workspace_prefix("api."), "api")
+        self.assertEqual(state.workspace_prefix("api-"), "api")
+        self.assertEqual(state.workspace_prefix("api_"), "api")
+        self.assertEqual(state.workspace_prefix("_api"), "api",
+                         "the leading end too, so `_launcher_pid` still finds a head")
+        self.assertEqual(state.workspace_prefix("a.p-i"), "a.p-i",
+                         "and only at the ENDS: the three characters are ordinary inside "
+                         "a name, or `harness-wrapper` would come back as `harness`")
+        self.assertEqual(state.new_chat_id("api."), "api.1")
+        self.assertEqual(state.workspace_prefix("..."), "frame",
+                         "a name that strips to nothing falls back, or `_launcher_pid` "
+                         "would read a head-less name")
+
+    def test_an_id_mkdir_will_not_take_is_a_refusal_rather_than_a_raise(self):
+        """`contain.child` bounds shape, not length, so a workspace name thousands of
+        characters long passes it and then hits `ENAMETOOLONG`. A launch has to be told
+        it cannot open a chat, not handed an exception."""
+        self.assertIsNone(state.new_chat_id("x" * 5000))
+
+    def test_giving_up_is_bounded_rather_than_a_spin(self):
+        """The loop has a ceiling, and it answers `None` at it. Asserted by shrinking the
+        ceiling rather than by making ten thousand directories."""
+        with mock.patch.object(state, "_CHAT_ORDINAL_MAX", 2):
+            self.assertEqual(state.new_chat_id("api"), "api.1")
+            self.assertEqual(state.new_chat_id("api"), "api.2")
+            self.assertIsNone(state.new_chat_id("api"))
+
+    def test_the_ceiling_is_the_number_it_was_argued_at(self):
+        """The test above shrinks it, so it cannot also say what it is. Ten thousand is
+        the number: the scan costs one `mkdir` per taken ordinal and a plane holds tens of
+        frame directories, so it is far past any real plane and small enough that giving
+        up is a refusal a caller can report rather than a spin nobody can see. Moving it
+        needs that argument re-made, which is what this literal asks for."""
+        self.assertEqual(state._CHAT_ORDINAL_MAX, 10_000)
+
+    def test_a_frame_root_that_cannot_be_made_is_a_refusal(self):
+        """The first thing that can fail, and it fails before any ordinal is tried. A
+        launch has to be told it cannot open a chat — not handed an `OSError` out of a
+        function this module promises never raises."""
+        with mock.patch.object(state.config, "private_mkdir",
+                               side_effect=OSError(28, "No space left on device")):
+            self.assertIsNone(state.new_chat_id("api"))
+
+    def test_a_filesystem_that_refuses_the_claim_is_a_refusal_too(self):
+        """The second, and it is deliberately NOT retried at `n+1`: a full filesystem or a
+        permission this plane does not have does not get better one ordinal along, and
+        looping over it would spend `_CHAT_ORDINAL_MAX` syscalls to answer the same
+        `None`. `FileExistsError` is the one `OSError` that DOES mean "try `n+1`", and
+        `test_a_taken_ordinal_is_skipped_rather_than_adopted` is what keeps the two
+        apart."""
+        with mock.patch.object(state.config, "claim_private_dir",
+                               side_effect=OSError(13, "Permission denied")) as claim:
+            self.assertIsNone(state.new_chat_id("api"))
+        self.assertEqual(claim.call_count, 1,
+                         "a failure that cannot get better was retried to the ceiling")
+
+
+class TheDotIsTheVersionDiscriminator(PersonaIso, unittest.TestCase):
+    """Why `{workspace}.{n}` and not `{workspace}-{n}`, measured rather than argued.
+
+    `_launcher_pid` reads a `-<digits>` tail as a launcher pid, and `reap` keeps any
+    directory whose launcher is still running. Pid 1 is `launchd`/`init` and pid 2 is a
+    kernel thread on every Unix, so a `-{ordinal}` id would make every dead chat look
+    live forever — and `reap` is the only thing bounding `.charter/frame/`.
+    """
+
+    def test_a_dash_ordinal_would_read_as_a_live_pid(self):
+        """The control, and the reason the dot is not cosmetic. Not a claim about the
+        design — a measurement of the function the design had to route around."""
+        self.assertEqual(state._launcher_pid("myws-2"), 2)
+        self.assertEqual(state._launcher_pid("myws-1"), 1)
+        self.assertTrue(state._launcher_is_alive(1),
+                        "pid 1 is init — if this is ever false the measurement above "
+                        "stops meaning what this class says it means")
+
+    def test_a_chat_id_carries_no_pid_at_all(self):
+        for name in ("api.3", "harness-wrapper.3", "a-b.1", "api.2.1"):
+            with self.subTest(name=name):
+                self.assertIsNone(state._launcher_pid(name))
+
+    def test_an_old_frame_id_still_parses_and_still_reports_liveness_by_pid(self):
+        """No migration ran, so a frame launched by a charter that predates chats keeps
+        the rule it was launched under."""
+        old = state.frame_id("legacy", os.getpid())
+        state.record_server(old, "charter")
+        state.record_harness_pane(old, "%3")
+        self.assertEqual(state._launcher_pid(old), os.getpid())
+        self.assertTrue(state.is_live(old, pane="%3"))
+        self.assertEqual(state.reap(set(), server="charter"), [],
+                         "an old frame whose launcher is alive was reaped")
+
+    def test_an_old_frame_whose_launcher_died_is_still_reaped_by_the_old_rule(self):
+        old = state.frame_id("legacy", _a_dead_pid())
+        state.bump(old)
+        self.assertEqual(state.reap(set(), server="charter"), [old])
+
+    def test_a_chat_is_kept_by_the_liveness_list_alone(self):
+        """The whole of a chat's bounding rule: no pid abstains in its favour, so the set
+        `reap` is handed decides. `commands_frame._live_chats` is what fills it."""
+        chat = state.new_chat_id("api")
+        state.bump(chat)
+        self.assertEqual(state.reap({chat}, server="charter"), [])
+        self.assertTrue(state.frame_dir(chat).exists())
+
+    def test_a_chat_whose_window_is_gone_is_removed_with_no_launcher_process_alive(self):
+        """The other half, and the one the dash would have broken: nothing in the name
+        can keep this directory, so an absent chat id really does reap."""
+        chat = state.new_chat_id("api")
+        state.bump(chat)
+        self.assertEqual(state.reap(set(), server="charter"), [chat])
+        self.assertFalse(state.frame_dir(chat).exists())
+
+    def test_an_old_frame_answers_live_with_no_pane_offered_at_all(self):
+        """`pane` is optional because `reap`'s question is the frame's EXISTENCE, not any
+        process's membership of it — `None` means "do not ask", never "assume no". Drop
+        the `pane is not None` half of that check and an old frame with a live launcher
+        reads as dead, which for `statusline` means a frame that never suppresses."""
+        old = state.frame_id("legacy", os.getpid())
+        state.record_server(old, "charter")
+        state.record_harness_pane(old, "%3")
+        self.assertTrue(state.is_live(old),
+                        "no pane was offered, so there was nothing to disagree with")
+        self.assertTrue(state.is_live(old, pane="%3"))
+        self.assertFalse(state.is_live(old, pane="%4"))
+
+    def test_a_chats_liveness_is_the_harness_pane_rather_than_a_pid(self):
+        """`is_live` runs on Claude Code's own repaint path, so it may not spawn a tmux
+        subprocess. For a chat the record of which pane the LAUNCHER started the harness
+        in is the evidence: a process running in that pane is inside a window that still
+        exists."""
+        chat = state.new_chat_id("api")
+        state.record_server(chat, "charter")
+        state.record_harness_pane(chat, "%4")
+        self.assertTrue(state.is_live(chat, pane="%4"))
+        self.assertFalse(state.is_live(chat, pane="%5"),
+                         "a process that merely inherited this chat's id is not its "
+                         "harness")
+        self.assertFalse(state.is_live(chat),
+                         "with no pane offered there is nothing here that can answer "
+                         "for a chat, and a claim with no evidence is the wrong answer")
+
+    def test_a_chat_with_no_server_marker_is_not_live(self):
+        """The marker is what says a LAUNCHER made this directory rather than a stray
+        `$CHARTER_SESSION_ID` and the first hook that fired for it."""
+        chat = state.new_chat_id("api")
+        state.record_harness_pane(chat, "%4")
+        self.assertFalse(state.is_live(chat, pane="%4"))
+
+
+class TheIdIsANameAndNotAPointer(PersonaIso, unittest.TestCase):
+    """Renaming a workspace under live chats changes nothing, because nothing ever parses
+    an id for meaning. `frame_workspace` reads the workspace out of the frame's own file,
+    which can be repointed."""
+
+    def test_two_live_chats_survive_their_workspace_being_renamed(self):
+        one, two = state.new_chat_id("oldname"), state.new_chat_id("oldname")
+        for fid in (one, two):
+            state.record_server(fid, "charter")
+            state.record_workspace(fid, "oldname")
+        self.assertEqual([one, two], ["oldname.1", "oldname.2"])
+
+        for fid in (one, two):
+            state.record_workspace(fid, "newname")
+
+        # Both still resolve, both keep the old-spelled id, and the bar reads the file.
+        for fid in (one, two):
+            with self.subTest(fid=fid):
+                self.assertTrue(fid.startswith("oldname."),
+                                "an id was rewritten — every $CHARTER_SESSION_ID already "
+                                "exported into a live process would now name nothing")
+                self.assertEqual(state.frame_workspace(fid), "newname")
+                self.assertTrue(state.frame_dir(fid).is_dir())
+        self.assertEqual(state.reap({one, two}, server="charter"), [])
+
+    def test_a_chat_allocated_after_the_rename_is_spelled_for_the_new_name(self):
+        """The one visible cost, and it is deliberately not fixed: allocation scans for
+        `{new name}.*`, so a renamed workspace's next chat is `newname.1` beside a
+        sibling still called `oldname.2`. Ugly, harmless, and rewriting ids to tidy it
+        would break every id already exported into a running process."""
+        state.new_chat_id("oldname")
+        state.new_chat_id("oldname")
+        self.assertEqual(state.new_chat_id("newname"), "newname.1")
+
+
 class Version(PersonaIso, unittest.TestCase):
     def test_a_fresh_frame_has_a_version(self):
         self.assertTrue(state.version("f-1"))

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -1388,6 +1388,11 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
     def _a_death_the_hook_saw(self, dies_by: str, status_path: str):
         """One trial of "a pane dies, charter's write hook records its status".
 
+        *status_path* must be spelled ``<root>/<chat>/exit``: the write hook builds it
+        from ``$CHARTER_FRAME_EXIT`` (the frame root, carried by `set-environment`) and
+        ``#{@charter_chat}`` (the chat, read off this window's own option), so this helper
+        splits it back into the two halves and delivers each the way production does.
+
         Returns the status file's CONTENT, or ``None`` when tmux never ran this pane's
         `pane-died` array at all — the tmux 3.4 window :data:`_HOOK_TRIALS` describes,
         which is a trial that measured nothing rather than a result. The probe hook that
@@ -1401,8 +1406,15 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
         still fires, so this says so rather than skipping.
         """
         session, pane, gate = self._new_pane(dies_by)
+        # The variable carries the frame ROOT and the hook appends this window's own
+        # chat, so the caller's *status_path* is `<root>/<chat>/exit` and BOTH halves are
+        # exercised: a hostile root through `set-environment`, and the chat through a
+        # tmux format expanded in the dying pane's own context.
+        root, chat = os.path.split(os.path.dirname(status_path))
         self.assertEqual(_run(commands_frame._exit_path_env_argv(
-            socket=SOCKET, session=session, status_path=status_path)).returncode, 0)
+            socket=SOCKET, session=session, frame_root=root)).returncode, 0)
+        self.assertEqual(_run(commands_frame._chat_option_argv(
+            socket=SOCKET, harness_pane=pane, chat=chat)).returncode, 0)
         self.assertEqual(_run(commands_frame._pane_died_write_hook_argv(
             socket=SOCKET, harness_pane=pane)).returncode, 0)
         self._arm_array_probe(pane)
@@ -1439,8 +1451,11 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
         self.addCleanup(shutil.rmtree, tmp, True)
         canary = os.path.join(tmp, "canary")
         hostile_dir = os.path.join(tmp, "it's a $(touch " + canary + ") dir")
-        os.makedirs(hostile_dir, exist_ok=True)
-        status_path = os.path.join(hostile_dir, "exit")
+        # `<hostile root>/<chat>/exit`: the root is what `set-environment` carries and the
+        # chat is what the hook's own `#{@charter_chat}` expands to, so the injection
+        # attempt is still in the half that travels out of band.
+        os.makedirs(os.path.join(hostile_dir, "hostile.1"), exist_ok=True)
+        status_path = os.path.join(hostile_dir, "hostile.1", "exit")
 
         for _ in range(self._HOOK_TRIALS):
             content, _pane = self._a_death_the_hook_saw("exit 42", status_path)
@@ -1483,8 +1498,11 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
 
         for attempt in range(self._HOOK_TRIALS):
             # A fresh path per trial, so a file left by an earlier trial can never be
-            # what a later one reads back.
-            status_path = os.path.join(tmp, f"exit-{attempt}")
+            # what a later one reads back. `<root>/<chat>/exit` is the shape the write
+            # hook produces now — the root out of band, the chat expanded from the
+            # window's own `@charter_chat`.
+            status_path = os.path.join(tmp, f"sig.{attempt}", "exit")
+            os.makedirs(os.path.dirname(status_path), exist_ok=True)
             content, pane = self._a_death_the_hook_saw("kill -9 $$", status_path)
             if content is None:
                 continue   # tmux never ran the array — see `_HOOK_TRIALS`
@@ -1724,9 +1742,9 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
         # Both calls, in the order `cmd_launch` would issue them across two launches:
         # the OLDER frame's own id first, seeded before the newer one ever existed.
         self.assertEqual(_run(commands_frame._session_id_env_argv(
-            socket=SOCKET, session="sid-one")).returncode, 0)
+            socket=SOCKET, session="sid-one", chat="sid-one")).returncode, 0)
         self.assertEqual(_run(commands_frame._session_id_env_argv(
-            socket=SOCKET, session="sid-two")).returncode, 0)
+            socket=SOCKET, session="sid-two", chat="sid-two")).returncode, 0)
 
         _tmux("run-shell", "-t", "sid-one",
              f"env | grep CHARTER_SESSION_ID > {first_out} 2>&1 || echo NONE > {first_out}")
@@ -3718,7 +3736,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
             worker = threading.Thread(target=_run_launch, daemon=True)
             worker.start()
             self.assertTrue(self._wait_until(
-                lambda: "demo-" in self._srv("list-windows", "-a", "-F",
+                lambda: "demo." in self._srv("list-windows", "-a", "-F",
                                          "#{window_name}").stdout),
                 "the frame's own window never appeared in the operator's server")
             fid, harness_pane = self._the_frames_own_window()
@@ -3746,7 +3764,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
             self.assertEqual(before, _snapshot())
             self.assertIn(name,
                           self._srv("list-sessions", "-F", "#{session_name}").stdout.split())
-            self.assertNotIn("demo-", self._srv("list-windows", "-a", "-F",
+            self.assertNotIn("demo.", self._srv("list-windows", "-a", "-F",
                                             "#{window_name}").stdout,
                              "the frame's window was left behind")
             self.assertFalse(decoy.exists(),
@@ -3803,15 +3821,15 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
     def _the_frames_own_window(self) -> tuple[str, str]:
         """The frame id and harness pane of the window a launch just opened here.
 
-        The window's NAME is the frame id (`layout.window_argv` is given `fid`), and with
+        The window's NAME is the chat id (`layout.window_argv` is given `fid`), and with
         `[frame] slots` empty the frame's window holds exactly the harness pane — so
         `#{pane_id}` for that window is it. Read off tmux rather than guessed, because the
-        launcher mints `<workspace>-<its own pid>` on a worker thread and this test never
-        sees the value.
+        launcher ALLOCATES `demo.<n>` on a worker thread against whatever this plane's
+        frame root already holds, and this test never sees the value.
         """
         rows = [line.split() for line in self._srv(
             "list-windows", "-a", "-F", "#{window_name} #{pane_id}").stdout.splitlines()
-            if line.startswith("demo-")]
+            if line.startswith("demo.")]
         self.assertEqual(len(rows), 1, f"expected exactly one frame window, got {rows!r}")
         return rows[0][0], rows[0][1]
 
@@ -4697,6 +4715,310 @@ class FocusEventsIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase
             _tmux("show-options", "-t", "focus-two", "mouse").stdout.strip(), "",
             "the control failed: even `mouse`, which conf_text relies on being "
             "session-scoped, reached the sibling here — this probe measures nothing")
+
+
+class ChatsAreWindowsOnOneWorkspaceSession(_TmuxServerFixture, PersonaIso):
+    """Phase 5 Stage 5a, against a real server: a workspace is a SESSION and a chat is a
+    WINDOW in it.
+
+    Every claim here is one a mock cannot make. Whether `new-window -n` pins a name and
+    whether a pane can take it back; whether a window user option survives that; whether
+    a pane-scoped `pane-died[1] kill-window` leaves its siblings alone and still ends the
+    session when it is the last window; and whether a per-window `-e` really beats a
+    session-wide `set-environment` in the pane's own environment.
+
+    **Re-run against tmux 3.2 — `tmuxctl.FLOOR` — as well as 3.7c**, by putting a 3.2
+    built from the release tarball first on `$PATH` and running this module: every
+    assertion below passed identically on both, so nothing here carries a version gate.
+    The two versions' answers are quoted in the tests that turn on them.
+    """
+
+    #: The workspace these chats belong to — the tmux SESSION's name, and the part of each
+    #: chat id before the dot. A literal, so a test cannot be satisfied by whatever
+    #: `state.workspace_prefix` happens to do with it.
+    WS = "wsdemo"
+
+    def _chat(self, chat: str, *, first: bool, dies_by: str = "exit 0") -> tuple[str, str]:
+        """Open *chat* on this class's server and return its pane id and gate.
+
+        The FIRST chat of a workspace starts the session (`layout.session_argv`); every
+        later one joins it (`layout.chat_window_argv`). Both are the production builders,
+        never a hand-retyped command, so this measures the argv charter really sends.
+        """
+        gate = os.path.join(self._gate_dir, f"gate-{chat}")
+        argv = _gate_argv(gate, dies_by)
+        if first:
+            conf = os.path.join(self._gate_dir, f"{chat}.conf")
+            Path(conf).write_text(commands_frame._PLACEHOLDER_CONF)
+            cmd = layout.session_argv(session=self.WS, conf=conf, chat=chat,
+                                      socket=self.SOCKET_NAME, cols=80, rows=24,
+                                      harness_argv=argv,
+                                      env={"CHARTER_SESSION_ID": chat})
+        else:
+            cmd = layout.chat_window_argv(socket=self.SOCKET_NAME, session=self.WS,
+                                          chat=chat, cwd=self._gate_dir,
+                                          harness_argv=argv,
+                                          env={"CHARTER_SESSION_ID": chat})
+        r = _run(cmd)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pane = r.stdout.strip()
+        self.assertTrue(pane.startswith("%"), f"tmux reported no pane id: {r.stdout!r}")
+        self.addCleanup(_kill_pid, self._pane_pid_on(pane))
+        named = commands_frame._chat_option_argv(socket=self.SOCKET_NAME,
+                                                 harness_pane=pane, chat=chat)
+        self.assertIsNotNone(named, f"charter refused to name the chat {chat!r}")
+        self.assertEqual(_run(named).returncode, 0)
+        # `state.reap` only ever removes a directory whose server it can match, so the
+        # marker is what makes the reaping tests below about liveness rather than about
+        # the migration case.
+        state.record_server(chat, self.SOCKET_NAME)
+        state.record_harness_pane(chat, pane)
+        state.bump(chat)
+        return pane, gate
+
+    def _window_names(self) -> list[str]:
+        return self._srv("list-windows", "-a", "-F",
+                         "#{window_name}").stdout.split()
+
+    def _pane_pid_on(self, target: str) -> str:
+        return self._srv("display-message", "-p", "-t", target,
+                         "#{pane_pid}").stdout.strip()
+
+    def _wait_until(self, predicate, timeout=_DEADLINE) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return True
+            time.sleep(0.05)
+        return False
+
+    def test_two_chats_in_one_workspace_are_two_windows_on_one_session(self):
+        """The shape, end to end. One session named for the workspace, one window per
+        chat, and each window answering for its own chat through `@charter_chat`."""
+        self._chat("wsdemo.1", first=True)
+        self._chat("wsdemo.2", first=False)
+        # A window that is NOT a chat, on the same server — the operator's own, or one
+        # tmux made for a reason charter had nothing to do with. It carries no
+        # `@charter_chat`, so `list-windows -F` prints an EMPTY line for it, and an empty
+        # string in the live set is a name `state.reap` would compare every directory
+        # against.
+        stray = self._srv("new-window", "-d", "-t", self.WS, "-P", "-F", "#{pane_id}",
+                          "sleep", "600")
+        self.assertEqual(stray.returncode, 0, stray.stderr)
+        self.addCleanup(_kill_pid, self._pane_pid_on(stray.stdout.strip()))
+
+        self.assertEqual(self._srv("list-sessions", "-F", "#{session_name}").stdout.split(),
+                         [self.WS])
+        names = self._window_names()
+        self.assertIn("wsdemo.1", names)
+        self.assertIn("wsdemo.2", names)
+        self.assertEqual(commands_frame._live_chats(self.SOCKET_NAME),
+                         {"wsdemo.1", "wsdemo.2"})
+
+    def test_reap_keeps_both_chats_while_their_windows_exist_and_no_launcher_does(self):
+        """The bounding rule, with the pid rule deliberately unable to help: a chat id
+        carries no launcher pid, so the liveness list is the only thing keeping these
+        directories. Both are kept while their windows are there; kill one window and
+        exactly that one is removed."""
+        self._chat("wsdemo.1", first=True)
+        pane_two, _ = self._chat("wsdemo.2", first=False)
+        for chat in ("wsdemo.1", "wsdemo.2"):
+            self.assertIsNone(state._launcher_pid(chat),
+                              "a chat id must carry no pid, or this test is measuring "
+                              "the rule it exists to replace")
+
+        live = commands_frame._live_chats(self.SOCKET_NAME)
+        self.assertEqual(state.reap(live, server=self.SOCKET_NAME), [])
+        self.assertTrue(state.frame_dir("wsdemo.1").exists())
+        self.assertTrue(state.frame_dir("wsdemo.2").exists())
+
+        self.assertEqual(self._srv("kill-window", "-t", pane_two).returncode, 0)
+        live = commands_frame._live_chats(self.SOCKET_NAME)
+        self.assertEqual(live, {"wsdemo.1"})
+        self.assertEqual(state.reap(live, server=self.SOCKET_NAME), ["wsdemo.2"])
+        self.assertTrue(state.frame_dir("wsdemo.1").exists())
+
+    def test_a_pane_can_take_its_windows_name_and_not_its_chat(self):
+        """**The measurement that decides where liveness is read from.**
+
+        `new-window -n` pins the name — it turns that window's `automatic-rename` off —
+        but with `allow-rename on` the pane's own output takes it anyway. Measured here,
+        and identically on tmux 3.7c and tmux 3.2: after the pane writes
+        `\033kPWNED\033\\`, `#{window_name}` is `PWNED` while `#{@charter_chat}` is
+        untouched. `automatic-rename` is ON by default too, so a window charter did not
+        name follows whatever runs in it.
+
+        A liveness list read from `#{window_name}` therefore loses this chat, and
+        `state.reap` — the only bound on `.charter/frame/` — deletes the state of a chat
+        that is still running. `_live_chats` reads the option, and this test is what says
+        the two are not the same fact.
+        """
+        pane, _ = self._chat("wsdemo.1", first=True)
+        window = self._srv("display-message", "-p", "-t", pane,
+                           "#{window_id}").stdout.strip()
+        self.assertEqual(self._srv("show", "-w", "-t", window,
+                                   "automatic-rename").stdout.strip(),
+                         "automatic-rename off",
+                         "`-n` no longer pins a window's name on this tmux")
+        self.assertEqual(self._srv("set", "-w", "-t", window,
+                                   "allow-rename", "on").returncode, 0)
+        self.assertEqual(self._srv("respawn-window", "-k", "-t", window,
+                                   "sh -c 'printf \"\\033kPWNED\\033\\\\\"; "
+                                   "sleep 600'").returncode, 0)
+        renamed = self._wait_until(lambda: "PWNED" in self._window_names())
+        self.assertTrue(renamed,
+                        "the pane did not manage to rename its window — this tmux may "
+                        "have stopped honouring `allow-rename`, in which case the risk "
+                        "this test measures is gone and the claim should be re-argued")
+        self.addCleanup(_kill_pid, self._pane_pid_on(window))
+
+        self.assertNotIn("wsdemo.1", self._window_names())
+        self.assertEqual(commands_frame._live_chats(self.SOCKET_NAME), {"wsdemo.1"},
+                         "the chat's identity went with its name — reaping would now "
+                         "delete a running chat's state")
+
+    def _arm_the_production_pair(self, pane: str) -> None:
+        """Both `pane-died` hooks, in `cmd_launch`'s own order and from its own builders.
+
+        **No `_arm_array_probe` beside them, and that is not an oversight.**
+        :data:`_PROBE_INDEX` is `1`, which is exactly where the teardown hook lands, so a
+        probe here would REPLACE the thing under test and the test would be measuring its
+        own probe. The window disappearing is this pair's own evidence, and a trial where
+        it does not is classified by `_the_array_never_ran` on the pane itself.
+        """
+        self.assertEqual(_run(commands_frame._pane_died_write_hook_argv(
+            socket=self.SOCKET_NAME, harness_pane=pane)).returncode, 0)
+        self.assertEqual(_run(commands_frame._pane_died_teardown_hook_argv(
+            socket=self.SOCKET_NAME, harness_pane=pane)).returncode, 0)
+
+    def test_one_chats_harness_dying_leaves_every_other_chat_running(self):
+        """`pane-died[1]` runs `kill-window`, and this is what that buys.
+
+        Two chats, one workspace, real hooks armed exactly as `cmd_launch` arms them.
+        The first chat's harness dies; its window goes and NOTHING else does — the
+        sibling's window is still listed, its pane is not dead, and the session is still
+        there. With `kill-session` in that hook (which is what shipped while a frame WAS a
+        session) the sibling's harness goes down mid-turn for a death that was not its
+        own. Measured identically on tmux 3.7c and tmux 3.2.
+
+        Retried like every death-dependent test here, and for #487's reason rather than
+        for flakiness: a death tmux never ran the array for measured nothing."""
+        self._require_pane_died_fires()
+        for attempt in range(self._HOOK_TRIALS):
+            dying, live = f"wsdemo.{attempt}1", f"wsdemo.{attempt}2"
+            one, gate = self._chat(dying, first=(attempt == 0), dies_by="exit 9")
+            two, _ = self._chat(live, first=False)
+            self._arm_the_production_pair(one)
+            self._release(gate)
+            if not self._wait_until(lambda: dying not in self._window_names()):
+                self._the_array_never_ran(
+                    one, "the dying chat's window is still there")
+                continue
+            self.assertIn(live, self._window_names(),
+                          "a sibling chat's window went down with the one that died")
+            self.assertEqual(self._srv("display-message", "-p", "-t", two,
+                                       "#{pane_dead}").stdout.strip(), "0",
+                             "the sibling chat's harness was killed")
+            # `assertIn`, not equality: `_require_pane_died_fires` leaves its own probe
+            # session on this server, and it is not what this test is about.
+            self.assertIn(
+                self.WS,
+                self._srv("list-sessions", "-F", "#{session_name}").stdout.split(),
+                "the workspace's session went down with one of its chats")
+            return
+        self.skipTest("every trial was a death tmux never ran the array for")
+
+    def test_the_last_chats_teardown_still_ends_the_session(self):
+        """The half that keeps the single-chat case unchanged: killing a session's LAST
+        window destroys the session, so `cmd_launch`'s `attach` returns exactly as it did
+        when the teardown said `kill-session`. Measured on tmux 3.7c and tmux 3.2."""
+        self._require_pane_died_fires()
+        for attempt in range(self._HOOK_TRIALS):
+            chat = f"wsdemo.{attempt}"
+            pane, gate = self._chat(chat, first=True, dies_by="exit 3")
+            self._arm_the_production_pair(pane)
+            self._release(gate)
+            if self._wait_until(lambda: self.WS not in self._srv(
+                    "list-sessions", "-F", "#{session_name}").stdout.split()):
+                return
+            self._the_array_never_ran(
+                pane, "the workspace's session outlived its last chat, so a launcher's "
+                      "`attach` would never return")
+        self.skipTest("every trial was a death tmux never ran the array for")
+
+    def test_each_chat_reports_its_own_identity_over_a_session_wide_one(self):
+        """Task 3's whole mechanism, measured. A per-window `-e` beats a session-wide
+        `set-environment` inside the pane — `chat-A claude-code` and `chat-B codex` on
+        tmux 3.7c and on tmux 3.2 alike, under a session that says `session-wide`.
+
+        This is what makes `.charter/sessions/<chat id>.persona`, `.workspace`, `.tools`
+        and `.gate` per chat with no new code: `session.current()` reads
+        `$CHARTER_SESSION_ID`, and every process in a chat's pane gets the chat's own.
+        """
+        out = os.path.join(self._gate_dir, "identity")
+        os.makedirs(out, exist_ok=True)
+        conf = os.path.join(self._gate_dir, "identity.conf")
+        Path(conf).write_text(commands_frame._PLACEHOLDER_CONF)
+        first = _run(layout.session_argv(
+            session=self.WS, conf=conf, socket=self.SOCKET_NAME, cols=80, rows=24,
+            harness_argv=["sleep", "600"],
+            env={"CHARTER_SESSION_ID": "wsdemo.1", "CHARTER_HARNESS": "claude-code"}))
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.addCleanup(_kill_pid, self._pane_pid_on(first.stdout.strip()))
+        # The session says something else entirely, and says it BEFORE the windows are
+        # created — which is the order `cmd_launch` uses and the order that makes the
+        # override a real one rather than a last-writer-wins accident.
+        self.assertEqual(_run(commands_frame._session_id_env_argv(
+            socket=self.SOCKET_NAME, session=self.WS,
+            chat="session-wide")).returncode, 0)
+
+        for chat, harness in (("wsdemo.2", "codex"), ("wsdemo.3", "opencode")):
+            cmd = layout.chat_window_argv(
+                socket=self.SOCKET_NAME, session=self.WS, chat=chat,
+                cwd=self._gate_dir,
+                # ONE write, then an atomic rename: two appends make the file non-empty
+                # after the first, and `_await_text` stops at non-empty — measured, that
+                # read back `wsdemo.3` with the harness line still in flight.
+                harness_argv=["/bin/sh", "-c",
+                              f'printf "%s\n%s\n" "$CHARTER_SESSION_ID" '
+                              f'"$CHARTER_HARNESS" > {out}/{chat}.part && '
+                              f"mv {out}/{chat}.part {out}/{chat}; sleep 600"],
+                env={"CHARTER_SESSION_ID": chat, "CHARTER_HARNESS": harness})
+            r = _run(cmd)
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.addCleanup(_kill_pid, self._pane_pid_on(r.stdout.strip()))
+
+        for chat, harness in (("wsdemo.2", "codex"), ("wsdemo.3", "opencode")):
+            with self.subTest(chat=chat):
+                self.assertEqual(_await_text(os.path.join(out, chat)),
+                                 f"{chat}\n{harness}",
+                                 "a chat's pane read the session's identity instead of "
+                                 "its own")
+
+    def test_the_session_wide_value_is_what_a_run_shell_child_reads(self):
+        """The other side of the same measurement, and the reason `conf_text`'s binds
+        carry `#{@charter_chat}` rather than trusting the variable.
+
+        A bind's action is a `run-shell`, and a `run-shell` child reads the SESSION's
+        environment — never the window's `-e`. Measured on tmux 3.7c and on tmux 3.2: the
+        pane above reports its own chat, and this reports `session-wide`. So the variable
+        cannot tell two chats of one workspace apart, and the window option is what does.
+        """
+        conf = os.path.join(self._gate_dir, "runshell.conf")
+        Path(conf).write_text(commands_frame._PLACEHOLDER_CONF)
+        first = _run(layout.session_argv(
+            session=self.WS, conf=conf, socket=self.SOCKET_NAME, cols=80, rows=24,
+            harness_argv=["sleep", "600"], env={"CHARTER_SESSION_ID": "wsdemo.1"}))
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.addCleanup(_kill_pid, self._pane_pid_on(first.stdout.strip()))
+        self.assertEqual(_run(commands_frame._session_id_env_argv(
+            socket=self.SOCKET_NAME, session=self.WS,
+            chat="session-wide")).returncode, 0)
+        seen = os.path.join(self._gate_dir, "runshell-saw")
+        self.assertEqual(self._srv(
+            "run-shell", "-b", "-t", self.WS,
+            f"printenv CHARTER_SESSION_ID > {seen}").returncode, 0)
+        self.assertEqual(_await_text(seen), "session-wide")
 
 
 if __name__ == "__main__":

--- a/tests/test_the_state_directory_is_charters_to_choose.py
+++ b/tests/test_the_state_directory_is_charters_to_choose.py
@@ -798,6 +798,73 @@ class ThePrivateWalkItself(PersonaIso):
             config.private_mkdir(root / "a" / "b", parents=False)
         self.assertFalse(root.exists())
 
+
+class TheClaimIsAMkdirThatCanFail(PersonaIso):
+    """`config.claim_private_dir` — `private_mkdir` with its idempotence removed.
+
+    `frame.state.new_chat_id` claims a chat's ordinal with it, so the `FileExistsError`
+    `private_mkdir` swallows on a directory (#331) is the whole answer here: the `mkdir`
+    IS the mutual exclusion, and two allocators racing one workspace cannot both be told
+    they won."""
+
+    def test_it_creates_the_directory_at_charters_own_mode(self) -> None:
+        for um in UMASKS:
+            with self.subTest(umask=oct(um)):
+                old = os.umask(um)
+                self.addCleanup(os.umask, old)
+                d = Path(self.tmp) / f"claim-{um:03o}"
+                config.claim_private_dir(d)
+                self.assertEqual(stat.S_IMODE(d.stat().st_mode), 0o700,
+                                 f"the umask decided the mode at {oct(um)}")
+
+    def test_there_is_no_window_in_which_it_is_looser_than_it_ends_up(self) -> None:
+        """`os.mkdir`'s own *mode* argument, and it is not redundant with the `chmod`.
+
+        The chmod is what NAMES 0700 (mkdir's mode is masked by the umask, so a process
+        under a permissive one is not guaranteed the bits it asked for), and the mkdir
+        mode is what keeps the directory from existing at a wider mode for the moment
+        between the two calls. Only one of those is observable after the fact, so the
+        chmod is held back here to observe the other: with it gone, what `mkdir` asked
+        for is what the directory has, and under `umask 0` that must still be 0700 rather
+        than 0777."""
+        old = os.umask(0)
+        self.addCleanup(os.umask, old)
+        d = Path(self.tmp) / "no-window"
+        with mock.patch.object(config.os, "chmod") as chmod:
+            config.claim_private_dir(d)
+        self.assertTrue(chmod.called, "the chmod was not the thing held back")
+        self.assertEqual(stat.S_IMODE(d.stat().st_mode), 0o700,
+                         "the directory existed at a wider mode between `mkdir` and the "
+                         "`chmod` that was going to fix it")
+
+    def test_a_chmod_it_cannot_do_still_leaves_the_claim_won(self) -> None:
+        """The claim succeeded — the directory is this caller's and nobody else's — and
+        reporting that as a failure would send an allocator on to `n+1` for a name it
+        already holds, leaking one directory per launch. Same posture as `_mkdir_0700`'s
+        own `except OSError: pass`."""
+        d = Path(self.tmp) / "chmod-refused"
+        with mock.patch.object(config.os, "chmod",
+                               side_effect=OSError(1, "Operation not permitted")):
+            config.claim_private_dir(d)      # must not raise
+        self.assertTrue(d.is_dir())
+
+    def test_a_name_already_taken_raises_rather_than_being_adopted(self) -> None:
+        """The difference from `private_mkdir`, and the whole reason this exists."""
+        d = Path(self.tmp) / "taken"
+        config.claim_private_dir(d)
+        with self.assertRaises(FileExistsError):
+            config.claim_private_dir(d)
+        config.private_mkdir(d)              # the control: this one is idempotent
+
+    def test_it_does_not_build_the_path_above_it(self) -> None:
+        """An allocator that could bring the frame root into being on the way past would
+        resurrect a directory `reap` had just deleted — the hazard `frame.state`'s own
+        `respawn_attempt` passes `parents=False` for."""
+        root = Path(self.tmp) / "claim-noparents"
+        with self.assertRaises(FileNotFoundError):
+            config.claim_private_dir(root / "a" / "b")
+        self.assertFalse(root.exists())
+
     def test_a_file_in_the_way_is_still_an_error(self) -> None:
         """``mkdir(exist_ok=True)`` raises when the path exists and is not a directory, and
         every caller here writes into the path afterwards. Swallowing it would turn a


### PR DESCRIPTION
Phase 5 **Stage 5a**, tasks 1–3 of
`docs/superpowers/plans/2026-08-28-phase5-workspace-and-chat-tabs.md`. Nothing visible
changes; what a frame *is* moves. Stages 5b (switching, the surface) and 5c (the cost, the
honesty) are not in this branch.

- **Task 1 (§91)** — a chat id is allocated, not computed.
- **Task 2 (§112)** — the private server grows windows, and liveness moves.
- **Task 3 (§132)** — identity is per chat.

---

## What changed

A workspace is a tmux **session** on `-L charter`; a chat is a **window** in it. `charter
claude` in a workspace that already has a chat open adds a second window rather than a
second session, and the two harnesses run side by side with their own personas, their own
tool ceilings and their own frame directories.

### Task 1 — `state.new_chat_id(workspace)` → `{workspace}.{n}`, claimed by `mkdir`

`config.claim_private_dir` is `config.private_mkdir` with its idempotence removed:
`private_mkdir` swallows `FileExistsError` on a directory (#331), which is right for "make
sure this exists" and is exactly wrong for "is this name mine?". The `mkdir` **is** the
mutual exclusion — 20 threads racing one workspace get 20 distinct ordinals, and a scan
would hand two racers the same answer.

The dot is not cosmetic. Re-verified on this tree, as the brief asked:

```
state._launcher_pid("myws-2")  ->  2       # the ordinal read as a process id
state._launcher_pid("myws.2")  ->  None    # the dot makes it not a claim
```

Pid 1 is `launchd`/`init`, so a `-{ordinal}` tail makes every dead chat look live forever
and `reap` stops bounding `.charter/frame/`. `None` doubles as the version discriminator:
an id `_launcher_pid` can parse keeps the pid rule, one it cannot takes liveness from the
window list. No migration, no version field. `_launcher_pid` itself is unchanged.

### Task 2 — windows, and liveness

- `layout.chat_window_argv` — `new-window -d -a -t <workspace> -n <chat> … -P -F
  '#{pane_id}'`, the same reported field and the same `-e` overlay as `session_argv`, so
  `cmd_launch` does not branch downstream on which one started its frame. **`-a` is
  load-bearing**: `-t <session>` resolves to that session's current window and
  `new-window` reads a resolved window target as the index to create at, so without it
  tmux answers `create window failed: index 0 in use` (3.7c and 3.2).
- `layout.session_argv` gained `chat=` → `-n <chat>`, so the first chat's window is
  legible beside its siblings instead of showing `automatic-rename`'s idea of the harness.
- **`@charter_chat`, a window option, is the identity** — not the window name. Measured on
  3.7c **and** 3.2: `-n` does pin a name (it turns that window's `automatic-rename` off),
  and with `allow-rename on` the pane's own `printf '\033kPWNED\033\\'` takes it back
  while the option is untouched. So `_live_chats` reads `list-windows -a -F
  '#{@charter_chat}'`. **This is where I depart from the plan**: Task 2 step 3 says the
  live set is `#{window_name}`, and step 4 says the lookup should ask the window what chat
  it is. §7.3's own measurement settles the tension — read liveness from the name and a
  harness that renames its own window has its state reaped while it is running. The option
  is also unioned into the guest path's reap, where `allow-rename on` in somebody's
  `.tmux.conf` is an ordinary thing to have.
- **`pane-died[1]` runs `kill-window`.** Measured on 3.7c and 3.2 with two chats in one
  session: the dying chat's window goes, every sibling window and the session are still
  listed, and killing a session's *last* window still destroys the session — so `attach`
  returns exactly as it did.
- **A server that lists sessions and then will not list its windows reaps nothing.** A
  chat has no pid to fall back on, so `_live_chats` answers `None` for a non-zero return
  and both callers refuse to reap on it. An *empty* session list is the opposite fact and
  reaps as it always did (a reboot leaves exactly that).
- **`$CHARTER_FRAME_EXIT` names the frame ROOT and the hook appends `#{@charter_chat}`.**
  A `set-environment` is session-scoped and a session holds several chats, so a value
  naming one chat's `exit` file is one the next chat's launch repoints — and then the
  first chat's death writes its status into the second chat's file. Measured on 3.7c and
  3.2: a real `pane-died` hook expanded the window option and wrote `42` to
  `<root>/<chat>/exit`. The action stays a constant string; the operator-controlled half
  still travels out of band and the interpolated half is a closed alphabet.

### Task 3 — identity is per chat

- The window's `-e CHARTER_SESSION_ID` / `-e CHARTER_HARNESS` beat a session-wide
  `set-environment` inside the pane — 3.7c and 3.2, `chat-A claude-code` and `chat-B
  codex` under a session saying `session-wide`. **Nothing was added to
  `layout.CARRIABLE`**, and there is a test that says so as a literal set.
- The consequence needs no new code: `session.current()` reads `$CHARTER_SESSION_ID`, so
  `.charter/sessions/<chat>.persona`, `.workspace` and `.tools` are per chat. Tested
  through the real writers.
- **The same measurement has a second half that changed a design decision.** A `run-shell`
  child — which every `bind -n` action is — reads the **session's** environment and never
  the window's `-e` (measured on both versions). So `$CHARTER_SESSION_ID` cannot tell two
  chats of one workspace apart, and `F2` would have opened whichever chat's palette was
  set last. `conf_text`'s hotkey and toggle binds now carry `#{@charter_chat}`, expanded
  in the presser's own window — the same mechanism `#{client_name}` and `@charter_hatch`
  already use — and `commands_frame._pressers_chat` prefers it, falling back to the
  variable for a frame launched by an older charter (whose bind text a newer frame's
  `source-file` replaces, key tables being server-wide).

---

## Contended files — the exact lines

- **`charter/frame/state.py`** — new `workspace_prefix`, `new_chat_id`, `_CHAT_SEP`,
  `_CHAT_ORDINAL_MAX`; `is_live` gains the chat branch (`pid is None → pane_matches`);
  `frame_id`, `_launcher_pid` and `reap` are **unchanged code**, docstrings only.
- **`charter/commands_frame.py`** — the launch half: `_CHAT_OPTION`, `_chat_option_argv`,
  `_live_chats`, `_pressers_chat`, `_pin_workspace` (lifted out of `cmd_launch` so both
  paths can allocate after their own reap); `_exit_path_env_argv` and
  `_session_id_env_argv` signatures; `_pane_died_write_hook_argv` and
  `_pane_died_teardown_hook_argv` actions; `conf_text`'s two bind lines; `_frame_is_live`
  and `_reap_this_server`; and inside `cmd_launch`/`_launch_in_operator_tmux` the
  allocation, the session/window branch, the chat option, the reap set, `kill-window`, and
  the attach/detach target.
- **`charter/instance.py` — untouched.** Nothing in Stage 5a needed it.

---

## Verification

**Real tmux, both versions.** New class
`tests/test_frame_tmux_integration.ChatsAreWindowsOnOneWorkspaceSession` (7 tests) passes
on tmux 3.7c and on tmux 3.2 built from the release tarball. The whole tmux-dependent set
(`test_frame_tmux_integration`, `test_frame_surface_live`,
`test_frame_overlay_escape_hatch`, `test_frame_palette_integration`) was run at the 3.2
floor on this branch and on `d505eb0`: **the same 8 pre-existing failures on both**, all
of them features that do not exist at 3.2 (pane-scoped border options, the
`window-resized` hook). No new floor failure. Every server is killed and its socket
unlinked by the module's own cleanup.

**Mutation testing** — 32 mutations, each with an unmutated GREEN baseline first, each
asserted to have changed the file, each restored and the restore verified by **sha256**
(not mtime), every child run under `PYTHONDONTWRITEBYTECODE=1`. **32/32 RED**, including
CI's own surviving mutation reproduced verbatim. The two guards this stage owns from the
plan's list of four are in it by name: the allocator's `FileExistsError` claim, and the
teardown running `kill-window` and not `kill-session`.

**Deletion sweep — the gate went `14 survivors` → `no survivors`, and here is the split.**

The first push read `14 survivors`. I read all of them rather than filing them as debt.
None was a masked cluster in the end; the classifier's own split was **6 unpinned + 1
masked + 1 platform-deferred per shard**, and every one decomposed into a guard I could
either pin or delete:

| what the sweep found | verdict | what I did |
|---|---|---|
| `chat or ""` and the whole `_FRAME_ID_RE` refusal in `_chat_option_argv` | unpinned | `TheChatOptionIsCheckedWhereItEntersTmux` — a hostile chat, an empty one, a `None` |
| `if out.returncode != 0` in `_live_chats` | unpinned | it answered `set()`; it answers `None` now, and both callers refuse to reap on it |
| `line.strip()` twice in `_live_chats`' comprehension | **equivalent mutant** | `s.strip()` and `s.lstrip()` are truthy for the same strings, so no test could tell the guard from its mutation — stripped once into a name, then `if name`, and both halves are pinned |
| `if named is not None` on the guest path | unpinned | `test_the_chat_is_written_on_the_window_here_too` |
| `if chat_set.returncode != 0` warning | unpinned | `test_a_window_option_tmux_refused_is_reported_with_what_it_costs` |
| `if not picked: return` in `_pin_workspace` | unpinned | `PickingAWorkspaceLocksTheChatToIt` — the lifted block had never been pinned inline either |
| `contain.one_line(ws)` in the locked line | unpinned | a workspace name carrying `\n✗ …` must not forge a second line of charter's own output |
| `chat and _FRAME_ID_RE.fullmatch(chat)` | **equivalent mutant** | `_FRAME_ID_RE` is `+`, so it already refuses `""` — `chat and` deleted, the rule `frame_workspace` states for `valid_name` |
| `if d is None: return None` in `new_chat_id` | **unreachable** | `workspace_prefix` cannot produce a name `contain.child` refuses — deleted, with the reason in the docstring, the way `record_identity`'s unreachable `isinstance` filter was |
| `v >= tmuxctl.SESSION_ENV_FLOOR` boundary | unpinned | both sides asserted: at the floor the identity rides, one release below it does not |
| `.strip()` in `_pressers_chat` | unpinned | a trailing space would fail the shape check and silently resolve another chat |
| `os.mkdir(p, 0o700)` and its `except OSError` in `claim_private_dir` | unpinned | `TheClaimIsAMkdirThatCanFail` — the mkdir mode is observed with the `chmod` held back under `umask 0`, which is the only way to see "no window in which it is looser than it ends up" |
| `except OSError` around `private_mkdir(root)`, `_CHAT_ORDINAL_MAX`, `strip("._-")`, `pane is not None and …` | unpinned | four tests in `tests/test_frame_state.py` |
| `if live is not None and chats is not None` in `_reap_this_server` | **masked** | two reaps in sequence; the existing test spies on each reap's *server*, so the opening one answered for the closing one. Unmasked by asserting the one thing only the closing reap can do — a finished frame leaves no directory, its own included |

Local `python3 tools/sweep.py` and both CI shards now read **`gate: no survivors`**.

**Suite in two environments** — python3.14 (default environment) and python3.12 with
`CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset. Both 8142/8143 OK.

**One flake seen and chased down, not swallowed.** Two full-suite runs each failed once in
`tests/test_frame_input_reaches_a_component.py` on `assertIn("SIZE-0", …)` reading
`SIZE-1`. It reproduces on **`main` at `f6d42f0` with no branch applied** (four concurrent
copies of that module: 3 pass, 1 fails with the identical line), so it is a pre-existing
timing race that arrived with #640/#642 rather than anything here — that module builds its
own frame from `state.frame_id(...)` and never calls `cmd_launch`. Filed as **#653** and
deliberately not patched around, since the module is not this branch's.

---

## Two things I am naming rather than hiding

1. **Four calls on the launch path now have nothing to do.** `state.clear_exit`,
   `clear_shape`, `clear_respawn` and `gather.discard` exist because a recycled pid let a
   launch adopt a previous frame's directory (#383/#387/#382). An allocated id cannot be a
   previous frame's, so on this path they are unreachable-effect. They are kept, not
   deleted, because Stage 5c Task 9 reopens a **cold chat into its own existing
   directory** — which is the case they are actually for, and where `clear_shape`
   unlinking `session` (#413) becomes load-bearing again. The four tests that used to pin
   them now pin the stronger property allocation gives: a launch steps over a taken
   ordinal, writes nothing in that directory, and inherits none of it.
2. **One residual, in a comment at the branch.** `live_sessions` also holds the sessions
   of frames an older charter launched (`<workspace>-<pid>`), so a workspace named exactly
   like one — `api-4242`, beside a live old frame for workspace `api` with launcher pid
   4242 — would join it. It needs that name and that frame live across the upgrade, and it
   stops being reachable once the last pre-chat frame on the machine has ended.

`docs/frame.md` had two sentences this makes false ("each frame a session on it", `attach
-t <frame-id>`); both are corrected. The full doc pass is Stage 5c Task 11.

News entry: `docs/news/unreleased-a-workspace-holds-several-chats.md`, `version:
unreleased`. **No version bump, no stamping, no tag.**
