### PR TITLE
The repo table scrolls, a row can be picked, and the attention bar says what you picked

### DIFF
--- a/charter.toml
+++ b/charter.toml
@@ -31,6 +31,30 @@ default = "steward"
 # more — it drew a 22-column copy of the rows `repos` now draws at full width.
 slots = ["top", "bottom", "repos", "right"]
 
+# This plane opts into the pointer. `false` is the shipped default and stays that way for
+# the reason `docs/frame.md` gives an operator: turning it on makes tmux ask the terminal
+# to report the mouse from attach, and from that moment the terminal's OWN drag-select
+# stops working inside this window — you get tmux's copy-mode selection instead. That is a
+# real cost and it is not charter's to impose on a stranger's plane.
+#
+# It is this plane's own file, and this plane's operator asked for the repo table to be
+# scrollable and clickable — which is what the flag buys. With it off, tmux asks the
+# terminal to report from the ACTIVE pane's request alone, so with the harness active
+# nothing has asked, no bytes are sent, and a click on the `repos` pane is not an event
+# charter drops but an event that never happens (`frame/events.py` measures both regimes).
+# The panel's own declaration is not enough on its own and was never meant to be.
+#
+# What it does NOT cost, since #634: the keyboard. tmux's default `MouseDown1Pane` selects
+# the pane under the pointer before forwarding, so `mouse = true` used to move the harness
+# focus onto whatever you clicked; charter rebinds that key to forward without selecting
+# for panes it marked as panels, and to leave tmux's own two commands alone for everything
+# else. Measured on 3.7c and at the 3.2 floor. So clicking a repo row selects the row and
+# leaves you typing where you were.
+#
+# The selection has a keyboard route as well and always will: `F2` → `repo: select the
+# next row`. A pointer affordance with no key is a feature most planes cannot reach.
+mouse = true
+
 # This plane opts into the pane surface. `off` is the shipped default and stays that way:
 # charter cannot detect a terminal's theme (OSC 11 through tmux answers nothing, and
 # `$COLORTERM` inside a pane describes the terminal that started the SERVER, not the one

--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -150,8 +150,18 @@ def _register_detach(reg: actions.ActionRegistry) -> None:
 NO_REPOS = ("this workspace has no clones for the repo table to select from — "
             "charter clone <repo>")
 
-#: Which way each row walks the table, in the order the palette lists them.
-_SELECT_STEPS = (("next", 1), ("previous", -1))
+#: Which way each row walks the table, in the order the palette lists them, and where a
+#: walk with no selection under it STARTS — the row before the first for `next`, the row
+#: after the last for `previous`, so that `(start + step) % len` lands on the end the
+#: direction is coming from.
+#:
+#: **Spelled per direction rather than derived from the step's sign**, and the deletion
+#: sweep is why. `-1 if step > 0 else 0` reads fine and cannot be tested: a step here is
+#: only ever `+1` or `-1`, so `step > 0` and `step >= 0` answer identically for every value
+#: that reaches them, and a comparison no test can distinguish is a line this repository
+#: deletes rather than documents. Written down, the two starts are data and the arithmetic
+#: below has no branch left in it.
+_SELECT_STEPS = (("next", 1, -1), ("previous", -1, 0))
 
 
 def _register_selection(reg: actions.ActionRegistry) -> None:
@@ -197,29 +207,30 @@ def _register_selection(reg: actions.ActionRegistry) -> None:
     the pane (`_ACTION_START_GRACE`), so a subprocess would buy nothing and cost a whole
     interpreter start.
     """
-    for word, step in _SELECT_STEPS:
+    for word, step, start in _SELECT_STEPS:
         reg.register(action.Action(
             id=f"repo.{word}", title=f"repo: select the {word} row",
             touches=("repos",),
-            run=(lambda ctx, st=step: _select(ctx, st)),
+            run=(lambda ctx, st=step, sr=start: _select(ctx, st, sr)),
             available=lambda ctx: bool(ctx.repos),
             reason_unavailable=lambda ctx: NO_REPOS))
 
 
-def _select(ctx, step: int):
+def _select(ctx, step: int, start: int):
     """Move this frame's repo selection *step* rows through the table's display order.
 
     Split out of the row above so the walk can be exercised against a list of names
     without a palette, a tmux server or a frame directory — the same reason
     `slots._fit_fields` is not inside `slots._bottom`.
 
-    The modulo is what wraps. **Where a walk with no selection under it STARTS depends on
-    the direction, and one starting point for both was the first version and was wrong**:
-    `next` has to land on the first row and `previous` on the last, and a single sentinel
-    can only be right for one of them — `-1` gives `next` its 0 and gives `previous` the
-    row second from the bottom, which is a cursor appearing in the middle of a list nobody
-    had put one in. So the sentinel is the end the direction is coming FROM, and the same
-    arithmetic then serves both.
+    The modulo is what wraps. *start* is where a walk with no selection under it begins,
+    and it is :data:`_SELECT_STEPS`' third column rather than something worked out here —
+    **one starting point for both directions was the first version and was wrong**: `next`
+    has to land on the first row and `previous` on the last, and a single sentinel can only
+    be right for one of them (`-1` gives `next` its 0 and gives `previous` the row second
+    from the bottom, a cursor appearing in the middle of a list nobody had put one in).
+    Deriving it from the step's SIGN was the second version and could not be tested; see
+    that constant for why.
 
     `ctx.repos` is never empty here: `available` refuses the row on a plane with no clones,
     and `ActionRegistry._check` builds ONE ctx and hands that same one to `run` — so the
@@ -228,7 +239,7 @@ def _select(ctx, step: int):
     """
     names = [r.get("name") for r in ctx.repos]
     chosen = state.selection(ctx.fid)
-    here = names.index(chosen) if chosen in names else (-1 if step > 0 else 0)
+    here = names.index(chosen) if chosen in names else start
     name = names[(here + step) % len(names)]
     state.record_selection(ctx.fid, name)
     # The `repos` pane redraws its highlight and the `attention` pane redraws the detail,

--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -142,6 +142,102 @@ def _register_detach(reg: actions.ActionRegistry) -> None:
             "with your own prefix key")))
 
 
+#: What a plane with nothing to select is told instead of a row that does nothing.
+#: Its own sentence rather than :data:`NO_LAYOUT`'s or :data:`NO_PANES`': those are about
+#: records charter lost, and this is about a workspace that has no clones in it yet — a
+#: state that is ordinary and fixable, so the row carries the fix the way `_empty_lines`
+#: does in the pane it is about.
+NO_REPOS = ("this workspace has no clones for the repo table to select from — "
+            "charter clone <repo>")
+
+#: Which way each row walks the table, in the order the palette lists them.
+_SELECT_STEPS = (("next", 1), ("previous", -1))
+
+
+def _register_selection(reg: actions.ActionRegistry) -> None:
+    """Two rows that move the `repos` table's selected row — **the keyboard's half.**
+
+    **`[frame] mouse` is off on most planes and charter does not own the harness**, so a
+    component whose only route to a piece of state is a click has no route to it there —
+    `component.EVENT_KINDS` states that to a provider and then asks for the one thing that
+    fixes it: *give every pointer affordance a key as well.* The `repos` table's selection
+    is charter's own first pointer affordance, so this is charter keeping its own rule. On
+    a plane with the flag off these rows are the ONLY way to move it, and on a plane with
+    it on they are still the way to move it without reaching for the mouse.
+
+    **The palette is the keyboard, and arrow keys are how it is driven.** `F2` opens it,
+    `overlay.Surface` moves its selection on `up`/`down`, and `Enter` chooses — which is
+    the vocabulary the pointer half is deliberately held to as well (a click SELECTS, only
+    a keypress chooses). Charter cannot put a bare arrow key in front of the repo table
+    itself: a `bind -n Up` is server-wide and would intercept the arrow BEFORE the harness
+    the frame exists to protect, and `frame/events.py` does not deliver `key` to a panel
+    for the matching reason — tmux routes typing to the ACTIVE pane, which is the harness's.
+
+    **They walk the table's DISPLAY order, which is the gather's**, not the ranking the
+    pane's window is cut from (`statusline._pick_rows` re-sorts its pick back into cache
+    order for exactly this reason: a row that moves as its state changes stops being a
+    place you can look). So "next" is the row under the one that is highlighted, as read.
+
+    **It wraps, and no-wrap was the alternative.** Stepping off the end and stopping makes
+    a palette row that visibly does nothing, which reads as broken and costs the operator
+    a whole `F2` to find out; wrapping makes every press move something. Nothing here is
+    irreversible, so there is no half of this a wrap could do damage with.
+
+    **Nothing is selected yet is not a failure**, and it is the common case the first time
+    this is pressed: the walk starts at the top of the table for `next` and at the bottom
+    for `previous`, which is what an operator who pressed a direction key on a list with no
+    cursor in it means. A selection naming a repo this plane no longer has is the same
+    case — it is not in the list, so the walk starts from the end the direction came from
+    rather than from a position that does not exist.
+
+    Both `state.record_selection` and `state.bump` run HERE, in the palette's own process,
+    rather than through :func:`_spawn` like the density and surface rows. Those two have to
+    outlive the pane because they re-lay-out a frame through several tmux calls; this is one
+    atomic file write and one more, and `cmd_palette` joins the invocation before it closes
+    the pane (`_ACTION_START_GRACE`), so a subprocess would buy nothing and cost a whole
+    interpreter start.
+    """
+    for word, step in _SELECT_STEPS:
+        reg.register(action.Action(
+            id=f"repo.{word}", title=f"repo: select the {word} row",
+            touches=("repos",),
+            run=(lambda ctx, st=step: _select(ctx, st)),
+            available=lambda ctx: bool(ctx.repos),
+            reason_unavailable=lambda ctx: NO_REPOS))
+
+
+def _select(ctx, step: int):
+    """Move this frame's repo selection *step* rows through the table's display order.
+
+    Split out of the row above so the walk can be exercised against a list of names
+    without a palette, a tmux server or a frame directory — the same reason
+    `slots._fit_fields` is not inside `slots._bottom`.
+
+    The modulo is what wraps. **Where a walk with no selection under it STARTS depends on
+    the direction, and one starting point for both was the first version and was wrong**:
+    `next` has to land on the first row and `previous` on the last, and a single sentinel
+    can only be right for one of them — `-1` gives `next` its 0 and gives `previous` the
+    row second from the bottom, which is a cursor appearing in the middle of a list nobody
+    had put one in. So the sentinel is the end the direction is coming FROM, and the same
+    arithmetic then serves both.
+
+    `ctx.repos` is never empty here: `available` refuses the row on a plane with no clones,
+    and `ActionRegistry._check` builds ONE ctx and hands that same one to `run` — so the
+    list this indexes is the list that was asked about, and a guard for an empty one would
+    be a line nothing could turn red.
+    """
+    names = [r.get("name") for r in ctx.repos]
+    chosen = state.selection(ctx.fid)
+    here = names.index(chosen) if chosen in names else (-1 if step > 0 else 0)
+    name = names[(here + step) % len(names)]
+    state.record_selection(ctx.fid, name)
+    # The `repos` pane redraws its highlight and the `attention` pane redraws the detail,
+    # and neither is this process — see `frame/builtins._repos_events` for the same two
+    # lines said from the pointer's side.
+    state.bump(ctx.fid)
+    return f"selected {name}"
+
+
 def _register_density(reg: actions.ActionRegistry, *, current: str) -> None:
     """One row per density level, with the level in effect marked rather than dropped.
 
@@ -247,6 +343,7 @@ def build(fid: str, *, current_density: str,
     """
     reg = actions.ActionRegistry()
     _register_detach(reg)
+    _register_selection(reg)
     _register_density(reg, current=current_density)
     _register_chrome(reg, current=current_chrome)
     for aid in reg.providers.ids():

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -55,6 +55,16 @@ not the same as what the slice names suggest.**
   `…(+N more)` line can say how many are hidden; a component built on the `todos` slice
   alone would report zero hidden todos with no way to know it was wrong.
 
+**One of them takes EVENTS, and it is the first thing anywhere that does.** #607 built the
+whole path — the decoder, the dispatcher, `DELIVERED` — and shipped it with no consumer:
+every one of these six declared `events = ()`, so a release went by in which a provider
+could declare `scroll`, pass validation, and be the only thing on the machine receiving
+anything. `repos` declares `scroll` and `click` and :func:`_repos_events` receives them,
+which makes charter's own panel the worked example rather than the exception — the same
+sequencing §4b asks for and the same reason charter's panels went through the component
+seam first. What that handler does and does not do is its own docstring; the short of it is
+that a click SELECTS and never chooses, because a pointer event can arrive unpaired.
+
 **Registration order is split order** (`registry.Registry`), so the four placed components
 are registered in the order charter splits their panes off the harness: identity,
 attention, repos, sidebar. The two parts of the sidebar are registered between them,
@@ -162,6 +172,75 @@ def _panel(slot: str):
     return render
 
 
+#: Which mouse button selects a row. One, and it is named rather than "whatever came":
+#: middle-click is paste on every terminal an operator has ever used and right-click opens
+#: their emulator's own menu, so acting on either would be charter taking a gesture that
+#: already means something else. `overlay._SGR_BUTTONS` is where the three get their names,
+#: and the ones §4f named no kind for never arrive here at all.
+_SELECT_BUTTON = "left"
+
+
+def _repos_events(fid: str):
+    """The `repos` table's handler: the wheel scrolls it, a click selects a row.
+
+    **Charter's own first consumer of the event path #607 built**, and the six built-ins
+    declared nothing until this one. What it demonstrates is meant to be the shape a
+    provider copies, so the two rules it keeps are the two that are easy to get wrong:
+
+    **A click only ever SELECTS.** Nothing here is irreversible, nothing here starts work,
+    and that is not caution — it follows from what `frame/overlay.py` measured. A `click`
+    release may arrive with no matching press (a drag begun on a pane border delivers
+    exactly one release), so a pointer event is a thing that can arrive unpaired, and §4i's
+    rule is that the irreversible half is never driven by one. Choosing is a keypress's job.
+    A component that wanted to *do* something to the selected repo would put that behind
+    `Enter` in a palette row, where it has a name and a confirmation.
+
+    **The PRESS is acted on and the release is dropped**, which is `component.EVENT_KINDS`'
+    "act on one of them, never wait for the pair" answered in the direction that matches
+    what the operator did: the press is where they pointed. A drag that BEGAN elsewhere and
+    happens to release over this pane delivers only a release and selects nothing, which is
+    right — they never pointed here.
+
+    **Neither branch reads the plane, and that is the contract rather than thrift.** A
+    handler is handed no ctx (§4f), so it cannot know how many repos there are or how tall
+    this pane is; both are `slots._repos`' to compute, and it hands them to
+    `slots.VIEWPORT` on every paint. So a wheel notch on a pane that already shows every
+    repo — which is the ordinary plane, because the pane is sized to its content — moves
+    nothing and answers falsy, and the frame does not repaint. The one plane read here is
+    `state.selection`, and it is read to answer *has anything changed*, not to draw.
+
+    **The click bumps the frame's version, and that is what makes the third surface work.**
+    The selected row's detail is drawn on the ATTENTION row, which is a different pane and a
+    different process (`slots._selected_detail`). Returning truthy repaints this panel and
+    only this panel; `state.bump` is how every other cross-panel fact in this frame travels,
+    and the poll it wakes is `panel._tick`'s existing one. Re-selecting the row that is
+    already selected is not news for either pane, so it does neither — which is also what
+    keeps a double-click from bumping the frame twice.
+
+    *fid* is closed over rather than resolved: this process was told which frame it is
+    drawing (`charter panel repos --session <fid>`), and a handler that read
+    `$CHARTER_SESSION_ID` back out of its own environment would be answering from a variable
+    one tmux server shares between every frame on the machine — the trap
+    `state.record_identity` measured.
+    """
+    def on_event(ev):
+        from . import overlay, state
+        from . import slots as _slots
+        if ev.kind == overlay.SCROLL:
+            return _slots.VIEWPORT.move(
+                _slots.SCROLL_ROWS if ev.name == "down" else -_slots.SCROLL_ROWS)
+        if not ev.pressed or ev.name != _SELECT_BUTTON:
+            return False
+        name = _slots.VIEWPORT.repo_at(ev.row)
+        if name is None or name == state.selection(fid):
+            return False
+        state.record_selection(fid, name)
+        state.bump(fid)
+        return True
+
+    return on_event
+
+
 def _personas(ctx) -> list[str]:
     """The sidebar's persona rows — `slots.persona_section` at this pane's size."""
     from . import slots
@@ -186,7 +265,7 @@ def _changes(ctx) -> list[str]:
     return slots.changes_section(ctx.fid, ctx.width, ctx.height)
 
 
-def build() -> Registry:
+def build(fid: str = "") -> Registry:
     """A registry holding charter's six built-in components, in split order.
 
     A fresh one per call, deliberately — `registry.Registry`'s own docstring argues it:
@@ -196,6 +275,19 @@ def build() -> Registry:
 
     Cheap enough to mean it: six frozen dataclasses and no I/O. The renderers are reached
     lazily from inside each ``render``, so building a registry imports nothing.
+
+    **`fid` is which frame the components will be DRIVEN in, and it is optional because
+    most callers never drive them.** `Component.on_event` is handed one event and nothing
+    else (§4f), so a handler that has to write down a selection for this frame can only
+    have the id by closing over it, and this is where the closing happens. `layout` builds a
+    registry at import to read edges and sizes off it, and `instance` builds one to resolve
+    a plane's arrangement; neither dispatches an event through what it built, so neither has
+    an id to give and neither needs one. `panel._run` — the one caller that DOES build a
+    dispatcher — passes it.
+
+    There is deliberately no refusal for the empty default and no guard downstream of it: a
+    handler built without an id is one nothing calls, so a check for it would be a line no
+    test could turn red, which is the second-weaker-answer shape #568 deleted.
     """
     from . import slots
 
@@ -210,9 +302,25 @@ def build() -> Registry:
     # what the plane's repos need, bounded by what the harness may not be charged
     # (`layout.HARNESS_MIN_ROWS`), which is a fact about the WINDOW rather than about the
     # component. A cap here would be a second, weaker copy of that arithmetic.
+    #
+    # **The one component that declares events, and it is the first thing in charter that
+    # ever has** (#607 built the path; nothing consumed it). `scroll` and `click` are the
+    # two `frame/events.py` can carry to a pane the pointer is over without moving the
+    # keyboard, and they are declared TOGETHER because `events.Dispatcher.open` asks the
+    # terminal for one request that serves both — a component declaring only one of them
+    # would still pay `overlay.MOUSE_ON`'s whole price.
+    #
+    # **Declaring them is not a promise they fire**, which is the rule `EVENT_KINDS`
+    # states and this is the first place charter itself is bound by it: with `[frame]
+    # mouse` off — the shipped default — the harness decides whether the terminal reports
+    # at all, so on most planes this handler is never called and the table is exactly what
+    # it always was. That is why the selection has a keyboard route as well
+    # (`builtin_actions._register_selection`), and why the pane is still readable with no
+    # selection at all.
     reg.register(Component(
         id="repos", title="repos", edge="bottom", size=Content(),
-        needs=("gather",), render=_panel("repos")))
+        needs=("gather",), render=_panel("repos"),
+        events=("scroll", "click"), on_event=_repos_events(fid)))
     # The two parts of the sidebar, registered before the composite that draws them.
     # `personas` is the `Fill()`: the pane is the persona column everywhere else charter
     # names it, so it takes what is left and the todos are capped

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -53,9 +53,18 @@ construction rather than by a budget: the ticking stops when the records do.
 below is otherwise unchanged: `_wait` replaces the tick's `time.sleep` with a `select` of
 the same length when — and only when — the placed component declared an event kind charter
 delivers, so an event wakes the panel the instant it arrives instead of at the next tick
-boundary, and a panel that declared nothing pays and changes nothing at all. Charter's own
-four are in that second group, so the frame an operator has today is byte-identical and
-syscall-identical to the one they had before the dispatcher existed.
+boundary, and a panel that declared nothing pays and changes nothing at all.
+
+**Three of charter's own four are in that second group and `repos` is not, which is the
+one thing that changed about this module since.** #607 shipped with no consumer at all, so
+the sentence here used to be that charter's four panels were byte-identical and
+syscall-identical to the release before the dispatcher existed. `repos` declares `scroll`
+and `click` now (`frame/builtins.py`), so ITS pane goes to cbreak and asks its terminal for
+mouse reports, and `_run` asks the registry what a built-in declared instead of assuming
+nothing. `top`, `bottom` and `right` still declare nothing, still get `None` from
+`_dispatcher`, still sleep rather than `select`, and their panes' terminals are still left
+exactly as they were found — which is the property `_dispatcher`'s "``None`` is the whole
+cost promise" is about, and it is narrower now rather than gone.
 
 The event itself never draws. A handler answers "repaint me" and `_tick` treats that as a
 fourth reason to run the paint it already had — the rows are still `render`'s, still
@@ -268,6 +277,61 @@ def _paint(slot: str, fid: str) -> None:
     _write(_unmeasured() or slots.render(slot, fid))
 
 
+def _slot_painter(evs):
+    """:func:`_paint`, plus the one thing a raw slot render cannot say for itself.
+
+    **Charter's own panels are drawn by `slots.SLOTS` and not through the registry**, which
+    was fine while none of them took events and is not fine now that one does (`repos`,
+    #607's first consumer). `Registry.draw` is what turns a component's failure into a
+    message in its own pane, and a built-in never goes near it — so a handler that raised
+    would have `events.Dispatcher` retire the input path, correctly, and leave the pane
+    drawing a perfectly good table that had silently stopped being clickable. That is the
+    convincing-empty §4b refuses and #512 measured the cost of: a component that quietly
+    stops being interactive is indistinguishable from one nobody has clicked yet.
+
+    So the failure is painted here, ahead of the renderer, exactly as
+    :func:`_component_text` paints it for a provider's component — same wrap, same width,
+    same containment, same trade (a working ``render`` loses its pane because its HANDLER
+    broke, which `frame/events.py` argues is the smaller of the two wrongs).
+
+    **Only built for a panel that has a dispatcher at all.** The other three built-ins
+    declare no events, `_run` hands them ``paint=None``, and `_watch` calls :func:`_paint`
+    exactly as it did before this function existed — so their panes are byte-identical and
+    syscall-identical to the release before, which is the promise `_dispatcher`'s own
+    docstring makes and this must not spend.
+    """
+    def paint(slot: str, fid: str) -> None:
+        _write(_unmeasured() or _failure_text(evs, slot) or slots.render(slot, fid))
+    return paint
+
+
+def _failure_text(evs, name: str) -> str:
+    """Why *name* stopped taking events, wrapped to its own rectangle — or ``""``.
+
+    ``""`` for a component still taking them, which is every tick but the ones after a
+    handler raised, and it is falsy so both painters read it as "nothing to say here".
+
+    One composition, two callers, because the message and the rectangle it is measured
+    against must not come to disagree: `_component_text` draws it for a provider's
+    component and :func:`_slot_painter` for charter's own, and a second spelling would be a
+    second answer to how wide the pane is. WRAPPED and never truncated to one line —
+    `_wrap`'s own docstring says why that is not cosmetic: " charter: repos stopped taking
+    events — " is 41 characters before the exception has said anything, so a single
+    `tui.truncate` clips the only part naming what broke.
+
+    `contain.one_line` BEFORE the width arithmetic (#472): the text quotes a stranger's
+    exception — or charter's own, here — and `tui.width` on an unescaped escape sequence
+    measures something the terminal is not about to draw.
+    """
+    from .registry import _fit, _wrap
+    if evs is None or not evs.failure:
+        return ""
+    width = slots.content_width(name)
+    return slots.inset_rows(
+        "\n".join(_fit(_wrap(f"charter: {contain.one_line(evs.failure)}", width),
+                       width=width, height=_rows(), escape=True)), name)
+
+
 def _component_painter(reg, cid: str, evs=None):
     """A paint function for *cid*, drawn out of *reg* — `_paint`'s shape for a component.
 
@@ -344,26 +408,17 @@ def _component_text(reg, cid: str, fid: str, *, evs=None) -> str:
     #512 is what it costs to ship.
     """
     from . import ctx as _ctx, gather
-    from .registry import _fit, _wrap
     try:
-        if evs is not None and evs.failure:
-            # WRAPPED across the pane's rows, exactly as `Registry.draw` wraps the same
-            # class of message, and never truncated to one line. `_wrap`'s own docstring
-            # says why that is not cosmetic: "the tail of a refusal is the half that says
-            # what to do about it". Measured against this message in a 30-column `right`
-            # panel — " charter: acme.metrics stopped taking events — " is 45 characters
-            # on its own, so a single `tui.truncate` clips the exception text ALWAYS,
-            # which is the only part naming what broke.
-            #
-            # `content_width`/`inset_rows`, not `slots._width()`, so the reason sits in
-            # the same rectangle the component's own rows do and the operator's `pad`
-            # reaches it. `contain.one_line` BEFORE the width arithmetic (#472): the text
-            # quotes a stranger's exception, and `tui.width` on an unescaped escape
-            # sequence measures something the terminal is not about to draw.
-            width = slots.content_width(cid)
-            return slots.inset_rows(
-                "\n".join(_fit(_wrap(f"charter: {contain.one_line(evs.failure)}", width),
-                               width=width, height=_rows(), escape=True)), cid)
+        # WRAPPED across the pane's rows, exactly as `Registry.draw` wraps the same class
+        # of message, and never truncated to one line; `content_width`/`inset_rows`, not
+        # `slots._width()`, so the reason sits in the same rectangle the component's own
+        # rows do and the operator's `pad` reaches it. All of that lives in
+        # :func:`_failure_text` now, because charter's OWN panels take events too since
+        # #607's first consumer and a second spelling of this message would be a second
+        # answer to how wide their pane is.
+        failed = _failure_text(evs, cid)
+        if failed:
+            return failed
         c = reg.get(cid)
         snapshot = gather.read(fid) if c.needs else {}
         drew = reg.draw(cid, _ctx.build(c.needs, width=slots.content_width(cid),
@@ -385,9 +440,16 @@ def _dispatcher(reg, cid: str):
     **``None`` is the whole cost promise** (#607). A panel whose component declared no
     event kind charter fires builds no dispatcher, so `_watch` sleeps as it always has, the
     pane's tty keeps whatever mode it was in, and nothing asks the terminal to report
-    anything. Charter's own four panels never reach this function at all — they are drawn
-    by `slots.SLOTS` off the branch above — so the frame an operator has today is
-    byte-identical and syscall-identical to the one they had before this existed.
+    anything.
+
+    **Charter's own panels reach this function now, and three of the four still answer
+    ``None``.** They used to skip it entirely — `slots.SLOTS` drew them off the branch
+    above and no registry was built — which was correct while none of them declared
+    anything and became the one way a built-in could declare `events` and never be
+    delivered them. `repos` declares two, so `_run` asks here for every name; `identity`,
+    `attention` and `sidebar` declare nothing, so `wanted` answers `()` and their panes'
+    terminals are left exactly as they were found, which is the cost promise kept at the
+    grain it was always about.
 
     Built from the REGISTERED component rather than from the id, so a provider that failed
     to load gets no event path either: `Registry._stand_in` declares no events, which is
@@ -750,9 +812,22 @@ def _run(slot: str, fid: str, *, once: bool = False) -> int:
         if cid in _builtins.SLOT_OF:
             # One of charter's own, under either spelling: `slots.SLOTS` draws it,
             # exactly as it has since there were four names and nothing else.
+            #
+            # **It still asks the registry what that component DECLARED**, and until #607's
+            # first consumer it did not have to. Charter's own panels are drawn off
+            # `slots.SLOTS` rather than through `Registry.draw`, so this branch built no
+            # registry at all — which meant a built-in could declare `events` and be the one
+            # kind of component charter would never deliver them to. `repos` declares two,
+            # so the declaration has to be read here as well, and `_dispatcher` answers
+            # `None` for the other three exactly as it does for a provider that declared
+            # nothing. Their panes keep the paint they always had (`paint` stays `None`);
+            # a built-in WITH a dispatcher gets `_slot_painter`, which is the same paint
+            # plus the failure message a raw slot render cannot say for itself.
             slot = _builtins.SLOT_OF[cid]
+            evs = _dispatcher(_builtins.build(fid), cid)
+            painter = _slot_painter(evs) if evs is not None else None
         else:
-            reg = _builtins.build()
+            reg = _builtins.build(fid)
             # The one production caller `Registry.place` was written for. It does not
             # propagate a provider's failure: one that cannot be loaded becomes a standin
             # component holding this pane and drawing the reason, which is what makes a

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -262,7 +262,7 @@ def _unmeasured() -> str | None:
     return _UNMEASURED
 
 
-def _paint(slot: str, fid: str) -> None:
+def _paint(slot: str, fid: str, evs=None) -> None:
     """Clear the pane and draw *slot* whole, clamped to this pane's real row count.
 
     `slots.render` already clamps every line to the pane's WIDTH; clamping the line
@@ -273,36 +273,37 @@ def _paint(slot: str, fid: str) -> None:
     A pane that could not be measured is told so instead (:func:`_unmeasured`), and
     `slots.render` is not called at all: every line of it would be clamped to a width this
     pane has not agreed to.
+
+    *evs* is this panel's event path, and it is here because **charter's own panels are
+    drawn by `slots.SLOTS` and never through the registry**, which was fine while none of
+    them took events and is not fine now that one does (`repos`, #607's first consumer).
+    `Registry.draw` is what turns a component's failure into a message in its own pane, and
+    a built-in never goes near it — so a handler that raised would have `events.Dispatcher`
+    retire the input path, correctly, and leave the pane drawing a perfectly good table
+    that had silently stopped being clickable. That is the convincing-empty §4b refuses and
+    #512 measured the cost of. ``None`` — the default, and the whole of what the three
+    built-ins that declare nothing pass — makes :func:`_failure_text` answer ``""`` and
+    this line exactly what it was.
     """
-    _write(_unmeasured() or slots.render(slot, fid))
+    _write(_unmeasured() or _failure_text(evs, slot) or slots.render(slot, fid))
 
 
 def _slot_painter(evs):
-    """:func:`_paint`, plus the one thing a raw slot render cannot say for itself.
+    """:func:`_paint` with this panel's event path bound in — the shape `_tick` takes.
 
-    **Charter's own panels are drawn by `slots.SLOTS` and not through the registry**, which
-    was fine while none of them took events and is not fine now that one does (`repos`,
-    #607's first consumer). `Registry.draw` is what turns a component's failure into a
-    message in its own pane, and a built-in never goes near it — so a handler that raised
-    would have `events.Dispatcher` retire the input path, correctly, and leave the pane
-    drawing a perfectly good table that had silently stopped being clickable. That is the
-    convincing-empty §4b refuses and #512 measured the cost of: a component that quietly
-    stops being interactive is indistinguishable from one nobody has clicked yet.
+    A binder and nothing more: `_tick` calls what it is given with ``(slot, fid)``, and
+    `_paint` grew a third parameter that only `_run` knows the value of.
 
-    So the failure is painted here, ahead of the renderer, exactly as
-    :func:`_component_text` paints it for a provider's component — same wrap, same width,
-    same containment, same trade (a working ``render`` loses its pane because its HANDLER
-    broke, which `frame/events.py` argues is the smaller of the two wrongs).
-
-    **Only built for a panel that has a dispatcher at all.** The other three built-ins
-    declare no events, `_run` hands them ``paint=None``, and `_watch` calls :func:`_paint`
-    exactly as it did before this function existed — so their panes are byte-identical and
-    syscall-identical to the release before, which is the promise `_dispatcher`'s own
-    docstring makes and this must not spend.
+    **Built for EVERY built-in, not only the one with a dispatcher**, and the conditional
+    that used to stand here was deleted rather than kept. `_failure_text(None, …)` answers
+    ``""``, so a panel with no event path paints through this closure exactly what it
+    painted through `_paint` — the branch could not change an outcome, which is the sweep's
+    own definition of a line that should not be there and #568's argument for deleting the
+    last one of those. What the three quiet panels are promised is that their pane's
+    TERMINAL is untouched and their loop still sleeps rather than polls, and that is
+    `_dispatcher` answering ``None`` — not this.
     """
-    def paint(slot: str, fid: str) -> None:
-        _write(_unmeasured() or _failure_text(evs, slot) or slots.render(slot, fid))
-    return paint
+    return lambda slot, fid: _paint(slot, fid, evs)
 
 
 def _failure_text(evs, name: str) -> str:

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -826,7 +826,7 @@ def _run(slot: str, fid: str, *, once: bool = False) -> int:
             # plus the failure message a raw slot render cannot say for itself.
             slot = _builtins.SLOT_OF[cid]
             evs = _dispatcher(_builtins.build(fid), cid)
-            painter = _slot_painter(evs) if evs is not None else None
+            painter = _slot_painter(evs)
         else:
             reg = _builtins.build(fid)
             # The one production caller `Registry.place` was written for. It does not

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import os
 import time
+from typing import NamedTuple
 
 from .. import contain, tui
 from . import pane
@@ -423,6 +424,183 @@ def _needs_attention(r: dict) -> bool:
                or r.get("ci") in ("failed", "running") or r.get("change"))
 
 
+class _Line(NamedTuple):
+    """One composed row of the repo table, and **which repo it is a row about**.
+
+    The second field is the whole reason this is a pair rather than a string. A click
+    arrives as a row NUMBER (`frame/events.py`), and the only thing that knows what is on
+    that row is the pass that composed it: the table's rows are a ranked window over the
+    repos, with piece rows nested under them and an overflow line that is about no repo at
+    all, so nothing downstream can work back from an index to a name without redoing the
+    picking — which would be a second answer to "which repos are on screen", and the two
+    would disagree the moment a repaint landed between the paint and the click.
+
+    *repo* is the repo the line BELONGS to, not the row's own subject: a piece row carries
+    its parent repo's name (`gather`'s ``worktrees`` rows carry ``repo``), so every row of
+    the tree resolves to a repo and a click anywhere in it selects something. The one line
+    that answers ``None`` is `…(+N more)`, which stands for rows that are not on screen —
+    there is nothing there to select, and saying so is better than picking one of them.
+    """
+
+    repo: str | None
+    text: str
+
+
+class _Viewport:
+    """Where the `repos` table is scrolled to, and what it drew last — for ONE pane.
+
+    **A panel process holds one pane, so this is one object at module scope rather than a
+    map keyed by anything.** `panel.run` resolves a component name once and then draws that
+    one component for the life of the process (`panel._component_painter` closes over the
+    same decision), so "which pane is this" has exactly one answer here and a key for it
+    would be a second, weaker one. Tests reach the same object and :meth:`forget` is what
+    puts it back — the reset is the price of the singleton and is not hidden.
+
+    **It holds an intent, and the renderer is what settles it against the data.** The
+    handler moves an offset knowing nothing about how many repos there are or how tall the
+    pane is — `Component.on_event` is handed no ctx by contract (§4f), and it must not grow
+    a second reading of a plane the repaint is about to read anyway. So :meth:`settle` is
+    called by `_repos` with the bound it just computed, and that is also the answer to *what
+    happens when the offset outlives a repo list that shrank under it*: the next paint
+    clamps it down and the pane draws the last window there is, rather than an empty table
+    the operator has to guess their way back out of.
+
+    :attr:`limit` is that bound REMEMBERED, which is what lets the handler refuse a scroll
+    that would change nothing. Zero until the first paint, and the first paint always
+    happens before the first event can: `panel._watch` seeds its resize flag ``True`` and
+    calls `_tick` before it ever reaches `_wait`. So a pane exactly tall enough for its
+    content answers every wheel notch with "nothing moved" from the very first one.
+    """
+
+    __slots__ = ("offset", "limit", "_rows")
+
+    def __init__(self) -> None:
+        self.offset = 0
+        self.limit = 0
+        self._rows: tuple[str | None, ...] = ()
+
+    def forget(self) -> None:
+        """Back to a pane nobody has scrolled or drawn — for a test, and only a test.
+
+        Production never calls it: a panel process is born here and the object dies with
+        the process. It exists because the alternative for a test is reaching into
+        ``__slots__`` by name, which is a test that keeps working after the attribute it
+        pokes has stopped being the one that matters.
+        """
+        self.offset = 0
+        self.limit = 0
+        self._rows = ()
+
+    def settle(self, limit: int) -> int:
+        """Record how far this table may scroll, and answer where it actually is.
+
+        The clamp is here and nowhere else. `_scroll_limit` computes the bound from the
+        repo count and the pane's rows; this is what applies it, so an offset left over
+        from a longer list — the operator scrolled to the bottom, then a repo was removed —
+        comes back as the largest offset the CURRENT list has, on the very next paint.
+
+        Never below zero, and that half is not symmetry: :meth:`move` already refuses to go
+        under, so what this guards is a *limit* that has gone negative, which
+        `_scroll_limit` cannot produce — and a `max` here would be a second answer to a
+        question that one already answers. It is spelled `min` alone for that reason.
+        """
+        self.limit = limit
+        self.offset = min(self.offset, limit)
+        return self.offset
+
+    def move(self, rows: int) -> bool:
+        """Scroll by *rows*, and answer whether anything actually moved.
+
+        **The answer IS the repaint decision** (§4f: a handler answers truthy for "repaint
+        me"), and answering it here rather than in the handler is what makes "a pane tall
+        enough for its content does not scroll" a property of one object with one test
+        rather than an accident of two. A wheel notch on such a pane finds ``limit`` zero,
+        moves nothing, and costs the frame no paint at all.
+        """
+        moved = min(max(self.offset + rows, 0), self.limit)
+        if moved == self.offset:
+            return False
+        self.offset = moved
+        return True
+
+    def publish(self, rows) -> None:
+        """Record which repo each row of the pane is about, the paint that just happened.
+
+        Indexed by the PANE's row, not the table's: `_repos` puts a heading on row 0 and
+        the table under it, and the three one-line answers it draws instead of a table
+        (`_unknown_lines`, `_empty_lines`, `_too_narrow_lines`) publish nothing at all. So
+        a click on the heading, on a message, or below the last row lands on ``None`` and
+        is not a selection — which is the same rule `events.Dispatcher._on_canvas` applies
+        to the pad, one axis over: cells the component did not draw a row into are not
+        cells it was clicked in.
+        """
+        self._rows = tuple(rows)
+
+    def repo_at(self, row: int):
+        """The repo on pane row *row*, or ``None`` — the paint the operator was looking at.
+
+        Out of range answers ``None`` rather than raising, and a negative index answers
+        ``None`` rather than counting from the end — which is what Python's own indexing
+        would have done and is the one wrong answer available here: `overlay.Event` rows
+        are already 0-based and non-negative, so a negative one would mean charter's
+        arithmetic was wrong, and reporting the LAST row for it would hide that.
+        """
+        return self._rows[row] if 0 <= row < len(self._rows) else None
+
+
+#: The one viewport this process's `repos` pane scrolls. See :class:`_Viewport` for why
+#: there is exactly one; `frame/builtins.py` is the other half, and it holds no state of
+#: its own so that the handler and the renderer cannot come to disagree about where the
+#: table is scrolled to.
+VIEWPORT = _Viewport()
+
+#: Rows one wheel notch moves the table. One, deliberately: a terminal sends one report
+#: per notch and tmux forwards each, so a larger step multiplies whatever the operator's
+#: mouse or trackpad already decided — and the pane is at most `statusline._MAX_REPO_LINES`
+#: rows, where a three-row step would put the whole table past you in two flicks.
+SCROLL_ROWS = 1
+
+
+def _scroll_limit(repos: int, budget: int) -> int:
+    """The largest offset a table of *repos* repos may hold in a *budget*-row pane.
+
+    **Zero whenever every repo already fits, and that is the tested nothing.** The `repos`
+    pane is sized to its content (`layout.repos_rows`), so on an ordinary plane the pane is
+    exactly tall enough and this answers 0 — every wheel notch then moves nothing, repaints
+    nothing and costs nothing, because :meth:`_Viewport.move` reads this bound before it
+    changes anything. A scroll that quietly did nothing *because the arithmetic happened to
+    cancel* would be indistinguishable from a scroll that was dropped, which is the class of
+    convincing-empty this module refuses everywhere else.
+
+    The row the overflow line takes is subtracted here for the same reason
+    :func:`_table_lines` reserves it out of the budget rather than trimming it off the end:
+    it is a row of the pane and a row the repos do not get. Reserved on exactly the same
+    condition — more repos than rows — so the two cannot disagree about whether that row
+    exists, which would leave the last repo permanently one notch out of reach.
+
+    **The window moves over REPOS and not over PIECES, and that is a stated limit rather
+    than an oversight.** Piece rows appear only in the one-repo shape (`_table_lines`, from
+    `gather`'s ``worktrees``), where one repo always fits and this answers 0; pieces past
+    the pane's remaining rows are dropped by that function as they always were. Scrolling
+    them would need a second kind of offset — an index into a nested list rather than into
+    the ranking — and one mechanism that answers for half the cases honestly is worth more
+    than two that overlap.
+
+    **A pane with room for one row is a pane with room for the overflow line and nothing
+    else**, and it answers 0 too. :func:`_table_lines` spends a one-row budget on
+    `…(+N more)` rather than on an arbitrary repo — "there is more here than fits" outranks
+    "here is one of them" — so every offset over such a table draws the identical line. A
+    limit taken from the repo count alone would let the wheel repaint that line forty times,
+    each repaint byte-identical to the last: motion the operator can see is not happening,
+    charged to their terminal.
+    """
+    if repos <= budget:
+        return 0
+    if budget <= 1:
+        return 0
+    return repos - (budget - 1)
+
+
 def _table_row(lead: str, name_markup: str, r: dict, width: int,
                branch_override: str | None = None) -> str:
     """One row of the WIDE repo table — the same four columns
@@ -476,8 +654,14 @@ def _table_row(lead: str, name_markup: str, r: dict, width: int,
     return row.render(width)[0]
 
 
-def _table_lines(data: dict, width: int, budget: int) -> list[str]:
+def _table_lines(data: dict, width: int, budget: int, *, offset: int = 0,
+                 selected: str | None = None) -> list[_Line]:
     """The repo table the `repos` pane draws under its heading, at most *budget* lines.
+
+    **Each line comes back with the repo it is about** (:class:`_Line`), because a click
+    arrives as a row number and this is the only pass that knows what is on a row. See that
+    class for why the alternative — resolving an index back to a name afterwards — is a
+    second answer rather than a lookup.
 
     **This is #488's actual answer**: the frame used to show LESS of the plane's repo
     state than the status line it suppresses (#386), because the only slot drawing repos
@@ -513,8 +697,26 @@ def _table_lines(data: dict, width: int, budget: int) -> list[str]:
     verbatim. Every OTHER repo's pieces get a `⑂N` badge on the repo's own row instead,
     from `worktree_count`; the badge means "there is more you cannot see here", so it is
     dropped whenever every piece already has its own row.
+
+    *offset* is how far down the RANKING the window has been scrolled, and it changes
+    nothing at all at zero — which is the whole of how this stayed compatible.
+    `statusline._pick_rows` already sliced `[:budget]` off a ranked list, so `[offset:]` of
+    the same list is the same table one window further along: the repos come back in
+    priority order, the display order is still the cache's (a row that moved as it was
+    scrolled past would be the thing that function's own docstring refuses), and scrolling
+    back to zero lands on the exact bytes that were there before the first notch. The
+    `…(+N more)` line needs no arithmetic of its own for the same reason: what is HIDDEN is
+    still "every key that is not in *show*", which is true at every offset.
+
+    *selected* is the repo `state.selection` says this frame has picked, and the row for it
+    is drawn in reverse video by `frame/chrome.reverse` — the same call `persona_section`
+    already makes for the persona a frame is on, at the same place in the pipeline (a
+    FINISHED row, at the width the renderer measured), so there is one answer to what a
+    chosen row looks like in this frame. A name matching no row highlights nothing, which
+    is what a selection left over from a repo that has since gone degrades to.
     """
     from .. import statusline as sl
+    from . import chrome
 
     repos = data.get("repos") or []
     if not repos or budget <= 0:
@@ -555,7 +757,7 @@ def _table_lines(data: dict, width: int, budget: int) -> list[str]:
     # the false-clean reading this module refuses everywhere else. A budget of exactly one
     # therefore spends it on the note, which is the honest half of the pair: "there is
     # more here than fits" outranks "here is an arbitrary one of them".
-    show = (sl._pick_rows(keys, budget - 1, cur_repo, by_key, by_key)
+    show = (sl._pick_rows(keys, budget - 1, cur_repo, by_key, by_key, offset=offset)
             if capped else keys)
 
     pieces = list(data.get("worktrees") or [])
@@ -570,7 +772,7 @@ def _table_lines(data: dict, width: int, budget: int) -> list[str]:
     room = budget - len(show) - (1 if capped else 0)
     kids = pieces[:max(0, room)] if len(show) == 1 else []
 
-    lines: list[str] = []
+    lines: list[_Line] = []
     for i, k in enumerate(show):
         r = by_key[k]
         total = r.get("worktree_count") or 0
@@ -581,16 +783,26 @@ def _table_lines(data: dict, width: int, budget: int) -> list[str]:
         # `├─` — `statusline._repo_rows`' own rule, and the reason `_TREE_WT` exists.
         is_last = (not capped) and i == len(show) - 1 and not kids
         tree = sl._TREE_END if is_last else sl._TREE_MID
-        lines.append(_table_row(f"  {sl._DIM}{tree}{sl._R}",
-                                f"{emph}{palette[r['name']]}{r['name']}{sl._R}{badge}",
-                                r, width))
+        row = _table_row(f"  {sl._DIM}{tree}{sl._R}",
+                         f"{emph}{palette[r['name']]}{r['name']}{sl._R}{badge}",
+                         r, width)
+        # **The highlight goes on LAST and re-asserts itself through the row's own resets**
+        # — `chrome.reverse`'s whole reason, measured on this exact shape of row: every
+        # coloured span here ends in `sl._R`, and a `\x1b[7m` wrapped naively around the
+        # outside dies at the first one. Applied to the finished row rather than composed
+        # into it so that the branch, CI and change cells keep their own colours inside it.
+        lines.append(_Line(r["name"],
+                           chrome.reverse(row, width) if r["name"] == selected else row))
 
     if capped:
         hidden = [k for k in keys if k not in set(show)]
         quiet = not any(_needs_attention(by_key[k]) for k in hidden)
         note = ", all clean" if quiet else ""
-        lines.append(tui.truncate(
-            f"  {sl._DIM}…(+{len(hidden)} more{note}){sl._R}", width))
+        # **About no repo, so a click here selects nothing.** It stands for the rows that
+        # are NOT on screen, and picking one of them because the operator clicked the line
+        # that says they exist would be charter answering a question nobody asked.
+        lines.append(_Line(None, tui.truncate(
+            f"  {sl._DIM}…(+{len(hidden)} more{note}){sl._R}", width)))
 
     for j, p in enumerate(kids):
         mark = sl._TREE_WT if j == len(kids) - 1 else sl._TREE_MID
@@ -601,9 +813,16 @@ def _table_lines(data: dict, width: int, budget: int) -> list[str]:
         # to mean "this piece is NOT on the branch you would assume". The markers still
         # render: dirty and ahead/behind are true of the tree whatever its branch.
         wb = p.get("branch") or "?"
-        lines.append(_table_row(f"  {sl._DIM}{sl._TREE_PIPE}{mark}{sl._R}",
-                                f"{emph}{sl._DIM}{p['name']}{sl._R}", p, width,
-                                branch_override="" if wb == p.get("name") else None))
+        # **A piece row belongs to its parent REPO**, which is what keeps one namespace
+        # rather than two. `gather` writes `repo` on every worktree row, so a click on a
+        # nested row selects the clone it is a piece of — and a repo name and a piece name
+        # can never come to mean the same selection, which they could if pieces were
+        # selectable in their own right (a piece is named after a branch, and nothing stops
+        # one being named after a sibling clone).
+        lines.append(_Line(p.get("repo"), _table_row(
+            f"  {sl._DIM}{sl._TREE_PIPE}{mark}{sl._R}",
+            f"{emph}{sl._DIM}{p['name']}{sl._R}", p, width,
+            branch_override="" if wb == p.get("name") else None)))
     return lines[:budget]
 
 
@@ -1544,6 +1763,90 @@ def _fit_fields(priority: list[tuple[str, str]], width: int,
     return keep
 
 
+def _selected_detail(fid: str) -> str:
+    """The selected repo said in WORDS — the attention row's right-hand field, or ``""``.
+
+    **The `repos` table shows glyphs because it has four columns to fit forty repos into;
+    this has one row and one repo, so it spends it on words.** `!` and a number, a coloured
+    branch cell and a CI mark are a table's vocabulary and they are learned; `dirty`,
+    `2 ahead` and `CI failed` are what somebody who has just pointed at a row wants read
+    back to them. Nothing here is a second SOURCE — every field comes out of the same
+    gather row `_table_row` drew, so the two surfaces cannot disagree about a repo, only
+    about how much space they have to say it in.
+
+    **`clean` is `_needs_attention`'s answer and not a separate reading of the same
+    fields.** A detail that listed the problems and said nothing when there were none would
+    be an absence standing in for a claim — the reader cannot tell "nothing is wrong" from
+    "this field was cut". The predicate is the one the `…(+N more), all clean` note already
+    asks, so the row and the note cannot come to disagree about what clean means.
+
+    **Empty for every plane that has never selected anything**, which is what keeps this
+    field free: `_fit_fields` drops an empty field whole, so the attention row of a frame
+    nobody has clicked is byte-identical to the one before this existed.
+
+    **What a repaint pays.** One `state.selection` read — a `read_text` of a file that is
+    usually not there — and, only when it IS, one `gather.cached`. That second read is the
+    one worth stating, because `bottom` is the frame's ANIMATED slot and repaints at
+    `panel.TICK` for the whole length of a dispatch: with a row selected, that is one small
+    JSON read five times a second, against the `_inflight_field` record scan the same tick
+    already pays. It is charged only to a frame whose operator has selected something, and
+    it is the same cache the `repos` pane beside it reads on every one of its own paints.
+
+    **`gather.cached` and never `gather.read`, for `_repos`' reason exactly**: `read` falls
+    back to a live `scan()`, and a panel must not sweep. A frame whose gather has not landed
+    yet has nothing to say about the selected repo and says nothing, rather than walking
+    every clone on the plane five times a second to find out.
+    """
+    from . import gather, state
+
+    name = state.selection(fid)
+    if not name:
+        return ""
+    data = gather.cached(fid)
+    if data is None:
+        return ""
+    row = next((r for r in data.get("repos") or [] if r.get("name") == name), None)
+    if row is None:
+        # A selection pointing at a repo this plane no longer has. The table drew no
+        # highlight for it either (`_table_lines` matches on the same name), so both
+        # surfaces go quiet together — which is the honest pair. Saying "gone" here would
+        # be the only thing on screen claiming a repo ever existed.
+        return ""
+    return _detail_text(row)
+
+
+def _detail_text(row: dict) -> str:
+    """*row*'s state as the words :func:`_selected_detail` puts on the attention row.
+
+    Split out so the composition can be tested against a row without a plane, a frame
+    directory or a gather cache underneath it — the same reason `_fit_fields` is not inside
+    `_bottom`. It is also the whole of what a reader has to check against `_table_row`: two
+    surfaces, one set of fields, and this is the list.
+
+    Every part is dropped when it is not true, so a clean repo on its own branch reads
+    `▪ charter · main · clean` and a busy one reads
+    `▪ charter · fix/x · dirty · 2 ahead · CI failed · !123 · ⑂3`.
+    """
+    from .. import statusline as sl
+
+    parts = [f"{sl._BOLD}{row.get('name')}{sl._R}", row.get("branch") or "?"]
+    if row.get("dirty"):
+        parts.append("dirty")
+    if row.get("ahead"):
+        parts.append(f"{row['ahead']} ahead")
+    if row.get("behind"):
+        parts.append(f"{row['behind']} behind")
+    if row.get("ci"):
+        parts.append(f"CI {row['ci']}")
+    if row.get("change"):
+        parts.append(f"{row.get('sigil') or '!'}{row['change']}")
+    if row.get("worktree_count"):
+        parts.append(f"⑂{row['worktree_count']}")
+    if not _needs_attention(row):
+        parts.append("clean")
+    return f"{sl._DIM}▪{sl._R} " + f"{sl._DIM} · {sl._R}".join(parts)
+
+
 def _bottom(fid: str) -> str:
     """What still wants attention, and how to act on it — the frame's last row.
 
@@ -1647,20 +1950,23 @@ def _bottom(fid: str) -> str:
                    else f"{config.FRAME['hotkey']} palette")
 
     inflight_text = _inflight_field()
+    repo_text = _selected_detail(fid)
 
     # Decide who survives, highest priority first (see this function's own docstring
     # above for why); `_fit_fields` does the actual budgeting so it can be tested in
     # isolation.
     keep = _fit_fields(
-        [("alert", alert_text), ("inflight", inflight_text), ("news", news_text),
-         ("todo", todo_text), ("hotkey", hotkey_text)], w,
+        [("alert", alert_text), ("inflight", inflight_text), ("repo", repo_text),
+         ("news", news_text), ("todo", todo_text), ("hotkey", hotkey_text)], w,
         limit=1 if verbosity(fid) == "terse" else None)
 
     # Re-assembled in the original reading order, not priority order — priority decided
-    # only who was cut.
+    # only who was cut. `repo` is LAST, which is the "right side" the selected row's
+    # detail was asked for: this row is composed left to right and joined with ` · `, so
+    # last is as far right as a field gets without a second layout rule for one field.
     fields = {"alert": alert_text, "inflight": inflight_text, "news": news_text,
-              "todo": todo_text, "hotkey": hotkey_text}
-    parts = [fields[n] for n in ("todo", "alert", "inflight", "news", "hotkey")
+              "todo": todo_text, "hotkey": hotkey_text, "repo": repo_text}
+    parts = [fields[n] for n in ("todo", "alert", "inflight", "news", "hotkey", "repo")
              if n in keep]
     return tui.truncate(" · ".join(parts), w)
 
@@ -1728,7 +2034,28 @@ def _repos(fid: str) -> str:
     that walked a directory per row would cost fourteen walks per repaint. Everything the
     table draws comes out of the cache; see :func:`_table_row` for the one column that
     costs (presence) and is therefore absent.
+
+    **This is also the pane that can be SCROLLED and CLICKED, and both halves are settled
+    here rather than in the handler** (#607's first consumer). `frame/builtins.py` declares
+    `scroll` and `click` and moves :data:`VIEWPORT`; a handler is handed no ctx by contract
+    (§4f), so it knows neither how many repos there are nor how tall this pane is. Both
+    numbers are read on this line and nowhere else:
+
+    * :func:`_scroll_limit` is how far the window may move, handed to
+      :meth:`_Viewport.settle`, which clamps an offset left over from a longer list and
+      leaves the handler a bound it can refuse a pointless scroll against. On the ordinary
+      plane — a pane sized to its own content — it is 0 and the wheel does nothing at all.
+    * :meth:`_Viewport.publish` records which repo each PANE ROW is about, so a click that
+      arrives as a row number resolves against the paint the operator was looking at. The
+      three one-line answers below publish nothing, which is what makes a click on
+      `gathering this workspace's repos…` not a selection.
+
+    `state.selection` is read here and handed to :func:`_table_lines`, which is what draws
+    the chosen row in reverse video. One extra file read per repaint of a pane that is not
+    animated — it repaints on a version bump or a resize, and a click is a version bump
+    (`frame/builtins.py` bumps so the ATTENTION pane, a different process, redraws too).
     """
+    from . import state
     w = content_width("repos")
     # `_table_cap` is the SAME call `repos_rows_wanted` made to size this pane, with the
     # pane's own measured width instead of the window's.
@@ -1746,6 +2073,7 @@ def _repos(fid: str) -> str:
         # needs rather than what the table needs — see :func:`_too_narrow_lines`. Asked of
         # :func:`pad_of` and not subtracted back out of `w`, because `pad_of` is the one
         # that knows whether the pad was afforded at all.
+        VIEWPORT.publish(())
         return "\n".join(_too_narrow_lines(w, pad_of("repos")))
     from . import gather
     # `gather.cached`, never `gather.read` (#512). The two differ by exactly one thing:
@@ -1771,12 +2099,14 @@ def _repos(fid: str) -> str:
     # hook refreshes it after that (`notify.plane_changed`).
     data = gather.cached(fid)
     if data is None:
+        VIEWPORT.publish(())
         return "\n".join(_unknown_lines(w))
     repos = data.get("repos") or []
     if not repos:
         # Gathered, and there is nothing in it. Said out loud rather than left as an
         # empty bordered rectangle — see :func:`_empty_lines`. No heading: `▪ repos 0`
         # above "no clones in demo" is the same fact twice in a two-row pane.
+        VIEWPORT.publish(())
         return "\n".join(_empty_lines(_frame_workspace(fid), w))
     # The heading takes the first row and the table spends what is left. Asked for fewer
     # ROWS rather than sliced afterwards, so what survives at `terse` (or in a pane a
@@ -1784,8 +2114,20 @@ def _repos(fid: str) -> str:
     # in, the ones with something on them — rather than whichever happened to come
     # first, the same discipline the `terse` chip list in `_right` keeps.
     budget = min(_height() - 1, cap)
+    # **`settle` is unconditional, and the `if budget > 0` that used to guard the call
+    # below went with it.** `_table_lines` already answers `[]` for a non-positive budget
+    # (its first line), so the conditional could not change an outcome — the sweep's own
+    # definition of a line that should not be there — and it could change one HERE, in the
+    # direction that matters: a pane starved to no rows by a resize would have kept
+    # whatever bound the last taller paint recorded, and the wheel would go on moving an
+    # offset over a table that is not on screen. `_scroll_limit` answers 0 for that pane.
+    offset = VIEWPORT.settle(_scroll_limit(len(repos), budget))
+    lines = _table_lines(data, w, budget, offset=offset, selected=state.selection(fid))
+    # The heading is row 0 of the PANE and belongs to no repo, so the map the handler
+    # resolves a click against starts with it — see :meth:`_Viewport.publish`.
+    VIEWPORT.publish((None, *(ln.repo for ln in lines)))
     return "\n".join([_sidebar_head("repos", len(repos), w),
-                      *(_table_lines(data, w, budget) if budget > 0 else [])])
+                      *(ln.text for ln in lines)])
 
 
 #: How a member's derived state is spelled on a row. `change.MEMBER_STATES`' own words,

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -1881,7 +1881,7 @@ def _bottom(fid: str) -> str:
     `$CHARTER_SESSION_ID`/`$CLAUDE_CODE_SESSION_ID` a launched panel inherits whole from
     the harness (`_right`'s docstring makes the identical point for `_persona_chips`).
 
-    **Four candidate fields on that row, each shown WHOLE or dropped WHOLE — never one
+    **Six candidate fields on that row, each shown WHOLE or dropped WHOLE — never one
     assembled string cut once from the right.** The attention row is one row and its
     WIDTH is the frame's own, not a narrow side panel's, so ordinarily every field fits
     comfortably and this never has to choose. But `layout.py`'s own module docstring
@@ -1895,13 +1895,27 @@ def _bottom(fid: str) -> str:
     Priority order, highest first: the one alert (`_alerts()`'s own top pick — an
     actionable control-plane problem, carrying its own fix); the in-flight spinner
     (:func:`_inflight_field` — work happening RIGHT NOW, and the only thing on this row
-    that will be different in a second); `_session_news` (this session's own activity —
-    silent unless it already has something to say, so its mere presence is the signal);
-    the todo count (persistent state, not urgent); the configured hotkey hint (the one
-    thing always rediscoverable another way, so it is first to give up its columns). Once
-    decided, the survivors are RE-JOINED in the original reading order (todo, alert,
-    inflight, news, hotkey) — priority governs only who is dropped when the pane is
-    starved, not how a healthy pane reads.
+    that will be different in a second); the selected repo's detail
+    (:func:`_selected_detail` — the direct answer to the last thing the operator DID, which
+    is why it outranks the two ambient fields below it and not the two urgent ones above);
+    `_session_news` (this session's own activity — silent unless it already has something
+    to say, so its mere presence is the signal); the todo count (persistent state, not
+    urgent); the configured hotkey hint (the one thing always rediscoverable another way,
+    so it is first to give up its columns). Once decided, the survivors are RE-JOINED in
+    the original reading order (todo, alert, inflight, news, hotkey, repo) — priority
+    governs only who is dropped when the pane is starved, not how a healthy pane reads.
+
+    **The selected repo's detail is the row's "right side" and is drawn LAST**, which is
+    what the ask for a tooltip resolves to on a row composed left to right: last is as far
+    right as a field gets without a second layout rule for one field. It is also empty on
+    every plane that has never selected anything, and `_fit_fields` drops an empty field
+    whole — so a frame nobody has clicked draws the row it always drew.
+
+    **At `terse` it is subject to the same one-field limit as everything else**, so a
+    selection made on a minimal frame shows only when nothing above it has anything to say.
+    That is the density doing what it is for rather than an exception carved for the newest
+    field; `charter frame-density full` is a keypress away and the highlight in the table
+    is still there either way.
 
     **`_session_news` is asked to leave its own in-flight count out** (`inflight=False`).
     Both would otherwise draw the same fact from the same tracker on the same row —

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -1805,7 +1805,12 @@ def _selected_detail(fid: str) -> str:
     data = gather.cached(fid)
     if data is None:
         return ""
-    row = next((r for r in data.get("repos") or [] if r.get("name") == name), None)
+    # `data["repos"]`, with no `or []` under it: `gather.cached` answers `None` for
+    # anything whose `repos` is not a LIST (`gather._shaped_like_a_scan`), so a fallback
+    # here could only ever stand in for an empty list with an empty list. The sweep found
+    # it surviving, correctly — a line that cannot change an outcome is not documentation
+    # of an intent.
+    row = next((r for r in data["repos"] if r.get("name") == name), None)
     if row is None:
         # A selection pointing at a repo this plane no longer has. The table drew no
         # highlight for it either (`_table_lines` matches on the same name), so both

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -792,6 +792,67 @@ def frame_change(fid: str) -> str | None:
         return None
 
 
+def record_selection(fid: str, name: str) -> None:
+    """Write down which repo row THIS RUNNING FRAME has selected.
+
+    :func:`record_change`'s twin, and it is here for the reason that module cannot be:
+    **the pane that takes the click and the pane that shows the detail are two
+    processes.** A click lands in the `repos` panel, which owns that rectangle and nothing
+    else; the attention row is `bottom`'s pane, a separate `charter panel` with its own
+    tty and its own loop. There is no shared memory between them and deliberately none —
+    `panel.py`'s "liveness is a poll, not a push" is the whole shape of this frame — so a
+    selection one panel makes and another draws is a file, and the repaint that follows is
+    the `state.bump` every other cross-panel fact already travels on.
+
+    No committed setting behind it, exactly as :func:`record_change` has none, and for the
+    same reason said one noun over: which row you last pointed at is a fact about the
+    minute you are in, and a `[frame]` key for it would be config that is stale before the
+    frame is.
+
+    **The value is a repo NAME and it is never drawn as itself.** `slots._table_lines`
+    compares it against the ``name`` of each row it is already drawing and highlights the
+    one that matches; a name matching nothing highlights nothing. That is what makes a
+    hand-edited or truncated file cost a highlight rather than a line — the same
+    degrade-to-nothing :func:`density` gets by leaving validation at the point of use, with
+    the sharper edge that here there is no point of use to validate at: the only thing
+    charter does with this string is an equality test against names it read out of its own
+    gather. What `slots._selected_detail` puts on the attention row is composed from the
+    matched GATHER ROW, not from this file.
+
+    Same must-not-raise, atomic-write shape as :func:`record_density`.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "selection.tmp"
+    try:
+        config.write_for(tmp, f"{name}\n")
+        os.replace(tmp, d / "selection")
+    except OSError:
+        return
+
+
+def selection(fid: str) -> str | None:
+    """The repo row this frame has selected, or ``None`` for "nothing selected".
+
+    ``None`` is the ordinary case and is not a failure: a frame comes up with no row
+    selected, the table draws no highlight and the attention row spends its columns on the
+    fields it always had. That is the state every plane with `[frame] mouse` off stays in
+    unless the operator moves the selection from the palette, and it is the state
+    `frame/component.py` asks a pointer affordance to degrade to.
+
+    Read on every `bottom` repaint, which is the one place this costs anything, so it is
+    one `read_text` of a file that usually is not there. See `slots._bottom` for the bill.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        return (d / "selection").read_text().strip() or None
+    except (OSError, ValueError):
+        return None
+
+
 def record_hidden(fid: str, names) -> None:
     """Write down which components THIS RUNNING FRAME is not drawing.
 
@@ -893,12 +954,19 @@ def clear_shape(fid: str) -> None:
       reading zero is worse than no gauge; a gauge reading somebody else's 78% is worse
       than either.
 
+    * ``selection`` is the same keypress or the same click said about a ROW
+      (:func:`record_selection`), and it inherits with the mildest of these consequences
+      and the same shape: a brand-new frame comes up with one repo highlighted and its
+      detail on the attention row, because somebody pointed at it in a session that is
+      over. Nothing on screen explains it and nothing the new operator does explains it
+      either — the highlight is a claim about an action they did not take.
+
     Never raises, and never creates, like everything else here.
     """
     d = frame_dir(fid)
     if d is None:
         return
-    for name in ("density", "hidden", "panes", "session"):
+    for name in ("density", "hidden", "panes", "session", "selection"):
         try:
             (d / name).unlink(missing_ok=True)
         except OSError:

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1051,7 +1051,7 @@ def _tree_cells(lead: str, label: str, d, states, branches, gl, branch=None,
     return tui.Row(*cells, gap=_GAP)
 
 
-def _pick_rows(dirs, budget: int, cur_repo, states, gl) -> list[Path]:
+def _pick_rows(dirs, budget: int, cur_repo, states, gl, *, offset: int = 0) -> list[Path]:
     """Which repos get a row when there are more repos than rows.
 
     The cap was a bare positional slice, so with the list in directory order the rows went
@@ -1067,6 +1067,20 @@ def _pick_rows(dirs, budget: int, cur_repo, states, gl) -> list[Path]:
     repo you were just in. Same reason `_repo_rows` colours by position in the FULL list
     rather than by position among the shown: a repo keeps its colour and its row whether
     or not its neighbour went dirty.
+
+    *offset* is where in that ranking the *budget* rows start, and it is what makes the
+    frame's repo table scrollable without a second answer to "which repos matter"
+    (`slots._table_lines`). **Zero is the whole of today**: every existing caller omits it
+    and gets the same list it always got, byte for byte, because ``[0:budget]`` is the
+    slice this line has always taken. A `repos` pane the operator has wheeled down asks for
+    a window further along the SAME ranking rather than a differently-chosen set — so
+    scrolling reveals the rest in priority order, and scrolling back lands on the exact
+    table that was there before the first notch.
+
+    Past the end it answers fewer rows, and eventually none, rather than clamping: the
+    caller that scrolls is the one that knows how many rows the pane has and how many repos
+    there are (`slots._viewport_limit`), and a clamp here would be a second, weaker copy of
+    that arithmetic — the shape #500 shipped twice.
     """
     order = {d: i for i, d in enumerate(dirs)}
 
@@ -1082,7 +1096,7 @@ def _pick_rows(dirs, budget: int, cur_repo, states, gl) -> list[Path]:
             order[d],                              # stable: original order breaks ties
         )
 
-    chosen = sorted(dirs, key=rank)[:budget]
+    chosen = sorted(dirs, key=rank)[offset:offset + budget]
     return sorted(chosen, key=lambda d: order[d])
 
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -111,8 +111,28 @@ One consequence of that first column worth knowing, because it is new: a panel w
 component declares `click` or `scroll` asks *its own* terminal to report, so if you select
 that panel's pane (with your tmux prefix, say), your terminal starts reporting and native
 selection goes for as long as it is the active pane. Selecting the harness back — or `F12`
-— ends it. Panels that declare neither ask for nothing and change nothing, which is every
-panel charter ships.
+— ends it. Panels that declare neither ask for nothing and change nothing, which is three
+of the four panels charter ships.
+
+**The repo table is the fourth: it scrolls and it selects.** Roll the wheel over it and the
+window moves down the list; click a row and that repo is selected, its row drawn in reverse
+video and its state read back in words on the right of the attention row — `▪ charter ·
+fix/x · dirty · 2 ahead · CI failed`. A click only ever *selects*; nothing charter does from
+a pointer is irreversible, because a click can reach a pane without its matching press (a
+drag begun on a pane border delivers exactly one release), and a gesture that can arrive
+half-formed is not one to hang an action on.
+
+Two things follow that are worth saying plainly rather than leaving you to find:
+
+- **The wheel does nothing when the table already fits**, which is most of the time — the
+  pane is sized to its own content. There is nothing below to scroll to, so nothing moves
+  and nothing repaints. It starts moving on a plane with more clones than the pane has rows,
+  which is the same plane that shows `…(+7 more)`.
+- **You do not need a mouse.** `F2` → `repo: select the next row` (and `previous`) moves the
+  selection with the arrow keys and Enter you already drive the palette with. That is the
+  only route on a plane with `mouse = false`, which is the default, and charter will not
+  bind a bare arrow key to change it: a `bind -n Up` is server-wide and would take the arrow
+  before your harness sees it.
 
 **Focus events are on inside a frame charter launched, and off inside your own tmux.** tmux
 ships `focus-events` off, and it is a server-wide setting; charter turns it on for its own
@@ -1057,10 +1077,12 @@ remember the flags. The workspace is the session; tmux puts you back on whicheve
 chats was last in front of you.
 
 ```
-charter · 9 to choose from
+charter · 11 to choose from
 > workspace: alpha — pick another
     persona: steward — pick another
     detach — leave the harness running
+    repo: select the next row
+    repo: select the previous row
     density: minimal
     density: normal
   * density: full

--- a/docs/news/unreleased-the-repo-table-scrolls-and-a-row-can-be-picked.md
+++ b/docs/news/unreleased-the-repo-table-scrolls-and-a-row-can-be-picked.md
@@ -1,0 +1,68 @@
+---
+version: unreleased
+headline: The repo table scrolls, a row can be picked, and the attention bar says what you picked
+---
+
+*"I tried to scroll the repo table and nothing happened."*
+
+Nothing was going to. Charter built the whole pointer path a release ago — an SGR decoder,
+a dispatcher that translates a click into a component's own cells, a `DELIVERED` set naming
+five kinds it can carry — and shipped it with **no consumer at all**. Every one of the six
+components charter draws declared `events = ()`, so the only thing on the machine that could
+have received a wheel notch was a component somebody else wrote.
+
+**`repos` declares `scroll` and `click` now**, which makes charter's own panel the worked
+example rather than the exception:
+
+```
+ ▪ repos 6
+   ├─ charter        main                    ✓
+   ├─ harness        fix/pane-width   ●⇡2    ✗    !412
+   ├─ statusline     main                    ✓                 <- clicked: reversed
+   …(+3 more)
+
+ 3 todos · ⠙ 1 running · F2 palette · ▪ statusline · main · clean
+                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+- **The wheel moves a window over the list.** The table has always shown a *ranked* pick
+  when there are more repos than rows — the one you are standing in, the dirty ones, the
+  ones with a failing pipeline — and the wheel now walks down that same ranking. Scroll back
+  to the top and you are on the exact table that was there before you touched it.
+- **A click selects a row.** The row is drawn in reverse video, and the right-hand end of
+  the attention bar reads its state back in words: `▪ statusline · main · dirty · 2 ahead ·
+  CI failed · !123`. That is the "tooltip" the table has no columns for, keyed to what you
+  picked rather than to where the pointer happens to be — charter asks its terminal for
+  press/release reporting and deliberately not for motion, so there is no hover to key it to
+  and there will not be one.
+- **A click only ever SELECTS.** Nothing charter does from a pointer is irreversible, and
+  that is a property rather than caution: a click can reach a pane without its matching
+  press — a drag begun on a pane border delivers exactly one release, measured — and a
+  gesture that can arrive half-formed is not one to hang an action on. Choosing stays a
+  keypress's job.
+
+**The scroll that does nothing is the one worth knowing about.** The `repos` pane is sized
+to its own content, so on most planes it is exactly tall enough and there is nothing below
+to scroll to: the wheel moves nothing and repaints nothing. It starts moving on a plane with
+more clones than the pane has rows — the same plane that already shows `…(+3 more)`. That is
+tested as hard as the scrolling is, because a wheel that quietly did nothing *because the
+arithmetic happened to cancel* is indistinguishable from one that was dropped.
+
+**You do not need a mouse, and on most planes you do not have one.** `[frame] mouse` ships
+`false`, and with it off tmux asks your terminal to report from the *active* pane's request
+alone — so with the harness active, a click on a panel is not an event charter drops, it is
+an event that never happens. `F2` → `repo: select the next row` (and `previous`) moves the
+selection with the arrow keys and Enter you already drive the palette with. Charter will not
+bind a bare arrow key to do it: a `bind -n Up` is server-wide in tmux and would take the
+arrow before your harness ever saw it.
+
+**To adopt it, set `[frame] mouse = true`** — and read what that costs before you do. From
+the moment you attach, your terminal reports the mouse and stops doing its own drag-select
+over the window; you get tmux's copy-mode selection instead. There is no state in which
+panels are clickable and native selection survives, on any tmux from 3.1c to 3.7c. What it
+no longer costs is your keyboard: since charter rebound `MouseDown1Pane` inside its own
+server, clicking a panel acts where you pointed and leaves you typing in the harness.
+
+Charter's other three panels declare nothing and are untouched — their panes' terminals are
+left in whatever mode they were found in, and they still sleep between repaints rather than
+watching their own input.

--- a/tests/test_a_real_click_reaches_the_real_repo_table.py
+++ b/tests/test_a_real_click_reaches_the_real_repo_table.py
@@ -1,0 +1,419 @@
+"""A wheel notch and a click on a REAL `repos` pane, in a REAL tmux, change what is drawn.
+
+The report this answers is *"I tried to scroll the repo table and nothing happened"*, and
+nothing about that report could have been settled by a unit test: every link in it is a
+claim about tmux or about a separate process. `tests/test_the_repo_table_scrolls_and_selects
+.py` says what the viewport does with an event and what the renderer does with an offset;
+only this can say that a report injected into a client's terminal becomes an offset at all.
+
+Everything here is real: a real tmux server, a real attached client on a real pty, two real
+`charter panel` processes each holding their own pane, and the frame's own private config
+sourced from `commands_frame.conf_text` rather than hand-written. What that buys over the
+unit half, link by link:
+
+* that `charter panel repos` builds a dispatcher for a BUILT-IN component at all — until
+  this change that branch of `panel._run` built no registry, so charter's own components
+  were the one kind that could declare `events` and never be delivered any;
+* that the pane really asks its terminal to report (`overlay.MOUSE_ON` written to fd 1 by a
+  process nobody in this test can monkey-patch);
+* that tmux routes the report to the pane under the pointer, in that pane's own cells, and
+  **leaves the keyboard on the harness** — which is what makes a clickable table something
+  an operator can use rather than a trap;
+* that the click's `state.record_selection` + `state.bump` reach the OTHER pane: the
+  attention row is a third process, and the detail appearing there is the only proof that
+  the two panels are talking through the frame's state rather than through a shared object
+  that only exists in one interpreter.
+
+**`mouse = true`, because that is the regime this feature is for.** With charter's flag off,
+tmux asks the terminal to report from the ACTIVE pane's own request alone, and the active
+pane here is a `cat` — so nothing would be sent, nothing would arrive, and a green test
+would be measuring an empty room. `docs/frame.md` states that half to the operator; this
+states the other half.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import termios
+import time
+import unittest
+from pathlib import Path
+
+from charter import commands_frame, config, tui
+from charter.frame import gather, layout, slots, state, tmuxctl
+
+from tests import _tmuxreap
+from tests._isolation import PersonaIso
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SOCKET = _tmuxreap.name("repo-point")
+SOCKET_PATH = os.path.join(os.environ.get("TMUX_TMPDIR") or "/tmp",
+                           f"tmux-{os.getuid()}", SOCKET)
+
+_DEADLINE = 25.0
+
+_TERM_CANDIDATES = tuple(dict.fromkeys(
+    ([os.environ["TERM"]] if os.environ.get("TERM", "dumb") != "dumb" else [])
+    + ["xterm-256color", "screen", "vt100"]))
+
+#: Wide enough for the table — `statusline._LEFT_W` is 95 and the pane must clear it, or
+#: `_repos` correctly refuses to draw a cut table and every case here would be measuring
+#: that refusal instead.
+COLS = 120
+
+#: Rows the `repos` pane is split with: one heading and four rows of table. Six repos into
+#: four rows is the SCROLLABLE shape — three repo rows and `…(+3 more)` — which is the shape
+#: the report was about. A pane sized to its content would have nothing to scroll, which is
+#: the case the unit half pins and this one cannot reach without a second frame.
+REPOS_ROWS = 5
+
+
+def _row(name) -> dict:
+    return {"name": name, "branch": "main", "dirty": False, "tracked_dirty": False,
+            "ahead": 0, "behind": 0, "ci": None, "change": None, "sigil": "",
+            "current": False, "worktree_count": 0}
+
+
+def _tmux(*args: str, env=None) -> subprocess.CompletedProcess:
+    return subprocess.run(["tmux", "-L", SOCKET, *args], capture_output=True, text=True,
+                          timeout=20, env=env)
+
+
+def _await(predicate, timeout: float = _DEADLINE) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
+
+
+def _fork_pty(rows: int, cols: int) -> tuple[int, int]:
+    """`pty.fork` with the window size set BEFORE the exec — #648's fix, borrowed.
+
+    `tests/test_frame_input_reaches_a_component.py` carries the measurement: a client born
+    at the kernel's 80x24 default attaching to a wider session makes tmux resize the window,
+    which is a SIGWINCH in every pane. Here that would repaint the table for a reason no
+    case asked for, which is exactly the noise these cases have to be free of.
+    """
+    master, slave = os.openpty()
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+    pid = os.fork()
+    if pid == 0:
+        os.close(master)
+        os.login_tty(slave)
+        return 0, -1
+    os.close(slave)
+    return pid, master
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealPointerOnTheRealRepoTable(PersonaIso):
+    """One frame with charter's OWN `repos` and `attention` panels, and a real pointer."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        v = tmuxctl.version()
+        if v is None or v < tmuxctl.FLOOR:
+            self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}."
+                          f"{tmuxctl.FLOOR[1]}; this machine has {v}")
+        self.addCleanup(self._teardown_socket)
+        (self.tmp / "charter.toml").write_text("")
+
+        self.fid = state.frame_id("repo-point", os.getpid())
+        state.frame_dir(self.fid, create=True)
+        # Six repos into four rows of table, so there is somewhere to scroll TO. Written
+        # through `gather.save` — the cache a real scan writes and `slots._repos` reads —
+        # rather than by running a scan, which would need six real clones to say the same
+        # thing about tmux.
+        self.repos = [f"repo{i}" for i in range(6)]
+        gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
+                               "current_repo": None,
+                               "repos": [_row(n) for n in self.repos], "worktrees": []})
+
+        existing = os.environ.get("PYTHONPATH", "")
+        parts = [str(_REPO_ROOT)] + ([existing] if existing else [])
+        self.env = dict(os.environ, CHARTER_ROOT=str(self.tmp),
+                        PYTHONPATH=os.pathsep.join(parts))
+        self.env.pop("CHARTER_HOME", None)
+
+        started = _tmux("-f", "/dev/null", "new-session", "-d", "-s", self.fid,
+                        "-x", str(COLS), "-y", "24", "-P", "-F", "#{pane_id}", "cat",
+                        env=self.env)
+        self.assertEqual(started.returncode, 0, started.stderr)
+        self.harness = started.stdout.strip()
+        state.record_server(self.fid, SOCKET)
+        state.record_harness_pane(self.fid, self.harness)
+
+        # **`mouse=True`, sourced from charter's own `conf_text`.** Both halves matter:
+        # the flag is the regime this feature is for, and asking `conf_text` for the text
+        # rather than writing `set mouse on` by hand is what makes the `MouseDown1Pane`
+        # rebind (#634) part of what is under test — a hand-written config would leave
+        # tmux's default binding in place and the "keyboard stays on the harness" case
+        # below would be measuring a config this file invented.
+        conf = str(self.tmp / "frame.conf")
+        with open(conf, "w") as fh:
+            fh.write(commands_frame.conf_text(hotkey=config.FRAME["hotkey"], mouse=True,
+                                              history_limit=100, session=self.fid))
+        sourced = _tmux("source-file", conf)
+        self.assertEqual(sourced.returncode, 0, sourced.stderr)
+
+        self.attention = self._split("bottom", rows=1)
+        self.repos_pane = self._split("repos", rows=REPOS_ROWS)
+        # **The harness is put back in front, and that is the regime, not tidiness.**
+        # `split-window` selects the pane it made, and a frame whose repo table was the
+        # ACTIVE pane would be reporting the mouse because THAT pane asked — which is the
+        # `mouse = false` route `docs/frame.md` describes and would make every case below
+        # pass with charter's flag off. With the harness active, the only thing that can
+        # be making the terminal report is `[frame] mouse`, which is what these cases are
+        # about. `commands_frame._split_panels` ends the same way for the same reason.
+        selected = _tmux("select-pane", "-t", self.harness)
+        self.assertEqual(selected.returncode, 0, selected.stderr)
+
+        size = self._window_size()
+        self.assertNotEqual(size, (-1, -1), "tmux would not say how big its window is")
+        self.fd = self._attach(size)
+        self.assertTrue(_await(lambda: self._window_size() == size),
+                        "attaching the client resized the window, so every panel took a "
+                        "SIGWINCH the cases below would read as an event")
+
+        self.assertTrue(_await(lambda: "▪ repos 6" in self._shown(self.repos_pane)),
+                        f"the table never painted: {self._shown(self.repos_pane)!r}")
+        self.assertTrue(_await(lambda: self._shown(self.attention).strip() != ""),
+                        "the attention row never painted")
+        self.assertEqual(self._active(), self.harness,
+                         "the harness is not the active pane, so a report reaching a "
+                         "panel would prove nothing about `[frame] mouse`")
+
+    # -- the frame ---------------------------------------------------------- #
+
+    def _split(self, slot: str, *, rows: int) -> str:
+        """One of charter's OWN panels, run through the argv its launcher would run and
+        marked the way its launcher marks it (`commands_frame._panel_mark_argv`, called
+        rather than re-spelled — that mark is what the `MouseDown1Pane` bind asks about)."""
+        argv = layout.panel_command(slot=slot, session=self.fid)
+        r = _tmux("split-window", "-t", self.harness, "-v", "-l", str(rows),
+                  "-P", "-F", "#{pane_id}", "--", *argv, env=self.env)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pane = r.stdout.strip()
+        marked = subprocess.run(
+            commands_frame._panel_mark_argv(socket=SOCKET, pane_id=pane),
+            capture_output=True, text=True, timeout=20)
+        self.assertEqual(marked.returncode, 0, marked.stderr)
+        return pane
+
+    def _attach(self, size: tuple[int, int]) -> int:
+        cols, rows = size
+        refusals = []
+        for term in _TERM_CANDIDATES:
+            pid, fd = _fork_pty(rows=rows, cols=cols)
+            if pid == 0:
+                try:
+                    os.environ["TERM"] = term
+                    os.environ["CHARTER_ROOT"] = str(self.tmp)
+                    os.execvp("tmux", ["tmux", "-L", SOCKET, "attach", "-t", self.fid])
+                finally:
+                    os._exit(127)
+            if _await(lambda: bool(_tmux("list-clients", "-t", self.fid,
+                                         "-F", "#{client_name}").stdout.strip()),
+                      timeout=10.0):
+                self.addCleanup(self._reap, pid, fd)
+                return fd
+            refusals.append(term)
+            self._reap(pid, fd)
+        self.skipTest("no tmux client will attach on this machine, and a pointer needs "
+                      "one — tried TERM=" + ", ".join(refusals))
+
+    @staticmethod
+    def _reap(pid: int, fd: int) -> None:
+        for call in (lambda: os.kill(pid, 9), lambda: os.waitpid(pid, 0),
+                     lambda: os.close(fd)):
+            try:
+                call()
+            except OSError:
+                pass
+
+    def _teardown_socket(self) -> None:
+        said = _tmux("display-message", "-p", "#{socket_path}")
+        was_running = said.returncode == 0
+        path = said.stdout.strip()
+        _tmux("kill-server")
+        for candidate in {SOCKET_PATH, path if path.startswith("/") else SOCKET_PATH}:
+            try:
+                os.unlink(candidate)
+            except OSError:
+                pass
+        if not was_running:
+            return
+        self.assertTrue(path.startswith("/"), f"tmux would not say where its socket is")
+        self.assertFalse(os.path.exists(path), f"{path} survived this test's teardown")
+
+    # -- reading the frame back --------------------------------------------- #
+
+    def _shown(self, pane: str) -> str:
+        return _tmux("capture-pane", "-p", "-t", pane).stdout
+
+    def _painted(self, pane: str) -> str:
+        """The pane WITH its escapes (`capture-pane -e`), which is the only way to ask
+        whether a row is highlighted rather than merely present."""
+        return _tmux("capture-pane", "-p", "-e", "-t", pane).stdout
+
+    def _table(self) -> list[str]:
+        """The table's rows as plain text, heading dropped, blank tail dropped."""
+        rows = [ln.rstrip() for ln in self._shown(self.repos_pane).split("\n")]
+        return [ln for ln in rows[1:] if ln.strip()]
+
+    def _window_size(self) -> tuple[int, int]:
+        """The WINDOW's columns and rows, asked of tmux rather than re-spelled from the
+        `new-session` above (#514's rule). A pair no window has when the request fails, so
+        `setUp`'s comparison fails rather than something unpacking a traceback."""
+        r = _tmux("display-message", "-p", "-t", self.fid,
+                  "#{window_width} #{window_height}")
+        said = r.stdout.split()
+        if r.returncode != 0 or len(said) != 2:
+            return (-1, -1)
+        return int(said[0]), int(said[1])
+
+    def _rect(self, pane: str) -> tuple[int, int, int, int]:
+        r = _tmux("display-message", "-p", "-t", pane,
+                  "#{pane_left} #{pane_top} #{pane_width} #{pane_height}")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        left, top, w, h = (int(n) for n in r.stdout.split())
+        return left, top, w, h
+
+    def _active(self) -> str:
+        return _tmux("display-message", "-p", "#{pane_id}").stdout.strip()
+
+    def _inject(self, payload: bytes) -> None:
+        os.write(self.fd, payload)
+
+    def _point(self, pane: str, *, row: int, col: int = 2, button: int = 0,
+               release: bool = True) -> None:
+        left, top, _w, _h = self._rect(pane)
+        wcol, wrow = left + col + 1, top + row + 1
+        self._inject(b"\x1b[<%d;%d;%dM" % (button, wcol, wrow))
+        if release:
+            self._inject(b"\x1b[<%d;%d;%dm" % (button, wcol, wrow))
+
+    def _wheel(self, pane: str, *, down: bool, row: int = 1, col: int = 2) -> None:
+        """One notch. 64 is the wheel with bit 6 set, 65 the other direction — the
+        numbering `overlay._SGR_WHEEL` names, sent the way a reporting terminal sends it
+        (a press with no release, which is the second reason that module keeps no press
+        state)."""
+        left, top, _w, _h = self._rect(pane)
+        self._inject(b"\x1b[<%d;%d;%dM" % (64 + (1 if down else 0),
+                                           left + col + 1, top + row + 1))
+
+    # -- the cases ---------------------------------------------------------- #
+
+    def test_a_click_on_a_row_selects_that_repo_and_highlights_it(self):
+        """The report, answered end to end. Nothing here bumps the frame's version by
+        hand and nothing resizes anything, so a table that changed changed because of the
+        click."""
+        first = self._table()[0]
+        name = first.split()[1]
+        self.assertIn(name, self.repos, f"the first row is not a repo row: {first!r}")
+        self._point(self.repos_pane, row=1)
+        self.assertTrue(_await(lambda: state.selection(self.fid) == name),
+                        f"the click never reached the panel: "
+                        f"{state.selection(self.fid)!r}")
+        self.assertTrue(
+            _await(lambda: "\x1b[7m" in self._painted(self.repos_pane).split("\n")[1]),
+            f"the selected row was never highlighted: "
+            f"{self._painted(self.repos_pane)!r}")
+
+    def test_the_click_leaves_the_keyboard_on_the_harness(self):
+        """The property `mouse = true` used to take away and #634 gave back, asserted
+        here against charter's OWN panel rather than a fixture's. A table you cannot click
+        without losing your prompt is not a table an operator will click twice."""
+        self.assertEqual(self._active(), self.harness)
+        self._point(self.repos_pane, row=1)
+        self.assertTrue(_await(lambda: state.selection(self.fid) is not None))
+        self.assertEqual(self._active(), self.harness,
+                         "clicking the repo table moved the keyboard off the harness")
+
+    def test_the_attention_row_in_its_own_pane_learns_what_was_clicked(self):
+        """**Two processes.** The click lands in the `repos` panel and the detail is drawn
+        by the `bottom` panel, which has its own tty, its own loop and no memory in common
+        with the other. The only thing between them is `state.record_selection` and the
+        `state.bump` that wakes the poll — so this passing is the only proof that the
+        cross-pane half is real and not an artefact of one interpreter."""
+        name = self._table()[0].split()[1]
+        self._point(self.repos_pane, row=1)
+        self.assertTrue(_await(
+            lambda: f"▪ {name}" in self._shown(self.attention)),
+            f"the attention row never learned the selection: "
+            f"{self._shown(self.attention)!r}")
+
+    def test_a_click_on_the_heading_selects_nothing(self):
+        """Row 0 of the pane is `▪ repos 6`, which is about no repo. It is a row the
+        operator can see and click, so "nothing happens" has to be what happens rather
+        than the nearest row being picked for them."""
+        self._point(self.repos_pane, row=0)
+        time.sleep(1.0)
+        self.assertIsNone(state.selection(self.fid))
+
+    def test_the_wheel_moves_the_window_over_the_repos(self):
+        """The literal report. Six repos into four rows: three rows and `…(+3 more)`, so
+        there is somewhere below to go, and one notch must change WHICH repos are drawn."""
+        before = self._table()
+        self.assertIn("(+3 more", "\n".join(before), before)
+        self._wheel(self.repos_pane, down=True)
+        self.assertTrue(_await(lambda: self._table() != before),
+                        f"a wheel notch changed nothing: {before!r}")
+        after = self._table()
+        self.assertNotEqual(
+            [ln.split()[1] for ln in after if ln.split()[1] in self.repos],
+            [ln.split()[1] for ln in before if ln.split()[1] in self.repos])
+
+    def test_the_wheel_comes_back_to_the_table_it_started_on(self):
+        """Offset zero is the table that was always there, which is the compatibility
+        claim every plane that never scrolls depends on — asserted here against the real
+        rendered pane rather than against the function that composes it."""
+        before = self._table()
+        self._wheel(self.repos_pane, down=True)
+        self.assertTrue(_await(lambda: self._table() != before))
+        self._wheel(self.repos_pane, down=False)
+        self.assertTrue(_await(lambda: self._table() == before),
+                        f"scrolling back did not land on the table it left: "
+                        f"{self._table()!r} != {before!r}")
+
+    def test_the_wheel_never_selects(self):
+        """Two gestures, two pieces of state — and the one that would be a hover if
+        charter had asked for motion reporting. It did not (SGR 1000, not 1003), and a
+        wheel that moved the selection would be that hover arriving by the back door."""
+        self._wheel(self.repos_pane, down=True)
+        time.sleep(1.0)
+        self.assertIsNone(state.selection(self.fid))
+
+    def test_the_table_says_the_same_thing_it_would_with_no_pointer_at_all(self):
+        """The paint is not disturbed by the mode `events.Dispatcher.open` installs.
+        cbreak and never raw is the reason (`frame/events.py` measured the staircase
+        `tty.setraw` draws through `panel._write`'s `\\n`-joined rows), and a `repos` pane
+        is the first of charter's own to run in that mode — so the rows must still start
+        in column 0, every one of them."""
+        rows = [tui.strip_ansi(ln) for ln in self._shown(self.repos_pane).split("\n")
+                if ln.strip()]
+        self.assertGreater(len(rows), 1, rows)
+        for ln in rows:
+            indent = len(ln) - len(ln.lstrip(" "))
+            # The heading sits in column 0 and a table row is inset by `slots.INSET`. A
+            # raw-mode staircase indents each row by the WIDTH OF THE ONE ABOVE — ninety
+            # columns here, not four — so this bound is nowhere near the failure it names
+            # and cannot be met by accident.
+            self.assertLessEqual(indent, slots.INSET,
+                                 f"a row was shifted right — the pane is in raw mode, "
+                                 f"not cbreak: {ln!r}")
+        self.assertTrue(rows[0].startswith("▪ repos"), rows[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_palette.py
+++ b/tests/test_frame_palette.py
@@ -573,18 +573,27 @@ class TheActionsCharterOffersItself(PersonaIso, unittest.TestCase):
         """§4g plus the fact that the palette's pane is killed the instant it has invoked:
         `kill-pane` hands SIGHUP to that pane's process group, so a child inside it dies
         with it. Asserted on every built-in at once, because a new one added without this
-        would fail silently and only on a real frame."""
+        would fail silently and only on a real frame.
+
+        **Each action is driven with the ctx IT declared**, built by `action.build` from
+        its own `touches` — the same call `ActionRegistry._check` makes. It used to be one
+        hand-written `SimpleNamespace(fid=…)` for all of them, which was a second, weaker
+        copy of what a ctx carries: the first action to declare a slice (`repo.next`,
+        which reads the repo list to know what the next row is) raised `AttributeError` out
+        of the loop rather than failing this test's own claim.
+        """
         opened = []
 
         class _Popen:
             def __init__(self, argv, **kw):
                 opened.append(kw)
 
+        snapshot = {"repos": [{"name": "one"}, {"name": "two"}]}
         reg = builtin_actions.build(self.FID, current_density="normal",
                                     current_chrome="off")
         with mock.patch.object(builtin_actions.subprocess, "Popen", _Popen):
             for a in reg.all():
-                a.run(SimpleNamespace(fid=self.FID))
+                a.run(action.build(a.touches, fid=self.FID, snapshot=snapshot))
         self.assertTrue(opened)
         for kw in opened:
             self.assertTrue(kw.get("start_new_session"),

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -763,6 +763,12 @@ class NoCharterEscapesThroughTheExecFamily(unittest.TestCase):
             "to be put on a real client's terminal for tmux to route it — so neither "
             "`focus`/`blur` nor `click`/`scroll` can be exercised without a real one. "
             "`os._exit`s in its `finally`.",
+        "tests/test_a_real_click_reaches_the_real_repo_table.py:execvp":
+            "The same `tmux attach` inside a `pty.fork` child, for the sibling reason: "
+            "that file exercises the pointer against charter's OWN `repos` panel rather "
+            "than a fixture provider's, and a mouse report still has to be put on a real "
+            "client's terminal for tmux to route it anywhere. `os._exit`s in its "
+            "`finally`.",
     }
 
     _WATCHED = ("execl", "execle", "execlp", "execlpe", "execv", "execve", "execvp",

--- a/tests/test_the_repo_table_scrolls_and_selects.py
+++ b/tests/test_the_repo_table_scrolls_and_selects.py
@@ -157,6 +157,16 @@ class TheViewportRemembersOneThingAndClampsIt(unittest.TestCase):
         self.assertIsNone(self.v.repo_at(3))
         self.assertIsNone(self.v.repo_at(-1))
 
+    def test_row_zero_is_a_row_like_any_other_when_something_is_drawn_on_it(self):
+        """**The BOUNDARY, not the direction.** The map `_repos` publishes starts with the
+        heading, so every case above asks about a row 0 that is `None` anyway — and against
+        that map `0 <= row` and `0 < row` answer identically, which the deletion sweep
+        found. A map whose first entry is a repo is what tells them apart, and it is not
+        hypothetical: `publish` takes whatever the caller drew, and nothing in the contract
+        says row 0 must be chrome."""
+        self.v.publish(("a", "b"))
+        self.assertEqual(self.v.repo_at(0), "a")
+
 
 class TheWindowMovesAlongTheRanking(PersonaIso, unittest.TestCase):
     """What the table actually draws at each offset.
@@ -225,6 +235,20 @@ class TheWindowMovesAlongTheRanking(PersonaIso, unittest.TestCase):
         data = _data([_row("solo")],
                      worktrees=[_row("bit", repo="solo"), _row("other", repo="solo")])
         self.assertEqual(_names(self._lines(data, 6)), ["solo", "solo", "solo"])
+
+    def test_a_piece_on_the_branch_named_after_it_shows_no_branch_at_all(self):
+        """`charter worktree add <repo> <piece>` names the branch after the piece, so by
+        default the two columns print the same word twice. Emptying the cell is what makes
+        it mean *this piece is NOT on the branch you would assume* — and the OTHER arm of
+        that choice is what the sibling case above exercises, so both are here. The markers
+        still render either way: dirty and ahead/behind are true of the tree whatever its
+        branch."""
+        same = _data([_row("solo")],
+                     worktrees=[_row("bit", branch="bit", repo="solo")])
+        other = _data([_row("solo")],
+                      worktrees=[_row("bit", branch="fix/x", repo="solo")])
+        self.assertNotIn("bit  ", tui.strip_ansi(self._lines(same, 6)[1].text).strip())
+        self.assertIn("fix/x", tui.strip_ansi(self._lines(other, 6)[1].text))
 
 
 class TheSelectedRowIsDrawnAsSelected(PersonaIso, unittest.TestCase):
@@ -506,6 +530,17 @@ class TheAttentionRowSaysWhatWasPicked(PersonaIso, unittest.TestCase):
 
     def test_a_repo_with_no_branch_says_so_rather_than_leaving_the_cell_empty(self):
         self.assertIn("· ? ·", tui.strip_ansi(slots._detail_text(_row("x", branch=""))))
+
+    def test_a_change_with_no_sigil_still_gets_one(self):
+        """`gather` writes the forge's own word for a change — `!` on GitLab, `#` on
+        GitHub — and writes nothing when it does not know. The row must not then read
+        `123`, which is a number with no noun on it. The busy-repo case above hands a
+        sigil, so this is the one that tells the fallback from the field."""
+        self.assertIn("· !123",
+                      tui.strip_ansi(slots._detail_text(_row("x", change=123, sigil=""))))
+        self.assertIn("· #123",
+                      tui.strip_ansi(slots._detail_text(_row("x", change=123,
+                                                             sigil="#"))))
 
     def test_nothing_selected_is_nothing_on_the_row(self):
         """What every plane that has never clicked anything gets: `_fit_fields` drops an

--- a/tests/test_the_repo_table_scrolls_and_selects.py
+++ b/tests/test_the_repo_table_scrolls_and_selects.py
@@ -687,11 +687,31 @@ class ASelectionBelongsToOneFrame(PersonaIso, unittest.TestCase):
         self.assertIsNone(state.selection(FID))
 
     def test_never_recorded_reads_as_nothing_selected(self):
+        """The directory exists and the file does not, which is the ordinary state of
+        every frame nobody has clicked in — a missing file, not a missing frame."""
         state.frame_dir("f-untouched", create=True)
         self.assertIsNone(state.selection("f-untouched"))
 
+    def test_a_truncated_or_emptied_file_is_nothing_selected_and_not_an_empty_name(self):
+        """`None`, never ``""``. Two readers ask this — `slots._table_lines` matches it
+        against a row's name and `builtin_actions._select` looks it up in a list — and an
+        empty string is a THIRD value both of them would have to know about, for a file
+        that says exactly what a missing one says."""
+        d = state.frame_dir("f-empty", create=True)
+        (d / "selection").write_text("\n")
+        self.assertIsNone(state.selection("f-empty"))
+
     def test_a_frame_with_no_directory_answers_nothing_rather_than_raising(self):
         self.assertIsNone(state.selection("no-such-frame"))
+
+    def test_recording_for_an_id_no_directory_can_be_made_for_is_a_no_op(self):
+        """Every writer in `frame/state.py` makes this promise and this one is written
+        from a HANDLER — `frame/builtins._repos_events`, on the panel's own event path,
+        where an exception costs the component its events for the life of the pane
+        (`frame/events.py` retires a handler that raises). Degrading is the only answer
+        that leaves the table clickable."""
+        state.record_selection("../escape", "alpha")
+        self.assertIsNone(state.selection("../escape"))
 
 
 class TheRankingStillAnswersEveryOtherCaller(unittest.TestCase):

--- a/tests/test_the_repo_table_scrolls_and_selects.py
+++ b/tests/test_the_repo_table_scrolls_and_selects.py
@@ -684,6 +684,29 @@ class ThePanelDeliversToCharterSOwnComponent(PersonaIso, unittest.TestCase):
             said = panel._failure_text(evs, "repos")
         self.assertIn("repos stopped taking events", tui.strip_ansi(said))
 
+    def test_the_pane_paints_the_failure_instead_of_the_table(self):
+        """Not just that the message COMPOSES — that `_paint` puts it on the pane instead
+        of the rows. A built-in is drawn off `slots.SLOTS` and never through
+        `Registry.draw`, so this `or` is the only thing standing between a handler that
+        raised and a pane that goes on drawing a perfectly good table nobody can click."""
+        state.frame_dir(FID, create=True)
+        gather.save(FID, _data([_row("alpha")]))
+        evs = events.Dispatcher(builtins.build(FID).get("repos"),
+                                stream=mock.MagicMock())
+        evs._failure = "repos stopped taking events — RuntimeError: no"
+        written = []
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((WIDE, 6))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch.object(panel, "_write", written.append):
+            panel._paint("repos", FID, evs)
+            self.assertIn("stopped taking events", tui.strip_ansi(written[-1]))
+            self.assertNotIn("▪ repos", tui.strip_ansi(written[-1]),
+                             "the table was drawn as though nothing had broken")
+            evs._failure = None
+            panel._paint("repos", FID, evs)
+        self.assertIn("▪ repos", tui.strip_ansi(written[-1]))
+
     def test_a_panel_still_taking_events_paints_its_rows(self):
         """The other side of the same branch, so "" is read as "nothing to say" rather
         than as a message of its own."""
@@ -733,6 +756,19 @@ class ASelectionBelongsToOneFrame(PersonaIso, unittest.TestCase):
         that leaves the table clickable."""
         state.record_selection("../escape", "alpha")
         self.assertIsNone(state.selection("../escape"))
+
+    def test_a_write_that_cannot_complete_leaves_the_previous_selection_alone(self):
+        """The other half of "must not raise", and the half a directory that cannot be
+        made does not reach: a full disk, a read-only tree, a `charter/` somebody chmod'd.
+        The atomic replace is what makes "left alone" the outcome rather than "left
+        half-written" — the temp file is what fails, and the file a reader is looking at
+        was never touched."""
+        state.frame_dir(FID, create=True)
+        state.record_selection(FID, "alpha")
+        with mock.patch.object(state.config, "write_for",
+                               side_effect=OSError("no room on device")):
+            state.record_selection(FID, "beta")
+        self.assertEqual(state.selection(FID), "alpha")
 
 
 class TheRankingStillAnswersEveryOtherCaller(unittest.TestCase):

--- a/tests/test_the_repo_table_scrolls_and_selects.py
+++ b/tests/test_the_repo_table_scrolls_and_selects.py
@@ -531,6 +531,27 @@ class TheAttentionRowSaysWhatWasPicked(PersonaIso, unittest.TestCase):
                                side_effect=AssertionError("the panel swept")):
             self.assertEqual(slots._selected_detail(FID), "")
 
+    def test_a_frame_with_nothing_selected_does_not_read_the_gather_for_it(self):
+        """**The cost claim, counted rather than timed** — a wall-clock assertion on a
+        shared box measures the box, which is `test_frame_slots`' own rule one budget
+        over. `bottom` is the frame's ANIMATED slot: it repaints at `panel.TICK` for the
+        whole length of every dispatch, so a `gather.cached` added unconditionally here
+        would be a JSON read five times a second on every plane, forever, for a field
+        that is empty on almost all of them.
+
+        What it pays instead is one `read_text` of a file that is usually not there, and
+        the gather read only when a row has actually been picked."""
+        gather.save(FID, _data([_row("alpha")]))
+        with mock.patch.object(gather, "cached",
+                               side_effect=AssertionError("read the gather")) as never:
+            self.assertEqual(slots._selected_detail(FID), "")
+            self.assertEqual(never.call_count, 0)
+        state.record_selection(FID, "alpha")
+        with mock.patch.object(gather, "cached",
+                               wraps=gather.cached) as once:
+            self.assertNotEqual(slots._selected_detail(FID), "")
+            self.assertEqual(once.call_count, 1, "the detail read the gather twice")
+
     def test_the_detail_is_the_last_field_on_the_attention_row(self):
         """"The right side" of a row composed left to right and joined with ` · ` is the
         last field, and last is where it goes."""

--- a/tests/test_the_repo_table_scrolls_and_selects.py
+++ b/tests/test_the_repo_table_scrolls_and_selects.py
@@ -1,0 +1,722 @@
+"""The `repos` pane takes the wheel and the pointer — #607's first consumer.
+
+`frame/events.py` shipped the whole path a release ago and nothing used it: `component
+.EVENT_KINDS` was a closed vocabulary, `DELIVERED` named five kinds charter could carry,
+and every one of charter's own six components declared `events = ()`. So a provider could
+declare `scroll`, pass validation, and be the only thing on the machine receiving anything.
+`repos` declares `scroll` and `click` now, which is the same sequencing §4b asks for one
+contract over: charter's own panel is the worked example, not the exception.
+
+**What is asserted here is a VALUE wherever a value is what the code computes.** The
+clamping in `slots._Viewport` and `slots._scroll_limit` is exactly the place a test that
+computes its expectation from the thing under test survives every mutation — `_scroll_limit
+(20, 14)` is asserted to be `7` and not to be "positive", the window at offset 1 is compared
+against a ranking this module works out for itself, and the attention row's detail is
+compared against the sentence it should read rather than against "contains the name".
+
+**The scroll that does NOTHING is tested as hard as the one that does.** The `repos` pane
+is sized to its own content (`layout.repos_rows`), so the ordinary plane is one where every
+repo already fits and the wheel must move nothing, repaint nothing and cost nothing — an
+accident that happened to cancel would be indistinguishable from a design that refuses.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+from charter import statusline, tui
+from charter.frame import (builtin_actions, builtins, chrome, events, gather, overlay,
+                           panel, slots, state)
+from charter.frame import action as faction
+
+from tests._isolation import PersonaIso
+
+FID = "f-scroll"
+
+#: A pane wide enough for the table (`statusline._LEFT_W` is 95) with room to spare, so
+#: nothing here is accidentally testing the too-narrow refusal.
+WIDE = 200
+
+
+def _row(name, *, branch="main", dirty=False, ahead=0, behind=0, ci=None, change=None,
+         sigil="", current=False, repo=None, worktree_count=0) -> dict:
+    """A `gather`-cache-shaped row — the fields `gather._entry` writes."""
+    d = {"name": name, "branch": branch, "dirty": dirty, "tracked_dirty": False,
+         "ahead": ahead, "behind": behind, "ci": ci, "change": change, "sigil": sigil,
+         "current": current, "worktree_count": worktree_count}
+    if repo is not None:
+        d["repo"] = repo
+    return d
+
+
+def _data(repos, *, current=None, worktrees=()) -> dict:
+    return {"gathered_at": 0.0, "workspace": "w", "current_repo": current,
+            "repos": list(repos), "worktrees": list(worktrees)}
+
+
+def _names(lines) -> list[str | None]:
+    return [ln.repo for ln in lines]
+
+
+class TheOffsetIsBoundedByTheDataAndThePane(unittest.TestCase):
+    """`slots._scroll_limit` — how far the window may move, and when it may not at all.
+
+    Every case here is a number this function computes, asserted as a number. A test that
+    only asked "can this scroll?" would go green over a clamp deleted, because the answer
+    to that question is `True` for both `20 - 13` and `20`.
+    """
+
+    def test_a_pane_tall_enough_for_its_repos_does_not_scroll_at_all(self):
+        """**The tested nothing.** `layout.repos_rows` sizes this pane to its content, so
+        the ordinary plane has exactly as many rows as repos and the wheel must be inert.
+        Asserted at the boundary and one either side of it, because the guard that makes it
+        true is a comparison and an off-by-one there is a table that slides by one row on
+        every plane charter ships."""
+        self.assertEqual(slots._scroll_limit(6, 6), 0)
+        self.assertEqual(slots._scroll_limit(5, 6), 0)
+        self.assertEqual(slots._scroll_limit(1, 14), 0)
+
+    def test_the_limit_leaves_the_overflow_line_its_row(self):
+        """`_table_lines` reserves `…(+N more)` OUT of the budget rather than trimming it
+        off the end, so a 14-row pane draws 13 repo rows — and the last repo is reachable
+        only if this subtracts the same row. Twenty repos, thirteen rows of them, so the
+        window's last position is 7; at 7 it shows ranks 7..19 and nothing is out of
+        reach."""
+        self.assertEqual(slots._scroll_limit(20, 14), 7)
+        self.assertEqual(slots._scroll_limit(7, 6), 2)
+
+    def test_a_one_row_pane_is_all_overflow_line_and_does_not_scroll(self):
+        """A budget of exactly one is spent on `…(+N more)` — "there is more here than
+        fits" outranks "here is an arbitrary one of them" — so every offset over such a
+        table draws the identical line. A limit taken from the repo count alone would let
+        the wheel repaint that one line forty times, each repaint byte-identical."""
+        self.assertEqual(slots._scroll_limit(40, 1), 0)
+        self.assertEqual(slots._scroll_limit(40, 0), 0)
+
+
+class TheViewportRemembersOneThingAndClampsIt(unittest.TestCase):
+    """`slots._Viewport` — the offset the handler moves and the renderer settles."""
+
+    def setUp(self) -> None:
+        self.v = slots._Viewport()
+
+    def test_a_scroll_that_changes_nothing_answers_falsy(self):
+        """The answer IS the repaint decision (§4f), so "nothing moved" has to be a
+        different value from "moved", not merely a different offset. With no paint behind
+        it the limit is zero and every notch is refused."""
+        self.assertFalse(self.v.move(1))
+        self.assertFalse(self.v.move(-1))
+        self.assertEqual(self.v.offset, 0)
+
+    def test_it_stops_at_the_top_and_at_the_bottom(self):
+        self.v.settle(3)
+        self.assertTrue(self.v.move(1))
+        self.assertEqual(self.v.offset, 1)
+        self.assertTrue(self.v.move(99))
+        self.assertEqual(self.v.offset, 3, "it went past the last window there is")
+        self.assertFalse(self.v.move(1), "a notch at the bottom repainted for nothing")
+        self.assertTrue(self.v.move(-99))
+        self.assertEqual(self.v.offset, 0)
+        self.assertFalse(self.v.move(-1), "a notch at the top repainted for nothing")
+
+    def test_an_offset_that_outlives_a_shrunken_list_is_clamped_down(self):
+        """A repo is removed while the table is scrolled to the bottom. The stored offset
+        is now past the end of a list that no longer has those rows, and the NEXT paint is
+        where that is answered: `settle` takes the bound the renderer just computed and
+        hands back the largest window this list actually has.
+
+        Asserted as the value 2 rather than as "not 7": an unclamped offset is still an
+        integer and still renders *something* — an empty table the operator has to guess
+        their way back out of — so "it changed" is not the claim."""
+        self.v.settle(7)
+        self.v.move(7)
+        self.assertEqual(self.v.offset, 7)
+        self.assertEqual(self.v.settle(2), 2)
+        self.assertEqual(self.v.offset, 2)
+
+    def test_settling_a_pane_with_nothing_to_scroll_puts_it_back_at_the_top(self):
+        """The other end of the same clamp: a resize that starves the pane, or a plane
+        whose repos were all removed, answers a limit of 0 and the window goes home rather
+        than staying at an offset over a table that is not there."""
+        self.v.settle(4)
+        self.v.move(3)
+        self.assertEqual(self.v.settle(0), 0)
+        self.assertFalse(self.v.move(1))
+
+    def test_a_row_the_pane_never_drew_is_nobody(self):
+        """Out of range answers `None` rather than raising or counting from the end.
+        Python's own indexing would report the LAST row for `-1`, which is the one wrong
+        answer available here — an event carrying a negative row means charter's own
+        arithmetic was wrong, and a plausible answer would hide it."""
+        self.v.publish((None, "a", "b"))
+        self.assertEqual(self.v.repo_at(1), "a")
+        self.assertIsNone(self.v.repo_at(0))
+        self.assertIsNone(self.v.repo_at(3))
+        self.assertIsNone(self.v.repo_at(-1))
+
+
+class TheWindowMovesAlongTheRanking(PersonaIso, unittest.TestCase):
+    """What the table actually draws at each offset.
+
+    `statusline._pick_rows` ranks the whole list and slices it; the offset moves that slice.
+    The expectations below are worked out from the ranking's own documented order — where
+    you are, then dirty, then ahead/behind, then CI, then a change, then cache order — and
+    never from a second call to the function under test.
+    """
+
+    def _lines(self, data, budget, **kw):
+        return slots._table_lines(data, WIDE, budget, **kw)
+
+    def test_offset_zero_is_the_table_that_was_there_before(self):
+        """The compatibility claim, and the only one that matters for every plane that
+        never scrolls: `[0:budget]` is the slice `_pick_rows` has always taken, so an
+        unscrolled table is byte-for-byte what it was."""
+        data = _data([_row(f"r{i}") for i in range(20)])
+        self.assertEqual([ln.text for ln in self._lines(data, 14)],
+                         [ln.text for ln in self._lines(data, 14, offset=0)])
+
+    def test_one_notch_drops_the_top_rank_and_reveals_the_next(self):
+        """Five repos, a four-row budget: three rows of repos and the overflow line. The
+        ranking is `r1` (dirty) first, then `r0`/`r2`/`r3`/`r4` in cache order, so offset 0
+        shows r1 + r0 + r2 and offset 1 shows r0 + r2 + r3 — the highest rank leaves and the
+        next-highest hidden one arrives.
+
+        Display order is still the cache's, which is why the names come back sorted that
+        way rather than in the order they were ranked."""
+        data = _data([_row("r0"), _row("r1", dirty=True), _row("r2"), _row("r3"),
+                      _row("r4")])
+        self.assertEqual(_names(self._lines(data, 4)), ["r0", "r1", "r2", None])
+        self.assertEqual(_names(self._lines(data, 4, offset=1)), ["r0", "r2", "r3", None])
+        self.assertEqual(_names(self._lines(data, 4, offset=2)), ["r2", "r3", "r4", None])
+
+    def test_the_last_window_reaches_the_lowest_ranked_repo(self):
+        """The point of subtracting the overflow line's row in `_scroll_limit`: at the
+        limit, the bottom of the ranking is on screen. `r4` is last in cache order with
+        nothing on it, so it is the last rank, and it must be reachable."""
+        repos = [_row(f"r{i}") for i in range(5)]
+        data = _data(repos)
+        limit = slots._scroll_limit(5, 4)
+        self.assertEqual(limit, 2)
+        self.assertIn("r4", _names(self._lines(data, 4, offset=limit)))
+
+    def test_the_overflow_note_still_counts_every_hidden_repo(self):
+        """It needs no arithmetic of its own at any offset: what is hidden is "every key
+        not in *show*", which is true wherever the window is. Twenty repos, thirteen shown,
+        seven hidden — at the top and at the bottom alike."""
+        data = _data([_row(f"r{i}") for i in range(20)])
+        for offset in (0, 3, 7):
+            note = tui.strip_ansi(self._lines(data, 14, offset=offset)[-1].text)
+            self.assertIn("(+7 more", note)
+
+    def test_the_overflow_line_is_about_no_repo(self):
+        """It stands for the rows that are NOT on screen. Selecting one of them because
+        the operator clicked the line saying they exist would be charter answering a
+        question nobody asked."""
+        data = _data([_row(f"r{i}") for i in range(20)])
+        self.assertIsNone(self._lines(data, 14)[-1].repo)
+
+    def test_a_piece_row_belongs_to_the_repo_it_is_a_piece_of(self):
+        """One namespace, not two. `gather` writes `repo` on every worktree row, so a
+        click on a nested row selects the clone — and a piece named after a sibling clone
+        cannot come to mean that clone's selection."""
+        data = _data([_row("solo")],
+                     worktrees=[_row("bit", repo="solo"), _row("other", repo="solo")])
+        self.assertEqual(_names(self._lines(data, 6)), ["solo", "solo", "solo"])
+
+
+class TheSelectedRowIsDrawnAsSelected(PersonaIso, unittest.TestCase):
+    """The highlight — `frame/chrome.reverse`, the same call the persona column makes."""
+
+    def _lines(self, **kw):
+        data = _data([_row("alpha"), _row("beta")])
+        return slots._table_lines(data, WIDE, 6, **kw)
+
+    def test_the_selected_row_is_reversed_and_no_other_row_is(self):
+        lines = self._lines(selected="beta")
+        self.assertNotIn("\x1b[7m", lines[0].text, "an unselected row was highlighted")
+        self.assertIn("\x1b[7m", lines[1].text)
+
+    def test_the_highlight_survives_the_rows_own_resets(self):
+        """The defect `chrome.reverse` exists for: every coloured span in a repo row ends
+        in `statusline._R`, and a `\\x1b[7m` wrapped naively round the outside dies at the
+        first one. So reverse has to be re-asserted after each — measured here as "more
+        than one", which a naive wrapper cannot produce."""
+        row = self._lines(selected="alpha")[0].text
+        self.assertGreater(row.count("\x1b[7m"), 1)
+
+    def test_the_highlight_reaches_the_pane_s_last_column(self):
+        """A highlight that stopped at the text would mark two words rather than a row.
+        `chrome.reverse` fills to exactly the width the renderer measured — never one
+        more, which `chrome.fill`'s own measurement shows shears the pane."""
+        row = self._lines(selected="alpha")[0].text
+        self.assertEqual(tui.width(row), WIDE)
+
+    def test_the_row_says_the_same_thing_selected_as_unselected(self):
+        """The selection is paint and never content: a highlighted row must not gain,
+        lose or move a single visible cell, or the operator's eye has to re-read the table
+        every time they point at it."""
+        self.assertEqual(chrome.plain(self._lines(selected="alpha")[0].text),
+                         chrome.plain(self._lines()[0].text))
+
+    def test_a_selection_naming_no_row_highlights_nothing(self):
+        """What a selection left over from a repo that has since gone degrades to — and
+        the same answer a hand-edited `selection` file gets, which is why nothing validates
+        that file: the only thing charter does with the string is this equality."""
+        self.assertEqual([ln.text for ln in self._lines(selected="gone")],
+                         [ln.text for ln in self._lines()])
+
+
+class TheHandlerIsWhatTheContractSays(PersonaIso, unittest.TestCase):
+    """`builtins._repos_events` — what a pointer event does and, mostly, does not do."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        state.frame_dir(FID, create=True)
+        self.on_event = builtins.build(FID).get("repos").on_event
+        slots.VIEWPORT.forget()
+
+    def tearDown(self) -> None:
+        slots.VIEWPORT.forget()
+        super().tearDown()
+
+    def _click(self, row, *, pressed=True, name="left"):
+        return self.on_event(overlay.Event(overlay.CLICK, name, row=row, pressed=pressed))
+
+    def test_the_repo_table_declares_the_two_kinds_charter_can_carry(self):
+        """Declared TOGETHER because `events.Dispatcher.open` asks the terminal for one
+        request that serves both — a component declaring only one would still pay
+        `overlay.MOUSE_ON`'s whole price."""
+        c = builtins.build(FID).get("repos")
+        self.assertEqual(c.events, ("scroll", "click"))
+        self.assertEqual(events.wanted(c), ("scroll", "click"))
+
+    def test_a_click_on_a_drawn_row_selects_that_repo(self):
+        slots.VIEWPORT.publish((None, "alpha", "beta"))
+        self.assertTrue(self._click(2))
+        self.assertEqual(state.selection(FID), "beta")
+
+    def test_a_click_on_the_heading_selects_nothing(self):
+        """Row 0 of the pane is `▪ repos N`, which belongs to no repo."""
+        slots.VIEWPORT.publish((None, "alpha"))
+        self.assertFalse(self._click(0))
+        self.assertIsNone(state.selection(FID))
+
+    def test_a_click_below_the_last_row_selects_nothing(self):
+        slots.VIEWPORT.publish((None, "alpha"))
+        self.assertFalse(self._click(9))
+        self.assertIsNone(state.selection(FID))
+
+    def test_the_press_selects_and_the_release_does_not(self):
+        """`component.EVENT_KINDS`: a click arrives twice and either half can arrive
+        alone — a drag begun on a pane border delivers exactly one release. Acting on the
+        press is acting on where the operator pointed; a drag that began elsewhere and
+        released over this pane never pointed here."""
+        slots.VIEWPORT.publish((None, "alpha"))
+        self.assertFalse(self._click(1, pressed=False))
+        self.assertIsNone(state.selection(FID))
+        self.assertTrue(self._click(1, pressed=True))
+        self.assertEqual(state.selection(FID), "alpha")
+
+    def test_only_the_left_button_selects(self):
+        """Middle-click is paste on every terminal an operator has ever used and
+        right-click opens their emulator's own menu. Acting on either would be charter
+        taking a gesture that already means something else."""
+        slots.VIEWPORT.publish((None, "alpha"))
+        for button in ("middle", "right"):
+            self.assertFalse(self._click(1, name=button))
+            self.assertIsNone(state.selection(FID), f"{button}-click selected a row")
+
+    def test_re_selecting_the_row_already_selected_is_not_news(self):
+        """Neither pane has anything new to draw, so neither is asked to: the handler
+        answers falsy and the frame's version does not move. This is also what keeps a
+        double-click from bumping the frame twice."""
+        slots.VIEWPORT.publish((None, "alpha"))
+        self.assertTrue(self._click(1))
+        was = state.version(FID)
+        self.assertFalse(self._click(1))
+        self.assertEqual(state.version(FID), was)
+
+    def test_a_click_bumps_the_frame_so_the_attention_pane_redraws(self):
+        """The detail is drawn by `bottom`, which is a different pane and a different
+        process — returning truthy repaints THIS panel and only this panel. `state.bump`
+        is how every other cross-panel fact in this frame travels."""
+        slots.VIEWPORT.publish((None, "alpha"))
+        was = state.version(FID)
+        self._click(1)
+        self.assertNotEqual(state.version(FID), was)
+
+    def test_a_wheel_notch_over_a_pane_that_fits_moves_nothing(self):
+        """The whole of "scrolling means nothing when the pane is tall enough", from the
+        handler's side: it reads the bound the last paint settled and refuses. No repaint
+        is asked for, so the frame does not paint."""
+        slots.VIEWPORT.settle(0)
+        self.assertFalse(self.on_event(overlay.Event(overlay.SCROLL, "down")))
+        self.assertFalse(self.on_event(overlay.Event(overlay.SCROLL, "up")))
+
+    def test_a_wheel_notch_moves_exactly_one_row(self):
+        """One report per notch is what a terminal sends and what tmux forwards, so a
+        larger step multiplies whatever the operator's mouse already decided."""
+        slots.VIEWPORT.settle(5)
+        self.assertTrue(self.on_event(overlay.Event(overlay.SCROLL, "down")))
+        self.assertEqual(slots.VIEWPORT.offset, 1)
+        self.assertTrue(self.on_event(overlay.Event(overlay.SCROLL, "up")))
+        self.assertEqual(slots.VIEWPORT.offset, 0)
+
+    def test_the_wheel_never_selects_and_a_click_never_scrolls(self):
+        """Two gestures, two pieces of state. A wheel that moved the selection would make
+        the highlight follow the pointer, which is the hover charter deliberately does not
+        have (SGR 1000, not 1003)."""
+        slots.VIEWPORT.settle(5)
+        slots.VIEWPORT.publish((None, "alpha"))
+        self.on_event(overlay.Event(overlay.SCROLL, "down"))
+        self.assertIsNone(state.selection(FID))
+        self._click(1)
+        self.assertEqual(slots.VIEWPORT.offset, 1, "a click moved the window")
+
+    def test_nothing_it_does_is_irreversible(self):
+        """§4i, and the property this handler exists to demonstrate: a pointer event can
+        arrive unpaired, so nothing driven by one may be a thing you cannot take back.
+        Everything a click here can do is undone by clicking the row you were on."""
+        slots.VIEWPORT.publish((None, "alpha", "beta"))
+        self._click(1)
+        self._click(2)
+        self._click(1)
+        self.assertEqual(state.selection(FID), "alpha")
+
+
+class ThePaneWiresItAllTogether(PersonaIso, unittest.TestCase):
+    """`slots._repos` — the one place the bound, the map and the highlight are decided."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        state.frame_dir(FID, create=True)
+        slots.VIEWPORT.forget()
+
+    def tearDown(self) -> None:
+        slots.VIEWPORT.forget()
+        super().tearDown()
+
+    def _paint(self, *, cols=WIDE, rows=24) -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return slots.render("repos", FID)
+
+    def test_a_paint_records_which_repo_each_pane_row_is_about(self):
+        """Row 0 is the heading and belongs to nobody; the table starts at row 1. That
+        offset by one is the whole of what a click has to get right, and it is decided
+        here rather than in the handler."""
+        gather.save(FID, _data([_row("alpha"), _row("beta")]))
+        self._paint(rows=4)
+        self.assertIsNone(slots.VIEWPORT.repo_at(0))
+        self.assertEqual(slots.VIEWPORT.repo_at(1), "alpha")
+        self.assertEqual(slots.VIEWPORT.repo_at(2), "beta")
+
+    def test_a_paint_of_a_pane_that_fits_leaves_nothing_to_scroll(self):
+        """Two repos in a pane with room for two: the bound the handler will read is 0,
+        so the wheel is inert on the ordinary plane by construction rather than by luck."""
+        gather.save(FID, _data([_row("alpha"), _row("beta")]))
+        self._paint(rows=3)
+        self.assertEqual(slots.VIEWPORT.limit, 0)
+
+    def test_a_paint_of_a_pane_that_does_not_fit_leaves_room_to_scroll(self):
+        """Twenty repos in a pane with room for four rows of table: three repo rows and
+        the note, so the window's last position is 17."""
+        gather.save(FID, _data([_row(f"r{i}") for i in range(20)]))
+        self._paint(rows=5)
+        self.assertEqual(slots.VIEWPORT.limit, 17)
+
+    def test_a_pane_with_no_table_in_it_is_clicked_on_nobody(self):
+        """The three one-line answers this pane draws instead of a table — not gathered
+        yet, gathered and empty, too narrow — publish no map at all, so a click on the
+        sentence is not a selection. A map left over from an earlier paint would sell the
+        operator a repo that is no longer on screen."""
+        gather.save(FID, _data([_row("alpha")]))
+        self._paint(rows=4)
+        self.assertEqual(slots.VIEWPORT.repo_at(1), "alpha")
+        gather.save(FID, _data([]))
+        self._paint(rows=4)
+        self.assertIsNone(slots.VIEWPORT.repo_at(1))
+        gather.discard(FID)
+        self._paint(rows=4)
+        self.assertIsNone(slots.VIEWPORT.repo_at(1))
+        gather.save(FID, _data([_row("alpha")]))
+        self._paint(cols=40, rows=4)
+        self.assertIsNone(slots.VIEWPORT.repo_at(1))
+
+    def test_a_starved_pane_puts_the_window_back_rather_than_keeping_a_stale_bound(self):
+        """A resize takes the table's rows away. `settle` runs on every paint, not only
+        the ones that draw rows, so the bound the handler reads is this pane's rather than
+        whatever the last taller one recorded."""
+        gather.save(FID, _data([_row(f"r{i}") for i in range(20)]))
+        self._paint(rows=8)
+        self.assertGreater(slots.VIEWPORT.limit, 0)
+        self._paint(rows=1)
+        self.assertEqual(slots.VIEWPORT.limit, 0)
+
+    def test_the_pane_draws_the_selection_the_frame_recorded(self):
+        gather.save(FID, _data([_row("alpha"), _row("beta")]))
+        state.record_selection(FID, "beta")
+        rows = self._paint(rows=4).split("\n")
+        self.assertNotIn("\x1b[7m", rows[1])
+        self.assertIn("\x1b[7m", rows[2])
+
+    def test_the_scrolled_window_is_what_the_pane_paints(self):
+        """The offset is not a number kept beside the table — it is the table. Scrolled
+        by one, the pane's own rows are the ones offset 1 composes."""
+        gather.save(FID, _data([_row(f"r{i}") for i in range(20)]))
+        self._paint(rows=6)
+        slots.VIEWPORT.move(1)
+        got = [tui.strip_ansi(ln) for ln in self._paint(rows=6).split("\n")]
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((WIDE, 6))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            want = slots._table_lines(gather.cached(FID),
+                                      slots.content_width("repos"), 5, offset=1)
+        self.assertEqual(got[1:], [tui.strip_ansi(ln.text) for ln in want])
+
+
+class TheAttentionRowSaysWhatWasPicked(PersonaIso, unittest.TestCase):
+    """`slots._selected_detail` and `slots._detail_text` — the operator's "tooltip"."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        state.frame_dir(FID, create=True)
+
+    def test_a_busy_repo_is_read_back_in_words(self):
+        """Every field the table draws as a glyph, said. Asserted as the sentence rather
+        than as "contains the name": a detail that dropped a field would still contain the
+        name, and the field it dropped is the one the operator clicked to see."""
+        self.assertEqual(
+            tui.strip_ansi(slots._detail_text(
+                _row("charter", branch="fix/x", dirty=True, ahead=2, behind=1,
+                     ci="failed", change=123, sigil="!", worktree_count=3))),
+            "▪ charter · fix/x · dirty · 2 ahead · 1 behind · CI failed · !123 · ⑂3")
+
+    def test_a_quiet_repo_says_clean_rather_than_saying_nothing(self):
+        """An absence standing in for a claim is the defect this repository keeps finding:
+        a reader cannot tell "nothing is wrong" from "this field was cut". The word comes
+        from `_needs_attention`, the same predicate the `…(+N more), all clean` note asks,
+        so the two cannot come to disagree about what clean means."""
+        self.assertEqual(tui.strip_ansi(slots._detail_text(_row("charter"))),
+                         "▪ charter · main · clean")
+
+    def test_a_repo_with_no_branch_says_so_rather_than_leaving_the_cell_empty(self):
+        self.assertIn("· ? ·", tui.strip_ansi(slots._detail_text(_row("x", branch=""))))
+
+    def test_nothing_selected_is_nothing_on_the_row(self):
+        """What every plane that has never clicked anything gets: `_fit_fields` drops an
+        empty field whole, so the attention row is what it was before this existed."""
+        gather.save(FID, _data([_row("alpha")]))
+        self.assertEqual(slots._selected_detail(FID), "")
+
+    def test_a_selection_naming_a_repo_that_is_gone_says_nothing(self):
+        """The table drew no highlight for it either, so both surfaces go quiet together.
+        Saying "gone" here would leave the attention row as the only thing on screen
+        claiming that repo ever existed."""
+        gather.save(FID, _data([_row("alpha")]))
+        state.record_selection(FID, "vanished")
+        self.assertEqual(slots._selected_detail(FID), "")
+
+    def test_a_frame_whose_gather_has_not_landed_says_nothing_rather_than_scanning(self):
+        """`gather.cached` and never `gather.read`: a panel must not sweep, and `bottom`
+        is the animated slot — a fallback scan here would walk every clone on the plane
+        five times a second for the length of every dispatch."""
+        gather.discard(FID)
+        state.record_selection(FID, "alpha")
+        with mock.patch.object(gather, "scan",
+                               side_effect=AssertionError("the panel swept")):
+            self.assertEqual(slots._selected_detail(FID), "")
+
+    def test_the_detail_is_the_last_field_on_the_attention_row(self):
+        """"The right side" of a row composed left to right and joined with ` · ` is the
+        last field, and last is where it goes."""
+        gather.save(FID, _data([_row("alpha")]))
+        state.record_selection(FID, "alpha")
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((WIDE, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            row = tui.strip_ansi(slots.render("bottom", FID))
+        self.assertTrue(row.rstrip().endswith("▪ alpha · main · clean"), row)
+
+
+class TheSelectionHasAKeyboardRoute(PersonaIso, unittest.TestCase):
+    """`builtin_actions._register_selection` — `F2`, arrow keys, Enter.
+
+    `[frame] mouse` ships off and charter does not own the harness, so a component whose
+    only route to a piece of state is a click has no route to it on most planes
+    (`component.EVENT_KINDS`). These rows are charter keeping its own rule about its own
+    first pointer affordance.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        state.frame_dir(FID, create=True)
+
+    def _ctx(self, names):
+        a = builtin_actions.build(FID, current_density="normal",
+                                  current_chrome="off").get("repo.next")
+        return faction.build(a.touches, fid=FID,
+                             snapshot={"repos": [_row(n) for n in names]})
+
+    def _run(self, aid, names):
+        reg = builtin_actions.build(FID, current_density="normal", current_chrome="off")
+        a = reg.get(aid)
+        return a.run(faction.build(a.touches, fid=FID,
+                                   snapshot={"repos": [_row(n) for n in names]}))
+
+    def test_the_palette_offers_both_directions(self):
+        reg = builtin_actions.build(FID, current_density="normal", current_chrome="off")
+        self.assertEqual([a.title for a in reg.all() if a.id.startswith("repo.")],
+                         ["repo: select the next row", "repo: select the previous row"])
+
+    def test_next_from_nothing_starts_at_the_top_and_previous_at_the_bottom(self):
+        """The two ends a walk with no cursor under it can be entered from. One sentinel
+        for both directions was the first version and was wrong: `-1` gives `next` its
+        first row and gives `previous` the row SECOND from the bottom, which is a cursor
+        appearing in the middle of a list nobody had put one in."""
+        self._run("repo.next", ["a", "b", "c"])
+        self.assertEqual(state.selection(FID), "a")
+        state.record_selection(FID, "")
+        self._run("repo.previous", ["a", "b", "c"])
+        self.assertEqual(state.selection(FID), "c")
+
+    def test_it_walks_the_tables_display_order(self):
+        state.record_selection(FID, "a")
+        self._run("repo.next", ["a", "b", "c"])
+        self.assertEqual(state.selection(FID), "b")
+        self._run("repo.previous", ["a", "b", "c"])
+        self.assertEqual(state.selection(FID), "a")
+
+    def test_it_wraps_at_both_ends(self):
+        """Stepping off the end and stopping makes a palette row that visibly does
+        nothing, which reads as broken and costs a whole `F2` to find out."""
+        state.record_selection(FID, "c")
+        self._run("repo.next", ["a", "b", "c"])
+        self.assertEqual(state.selection(FID), "a")
+        self._run("repo.previous", ["a", "b", "c"])
+        self.assertEqual(state.selection(FID), "c")
+
+    def test_a_selection_naming_a_repo_that_is_gone_re_enters_from_the_end(self):
+        state.record_selection(FID, "vanished")
+        self._run("repo.next", ["a", "b"])
+        self.assertEqual(state.selection(FID), "a")
+
+    def test_it_bumps_the_frame_so_both_panes_redraw(self):
+        was = state.version(FID)
+        self._run("repo.next", ["a"])
+        self.assertNotEqual(state.version(FID), was)
+
+    def test_the_work_is_done_before_run_returns(self):
+        """These two rows do NOT spawn, unlike every other built-in action, and that is
+        safe for one measured reason: the work is two atomic file writes and `cmd_palette`
+        joins the invocation before it closes the pane. A subprocess would buy nothing and
+        cost a whole interpreter start."""
+        note = self._run("repo.next", ["a", "b"])
+        self.assertEqual(state.selection(FID), "a")
+        self.assertEqual(note, "selected a")
+
+    def test_a_plane_with_no_clones_is_told_why_rather_than_pressing_nothing(self):
+        reg = builtin_actions.build(FID, current_density="normal", current_chrome="off")
+        offers = {o.id: o for o in reg.offers(fid=FID, snapshot={"repos": []})}
+        self.assertFalse(offers["repo.next"].available)
+        self.assertIn("charter clone", offers["repo.next"].reason)
+        self.assertTrue(
+            {o.id: o for o in reg.offers(
+                fid=FID, snapshot={"repos": [_row("a")]})}["repo.next"].available)
+
+
+class ThePanelDeliversToCharterSOwnComponent(PersonaIso, unittest.TestCase):
+    """`panel._run` — charter's own panels are drawn off `slots.SLOTS`, and one of them
+    now also has to be DRIVEN. Until this, that branch built no registry at all, so a
+    built-in was the one kind of component that could declare `events` and never receive
+    any."""
+
+    def test_only_the_repo_table_gets_an_event_path(self):
+        reg = builtins.build(FID)
+        self.assertIsNotNone(panel._dispatcher(reg, "repos"))
+        for cid in ("identity", "attention", "sidebar"):
+            self.assertIsNone(panel._dispatcher(reg, cid),
+                              f"{cid} pays for an input path it declared nothing for")
+
+    def test_a_handler_that_raises_costs_its_pane_and_says_so(self):
+        """§4b's answer for a provider, given to charter's own: a component that quietly
+        stopped being interactive is indistinguishable from one nobody has clicked yet.
+        The trade is stated and it is real — a working `render` loses its pane because the
+        HANDLER broke."""
+        c = builtins.build(FID).get("repos")
+        broken = c.__class__(id=c.id, title=c.title, edge=c.edge, size=c.size,
+                             render=c.render, needs=c.needs, events=c.events,
+                             on_event=lambda ev: (_ for _ in ()).throw(
+                                 RuntimeError("no")))
+        evs = events.Dispatcher(broken, stream=mock.MagicMock())
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((WIDE, 6))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch.object(events.pane, "size",
+                               return_value=os.terminal_size((WIDE, 6))):
+            evs._deliver(overlay.Event(overlay.CLICK, "left", row=1, pressed=True))
+            self.assertIn("repos stopped taking events", evs.failure or "")
+            said = panel._failure_text(evs, "repos")
+        self.assertIn("repos stopped taking events", tui.strip_ansi(said))
+
+    def test_a_panel_still_taking_events_paints_its_rows(self):
+        """The other side of the same branch, so "" is read as "nothing to say" rather
+        than as a message of its own."""
+        self.assertEqual(panel._failure_text(None, "repos"), "")
+        evs = events.Dispatcher(builtins.build(FID).get("repos"),
+                                stream=mock.MagicMock())
+        self.assertEqual(panel._failure_text(evs, "repos"), "")
+
+
+class ASelectionBelongsToOneFrame(PersonaIso, unittest.TestCase):
+    """`state.record_selection` / `state.selection` / `state.clear_shape`."""
+
+    def test_a_new_frame_claiming_a_recycled_id_does_not_inherit_a_selection(self):
+        """The mildest of the files `clear_shape` clears and the same shape: a brand-new
+        frame comes up with one repo highlighted and its detail on the attention row
+        because somebody pointed at it in a session that is over. The highlight is a claim
+        about an action this operator did not take."""
+        state.frame_dir(FID, create=True)
+        state.record_selection(FID, "alpha")
+        self.assertEqual(state.selection(FID), "alpha")
+        state.clear_shape(FID)
+        self.assertIsNone(state.selection(FID))
+
+    def test_never_recorded_reads_as_nothing_selected(self):
+        state.frame_dir("f-untouched", create=True)
+        self.assertIsNone(state.selection("f-untouched"))
+
+    def test_a_frame_with_no_directory_answers_nothing_rather_than_raising(self):
+        self.assertIsNone(state.selection("no-such-frame"))
+
+
+class TheRankingStillAnswersEveryOtherCaller(unittest.TestCase):
+    """`statusline._pick_rows` gained an *offset* and every existing caller omits it."""
+
+    def test_the_default_is_the_slice_it_always_took(self):
+        dirs = [statusline.Path(f"/tmp/r{i}") for i in range(6)]
+        st = {d: {} for d in dirs}
+        self.assertEqual(statusline._pick_rows(dirs, 3, None, st, {}),
+                         statusline._pick_rows(dirs, 3, None, st, {}, offset=0))
+        self.assertEqual(statusline._pick_rows(dirs, 3, None, st, {}), dirs[:3])
+
+    def test_an_offset_walks_down_the_ranking(self):
+        dirs = [statusline.Path(f"/tmp/r{i}") for i in range(6)]
+        st = {d: {} for d in dirs}
+        self.assertEqual(statusline._pick_rows(dirs, 3, None, st, {}, offset=2), dirs[2:5])
+
+    def test_past_the_end_answers_fewer_rows_rather_than_clamping(self):
+        """The caller that scrolls is the one that knows how many rows the pane has;
+        a clamp here would be a second, weaker copy of `slots._scroll_limit`."""
+        dirs = [statusline.Path(f"/tmp/r{i}") for i in range(3)]
+        st = {d: {} for d in dirs}
+        self.assertEqual(statusline._pick_rows(dirs, 3, None, st, {}, offset=2), dirs[2:])
+        self.assertEqual(statusline._pick_rows(dirs, 3, None, st, {}, offset=9), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
*"I tried to scroll the repo table and nothing happened."*

Nothing was going to. #607 built the whole pointer path — the SGR decoder, the dispatcher
that translates a click into a component's own cells, `DELIVERED` naming five kinds charter
can carry — and shipped it with **no consumer at all**: every one of the six components
`frame/builtins.py` registers declared `events = ()`. Worse, `panel._run`'s built-in branch
built no registry, so charter's own components were the one kind that *could not* have been
delivered an event even if they had declared one.

`repos` declares `scroll` and `click` now, and it is charter's own panel that is the worked
example rather than the exception — the same sequencing §4b asks for one contract over.

```
 ▪ repos 6
   ├─ charter        main                    ✓
   ├─ harness        fix/pane-width   ●⇡2    ✗    !412
   ├─ statusline     main                    ✓          <- clicked: reverse video
   …(+3 more)

 3 todos · ⠙ 1 running · F2 palette · ▪ statusline · main · dirty · 2 ahead · CI failed
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## What is in it

- **The wheel moves a window over the ranking the table was already cut from.**
  `statusline._pick_rows` has always sliced `[:budget]` off a ranked list; it takes an
  `offset` now and `[offset:offset+budget]` is the same table one window further along.
  **Offset zero is byte-for-byte what was there before**, which is the whole compatibility
  story for every plane that never scrolls.
- **A click selects a row**, drawn through `frame/chrome.reverse` — the same call
  `persona_section` already makes for the persona a frame is on, so there is one answer in
  this frame to what a chosen row looks like.
- **The attention row's right-hand field reads the selection back in words.** That is a
  different pane and a different process; the two talk through `state.record_selection` and
  the `state.bump` that wakes the other panel's poll.
- **`repo: select the next row` / `previous` in the palette** — the keyboard's half.
- **`[frame] mouse = true` in this plane's own `charter.toml`**, so the feature is usable
  where it lands rather than needing a second step.

## What I refused, and why

**Arrow keys into the repo table itself — not deliverable, and I am not going to fake it.**
`frame/events.py` does not deliver `key`, because tmux routes typing to the ACTIVE pane and
that is the harness's; #634 deliberately stops a click on a panel from moving the keyboard,
so the pane never becomes active either. The two ways to get a literal bare arrow into that
pane are both worse than the problem: deliver `key` (which `events.py` refuses with its
reasons) or `bind -n Up …` in the root table, which is server-wide and would intercept the
arrow **before the harness the frame exists to protect**. So the keyboard route is `F2` and
two palette rows, where arrow keys move a selection and Enter chooses — the vocabulary the
pointer half is deliberately held to as well. **If you want the root-table bind, say so and
I will build it behind an opt-in config key; I am not shipping it unasked.**

**Hover — still out, and nothing here reintroduces it.** Charter asks for SGR 1000, the
parser drops motion, and §4f closed the kinds without `drag`. The selected-row highlight is
the substitute and it works for a keyboard-only operator, which a hover cannot.

**A click SELECTS and never chooses.** Nothing this handler does is irreversible, and that
is a property rather than caution: `overlay.py` measured a drag begun on a pane border
delivering exactly one release, so a pointer event can arrive unpaired and §4i's rule is
that the irreversible half is never driven by one. The handler acts on the **press** (where
the operator pointed) and on the **left button only** — middle is paste and right is the
emulator's own menu on every terminal an operator has used.

## The viewport, grilled before it was built

*What does scrolling mean when the pane is exactly tall enough for its content?* **Nothing,
and it is a tested nothing.** `layout.repos_rows` sizes this pane to its content, so that is
the ordinary plane: `slots._scroll_limit` answers 0, `_Viewport.move` reads that bound
before it changes anything, and the handler answers falsy — no offset moves and no repaint
is asked for. A wheel that quietly did nothing *because the arithmetic happened to cancel*
is indistinguishable from one that was dropped, so `TheOffsetIsBoundedByTheDataAndThePane`
asserts the number at the boundary and one either side of it.

*And a one-row pane?* Also nothing. A budget of one is spent on `…(+N more)` rather than an
arbitrary repo, so every offset draws the identical line; a limit taken from the repo count
alone would let the wheel repaint it forty times, byte-identical each time.

*What happens when the offset outlives a repo list that shrank under it?* The next paint
clamps it. The handler is handed no ctx by contract (§4f) so it cannot know how many repos
there are; `_repos` computes the bound and `_Viewport.settle` applies it, which is also what
puts the window home when a resize starves the pane. `settle` is called on **every** paint,
including the ones that draw no rows — the `if budget > 0` that used to guard the call below
it went with the change, because it could not change an outcome there and could change one
here (a stale bound from the last taller paint).

*Which rows?* The window is over the **ranking**, so scrolling reveals the rest in priority
order and scrolling back lands on the exact table you left. Display order stays the cache's,
which is `_pick_rows`' own rule (a row that moved as it was scrolled past would be the thing
that function exists to prevent).

*Pieces?* **Stated limit, not silently half-done.** Piece rows only appear in the one-repo
shape, where one repo always fits and the limit is 0; scrolling them needs an index into a
nested list rather than into the ranking, and one mechanism that answers half the cases
honestly beats two that overlap. A click on a piece row selects its **parent repo**, so
there is no dead row and no second namespace that could collide with a clone's name.

## Where the seams moved

- `charter/frame/builtins.py` — `repos` declares the two kinds; `build(fid="")` closes the
  frame id into the handler, because `on_event` is handed one event and nothing else.
  `layout` and `instance` build registries they never dispatch through, so neither passes
  one and neither needs to.
- `charter/frame/panel.py` — the built-in branch asks the registry what a component
  declared instead of assuming nothing, and `_paint` takes the dispatcher so a handler that
  raised paints why into its own pane (§4b's answer for a provider, given to charter's own).
  `identity`, `attention` and `sidebar` still get `None` from `_dispatcher`: their panes'
  terminals are untouched and their loops still sleep rather than poll.
- `charter/frame/slots.py` — `_Viewport`, `_scroll_limit`, `_Line` (a row and the repo it is
  about), `_selected_detail`/`_detail_text`.
- `charter/frame/state.py` — `record_selection`/`selection`, and `clear_shape` clears it: a
  recycled frame id inheriting a highlight is a claim about an action this operator did not
  take.
- `charter/statusline.py` — one keyword-only `offset` on `_pick_rows`, defaulted, so every
  existing caller answers exactly what it answered.

## Cost

`repos` is not animated: one extra `read_text` per repaint, on a pane that repaints on a
version bump or a resize. `bottom` **is** animated, so its bill is stated and counted rather
than timed — one `read_text` of a file that is usually not there, and `gather.cached` **only
when a row has been picked**. `test_a_frame_with_nothing_selected_does_not_read_the_gather
_for_it` is that claim as a call count.

The one cost every plane pays, `[frame] mouse` or not: the `repos` pane now asks its own
terminal to report, so an operator who *selects that pane* loses native drag-select while it
is active. `docs/frame.md` says so where it already said it for a provider's panel.

## Verification

- Full suite green.
- **A real tmux, a real client on a real pty, two real `charter panel` processes**
  (`tests/test_a_real_click_reaches_the_real_repo_table.py`): a click on a row selects it and
  highlights it, the wheel moves the window and scrolling back lands on the table it left,
  the click **leaves the keyboard on the harness**, and the attention row **in its own
  process** learns what was clicked. The harness is put back in front before the client
  attaches — with the table as the active pane the terminal would be reporting because THAT
  pane asked, which is the `mouse = false` route and would let every case pass with the flag
  off.
- `python3 tools/sweep.py` — see below.

### Deletion sweep

CI's own gate ran it, sharded three ways, on 3.12 (`Size the sweep` → three shards →
`Add up what the shards found`).

**Final verdict, on `260464a`:**

```
merged 71 result(s) from 3 of 3 shard(s)
gate: 0 unpinned, 0 in masked cluster(s), 0 platform-deferred, 0 unresolved, 0 not applied, 71 pinned
gate: no survivors
```

It did not start there. The **first** verdict, on `d5f940a`:

```
merged 77 result(s) from 3 of 3 shard(s)
gate: 5 unpinned, 2 in masked cluster(s), 0 platform-deferred, 0 unresolved, 0 not applied, 70 pinned
gate: 7 survivors
```

**None of the seven is suppressed and none is argued away** — the repo has no suppression
mechanism on purpose, and "equivalent mutant" and "dead code" are one finding. Decomposed:

| where | verdict | what was done |
|---|---|---|
| `panel.py:829` ×2 | **masked cluster** | `painter = _slot_painter(evs) if evs is not None else None` — the branch a previous commit's message claimed to have removed and did not. `_slot_painter(None)` paints exactly what `_paint` painted. **Deleted.** |
| `slots.py:1808` | unpinned | `data.get("repos") or []` — `gather.cached` refuses a scan whose `repos` is not a list, so the fallback stood in for an empty list with an empty list. **Deleted.** |
| `builtin_actions.py:231` | unpinned | `-1 if step > 0 else 0` — a step here is only ever ±1, so `>` and `>=` answer identically and no test could ever tell them apart. **The comparison is gone**: where a walk with no selection under it starts is `_SELECT_STEPS`' own third column now. |
| `slots.py:548` | unpinned | `0 <= row` in `repo_at` — every case asked about a row 0 the heading owns, where the boundary and the direction agree. **Pinned** by a map whose first entry is a repo. |
| `slots.py:1842` | unpinned | `row.get('sigil') or '!'` — a change with no sigil must not read as a bare number. **Pinned.** |
| `slots.py:825` | unpinned | both arms of a piece row's `branch_override` — the empty cell is what means *this piece is NOT on the branch you would assume*. **Pinned.** |

Each of the four pins was hand-verified red over its own mutation before being committed,
and the run above is CI's own confirmation: 77 mutations became 71 (three lines are gone),
and all 71 are pinned.

### One environment note, not a change

`PYTHONSAFEPATH=1` in a shell makes `tests/test_self_relaunch_shadowing.py` fail on `main`
as well as here — it is `-P` applied globally, so the decoy can never shadow and the two
cases that prove it does go red. The sweep refuses to run under it ("the tree is RED before
any mutation"). Run the suite and the sweep with it unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGTJ3Zg7dgCQEeQLXWWo1d
