### PR TITLE
The security notes describe the class, not the recipe — no backport branch means a note arms the unpatched

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,28 @@ charter is pre-1.0 and moves quickly. Fixes land on the latest release; there ar
 maintained backport branches. Upgrade with `uv tool upgrade charter-cp` (and
 `claude plugin update charter@charter`, which is a separate artifact with its own version).
 
+## What a security release note will and will not tell you
+
+No backport branches has a consequence for how a fix gets announced, and it is worth stating
+rather than leaving for you to notice. A reader on the previous release is **permanently
+unpatched at the moment they learn the hole exists** — there is no patched 0.53.x to move
+sideways onto, only forward. So a note that shipped a working bypass alongside "we fixed it"
+would arm the people who have not upgraded yet against themselves, and the people it arms
+are the ones with the least ability to do anything about it.
+
+The rule those notes are written to is therefore: **describe the class, never the recipe.**
+Every security entry states the affected versions, the shape of the weakness, what it could
+reach, and the fix — enough to answer *am I exposed, and what do I do*. None of them prints
+an assembled command line that walks past a guard, or a table of working spellings. That is
+a deliberate narrowing of a note, not an omission, and it is not a claim that the underlying
+technique is secret: charter's guard tables ship in the source, and this page describes the
+guard's ceiling in detail on purpose. What the notes withhold is the assembled, runnable
+form, because that is the part whose only use is running it.
+
+Being vague is the other way to fail, so it is not the trade being made here. If a note
+leaves you unable to tell whether it matters to your plane, that is a defect in the note —
+report it the same way you would report anything else on this page.
+
 ## What charter's vault does and does not protect
 
 This is the part most worth reading before you trust charter with anything real, and the

--- a/docs/news/unreleased-a-background-refresh-refreshes-the-plane-that-asked-for-it.md
+++ b/docs/news/unreleased-a-background-refresh-refreshes-the-plane-that-asked-for-it.md
@@ -96,9 +96,12 @@ does not ask: a shell's `-c` string, Python source, a script file, and an interp
 resolved to what it really is rather than what the symlink is called. A structural test
 fails if the tables drift apart again.
 
-Doing that turned up a real defect in the production guard, filed as #547 rather than
-patched around here: `env -Sfoo=1 cat .charter/vaults/x.json` is currently ALLOWED by the
-Bash tool-gate, because the packed command is split at the wrong `=`.
+Doing that turned up a real defect in the production guard, filed as
+[#547](https://github.com/diazoxide/charter/issues/547) rather than patched around here: a
+wrapper prefix that packs a whole command into one token was split at the wrong `=`, so the
+Bash tool-gate never saw the reader inside it and allowed the read. **That is fixed in this
+same release** — see "A value glued to a short flag is read as one value again", which is
+also why the command itself is not written out here.
 
 This reaches you as a correctness fix in `charter gl-refresh`; the rest only ever mattered
 if you run charter's own test suite. Nothing to adopt — upgrading is the whole of it.

--- a/docs/news/unreleased-a-name-ends-where-the-string-ends.md
+++ b/docs/news/unreleased-a-name-ends-where-the-string-ends.md
@@ -4,6 +4,9 @@ headline: A name ends where the string ends — a trailing newline is no longer 
 security: true
 ---
 
+**Affected: 0.53.0 and earlier. Fixed here.** No name charter has ever minted is affected;
+see *Who this refuses that it used to accept* below before assuming this reached you.
+
 `persona.valid_name("evil\n")` returned **True**, and a directory `personas/evil<LF>/`
 holding an ordinary `persona.md` resolved, loaded, and was rendered by
 `charter persona sync-agents` into a generated sub-agent whose YAML frontmatter carried a

--- a/docs/news/unreleased-a-news-key-is-honoured-or-reported.md
+++ b/docs/news/unreleased-a-news-key-is-honoured-or-reported.md
@@ -4,6 +4,11 @@ headline: A news entry is read the way its author wrote it, or charter says so â
 security: true
 ---
 
+**Affected: 0.53.0 and earlier. Fixed here.** Nothing on your plane is exposed by this;
+what was at risk is charter's own disclosure process â€” a security entry could sink out of
+the release notes in silence, and a committed filename could write a line of charter's own
+report in charter's voice.
+
 Two defects in the same subsystem, and the same shape twice: **a value crossing from a
 committed file into something somebody reads, where the code handled one spelling and not
 its neighbours.**

--- a/docs/news/unreleased-a-persona-key-is-honoured-or-reported.md
+++ b/docs/news/unreleased-a-persona-key-is-honoured-or-reported.md
@@ -4,6 +4,11 @@ headline: A persona frontmatter key is honoured or reported — and a miscased `
 security: true
 ---
 
+**Affected: 0.53.0 and earlier. Fixed here.** This is the one entry in this release that
+narrows a **live tool grant**: if a persona on your plane has a miscased key, tools are
+being auto-approved today that its author wrote the line to give up. No attacker is
+needed — a shift key is enough. The last section is how to check.
+
 Two defects in the persona parser, and one property between them: **a key the author
 declared is honoured or reported, never silently resolved.** One is "the key was not
 recognised", the other is "the key was recognised twice", and both used to end in a value

--- a/docs/news/unreleased-a-reference-vault-says-where-it-lives.md
+++ b/docs/news/unreleased-a-reference-vault-says-where-it-lives.md
@@ -4,6 +4,11 @@ headline: a reference vault reports the directory it is listed in, the mode of i
 security: true
 ---
 
+**Affected: 0.53.0 and earlier. Fixed here.** Nothing here narrows an exposure; it makes an
+existing one *sayable*. A reference vault sat in a directory another account could list and
+reported nothing about it, and a committed non-string entry could crash the reporting
+command outright — including `charter doctor`, which runs from the SessionStart hook.
+
 `charter vault list` and `charter doctor` name a state directory another account on the
 machine can list, and print the `chmod` — charter will not tighten a directory it did not
 create, so saying it is the remedy

--- a/docs/news/unreleased-a-report-that-tells-you-to-fix-a-persona-names-it.md
+++ b/docs/news/unreleased-a-report-that-tells-you-to-fix-a-persona-names-it.md
@@ -4,6 +4,11 @@ headline: A report that tells you to fix a persona now names it — three rows r
 security: true
 ---
 
+**Affected: 0.53.0 and earlier. Fixed here.** Exposure needs a persona directory committed
+to your plane whose name renders as nothing — which no `charter persona create` can mint,
+so it arrives by commit or by hand. The consequence is concealment: the reports whose job
+is to name the thing you must fix named nothing at all.
+
 `charter persona lint` printed `✗ : no role` for a persona whose directory name is three
 U+3164 HANGUL FILLERs. The sentence beside it read `persona '' does not load`. And the brief
 a dispatched sub-agent reads listed `` `personas/<name>/bin/` `` — a path with no filename

--- a/docs/news/unreleased-a-repository-can-name-its-own-work-tree.md
+++ b/docs/news/unreleased-a-repository-can-name-its-own-work-tree.md
@@ -4,20 +4,20 @@ headline: A repository that names its own work tree cannot use it to reach the p
 security: true
 ---
 
+**Affected: 0.53.0, and earlier releases carrying the plane-root guards. Fixed here.**
+
 `--work-tree` and `GIT_WORK_TREE` are tokens. `core.worktree` is not: it is a key in a
 repository's own `.git/config`, and a repository carrying it has the named directory as its
 working tree for **every** command it runs. So the plane-root guards, which read a
 command's argv and environment, saw a plain `git checkout feature` typed inside a workspace
 clone — and git wrote that branch's content into the plane root.
 
-Reproduced end to end on git 2.50.1, with the plane's file changing:
-
-```
-git clone <plane> /tmp/cfgclone
-git -C /tmp/cfgclone config core.worktree <plane>
-git -C /tmp/cfgclone rev-parse --show-toplevel      # -> <plane>
-git -C /tmp/cfgclone checkout feature               # -> <plane>/f.txt is the branch's now
-```
+Reproduced end to end on git 2.50.1, with the plane's own file changing: give a clone's
+`.git/config` that key pointing at the plane root, and `git rev-parse --show-toplevel` inside
+the clone answers the plane root — after which an ordinary branch checkout, typed with no
+unusual argument on it at all, writes the branch's content over the plane's files. The
+command line is not printed here; it is three lines of `git config`, and this note reaches
+readers who have no backport branch to move to.
 
 `_plane_root_branch_reason` and `_plane_root_reset_reason` both answered `None`, because
 every subject `_git_target` reported was inside the clone.
@@ -71,6 +71,21 @@ to already say this, so it is not the ordinary mistake the plane-root guards exi
 it is closed because a workspace clone's config is exactly the kind of thing a repo's own
 tooling writes.
 
-Nothing to adopt: upgrading is the whole of it.
+## Are you exposed, and what do you do
+
+**Yes, if** you are on 0.53.0 or earlier *and* a repository a workspace clones carries this
+key in its committed or local git config. That is the narrow part and it is why this sits
+below the guard-parse fixes: a repository's own config has to already say it, so this is not
+the ordinary mistake the plane-root guards exist to catch. It is closed because a workspace
+clone's config is exactly the kind of thing a repo's own tooling writes without anyone
+reading it.
+
+**Checking a clone costs one command**, and it is a read: `git config --get core.worktree`
+inside each clone a plane owns. Empty is the answer you want. If one names your plane root,
+that clone could move the plane root's files on any checkout or reset, and it could have
+already — `git -C <plane> status` and `git -C <plane> reflog` are where that would show.
+
+**The fix is the upgrade**, and there are no backport branches. Nothing to adopt beyond
+moving.
 
 [#504](https://github.com/diazoxide/charter/issues/504).

--- a/docs/news/unreleased-a-state-files-mode-comes-from-charter.md
+++ b/docs/news/unreleased-a-state-files-mode-comes-from-charter.md
@@ -4,6 +4,9 @@ headline: the persona pointers and every frame state file are 0600 because chart
 security: true
 ---
 
+**Affected: 0.53.x and earlier. Fixed here.** Exposure needs a second account on the same
+machine, or a backup or disk image somebody else can read.
+
 0.53.x settled the mode of the files under `.charter/`: they are written through
 `config.write_for` / `open_for` / `touch_for`, which settle the mode on the descriptor
 before any content lands ([#505](https://github.com/diazoxide/charter/issues/505)).

--- a/docs/news/unreleased-a-value-glued-to-a-short-flag-is-read-as-one.md
+++ b/docs/news/unreleased-a-value-glued-to-a-short-flag-is-read-as-one.md
@@ -1,48 +1,48 @@
 ---
 version: unreleased
-headline: A value glued to a short flag is read as one value again — `env -Sfoo=1 cat <vault>` printed a vault and is denied
+headline: A value glued to a short flag is read as one value again — a one-word wrapper prefix walked past the vault guard, and is denied
 security: true
 ---
 
-`env -Sfoo=1 cat .charter/vaults/x.json` printed a fabricated vault on a real plane while
-`cat .charter/vaults/x.json` on the same plane was denied. One wrapper word, one flag, and
-the guard that exists to keep a credential out of a transcript had nothing to say.
+**Affected: 0.53.0, and every earlier release carrying the vault guard. Fixed here.** A
+single wrapper word placed in front of an ordinary file read walked past the guard that
+exists to keep a credential out of a transcript, on a plane built by `charter init` — while
+the same read written without that word was denied. Confirmed live before anything was
+changed.
 
-The parse is the whole of it. `env` packs a command into one token two ways —
-`--split-string=<command>` and the glued short `-S<command>` — and `hooks._split_env_chdir`
-read the long form's rule first. So a packed command carrying its **own** `=` was split at
-the wrong one: `-Sfoo=1 cat …` yielded `1` as the program, the `cat` was never named, and no
-guard downstream had a reader to object to. getopt hands a short option everything glued
-after it, `=` included; the rule for the long form was answering about a token that was
-never a long form.
+The assembled command is not printed in this note. There are no backport branches, so this
+note reaches people who cannot yet be protected by it, and a runnable line would arm them
+against themselves faster than it would inform them. What follows is the shape, which is
+what you need in order to decide whether it reached you.
 
-**Four of its five neighbours were denied the whole time, and that is the part worth
-recording.** Measured against the shipped hook, one row at a time:
+**The class.** `env` packs a whole command into one token two ways — a long
+`--split-string=` form and a glued short form — and `hooks._split_env_chdir` applied the
+long form's splitting rule first. A packed command carrying an `=` of its own was therefore
+split at the wrong one: the wrong token was named as the program, the file-reading program
+was never named at all, and no guard downstream had a reader to object to. getopt hands a
+short option everything glued after it, `=` included; the rule for the long form was
+answering about a token that was never a long form.
 
-```
-cat .charter/vaults/x.json                           -> DENY   (control)
-env -Sfoo=1 cat .charter/vaults/x.json               -> ALLOW  <-- the bypass
-env -S "cat .charter/vaults/x.json"                  -> DENY
-env --split-string=foo=1 cat .charter/vaults/x.json  -> DENY
-env -S "foo=1 cat .charter/vaults/x.json"            -> DENY
-env FOO=1 cat .charter/vaults/x.json                 -> DENY
-```
-
-Anyone probing this by hand would very likely have stopped at the third row and concluded
-the guard held. It took the one form combining a glued short flag with a value that itself
-contains an `=` — which is exactly the form a real `env -S` setting a variable takes. All
-six rows are now one table in `tests/test_guard_attached_option_values.py`, driven by one
+**Why probing this by hand would have missed it, and that is the part worth recording.**
+Measured against the shipped hook, the neighbouring spellings of the same idea were **all**
+denied the whole time — the separated long form, the quoted short form, the long form
+carrying the same value, and an ordinary assignment prefix. Four of five neighbours held.
+Only the one form combining a glued short flag with a value that itself contains an `=` got
+through, and that is exactly the form a real `env -S` setting a variable takes. Anyone
+walking the obvious spellings would have stopped two rows in and concluded the guard held.
+All six are one table in `tests/test_guard_attached_option_values.py` now, driven by one
 loop, because the five that already denied are what make the sixth's regression visible: a
 later refactor that trades one spelling for another has to redden something.
 
 **And its siblings, because a bug with a shape has them.** Every flag whose value may be
-attached went through the same two rules in the same wrong order, and `env -C` — the chdir
-whose value is what makes a later relative operand resolve — was live in the same way:
-`env -Cx=y/../.charter/vaults cat x.json` was allowed and printed the vault, after the
-`mkdir x=y` a shell does without being asked twice. `sudo -D` and `xargs -a` are the same
-parse. The two rules are now disjoint rather than merely ordered — a glued short form never
-starts with `--`, and the `=` rule now requires it — so the ordering cannot quietly come
-back, and all three wrappers are walked across all four spellings in the tests.
+attached went through the same two rules in the same wrong order. That includes the
+directory-changing flags, whose value is what makes a later relative operand resolve
+somewhere else — so the same mis-ordering reached the vault directory by *relocating into
+it* as well as by naming it, and that is the reach that matters, because the operand
+afterwards looks like nothing at all. `env`, `sudo` and `xargs` are the same parse. The two
+rules are disjoint now rather than merely ordered — a glued short form never starts with
+`--`, and the `=` rule now requires it — so the ordering cannot quietly come back, and all
+three wrappers are walked across all four spellings in the tests.
 
 The same parser is what charter's own test harness uses to decide whether a test is about to
 spawn charter against your live plane. It had been repairing this ordering on its way in
@@ -50,22 +50,35 @@ since the defect was filed; that repair is deleted with this fix, which makes it
 second regression test — the suite stays green on production's parse alone.
 
 Two neighbours found while measuring this one are **not** fixed here, and were filed rather
-than quietly absorbed: [#556](https://github.com/diazoxide/charter/issues/556), a value
-attached to a *bundled* short option (`env -iC<dir> cat x.json`, which relocates into the
-vault directory and is allowed), and
-[#555](https://github.com/diazoxide/charter/issues/555), `env` accepting assignments to
-names that are not shell identifiers while the parser stops at the first token it cannot
-read as one (`env a-b=1 cat <vault>`). Both were live, both were unchanged in either
-direction by this fix, and both are a different question from the one #547 asked — a fix
-that widens its own scope until it is answering three questions is how a guard change stops
-being reviewable. *(Both are closed in this same release, by their own change: see "An
-option is its letter, and an assignment is whatever will do the assigning".)*
-`SECURITY.md`'s position is unmoved: guard rails, not guarantees — four
-rounds of adversarial review established that deciding what a shell will execute, without
-executing it, is not winnable in a Python tokeniser. This was a mis-ordering with a correct
-answer, and it has one now.
+than quietly absorbed: a value attached to a *bundled* short option, and `env` accepting
+assignments to names that are not shell identifiers while the parser stopped at the first
+token it could not read as one. Both were live, both were unchanged in either direction by
+this fix, and both are a different question from the one #547 asked — a fix that widens its
+own scope until it is answering three questions is how a guard change stops being
+reviewable. *(Both are closed in this same release, by their own change: see "An option is
+its letter, and an assignment is whatever will do the assigning" —
+[#556](https://github.com/diazoxide/charter/issues/556),
+[#555](https://github.com/diazoxide/charter/issues/555).)*
 
-Nothing to adopt: upgrading is the whole of it.
+`SECURITY.md`'s position is unmoved: guard rails, not guarantees — four rounds of
+adversarial review established that deciding what a shell will execute, without executing
+it, is not winnable in a Python tokeniser. This was a mis-ordering with a correct answer,
+and it has one now.
+
+## Are you exposed, and what do you do
+
+**Yes, if** you are on 0.53.0 or earlier *and* you rely on the plugin's `PreToolUse` guard
+to keep an agent away from `.charter/vaults/`. This is one more spelling past a fence
+`SECURITY.md` already describes as holding against mistakes rather than against an attacker
+with shell access as your user.
+
+**The fix is the upgrade.** There are no backport branches, and there is nothing to adopt
+beyond moving: no config to change, no flag to set.
+
+**What does not change with it.** If something you did not fully trust has had shell access
+as your user on a plane holding real credentials, rotate them. That was true before this fix
+and is true after it, because the guard was never the boundary — the boundary is that
+charter itself never prints a value.
 
 [#547](https://github.com/diazoxide/charter/issues/547), found by external review and
 confirmed on a plane built by `charter init`.

--- a/docs/news/unreleased-a-withheld-credential-is-still-reported.md
+++ b/docs/news/unreleased-a-withheld-credential-is-still-reported.md
@@ -4,6 +4,10 @@ headline: `persona lint` and `doctor` report a persona running without the crede
 security: true
 ---
 
+**Affected: 0.53.0 and earlier. Fixed here.** The failure direction is **fail-closed** — a
+credential is withheld and stays withheld. Nothing leaks and nothing escalates; what was
+lost was the operator's view of a gate that worked.
+
 When `charter persona sync-agents` withholds a vault from an MCP server, it says so, and it
 names the command that would restore it. That warning is correct and it was the **only**
 place it was ever said ([#489](https://github.com/diazoxide/charter/issues/489)).
@@ -75,3 +79,7 @@ separately and correctly calling the same persona one that names no vault. One s
 two readings, and the consent record was on the wrong side of it. The render and the consent
 list now normalise it in one place, because those two disagreeing is an operator asked about
 a server the file does not wrap.
+
+Nothing to adopt: upgrading is the whole of it. If a persona of yours has been running an
+MCP server that will not authenticate, `charter persona lint` is now where that is said, and
+it names both ways out.

--- a/docs/news/unreleased-an-option-is-its-letter-and-an-export-reaches-the-next-segment.md
+++ b/docs/news/unreleased-an-option-is-its-letter-and-an-export-reaches-the-next-segment.md
@@ -1,92 +1,95 @@
 ---
 version: unreleased
-headline: An option is its letter, an assignment is whatever will do the assigning, and an `export` reaches the next segment — three vault-reachable bypasses closed
+headline: An option is its letter, an assignment is whatever will do the assigning, and an `export` reaches the next segment — sixteen guard bypasses closed, including one that chose git's transport
 security: true
+lead: true
 ---
 
-Three commands printed a fabricated vault, or moved the plane root's HEAD, on a plane built
-by `charter init` — each while the spelling next to it was refused. All three are the same
-defect wearing three costumes: **a guard matching a spelling instead of the property behind
-it.** That is the seventh time this month, so each fix below names its property and is
-written against that, and each swept its own siblings before stopping.
+**Affected: 0.53.0, and earlier releases carrying these guards. Fixed here.** Sixteen
+commands walked past a guard on a plane built by `charter init` — each one while the
+spelling next to it was refused. All are the same defect wearing three costumes: **a guard
+matching a spelling instead of the property behind it.** That is the seventh time this
+month, so each fix below names its property and is written against that, and each swept its
+own siblings before stopping.
 
-Measured against the real `charter hook pretooluse`, one command at a time (the decision is
-nested under `hookSpecificOutput`; reading `permissionDecision` from the root answers
-nothing for every input and looks exactly like a guard that has stopped working):
+The assembled command lines are not printed in this note. There are no backport branches,
+so this note reaches people who cannot yet be protected by it, and a runnable line would arm
+them against themselves faster than it would inform them. The shapes are named instead,
+which is what you need in order to decide whether this reached you.
 
-| command | before | after |
-| --- | --- | --- |
-| `cat .charter/vaults/x.json` | DENY | DENY |
-| `env -C .charter/vaults cat x.json` | DENY | DENY |
-| `env a-b=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
-| `env a.b=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
-| `env 1FOO=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
-| `env -- a-b=1 cat .charter/vaults/x.json` | **ALLOW** | DENY |
-| `env -Sfoo=1 -Sbar=2 cat .charter/vaults/x.json` | **ALLOW** | DENY |
-| `env -iC.charter/vaults cat x.json` | **ALLOW** | DENY |
-| `env -iC .charter/vaults cat x.json` | **ALLOW** | DENY |
-| `env -viC.charter/vaults cat x.json` | **ALLOW** | DENY |
-| `env -iS'cat .charter/vaults/x.json'` | **ALLOW** | DENY |
-| `sudo -bD.charter/vaults cat x.json` | **ALLOW** | DENY |
-| `env -P /bin cat .charter/vaults/x.json` | **ALLOW** | DENY |
-| `sudo -T 5 cat .charter/vaults/x.json` | **ALLOW** | DENY |
-| `chrt 5 cat .charter/vaults/x.json` | **ALLOW** | DENY |
-| `su-exec root cat .charter/vaults/x.json` | **ALLOW** | DENY |
-| `export GIT_DIR=<plane>/.git && git checkout feature` | **ALLOW** | DENY |
-| `export GIT_SSH_COMMAND=/tmp/k && git push` | **ALLOW** | DENY |
+## What was reachable
 
-Every row marked ALLOW really did the thing: each `cat` printed
-`{"k":"FABRICATED-NOT-A-REAL-SECRET-9271"}`, the `export GIT_DIR` line moved the plane
-root's HEAD (`git -C <plane> symbolic-ref --short HEAD` answers `feature` afterwards), and
-the hook printed nothing in any of them. The two exceptions are the `chrt` and `su-exec`
-rows: those are Linux tools this machine does not have, so they come from their documented
-grammars rather than from a run here.
+Two classes, both confirmed live against the real `charter hook pretooluse` before anything
+was changed.
+
+**Reading a vault — fourteen spellings.** Each put a file-reading program in front of
+charter's vault directory in a way that left the guard with no reader to object to, either
+by naming the directory or by relocating into it first. Every one of them printed a
+fabricated vault's contents while the hook printed nothing. Twelve were run here; two are
+Linux-only wrappers this machine does not have, and come from their documented grammars
+rather than from a run.
+
+**Reaching past the git policy — two spellings, and this is the half that is not just a
+read.** An `export` in an earlier segment of a command line sets a variable for the same
+shell and reaches a `git` in a later segment, and the plane-root guards read only the
+assignment prefix attached to the git invocation itself. So a checkout was redirected into
+the plane root and the plane root's HEAD moved. The same hole sat under the one-credential
+guard, where the variable git consults to choose its SSH transport went unread in the
+`export` spelling while the inline-prefix spelling was refused. That second one is
+**transport substitution** — the golden rule is that every git operation authenticates with
+the forge CLI's token over HTTPS, and this was a way to have git run something else
+entirely. Nobody had reported it; it was found by fixing its sibling.
+
+One note for anyone verifying a guard by hand, because it costs a false negative rather
+than a false positive: the decision is nested under `hookSpecificOutput`. Reading
+`permissionDecision` from the root of the payload answers nothing for every input, and looks
+exactly like a guard that has stopped working.
 
 ## An option is its LETTER, not its position in the token
 
 [#556](https://github.com/diazoxide/charter/issues/556). The parser matched a wrapper's
 value-taking flags with `tok.startswith(flag)`, so it only ever saw a short option written
-**first**. getopt bundles: `-iC<dir>` is `-i -C <dir>`, and `env`'s `-i` takes no value, so
-the `C` after it is the chdir flag and the rest of the token is where the program will run.
-`env -iC.charter/vaults cat x.json` relocated into the vault directory, printed it, and was
-allowed — while `env -C <dir>`, `env -C<dir>` and `env --chdir=<dir>` were all denied. Three
-spellings of one flag refused is what a spelling-shaped guard looks like from the inside.
+**first**. getopt bundles: a no-value letter in front of a value-taking letter hides the
+latter, and for the chdir flag the rest of that token is where the program will run. So a
+bundled chdir relocated into the vault directory, printed it, and was allowed — while the
+separated, glued and long spellings of that same flag were all denied. Three spellings of
+one flag refused is what a spelling-shaped guard looks like from the inside.
 
 The guard now walks the letters. Two per-wrapper tables decide each one — the existing
 `_WRAPPER_VALUE_FLAGS` (letters that take a value, consulted **first**) and a new
 `_WRAPPER_NOVALUE_LETTERS` (letters that take none) — and a letter in neither ends the walk
 rather than being guessed at. Guessing "takes a value" swallows the program, which is the
-fail-open `env -i cat <vault>` punishes; guessing "takes none" walks into somebody's data.
+fail-open that an empty-environment flag in front of a reader punishes; guessing "takes
+none" walks into somebody's data.
 
 **And the end of a walk is no longer silent**, which is the part that stops this being a
-longer list. An option the grammar could not place leaves the program unnamed — a value flag
-nobody has listed is indistinguishable from one that takes nothing — so the rest of the
+longer list. An option the grammar could not place leaves the program unnamed — a value
+flag nobody has listed is indistinguishable from one that takes nothing — so the rest of the
 segment is reported as files the command may open, and the leak guard asks them the same
 question it asks a reader's operands. The sweep found two live fail-opens of exactly that
-kind and they are the last two vault rows in the table: BSD's `env -P <utilpath>` and
-`sudo -T <n>`, both of which had their value read as the program. They are in the value
-table now *and* covered by the fallback, so the next missing letter is a false negative
-instead of a way in.
+kind and they are the last two vault spellings in the count above: BSD `env`'s utility-path
+option and `sudo`'s timeout option, both of which had their value read as the program. They
+are in the value table now *and* covered by the fallback, so the next missing letter is a
+false negative instead of a way in.
 
-**One branch over, the same sweep found a third thing.** `timeout 5 cat <vault>` is the only
-wrapper whose leading *positional* was modelled, and the branch that models it reads as if
-`timeout` were the only wrapper with one. `chrt [options] <priority> <command>` and
-`su-exec <user-spec> <command>` each put an argument of their own in front of the program,
-and the parser named that argument as the program — so `chrt 5 cat <vault>` and
-`su-exec root cat <vault>` were both allowed. Those two are Linux tools rather than macOS
-ones, so unlike every other row above they come from their documented grammars rather than
-from a run on the reporting machine; the guard runs on planes where they exist.
+**One branch over, the same sweep found a third thing.** `timeout` was the only wrapper
+whose leading *positional* was modelled, and the branch that models it reads as if it were
+the only wrapper with one. Two more — a scheduling wrapper and a privilege-dropping one,
+both Linux — each put an argument of their own in front of the program, and the parser named
+that argument as the program. Those are the two rows above that come from documented
+grammars rather than from a run on the reporting machine; the guard runs on planes where
+they exist.
 
 ## An assignment is whatever will do the assigning
 
 [#555](https://github.com/diazoxide/charter/issues/555). One constant,
 `^[A-Za-z_][A-Za-z0-9_]*=`, was answering two different parsers' questions. At the front of
-a shell command it is exactly right — bash answers *"a-b=1: command not found"*, so
-`a-b=1 cat <vault>` runs a program with that name and reads nothing. `env` is a different
-parser reading the same bytes: its operand scan is `strchr(arg, '=')`, GNU and BSD alike, so
-**any** argument containing an `=` is an assignment and the scan keeps going until it meets
-one without. The guard stopped at the first token it could not read as a shell identifier
-and called that token the program.
+a shell command it is exactly right — a token that is not a shell identifier is a program
+name, and bash says so. `env` is a different parser reading the same bytes: its operand scan
+is `strchr(arg, '=')`, GNU and BSD alike, so **any** argument containing an `=` is an
+assignment and the scan keeps going until it meets one without. The guard stopped at the
+first token it could not read as a shell identifier and called that token the program — so
+an assignment to a name a shell would reject slid the reader out of view.
 
 Widening the constant would have moved denials in both directions, because the same
 predicate stands in front of ordinary segments where a token with an `=` is not an
@@ -95,15 +98,15 @@ the shell decides, and a second one is applied only inside the operand scan of a
 really does the assigning — `env`, and `sudo`, whose usage prints `[VAR=value]`. Not `doas`,
 whose usage has no assignment operand in it: a table that is fail-closed is still a table,
 and padding it because padding is safe is the same reflex as a longer list of spellings.
-Consuming a token there can only move the
-program rightward, never swallow one, so the fail-closed direction is also the correct one.
+Consuming a token there can only move the program rightward, never swallow one, so the
+fail-closed direction is also the correct one.
 
 ## An `export` reaches the next segment
 
-[#496](https://github.com/diazoxide/charter/issues/496). The plane-root guards read
-`GIT_DIR` / `GIT_WORK_TREE` off the env-assignment prefix attached to a git invocation. An
-`export` in an earlier segment of the same command line sets the same variable for the same
-shell and reaches the same git, and nothing read it.
+[#496](https://github.com/diazoxide/charter/issues/496). The plane-root guards read git's
+directory and work-tree variables off the env-assignment prefix attached to a git
+invocation. An `export` in an earlier segment of the same command line sets the same
+variable for the same shell and reaches the same git, and nothing read it.
 
 `_plane_root_git` already carried one shell effect across segments — a `cd`. The environment
 a command line establishes is the same shape of carried state, and it is computed once and
@@ -112,23 +115,22 @@ hand-written copy grows its own blind spots on its own schedule. The shapes mode
 ones a shell really exports with, each checked against bash 5 and zsh: `export NAME=VALUE`;
 `declare -x` / `typeset -x`, whose `x` bundles; `NAME=VALUE` in one segment and `export NAME`
 in a later one; and `set -a`, after which a bare assignment segment is exported too. A bare
-`NAME=VALUE` segment on its own is deliberately **not** — `FOO=1; <child>` leaves `FOO`
-unset in the child, so treating it as an export would be a denial invented out of nothing.
+`NAME=VALUE` segment on its own is deliberately **not** — `FOO=1; <child>` leaves `FOO` unset
+in the child, so treating it as an export would be a denial invented out of nothing.
 
 That environment only ever grows. `unset`, `export -n` and a subshell ending are not
 modelled, because forgetting a variable is the direction that opens a door — the same
 invariant `_git_target`'s subject list keeps. The boundary is `cd`'s boundary: a `$(…)`, a
-sourced file, and a `GIT_DIR` already in the session's environment before the hook ran are
+sourced file, and a git variable already in the session's environment before the hook ran are
 outside it, and for the last one the `PreToolUse` payload carries the command and the cwd,
 not the environment the command will inherit. Those are stated limits with tests on them,
 not gaps.
 
 **The sibling this one found.** The golden rule's one-credential guard reads the same env
-prefix, and had the identical hole:
-`export GIT_SSH_COMMAND=/tmp/k && git push` walked past it while
-`GIT_SSH_COMMAND=/tmp/k git push` was refused. Nobody had reported it. Both guards are wired
-to the same carried environment, so neither can be fixed while the other is left behind —
-which is how `GIT_DIR` came to be refused in one spelling and allowed in the next.
+prefix and had the identical hole, one variable over: the one that decides what git runs as
+its SSH transport. Both guards are wired to the same carried environment now, so neither can
+be fixed while the other is left behind — which is how the work-tree variable came to be
+refused in one spelling and allowed in the next.
 
 ## Three lines deleted, and one table row that had no grammar behind it
 
@@ -153,15 +155,16 @@ Every one of those deletions rests on a fact, and every one of those facts is no
 assertion, because "it happens to be equivalent today" is how a deleted guard comes back to
 life as a bypass.
 
-**The opposite finding is the more useful one**, and there were five: the `()` default on the
-value-flag lookup (without it `nohup -q cat <vault>` raises out of the leak guard, and a
-guard that raises is a guard that is not there); the `and toks` that stops `env -C` at the
-end of a segment popping from an empty list; the `except ValueError` that keeps an
-unbalanced `env -S "cat '<vault>"` from doing the same; the `base == "env"` beside the
-split-string test, without which `xargs -S 4096 cat <vault>` — `xargs` has a `-S` of its own,
-and it means something else — would unpack `4096` as a command and lose the reader; and the
-test that keeps a *separated* value from reporting its whole segment, which is what lets
-`env -C /tmp echo <vault>` stay allowed, because printing a path is not reading a file.
+**The opposite finding is the more useful one**, and there were five — each a line that
+looks removable and is load-bearing: the `()` default on the value-flag lookup, without which
+an unlisted wrapper flag raises out of the leak guard, and a guard that raises is a guard
+that is not there; the `and toks` that stops a chdir flag at the end of a segment popping
+from an empty list; the `except ValueError` that keeps an unbalanced quote inside a packed
+command from doing the same; the `base == "env"` beside the split-string test, without which
+`xargs` — which has a `-S` of its own, meaning something else — would unpack its argument as
+a command and lose the reader; and the test that keeps a *separated* value from reporting its
+whole segment, which is what lets `env -C /tmp echo <path>` stay allowed, because printing a
+path is not reading a file.
 
 ## What did not change
 
@@ -171,7 +174,27 @@ attempt to close that class. What it does close is three cases where the guard a
 modelled the thing and was matching one way of writing it — plus the sweep's four, which
 nobody had reported.
 
-Nothing to adopt: upgrading is the whole of it.
+## Are you exposed, and what do you do
+
+**Yes, if** you are on 0.53.0 or earlier and either of these is true:
+
+* You rely on the plugin's `PreToolUse` guard to keep an agent away from `.charter/vaults/`.
+  Fourteen spellings reached it. `SECURITY.md` already describes that guard as holding
+  against mistakes rather than against an attacker with shell access as your user, and these
+  do not change that ceiling — they lower where it sat.
+* **You rely on the one-credential rule** — that every git operation charter performs
+  authenticates with the forge CLI's token over HTTPS, never an SSH key. That is the one to
+  weigh, because it is not a read: a command line could arrange for git to use a transport of
+  its own choosing, and the guard that exists to refuse exactly that did not see it.
+
+**The fix is the upgrade.** There are no backport branches, and there is nothing to adopt
+beyond moving.
+
+**What to check afterwards, on the git half.** Look at what has actually been pushed from
+your plane and by what — `git log --format='%an %ae' -20` on the clones a plane owns, and
+your forge's audit log for pushes you cannot account for. If something you did not fully
+trust has had shell access as your user, rotate the forge token as well as anything in a
+vault; the guard was never the boundary.
 
 [#555](https://github.com/diazoxide/charter/issues/555),
 [#556](https://github.com/diazoxide/charter/issues/556),

--- a/docs/news/unreleased-the-files-under-charter-are-charters-to-choose.md
+++ b/docs/news/unreleased-the-files-under-charter-are-charters-to-choose.md
@@ -4,6 +4,11 @@ headline: the files under `.charter/` are 0600 because charter says so — a sta
 security: true
 ---
 
+**Affected: 0.53.0 and earlier. Fixed here.** Exposure needs a second account on the same
+machine, or a backup or disk image somebody else can read — and one of the files at stake
+is world-*writable* under a permissive umask, which makes this an integrity question and
+not only a disclosure one.
+
 0.53.0 settled the mode of every **directory** charter creates under `.charter/`: whichever
 writer gets there first, each level comes out 0700, and the umask does not get a say
 ([#470](https://github.com/diazoxide/charter/issues/470)). The **files** inside them were


### PR DESCRIPTION
## Why this is urgent rather than tidy

`SECURITY.md` states there are no maintained backport branches. Every reader still on 0.53.0 is therefore **permanently unpatched at the moment they learn the hole exists** — there is no patched 0.53.x to move sideways onto. Publishing a runnable bypass beside "we fixed it" arms exactly the people who can do least about it.

All eleven `security: true` entries reproduce and are correctly described. The defect was *how much* they described.

## What was redacted — three files actually leaked

| entry | what it handed over |
| --- | --- |
| `a-value-glued-to-a-short-flag…` | the bypass was **in the headline**; body line 1 spelled the real vault path |
| `an-option-is-its-letter…` | an **18-row ALLOW/DENY table** — 14 working techniques against a literal vault path, plus a runnable transport-substitution line |
| `a-repository-can-name-its-own-work-tree` | a **4-line runnable reproduction** for redirecting a checkout into the plane root |

Each keeps its full technical reasoning. What is gone is the assembled, runnable form — the part whose only use is running it.

`an-option-is-its-letter…`'s table is replaced by a severity summary that keeps every count and both classes: fourteen vault-read spellings, and two that reach past the git policy — one of which is **transport substitution**, not a read. The severity got *sharper*, not softer.

## One out-of-lane edit, flagged

The **non-security** entry `a-background-refresh…` announced in the **present tense** that a named command "is currently ALLOWED", with the literal vault path, in the same release that fixes it. That is the single highest-harm sentence in the set, so it is corrected to past tense with the command removed. **Nothing else in that file is touched** — its owner should know.

## What was deliberately kept

Every diagnostic block an operator needs to audit their own plane: the persona frontmatter examples, the state-file mode listings, charter's own report output. Those tell you whether you are exposed; they do not exploit anyone. Redaction here is surgical, not blanket — eight of the eleven needed no content removed at all.

## What was added

None of the eleven stated **the affected versions** or answered **"am I exposed, and what do I do"**. All eleven now do. Severity is unhedged:

- the tool-grant entry says a shift key is enough and no attacker is needed;
- the git entry names transport substitution and tells you to check your forge audit log;
- the fail-closed one says so plainly, rather than implying exposure it does not have.

`lead: true` goes on `an-option-is-its-letter…`. Nobody had claimed it on any of the 69, so the notes would have opened on the weakest of the eleven while the confirmed bypasses landed mid-block.

`SECURITY.md` gains the disclosure convention under **Supported versions**, where the no-backports fact already lives — including the statement that a note too vague to act on is itself a defect to report, so this cannot be cited later as licence for vagueness.

## Severity calls — argued, not applied

Per instruction, **no `security: true` flag was added or removed.** Three judgements for the maintainer:

1. **`a-withheld-credential-is-still-reported` is over-flagged — agreed.** Its failure direction is fail-closed: a credential is withheld and stays withheld. The clean test: the other visibility entries make visible a state where you are *less* protected than you think; this one makes visible a state where you are *more* protected. Only the former answers "am I exposed" with a yes.
2. **`a-name-ends-where-the-string-ends` is over-flagged — agreed, but it is the closer call.** The headline defect needs the ability to write arbitrary directories into a committed repo, which already grants strictly more than the bug does. The one thread worth pulling before demoting is `commands_secrets._ENV_NAME_RE`, the one admitter of the fourteen guarding a value written into a **dotenv file another process reads**.
3. **`a-retry-says-what-it-is-retrying` is under-flagged — agreed, and strongly.** The only check guarding an irreversible PyPI upload was skipped-and-therefore-green on the retry path. That is supply-chain integrity, and it outranks at least three currently-flagged entries.

## Two findings that outlive this PR

- **The repo is public and the linked issues carry the full reproductions.** `gh issue view 547` returns the working bypass in its *title*. Redacting the notes while those issues stand is half a fix — the notes were the half I own.
- **`lead:` cannot express "second most important".** `security:` is a class and `lead:` is one position, so a release with eleven security entries orders exactly one; the rest fall in filename-alphabetical order. The second-worst confirmed bypass still lands mid-block. Worth filing upstream.

## Verification

`charter news --for unreleased` renders, lead sorts first. `charter news --pending` clean. Full suite green — **8622 tests**, `unittest`, `env -u PYTHONSAFEPATH`.

No version bump, no stamp, no tag. `charter/news.py` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
