### PR TITLE
The repo strip can be pinned to a height, and `size` stops being a key that does nothing on it

### DIFF
--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -259,6 +259,34 @@ def _key(name):
     return _builtins.SLOT_OF.get(name, name) if isinstance(name, str) else name
 
 
+def _arrangement():
+    """The placements this plane resolved, or nothing — the one read of `config.FRAME`.
+
+    **One line, because there are two callers and the fallback in it is unpinned.**
+    :func:`_placed_here` reads the arrangement for a component charter did not write and
+    :func:`_pinned_rows` reads it for the one built-in whose height a plane may commit; the
+    `or ()` is the same defence for both, and a second copy of it is a second line nothing
+    can fail without. `tools/sweep.py` reported exactly that copy the day it appeared and
+    `docs/news/unreleased-the-deletion-sweep-is-a-thing-the-repo-runs.md` records the
+    original at this module's line 289 as a survivor it examined — so the answer to a
+    second one is to have one, not to accept two.
+
+    It stays a fallback rather than a plain subscript. `instance.frame_of` sets
+    ``components`` before its own early return, deliberately ("a key present on one path
+    and absent on another is two shapes for one answer"), so nothing in production reaches
+    here without it — but `config.FRAME` is module state that a caller may replace whole,
+    and a `KeyError` out of :func:`repos_rows` costs a launch its entire frame. Pinning it
+    would mean a test constructing a `config.FRAME` that `frame_of` cannot produce, which
+    is a test of the line rather than of any property.
+
+    Imported inside the call, the way :func:`_table_min_cols` reaches for `statusline` and
+    for the same reason: this module is imported by every launch path, and `config`'s
+    import resolves the plane root.
+    """
+    from .. import config
+    return config.FRAME.get("components") or ()
+
+
 def _placed_here() -> dict[str, tuple[str, int]]:
     """name → (edge, cells) for what THIS PLANE places and charter did not write.
 
@@ -274,19 +302,19 @@ def _placed_here() -> dict[str, tuple[str, int]]:
     wrong and each test could omit — which is how the two answers to "how wide is the
     table's pane" came apart in #500.
 
-    Imported inside the call, the way :func:`_table_min_cols` reaches for `statusline` and
-    for the same reason: this module is imported by every launch path, and `config`'s
-    import resolves the plane root.
+    The read itself is :func:`_arrangement`'s, which is where the "imported inside the
+    call" reasoning moved when a second caller appeared.
 
     Only names the shipped tables do not already carry. A plane cannot move charter's own
-    `right` from here — `component_tables` refuses an edge or a size on a built-in that
-    disagrees with its declaration, because `layout` derives the built-in geometry at
-    import and a value read, validated and then ignored is the convincing empty this phase
-    was written against.
+    `right` from here — `component_tables` refuses an edge on a built-in that disagrees
+    with its declaration, and refuses a size on the three whose geometry `layout` derives
+    at import, because a value read, validated and then ignored is the convincing empty
+    this phase was written against. The repo table is the exception both of those rules now
+    have (`instance._built_in_size`), and it is still not read HERE: its height is
+    :func:`repos_rows`', and :func:`_pinned_rows` is what reads the number for it.
     """
-    from .. import config
     out: dict[str, tuple[str, int]] = {}
-    for placed in config.FRAME.get("components") or ():
+    for placed in _arrangement():
         name = placed.get("slot")
         if isinstance(name, str) and name not in SLOT_SIZE:
             out[name] = (placed["edge"], _policy_cells(placed["size"]))
@@ -313,7 +341,8 @@ def _pinned_rows() -> int | None:
     :func:`_placed_here`'s reason word for word — and this function is on exactly the path
     that docstring names. :func:`repos_rows` already reaches `config.FRAME` transitively
     through :func:`_is_fixed_row`, so nothing about when this module talks to the config
-    boundary changes.
+    boundary changes. Through :func:`_arrangement`, which both readers share so that the
+    fallback in it is one line rather than two.
 
     ``isinstance(placed["size"], Fixed)`` asks which POLICY the arrangement resolved to,
     which is the property and not a stand-in for it: a plane that writes its arrangement
@@ -323,8 +352,7 @@ def _pinned_rows() -> int | None:
     component it belongs to; without it the first placement in file order would decide the
     table's height, and on charter's own plane that is `identity`, `Fixed(1)`.
     """
-    from .. import config
-    for placed in config.FRAME.get("components") or ():
+    for placed in _arrangement():
         if placed.get("slot") == "repos" and isinstance(placed["size"], Fixed):
             return placed["size"].n
     return None

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -298,6 +298,38 @@ def _policy_cells(size) -> int:
     return size.n if isinstance(size, Fixed) else 1
 
 
+def _pinned_rows() -> int | None:
+    """The height this plane PINNED the repo strip to, or ``None`` for the shipped policy.
+
+    **The one per-plane override charter's own geometry has, and the reason it is the only
+    one.** Every other placed built-in is `Fixed` in its own declaration, so
+    :data:`SLOT_SIZE` — derived once, at import — is the whole answer for it and a
+    committed number could only be read and ignored (`instance._built_in_size` argues that
+    half). `repos` is `Content()`: its height never enters that table, it is computed by
+    :func:`repos_rows` from the resolved arrangement at every launch and again on every
+    `window-resized`, and this is what makes a number there mean something.
+
+    Read from the resolved config rather than threaded through five signatures, for
+    :func:`_placed_here`'s reason word for word — and this function is on exactly the path
+    that docstring names. :func:`repos_rows` already reaches `config.FRAME` transitively
+    through :func:`_is_fixed_row`, so nothing about when this module talks to the config
+    boundary changes.
+
+    ``isinstance(placed["size"], Fixed)`` asks which POLICY the arrangement resolved to,
+    which is the property and not a stand-in for it: a plane that writes its arrangement
+    out and puts no ``size`` on the table holds `Content()` there — the shipped policy
+    spelled longhand — and reading that as a pin would hand such a plane a one-row strip.
+    The name is tested too, because a placement's ``size`` says nothing about which
+    component it belongs to; without it the first placement in file order would decide the
+    table's height, and on charter's own plane that is `identity`, `Fixed(1)`.
+    """
+    from .. import config
+    for placed in config.FRAME.get("components") or ():
+        if placed.get("slot") == "repos" and isinstance(placed["size"], Fixed):
+            return placed["size"].n
+    return None
+
+
 def _edge_of(name):
     """Which side of the harness *name* attaches to, or ``None`` for a name nothing placed.
 
@@ -479,9 +511,23 @@ def repos_rows(*, content_rows: int, window_rows: int,
       costs columns, not rows, so it is not counted here — asking for the whole slot list
       rather than a pre-computed number is what keeps that decision in one place instead
       of at each call site.
-    * **Between the two, the content wins.** *content_rows* is what `slots._repos` would
-      actually fill (`slots.repos_rows_wanted`), so a two-repo plane gets a two-row strip
-      rather than a fourteen-row one padded with blanks.
+    * **Between the two, the content wins — unless the plane pinned a height.**
+      *content_rows* is what `slots._repos` would actually fill
+      (`slots.repos_rows_wanted`), so a two-repo plane gets a two-row strip rather than a
+      fourteen-row one padded with blanks. That is the DEFAULT and it is the answer for
+      every plane that does not say otherwise; a ``size`` on the table's own
+      `[[frame.component]]` table replaces it with a constant (:func:`_pinned_rows`),
+      which is the operator asking for a strip that does not move when a clone is added
+      or removed.
+
+    **A pin replaces the content, not the floor and not the cap**, and the cap is why.
+    tmux does not refuse an over-large height, it grants it out of the neighbour: measured
+    on 3.7c, `resize-pane -t <the table pane> -y 40` in a 20-row window left the HARNESS
+    pane one row tall. A committed ``size = 40`` is that command with a config file in
+    front of it, and a plane's frame is committed and shared — so a pin degrades in a
+    short terminal exactly as a fourteen-repo plane's table already does, and the operator
+    keeps :data:`HARNESS_MIN_ROWS` of the session the frame is drawn around. The floor
+    holds for the same reason it always did: `panel_argvs` cannot split a zero-row pane.
 
     The cap can come out below the floor — a 16-row window has no rows to spare at all —
     and the floor wins then, because `panel_argvs` has to be able to split the pane at
@@ -489,9 +535,11 @@ def repos_rows(*, content_rows: int, window_rows: int,
     every slot below half the size floors.
     """
     floor = SLOT_SIZE["repos"]
+    pinned = _pinned_rows()
+    wanted = content_rows if pinned is None else pinned
     other = sum(_size_of(s) + _BORDER_ROWS for s in slots if _is_fixed_row(s))
     cap = window_rows - other - _BORDER_ROWS - HARNESS_MIN_ROWS
-    return max(floor, min(content_rows, cap))
+    return max(floor, min(wanted, cap))
 
 
 def column_sizes(slots: list[str] | tuple[str, ...]) -> dict[str, int]:

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -1693,7 +1693,13 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
             # height is recomputed from this resolved arrangement on every launch and
             # every resize, so a number there is read. `None` is refused the way every
             # other unusable value in this loop is — whole arrangement, #535.
-            size = c.size
+            #
+            # `None` rather than `c.size` for a table that names no size, and that is this
+            # function's own #547 rule kept: `_built_in_placement` already declares what a
+            # built-in's rectangle is, and a second copy of it here is the masked default
+            # the sweep is written to catch — mutate the one in `_built_in_placement` and
+            # nothing would move, because every call arriving through here carried its own.
+            size = None
             if "size" in table:
                 size = _built_in_size(c, table["size"])
                 if size is None:

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -1399,7 +1399,7 @@ def _placement(cid: str, *, edge: str, size, visible: bool = True,
             "size": size, "visible": visible, "key": key, "bg": bg, "pad": pad}
 
 
-def _built_in_placement(reg, cid: str, **style) -> dict:
+def _built_in_placement(reg, cid: str, *, size=None, **style) -> dict:
     """:func:`_placement` for one of charter's own, in the rectangle it declares.
 
     **It forwards *style* and restates none of it, which is a defect fixed rather than a
@@ -1412,9 +1412,62 @@ def _built_in_placement(reg, cid: str, **style) -> dict:
 
     So the rectangle — ``edge`` and ``size``, which is all this function is FOR — is what
     it supplies, and everything else is the caller's or :func:`_placement`'s.
+
+    ``size`` is the one half of that rectangle a plane may now REPLACE, and ``None`` means
+    "whatever the component declares" — every caller that is not resolving a committed
+    ``size`` (the `slots` shorthand, a density level) passes nothing and gets exactly the
+    placement it always got. The override exists for the one built-in whose height is not
+    derived at import: see :func:`_built_in_size`. It is a parameter rather than a second
+    ``_placement`` literal at the call site for this function's own reason — a second dict
+    on the second path is the two-implementations shape #547 cost.
     """
     c = reg.get(cid)
-    return _placement(cid, edge=c.edge, size=c.size, **style)
+    return _placement(cid, edge=c.edge, size=c.size if size is None else size, **style)
+
+
+def _built_in_size(c, value):
+    """The size policy a committed ``size = <n>`` on the built-in *c* resolves to, or
+    ``None`` for a number charter will not honour.
+
+    **A committed value is accepted exactly where something reads it, and refused
+    everywhere else — which is the rule :func:`component_tables` already keeps for
+    ``edge``, not a new one.** `layout._derive` turns each component's declared size into
+    :data:`layout.SLOT_SIZE` once, at import, and `layout._size_of` answers `top`,
+    `bottom` and `right` out of that table on every launch. There is no per-plane
+    override between `charter.toml` and `split-window` for those three, so a ``size`` that
+    disagreed with the declaration would be a value read, validated, stored and then
+    ignored — the convincing empty the whole form is written against. It may therefore
+    only ECHO, which is what it could do before.
+
+    ``repos`` is the exception because it is the one placed built-in charter declares
+    ``Content()``, and a `Content` height is not in that table at all: `layout.slot_sizes`
+    routes it to `layout.repos_rows`, which is recomputed from the RESOLVED config on
+    every launch and on every `window-resized` (`commands_frame._reassert_sizes`). So
+    there is somewhere for a number to be read, and pinning it is what makes the strip a
+    fixed height instead of one that collapses to two rows on a two-repo plane.
+
+    The pin is `Fixed`, and `component.Fixed` is asked rather than re-checked: it refuses
+    a `bool`, a non-int and anything below one cell in `component.cells`, which is the one
+    place that rule is written. Asked inside a ``try`` because this runs while a committed
+    file is being resolved — on the path of `charter --version` as much as `charter frame`
+    — and a `ComponentError` escaping here would take every command with it, where the
+    form's own answer to a value it cannot honour is to refuse the arrangement whole
+    (#535).
+
+    ``not isinstance(value, bool)`` stays on the echo branch and is not redundant beside
+    it: ``True == 1`` in Python, so without it a ``size = true`` on `identity` or
+    `attention` — both `Fixed(1)` — would compare equal and be accepted as the number
+    nobody wrote. Four separate shapes of that trap have been caught in this suite.
+    """
+    from .frame.component import ComponentError, Content, Fixed
+    if isinstance(c.size, Content):
+        try:
+            return Fixed(value)
+        except ComponentError:
+            return None
+    if isinstance(c.size, Fixed) and value == c.size.n and not isinstance(value, bool):
+        return c.size
+    return None
 
 
 def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None:
@@ -1633,11 +1686,19 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
             c = reg.get(cid)
             if "edge" in table and table["edge"] != c.edge:
                 return None
-            if "size" in table and not (isinstance(c.size, Fixed)
-                                        and table["size"] == c.size.n
-                                        and not isinstance(table["size"], bool)):
-                return None
-            out.append(_built_in_placement(reg, cid, visible=visible, key=key,
+            # The one key on a built-in that a plane may do more with than echo, and
+            # :func:`_built_in_size` is where that asymmetry is argued: `top`, `bottom`
+            # and `right` are read out of a table `layout` derives at IMPORT, so a
+            # different number there could only be ignored; `repos` is `Content()` and its
+            # height is recomputed from this resolved arrangement on every launch and
+            # every resize, so a number there is read. `None` is refused the way every
+            # other unusable value in this loop is — whole arrangement, #535.
+            size = c.size
+            if "size" in table:
+                size = _built_in_size(c, table["size"])
+                if size is None:
+                    return None
+            out.append(_built_in_placement(reg, cid, size=size, visible=visible, key=key,
                                            bg=bg, pad=pad))
             continue
         # Not one of charter's own: a component id, which is placeable exactly when an

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -381,8 +381,10 @@ be followed by another one.
 the attention strip — one alert and the command that fixes it — which is the whole reason
 a cramped terminal is worth framing at all. It is one row at every size.
 
-`repos` is the one whose height moves. It is its content's: one row per repo (and per
-worktree, in a single-repo workspace), plus its own `▪ repos N` heading, capped so the
+`repos` is the one whose height moves — unless you pin it, which is a `size` on its
+`[[frame.component]]` table and is described under [The arrangement, written
+out](#the-arrangement-written-out). By default it is its content's: one row per repo (and
+per worktree, in a single-repo workspace), plus its own `▪ repos N` heading, capped so the
 harness always keeps at least 12 rows. "Its content" means *what the panel will actually
 draw*, not how many clones there are: the launcher and the resize hook ask the same
 function the panel asks, at the same density and — the part that is easy to get wrong — at
@@ -922,13 +924,46 @@ If your plane is spelled with `slots`, write the arrangement out first — the l
 above says exactly the same thing, and the `[[frame.component]]` tables for any `slots`
 list are one per name, in the same order.
 
-For one of charter's own four, `edge` and `size` may be written down and may only say what
-the component already declares — `edge = "right"` and `size = 22` on the sidebar, `edge =
-"top"` on identity. Charter derives the built-in geometry from those declarations, and
-nothing between `charter.toml` and tmux carries a per-plane override for them, so a value
-charter cannot honour is not quietly accepted and ignored: it takes the arrangement out of
-play. Writing them is still worth it if you like your config explicit — and it is what
-makes the two forms round-trip.
+For one of charter's own four, `edge` may be written down and may only say what the
+component already declares — `edge = "right"` on the sidebar, `edge = "top"` on identity.
+Charter derives the built-in geometry from those declarations, and nothing between
+`charter.toml` and tmux carries a per-plane override for them, so a value charter cannot
+honour is not quietly accepted and ignored: it takes the arrangement out of play. Writing
+it is still worth it if you like your config explicit — and it is what makes the two forms
+round-trip.
+
+`size` is the same for three of the four: `size = 1` on identity, `size = 1` on the
+attention strip, `size = 22` on the sidebar, and any other number takes the arrangement
+out of play for the reason above.
+
+**`size` on the repo table is the one exception, and it pins the strip's height.**
+
+```toml
+[[frame.component]]
+use  = "repos"
+size = 15
+```
+
+The table is the one panel charter sizes to its content — one row per repo, so a plane
+with two clones gets a two-row strip and a plane with fourteen gets a fourteen-row one.
+That is the default and it does not change. What `size` says is *stop doing that*: the
+strip is 15 rows whether you have one clone or thirty, which is what you want if your
+clone count moves and you would rather your session did not shuffle under it every time.
+Charter can honour it here because this height is not derived once at import like the
+other three — it is recomputed from your arrangement at every launch and on every terminal
+resize, so there is somewhere for your number to be read.
+
+It is a number of cells: a whole number, at least 1. Anything else — `0`, a negative, a
+`true`, a string, a float — takes the arrangement out of play like every other value
+charter cannot honour.
+
+**Your pin is still capped so your session keeps its 12 rows.** tmux does not refuse an
+over-large pane height, it grants it out of the neighbour, and the neighbour is your agent
+session — `size = 40` in a 20-row window would leave it one row tall. So a pin is what the
+strip *wants*, and what the window can spare is decided afterwards, exactly as it already
+is for a fourteen-repo plane on a short terminal. On a terminal with room, you get your
+number; on one without, you get what is left, and the strip is dropped entirely below the
+95 columns its table needs.
 
 `bg` and `pad` are the two keys that have no `slots` equivalent at all: they say how a pane
 *looks*, not where it sits, so they only exist in the long form.
@@ -1035,7 +1070,9 @@ frame your `slots` (or `density`, or the default) describes. You see your whole 
 not take effect, which is something you can act on, rather than one pane's worth of quiet
 fiction. A `key` charter will not bind, a key two components both claim, and a key equal to
 your frame's own `hotkey` are on that list too — and so are a `bg` that is not one of the
-seventeen words and a `pad` outside `0`–`8`.
+seventeen words, a `pad` outside `0`–`8`, and a `size` charter cannot give the component
+(any number but its own on the three whose height is fixed, and anything that is not a
+whole number of cells on the repo table).
 
 Precedence, most explicit first: `[[frame.component]]`, then an explicit `slots`, then
 `density`, then the shipped default.

--- a/docs/news/unreleased-the-repo-strip-can-have-a-height-you-chose.md
+++ b/docs/news/unreleased-the-repo-strip-can-have-a-height-you-chose.md
@@ -1,0 +1,68 @@
+---
+version: unreleased
+headline: The repo strip can have a height you chose, and the `size` key that used to do nothing on it now does
+---
+
+The repo table is the one panel charter sizes to its content: one row per clone, plus its
+heading. Two clones, two rows. That was a deliberate decision — a fourteen-row strip padded
+with blanks is worse than a two-row one — and it is still the default.
+
+It is the wrong default for a plane whose clone count moves. You add a repo and the pane
+grows; you remove one and it shrinks; your session shuffles up and down underneath it. What
+was missing was a way to say *stop*:
+
+```toml
+[[frame.component]]
+use  = "repos"
+size = 15
+```
+
+Fifteen rows with one clone, fifteen with thirty.
+
+**The key was already in the form, and on this component it did nothing.** `size` on a
+`[[frame.component]]` table could only echo a number charter had already declared — and the
+repo table declares no number at all, it declares "as tall as its content". So *any* `size`
+on it was a value charter could not honour, which takes the whole arrangement out of play
+(#535): the four tables dropped back to `slots` and you got a different frame with nothing
+said. An operator writing `size = 15` today gets today's content-sized strip and no error.
+
+## What charter can honour, and why the other three panels are different
+
+The three fixed panels — identity, the attention strip, the sidebar — have their heights
+turned into a table once, when charter starts. Nothing between your `charter.toml` and
+`split-window` carries a per-plane override for them, so a different number there could only
+be read, validated, stored and then ignored. They still only echo, and any other number
+still takes the arrangement out of play.
+
+The repo table's height never enters that table. It is recomputed from your resolved
+arrangement at every launch and again on every terminal resize, which is what a content-sized
+pane requires — and it is what gives your number somewhere to be read. One rule, not a
+carve-out: a committed value is honoured exactly where something reads it.
+
+It is a whole number of cells, at least 1. `0`, a negative, a `true`, a string and a float
+are refused the way every other unusable value in that form is.
+
+## Your session still keeps its twelve rows
+
+tmux does not refuse an over-large pane height. It grants it, and takes the difference out
+of the neighbour — measured on 3.7c, `resize-pane -y 40` in a 20-row window left the harness
+pane **one row tall**. A `size = 40` in a committed file is that command with a config file
+in front of it, and a plane's frame is shared: it arrives on a laptop whose terminal its
+author never saw.
+
+So a pin says what the strip *wants*. What the window can spare is decided afterwards, by
+exactly the same arithmetic that already caps a fourteen-repo plane on a short terminal. On a
+terminal with room you get your number; on one without you get what is left after the harness
+has its floor; below the 95 columns the table needs, the strip is dropped entirely, as before.
+
+## What did not change
+
+The repo pane is still the one pane tmux is never told the height of. In a stack of N panes
+only N-1 boundaries can be asserted — assert them all and the result depends on the order,
+which is how a re-assertion once came out with the table one row tall and the attention strip
+six. Everything around the strip is asserted and the strip lands on its number, whether that
+number came from your clone count or from your file. A pin changes the number, not the
+mechanism.
+
+A plane that writes no `size` — which is every plane today, charter's own included — draws
+exactly the frame it drew before.

--- a/tests/test_a_pinned_repo_strip_keeps_its_height.py
+++ b/tests/test_a_pinned_repo_strip_keeps_its_height.py
@@ -31,7 +31,7 @@ import unittest
 from unittest import mock
 
 from charter import commands_frame, config, instance
-from charter.frame import component, layout
+from charter.frame import builtins, component, layout
 
 
 def _arrangement(**repos) -> dict:
@@ -110,6 +110,26 @@ class TheConfigBoundaryDecidesWhichBuiltInsMayCarryASize(unittest.TestCase):
                                  [component.Fixed(echo)])
                 self.assertIsNone(instance.component_tables(
                     {"component": [{"use": use, "size": other}]}))
+
+    def test_a_component_with_no_number_to_echo_is_refused_rather_than_raising(self):
+        """The third size policy, asked of the one component that really has it.
+
+        `personas` is `Fill()` — neither a number to echo nor a content height to pin. It
+        is a CHILD of the sidebar today, so it cannot reach `_built_in_size` through
+        `builtins.SLOT_OF`, and that is exactly why the question is put to the function
+        rather than to a committed file: `value == c.size.n` on a `Fill` is an
+        `AttributeError`, raised while a committed file is being resolved — on the path of
+        `charter --version` as much as `charter frame` — where this form's answer to a
+        value it cannot honour is to refuse the arrangement and draw the `slots` frame.
+
+        Without this the `isinstance(c.size, Fixed)` half of that condition is a survivor
+        masked by the `Content` branch above it: every component `SLOT_OF` currently
+        reaches is one or the other, so nothing could observe it. Asked here, it is the
+        line that stands between a future `Fill` placement and a traceback.
+        """
+        fill = builtins.build().get("personas")
+        self.assertIsInstance(fill.size, component.Fill)
+        self.assertIsNone(instance._built_in_size(fill, 5))
 
     def test_an_arrangement_with_a_pin_round_trips_through_the_written_out_form(self):
         """`frame_components` promises the mapping is lossless in both directions, and a

--- a/tests/test_a_pinned_repo_strip_keeps_its_height.py
+++ b/tests/test_a_pinned_repo_strip_keeps_its_height.py
@@ -1,0 +1,280 @@
+"""`size` on the repo table's own `[[frame.component]]` table pins the strip's height.
+
+**The default is not changing.** `repos` ships `Content()` and a plane that says nothing
+still gets a strip as tall as its clone list — "a two-repo plane gets a two-row strip
+rather than a fourteen-row one padded with blanks", which is `layout.repos_rows`' own
+docstring and was a deliberate decision. What was missing is the way to *say otherwise*:
+an operator whose plane grows and shrinks its clone count wants a strip that stays where
+it is, and the `size` key that would have said so was accepted-but-inert — it could only
+echo a number charter had already declared, and since `repos` declares no number at all,
+**any** `size` on it took the whole arrangement down to `slots` with nothing said.
+
+Three claims are pinned here, and they are separable on purpose:
+
+* **the config boundary** decides which built-ins may carry a `size` that means
+  something, and `repos` is the only one — every other placed built-in is `Fixed` in its
+  own declaration, `layout` derives that into `SLOT_SIZE` at import, and a per-plane
+  number there could only be ignored;
+* **the arithmetic** replaces the CONTENT term and leaves the floor and the cap alone, so
+  the harness keeps `layout.HARNESS_MIN_ROWS` however large a number was committed —
+  measured on tmux 3.7c, an over-large `-y` is not refused, it is granted out of the
+  neighbour;
+* **the mechanism does not move.** `repos` stays the one variable-row slot and stays out
+  of `commands_frame._RESIZE_FLAG`, so it is still the stack's dependent pane and tmux is
+  still asked to move exactly N-1 boundaries in an N-pane stack. A pin changes the number
+  the other panes are sized around, and nothing about how they are asserted.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import commands_frame, config, instance
+from charter.frame import component, layout
+
+
+def _arrangement(**repos) -> dict:
+    """The shipped four, written out, with *repos* merged into the table's own.
+
+    Resolved through `instance.frame_of` rather than assembled by hand: this suite's
+    subject is what a committed file resolves to, and a fixture of placements would be a
+    second answer that agrees with the boundary until one of them is edited.
+    """
+    tables = [{"use": "identity"}, {"use": "attention"},
+              {"use": "repos", **repos}, {"use": "sidebar"}]
+    return instance.frame_of({"frame": {"component": tables}})
+
+
+#: The split order every case below uses — charter's own, and the one whose arithmetic
+#: `tests/test_frame_layout.py` already pins for the unpinned case.
+SLOTS = ["top", "bottom", "repos", "right"]
+
+
+class TheConfigBoundaryDecidesWhichBuiltInsMayCarryASize(unittest.TestCase):
+    """A committed number is honoured exactly where something reads it.
+
+    Not "on the components charter feels like allowing it on": the rule is mechanical and
+    is the same one `edge` already keeps. `layout._derive` turns each component's declared
+    size into `SLOT_SIZE` once, at import, and `_size_of` answers `top`, `bottom` and
+    `right` out of that table forever after — so a number on those three has nowhere to be
+    read. `repos` is `Content()`, which never enters that table: `slot_sizes` routes it to
+    `repos_rows`, recomputed from the resolved arrangement at every launch and again on
+    every `window-resized`.
+    """
+
+    def test_the_repo_table_resolves_a_committed_size_to_a_fixed_policy(self):
+        """The placement is where the number survives to, so it is asserted there and not
+        only in the rows that come out later — a boundary that accepted the key and then
+        dropped it would be the inert `size` this change exists to remove, one layer
+        further in."""
+        placed = _arrangement(size=15)["components"]
+        self.assertEqual([p["size"] for p in placed],
+                         [component.Fixed(1), component.Fixed(1),
+                          component.Fixed(15), component.Fixed(22)])
+
+    def test_a_table_that_names_no_size_keeps_the_policy_the_component_declares(self):
+        """Writing the arrangement out is not the same as pinning it. `Content()` here is
+        the SHIPPED policy spelled longhand — which is what charter's own `charter.toml`
+        commits — and reading it as a pin would hand every such plane a one-row strip."""
+        placed = _arrangement()["components"]
+        self.assertEqual([p["size"] for p in placed],
+                         [component.Fixed(1), component.Fixed(1),
+                          component.Content(), component.Fixed(22)])
+
+    def test_the_shorthand_spellings_place_the_component_at_its_own_size(self):
+        """`slots` and `density` have no place to write a number, so both must resolve to
+        the declared policy. Asserted through `frame_components`, which is the one place
+        all three spellings become one arrangement."""
+        for cfg in ({}, {"frame": {"slots": SLOTS}}, {"frame": {"density": "full"}}):
+            with self.subTest(cfg=cfg):
+                got = instance.frame_components(cfg)
+                repos, = [p for p in got if p["slot"] == "repos"]
+                self.assertEqual(repos["size"], component.Content())
+
+    def test_a_built_in_whose_geometry_is_derived_at_import_may_still_only_echo(self):
+        """The other side of the asymmetry, and the half that did NOT change.
+
+        Each pair is the same component with the number it declares and with one it does
+        not, so an accepted echo cannot be what makes the refusal look right. `True` is in
+        the list because `True == 1` in Python and both strips are `Fixed(1)`: without the
+        explicit `bool` check it would compare equal and be accepted as a number nobody
+        wrote.
+        """
+        for use, echo, other in (("identity", 1, 2), ("attention", 1, True),
+                                 ("sidebar", 22, 30)):
+            with self.subTest(use=use):
+                kept = instance.component_tables({"component": [{"use": use,
+                                                                "size": echo}]})
+                self.assertEqual([p["size"] for p in kept],
+                                 [component.Fixed(echo)])
+                self.assertIsNone(instance.component_tables(
+                    {"component": [{"use": use, "size": other}]}))
+
+    def test_an_arrangement_with_a_pin_round_trips_through_the_written_out_form(self):
+        """`frame_components` promises the mapping is lossless in both directions, and a
+        pin is the first value that mapping has ever had to carry which is NOT the
+        component's own declaration. Resolve it, write it back out, resolve that."""
+        first = _arrangement(size=15)["components"]
+        tables = [{"use": p["use"], "edge": p["edge"], "size": p["size"].n}
+                  for p in first]
+        again = instance.frame_of({"frame": {"component": tables}})["components"]
+        self.assertEqual(again, first)
+
+
+class ThePinnedStripIsTheHeightTheOperatorCommitted(unittest.TestCase):
+    """What the operator asked for: a strip that does not move with the clone count."""
+
+    def test_the_strip_is_the_committed_height_whatever_its_content_wants(self):
+        """The whole complaint, in one assertion: *"when less repos — its very small"*.
+        Every one of these content counts is a real answer `slots.repos_rows_wanted` gives
+        on some plane — none, one, a couple, a full table, more than the window has — and
+        the pinned strip is the same height for all of them."""
+        with mock.patch.dict(config.FRAME, _arrangement(size=15)):
+            for content in (0, 1, 2, 14, 30):
+                with self.subTest(content=content):
+                    self.assertEqual(
+                        layout.repos_rows(content_rows=content, window_rows=50,
+                                          slots=SLOTS),
+                        15)
+
+    def test_a_plane_that_pins_nothing_is_sized_by_its_content_exactly_as_before(self):
+        """The default, asserted against a written-out arrangement rather than against a
+        `slots` list — because a written-out arrangement is where a `repos` placement
+        exists to be misread, and charter's own plane commits one. Two counts, so a pin
+        read off the wrong placement (`identity` is `Fixed(1)` and comes first in file
+        order) cannot pass by coincidence."""
+        with mock.patch.dict(config.FRAME, _arrangement()):
+            for content in (4, 7):
+                with self.subTest(content=content):
+                    self.assertEqual(
+                        layout.repos_rows(content_rows=content, window_rows=50,
+                                          slots=SLOTS),
+                        content)
+
+    def test_the_pin_reaches_tmux_as_the_length_the_pane_is_split_to(self):
+        """The seam that makes any of this visible: `slot_sizes` into `panel_argvs` into
+        `-l`. Asserted as the literal string tmux would see, so a number computed
+        correctly and then dropped on the way out is red."""
+        with mock.patch.dict(config.FRAME, _arrangement(size=15)):
+            sizes = layout.slot_sizes(SLOTS, window_rows=50, content_rows=2)
+            cmds = layout.panel_argvs(slots=SLOTS, sizes=sizes, session="f-1",
+                                      socket="charter", harness_pane="%0")
+        self.assertEqual(sizes, {"top": 1, "bottom": 1, "repos": 15, "right": 22})
+        repos = cmds[SLOTS.index("repos")]
+        self.assertEqual(repos[repos.index("-l") + 1], "15")
+
+    def test_the_launcher_sizes_the_pane_from_the_pin_and_not_from_the_clone_count(self):
+        """`commands_frame._launch_sizes` is the launch-time half, and it is the caller
+        that reads the plane's real clone count. Stubbing `repos_rows_wanted` to a number
+        nothing else in this test could produce is what makes the assertion about which
+        of the two won."""
+        with mock.patch.dict(config.FRAME, _arrangement(size=15)), \
+                mock.patch("charter.frame.slots.repos_rows_wanted", return_value=3):
+            got = commands_frame._launch_sizes("f-1", SLOTS,
+                                               window_cols=200, window_rows=50)
+        self.assertEqual(got["repos"], 15)
+
+    def test_the_harness_takes_exactly_the_rows_the_pinned_strip_leaves(self):
+        """`harness_rows` is the number `_reassert_sizes` asserts on the harness itself,
+        and the pinned strip is still the pane left to take the remainder. So the two have
+        to add up to the window with nothing over: every strip, its border, and the
+        harness. A pin the harness arithmetic did not know about would show up here as
+        rows that belong to nobody."""
+        rows = 50
+        with mock.patch.dict(config.FRAME, _arrangement(size=15)):
+            sizes = layout.slot_sizes(SLOTS, window_rows=rows, content_rows=2)
+            harness = layout.harness_rows(sizes, window_rows=rows)
+        strips = sum(n + layout._BORDER_ROWS for slot, n in sizes.items()
+                     if slot != "right")
+        self.assertEqual(strips + harness, rows)
+        self.assertGreaterEqual(harness, layout.HARNESS_MIN_ROWS)
+
+
+class APinChangesTheNumberAndNotTheMechanism(unittest.TestCase):
+    """The design refutation this change was asked to consider, pinned as a property.
+
+    The obvious way to make `size` work is to call a pinned `repos` a FIXED row — derive
+    `VARIABLE_ROW_SLOTS` from the resolved arrangement instead of from the shipped
+    registry. Two things are wrong with it. `slot_sizes` would then answer `repos` from
+    `_size_of`, which reads `SLOT_SIZE["repos"]` — the shipped FLOOR, `1`, not the
+    committed number — so the pinned strip would come out one row tall. And it would buy
+    nothing at the tmux end: `_RESIZE_FLAG` has no `repos` entry, adding one would assert
+    N heights in an N-pane stack, and that is the measured failure (`top`, `bottom`,
+    `repos` in split order at 200x50 left the table 1 row and the strip 6 — the two sizes
+    swapped panes). The strip has to stay the dependent pane whether its height is
+    content-derived or committed.
+    """
+
+    def test_the_table_is_still_the_one_variable_row_slot_when_a_plane_pins_it(self):
+        """Derived from the SHIPPED registry, and it stays that way. `_variable_pane_cols`
+        picks the pane to measure with a `next()` over this set and its own comment says
+        there is exactly one member by construction; an empty set there would silently
+        fall back to a derivation, and a pin must not be what makes that happen."""
+        with mock.patch.dict(config.FRAME, _arrangement(size=15)):
+            self.assertEqual(layout.VARIABLE_ROW_SLOTS, frozenset({"repos"}))
+            self.assertIs(layout._is_fixed_row("repos"), False)
+
+    def test_the_pinned_strip_is_still_the_pane_tmux_is_never_told_the_height_of(self):
+        """In a stack of N panes only N-1 heights are free. `_RESIZE_FLAG` names the
+        three whose size is a constant; the strip lands on its number because everything
+        else was asserted around it, which is the same mechanism a content-sized strip
+        already uses."""
+        self.assertNotIn("repos", commands_frame._RESIZE_FLAG)
+        self.assertEqual(sorted(commands_frame._RESIZE_FLAG), ["bottom", "right", "top"])
+
+    def test_a_pin_does_not_move_the_shipped_geometry_tables(self):
+        """`SLOT_SIZE["repos"]` is the FLOOR and stays it: `repos_rows` reads it as the
+        floor, and `panel_argvs` falls back to it for a caller with no window to measure.
+        A pin that had edited this table would change both of those for a plane that never
+        asked."""
+        with mock.patch.dict(config.FRAME, _arrangement(size=15)):
+            self.assertEqual(layout.SLOT_SIZE["repos"], 1)
+            self.assertEqual(layout._size_of("repos"), 1)
+
+
+class APinIsStillCappedSoTheSessionKeepsItsFloor(unittest.TestCase):
+    """The one measured safety property a committed number must not be able to lift.
+
+    tmux does not refuse an over-large height — it grants it out of the neighbour. On
+    3.7c, `resize-pane -t <the table pane> -y 40` in a 20-row window left the HARNESS pane
+    one row tall. A committed `size = 40` is that command with a config file in front of
+    it, and a plane's frame is committed and shared, so it would arrive on a laptop whose
+    terminal its author never saw.
+    """
+
+    def test_a_pin_larger_than_the_window_can_spare_is_cut_to_what_it_can(self):
+        """Asserted as the HARNESS's remaining rows rather than as a literal height, so
+        the arithmetic is checked rather than restated — the shape
+        `tests/test_frame_layout.py` already uses for the content-sized cap."""
+        rows = 24
+        with mock.patch.dict(config.FRAME, _arrangement(size=15)):
+            got = layout.repos_rows(content_rows=2, window_rows=rows, slots=SLOTS)
+        harness = (rows - got - layout.SLOT_SIZE["top"] - layout.SLOT_SIZE["bottom"]
+                   - 3 * layout._BORDER_ROWS)
+        self.assertGreaterEqual(harness, layout.HARNESS_MIN_ROWS)
+        self.assertLess(got, 15, "the cap did not bind at all")
+
+    def test_the_cap_is_the_same_arithmetic_a_content_sized_strip_gets(self):
+        """One rule, not two. A pin replaces what the strip WANTS; what the window can
+        spare is decided afterwards and identically, which is what stops a second, weaker
+        copy of `HARNESS_MIN_ROWS` growing behind the new key."""
+        for rows in (18, 20, 24, 30, 50):
+            with self.subTest(rows=rows):
+                with mock.patch.dict(config.FRAME, _arrangement(size=99)):
+                    pinned = layout.repos_rows(content_rows=0, window_rows=rows,
+                                               slots=SLOTS)
+                with mock.patch.dict(config.FRAME, _arrangement()):
+                    grown = layout.repos_rows(content_rows=99, window_rows=rows,
+                                              slots=SLOTS)
+                self.assertEqual(pinned, grown)
+
+    def test_the_floor_holds_when_the_window_has_no_rows_to_spare_at_all(self):
+        """Below the floor is a zero or negative `-l`, which tmux refuses outright — the
+        frame would come up with no strip at all in exactly the terminal least able to
+        afford a missing panel. What protects the harness there is `visible_slots`, which
+        drops the slot rather than shrinking it."""
+        with mock.patch.dict(config.FRAME, _arrangement(size=15)):
+            self.assertEqual(
+                layout.repos_rows(content_rows=0, window_rows=6, slots=SLOTS),
+                layout.SLOT_SIZE["repos"])

--- a/tests/test_component_config.py
+++ b/tests/test_component_config.py
@@ -170,12 +170,27 @@ class AnArrangementCharterCannotDrawIsRefusedWhole(unittest.TestCase):
         self._fallback([{"use": "repos", "edge": "top"}], slots=["top", "repos"])
 
     def test_a_size_charter_cannot_give_the_component(self):
+        """`sidebar` is `Fixed(22)`, and `layout` turns that declaration into
+        `SLOT_SIZE["right"]` once, at import. Nothing between `charter.toml` and
+        `split-window` carries a per-plane override for it, so a different number could
+        only be read, validated, stored and ignored.
+
+        The repo table is the one built-in this is not true of — its height is recomputed
+        from the resolved arrangement on every launch and every resize — and
+        `tests/test_a_pinned_repo_strip_keeps_its_height.py` is where that asymmetry is
+        pinned from both sides."""
         self._fallback([{"use": "sidebar", "size": 30}])
 
-    def test_a_size_on_a_component_whose_height_is_its_content(self):
-        """`repos` is `Content()`: its height is the plane's repo count bounded by what
-        the harness may not be charged, so there is no number to accept here at all."""
-        self._fallback([{"use": "repos", "size": 4}])
+    def test_a_size_the_repo_table_could_not_be_given(self):
+        """The table's height IS committable (see the module named above), which makes
+        the numbers it will not take the interesting half. Zero and below are a pane tmux
+        refuses to split; `true` is the `isinstance(True, int)` trap; a string and a float
+        are not cells at all. `component.Fixed` is what refuses each of them, and this
+        asserts that its refusal reaches the arrangement rather than escaping as a
+        `ComponentError` out of a committed file being resolved."""
+        for size in (0, -1, True, "4", 4.0, [4]):
+            with self.subTest(size=size):
+                self._fallback([{"use": "repos", "size": size}])
 
     def test_the_same_component_claimed_twice(self):
         """One pane draws it, and two claims have no answer — the registry's own rule

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -1602,6 +1602,74 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
                 f"the pane #515 has to name explicitly, because with three strips the "
                 f"two below it trade rows with each other and never with it")
 
+    def test_a_pinned_table_really_lands_on_its_committed_height(self):
+        """A `size` on the repo table's `[[frame.component]]` table, driven against real
+        tmux — and it is the DESIGN this proves, not only the arithmetic.
+
+        The strip is the one pane `_reassert_sizes` never asserts a height for: in a stack
+        of N panes only N-1 boundaries are free, so `top`, `bottom` and the harness are
+        told their sizes and the table takes the remainder. That is the mechanism a
+        content-sized table already uses, and the whole claim of a pin is that it changes
+        the NUMBER the others are sized around and nothing else. Nothing inside charter
+        can check that claim — the remainder is tmux's arithmetic, not charter's — so it
+        is asked of tmux.
+
+        Which is also why the obvious alternative is not what shipped. Calling a pinned
+        table a FIXED row and adding it to `_RESIZE_FLAG` would assert all N heights, and
+        that is the measured failure `_reassert_sizes`' own docstring carries: at 200x50,
+        asserting `top`, `bottom` and `repos` in split order left the table 1 row and the
+        attention strip 6, the two sizes having swapped panes.
+
+        `repos_rows_wanted` is stubbed to a number the pin must beat and one it must not
+        lose to — 2 clones and 30 — because a pin that were quietly still content-sized
+        would pass a single-content-count version of this test at whichever of the two
+        happened to match.
+        """
+        fid = state.frame_id("pin", os.getpid())
+        r = _tmux("new-session", "-d", "-s", "pin", "-x", "120", "-y", "50",
+                  "-P", "-F", "#{pane_id}")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness_pane = r.stdout.strip()
+        panes = {}
+        for slot, args in (("top", ("-v", "-b", "-l", "1")),
+                           ("bottom", ("-v", "-l", "1")),
+                           ("repos", ("-v", "-l", "6"))):
+            out = _tmux("split-window", "-t", harness_pane, *args,
+                        "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+            self.assertEqual(out.returncode, 0, out.stderr)
+            panes[slot] = out.stdout.strip()
+
+        pinned = instance.frame_of({"frame": {"component": [
+            {"use": "identity"}, {"use": "attention"},
+            {"use": "repos", "size": 15}, {"use": "sidebar"}]}})
+        self.assertEqual(
+            [p["size"].n for p in pinned["components"] if p["slot"] == "repos"], [15],
+            "the arrangement did not resolve the pin at all — everything below this "
+            "would then be asserting the content-sized behaviour under a new name")
+
+        for content in (2, 30):
+            with self.subTest(content=content):
+                with mock.patch.dict(config.FRAME, pinned), \
+                        mock.patch("charter.frame.slots.repos_rows_wanted",
+                                   return_value=content):
+                    commands_frame._reassert_sizes(SOCKET, fid=fid, panes=panes,
+                                                   harness_pane=harness_pane,
+                                                   window_cols=120, window_rows=50)
+                height = _tmux("display-message", "-p", "-t", panes["repos"],
+                               "#{pane_height}").stdout.strip()
+                self.assertEqual(
+                    height, "15",
+                    f"the table pane is {height} rows on a plane with {content} clones "
+                    f"and a committed `size = 15` — a pinned strip is a constant, and "
+                    f"tmux is the only thing that can say whether it really landed")
+                harness = _tmux("display-message", "-p", "-t", harness_pane,
+                                "#{pane_height}").stdout.strip()
+                # 50 - top(1) - bottom(1) - repos(15) - a border for each of the three.
+                self.assertEqual(harness, "30",
+                                 f"the harness has {harness} rows, so the rows the pin "
+                                 f"took came from somewhere the arithmetic does not "
+                                 f"describe")
+
     def test_the_table_panes_width_is_tmuxs_answer_and_not_the_recorded_order(self):
         """#510, against the one authority there is.
 


### PR DESCRIPTION
The operator's ask, verbatim:

> "repos component will have fixed height, now its maybe have max height - but when less repos - its very small."

```toml
[[frame.component]]
use  = "repos"
size = 15
```

Fifteen rows with one clone, fifteen with thirty. A plane that writes no `size` draws
exactly the frame it drew before.

## What was actually wrong

`size` was already in the `[[frame.component]]` form, and on this component it did
nothing. It could only *echo* a number charter had already declared — and `repos` declares
`Content()`, not a number — so **any** `size` on a repos table made the whole arrangement
unusable, which drops all four tables back to `slots` (#535). Verified on `origin/main`:

```python
>>> instance.component_tables({"component": [
...     {"use": "identity"}, {"use": "attention"},
...     {"use": "repos", "size": 15}, {"use": "sidebar"}]})
None
```

An operator writing `size = 15` today gets a different frame and no error. That is worth
saying out loud, because it is the failure the key was *already* capable of.

## The design, and the design that was proposed and refuted

The brief recommended deriving `layout.VARIABLE_ROW_SLOTS` from the **resolved
arrangement** rather than from `_SHIPPED`, so that `size = 15` makes `repos` a fixed row
and the harness becomes the remainder. I did not build that, and here is the measurement:

```python
>>> layout.VARIABLE_ROW_SLOTS = frozenset()   # repos resolved as Fixed(15)
>>> layout.slot_sizes(["top","bottom","repos","right"], window_rows=50, content_rows=2)
{'top': 1, 'bottom': 1, 'repos': 1, 'right': 22}
```

**The pinned strip comes out one row tall.** `slot_sizes`' non-variable branch answers from
`_size_of`, which reads `SLOT_SIZE` — and `SLOT_SIZE["repos"]` is `1`, the *floor*, not a
size. Making that design work would additionally require `SLOT_SIZE`/`_size_of` to become
arrangement-aware, which means inverting `_placed_here`'s `name not in SLOT_SIZE` guard
(pinned by `tests/test_sweep.py`) and touching `repos_cols`, `column_sizes`,
`panel_argvs`' last resort, `_is_fixed_row` and `harness_rows`.

**And it buys nothing at the tmux end.** `_RESIZE_FLAG = {"top": "-y", "bottom": "-y",
"right": "-x"}` has no `repos` entry; adding one would assert N heights in an N-pane stack,
which is the measured failure `_reassert_sizes`' own docstring already carries (at 200x50,
asserting `top`, `bottom`, `repos` in split order left the table 1 row and the attention
strip 6 — the two sizes swapped panes). The strip has to stay the stack's dependent pane
whether its height comes from the clone count or from a committed file.

**On the empty variable set**, as asked: it is safe but unnecessary. `_variable_pane_cols`'
`next(..., "")` would return `""`, fail `_PANE_ID_RE`, and fall through to
`layout.repos_cols` — already the documented fallback for a pane that cannot be measured.
TWO is impossible in either design: the config boundary requires a provider component's
`size` to be an `int`, so `repos` is the only component that can ever be non-`Fixed`. Both
`tests/test_builtin_components.py` and `tests/test_change_surface.py` pin
`VARIABLE_ROW_SLOTS == frozenset({"repos"})`, and this PR keeps them green rather than
editing them.

### What shipped instead

A committed `size` on `repos` replaces the **content** term inside `repos_rows`, leaving
the floor and the cap exactly where they are:

```python
floor  = SLOT_SIZE["repos"]
pinned = _pinned_rows()                                   # the committed size, or None
wanted = content_rows if pinned is None else pinned
cap    = window_rows - other - _BORDER_ROWS - HARNESS_MIN_ROWS
return max(floor, min(wanted, cap))
```

`repos` stays in `VARIABLE_ROW_SLOTS`, stays out of `_RESIZE_FLAG`, stays the dependent
pane. `_variable_pane_cols` still finds exactly one. Nothing about how tmux is driven
moves — only the number the other panes are sized around.

**The cap is deliberate and is not negotiable away.** tmux does not refuse an over-large
height, it grants it out of the neighbour: `resize-pane -y 40` in a 20-row window leaves
the harness one row tall. A committed `size = 40` is that command with a config file in
front of it, on a plane whose frame is committed and shared. So a pin degrades on a short
terminal exactly as a fourteen-repo plane's table already does, and the harness keeps
`HARNESS_MIN_ROWS`. Documented in `docs/frame.md` and in the news entry rather than left
for someone to discover.

### Why `size` is honoured on `repos` and still refused on the other three

This is the form's existing rule, applied — not a carve-out. A committed value is honoured
exactly where something reads it. `top`, `bottom` and `right` are turned into
`layout.SLOT_SIZE` once, at import, and `_size_of` answers them out of that table forever
after; a different number there could only be read, validated, stored and ignored, which is
the convincing empty the whole form is written against. `repos` never enters that table —
its height is `repos_rows`, recomputed from the resolved arrangement at every launch and on
every `window-resized`. That is the entire asymmetry, and `instance._built_in_size` is where
it is argued in one place.

The pin is a `Fixed`, and `component.Fixed` is *asked* rather than re-checked — it already
refuses a `bool`, a non-int and anything below one cell — inside a `try`, because this runs
while a committed file is being resolved on the path of `charter --version`, and a
`ComponentError` escaping there would take every command with it.

## Verification

**A real tmux 3.7c** confirms the mechanism actually delivers the number, which is the one
thing no unit test can:
`TmuxIntegration.test_a_pinned_table_really_lands_on_its_committed_height` builds the four-
pane stack for real, drives `_reassert_sizes`, and reads the pane back — 15 rows with 2
clones and 15 with 30, harness on exactly 30. Red on both subtests without the change (30
rows and 2 rows).

**Full suite green**: 8485 tests, `python3 -m unittest discover -s tests`.

**Deletion sweep**: 26 mutations over the two changed files, **0 survivors**.

`tools/sweep.py` itself could not complete on this box — see the note below — so its plan
was taken from `sweep.plan_for` and every one of its 26 mutations applied and run by hand
against a 21-module covering subset. Decomposed, the first pass had two survivors and both
were acted on rather than counted:

| survivor | verdict | what was done |
|---|---|---|
| `layout.py` `config.FRAME.get("components") or ()` → `["components"]` | **unpinned**, and a second copy of a line `_placed_here` already carried — recorded at `layout.py:289` as an examined survivor in `docs/news/unreleased-the-deletion-sweep-is-a-thing-the-repo-runs.md` | both readers now share `_arrangement()`. Consolidating did more than deduplicate: `test_component_id_is_the_currency.test_a_frame_mapping_that_carries_no_arrangement_is_an_empty_one` already existed and could only ever see one of the two copies, so the shared line is now **pinned** by it (subTests `'no components key'` and `'None'`) |
| `_built_in_size` drop `isinstance(c.size, Fixed)` | **masked-cluster** — hidden behind the `Content` branch above it, since every component `SLOT_OF` reaches is one or the other | asked of a component that really has the third policy: `personas` is a real `Fill()`, and `value == c.size.n` on it is an `AttributeError` raised mid config-resolution. Now **pinned** |

Nothing platform-deferred. Second pass, on the final tree:

```
26/26 PINNED, 0 survivor(s)
```

The clamp mutations are worth naming because they are the ones that would have let the
cap quietly go: `min(wanted, cap) → wanted` (7 failures) and `max(floor, min(...)) → floor`
(76) both redden, so neither the harness floor nor the pane floor can be deleted in
silence.

## Note on the environment, not on the branch

`PYTHONSAFEPATH=1` is set in this shell. It makes the sweep's own baseline come back RED
(31 subprocess tests that shell out to `python -m charter`), which reads as "the tree is red
before any mutation" and is not. Every number above was measured with `env -u
PYTHONSAFEPATH`. Nothing in the repo needs changing for it; it is worth knowing before the
next person runs the sweep from an interactive shell.

## Files

- `charter/instance.py` — `_built_in_size`, and `_built_in_placement` grows a `size` override
- `charter/frame/layout.py` — `_pinned_rows`, `repos_rows` prefers it over the content, and
  `_arrangement()` is the one read of `config.FRAME` that `_placed_here` now shares
- `tests/test_a_pinned_repo_strip_keeps_its_height.py` — the new module
- `tests/test_frame_tmux_integration.py` — the real-tmux confirmation
- `tests/test_component_config.py` — the one test that asserted the old refusal, inverted
- `docs/frame.md`, `docs/news/unreleased-the-repo-strip-can-have-a-height-you-chose.md`

No version bump, no stamp, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGTJ3Zg7dgCQEeQLXWWo1d
