### PR TITLE
The repo table's viewport moves over rows, so a plane with one clone and many worktrees can scroll it (#663)

### DIFF
--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -457,13 +457,17 @@ class _Viewport:
     puts it back — the reset is the price of the singleton and is not hidden.
 
     **It holds an intent, and the renderer is what settles it against the data.** The
-    handler moves an offset knowing nothing about how many repos there are or how tall the
-    pane is — `Component.on_event` is handed no ctx by contract (§4f), and it must not grow
-    a second reading of a plane the repaint is about to read anyway. So :meth:`settle` is
-    called by `_repos` with the bound it just computed, and that is also the answer to *what
-    happens when the offset outlives a repo list that shrank under it*: the next paint
+    handler moves an offset knowing nothing about how many rows the table has or how tall
+    the pane is — `Component.on_event` is handed no ctx by contract (§4f), and it must not
+    grow a second reading of a plane the repaint is about to read anyway. So :meth:`settle`
+    is called by `_repos` with the bound it just computed, and that is also the answer to
+    *what happens when the offset outlives a table that shrank under it*: the next paint
     clamps it down and the pane draws the last window there is, rather than an empty table
     the operator has to guess their way back out of.
+
+    **The offset counts pane ROWS, not repos** (#663). A table is repo rows and the piece
+    rows nested under them, and a viewport whose unit was the repo could not move at all on
+    a plane with one clone — which was every control plane charter runs on.
 
     :attr:`limit` is that bound REMEMBERED, which is what lets the handler refuse a scroll
     that would change nothing. Zero until the first paint, and the first paint always
@@ -495,9 +499,10 @@ class _Viewport:
         """Record how far this table may scroll, and answer where it actually is.
 
         The clamp is here and nowhere else. `_scroll_limit` computes the bound from the
-        repo count and the pane's rows; this is what applies it, so an offset left over
-        from a longer list — the operator scrolled to the bottom, then a repo was removed —
-        comes back as the largest offset the CURRENT list has, on the very next paint.
+        table's ROW count (:func:`_content_rows`) and the pane's rows; this is what applies
+        it, so an offset left over from a longer table — the operator scrolled to the
+        bottom, then a repo or a worktree was removed — comes back as the largest offset
+        the CURRENT table has, on the very next paint.
 
         Never below zero, and that half is not symmetry: :meth:`move` already refuses to go
         under, so what this guards is a *limit* that has gone negative, which
@@ -561,44 +566,75 @@ VIEWPORT = _Viewport()
 SCROLL_ROWS = 1
 
 
-def _scroll_limit(repos: int, budget: int) -> int:
-    """The largest offset a table of *repos* repos may hold in a *budget*-row pane.
+def _piece_rows(data: dict) -> list[dict]:
+    """The rows this table nests UNDER a clone, or none at all.
 
-    **Zero whenever every repo already fits, and that is the tested nothing.** The `repos`
+    `statusline._detail_worktrees`' rule, asked of the cache rather than of the filesystem:
+    full piece rows exist only where the workspace resolves to exactly one repo, because at
+    two or more a repo must never lose its row to another repo's pieces — every other
+    plane's pieces are a `⑂N` badge on the repo's own row instead. `gather.scan` already
+    writes ``worktrees`` on that condition alone; asking it again here is what keeps a cache
+    written by another version from putting a piece row under each of six repos.
+
+    **One function because two callers must not disagree.** :func:`_table_lines` composes
+    these rows and :func:`_content_rows` counts them for :func:`_scroll_limit`; a count that
+    included a row the composer would not draw leaves an offset that scrolls onto nothing,
+    and one that excluded a drawn row leaves the bottom of the plane permanently out of
+    reach. #663 is what the second of those looks like when it ships.
+    """
+    return list(data.get("worktrees") or []) if len(data.get("repos") or []) == 1 else []
+
+
+def _content_rows(data: dict) -> int:
+    """How many ROWS of table this gather wants — the quantity :func:`_scroll_limit` bounds.
+
+    **Rows and not repos, and #663 is the whole cost of the difference.** The pane renders
+    rows: the budget is in rows, the overflow line takes a row, and :meth:`_Viewport.repo_at`
+    maps a row. A limit computed from the repo COUNT is therefore the one unit in that
+    expression that is not the pane's, and it agrees with this number only on a plane where
+    no repo has pieces. On the one-clone-many-worktrees plane — the ordinary state of a
+    control plane, and the state of the one #658 shipped from — it answered 0 for every
+    pane height, so the wheel was inert and the pieces past the pane's last row were
+    dropped with nothing on screen saying so.
+    """
+    return len(data.get("repos") or []) + len(_piece_rows(data))
+
+
+def _scroll_limit(rows: int, budget: int) -> int:
+    """The largest offset a table of *rows* content rows may hold in a *budget*-row pane.
+
+    *rows* is :func:`_content_rows` — repo rows and piece rows together, which is what the
+    pane actually draws. See that function for why counting repos here was #663.
+
+    **Zero whenever all of it already fits, and that is the tested nothing.** The `repos`
     pane is sized to its content (`layout.repos_rows`), so on an ordinary plane the pane is
     exactly tall enough and this answers 0 — every wheel notch then moves nothing, repaints
     nothing and costs nothing, because :meth:`_Viewport.move` reads this bound before it
     changes anything. A scroll that quietly did nothing *because the arithmetic happened to
     cancel* would be indistinguishable from a scroll that was dropped, which is the class of
-    convincing-empty this module refuses everywhere else.
+    convincing-empty this module refuses everywhere else. It is still the ordinary answer
+    for a one-clone plane: what changed is that it is now the answer because the pieces FIT,
+    not because they were never counted.
 
     The row the overflow line takes is subtracted here for the same reason
     :func:`_table_lines` reserves it out of the budget rather than trimming it off the end:
-    it is a row of the pane and a row the repos do not get. Reserved on exactly the same
-    condition — more repos than rows — so the two cannot disagree about whether that row
-    exists, which would leave the last repo permanently one notch out of reach.
-
-    **The window moves over REPOS and not over PIECES, and that is a stated limit rather
-    than an oversight.** Piece rows appear only in the one-repo shape (`_table_lines`, from
-    `gather`'s ``worktrees``), where one repo always fits and this answers 0; pieces past
-    the pane's remaining rows are dropped by that function as they always were. Scrolling
-    them would need a second kind of offset — an index into a nested list rather than into
-    the ranking — and one mechanism that answers for half the cases honestly is worth more
-    than two that overlap.
+    it is a row of the pane and a row the content does not get. Reserved on exactly the same
+    condition — more rows than the pane has — so the two cannot disagree about whether that
+    row exists, which would leave the last row permanently one notch out of reach.
 
     **A pane with room for one row is a pane with room for the overflow line and nothing
     else**, and it answers 0 too. :func:`_table_lines` spends a one-row budget on
-    `…(+N more)` rather than on an arbitrary repo — "there is more here than fits" outranks
+    `…(+N more)` rather than on an arbitrary row — "there is more here than fits" outranks
     "here is one of them" — so every offset over such a table draws the identical line. A
-    limit taken from the repo count alone would let the wheel repaint that line forty times,
-    each repaint byte-identical to the last: motion the operator can see is not happening,
-    charged to their terminal.
+    limit taken from the content count alone would let the wheel repaint that line forty
+    times, each repaint byte-identical to the last: motion the operator can see is not
+    happening, charged to their terminal.
     """
-    if repos <= budget:
+    if rows <= budget:
         return 0
     if budget <= 1:
         return 0
-    return repos - (budget - 1)
+    return rows - (budget - 1)
 
 
 def _table_row(lead: str, name_markup: str, r: dict, width: int,
@@ -687,26 +723,40 @@ def _table_lines(data: dict, width: int, budget: int, *, offset: int = 0,
     The row it subtracts is `▪ repos N`, not the attention row — that is another pane's
     since #515, and a budget still reserving a row for it would cost the table its
     lowest-ranked repo row for nothing. The budget is spent in priority order —
-    repo rows first, then the `…(+N more)` line that admits what was dropped, then piece
-    rows — so a short pane loses DETAIL rather than losing a repo. That ordering is
-    `statusline._repo_rows`' own (`wt_budget` there), kept because the two tables are
-    meant to read alike.
+    repo rows first, then piece rows, with the `…(+N more)` line that admits what was
+    dropped reserved out of it — so a short pane loses DETAIL rather than losing a repo.
+    That ordering is `statusline._repo_rows`' own (`wt_budget` there), kept because the two
+    tables are meant to read alike.
 
-    Piece rows come from ``data["worktrees"]``, which `gather.scan` populates only when
-    the workspace resolves to exactly one repo — `statusline._detail_worktrees`' rule
-    verbatim. Every OTHER repo's pieces get a `⑂N` badge on the repo's own row instead,
-    from `worktree_count`; the badge means "there is more you cannot see here", so it is
-    dropped whenever every piece already has its own row.
+    Piece rows are :func:`_piece_rows` — ``data["worktrees"]`` where the workspace resolves
+    to exactly one repo, `statusline._detail_worktrees`' rule verbatim. Every OTHER repo's
+    pieces get a `⑂N` badge on the repo's own row instead, from `worktree_count`; the badge
+    means "there is more you cannot see here", so it is dropped whenever every piece has a
+    row **on this screen** — counted from the pieces actually DRAWN and not from the ones
+    the cache holds, or a scrolled table would drop the badge while nine of the fourteen
+    were off the pane.
 
-    *offset* is how far down the RANKING the window has been scrolled, and it changes
-    nothing at all at zero — which is the whole of how this stayed compatible.
-    `statusline._pick_rows` already sliced `[:budget]` off a ranked list, so `[offset:]` of
-    the same list is the same table one window further along: the repos come back in
-    priority order, the display order is still the cache's (a row that moved as it was
-    scrolled past would be the thing that function's own docstring refuses), and scrolling
-    back to zero lands on the exact bytes that were there before the first notch. The
-    `…(+N more)` line needs no arithmetic of its own for the same reason: what is HIDDEN is
-    still "every key that is not in *show*", which is true at every offset.
+    *offset* is how far down the table's own rows the window has been scrolled, and it
+    changes nothing at all at zero — which is the whole of how this stayed compatible.
+    **It is one index into one list, and the list is the repo rows in ranking order
+    followed by the piece rows in the cache's** — the same order the budget is spent in
+    above, read one window further along rather than truncated. So while the window still
+    holds repo rows it is `statusline._pick_rows`' own `[offset:offset + room]` slice of
+    the ranking (the repos come back in priority order, the display order is still the
+    cache's, and scrolling back to zero lands on the exact bytes that were there before the
+    first notch); once every repo row is above the window it is an index into the pieces,
+    which is what #663 is. The `…(+N more)` line needs no arithmetic of its own either: what
+    is HIDDEN is the complement of what was drawn, which is true at every offset. An offset
+    past what this table can hold is the CALLER's to clamp and is deliberately not clamped
+    again here — `_repos` settles it against :func:`_scroll_limit` on the same *data* and
+    the same *budget* this is handed, and a second clamp would be a second answer to where
+    the bottom is (`statusline._pick_rows` refuses the same thing for the same reason).
+
+    **The one-clone plane is where this changed, and it changed because it was wrong.** A
+    table of one repo and fourteen pieces in a six-row pane used to draw six rows and say
+    nothing about the nine it dropped, because `capped` counted repos and one repo always
+    fits. It now reserves the overflow row on the same condition every other shape does.
+    Offset zero on a many-clones plane is byte-for-byte what it was.
 
     *selected* is the repo `state.selection` says this frame has picked, and the row for it
     is drawn in reverse video by `frame/chrome.reverse` — the same call `persona_section`
@@ -749,28 +799,40 @@ def _table_lines(data: dict, width: int, budget: int, *, offset: int = 0,
     cur_repo = data.get("current_repo")
     palette = {r["name"]: sl._PALETTE[i % len(sl._PALETTE)] for i, r in enumerate(repos)}
 
-    capped = len(keys) > budget
-    # `budget - 1` and no `max(1, …)` underneath it: the overflow line is reserved OUT of
-    # the budget rather than appended on top of it and trimmed off at the end. With a
-    # one-row budget the trimmed version showed a single repo row and dropped the
-    # `…(+N more)` line — a pane claiming that one clean repo is the whole plane, which is
-    # the false-clean reading this module refuses everywhere else. A budget of exactly one
+    pieces = _piece_rows(data)
+    # **What overflows is ROWS, pieces included** (#663). Counting repos here made this
+    # `False` on every one-clone plane however many worktrees hung off it, so a table that
+    # could not fit fifteen rows into six drew six and admitted nothing.
+    capped = _content_rows(data) > budget
+    # `- 1` and no `max(1, …)` underneath it: the overflow line is reserved OUT of the
+    # budget rather than appended on top of it and trimmed off at the end. With a one-row
+    # budget the trimmed version showed a single repo row and dropped the `…(+N more)`
+    # line — a pane claiming that one clean repo is the whole plane, which is the
+    # false-clean reading this module refuses everywhere else. A budget of exactly one
     # therefore spends it on the note, which is the honest half of the pair: "there is
     # more here than fits" outranks "here is an arbitrary one of them".
-    show = (sl._pick_rows(keys, budget - 1, cur_repo, by_key, by_key, offset=offset)
+    room = budget - (1 if capped else 0)
+    show = (sl._pick_rows(keys, room, cur_repo, by_key, by_key, offset=offset)
             if capped else keys)
 
-    pieces = list(data.get("worktrees") or [])
-    shown_pieces: dict = {}
-    for p in pieces:
-        shown_pieces[p.get("repo")] = shown_pieces.get(p.get("repo"), 0) + 1
+    # **The window is one window over one list, and the list is repo rows THEN piece rows.**
+    # That is the order this function already spent its budget in (`statusline._repo_rows`'
+    # `wt_budget`: a repo must never lose its row to another repo's pieces), so making the
+    # offset an index into it is the same ordering read one step further along rather than
+    # a second kind of offset. Where the window falls among the pieces is therefore
+    # whatever is left of it once the repo rows have been passed — zero while any repo row
+    # is still on screen, and `offset - len(keys)` once they are all above it.
+    # The `max` is on the START and not on the length: `offset - len(keys)` is negative
+    # while a repo row is still on screen and a negative index would count from the END of
+    # the pieces. `room - len(show)` needs no such guard — `_pick_rows` never returns more
+    # than the *room* it was given and an uncapped table's repos already fit in it, and a
+    # slice whose stop is below its start is empty either way.
+    start = max(0, offset - len(keys))
+    kids = pieces[start:start + room - len(show)]
 
-    # Rows left for piece detail once every repo has its own row and, if capped, the
-    # overflow line has been reserved. `statusline._repo_rows` spends its budget in
-    # exactly this order and for exactly this reason: a repo must never lose its row to
-    # another repo's pieces.
-    room = budget - len(show) - (1 if capped else 0)
-    kids = pieces[:max(0, room)] if len(show) == 1 else []
+    shown_pieces: dict = {}
+    for p in kids:
+        shown_pieces[p.get("repo")] = shown_pieces.get(p.get("repo"), 0) + 1
 
     lines: list[_Line] = []
     for i, k in enumerate(show):
@@ -794,18 +856,13 @@ def _table_lines(data: dict, width: int, budget: int, *, offset: int = 0,
         lines.append(_Line(r["name"],
                            chrome.reverse(row, width) if r["name"] == selected else row))
 
-    if capped:
-        hidden = [k for k in keys if k not in set(show)]
-        quiet = not any(_needs_attention(by_key[k]) for k in hidden)
-        note = ", all clean" if quiet else ""
-        # **About no repo, so a click here selects nothing.** It stands for the rows that
-        # are NOT on screen, and picking one of them because the operator clicked the line
-        # that says they exist would be charter answering a question nobody asked.
-        lines.append(_Line(None, tui.truncate(
-            f"  {sl._DIM}…(+{len(hidden)} more{note}){sl._R}", width)))
-
     for j, p in enumerate(kids):
-        mark = sl._TREE_WT if j == len(kids) - 1 else sl._TREE_MID
+        # A piece row is where the tree ends only when nothing follows it, and the
+        # `…(+N more)` line follows every capped table — the same `not capped` the repo
+        # rows above ask before they take `_TREE_END`. Without it a starved one-clone plane
+        # closes its tree with `╰─` and then prints ten more rows' worth of admission
+        # underneath, which is the glyph saying the opposite of the line below it.
+        mark = sl._TREE_WT if j == len(kids) - 1 and not capped else sl._TREE_MID
         emph = f"{sl._BOLD}{sl._UNDER}" if p.get("current") else ""
         # `charter worktree add <repo> <piece>` names the branch after the piece, so by
         # default these two columns print the same word twice — empty the branch cell
@@ -823,6 +880,28 @@ def _table_lines(data: dict, width: int, budget: int, *, offset: int = 0,
             f"  {sl._DIM}{sl._TREE_PIPE}{mark}{sl._R}",
             f"{emph}{sl._DIM}{p['name']}{sl._R}", p, width,
             branch_override="" if wb == p.get("name") else None)))
+
+    if capped:
+        # **Every row that is not on screen, repo rows and piece rows alike**, which is
+        # what makes the count honest at every offset: what is hidden is the complement of
+        # what was drawn, and that stays true wherever the window is. The pieces are
+        # excluded by INDEX rather than by membership — two worktrees of the same clone on
+        # the same branch are equal dicts, and `p not in kids` would call one of them
+        # shown because the other was.
+        hidden = ([by_key[k] for k in keys if k not in set(show)]
+                  + pieces[:start] + pieces[start + len(kids):])
+        quiet = not any(_needs_attention(r) for r in hidden)
+        note = ", all clean" if quiet else ""
+        # **About no repo, so a click here selects nothing.** It stands for the rows that
+        # are NOT on screen, and picking one of them because the operator clicked the line
+        # that says they exist would be charter answering a question nobody asked.
+        #
+        # **Last, under the rows it is about.** It used to be appended before the piece
+        # rows, which could not be told apart while `capped` and a piece row were mutually
+        # exclusive — they no longer are, and a "there is more below" line with three more
+        # rows below it is the note pointing at the wrong place.
+        lines.append(_Line(None, tui.truncate(
+            f"  {sl._DIM}…(+{len(hidden)} more{note}){sl._R}", width)))
     return lines[:budget]
 
 
@@ -2060,8 +2139,9 @@ def _repos(fid: str) -> str:
     (§4f), so it knows neither how many repos there are nor how tall this pane is. Both
     numbers are read on this line and nowhere else:
 
-    * :func:`_scroll_limit` is how far the window may move, handed to
-      :meth:`_Viewport.settle`, which clamps an offset left over from a longer list and
+    * :func:`_scroll_limit` is how far the window may move, asked about
+      :func:`_content_rows` — the table's ROWS, pieces included, which is #663 — and handed
+      to :meth:`_Viewport.settle`, which clamps an offset left over from a longer table and
       leaves the handler a bound it can refuse a pointless scroll against. On the ordinary
       plane — a pane sized to its own content — it is 0 and the wheel does nothing at all.
     * :meth:`_Viewport.publish` records which repo each PANE ROW is about, so a click that
@@ -2140,7 +2220,9 @@ def _repos(fid: str) -> str:
     # direction that matters: a pane starved to no rows by a resize would have kept
     # whatever bound the last taller paint recorded, and the wheel would go on moving an
     # offset over a table that is not on screen. `_scroll_limit` answers 0 for that pane.
-    offset = VIEWPORT.settle(_scroll_limit(len(repos), budget))
+    # **:func:`_content_rows` and not `len(repos)`** — the bound is over the rows this pane
+    # draws, and a repo with pieces draws more than one. See that function for #663.
+    offset = VIEWPORT.settle(_scroll_limit(_content_rows(data), budget))
     lines = _table_lines(data, w, budget, offset=offset, selected=state.selection(fid))
     # The heading is row 0 of the PANE and belongs to no repo, so the map the handler
     # resolves a click against starts with it — see :meth:`_Viewport.publish`.

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -581,8 +581,15 @@ def _piece_rows(data: dict) -> list[dict]:
     included a row the composer would not draw leaves an offset that scrolls onto nothing,
     and one that excluded a drawn row leaves the bottom of the plane permanently out of
     reach. #663 is what the second of those looks like when it ships.
+
+    **`data["repos"]` and `data["worktrees"]`, with no `or []` under either**, which is the
+    reason :func:`_selected_detail` already gives for the same subscript: `gather.cached`
+    answers ``None`` for anything whose `repos` or `worktrees` is not a LIST
+    (`gather._shaped_like_a_scan` checks both), so a fallback here could only ever stand in
+    for an empty list with an empty list. The sweep found both surviving, correctly — a
+    line that cannot change an outcome is not documentation of an intent.
     """
-    return list(data.get("worktrees") or []) if len(data.get("repos") or []) == 1 else []
+    return list(data["worktrees"]) if len(data["repos"]) == 1 else []
 
 
 def _content_rows(data: dict) -> int:
@@ -596,8 +603,12 @@ def _content_rows(data: dict) -> int:
     control plane, and the state of the one #658 shipped from — it answered 0 for every
     pane height, so the wheel was inert and the pieces past the pane's last row were
     dropped with nothing on screen saying so.
+
+    Subscripted rather than `.get`-with-a-fallback for the reason :func:`_piece_rows`
+    states: `gather.cached` is what refuses a scan whose `repos` is not a list, so a
+    fallback here stands in for an empty list with an empty list.
     """
-    return len(data.get("repos") or []) + len(_piece_rows(data))
+    return len(data["repos"]) + len(_piece_rows(data))
 
 
 def _scroll_limit(rows: int, budget: int) -> int:
@@ -812,8 +823,16 @@ def _table_lines(data: dict, width: int, budget: int, *, offset: int = 0,
     # therefore spends it on the note, which is the honest half of the pair: "there is
     # more here than fits" outranks "here is an arbitrary one of them".
     room = budget - (1 if capped else 0)
-    show = (sl._pick_rows(keys, room, cur_repo, by_key, by_key, offset=offset)
-            if capped else keys)
+    # **Ranked unconditionally, and the `if capped else keys` that used to be here is
+    # gone.** The sweep found the two arms indistinguishable and it is right: an UNCAPPED
+    # table has `room >= len(keys)` by definition and its offset is 0 (`_scroll_limit`
+    # answers 0 and `_Viewport.settle` holds it there), and `_pick_rows` re-sorts its pick
+    # back into cache order — so `[0:room]` of the ranking IS `keys`, element for element.
+    # The branch was an optimisation over two sorts of at most `statusline._MAX_REPO_LINES`
+    # rows on a pane that repaints on a version bump, and what it cost was a second shape
+    # for this line to have: with it, an offset over a table that fits moved the pieces and
+    # not the repos. One window over one list, at every offset, capped or not.
+    show = sl._pick_rows(keys, room, cur_repo, by_key, by_key, offset=offset)
 
     # **The window is one window over one list, and the list is repo rows THEN piece rows.**
     # That is the order this function already spent its budget in (`statusline._repo_rows`'

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1077,10 +1077,15 @@ def _pick_rows(dirs, budget: int, cur_repo, states, gl, *, offset: int = 0) -> l
     scrolling reveals the rest in priority order, and scrolling back lands on the exact
     table that was there before the first notch.
 
-    Past the end it answers fewer rows, and eventually none, rather than clamping: the
-    caller that scrolls is the one that knows how many rows the pane has and how many repos
-    there are (`slots._viewport_limit`), and a clamp here would be a second, weaker copy of
-    that arithmetic — the shape #500 shipped twice.
+    **Past the end it answers fewer rows, and eventually none, rather than clamping**, and
+    since #663 that is load-bearing rather than merely tidy: the frame's window is over the
+    table's ROWS — repo rows first, then the piece rows nested under them — so an offset
+    that has walked off the end of the repos is exactly how "every repo row is above the
+    window now" reaches this function, and a clamp would pin a repo row to the top of a
+    scrolled table for ever. The caller that scrolls is the one that knows how many rows the
+    pane has and how many the table wants (`slots._scroll_limit` over `slots._content_rows`),
+    and a clamp here would be a second, weaker copy of that arithmetic — the shape #500
+    shipped twice.
     """
     order = {d: i for i, d in enumerate(dirs)}
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -122,12 +122,17 @@ a pointer is irreversible, because a click can reach a pane without its matching
 drag begun on a pane border delivers exactly one release), and a gesture that can arrive
 half-formed is not one to hang an action on.
 
-Two things follow that are worth saying plainly rather than leaving you to find:
+Three things follow that are worth saying plainly rather than leaving you to find:
 
 - **The wheel does nothing when the table already fits**, which is most of the time — the
   pane is sized to its own content. There is nothing below to scroll to, so nothing moves
-  and nothing repaints. It starts moving on a plane with more clones than the pane has rows,
-  which is the same plane that shows `…(+7 more)`.
+  and nothing repaints. It starts moving on any plane with more table ROWS than the pane
+  has, which is the same plane that shows `…(+7 more)`.
+- **Rows, not clones.** A worktree gets a row of its own on a plane with a single clone, and
+  those rows scroll like any other: a monorepo plane with twenty worktrees is a
+  twenty-one-row table however few repos are in it. Scrolling past the clone's own row
+  leaves its worktrees hanging from a `│` whose root is above the window, which is what a
+  scrolled tree looks like; a click on a worktree row selects the clone it is a piece of.
 - **You do not need a mouse.** `F2` → `repo: select the next row` (and `previous`) moves the
   selection with the arrow keys and Enter you already drive the palette with. That is the
   only route on a plane with `mouse = false`, which is the default, and charter will not

--- a/docs/news/unreleased-the-repo-table-scrolls-on-the-plane-it-shipped-to.md
+++ b/docs/news/unreleased-the-repo-table-scrolls-on-the-plane-it-shipped-to.md
@@ -1,0 +1,68 @@
+---
+version: unreleased
+headline: The repo table's viewport moves over rows, so a plane with one clone and fourteen worktrees can finally scroll it
+---
+
+Charter shipped a scrollable repo table, and on the control plane it was written on the
+wheel did nothing at all. Not sometimes — never, at every pane height there is.
+
+```
+ ▪ repos 1
+   ├─ charter
+   │  ├─ frame-inside-tmux
+   │  ├─ guard-all-or-nothing
+   │  ├─ opencode-mcp-rule
+   │  ├─ op-asks-once
+   │  ╰─ reap-live-pid          <- and nine more worktrees, off the pane, unmentioned
+```
+
+Three wheel notches into that pane moved nothing, and the nine rows past its height were
+dropped with no line saying they existed.
+
+**The bound was computed in the wrong unit.** The pane renders ROWS: its budget is in rows,
+the `…(+N more)` line takes a row, and a click arrives as a row number. The scroll limit
+was computed from the REPO count — the one quantity in that expression that is not the
+pane's. The two agree only where no repo has pieces, so on a many-clones plane the feature
+worked and on a one-clone plane it answered *nothing to scroll* however many worktrees hung
+off the clone. A control plane is the second shape, which is why this shipped switched off
+for its own operator.
+
+It was written down, too. The limit's own docstring declared the repos-not-pieces window as
+a stated limit rather than an oversight, and the argument it gave was sound on its face:
+*piece rows appear only in the one-repo shape, where one repo always fits*. What nobody
+checked is that the plane in front of us was that shape. **A stated limit that happens to
+cover the only configuration you have is not a limit; it is a no-op with documentation.**
+
+**The window now moves over the table's own rows** — repo rows in the ranking's order,
+then the piece rows nested under them, which is the order the table already spent its
+budget in. So the first notch walks the clone's row off the top and the worktrees slide up
+behind it, and the last notch puts the last worktree on screen.
+
+**Two things a starved one-clone table now admits that it used to hide.** The `…(+N more)`
+line is reserved on the same condition every other shape reserves it on, so a table showing
+five of fifteen rows says so and says whether the ten it is hiding are clean — counting the
+hidden worktrees, not just the hidden clones. And the `⑂14` badge on the clone's row is
+counted from the pieces actually drawn rather than from the ones in the cache, so it stops
+disappearing exactly when it is most needed.
+
+**What did not change.** A many-clones table is byte-for-byte what it was, at every offset
+and every pane height: the ranking still decides which repos survive a starved pane, and
+scrolling still moves a window over that ranking rather than replacing it. A one-clone
+plane at its natural height — the pane is sized to its content — draws exactly what it drew
+before and still scrolls nothing, and that nothing is still asserted as a number at the
+boundary and one either side. What changed there is the reason: the pieces fit, rather than
+never having been counted.
+
+The half of the report that did not reproduce: a click on a worktree row already selected
+its parent clone, on the shipped code, on any cache written since worktree rows started
+carrying their repo. Every drawn row but the overflow line resolves to something, and did
+before.
+
+Verified on a real tmux with a real client on a real pty and charter's own two panels: five
+cases red before the change and green after, including a click on a piece row of a table
+scrolled far enough that the clone's own row is off the pane — where a dead row would have
+had nothing to answer.
+
+[#663](https://github.com/diazoxide/charter/issues/663), reported against
+[#658](https://github.com/diazoxide/charter/pull/658), which shipped the scroll and stated
+the limit.

--- a/tests/test_a_real_click_reaches_the_real_repo_table.py
+++ b/tests/test_a_real_click_reaches_the_real_repo_table.py
@@ -550,5 +550,58 @@ class ARealWheelOverAPlaneWithOneCloneAndManyPieces(_ARealFrame):
                         f"{self._table()!r} != {before!r}")
 
 
+#: Worktrees on the plane below — three, so one clone and three pieces is four rows in the
+#: four rows of table this pane has. `layout.repos_rows` sizes the real pane to its content,
+#: so this is the ORDINARY plane and the one the wheel must be inert on.
+PIECES_THAT_FIT = 3
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealWheelOverAPaneThatFitsItsPieces(_ARealFrame):
+    """**The tested nothing, on a real frame** — the same plane shape, tall enough.
+
+    The unit half asserts `slots._scroll_limit(15, 15) == 0` and one either side of it, and
+    that is the claim that matters; this is the claim that a real pane, with a real panel
+    process taking real SGR reports off its own pty, spends nothing on them either. The two
+    zeros #663 is about — *the pieces fit* and *the pieces were never counted* — look the
+    same from outside, and the class above is what tells them apart.
+    """
+
+    def _seed(self) -> dict:
+        return {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+                "repos": [_row("solo", worktree_count=PIECES_THAT_FIT)],
+                "worktrees": [_row(f"piece{i}", repo="solo")
+                              for i in range(PIECES_THAT_FIT)]}
+
+    def test_every_row_of_the_plane_is_on_screen_and_nothing_admits_otherwise(self):
+        """Four rows of content in four rows of table: no `…(+N more)` and no `⑂N`, because
+        there is nothing this pane is not showing. The badge is the half that would go
+        wrong in the other direction — counted from the pieces DRAWN, it must vanish here."""
+        rows = self._table()
+        self.assertEqual(len(rows), 1 + PIECES_THAT_FIT, rows)
+        self.assertNotIn("more)", "\n".join(rows))
+        self.assertNotIn("⑂", "\n".join(rows))
+
+    def test_the_wheel_moves_nothing_on_a_pane_that_fits(self):
+        """**A negative measured against a panel proved to be awake.** A pane that never
+        repaints would pass "nothing changed" for the wrong reason, which is the whole
+        failure mode #663 is: a green measurement of an empty room. So a click is landed
+        first and its highlight waited for — that IS this panel repainting on this pty —
+        and only then is the wheel asserted to cost nothing."""
+        before = self._table()
+        self._point(self.repos_pane, row=1)
+        self.assertTrue(_await(lambda: state.selection(self.fid) == "solo"),
+                        "the panel never took the click, so a wheel that changed nothing "
+                        "would prove nothing")
+        self.assertTrue(
+            _await(lambda: "\x1b[7m" in self._painted(self.repos_pane).split("\n")[1]),
+            "the panel never repainted, so it is not awake to be measured")
+        for _ in range(3):
+            self._wheel(self.repos_pane, down=True)
+        time.sleep(1.0)
+        self.assertEqual(self._table(), before,
+                         "a pane tall enough for its content scrolled")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_a_real_click_reaches_the_real_repo_table.py
+++ b/tests/test_a_real_click_reaches_the_real_repo_table.py
@@ -29,6 +29,13 @@ tmux asks the terminal to report from the ACTIVE pane's own request alone, and t
 pane here is a `cat` — so nothing would be sent, nothing would arrive, and a green test
 would be measuring an empty room. `docs/frame.md` states that half to the operator; this
 states the other half.
+
+**And it is run over TWO plane shapes, which is #663.** The first version of this file was
+built on a many-clones plane and went green while the wheel was a complete no-op on the
+plane charter itself runs on — one clone with fourteen worktrees, where the bound was
+computed from a repo count that is always 1. A harness that can only be pointed at one
+shape is a harness that reports on the shape somebody happened to pick, so the frame is
+built once in `_ARealFrame` and the CACHE is what a subclass supplies.
 """
 
 from __future__ import annotations
@@ -44,7 +51,7 @@ import time
 import unittest
 from pathlib import Path
 
-from charter import commands_frame, config, tui
+from charter import commands_frame, config, statusline, tui
 from charter.frame import gather, layout, slots, state, tmuxctl
 
 from tests import _tmuxreap
@@ -69,17 +76,23 @@ _TERM_CANDIDATES = tuple(dict.fromkeys(
 #: that refusal instead.
 COLS = 120
 
-#: Rows the `repos` pane is split with: one heading and four rows of table. Six repos into
-#: four rows is the SCROLLABLE shape — three repo rows and `…(+3 more)` — which is the shape
-#: the report was about. A pane sized to its content would have nothing to scroll, which is
-#: the case the unit half pins and this one cannot reach without a second frame.
+#: Rows the `repos` pane is split with: one heading and four rows of table. Four rows is
+#: the STARVED shape for both plane shapes below — three rows of content and `…(+N more)` —
+#: which is the shape both reports were about. A pane sized to its content would have
+#: nothing to scroll, which is the case the unit half pins and this one cannot reach
+#: without a second frame.
 REPOS_ROWS = 5
 
 
-def _row(name) -> dict:
-    return {"name": name, "branch": "main", "dirty": False, "tracked_dirty": False,
-            "ahead": 0, "behind": 0, "ci": None, "change": None, "sigil": "",
-            "current": False, "worktree_count": 0}
+def _row(name, *, repo=None, worktree_count=0) -> dict:
+    d = {"name": name, "branch": "main", "dirty": False, "tracked_dirty": False,
+         "ahead": 0, "behind": 0, "ci": None, "change": None, "sigil": "",
+         "current": False, "worktree_count": worktree_count}
+    if repo is not None:
+        # A piece row's parent clone — `gather.scan` writes it on every `worktrees` entry,
+        # and it is what makes a nested row resolve to a repo when it is clicked.
+        d["repo"] = repo
+    return d
 
 
 def _tmux(*args: str, env=None) -> subprocess.CompletedProcess:
@@ -115,9 +128,24 @@ def _fork_pty(rows: int, cols: int) -> tuple[int, int]:
     return pid, master
 
 
-@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
-class ARealPointerOnTheRealRepoTable(PersonaIso):
-    """One frame with charter's OWN `repos` and `attention` panels, and a real pointer."""
+class _ARealFrame(PersonaIso):
+    """One frame with charter's OWN `repos` and `attention` panels, and a real pointer.
+
+    **A base, and the two shapes below are what it exists for.** #663 is the measurement
+    that the shape a case is built on decides whether the feature is even switched on: a
+    scroll harness built only on many-clones planes went green while the plane it shipped
+    to — one clone, many worktrees — could not move a row. So the frame is built once here
+    and the CACHE is what a subclass supplies (:meth:`_seed`), which makes "a different
+    plane shape" a two-line subclass rather than a reason not to test the other one.
+    """
+
+    #: Rows the `repos` pane is split with, heading included. A subclass overrides it to
+    #: starve the table by however much its own shape needs.
+    ROWS = REPOS_ROWS
+
+    def _seed(self) -> dict:
+        """The gather cache this frame's `repos` pane draws from."""
+        raise NotImplementedError
 
     def setUp(self) -> None:
         super().setUp()
@@ -130,14 +158,12 @@ class ARealPointerOnTheRealRepoTable(PersonaIso):
 
         self.fid = state.frame_id("repo-point", os.getpid())
         state.frame_dir(self.fid, create=True)
-        # Six repos into four rows of table, so there is somewhere to scroll TO. Written
-        # through `gather.save` — the cache a real scan writes and `slots._repos` reads —
-        # rather than by running a scan, which would need six real clones to say the same
-        # thing about tmux.
-        self.repos = [f"repo{i}" for i in range(6)]
-        gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
-                               "current_repo": None,
-                               "repos": [_row(n) for n in self.repos], "worktrees": []})
+        # Written through `gather.save` — the cache a real scan writes and `slots._repos`
+        # reads — rather than by running a scan, which would need real clones on disk to
+        # say the same thing about tmux.
+        self.cache = self._seed()
+        self.repos = [r["name"] for r in self.cache["repos"]]
+        gather.save(self.fid, self.cache)
 
         existing = os.environ.get("PYTHONPATH", "")
         parts = [str(_REPO_ROOT)] + ([existing] if existing else [])
@@ -167,7 +193,7 @@ class ARealPointerOnTheRealRepoTable(PersonaIso):
         self.assertEqual(sourced.returncode, 0, sourced.stderr)
 
         self.attention = self._split("bottom", rows=1)
-        self.repos_pane = self._split("repos", rows=REPOS_ROWS)
+        self.repos_pane = self._split("repos", rows=self.ROWS)
         # **The harness is put back in front, and that is the regime, not tidiness.**
         # `split-window` selects the pane it made, and a frame whose repo table was the
         # ACTIVE pane would be reporting the mouse because THAT pane asked — which is the
@@ -185,7 +211,8 @@ class ARealPointerOnTheRealRepoTable(PersonaIso):
                         "attaching the client resized the window, so every panel took a "
                         "SIGWINCH the cases below would read as an event")
 
-        self.assertTrue(_await(lambda: "▪ repos 6" in self._shown(self.repos_pane)),
+        head = f"▪ repos {len(self.repos)}"
+        self.assertTrue(_await(lambda: head in self._shown(self.repos_pane)),
                         f"the table never painted: {self._shown(self.repos_pane)!r}")
         self.assertTrue(_await(lambda: self._shown(self.attention).strip() != ""),
                         "the attention row never painted")
@@ -312,7 +339,19 @@ class ARealPointerOnTheRealRepoTable(PersonaIso):
         self._inject(b"\x1b[<%d;%d;%dM" % (64 + (1 if down else 0),
                                            left + col + 1, top + row + 1))
 
-    # -- the cases ---------------------------------------------------------- #
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealPointerOnTheRealRepoTable(_ARealFrame):
+    """**Many clones, no pieces** — the shape #658 was built and measured on.
+
+    Six repos into four rows of table: three repo rows and `…(+3 more)`, so there is
+    somewhere below to scroll TO. A pane sized to its content would have nothing to
+    scroll, which is the case the unit half pins and this one cannot reach.
+    """
+
+    def _seed(self) -> dict:
+        return {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+                "repos": [_row(f"repo{i}") for i in range(6)], "worktrees": []}
 
     def test_a_click_on_a_row_selects_that_repo_and_highlights_it(self):
         """The report, answered end to end. Nothing here bumps the frame's version by
@@ -413,6 +452,102 @@ class ARealPointerOnTheRealRepoTable(PersonaIso):
                                  f"a row was shifted right — the pane is in raw mode, "
                                  f"not cbreak: {ln!r}")
         self.assertTrue(rows[0].startswith("▪ repos"), rows[0])
+
+
+#: Pieces on the one-clone plane. Nine into three rows of content is the shape #663
+#: reported and the shape the control plane this ships from actually has — and the number
+#: is over `statusline._MAX_REPO_LINES`-shaped starvation rather than under it, so nothing
+#: here is measuring a pane that happens to fit.
+PIECES = 9
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealWheelOverAPlaneWithOneCloneAndManyPieces(_ARealFrame):
+    """**One clone, many worktrees** — the plane #658 shipped to and could not scroll.
+
+    Every case above is on a many-clones plane, which is why #658 went green while the
+    feature was a no-op for its own operator: `_scroll_limit` counted REPOS, and one repo
+    always fits. This class is the same real frame with the same real pointer over the
+    other shape, and it is deliberately the shape with no second clone in it — a case that
+    passed because there were two repos to move between would say nothing about #663.
+
+    Ten rows of content (one clone plus nine pieces) into four rows of table, so seven
+    rows of the plane are off screen at the top of the scroll.
+    """
+
+    def _seed(self) -> dict:
+        return {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+                "repos": [_row("solo", worktree_count=PIECES)],
+                "worktrees": [_row(f"piece{i}", repo="solo") for i in range(PIECES)]}
+
+    def _shown_names(self) -> list[str]:
+        """The names on the table's rows, the overflow line dropped.
+
+        Read as *the token after the tree glyph*, because a piece row carries one more
+        glyph than a repo row (`│  ├─` against `├─`) and a fixed column index therefore
+        reads the wrong word on one of the two shapes — which is exactly the kind of
+        near-miss that would let a case go green on a table that never moved. The
+        overflow line has no glyph and drops out on its own.
+        """
+        glyphs = (statusline._TREE_MID.strip(), statusline._TREE_WT.strip(),
+                  statusline._TREE_END.strip())
+        out = []
+        for ln in self._table():
+            parts = ln.split()
+            for i, tok in enumerate(parts[:-1]):
+                if tok in glyphs:
+                    out.append(parts[i + 1])
+                    break
+        return out
+
+    def test_the_wheel_moves_the_window_over_the_worktrees(self):
+        """**#663, literally.** A wheel notch into this pane's own pty used to move
+        nothing at all: the pane renders ROWS and the bound was computed from the repo
+        count, so a plane with one clone answered 0 however many pieces hung off it."""
+        before = self._table()
+        self._wheel(self.repos_pane, down=True)
+        self.assertTrue(_await(lambda: self._table() != before),
+                        f"a wheel notch changed nothing: {before!r}")
+
+    def test_the_last_worktree_is_reachable(self):
+        """Not merely "something moved": the row at the BOTTOM of the plane has to come
+        into view, which is what the overflow line's reserved row costs and what a limit
+        that forgot to subtract it would leave permanently one notch out of reach."""
+        last = f"piece{PIECES - 1}"
+        self.assertNotIn(last, self._shown_names(), "the fixture already fits")
+        for _ in range(PIECES + 2):
+            self._wheel(self.repos_pane, down=True)
+        self.assertTrue(_await(lambda: last in self._shown_names()),
+                        f"the bottom of the plane never came into view: "
+                        f"{self._table()!r}")
+
+    def test_the_pieces_that_do_not_fit_are_admitted_rather_than_dropped(self):
+        """The other half of the report — "the worktrees past the pane's height are
+        simply dropped". A table that shows three of ten rows and says nothing is the
+        false-clean reading this module refuses everywhere else, so the count on the
+        overflow line has to be a count of ROWS and include the pieces."""
+        self.assertIn("(+7 more", "\n".join(self._table()), self._table())
+
+    def test_a_click_on_a_worktree_row_selects_its_clone(self):
+        """**No drawn row answers nobody.** Asserted with the table SCROLLED, so the only
+        row that could answer `solo` is a piece row — at offset zero the clone has a row
+        of its own and a click that silently resolved to it would pass either way."""
+        self._wheel(self.repos_pane, down=True)
+        self.assertTrue(_await(lambda: "solo" not in self._shown_names()),
+                        f"the clone's own row is still on screen: {self._table()!r}")
+        self._point(self.repos_pane, row=1)
+        self.assertTrue(_await(lambda: state.selection(self.fid) == "solo"),
+                        f"a piece row selected nothing: {state.selection(self.fid)!r}")
+
+    def test_the_wheel_comes_back_to_the_table_it_started_on(self):
+        """Offset zero is where scrolling back lands, on this shape too."""
+        before = self._table()
+        self._wheel(self.repos_pane, down=True)
+        self.assertTrue(_await(lambda: self._table() != before))
+        self._wheel(self.repos_pane, down=False)
+        self.assertTrue(_await(lambda: self._table() == before),
+                        f"scrolling back did not land on the table it left: "
+                        f"{self._table()!r} != {before!r}")
 
 
 if __name__ == "__main__":

--- a/tests/test_the_repo_table_scrolls_and_selects.py
+++ b/tests/test_the_repo_table_scrolls_and_selects.py
@@ -16,8 +16,15 @@ compared against the sentence it should read rather than against "contains the n
 
 **The scroll that does NOTHING is tested as hard as the one that does.** The `repos` pane
 is sized to its own content (`layout.repos_rows`), so the ordinary plane is one where every
-repo already fits and the wheel must move nothing, repaint nothing and cost nothing — an
+row already fits and the wheel must move nothing, repaint nothing and cost nothing — an
 accident that happened to cancel would be indistinguishable from a design that refuses.
+
+**And the nothing is tested on both plane shapes, which is #663.** Every case here was
+originally written over a many-clones plane, where a scroll limit computed from the repo
+count is right by coincidence. On the one-clone-many-worktrees plane — a control plane's
+ordinary state — that same limit is 0 at every pane height, so the feature was a no-op and
+the suite could not tell. `TheTableCountsTheRowsItWillDraw` and
+`TheWindowMovesOverPieceRowsToo` are the shape that was missing.
 """
 
 from __future__ import annotations
@@ -61,6 +68,50 @@ def _names(lines) -> list[str | None]:
     return [ln.repo for ln in lines]
 
 
+class TheTableCountsTheRowsItWillDraw(unittest.TestCase):
+    """`slots._content_rows` and `slots._piece_rows` — the quantity #663 turned on.
+
+    **This is the unit the whole feature is in.** The bound, the overflow reservation and
+    the click map are all rows of a pane; counting repos agreed with counting rows only on
+    a plane where no repo had pieces, and the plane #658 shipped from was not one.
+    """
+
+    def test_a_plane_with_no_pieces_counts_its_repos(self):
+        self.assertEqual(slots._content_rows(_data([_row(f"r{i}") for i in range(6)])), 6)
+
+    def test_one_clone_with_worktrees_counts_every_worktree_as_a_row(self):
+        """The number #663 is about: a table of one repo and fourteen pieces draws fifteen
+        rows, so fifteen is what the pane has to be measured against. Asserted as 15 and
+        not as "more than one" — `len(repos)` is also an int and also renders something."""
+        data = _data([_row("solo")],
+                     worktrees=[_row(f"w{i}", repo="solo") for i in range(14)])
+        self.assertEqual(slots._content_rows(data), 15)
+
+    def test_two_clones_draw_no_piece_rows_however_many_the_cache_holds(self):
+        """`statusline._detail_worktrees`' rule: at two repos or more a repo must never
+        lose its row to another repo's pieces, so the pieces are a `⑂N` badge instead.
+        `gather.scan` already writes `worktrees` on that condition alone — this asks the
+        question again, so a cache written by another version cannot put a piece row under
+        each of six repos and give the viewport a bound for rows nothing draws."""
+        data = _data([_row("a"), _row("b")],
+                     worktrees=[_row(f"w{i}", repo="a") for i in range(9)])
+        self.assertEqual(slots._piece_rows(data), [])
+        self.assertEqual(slots._content_rows(data), 2)
+
+    def test_the_counter_and_the_composer_agree_on_every_shape(self):
+        """**The two must not drift**, and this is that stated as an equality rather than
+        as a comment. A count above what is composed leaves an offset that scrolls onto
+        nothing; a count below it leaves the bottom of the plane permanently out of reach,
+        which is the half #663 shipped. Compared against a budget big enough to draw the
+        whole table, where the composed line count IS the content count."""
+        for repos, pieces in ((1, 0), (1, 1), (1, 9), (2, 4), (6, 0), (14, 3)):
+            with self.subTest(repos=repos, pieces=pieces):
+                data = _data([_row(f"r{i}") for i in range(repos)],
+                             worktrees=[_row(f"w{j}", repo="r0") for j in range(pieces)])
+                want = slots._content_rows(data)
+                self.assertEqual(len(slots._table_lines(data, WIDE, want)), want)
+
+
 class TheOffsetIsBoundedByTheDataAndThePane(unittest.TestCase):
     """`slots._scroll_limit` — how far the window may move, and when it may not at all.
 
@@ -69,15 +120,22 @@ class TheOffsetIsBoundedByTheDataAndThePane(unittest.TestCase):
     to that question is `True` for both `20 - 13` and `20`.
     """
 
-    def test_a_pane_tall_enough_for_its_repos_does_not_scroll_at_all(self):
+    def test_a_pane_tall_enough_for_its_rows_does_not_scroll_at_all(self):
         """**The tested nothing.** `layout.repos_rows` sizes this pane to its content, so
-        the ordinary plane has exactly as many rows as repos and the wheel must be inert.
+        the ordinary plane has exactly as many rows as content and the wheel must be inert.
         Asserted at the boundary and one either side of it, because the guard that makes it
         true is a comparison and an off-by-one there is a table that slides by one row on
-        every plane charter ships."""
+        every plane charter ships.
+
+        The last pair is the one-clone plane at its own natural height — one repo and
+        fourteen worktrees in the fifteen rows `slots.repos_rows_wanted` asks for. It still
+        answers 0, and now it answers 0 because the pieces FIT rather than because they
+        were never counted."""
         self.assertEqual(slots._scroll_limit(6, 6), 0)
         self.assertEqual(slots._scroll_limit(5, 6), 0)
         self.assertEqual(slots._scroll_limit(1, 14), 0)
+        self.assertEqual(slots._scroll_limit(15, 15), 0)
+        self.assertEqual(slots._scroll_limit(14, 15), 0)
 
     def test_the_limit_leaves_the_overflow_line_its_row(self):
         """`_table_lines` reserves `…(+N more)` OUT of the budget rather than trimming it
@@ -87,6 +145,15 @@ class TheOffsetIsBoundedByTheDataAndThePane(unittest.TestCase):
         reach."""
         self.assertEqual(slots._scroll_limit(20, 14), 7)
         self.assertEqual(slots._scroll_limit(7, 6), 2)
+
+    def test_a_clone_with_more_worktrees_than_the_pane_can_hold_scrolls(self):
+        """**#663 as a number.** One clone and fourteen worktrees is fifteen rows, and in
+        a six-row pane five of them are drawn beside the note — so the window's last
+        position is 10, and at 10 the fourteenth worktree is on screen. Every one of these
+        answered 0 while the argument was the repo count, on every pane height there is."""
+        self.assertEqual(slots._scroll_limit(15, 6), 10)
+        self.assertEqual(slots._scroll_limit(15, 17), 0)
+        self.assertEqual(slots._scroll_limit(15, 3), 13)
 
     def test_a_one_row_pane_is_all_overflow_line_and_does_not_scroll(self):
         """A budget of exactly one is spent on `…(+N more)` — "there is more here than
@@ -249,6 +316,124 @@ class TheWindowMovesAlongTheRanking(PersonaIso, unittest.TestCase):
                       worktrees=[_row("bit", branch="fix/x", repo="solo")])
         self.assertNotIn("bit  ", tui.strip_ansi(self._lines(same, 6)[1].text).strip())
         self.assertIn("fix/x", tui.strip_ansi(self._lines(other, 6)[1].text))
+
+
+class TheWindowMovesOverPieceRowsToo(PersonaIso, unittest.TestCase):
+    """#663: one clone, nine worktrees, four rows of table.
+
+    **The shape the feature shipped switched off on.** Ten rows of content into four is
+    over-full by six, so every expectation here is worked out from "repo rows first, then
+    the pieces, with one row reserved for the note" — the order `_table_lines` states — and
+    never from a second call to it.
+    """
+
+    def _lines(self, budget=4, offset=0, pieces=9, **kw):
+        data = _data([_row("solo", worktree_count=pieces)],
+                     worktrees=[_row(f"w{i}", repo="solo") for i in range(pieces)])
+        return slots._table_lines(data, WIDE, budget, offset=offset, **kw)
+
+    def _drawn(self, **kw):
+        """The names drawn, the overflow line dropped — read as *the token after the tree
+        glyph*, because a piece row carries one glyph more than a repo row and a fixed
+        column index would read the wrong word on one of the two shapes."""
+        glyphs = (statusline._TREE_MID.strip(), statusline._TREE_WT.strip(),
+                  statusline._TREE_END.strip())
+        out = []
+        for ln in self._lines(**kw):
+            parts = tui.strip_ansi(ln.text).split()
+            for i, tok in enumerate(parts[:-1]):
+                if tok in glyphs:
+                    out.append(parts[i + 1])
+                    break
+        return out
+
+    def test_offset_zero_keeps_the_clone_at_the_top(self):
+        """Three of ten rows and the note: the repo row first, because a repo row outranks
+        its own pieces for the same reason it outranks another repo's."""
+        self.assertEqual(self._drawn(), ["solo", "w0", "w1"])
+
+    def test_one_notch_walks_the_clone_off_the_top_and_a_piece_on_at_the_bottom(self):
+        """The window is over ROWS, so the first notch spends its move on the repo row —
+        the only row above the pieces — and the pieces slide up into the space."""
+        self.assertEqual(self._drawn(offset=1), ["w0", "w1", "w2"])
+        self.assertEqual(self._drawn(offset=2), ["w1", "w2", "w3"])
+
+    def test_the_last_window_reaches_the_last_worktree(self):
+        """The point of the reserved overflow row, on this shape: at the limit the bottom
+        of the plane is on screen. Computed from `_scroll_limit` over `_content_rows` and
+        then asserted as the three names it must be, so a limit that is merely *nonzero*
+        does not pass."""
+        limit = slots._scroll_limit(10, 4)
+        self.assertEqual(limit, 7)
+        self.assertEqual(self._drawn(offset=limit), ["w6", "w7", "w8"])
+
+    def test_the_note_counts_the_pieces_it_is_not_showing(self):
+        """Ten rows, three drawn, seven hidden — at the top and at the bottom alike. A
+        count over repos alone would say `(+0 more)` and there would be no note at all,
+        which is the half of #663 that reads as "the worktrees are simply dropped"."""
+        for offset in (0, 1, 7):
+            note = tui.strip_ansi(self._lines(offset=offset)[-1].text)
+            self.assertIn("(+7 more", note)
+
+    def test_a_dirty_worktree_off_screen_stops_the_note_saying_all_clean(self):
+        """`_needs_attention` is asked of the hidden PIECES too. A table admitting seven
+        hidden rows and calling them clean while one of them is dirty is the false-clean
+        reading this module refuses everywhere — and it is the reading a note that only
+        looked at repos would give on every one-clone plane."""
+        data = _data([_row("solo", worktree_count=9)],
+                     worktrees=[_row(f"w{i}", repo="solo", dirty=(i == 8))
+                                for i in range(9)])
+        note = tui.strip_ansi(slots._table_lines(data, WIDE, 4)[-1].text)
+        self.assertIn("(+7 more)", note)
+        self.assertNotIn("all clean", note)
+
+    def test_a_pane_that_fits_every_piece_draws_no_note_and_ends_its_tree(self):
+        """The uncapped half, unchanged: ten rows into ten is every row drawn, no reserved
+        row, and the last piece closes the tree with `╰─`. This is also the boundary of the
+        case above — one row less and the note appears."""
+        drawn = self._lines(budget=10)
+        plain = [tui.strip_ansi(ln.text) for ln in drawn]
+        self.assertEqual(len(drawn), 10)
+        self.assertNotIn("…(+", plain[-1])
+        # **Exactly one, and on the last row.** `╰─` on every piece row would satisfy "the
+        # tree ends here" on the row it is asked about and say it eight more times above.
+        self.assertEqual([i for i, ln in enumerate(plain)
+                          if statusline._TREE_WT.strip() in ln], [9])
+
+    def test_a_capped_table_never_closes_its_tree_above_the_note(self):
+        """`╰─` means *this is where the tree ends*, and on a capped table it does not:
+        `…(+N more)` is the next line. The glyph and the line under it would be saying
+        opposite things, which is the one thing `_TREE_WT` exists to prevent."""
+        drawn = self._lines()
+        self.assertNotIn(statusline._TREE_WT.strip(),
+                         tui.strip_ansi("".join(ln.text for ln in drawn)))
+
+    def test_the_note_is_the_last_row_and_not_the_middle_one(self):
+        """It says there is more BELOW. Composed before the piece rows it would land in
+        the middle of the table with three drawn rows under it, which could not happen
+        while a capped table had no piece rows and now can."""
+        drawn = self._lines()
+        self.assertIn("…(+7 more", tui.strip_ansi(drawn[-1].text))
+        self.assertIsNone(drawn[-1].repo)
+
+    def test_every_drawn_piece_row_still_answers_its_clone(self):
+        """**No drawn row is a dead row**, at every offset — including the offsets where
+        the clone has no row of its own on screen and a piece row is the only thing that
+        can answer. `gather` writes `repo` on every worktree entry and `_Line` carries it."""
+        for offset in (0, 1, 4, 7):
+            names = _names(self._lines(offset=offset))
+            self.assertEqual([n for n in names if n is None], [None],
+                             f"offset {offset} drew a row that selects nothing besides "
+                             f"the overflow line: {names}")
+            self.assertEqual(names[:-1], ["solo"] * 3)
+
+    def test_the_badge_counts_what_is_on_screen_rather_than_what_is_cached(self):
+        """`⑂N` means "there is more you cannot see here", so it is dropped only when every
+        piece has a row ON THIS SCREEN. Counted from the cache it disappeared exactly when
+        it was needed most — a starved pane showing two of nine worktrees and no sign of
+        the other seven."""
+        self.assertIn("⑂9", tui.strip_ansi(self._lines()[0].text))
+        self.assertNotIn("⑂", tui.strip_ansi(self._lines(budget=10)[0].text))
 
 
 class TheSelectedRowIsDrawnAsSelected(PersonaIso, unittest.TestCase):
@@ -452,6 +637,37 @@ class ThePaneWiresItAllTogether(PersonaIso, unittest.TestCase):
         gather.save(FID, _data([_row(f"r{i}") for i in range(20)]))
         self._paint(rows=5)
         self.assertEqual(slots.VIEWPORT.limit, 17)
+
+    def test_the_bound_a_paint_leaves_counts_worktrees_as_rows(self):
+        """**#663 at the seam it was wrong at.** The pane reads its own bound here and
+        nowhere else, and it used to read `len(repos)` — so this exact paint, on the exact
+        cache the control plane this ships from carries, left the handler a bound of 0 and
+        every wheel notch was refused before it reached the renderer.
+
+        One clone and nine worktrees into four rows of table: ten rows, three drawn beside
+        the note, so 7. Asserted as 7 rather than as "greater than zero", because the
+        second is also true of a bound that forgot the note's reserved row and would leave
+        the last worktree permanently out of reach."""
+        gather.save(FID, _data([_row("solo", worktree_count=9)],
+                               worktrees=[_row(f"w{i}", repo="solo")
+                                          for i in range(9)]))
+        self._paint(rows=5)
+        self.assertEqual(slots.VIEWPORT.limit, 7)
+
+    def test_a_clone_whose_worktrees_all_fit_still_leaves_nothing_to_scroll(self):
+        """The other side of the same boundary, and the ordinary state of a control plane:
+        `layout.repos_rows` sizes this pane to its content, so the pieces fit and the wheel
+        is inert. It answers 0 here for a different REASON than it used to — because ten
+        rows fit in ten, not because nine of them were never counted — and the two are told
+        apart by the case above."""
+        gather.save(FID, _data([_row("solo", worktree_count=9)],
+                               worktrees=[_row(f"w{i}", repo="solo")
+                                          for i in range(9)]))
+        self._paint(rows=11)
+        self.assertEqual(slots.VIEWPORT.limit, 0)
+        self.assertEqual(slots.VIEWPORT.repo_at(10), "solo",
+                         "the tenth row of the table is the ninth worktree and it must "
+                         "be drawn, not dropped")
 
     def test_a_pane_with_no_table_in_it_is_clicked_on_nobody(self):
         """The three one-line answers this pane draws instead of a table — not gathered

--- a/tests/test_the_repo_table_scrolls_and_selects.py
+++ b/tests/test_the_repo_table_scrolls_and_selects.py
@@ -697,6 +697,27 @@ class ThePaneWiresItAllTogether(PersonaIso, unittest.TestCase):
         self._paint(rows=1)
         self.assertEqual(slots.VIEWPORT.limit, 0)
 
+    def test_a_worktree_removed_under_a_scrolled_table_clamps_it_on_the_next_paint(self):
+        """The stale-offset clamp, in the unit that changed. `charter worktree remove`
+        takes rows off the bottom of this table without touching the repo list, so a bound
+        that only moved when a REPO went would leave the window parked over rows that are
+        no longer there. The operator scrolls to the bottom, four worktrees go, and the
+        next paint puts the window on the last one this table actually has.
+
+        Asserted as the value 3, not as "it changed": an unclamped offset is still an
+        integer and still renders something."""
+        wts = [_row(f"w{i}", repo="solo") for i in range(9)]
+        gather.save(FID, _data([_row("solo", worktree_count=9)], worktrees=wts))
+        self._paint(rows=5)
+        self.assertTrue(slots.VIEWPORT.move(99))
+        self.assertEqual(slots.VIEWPORT.offset, 7)
+        gather.save(FID, _data([_row("solo", worktree_count=5)], worktrees=wts[:5]))
+        self._paint(rows=5)
+        self.assertEqual(slots.VIEWPORT.limit, 3)
+        self.assertEqual(slots.VIEWPORT.offset, 3)
+        self.assertEqual(slots.VIEWPORT.repo_at(1), "solo",
+                         "the window was left over a table that is no longer there")
+
     def test_the_pane_draws_the_selection_the_frame_recorded(self):
         gather.save(FID, _data([_row("alpha"), _row("beta")]))
         state.record_selection(FID, "beta")


### PR DESCRIPTION
Closes #663.

`slots._scroll_limit` counted **repos**; the pane renders **rows**. Those are the same
number only where no repo has pieces — so on the one-clone-many-worktrees plane, which is
a control plane's ordinary state and is the state of the plane #658 shipped from, it
answered `0` at every pane height. The wheel was inert, and the worktrees past the pane's
last row were dropped with nothing on screen saying so.

## Re-measured before anything was written

Reported numbers, confirmed on `d6318be`:

```
_scroll_limit(repos=1,  budget=6 ) = 0     _scroll_limit(repos=1, budget=17) = 0
_scroll_limit(repos=1,  budget=3 ) = 0     _scroll_limit(repos=6, budget=4 ) = 3
```

And on the real cache this plane carries (1 clone, 13 worktrees) rendered into a 7-row
pane: the offset changes nothing at any value, five worktrees drawn, eight dropped, no
`…(+N more)` at all, and no `⑂13` badge either — `shown_pieces` counted every piece in the
*cache* rather than the ones on *screen*, so the badge that means "there is more you cannot
see here" disappeared exactly when it was true.

**The pane is capped at `statusline._MAX_REPO_LINES` (14) however tall it is**, so this is
not only a starved-pane case: a plane with fourteen worktrees overflows permanently. This
plane has thirteen. It is one `worktree add` from the defect.

## The docstring's argument, taken seriously and then overturned

`_scroll_limit` gave two reasons, and both were true as stated:

> Scrolling them would need a second kind of offset — an index into a nested list rather
> than into the ranking — and one mechanism that answers for half the cases honestly is
> worth more than two that overlap.

**It is not a second kind of offset, and that is what makes the limit wrong rather than
conservative.** The table already spends its budget in one order — repo rows first, then
the piece rows nested under them (`statusline._repo_rows`' `wt_budget`). One offset into
*that* list is the same ordering read one window further along:

* while any repo row is in the window it is `_pick_rows(keys, room, …, offset=offset)` —
  literally the call that was already there;
* once every repo row is above the window, `offset - len(keys)` indexes the pieces.

`_pick_rows` answering *fewer rows, and eventually none* past the end — already its
documented behaviour, already deliberate, already refusing to clamp — is exactly what makes
the handover free. One mechanism, one offset, no nested index.

The second reason ("one repo always fits") was arithmetic about repos, and it is true;
what it does not survive is that the pane does not draw repos.

## What is in it

- **`_content_rows(data)`** — repo rows plus `_piece_rows(data)`, one function that both
  the composer and the bound are asked. A count above what is composed leaves an offset
  that scrolls onto nothing; a count below it leaves the bottom of the plane out of reach,
  which is the half that shipped. `test_the_counter_and_the_composer_agree_on_every_shape`
  is that as an equality over six shapes.
- **`_scroll_limit(rows, budget)`** — same three lines, a different argument.
- **`_table_lines`** windows over rows: `room = budget - (1 if capped else 0)`,
  `show = _pick_rows(keys, room, …, offset)`, `kids = pieces[start : start + room - len(show)]`
  with `start = max(0, offset - len(keys))`.
- **The `…(+N more)` row is reserved on the same condition every other shape reserves it
  on**, is composed LAST (it used to be appended above the piece rows, which could not be
  told apart while `capped` and a piece row were mutually exclusive — they no longer are),
  and counts hidden **rows**: hidden repos *and* hidden pieces, so `, all clean` is not
  said over a dirty worktree that is off screen.
- **`╰─` only when nothing follows.** A capped table's last drawn piece row keeps `├─`; the
  glyph and the admission under it were saying opposite things.
- **`⑂N` counts the pieces DRAWN.**

## Seen moving on a real frame

Real tmux, real attached client on a real pty, real `charter panel repos` and `charter
panel bottom` processes, `[frame] mouse = true` from charter's own `conf_text`, harness
active so the reports arrive because of charter's flag and not because the pane is
selected. SGR wheel reports written to the client's terminal:

```
--- offset 0 (as the pane paints it)
      ├─ solo ⑂9                           main
      │  ├─ piece0                         main
      │  ├─ piece1                         main
      …(+7 more, all clean)
--- after seven wheel-downs (the limit is 7)
      │  ├─ piece6                         main
      │  ├─ piece7                         main
      │  ├─ piece8                         main
      …(+7 more, all clean)
--- an eighth wheel-down: at the bottom, nothing moves
      │  ├─ piece6                         main
      │  ├─ piece7                         main
      │  ├─ piece8                         main
      …(+7 more, all clean)
--- seven wheel-ups: back to the table it started on
      ├─ solo ⑂9                           main
      │  ├─ piece0                         main
      │  ├─ piece1                         main
      …(+7 more, all clean)
```

`tests/test_a_real_click_reaches_the_real_repo_table.py` was the harness that could not
have caught this: it was built entirely on a many-clones plane, where a repo-counted limit
is right by coincidence. Its setup is now a base class and the **cache** is what a subclass
supplies, so "the other plane shape" is a two-line subclass rather than a reason not to
test it. Three shapes now run through it; **15 cases, all green**, and the five new
one-clone cases were **red before the change**:

| case | before | after |
|---|---|---|
| a wheel notch moves the window over the worktrees | **FAIL** — nothing moved | ok |
| the last worktree is reachable | **FAIL** | ok |
| the pieces that do not fit are admitted rather than dropped | **FAIL** — no note at all | ok |
| a click on a worktree row selects its clone (table **scrolled**, so the clone has no row) | **FAIL** | ok |
| the wheel comes back to the table it started on | **FAIL** | ok |

## The four constraints

1. **Offset zero is byte-for-byte the current table** wherever the ranking is what decides.
   Measured, not asserted: `_table_lines` output diffed old-vs-new over a grid of 320
   shapes (0/1/2/3/5/6/14/20 repos × 0/1/3/9/14 worktrees × 8 budgets). **Every shape is
   identical except those satisfying `1 + pieces > budget`** — the overflowing one-clone
   table, which is the defect. The plane this ships from, rendered from its own live
   `gather.json` into its own 15-row pane, is byte-identical and still `limit=0`.

   The one-clone overflow shape changing at offset zero **is the fix**, and it is the
   change this module's own rules demand: a table drawing 6 of 15 rows and admitting
   nothing is the false-clean reading it refuses everywhere else. Stating it plainly rather
   than hiding it under "compatible".
2. **A pane tall enough still scrolls nothing, and it is a tested nothing** — at the
   boundary and one either side in the row unit (`_scroll_limit(15, 15) == 0`,
   `(14, 15) == 0`, `(15, 6) == 10`, `(15, 3) == 13`), at the paint level (one clone, nine
   worktrees, an 11-row pane → `VIEWPORT.limit == 0` with the ninth worktree drawn), and
   **on a real frame**: `ARealWheelOverAPaneThatFitsItsPieces` lands a click and waits for
   its highlight first — that is the panel proving it repaints on this pty — and only then
   asserts three wheel notches cost nothing. Verified meaningful by mutating
   `rows <= budget` to `rows < budget`: that case goes **red**, on the real pane.
3. **No drawn row answers `None`** — asserted at four offsets, including offsets where the
   clone has no row of its own on screen and a piece row is the only thing that can answer.
4. **A stale offset is clamped by the next paint** — `settle` unchanged, and the bound now
   moves when a **worktree** is removed as well as when a repo is
   (`test_a_worktree_removed_under_a_scrolled_table_clamps_it_on_the_next_paint`: scrolled
   to 7, four worktrees removed, next paint puts it at 3).

## One claim in the report that did not reproduce

> `VIEWPORT.repo_at()` answers `'charter'` for the repo row and **`None` for every worktree
> row**

**It does not, and did not.** On `d6318be`, painting one clone with nine worktrees into a
7-row pane:

```
BASE   rows drawn: 7   repo_at: [None, 'solo', 'solo', 'solo', 'solo', 'solo', 'solo', None]
```

`gather.scan` has written `entry["repo"] = repo_for_wt` on every worktree row since #388,
`_Line` carries it, and a click on a piece row already selected its parent clone. The two
ways to see `None` there are a cache written before #388, or a `VIEWPORT` that never
painted the table at that height. **What was true is the half underneath it**: nine of the
fourteen rows did not exist to be clicked. Constraint 3 is met, and was met — it is now
asserted at offsets where a piece row is the only row that can answer, which is where it
was never tested.

## Deletion sweep

CI's own gate, sharded, on `a9b9efe`:

```
merged 23 result(s) from 1 of 1 shard(s)
gate: 2 unpinned, 2 in masked cluster(s), 0 platform-deferred, 0 unresolved, 0 not applied, 19 pinned
gate: 4 survivors
```

**None is suppressed and none is argued away — all four lines are gone.** Decomposed:

| where | verdict | what was done |
|---|---|---|
| `slots.py:585` `_piece_rows` `[no-fallback] data.get("repos") or []` | **masked cluster** (2 survivors in one function) | **Deleted** → `data["repos"]` |
| `slots.py:585` `_piece_rows` `[no-fallback] data.get("worktrees") or []` | **masked cluster** (same pair) | **Deleted** → `data["worktrees"]` |
| `slots.py:600` `_content_rows` `[no-fallback] data.get("repos") or []` | unpinned | **Deleted** → `data["repos"]` |
| `slots.py:815` `_table_lines` `[collapse-ifexp] … if capped else keys` | unpinned | **Deleted** — the branch is gone |

The first three are one finding, and it is one this file already answers ten screens down
in `_selected_detail`:

> `data["repos"]`, with no `or []` under it: `gather.cached` answers `None` for anything
> whose `repos` is not a LIST (`gather._shaped_like_a_scan`), so a fallback here could only
> ever stand in for an empty list with an empty list.

`_shaped_like_a_scan` checks `worktrees` on the same line it checks `repos`, so the
argument covers both keys and both new functions. Writing a test to redden them would have
been pinning a line that cannot change an outcome.

The fourth: the sweep is right that the arms are indistinguishable, and the reason is
worth stating because it is what makes the whole fix one mechanism. An **uncapped** table
has `room >= len(keys)` by definition and its offset is 0 (`_scroll_limit` answers 0 and
`_Viewport.settle` holds it there), and `_pick_rows` re-sorts its pick back into cache
order — so `[0:room]` of the ranking **is** `keys`, element for element. The branch was an
optimisation over two sorts of at most fourteen rows on a pane that repaints on a version
bump, and what it cost was a second shape for the line to have: with it, an offset over a
table that fits moved the pieces and not the repos. One window over one list, at every
offset, capped or not.

Rendering re-diffed after the four deletions: **byte-identical** to the pre-deletion tree
over the same 320-shape grid.

## Verification

- Full suite green on the final tree.
- `tests/test_a_real_click_reaches_the_real_repo_table.py` — 15 cases over three plane
  shapes, real tmux throughout.
- Sweep verdict above; the re-run on the final commit is in a comment below.
- No version bump, no stamp, no tag. News entry under `docs/news/` at `version: unreleased`.
- `docs/frame.md` gains the operator-facing half: rows, not clones, and what a scrolled
  tree looks like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BwnjrnCu9t4pMooDm7r6H
