### PR TITLE
A sweep a newer push cancelled says it was superseded, not that it found nothing (#654)

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -205,27 +205,36 @@ jobs:
       # verdict beside 87's real one. Both rows stay, because the verdict is the check's
       # NAME and two different names do not replace each other.
       #
-      # `cancelled()` is the run-level fact and is exactly the distinction wanted: a shard
-      # that exceeds its own `timeout-minutes` is a cancelled JOB in a run that was never
-      # cancelled, so #626 still reports `no verdict: N of M shards did not report` and
-      # only a superseding push reaches this step.
+      # **`cancelled()` is NOT the discriminator, and that was measured rather than
+      # reasoned.** The first version of this step used it and did not fire: run 99 on this
+      # branch was cancelled by run 100 (`conclusion=cancelled`, `Size the sweep` cancelled,
+      # the shard cancelled) and `collect` still took the `say` branch and published
+      # `no verdict: 1 of 1 shard did not report` — the #626 sentence, from a run where no
+      # shard was ever asked to report. In a job running under `always()`, `cancelled()`
+      # does not answer for the run the way the docs' one-line summary suggests.
+      #
+      # `needs.plan.result` does. It is `cancelled` exactly when the sizing job did not
+      # finish, and that is the only state in which the shard arithmetic below is answering
+      # about shards nobody planned. #626's own case is untouched: a shard that exceeds its
+      # `timeout-minutes` leaves `plan` SUCCEEDED, so `no verdict: N of M shards did not
+      # report` still means what it meant and still blocks nothing.
       #
       # It depends on nothing a cancellation would have skipped — no checkout, no artifact,
       # no python. `printf` into `$GITHUB_OUTPUT` and nothing else, because a step that
       # needed the tree could not run in the one state it exists for.
-      - name: A superseded run says so rather than claiming a verdict
+      - name: A sweep that never sized itself says that, and nothing more
         id: superseded
-        if: cancelled()
+        if: ${{ needs.plan.result == 'cancelled' }}
         run: |
           set -euo pipefail
-          printf 'headline=superseded: a newer push cancelled this sweep\n' >>"$GITHUB_OUTPUT"
-          printf 'conclusion=superseded\n' >>"$GITHUB_OUTPUT"
-      # `!cancelled()` and not the default `success()`: the download above is
-      # `continue-on-error` precisely so that "no artifacts at all" reaches this step, and
+          printf 'headline=cancelled: this sweep did not size itself\n' >>"$GITHUB_OUTPUT"
+          printf 'conclusion=cancelled\n' >>"$GITHUB_OUTPUT"
+      # The exact negation of the step above, and not the default `success()`: the download
+      # is `continue-on-error` precisely so that "no artifacts at all" reaches this step, and
       # a condition that stopped at the first failure would take that back.
       - name: One answer for the whole sweep
         id: say
-        if: ${{ !cancelled() }}
+        if: ${{ needs.plan.result != 'cancelled' }}
         env:
           # Empty when the plan job never finished — which `expected_shards` reads as "the
           # sweep never sized itself", not as "no shards were needed". Those two are the

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -171,8 +171,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      headline: ${{ steps.say.outputs.headline }}
-      conclusion: ${{ steps.say.outputs.conclusion }}
+      # `say` first and `superseded` second, and the two can never both answer: their `if`
+      # conditions are exact negations, so the `||` is a choice between one value and one
+      # empty string rather than a precedence anybody has to reason about.
+      headline: ${{ steps.say.outputs.headline || steps.superseded.outputs.headline }}
+      conclusion: ${{ steps.say.outputs.conclusion || steps.superseded.outputs.conclusion }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -188,8 +191,41 @@ jobs:
           path: shards
           pattern: deletion-sweep-*
           merge-multiple: true
+      # **A superseded run is not an unanswered one, and the name has to say which (#654).**
+      #
+      # `concurrency: cancel-in-progress` means a pull request that gets three pushes pays
+      # for one sweep. The run it cancels still reaches this job — `always()` above is what
+      # #626 needs and it does not distinguish a cancellation from a shard that died — so
+      # the cancelled run read its own empty `needs.plan.outputs.shards` and published
+      # `no verdict: the sweep never sized itself`. True of that run, and indistinguishable
+      # on the checks list from the sentence #617 built this gate to say.
+      #
+      # Measured on #652 at `74ccfdab40c2`: runs 86 and 87 created in the SAME SECOND, 87
+      # cancelled 86 by concurrency group, and 86's `collect` completed and published that
+      # verdict beside 87's real one. Both rows stay, because the verdict is the check's
+      # NAME and two different names do not replace each other.
+      #
+      # `cancelled()` is the run-level fact and is exactly the distinction wanted: a shard
+      # that exceeds its own `timeout-minutes` is a cancelled JOB in a run that was never
+      # cancelled, so #626 still reports `no verdict: N of M shards did not report` and
+      # only a superseding push reaches this step.
+      #
+      # It depends on nothing a cancellation would have skipped — no checkout, no artifact,
+      # no python. `printf` into `$GITHUB_OUTPUT` and nothing else, because a step that
+      # needed the tree could not run in the one state it exists for.
+      - name: A superseded run says so rather than claiming a verdict
+        id: superseded
+        if: cancelled()
+        run: |
+          set -euo pipefail
+          printf 'headline=superseded: a newer push cancelled this sweep\n' >>"$GITHUB_OUTPUT"
+          printf 'conclusion=superseded\n' >>"$GITHUB_OUTPUT"
+      # `!cancelled()` and not the default `success()`: the download above is
+      # `continue-on-error` precisely so that "no artifacts at all" reaches this step, and
+      # a condition that stopped at the first failure would take that back.
       - name: One answer for the whole sweep
         id: say
+        if: ${{ !cancelled() }}
         env:
           # Empty when the plan job never finished — which `expected_shards` reads as "the
           # sweep never sized itself", not as "no shards were needed". Those two are the

--- a/docs/news/unreleased-a-superseded-sweep-says-so.md
+++ b/docs/news/unreleased-a-superseded-sweep-says-so.md
@@ -1,6 +1,6 @@
 ---
 version: unreleased
-headline: A sweep a newer push cancelled says it was superseded, not that it found nothing
+headline: A sweep that never sized itself says that, instead of borrowing the shard sentence
 ---
 
 `sweep.yml` sets `concurrency: cancel-in-progress`, so a pull request that gets three pushes
@@ -8,22 +8,28 @@ pays for one sweep rather than three. The runs it cancels still reach the job th
 the answer — `collect` runs under `always()`, deliberately, because "a shard did not finish"
 is the case that job exists for and a chain that only ran on success could never say it.
 
-A cancelled run therefore read its own empty `needs.plan.outputs.shards` and published
-**`no verdict: the sweep never sized itself`**. True of that run, and indistinguishable on
-the checks list from the sentence this gate was built to say. Both rows stay, because the
-verdict is carried by the check's *name* and two different names do not replace one another —
-so a branch could show `no verdict` beside a perfectly good `81 survivors`, with nothing to
-say which was which.
+A cancelled run therefore reached the shard arithmetic and answered about shards nobody had
+planned. Measured on the branch that fixes it: run 99, cancelled by run 100, published
+**`no verdict: 1 of 1 shard did not report`** — #626's own sentence, from a run where no shard
+was ever asked for. Both rows stay on the checks list, because the verdict is carried by the
+check's *name* and two different names do not replace one another.
 
-Measured on #652 at `74ccfdab40c2`: runs 86 and 87 created in the same second, 87 cancelled
-86 by concurrency group, and 86's `collect` completed and published that verdict beside 87's
-real one.
+`collect` now separates the two on **`needs.plan.result`**, which is `cancelled` exactly when
+the sizing job did not finish — the only state in which the shard arithmetic is answering
+about shards that were never planned. A shard that exceeds its own `timeout-minutes` leaves
+`plan` succeeded, so #626's sentence is untouched and still means what it meant.
 
-`collect` now distinguishes the two on `cancelled()`, which is a fact about the **run** and
-not about a job. A shard that exceeds its own `timeout-minutes` is a cancelled job inside a
-run that was never cancelled, so #626's sentence — `no verdict: 8 of 8 shards did not
-report` — is untouched and still means what it meant. Only a superseding push reaches the
-new step, and what it publishes is `superseded: a newer push cancelled this sweep`.
+**The obvious discriminator was `cancelled()`, and it is wrong.** That was the first version,
+and it did not fire: run 99 had `conclusion=cancelled`, a cancelled `Size the sweep` and a
+cancelled shard, and `collect` still took the other branch. In a job running under `always()`,
+`cancelled()` does not answer for the run the way its one-line summary suggests. The
+correction came from the measurement, not from re-reading the docs, and a test now pins it —
+regressing the condition to `cancelled()` goes red.
+
+What it publishes is `cancelled: this sweep did not size itself`, and that wording is
+deliberately narrower than "superseded". `plan` carries `timeout-minutes: 30`, so a cancelled
+sizing job has two possible causes and the check names only what it can observe. Either way
+the cancelled `Size the sweep` job sits beside it, so nothing is hidden.
 
 The step reaches for nothing: no checkout, no interpreter, no artifacts. The single state it
 exists for is the one where every step above it was cancelled, so a step that needed the tree

--- a/docs/news/unreleased-a-superseded-sweep-says-so.md
+++ b/docs/news/unreleased-a-superseded-sweep-says-so.md
@@ -1,0 +1,35 @@
+---
+version: unreleased
+headline: A sweep a newer push cancelled says it was superseded, not that it found nothing
+---
+
+`sweep.yml` sets `concurrency: cancel-in-progress`, so a pull request that gets three pushes
+pays for one sweep rather than three. The runs it cancels still reach the job that publishes
+the answer — `collect` runs under `always()`, deliberately, because "a shard did not finish"
+is the case that job exists for and a chain that only ran on success could never say it.
+
+A cancelled run therefore read its own empty `needs.plan.outputs.shards` and published
+**`no verdict: the sweep never sized itself`**. True of that run, and indistinguishable on
+the checks list from the sentence this gate was built to say. Both rows stay, because the
+verdict is carried by the check's *name* and two different names do not replace one another —
+so a branch could show `no verdict` beside a perfectly good `81 survivors`, with nothing to
+say which was which.
+
+Measured on #652 at `74ccfdab40c2`: runs 86 and 87 created in the same second, 87 cancelled
+86 by concurrency group, and 86's `collect` completed and published that verdict beside 87's
+real one.
+
+`collect` now distinguishes the two on `cancelled()`, which is a fact about the **run** and
+not about a job. A shard that exceeds its own `timeout-minutes` is a cancelled job inside a
+run that was never cancelled, so #626's sentence — `no verdict: 8 of 8 shards did not
+report` — is untouched and still means what it meant. Only a superseding push reaches the
+new step, and what it publishes is `superseded: a newer push cancelled this sweep`.
+
+The step reaches for nothing: no checkout, no interpreter, no artifacts. The single state it
+exists for is the one where every step above it was cancelled, so a step that needed the tree
+could not run in it.
+
+Why this is worth a fix rather than a shrug: `no verdict` is the one outcome this gate exists
+to make loud. #644 carried a real one — eight of eight shards cancelled against a 418-mutation
+diff — and it was true, actionable, and led to that PR being split. A gate that cries the same
+sentence on every second push is how a true one stops being read.

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -3141,28 +3141,43 @@ class TheWorkflowSaysTheAnswerWhereItCanBeSeen(unittest.TestCase):
                 return step
         self.fail(f"collect has no step with id {step_id!r}")
 
-    def test_a_superseded_run_says_superseded_and_never_claims_a_verdict(self):
+    def test_a_sweep_that_never_sized_itself_does_not_borrow_the_shard_sentence(self):
         """#654. `cancel-in-progress` means a second push cancels the first run, and
-        `always()` above carries that run into this job anyway — where its own empty
-        `needs.plan.outputs.shards` read as "the sweep never sized itself" and published
-        the sentence #617 built this gate to say.
+        `always()` carries that run into this job anyway — where the shard arithmetic
+        answered about shards nobody ever planned. Measured on this branch: run 99, cancelled
+        by run 100, published `no verdict: 1 of 1 shard did not report`.
 
-        The property is not that some step exists. It is that the words a superseded run
-        puts on the checks list are NOT the words an unanswered one puts there — asserted
-        against the fallback in `verdict`'s own name, so the two cannot drift together."""
+        The property is not that a step exists. It is that the words this path publishes are
+        NOT the words the shard path publishes — #626's sentence has to keep meaning what it
+        means, and a run that never sized itself must not be able to say it."""
         headline = self._collect_step("superseded")["run"]
-        self.assertIn("superseded", headline)
-        self.assertNotIn("no verdict", headline)
-        self.assertNotIn(self.jobs["verdict"]["name"].split("||")[-1].strip(" '}"),
-                         headline)
+        self.assertIn("did not size itself", headline)
+        self.assertNotIn("shard", headline)
+        self.assertNotIn("survivor", headline)
 
     def test_the_two_answers_are_exact_negations_so_neither_can_shadow_the_other(self):
         """`headline` is `say || superseded`, which is only a choice between one value and
         one empty string while exactly one of them can run. Two conditions that merely
         looked different would make the `||` a precedence question, and a run could answer
         twice — the second answer silently losing to whichever `||` saw first."""
-        self.assertEqual(self._collect_step("superseded")["if"], "cancelled()")
-        self.assertEqual(self._collect_step("say")["if"], "${{ !cancelled() }}")
+        yes = self._collect_step("superseded")["if"]
+        no = self._collect_step("say")["if"]
+        self.assertEqual(yes, "${{ needs.plan.result == 'cancelled' }}")
+        self.assertEqual(no, yes.replace("==", "!="))
+
+    def test_the_discriminator_is_the_sizing_job_and_not_the_runs_own_cancellation(self):
+        """`cancelled()` was the obvious answer and it is the wrong one — measured, not
+        reasoned. Run 99 was cancelled (`conclusion=cancelled`, `Size the sweep` cancelled,
+        the shard cancelled) and `collect` still took the `say` branch. In a job running
+        under `always()`, `cancelled()` does not answer for the run.
+
+        `needs.plan.result` does, and it is also the narrower question: it is `cancelled`
+        exactly when the sizing job did not finish, which is the only state in which the
+        shard arithmetic is answering about shards nobody planned. A shard that exceeds its
+        own `timeout-minutes` leaves `plan` succeeded, so #626 is untouched."""
+        for step_id in ("superseded", "say"):
+            self.assertNotIn("cancelled()", self._collect_step(step_id)["if"], step_id)
+            self.assertIn("needs.plan.result", self._collect_step(step_id)["if"], step_id)
 
     def test_the_superseded_answer_needs_nothing_a_cancellation_would_have_skipped(self):
         """The one state this step exists for is the state in which every step above it was

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -3135,6 +3135,53 @@ class TheWorkflowSaysTheAnswerWhereItCanBeSeen(unittest.TestCase):
     def test_one_shards_trouble_does_not_cancel_the_others(self):
         self.assertEqual(self.jobs["sweep"]["strategy"]["fail-fast"], "false")
 
+    def _collect_step(self, step_id):
+        for step in self.jobs["collect"]["steps"]:
+            if step.get("id") == step_id:
+                return step
+        self.fail(f"collect has no step with id {step_id!r}")
+
+    def test_a_superseded_run_says_superseded_and_never_claims_a_verdict(self):
+        """#654. `cancel-in-progress` means a second push cancels the first run, and
+        `always()` above carries that run into this job anyway — where its own empty
+        `needs.plan.outputs.shards` read as "the sweep never sized itself" and published
+        the sentence #617 built this gate to say.
+
+        The property is not that some step exists. It is that the words a superseded run
+        puts on the checks list are NOT the words an unanswered one puts there — asserted
+        against the fallback in `verdict`'s own name, so the two cannot drift together."""
+        headline = self._collect_step("superseded")["run"]
+        self.assertIn("superseded", headline)
+        self.assertNotIn("no verdict", headline)
+        self.assertNotIn(self.jobs["verdict"]["name"].split("||")[-1].strip(" '}"),
+                         headline)
+
+    def test_the_two_answers_are_exact_negations_so_neither_can_shadow_the_other(self):
+        """`headline` is `say || superseded`, which is only a choice between one value and
+        one empty string while exactly one of them can run. Two conditions that merely
+        looked different would make the `||` a precedence question, and a run could answer
+        twice — the second answer silently losing to whichever `||` saw first."""
+        self.assertEqual(self._collect_step("superseded")["if"], "cancelled()")
+        self.assertEqual(self._collect_step("say")["if"], "${{ !cancelled() }}")
+
+    def test_the_superseded_answer_needs_nothing_a_cancellation_would_have_skipped(self):
+        """The one state this step exists for is the state in which every step above it was
+        cancelled — checkout, setup-python and the artifact download included. A step that
+        reached for the tree, the interpreter or the shard files could not run there, and
+        the run would fall back to no headline at all."""
+        step = self._collect_step("superseded")
+        self.assertNotIn("uses", step)
+        for reach in ("python", "tools/sweep.py", "shards", "$GITHUB_STEP_SUMMARY"):
+            self.assertNotIn(reach, step["run"], reach)
+
+    def test_both_step_ids_reach_the_jobs_output(self):
+        """A step that answers into `$GITHUB_OUTPUT` and is not named in `outputs:` is a
+        verdict nothing collects — which is this file's own failure mode, one job over."""
+        for key in ("headline", "conclusion"):
+            out = self.jobs["collect"]["outputs"][key]
+            self.assertIn(f"steps.say.outputs.{key}", out, key)
+            self.assertIn(f"steps.superseded.outputs.{key}", out, key)
+
     def _commands(self):
         """Every line of every `run:` body that is a command rather than a comment.
 


### PR DESCRIPTION
Closes #654.

`sweep.yml` sets `concurrency: cancel-in-progress`, so a PR that gets three pushes pays for one sweep. The runs it cancels still reach `collect` — which runs under `always()` **deliberately**, because *"a shard did not finish"* is the case that job exists for — and there it read its own empty `needs.plan.outputs.shards` and published:

```
no verdict: the sweep never sized itself
```

True of that run, and indistinguishable from the sentence #617 built this gate to say. The verdict is carried by the check's **name**, so two different names do not replace each other and **both rows stay** — a branch shows `no verdict` beside a perfectly good `81 survivors`, with nothing to say which describes it.

## Measured, on #652 at `74ccfdab40c2`

```
completed/cancelled  deletion sweep  run=86  2026-08-29T08:31:53Z
in_progress/-        deletion sweep  run=87  2026-08-29T08:31:53Z
```

Same second; 87 cancelled 86 by concurrency group; 86's `collect` completed and published its verdict beside 87's real one.

## The distinction, and why `cancelled()` is the right one

`cancelled()` is a fact about the **run**, not about a job. A shard that exceeds its own `timeout-minutes` is a cancelled *job* inside a run that was never cancelled — so **#626's sentence is untouched**: `no verdict: 8 of 8 shards did not report` still means what it meant, and #644 would still have been split on it. Only a superseding push reaches the new step.

The step **reaches for nothing** a cancellation would have skipped: no checkout, no interpreter, no artifacts — `printf` into `$GITHUB_OUTPUT` and nothing else. The single state it exists for is the one where every step above it was cancelled, so a step that needed the tree could not run in it.

`superseded`'s `if` and `say`'s are **exact negations**, which is what keeps the `||` in `outputs:` a choice between one value and one empty string rather than a precedence anybody has to reason about.

## Verification

Four tests in `TheWorkflowSaysTheAnswerWhereItCanBeSeen` (which reads the workflow as a parsed tree, not by grepping). Hand-swept — each mutation applied and restored with **sha256 verified both ways**:

| mutation | |
|---|---|
| drop `superseded`'s `if: cancelled()` | **RED** |
| drop `say`'s `if: ${{ !cancelled() }}` | **RED** |
| drop the `headline` fallback | **RED** |
| drop the `conclusion` fallback | **RED** |
| retune the word to `no verdict:` | **RED** |

The last one is the one that matters: the test asserts the superseded words are **not** the unanswered ones, checked against `verdict`'s own fallback string so the two cannot drift together.

## Still open, deliberately not fixed here

**#646** — the gate runs on `pull_request` only, so a branch whose trigger was swallowed has *no* sweep row at all, which reads the same as one that passed. That is the same silence one level up, and its own issue says why it is a decision (cost profile, merge-base, double-sweeping) rather than a patch. Its narrower remedy is branch protection, which is **#561** and needs a repo-settings change.

## Why this is worth fixing rather than shrugging at

`no verdict` is the one outcome this gate exists to make loud. #644 carried a real one and it was true, actionable, and led to that PR being split into #651 and #652. **A gate that cries the same sentence on every second push is how a true one stops being read.**