### PR TITLE
The suite stops spending the operator's forge token and their signing key (#638, #641)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,13 @@ command.
   stdout — `os.get_terminal_size()` answers what a pipe answers, so a render is the same
   width in your window as it is in CI. A test that wants a size states one with
   `mock.patch("os.get_terminal_size", …)`.
+  `tests/_gitguard.py` is the fifth, for the one config file charter never writes and every
+  `git` it spawns reads: **your own `~/.gitconfig`.** `$GIT_CONFIG_GLOBAL` points at a file
+  this repository writes, so a fixture repo commits as the suite, on `main`, and — the part
+  that matters — **unsigned**. Inheriting `commit.gpgsign = true` with a hardware or
+  1Password signer behind it does not fail a test, it *hangs* it, and no runner can ever
+  see that. A test that builds a child environment by hand carries
+  `tests._gitguard.environment()` into it, or is refused by name at the spawn.
 - **The suite spends nothing it was not asked to.** `tests/_planeguard.py` also refuses a
   charter child started with `start_new_session=True` — charter's own shape for a
   background refresh that outlives the process that started it. Those fire in tests and
@@ -60,7 +67,12 @@ command.
   `tests._isolation.no_background_refresh(self)`; if it is *about* the child, call
   `tests._planeguard.allow_background_children(self)`. A test that starts a real tmux
   server names its socket with `tests._tmuxreap.name("<slug>")`, so the next run can reap
-  it when this one is killed before its cleanup runs.
+  it when this one is killed before its cleanup runs. **Nor does it spend a credential.**
+  `doctor`'s preflight asks a forge whether your token is still good, and eighteen modules
+  reach that line — 28 authenticated round trips to github.com and gitlab.com per run, and
+  the sweep gate spends that again per mutation. `tests/_forgeprobe.py` answers the probe
+  with a recorded reply, and `tests._planeguard.RealForgeReach` refuses every other `gh` or
+  `glab` invocation: a forge test drives `charter.util.run` with a recorded reply instead.
 - **Comments explain *why*.** The codebase leans hard on this: a comment that restates the
   code earns nothing, one that records the failure a line prevents is worth several
   paragraphs of docs. Read a few modules before writing your first one.
@@ -148,18 +160,22 @@ outside the test — git config, `$PATH`, locale, the default shell, an env var,
 filesystem's case sensitivity — is either set explicitly by the test or is a bug waiting
 for someone else's machine.
 
-For git specifically, pin it on the invocation rather than trusting the environment:
+**For git specifically, that is now done for you** — and the fifth entry above is the
+reason it had to be. Thirty-one modules ran `git commit`, 1,384 children in one green run,
+each protected by hand in one of three different spellings or not at all; the module that
+remembers none of them does not fail, it hangs. `tests/_gitguard.py` points
+`$GIT_CONFIG_GLOBAL` at a file this repository writes — `init.defaultBranch = main`,
+signing off, no global hooks path, none of your filter drivers — before any test module is
+collected, and `tests._planeguard.AmbientGitConfig` refuses a git child that steps outside
+it. So a plain `subprocess.run(["git", "commit", …])` in a fixture repo is now correct on
+every machine, and the per-invocation `-c commit.gpgsign=false` several modules still carry
+is belt and braces rather than the only thing standing between the suite and a biometric
+prompt.
 
-```python
-_PINS = ["-c", "init.defaultBranch=main", "-c", "commit.gpgsign=false",
-         "-c", "tag.gpgsign=false"]
-subprocess.run(["git", *_PINS, "-C", str(cwd), *args], ...)
-```
-
-Signing belongs in that list even when the test has nothing to do with signing: a developer
-with a signing helper configured gets a fixture commit that stops to ask for a passphrase,
-and a suite with nobody at the keyboard hangs rather than fails. That is the same failure
-`docs/git-policy.md` exists to prevent in charter itself.
+Signing was always the one worth the paranoia: a developer with a signing helper configured
+gets a fixture commit that stops to ask for a passphrase, and a suite with nobody at the
+keyboard hangs rather than fails. That is the same failure `docs/git-policy.md` exists to
+prevent in charter itself.
 
 ### Reproducing the runner before you push
 
@@ -169,6 +185,9 @@ You can hand git a config the way the runner has it, without touching your own:
 GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=init.defaultBranch GIT_CONFIG_VALUE_0=master \
   python3 -m unittest discover -s tests
 ```
+
+`GIT_CONFIG_COUNT` is applied as if by `git -c`, so it still wins over the suite's own
+`$GIT_CONFIG_GLOBAL` redirect — the recipe means what it says.
 
 If a change touches git behaviour, run the suite that way once. It is cheaper than a red
 `main`, and it is how the last one was diagnosed.

--- a/docs/news/unreleased-the-suite-stops-spending-your-forge-token-and-your-thumb.md
+++ b/docs/news/unreleased-the-suite-stops-spending-your-forge-token-and-your-thumb.md
@@ -1,0 +1,133 @@
+---
+version: unreleased
+headline: charter's own test suite stops spending your forge token and your signing key — 28 authenticated round trips a run become zero, and the git it runs 9,735 times a run reads this repository's config instead of yours
+---
+
+These are the last two of the family the last two releases have been closing: the suite
+reading or spending the machine it runs on instead of the repository. The plane, the shell,
+the filesystem, the clock, the working directory, PyPI, a real keyboard, the operator's
+1Password vault and leaked tmux servers all went the same way. These two are a credential
+and a private key.
+
+## The forge token: 28 round trips a run, ~2,200 per pull request's gate
+
+`doctor.check_forge_auth` runs `gh auth status --hostname github.com`. That is not a leak —
+`auth status` never prints the token — but it is the operator's real authority reaching a
+real remote from a unit test, on every run.
+
+**The number in the issue was wrong, and re-measuring is why the fix works.** It said 23,
+all `gh`. Counted in-process — `subprocess.Popen.__init__` wrapped before the test package
+is imported, because a `ps | grep` of a running suite matches its own command line, which
+is how the PyPI issue arrived at a figure that was an artefact — one green run forks **28
+forge-auth children from 18 test modules**, identically on CPython 3.12 and 3.14:
+
+| child | per run |
+|---|---|
+| `glab auth status --hostname gitlab.com` | 20 |
+| `gh auth status --hostname github.com` | 8 |
+
+The split is a property of the fixtures, not of the machine: a plane that declares no
+`[[forge]]` block falls back to the historical single-GitLab default, and every plane the
+shared test base class hands out is one of those. A fix aimed at the `gh` the issue named
+would have left twenty of the twenty-eight in place.
+
+**And the multiplier is what made it urgent.** The deletion sweep runs the suite once per
+mutation and its gate runs on every pull request, so 28 becomes 28 × the mutation count —
+around **2,200 authenticated requests to a forge from one pull request's gate**, on the
+operator's own token, for a diff of ordinary size.
+
+### The preflight is answered, not stubbed
+
+`mock.patch("charter.doctor.check_forge_auth")` would have been one line, and it would have
+made a function that never runs: its `"Logged in" in blob` branch, its summary-line
+extraction, its `stdout + stderr` concatenation and its timeout arm would all have gone dark
+for the whole suite, and the next case written against any of them would pass without
+running anything. That is the trap the PyPI fix names, and it is why that one refused the
+fork rather than stubbing the spawner.
+
+So the answer sits at the child instead. One wrapper on `charter.util.run` recognises
+`<forge cli> auth status` — and nothing else — and returns a recorded reply, on stderr,
+which is where `gh auth status` really writes it. Every line of `check_forge_auth` still
+executes. The backends' own `check_auth` builds the identical argv and is answered by the
+same wrapper. A test that wants a different answer patches `charter.util.run` itself, which
+replaces the fixture and puts it back afterwards.
+
+The reply names itself, so a doctor row printed from a test run says `Logged in to
+github.com account charter-test-fixture (tests/_forgeprobe.py — no forge was contacted)`
+rather than looking like a real session belonging to whoever ran the suite.
+
+### The allowance came out on the same commit as the reach
+
+The forge tripwire that found this shipped **allowing** `auth status`, refused `auth login`
+and `auth token`, and wrote the residual into its own docstring rather than hiding it —
+the right call for a change that had no business stubbing eighteen modules.
+
+It is now refused with everything else. The rule is a one-item allowance rather than a
+denial list: an argv that names no subcommand at all (`gh --version`, the local probe that
+reports which CLI is installed) is allowed, and anything else — `api`, `pr merge`,
+`mr merge`, `repo clone`, `auth status`, and a subcommand charter has never heard of —
+fails the test that spawned it, by name, having contacted nothing.
+
+A guard that permits what nothing does any more is a guard that will quietly re-permit it.
+The answer is what made the refusal affordable, and the refusal is what stops the answer
+from being a stub the next test walks around.
+
+**After: zero.**
+
+## The signing key: a hang, and the one CI can never see
+
+A fixture repository created by a test inherits `commit.gpgsign = true` from the machine's
+own `~/.gitconfig`. With 1Password's `op-ssh-sign` as `gpg.ssh.program` — the setup on the
+machine this was found on — `git commit` parks on a biometric prompt and the suite never
+returns. Not a failure. A **hang**: no pass, no fail, no verdict, and no line saying why.
+
+Measured, in a bare temp repository with charter's own checkout out of the picture:
+
+```
+$ git init -q . && echo x > a && git add a && git commit -m probe
+error: 1Password: failed to fill whole buffer
+fatal: failed to write commit object
+git commit -m probe  0.01s user 0.01s system 0% cpu 1:00.36 total
+```
+
+Sixty seconds and a failed commit with stdin closed; indefinite with a terminal attached.
+**A runner has no signing config**, so CI cannot see this and never will — the same reason
+122 blocked `input()` calls passed in CI and hung for a human.
+
+### Thirty-one modules, three spellings, and no shared answer
+
+31 test modules run `git commit`, **1,384 children in one green run**, and each was
+protected by hand or not at all, in three different spellings: `-c commit.gpgsign=false` on
+the argv (1,068 of them), a repo-local `git config commit.gpgsign false` in the fixture's
+`setUp` (208 more, all in one module), and `GIT_CONFIG_GLOBAL=/dev/null` in a hand-built
+child environment. A module that remembers none of the three is not refused, not reported
+and not slow — it hangs, and the thirty-second module was always going to be the one.
+
+So the fix is not thirty-one patches. `$GIT_CONFIG_GLOBAL` now points at a file this
+repository writes and `$GIT_CONFIG_SYSTEM` at `os.devnull`, installed before any test module
+is collected and above the import that pulls charter in. Every `git` this suite runs — all
+**9,735 of them per run** — reads a config the repository controls: signing off, an identity
+at a reserved `.invalid` domain, `init.defaultBranch = main` so a fixture repo's first branch
+is the same on every machine, no global hooks path, and none of the machine's filter or diff
+drivers.
+
+**Redirected, not merely defaulted**, for the reason the config-directory redirect already
+gives: a developer who has these set is exactly the case that hangs, and inheriting theirs
+would keep the hole open for them.
+
+### And then the tripwire found the module the redirect could not reach
+
+A default is something a new module can walk past, so a `git` spawned with an environment
+that drops the redirect now fails the test that spawned it, by name, before the child
+starts. Turning it on across 7,984 tests found exactly one module — ten cases in
+`test_frame_owns_the_surface`, which builds its environment with `clear=True` and so handed
+`git remote get-url origin` an empty one. Those ten really were reading the operator's own
+git config; they now carry the redirect explicitly, and the eleventh case that forgets will
+say so instead of hanging.
+
+The suite also gained the thirty-second module on purpose: a fixture repository, a plain
+`git commit`, and no neutraliser of its own anywhere. Before the redirect that case took
+60.2 seconds and failed on this machine. After it, the module runs in 2.7 seconds and
+asserts the commit is unsigned, authored by the suite, and on `main`.
+
+None of this reaches you unless you run charter's own test suite. Nothing to adopt.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,6 +30,19 @@ os.environ["CODEX_HOME"] = os.path.join(_SANDBOX, "codex")
 os.makedirs(os.environ["XDG_CONFIG_HOME"], exist_ok=True)
 os.makedirs(os.environ["CODEX_HOME"], exist_ok=True)
 
+# The config file charter never writes and every `git` it spawns reads: the operator's own
+# `~/.gitconfig`. Redirected here for the same reason as the two above and with a sharper
+# consequence — a fixture repository inherits `commit.gpgsign = true`, and with 1Password's
+# `op-ssh-sign` behind it `git commit` parks on a biometric prompt and the suite never
+# returns (#641). Not a failure: a hang, with no verdict and no line saying why, and one CI
+# can never see because a runner has no signing config. See `tests/_gitguard.py`.
+#
+# ABOVE the `_ttyguard` import below and so above everything that pulls charter in:
+# `charter.config` resolves a plane at import and reads a git worktree pointer on the way.
+from . import _gitguard      # noqa: E402  (imports no charter module, by design)
+
+_gitguard.install()
+
 # The FOURTH fixture, installed FIRST because it is the one thing here that must be true
 # before `charter` is imported at all: the suite's own file descriptors. `charter.util`
 # computes `_USE_COLOR` from `sys.stderr.isatty()` at import, and `sys.stdin`'s tty-ness
@@ -67,6 +80,17 @@ _envguard.install()
 from . import _planeguard      # noqa: E402  (env above must be set before charter loads)
 
 _planeguard.install()
+
+# The one thing the tripwire above cannot do is ANSWER. `doctor.check_forge_auth` runs
+# `gh auth status --hostname github.com` — the operator's real token, validated against a
+# real forge, 28 times per run from 18 modules (#638). Refusing that would only redden
+# them, so this answers it with a recorded reply, and `_planeguard.RealForgeReach` refuses
+# every forge-CLI spawn that is left. BELOW `_planeguard.install()`, deliberately: the
+# refusal is armed first, so anything this fixture does not cover fails by name rather than
+# reaching github.com.
+from . import _forgeprobe      # noqa: E402
+
+_forgeprobe.install()
 
 # And the one thing no guard can prevent, only clean up after: a run that was KILLED.
 # Measured — a `kill -9` two seconds into `test_frame_overlay_escape_hatch` leaves a live

--- a/tests/_forgeprobe.py
+++ b/tests/_forgeprobe.py
@@ -1,0 +1,154 @@
+"""The preflight's forge-auth probe, answered here instead of at github.com.
+
+`doctor.check_forge_auth` runs ``gh auth status --hostname github.com`` — or ``glab auth
+status --hostname gitlab.com``, which is what a plane declaring no ``[[forge]]`` block
+falls back to, and every plane `PersonaIso` hands out is one of those. Eighteen test
+modules reach that line through `doctor.run_all()`.
+
+It is not a leak: ``auth status`` does not print the token. It is the operator's REAL
+authority reaching a REAL remote, from a unit test, on every run (#638).
+
+**Measured in-process**, by wrapping `subprocess.Popen.__init__` before the `tests`
+package is imported — a ``ps | grep`` of a running suite matches its own command line,
+which is how #542's issue arrived at a figure that turned out to be an artefact. One green
+run at 7af3d7f: **28 forge-auth children from 18 modules**, 20 ``glab auth status
+--hostname gitlab.com`` and 8 ``gh auth status --hostname github.com``, on CPython 3.12
+and 3.14 alike.
+
+The issue that filed this said "23, all ``gh``". Re-measuring is what turned that into 28
+across two forges: a module whose plane declares no ``[[forge]]`` block gets the GitLab
+default, so the split is a property of the fixtures rather than of the machine, and a fix
+aimed only at ``gh`` would have left twenty of the twenty-eight in place.
+
+**And the multiplier is why a fixture is worth writing.** `tools/sweep.py` runs the suite
+once per mutation and the gate runs on every pull request, so 28 becomes 28 × the mutation
+count — roughly **2,200 authenticated requests from one pull request's gate** on a diff the
+size of #626's. #542 made exactly this argument about PyPI and it held.
+
+**Answered at the child, not at the check**, and that is the difference between this and
+the stub it replaces. `mock.patch("charter.doctor.check_forge_auth")` would have been one
+line and would have made a function that never runs: its ``"Logged in" in blob`` branch,
+its summary-line extraction, its ``stdout + stderr`` concatenation and its `ProcTimeout`
+arm would all have gone dark for the whole suite, and the next case written against them
+would pass without running anything — the trap #542 names. Wrapping `util.run` leaves
+every one of those lines executing, on a recorded reply, and removes only the part nobody
+was asserting about: the round trip to the forge.
+
+**One wrapper, every caller.** `charter.forge.github` and `charter.forge.gitlab` reach
+`util.run` by attribute lookup on the same module object, so `Forge.check_auth`'s identical
+``auth status`` argv is answered here too. A test that wants a different answer patches
+`charter.util.run` itself — `mock.patch` replaces this wrapper and puts it back after, so
+the twenty-odd cases that already do that keep winning.
+
+**The reply lands on stderr**, where `gh auth status` really writes it, so
+`check_forge_auth`'s ``(proc.stdout or "") + (proc.stderr or "")`` stays load-bearing
+rather than becoming a line no test can kill.
+
+**Answered, not refused, and the refusal is next door.** `tests._planeguard.RealForgeReach`
+fails any test that spawns a forge CLI with a subcommand at all — ``auth status``
+included, now that nothing reaches it. This module is what keeps that refusal from
+reddening twenty-three modules; the refusal is what keeps this module from being a stub
+the next test walks around.
+
+**The residual, written down rather than hidden.** ``gh --version`` still runs, 28 times a
+run, from `doctor.check_forge_cli`: a local probe that contacts no host and reads no token,
+which `RealForgeReach` therefore allows. `shutil.which(cli)` still reads this machine too,
+and answering that would foreclose the tests about a CLI that is not installed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+from . import _planeguard
+
+#: What this fixture answers ``<cli> auth status`` with. Recorded rather than invented:
+#: the shape is `gh auth status`'s own — the host on its own line, the verdict indented
+#: under it — and ``Logged in`` is the substring `doctor.check_forge_auth` and
+#: `Forge.check_auth` both key off. It names itself, so a doctor row printed from a test
+#: run says where the answer came from instead of looking like a real session.
+REPLY = ("{host}\n"
+         "  ✓ Logged in to {host} account charter-test-fixture "
+         "(tests/_forgeprobe.py — no forge was contacted)\n")
+
+#: Every ``auth status`` this fixture has answered, newest last, as the argv it was asked.
+#: A test asserting the reach is closed can read a positive fact here rather than only the
+#: absence of a spawn.
+CALLS: list[list[str]] = []
+
+_INSTALLED = False
+
+#: What :func:`install` wrapped. Kept, and not only for the restore that never happens:
+#: a case that puts it back for one call is how this suite watches the refusal next door
+#: fire for real, and a fixture nobody has watched be necessary is a fixture nobody knows
+#: is doing anything.
+_ORIGINAL = None
+
+#: Filled by :func:`install`. Asked of `_planeguard._forge_clis`, which asks
+#: `charter.forge.registry.KINDS`, so the fixture and the tripwire beside it cannot
+#: disagree about what counts as a forge CLI — and a forge added to that table is covered
+#: on the commit that adds it.
+_CLIS: frozenset[str] = frozenset()
+
+
+def _hostname(argv: list[str]) -> str:
+    """The host this probe names, for the reply to name back.
+
+    Both backends pass ``--hostname`` (`GitHubForge` always did; `GitLabForge` was fixed to
+    in FINDING I2, so a self-hosted plane stops asking gitlab.com about its own token), so
+    the fallback is for an argv charter does not write today rather than for one it does.
+    """
+    for flag, value in zip(argv, argv[1:]):
+        if flag == "--hostname":
+            return value
+    return "a forge"
+
+
+def asks_a_forge_who_it_is(argv: list[str]) -> bool:
+    """True when *argv* is the ``<forge cli> auth status`` probe and nothing else.
+
+    Deliberately the narrowest possible match. ``auth login`` opens a browser and waits,
+    ``auth token`` prints the credential onto stdout, and every ``api``/``pr``/``mr`` call
+    reads or writes somebody's repository — answering any of those with a recorded reply
+    would be this fixture pretending a test did something it did not. They are refused by
+    `_planeguard.RealForgeReach` instead, which is a failure with a name on it.
+
+    The program is compared on its BASENAME, because `shutil.which` has already resolved it
+    to a full path by the time `doctor` builds the argv on some paths and has not on
+    others.
+
+    No length check in front of the slice: ``["gh"][1:3]`` is ``[]``, which is already not
+    ``["auth", "status"]``. A guard that cannot be wrong is a line no test can kill.
+    """
+    return (bool(argv)
+            and os.path.basename(argv[0]) in _CLIS
+            and argv[1:3] == ["auth", "status"])
+
+
+def install() -> None:
+    """Answer the probe for the whole suite. Idempotent; called once at `tests` import.
+
+    Idempotent because it is reachable twice — `tests` can be imported by a child process
+    that also imports a test module — and a second wrap would put this fixture on top of
+    whatever a running test had patched onto `util.run`, silently discarding it.
+    """
+    global _INSTALLED, _CLIS, _ORIGINAL
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+    _CLIS = _planeguard._forge_clis()
+
+    from charter import util
+
+    original = _ORIGINAL = util.run
+
+    def run(cmd, *args, **kw):
+        argv = list(cmd)
+        if asks_a_forge_who_it_is(argv):
+            CALLS.append(argv)
+            return subprocess.CompletedProcess(
+                argv, 0, "", REPLY.format(host=_hostname(argv)))
+        return original(cmd, *args, **kw)
+
+    util.run = run

--- a/tests/_gitguard.py
+++ b/tests/_gitguard.py
@@ -1,0 +1,129 @@
+"""The git config every child of this suite reads is written here, not by the operator.
+
+`_isolation` redirects the config directories charter writes outside the plane. This is the
+same move for the one config file charter never writes and every `git` it spawns reads:
+``~/.gitconfig``.
+
+**The defect it closes is a HANG, and it is the operator's thumb.** A fixture repository
+created by a test inherits ``commit.gpgsign = true`` from the machine's own global config.
+With 1Password's ``op-ssh-sign`` as ``gpg.ssh.program`` — the setup on the machine this was
+written on — ``git commit`` parks on a biometric prompt and the suite never returns. Not a
+pass, not a fail, no verdict and no line saying why (#641). Measured on that machine, in a
+bare temp repository with charter's own checkout out of the picture::
+
+    $ git init -q . && echo x > a && git add a && git commit -m probe
+    error: 1Password: failed to fill whole buffer
+    fatal: failed to write commit object
+    git commit -m probe  0.01s user 0.01s system 0% cpu 1:00.36 total
+
+Sixty seconds and a failure with stdin closed; an indefinite prompt with a terminal
+attached. **CI can never see this** — a runner has no signing config — so it is invisible
+in the one place everybody looks, exactly as #545's 122 blocked `input()` calls were.
+
+**Thirty-one modules run ``git commit``**, 1,384 children in one green run, and every one of
+them was neutralised by hand or not at all. Three different spellings were in use:
+``git -c commit.gpgsign=false commit`` on the argv (1,068 of the 1,384), a repo-local
+``git config commit.gpgsign false`` in the fixture's ``setUp`` (208 more, all in one
+module), and ``GIT_CONFIG_GLOBAL=/dev/null`` in a hand-built child environment. A test that
+remembers none of the three is not refused, not reported and not slow — it hangs, and the
+thirty-second module to be written is the one that will.
+
+**So the answer is not thirty-one patches, it is one redirect.** ``$GIT_CONFIG_GLOBAL``
+points at a file this package writes and ``$GIT_CONFIG_SYSTEM`` at ``os.devnull``, before
+any test module is collected, so every `git` this process or its children run reads a
+config the repository controls. Signing is off there because nothing here signs; the
+identity, the default branch name and the rest are stated for the same reason `_ttyguard`
+states what the terminal answers — so a green run means the same thing on a laptop with
+1Password, on a laptop without it, and on a runner with no config at all.
+
+**Redirected, not merely defaulted**, and that is `_isolation`'s rule for the same reason:
+a developer who already has these set in their shell is exactly the case that hangs, and
+inheriting theirs would keep the hole open for them.
+
+What the redirect does NOT do is stop a test from spelling its own environment and dropping
+it. `tests._planeguard.AmbientGitConfig` refuses that at the `Popen`, which is what makes
+this a property of the suite rather than a default a new module can walk past.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+#: The environment variables that decide which git config files a child reads, and what
+#: this package sets them to. `_planeguard` asks for these names rather than spelling them
+#: again, so the refusal and the redirect cannot disagree about what "neutralised" means.
+#:
+#: ``GIT_CONFIG_SYSTEM`` and ``GIT_CONFIG_NOSYSTEM`` are both set. Either alone would do;
+#: together they cover git's two spellings of the same instruction, and a child that
+#: rebuilds one of them by hand is still covered by the other.
+NAMES: tuple[str, ...] = ("GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM", "GIT_CONFIG_NOSYSTEM")
+
+#: What the suite's global git config says. Every line is here because a git child would
+#: otherwise read the operator's answer to the same question:
+#:
+#: * ``user`` — a commit needs an identity, and 1,384 of them were being made under
+#:   whoever ran the suite. Ends in ``.invalid``, which RFC 2606 reserves, so an address
+#:   that escapes into a fixture's output can never be a real person's.
+#: * ``commit.gpgsign``/``tag.gpgsign`` — the hang.
+#: * ``init.defaultBranch`` — a fixture repo's first branch is ``main`` on every machine
+#:   rather than ``main`` or ``master`` depending on whose config it read.
+#: * ``core.hooksPath`` — an operator with a global hooks path was running their own hooks
+#:   inside every fixture repository this suite creates.
+#: * ``filter``/``diff``/``merge`` drivers are simply absent, which is the point of
+#:   redirecting the whole file rather than overriding four keys: the machine this was
+#:   written on has ``filter.lfs.*`` globally, and a fixture repo that shells out to
+#:   ``git-lfs`` is reading the machine again.
+CONFIG = """\
+[user]
+\tname = charter test suite
+\temail = suite@charter.invalid
+[commit]
+\tgpgsign = false
+[tag]
+\tgpgsign = false
+[init]
+\tdefaultBranch = main
+[core]
+\thooksPath =
+"""
+
+#: The file :func:`install` wrote, so a case can read it back rather than guess at it.
+#: Named for what it is rather than ``PATH``, which in a file about child environments is
+#: already taken by something else entirely.
+FILE: str = ""
+
+_INSTALLED = False
+
+
+def environment() -> dict[str, str]:
+    """The three variables, as a child of this suite must carry them.
+
+    A mapping rather than the names alone, so a case that really does build its whole
+    environment can splat it in — ``{"PATH": ..., **_gitguard.environment()}`` — which is
+    the way out `_planeguard.AmbientGitConfig` names and `test_frame_owns_the_surface`
+    takes. Raises rather than filtering if :func:`install` has not run: an empty answer
+    would be a way out that quietly does nothing.
+    """
+    return {name: os.environ[name] for name in NAMES}
+
+
+def install() -> None:
+    """Write the config and point every git child at it. Idempotent.
+
+    Called from ``tests/__init__.py`` **above the import that pulls charter in**, for
+    `_ttyguard`'s reason one tool over: `charter.config` resolves a plane at import and
+    `charter.root` reads a git worktree pointer while doing it, so the redirect has to be
+    in force before charter is a module rather than after.
+    """
+    global _INSTALLED, FILE
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+    directory = tempfile.mkdtemp(prefix="charter-suite-gitconfig-")
+    FILE = os.path.join(directory, "config")
+    with open(FILE, "w", encoding="utf-8") as fh:
+        fh.write(CONFIG)
+    os.environ["GIT_CONFIG_GLOBAL"] = FILE
+    os.environ["GIT_CONFIG_SYSTEM"] = os.devnull
+    os.environ["GIT_CONFIG_NOSYSTEM"] = "1"

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -133,7 +133,54 @@ because reading somebody's credential store is wrong on a machine with no contro
 all. Which CLIs count is asked of `reference._RESOLVERS` — production's own scheme table —
 so a provider added there is covered on the commit that adds it.
 
-**The fifth, and the other half of the measurement above:
+**The fifth is the fourth one host out: :class:`RealForgeReach`.** ``gh`` and ``glab`` hold
+a real token for the operator's real account, so a test that reaches one enumerates and
+reads somebody's private repositories as whoever is signed in on this machine — and the
+cross-repo change surface will open and merge pull requests through the same two binaries,
+which is the direction the blast radius is heading rather than where it already is. It is
+also a flake (CI has no forge credentials) and a hang (both CLIs can park on a device-flow
+prompt that `subprocess.communicate` will wait out). Which CLIs count is asked of
+`registry.KINDS` — production's own forge table — exactly as the vault tripwire asks
+`reference._RESOLVERS`.
+
+**The rule is a one-item allowance rather than a list of what is forbidden**, so a
+subcommand charter has never heard of is refused rather than waved through: an argv that
+names no subcommand at all is allowed, and everything else is refused. ``gh --version`` is
+`doctor.check_forge_cli` reporting which CLI is installed — a local probe that contacts no
+host, reads no token and cannot prompt — and a flat refusal reddened twenty-six tests here,
+every one of them that.
+
+``auth status`` is refused with the rest, and the ORDER that happened in is the point.
+When the tripwire arrived it allowed ``auth status``, because refusing it would have
+reddened the eighteen modules that reach `doctor.run_all()`: measured in-process at 28
+forge-auth children per run, 20 ``glab`` and 8 ``gh``, so the suite really did validate the
+operator's own token against a real forge on every run, and a sweep spent that again per
+mutation (#638). That residual was written down rather than hidden, and it is now closed at
+the other end: `tests._forgeprobe` answers the probe with a recorded reply and nothing
+reaches a real forge CLI to be refused. A guard that permits what nothing does any more is
+a guard that will quietly re-permit it, which is why the allowance came out on the same
+commit the reach did.
+
+**The sixth is the same shape on the program this suite spawns more than any other:
+:class:`AmbientGitConfig`.** 9,735 `git` children in one green run, and every one of them
+read the operator's own ``~/.gitconfig``. That is the plane guard's argument about
+`charter.toml` moved one file over — what a test asserts should not depend on whose machine
+it ran on — but it arrived as something worse than a wrong answer. A fixture repository
+inherits ``commit.gpgsign = true``, and with 1Password's ``op-ssh-sign`` as
+``gpg.ssh.program`` `git commit` parks on a biometric prompt: measured at 60 seconds and a
+failed commit with stdin closed, indefinite with a terminal attached (#641). No pass, no
+fail, no verdict. CI has no signing config and never will, so this is invisible in the one
+place everybody looks — #545's shape exactly.
+
+31 modules run ``git commit``, 1,384 children per run, and they were protected by hand in
+three different spellings or not at all: ``-c commit.gpgsign=false`` on the argv (1,068), a
+repo-local ``git config`` in the fixture's ``setUp`` (208, all one module), and
+``GIT_CONFIG_GLOBAL=/dev/null`` in a hand-built environment. `tests._gitguard` replaces all
+three with one redirect installed before any module is collected, and this refuses the
+spawn that would step outside it — because a default a new module can walk past is not a
+property of the suite, and the 32nd module is the one that will.
+
+**The seventh, and the other half of the measurement above:
 :class:`BackgroundCharterChild`.** #527 answered WHICH plane a spawned charter lands on;
 it did not answer HOW MANY a unit test forks. Counted in-process on one green run at
 b3dbd54 — by wrapping `Popen.__init__` before this package is imported, because a
@@ -417,11 +464,117 @@ class RealVaultReach(BaseException):
     """A test spawned the CLI that reads the developer's own credential store."""
 
 
+class RealForgeReach(BaseException):
+    """A test spawned the CLI that holds the operator's forge token."""
+
+
+class AmbientGitConfig(BaseException):
+    """A test spawned a git that would read the operator's own ``~/.gitconfig``."""
+
+
 class BackgroundCharterChild(BaseException):
     """A test forked a detached charter the test itself will never wait for."""
 
 
 _VAULT_CLIS: frozenset[str] = frozenset()
+_FORGE_CLIS: frozenset[str] = frozenset()
+
+
+def _forge_clis() -> frozenset[str]:
+    """The CLI names charter shells out to in order to reach a code-hosting forge.
+
+    **Asked of production's own table**, exactly as :func:`_credential_clis` asks
+    `reference._RESOLVERS`: `registry.KINDS` maps a forge kind to its backend class and
+    each class spells its binary in ``cli``, so a forge added there is guarded on the
+    commit that adds it rather than on the commit somebody remembers this list exists.
+
+    `tests._forgeprobe` asks this too, so the tripwire and the fixture that answers the one
+    allowed probe cannot drift apart about what "a forge CLI" means.
+    """
+    from charter.forge import registry
+    return frozenset(cls.cli for cls in registry.KINDS.values())
+
+
+def _names_a_subcommand(argv: list[str]) -> bool:
+    """Would this forge-CLI *argv* do anything but describe the CLI itself?
+
+    The whole rule, and it is an allowance rather than a denial list: a command line with
+    no bare word after the program — ``gh --version``, ``glab --help`` — prints about
+    itself and stops, and anything else is refused. Charter's own reach is ``api``, ``pr``,
+    ``mr``, ``repo``, ``release`` and ``auth``; a reader that listed those would wave
+    through the next one somebody writes, which is the wrong direction for a guard to be
+    wrong in.
+    """
+    return any(not a.startswith("-") for a in argv[1:])
+
+
+def _explain_forge(parts: list[str], name: str) -> str:
+    return (
+        f"REFUSED: spawning `{name}` — the CLI holding the operator's forge token\n"
+        f"{_current_test()} is about to run `{' '.join(parts)}`. That is not a fake: it "
+        f"authenticates as whoever is signed in on this machine, against whatever host the "
+        f"argv names — enumerating and reading somebody's private repositories, and soon "
+        f"opening and merging pull requests in them.\n"
+        f"  It is also a flake and a hang: CI has no forge credentials, and both CLIs can "
+        f"park on a device-flow prompt the suite will wait out.\n"
+        f"  `auth status` is refused too, and was not always: it reached a real forge 28 "
+        f"times per run from `doctor.run_all()` until `tests/_forgeprobe.py` began "
+        f"answering it (#638). If you are here because a preflight stopped working, that "
+        f"is the file to read — not this one.\n"
+        f"  The way out is what every forge test here already does: patch `util.run` in the "
+        f"backend module under test — `charter.forge.github.util.run` or "
+        f"`charter.forge.gitlab.util.run` — and answer with a recorded reply. See "
+        f"`tests/test_forge_github.py` for the read side and `tests/test_forge_gitlab.py` "
+        f"for a command driven entirely through recorded replies.")
+
+
+#: The one program whose configuration is the operator's rather than this repository's.
+#: A frozenset because :func:`_reaches_a_credential_cli` takes one, which is what routes
+#: ``git`` through the same program-name resolution as ``op`` and ``gh`` — a path, a
+#: symlink or a wrapper cannot walk past a basename compare here either.
+_GIT: frozenset[str] = frozenset({"git"})
+
+
+def _reads_the_operators_git_config(opts: dict) -> bool:
+    """Would this child read ``~/.gitconfig`` and ``/etc/gitconfig``?
+
+    The question is answered from the environment the CHILD will get — its own ``env=``
+    when it has one, this process's otherwise, which is how `Popen` resolves it — because
+    that is the only thing that decides which files git opens.
+
+    Two conditions, and both are the redirect `tests._gitguard` installs: the global file
+    is pointed somewhere else, and the system file is off in one of git's two spellings for
+    it. Presence rather than equality, deliberately: four modules here already spell this
+    for themselves as ``GIT_CONFIG_GLOBAL=/dev/null``, and a rule that insisted on the
+    suite's own path would refuse a test for being MORE hermetic than it asks.
+    """
+    env = opts.get("env")
+    env = os.environ if env is None else env
+    if "GIT_CONFIG_GLOBAL" not in env:
+        return True
+    return "GIT_CONFIG_SYSTEM" not in env and "GIT_CONFIG_NOSYSTEM" not in env
+
+
+def _explain_git_config(parts: list[str], name: str) -> str:
+    from . import _gitguard
+    return (
+        f"REFUSED: spawning `{name}` with the operator's own git config in force\n"
+        f"{_current_test()} is about to run `{' '.join(parts)}` in a child whose "
+        f"environment does not redirect ``~/.gitconfig``, so this git reads whatever the "
+        f"machine running the suite happens to declare — and the answer decides what the "
+        f"test asserts.\n"
+        f"  It is also a HANG, which is how it was found (#641). A fixture repository "
+        f"inherits ``commit.gpgsign = true``, and with 1Password's ``op-ssh-sign`` behind "
+        f"it `git commit` parks on a biometric prompt: measured at 60s and a failed commit "
+        f"with stdin closed, indefinite with a terminal attached. CI has no signing config, "
+        f"so it can never see this — only a developer can, and only as a suite that never "
+        f"returns.\n"
+        f"  The way out is to stop building the environment by hand: `Popen(..., env=None)` "
+        f"inherits this process's, which `tests/_gitguard.py` has already redirected, and "
+        f"`{{**os.environ, ...}}` carries it too — which is what `charter.util.run` and "
+        f"`util.child_env` both do. A child that really must state its whole environment "
+        f"adds `tests._gitguard.environment()` to it, or points "
+        f"{sorted(_gitguard.NAMES)} somewhere of its own.")
 
 
 def _credential_clis() -> frozenset[str]:
@@ -484,8 +637,11 @@ def _explain_vault(parts: list[str], name: str) -> str:
         f"credential store is not a unit test.")
 
 
-def _reaches_a_credential_cli(args, opts: dict) -> tuple[list[str], str] | None:
-    """``(argv, CLI name)`` when *args* would run one of :func:`_credential_clis`.
+def _reaches_a_credential_cli(args, opts: dict, wanted=None) -> tuple[list[str], str] | None:
+    """``(argv, CLI name)`` when *args* would run one of :func:`_credential_clis` — or, when
+    *wanted* is given, one of THOSE names. The parameter is what lets the forge tripwire
+    beside this one be the same matcher rather than a second one that can drift out of
+    agreement about what "running `gh`" means.
 
     Deliberately narrower than :func:`_charter_argv`, and the asymmetry is the point.
     That function has to chase every spelling because charter re-spawns ITSELF and the
@@ -531,7 +687,7 @@ def _reaches_a_credential_cli(args, opts: dict) -> tuple[list[str], str] | None:
         # no program left to name. Reached on every such spawn, not a hypothetical.
         return None
     for name in _program_names(argv[0], opts.get("cwd"), opts.get("env")):
-        if name in _VAULT_CLIS:
+        if name in (_VAULT_CLIS if wanted is None else wanted):
             return parts, name
     return None
 
@@ -1244,11 +1400,12 @@ def _guard_spawns() -> None:
     a call to one of them that is not the two known non-charter uses. The day a charter
     spawn is written that way, that case turns red and this docstring is what it points at.
     """
-    global _SPAWN_GUARDED, _VAULT_CLIS
+    global _SPAWN_GUARDED, _VAULT_CLIS, _FORGE_CLIS
     if _SPAWN_GUARDED:
         return
     _SPAWN_GUARDED = True
     _VAULT_CLIS = _credential_clis()
+    _FORGE_CLIS = _forge_clis()
     original = subprocess.Popen.__init__
 
     def __init__(self, args=None, *rest, **kw):
@@ -1260,6 +1417,21 @@ def _guard_spawns() -> None:
         reached = _reaches_a_credential_cli(args, opts)
         if reached is not None:
             raise RealVaultReach(_explain_vault(*reached))
+        # Same shape, same reason, one host out: `gh` and `glab` carry the operator's forge
+        # token, and charter writes through them. Also before the plane question, for
+        # `_explain_vault`'s reason — a real `gh` reaches somebody's repositories whatever
+        # plane the child would resolve, and on a machine with no plane at all. The argv is
+        # unwrapped again rather than read off `parts`, so `env gh --version` is judged on
+        # `gh --version` and not on the wrapper's own words.
+        reached = _reaches_a_credential_cli(args, opts, _FORGE_CLIS)
+        if reached is not None and _names_a_subcommand(_launcher_argv(reached[0])[0]):
+            raise RealForgeReach(_explain_forge(*reached))
+        # And the third program whose behaviour is the operator's rather than this
+        # repository's. Same matcher again, for the same reason: "is this git" is one
+        # question, and a second reader of it would drift.
+        reached = _reaches_a_credential_cli(args, opts, _GIT)
+        if reached is not None and _reads_the_operators_git_config(opts):
+            raise AmbientGitConfig(_explain_git_config(*reached))
         parts = _charter_argv(args, opts)
         if parts is not None:
             if _REAL_ROOT:

--- a/tests/test_frame_owns_the_surface.py
+++ b/tests/test_frame_owns_the_surface.py
@@ -28,6 +28,7 @@ from unittest import mock
 from charter import statusline, workspace
 from charter.frame import slots, state
 
+from tests import _gitguard
 from tests._isolation import PersonaIso
 
 
@@ -76,7 +77,15 @@ class FrameOwnsTheSurface(PersonaIso, unittest.TestCase):
 
     def _run(self, *, fid: str | None, tty: bool = False, pane: str = _PANE,
              harness: str = "claude-code", payload: dict | None = None) -> str:
-        env = {"CHARTER_SESSION_ID": fid} if fid else {}
+        # `clear=True` below empties the environment, and `statusline.render` reaches
+        # `inventory.plane_repo`, which runs `git remote get-url origin`. A git child of a
+        # cleared environment reads the operator's own `~/.gitconfig` — the one thing this
+        # suite must not let it do (#641) — so the redirect is put back explicitly. Ten
+        # cases in this module were the only place in 7,984 that stepped outside it, and
+        # `tests._planeguard.AmbientGitConfig` is what found them.
+        env = dict(_gitguard.environment())
+        if fid:
+            env["CHARTER_SESSION_ID"] = fid
         if pane:
             env["TMUX_PANE"] = pane
         if harness:
@@ -301,6 +310,7 @@ class SuppressionSaysSoOnDemand(PersonaIso, unittest.TestCase):
 
     def _row(self, env: dict):
         from charter import doctor
+        env = {**_gitguard.environment(), **env}      # `clear=True`, see `_run` above
         with mock.patch.dict(os.environ, env, clear=True), \
              mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)):
             return doctor.check_frame()

--- a/tests/test_no_test_signs_with_the_operators_key.py
+++ b/tests/test_no_test_signs_with_the_operators_key.py
@@ -1,0 +1,249 @@
+"""The seventh tripwire: `git` reads the repository's configuration, never the operator's.
+
+`test_no_test_reads_the_operators_shell` covers what the launching shell exports;
+`test_no_test_reads_the_operators_terminal` covers what its file descriptors are. This
+covers the one file charter never writes and every `git` it spawns reads — ``~/.gitconfig``
+— and the reason it is loud rather than merely redirected is that its wrong answer is not a
+wrong answer at all. It is a **hang**.
+
+A fixture repository inherits ``commit.gpgsign = true`` from the machine's own config. With
+1Password's ``op-ssh-sign`` as ``gpg.ssh.program``, `git commit` parks on a biometric
+prompt (#641). Measured on the machine this was written on, in a bare temp repository::
+
+    $ git init -q . && echo x > a && git add a && git commit -m probe
+    error: 1Password: failed to fill whole buffer
+    fatal: failed to write commit object
+    git commit -m probe  0.01s user 0.01s system 0% cpu 1:00.36 total
+
+Sixty seconds and a failed commit with stdin closed; indefinite with a terminal attached.
+No pass, no fail, no verdict. **A runner has no signing config**, so CI cannot see this and
+never will — it costs developers, on their own machines, in the shape hardest to diagnose.
+
+`WhatIsAnswered` pins the redirect, and `TheThirtySecondModule` is the case #641 is about,
+written on purpose: a fixture repository, a plain `git commit`, and no neutraliser of its
+own anywhere. Before `tests/_gitguard.py` that case was the hang; after it, it is a test.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from tests import _gitguard, _planeguard
+
+
+def _git(where, *args, env=None):
+    return subprocess.run(["git", "-C", str(where), *args], text=True,
+                          capture_output=True, env=env)
+
+
+class WhatIsAnswered(unittest.TestCase):
+    """Move one: every git child reads a file this repository wrote."""
+
+    def test_the_three_variables_point_a_child_away_from_the_machine(self):
+        self.assertEqual(os.environ["GIT_CONFIG_GLOBAL"], _gitguard.FILE)
+        self.assertEqual(os.environ["GIT_CONFIG_SYSTEM"], os.devnull)
+        self.assertEqual(os.environ["GIT_CONFIG_NOSYSTEM"], "1")
+
+    def test_a_child_really_reads_it_rather_than_the_operators(self):
+        """Asked of `git` itself, not of the environment: the variables being set proves
+        the intent, and this proves the effect. The address is one only this suite's file
+        carries, so the assertion cannot pass by coincidence on somebody's machine."""
+        proc = subprocess.run(["git", "config", "--get", "user.email"],
+                              text=True, capture_output=True)
+        self.assertEqual(proc.stdout.strip(), "suite@charter.invalid")
+
+    def test_every_key_the_config_states_is_the_one_git_answers_with(self):
+        """Asked of `git`, key by key, and every value spelled out here rather than read
+        back off `_gitguard.CONFIG` — a case that compared the file against the constant it
+        was written from would pass whatever either of them said."""
+        for key, value in (("user.name", "charter test suite"),
+                           ("user.email", "suite@charter.invalid"),
+                           ("commit.gpgsign", "false"), ("tag.gpgsign", "false"),
+                           ("init.defaultBranch", "main"), ("core.hooksPath", "")):
+            with self.subTest(key=key):
+                proc = subprocess.run(["git", "config", "--get", key],
+                                      text=True, capture_output=True)
+                self.assertEqual(proc.returncode, 0, f"{key} is not set at all")
+                self.assertEqual(proc.stdout.strip(), value)
+
+    def test_the_file_git_reads_is_the_one_this_package_wrote(self):
+        self.assertEqual(pathlib.Path(_gitguard.FILE).read_text(), _gitguard.CONFIG)
+        self.assertTrue(_gitguard.FILE.startswith(tempfile.gettempdir()),
+                        "the suite's config must not be a path on this developer's own "
+                        f"machine: {_gitguard.FILE}")
+
+    def test_installing_twice_does_not_hand_out_a_second_config_file(self):
+        """Reachable twice — `tests` can be imported by a child process that also imports a
+        test module — and a second install would repoint every later git child at a file
+        this run had not written yet."""
+        before = (_gitguard.FILE, os.environ["GIT_CONFIG_GLOBAL"])
+        _gitguard.install()
+        self.assertEqual((_gitguard.FILE, os.environ["GIT_CONFIG_GLOBAL"]), before)
+
+    def test_the_redirect_is_installed_before_charter_is_imported(self):
+        """Ordering, read off the source because that is where it lives. `charter.config`
+        resolves a plane at import and reads a git worktree pointer on the way, so a
+        redirect installed below that import is a redirect that arrives one plane too late.
+        A comment saying so is not a test."""
+        src = (pathlib.Path(__file__).parent / "__init__.py").read_text()
+        self.assertLess(src.index("_gitguard.install()"), src.index("import _ttyguard"))
+
+
+class TheThirtySecondModule(unittest.TestCase):
+    """Move two: the case #641 is about, written deliberately.
+
+    A fixture repository, a plain `git commit`, and no neutraliser anywhere in this module —
+    no ``-c commit.gpgsign=false`` on the argv, no ``git config`` in `setUp`, no hand-built
+    environment. That is the shape thirty-one modules here were each protecting themselves
+    from by hand, in three different spellings, and the shape the thirty-second was always
+    going to forget.
+    """
+
+    def setUp(self):
+        self.repo = pathlib.Path(tempfile.mkdtemp(prefix="charter-signing-"))
+        self.addCleanup(shutil.rmtree, self.repo, True)
+        self.assertEqual(_git(self.repo, "init", "-q", ".").returncode, 0)
+        (self.repo / "a").write_text("x\n")
+        self.assertEqual(_git(self.repo, "add", "a").returncode, 0)
+
+    def test_a_commit_in_a_fixture_repo_completes(self):
+        proc = _git(self.repo, "commit", "-qm", "probe")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_and_it_is_not_signed(self):
+        """``%G?`` is git's own verdict on a commit's signature, and ``N`` is "no
+        signature". On a machine with no signing config this passes with the redirect
+        deleted — and on the machine that filed #641 it is the difference between a test and
+        a biometric prompt. That asymmetry is the whole reason the guard below exists: the
+        environment that can catch this is never CI's."""
+        self.assertEqual(_git(self.repo, "commit", "-qm", "probe").returncode, 0)
+        self.assertEqual(_git(self.repo, "log", "-1", "--format=%G?").stdout.strip(), "N")
+
+    def test_and_it_is_committed_by_the_suite_rather_than_by_whoever_ran_it(self):
+        self.assertEqual(_git(self.repo, "commit", "-qm", "probe").returncode, 0)
+        self.assertEqual(_git(self.repo, "log", "-1", "--format=%an <%ae>").stdout.strip(),
+                         "charter test suite <suite@charter.invalid>")
+
+    def test_and_its_branch_is_main_on_every_machine(self):
+        self.assertEqual(_git(self.repo, "commit", "-qm", "probe").returncode, 0)
+        self.assertEqual(_git(self.repo, "branch", "--show-current").stdout.strip(), "main")
+
+
+class TheGuardIsNotBlind(unittest.TestCase):
+    """Move three: a git child that steps outside the redirect is refused, for real.
+
+    The redirect alone would only be a default, and #641 is a story about a default nobody
+    noticed they had walked past. Same control as the other spawn tripwires: the refusal is
+    made to happen, and a marker file that stays absent is the evidence that nothing ran.
+    """
+
+    def setUp(self):
+        self.dir = pathlib.Path(tempfile.mkdtemp(prefix="gitconfigguard-"))
+        self.addCleanup(shutil.rmtree, self.dir, True)
+        self.marker = self.dir / "the-cli-ran"
+        for name in ("git", "tar"):
+            p = self.dir / name
+            p.write_text(f"#!/bin/sh\necho {name} >> {self.marker}\n")
+            p.chmod(0o755)
+
+    def test_a_hand_built_environment_that_drops_the_redirect_is_refused(self):
+        with self.assertRaises(_planeguard.AmbientGitConfig):
+            subprocess.run([str(self.dir / "git"), "commit", "-m", "x"],
+                           env={"PATH": os.environ["PATH"]})
+        self.assertFalse(self.marker.exists(), "refused, and yet it ran")
+
+    def test_an_empty_environment_is_refused_too(self):
+        with self.assertRaises(_planeguard.AmbientGitConfig):
+            subprocess.run([str(self.dir / "git"), "status"], env={})
+        self.assertFalse(self.marker.exists())
+
+    def test_redirecting_the_global_file_but_not_the_system_one_is_still_refused(self):
+        """Half a redirect reads ``/etc/gitconfig``, which on a managed machine is where
+        an organisation puts exactly the kind of setting this is about."""
+        with self.assertRaises(_planeguard.AmbientGitConfig):
+            subprocess.run([str(self.dir / "git"), "status"],
+                           env={"GIT_CONFIG_GLOBAL": os.devnull})
+        self.assertFalse(self.marker.exists())
+
+    def test_a_bare_name_on_the_path_is_refused_too(self):
+        """How a test actually spells it — `["git", "status"]`, letting `$PATH` resolve it —
+        so a rule that only recognised full paths would miss nearly every real call."""
+        with self.assertRaises(_planeguard.AmbientGitConfig):
+            subprocess.run(["git", "status"], env={"PATH": str(self.dir)})
+        self.assertFalse(self.marker.exists())
+
+    def test_the_refusal_names_the_test_the_command_and_the_ways_out(self):
+        with self.assertRaises(_planeguard.AmbientGitConfig) as caught:
+            subprocess.run([str(self.dir / "git"), "commit", "-m", "x"], env={})
+        text = str(caught.exception)
+        self.assertIn("test_the_refusal_names_the_test_the_command_and_the_ways_out", text)
+        self.assertIn("commit", text)
+        self.assertIn("op-ssh-sign", text)          # what it costs
+        self.assertIn("env=None", text)             # way out 1
+        self.assertIn("os.environ", text)           # way out 2
+        self.assertIn("_gitguard.environment()", text)   # way out 3
+        for name in _gitguard.NAMES:                # way out 4, named rather than implied
+            self.assertIn(name, text)
+
+    def test_it_is_a_base_exception_so_a_fallback_cannot_eat_it(self):
+        """`charter.planegit` and `charter.gitpolicy` both turn a failed git call into a
+        degraded answer through `except Exception`, and a tripwire something catches
+        reports a benign state instead of failing."""
+        self.assertTrue(issubclass(_planeguard.AmbientGitConfig, BaseException))
+        self.assertFalse(issubclass(_planeguard.AmbientGitConfig, Exception))
+
+    def test_a_program_that_is_not_git_may_state_its_own_environment(self):
+        """The boundary. This is a rule about ONE program's configuration, not a ban on
+        building an environment: `test_cli_smoke` and `test_config` both launch charter
+        itself with a hand-built one, on purpose."""
+        subprocess.run([str(self.dir / "tar"), "--version"], env={})
+        self.assertTrue(self.marker.exists())
+
+
+class EveryWayOutOfTheRefusalWorks(unittest.TestCase):
+    """A tripwire with no usable exit is deleted by whoever hits it next."""
+
+    def setUp(self):
+        self.dir = pathlib.Path(tempfile.mkdtemp(prefix="gitconfigout-"))
+        self.addCleanup(shutil.rmtree, self.dir, True)
+        self.marker = self.dir / "the-cli-ran"
+        p = self.dir / "git"
+        p.write_text(f"#!/bin/sh\necho git >> {self.marker}\n")
+        p.chmod(0o755)
+
+    def test_inheriting_this_processs_environment(self):
+        subprocess.run([str(self.dir / "git"), "status"])
+        self.assertTrue(self.marker.exists())
+
+    def test_building_it_from_os_environ(self):
+        subprocess.run([str(self.dir / "git"), "status"],
+                       env={**os.environ, "GIT_AUTHOR_NAME": "someone"})
+        self.assertTrue(self.marker.exists())
+
+    def test_adding_the_helpers_own_answer_to_a_bare_environment(self):
+        subprocess.run([str(self.dir / "git"), "status"],
+                       env={"PATH": os.environ["PATH"], **_gitguard.environment()})
+        self.assertTrue(self.marker.exists())
+
+    def test_a_test_that_spells_its_own_devnull_redirect_is_not_refused(self):
+        """Four modules here already write this, and one of them predates the redirect by
+        months. A rule that insisted on the suite's own path would refuse a test for being
+        MORE hermetic than it asks."""
+        subprocess.run([str(self.dir / "git"), "status"],
+                       env={"GIT_CONFIG_GLOBAL": os.devnull,
+                            "GIT_CONFIG_SYSTEM": os.devnull})
+        self.assertTrue(self.marker.exists())
+
+    def test_and_the_nosystem_spelling_counts_as_the_system_half(self):
+        subprocess.run([str(self.dir / "git"), "status"],
+                       env={"GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_NOSYSTEM": "1"})
+        self.assertTrue(self.marker.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_no_test_validates_a_real_forge_token.py
+++ b/tests/test_no_test_validates_a_real_forge_token.py
@@ -1,0 +1,250 @@
+"""The sixth tripwire's other half: the forge token is not a fixture, and neither is the
+answer a forge gives about it.
+
+`test_plane_spawn_guard.TheOperatorsForgeTokenIsNeverReached` covers the REFUSAL —
+`gh api`, `gh pr merge`, and since #638 `gh auth status` too. This covers the ANSWER,
+which is the only reason that last one could be refused at all: `doctor.check_forge_auth`
+is reached by eighteen test modules through `doctor.run_all()`, and it ran
+``gh auth status --hostname github.com`` — the operator's real token, validated against a
+real forge — 28 times per green run, 20 of them ``glab`` against gitlab.com.
+
+`tests/_forgeprobe.py` answers that probe with a recorded reply. The cases here are the
+control: `TheProbeIsAnswered` pins what the answer is, `WhatIsNotAnswered` pins how narrow
+the match is, `NothingIsForeclosed` pins that `check_forge_auth` still runs every line it
+ran before, and `TheFixtureIsTheOnlyThingInTheWay` takes the fixture away and watches the
+refusal happen for real — because a fixture nobody has watched be necessary is a fixture
+nobody knows is doing anything.
+
+**There is deliberately no case here that drives `doctor.run_all()` to prove the eighteen
+modules are clean.** They prove it themselves: `RealForgeReach` is armed for the whole
+suite, so if this fixture stopped answering, every one of them would fail on the spawn
+rather than on an assertion written here. A guard that runs against 7,985 tests is a
+stronger statement than a nineteenth caller of the same function — and it is the one that
+does not depend on whether the machine running the suite happens to have `glab` installed.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import unittest
+from unittest import mock
+
+from charter import doctor, util
+from charter.forge.github import GitHubForge
+from charter.forge.gitlab import GitLabForge
+from tests import _forgeprobe, _planeguard
+
+
+def _the_cli_is_installed(case) -> None:
+    """Say the forge CLI is on this machine, because whether it really is decides the
+    branch these cases are about.
+
+    `check_forge_auth` returns "Install gh first" without spawning anything when
+    `shutil.which` answers None — and what it answers is the machine: GitHub's ubuntu
+    runners ship `gh` and not `glab`, this laptop has both, a fresh container has neither.
+    A case that only passes where the probe happens to be reachable is the same defect this
+    whole file is about, one question along. Nothing here lies about more than existence:
+    the argv `doctor` then builds is the CLI's own name, not this path, so the fixture and
+    the tripwire both see exactly what production writes.
+    """
+    real = shutil.which
+
+    def which(cmd, *args, **kw):
+        return f"/usr/bin/{cmd}" if cmd in ("gh", "glab") else real(cmd, *args, **kw)
+
+    patcher = mock.patch("shutil.which", side_effect=which)
+    patcher.start()
+    case.addCleanup(patcher.stop)
+
+
+class TheProbeIsAnswered(unittest.TestCase):
+    """Move one: the preflight gets a verdict, and nothing left this process to get it."""
+
+    def setUp(self):
+        _the_cli_is_installed(self)
+
+    def test_the_preflight_reports_authenticated_without_contacting_a_forge(self):
+        before = len(_forgeprobe.CALLS)
+        result = doctor.check_forge_auth(GitHubForge())
+        self.assertEqual(result.status, doctor.OK)
+        self.assertEqual(
+            result.detail,
+            "✓ Logged in to github.com account charter-test-fixture "
+            "(tests/_forgeprobe.py — no forge was contacted)")
+        self.assertEqual(_forgeprobe.CALLS[before:],
+                         [["gh", "auth", "status", "--hostname", "github.com"]])
+
+    def test_the_gitlab_half_is_answered_too_and_it_is_the_larger_half(self):
+        """Twenty of the twenty-eight measured children were `glab`, not `gh`: a plane that
+        declares no `[[forge]]` block falls back to `GitLabForge`, and that is every plane
+        `PersonaIso` hands out. A fix aimed only at the issue's `gh` would have left them."""
+        before = len(_forgeprobe.CALLS)
+        result = doctor.check_forge_auth(GitLabForge())
+        self.assertEqual(result.status, doctor.OK)
+        self.assertIn("gitlab.com", result.detail)
+        self.assertEqual(_forgeprobe.CALLS[before:],
+                         [["glab", "auth", "status", "--hostname", "gitlab.com"]])
+
+    def test_the_backends_own_probe_is_answered_by_the_same_wrapper(self):
+        """`Forge.check_auth` builds the identical argv. One wrapper on `charter.util.run`
+        answers both, because both reach it by attribute lookup on the same module."""
+        GitHubForge().check_auth()          # must not raise, and must not spawn
+        self.assertEqual(_forgeprobe.CALLS[-1],
+                         ["gh", "auth", "status", "--hostname", "github.com"])
+
+    def test_the_reply_lands_on_stderr_where_gh_really_writes_it(self):
+        """Which keeps `check_forge_auth`'s ``(proc.stdout or "") + (proc.stderr or "")``
+        load-bearing. Answered on stdout, that concatenation would be a line no test in
+        this suite could kill."""
+        proc = util.run(["gh", "auth", "status", "--hostname", "github.com"], check=False)
+        self.assertEqual(proc.stdout, "")
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(
+            proc.stderr,
+            "github.com\n"
+            "  ✓ Logged in to github.com account charter-test-fixture "
+            "(tests/_forgeprobe.py — no forge was contacted)\n")
+
+    def test_the_reply_names_itself_so_a_doctor_row_is_not_mistaken_for_a_session(self):
+        """These rows are printed by cases that capture doctor's output. One reading
+        "Logged in to github.com account <the operator>" would be a fixture impersonating a
+        real session."""
+        proc = util.run(["gh", "auth", "status", "--hostname", "github.com"], check=False)
+        self.assertIn("charter-test-fixture", proc.stderr)
+        self.assertIn("_forgeprobe.py", proc.stderr)
+
+    def test_a_probe_naming_no_host_still_gets_an_answer(self):
+        """Both backends pass `--hostname` today, so this is the shape charter does not
+        write — and a fixture that raised or returned nothing on it would be a fixture that
+        breaks on the first caller that stops passing it."""
+        proc = util.run(["gh", "auth", "status"], check=False)
+        self.assertIn("Logged in to a forge", proc.stderr)
+
+    def test_a_full_path_is_recognised_as_the_same_cli(self):
+        """`shutil.which` has already resolved the program on some paths and not on
+        others, so the match is on the basename."""
+        self.assertTrue(_forgeprobe.asks_a_forge_who_it_is(
+            ["/opt/homebrew/bin/glab", "auth", "status"]))
+
+
+class WhatIsNotAnswered(unittest.TestCase):
+    """Move two: the fixture is as narrow as it can be, so everything else is refused
+    rather than quietly pretended at."""
+
+    def test_only_auth_status_is_answered(self):
+        for argv in (["gh", "auth", "login"], ["gh", "auth", "token"],
+                     ["gh", "api", "user"], ["gh", "status", "auth"],
+                     ["glab", "mr", "merge", "14"]):
+            with self.subTest(argv=argv):
+                self.assertFalse(_forgeprobe.asks_a_forge_who_it_is(argv))
+
+    def test_a_bare_forge_cli_with_nothing_after_it_is_not_the_probe(self):
+        self.assertFalse(_forgeprobe.asks_a_forge_who_it_is(["gh"]))
+        self.assertFalse(_forgeprobe.asks_a_forge_who_it_is(["gh", "auth"]))
+
+    def test_an_empty_command_is_answered_rather_than_raising(self):
+        """`util.run` accepts an empty command — it asks `cmd and cmd[0] == "git"` before
+        indexing, and this wrapper stands in front of it. A filter that raised where the
+        function it wraps does not would be the fixture breaking a call it has no opinion
+        about."""
+        self.assertFalse(_forgeprobe.asks_a_forge_who_it_is([]))
+
+    def test_a_binary_that_is_not_a_forge_cli_is_never_answered(self):
+        """`git` is spawned by this suite constantly, and `op auth status` is a shape the
+        vault tripwire owns."""
+        self.assertFalse(_forgeprobe.asks_a_forge_who_it_is(["git", "auth", "status"]))
+        self.assertFalse(_forgeprobe.asks_a_forge_who_it_is(["op", "auth", "status"]))
+
+    def test_the_names_are_the_tripwires_names(self):
+        """One reader of "what is a forge CLI", asked of `registry.KINDS` through
+        `_planeguard._forge_clis`. Two copies would drift, and the drift would be silent:
+        the fixture would stop answering a CLI the guard still refused, and eighteen
+        modules would go red for a reason neither file explained."""
+        self.assertEqual(_forgeprobe._CLIS, _planeguard._forge_clis())
+        self.assertEqual(_forgeprobe._CLIS, frozenset({"gh", "glab"}))
+
+    def test_a_real_run_still_goes_through_to_the_real_thing(self):
+        """The half that proves the wrapper is a filter and not a replacement: everything
+        that is not the probe reaches `subprocess` exactly as before."""
+        proc = util.run(["git", "--version"], check=False)
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("git version", proc.stdout)
+
+
+class NothingIsForeclosed(unittest.TestCase):
+    """Move three: the check still runs. `mock.patch("charter.doctor.check_forge_auth")`
+    would have been one line and would have left the function's own branches dark for the
+    whole suite — the trap #542 names. Answering the CHILD instead leaves every line of it
+    executing on a recorded reply, and these cases are what say so."""
+
+    def setUp(self):
+        _the_cli_is_installed(self)
+
+    def test_a_forge_that_answers_without_logged_in_is_still_a_failure(self):
+        """F3's shape: `auth status` can exit 0 while saying something else entirely."""
+        with mock.patch.object(util, "run", return_value=subprocess.CompletedProcess(
+                [], 0, "", "not logged in to any hosts\n")):
+            result = doctor.check_forge_auth(GitHubForge())
+        self.assertEqual(result.status, doctor.FAIL)
+        self.assertIn("gh auth login", result.hint)
+
+    def test_a_probe_that_never_answers_is_a_warning_naming_the_timeout(self):
+        with mock.patch.object(util, "run", side_effect=util.ProcTimeout(["gh"], 5.0)):
+            result = doctor.check_forge_auth(GitHubForge())
+        self.assertEqual(result.status, doctor.WARN)
+        self.assertIn("timed out", result.detail)
+
+    def test_a_test_that_wants_its_own_answer_still_wins(self):
+        """`mock.patch` replaces this fixture and puts it back afterwards, which is what
+        keeps the twenty-odd cases that already patch `charter.util.run` working."""
+        with mock.patch.object(util, "run", return_value=subprocess.CompletedProcess(
+                [], 0, "✓ Logged in to github.com as somebody-else\n", "")):
+            result = doctor.check_forge_auth(GitHubForge())
+        self.assertEqual(result.detail, "✓ Logged in to github.com as somebody-else")
+        self.assertEqual(doctor.check_forge_auth(GitHubForge()).detail,
+                         "✓ Logged in to github.com account charter-test-fixture "
+                         "(tests/_forgeprobe.py — no forge was contacted)")
+
+
+class TheFixtureIsTheOnlyThingInTheWay(unittest.TestCase):
+    """Move four, and the one that makes the other three mean something: take the answer
+    away and the preflight really does reach for the operator's forge CLI."""
+
+    def setUp(self):
+        _the_cli_is_installed(self)
+
+    def test_without_the_fixture_the_preflight_is_refused_by_name(self):
+        with mock.patch.object(util, "run", _forgeprobe._ORIGINAL), \
+                self.assertRaises(_planeguard.RealForgeReach) as caught:
+            doctor.check_forge_auth(GitHubForge())
+        self.assertIn("gh auth status --hostname github.com", str(caught.exception))
+
+    def test_the_wrapper_is_installed_rather_than_inherited(self):
+        """Under an operator who happens to be logged out, the fixture's OK and a real
+        `gh`'s FAIL are both just a doctor row, and every assertion above would pass with
+        `install()` deleted — on that machine. This asks the question with a different
+        answer either way: whose `run` is `charter.util.run`?"""
+        self.assertEqual(util.run.__module__, "tests._forgeprobe")
+        self.assertIsNot(util.run, _forgeprobe._ORIGINAL)
+
+    def test_installing_twice_does_not_wrap_a_pin_a_running_test_has_put_in_place(self):
+        """`install()` is reachable twice — `tests` can be imported by a child process that
+        also imports a test module — and a second wrap would put the fixture on top of
+        whatever a case had patched onto `util.run`, silently discarding it."""
+        before = util.run
+        _forgeprobe.install()
+        self.assertIs(util.run, before)
+
+    def test_the_answer_is_installed_below_the_refusal(self):
+        """Order, read off the source because that is where it lives. The tripwire is armed
+        first, so a forge spawn this fixture does not cover fails by name instead of
+        reaching github.com. A comment saying so is not a test."""
+        src = (pathlib.Path(__file__).parent / "__init__.py").read_text()
+        self.assertLess(src.index("_planeguard.install()"),
+                        src.index("_forgeprobe.install()"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -1114,5 +1114,146 @@ class TheOperatorsCredentialStoreIsNeverReached(unittest.TestCase):
             self._run([str(self.dir / "op"), "item", "list"])
 
 
+class TheOperatorsForgeTokenIsNeverReached(unittest.TestCase):
+    """`RealForgeReach` — the credential-store tripwire, one host out.
+
+    `gh` and `glab` hold a real token for the operator's real account, so a test that
+    reaches one enumerates and reads somebody's private repositories as whoever is signed in
+    on this machine — and the cross-repo change surface will open and merge pull requests
+    through the same binaries. It is also a flake, because CI has no forge credentials, and
+    a hang, because both CLIs can park on a device-flow prompt.
+
+    Same control as the class above: the refusal is made to happen for real, and a marker
+    file that stays absent is the evidence that nothing ran — "the child never started" and
+    "the child started and could not write" look identical without it.
+    """
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp(prefix="forgeguard-"))
+        self.addCleanup(shutil.rmtree, self.dir, True)
+        self.marker = self.dir / "the-cli-ran"
+        for name in ("gh", "glab", "git"):
+            p = self.dir / name
+            p.write_text(f"#!/bin/sh\necho {name} >> {self.marker}\n")
+            p.chmod(0o755)
+
+    def test_the_names_come_from_the_registry_not_from_a_list_here(self):
+        """`_credential_clis` asks `reference._RESOLVERS`; this asks `registry.KINDS`, so a
+        forge added there is guarded on the commit that adds it."""
+        from charter.forge import registry
+        self.assertEqual(_planeguard._forge_clis(),
+                         frozenset({cls.cli for cls in registry.KINDS.values()}))
+        self.assertEqual(_planeguard._forge_clis(), frozenset({"gh", "glab"}))
+        self.assertEqual(_planeguard._FORGE_CLIS, frozenset({"gh", "glab"}))
+
+    def test_running_gh_is_refused(self):
+        with self.assertRaises(_planeguard.RealForgeReach) as caught:
+            subprocess.run([str(self.dir / "gh"), "api", "repos/acme/api/pulls"])
+        self.assertFalse(self.marker.exists(), "refused, and yet it ran")
+        self.assertIn("REFUSED", str(caught.exception))
+
+    def test_running_glab_is_refused(self):
+        with self.assertRaises(_planeguard.RealForgeReach):
+            subprocess.run([str(self.dir / "glab"), "api", "projects/1/merge_requests"])
+        self.assertFalse(self.marker.exists())
+
+    def test_a_bare_name_on_the_path_is_refused_too(self):
+        """How the backends actually spell it: `[self.cli, "api", …]`, letting `$PATH`
+        resolve it — so a guard that only recognised full paths would miss every real
+        call."""
+        with self.assertRaises(_planeguard.RealForgeReach):
+            subprocess.run(["gh", "api", "repos/acme/api/pulls"],
+                           env={**os.environ, "PATH": f"{self.dir}:{os.environ['PATH']}"})
+        self.assertFalse(self.marker.exists())
+
+    def test_the_refusal_names_the_way_out(self):
+        """A tripwire that only says no costs the next person an afternoon."""
+        with self.assertRaises(_planeguard.RealForgeReach) as caught:
+            subprocess.run([str(self.dir / "gh"), "pr", "merge", "601"])
+        text = str(caught.exception)
+        self.assertIn("util.run", text)
+        self.assertIn("test_forge_github", text)
+        self.assertIn("_forgeprobe", text)
+
+    def test_a_flags_only_invocation_is_allowed_because_it_reaches_no_forge(self):
+        """`doctor.check_forge_cli` runs `gh --version` to report which CLI is installed:
+        a local probe that contacts no host, reads no token and cannot prompt. A flat
+        refusal reddened twenty-six tests in this suite, every one of them that, and
+        refusing it would have been the guard being wrong about its own subject."""
+        subprocess.run([str(self.dir / "gh"), "--version"])
+        self.assertTrue(self.marker.exists())
+
+    def test_a_wrapper_in_front_of_a_flags_only_invocation_is_still_allowed(self):
+        """The wrapper's own words are not the CLI's. `_launcher_argv` comes off first, so
+        the rule reads `gh --version` here rather than `env gh --version` — which has a
+        bare word in it and would otherwise be refused for a spawn that reaches nothing."""
+        subprocess.run(["env", str(self.dir / "gh"), "--version"])
+        self.assertTrue(self.marker.exists())
+
+    def test_auth_status_is_refused_now_that_nothing_reaches_it(self):
+        """The residual this tripwire shipped with, and closing it is the whole of #638.
+
+        `doctor.check_forge_auth` runs `gh auth status --hostname github.com`, and the
+        first version of this guard ALLOWED it: 28 such children per run, 20 `glab` and 8
+        `gh`, from the eighteen modules that reach `doctor.run_all()`, and refusing it then
+        would only have reddened them. `tests/_forgeprobe.py` now answers that probe with a
+        recorded reply, so nothing reaches a real forge CLI — and an allowance nothing
+        needs is an allowance that quietly comes back."""
+        with self.assertRaises(_planeguard.RealForgeReach):
+            subprocess.run([str(self.dir / "gh"), "auth", "status",
+                            "--hostname", "github.com"])
+        self.assertFalse(self.marker.exists())
+
+    def test_auth_login_and_auth_token_are_refused_too(self):
+        """They always were, and they are the reason the allowance was `auth status` rather
+        than `auth`: `login` opens a browser and waits, `token` prints the credential onto
+        stdout."""
+        for sub in (["auth", "login"], ["auth", "token"], ["auth", "refresh"]):
+            with self.subTest(sub=sub):
+                with self.assertRaises(_planeguard.RealForgeReach):
+                    subprocess.run([str(self.dir / "gh"), *sub])
+        self.assertFalse(self.marker.exists())
+
+    def test_the_calls_the_change_surface_makes_are_all_refused(self):
+        """The half that matters most: every way charter's own change surface touches a
+        forge goes through `api`, and merging goes through `pr`/`mr`."""
+        for sub in (["api", "repos/acme/api/pulls"], ["pr", "merge", "601"],
+                    ["mr", "merge", "14"], ["repo", "clone", "acme/api"],
+                    ["release", "create", "v1"]):
+            with self.subTest(sub=sub):
+                with self.assertRaises(_planeguard.RealForgeReach):
+                    subprocess.run([str(self.dir / "gh"), *sub])
+        self.assertFalse(self.marker.exists())
+
+    def test_a_subcommand_charter_has_never_heard_of_still_counts(self):
+        """The rule is "does this argv name a subcommand", not a list of the ones charter
+        happens to use — so a name nobody here recognises is refused rather than waved
+        through, which is the direction a guard should be wrong in."""
+        with self.assertRaises(_planeguard.RealForgeReach):
+            subprocess.run([str(self.dir / "gh"), "codespace", "ssh"])
+        self.assertFalse(self.marker.exists())
+
+    def test_it_is_a_base_exception_so_charters_own_fallbacks_cannot_eat_it(self):
+        """`GitHubForge.check_auth` and `report.gh` both wrap their `util.run` in
+        `except Exception` and turn a failure into a degraded answer, so an `Exception`
+        here would be reported as "not authenticated" and the test would pass."""
+        self.assertTrue(issubclass(_planeguard.RealForgeReach, BaseException))
+        self.assertFalse(issubclass(_planeguard.RealForgeReach, Exception))
+
+    def test_the_guard_does_not_wait_on_a_plane(self):
+        """`RealVaultReach`'s reason exactly: a real `gh` reaches somebody's repositories
+        on a machine with no control plane at all."""
+        with mock.patch.object(_planeguard, "_REAL_ROOT", ()), \
+                self.assertRaises(_planeguard.RealForgeReach):
+            subprocess.run([str(self.dir / "gh"), "api", "user"])
+
+    def test_git_is_not_guarded(self):
+        """The boundary. Charter's whole design is that git talks to a forge over HTTPS
+        with the forge CLI's token, and tests here really do run git against local
+        repositories — so guarding `git` would refuse the thing the suite is built on."""
+        subprocess.run([str(self.dir / "git"), "status"])
+        self.assertTrue(self.marker.exists())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two issues, one pull request, because they are one defect on two credentials: the suite
spends the operator's forge token, and the suite spends the operator's signing key. Same
family as #546/#587 (the 1Password vault), #545 (a real keyboard), #542 (PyPI and forge
clients), #564 (leaked tmux servers) — *the suite reads or spends the machine instead of
the repository* — and the same prior art: **one fixture that answers, one tripwire that
refuses, both installed before any test module is collected.**

They are together rather than split because they share the file that refuses
(`tests/_planeguard.py`), the file that installs (`tests/__init__.py`) and the argument
for the shape. Splitting them would have meant two conflicting edits to the same wrapper.

---

## #638 — the forge token

`doctor.check_forge_auth` runs `gh auth status --hostname github.com`. Not a leak —
`auth status` never prints the token — but it is the operator's real authority reaching a
real remote from a unit test, on every run.

### Re-measured, and the issue's number was wrong

The issue said 23, all `gh`. Counted in-process (`Popen.__init__` wrapped before `tests`
is imported, because a `ps | grep` of a running suite matches its own command line — how
#542's "~90" turned out to be an artefact):

| child | before | after |
|---|---|---|
| `glab auth status --hostname gitlab.com` | 20 | 0 |
| `gh auth status --hostname github.com` | 8 | 0 |
| **forge-auth children per run** | **28** | **0** |

From **18** test modules, identically on CPython 3.12 and 3.14. The split is a property of
the fixtures, not the machine: a plane declaring no `[[forge]]` block falls back to the
single-GitLab default, and every plane `PersonaIso` hands out is one of those — so a fix
aimed only at the `gh` the issue named would have left twenty of the twenty-eight.

At 28 per run, the sweep gate spends that again per mutation: roughly **2,200 authenticated
requests from one pull request's gate** on a diff the size of #626's.

### Answered at the child, not at the check

`tests/_forgeprobe.py` wraps `charter.util.run`, recognises `<forge cli> auth status` and
nothing else, and returns a recorded reply on stderr — where `gh auth status` really writes
it, so `check_forge_auth`'s `(stdout or "") + (stderr or "")` stays load-bearing.

`mock.patch("charter.doctor.check_forge_auth")` would have been one line and would have
left that function's `"Logged in"` branch, its summary extraction, its concatenation and
its `ProcTimeout` arm dark for the whole suite — the trap #542 names. Every one of those
lines still executes, on a recorded reply. A test that wants a different answer patches
`charter.util.run`, which replaces the fixture and puts it back.

### And the allowance came out on the same commit as the reach

`RealForgeReach` (from the Phase 4 branch, converged here) shipped **allowing**
`auth status` and wrote the residual into its own docstring. It is now refused with
everything else. The rule is a one-item allowance, not a denial list: an argv naming no
subcommand at all (`gh --version` — the local probe reporting which CLI is installed) is
allowed; everything else, `api`/`pr merge`/`mr merge`/`repo clone`/`auth status` and any
subcommand charter has never heard of, fails the test that spawned it before the child
starts.

A guard that permits what nothing does any more is a guard that will quietly re-permit it.

**Residual, stated:** `gh --version` still runs 28 times a run, and `shutil.which` still
reads this machine. Both are local, and answering `which` would foreclose the tests about a
CLI that is not installed.

---

## #641 — the signing key

A fixture repository inherits `commit.gpgsign = true` from the machine's own
`~/.gitconfig`. With 1Password's `op-ssh-sign` behind it, `git commit` parks on a biometric
prompt. Not a failure — a **hang**: no pass, no fail, no verdict, no line saying why.

Reproduced on this machine, in a bare temp repository, with charter's own checkout (which
carries a local `commit.gpgsign=false`) out of the picture:

```
$ git init -q . && echo x > a && git add a && git commit -m probe
error: 1Password: failed to fill whole buffer
fatal: failed to write commit object
git commit -m probe  0.01s user 0.01s system 0% cpu 1:00.36 total
```

60.2 s and a failed commit with stdin closed; indefinite with a terminal attached. **A
runner has no signing config**, so CI cannot see this and never will.

### Measured

| | before | after |
|---|---|---|
| `git` children per run | 9,735 | 9,761 |
| …reading the operator's `~/.gitconfig` | **9,319** | **0** |
| `git commit` children per run | 1,384 from 31 modules | — |

Of those 1,384 commits, 1,068 carried `-c commit.gpgsign=false` on the argv, 208 relied on
a repo-local `git config` written in one module's `setUp`, and the rest on
`GIT_CONFIG_GLOBAL=/dev/null` in a hand-built environment. Three spellings, no shared
answer, and a module that remembers none of them does not fail — it hangs.

### One redirect, then a tripwire for what the redirect cannot reach

`tests/_gitguard.py` points `$GIT_CONFIG_GLOBAL` at a file this repository writes and
`$GIT_CONFIG_SYSTEM` at `os.devnull`, installed **above the import that pulls charter in**
(`charter.config` resolves a plane at import and reads a git worktree pointer on the way).
Signing off, an identity at a reserved `.invalid` domain, `init.defaultBranch = main`, no
global hooks path, and none of the machine's filter drivers — this machine has
`filter.lfs.*` globally, which every fixture repo was inheriting.

`_planeguard.AmbientGitConfig` then refuses a `git` spawned with an environment that drops
it. **Turning it on across 7,984 tests found exactly one module**: ten cases in
`test_frame_owns_the_surface`, which builds its environment with `clear=True` and so handed
`git remote get-url origin` an empty one. Those ten really were reading the operator's git
config; they now carry the redirect explicitly.

The suite also gains the thirty-second module on purpose — a fixture repo, a plain
`git commit`, no neutraliser of its own — which took 60.2 s and failed here before the
redirect and runs in 2.7 s after it, asserting the commit is unsigned, authored by the
suite, and on `main`.

---

## Verification

Full suite, before and after, in two environments — CPython 3.14 with the operator's own
shell, and CPython 3.12 with `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*`/`COLUMNS`/`LINES`
removed (asserted, not assumed, before each run):

<!--COUNTS-->

Deletion sweep over the diff: <!--SWEEP-->

Both legs ran on a machine **with signing configured** (`commit.gpgsign = true`,
`gpg.format = ssh`, `gpg.ssh.program = op-ssh-sign`) — the environment #641 only reproduces
in, and the one CI can never provide.

Closes #638
Closes #641
