### PR TITLE
What runs beside charter's publishing identity is written down, and moving a pin makes that reading go stale loudly (#473)

### DIFF
--- a/.github/publish-closure.json
+++ b/.github/publish-closure.json
@@ -1,0 +1,82 @@
+{
+  "about": [
+    "What a pinned action's OWN tree names, read at the SHA this repository pins it to (#473).",
+    "",
+    "`tests/test_workflows.py` refuses any reference charter WRITES that is not a content address.",
+    "It stops at charter's boundary: `uses: owner/action@<sha>` pins that action's tree, and what",
+    "that tree then names is a file in somebody else's repository, which no test here can read",
+    "because no test here makes a network call. So the hop is taken by a person, with the network,",
+    "and written down here.",
+    "",
+    "THIS FILE IS A RECORD, NOT A CHECK. Nothing offline can verify that the transitive refs below",
+    "are still what that SHA names — only that this record and the workflow name the same SHA. The",
+    "reading is the human's; the test's job is to make the reading go stale LOUDLY, at the moment",
+    "somebody is already looking at the pin, instead of silently six days later. It has already",
+    "gone stale silently once: the reading recorded on #473 on 2026-08-28 named",
+    "`actions/download-artifact@d3f86a1 # v4.3.0` and was 27 hours from being wrong (032a061 moved",
+    "it to v8.0.1, and `runs.using` moved with it, from node20 to node24).",
+    "",
+    "TO UPDATE, when the test tells you an entry is stale: run the entry's `reread` command, read",
+    "the `runs:` block that comes back, and write down what it names — every `uses:` for a",
+    "composite, the `image:`/`Dockerfile` `FROM` for a Docker action, nothing at all for a",
+    "JavaScript one. Then set `sha`, `tag`, `runs` and `reread` to the new pin. Changing the SHA",
+    "without re-reading the tree passes this test and is the one thing it cannot catch, which is",
+    "why it is written here rather than left to be inferred."
+  ],
+  "scope": [
+    "Jobs holding `id-token: write`, and no others. That grant mints the OIDC token PyPI accepts",
+    "as charter's genuine publisher, so code in such a job can act as charter off this platform,",
+    "and the upload it makes cannot be taken back. `contents: write` — which `announce` holds —",
+    "acts inside this repository, where every other guard in this suite still applies.",
+    "",
+    "The narrower scope is also what keeps the prompt worth reading. Widening it to every write",
+    "grant would put a re-read of `actions/checkout` and `actions/setup-python` on every Dependabot",
+    "pull request, and a prompt that fires that often is a prompt that gets waved through — the",
+    "crying-wolf failure `doctor` has already paid for twice (#171, #55).",
+    "",
+    "And it follows `uses:` only. A `container:`/`services:` image beside the identity is already",
+    "held to a digest by the rule in `tests/test_workflows.py`, and a digest is a content address",
+    "for the whole image — there is no hop left to take.",
+    "",
+    "A local `uses: ./x` is followed rather than listed: a composite action in this repository runs",
+    "inside the calling job with the calling job's token, so a remote action IT names stands beside",
+    "the identity too and needs an entry here of its own. There are no local actions in this tree",
+    "today; the walk is there so that adding one does not quietly shrink what this record covers."
+  ],
+  "reviewed": [
+    {
+      "uses": "actions/download-artifact",
+      "sha": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+      "tag": "v8.0.1",
+      "runs": "using: node24, main: dist/index.js",
+      "reread": "gh api \"repos/actions/download-artifact/contents/action.yml?ref=3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c\" --jq .content | base64 -d",
+      "note": "A JavaScript action takes no hop at all: the bytes it runs are a file inside the pinned tree, and the node24 runtime is the runner's rather than anything this action or this repository names. This one is genuinely closed by its pin.",
+      "transitive": []
+    },
+    {
+      "uses": "pypa/gh-action-pypi-publish",
+      "sha": "dc37677b2e1c63e2034f94d8a5b11f265b73ba33",
+      "tag": "v1.14.2",
+      "runs": "using: composite",
+      "reread": "gh api \"repos/pypa/gh-action-pypi-publish/contents/action.yml?ref=dc37677b2e1c63e2034f94d8a5b11f265b73ba33\" --jq .content | base64 -d",
+      "note": "The action's `Dockerfile` also installs from PyPI under pip-compile constraints committed inside the pinned tree (`requirements/runtime-prerequisites.txt` pins pip==25.2; `requirements/runtime.txt` pins the rest). Those are version pins, not hashes, so those bytes rest on PyPI refusing to let a version be re-uploaded rather than on a content address. Written down because it is exposure; not listed as a reference below because this record follows `uses:` and images, which is the boundary of what the rule in tests/test_workflows.py judges.",
+      "transitive": [
+        {
+          "ref": "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
+          "pinned": true,
+          "note": "A full commit SHA (v6.2.0) — the same rule this repository holds itself to, applied by somebody else. Its own tree at that SHA is `using: node24`, `main: dist/setup/index.js`, `post: dist/cache-save/index.js`, so the chain stops there."
+        },
+        {
+          "ref": "./.github/.tmp/.generated-actions/run-pypi-publish-in-docker-container",
+          "pinned": true,
+          "note": "A Docker action the composite WRITES at run time, from `create-docker-action.py` and the `Dockerfile` beside it. Both the generator and its input are inside the tree the SHA above addresses, so the path is immutable for the same reason the tree is. What it generates points at the image on the next line."
+        },
+        {
+          "ref": "docker://python:3.13-slim",
+          "pinned": false,
+          "note": "THE ONE MOVING REFERENCE beside `id-token: write`. Line 1 of that `Dockerfile` at this SHA is `FROM python:3.13-slim`: a Docker Hub tag its publisher rewrites, pulled fresh inside the job that can publish charter. Nothing in this repository can pin it. Closing it means PyPA naming a digest, or charter vendoring the action (#473 option 2), or charter uploading from a `run:` step with the OIDC token (#473 option 3) — a change to how charter releases itself, which is the operator's call and not this file's. Accepted, and re-read whenever the SHA above moves."
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,21 @@ name: release
 # text — and fails on any ref written here that is not a full commit SHA, an image digest,
 # or a file tracked in this repository. `container:`/`services:` count as refs, in both
 # shapes GitHub writes an image in: the `image:` mapping and the bare scalar shorthand.
-# What it does NOT reach is what a pinned action's own tree then names — see #473.
+#
+# What it does NOT reach is what a pinned action's own tree then names (#473). Pinning
+# `owner/action@<sha>` freezes that action's tree; it does not pin the `uses:` lines a
+# composite action writes, or the `FROM` a Docker action builds from, and reading those
+# needs the network no test in this suite has. So for `publish` — the job holding
+# `id-token: write` — that reading is done by a person and written down in
+# `.github/publish-closure.json`. BUMPING A PIN IN `publish` MAKES THAT RECORD STALE AND
+# THE SUITE RED, with the command to re-read the new tree in the failure message. It is a
+# prompt and not a proof: nothing offline can tell a re-reading from a retyped SHA.
+#
+# At the pins below, exactly one reference in that closure is movable and nothing here can
+# pin it: `pypa/gh-action-pypi-publish` builds from `FROM python:3.13-slim`, a Docker Hub
+# tag its publisher rewrites, inside the job that can publish charter. Closing THAT means
+# vendoring the action or uploading from a `run:` step with the OIDC token — a change to
+# how charter releases itself, and it is still open on #473.
 #
 # Trigger: push a version tag.
 #   git tag v0.1.0 && git push origin v0.1.0
@@ -184,6 +198,12 @@ jobs:
       # downloads the artifact `build` produced, which `actions/download-artifact` reads
       # from the same run with the runtime token, needing no `GITHUB_TOKEN` scope at all.
       id-token: write        # REQUIRED: mints the OIDC token PyPI verifies
+    # Every remote `uses:` this job reaches — the steps below, and anything a local action
+    # of theirs names in turn — has a reading of its own tree in
+    # `.github/publish-closure.json`, because this is where a pinned action's own refs run
+    # beside the identity that can publish charter. Moving a SHA below without re-reading
+    # the tree it now names reddens `tests/test_workflows.py`; adding a step here without
+    # a record does the same. The header explains why that is a prompt and not a proof.
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/docs/news/unreleased-a-pin-bump-cannot-outrun-its-own-reading.md
+++ b/docs/news/unreleased-a-pin-bump-cannot-outrun-its-own-reading.md
@@ -1,0 +1,95 @@
+---
+version: unreleased
+headline: What runs beside charter's publishing identity is written down, and moving a pin now makes that reading go stale loudly instead of silently
+---
+
+`tests/test_workflows.py` refuses any reference charter writes that is not a content
+address — a full commit SHA, an image digest, or a file tracked here. It stops at charter's
+own boundary, and #473 is about the sentence people read it as. `uses: owner/action@<sha>`
+pins that action's **tree**. It does not pin what that tree then names: a composite action
+has its own `uses:` lines, and a Docker action builds from a `Dockerfile` whose `FROM` is a
+tag its publisher rewrites. All of it runs in the job holding `id-token: write` — the job
+whose OIDC claim PyPI accepts as charter's genuine publisher.
+
+**That hop cannot be checked offline, and nothing here now pretends it can.** The tree is
+in somebody else's repository, reading it needs the network, and no test in this suite
+makes a network call. The answer already merged was to say so in the docstring and stop.
+
+**The measurement that says why saying so was not enough.** #473's reading was published on
+2026-08-24 and deliberately re-verified on 2026-08-28. Both times it recorded
+
+```
+actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+    runs: using: node20, main: dist/index.js   — no hop at all
+```
+
+Twenty-seven hours after the second reading, `032a061` moved that pin to
+`3e5f45b…` (v8.0.1). The tree at the new SHA says `using: node24`. Nobody re-read it,
+because nothing anywhere asked anybody to. A documented boundary was wrong inside a day, on
+the one job the document was about, and the only reason it was ever noticed is that
+somebody went back to the issue.
+
+## What is here now
+
+`.github/publish-closure.json` — the reading, done with the network by a person, for every
+remote `uses:` in a job holding `id-token: write`. What action, at what SHA, what its
+`runs:` block said, what it named, and the exact command to read it again.
+
+`TheHopIntoAPinnedActionIsRecordedRatherThanChecked` holds the record against the tree with
+no network at all:
+
+- every action beside the identity has an entry, at **the SHA the workflow actually pins**;
+- no entry outlives the pin it was written for;
+- each entry names its SHA, its tag, the `runs:` it read, and a re-read command that names
+  that same SHA — which is what catches the half-update, a bumped SHA beside a command that
+  still fetches the old tree;
+- the record's own `pinned` verdicts are judged by `immutable`, the predicate this file
+  already applies to charter's refs, **in both directions**: it may not call
+  `docker://python:3.13-slim` a pin, and it may not call a full commit SHA movable either,
+  because overstating the residual exposure is how a real one stops being read.
+
+The collector walks a local `uses: ./x` into charter's own action files rather than
+stopping at the workflow, because a composite action runs inside the calling job with the
+calling job's token. Its first draft did stop there — which would have made it bound the
+refs a *file* names rather than the refs that run beside the identity, this issue's own
+defect committed inside this issue's fix. There are no local actions in this tree today;
+the walk is there so that adding one cannot quietly shrink what the record covers.
+
+So bumping a pin in `publish` reddens the suite, at the moment somebody is already looking
+at that pin, with the command to re-read the new tree in the failure message.
+
+## What it is not
+
+**A prompt, not a proof.** Nothing offline can tell a re-reading from a retyped SHA. That
+limit is written in the class, in the record's own `about` block, and in `release.yml`'s
+header, because a guard that reads as wider than it is would be #473 committed one level up.
+
+**And it is scoped to `id-token: write`, not to every write grant.** That grant mints an
+identity charter can be impersonated by off this platform, and the upload it makes cannot
+be taken back; `contents: write` acts inside this repository, where every other guard here
+still applies. Widening it would put a re-read of `actions/checkout` on every Dependabot
+pull request, and a prompt that fires that often gets waved through — the crying-wolf
+failure `doctor` has already paid for twice.
+
+## What the reading found, today
+
+```
+publish  (id-token: write)
+├── actions/download-artifact@3e5f45b…  v8.0.1
+│     using: node24, main: dist/index.js        → no hop; the bytes are inside the pin
+└── pypa/gh-action-pypi-publish@dc37677…  v1.14.2
+      using: composite
+      ├── actions/setup-python@a309ff8b…        → a full commit SHA; node24; no further hop
+      ├── ./.github/.tmp/.generated-actions/…   → written at run time from files inside the pin
+      └── docker://python:3.13-slim             ← MOVABLE
+```
+
+One reference, one hop deep, and nothing in this repository can pin it: PyPA's `Dockerfile`
+says `FROM python:3.13-slim`, a Docker Hub tag its publisher rewrites, pulled fresh inside
+the job that can publish charter. (The same `Dockerfile` installs from PyPI under
+pip-compile constraints committed in the pinned tree — version pins, not hashes, so those
+bytes rest on PyPI refusing a re-upload rather than on a content address. Recorded too.)
+
+Closing *that* means vendoring the action, or uploading from a `run:` step with the OIDC
+token. Both change how charter releases itself, both carry a standing cost, and #473 stays
+open for whoever decides which.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -76,8 +76,23 @@ action's tree; it does not pin what that tree then names. A Docker action builds
 own `uses:` lines — neither is in this repository, neither can be read without the network,
 and both run in the job holding `id-token: write`. So the property this file enforces is
 "every reference charter *writes* is a content address", which is narrower than "every byte
-that runs in the publishing job is pinned", and the gap between those two sentences is
-where the next look goes.
+that runs in the publishing job is pinned".
+
+**The gap between those two sentences is now written down, and going stale in it is now
+loud.** `.github/publish-closure.json` records, for every remote action that runs in a job
+holding `id-token: write`, what that action's own tree names — read with the network, by a
+person, at the SHA pinned here. `TheHopIntoAPinnedActionIsRecordedRatherThanChecked`
+asserts that the record and the workflow name the same SHAs, so bumping a pin in `publish`
+reddens the suite until somebody re-reads the tree it now points at. It is a **prompt, not
+a proof**: nothing here can tell a re-reading from a retyped SHA, and that limit is stated
+in the record, in that class, and in the news entry rather than left to be discovered. What
+it removes is the failure that had already happened — the reading published on #473 on
+2026-08-28 was wrong twenty-seven hours later, when `actions/download-artifact` moved from
+v4.3.0 to v8.0.1 and `runs.using` moved from node20 to node24 with it, and nothing asked
+anybody to look. Today one reference in that closure is movable and no test here can pin
+it: PyPA's `Dockerfile` says `FROM python:3.13-slim`. Closing *that* means vendoring the
+action or uploading from a `run:` step — a change to how charter releases itself, which is
+the operator's decision and stays in #473.
 
 **A second question, and a second reader for it (#558).** Pinning asks *what code runs*.
 The other thing this file has to hold is *which trigger reaches the job that publishes,
@@ -95,8 +110,10 @@ satisfied by a lie: the **shape** — no `if:` on the guard job, none on any ste
 why. Not that it passed; that it ran.
 
 **The next place to look**, since that is the question this file exists to keep asking. The
-transitive hop above is the first. Then the two mismatches a reader like this always has
-with the real one: what counts as a line break — see
+transitive hop above is recorded now, not closed: what a re-read of `python:3.13-slim`
+costs is a decision about how charter releases itself, and it is open. Then the two
+mismatches a reader like this always has with the real one: what counts as a line break —
+see
 `ALineBreakIsTheOtherHalfOfTheSpellingProblem`, which shows the mismatch runs the safe way
 round — and a ref that is well formed here and means something else on the runner, such as a
 branch somebody named after a 40-character hex string. And last, this reader judges a key by
@@ -108,6 +125,7 @@ guess — all of it stated rather than quietly assumed.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shlex
@@ -1730,6 +1748,598 @@ class TheVersionCheckRunsOnEveryTriggerThatCanPublish(unittest.TestCase):
         code, said = _execute(script, _Run("the same tag", "push", "v9.9.9"),
                               packaged="0.53.0")
         self.assertNotEqual(code, 0, said)
+
+
+# ------------------------------------------------- what a pinned action then names (#473)
+
+#: The record of the hop this suite cannot take, read at the SHAs this repository pins.
+#:
+#: `.json` and not `.y*ml`, on purpose and load-bearing: the record NAMES a movable
+#: reference, because naming one is the whole point of it, and every `.y*ml` under
+#: `.github/` is a seed file whose every reference the rule above refuses. Written as YAML
+#: there, a record of somebody else's tree would be read as a claim about charter's — and
+#: correctly refused, with no config key anywhere that could lift the denial (#370).
+PUBLISH_CLOSURE = GITHUB / "publish-closure.json"
+
+#: The permission that makes a job the one this record is about. PyPI's Trusted Publishing
+#: accepts the token minted under it as charter's genuine publisher, so code in such a job
+#: can act as charter off this platform, and what it uploads cannot be taken back.
+_IDENTITY = "id-token"
+
+
+def the_grant_that_can_publish(workflow: dict, job: dict) -> str | None:
+    """What makes this job one that can publish charter — in words — or None if nothing.
+
+    A sentence rather than a boolean, and that is not decoration. The three ways a job
+    arrives here are not the same claim: two of them are grants somebody wrote down, and
+    the third is this reader admitting it cannot see the answer. Telling a reader "this
+    job holds `id-token: write`" when what actually happened is "nobody declared any
+    permissions" would be a guard overstating what it verified — which is the defect #473
+    is about, committed by #473's own fix. It said exactly that in its first draft.
+
+    A job-level `permissions:` **replaces** the workflow's rather than adding to it, which
+    `release.yml` says at length about `publish` itself. So the job's own block is the
+    whole answer when it has one, and the workflow's is the answer when it does not.
+
+    Fail-closed on everything else, exactly as the two readers above are. A workflow that
+    declares no permissions at all runs on the repository's DEFAULT token permissions — a
+    setting in GitHub's web UI, not a byte in this tree — so answering "no identity" there
+    would be this file confidently reporting a value it cannot see. It answers with the
+    admission instead, and the fix is to declare the permissions, which every workflow
+    here already does. A spelling neither this function nor GitHub's schema knows raises
+    `Unparsed` rather than being read as an absence, for the same reason `container:` had
+    to grow its second shape: an unrecognised spelling that reads as "nothing here" is a
+    blind spot with a green tick on it.
+    """
+    where = job if "permissions" in job else workflow
+    declared = where.get("permissions")
+    if "permissions" in where and declared is None:
+        # The key with nothing under it is neither a grant nor a silence, and reading it
+        # as either would put a wrong sentence in a failure message. `permissions: {}` —
+        # GitHub's own spelling of "no scopes at all" — is a flow mapping and already
+        # stops the reader above by name, so this is the one shape left where "declared
+        # and empty" and "never declared" would be told apart by nothing.
+        raise Unparsed(0, "a `permissions:` key with no scopes under it")
+    if declared is None:
+        return ("no `permissions:` is declared on the job or on the workflow, so it runs "
+                "on the repository's default token permissions — a setting in GitHub's "
+                "web UI and not a byte in this tree. Which is to say this reader cannot "
+                "see the identity WITHHELD, not that it saw it granted; declare the "
+                "permissions and this job stops being one of these")
+    if isinstance(declared, str):
+        if declared == "write-all":
+            return "`permissions: write-all`, which is every scope including this one"
+        if declared == "read-all":
+            return None
+        raise Unparsed(0, f"a `permissions:` scalar this reader does not know: {declared!r}")
+    if not isinstance(declared, dict):
+        raise Unparsed(0, "a `permissions:` value that is neither a mapping nor a scalar")
+    granted = declared.get(_IDENTITY)
+    if granted is None or granted in ("none", "read"):
+        return None
+    if granted == "write":
+        return f"`{_IDENTITY}: write`"
+    raise Unparsed(0, f"an `{_IDENTITY}:` value this reader does not know: {granted!r}")
+
+
+class Beside(NamedTuple):
+    """A remote action that runs in a job which can publish charter."""
+    workflow: str      # the file it is written in
+    job: str           # the job it runs in
+    action: str        # `owner/repo`, or `owner/repo/path`, with no ref on it
+    sha: str           # what it is pinned to — a full commit SHA, by the rule above
+    grant: str         # why the job counts, in `the_grant_that_can_publish`'s own words
+
+
+def beside_the_publishing_identity(root: Path = REPO,
+                                   index: set[str] | None = None) -> list[Beside]:
+    """Every remote `uses:` that runs in a job which can publish charter.
+
+    Read from the tree and not from `scan_text`, because this question is about a JOB and a
+    reference scanner does not know which job a step is in — the same reason `load` exists
+    for #558. Images are skipped: a `container:` beside the identity is already held to a
+    digest by the rule above, and a digest addresses the whole image, so there is no hop
+    left to record.
+
+    A local `uses:` is **followed**, not skipped, and getting that wrong was this
+    collector's first draft. `uses: ./x` names charter's own file, so the rule above does
+    reach it — but a local composite action runs INSIDE the calling job with the calling
+    job's token, so a remote action written in one stands beside `id-token: write` exactly
+    as a remote action written in the job does. Stopping at the job would have been this
+    collector bounding the refs the *workflow file* names rather than the refs that
+    actually run beside the identity: #473's own defect, one level in, inside #473's fix.
+    """
+    index = tracked() if index is None else index
+    found: list[Beside] = []
+    # `sorted` for the failure messages, not for the answer: every caller compares sets, so
+    # the deletion sweep is right that dropping it changes nothing a test can see. It stays
+    # because a `subTest` list that reorders between runs makes two red runs of the same
+    # branch look like two different findings.
+    for path in sorted((root / ".github" / "workflows").glob("*.y*ml")):
+        workflow = load(path.read_text())
+        # `or {}` because a file under `.github/workflows/` need not be a workflow yet — a
+        # half-written one has no `jobs:` — and this reader crashing the suite on it would
+        # be an unrelated failure standing where a pin check should be.
+        for name, job in (workflow.get("jobs") or {}).items():
+            grant = the_grant_that_can_publish(workflow, job)
+            if grant is None:
+                continue
+            found.extend(
+                _reached_from(root, index, path.name, name, grant, _every(job, "uses")))
+    return found
+
+
+def _reached_from(root: Path, index: set[str], workflow: str, job: str, grant: str,
+                  refs: list) -> list[Beside]:
+    """The remote actions these references reach, through this repository's own files.
+
+    One hop per local reference and as many hops as there are local references, which is
+    the same walk `closure` describes and the same one GitHub takes: a local `uses:`
+    resolves to a tracked `action.y*ml`, or to a reusable workflow under
+    `.github/workflows/`, and both may name further references of their own.
+
+    A local reference to a file this repository does not track contributes nothing here —
+    deliberately, and not silently: `test_every_local_action_is_a_file_committed_to_this_
+    repository` already refuses that ref by name, so swallowing it a second time here
+    would only produce a second complaint about the same line.
+
+    A local reference to a **reusable workflow** is read whole rather than job by job, and
+    that over-collects on purpose. `workflow_call` hands the called workflow the caller
+    job's permissions, which it can reduce but not exceed, so every job in it may be
+    holding the identity — and this reader would be guessing which. Asking for a record of
+    one action too many is a question somebody answers; missing one is the whole of #473.
+    """
+    out: list[Beside] = []
+    queue = [_unquote(r) for r in refs]
+    walked: set[str] = set()
+    while queue:
+        ref = queue.pop()
+        if not is_local(ref):
+            action, _, sha = ref.rpartition("@")
+            out.append(Beside(workflow, job, action, sha, grant))
+            continue
+        target = local_target(ref)
+        # Two refusals, deliberately on two lines: they are two different facts, and the
+        # deletion sweep can only charge them separately when they are written separately.
+        if target is None:
+            continue                       # a path out of the tree names nothing in it
+        if target in walked:
+            continue                       # a cycle ends here rather than spinning
+        walked.add(target)
+        for rel in _action_files(target, index):
+            queue.extend(_unquote(r.ref)
+                         for r in scan_text((root / rel).read_text()) if r.key == "uses")
+    return out
+
+
+def publish_closure(path: Path = PUBLISH_CLOSURE) -> dict:
+    """The record, as data. Read with `json` and never with this file's YAML reader: the
+    record is not a workflow, and the one thing that must not happen to it is being read
+    as one."""
+    return json.loads(path.read_text())
+
+
+class TheHopIntoAPinnedActionIsRecordedRatherThanChecked(unittest.TestCase):
+    """The boundary the docstring states, given the one tooth it can honestly have (#473).
+
+    `uses: owner/action@<sha>` pins that action's tree. It does not pin what that tree then
+    names: a composite action has its own `uses:` lines, a Docker action builds from a
+    `Dockerfile` whose `FROM` is a tag its publisher rewrites. Both run in the job holding
+    `id-token: write`, both are files in somebody else's repository, and no test in this
+    suite makes a network call. **So this cannot be checked here, and nothing in this class
+    pretends to check it.**
+
+    What it checks is that the RECORD of that reading names the same code the workflow
+    runs. `.github/publish-closure.json` says which action was read, at which SHA, what its
+    `runs:` block said and what it named; these tests say the SHA in the record is the SHA
+    in the workflow, that nothing runs beside the identity without an entry, that no entry
+    outlives the pin it was written for, and that the record's own `pinned` verdicts agree
+    with the very predicate this file applies to charter's own refs. When a pin moves the
+    record is stale, and this goes red **at the moment somebody is already reading that
+    pin**, with the command to re-read the tree in the failure message.
+
+    **That is a prompt, not a proof.** Nothing offline can tell whether the person who
+    bumped the SHA re-read the tree or merely retyped the record, and the record says so
+    about itself. What it removes is the failure that actually happened here rather than a
+    hypothetical one: the reading published on #473 on 2026-08-28 named
+    `actions/download-artifact@d3f86a1 # v4.3.0`; commit 032a061 moved that pin the next
+    day; `runs.using` moved with it, node20 to node24; and nothing anywhere asked anybody
+    to look. Six days of documented boundary, wrong within twenty-seven hours of being
+    re-verified on purpose.
+
+    **Why `id-token: write` and not every write grant** is argued in the record's own
+    `scope` block, and it is the same crying-wolf argument that kept option (2) of #473 —
+    a scheduled network job — unbuilt: a prompt that fires on every `actions/checkout`
+    bump is a prompt that gets waved through, and it takes whatever else it would have
+    caught with it (#171, #55).
+    """
+
+    def test_there_is_a_job_holding_the_publishing_identity_for_this_to_be_about(self):
+        """A reader that found no privileged job would pass every test below it, and a
+        record with nothing in it would pass most of them."""
+        self.assertIn(
+            ("release.yml", "publish"),
+            {(b.workflow, b.job) for b in beside_the_publishing_identity()},
+            "no remote action was found in a job that can publish charter — either the "
+            "grant moved, or the permissions reader has gone blind, and every assertion "
+            "below is vacuous either way")
+        self.assertTrue(
+            publish_closure()["reviewed"],
+            f"{PUBLISH_CLOSURE.name} records no reading at all, which is not the same "
+            f"claim as `there was no hop to read`")
+
+    def test_every_action_beside_the_identity_is_recorded_at_the_sha_it_is_pinned_to(self):
+        """The whole point. Bump a pin in `publish` without re-reading the tree it now
+        names, and the record is a description of code nothing runs."""
+        entries = {e["uses"]: e for e in publish_closure()["reviewed"]}
+        for b in beside_the_publishing_identity():
+            with self.subTest(workflow=b.workflow, job=b.job, action=b.action):
+                entry = entries.get(b.action)
+                self.assertIsNotNone(
+                    entry,
+                    f"`{b.action}` runs in `{b.workflow}`'s `{b.job}` job, which can "
+                    f"publish charter — {b.grant} — and nothing in "
+                    f"{PUBLISH_CLOSURE.name} says what its own tree names. Read it at the "
+                    f"SHA it is pinned to and add an entry: a composite action's `uses:` "
+                    f"lines, a Docker action's `image:` or its `Dockerfile` `FROM`, "
+                    f"nothing at all for a JavaScript one. That reading needs the "
+                    f"network, which is why no test here can do it for you.")
+                self.assertEqual(
+                    entry["sha"], b.sha,
+                    f"`{b.action}` is recorded at {entry['sha']} ({entry['tag']}), and "
+                    f"`{b.workflow}` now pins {b.sha}. The record describes a tree nothing "
+                    f"runs any more. Re-read the new one:\n\n    "
+                    f"{entry['reread'].replace(entry['sha'], b.sha)}\n\n"
+                    f"then set `sha`, `tag`, `runs`, `reread` and `transitive` from what "
+                    f"comes back. Retyping the SHA without reading the tree passes this "
+                    f"test, and is the one thing it cannot catch.")
+
+    def test_the_record_keeps_no_entry_for_a_hop_nothing_takes_any_more(self):
+        """The other direction, and it is not decoration: a record free to accumulate
+        entries reads as more thorough the longer it goes untended, and an entry for an
+        action this repository has dropped is a reading nobody has any reason to refresh —
+        so it is exactly the entry that will still be there, and still believed, when
+        somebody adds the action back at a different SHA."""
+        live = {(b.action, b.sha) for b in beside_the_publishing_identity()}
+        for entry in publish_closure()["reviewed"]:
+            with self.subTest(action=entry["uses"]):
+                self.assertIn(
+                    (entry["uses"], entry["sha"]), live,
+                    f"{PUBLISH_CLOSURE.name} records `{entry['uses']}@{entry['sha']}` and "
+                    f"no job that can publish charter runs it. Delete the entry, or put "
+                    f"back the pin it was written for.")
+
+    def test_each_entry_says_what_was_read_and_how_to_read_it_again(self):
+        """Two SHAs and a verdict would be a record nobody can check or refresh. The
+        `reread` command has to name the entry's own SHA, which is what catches the
+        half-update: a bumped `sha` beside a command that still fetches the old tree is
+        a record claiming to have read something it did not.
+
+        `.strip()` here — and in the two assertions after it — survives the deletion sweep
+        as `.lstrip()`, and that is a genuine equivalent rather than a gap. A string is
+        all-whitespace exactly when its `lstrip` is empty and exactly when its `strip` is,
+        so inside `assertTrue` the two cannot be told apart by any input at all. The call
+        still earns its place: without it a record whose `tag` is `"  "` would pass.
+        """
+        for entry in publish_closure()["reviewed"]:
+            with self.subTest(action=entry["uses"]):
+                self.assertTrue(
+                    _SHA.match(entry["sha"]),
+                    f"`{entry['uses']}` is recorded at {entry['sha']!r}, which is not a "
+                    f"full commit SHA — the record has to name a content address for the "
+                    f"same reason the workflow does")
+                self.assertTrue(entry["tag"].strip(),
+                                f"`{entry['uses']}` is recorded at a SHA with no version "
+                                f"beside it, so nobody can tell how stale the reading is")
+                self.assertTrue(entry["runs"].strip(),
+                                f"`{entry['uses']}` has no `runs:` recorded, and `runs:` "
+                                f"is what decides whether there is a hop at all")
+                self.assertIn(
+                    entry["sha"], entry["reread"],
+                    f"`{entry['uses']}`'s `reread` command does not name the SHA the "
+                    f"entry claims to have read, so running it would read a different "
+                    f"tree than the one recorded")
+
+    def test_the_records_own_verdicts_are_judged_by_the_rule_this_file_already_applies(self):
+        """The reference is somebody else's; the claim about it is this repository's, and
+        that claim is checkable offline. `immutable` is the same predicate that judges
+        charter's own refs, so a record calling `docker://python:3.13-slim` a pin
+        disagrees with the rule the file is built on — and so does one calling a full
+        commit SHA movable, which inflates the exposure instead of hiding it. Both
+        directions, because a record that overstates is as unreadable as one that lies."""
+        for entry in publish_closure()["reviewed"]:
+            for hop in entry["transitive"]:
+                with self.subTest(action=entry["uses"], ref=hop["ref"]):
+                    self.assertTrue(
+                        hop["note"].strip(),
+                        f"`{hop['ref']}` is recorded under `{entry['uses']}` with no note "
+                        f"— a bare list of refs is a count, and this file reports "
+                        f"findings rather than counts")
+                    fixed = immutable(hop["ref"]) or is_local(hop["ref"])
+                    if hop["pinned"]:
+                        self.assertTrue(
+                            fixed,
+                            f"the record calls `{hop['ref']}` pinned, and `immutable` — "
+                            f"the predicate this file uses on charter's own refs — says "
+                            f"it is a promise its owner can move")
+                    else:
+                        self.assertFalse(
+                            fixed,
+                            f"the record calls `{hop['ref']}` movable, and it is a "
+                            f"content address by this file's own rule. Overstating the "
+                            f"residual exposure is how a real one stops being read.")
+
+    def test_the_record_is_a_tracked_file_this_suite_does_not_read_as_a_workflow(self):
+        """Tracked, because an untracked record is one a working tree rewrites between the
+        reading and the release. And NOT a seed file, because it names a movable reference
+        on purpose: rename it to `.yml` under `.github/` and the rule above would read
+        `docker://python:3.13-slim` as a ref charter had written and refuse it — correctly,
+        unanswerably, and about the wrong repository's file."""
+        self.assertIn(
+            PUBLISH_CLOSURE.relative_to(REPO).as_posix(), tracked(),
+            "the closure record is not committed, so 'it moves only with a commit here' "
+            "is false of it")
+        self.assertNotIn(
+            PUBLISH_CLOSURE, seed_files(),
+            "the closure record is being read as a workflow. It names refs charter does "
+            "not write and cannot pin; judging them by the rule above is a refusal aimed "
+            "at somebody else's repository, and there is no key that lifts one (#370).")
+
+    def test_the_record_states_its_own_reach(self):
+        """Shape, not content, and said plainly rather than dressed up: this holds that
+        the `about` and `scope` blocks exist and are not empty. They are where the record
+        says it is a reading and not a verification, and which jobs it covers — and a
+        guard whose reach is not written down beside it gets read as a wider guard than it
+        is, which is #473 itself one level up."""
+        record = publish_closure()
+        self.assertTrue("".join(record["about"]).strip(),
+                        "the record does not say what it is, or that it is not a check")
+        self.assertTrue("".join(record["scope"]).strip(),
+                        "the record does not say which jobs it covers")
+
+
+class TheJobThisIsAboutIsTheOneThatCanPublish(unittest.TestCase):
+    """`the_grant_that_can_publish` on the spellings a `grep id-token` gets wrong.
+
+    Both directions, and the withheld cases are the load-bearing half: a reader that said
+    "privileged" about everything would satisfy every assertion in the class above by
+    demanding a record entry for `actions/checkout`, and a reader that said it about
+    nothing would satisfy them by demanding none at all.
+
+    The granted cases assert **which** grant was found and not merely that one was, since
+    the three are three different sentences and one of them is an admission rather than a
+    finding. A boolean here is how the first draft of this told a reader that a job with
+    no declared permissions "holds `id-token: write`" — the guard-overstates-its-reach
+    defect, inside the fix for the guard-overstates-its-reach defect.
+    """
+
+    SHA = "a" * 40
+
+    def _grants(self, text: str) -> dict[str, str | None]:
+        workflow = load(text)
+        return {name: the_grant_that_can_publish(workflow, job)
+                for name, job in workflow["jobs"].items()}
+
+    GRANTED = [
+        ("a job that asks for it",
+         "permissions:\n  contents: read\njobs:\n  publish:\n    permissions:\n"
+         "      id-token: write\n    steps:\n      - uses: owner/act@" + SHA + "\n",
+         "`id-token: write`"),
+        ("a workflow grant, inherited by a job that declares nothing",
+         "permissions:\n  id-token: write\njobs:\n  publish:\n    steps:\n"
+         "      - uses: owner/act@" + SHA + "\n",
+         "`id-token: write`"),
+        ("write-all, which is every scope including this one",
+         "permissions: write-all\njobs:\n  publish:\n    steps:\n"
+         "      - uses: owner/act@" + SHA + "\n",
+         "write-all"),
+        ("no permissions declared anywhere — the repository default, which is a setting "
+         "in a web UI and not a byte in this tree",
+         "jobs:\n  publish:\n    steps:\n      - uses: owner/act@" + SHA + "\n",
+         "cannot see the identity WITHHELD"),
+    ]
+
+    WITHHELD = [
+        ("a job block, which REPLACES the workflow's rather than adding to it",
+         "permissions:\n  id-token: write\njobs:\n  publish:\n    permissions:\n"
+         "      contents: read\n    steps:\n      - uses: owner/act@" + SHA + "\n"),
+        ("read-all",
+         "permissions: read-all\njobs:\n  publish:\n    steps:\n"
+         "      - uses: owner/act@" + SHA + "\n"),
+        ("id-token: read",
+         "jobs:\n  publish:\n    permissions:\n      id-token: read\n    steps:\n"
+         "      - uses: owner/act@" + SHA + "\n"),
+        ("id-token: none",
+         "jobs:\n  publish:\n    permissions:\n      id-token: none\n    steps:\n"
+         "      - uses: owner/act@" + SHA + "\n"),
+        ("a write grant that is not this one",
+         "jobs:\n  publish:\n    permissions:\n      contents: write\n    steps:\n"
+         "      - uses: owner/act@" + SHA + "\n"),
+    ]
+
+    REFUSED = [
+        ("a `permissions:` scalar nobody taught this reader",
+         "permissions: bananas\njobs:\n  publish:\n    steps:\n"
+         "      - uses: owner/act@" + SHA + "\n",
+         "a `permissions:` scalar this reader does not know"),
+        ("an `id-token:` value nobody taught this reader",
+         "jobs:\n  publish:\n    permissions:\n      id-token: maybe\n    steps:\n"
+         "      - uses: owner/act@" + SHA + "\n",
+         "an `id-token:` value this reader does not know"),
+        ("a `permissions:` sequence, which is not a permission set at all",
+         "permissions:\n  - id-token\njobs:\n  publish:\n    steps:\n"
+         "      - uses: owner/act@" + SHA + "\n",
+         "neither a mapping nor a scalar"),
+        ("a `permissions:` key with nothing under it, which is neither a grant nor a "
+         "silence and must not be read as the second",
+         "jobs:\n  publish:\n    permissions:\n    steps:\n"
+         "      - uses: owner/act@" + SHA + "\n",
+         "a `permissions:` key with no scopes under it"),
+        ("the same empty key at the workflow level",
+         "permissions:\njobs:\n  publish:\n    steps:\n"
+         "      - uses: owner/act@" + SHA + "\n",
+         "a `permissions:` key with no scopes under it"),
+    ]
+
+    def test_a_job_that_can_publish_is_recognised_and_says_which_grant_made_it_one(self):
+        for name, text, says in self.GRANTED:
+            with self.subTest(case=name):
+                grant = self._grants(text)["publish"]
+                self.assertIsNotNone(grant, "a job that can publish charter read as one "
+                                            "that cannot")
+                self.assertIn(says, grant,
+                              "the job was recognised, and for a different reason than "
+                              "the one this case exists to exercise — which is the whole "
+                              "of what the failure message will tell somebody")
+
+    def test_a_job_that_cannot_publish_is_not_dragged_in(self):
+        for name, text in self.WITHHELD:
+            with self.subTest(case=name):
+                self.assertIsNone(self._grants(text)["publish"])
+
+    def test_a_permission_set_this_reader_cannot_read_stops_the_suite_by_name(self):
+        """Fail-closed, and the message is asserted rather than the exception: three
+        different unreadable shapes all raise `Unparsed`, so a test that only checked the
+        type would pass while the reader stopped being able to say which one it met."""
+        for name, text, says in self.REFUSED:
+            with self.subTest(case=name):
+                with self.assertRaises(Unparsed) as caught:
+                    self._grants(text)
+                self.assertIn(says, str(caught.exception))
+
+    def test_only_the_remote_actions_of_a_privileged_job_are_collected(self):
+        """The collector, on a tree built to trip every branch of it: an action in an
+        unprivileged job beside one in a privileged job, a local reference, and an image
+        that is not a `uses:` at all."""
+        text = (
+            "permissions:\n"
+            "  contents: read\n"
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - uses: owner/unprivileged@" + "b" * 40 + "\n"
+            "  publish:\n"
+            "    permissions:\n"
+            "      id-token: write\n"
+            "    container: ghcr.io/x@sha256:" + "c" * 64 + "\n"
+            "    steps:\n"
+            "      - uses: owner/act@" + self.SHA + "\n"
+            "      - uses: owner/act/sub@" + self.SHA + "\n"
+            "      - uses: ./tools/local\n")
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(os.path.realpath(raw))
+            (tmp / ".github" / "workflows").mkdir(parents=True)
+            (tmp / ".github" / "workflows" / "release.yml").write_text(text)
+            found = beside_the_publishing_identity(tmp)
+        self.assertEqual(
+            {(b.job, b.action, b.sha) for b in found},
+            {("publish", "owner/act", self.SHA), ("publish", "owner/act/sub", self.SHA)})
+        self.assertEqual({b.workflow for b in found}, {"release.yml"})
+        self.assertEqual({b.grant for b in found}, {f"`{_IDENTITY}: write`"},
+                         "the reason the job counted did not reach the finding, so the "
+                         "failure message cannot say why this action needs a record")
+
+    def _tree(self, tmp: Path, files: dict[str, str]) -> set[str]:
+        for rel, text in files.items():
+            path = tmp / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text)
+        return set(files)
+
+    def test_a_remote_action_reached_through_a_local_one_is_collected_too(self):
+        """A composite action runs INSIDE the calling job with the calling job's token, so
+        every remote action it names stands beside `id-token: write` exactly as the job's
+        own steps do. A collector that stopped at the workflow file would report the
+        closure of a FILE and call it the closure of a JOB — #473's own defect, one level
+        in. The cycle back to the first action is here because a walk that can be sent
+        round one is a walk that hangs the suite rather than failing it.
+
+        The **image** in the deeper action is here for the other half: this walk follows
+        `uses:` and nothing else, and a `runs.image` reached through a local action is a
+        reference the rule above already holds to a digest — collecting it would ask for a
+        reading of an action that is not one. The **doubly-`@`'d** ref is here for the
+        third: the split has to take the LAST `@`, because that is the end `immutable`
+        judges, and a collector splitting at a different one would key the record on a
+        name the rule above never saw."""
+        far = "d" * 40
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(os.path.realpath(raw))
+            index = self._tree(tmp, {
+                ".github/workflows/release.yml":
+                    "jobs:\n  publish:\n    permissions:\n      id-token: write\n"
+                    "    steps:\n      - uses: ./.github/actions/inner\n",
+                ".github/actions/inner/action.yml":
+                    "runs:\n  using: composite\n  steps:\n"
+                    "    - uses: owner/reached@" + self.SHA + "\n"
+                    "    - uses: owner/odd@branch@" + far + "\n"
+                    "    - uses: ./.github/actions/deeper\n",
+                ".github/actions/deeper/action.yml":
+                    "runs:\n  using: docker\n"
+                    "  image: docker://ghcr.io/x@sha256:" + "e" * 64 + "\n"
+                    "  steps:\n"
+                    "    - uses: owner/deeper@" + far + "\n"
+                    "    - uses: ./.github/actions/inner\n",
+            })
+            found = beside_the_publishing_identity(tmp, index)
+        self.assertEqual(
+            {(b.job, b.action, b.sha) for b in found},
+            {("publish", "owner/reached", self.SHA),
+             ("publish", "owner/odd@branch", far),
+             ("publish", "owner/deeper", far)},
+            "this is not the closure of that job. A remote action reached through a local "
+            "composite action has to be in it — nothing would ask for a reading of its "
+            "tree otherwise; an image must not be, because a digest is already a content "
+            "address with no hop behind it; and a ref splits at its LAST `@`, the end "
+            "`immutable` reads.")
+
+    def test_a_local_reference_this_repository_does_not_track_adds_nothing_here(self):
+        """It is not swallowed, it is somebody else's complaint: `uses: ./nope` is already
+        refused by name for not being a file committed here, and a second finding about
+        the same line would be this collector inventing a reason of its own.
+
+        The tracked step beside them is what keeps this from passing for the wrong reason.
+        Its first version asserted an empty result, which a collector that read nothing at
+        all — a mistyped path, a glob that stopped matching — satisfies just as well. The
+        deletion sweep found exactly that: the workflow's filename could be replaced with
+        gibberish and the test stayed green. So the job also holds one ref that MUST come
+        back, and the assertion is the whole set rather than its emptiness."""
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(os.path.realpath(raw))
+            index = self._tree(tmp, {
+                ".github/workflows/release.yml":
+                    "jobs:\n  publish:\n    permissions:\n      id-token: write\n"
+                    "    steps:\n      - uses: ./node_modules/probe\n"
+                    "      - uses: ../outside/the/tree\n"
+                    "      - uses: owner/tracked@" + self.SHA + "\n",
+            })
+            (tmp / "node_modules" / "probe").mkdir(parents=True)
+            (tmp / "node_modules" / "probe" / "action.yml").write_text(
+                "runs:\n  using: composite\n  steps:\n"
+                "    - uses: owner/untracked@" + self.SHA + "\n")
+            found = beside_the_publishing_identity(tmp, index)
+        self.assertEqual(
+            {(b.action, b.sha) for b in found}, {("owner/tracked", self.SHA)},
+            "either an untracked local action leaked a remote ref into this closure, or "
+            "the collector read nothing at all — and an empty result cannot tell those "
+            "two apart, which is what the tracked step is here to stop")
+
+    def test_a_file_under_workflows_that_is_not_a_workflow_yet_is_not_a_crash(self):
+        """A half-written file under `.github/workflows/` has no `jobs:`, and this reader
+        raising on it would put an unrelated `AttributeError` exactly where a pin check
+        should be — a red suite that says nothing about pinning, on a branch that has not
+        finished writing its workflow. The job beside it still has to come back, so this
+        is not "reads nothing and survives"."""
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(os.path.realpath(raw))
+            index = self._tree(tmp, {
+                ".github/workflows/half-written.yml": "name: not finished\non:\n  push:\n",
+                ".github/workflows/release.yml":
+                    "jobs:\n  publish:\n    permissions:\n      id-token: write\n"
+                    "    steps:\n      - uses: owner/act@" + self.SHA + "\n",
+            })
+            found = beside_the_publishing_identity(tmp, index)
+        self.assertEqual({(b.workflow, b.action) for b in found},
+                         {("release.yml", "owner/act")})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #473.

## What I checked first

**The hole is still real.** #473's reproduction, run against `7dcf09c`, gives the same two lines it gave on 2026-08-24: the same action content is refused as a local file and accepted as `owner/act@<sha>`, and the only difference is which side of this repository's boundary it sits on. Nothing since has closed it incidentally.

**And the documented boundary — option (1), already merged — had measurably decayed.** #473's reading was published on 2026-08-24 and deliberately re-verified by its author on 2026-08-28. Both times it recorded:

```
actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
    runs: using: node20, main: dist/index.js   — no hop at all
```

`032a061` moved that pin to `3e5f45b…` (v8.0.1) on 2026-08-29 — **27 hours after the second reading**. I read the tree at the new SHA: `using: 'node24'`. Nobody re-read it, because nothing anywhere asked anybody to. That is the measurement that decides between "document the boundary" and "document it with something that notices when the document goes stale", and it points at the second.

## What I read at today's pins

With the network, by hand, since no test in this suite can:

```
publish  (id-token: write)
├── actions/download-artifact@3e5f45b…  v8.0.1
│     using: node24, main: dist/index.js        → no hop; the bytes are inside the pin
└── pypa/gh-action-pypi-publish@dc37677…  v1.14.2
      using: composite
      ├── actions/setup-python@a309ff8b…        → a full commit SHA; node24; no further hop
      ├── ./.github/.tmp/.generated-actions/…   → written at run time from files inside the pin
      └── docker://python:3.13-slim             ← MOVABLE
```

**Residual exposure beside `id-token: write` is exactly one reference, one hop deep**, and nothing in this repository can pin it: PyPA's `Dockerfile` at that SHA begins `FROM python:3.13-slim`. (Its `pip install` runs under pip-compile constraints committed inside the pinned tree — version pins, not hashes, so those bytes rest on PyPI refusing a re-upload rather than on a content address. Recorded too, and stated as the record's own boundary: it follows `uses:` and images, not package installs.)

## What this ships, and what it deliberately does not

`.github/publish-closure.json` holds that reading. `TheHopIntoAPinnedActionIsRecordedRatherThanChecked` holds the record against the tree, offline:

- every remote action reached from a job holding `id-token: write` has an entry **at the SHA the workflow actually pins**;
- no entry outlives the pin it was written for;
- each entry names its SHA, tag, the `runs:` it read, and a re-read command **carrying that same SHA** — which catches the half-update, a bumped SHA beside a command that still fetches the old tree;
- the record's own `pinned` verdicts are judged by `immutable`, this file's existing predicate, **in both directions**: it may not call `docker://python:3.13-slim` a pin, and it may not call a full commit SHA movable either, because overstating the residual exposure is how a real one stops being read;
- the record must be tracked, and must **not** be a seed file — it names a movable ref on purpose, and a `.y*ml` under `.github/` naming one is refused by the rule above, unanswerably (#370).

**It is a prompt, not a proof.** Nothing offline can distinguish a re-reading from a retyped SHA. That limit is stated in the class docstring, in the record's own `about` block, and in `release.yml`'s header, rather than left to be discovered — a guard that reads as wider than it is would be this issue committed one level up.

**Scoped to `id-token: write`, not to every write grant**, and the reason is the same one that kept option (2) unbuilt: `contents: write` acts inside this repository where every other guard still applies, while widening the scope would put a re-read of `actions/checkout` on every Dependabot PR — and a prompt that fires that often gets waved through (#171, #55). The argument is in the record's `scope` block, where somebody widening it will read it.

**Options (2) and (3) are not taken.** Vendoring `gh-action-pypi-publish`, or dropping it for a `run:` step with the OIDC token, are the two changes that make "every byte in `publish` is pinned" *true* rather than *recorded*. Both change how charter releases itself and both carry a standing cost. Not a subagent's call; #473's own comments say so twice, and this PR does not decide it.

## Two defects I put in and took out

Both were this issue's own defect, committed inside this issue's fix — which is the thing this repo has measured three times.

1. The permissions reader returned a **boolean**, so a job with no declared `permissions:` produced the message "*which holds `id-token: write`*". It does not; the reader simply cannot see the repository default. It returns the **reason in words** now, and the granted cases assert *which* reason, not merely that one was found.
2. The collector read only workflow files, so a remote action reached through a **local composite action** — which runs inside the calling job with the calling job's token — would have been missed. It walks local `uses:` into this repository's tracked action files now, with a cycle guard and a test that sends it round one. There are no local actions in this tree today; the walk is there so adding one cannot quietly shrink what the record covers.

## Verification

- Full suite: **8636 tests, OK** (`env -u PYTHONSAFEPATH python3 -m unittest discover -s tests`), and green on CI across 3.11–3.14.

### The deletion sweep, decomposed

The gate on CI sweeps `charter/`, and this branch adds **0 mutations there** — every line
of it is a test or a record — so `Add up what the shards found` reports `no survivors`
from an empty measurement. That number is worth nothing on its own, so two real ones were
taken instead.

**1. `tools/sweep.py --gate --path tests`, over the 432 added lines.** Three runs, because
the first two found real gaps and I fixed them.

| run | pinned | unpinned | masked cluster | unresolved |
|---|---|---|---|---|
| first | 61 | 2 | 8 | 1 |
| after the first round of fixes | 64 | 1 | 6 | 1 |
| final | **67** | 3 | 4 | 1 |

The final seven survivors are **all genuine equivalents**, and each is explained where it
lives rather than left for the next reader to re-litigate:

- **five** `x.strip()` → `x.lstrip()` inside `assertTrue`. A string is all-whitespace
  exactly when its `lstrip` is empty and exactly when its `strip` is, so no input can tell
  them apart. The call still earns its place: without it a record whose `tag` is `"  "`
  passes.
- **one** `sorted(glob(...))` → `list(glob(...))`. Every caller compares sets, so the sweep
  is right that nothing observes the order. It stays so that two red runs of one branch do
  not print their findings in two different orders.
- **one** retune of the fixture filename in the "a half-written workflow is not a crash"
  test. Renaming it to a non-`.y*ml` removes the input that would crash rather than the
  guard that stops it, and a test whose subject is the absence of an exception cannot tell
  those apart.

The **one unresolved** is the walk's cycle guard: deleting `if target in walked` does not
make the suite fail, it makes the walk never return, and the sweep reports a 900-second
timeout. That is the guard being load-bearing in the only way a non-terminating program
can say so.

**What the sweep actually caught, before those numbers settled** — three real gaps in my
own tests, all of which I had believed covered:

1. `_reached_from` split refs with `rpartition` and nothing distinguished it from
   `partition`. Now a doubly-`@`'d ref pins the split at the end `immutable` reads.
2. The walk filtered `r.key == "uses"`, and no fixture had an `image:` in a local action —
   so nothing stopped a digest-pinned image being collected as an action needing a
   reading. The deeper fixture is a Docker action now.
3. `test_a_local_reference_..._adds_nothing_here` asserted an **empty** result, which a
   collector that read nothing at all satisfies just as well — the sweep proved it by
   replacing the workflow's filename with gibberish and staying green. It asserts a
   non-empty set now, with one ref that must come back.

**2. The world-mutation matrix**, which is the deletion sweep's real equivalent for a guard
that *is* a test: mutate the record and `release.yml`, one change at a time, and check
which test reddens and with what message. **20 mutations, 20 red, 0 survivors**, each
naming its own reason — a moved pin, a missing entry, a stale entry, an entry with no
`runs:`/tag/content-address SHA, a `reread` pointing at another tree, an unannotated hop,
`python:3.13-slim` called pinned, a full SHA called movable, an empty record, a record that
does not state its reach, a new action in `publish`, `id-token: write` removed, the record
left untracked, the record read as a workflow, a `permissions:` key with nothing under it,
and a `permissions:` scalar the reader was never taught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
