### PR TITLE
The input test stops reading its own client's arrival as a resize (#648)

### DIFF
--- a/docs/news/unreleased-the-input-test-stops-reading-the-clients-arrival-as-a-resize.md
+++ b/docs/news/unreleased-the-input-test-stops-reading-the-clients-arrival-as-a-resize.md
@@ -1,0 +1,102 @@
+---
+version: unreleased
+headline: The frame's input test stops reading its own client's arrival as a resize
+---
+
+`tests/test_frame_input_reaches_a_component.py` arrived with #636 and flaked from the day
+it landed. Because it was a **new** module, every branch in flight had to prove the red
+was not its own: three agents on three different branches each reproduced it on a clean
+`origin/main`, each checked that it passed in isolation, each compared two runs at the
+same sha — and each arrived independently at "not mine". A fourth pull request sat on a
+`test (3.12)` failure that was this and nothing else.
+
+That cost is the reason this was worth chasing to the bottom rather than re-running. A
+flaky new module does not just waste time; it makes **a genuine regression in that file
+indistinguishable from the known noise**, which is the same confusion #561 is about from
+the other direction.
+
+## It was not tmux, and it was not load
+
+The failure always read the same way:
+
+```
+AssertionError: 'SIZE-0' not found in 'SIZE-1\n\n\n'
+```
+
+`acme.sized` is the fixture's third panel and it counts `resize` events — `SIZE-0` means
+"nothing has resized this pane". Two cases assert it, as their way of saying *this event
+reached the pane it was about and no other*.
+
+The count was right. The fixture was wrong, and by exactly one:
+
+```
+new-session -x 100 -y 24     ->  window 100x24
+pty.fork()                   ->  pty     80x24     <- the kernel's default, not a choice
+tmux attach                  ->  window  80x24     <- tmux resizes to fit the client
+                                 every pane: SIGWINCH
+                                 acme.sized: SIZE-0 -> SIZE-1
+```
+
+The session is created at 100 columns. `pty.fork` — and `os.forkpty` under it — takes no
+window size, so the pty the client attaches on comes up at the kernel's default, measured
+here and on `ubuntu-latest` as 80x24. tmux then resizes the window to fit the client that
+just arrived, a resize reaches every pane in it, and the panel that counts resizes counted
+one. **The test was reading its own fixture's client attaching as an event.**
+
+## Why it flaked instead of simply failing
+
+`note_resize` compares the pane's rectangle to the last one the panel saw, so a panel only
+counts a resize it was *running to observe*. The fixture attaches the client immediately
+after splitting the four panels, so the outcome is a race between one tmux client
+connecting and four Python interpreters importing charter:
+
+* client connects first — the panel's first tick already measures the new size, nothing
+  changed, `SIZE-0`, green;
+* a panel finishes booting first — it measures 100, then 80, `SIZE-1`, red.
+
+On an idle machine the interpreters lose that race reliably and the suite is green. Under
+load the ordering stops being reliable, which is why it moved between cases run to run,
+why it vanished in isolation, and why the same commit passed and failed in two CI runs.
+
+Counted on a loaded box, 60 runs of the module on `main`: **2 runs failed, 3 assertions,
+every one of them `SIZE-0`/`SIZE-1`**, split across the two cases that assert it — the
+same two the reports named.
+
+## One case was passing without testing anything
+
+`test_resizing_the_window_reaches_a_component_that_asked_for_it` resizes the window and
+waits for `SIZE-1`. When the attach had already made it `SIZE-1`, that wait was satisfied
+**before `resize-window` ran** — the case passed, having asserted nothing about the resize
+it exists to test. On a quiet box the panel then reached `SIZE-2` fast enough for the same
+case to fail instead. One bug, both readings, depending on the scheduler.
+
+It now asserts `SIZE-0` first. A case that reads a running total only means something if
+it pins where the count started.
+
+## The fix is a construction, not a wait
+
+There is no new sleep. The pty is created at the size tmux says the window **already is**
+— asked rather than re-spelled, which is `_rect`'s own rule (#514) one method over — so
+the client arrives agreeing with the session and the attach is not a geometry change at
+all. Nothing has to settle, because nothing moves.
+
+Two checks stand behind it, in #609's shape rather than #598's, since the probe is what
+decides:
+
+* the window's size is compared across the attach, so a tmux that resized anyway fails in
+  `setUp` naming the reason, instead of surfacing three cases later as a stray `SIZE-1`;
+* the four first-paint rows are read a **second** time once all four have painted. The
+  polling helper returns on the first match, so on its own it only ever says "this pane
+  showed X at some instant" — never "X is what it shows". A panel that painted the row and
+  then took an event satisfied it and was still wrong for every case below. That is
+  precisely the shape #648 arrived as.
+
+Measured with the race pinned to its losing side — panels booted and painted before the
+client attaches, which is what a loaded box drifts toward — `main` fails every run and
+never once comes up clean; the same construction on this branch is clean every run. The
+fix stops the test depending on which process the scheduler picked, rather than making it
+luckier.
+
+Nothing to adopt: this is the test suite, and no production code changed. `frame/` behaves
+exactly as it did — the claims the file makes about tmux were right, and it is the fixture
+that was not establishing them.

--- a/tests/test_frame_input_reaches_a_component.py
+++ b/tests/test_frame_input_reaches_a_component.py
@@ -46,17 +46,25 @@ sends one at all* — the `[frame] mouse` question, which charter does not contr
 documentation and to `frame/events.py`'s own measurements. A case that needed a physical
 mouse could assert neither.
 
+**The client is attached on a pty born the size the session already is**, and that is
+load-bearing rather than tidiness: a client that arrives disagreeing makes tmux resize the
+window to fit it, every pane takes a SIGWINCH, and `acme.sized` — which counts resize
+events — reads the fixture's own attach as one. `_fork_pty` carries the measurement and
+#648 is what it cost before it was one.
+
 `tests/test_a_component_event_reaches_its_handler.py` is the unit half; it can say what
 the dispatcher does with a byte, and cannot say whether the byte ever arrives.
 """
 
 from __future__ import annotations
 
+import fcntl
 import os
-import pty
 import shutil
+import struct
 import subprocess
 import sys
+import termios
 import textwrap
 import time
 import unittest
@@ -99,6 +107,13 @@ _TERM_CANDIDATES = tuple(dict.fromkeys(
 #: not carry, or it stops being one.
 FOCUS_CID, DEAF_CID, SIZE_CID = "acme.focus", "acme.deaf", "acme.sized"
 POINT_CID = "acme.pointed"
+
+#: What each pane says when it has painted once and nothing has reached it — the fixture's
+#: settled state, and the baseline every "…only the pane it is about" case below is a
+#: departure from. Named once because `setUp` reads it twice, for two different reasons
+#: that are both spelled out there.
+_FIRST_PAINT = ((FOCUS_CID, "FOCUS-off"), (DEAF_CID, "DEAF-quiet"),
+                (SIZE_CID, "SIZE-0"), (POINT_CID, "POINT-quiet"))
 
 _PROVIDER = textwrap.dedent("""\
     from charter.frame import component
@@ -175,6 +190,44 @@ def _await(predicate, timeout: float = _DEADLINE) -> bool:
     return predicate()
 
 
+def _fork_pty(rows: int, cols: int) -> tuple[int, int]:
+    """`pty.fork`, except the pty is the size it should be BEFORE the child execs.
+
+    `pty.fork` — and `os.forkpty` under it — takes no window size, so the pty it hands
+    back comes up at the kernel's default. **Measured**, on this machine and on
+    `ubuntu-latest`, that default is ``80x24``, and the session below is created at
+    ``100x24``. So attaching the client made tmux resize the window 100 -> 80, and a
+    resize reaches every pane in it (`test_resizing_the_window_reaches_a_component_that
+    _asked_for_it` is the case that says so). `acme.sized` counts resize events, so the
+    ATTACH was arriving as one:
+
+        stock pty.fork   before attach window=100x24 SIZE-0 -> after 80x24 SIZE-1
+        this            before attach window=100x24 SIZE-0 -> after 100x24 SIZE-0
+
+    That is #648. It flaked rather than failing outright because the fixture attaches
+    immediately after the four splits, so the panels are normally still importing when
+    the SIGWINCH goes out and never see it — on a loaded box a panel finishes booting
+    first and does, which is why the same sha passed and failed in two CI runs, why it
+    moved between cases run to run, and why it went away in isolation.
+
+    Setting the size on the slave before the fork means tmux reads it at startup rather
+    than being corrected by a SIGWINCH afterwards. **The correction is the event, so
+    there must not be one** — a pty resized after the exec would deliver exactly the
+    signal this exists to avoid.
+    """
+    master, slave = os.openpty()
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+    pid = os.fork()
+    if pid == 0:
+        os.close(master)
+        # setsid, controlling terminal, and dup onto 0/1/2 — the three things `pty.fork`
+        # does that this must keep doing. Available since 3.11, which is `requires-python`.
+        os.login_tty(slave)
+        return 0, -1
+    os.close(slave)
+    return pid, master
+
+
 @unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
 class _AFrameWithProviderPanels(PersonaIso):
     """One frame, one attached client, four provider panels.
@@ -233,13 +286,42 @@ class _AFrameWithProviderPanels(PersonaIso):
         self.pane = {}
         for cid in (FOCUS_CID, DEAF_CID, SIZE_CID, POINT_CID):
             self.pane[cid] = self._split(cid)
-        self.fd = self._attach()
+
+        # The window's size, ASKED of tmux rather than re-spelled from the `new-session`
+        # above — `_rect`'s rule (#514) one method over, and here it is load-bearing: the
+        # client is given exactly this size, so attaching it is not a geometry change and
+        # no pane takes a SIGWINCH for it. `_fork_pty` has the measurement.
+        size = self._window_size()
+        # Refused here rather than carried into `_fork_pty`, where an unreadable size is
+        # a `struct.error` out of `struct.pack` — a traceback about packing an unsigned
+        # short, three frames from anything that would tell a reader the session had gone.
+        self.assertNotEqual(size, (-1, -1),
+                            "tmux would not say how big its own window is, so the client "
+                            "below cannot be born the size that window already is")
+        self.fd = self._attach(size)
+        # And CHECKED, rather than assumed, because everything below that reads `SIZE-N`
+        # is reading a count of resize events: a window that moved while the client
+        # arrived would add one, and the cases would report it as a stray focus or click.
+        self.assertTrue(_await(lambda: self._window_size() == size),
+                        f"attaching the client resized the window from {size} to "
+                        f"{self._window_size()}, so every panel took a SIGWINCH that the "
+                        f"cases below would read as an event that reached it")
+
         # Every panel has painted its first frame before any case touches focus, so a
         # later change can only be the event.
-        for cid, expect in ((FOCUS_CID, "FOCUS-off"), (DEAF_CID, "DEAF-quiet"),
-                            (SIZE_CID, "SIZE-0"), (POINT_CID, "POINT-quiet")):
+        for cid, expect in _FIRST_PAINT:
             self.assertTrue(_await(lambda c=cid, e=expect: e in self._shown(c)),
                             f"{cid} never painted {expect}: {self._shown(cid)!r}")
+        # Read a SECOND time, now that all four have painted. The loop above returns on
+        # the first poll that matches, so on its own it says "this pane showed X at some
+        # instant", never "X is what it shows" — a panel that painted the expected row and
+        # then took an event satisfies it and is still wrong for every case below. That is
+        # the shape #648 arrived as, and this is the cheap check that names it here, in
+        # the fixture, instead of somewhere downstream as a stray `SIZE-1`.
+        for cid, expect in _FIRST_PAINT:
+            self.assertIn(expect, self._shown(cid),
+                          f"{cid} painted {expect} and then left it before the first "
+                          f"case ran, so something reached it that the fixture did not do")
 
     # -- the frame ---------------------------------------------------------- #
 
@@ -288,10 +370,17 @@ class _AFrameWithProviderPanels(PersonaIso):
         self.assertEqual(marked.returncode, 0, marked.stderr)
         return pane
 
-    def _attach(self) -> int:
+    def _attach(self, size: tuple[int, int]) -> int:
+        """Attach a real client on a real pty, *size* being the size that pty is born.
+
+        *size* is what tmux says the window ALREADY is, passed in rather than spelled
+        again here, so the client cannot arrive disagreeing with the session and make
+        tmux resize the window to settle it. `_fork_pty` is where that matters and why.
+        """
+        cols, rows = size
         refusals = []
         for term in _TERM_CANDIDATES:
-            pid, fd = pty.fork()
+            pid, fd = _fork_pty(rows=rows, cols=cols)
             if pid == 0:
                 try:
                     os.environ["TERM"] = term
@@ -353,6 +442,20 @@ class _AFrameWithProviderPanels(PersonaIso):
 
     def _active(self) -> str:
         return _tmux("display-message", "-p", "#{pane_id}").stdout.strip()
+
+    def _window_size(self) -> tuple[int, int]:
+        """The WINDOW's columns and rows, asked of tmux for `_rect`'s reason (#514).
+
+        Returned as a pair so `setUp` can compare one reading with another; a request
+        that fails returns a pair no window has, which fails that comparison rather than
+        raising something a caller would have to unpack.
+        """
+        r = _tmux("display-message", "-p", "-t", self.fid,
+                  "#{window_width} #{window_height}")
+        said = r.stdout.split()
+        if r.returncode != 0 or len(said) != 2:
+            return (-1, -1)
+        return int(said[0]), int(said[1])
 
     def _rect(self, pane: str) -> tuple[int, int, int, int]:
         """*pane*'s place in the WINDOW: left, top, width, height — asked of tmux rather
@@ -439,8 +542,20 @@ class AFocusChangeReachesTheComponentThatOwnsThePane(_AFrameWithProviderPanels):
     def test_resizing_the_window_reaches_a_component_that_asked_for_it(self):
         """A resize does not bump the frame's version — `panel.py`'s SIGWINCH section is
         the same fact for charter's own renderers. It reaches every pane, focused or not,
-        which is why this case never selects the pane it asserts about."""
+        which is why this case never selects the pane it asserts about.
+
+        **The count before the resize is asserted, and that is not scene-setting.** This
+        case reads a running total, so "it says SIZE-1" only means "this resize reached
+        it" if it said SIZE-0 first — otherwise the row it is waiting for is one some
+        earlier resize already put there, and the case passes without the `resize-window`
+        below having done anything. Under #648 that is exactly what happened: the client
+        attach resized the window, the panel was at SIZE-1 before this case began, and
+        this assertion was satisfied by that.
+        """
         self._select(self.harness)
+        self.assertIn("SIZE-0", self._shown(SIZE_CID),
+                      "something resized this pane before the case did, so waiting for "
+                      "SIZE-1 would prove nothing about the `resize-window` below")
         r = _tmux("resize-window", "-t", self.fid, "-x", "120", "-y", "26")
         self.assertEqual(r.returncode, 0, r.stderr)
         self.assertTrue(_await(lambda: "SIZE-1" in self._shown(SIZE_CID)),


### PR DESCRIPTION
Closes #648.

`tests/test_frame_input_reaches_a_component.py` was reading **its own client attaching** as a resize event. No production code changed; nothing under `charter/` is touched.

## What it was

```
new-session -x 100 -y 24   ->  window 100x24
pty.fork()                 ->  pty     80x24    <- the kernel's default; pty.fork takes no size
tmux attach                ->  window  80x24    <- tmux resizes the window to fit the client
                               every pane: SIGWINCH
                               acme.sized: SIZE-0 -> SIZE-1
```

`acme.sized` counts `resize` events, and two cases assert `SIZE-0` as their way of saying *this event reached the pane it was about and no other*. The count was right; the fixture was wrong by exactly one.

**Why it flaked instead of failing.** `note_resize` compares the pane's rectangle to the last one the panel saw, so a panel only counts a resize it was running to observe. The fixture attaches immediately after the four splits, making it a race between one tmux client connecting and four Python interpreters importing charter. Idle, the interpreters lose reliably and the suite is green; loaded, the ordering stops being reliable. That is why it moved between cases run to run, vanished in isolation, and passed and failed at the same sha.

## The fix is a construction, not a wait

**No sleep is added.** The pty is born at the size tmux says the window *already is* — asked rather than re-spelled, `_rect`'s own rule (#514) one method over — so the client arrives agreeing with the session and the attach is not a geometry change. Nothing has to settle because nothing moves.

Two checks stand behind it, in #609's probe shape rather than #598's wait:

- the window size is compared across the attach, so a tmux that resized anyway fails in `setUp` naming the reason instead of surfacing three cases later as a stray `SIZE-1`;
- the four first-paint rows are read a **second** time once all four have painted. `_await` returns on the first match, so alone it only says "this pane showed X at some instant", never "X is what it shows".

## One case was passing without testing anything

`test_resizing_the_window_reaches_a_component_that_asked_for_it` waits for `SIZE-1`. When the attach had already produced `SIZE-1`, that wait was satisfied **before `resize-window` ran**. It now asserts `SIZE-0` first — a case reading a running total only means something if it pins where the count started.

## Evidence

**Forced ordering** — the race pinned to its losing side (panels booted and painted before the client attaches), which is what load drifts toward. This is the point of the change: it makes the test immune to scheduling rather than lucky.

| leg | runs | result |
|---|---|---|
| `main` @`bb6cab3` | 3 | **3 of 3 cases fail, every run** |
| this branch | 3 | **0 failures, every run** |

Re-verified after rebasing onto current `main` (post-#647); identical both times.

**Counted paired legs**, both worktrees run simultaneously under identical load, 100 runs each, `python3.12`:

| leg | runs | failed |
|---|---|---|
| `main` @`bb6cab3` | 100 | **29** |
| this branch @`9a22027` | 100 | **0** |

**Every one of `main`'s 34 failing assertions is the resize count**, and nothing else:

```
21  acme.sized never painted SIZE-0: 'SIZE-1'      (the fixture's own gate)
12  'SIZE-0' not found in 'SIZE-1'                 (the two "only the pane it is about" cases)
 1  a resize never reached it: 'SIZE-2'            (the resize case, the other way round)
```

The top failure is `test_a_focus_change_reaches_only_the_pane_it_is_about` (9 of 29) — the case #643's author reported. That lone `SIZE-2` is the resize case failing in the direction the vacuity works out to when the panel is quick: the attach made it `SIZE-1`, its own `resize-window` made it `SIZE-2`, and the wait for `SIZE-1` never came true.

## Full suite, two environments

| environment | tests | result |
|---|---|---|
| `python3.14`, `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset | 8073 | OK |
| `python3.12`, ambient environment | 8073 | OK |

And the module's own counted legs repeated on a second minor, `python3.14`, 30 runs each:

| leg | runs | failed |
|---|---|---|
| `main` @`bb6cab3` | 30 | 1 (`acme.sized never painted SIZE-0: 'SIZE-1'`) |
| this branch | 30 | **0** |

## Deletion sweep — the `no survivors` on this PR is vacuous, and should be read as such

The check reads **`no survivors`**, and that is **not a real zero**. From the gate's own log at this head:

```
sweeping bea9edbd6f71 (paths: charter)
  diff against 032a0610bcec: 0 file(s), 0 added line(s)
  0 mutations -> 1 shard(s) of at most 28 each
merged 0 result(s) from 1 of 1 shard(s)
gate: no survivors
```

The swept path is `charter/`; this diff adds **no lines** there. So the sweep planned 0 mutations and merged 0 results. `no survivors` here means **"there was nothing to charge"**, not "everything is pinned" — the gate does not reach a test file, and never did. Saying so explicitly because the two readings are different and only one of them is evidence.

## Hand-checked instead, since the sweep cannot reach a test file

Every mutation asserted it applied **and** that its restore landed, by **sha256** (not mtime), under `PYTHONDONTWRITEBYTECODE=1`, against a verified-green unmutated baseline, each run under the forced ordering.

| finding | verdict |
|---|---|
| `TIOCSWINSZ` line deleted | **pinned** — caught red |
| geometry check deleted | **masked-cluster** — masked by the `TIOCSWINSZ` line |
| second first-paint read deleted | **masked-cluster** — masked by the `TIOCSWINSZ` line |
| resize case's `SIZE-0` pin deleted | **masked-cluster** — masked by the `TIOCSWINSZ` line |
| unpinned | none |
| platform-deferred | none |
| unresolved | none |

**What masks what.** All three survive individually for one reason: the fix line prevents the condition they guard, so with the fix in place nothing can make them fire. That is a masked cluster, not three unpinned lines — and peeling the masker off one layer at a time shows each is an independent guard that catches #648 on its own:

| mutation | caught by |
|---|---|
| `TIOCSWINSZ` deleted | the geometry check, naming `(100, 24) -> (80, 24)` |
| \+ geometry check deleted | the second first-paint read |
| \+ second read deleted | the resize case's `SIZE-0` pin |
| \+ resize pin deleted (the pre-#648 file) | **2 of 3** — the resize case goes quiet, which is the vacuous pass above, reproduced |

That last row demonstrates the vacuity claim: with every guard gone the resize case passes while asserting nothing.

## CI

All green at head `8440eb9`, and one green run would prove nothing here, so:

- **6 `tests` workflow executions** across the two heads of this branch (4 at `9a22027` — two runs, each rerun — and 2 at `8440eb9`), every one `success`;
- each covers `3.11`/`3.12`/`3.13`/`3.14`, so **24 per-version jobs, all success**;
- `deletion sweep` success at both heads.

## Note for reviewers

An earlier run of these legs showed 3 failures on the fix side. Those were **my own contamination** — the hand-check script mutates the file in place, and I had pointed it at the same worktree a counting leg was reading. The three failures are consecutive runs inside that window, all carrying the mutation's signature. Hand-checks now run in a separate worktree and the numbers above are from clean legs.
