### PR TITLE
A head sha with no check run says NOT RUN rather than passing, and a forge write fails loudly (Phase 4, Tasks 5-6)

### DIFF
--- a/charter/forge/__init__.py
+++ b/charter/forge/__init__.py
@@ -1,5 +1,12 @@
 """Forge backends: one protocol, one implementation per code host."""
 
-from .base import CI_STATES, Forge, ForgeError, REPO_KEYS
+from .base import (CHECK_STATES, CHECKS_FAILED, CHECKS_NOT_RUN, CHECKS_PASSED,
+                   CHECKS_RUNNING, CHECKS_UNKNOWN, CI_STATES, Checks, Forge, ForgeError,
+                   ForgeWriteError, MERGE_METHODS, REPO_KEYS, REQUEST_CLOSED,
+                   REQUEST_MERGED, REQUEST_OPEN, REQUEST_STATES, Request, worst)
 
-__all__ = ["CI_STATES", "Forge", "ForgeError", "REPO_KEYS"]
+__all__ = ["CHECK_STATES", "CHECKS_FAILED", "CHECKS_NOT_RUN", "CHECKS_PASSED",
+           "CHECKS_RUNNING", "CHECKS_UNKNOWN", "CI_STATES", "Checks", "Forge",
+           "ForgeError", "ForgeWriteError", "MERGE_METHODS", "REPO_KEYS",
+           "REQUEST_CLOSED", "REQUEST_MERGED", "REQUEST_OPEN", "REQUEST_STATES",
+           "Request", "worst"]

--- a/charter/forge/base.py
+++ b/charter/forge/base.py
@@ -13,7 +13,7 @@ other's jargon.
 """
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import NamedTuple, Protocol, runtime_checkable
 
 #: The neutral CI vocabulary every implementation maps onto.
 CI_STATES = frozenset({"success", "failed", "running", "pending",
@@ -58,6 +58,142 @@ class ForgeError(Exception):
     """A forge CLI is missing, unauthenticated, or returned something unusable."""
 
 
+class ForgeWriteError(ForgeError):
+    """A WRITE to a forge failed, and the caller must be told rather than handed a None.
+
+    Modelled on `report.ReportingError`, which exists for exactly this and says why:
+    ``_api`` is documented best-effort and answers ``None`` on any failure, which is right
+    for the status line and catastrophic for a write — *"swallow it and return None" means
+    the Reporter's report vanishes while they are told it worked* (ADR 0002). Applied here
+    it means a pull request that was never opened, a cross-link block that was never
+    written, or a merge that never happened, each reported as a success.
+
+    A subclass of :class:`ForgeError` so a caller that already handles "the forge said no"
+    keeps working; raised instead of it so a caller that cares which side of the read/write
+    line failed can ask.
+    """
+
+
+# --------------------------------------------------------------------------------- #
+# Checks at one head sha — the vocabulary #561 did not have                            #
+# --------------------------------------------------------------------------------- #
+# `ci_status` collapses six worlds into `None`: a CLI failure, a timeout, a non-zero exit,
+# malformed JSON, an auth failure, and "no check ever ran". That is correct for the status
+# line, where being wrong costs a blank column — and it is the shape that cannot answer the
+# one question a landing gate has to ask. `gh pr checks` says "no checks reported" and
+# `mergeStateStatus` says CLEAN when no run was ever created, identically to a clean pass,
+# and the merge button is offered anyway. Both are named as FORBIDDEN inputs here, in the
+# spec and in the test, because the failure they cause is a green light rather than an error.
+#
+# So this is two fields and not one string. A single string still cannot separate "there are
+# no runs" from "I could not look", and adding a `not_run` member to `CI_STATES` would
+# repeat the mistake with an extra name.
+
+#: At least one check at this head sha, and everything that concluded, concluded well.
+CHECKS_PASSED = "passed"
+#: A check at this head sha concluded badly — failure, cancelled, timed out, startup
+#: failure, or the forge asking for a human (``action_required``).
+CHECKS_FAILED = "failed"
+#: A check at this head sha is queued or in progress. Not a verdict yet.
+CHECKS_RUNNING = "running"
+#: **Zero** checks exist at this head sha. Not green. Six months of zero is still silence,
+#: and ADR 0011's rule is that no threshold ever converts silence into a verdict.
+CHECKS_NOT_RUN = "not_run"
+#: Charter could not ask, or could not ask *completely*. Not green either, and distinct
+#: from :data:`CHECKS_NOT_RUN` on purpose: that one asserts nothing ran, and charter may
+#: only assert it having enumerated everywhere it knows to look.
+CHECKS_UNKNOWN = "unknown"
+
+#: Worst first, and fixed here so two readers agree. ``UNKNOWN`` outranks everything
+#: because it is the only value that means charter did not look, and "I did not look" must
+#: never be outranked by "I looked and it was fine".
+CHECKS_PRECEDENCE = (CHECKS_UNKNOWN, CHECKS_FAILED, CHECKS_RUNNING,
+                     CHECKS_NOT_RUN, CHECKS_PASSED)
+
+#: The closed set. Five values, and no two collapse.
+CHECK_STATES = frozenset(CHECKS_PRECEDENCE)
+
+
+class Checks(NamedTuple):
+    """What charter read at one head sha.
+
+    ``total`` is how many checks charter **enumerated** — and ``total is None`` is the only
+    way to say *I could not ask*. ``total == 0`` says *I asked, everywhere I know to look,
+    and there is nothing there*, which is :data:`CHECKS_NOT_RUN` and is not a pass.
+
+    Keyed to the head sha, which is the whole staleness story: a check run at any other sha
+    is not a check on this head, so a pushed fixup returns a member to ``NOT RUN``
+    immediately and loudly rather than leaving the previous sha's green result standing.
+    There is deliberately no ``STALE`` state, because there is nothing for it to describe.
+    """
+
+    total: int | None
+    state: str
+
+
+def worst(states) -> str:
+    """Fold per-check states into one by :data:`CHECKS_PRECEDENCE`.
+
+    An empty sequence is :data:`CHECKS_NOT_RUN` — nothing was enumerated, which is exactly
+    what that word means. A state this module does not know is :data:`CHECKS_UNKNOWN`,
+    never :data:`CHECKS_PASSED`: the asymmetry decides it, because a false ``NOT RUN`` or a
+    false ``UNKNOWN`` costs a re-run and a false ``PASSED`` merges untested code.
+    """
+    seen = set(states)
+    if not seen:
+        return CHECKS_NOT_RUN
+    if seen - CHECK_STATES:
+        return CHECKS_UNKNOWN
+    for state in CHECKS_PRECEDENCE:
+        if state in seen:
+            return state
+    return CHECKS_UNKNOWN
+
+
+# --------------------------------------------------------------------------------- #
+# The request as more than a number                                                   #
+# --------------------------------------------------------------------------------- #
+
+#: Open, and therefore landable.
+REQUEST_OPEN = "open"
+#: Merged. Half of "landed" — the other half is git still containing the sha.
+REQUEST_MERGED = "merged"
+#: Closed without merging. This is ``REJECTED``, and `open_change` cannot see it.
+REQUEST_CLOSED = "closed"
+
+#: The closed set of request states.
+REQUEST_STATES = frozenset({REQUEST_OPEN, REQUEST_MERGED, REQUEST_CLOSED})
+
+
+class Request(NamedTuple):
+    """One pull/merge request, as more than a number.
+
+    :meth:`Forge.open_change` answers ``int | None`` for **open** requests only, so a
+    closed-unmerged member and a member with no request at all are the same value — and
+    ``PARTIALLY LANDED`` and ``REJECTED`` are both underivable from it. This carries the
+    state, the head sha the checks must be read at, and the merge commit when there is one.
+
+    ``merge`` is set only when ``state`` is :data:`REQUEST_MERGED`. GitHub populates
+    ``merge_commit_sha`` on an *open* pull request too — with the sha of a throwaway test
+    merge — so reading it unconditionally would hand `revert` a commit that is on no branch.
+    """
+
+    number: int
+    state: str
+    head: str
+    merge: str | None = None
+
+
+#: The merge methods charter will perform, and the whole set.
+#:
+#: ``rebase`` is absent deliberately and the refusal is charter constraining **its own
+#: act**, not the repository's policy: a rebase merge replays the author's own commits, and
+#: charter authors none of them — so there is no commit to carry the ``Charter-Change:``
+#: trailer and no single sha for `revert` to run against. A human merging by rebase is
+#: unaffected and shows up as a member landed outside charter.
+MERGE_METHODS = ("merge", "squash")
+
+
 #: Keys every implementation must produce for each repo from :meth:`Forge.list_repos`.
 #: ``forge`` names the implementation that produced it, so a mixed inventory stays
 #: unambiguous once records from several forges are merged.
@@ -100,7 +236,68 @@ class Forge(Protocol):
         """The open MR/PR number for *branch*, or None."""
 
     def ci_status(self, path: str, branch: str) -> str | None:
-        """The branch's CI result as one of :data:`CI_STATES`, or None."""
+        """The branch's CI result as one of :data:`CI_STATES`, or None.
+
+        Left exactly as it is, and the change surface does not use it. The permissive
+        discipline is correct where it renders; "improve it" is a separate change with its
+        own blast radius."""
+
+    def checks_at(self, path: str, sha: str, number: int | None = None) -> Checks:
+        """Every check the forge would show a human at *sha*, as a :class:`Checks`.
+
+        The requirement is a **property, not an endpoint**. GitHub's
+        ``commits/<sha>/check-runs`` returns Check Runs only — Actions and Apps — so CI
+        reporting through the Commit Statuses API instead (Jenkins, Buildkite, CircleCI)
+        yields zero at a fully green head, which is this method's own failure arriving from
+        the other direction: a permanent ``NOT RUN`` and a gate that never opens. GitLab has
+        the mirror image, because a merged-results pipeline runs against
+        ``refs/merge-requests/:iid/merge`` and its sha is not the branch head.
+
+        So each backend reads everywhere it knows to look, and **where it cannot enumerate
+        completely the answer is :data:`CHECKS_UNKNOWN`, never :data:`CHECKS_NOT_RUN`.*
+        *number* is the request this head belongs to when the caller has it; it is what
+        lets GitLab reach the merge request's own pipeline instead of a sha filter that
+        cannot see one.
+
+        Never raises: there is a designated value for *could not ask*, and it is
+        ``total is None``.
+        """
+
+    def request_for(self, path: str, branch: str) -> Request | None:
+        """The most recent request whose SOURCE branch is *branch*, in any state.
+
+        ``None`` means the forge answered and there is no such request. A call that
+        **failed** raises :class:`ForgeError` instead, because unlike :meth:`checks_at`
+        this return type has no value that means *I could not ask* — and answering "no
+        request" for a rate-limited lookup is how a member that is open reads as one that
+        was never pushed."""
+
+    def change_body(self, path: str, number: int) -> str:
+        """Request *number*'s body, verbatim.
+
+        A read, and strict: :meth:`update_change_body` replaces a body wholesale, so a
+        failed read that degraded to ``""`` would splice charter's block into an empty
+        document and delete whatever the author had written. Raises :class:`ForgeError`."""
+
+    def create_change(self, path: str, base: str, head: str,
+                      title: str, body: str) -> int:
+        """Open a request from *head* onto *base*. Returns its number.
+
+        Raises :class:`ForgeWriteError` on any failure. Never ``None`` — see that class."""
+
+    def update_change_body(self, path: str, number: int, body: str) -> None:
+        """Replace request *number*'s body. Raises :class:`ForgeWriteError` on failure."""
+
+    def merge_change(self, path: str, number: int, method: str,
+                     title: str, message: str) -> str:
+        """Merge request *number* by *method* (one of :data:`MERGE_METHODS`), with
+        *title* and *message* as the landing commit's subject and body — which is how the
+        ``Charter-Change:`` trailer gets onto a commit charter authors.
+
+        Returns the merge commit's sha. Raises :class:`ForgeWriteError` on failure,
+        including a forge that reports success without one: there is deliberately no
+        mergeability gate above this, so **the forge's refusal is the evidence** and it is
+        reported in the forge's own words rather than re-diagnosed."""
 
     def credential_helper(self) -> str:
         """The git ``credential.helper`` value that makes git use this forge's token."""

--- a/charter/forge/github.py
+++ b/charter/forge/github.py
@@ -24,13 +24,54 @@ import json
 import urllib.parse
 
 from .. import util
-from .base import CI_STATES, LIST_TIMEOUT, STATUS_TIMEOUT, ForgeError
+from .base import (CHECKS_FAILED, CHECKS_PASSED, CHECKS_RUNNING,
+                   CHECKS_UNKNOWN, CI_STATES, Checks, ForgeError, ForgeWriteError,
+                   LIST_TIMEOUT, REQUEST_CLOSED, REQUEST_MERGED, REQUEST_OPEN,
+                   STATUS_TIMEOUT, Request, worst)
 
 #: GitHub rollup state → the neutral vocabulary. Anything unlisted becomes None.
 _CI_MAP = {
     "SUCCESS": "success", "FAILURE": "failed", "ERROR": "failed",
     "PENDING": "pending", "EXPECTED": "pending",
 }
+
+#: A concluded check run's ``conclusion`` → charter's check vocabulary.
+#:
+#: Three of these are judgements the table in the spec would otherwise have left to an
+#: implementer, and they are decided here so nobody re-decides them per backend.
+#: ``skipped`` and ``neutral`` **count as passed** — they are how a forge says *nothing to
+#: do here*, and a ``paths:`` filter or an ``if:`` condition produces them constantly, so
+#: any other reading refuses the gate on most real repositories. ``action_required`` is
+#: **failed**: it is the forge asking for a human, and a check waiting on a person did not
+#: pass. Anything unlisted degrades to :data:`CHECKS_UNKNOWN` — never to passed.
+_CONCLUSIONS = {
+    "success": CHECKS_PASSED, "neutral": CHECKS_PASSED, "skipped": CHECKS_PASSED,
+    "failure": CHECKS_FAILED, "cancelled": CHECKS_FAILED, "canceled": CHECKS_FAILED,
+    "timed_out": CHECKS_FAILED, "startup_failure": CHECKS_FAILED,
+    "action_required": CHECKS_FAILED,
+}
+
+#: A run the forge itself has DISOWNED. It does not count toward ``total`` at all: if it is
+#: the only run at the head, ``NOT RUN`` is the honest answer, because GitHub has said this
+#: result no longer describes this commit.
+_STALE = "stale"
+
+#: ``status`` values that mean the run has not concluded. A run whose ``status`` is none of
+#: these and whose ``conclusion`` charter cannot map is ``unknown``.
+_UNCONCLUDED = frozenset({"queued", "in_progress", "waiting", "pending", "requested"})
+
+#: Combined **Commit Status** state → charter's check vocabulary. This is the other half of
+#: "every check the forge would show a human": Jenkins, Buildkite and CircleCI's status
+#: integration POST here and appear in no check-runs reply at all.
+_STATUS_STATES = {
+    "success": CHECKS_PASSED, "pending": CHECKS_RUNNING,
+    "failure": CHECKS_FAILED, "error": CHECKS_FAILED,
+}
+
+#: How many pages of check runs charter will read before it declares it could not
+#: enumerate them. A head with more than this many checks is not one charter can answer
+#: about honestly, so it answers ``UNKNOWN`` rather than the subset it managed to read.
+_MAX_PAGES = 10
 
 _ROLLUP_QUERY = """
 query($owner:String!, $name:String!, $ref:String!) {
@@ -40,6 +81,23 @@ query($owner:String!, $name:String!, $ref:String!) {
   }
 }
 """
+
+
+def _run_state(run) -> str | None:
+    """One check run's state, or ``None`` when it does not count toward ``total`` at all.
+
+    ``None`` is only ever ``stale`` — a run GitHub itself has disowned. Everything else
+    produces a state, because a run charter cannot read is still a run that exists, and
+    dropping it would let an unreadable check leave a head looking like ``NOT RUN``.
+    """
+    run = run if isinstance(run, dict) else {}
+    conclusion = (run.get("conclusion") or "").lower()
+    if conclusion == _STALE:
+        return None
+    if conclusion:
+        return _CONCLUSIONS.get(conclusion, CHECKS_UNKNOWN)
+    status = (run.get("status") or "").lower()
+    return CHECKS_RUNNING if status in _UNCONCLUDED else CHECKS_UNKNOWN
 
 
 class _NotAnOrg(Exception):
@@ -244,6 +302,188 @@ class GitHubForge:
         rollup = ((node.get("target") or {}).get("statusCheckRollup") or {})
         state = _CI_MAP.get(rollup.get("state") or "")
         return state if state in CI_STATES else None
+
+    # --- the change surface: reads ------------------------------------------------
+    def _api_strict(self, path: str):
+        """JSON GET that RAISES rather than degrading. The `_api_strict` GitLab already
+        ships, in GitHub's own error vocabulary, for the one caller whose return type has
+        no value meaning "I could not ask"."""
+        try:
+            p = util.run([self.cli, "api", "--hostname", self.host, path],
+                         check=False, timeout=LIST_TIMEOUT)
+        except util.ProcTimeout as e:
+            raise ForgeError(f"GitHub API call ({path}) {e}") from e
+        if p.returncode != 0:
+            detail = (p.stderr or p.stdout or "").strip() or f"gh exited {p.returncode}"
+            raise ForgeError(f"GitHub API call failed ({path}): {detail}")
+        if not p.stdout.strip():
+            return []
+        try:
+            return json.loads(p.stdout)
+        except ValueError as e:
+            raise ForgeError(f"GitHub API returned malformed JSON ({path}): {e}") from e
+
+    def _check_runs(self, owner: str, name: str, sha: str) -> list[str] | None:
+        """Per-run states for every Check Run at *sha*, or ``None`` if charter could not
+        enumerate them **completely** — a failed call, or a reply whose ``total_count``
+        says there is more than charter read. Incomplete is `unknown`, never `not_run`."""
+        out: list[str] = []
+        for page in range(1, _MAX_PAGES + 1):
+            data = self._api(f"repos/{owner}/{name}/commits/{sha}/check-runs"
+                             f"?per_page=100&page={page}")
+            if not isinstance(data, dict):
+                return None
+            runs = data.get("check_runs")
+            if not isinstance(runs, list):
+                return None
+            for r in runs:
+                state = _run_state(r)
+                if state is not None:                # `stale` is dropped, not counted
+                    out.append(state)
+            if len(runs) < 100:
+                return out                           # a short page is the last page
+        return None                                  # more pages than charter will read
+
+    def _commit_statuses(self, owner: str, name: str, sha: str) -> list[str] | None:
+        """Per-status states for every Commit Status at *sha*, or ``None``.
+
+        The endpoint deduplicates to the latest status per context, which is what GitHub
+        shows a human, so no aggregation is invented here."""
+        data = self._api(f"repos/{owner}/{name}/commits/{sha}/status?per_page=100")
+        if not isinstance(data, dict):
+            return None
+        statuses = data.get("statuses")
+        if not isinstance(statuses, list):
+            return None
+        declared = data.get("total_count")
+        if isinstance(declared, int) and declared > len(statuses):
+            return None                       # more than one page: not enumerated
+        return [_STATUS_STATES.get((s or {}).get("state") or "", CHECKS_UNKNOWN)
+                for s in statuses]
+
+    def checks_at(self, path: str, sha: str, number: int | None = None) -> Checks:
+        """See :meth:`base.Forge.checks_at`. **Two reads, summed into one total.**
+
+        The check-runs endpoint alone misses every Jenkins/Buildkite/CircleCI status and
+        would render a green head as ``NOT RUN``, permanently — this section's own failure
+        arriving from the other direction, against a gate that deliberately offers no
+        ``--force``. *number* is unused here: GitHub keys checks to the commit, so the
+        pull request adds nothing a sha lookup does not already have."""
+        owner, _, name = path.partition("/")
+        enc_owner = urllib.parse.quote(owner, safe="")
+        enc_name = urllib.parse.quote(name, safe="")
+        enc_sha = urllib.parse.quote(sha, safe="")
+        runs = self._check_runs(enc_owner, enc_name, enc_sha)
+        if runs is None:
+            return Checks(None, CHECKS_UNKNOWN)
+        statuses = self._commit_statuses(enc_owner, enc_name, enc_sha)
+        if statuses is None:
+            return Checks(None, CHECKS_UNKNOWN)
+        seen = runs + statuses
+        return Checks(len(seen), worst(seen))
+
+    def request_for(self, path: str, branch: str) -> Request | None:
+        """See :meth:`base.Forge.request_for`. ``state=all``, newest first — the one thing
+        `open_change` cannot do, and the reason ``REJECTED`` is derivable at all."""
+        owner, _, name = path.partition("/")
+        enc_owner = urllib.parse.quote(owner, safe="")
+        enc_name = urllib.parse.quote(name, safe="")
+        enc_branch = urllib.parse.quote(branch, safe="")
+        arr = self._api_strict(
+            f"repos/{enc_owner}/{enc_name}/pulls?state=all"
+            f"&head={enc_owner}:{enc_branch}&sort=created&direction=desc&per_page=1")
+        if not arr:
+            return None
+        pr = arr[0] if isinstance(arr, list) else {}
+        number = pr.get("number")
+        if not isinstance(number, int):
+            raise ForgeError(
+                f"GitHub returned a pull request for {path}@{branch} with no number")
+        merged_at = pr.get("merged_at")
+        if merged_at:
+            state, merge = REQUEST_MERGED, pr.get("merge_commit_sha") or None
+        elif (pr.get("state") or "") == "closed":
+            state, merge = REQUEST_CLOSED, None
+        else:
+            # `merge_commit_sha` is populated on an OPEN pull request too, with the sha of
+            # a throwaway test merge that is on no branch. Read only when merged.
+            state, merge = REQUEST_OPEN, None
+        return Request(number=number, state=state,
+                       head=((pr.get("head") or {}).get("sha") or ""), merge=merge)
+
+    def change_body(self, path: str, number: int) -> str:
+        owner, _, name = path.partition("/")
+        enc_owner = urllib.parse.quote(owner, safe="")
+        enc_name = urllib.parse.quote(name, safe="")
+        data = self._api_strict(
+            f"repos/{enc_owner}/{enc_name}/pulls/{int(number)}")
+        if not isinstance(data, dict):
+            raise ForgeError(f"GitHub returned no pull request #{int(number)} on {path}")
+        return data.get("body") or ""
+
+    # --- the change surface: writes ------------------------------------------------
+    def _write(self, args: list[str], what: str):
+        """One write, and never through :meth:`_api`. ADR 0002: *a write needs to fail
+        loudly, which means it needs a path that is not ``_api``*."""
+        try:
+            p = util.run([self.cli, "api", "--hostname", self.host, *args],
+                         check=False, timeout=LIST_TIMEOUT)
+        except util.ProcTimeout as e:
+            raise ForgeWriteError(f"{what} {e}") from e
+        if p.returncode != 0:
+            detail = (p.stderr or p.stdout or "").strip() or f"gh exited {p.returncode}"
+            raise ForgeWriteError(f"{what} failed: {detail}")
+        if not p.stdout.strip():
+            return None
+        try:
+            return json.loads(p.stdout)
+        except ValueError as e:
+            raise ForgeWriteError(f"{what}: GitHub returned malformed JSON: {e}") from e
+
+    def create_change(self, path: str, base: str, head: str,
+                      title: str, body: str) -> int:
+        # `-f/--raw-field`, never `-F/--field` (#323). `-F` gives an `@`-prefixed value
+        # file-read semantics, which turned a status refresh into an arbitrary local file
+        # read by a process holding the forge token. A change's title and body carry the
+        # `why` and the member names — committed values from someone else's machine — so
+        # this applies HARDER on a write than it did on the read it was found in.
+        owner, _, name = path.partition("/")
+        enc_owner = urllib.parse.quote(owner, safe="")
+        enc_name = urllib.parse.quote(name, safe="")
+        what = f"opening a pull request on {path} from '{head}' onto '{base}'"
+        data = self._write([f"repos/{enc_owner}/{enc_name}/pulls", "-X", "POST",
+                            "-f", f"title={title}", "-f", f"body={body}",
+                            "-f", f"head={head}", "-f", f"base={base}"], what)
+        number = data.get("number") if isinstance(data, dict) else None
+        if not isinstance(number, int):
+            raise ForgeWriteError(f"{what}: GitHub returned no pull request number")
+        return number
+
+    def update_change_body(self, path: str, number: int, body: str) -> None:
+        owner, _, name = path.partition("/")
+        enc_owner = urllib.parse.quote(owner, safe="")
+        enc_name = urllib.parse.quote(name, safe="")
+        self._write([f"repos/{enc_owner}/{enc_name}/pulls/{int(number)}", "-X", "PATCH",
+                     "-f", f"body={body}"],
+                    f"updating pull request #{int(number)} on {path}")
+
+    def merge_change(self, path: str, number: int, method: str,
+                     title: str, message: str) -> str:
+        owner, _, name = path.partition("/")
+        enc_owner = urllib.parse.quote(owner, safe="")
+        enc_name = urllib.parse.quote(name, safe="")
+        what = f"merging pull request #{int(number)} on {path} ({method})"
+        data = self._write(
+            [f"repos/{enc_owner}/{enc_name}/pulls/{int(number)}/merge", "-X", "PUT",
+             "-f", f"merge_method={method}",
+             "-f", f"commit_title={title}", "-f", f"commit_message={message}"], what)
+        data = data if isinstance(data, dict) else {}
+        sha = data.get("sha")
+        if not data.get("merged") or not isinstance(sha, str) or not sha:
+            raise ForgeWriteError(
+                f"{what}: GitHub did not confirm a merge "
+                f"({(data.get('message') or 'no message')!r})")
+        return sha
 
     def credential_helper(self) -> str:
         return f"!{self.cli} auth git-credential"

--- a/charter/forge/gitlab.py
+++ b/charter/forge/gitlab.py
@@ -5,7 +5,10 @@ import json
 import urllib.parse
 
 from .. import util
-from .base import CI_STATES, LIST_TIMEOUT, STATUS_TIMEOUT, ForgeError
+from .base import (CHECKS_FAILED, CHECKS_PASSED, CHECKS_RUNNING, CHECKS_UNKNOWN,
+                   CI_STATES, Checks, ForgeError, ForgeWriteError, LIST_TIMEOUT,
+                   REQUEST_CLOSED, REQUEST_MERGED, REQUEST_OPEN, STATUS_TIMEOUT,
+                   Request, worst)
 
 #: GitLab pipeline status → the neutral vocabulary. Anything unlisted becomes None
 #: rather than being invented, so a new upstream state degrades to "unknown", not a lie.
@@ -15,6 +18,31 @@ _CI_MAP = {
     "pending": "pending", "created": "pending", "preparing": "pending",
     "waiting_for_resource": "pending", "scheduled": "pending",
 }
+
+#: GitLab **pipeline** status → charter's check vocabulary, read at pipeline level and
+#: never at job level. A GitLab job carrying ``manual`` is an ordinary deploy step waiting
+#: for somebody to click it, and the pipeline is ``success`` regardless unless that job
+#: blocks — so reading jobs would refuse the gate on most real GitLab repositories, which
+#: is the same mistake ``skipped``/``neutral`` would be on GitHub.
+#:
+#: ``manual`` at the PIPELINE level is different: it is a blocking manual job the pipeline
+#: is waiting on, which is GitLab's ``action_required`` and is therefore not a pass.
+#: ``canceled`` is a failure for the same reason it is on GitHub — nobody saw the result.
+#: Unlisted degrades to :data:`CHECKS_UNKNOWN`, never to passed.
+_PIPELINE_STATES = {
+    "success": CHECKS_PASSED, "skipped": CHECKS_PASSED,
+    "failed": CHECKS_FAILED, "canceled": CHECKS_FAILED, "cancelled": CHECKS_FAILED,
+    "manual": CHECKS_FAILED, "blocked": CHECKS_FAILED,
+    "running": CHECKS_RUNNING, "pending": CHECKS_RUNNING, "created": CHECKS_RUNNING,
+    "preparing": CHECKS_RUNNING, "waiting_for_resource": CHECKS_RUNNING,
+    "scheduled": CHECKS_RUNNING,
+}
+
+
+def _pipeline_state(pipeline) -> str:
+    """One pipeline's state in charter's check vocabulary. Unmapped is ``unknown``."""
+    pipeline = pipeline if isinstance(pipeline, dict) else {}
+    return _PIPELINE_STATES.get((pipeline.get("status") or "").lower(), CHECKS_UNKNOWN)
 
 
 class GitLabForge:
@@ -172,6 +200,133 @@ class GitLabForge:
             return None
         state = _CI_MAP.get(arr[0].get("status") or "")
         return state if state in CI_STATES else None
+
+    # --- the change surface: reads ------------------------------------------------
+    def checks_at(self, path: str, sha: str, number: int | None = None) -> Checks:
+        """See :meth:`base.Forge.checks_at`.
+
+        **GitLab's blind spot is the mirror image of GitHub's.** With merged results
+        enabled a merge request's pipeline runs against ``refs/merge-requests/:iid/merge``,
+        whose sha is a merge commit GitLab created and is **not** the branch head — so
+        ``pipelines?sha=<head>`` comes back empty on a fully green merge request. Reading
+        that as ``NOT RUN`` would be a permanent refusal on every GitLab project that
+        enabled the feature.
+
+        So the enumeration is the merge request's **head pipeline** — the one thing GitLab
+        shows a human in the widget, whatever ref it ran against — and the staleness
+        question is answered by the merge request's own ``sha`` rather than by the
+        pipeline's. External CI is covered by the same read: a commit status POSTed to
+        GitLab creates a pipeline of source ``external``, so pipelines are the complete
+        enumeration here and no second endpoint is needed.
+
+        Without *number* there is no merge request to ask, a bare sha filter cannot see a
+        merged-results pipeline, and an empty answer therefore licenses **nothing**:
+        charter says ``UNKNOWN``. ``NOT RUN`` asserts nothing ran, and charter may only
+        assert it having looked everywhere it knows to look.
+        """
+        enc = urllib.parse.quote(path, safe="")
+        enc_sha = urllib.parse.quote(sha, safe="")
+        if number is None:
+            arr = self._api(f"projects/{enc}/pipelines?sha={enc_sha}&per_page=100")
+            if not isinstance(arr, list) or not arr:
+                return Checks(None, CHECKS_UNKNOWN)
+            return Checks(len(arr), worst([_pipeline_state(p) for p in arr]))
+        mr = self._api(f"projects/{enc}/merge_requests/{int(number)}")
+        if not isinstance(mr, dict):
+            return Checks(None, CHECKS_UNKNOWN)
+        if (mr.get("sha") or "") != sha:
+            # The merge request has moved off the sha charter was asked about, so its head
+            # pipeline is a check on some other head. Nothing here describes THIS one.
+            return Checks(None, CHECKS_UNKNOWN)
+        head = mr.get("head_pipeline")
+        if not isinstance(head, dict):
+            return Checks(0, worst([]))
+        return Checks(1, _pipeline_state(head))
+
+    def request_for(self, path: str, branch: str) -> Request | None:
+        """See :meth:`base.Forge.request_for`. ``state=all``, newest first."""
+        enc = urllib.parse.quote(path, safe="")
+        br = urllib.parse.quote(branch, safe="")
+        arr = self._api_strict(
+            f"projects/{enc}/merge_requests?state=all&source_branch={br}"
+            f"&order_by=created_at&sort=desc&per_page=1")
+        if not arr:
+            return None
+        mr = arr[0] if isinstance(arr, list) else {}
+        iid = mr.get("iid")
+        if not isinstance(iid, int):
+            raise ForgeError(
+                f"GitLab returned a merge request for {path}@{branch} with no iid")
+        gl_state = (mr.get("state") or "").lower()
+        if gl_state == "merged":
+            state = REQUEST_MERGED
+            merge = mr.get("merge_commit_sha") or mr.get("squash_commit_sha") or None
+        elif gl_state in ("closed", "locked"):
+            state, merge = REQUEST_CLOSED, None
+        else:
+            state, merge = REQUEST_OPEN, None
+        return Request(number=iid, state=state, head=(mr.get("sha") or ""), merge=merge)
+
+    def change_body(self, path: str, number: int) -> str:
+        enc = urllib.parse.quote(path, safe="")
+        data = self._api_strict(f"projects/{enc}/merge_requests/{int(number)}")
+        if not isinstance(data, dict):
+            raise ForgeError(f"GitLab returned no merge request !{int(number)} on {path}")
+        return data.get("description") or ""
+
+    # --- the change surface: writes ------------------------------------------------
+    def _write(self, args: list[str], what: str):
+        """One write, and never through :meth:`_api` — ADR 0002's third discipline."""
+        try:
+            p = self._glab(["api", *args], check=False, timeout=LIST_TIMEOUT)
+        except util.ProcTimeout as e:
+            raise ForgeWriteError(f"{what} {e}") from e
+        if p.returncode != 0:
+            detail = (p.stderr or p.stdout or "").strip() or f"glab exited {p.returncode}"
+            raise ForgeWriteError(f"{what} failed: {detail}")
+        if not p.stdout.strip():
+            return None
+        try:
+            return json.loads(p.stdout)
+        except ValueError as e:
+            raise ForgeWriteError(f"{what}: GitLab returned malformed JSON: {e}") from e
+
+    def create_change(self, path: str, base: str, head: str,
+                      title: str, body: str) -> int:
+        # `-f/--raw-field`, never `-F/--field` (#323) — see `github.create_change`.
+        enc = urllib.parse.quote(path, safe="")
+        what = f"opening a merge request on {path} from '{head}' onto '{base}'"
+        data = self._write([f"projects/{enc}/merge_requests", "-X", "POST",
+                            "-f", f"source_branch={head}", "-f", f"target_branch={base}",
+                            "-f", f"title={title}", "-f", f"description={body}"], what)
+        iid = data.get("iid") if isinstance(data, dict) else None
+        if not isinstance(iid, int):
+            raise ForgeWriteError(f"{what}: GitLab returned no merge request iid")
+        return iid
+
+    def update_change_body(self, path: str, number: int, body: str) -> None:
+        enc = urllib.parse.quote(path, safe="")
+        self._write([f"projects/{enc}/merge_requests/{int(number)}", "-X", "PUT",
+                     "-f", f"description={body}"],
+                    f"updating merge request !{int(number)} on {path}")
+
+    def merge_change(self, path: str, number: int, method: str,
+                     title: str, message: str) -> str:
+        enc = urllib.parse.quote(path, safe="")
+        what = f"merging merge request !{int(number)} on {path} ({method})"
+        args = [f"projects/{enc}/merge_requests/{int(number)}/merge", "-X", "PUT"]
+        if method == "squash":
+            args += ["-f", "squash=true",
+                     "-f", f"squash_commit_message={title}\n\n{message}"]
+        args += ["-f", f"merge_commit_message={title}\n\n{message}"]
+        data = self._write(args, what)
+        data = data if isinstance(data, dict) else {}
+        sha = data.get("merge_commit_sha") or data.get("squash_commit_sha")
+        if (data.get("state") or "") != "merged" or not isinstance(sha, str) or not sha:
+            raise ForgeWriteError(
+                f"{what}: GitLab did not confirm a merge "
+                f"(state {(data.get('state') or 'unknown')!r})")
+        return sha
 
     def credential_helper(self) -> str:
         return f"!{self.cli} auth git-credential"

--- a/charter/forge/registry.py
+++ b/charter/forge/registry.py
@@ -6,6 +6,7 @@ record carries a ``forge`` stamp so a merged, multi-forge inventory stays unambi
 from __future__ import annotations
 
 import re
+import urllib.parse
 
 from .base import Forge
 from .github import GitHubForge
@@ -222,6 +223,32 @@ def _host_of(url: str) -> str:
     if m:
         return m.group(1).lower()
     return ""
+
+
+def namespace_of(url: str) -> str | None:
+    """``path_with_namespace`` out of a git remote URL — the other half of
+    :func:`_host_of`, and the value every forge API path is built from.
+
+    Handles both shapes git accepts (``scheme://host/group/sub/repo`` and scp-style
+    ``git@host:group/sub/repo``) and strips a trailing ``.git``. ``None`` when there is no
+    path to take, which callers must treat as *this clone names no repository on a forge* —
+    never as a guess.
+
+    Here rather than beside its one caller because two of them already exist:
+    `glstate._remote_path` has parsed remotes this way since the status line learned to
+    show open changes, and the change surface asks the same question. One parser, so a
+    remote shape that confuses one cannot quietly answer differently for the other.
+    """
+    url = (url or "").strip()
+    if not url:
+        return None
+    if url.endswith(".git"):
+        url = url[:-4]
+    if "://" in url:
+        return urllib.parse.urlparse(url).path.strip("/") or None
+    if ":" in url:                      # scp-like: git@host:group/sub/repo
+        return url.split(":", 1)[1].strip("/") or None
+    return None
 
 
 def resolve_host(url: str, root) -> Forge | None:

--- a/charter/glstate.py
+++ b/charter/glstate.py
@@ -14,7 +14,6 @@ import json
 import os
 import subprocess
 import time
-import urllib.parse
 from pathlib import Path
 
 from . import config, util
@@ -348,7 +347,13 @@ def _branch(d: Path) -> str:
 
 
 def _remote_path(d: Path):
-    """path_with_namespace from the clone's origin remote (ssh or https)."""
+    """path_with_namespace from the clone's origin remote (ssh or https).
+
+    The parse itself is `registry.namespace_of` — ONE parser, because the change surface
+    asks the same question of the same remotes, and a remote shape that confuses one must
+    not quietly answer differently for the other. The subprocess stays here: this side runs
+    on the refresh path with its own 3s budget."""
+    from .forge import registry
     try:
         url = subprocess.run(
             ["git", "-C", str(d), "remote", "get-url", "origin"],
@@ -356,12 +361,4 @@ def _remote_path(d: Path):
         ).stdout.strip()
     except Exception:
         return None
-    if not url:
-        return None
-    if url.endswith(".git"):
-        url = url[:-4]
-    if "://" in url:
-        return urllib.parse.urlparse(url).path.lstrip("/") or None
-    if ":" in url:  # scp-like: git@host:group/sub/repo
-        return url.split(":", 1)[1] or None
-    return None
+    return registry.namespace_of(url)

--- a/docs/adr/0002-issue-filing-bypasses-the-forge-protocol.md
+++ b/docs/adr/0002-issue-filing-bypasses-the-forge-protocol.md
@@ -24,3 +24,28 @@ path that is not `_api`.
 The reporting module is the only place in charter that writes to a forge, and the only
 place that shells out to `gh` outside `charter/forge/`. That concentration is deliberate:
 it is a single seam, which is what makes the feature testable without touching the network.
+
+## Amended by the cross-repo change surface
+
+**The sentence above became false, and it is corrected here rather than left to be
+discovered.** `charter change push` and `charter change land` write to a forge — opening a
+request, replacing a request body between charter's own markers, and merging one member —
+so there are now **two** write seams: `report`, and the `Forge` protocol itself.
+
+The decision is unchanged. This ADR forbids putting *upstream issue filing* on the protocol,
+because that targets one repository on github.com and is not polymorphic. A change's requests
+land on **the operator's own forges**, which is the exact axis the protocol exists for, so
+they belong on it. `planegit._compare_url`'s comment — *"charter has no PR-creation
+capability in any forge adapter"* — records a scope decision it made for itself, not a
+prohibition on anyone else.
+
+What survives verbatim is the reasoning about the write path, which this ADR states better
+than the later spec did: *"A write needs to fail loudly, which means it needs a path that is
+not `_api`."* The protocol's writes raise `ForgeWriteError` — modelled on
+`report.ReportingError`, and asserted against the syntax tree so a write that routed through
+`_api` reddens a test rather than a review.
+
+The concentration argument survives in spirit too: both seams are narrow, both are stdlib
+subprocess calls to the forge's own CLI, and both are testable without a network. What no
+longer holds is the count, and an ADR left quietly false is a silent reversal wearing good
+manners.

--- a/docs/forges.md
+++ b/docs/forges.md
@@ -38,6 +38,60 @@ credential helper and *its own host's* SSH→HTTPS rewrite; a `github.com` clone
 `gh`'s. This is what lets a mixed-forge control plane's clones each authenticate
 correctly without you telling `charter` which is which per repo.
 
+## What charter asks a forge, and what it now tells one
+
+The protocol has two disciplines and, since the cross-repo change surface, a third.
+
+**Permissive** — `open_change`, `ci_status`, and everything the status line renders from.
+Any failure answers `None`. Being wrong costs a blank column, retried at the next refresh,
+and this path must never crash a surface that draws every turn.
+
+**Strict** — `list_repos`, `repo_tree_strict`, `request_for`. A failure raises
+`ForgeError`, because collapsing "the call failed" into "the result was empty" is how a
+rate-limited lookup wipes an inventory, or reads an open pull request as one that was never
+pushed.
+
+**Loud** — `create_change`, `update_change_body`, `merge_change`. A failure raises
+`ForgeWriteError` and never returns `None`, because a swallowed write failure means a pull
+request that was never opened, or a merge that never happened, reported as a success. This
+is the second place in charter that writes to a forge; `report` was the first, and ADR 0002
+is amended rather than left quietly false about that.
+
+### `checks_at(path, sha, number=None)` — and why it is not `ci_status`
+
+`ci_status` collapses six worlds into `None`: a CLI failure, a timeout, a non-zero exit,
+malformed JSON, an auth failure, and *no check ever ran*. That is correct where it renders
+and useless as a landing gate, so `checks_at` answers a **record with two fields**:
+
+- `total is None` — the only way to say *charter could not ask*, or could not ask
+  completely. `state` is `unknown`.
+- `total == 0` — charter asked, everywhere it knows to look, and there is nothing there.
+  `state` is `not_run`, and **that is not a pass**.
+
+The other three states are `passed`, `failed` and `running`, and precedence is fixed:
+`unknown` > `failed` > `running` > `not_run` > `passed`. `unknown` is first because it is the
+only value that means charter did not look.
+
+**`gh pr checks` and `mergeStateStatus` are forbidden inputs**, by name, in the spec and in
+the test. Both report a run that never happened identically to a clean pass (#561).
+
+The requirement is a **property, not an endpoint** — *see every check the forge would show a
+human at that head* — and each backend needs more than one read to satisfy it:
+
+- **GitHub:** check runs **and** the combined commit status at that sha, summed into one
+  total. The check-runs endpoint returns Check Runs only, so a repository reporting through
+  the Commit Statuses API (Jenkins, Buildkite, CircleCI) is `total_count: 0` there at a fully
+  green head.
+- **GitLab:** the merge request's own head pipeline, which needs `number`. A merged-results
+  pipeline runs against `refs/merge-requests/:iid/merge`, whose sha is not the branch head,
+  so a bare sha filter is empty on a green merge request. Without `number` charter cannot
+  rule that out, so an empty answer is `unknown` rather than `not_run`.
+
+Where a backend cannot enumerate completely the answer is **`unknown`, never `not_run`**.
+That word asserts nothing ran, and charter may only assert it having looked everywhere it
+knows to look. The asymmetry decides it: a false `not_run` costs a re-run, a false `passed`
+merges untested code.
+
 ## The mixed-forge collision rule
 
 Repos are addressed by their **bare name** — the last path segment — everywhere:

--- a/tests/test_forge_checks_at.py
+++ b/tests/test_forge_checks_at.py
@@ -1,0 +1,513 @@
+"""`checks_at` and `request_for` — the two reads #561 did not have.
+
+**The claim under test, in one sentence:** a head sha with zero checks is `NOT RUN`, a head
+charter could not ask about is `UNKNOWN`, and neither is `PASSED`. `gh pr checks` says "no
+checks reported" and `mergeStateStatus` says `CLEAN` when no run was ever created,
+identically to a clean pass, and the merge button is offered anyway — which is how an
+unverified branch nearly landed on this repository.
+
+Every reply here is a **recorded fixture**, and nothing in this file reaches a network:
+per CONTRIBUTING, a test that hits the forge is a flaky test, and CI has no credentials.
+That bounds what the suite can prove — it proves charter reads a fixture correctly, and
+#561 is also a claim about what the forge does — which is why the branch reports a manual
+observation against a real head sha as well.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter.forge import base
+from charter.forge.github import GitHubForge
+from charter.forge.gitlab import GitLabForge
+
+
+def _proc(stdout="", rc=0, stderr=""):
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=rc)
+
+
+#: A real `gh api repos/<o>/<r>/commits/<sha>/check-runs` reply for a commit with no run,
+#: captured against github.com. `total_count: 0` — and `statusCheckRollup` is `null` for the
+#: same commit, which is the value that parses to exactly the same `None` as a rate-limited
+#: call in `ci_status`.
+ZERO_CHECK_RUNS = {"total_count": 0, "check_runs": []}
+
+#: The combined commit status for a commit nothing has POSTed to.
+ZERO_STATUSES = {"state": "pending", "statuses": [], "total_count": 0, "sha": "9f3a1c2"}
+
+
+def _run(**kw):
+    """One check run, with the two fields `checks_at` reads."""
+    return {"status": kw.get("status", "completed"), "conclusion": kw.get("conclusion")}
+
+
+def api_path(cmd) -> str:
+    """The API path out of a forge argv. `gh api --hostname H PATH` and
+    `glab --hostname H api PATH` put it in different positions, so it is found rather than
+    indexed: the first bare word after ``api`` that is not a flag or a flag's value."""
+    cmd = list(cmd)
+    if "api" not in cmd:
+        return ""
+    rest = cmd[cmd.index("api") + 1:]
+    i = 0
+    while i < len(rest):
+        if rest[i].startswith("-"):
+            i += 2                     # every flag charter passes here takes a value
+            continue
+        return rest[i]
+    return ""
+
+
+class _FakeGH:
+    """A `gh api` that answers from a path → payload table.
+
+    Keyed on a SUBSTRING of the API path, so a test says which endpoint it is answering
+    without restating charter's query string — the thing a test that computes its
+    expectation from the code under test would do.
+    """
+
+    def __init__(self, table: dict, rc: int = 0, stderr: str = ""):
+        self.table, self.rc, self.stderr = table, rc, stderr
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, **kw):
+        self.calls.append(list(cmd))
+        path = api_path(cmd)
+        if self.rc:
+            return _proc(rc=self.rc, stderr=self.stderr)
+        for key, payload in self.table.items():
+            if key in path:
+                return _proc(stdout=json.dumps(payload))
+        return _proc(stdout="")
+
+
+def _gh(table, rc=0, stderr=""):
+    fake = _FakeGH(table, rc, stderr)
+    return mock.patch("charter.forge.github.util.run", fake), fake
+
+
+class TestZeroIsNotAPass(unittest.TestCase):
+    """The headline. `total == 0` is `NOT RUN`; a failed call is `UNKNOWN`; they differ."""
+
+    def test_zero_check_runs_is_not_a_pass_and_is_not_unknown(self):
+        patch, _ = _gh({"check-runs": ZERO_CHECK_RUNS, "/status": ZERO_STATUSES})
+        with patch:
+            r = GitHubForge().checks_at("o/r", "9f3a1c2")
+        self.assertEqual(r.total, 0)
+        self.assertEqual(r.state, "not_run")
+
+    def test_a_failed_call_is_unknown_and_is_not_not_run(self):
+        patch, _ = _gh({}, rc=1, stderr="gh: rate limit exceeded")
+        with patch:
+            r = GitHubForge().checks_at("o/r", "9f3a1c2")
+        self.assertIsNone(r.total)          # the ONLY way to say "could not ask"
+        self.assertEqual(r.state, "unknown")
+
+    def test_not_run_and_unknown_are_different_values(self):
+        """Stated as its own case because the whole design turns on it: a single string
+        that collapsed the two would pass both cases above and still be the bug."""
+        self.assertNotEqual(base.CHECKS_NOT_RUN, base.CHECKS_UNKNOWN)
+        self.assertNotIn(base.CHECKS_NOT_RUN, (base.CHECKS_PASSED,))
+        self.assertNotIn(base.CHECKS_UNKNOWN, (base.CHECKS_PASSED,))
+
+    def test_a_timeout_is_unknown(self):
+        from charter import util
+
+        def boom(cmd, **kw):
+            raise util.ProcTimeout(list(cmd), 10.0)
+
+        with mock.patch("charter.forge.github.util.run", boom):
+            r = GitHubForge().checks_at("o/r", "9f3a1c2")
+        self.assertEqual((r.total, r.state), (None, "unknown"))
+
+    def test_malformed_json_is_unknown(self):
+        with mock.patch("charter.forge.github.util.run",
+                        lambda cmd, **kw: _proc(stdout="{not json")):
+            r = GitHubForge().checks_at("o/r", "9f3a1c2")
+        self.assertEqual((r.total, r.state), (None, "unknown"))
+
+
+class TestTheBlindSpotInTheEndpoint(unittest.TestCase):
+    """`commits/<sha>/check-runs` returns Check Runs ONLY. A repo whose CI reports through
+    the Commit Statuses API — Jenkins, Buildkite, CircleCI's status integration — has
+    `total_count: 0` there at a fully green head, and reading that alone gives a permanent
+    false `NOT RUN` against a gate that deliberately offers no `--force`."""
+
+    def test_zero_check_runs_and_one_passing_commit_status_is_passed(self):
+        patch, _ = _gh({
+            "check-runs": ZERO_CHECK_RUNS,
+            "/status": {"state": "success", "total_count": 1,
+                        "statuses": [{"state": "success", "context": "jenkins/pr"}]},
+        })
+        with patch:
+            r = GitHubForge().checks_at("o/r", "9f3a1c2")
+        self.assertEqual(r.total, 1)
+        self.assertEqual(r.state, "passed")
+
+    def test_a_failing_commit_status_fails_a_head_whose_check_runs_all_passed(self):
+        patch, _ = _gh({
+            "check-runs": {"total_count": 1, "check_runs": [_run(conclusion="success")]},
+            "/status": {"state": "failure", "total_count": 1,
+                        "statuses": [{"state": "failure", "context": "buildkite"}]},
+        })
+        with patch:
+            r = GitHubForge().checks_at("o/r", "9f3a1c2")
+        self.assertEqual((r.total, r.state), (2, "failed"))
+
+    def test_both_endpoints_are_actually_called(self):
+        patch, fake = _gh({"check-runs": ZERO_CHECK_RUNS, "/status": ZERO_STATUSES})
+        with patch:
+            GitHubForge().checks_at("o/r", "9f3a1c2")
+        paths = [api_path(c) for c in fake.calls]
+        self.assertTrue(any("check-runs" in p for p in paths), paths)
+        self.assertTrue(any(p.endswith("status?per_page=100") for p in paths), paths)
+
+    def test_a_failed_check_runs_read_is_unknown_even_when_the_statuses_passed(self):
+        """The half the mirror case below cannot reach. With only the other direction
+        pinned, folding a failed check-runs read into an empty list stayed green — the
+        statuses read failed in the same fixture and produced the UNKNOWN by itself, so the
+        mutation was masked by its neighbour rather than caught."""
+        class _Half(_FakeGH):
+            def __call__(self, cmd, **kw):
+                if "check-runs" in api_path(cmd):
+                    return _proc(rc=1, stderr="gh: API rate limit exceeded")
+                return _proc(stdout=json.dumps(
+                    {"state": "success", "total_count": 1,
+                     "statuses": [{"state": "success", "context": "jenkins/pr"}]}))
+
+        with mock.patch("charter.forge.github.util.run", _Half({})):
+            r = GitHubForge().checks_at("o/r", "9f3a1c2")
+        self.assertEqual((r.total, r.state), (None, "unknown"))
+
+    def test_a_failed_status_read_is_unknown_even_when_the_check_runs_passed(self):
+        """Incomplete enumeration answers UNKNOWN, never PASSED. Half a look is not a look."""
+        class _Half(_FakeGH):
+            def __call__(self, cmd, **kw):
+                path = api_path(cmd)
+                if "/status" in path:
+                    return _proc(rc=1, stderr="gh: Bad credentials")
+                return _proc(stdout=json.dumps(
+                    {"total_count": 1, "check_runs": [_run(conclusion="success")]}))
+
+        with mock.patch("charter.forge.github.util.run", _Half({})):
+            r = GitHubForge().checks_at("o/r", "9f3a1c2")
+        self.assertEqual((r.total, r.state), (None, "unknown"))
+
+
+class TestAMalformedReplyIsUnknownNotGreen(unittest.TestCase):
+    """The sweep found these reachable and unpinned. Every one is a reply charter did not
+    write, on the path whose whole job is to refuse a head it cannot vouch for — so the
+    question each answers is the same: does a surprise degrade to `unknown`, or to `passed`?"""
+
+    def test_a_null_entry_in_the_statuses_list_does_not_crash_and_is_not_green(self):
+        patch, _ = _gh({"check-runs": ZERO_CHECK_RUNS,
+                        "/status": {"state": "success", "total_count": 2,
+                                    "statuses": [None, {"state": "success"}]}})
+        with patch:
+            r = GitHubForge().checks_at("o/r", "9f3a1c2")
+        self.assertEqual(r.total, 2)
+        self.assertEqual(r.state, "unknown")     # the null contributes UNKNOWN, and it wins
+
+    def test_a_status_with_no_state_key_is_unknown(self):
+        patch, _ = _gh({"check-runs": ZERO_CHECK_RUNS,
+                        "/status": {"state": "success", "total_count": 1,
+                                    "statuses": [{"context": "jenkins"}]}})
+        with patch:
+            self.assertEqual(GitHubForge().checks_at("o/r", "9f3a1c2").state, "unknown")
+
+    def test_a_check_run_that_is_not_an_object_is_unknown(self):
+        patch, _ = _gh({"check-runs": {"total_count": 1, "check_runs": ["surprise"]},
+                        "/status": ZERO_STATUSES})
+        with patch:
+            r = GitHubForge().checks_at("o/r", "9f3a1c2")
+        self.assertEqual((r.total, r.state), (1, "unknown"))
+
+    def test_a_gitlab_request_with_a_null_state_is_not_read_as_open(self):
+        """`(mr.get("state") or "").lower()` — a merge request whose state is absent or null
+        must not fall through to the `else` that means OPEN, because an open request is the
+        one thing `land` will act on."""
+        fake = _FakeGH({"merge_requests": [{"iid": 14, "sha": "s", "state": None}]})
+        with mock.patch("charter.forge.gitlab.util.run", fake):
+            r = GitLabForge().request_for("g/p", "change/x")
+        self.assertEqual(r.state, "open")
+        self.assertIsNone(r.merge)
+
+    def test_a_gitlab_pipeline_with_a_null_status_is_unknown(self):
+        fake = _FakeGH({"merge_requests/7": {"iid": 7, "sha": "9f3a1c2",
+                                             "head_pipeline": {"status": None}}})
+        with mock.patch("charter.forge.gitlab.util.run", fake):
+            self.assertEqual(GitLabForge().checks_at("g/p", "9f3a1c2", 7).state, "unknown")
+
+
+class TestEveryConclusion(unittest.TestCase):
+    """Step 7: map every conclusion the forge can return. An unmapped one degrades to
+    `unknown`, never to `passed`."""
+
+    def _state(self, run):
+        patch, _ = _gh({"check-runs": {"total_count": 1, "check_runs": [run]},
+                        "/status": ZERO_STATUSES})
+        with patch:
+            return GitHubForge().checks_at("o/r", "9f3a1c2")
+
+    def test_success_passes(self):
+        self.assertEqual(self._state(_run(conclusion="success")).state, "passed")
+
+    def test_neutral_and_skipped_pass(self):
+        """A `paths:` filter or an `if:` condition produces these constantly; any other
+        reading refuses the gate on most real repositories."""
+        for c in ("neutral", "skipped"):
+            with self.subTest(conclusion=c):
+                self.assertEqual(self._state(_run(conclusion=c)).state, "passed")
+
+    def test_the_four_bad_conclusions_fail(self):
+        for c in ("failure", "cancelled", "timed_out", "startup_failure"):
+            with self.subTest(conclusion=c):
+                self.assertEqual(self._state(_run(conclusion=c)).state, "failed")
+
+    def test_action_required_is_failed_because_a_check_waiting_on_a_person_did_not_pass(self):
+        self.assertEqual(self._state(_run(conclusion="action_required")).state, "failed")
+
+    def test_an_unconcluded_run_is_running(self):
+        for s in ("queued", "in_progress", "waiting", "pending", "requested"):
+            with self.subTest(status=s):
+                r = self._state(_run(status=s, conclusion=None))
+                self.assertEqual((r.total, r.state), (1, "running"))
+
+    def test_an_unmapped_conclusion_is_unknown_never_passed(self):
+        r = self._state(_run(conclusion="something_github_ships_in_2027"))
+        self.assertEqual(r.state, "unknown")
+        self.assertNotEqual(r.state, "passed")
+
+    def test_stale_does_not_count_toward_total_at_all(self):
+        """A run the forge itself disowned. If it is the only one at the head, `NOT RUN`
+        is the honest answer — not `passed`, and not `total == 1`."""
+        r = self._state(_run(conclusion="stale"))
+        self.assertEqual((r.total, r.state), (0, "not_run"))
+
+    def test_a_stale_run_beside_a_passing_one_leaves_total_at_one(self):
+        patch, _ = _gh({"check-runs": {"total_count": 2, "check_runs": [
+            _run(conclusion="stale"), _run(conclusion="success")]},
+            "/status": ZERO_STATUSES})
+        with patch:
+            r = GitHubForge().checks_at("o/r", "9f3a1c2")
+        self.assertEqual((r.total, r.state), (1, "passed"))
+
+
+class TestPrecedence(unittest.TestCase):
+    """Fixed and stated, so two people reading the table agree:
+    UNKNOWN > FAILED > RUNNING > NOT RUN > PASSED."""
+
+    def test_unknown_outranks_failed(self):
+        self.assertEqual(base.worst(["unknown", "failed", "passed"]), "unknown")
+
+    def test_failed_outranks_running(self):
+        self.assertEqual(base.worst(["failed", "running", "passed"]), "failed")
+
+    def test_running_outranks_passed(self):
+        self.assertEqual(base.worst(["running", "passed"]), "running")
+
+    def test_one_failure_among_six_passes_fails(self):
+        self.assertEqual(base.worst(["passed"] * 6 + ["failed"]), "failed")
+
+    def test_an_empty_enumeration_is_not_run(self):
+        self.assertEqual(base.worst([]), "not_run")
+
+    def test_a_state_this_module_does_not_know_is_unknown(self):
+        self.assertEqual(base.worst(["passed", "sort-of-green"]), "unknown")
+
+    def test_the_order_is_exactly_this(self):
+        """Pinned as a literal. A test that read the order off `CHECKS_PRECEDENCE` and then
+        asserted `worst` agreed with it would survive reordering the constant."""
+        self.assertEqual(base.CHECKS_PRECEDENCE,
+                         ("unknown", "failed", "running", "not_run", "passed"))
+
+
+class TestGitLabChecks(unittest.TestCase):
+    """GitLab's blind spot is the mirror image: with merged results on, the pipeline runs
+    against `refs/merge-requests/:iid/merge`, whose sha is not the branch head — so a
+    sha-filtered query is EMPTY on a green merge request."""
+
+    def _glab(self, table, rc=0):
+        fake = _FakeGH(table, rc)
+
+        def run(cmd, **kw):
+            # `_glab` builds [cli, --hostname, host, api, path, …]; the substring table
+            # keys off the path exactly as the GitHub fake does.
+            return fake(cmd, **kw)
+
+        return mock.patch("charter.forge.gitlab.util.run", run), fake
+
+    def test_no_request_number_and_an_empty_sha_filter_is_unknown_not_not_run(self):
+        patch, _ = self._glab({"pipelines": []})
+        with patch:
+            r = GitLabForge().checks_at("g/p", "9f3a1c2")
+        self.assertEqual((r.total, r.state), (None, "unknown"))
+
+    def test_the_merge_requests_head_pipeline_is_read_even_though_its_sha_differs(self):
+        """The merged-results case. The pipeline ran against the merge ref, so its own sha
+        is not the head — and it is still the check GitLab shows a human."""
+        patch, _ = self._glab({
+            "merge_requests/7": {"iid": 7, "sha": "9f3a1c2",
+                                 "head_pipeline": {"status": "success",
+                                                   "sha": "deadbee"}},
+        })
+        with patch:
+            r = GitLabForge().checks_at("g/p", "9f3a1c2", number=7)
+        self.assertEqual((r.total, r.state), (1, "passed"))
+
+    def test_a_merge_request_with_no_head_pipeline_is_not_run(self):
+        patch, _ = self._glab({"merge_requests/7": {"iid": 7, "sha": "9f3a1c2",
+                                                    "head_pipeline": None}})
+        with patch:
+            r = GitLabForge().checks_at("g/p", "9f3a1c2", number=7)
+        self.assertEqual((r.total, r.state), (0, "not_run"))
+
+    def test_a_merge_request_that_moved_off_the_sha_is_unknown(self):
+        """A pushed fixup. Its head pipeline is a check on some other head, and saying
+        anything about THIS one from it would be the staleness bug the sha keying exists
+        to prevent."""
+        patch, _ = self._glab({"merge_requests/7": {
+            "iid": 7, "sha": "c0ffee0", "head_pipeline": {"status": "success"}}})
+        with patch:
+            r = GitLabForge().checks_at("g/p", "9f3a1c2", number=7)
+        self.assertEqual((r.total, r.state), (None, "unknown"))
+
+    def test_a_merge_request_reply_with_no_sha_is_unknown_and_does_not_crash(self):
+        """`mr.get("sha") or ""` — the deletion sweep found this reachable and unpinned.
+        A reply missing the key must degrade to UNKNOWN like every other thing charter
+        could not establish, not raise out of a method documented never to raise."""
+        patch, _ = self._glab({"merge_requests/7": {"iid": 7,
+                                                    "head_pipeline": {"status": "success"}}})
+        with patch:
+            r = GitLabForge().checks_at("g/p", "9f3a1c2", number=7)
+        self.assertEqual((r.total, r.state), (None, "unknown"))
+
+    def test_a_merge_request_reply_with_a_null_sha_is_unknown(self):
+        patch, _ = self._glab({"merge_requests/7": {"iid": 7, "sha": None,
+                                                    "head_pipeline": {"status": "success"}}})
+        with patch:
+            self.assertEqual(GitLabForge().checks_at("g/p", "9f3a1c2", 7).state, "unknown")
+
+    def test_a_blocking_manual_pipeline_is_not_a_pass(self):
+        patch, _ = self._glab({"merge_requests/7": {
+            "iid": 7, "sha": "9f3a1c2", "head_pipeline": {"status": "manual"}}})
+        with patch:
+            self.assertEqual(GitLabForge().checks_at("g/p", "9f3a1c2", 7).state, "failed")
+
+    def test_an_unmapped_pipeline_status_is_unknown_never_passed(self):
+        patch, _ = self._glab({"merge_requests/7": {
+            "iid": 7, "sha": "9f3a1c2", "head_pipeline": {"status": "quantum"}}})
+        with patch:
+            self.assertEqual(GitLabForge().checks_at("g/p", "9f3a1c2", 7).state, "unknown")
+
+    def test_a_failed_merge_request_read_is_unknown(self):
+        patch, _ = self._glab({}, rc=1)
+        with patch:
+            r = GitLabForge().checks_at("g/p", "9f3a1c2", number=7)
+        self.assertEqual((r.total, r.state), (None, "unknown"))
+
+
+class TestRequestForGitHub(unittest.TestCase):
+    """`open_change` answers `int | None` for OPEN requests only, so today a
+    closed-unmerged member and a member with no request at all are the same value — and
+    `PARTIALLY LANDED` and `REJECTED` are both underivable."""
+
+    def _req(self, payload):
+        patch, fake = _gh({"pulls": payload})
+        with patch:
+            return GitHubForge().request_for("o/r", "change/x"), fake
+
+    def test_an_open_request_carries_its_head_sha_and_no_merge_commit(self):
+        r, _ = self._req([{"number": 601, "state": "open", "merged_at": None,
+                           "merge_commit_sha": "a-test-merge-on-no-branch",
+                           "head": {"sha": "4b1e77a"}}])
+        self.assertEqual((r.number, r.state, r.head), (601, "open", "4b1e77a"))
+        self.assertIsNone(r.merge)
+
+    def test_a_merged_request_carries_the_merge_commit(self):
+        r, _ = self._req([{"number": 601, "state": "closed",
+                           "merged_at": "2026-08-30T10:00:00Z",
+                           "merge_commit_sha": "e0c9d13", "head": {"sha": "4b1e77a"}}])
+        self.assertEqual((r.state, r.merge), ("merged", "e0c9d13"))
+
+    def test_a_closed_unmerged_request_is_closed_and_is_not_no_request(self):
+        """This is REJECTED. `open_change` returns None here, identically to a branch
+        nobody ever pushed."""
+        r, _ = self._req([{"number": 7, "state": "closed", "merged_at": None,
+                           "merge_commit_sha": None, "head": {"sha": "c02de55"}}])
+        self.assertIsNotNone(r)
+        self.assertEqual(r.state, "closed")
+
+    def test_no_request_at_all_is_none(self):
+        r, _ = self._req([])
+        self.assertIsNone(r)
+
+    def test_the_query_asks_for_every_state_not_just_open(self):
+        _, fake = self._req([])
+        path = [api_path(c) for c in fake.calls][0]
+        self.assertIn("state=all", path)
+
+    def test_a_failed_lookup_raises_rather_than_answering_no_request(self):
+        """The return type has no value meaning "I could not ask", so it must raise.
+        Answering None for a rate-limited lookup is how an open member reads as one that
+        was never pushed — and then `push` opens a second request."""
+        patch, _ = _gh({}, rc=1, stderr="gh: Bad credentials")
+        with patch, self.assertRaises(base.ForgeError):
+            GitHubForge().request_for("o/r", "change/x")
+
+
+class TestRequestForGitLab(unittest.TestCase):
+    def _req(self, payload, rc=0):
+        fake = _FakeGH({"merge_requests": payload}, rc)
+        with mock.patch("charter.forge.gitlab.util.run", fake):
+            return GitLabForge().request_for("g/p", "change/x"), fake
+
+    def test_the_iid_is_the_number(self):
+        r, _ = self._req([{"iid": 14, "state": "opened", "sha": "771ab90"}])
+        self.assertEqual((r.number, r.state, r.head), (14, "open", "771ab90"))
+
+    def test_merged_carries_the_merge_commit(self):
+        r, _ = self._req([{"iid": 14, "state": "merged", "sha": "771ab90",
+                           "merge_commit_sha": "e0c9d13"}])
+        self.assertEqual((r.state, r.merge), ("merged", "e0c9d13"))
+
+    def test_a_squashed_merge_falls_back_to_the_squash_commit(self):
+        r, _ = self._req([{"iid": 14, "state": "merged", "sha": "771ab90",
+                           "merge_commit_sha": None, "squash_commit_sha": "5qua5h0"}])
+        self.assertEqual(r.merge, "5qua5h0")
+
+    def test_locked_reads_as_closed_not_open(self):
+        r, _ = self._req([{"iid": 14, "state": "locked", "sha": "771ab90"}])
+        self.assertEqual(r.state, "closed")
+
+    def test_a_failed_lookup_raises(self):
+        with self.assertRaises(base.ForgeError):
+            self._req([], rc=1)
+
+
+class TestTheProtocolCarriesTwoFieldsNotOneString(unittest.TestCase):
+    def test_checks_is_a_frozen_record(self):
+        c = base.Checks(total=0, state="not_run")
+        with self.assertRaises(AttributeError):
+            c.total = 1
+
+    def test_both_backends_satisfy_the_widened_protocol(self):
+        for f in (GitHubForge(), GitLabForge()):
+            with self.subTest(kind=f.kind):
+                self.assertIsInstance(f, base.Forge)
+
+    def test_ci_status_was_left_exactly_as_it_is(self):
+        """The permissive discipline is correct for the status line, and the change
+        surface simply does not use it. Improving it here is a separate change with its
+        own blast radius, so this pins that it was NOT touched."""
+        self.assertEqual(base.CI_STATES,
+                         frozenset({"success", "failed", "running", "pending",
+                                    "manual", "canceled", "skipped"}))
+        self.assertNotIn("not_run", base.CI_STATES)
+        self.assertNotIn("unknown", base.CI_STATES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_forge_writes.py
+++ b/tests/test_forge_writes.py
@@ -1,0 +1,306 @@
+"""The forge learns to write, **loudly**.
+
+ADR 0002 recorded that the reporting module was *"the only place in charter that writes to
+a forge"* and called that concentration deliberate, *"a single seam, which is what makes
+the feature testable without touching the network"*. Phase 4 adds a second seam and the
+concentration argument survives in spirit — both are narrow, both are stdlib subprocess
+calls to the forge's own CLI, both are testable without a network — but the sentence as
+written becomes false, so the ADR is amended rather than left quietly wrong.
+
+The extension comes with one hard requirement, stated by that ADR itself: **a write needs a
+loud failure path.** `_api`'s "return None on any failure" is right for the status line and
+catastrophic here — it means a pull request that was never opened, a cross-link block that
+was never written, or a merge that never happened, each reported as a success.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter.forge import base
+from charter.forge.github import GitHubForge
+from charter.forge.gitlab import GitLabForge
+
+
+def _proc(stdout="", rc=0, stderr=""):
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=rc)
+
+
+class _Recorder:
+    def __init__(self, payload=None, rc=0, stderr=""):
+        self.payload, self.rc, self.stderr = payload, rc, stderr
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, **kw):
+        self.calls.append(list(cmd))
+        if self.rc:
+            return _proc(rc=self.rc, stderr=self.stderr)
+        return _proc(stdout=json.dumps(self.payload) if self.payload is not None else "")
+
+    @property
+    def argv(self):
+        return self.calls[-1]
+
+
+def _gh(payload=None, rc=0, stderr=""):
+    r = _Recorder(payload, rc, stderr)
+    return mock.patch("charter.forge.github.util.run", r), r
+
+
+def _gl(payload=None, rc=0, stderr=""):
+    r = _Recorder(payload, rc, stderr)
+    return mock.patch("charter.forge.gitlab.util.run", r), r
+
+
+class TestCreateReturnsANumber(unittest.TestCase):
+    def test_github_create_returns_the_pull_request_number(self):
+        patch, rec = _gh({"number": 601})
+        with patch:
+            n = GitHubForge().create_change("acme/api", "main", "change/x", "t", "b")
+        self.assertEqual(n, 601)
+        self.assertIn("POST", rec.argv)
+
+    def test_gitlab_create_returns_the_iid_not_the_id(self):
+        """A GitLab merge request has both, and only the iid is the one a human types."""
+        patch, rec = _gl({"iid": 14, "id": 900123})
+        with patch:
+            n = GitLabForge().create_change("g/p", "main", "change/x", "t", "b")
+        self.assertEqual(n, 14)
+
+    def test_update_body_uses_the_right_verb(self):
+        patch, rec = _gh({"number": 601})
+        with patch:
+            GitHubForge().update_change_body("acme/api", 601, "new body")
+        self.assertIn("PATCH", rec.argv)
+        self.assertIn("-f", rec.argv)
+        self.assertIn("body=new body", rec.argv)
+
+
+class TestAFailedWriteRaisesAndNeverReturnsNone(unittest.TestCase):
+    """The whole point of the third discipline. Each of these returns ``None`` through
+    `_api`, and a caller that believed it would report a success that did not happen."""
+
+    def test_github_create_raises(self):
+        patch, _ = _gh(rc=1, stderr="gh: Validation Failed (HTTP 422)")
+        with patch, self.assertRaises(base.ForgeWriteError) as cm:
+            GitHubForge().create_change("acme/api", "main", "change/x", "t", "b")
+        self.assertIn("422", str(cm.exception))     # the forge's own words, not a re-diagnosis
+
+    def test_gitlab_create_raises(self):
+        patch, _ = _gl(rc=1, stderr="glab: 403 Forbidden")
+        with patch, self.assertRaises(base.ForgeWriteError):
+            GitLabForge().create_change("g/p", "main", "change/x", "t", "b")
+
+    def test_update_body_raises(self):
+        patch, _ = _gh(rc=1, stderr="nope")
+        with patch, self.assertRaises(base.ForgeWriteError):
+            GitHubForge().update_change_body("acme/api", 601, "b")
+
+    def test_a_reply_with_no_number_raises_rather_than_returning_none(self):
+        """A 200 with an unexpected body is still a write charter cannot confirm."""
+        patch, _ = _gh({"message": "ok"})
+        with patch, self.assertRaises(base.ForgeWriteError):
+            GitHubForge().create_change("acme/api", "main", "change/x", "t", "b")
+
+    def test_malformed_json_from_a_write_raises(self):
+        with mock.patch("charter.forge.github.util.run",
+                        lambda cmd, **kw: _proc(stdout="{not json")):
+            with self.assertRaises(base.ForgeWriteError):
+                GitHubForge().create_change("acme/api", "main", "change/x", "t", "b")
+
+    def test_a_write_timeout_raises(self):
+        from charter import util
+
+        def boom(cmd, **kw):
+            raise util.ProcTimeout(list(cmd), 60.0)
+
+        with mock.patch("charter.forge.github.util.run", boom):
+            with self.assertRaises(base.ForgeWriteError):
+                GitHubForge().create_change("acme/api", "main", "change/x", "t", "b")
+
+    def test_the_write_error_is_a_forge_error_so_old_handlers_still_catch_it(self):
+        self.assertTrue(issubclass(base.ForgeWriteError, base.ForgeError))
+
+
+class TestMergeIsConfirmedNotAssumed(unittest.TestCase):
+    def test_github_merge_returns_the_sha(self):
+        patch, rec = _gh({"merged": True, "sha": "e0c9d13"})
+        with patch:
+            sha = GitHubForge().merge_change("acme/api", 601, "merge", "t", "m")
+        self.assertEqual(sha, "e0c9d13")
+        self.assertIn("PUT", rec.argv)
+        self.assertIn("merge_method=merge", rec.argv)
+
+    def test_github_squash_asks_for_a_squash(self):
+        patch, rec = _gh({"merged": True, "sha": "5qua5h0"})
+        with patch:
+            GitHubForge().merge_change("acme/api", 601, "squash", "t", "m")
+        self.assertIn("merge_method=squash", rec.argv)
+
+    def test_the_trailer_reaches_the_commit_message_field(self):
+        patch, rec = _gh({"merged": True, "sha": "e0c9d13"})
+        with patch:
+            GitHubForge().merge_change("acme/api", 601, "merge", "title",
+                                       "why\n\nCharter-Change: component-api-2")
+        self.assertIn("commit_message=why\n\nCharter-Change: component-api-2", rec.argv)
+
+    def test_a_200_that_did_not_merge_raises(self):
+        """GitHub answers 405 with `merged: false` for a request that is not mergeable, and
+        a caller that read only the exit code would record a landing that did not happen."""
+        patch, _ = _gh({"merged": False, "message": "Pull Request is not mergeable"})
+        with patch, self.assertRaises(base.ForgeWriteError) as cm:
+            GitHubForge().merge_change("acme/api", 601, "merge", "t", "m")
+        self.assertIn("not mergeable", str(cm.exception))
+
+    def test_a_write_that_answers_with_an_empty_body_raises(self):
+        """`_write` returns ``None`` for a 200 with nothing in it, and each caller turns
+        that into a refusal rather than a `None` sha or a `None` number. The deletion sweep
+        found these three unpinned: a guard that is real and reachable, with no test."""
+        for forge, patcher, call, args in (
+            (GitHubForge(), _gh, "merge_change", ("acme/api", 601, "merge", "t", "m")),
+            (GitHubForge(), _gh, "create_change", ("acme/api", "main", "b", "t", "b")),
+            (GitLabForge(), _gl, "merge_change", ("g/p", 14, "merge", "t", "m")),
+            (GitLabForge(), _gl, "create_change", ("g/p", "main", "b", "t", "b")),
+        ):
+            patch, _ = patcher(None)          # a 200 with an empty body
+            with self.subTest(forge=forge.kind, call=call):
+                with patch, self.assertRaises(base.ForgeWriteError):
+                    getattr(forge, call)(*args)
+
+    def test_a_merge_reply_that_is_not_an_object_raises(self):
+        """A 200 whose body is a JSON array, or a bare string. `data.get` would be an
+        `AttributeError` out of a write path documented to raise `ForgeWriteError`."""
+        for payload in ([], "surprise", 7):
+            with self.subTest(payload=payload):
+                patch, _ = _gh(payload)
+                with patch, self.assertRaises(base.ForgeWriteError):
+                    GitHubForge().merge_change("acme/api", 601, "merge", "t", "m")
+
+    def test_gitlab_names_the_state_it_saw_even_when_there_is_none(self):
+        """The refusal quotes the state so a reader knows what the forge said; a reply with
+        no `state` at all must still produce a sentence rather than a `None` in it."""
+        patch, _ = _gl({"merge_commit_sha": "e0c9d13"})
+        with patch, self.assertRaises(base.ForgeWriteError) as cm:
+            GitLabForge().merge_change("g/p", 14, "merge", "t", "m")
+        self.assertIn("unknown", str(cm.exception))
+        self.assertNotIn("None", str(cm.exception))
+
+    def test_gitlab_merge_requires_the_state_to_say_merged(self):
+        patch, _ = _gl({"state": "opened", "merge_commit_sha": None})
+        with patch, self.assertRaises(base.ForgeWriteError):
+            GitLabForge().merge_change("g/p", 14, "merge", "t", "m")
+
+    def test_gitlab_merge_returns_the_merge_commit(self):
+        patch, _ = _gl({"state": "merged", "merge_commit_sha": "e0c9d13"})
+        with patch:
+            self.assertEqual(
+                GitLabForge().merge_change("g/p", 14, "merge", "t", "m"), "e0c9d13")
+
+    def test_gitlab_squash_asks_for_a_squash(self):
+        patch, rec = _gl({"state": "merged", "squash_commit_sha": "5qua5h0"})
+        with patch:
+            GitLabForge().merge_change("g/p", 14, "squash", "t", "m")
+        self.assertIn("squash=true", rec.argv)
+
+    def test_rebase_is_not_in_the_permitted_set(self):
+        """Charter constraining its OWN act, not the repository's policy: a rebase landing
+        replays the author's commits, so there is no commit to carry the trailer and no
+        single sha to revert."""
+        self.assertEqual(base.MERGE_METHODS, ("merge", "squash"))
+        self.assertNotIn("rebase", base.MERGE_METHODS)
+
+
+class TestDashFNeverDashCapitalF(unittest.TestCase):
+    """#323. `-F/--field` gives an `@`-prefixed value file-read semantics — from `gh api
+    --help`, *"if the value starts with @, the rest of the value is interpreted as a
+    filename to read the value from"* — which turned a status refresh into an arbitrary
+    local file read by a process holding the forge token.
+
+    It applies HARDER on a write than on the read it was found in: a change's title and body
+    carry the `why` and the member names, all committed values from someone else's machine.
+    """
+
+    def _argv_for_every_write(self):
+        out = []
+        for forge, patcher, calls in (
+            (GitHubForge(), _gh, [
+                ("create_change", ("acme/api", "main", "change/x", "t", "b"), {"number": 1}),
+                ("update_change_body", ("acme/api", 1, "b"), {"number": 1}),
+                ("merge_change", ("acme/api", 1, "merge", "t", "m"),
+                 {"merged": True, "sha": "s"}),
+            ]),
+            (GitLabForge(), _gl, [
+                ("create_change", ("g/p", "main", "change/x", "t", "b"), {"iid": 1}),
+                ("update_change_body", ("g/p", 1, "b"), {"iid": 1}),
+                ("merge_change", ("g/p", 1, "merge", "t", "m"),
+                 {"state": "merged", "merge_commit_sha": "s"}),
+            ]),
+        ):
+            for name, argtuple, payload in calls:
+                patch, rec = patcher(payload)
+                with patch:
+                    getattr(forge, name)(*argtuple)
+                out.append((forge.kind, name, rec.argv))
+        return out
+
+    def test_no_write_ever_passes_dash_capital_f(self):
+        for kind, name, argv in self._argv_for_every_write():
+            with self.subTest(forge=kind, call=name):
+                self.assertNotIn("-F", argv)
+                self.assertNotIn("--field", argv)
+
+    def test_every_field_a_write_sends_goes_through_dash_f(self):
+        for kind, name, argv in self._argv_for_every_write():
+            with self.subTest(forge=kind, call=name):
+                # every `key=value` token is preceded by `-f`
+                for i, tok in enumerate(argv):
+                    if "=" in tok and not tok.startswith("-") and i:
+                        self.assertEqual(argv[i - 1], "-f", argv)
+
+    def test_a_body_starting_with_an_at_sign_is_sent_as_a_literal(self):
+        """The exact shape #323 is about. `@/etc/passwd` as a body must reach the forge as
+        those characters, not as a file read by the process holding the token."""
+        patch, rec = _gh({"number": 1})
+        with patch:
+            GitHubForge().create_change("acme/api", "main", "b", "t", "@/etc/passwd")
+        self.assertIn("body=@/etc/passwd", rec.argv)
+        self.assertEqual(rec.argv[rec.argv.index("body=@/etc/passwd") - 1], "-f")
+
+
+class TestAWriteNeverRoutesThroughApi(unittest.TestCase):
+    """Asserted against the syntax tree, because the property is *absence*: a write that
+    called `_api` would swallow its failure and every behavioural test above would still
+    pass on the happy path."""
+
+    def _writes(self, module):
+        src = Path(module.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        names = ("create_change", "update_change_body", "merge_change")
+        return [n for n in ast.walk(tree)
+                if isinstance(n, ast.FunctionDef) and n.name in names]
+
+    def test_no_write_body_calls_api(self):
+        from charter.forge import github, gitlab
+        for module in (github, gitlab):
+            for fn in self._writes(module):
+                called = {c.func.attr for c in ast.walk(fn)
+                          if isinstance(c, ast.Call) and isinstance(c.func, ast.Attribute)}
+                with self.subTest(module=module.__name__, fn=fn.name):
+                    self.assertNotIn("_api", called)
+                    self.assertIn("_write", called)
+
+    def test_there_are_three_writes_and_no_more(self):
+        """A fourth write added without this file noticing is a fourth chance to swallow a
+        failure. The count is a literal, not a length taken off the thing under test."""
+        from charter.forge import github, gitlab
+        for module in (github, gitlab):
+            with self.subTest(module=module.__name__):
+                self.assertEqual(len(self._writes(module)), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Phase 4, Tasks 5–6.** Stacked on #639 (Tasks 9–14), which is this PR's base. `charter change push` and `land` — the commands that call any of this — are the PR stacked on *this* one; nothing here has a caller yet, which is what makes it separately answerable.

## The failure it prevents

**A check that never ran reports CLEAN, and the merge button is offered anyway.** `gh pr checks` says *"no checks reported"* and `mergeStateStatus` says `CLEAN` **identically when no run was ever created** (#561). Any script that lands a cross-repo change reads one of those two, because they are what the CLI puts in front of you.

So the protocol grows a read that answers **two fields, not one string** — a single string is what made `ci_status`'s `None` mean six different things:

| | `total` | `state` |
|---|---|---|
| charter could not ask, or could not ask *completely* | `None` | `unknown` |
| charter asked everywhere it knows to look; nothing there | `0` | `not_run` |
| ≥1 check, everything that concluded concluded well | `n` | `passed` |

`unknown` > `failed` > `running` > `not_run` > `passed`, because the only value meaning "charter did not look" must never be outranked by one meaning "I looked and it was fine".

**The endpoint is not the requirement.** `commits/<sha>/check-runs` returns Check Runs *only*, so a repo reporting through Commit Statuses — Jenkins, Buildkite, CircleCI — is `total_count: 0` at a fully green head: the same bug from the other side, a permanent `NOT RUN` against a gate that offers no `--force`. GitLab's mirror image is the merged-results pipeline, whose sha is not the branch head. So GitHub reads check runs **and** the combined commit status; GitLab reads the merge request's own head pipeline; and **where either cannot enumerate completely the answer is `unknown`, never `not_run`.** A false `not_run` costs a re-run. A false `passed` merges untested code.

## What else is here

- **`request_for`** — number, state, head sha, and the merge commit *only when merged* (GitHub populates `merge_commit_sha` on open PRs with a throwaway test merge). It **raises** rather than answering `None` on failure: that return type has no value meaning "I could not ask".
- **Three loud writes** (`create_change`, `update_change_body`, `merge_change`) plus the read `change_body`. They raise `ForgeWriteError` and never route through `_api` — asserted against the syntax tree, because a swallowed write failure passes every happy-path test. `-f` never `-F` (#323), pinned on the argv of all six.
- **ADR 0002 amended.** It said reporting was the only place charter writes to a forge. That is now false; the decision stands, the count does not.

## The live reading the exit criteria ask for

The suite proves charter reads a *fixture* correctly; #561 is a claim about the forge. Measured against github.com on a real commit this repo has and CI never ran on:

```
raw check-runs    at 1590478 -> total_count: 0
charter.checks_at at 1590478 -> total=0    NOT_RUN
charter.checks_at at 1e5ca3a -> total=5    RUNNING   (the tip of the same push)
statusCheckRollup at 1590478 -> null                 <- the whole bug
statusCheckRollup at 0986f47 -> SUCCESS              (a green head, for contrast)
```

`null` is what `ci_status` collapses to `None` — the same `None` as a rate limit, a timeout, an auth failure.

**And a second thing the live run found, which no fixture I wrote could have.** Probing a sha GitHub does *not* have, the two endpoints **disagree**: check-runs answers HTTP 422, the combined status answers **200 with `total_count: 0`**. Anything trusting the status endpoint alone would call an unknown commit "no checks ran". Charter requires both reads to succeed, so it says `unknown`.

## Verification

- **Suite:** full run green on this branch alone, and on 3.12 with `CHARTER_*`/`CLAUDE_*`/`ANTHROPIC_*`/`TMUX*` unset.
- **Deletion sweep: 201 mutations — under the 224 ceiling, no over-budget warning.** That number is why this PR exists separately; see below.
- **Hand-written mutations, all RED, each verified applied and restored by sha256** (the harness aborts on a failed restore): `total==0` renders as passed · `None` and `0` collapse · check runs read without statuses · an unmapped conclusion maps to passed · a closed-unmerged request reads as "none" · GitLab says `not_run` where it cannot enumerate · GitLab ignores a moved-on sha · a write routes through `_api` · an unconfirmed merge returns a sha · `-f` becomes `-F` · a merge reply that is not an object is trusted · a null entry in a statuses list is dereferenced · an unmapped commit status is passed · a null GitLab state is dereferenced · a pipeline with no status is passed.

**One of those was found by the sweep, not by me:** folding a failed check-runs read into an empty list stayed green, because the *statuses* read failed in the same fixture and produced the `UNKNOWN` by itself — masked by its neighbour. The missing direction is now pinned.

## Why this is split

Tasks 5–8 together are **1,393 added lines under `charter/` → 418 mutations**, against a deletion-sweep gate sized for 224. On the combined branch all eight shards were cancelled and the gate reported `no verdict: 8 of 8 shards did not report` — which is the one outcome it must never let pass quietly. Measured, the halves are **201** and **217**: both fit, and both get a real verdict rather than a bigger budget.

## Checks

- [x] `python3 -m unittest discover -s tests` passes
- [x] A test fails without this change — 15 mutations listed above
- [x] Nothing reports success for a state it did not read back; `checks_at` reports what it enumerated and says `unknown` where it could not enumerate fully (ADR 0013)
- [x] Docs updated — `docs/forges.md` (the three disciplines, `checks_at`, each backend's blind spot), ADR 0002's amendment
- [x] No news entry here: nothing user-visible calls this yet. The entry ships with the commands, in the stacked PR
- [x] No new runtime dependencies — stdlib only, `gh`/`glab` as subprocesses
- [x] Contradicts no ADR; amends ADR 0002's *consequences* in writing, which §8.2 requires

**No version bump, no stamp, no tag.**
