### PR TITLE
The artifact round-trip the sweep depends on is bumped in both workflows, not one (#480, #478)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,7 @@ jobs:
         run: pipx run build
       - name: Validate metadata renders on PyPI
         run: pipx run twine check dist/*
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
@@ -185,7 +185,7 @@ jobs:
       # from the same run with the runtime token, needing no `GITHUB_TOKEN` scope at all.
       id-token: write        # REQUIRED: mints the OIDC token PyPI verifies
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -152,7 +152,7 @@ jobs:
             --json "sweep-results-$SHARD.json" "$@"
       - name: Keep the result set, whatever the sweep said
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deletion-sweep-${{ matrix.shard }}
           path: sweep-results-${{ matrix.shard }}.json
@@ -182,7 +182,7 @@ jobs:
       # be able to reach the next line with. Every shard being cancelled is exactly the
       # #626 failure, and it must produce `no verdict` rather than a second red job with
       # a download error in it.
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           path: shards


### PR DESCRIPTION
Supersedes #480 and #478.

Dependabot opened those two for `upload-artifact` v4.6.2 → v7.0.1 and `download-artifact` v4.3.0 → v8.0.1, and **both touch `release.yml` alone**. They predate `sweep.yml`, which uses the same pair for the thing the gate's verdict is made of — each shard uploads `deletion-sweep-<n>`, and `collect` downloads them back with `pattern:` + `merge-multiple: true`. Merging either as filed leaves the gate on v4 and the release on v7/v8.

## Neither PR could have tested what it changed

`sweep.yml` and `release.yml` are the only two files using these actions. On a workflows-only PR the sweep gate does not report at all, so #480 and #478 each went green on `test (3.11–3.14)` plus a skipped install check — nothing that touches an artifact. `release.yml`'s round-trip runs only during an actual release.

## So the inputs were read at the pinned shas

| pass | where | v7/v8 |
|---|---|---|
| `name` | sweep upload, release upload | present |
| `path` | both | present |
| `if-no-files-found` | sweep upload | present |
| `pattern` | sweep collect | present |
| `merge-multiple` | sweep collect | present |

**`merge-multiple` is the one that mattered.** `collect` reads a flat `shards/` directory. Had v8 dropped it, the download would have *succeeded* into a nested layout, `--verdict shards` would have found nothing, and every pull request would have read `no verdict` while every job stayed green — the #626 failure arriving by upgrade instead of by cancellation.

Both actions are `node24` at these versions. Tag→sha verified against `actions/*` directly; `tests/test_workflows.py` (45 tests) green.

## What is proven and what is not

The gate now tests itself: **the next PR touching Python** runs shards through v7/v8 and either produces a count or says `no verdict`. Four such PRs are in flight (#639, #644, #645, and #648's).

`release.yml` is **not** directly exercised — same action pair, used the same way, but the release itself remains its first real run. Worth a glance at the artifact steps when we cut it.