### PR TITLE
The frame's arithmetic stops reading the plane's own `charter.toml`, so `size = 15` can be committed (#661)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1568,6 +1568,46 @@ def _spawn_gather(fid: str, ws: str) -> None:
         return
 
 
+def _slot_sizes(fid: str, slots: list[str], *,
+                window_rows: int, pane_cols: int) -> dict[str, int]:
+    """`layout.slot_sizes` for a frame that has a plane behind it — the only place in
+    charter where a committed arrangement becomes a pane height.
+
+    **This function is the boundary, and it is one function because the boundary is one
+    line.** `layout` is arithmetic: hand it a row count and a slot list and it answers the
+    same thing on every machine, which is what makes `layout.repos_rows` testable with no
+    tmux, no cache and no plane. The two facts it cannot derive are what the table's
+    content wants (`frame_slots.repos_rows_wanted`, which reads this frame's gather) and
+    whether the operator pinned the strip to a height (`layout.pinned_repo_rows`, which
+    reads this plane's `charter.toml`). Both are read HERE, once, and passed down.
+
+    #660 put the second read inside `layout.repos_rows` instead, borrowing
+    `layout._placed_here`'s "rather than threaded through five signatures". #661 is the
+    bill: `repos_rows(content_rows=4, window_rows=50, slots=["top","bottom","repos"])`
+    answered `15` on a plane whose `charter.toml` carried `size = 15`, from a file the
+    caller never named, in the module's one provably pure function. On this repository
+    `charter.toml` is tracked, so committing the line the feature's own news entry tells
+    an operator to write turned six tests red for everybody.
+
+    And the five was not this path's number. `_placed_here`'s five is real for
+    `_placed_here` — an edge and a cell count for a name `slot_sizes`, `panel_argvs`,
+    `repos_cols`, `repos_rows` and `harness_rows` each have to ask about, none of which
+    knows it in advance. The pin is one number for one slot with one consumer, so its
+    path is two signatures (`slot_sizes`, `repos_rows`) and the three call sites below —
+    which were already building `content_rows` the same way three times over, and now do
+    not.
+
+    The three are `_launch_sizes` (both launch paths), `_relayout`'s splits for a density
+    the frame did not have, and `_reassert_sizes` on every `window-resized`. They differ
+    only in how the table pane's width is arrived at, which is why that arrives here as
+    *pane_cols* already measured rather than as a window to measure.
+    """
+    return layout.slot_sizes(
+        slots, window_rows=window_rows,
+        content_rows=frame_slots.repos_rows_wanted(fid, pane_cols=pane_cols),
+        pinned_rows=layout.pinned_repo_rows())
+
+
 def _launch_sizes(fid: str, slots: list[str], *,
                   window_cols: int, window_rows: int) -> dict[str, int]:
     """How big each of *slots* is split, in a *window_cols* x *window_rows* window —
@@ -1604,11 +1644,12 @@ def _launch_sizes(fid: str, slots: list[str], *,
     `gather.discard(fid)` before it draws anything, so this reaches `gather.row_count`
     with no cache and gets the directory-listing answer — an `iterdir`, never the git
     sweep `gather.scan` would run. See `gather.row_count`'s own docstring for both paths.
+
+    Through :func:`_slot_sizes`, which is where the plane's own pinned height is read and
+    why this is not a call to `layout.slot_sizes` directly.
     """
-    return layout.slot_sizes(
-        slots, window_rows=window_rows,
-        content_rows=frame_slots.repos_rows_wanted(
-            fid, pane_cols=layout.repos_cols(slots, window_cols=window_cols)))
+    return _slot_sizes(fid, slots, window_rows=window_rows,
+                       pane_cols=layout.repos_cols(slots, window_cols=window_cols))
 
 
 def _drawable_slots(cols: int, rows: int, configured: list[str] | None = None) -> list[str]:
@@ -4034,11 +4075,10 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
         keep.update(_split_panels(
             socket, slots=missing, fid=fid, harness_pane=harness_pane, env=None,
             pane_env=pane_env, v=v,
-            sizes=layout.slot_sizes(
-                want, window_rows=window_rows,
-                content_rows=frame_slots.repos_rows_wanted(
-                    fid, pane_cols=layout.repos_cols(list(keep) + missing,
-                                                      window_cols=window_cols)))))
+            sizes=_slot_sizes(
+                fid, want, window_rows=window_rows,
+                pane_cols=layout.repos_cols(list(keep) + missing,
+                                            window_cols=window_cols))))
         _arm_panel_respawn(socket, fid=fid,
                            panes={s: keep[s] for s in missing if s in keep}, env=None)
 
@@ -4238,11 +4278,9 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str], harness_pan
     # here, and it has to land before anything is measured — see :func:`_variable_pane_cols`
     # for the tmux measurement that makes this an order rather than a preference.
     _apply_sizes(socket, panes=panes, sizes=layout.column_sizes(order), flag="-x")
-    sizes = layout.slot_sizes(
-        order, window_rows=window_rows,
-        content_rows=frame_slots.repos_rows_wanted(
-            fid, pane_cols=_variable_pane_cols(socket, panes=panes,
-                                               window_cols=window_cols)))
+    sizes = _slot_sizes(
+        fid, order, window_rows=window_rows,
+        pane_cols=_variable_pane_cols(socket, panes=panes, window_cols=window_cols))
     # Pass two: the ROWS, and the harness below them.
     _apply_sizes(socket, panes=panes, sizes=sizes, flag="-y")
     if _PANE_ID_RE.fullmatch(harness_pane or ""):

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -264,10 +264,10 @@ def _arrangement():
 
     **One line, because there are two callers and the fallback in it is unpinned.**
     :func:`_placed_here` reads the arrangement for a component charter did not write and
-    :func:`_pinned_rows` reads it for the one built-in whose height a plane may commit; the
-    `or ()` is the same defence for both, and a second copy of it is a second line nothing
-    can fail without. `tools/sweep.py` reported exactly that copy the day it appeared and
-    `docs/news/unreleased-the-deletion-sweep-is-a-thing-the-repo-runs.md` records the
+    :func:`pinned_repo_rows` reads it for the one built-in whose height a plane may
+    commit; the `or ()` is the same defence for both, and a second copy of it is a second
+    line nothing can fail without. `tools/sweep.py` reported that copy the day it appeared
+    and `docs/news/unreleased-the-deletion-sweep-is-a-thing-the-repo-runs.md` records the
     original at this module's line 289 as a survivor it examined — so the answer to a
     second one is to have one, not to accept two.
 
@@ -275,7 +275,7 @@ def _arrangement():
     ``components`` before its own early return, deliberately ("a key present on one path
     and absent on another is two shapes for one answer"), so nothing in production reaches
     here without it — but `config.FRAME` is module state that a caller may replace whole,
-    and a `KeyError` out of :func:`repos_rows` costs a launch its entire frame. Pinning it
+    and a `KeyError` out of either reader costs a launch its entire frame. Pinning it
     would mean a test constructing a `config.FRAME` that `frame_of` cannot produce, which
     is a test of the line rather than of any property.
 
@@ -311,7 +311,14 @@ def _placed_here() -> dict[str, tuple[str, int]]:
     at import, because a value read, validated and then ignored is the convincing empty
     this phase was written against. The repo table is the exception both of those rules now
     have (`instance._built_in_size`), and it is still not read HERE: its height is
-    :func:`repos_rows`', and :func:`_pinned_rows` is what reads the number for it.
+    :func:`repos_rows`', and :func:`pinned_repo_rows` is what reads the number for it.
+
+    **The signature count above is THIS function's measurement and does not transfer.**
+    It is what the five named functions would each have to carry to answer one question
+    for a name none of them knows in advance: where a placed component sits and how many
+    cells it costs. The repo strip's pin is one number for one slot with one consumer, and
+    #661 is what came of borrowing the count anyway — measured, that path is two
+    signatures and three call sites. See :func:`pinned_repo_rows`.
     """
     out: dict[str, tuple[str, int]] = {}
     for placed in _arrangement():
@@ -326,7 +333,7 @@ def _policy_cells(size) -> int:
     return size.n if isinstance(size, Fixed) else 1
 
 
-def _pinned_rows() -> int | None:
+def pinned_repo_rows() -> int | None:
     """The height this plane PINNED the repo strip to, or ``None`` for the shipped policy.
 
     **The one per-plane override charter's own geometry has, and the reason it is the only
@@ -334,15 +341,27 @@ def _pinned_rows() -> int | None:
     :data:`SLOT_SIZE` — derived once, at import — is the whole answer for it and a
     committed number could only be read and ignored (`instance._built_in_size` argues that
     half). `repos` is `Content()`: its height never enters that table, it is computed by
-    :func:`repos_rows` from the resolved arrangement at every launch and again on every
+    :func:`repos_rows` from the arrangement it is HANDED at every launch and again on every
     `window-resized`, and this is what makes a number there mean something.
 
-    Read from the resolved config rather than threaded through five signatures, for
-    :func:`_placed_here`'s reason word for word — and this function is on exactly the path
-    that docstring names. :func:`repos_rows` already reaches `config.FRAME` transitively
-    through :func:`_is_fixed_row`, so nothing about when this module talks to the config
-    boundary changes. Through :func:`_arrangement`, which both readers share so that the
-    fallback in it is one line rather than two.
+    **The one function in this module that reads a committed file, and it is public so
+    that its callers can be counted.** It used to be called from inside
+    :func:`repos_rows`, borrowing :func:`_placed_here`'s "rather than threaded through
+    five signatures" word for word — and that cost was mispriced (#661). `repos_rows` was
+    this module's one provably pure function and its tests were written to that property,
+    so a `size` in the plane's own `charter.toml` answered a caller that had passed
+    `content_rows=4` with `15`: `layout.repos_rows(content_rows=4, window_rows=50,
+    slots=["top","bottom","repos"])` returned the committed number. On this repo, whose
+    `charter.toml` is tracked, that turned six tests red for everyone the moment an
+    operator did what the feature's own news entry told them to do.
+
+    The measurement the borrowed reason skipped: the pin is ONE number for ONE slot with
+    ONE consumer, so the path is `repos_rows` ← `slot_sizes` ← the three sites in
+    `commands_frame` that already build `content_rows` the same way. Two signatures, and
+    the three sites share `commands_frame._slot_sizes`, which is where this is called from
+    and the only place it is. `_placed_here`'s five is real for `_placed_here` — an edge
+    and a cell count for a name `panel_argvs`, `repos_cols` and `harness_rows` each have
+    to ask about — and it does not transfer to this.
 
     ``isinstance(placed["size"], Fixed)`` asks which POLICY the arrangement resolved to,
     which is the property and not a stand-in for it: a plane that writes its arrangement
@@ -521,13 +540,24 @@ def visible_slots(slots: list[str], cols: int, rows: int,
 
 
 def repos_rows(*, content_rows: int, window_rows: int,
-               slots: list[str] | tuple[str, ...] = ()) -> int:
+               slots: list[str] | tuple[str, ...] = (),
+               pinned_rows: int | None = None) -> int:
     """How many rows the `repos` pane gets: what its content wants, floored and capped.
 
     Pure arithmetic, deliberately — this is the whole of #488's "how tall is the table?"
     and it is decided here, with no tmux and no filesystem, so both callers that need an
     answer (a launch, and the `window-resized` hook's own recompute) necessarily get the
     same one.
+
+    **Every term is an argument, and *pinned_rows* is one of them for a measured reason.**
+    #660 reached `config.FRAME` from inside this function instead, and #661 is what that
+    cost: a `size` committed to the plane's own `charter.toml` made this answer `15` to a
+    caller that had passed `content_rows=4`, `window_rows=50` and neither bound binding —
+    a number out of a file the caller never named, from the module's one function whose
+    tests assert it is arithmetic. `None` is "this plane pinned nothing", which is every
+    plane that does not say otherwise and every test that is asking about the arithmetic;
+    `layout.pinned_repo_rows` is the read, and `commands_frame._slot_sizes` is the one
+    caller that makes it.
 
     * **The floor is `SLOT_SIZE["repos"]`.** A workspace with no clones still has one
       line to draw — that it has none, and the command that gets it one
@@ -544,9 +574,9 @@ def repos_rows(*, content_rows: int, window_rows: int,
       (`slots.repos_rows_wanted`), so a two-repo plane gets a two-row strip rather than a
       fourteen-row one padded with blanks. That is the DEFAULT and it is the answer for
       every plane that does not say otherwise; a ``size`` on the table's own
-      `[[frame.component]]` table replaces it with a constant (:func:`_pinned_rows`),
-      which is the operator asking for a strip that does not move when a clone is added
-      or removed.
+      `[[frame.component]]` table replaces it with a constant, which arrives here as
+      *pinned_rows* and is the operator asking for a strip that does not move when a
+      clone is added or removed.
 
     **A pin replaces the content, not the floor and not the cap**, and the cap is why.
     tmux does not refuse an over-large height, it grants it out of the neighbour: measured
@@ -563,8 +593,7 @@ def repos_rows(*, content_rows: int, window_rows: int,
     every slot below half the size floors.
     """
     floor = SLOT_SIZE["repos"]
-    pinned = _pinned_rows()
-    wanted = content_rows if pinned is None else pinned
+    wanted = content_rows if pinned_rows is None else pinned_rows
     other = sum(_size_of(s) + _BORDER_ROWS for s in slots if _is_fixed_row(s))
     cap = window_rows - other - _BORDER_ROWS - HARNESS_MIN_ROWS
     return max(floor, min(wanted, cap))
@@ -599,7 +628,8 @@ def column_sizes(slots: list[str] | tuple[str, ...]) -> dict[str, int]:
     return out
 
 
-def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int) -> dict[str, int]:
+def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int,
+               pinned_rows: int | None = None) -> dict[str, int]:
     """Every slot in *slots* mapped to the size it should be given — rows for the
     horizontal strips, columns for the side.
 
@@ -609,6 +639,12 @@ def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int) -> dict
     recompute calls it again with the window's NEW row count — which is the whole reason
     it takes *window_rows* rather than closing over a launch-time value.
 
+    *pinned_rows* is :func:`repos_rows`' and is carried rather than read, for that
+    function's reason: this is the last hop of a value the plane committed, not a second
+    place to look it up. `None` — the default, and what every caller asking about the
+    arithmetic passes — is a plane that pinned nothing, which is charter's own and very
+    nearly everyone's.
+
     Unknown slot names are dropped rather than raised on, matching `visible_slots`'
     filter-don't-refuse discipline: `[frame] slots` is committed, untrusted input, and by
     the time a list reaches here it has already been through `instance.FRAME_SLOTS`.
@@ -616,7 +652,7 @@ def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int) -> dict
     out: dict[str, int] = {}
     for slot in slots:
         if _key(slot) in VARIABLE_ROW_SLOTS:
-            out[slot] = repos_rows(content_rows=content_rows,
+            out[slot] = repos_rows(content_rows=content_rows, pinned_rows=pinned_rows,
                                    window_rows=window_rows, slots=slots)
             continue
         cells = _size_of(slot)

--- a/docs/news/unreleased-pinning-the-repo-strip-on-charters-own-plane-stops-turning-the-suite-red.md
+++ b/docs/news/unreleased-pinning-the-repo-strip-on-charters-own-plane-stops-turning-the-suite-red.md
@@ -1,0 +1,62 @@
+---
+version: unreleased
+headline: The frame's geometry stops reading `charter.toml` behind its callers' backs, so pinning the repo strip on charter's own plane no longer turns the test suite red
+---
+
+The repo strip gained a height you could choose, and on one plane you could not use it:
+**charter's own.** Writing the three lines that feature's own news entry gives you
+
+```toml
+[[frame.component]]
+use  = "repos"
+size = 15
+```
+
+into this repository's `charter.toml` turned six tests red. `charter.toml` is a tracked
+file here, so committing them would have turned CI red for everyone — a feature that
+could not be used on the plane that shipped it.
+
+Nothing about the feature changes. A pin is still fifteen rows with one clone and fifteen
+with thirty, still capped so your session keeps its floor, still the one pane tmux is
+never told the height of. What changes is where charter reads your number.
+
+## What went wrong
+
+`layout.repos_rows` answers one question — *how tall is the repo strip?* — from the rows
+its content wants, a floor, and what the window can spare. It is charter's one piece of
+frame geometry that is nothing but arithmetic: hand it a content count and a window size
+and it answers the same thing on every machine, with no tmux, no cache and no plane
+behind it. Its tests are written to exactly that, and they say so.
+
+The pin was read from inside it. So on a plane that had committed one:
+
+```
+repos_rows(content_rows=4, window_rows=50, slots=["top","bottom","repos"])  ->  15
+```
+
+Four rows of content, a fifty-row window, neither the floor nor the cap anywhere near
+binding — and the answer is a number out of a file the caller never named.
+
+That is not the same defect as a test that reads your clock or your terminal width. Those
+read a machine that happens to differ. This read the repository's own committed file, so
+the failure was deterministic and arrived by following the documentation.
+
+## What changed
+
+The plane is read once, at the boundary that already turns a frame into pane sizes
+(`commands_frame._slot_sizes`), and the number is handed down to the arithmetic. All
+three paths that size panes — a launch, a density re-layout, and the recompute on every
+terminal resize — go through it, so they cannot disagree, and `layout.repos_rows` is
+arithmetic again.
+
+The first cut chose the config read deliberately, arguing that threading a value through
+five signatures to reach one leaf is its own defect. That argument is real, and it was
+borrowed from a different question: five is the count for *where does a placed component
+sit and how many cells does it cost*, which five separate functions each have to ask
+about a name none of them knows in advance. A pinned strip is one number, for one slot,
+with one consumer. Measured, its path is two signatures and three call sites — and the
+three were already building the sibling argument the same way three times over, so the
+read landed in one line and deleted two copies of something else.
+
+Pinned by a test that adds `size = 15` to this repository's real `charter.toml` and
+asserts the arithmetic still answers what it was asked.

--- a/tests/test_a_pinned_repo_strip_keeps_its_height.py
+++ b/tests/test_a_pinned_repo_strip_keeps_its_height.py
@@ -9,7 +9,7 @@ it is, and the `size` key that would have said so was accepted-but-inert — it 
 echo a number charter had already declared, and since `repos` declares no number at all,
 **any** `size` on it took the whole arrangement down to `slots` with nothing said.
 
-Three claims are pinned here, and they are separable on purpose:
+Four claims are pinned here, and they are separable on purpose:
 
 * **the config boundary** decides which built-ins may carry a `size` that means
   something, and `repos` is the only one — every other placed built-in is `Fixed` in its
@@ -22,16 +22,32 @@ Three claims are pinned here, and they are separable on purpose:
 * **the mechanism does not move.** `repos` stays the one variable-row slot and stays out
   of `commands_frame._RESIZE_FLAG`, so it is still the stack's dependent pane and tmux is
   still asked to move exactly N-1 boundaries in an N-pane stack. A pin changes the number
-  the other panes are sized around, and nothing about how they are asserted.
+  the other panes are sized around, and nothing about how they are asserted;
+* **the plane is read at a boundary and the arithmetic is handed the answer** (#661).
+  `layout.repos_rows` is charter's one provably pure geometry function and its tests are
+  written to that property; the first cut of this feature read `config.FRAME` from inside
+  it, so `repos_rows(content_rows=4, window_rows=50, slots=[...])` answered `15` with
+  neither bound binding, out of a file the caller never named. On this repository
+  `charter.toml` is tracked, so an operator following this feature's own news entry
+  turned six tests red for everyone. `commands_frame._slot_sizes` is the boundary now and
+  `layout.pinned_repo_rows` is the read.
 """
 
 from __future__ import annotations
 
+import pathlib
+import subprocess
+import tomllib
 import unittest
 from unittest import mock
 
 from charter import commands_frame, config, instance
 from charter.frame import builtins, component, layout
+
+#: This repository's own committed plane file. Read rather than described, for
+#: `test_component_id_is_the_currency.CharterOwnConfigIsUnchanged`'s reason and for one
+#: more of its own: #661 was a defect an operator triggered by editing exactly this file.
+_COMMITTED = pathlib.Path(__file__).resolve().parents[1] / "charter.toml"
 
 
 def _arrangement(**repos) -> dict:
@@ -44,6 +60,20 @@ def _arrangement(**repos) -> dict:
     tables = [{"use": "identity"}, {"use": "attention"},
               {"use": "repos", **repos}, {"use": "sidebar"}]
     return instance.frame_of({"frame": {"component": tables}})
+
+
+def _pin(**repos) -> int | None:
+    """What `layout.pinned_repo_rows` reads out of the arrangement *repos* describes.
+
+    **The seam, called as the launcher calls it, and never a literal.** The number the
+    arithmetic is handed below is this function's answer and not a `15` written twice, so
+    a boundary that stopped resolving `size`, or a reader that stopped finding it, is red
+    in every case that depends on the pin rather than only in the one that asserts the
+    read. `config.FRAME` is patched HERE and only here, which is the whole shape #661
+    asked for: the plane is read at a boundary and its answer is passed down.
+    """
+    with mock.patch.dict(config.FRAME, _arrangement(**repos)):
+        return layout.pinned_repo_rows()
 
 
 #: The split order every case below uses — charter's own, and the one whose arithmetic
@@ -59,8 +89,8 @@ class TheConfigBoundaryDecidesWhichBuiltInsMayCarryASize(unittest.TestCase):
     size into `SLOT_SIZE` once, at import, and `_size_of` answers `top`, `bottom` and
     `right` out of that table forever after — so a number on those three has nowhere to be
     read. `repos` is `Content()`, which never enters that table: `slot_sizes` routes it to
-    `repos_rows`, recomputed from the resolved arrangement at every launch and again on
-    every `window-resized`.
+    `repos_rows`, which is handed the resolved arrangement's number at every launch and
+    again on every `window-resized` (`commands_frame._slot_sizes`).
     """
 
     def test_the_repo_table_resolves_a_committed_size_to_a_fixed_policy(self):
@@ -150,13 +180,12 @@ class ThePinnedStripIsTheHeightTheOperatorCommitted(unittest.TestCase):
         Every one of these content counts is a real answer `slots.repos_rows_wanted` gives
         on some plane — none, one, a couple, a full table, more than the window has — and
         the pinned strip is the same height for all of them."""
-        with mock.patch.dict(config.FRAME, _arrangement(size=15)):
-            for content in (0, 1, 2, 14, 30):
-                with self.subTest(content=content):
-                    self.assertEqual(
-                        layout.repos_rows(content_rows=content, window_rows=50,
-                                          slots=SLOTS),
-                        15)
+        for content in (0, 1, 2, 14, 30):
+            with self.subTest(content=content):
+                self.assertEqual(
+                    layout.repos_rows(content_rows=content, window_rows=50,
+                                      slots=SLOTS, pinned_rows=_pin(size=15)),
+                    15)
 
     def test_a_plane_that_pins_nothing_is_sized_by_its_content_exactly_as_before(self):
         """The default, asserted against a written-out arrangement rather than against a
@@ -164,22 +193,22 @@ class ThePinnedStripIsTheHeightTheOperatorCommitted(unittest.TestCase):
         exists to be misread, and charter's own plane commits one. Two counts, so a pin
         read off the wrong placement (`identity` is `Fixed(1)` and comes first in file
         order) cannot pass by coincidence."""
-        with mock.patch.dict(config.FRAME, _arrangement()):
-            for content in (4, 7):
-                with self.subTest(content=content):
-                    self.assertEqual(
-                        layout.repos_rows(content_rows=content, window_rows=50,
-                                          slots=SLOTS),
-                        content)
+        self.assertIsNone(_pin(), "a written-out arrangement with no size is not a pin")
+        for content in (4, 7):
+            with self.subTest(content=content):
+                self.assertEqual(
+                    layout.repos_rows(content_rows=content, window_rows=50,
+                                      slots=SLOTS, pinned_rows=_pin()),
+                    content)
 
     def test_the_pin_reaches_tmux_as_the_length_the_pane_is_split_to(self):
         """The seam that makes any of this visible: `slot_sizes` into `panel_argvs` into
         `-l`. Asserted as the literal string tmux would see, so a number computed
         correctly and then dropped on the way out is red."""
-        with mock.patch.dict(config.FRAME, _arrangement(size=15)):
-            sizes = layout.slot_sizes(SLOTS, window_rows=50, content_rows=2)
-            cmds = layout.panel_argvs(slots=SLOTS, sizes=sizes, session="f-1",
-                                      socket="charter", harness_pane="%0")
+        sizes = layout.slot_sizes(SLOTS, window_rows=50, content_rows=2,
+                                  pinned_rows=_pin(size=15))
+        cmds = layout.panel_argvs(slots=SLOTS, sizes=sizes, session="f-1",
+                                  socket="charter", harness_pane="%0")
         self.assertEqual(sizes, {"top": 1, "bottom": 1, "repos": 15, "right": 22})
         repos = cmds[SLOTS.index("repos")]
         self.assertEqual(repos[repos.index("-l") + 1], "15")
@@ -202,9 +231,9 @@ class ThePinnedStripIsTheHeightTheOperatorCommitted(unittest.TestCase):
         harness. A pin the harness arithmetic did not know about would show up here as
         rows that belong to nobody."""
         rows = 50
-        with mock.patch.dict(config.FRAME, _arrangement(size=15)):
-            sizes = layout.slot_sizes(SLOTS, window_rows=rows, content_rows=2)
-            harness = layout.harness_rows(sizes, window_rows=rows)
+        sizes = layout.slot_sizes(SLOTS, window_rows=rows, content_rows=2,
+                                  pinned_rows=_pin(size=15))
+        harness = layout.harness_rows(sizes, window_rows=rows)
         strips = sum(n + layout._BORDER_ROWS for slot, n in sizes.items()
                      if slot != "right")
         self.assertEqual(strips + harness, rows)
@@ -268,8 +297,8 @@ class APinIsStillCappedSoTheSessionKeepsItsFloor(unittest.TestCase):
         the arithmetic is checked rather than restated — the shape
         `tests/test_frame_layout.py` already uses for the content-sized cap."""
         rows = 24
-        with mock.patch.dict(config.FRAME, _arrangement(size=15)):
-            got = layout.repos_rows(content_rows=2, window_rows=rows, slots=SLOTS)
+        got = layout.repos_rows(content_rows=2, window_rows=rows, slots=SLOTS,
+                                pinned_rows=_pin(size=15))
         harness = (rows - got - layout.SLOT_SIZE["top"] - layout.SLOT_SIZE["bottom"]
                    - 3 * layout._BORDER_ROWS)
         self.assertGreaterEqual(harness, layout.HARNESS_MIN_ROWS)
@@ -281,12 +310,10 @@ class APinIsStillCappedSoTheSessionKeepsItsFloor(unittest.TestCase):
         copy of `HARNESS_MIN_ROWS` growing behind the new key."""
         for rows in (18, 20, 24, 30, 50):
             with self.subTest(rows=rows):
-                with mock.patch.dict(config.FRAME, _arrangement(size=99)):
-                    pinned = layout.repos_rows(content_rows=0, window_rows=rows,
-                                               slots=SLOTS)
-                with mock.patch.dict(config.FRAME, _arrangement()):
-                    grown = layout.repos_rows(content_rows=99, window_rows=rows,
-                                              slots=SLOTS)
+                pinned = layout.repos_rows(content_rows=0, window_rows=rows,
+                                           slots=SLOTS, pinned_rows=_pin(size=99))
+                grown = layout.repos_rows(content_rows=99, window_rows=rows,
+                                          slots=SLOTS, pinned_rows=_pin())
                 self.assertEqual(pinned, grown)
 
     def test_the_floor_holds_when_the_window_has_no_rows_to_spare_at_all(self):
@@ -294,7 +321,162 @@ class APinIsStillCappedSoTheSessionKeepsItsFloor(unittest.TestCase):
         frame would come up with no strip at all in exactly the terminal least able to
         afford a missing panel. What protects the harness there is `visible_slots`, which
         drops the slot rather than shrinking it."""
+        self.assertEqual(
+            layout.repos_rows(content_rows=0, window_rows=6, slots=SLOTS,
+                              pinned_rows=_pin(size=15)),
+            layout.SLOT_SIZE["repos"])
+
+
+class TheCommittedFileIsReadAtABoundaryAndNotInTheArithmetic(unittest.TestCase):
+    """#661: `layout` answers the same thing whatever this plane committed.
+
+    **The defect this class exists for was not environmental.** Nine earlier instances of
+    "the suite reads or spends the machine" read something that merely *differs* between
+    machines — the clock, the cwd, `$COLUMNS`, a real vault, a real tmux. This one read
+    `charter.toml`, a file tracked IN this repository, from inside `layout.repos_rows` —
+    so the failure was deterministic and was triggered by following the documentation.
+    Writing the three lines this feature's own news entry gives an operator turned six
+    tests red, and committing them would have turned CI red for everyone.
+
+    So the property is not "`repos_rows` happens to be right today". It is that no
+    arrangement a plane can commit changes what these two functions answer, which is what
+    `ReposIsSizedToItsContent`'s "pure arithmetic, so it is pinned here with no tmux and
+    no cache" has always claimed and could not enforce.
+    """
+
+    def arrangements(self) -> dict:
+        """Every shape a plane's `[[frame.component]]` tables can take on the repo table —
+        no arrangement at all, one written out with no pin, and pins on either side of
+        both bounds. If any of them reaches the arithmetic, one of the answers below is
+        not the content the caller named."""
+        return {"no arrangement": {},
+                "written out, no size": _arrangement(),
+                "pinned small": _arrangement(size=2),
+                "pinned large": _arrangement(size=15),
+                "pinned past the cap": _arrangement(size=99)}
+
+    def test_no_arrangement_a_plane_can_commit_changes_what_repos_rows_answers(self):
+        """The issue's own measurement, as a property: 4 rows of content in a 50-row
+        window with neither bound binding can only be answered `4`. Asserted as the
+        content and not as "the same for all five", because equal-and-wrong is exactly
+        what a `repos_rows` that read the file would give five identical planes."""
+        for name, frame in self.arrangements().items():
+            with self.subTest(arrangement=name):
+                with mock.patch.dict(config.FRAME, frame):
+                    self.assertEqual(
+                        layout.repos_rows(content_rows=4, window_rows=50,
+                                          slots=["top", "bottom", "repos"]),
+                        4)
+
+    def test_no_arrangement_a_plane_can_commit_changes_what_slot_sizes_answers(self):
+        """`slot_sizes` is the one callers actually reach, and three of #661's six red
+        tests were its — so pinning only the leaf would have left the defect in the
+        function above it. The whole map, so a `repos` answered from the file cannot hide
+        behind the fixed strips being right."""
+        for name, frame in self.arrangements().items():
+            with self.subTest(arrangement=name):
+                with mock.patch.dict(config.FRAME, frame):
+                    self.assertEqual(
+                        layout.slot_sizes(SLOTS, window_rows=50, content_rows=4),
+                        {"top": 1, "bottom": 1, "repos": 4, "right": 22})
+
+    def test_this_repositorys_own_committed_file_with_a_pin_in_it_is_not_read_here(self):
+        """The reproduction from #661, run against the real file rather than a fixture.
+
+        `charter.toml` is tracked here, and an operator adding `size = 15` to its `repos`
+        table is doing what `docs/frame.md` tells them to do. The three lines are added to
+        what is actually on disk — so a plane that later commits them for real is running
+        the case this test already ran, and the day charter's own frame gains a pin this
+        stays green rather than needing to be rewritten.
+        """
+        cfg = tomllib.loads(_COMMITTED.read_text(encoding="utf-8"))
+        tables = cfg["frame"]["component"]
+        repos, = [t for t in tables if t["use"] == "repos"]
+        repos["size"] = 15
+        resolved = instance.frame_of(cfg)
+        self.assertEqual(
+            [p["size"] for p in resolved["components"] if p["slot"] == "repos"],
+            [component.Fixed(15)],
+            "the pin did not survive the boundary, so nothing below could have read it "
+            "even if the arithmetic still did")
+        with mock.patch.dict(config.FRAME, resolved):
+            self.assertEqual(
+                layout.repos_rows(content_rows=4, window_rows=50,
+                                  slots=["top", "bottom", "repos"]),
+                4)
+            self.assertEqual(
+                layout.slot_sizes(resolved["slots"], window_rows=50, content_rows=6),
+                {"top": 1, "bottom": 1, "repos": 6, "right": 22})
+
+    def test_the_number_the_arithmetic_was_handed_is_the_number_it_used(self):
+        """The other half, and it is what stops the two tests above being satisfied by a
+        `repos_rows` that ignores pins altogether. Passed explicitly, with `config.FRAME`
+        holding an arrangement that pins something ELSE — so an argument quietly dropped
+        in favour of a re-read would answer 15 here, and a pin never read at all would
+        answer 4."""
         with mock.patch.dict(config.FRAME, _arrangement(size=15)):
             self.assertEqual(
-                layout.repos_rows(content_rows=0, window_rows=6, slots=SLOTS),
-                layout.SLOT_SIZE["repos"])
+                layout.repos_rows(content_rows=4, window_rows=50,
+                                  slots=["top", "bottom", "repos"], pinned_rows=7),
+                7)
+
+
+class TheBoundaryIsWhereThePlaneIsRead(unittest.TestCase):
+    """`commands_frame._slot_sizes` — the one place a committed arrangement becomes a
+    pane height, and the three callers that go through it.
+
+    They differ only in how the table pane's width is arrived at (a launch derives it, a
+    re-layout derives it from the panes that survived, a resize measures it), so the read
+    is one line rather than three — which is also the answer to #660's "five signatures":
+    the pin's path is `slot_sizes` and `repos_rows`, two, and this is the third place a
+    line changed.
+    """
+
+    def test_the_boundary_reads_the_plane_and_hands_the_arithmetic_the_number(self):
+        """`repos_rows_wanted` is stubbed to a number nothing else here could produce, so
+        the assertion is about which of the two terms won rather than about whether the
+        answer is plausible."""
+        with mock.patch.dict(config.FRAME, _arrangement(size=15)), \
+                mock.patch("charter.frame.slots.repos_rows_wanted", return_value=3):
+            got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=200)
+        self.assertEqual(got["repos"], 15)
+
+    def test_a_plane_that_pins_nothing_still_gets_its_clone_count_through(self):
+        """The default path, through the same boundary. Without this, a `_slot_sizes` that
+        passed `pinned_rows` and dropped `content_rows` would pass the case above."""
+        with mock.patch.dict(config.FRAME, _arrangement()), \
+                mock.patch("charter.frame.slots.repos_rows_wanted", return_value=3):
+            got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=200)
+        self.assertEqual(got["repos"], 3)
+
+    def test_the_resize_hook_sizes_the_strip_from_the_pin_and_not_the_clone_count(self):
+        """`_reassert_sizes` runs on every `window-resized`, which is the path a frame
+        spends its life on — and it is a SECOND call site, so a pin read only at launch
+        would give the operator a strip that snapped back to its clone count the first
+        time they dragged the divider.
+
+        The strip is the pane tmux is never told the height of, so it is read back the way
+        `test_frame_density` reads it: the window's rows, minus every height asserted,
+        minus one border per horizontal split. `test_frame_tmux_integration` asks real
+        tmux the same question; this asks charter's arithmetic, on a box with no tmux.
+        """
+        calls: list[list[str]] = []
+
+        def fake(action, argv, *, env=None, timeout=None, report=True):
+            calls.append(list(argv))
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+        panes = {"top": "%1", "bottom": "%2", "repos": "%3"}
+        with mock.patch.dict(config.FRAME, _arrangement(size=15)), \
+                mock.patch("charter.frame.slots.repos_rows_wanted", return_value=3), \
+                mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            commands_frame._reassert_sizes("sock", fid="f-1", panes=panes,
+                                           harness_pane="%0", window_cols=200,
+                                           window_rows=50)
+        heights = {c[c.index("-t") + 1]: int(c[c.index("-y") + 1])
+                   for c in calls if "resize-pane" in c and "-y" in c}
+        self.assertNotIn(panes["repos"], heights,
+                         "the strip is the dependent pane and must stay unasserted — "
+                         "asserting N heights in an N-pane stack is what swapped the "
+                         "table's and the attention strip's sizes on 3.7c")
+        self.assertEqual(50 - sum(heights.values()) - len(heights), 15)

--- a/tests/test_a_pinned_repo_strip_keeps_its_height.py
+++ b/tests/test_a_pinned_repo_strip_keeps_its_height.py
@@ -384,10 +384,11 @@ class TheCommittedFileIsReadAtABoundaryAndNotInTheArithmetic(unittest.TestCase):
         """The reproduction from #661, run against the real file rather than a fixture.
 
         `charter.toml` is tracked here, and an operator adding `size = 15` to its `repos`
-        table is doing what `docs/frame.md` tells them to do. The three lines are added to
-        what is actually on disk — so a plane that later commits them for real is running
-        the case this test already ran, and the day charter's own frame gains a pin this
-        stays green rather than needing to be rewritten.
+        table is doing what `docs/frame.md` tells them to do. The key is added to the
+        table that is actually on disk rather than to a written-out copy of it — so a
+        plane that later commits the same key for real is running the case this test
+        already ran, and the day charter's own frame gains a pin this stays green rather
+        than needing to be rewritten.
         """
         cfg = tomllib.loads(_COMMITTED.read_text(encoding="utf-8"))
         tables = cfg["frame"]["component"]


### PR DESCRIPTION
Closes #661.

## Reproduced first, on `origin/main` at `9e6df55`

Adding the one line #660's news entry tells an operator to add:

```toml
[[frame.component]]
use  = "repos"
size = 15
```

```
FAIL: test_a_small_plane_gets_exactly_the_rows_its_content_wants   (test_frame_layout.ReposIsSizedToItsContent)
FAIL: test_it_never_goes_below_one_row (content=0) and (content=1) (test_frame_layout.ReposIsSizedToItsContent)
FAIL: test_a_size_map_is_what_panel_argvs_splits_with              (test_frame_layout.SlotSizesAnswersEverySlotAtOnce)
FAIL: test_left_is_not_a_slot_this_module_will_size_or_split       (test_frame_layout.PanelGeometry)
FAIL: test_the_frame_it_splits_is_byte_for_byte_the_frame_it_split (test_component_id_is_the_currency.CharterOwnConfigIsUnchanged)
```

Six, deterministic, and the mechanism confirmed at the leaf:

```
layout.repos_rows(content_rows=4, window_rows=50, slots=["top","bottom","repos"])  ->  15
```

## The measurement I was asked to take, and what it changed

The recommendation was option 1 — thread the pin from `slot_sizes` into `repos_rows`,
leaving `slot_sizes` to do the read. **Measured, that fixes three of the six.** Three of
the red tests are `slot_sizes`' own:

```python
layout.slot_sizes(["repos"], window_rows=50, content_rows=7)          # expects repos: 7
layout.slot_sizes(["top","left","bottom","repos"], ..., content_rows=3)  # expects repos: 3
layout.slot_sizes(f["slots"], window_rows=50, content_rows=6)         # expects repos: 6
```

They pass explicit arguments and assert the content, exactly as `repos_rows`' do. A
`slot_sizes` that still reads `config.FRAME` answers 15 to all three. So the read cannot
stop at `slot_sizes` — it has to leave `layout`.

**And the "five signatures" does not survive being counted either.** The path is:

| hop | what it needs |
|---|---|
| `layout.repos_rows` | the pin — one new keyword |
| `layout.slot_sizes` | carries it — one new keyword |
| `commands_frame._launch_sizes` | supplies it |
| `commands_frame._relayout` | supplies it |
| `commands_frame._reassert_sizes` | supplies it |

**Two signatures and three call sites.** `panel_argvs`, `repos_cols` and `harness_rows` —
three of the five `_placed_here`'s docstring names — never need it: two take a `sizes` map
that is already computed and one is about columns. `_placed_here`'s five is real *for
`_placed_here`*, which answers "where does this placed component sit and how many cells
does it cost" for a name none of those functions knows in advance. A pinned strip is one
number, for one slot, with one consumer. The count was borrowed, not measured.

The three call sites were already building `content_rows=frame_slots.repos_rows_wanted(fid,
pane_cols=…)` the same way three times over, so they collapse into one boundary function
and the change **removes** two copies of that while adding one read:

```python
def _slot_sizes(fid, slots, *, window_rows, pane_cols):
    return layout.slot_sizes(
        slots, window_rows=window_rows,
        content_rows=frame_slots.repos_rows_wanted(fid, pane_cols=pane_cols),
        pinned_rows=layout.pinned_repo_rows())
```

So the answer to "is threading worse than reading?" here is no, and it is not close: one
read, one place, and `layout` is arithmetic again.

**Option 3 was considered and is refused for #661's own reason** — but it is worth naming
what it would have cost, because one of the six red tests looks like it *wants* the
config. `CharterOwnConfigIsUnchanged.test_the_frame_it_splits_is_byte_for_byte_the_frame_it_split`
reads `charter.toml` off disk deliberately and asserts the whole launch argv. It is red
under #660 because it asserts `repos: 6` for `content_rows=6`. Changing it to expect 15
would have made this repository's committed frame a term in charter's geometry tests —
the defect, restated as the fix.

## What shipped

* `layout.pinned_repo_rows` (was `_pinned_rows`) — the read, made public **so that its
  callers can be counted**. One caller.
* `layout.repos_rows(..., pinned_rows=None)` and `layout.slot_sizes(..., pinned_rows=None)`
  — every term is an argument again. `None` is "this plane pinned nothing", which is every
  plane that does not say otherwise and every test asking about the arithmetic.
* `commands_frame._slot_sizes` — the boundary. `_launch_sizes` (both launch paths),
  `_relayout`'s splits and `_reassert_sizes` on every `window-resized` all go through it,
  so the three cannot disagree about what the plane committed.

`docs/frame.md` is **unedited**: nothing an operator sees changes, and the page already
describes the behaviour the code now has.

## The test that would have caught it

`TheCommittedFileIsReadAtABoundaryAndNotInTheArithmetic`, in the module #660 added:

* `test_this_repositorys_own_committed_file_with_a_pin_in_it_is_not_read_here` — reads
  **this repository's real `charter.toml`**, adds `size = 15` to its `repos` table,
  resolves it, and asserts `repos_rows(content_rows=4, …) == 4` and the whole `slot_sizes`
  map. #661's reproduction, as a test. It asserts the pin *survived the boundary* first,
  so a green cannot mean "the arrangement stopped resolving `size` at all". It adds the
  key to what is on disk rather than replacing the file, so the day charter's own frame
  gains a pin it stays green instead of needing a rewrite.
* two cases sweeping every arrangement a plane can commit — none, written out with no
  `size`, and pins at 2, 15 and 99 — against both `repos_rows` and `slot_sizes`.
  **Asserted as the content the caller named, not as "the same for all five"**: five
  identical wrong answers is exactly what a function reading the file would give.
* `test_the_number_the_arithmetic_was_handed_is_the_number_it_used` — the other half, and
  what stops the above being satisfied by a `repos_rows` that ignores pins altogether:
  `pinned_rows=7` passed explicitly while `config.FRAME` holds a `size = 15`. An argument
  quietly dropped in favour of a re-read answers 15; a pin never read at all answers 4.

Confirmed RED: reinstating the read inside `repos_rows` turns 7 of these subtests red,
including the reproduction. Restored, 24/24 green.

`TheBoundaryIsWhereThePlaneIsRead` pins the boundary itself — the pinned path, the default
path (so a `_slot_sizes` that passed `pinned_rows` and dropped `content_rows` cannot pass),
and `_reassert_sizes` on the resize path with no tmux, reading the strip back the way
`test_frame_density` does: the window's rows minus every asserted height minus one border
per split. `test_frame_tmux_integration.test_a_pinned_table_really_lands_on_its_committed_height`
asks real tmux the same question and is unchanged and green.

#660's existing cases now take the pin through `_pin(**repos)`, which calls
`layout.pinned_repo_rows` under a patched `config.FRAME` — so the number the arithmetic is
handed is still the boundary's answer and never a `15` written twice, and `config.FRAME` is
patched in exactly one place in the module.

## Verification

* **Baseline**, `origin/main` at `9e6df55`, unpinned: **8590 tests, OK**.
* **Acceptance**, `size = 15` committed to `charter.toml`: **8597 tests, OK** — see the
  comment below for the run, since a linked worktree resolves its plane to the main tree
  and the main tree is not mine to edit.
* `test_frame_tmux_integration` against **real tmux 3.7c**: 67 tests, OK.
* Deletion sweep: pushed for the sharded gate rather than run locally.

All measured with `env -u PYTHONSAFEPATH` — `PYTHONSAFEPATH=1` makes 31 subprocess tests
fail and reads as a red tree before any mutation. Unchanged from #660's note.

**`size = 15` is not committed to `charter.toml` in this PR.** That is the operator's call
now that it works.

No version bump, no stamp, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGTJ3Zg7dgCQEeQLXWWo1d
