### PR TITLE
F2 switches between the chats of a workspace, and the panels move with it (Phase 5, Stage 5b — tasks 4, 6, 7)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -724,7 +724,7 @@ def _add_frame_parsers(sub) -> None:
     _core_commands = set(sub.choices) | {"frame", "panel", "frame-palette",
                                          "frame-probe", "frame-respawn", "frame-density",
                                          "frame-resize", "frame-gather", "frame-switch",
-                                         "frame-toggle", "frame-chrome"}
+                                         "frame-toggle", "frame-chrome", "frame-chat"}
 
     # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
     # already claimed each word, so a SECOND harness wanting it is told who got there
@@ -924,6 +924,30 @@ def _add_frame_parsers(sub) -> None:
     # (`#{@charter_chat}` in this component's own `bind -n`), same reason it is optional.
     tg.add_argument("--chat", dest="chat", default="")
     tg.set_defaults(func=commands_frame.cmd_toggle)
+
+    # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
+    # ones above. Started DETACHED by a palette row whose argv is exactly
+    # `util.self_relaunch_argv("frame-chat", <chat id>)`
+    # (`commands_frame._start_chat_switch`), and typeable by hand from inside a frame. It
+    # moves the tmux CLIENT to another chat of this workspace and re-lays-out the panels
+    # into the window tmux resized on the way (Phase 5 §3.7); charter.toml is not touched
+    # and neither is any frame's recorded identity, for `frame-density`'s reason.
+    #
+    # **Two chat ids, and they are two different questions.** The POSITIONAL is where to
+    # go — a name off a picker, or one typed. `--chat` is where the keypress came FROM,
+    # `frame-toggle`'s twin and from the same source (`#{@charter_chat}` expanded in the
+    # presser's own window), because one bind text is shared by every frame on the socket
+    # and `$CHARTER_SESSION_ID` cannot tell two chats of one workspace apart.
+    #
+    # Deliberately NOT `choices=`, and for a stronger version of `frame-toggle`'s
+    # argument: which chats exist is a property of the plane's frame directory at the
+    # moment the key fires, so there is no set for argparse to hold at parser-build time.
+    # `frame/chats.check` is the one gate, asked by this command and by the palette row
+    # that starts it.
+    ch = sub.add_parser("frame-chat")
+    ch.add_argument("chat_id")
+    ch.add_argument("--chat", dest="chat", default="")
+    ch.set_defaults(func=commands_frame.cmd_chat)
 
     # A TOP-LEVEL sibling of `frame` for a DIFFERENT reason than `frame-palette` above:
     # that one exists because `_split_frame_argv` eats everything

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4917,6 +4917,16 @@ def cmd_chat(args) -> int:
     :func:`_say_on_screen` instead.
     """
     fid = _pressers_chat(args)
+    if not fid:
+        # **Not fired from inside a frame at all, and unlike `cmd_toggle` this refusal is
+        # not free.** That command emits nothing by construction with an empty id, which
+        # is why the deletion sweep found its own `if not fid` equivalent and it was
+        # deleted. This one reaches :func:`_say_on_screen`, whose `-t <fid>` with an empty
+        # target resolves to whichever session on the SHARED server was attached most
+        # recently — so `charter frame-chat api.2` typed in an ordinary shell drew
+        # charter's refusal across somebody else's frame. Measured by hand against the
+        # real server, which is how it was found. `cmd_switch`'s guard, for its reason.
+        return 0
     target = (getattr(args, "chat_id", None) or "").strip()
     # Asked again rather than trusted from the palette that spawned this: the same
     # command is typeable by hand on a name nobody drew, and `chats.check` is the one

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4951,8 +4951,12 @@ def cmd_chat(args) -> int:
         # instant it matters. Nothing has been torn down at this point — the teardown is
         # below this line on purpose, so a chat whose window is gone costs the operator
         # nothing but a sentence.
-        _say_on_screen(fid, f"cannot switch: chat "
-                            f"'{contain.one_line(target)}' has no window any more")
+        # No `contain.one_line` on *target*: `chats.check` has already held it to
+        # `chats.ID_RE`, whose alphabet holds nothing `one_line` touches, so the call
+        # would be one whose result is provably its argument — the sweep found it as a
+        # survivor for that reason. `_say_on_screen`'s own `inert_format` is what makes
+        # this a tmux format's business rather than this line's.
+        _say_on_screen(fid, f"cannot switch: chat '{target}' has no window any more")
         return 0
     here = _relayout_target(fid)
     if here is not None:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4938,10 +4938,19 @@ def cmd_chat(args) -> int:
         _say_on_screen(fid, out.message)
         return 0
     socket = state.frame_server(fid) or SOCKET
-    # `chats.check` has already held this to `tmuxctl.PANE_ID_RE`, which is what makes it
-    # a `-t` target rather than a string off disk (#475). Read again rather than carried
-    # out of the check, so the value that reaches tmux is the one the file holds now.
-    pane = state.harness_pane(target) or ""
+    # `chats.pane_of` and never a bare `state.harness_pane`: the read is the same one
+    # `chats.check` made a moment ago, so this is a SECOND reading of a record that can
+    # have moved — a reap, a relaunch — and the fallback the sweep found here turned that
+    # into `select-window -t ""`. An empty tmux target resolves to the CURRENT window, so
+    # charter would have reported a switch that did not happen and then torn this chat's
+    # panels down around it. Its own sentence rather than the check's, because it is a
+    # different fact: the check answered about a record, and this is about that record
+    # going away underneath the answer.
+    pane = chats.pane_of(target)
+    if pane is None:
+        _say_on_screen(fid, f"cannot switch: chat '{target}' stopped being one while "
+                            "charter was switching to it")
+        return 0
     selected = tmuxctl.run("switching to the chat",
                            tmuxctl.server_argv(socket, "select-window", "-t", pane))
     if selected.returncode != 0:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -148,8 +148,8 @@ import sys
 import time
 
 from . import config, contain, harness, instance, tui, util, workspace
-from .frame import (builtin_actions, choose, component, gather, layout, overlay, pane,
-                    palette, picker, state, switch, tmuxctl)
+from .frame import (builtin_actions, chats, choose, component, gather, layout, overlay,
+                    pane, palette, picker, state, switch, tmuxctl)
 # Aliased: `cmd_launch` already has a local variable named `slots` (the VISIBLE slot
 # list `layout.visible_slots` returns) — importing the renderer registry under its own
 # name would be shadowed by that local the moment it's assigned, and a `slots.SLOTS`
@@ -4858,6 +4858,102 @@ def cmd_toggle(args) -> int:
 #: action still inside one after two seconds has broken the contract — at which point the
 #: palette closes anyway rather than holding a pane open on a hung action, which is the
 #: escape hatch's own argument applied one layer up.
+def cmd_chat(args) -> int:
+    """`charter frame-chat <chat id>` — put this client on another chat of this workspace.
+
+    Started DETACHED by a palette row (:func:`_draw_palette`), and typeable by hand from
+    inside a frame. The chat the keypress came from is :func:`_pressers_chat`'s, for its
+    reason: one bind text is shared by every frame on `SOCKET`, and a session now holds
+    several chats.
+
+    **Four steps, and every one of them is an existing path** (spec §3.7):
+
+    1. `select-window` at the target chat's own harness PANE. A pane id resolves to that
+       pane's window — measured on tmux 3.7c and on tmux 3.2 — which is why charter needs
+       no window-id record beside the pane record it already keeps
+       (`state.record_harness_pane`), and why there is no second thing to keep in step.
+    2. :func:`_apply_arrangement` with ``want=[]`` on the chat being left, which tears its
+       panels down. Not a saving — a correctness rule. A background window keeps STALE
+       geometry (§7.4, measured identically on 3.7c and 3.2), so panels left running there
+       are not idle, they are rendering at a width that is no longer their window's, which
+       is the exact defect `panel._component_text`'s `width=slots._width()` guard exists
+       for.
+    3. :func:`_apply_arrangement` on the chat being entered, which splits its panels into
+       the window **tmux has just resized**. Measured here on 3.7c and 3.2: the very next
+       tmux invocation after `select-window` already reports the target window at the
+       client's size (200x50 → 100x29 with no sleep at all). So the panels are born at the
+       true width and there is nothing stale to repair —
+    4. **which is why the switch never asks for a `window-resized` hook, and must not.**
+       On tmux 3.2 — `tmuxctl.FLOOR` — `set-hook -w window-resized` answers `invalid
+       option`, rc=1: the hook does not exist. A switch that relied on it would be correct
+       on the author's tmux and silently wrong on the floor charter promises to run on.
+       `_apply_arrangement` measures and re-asserts the layout itself, which is the same
+       thing a density change already does and not a second path.
+
+    The bump is step 3's own last line (`_apply_arrangement`), so the new chat's panels
+    repaint into the shape that has already settled — #411/#412's rule, and the reason
+    this does not write a pointer of its own for anything to read.
+
+    **Both re-layouts are attempted independently, and a failure of the first does not
+    cancel the second.** They are two different frames' panes; the one the operator is now
+    looking at is the one that matters, and abandoning it because the window they just
+    left could not be tidied would leave them on a bare harness pane. The reverse — the
+    old chat keeping its panels because the new one could not be laid out — is a frame
+    that is merely untidy in a window nobody is looking at.
+
+    **`select-pane` is deliberately not issued here and neither is anything to undo the
+    palette's own close.** Measured on 3.7c and on 3.2: `select-pane -t %N` where `%N` is
+    in another window of the same session sets that window's active pane and does **not**
+    move the client — current window `@0` before and `@0` after. So `_close_palette`,
+    which runs in the palette's own process after this one has been started and aims
+    `select-pane` at the chat being LEFT, cannot drag the client back off the chat this
+    just switched to. That measurement is what makes the switch safe to detach at all;
+    without it the two processes would be racing for which window the operator ends on.
+
+    **Always 0**, like every other `frame-*` command: this runs detached with its streams
+    on `/dev/null` (`builtin_actions._spawn`), so a non-zero exit is read by nothing —
+    and inside a `run-shell` it is what makes tmux print into the harness pane, the one
+    rectangle ADR 0018 says charter never draws in. Every refusal goes to
+    :func:`_say_on_screen` instead.
+    """
+    fid = _pressers_chat(args)
+    target = (getattr(args, "chat_id", None) or "").strip()
+    # Asked again rather than trusted from the palette that spawned this: the same
+    # command is typeable by hand on a name nobody drew, and `chats.check` is the one
+    # rule both askers get (see `choose.switch_to`). It is also a second reading of a
+    # plane that has moved since the palette opened — a chat reaped between the keypress
+    # and here is refused with its own sentence rather than aimed at.
+    out = chats.check(fid, target)
+    if not out.ok:
+        _say_on_screen(fid, out.message)
+        return 0
+    socket = state.frame_server(fid) or SOCKET
+    # `chats.check` has already held this to `tmuxctl.PANE_ID_RE`, which is what makes it
+    # a `-t` target rather than a string off disk (#475). Read again rather than carried
+    # out of the check, so the value that reaches tmux is the one the file holds now.
+    pane = state.harness_pane(target) or ""
+    selected = tmuxctl.run("switching to the chat",
+                           tmuxctl.server_argv(socket, "select-window", "-t", pane))
+    if selected.returncode != 0:
+        # The one refusal `chats.check` deliberately does not guess at, and the reason it
+        # does not: liveness is a question only tmux can answer, and answering it in the
+        # check would be answering it at the instant the palette opened rather than at the
+        # instant it matters. Nothing has been torn down at this point — the teardown is
+        # below this line on purpose, so a chat whose window is gone costs the operator
+        # nothing but a sentence.
+        _say_on_screen(fid, f"cannot switch: chat "
+                            f"'{contain.one_line(target)}' has no window any more")
+        return 0
+    here = _relayout_target(fid)
+    if here is not None:
+        _apply_arrangement(fid, where=here, want=[])
+    there = _relayout_target(target)
+    if there is not None:
+        _apply_arrangement(target, where=there,
+                           want=_visible_now(target, config.FRAME))
+    return 0
+
+
 def _pressers_chat(args) -> str:
     """Which chat the keypress that started this process was fired in.
 
@@ -5057,6 +5153,8 @@ def _draw_palette(args) -> int:
         if picked is not None:
             noun, name = picked
             out = choose.switch_to(noun, fid, name)
+            if out.ok and noun == choose.CHAT:
+                _start_chat_switch(fid, name)
             _say_on_screen(fid, out.message, client)
             return 0
         if choose.noun_of(chosen) is not None:
@@ -5072,6 +5170,35 @@ def _draw_palette(args) -> int:
         _close_palette(socket, harness=harness,
                        overlay_pane=os.environ.get("TMUX_PANE", ""))
     return 0
+
+
+def _start_chat_switch(fid: str, chat: str) -> None:
+    """Start :func:`cmd_chat` for *chat*, detached, and return having started it.
+
+    **Fire-and-report, and this is the one place the chat switch could have failed to
+    be** (§4g). Every other row the palette runs is a detached process for a measured
+    reason `builtin_actions._spawn` records: the palette closes the instant it has
+    invoked, `kill-pane` hands SIGHUP to that pane's process group, and a switch that ran
+    in this process would be racing its own teardown for the last three of its four tmux
+    calls. Detaching also keeps the palette's promise that a row returns immediately: the
+    switch is ~20 tmux round trips, and a palette that sat through them would be a pane
+    the operator is watching do nothing.
+
+    **What makes detaching SAFE is a measurement, not an assumption.** On 3.7c and on
+    3.2, `select-pane -t %N` on a pane in another window of the same session does not
+    move the client (current window `@0` before and after) — so `_close_palette`, which
+    runs from the `finally` below and aims `select-pane` at the chat being LEFT, cannot
+    pull the client back off the window `cmd_chat` is switching to. The two processes are
+    not racing for the operator's screen; only one of them moves it.
+
+    `builtin_actions._spawn` and not a `Popen` here, because *which* frame the child acts
+    on must be stated rather than inherited: this process is a `run-shell` child of a tmux
+    server shared between every frame on the machine, and its own `$CHARTER_SESSION_ID`
+    may be another chat's (`state.record_identity` measures exactly that). The child is
+    handed the PRESSER's chat as its own id and the target on its argv, which is the same
+    split `frame-toggle`'s `--chat` already makes.
+    """
+    builtin_actions._spawn(util.self_relaunch_argv("frame-chat", chat), fid=fid)
 
 
 def _picker(row, fid: str, opened: list) -> "palette.Palette | None":

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -74,7 +74,7 @@ numbers of their own and are never placed, which `Registry.on_edge` is what enfo
 
 from __future__ import annotations
 
-from .component import Component, Content, Fill, Fixed
+from .component import EDGES, Component, Content, Fill, Fixed
 from .registry import Registry
 
 #: Component id → the `[frame] slots` name it is spelled with in a committed charter.toml
@@ -119,6 +119,34 @@ def component_id(name):
     away from the line that was wrong.
     """
     return COMPONENT_OF.get(name, name) if isinstance(name, str) else name
+
+
+def places(cid) -> bool:
+    """Whether charter's OWN registry puts *cid* on an edge — a component a plane may
+    place, whether or not it has a committed slot-name spelling.
+
+    **The question `SLOT_OF` was standing in for, asked directly.** That table is the
+    shorthand between two vocabularies — a committed `[frame] slots` name and a component
+    id — and three separate places had come to read "is it in `SLOT_OF`" as "is it one of
+    charter's own placeable components". Those were the same set for as long as every
+    component charter placed had a slot name, and Phase 5's two bars are the first that do
+    not: they have no committed spelling, because there is no `[frame] slots` word for a
+    thing that did not exist when that list was frozen, and adding one would put them on
+    every operator's frame (`build`'s own comment measures what that costs).
+
+    Without this the bars would be registered and unplaceable — a component charter can
+    draw that no configuration can ask for, which is dead code wearing a feature's name.
+    With it they are exactly as placeable as a provider's component, through the one form
+    that can place one: a `[[frame.component]]` table.
+
+    `Registry.on_edge` is what answers, so a composite's PARTS are excluded for free —
+    `personas`, `todos` and `changes` are drawn inside the sidebar's pane, and a part that
+    could be placed as well would be drawn twice.
+    """
+    if not isinstance(cid, str):
+        return False
+    reg = build()
+    return any(c.id == cid for edge in EDGES for c in reg.on_edge(edge))
 
 
 def supplies(cid) -> bool:
@@ -239,6 +267,23 @@ def _repos_events(fid: str):
         return True
 
     return on_event
+
+
+def _chats(ctx) -> list[str]:
+    """The chat bar — `slots.chats_bar` at this pane's OWN width.
+
+    `ctx.width`, unlike the four wrapped whole-pane renderers (:func:`_panel`), which
+    measure their own tty and ignore it. A bar written for the contract can read the
+    geometry the contract carries, and this is the first charter component that does.
+    """
+    from . import slots
+    return slots.chats_bar(ctx.fid, ctx.width)
+
+
+def _workspaces(ctx) -> list[str]:
+    """The workspace bar — `slots.workspaces_bar` at this pane's own width."""
+    from . import slots
+    return slots.workspaces_bar(ctx.fid, ctx.width)
 
 
 def _personas(ctx) -> list[str]:
@@ -371,4 +416,31 @@ def build(fid: str = "") -> Registry:
         id="sidebar", title="sidebar", edge="right", size=Fixed(22),
         needs=("gather", "changes"), render=_panel("right"),
         children=("personas", "todos", "changes")))
+    # **Phase 5's two bars, and they are REGISTERED but not PLACED** — the same shape
+    # `changes` takes above, and for a stronger version of its argument.
+    #
+    # `changes` is not in `SLOT_OF` because a plane with no cross-repo change is the
+    # ordinary, permanent state and a pane saying so on every frame is a pane earning
+    # nothing. A plane with ONE chat is that state too, and the numbers are worse rather
+    # than better: measured on this tree, a chat switch is 41 tmux invocations and ~360 ms
+    # (3.7c) / ~395 ms (3.2) with four panels, and each placed pane is ~7 of those
+    # invocations on the way out and back — so a bar placed by default makes every switch
+    # slower for every operator, permanently, to draw a name most of them already know
+    # from `top`. The palette reaches every chat in two keystrokes at every width (§3.6:
+    # the bar is a readout, not the mechanism), so nothing is unreachable without them.
+    #
+    # A plane that wants a bar writes a `[[frame.component]]` table — which is also the
+    # only way any component gets a toggle key, built-in or not, and a key on the chat bar
+    # is exactly what an operator who wants it occasionally should have.
+    #
+    # Both declare nothing in `needs`: neither renderer goes near `gather`.
+    # `slots.chats_bar` reads `.charter/frame/` and `slots.workspaces_bar` reads
+    # `workspaces/`, and a declaration naming a slice `ctx` carries would make the frame's
+    # cost budget describe a cost that is not there — `identity`'s own reasoning, above.
+    reg.register(Component(
+        id="chats", title="chats", edge="top", size=Fixed(1),
+        needs=(), render=_chats))
+    reg.register(Component(
+        id="workspaces", title="workspaces", edge="top", size=Fixed(1),
+        needs=(), render=_workspaces))
     return reg

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -11,10 +11,16 @@ is no private table of edges beside the one a provider's component will be place
 strips are a fixed height, which one takes what its content needs — from
 :func:`build`'s registry, and nothing derives them from a list position any more.
 
-**This task changed no output, and that is the point.** Each component wraps the renderer
-`frame/slots.py` already had, unchanged; the six declarations below are a statement of
-what those renderers already do, not a new arrangement. The before/after render at 200x50
-and 80x24 is byte-identical.
+**Phase 1's own task changed no output, and that was its point.** Each of the components
+below wraps a renderer `frame/slots.py` already had, unchanged; those declarations are a
+statement of what the renderers already do, not a new arrangement, and the before/after
+render at 200x50 and 80x24 was byte-identical.
+
+**Phase 5's two bars are the first entries here that are not that**, and they change no
+output either — for a different reason. `chats` and `workspaces` are registered and NOT
+placed (see :func:`build`), so nothing draws them until a plane writes a
+`[[frame.component]]` table naming one. :func:`places` is the question that makes that
+route work at all.
 
 **The slot names survive as SHORTHAND, because they are committed** (:data:`SLOT_OF`).
 `[frame] slots = ["top", "bottom", "repos", "right"]` sits in charter.toml on every plane
@@ -69,7 +75,9 @@ that a click SELECTS and never chooses, because a pointer event can arrive unpai
 are registered in the order charter splits their panes off the harness: identity,
 attention, repos, sidebar. The two parts of the sidebar are registered between them,
 because the registry refuses a composite whose parts it has not seen — they take split
-numbers of their own and are never placed, which `Registry.on_edge` is what enforces.
+numbers of their own and are never placed, which `Registry.on_edge` is what enforces. The
+two bars are registered LAST, after everything charter places, so adding them moved no
+existing component's split number.
 """
 
 from __future__ import annotations
@@ -127,8 +135,9 @@ def places(cid, reg: Registry | None = None) -> bool:
 
     **The question `SLOT_OF` was standing in for, asked directly.** That table is the
     shorthand between two vocabularies — a committed `[frame] slots` name and a component
-    id — and three separate places had come to read "is it in `SLOT_OF`" as "is it one of
-    charter's own placeable components". Those were the same set for as long as every
+    id — and two separate places had come to read "is it in `SLOT_OF`" as "is it one of
+    charter's own placeable components" (`instance.component_tables` and
+    `slots.drawable`). Those were the same set for as long as every
     component charter placed had a slot name, and Phase 5's two bars are the first that do
     not: they have no committed spelling, because there is no `[frame] slots` word for a
     thing that did not exist when that list was frozen, and adding one would put them on

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -162,8 +162,14 @@ def places(cid, reg: Registry | None = None) -> bool:
     charter had then, which is wrong for a long-lived process and wrong in the direction
     that is hard to see.
     """
-    if not isinstance(cid, str):
-        return False
+    # **No `isinstance` refusal, and the deletion sweep is why.** This is asked of a value
+    # read out of a committed `charter.toml`, so a TOML array or table can reach it — and
+    # `Registry.on_edge` answers with components whose `id` is always a string, so
+    # `c.id == cid` is already False for every one of them. A guard in front of that is a
+    # line no input can make observable, which the sweep found as a survivor. The property
+    # it was protecting is structural rather than guarded, and
+    # `ABarIsPlaceableByConfig.test_places_refuses_anything_that_is_not_a_name` keeps
+    # asking for it.
     if reg is None:
         reg = build()
     return any(c.id == cid for edge in EDGES for c in reg.on_edge(edge))

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -121,7 +121,7 @@ def component_id(name):
     return COMPONENT_OF.get(name, name) if isinstance(name, str) else name
 
 
-def places(cid) -> bool:
+def places(cid, reg: Registry | None = None) -> bool:
     """Whether charter's OWN registry puts *cid* on an edge — a component a plane may
     place, whether or not it has a committed slot-name spelling.
 
@@ -142,10 +142,21 @@ def places(cid) -> bool:
     `Registry.on_edge` is what answers, so a composite's PARTS are excluded for free —
     `personas`, `todos` and `changes` are drawn inside the sidebar's pane, and a part that
     could be placed as well would be drawn twice.
+
+    *reg* is a registry the caller already has. `instance.component_tables` builds one to
+    resolve the arrangement and then asks this once per table, so without it a committed
+    `[[frame.component]]` list would rebuild the registry per row — on the path of every
+    charter command, `charter --version` included, since `config.derive` resolves `FRAME`
+    at import. ``None`` builds one, which is what the callers that have none do
+    (`slots.drawable`, and every test). It is a parameter and not a module-level cache for
+    `supplies`' reason: a registry kept from the first ask answers for the ``sys.path``
+    charter had then, which is wrong for a long-lived process and wrong in the direction
+    that is hard to see.
     """
     if not isinstance(cid, str):
         return False
-    reg = build()
+    if reg is None:
+        reg = build()
     return any(c.id == cid for edge in EDGES for c in reg.on_edge(edge))
 
 

--- a/charter/frame/chats.py
+++ b/charter/frame/chats.py
@@ -144,6 +144,25 @@ def of_workspace(workspace: str) -> list[str]:
                   key=_order)
 
 
+#: How many digits an ordinal `state.new_chat_id` can mint has, derived from its own
+#: ceiling rather than written down twice.
+#:
+#: **It is a bound on `int()`, not on taste.** CPython refuses to convert a string of more
+#: than 4,300 digits to an integer — `int("9" * 5000)` raises `ValueError`, not
+#: `OverflowError` — and a name off `os.scandir` is whatever is on disk. Without this, a
+#: directory called `api.<5000 nines>` under `.charter/frame/` would raise out of
+#: `sorted`, in a panel's render path, and take the bar down with it. The state directory
+#: is 0700 and `SECURITY.md:43-46` is honest about what that is worth; this is a guard
+#: against a mistake, and the mistake is a crash where a sort was wanted.
+#:
+#: Bounded HERE and not in :func:`is_chat`, deliberately: that function is Stage 5a's
+#: version discriminator, and teaching it about ordinal size would make `api.100000` —
+#: perfectly parseable, merely above the allocator's ceiling — stop being a chat and
+#: start being reaped by the wrong rule. A name this cannot read the ordinal of is still
+#: a chat; it just sorts with the others it cannot read.
+_MAX_ORDINAL_DIGITS = len(str(state._CHAT_ORDINAL_MAX))
+
+
 def _order(fid: str) -> tuple[int, int, str]:
     """Sort key for :func:`of_workspace` — ordinal first, unparsable names last.
 
@@ -158,7 +177,7 @@ def _order(fid: str) -> tuple[int, int, str]:
     That is the shape `state.frame_workspace` names for its own `valid_name`.
     """
     _head, sep, tail = fid.rpartition(state._CHAT_SEP)
-    if sep and tail.isdigit():
+    if sep and tail.isdigit() and len(tail) <= _MAX_ORDINAL_DIGITS:
         return (0, int(tail), fid)
     return (1, 0, fid)
 

--- a/charter/frame/chats.py
+++ b/charter/frame/chats.py
@@ -1,0 +1,269 @@
+"""Which chats a workspace holds, which one you are in, and which may be switched to.
+
+**The reading half of Phase 5's switch. Nothing here touches tmux and nothing here
+starts anything** — `frame/switch.py`'s own rule, kept for its own reason: this is what
+a panel process asks on every repaint and what the palette asks when it opens, and a
+module that shelled out to tmux to answer would be a round trip on both paths.
+`commands_frame.cmd_chat` is the tmux half.
+
+**The directory IS the list** (spec §3.5). There is no per-workspace index of chats,
+because an index is a second source of truth for a fact `.charter/frame/` already holds
+and is free to disagree with it — the #411 shape. So :func:`of_workspace` scans, and
+what it scans is bounded by `state.reap`, which is the only thing bounding that
+directory at all.
+
+**Two things tell a chat from an old frame, and only one of them is a name.** A chat's
+id is `{workspace}.{n}` and an old frame's is `{workspace}-{pid}`, so
+`state._launcher_pid` answers ``None`` for the first and an integer for the second —
+that ``None`` is Stage 5a's version discriminator and it is asked here rather than
+re-derived, because a second reading of "is this a chat" is a second answer. The other
+is `state.frame_workspace`, which is a FILE and can be repointed: a renamed workspace's
+chats keep ids spelling the old name and still belong to the new one (spec §3.2), so
+membership is never read off the id's prefix.
+
+**A directory name is not an identity either.** Every id here comes off `os.scandir`,
+which means it is whatever is on disk — and it goes on to a palette row, to a
+`charter frame-chat <id>` argv and, one hop later, to a tmux target. :data:`ID_RE` is
+the alphabet a frame id travels to tmux under (`commands_frame._FRAME_ID_RE`, the same
+expression asked at the same boundary), and it is applied HERE, where the name enters
+charter's own vocabulary, rather than at each of the three places it leaves it. The
+state directory is 0700 and `SECURITY.md:43-46` is honest about what that is worth; this
+is a guard against a mistake, and the mistake it is against is a name reaching a row or
+an argv unexamined.
+
+**What is drawn is contained by whatever draws it, and never here.** `overlay.Surface`
+runs `contain.one_line` over every title and note before `tui.width` sees them (#472),
+and the bars run it before their own width arithmetic. A second containment on the way
+out of this module would be a line no test could go red without — `frame/choose.py`
+records the same finding about `builtin_actions._register_names`, whose masked
+`contain.one_line` stayed green over its own deletion.
+
+**There is no `label` file, and its absence is a decision rather than an omission.**
+Spec §3.5 asks for one per chat, an open-alphabet display name. Nothing in this stage
+writes one: renaming a chat is not a task here, and a reader whose writer does not exist
+is a line no test can turn red — the shape this repository deletes rather than
+documents (`state.new_chat_id`'s own unreachable `None` went the same way in Stage 5a).
+What a chat is CALLED today is its id and the harness recorded beside it, and both of
+those are real values off disk that the containment tests are measured against. The file
+arrives with the stage that writes one.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import NamedTuple
+
+from .. import contain
+from . import state, tmuxctl
+from .switch import Outcome, _some
+
+#: The alphabet a chat id may be spelled in — `commands_frame._FRAME_ID_RE`'s, and the
+#: same expression on purpose. That is the alphabet `state.workspace_prefix` mints in and
+#: the one a frame id has to survive to reach a tmux argv, so asking it here means the
+#: three exits from this module (a palette row, a `frame-chat` argv, a `select-window`
+#: target) are asking one question once rather than three times differently.
+#:
+#: `fullmatch`, never `search`: a directory called `api.1;kill-server` contains a name
+#: this pattern matches and is not one.
+ID_RE = re.compile(r"[A-Za-z0-9._-]+")
+
+
+class Chat(NamedTuple):
+    """One chat of a workspace, as every surface that draws one reads it.
+
+    Carried as a record rather than assembled per surface, so the bar, the picker and
+    the refusal cannot come to disagree about what a chat is called or which one is
+    active — the same reason `choose.Roster` carries its rows and its names together.
+    """
+
+    #: The chat id, held to :data:`ID_RE`. Charter's own currency: it is the frame
+    #: directory's name, `$CHARTER_SESSION_ID` inside the pane, and `@charter_chat` on
+    #: the window.
+    id: str
+    #: The harness recorded for it (`CHARTER_HARNESS`, `harness.base.name`), or ``""``
+    #: for a chat whose identity file charter could not read. Display text with an open
+    #: alphabet — it is a harness's own display name — so it is contained where it is
+    #: drawn and never here.
+    harness: str
+    #: Whether this is the chat asking.
+    active: bool
+
+
+def is_chat(fid: str) -> bool:
+    """Whether *fid* names a chat rather than an old `{workspace}-{pid}` frame.
+
+    `state._launcher_pid` and nothing else, for the module docstring's reason: Stage 5a
+    made that ``None`` the version discriminator, and a second rule for the same question
+    (say, "does it contain a dot") would answer differently for a workspace called
+    `v1.2`. The id is still held to :data:`ID_RE` here, because this is where a name off
+    `os.scandir` enters charter's vocabulary.
+    """
+    return bool(ID_RE.fullmatch(fid)) and state._launcher_pid(fid) is None
+
+
+def of_workspace(workspace: str) -> list[str]:
+    """Every chat id whose record names *workspace*, in ordinal order.
+
+    **Ordinal order, and it is not `created`'s.** Spec §3.5 asks for a `created` stamp
+    per chat "so tab order and the ordinal allocator do not depend on directory mtime".
+    Neither does: the allocator counts upwards from 1 claiming directories
+    (`state.new_chat_id`) and never reads a timestamp, and sorting by the ordinal gives
+    allocation order for every chat that has not outlived a reap. Where the two differ —
+    an ordinal freed by `state.reap` and handed out again — ordinal order is the one a
+    tab bar wants: `api.1` stays leftmost, where an operator learned to look for it,
+    instead of jumping to the end because it happens to be the newest. So there is no
+    `created` file and nothing to keep in step with the directory.
+
+    A name that is not an ordinal sorts by its text, after every name that is. That is
+    the migration and corruption case rather than a shape charter mints, and it is
+    ordered rather than dropped for `frame_workspace`'s reason: a chat charter cannot
+    read the ordinal of is still a chat, and leaving it out of the list would leave it
+    out of the picker while its window is on screen.
+
+    The scan is `os.scandir` over ~30 entries and it is asked when a palette opens and
+    when a bar repaints, not on a tick. `state.reap` is what bounds it.
+    """
+    root = state._root()
+    out: list[str] = []
+    try:
+        entries = list(os.scandir(root))
+    except OSError:
+        # No frame root at all is an ordinary answer on a plane that has never launched
+        # one, and an unreadable one is the same answer for the caller: no chats to
+        # offer. Never a raise — a bar that could not scan draws nothing, and a picker
+        # that could not scan refuses with its own sentence one layer up.
+        return []
+    for entry in entries:
+        try:
+            if not entry.is_dir():
+                continue
+        except OSError:
+            continue
+        if not is_chat(entry.name):
+            continue
+        if state.frame_workspace(entry.name) != workspace:
+            continue
+        out.append(entry.name)
+    return sorted(out, key=_order)
+
+
+def _order(fid: str) -> tuple[int, int, str]:
+    """Sort key for :func:`of_workspace` — ordinal first, unparsable names last.
+
+    Split out so the ordering is a thing a test can hand a list of names to without a
+    plane underneath it, and so the two halves of "unparsable sorts last" are one
+    expression rather than a branch in the loop above.
+    """
+    head, sep, tail = fid.rpartition(state._CHAT_SEP)
+    if sep and head and tail.isdigit():
+        return (0, int(tail), fid)
+    return (1, 0, fid)
+
+
+def harness_of(fid: str) -> str:
+    """The harness name recorded for chat *fid*, or ``""``.
+
+    `state.identity`, which is what the LAUNCH put on tmux's `-e` — never
+    `os.environ["CHARTER_HARNESS"]`. This is asked by a palette and by a panel, both of
+    which are children of a tmux server shared between every frame on the machine, so
+    this process's own variable may be another chat's (`state.record_identity` measures
+    exactly that).
+
+    ``""`` for a chat charter has no identity record for, which is the migration case and
+    an ordinary one — a bar draws the id alone rather than inventing a harness.
+    """
+    return state.identity(fid).get("CHARTER_HARNESS", "").strip()
+
+
+def roster(fid: str) -> list[Chat]:
+    """Every chat in *fid*'s workspace, with *fid* marked.
+
+    **Keyed on the FRAME's workspace, not this process's** (#512) — `state.workspace_for`
+    is the one rule every frame surface asks, and resolving locally would list another
+    plane's chats on this frame's screen.
+
+    *fid* itself is folded in whether or not the scan found it, and that is the honest
+    answer rather than a convenience: a frame whose `workspace` file could not be read is
+    still the chat you are typing in, and a bar that omitted the active chat would be
+    drawing a list the operator is not in. It is folded in at the FRONT of nothing —
+    :func:`of_workspace`'s order decides where it lands, so the active chat does not move
+    to the end of the bar because its record was unreadable.
+    """
+    names = of_workspace(state.workspace_for(fid))
+    if fid and is_chat(fid) and fid not in names:
+        names = sorted([*names, fid], key=_order)
+    return [Chat(id=n, harness=harness_of(n), active=n == fid) for n in names]
+
+
+def others(fid: str) -> list[str]:
+    """The chat ids in *fid*'s workspace that are not *fid*.
+
+    What "is there anything to switch to" is asked as, in one place, so the doorway that
+    refuses a picker and the bar that hides itself cannot answer it differently.
+    """
+    return [c.id for c in roster(fid) if not c.active]
+
+
+#: What a frame alone in its workspace is told instead of a picker over one row —
+#: itself. Its own sentence rather than `choose.NO_CHANGES`': that one is about a
+#: workspace with no cross-repo change, this is about a workspace with nothing to switch
+#: BETWEEN, and it names what makes a second one rather than leaving the operator to
+#: guess. A picker over the row you are already on is an offer charter knows it cannot
+#: honour, which is the same rule the change doorway keeps.
+ONLY_CHAT = ("this workspace has one chat — open another with `charter <harness>` in "
+             "this workspace, and it joins this one as a second tab")
+
+
+def check(fid: str, chat: str) -> Outcome:
+    """Whether frame *fid* may switch to *chat*, and the one line to say either way.
+
+    **Validation only: nothing here selects a window, and that is what lets the palette
+    and `charter frame-chat` ask the same question.** The palette asks it before it
+    spawns, so a refusal reaches the pane the operator is still looking at; the command
+    asks it again because it is also typeable by hand, on a name nobody drew. Two
+    askers, one rule — the shape `switch.to_workspace` already has for a name off a
+    picker and a name off an argv.
+
+    Refusals, in the order they are checked, and each names a thing the operator can act
+    on:
+
+    * **not a chat id** — :data:`ID_RE`, the alphabet a frame id reaches tmux under. A
+      name off a picker charter built cannot fail this; one typed at `charter frame-chat`
+      can, and it is the last point before the name becomes a state path.
+    * **not a chat of this workspace** — an unknown name is a question, never an implicit
+      create (`switch.py`'s rule, one noun over), and the existing names go in the message
+      the way `switch.to_workspace` already answers an unknown workspace.
+    * **already here** — refused rather than performed. A switch to the chat you are in
+      would tear down this chat's panels and split them again for no change on screen,
+      which is a re-layout an operator did not ask for and ~90 ms of blank panes; and the
+      row is drawn with `choose.MARK` beside it, so the operator can see they are already
+      there before they press it.
+    * **no usable harness pane** — the target's window cannot be named. `select-window`
+      is aimed at the chat's own harness pane (measured on tmux 3.7c and 3.2: a pane id
+      resolves to that pane's window), and `state.harness_pane` is the record that holds
+      it. A chat launched by a charter that predates that record, or one whose directory
+      was truncated, has nothing to aim at — and guessing at a pane id is the one thing
+      `frame/layout.py`'s module docstring measures the cost of. `tmuxctl.PANE_ID_RE` and
+      not merely "non-empty", for #475's reason and at #475's boundary: this value comes
+      off disk and is about to be a `-t` target, and `%1;kill-server` in that file is
+      the shape that already cost this project a `kill-server` armed on every resize.
+
+    **Liveness is deliberately NOT a refusal here**, and that is not an oversight: it is
+    the one question this module cannot answer without tmux, and asking it twice — once
+    for the row and once for the switch — would be two answers to it. `cmd_chat` selects
+    the window and reports what tmux said, which is the reading that is true at the
+    instant it matters rather than the instant the palette opened.
+    """
+    shown = contain.one_line(chat)
+    if not ID_RE.fullmatch(chat or ""):
+        return Outcome(False, f"'{shown}' cannot name a chat")
+    names = [c.id for c in roster(fid)]
+    if chat not in names:
+        return Outcome(False, f"no chat '{shown}' here — have: {_some(names)}")
+    if chat == fid:
+        return Outcome(False, f"already in chat '{shown}'")
+    if not tmuxctl.PANE_ID_RE.fullmatch(state.harness_pane(chat) or ""):
+        return Outcome(False, f"charter has no usable record of chat {shown}'s harness "
+                              "pane, so it cannot find its window — relaunch that chat")
+    return Outcome(True, f"chat → {shown}")

--- a/charter/frame/chats.py
+++ b/charter/frame/chats.py
@@ -124,28 +124,24 @@ def of_workspace(workspace: str) -> list[str]:
     The scan is `os.scandir` over ~30 entries and it is asked when a palette opens and
     when a bar repaints, not on a tick. `state.reap` is what bounds it.
     """
-    root = state._root()
-    out: list[str] = []
     try:
-        entries = list(os.scandir(root))
+        # `is_dir()` inside the same `try` as the scan, deliberately, and it is one guard
+        # rather than two. A `DirEntry.is_dir()` can raise `OSError` of its own — a
+        # `stat` on an entry that went away between the scan and the question, or one the
+        # process may not stat — and a second `try` around it would be a line that only a
+        # race could turn red, which is a line no test can pin. Answered the same way for
+        # the same reason the outer one is: a bar that could not read the directory draws
+        # nothing.
+        names = [e.name for e in os.scandir(state._root()) if e.is_dir()]
     except OSError:
-        # No frame root at all is an ordinary answer on a plane that has never launched
+        # No frame root at all is the ordinary answer on a plane that has never launched
         # one, and an unreadable one is the same answer for the caller: no chats to
-        # offer. Never a raise — a bar that could not scan draws nothing, and a picker
-        # that could not scan refuses with its own sentence one layer up.
+        # offer. Never a raise — a picker that could not scan refuses with its own
+        # sentence one layer up.
         return []
-    for entry in entries:
-        try:
-            if not entry.is_dir():
-                continue
-        except OSError:
-            continue
-        if not is_chat(entry.name):
-            continue
-        if state.frame_workspace(entry.name) != workspace:
-            continue
-        out.append(entry.name)
-    return sorted(out, key=_order)
+    return sorted((n for n in names
+                   if is_chat(n) and state.frame_workspace(n) == workspace),
+                  key=_order)
 
 
 def _order(fid: str) -> tuple[int, int, str]:
@@ -154,9 +150,15 @@ def _order(fid: str) -> tuple[int, int, str]:
     Split out so the ordering is a thing a test can hand a list of names to without a
     plane underneath it, and so the two halves of "unparsable sorts last" are one
     expression rather than a branch in the loop above.
+
+    **`sep` and not `head`.** `rpartition` answers `("", "", name)` for a name with no
+    separator in it, so the empty separator already refuses `api5` — a truthiness test on
+    the head would be a second guard for the case the first one caught, and the only name
+    it could tell apart is `.5`, whose ordinal is as good an answer as sorting it last.
+    That is the shape `state.frame_workspace` names for its own `valid_name`.
     """
-    head, sep, tail = fid.rpartition(state._CHAT_SEP)
-    if sep and head and tail.isdigit():
+    _head, sep, tail = fid.rpartition(state._CHAT_SEP)
+    if sep and tail.isdigit():
         return (0, int(tail), fid)
     return (1, 0, fid)
 

--- a/charter/frame/chats.py
+++ b/charter/frame/chats.py
@@ -125,14 +125,14 @@ def of_workspace(workspace: str) -> list[str]:
     when a bar repaints, not on a tick. `state.reap` is what bounds it.
     """
     try:
-        # `is_dir()` inside the same `try` as the scan, deliberately, and it is one guard
-        # rather than two. A `DirEntry.is_dir()` can raise `OSError` of its own — a
-        # `stat` on an entry that went away between the scan and the question, or one the
-        # process may not stat — and a second `try` around it would be a line that only a
-        # race could turn red, which is a line no test can pin. Answered the same way for
-        # the same reason the outer one is: a bar that could not read the directory draws
-        # nothing.
-        names = [e.name for e in os.scandir(state._root()) if e.is_dir()]
+        # **No `is_dir()` filter, and the deletion sweep is what settled that too.** It
+        # reads as the obvious first question and it cannot change the answer: a frame's
+        # workspace is a FILE inside its directory, so `frame_workspace` answers ``None``
+        # for a loose file whatever its name is, and the filter below already refuses it.
+        # A guard that passes only because a different guard caught it is the shape this
+        # repository deletes. What it cost was one `stat` per entry, which the read below
+        # pays anyway.
+        names = [e.name for e in os.scandir(state._root())]
     except OSError:
         # No frame root at all is the ordinary answer on a plane that has never launched
         # one, and an unreadable one is the same answer for the caller: no chats to
@@ -212,7 +212,7 @@ def roster(fid: str) -> list[Chat]:
     to the end of the bar because its record was unreadable.
     """
     names = of_workspace(state.workspace_for(fid))
-    if fid and is_chat(fid) and fid not in names:
+    if is_chat(fid) and fid not in names:
         names = sorted([*names, fid], key=_order)
     return [Chat(id=n, harness=harness_of(n), active=n == fid) for n in names]
 

--- a/charter/frame/chats.py
+++ b/charter/frame/chats.py
@@ -197,6 +197,25 @@ def harness_of(fid: str) -> str:
     return state.identity(fid).get("CHARTER_HARNESS", "").strip()
 
 
+def pane_of(chat: str) -> str | None:
+    """The tmux pane charter records for *chat*, held to tmux's own shape — or ``None``.
+
+    **One read of that record, asked by both the check and the switch**, and the reason it
+    is a function rather than a line in each is what the sweep found: `cmd_chat` re-read
+    it with an `or ""` fallback, so a record that changed between the two reads — a reap,
+    a relaunch — became `select-window -t ""`. An empty tmux target is not nothing; it
+    resolves to the CURRENT window, so charter would have reported a switch that did not
+    happen and then torn the panels down around it.
+
+    `tmuxctl.PANE_ID_RE` and not merely "non-empty", for #475's reason and at #475's
+    boundary: this value comes off disk and is about to be a `-t` target, and
+    `%1;kill-server` in that file is the shape that already cost this project a
+    `kill-server` armed on every window resize.
+    """
+    pane = state.harness_pane(chat) or ""
+    return pane if tmuxctl.PANE_ID_RE.fullmatch(pane) else None
+
+
 def roster(fid: str) -> list[Chat]:
     """Every chat in *fid*'s workspace, with *fid* marked.
 
@@ -284,7 +303,7 @@ def check(fid: str, chat: str) -> Outcome:
         return Outcome(False, f"no chat '{shown}' here — have: {_some(names)}")
     if chat == fid:
         return Outcome(False, f"already in chat '{shown}'")
-    if not tmuxctl.PANE_ID_RE.fullmatch(state.harness_pane(chat) or ""):
+    if pane_of(chat) is None:
         return Outcome(False, f"charter has no usable record of chat {shown}'s harness "
                               "pane, so it cannot find its window — relaunch that chat")
     return Outcome(True, f"chat → {shown}")

--- a/charter/frame/choose.py
+++ b/charter/frame/choose.py
@@ -72,18 +72,27 @@ from __future__ import annotations
 from typing import NamedTuple
 
 from .. import contain
-from . import overlay, switch
+from . import chats, overlay, switch
 
 #: The three nouns a picker offers. Values rather than an enum for the reason the rest of
 #: this package uses strings — they appear in a test's failure message as themselves —
 #: and the first two are also what `charter frame-switch` already spells its flags with,
 #: so the one word travels from the row to the command without a table in between.
-WORKSPACE, PERSONA, CHANGE = "workspace", "persona", "change"
+WORKSPACE, PERSONA, CHANGE, CHAT = "workspace", "persona", "change", "chat"
 
-#: All three, in the order the palette offers them. Workspace first: it is the plane a
+#: All four, in the order the palette offers them. Workspace first: it is the plane a
 #: frame is looking at, a persona is who is looking, and a change is what they are in the
-#: middle of — which is the narrowest of the three and so goes last.
-NOUNS = (WORKSPACE, PERSONA, CHANGE)
+#: middle of — which is the narrowest of those three and so goes third.
+#:
+#: **`chat` is last, and not because it is narrower still — it is a different KIND of
+#: thing, which is why it does not slot into that ordering at all.** The first three move
+#: what THIS frame is looking at, by writing a file the frame's own panels then read
+#: (`frame/switch.py`). A chat is a sibling frame: choosing one moves the tmux client to
+#: another window and leaves this frame exactly as it was, still running, still burning
+#: whatever it was burning. Putting it at the end keeps the three that share a mechanism
+#: together and puts the one that does not beside them rather than among them;
+#: :func:`switch_to` says the same thing in code.
+NOUNS = (WORKSPACE, PERSONA, CHANGE, CHAT)
 
 #: Which launch pin outranks a switch of each noun — the rung nothing charter writes can
 #: reach, because it is already in every panel pane's environment (`switch.py`'s module
@@ -96,6 +105,12 @@ NOUNS = (WORKSPACE, PERSONA, CHANGE)
 #: variable nothing sets would make `pin_reason` answer "" through a lookup rather than
 #: through a decision, and the reason a change doorway carries is a different one
 #: entirely — see :func:`pin_reason`.
+#:
+#: **`chat` is absent for a stronger version of the same reason.** `$CHARTER_SESSION_ID`
+#: IS a chat's identity and is set on every frame, so an entry here would name a variable
+#: that is always set and make `pin_reason` refuse the chat doorway on every frame there
+#: has ever been. A launch pin is a thing that stops a frame MOVING; a chat's id is what
+#: the frame is, and moving to another chat does not move it.
 PIN = {WORKSPACE: "CHARTER_WORKSPACE", PERSONA: "CHARTER_PERSONA"}
 
 #: What a doorway says when this workspace has no changes at all. Its own sentence rather
@@ -169,6 +184,8 @@ def names_of(noun: str, fid: str = "") -> list[str]:
         return switch.workspaces()
     if noun == PERSONA:
         return switch.personas()
+    if noun == CHAT:
+        return [c.id for c in chats.roster(fid)]
     return switch.changes(fid)
 
 
@@ -183,6 +200,12 @@ def current(noun: str, fid: str) -> str:
         return switch.current_workspace(fid)
     if noun == PERSONA:
         return switch.current_persona(fid) or ""
+    if noun == CHAT:
+        # The frame IS the chat (ADR 0019), so this is the one noun whose "which am I
+        # on" needs no resolution at all — and it is asked here rather than spelled
+        # `fid` at the call site so that the mark on a row and the refusal
+        # `chats.check` gives for pressing it come from one answer.
+        return fid
     return switch.current_change(fid) or ""
 
 
@@ -208,6 +231,12 @@ def pin_reason(noun: str, fid: str) -> str:
     """
     if noun == CHANGE:
         return "" if names_of(CHANGE, fid) else NO_CHANGES
+    if noun == CHAT:
+        # `others`, not `names_of` — a chat picker always has at least one row (the chat
+        # asking), so "has any names" is the question that would answer yes on every
+        # frame ever launched. What makes the picker worth opening is a chat that is not
+        # this one, which is exactly what `chats.check` refuses to switch to.
+        return "" if chats.others(fid) else chats.ONLY_CHAT
     pinned = switch._pin(fid, PIN[noun])
     if not pinned:
         return ""
@@ -222,18 +251,43 @@ def roster(noun: str, fid: str) -> Roster:
     operator types and never reorders it, so the row under the cursor stays under the
     cursor between keystrokes.
 
-    The note column is left empty. The one refusal a picker could carry per row is the
-    launch pin, and that is reported by the row that OPENS the picker (:func:`open_rows`)
-    — where it stops the pane being drawn at all, one keypress earlier. A reason repeated
-    on every row of a picker that cannot be reached while it is true is a line nothing
-    could go red without.
+    The note column is left empty for three of the four nouns. The one refusal a picker
+    could carry per row is the launch pin, and that is reported by the row that OPENS the
+    picker (:func:`open_rows`) — where it stops the pane being drawn at all, one keypress
+    earlier. A reason repeated on every row of a picker that cannot be reached while it is
+    true is a line nothing could go red without.
+
+    **A chat's note is not a reason and that objection does not reach it.** It is which
+    harness that chat is running (:func:`_note`) — a fact that differs per ROW, which is
+    the whole point of the column, and the one the operator is choosing between when two
+    tabs are two agents. The objection above is about a sentence that is the same on
+    forty rows.
     """
     names = tuple(names_of(noun, fid))
     now = current(noun, fid)
     rows = tuple(overlay.Row(id=NAME_ID.format(noun, i),
-                             title=f"{MARK[0] if n == now else MARK[1]}{n}")
+                             title=f"{MARK[0] if n == now else MARK[1]}{n}",
+                             note=_note(noun, n))
                  for i, n in enumerate(names))
     return Roster(noun=noun, rows=rows, names=names)
+
+
+def _note(noun: str, name: str) -> str:
+    """What *name*'s row carries in its note column, or ``""``.
+
+    One function rather than a branch inside :func:`roster`'s comprehension, so that
+    "which nouns have a per-row note" is a thing a test can ask directly and so the
+    default is stated once: nothing. A noun with nothing per-row to say says nothing —
+    it does not borrow the kind label, which is :func:`labelled`'s job on the TOP-LEVEL
+    list and is a different question (there the note tells `zeb` the persona from
+    `zeb-api` the workspace; inside a picker every row is the same noun and the heading
+    already says which).
+
+    Not contained here. `overlay.Surface.render` runs `contain.one_line` over every note
+    before `tui.width` sees it (#472), and a second call would be the masked line
+    `builtin_actions._register_names` shipped and this module's docstring records.
+    """
+    return chats.harness_of(name) if noun == CHAT else ""
 
 
 def labelled(roster: Roster, reason: str = "") -> tuple[overlay.Row, ...]:
@@ -308,15 +362,32 @@ def noun_of(row: overlay.Row) -> str | None:
 def switch_to(noun: str, fid: str, name: str) -> switch.Outcome:
     """Move frame *fid* to *name*, and answer with what happened and what to say.
 
-    One call into `frame/switch.py` and nothing else, which is what makes "the switch
-    moves the frame's own identity and bumps it" (#411/#412) a property of one function
-    rather than of every surface that switches. The pointer under the frame's id, the
-    frame's recorded workspace, the gather cache and the bump are all that function's, in
-    that order, and a picker that wrote any of them itself would be the second answer #411
-    is about.
+    One call into `frame/switch.py` and nothing else for the first three, which is what
+    makes "the switch moves the frame's own identity and bumps it" (#411/#412) a property
+    of one function rather than of every surface that switches. The pointer under the
+    frame's id, the frame's recorded workspace, the gather cache and the bump are all that
+    function's, in that order, and a picker that wrote any of them itself would be the
+    second answer #411 is about.
+
+    **`chat` is the one noun this function does not perform, and saying so is the point
+    of it having a branch here at all.** A chat switch is not a file write: it is
+    `select-window` plus a re-layout of the panels into the window tmux has just resized
+    (spec §3.7), and no tmux call may be made from this module or from `frame/switch.py`
+    — both are asked on a panel's repaint path and on the palette's open, and both are
+    testable without a server precisely because they never call one. So this returns
+    `chats.check`, which is the same rule `charter frame-chat` applies to a name nobody
+    drew, and `commands_frame._draw_palette` starts the switch when it says yes.
+
+    **That split is not a hole**: the check is the whole of the decision, and the command
+    asks it again rather than trusting it — one rule, two askers, exactly as
+    `switch.to_workspace` is asked by a picker row and by a hand-typed `charter
+    frame-switch`. What the command adds is the one refusal only tmux can give (the
+    chat's window is gone), which the check deliberately does not guess at.
     """
     if noun == WORKSPACE:
         return switch.to_workspace(fid, name)
     if noun == PERSONA:
         return switch.to_persona(fid, name)
+    if noun == CHAT:
+        return chats.check(fid, name)
     return switch.to_change(fid, name)

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -59,7 +59,36 @@ from .. import util
 #: 22-column pane; `repos` now draws the same rows as the full-width table the status
 #: line draws, so the sidebar's only remaining job was a lesser copy of its neighbour's.
 #: Retiring it hands those 22 columns back to the harness at every density.
-_DROP_ORDER = ("right", "repos", "top")
+#:
+#: **Phase 5's two bars go above `top`, and they are here even though charter does not
+#: place either of them** (`frame/builtins.py` says why). This list is a filter over
+#: whatever a plane's arrangement holds, so an entry for a component nobody placed costs
+#: nothing and is not dead: the day a plane writes `[[frame.component]] use = "chats"`,
+#: the bar degrades in the order §3.6 decided rather than in whatever order it happened
+#: to be listed in. They go first because they are readouts and the palette reaches every
+#: chat and every workspace in two keystrokes at every width — so a short terminal loses
+#: the reminder and nothing else, which is exactly what `top` cannot say for itself.
+_DROP_ORDER = ("right", "repos", "chats", "workspaces", "top")
+
+#: The entries of :data:`_DROP_ORDER` that go when ROWS are the tight dimension — its
+#: tail, after the two that answer to columns and have thresholds of their own.
+#:
+#: **This is what makes :data:`_DROP_ORDER` a constant rather than a comment.** Until
+#: Phase 5 nothing read that list: `visible_slots` spelled `s != "right"` and `s != "top"`
+#: by hand, so the order was documented in one place and implemented in another, and an
+#: entry added to it changed nothing at all. Derived, deleting an entry changes what a
+#: short terminal draws — which is the property the deletion sweep can see.
+#:
+#: `right` and `repos` are named as the exceptions rather than the members being listed,
+#: so a component added to `_DROP_ORDER` joins the row drops by default. That is the safe
+#: direction: a new readout that a short terminal keeps is a frame with less harness in
+#: it, and a new one it drops is a reminder the palette already replaces.
+#:
+#: All at once and not one per threshold, because `visible_slots` has two thresholds and
+#: not five. The ORDER still decides which of them survives a future third — it is not
+#: decoration — but inventing one now to space these out would be arithmetic no
+#: measurement asked for.
+_ROW_DROPS = tuple(s for s in _DROP_ORDER if s not in ("right", "repos"))
 
 #: The frame charter itself draws, as components — `frame/builtins.py`, asked ONCE at
 #: import for the edges and sizes every constant below is derived from.
@@ -526,12 +555,21 @@ def visible_slots(slots: list[str], cols: int, rows: int,
     `bottom` never goes here, and it is the only slot that never does: it is the one
     alert and the command that fixes it, which is why a frame is worth drawing on a
     terminal with room for nothing else.
+
+    **The row-edge drops read :data:`_ROW_DROPS`, which is derived from
+    :data:`_DROP_ORDER` — and until Phase 5 that constant was read by nothing at all.** It
+    documented an order this function then spelled out by hand, so §3.6's instruction to
+    "join `_DROP_ORDER` above `top`" would have changed no behaviour whatever: the two
+    bars would have survived a shortage that took `top`, which is the wrong way round for
+    a readout the palette makes redundant. Derived, the list is load-bearing — an entry
+    deleted from it changes what a short terminal draws — and that is the difference
+    between a constant and a comment with a name.
     """
     keep = list(slots)
     if cols < min_cols or rows < min_rows:
         keep = [s for s in keep if s != "right"]
     if rows < min_rows:
-        keep = [s for s in keep if s != "top"]
+        keep = [s for s in keep if s not in _ROW_DROPS]
     if "repos" in keep and not repos_fits(keep, window_cols=cols):
         keep = [s for s in keep if s != "repos"]
     if cols < min_cols // 2 or rows < min_rows // 2:

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2471,15 +2471,26 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     shown = [contain.one_line(n) for n in names]
     marked = [f"{_BAR_MARK[0] if i == at else _BAR_MARK[1]}{n}"
               for i, n in enumerate(shown)]
-    lead = _inset() + contain.one_line(head) + " " * _BAR_GAP
+    # **`head` and `note` are NOT contained, and the deletion sweep is what settled it.**
+    # Both are charter's own literals — `"chats"`, `"workspaces"`, :data:`ADD_CHAT` — and
+    # no caller can hand this an open-alphabet one, so a `contain.one_line` on either is a
+    # call whose result is provably its argument. The sweep found both as survivors for
+    # exactly that reason: no input could make the mutation differ. The NAMES are
+    # contained, one line up, which is where the open alphabet actually is.
+    lead = _inset() + head + " " * _BAR_GAP
     room = width - tui.width(lead)
     joined = (" " * _BAR_GAP).join(marked)
     if note and tui.width(joined) + _BAR_GAP + tui.width(note) <= room:
-        return [lead + joined + " " * _BAR_GAP + contain.one_line(note)]
+        return [lead + joined + " " * _BAR_GAP + note]
     if tui.width(joined) <= room:
         return [lead + joined]
     if at >= 0:
-        rest = f"{' ' * _BAR_GAP}+{len(names) - 1}" if len(names) > 1 else ""
+        # **No `if len(names) > 1` on the count, and it is unreachable rather than merely
+        # untested.** With ONE name `joined` IS `marked[at]` and the count is empty, so
+        # the rung above asks exactly what this one asks and always answers first: a `+0`
+        # can be built here and can never be returned. The sweep found the conditional as
+        # a survivor for that reason.
+        rest = f"{' ' * _BAR_GAP}+{len(names) - 1}"
         if tui.width(marked[at]) + tui.width(rest) <= room:
             return [lead + marked[at] + rest]
     counted = f"{at + 1}/{len(names)}" if at >= 0 else str(len(names))

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2394,6 +2394,131 @@ def changes_section(fid: str, width: int, budget: int) -> list[str]:
 SLOTS = {"top": _top, "bottom": _bottom, "repos": _repos, "right": _right}
 
 
+#: What marks the chat (or workspace) a bar's row says you are IN, and what marks the
+#: others. Two entries of the same width by construction, so the mark moving does not move
+#: the names beside it.
+#:
+#: **ASCII, deliberately** — `overlay._MARK`'s own rule and `_persona_chips`' measurement
+#: behind it: `●`, `◆` and the pointing triangles are East-Asian *Ambiguous* and have
+#: broken this layout twice. `choose.MARK` is the same decision one surface over and is
+#: deliberately NOT reused: that one is `("* ", "  ")`, two cells, because a picker draws
+#: one name per row and the mark owns a column of its own; a bar draws several names on
+#: one row, so a two-cell blank in front of every inactive name would spend exactly the
+#: columns the names are competing for.
+_BAR_MARK = ("*", " ")
+
+#: Columns a bar spends between two names. Two, so a name reads as one name — a single
+#: space runs `api.1 api.2` together at the widths where this matters most.
+_BAR_GAP = 2
+
+
+def _bar(head: str, names: list[str], here: str, width: int, *,
+         note: str = "") -> list[str]:
+    """One bar row: *head*, then *names* with *here* marked, inside *width* columns.
+
+    **One function for both bars, so the two cannot degrade differently.** That is why it
+    exists rather than each renderer composing its own: `workspaces` and `chats` sit on
+    adjacent rows of the same frame, and two ladders would have them give up their names
+    at two different widths — which reads as a bug in whichever gave up first.
+
+    **The ladder, and every rung drops a whole thing rather than truncating one.**
+
+    1. **Every name in full**, *here* marked. What a wide row shows.
+    2. **The one you are in, in full, plus a count of the rest** (`+2`). The others go
+       WHOLE, which is `_fit_fields`' own discipline one row over: a list cut off
+       mid-name is a list where `api-staging` and `api-standby` are the same string, and
+       half a name is worse than an honest count.
+    3. **`n/N` alone** — which position you are in and how many there are. This is the
+       rung §3.6 calls "marks only", and a count IS what a mark per chat degenerates to
+       once there is no room to draw one per chat. It says strictly more: `2/3` tells you
+       where you are, three dots do not.
+    4. **Nothing at all.** A bar with no room for rung 3 draws no row rather than a
+       fragment of one.
+
+    **There is no :data:`_NAME_MIN_W` check here, and its absence is the ladder working
+    rather than a rule dropped.** §3.6 asks that the bar "never truncates a name below
+    `slots._NAME_MIN_W` (12 cells) — below that it shows marks only", which is a floor
+    against a TRUNCATION. This renderer never truncates: every rung drops whole names, so
+    the property the floor exists to guarantee — that no name is ever shown in part — is
+    unconditional here rather than conditional on a width. Written as an `if`, the check
+    would be a line no input can reach past the rung above it, which is precisely the
+    equivalent mutant the deletion sweep asks be deleted rather than documented.
+    `TheBarNeverShowsHalfAName` pins the property directly, at 200, 80 and 40 columns and
+    at every width in between.
+
+    **`contain.one_line` runs before any of this arithmetic** (#472). Every name here has
+    already been through a name check where it was read (`switch.workspaces`,
+    `chats.of_workspace`), so this is a floor rather than the whole guard — but the
+    arithmetic below is exactly the position #472 was filed about, where a table sized its
+    columns from a raw name and one separator made the row wider than the pane.
+
+    *note* is an extra field drawn after the names when there is room for it whole — the
+    "add chat" affordance, and nothing else today. Dropped first, before any name, because
+    it is a reminder and the names are the readout.
+    """
+    head = contain.one_line(head)
+    names = [contain.one_line(n) for n in names]
+    if not names:
+        return []
+    marked = [f"{_BAR_MARK[0] if n == here else _BAR_MARK[1]}{n}" for n in names]
+    lead = _inset() + head + " " * _BAR_GAP
+    room = width - tui.width(lead)
+    joined = (" " * _BAR_GAP).join(marked)
+    if note and tui.width(joined) + _BAR_GAP + tui.width(note) <= room:
+        return [lead + joined + " " * _BAR_GAP + contain.one_line(note)]
+    if tui.width(joined) <= room:
+        return [lead + joined]
+    at = names.index(here) if here in names else -1
+    if at >= 0:
+        rest = f"{' ' * _BAR_GAP}+{len(names) - 1}" if len(names) > 1 else ""
+        if tui.width(marked[at]) + tui.width(rest) <= room:
+            return [lead + marked[at] + rest]
+    counted = f"{at + 1}/{len(names)}" if at >= 0 else str(len(names))
+    if tui.width(counted) <= room:
+        return [lead + counted]
+    return []
+
+
+#: What the chat bar says instead of a second name when this workspace has one chat.
+#:
+#: §3.6: the bar "hides itself when there is one chat, showing only the add-chat
+#: affordance". It names the command that opens a second one TODAY — `charter <harness>`
+#: in this workspace joins the session as a second window, which is what Stage 5a shipped
+#: — rather than a palette row this stage does not have. A reminder naming something that
+#: does not work is worse than no reminder.
+ADD_CHAT = "+ charter <harness> opens another"
+
+
+def chats_bar(fid: str, width: int) -> list[str]:
+    """Which chats this workspace holds and which one you are typing in.
+
+    **A readout, never the mechanism** (§3.6). The palette reaches every chat in two
+    keystrokes at every width, including widths where this row cannot be drawn at all —
+    which is why the row may degrade to a count and then to nothing, and why
+    `layout._DROP_ORDER` gives it up before `top`.
+
+    Never raises for a plane it cannot read: `chats.roster` already answers with the chat
+    asking and nothing else for a frame root it could not scan, and `_bar` answers `[]`
+    for an empty list.
+    """
+    from . import chats as chats_mod
+    names = [c.id for c in chats_mod.roster(fid)]
+    return _bar("chats", names, fid, width,
+                note=ADD_CHAT if len(names) < 2 else "")
+
+
+def workspaces_bar(fid: str, width: int) -> list[str]:
+    """Which workspaces this plane has and which one this frame is drawing.
+
+    :func:`chats_bar`'s rules and its ladder, one noun over. The name is the FRAME's
+    (`switch.current_workspace` → `state.workspace_for`), never one this pane resolved for
+    itself — #512, and the same rung order `_top` reads two rows up.
+    """
+    from . import switch as switch_mod
+    return _bar("workspaces", switch_mod.workspaces(),
+                switch_mod.current_workspace(fid), width)
+
+
 #: Which slots draw something that CHANGES ON ITS OWN, with no version bump and no
 #: resize behind it. Exactly the renderers that reach :func:`spinner_frame`, which today
 #: is `_bottom` and only `_bottom` (through :func:`_inflight_field`).
@@ -2475,6 +2600,14 @@ def drawable(name) -> bool:
         # through to the providers: a distribution declaring `sidebar` must not become
         # the answer to a question about charter's own component.
         return _builtins.SLOT_OF[cid] in SLOTS
+    if _builtins.places(cid):
+        # One of charter's own with no committed slot-name spelling — Phase 5's two bars.
+        # It is drawn through the component contract (`panel._component_painter`) rather
+        # than out of :data:`SLOTS`, so the `SLOT_OF` question above cannot answer for it,
+        # and it does not fall through to the providers for that question's own reason: a
+        # distribution declaring `chats` must not become the answer to a question about
+        # charter's own component.
+        return True
     return _builtins.supplies(cid)
 
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2456,19 +2456,27 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     "add chat" affordance, and nothing else today. Dropped first, before any name, because
     it is a reminder and the names are the readout.
     """
-    head = contain.one_line(head)
-    names = [contain.one_line(n) for n in names]
     if not names:
         return []
-    marked = [f"{_BAR_MARK[0] if n == here else _BAR_MARK[1]}{n}" for n in names]
-    lead = _inset() + head + " " * _BAR_GAP
+    # **Which row is yours is decided on the RAW names; only the drawing uses the
+    # contained ones.** `choose.Roster` makes the same split one surface over and for the
+    # same reason: `contain.one_line` is a repair, so two names that differ only in what
+    # it repairs are one string after it, and a mark matched on the drawn text would
+    # follow the repair rather than the identity. Neither caller can reach that today
+    # (`chats.ID_RE` and `workspace.valid_name` both refuse the characters `one_line`
+    # touches), which is exactly why it is written as an index now rather than found as a
+    # bug by whichever caller stops.
+    at = names.index(here) if here in names else -1
+    shown = [contain.one_line(n) for n in names]
+    marked = [f"{_BAR_MARK[0] if i == at else _BAR_MARK[1]}{n}"
+              for i, n in enumerate(shown)]
+    lead = _inset() + contain.one_line(head) + " " * _BAR_GAP
     room = width - tui.width(lead)
     joined = (" " * _BAR_GAP).join(marked)
     if note and tui.width(joined) + _BAR_GAP + tui.width(note) <= room:
         return [lead + joined + " " * _BAR_GAP + contain.one_line(note)]
     if tui.width(joined) <= room:
         return [lead + joined]
-    at = names.index(here) if here in names else -1
     if at >= 0:
         rest = f"{' ' * _BAR_GAP}+{len(names) - 1}" if len(names) > 1 else ""
         if tui.width(marked[at]) + tui.width(rest) <= room:

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2443,8 +2443,9 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     unconditional here rather than conditional on a width. Written as an `if`, the check
     would be a line no input can reach past the rung above it, which is precisely the
     equivalent mutant the deletion sweep asks be deleted rather than documented.
-    `TheBarNeverShowsHalfAName` pins the property directly, at 200, 80 and 40 columns and
-    at every width in between.
+    `tests/test_frame_bars.TheLadderGivesUpWholeThings
+    .test_no_name_is_ever_shown_in_part_at_any_width` pins the property directly, at every
+    width from 0 to 200.
 
     **`contain.one_line` runs before any of this arithmetic** (#472). Every name here has
     already been through a name check where it was read (`switch.workspaces`,

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -1774,7 +1774,16 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
         pad = pane_pad(table.get("pad", 0))
         if pad is None:
             return None
-        if cid in _builtins.SLOT_OF:
+        # **`places`, not `cid in SLOT_OF`, and the difference is Phase 5's two bars.**
+        # That table is the shorthand between a committed `[frame] slots` word and a
+        # component id; this asks the question this branch is actually about — is *cid*
+        # one charter's own registry puts on an edge. The two were the same set for as
+        # long as every component charter placed had a slot name, and `chats` and
+        # `workspaces` are the first that do not (`frame/builtins.places` argues why they
+        # have none). Asked the old way they fell to the provider branch below, which
+        # refuses anything no installed distribution supplies — so a component charter
+        # registers, sizes, and can draw was one no configuration could ever ask for.
+        if _builtins.places(cid):
             c = reg.get(cid)
             if "edge" in table and table["edge"] != c.edge:
                 return None

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -1783,7 +1783,7 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
         # have none). Asked the old way they fell to the provider branch below, which
         # refuses anything no installed distribution supplies — so a component charter
         # registers, sizes, and can draw was one no configuration could ever ask for.
-        if _builtins.places(cid):
+        if _builtins.places(cid, reg):
             c = reg.get(cid)
             if "edge" in table and table["edge"] != c.edge:
                 return None

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -243,6 +243,55 @@ terminals attached to the same workspace look at the same chat. Opening a second
 a second terminal moves both. That is what "one workspace, several chats" means — the
 chats are independent, the *view* is the session's.
 
+### Switching between them
+
+`F2` → `chat` lists this workspace's chats with the one you are typing in marked and the
+harness each is running beside it; choose one and the client moves to that chat's window.
+Typing the chat's name at the palette finds the same row without the doorway, so a chat is
+two keystrokes away at any terminal width. `charter frame-chat <chat id>` is the same
+switch by hand.
+
+**The panels move with you rather than existing per chat**, and that is correctness before
+it is thrift. A tmux window that is not the current one keeps the size it had when it was —
+measured on tmux 3.7c and at the 3.2 floor alike — so panels left running in a chat you
+switched away from are not idle, they are drawing at a width that is not their window's.
+The switch therefore tears the old chat's panels down, selects the new window (tmux resizes
+it *at* that moment), and splits fresh panels into a window that is already the right size.
+
+**It costs about a third of a second.** Measured with a real client and four panels: 41
+tmux commands, median 360 ms on tmux 3.7c and 395 ms at the 3.2 floor, with the panels
+painting roughly 90 ms after that. That is the price of not keeping four panel processes
+per chat drawing at the wrong width, and it is the whole cost — nothing is lost, no harness
+is restarted, and the chat you left goes on running exactly as it was.
+
+A switch is refused, with the reason on your own screen, for a chat this workspace does not
+have, one whose window has gone, one charter has no pane record for, and the chat you are
+already in.
+
+### The two bars, and why they are off unless you ask
+
+`chats` and `workspaces` are one-row components: the chat bar names every chat in this
+workspace with yours marked, and the workspace bar does the same for the plane. Where the
+names do not all fit the bar keeps yours whole and counts the rest (`*api.2  +2`); narrower
+still it says only where you are (`2/3`). It never shows half a name.
+
+**Neither is drawn unless a plane places it**, and that is deliberate rather than
+unfinished: on the ordinary plane there is one chat, and a row saying so permanently costs
+a row off your harness, a 24 MB panel process, and about seven of every switch's 41 tmux
+commands — to draw a name `F2` already reaches in two keystrokes. Turn one on with a
+`[[frame.component]]` table, which is also how it gets a key of its own:
+
+```toml
+[[frame.component]]
+use = "chats"
+edge = "top"
+size = 1
+key = "F9"
+```
+
+Both are the first things a short terminal gives up — before the identity row, because the
+palette reaches everything they show and nothing is lost but the reminder.
+
 ## Inside a tmux you already have
 
 **Run from inside an existing tmux session, the frame does not nest.** Charter reads

--- a/docs/news/unreleased-switching-between-the-chats-of-one-workspace.md
+++ b/docs/news/unreleased-switching-between-the-chats-of-one-workspace.md
@@ -1,0 +1,91 @@
+---
+version: unreleased
+headline: F2 switches between the chats of a workspace, and the panels move with you — torn down in the window you left and split into the one tmux has just resized
+---
+
+Stage 5a made a workspace a tmux session and a chat a window in it. This is the half that
+lets you move between them. `F2` → `chat` lists every chat this workspace holds, marks the
+one you are typing in and names the harness each is running; choosing one puts your client
+on that chat's window and moves the frame's panels with it. Typing the chat's name at the
+palette reaches the same row without the doorway, so a chat is two keystrokes away at every
+terminal width — including the widths where no bar can be drawn at all.
+
+**The panels follow the active chat rather than duplicating per chat, and that is a
+correctness rule before it is a saving.** A background tmux window keeps STALE geometry —
+measured again on this tree, on tmux 3.7c and at the 3.2 floor alike: with the client
+resized 200x50 → 100x30 the active window follows and the background one is still 200
+columns wide. Panels left running there are not idle, they are rendering at a width that is
+not their window's. So the switch tears the old chat's panels down, selects the new window
+— and tmux resizes it **at** the switch, reported correctly by the very next tmux
+invocation with no sleep and no hook — and splits the new panels into a window that is
+already the right size. They are born correct, which is why the switch never needs the
+`window-resized` hook that does not exist on tmux 3.2 (`set-hook -w window-resized` →
+`invalid option`, rc=1).
+
+**Refusals say which one fired.** A chat of another workspace, a chat that has been reaped,
+a chat whose window has gone, the chat you are already in — each is its own sentence on
+your own screen, with the chats this workspace does have listed beside it. `charter
+frame-chat <id>` is the same rule by another door, for typing by hand.
+
+## Two measurements that correct the spec
+
+**A switch is ~360 ms, not the ~16 ms the spec's §7.7 extrapolated.** That figure counted
+nine tmux commands — one `select-window`, four `kill-pane`, four `split-window`. Charter's
+one live pane-mutation path issues **41**: the disarm before each kill, the arm after each
+split, the pane surface and border options, the resize hook, and the size re-assertion that
+`kill-pane` and `split-window` both make necessary. Measured end to end with a real
+attached client and four panels, six switches each way: **median 360 ms on tmux 3.7c and
+395 ms at the 3.2 floor**, against a one-invocation baseline of 6.2 ms.
+
+The decision §3.7 took does not change — 41 invocations is still enormously cheaper than
+758 MB of panel processes rendering at widths that are wrong — but the argument's numbers
+do, and so does the plan's instruction to chain the kills and the splits: chaining the
+eight commands it names would save under a fifth of the round trips, so it is a ~10 %
+improvement to the switch rather than the 3.3× the plan expected. Collapsing the whole
+re-layout into one invocation is where the rest is, and that is a change to the funnel
+every density change and every toggle key also goes through.
+
+**`layout._DROP_ORDER` was read by nothing.** The spec asks the two new bars to "join
+`_DROP_ORDER`, above `top`" — but `visible_slots` spelled that order out by hand, so
+joining the list would have changed no behaviour and both bars would have survived exactly
+the shortage that takes the identity row. The row-edge half of the list is derived from it
+now, so an entry deleted from it changes what a short terminal draws.
+
+## The two bars ship, and neither is on your frame unless you ask
+
+`chats` and `workspaces` are components in the registry, one row each on the top edge. The
+chat bar shows every chat with the one you are in marked; at widths where they do not all
+fit it keeps yours whole and counts the rest (`*charter.2  +2`), and below that it says
+where you are and how many there are (`2/3`). It never truncates a name, because every rung
+of that ladder drops whole names rather than cutting one. With a single chat it says so and
+names what opens a second.
+
+**Neither is placed by default, and the reason is the measurement above.** A plane with one
+chat is the ordinary, permanent state — the same fact that keeps the `changes` section out
+of every operator's sidebar — and each placed pane is around seven of a switch's 41 tmux
+invocations plus a 24 MB panel process and a row off the harness, permanently, to draw a
+name `F2` already reaches. Ask for one with a `[[frame.component]]` table, which is also
+the only way any component gets a toggle key:
+
+```toml
+[[frame.component]]
+use = "chats"
+edge = "top"
+size = 1
+key = "F9"
+```
+
+That route is new in itself: a component charter registers but gives no committed `[frame]
+slots` word could not be placed by any configuration at all, because the config boundary
+asked "is this one of the four slot names" where it meant "is this one charter places".
+`frame/builtins.places` is that question asked directly, so charter's own components are
+now exactly as placeable as an installed provider's.
+
+## What this stage does not do
+
+Creating a chat from inside a frame — `F2` → pick a harness → a new tab — is not here.
+`charter <harness>` in the workspace still opens one, from a shell, and the chat bar's
+affordance names that rather than a palette row that does not exist. Neither is the
+per-chat token gauge, the live-chat cap, or reopening a chat that has been closed: those
+are Stage 5c, and until then a chat whose window is gone has its record reaped like any
+other frame's.

--- a/docs/superpowers/specs/2026-08-28-phase5-workspace-and-chat-tabs.md
+++ b/docs/superpowers/specs/2026-08-28-phase5-workspace-and-chat-tabs.md
@@ -988,6 +988,59 @@ claims.
   (`RESIZE_HOOK_FLOOR`, `PANE_ENV_FLOOR`) are read from tmux's own CHANGES, and only their
   endpoints were run.
 
+### 7.10 The switch, measured against §7.7's extrapolation (Stage 5b)
+
+**Added 2026-08-30, when Task 4 was built. §7.7's ~16 ms is wrong by a factor of 22, and
+the reason is that it counted the wrong commands.**
+
+§7.7 timed `select-window` (4.4 ms), four `kill-pane` chained (4.9 ms) and four
+`split-window` chained (6.7 ms) and added them up — nine tmux commands. Charter's one live
+pane-mutation path (`commands_frame._apply_arrangement` → `_relayout`) issues **41**, and
+the extra thirty-two are not incidental: `_disarm_panel_respawn` before each kill,
+`_arm_panel_respawn` after each split, `_panel_mark_argv`, the pane surface and border
+options, `_install_resize_hook`, and `_reassert_sizes` — which exists precisely because a
+`kill-pane` or a `split-window -l` makes tmux redistribute every surviving pane.
+
+Measured end to end: `cmd_chat` between two real chats of one workspace session, a real
+attached client at 200x50, four panels on the chat being left, six switches alternating
+direction.
+
+```
+tmux 3.7c   median 360.2 ms   min 282.2   max 600.3   41 invocations each
+tmux 3.2    median 394.7 ms   min 330.2   max 428.4   41 invocations each
+one tmux invocation, median: 6.18 ms (3.7c) / 6.70 ms (3.2)
+```
+
+41 × 6.2 ms is 254 ms of round trips; the rest is charter's own work between them.
+
+**What this changes and what it does not.** §3.7's decision stands and is not close: 41
+invocations once per switch against 758 MB of panel processes permanently rendering at
+widths that are wrong is not a trade this reopens. What changes is the adversary's answer
+in §3.7 — "16 ms instead of 4.4 ms, both comfortably inside the band where a terminal reads
+as instant" is no longer true at 360 ms, and the honest statement is that a switch is
+perceptible and roughly half a second before the panels have text in them.
+
+**And it changes the plan's Task 4 step 4.** "One `tmuxctl.chain` per group … chaining is
+worth 3.3× here and is not optional" was derived from the nine-command model. The eight
+commands a chain would collapse are under a fifth of the forty-one, so chaining them buys
+about 10 % of the switch. The rest is in the other thirty-three, which means the real
+optimisation is collapsing the whole of `_relayout` into one invocation — a change to the
+funnel a density change and every component's toggle key also go through, and not one to
+make at the end of a stage. Stage 5b therefore ships the switch over the existing funnel,
+unchained, and this is the measurement that says why.
+
+### 7.11 `layout._DROP_ORDER` was read by nothing (Stage 5b)
+
+**§3.6's instruction "Both join `layout._DROP_ORDER`, **above `top`**" does not, on its
+own, do anything.** Checked on the tree at `7dcf09c`: `grep -rn _DROP_ORDER charter/`
+returns the definition and one docstring mention. `layout.visible_slots` spells the same
+order out by hand — `s != "right"`, then `s != "top"` — so adding two names to the tuple
+would have left both bars surviving exactly the shortage that takes the identity row, which
+is the wrong way round for a readout the palette makes redundant.
+
+Stage 5b derives the row-edge half of the list (`layout._ROW_DROPS`) from `_DROP_ORDER`, so
+the constant is now the mechanism and an entry deleted from it changes what a short
+terminal draws.
 ---
 
 ## 8. What this spec deliberately does not do

--- a/tests/test_builtin_components.py
+++ b/tests/test_builtin_components.py
@@ -67,19 +67,35 @@ class Declared(unittest.TestCase):
         measurement is `frame/builtins.py`'s own — a placed component has to be in
         `instance.FRAME_SLOTS`, and that list is pinned to agree with the shipped `slots`
         and with `full`, so placing it would put a pane saying "no changes" on every
-        operator's frame for a feature most planes never use."""
+        operator's frame for a feature most planes never use.
+
+        `chats` and `workspaces` are last, registered and not placed for the same reason
+        one measurement further on: a plane with one chat is that same ordinary,
+        permanent state, and every placed pane is ~7 of a switch's 41 tmux invocations."""
         self.assertEqual([c.id for c in self.reg.all()],
                          ["identity", "attention", "repos", "personas", "todos",
-                          "changes", "sidebar"])
+                          "changes", "sidebar", "chats", "workspaces"])
 
-    def test_only_the_four_placed_components_are_on_an_edge(self):
+    def test_only_the_components_charter_places_are_split_for(self):
         """`personas`, `todos` and `changes` are registered and never split for: their
         parent draws them inside its own pane, and a part that appeared on an edge too
-        would be drawn twice — once in its own pane and once inside the sidebar's."""
+        would be drawn twice — once in its own pane and once inside the sidebar's.
+
+        **`chats` and `workspaces` DO declare an edge and are still not placed**, and the
+        two kinds of absence are the point. A sidebar part cannot be placed at all — its
+        parent draws it. A bar is a pane charter COULD split and deliberately does not, so
+        it carries the edge and the size it would take, and a `[[frame.component]]` table
+        naming it gets exactly that geometry. What keeps it off every operator's frame is
+        `instance.FRAME_SLOTS`, not the registry."""
         placed = {edge: [c.id for c in self.reg.on_edge(edge)]
                   for edge in component.EDGES}
-        self.assertEqual(placed, {"top": ["identity"], "bottom": ["attention", "repos"],
+        self.assertEqual(placed, {"top": ["identity", "chats", "workspaces"],
+                                  "bottom": ["attention", "repos"],
                                   "left": [], "right": ["sidebar"]})
+        for bar in ("chats", "workspaces"):
+            self.assertNotIn(bar, builtins.SLOT_OF,
+                             f"{bar} became a placed slot — a bar on every operator's "
+                             f"frame is the decision `frame/builtins.py` argues against")
 
     def test_the_sidebar_is_the_composite_of_personas_then_todos_then_changes(self):
         """In the order the pane stacks them, which is not split order — nothing splits
@@ -103,12 +119,18 @@ class Declared(unittest.TestCase):
 
         `changes` is on `right` with a CAP, which is what says it is a section of the
         sidebar rather than a pane: it is bounded like `todos` and for the same reason —
-        a column that is one list has no room to let a second one grow without end."""
+        a column that is one list has no room to let a second one grow without end.
+
+        The two bars are `Fixed(1)` on `top`, §3.6's own literals: a bar is one row or it
+        is nothing, and a `Content()` bar would be a row that appeared and disappeared as
+        a sibling chat opened, moving every pane below it."""
         got = {c.id: (c.edge, c.size) for c in self.reg.all()}
         self.assertEqual(got, {
             "identity": ("top", component.Fixed(1)),
             "attention": ("bottom", component.Fixed(1)),
             "repos": ("bottom", component.Content(None)),
+            "chats": ("top", component.Fixed(1)),
+            "workspaces": ("top", component.Fixed(1)),
             "personas": ("right", component.Fill()),
             "todos": ("right", component.Content(slots._MAX_TODO_LINES)),
             "changes": ("right", component.Content(slots._MAX_CHANGE_LINES)),

--- a/tests/test_change_surface.py
+++ b/tests/test_change_surface.py
@@ -605,7 +605,11 @@ class TestTwoKeystrokes(SurfaceCase):
         every test in that contract and describe nothing that happens."""
         ids = [r.id for r in choose.open_rows(FID)]
         self.assertIn("pick:change", ids)
-        self.assertEqual(choose.noun_of(choose.open_rows(FID)[-1]), choose.CHANGE)
+        # Found by id rather than by position: `chat` joined `choose.NOUNS` after
+        # `change`, and a test pinned to "the last row" goes on passing while measuring
+        # a different doorway. Which noun this id stands for is the claim.
+        row = next(r for r in choose.open_rows(FID) if r.id == "pick:change")
+        self.assertEqual(choose.noun_of(row), choose.CHANGE)
 
     def test_an_unavailable_picker_says_why_before_the_keypress(self):
         """#512: an operator cannot ask about an option they cannot see. A pane of no

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -143,6 +143,71 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         row = self._row(20, names=["averylongchatname.1"], here="averylongchatname.1")
         self.assertNotIn("+0", row)
 
+    def _rung(self, width, names=None, here="api.2", note=""):
+        rows = slots._bar("chats", list(names or self.NAMES), here, width, note=note)
+        return rows[0] if rows else ""
+
+    def _fits_at(self, names, here, note=""):
+        """Each rung's own row, and the exact width at which it stops fitting.
+
+        Measured off the row rather than written down, so the assertions below follow the
+        ladder if the inset or the gap ever moves.
+        """
+        seen, out = None, []
+        for width in range(200, 0, -1):
+            row = self._rung(width, names, here, note)
+            if row != seen:
+                if seen:
+                    out.append((seen, width + 1))
+                seen = row
+                if not row:
+                    break
+        return out
+
+    def test_every_rung_is_drawn_at_its_own_width_and_gone_one_cell_narrower(self):
+        """**Each `<=` asserted on both sides of its own boundary**, which is the only way
+        a comparison is pinned rather than its direction.
+
+        The deletion sweep found eight `shift-boundary` survivors in this function — every
+        `<=` → `<` and every `>=` → `>` — and each was a test measuring at a round width
+        instead of at the width where the rung actually changes. A row that fits in
+        exactly N cells must be drawn at N and must be gone at N-1.
+        """
+        for names, here, note in ((self.NAMES, "api.2", ""),
+                                  (self.NAMES, "api.1", ""),
+                                  (self.NAMES, "api.2", slots.ADD_CHAT),
+                                  (["only.1"], "only.1", slots.ADD_CHAT)):
+            rungs = self._fits_at(list(names), here, note)
+            self.assertGreaterEqual(len(rungs), 2,
+                                    f"{names} at {here!r} never changed rung")
+            for row, width in rungs:
+                with self.subTest(row=row, width=width):
+                    self.assertEqual(tui.width(row), width,
+                                     "the row does not fill the width it needs, so this "
+                                     "measures no boundary")
+                    self.assertEqual(self._rung(width, names, here, note), row)
+                    self.assertNotEqual(self._rung(width - 1, names, here, note), row,
+                                        "the row was still drawn one cell too narrow")
+
+    def test_the_chat_you_are_in_being_FIRST_still_reaches_every_rung(self):
+        """`at >= 0`, twice. The first name has index 0, so `at > 0` skips rung 2 entirely
+        and turns `1/3` into a bare `3` — a row that has stopped saying where you are.
+        Every other test here marks the middle name, which is exactly why the sweep found
+        both comparisons unpinned."""
+        rung2 = [r for r, _ in self._fits_at(self.NAMES, "api.1")
+                 if "+2" in r]
+        self.assertTrue(rung2, "rung 2 was never reached with the first name marked")
+        self.assertIn(f"{slots._BAR_MARK[0]}api.1", rung2[0])
+        counted = [r for r, _ in self._fits_at(self.NAMES, "api.1") if "/" in r]
+        self.assertEqual([r.strip() for r in counted], ["chats  1/3"])
+
+    def test_a_row_with_no_note_spends_no_columns_pretending_to_have_one(self):
+        """`note and …` — without it an empty note still buys its own gap, and the row
+        gains a trailing two cells that belong to the names."""
+        row = self._rung(200, ["a.1"], "a.1", note="")
+        self.assertEqual(row, row.rstrip(),
+                         "an absent note still spent its separator")
+
     def test_the_mark_follows_the_raw_name_and_not_the_repaired_one(self):
         """`contain.one_line` is a REPAIR, so two names differing only in what it repairs
         are one string after it — and a mark matched on the drawn text would follow the

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -143,6 +143,21 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         row = self._row(20, names=["averylongchatname.1"], here="averylongchatname.1")
         self.assertNotIn("+0", row)
 
+    def test_the_mark_follows_the_raw_name_and_not_the_repaired_one(self):
+        """`contain.one_line` is a REPAIR, so two names differing only in what it repairs
+        are one string after it — and a mark matched on the drawn text would follow the
+        repair rather than the identity. Neither caller can produce such a pair today
+        (`chats.ID_RE` and `workspace.valid_name` both refuse those characters), which is
+        why the index is taken before containment rather than left to be found later."""
+        names = ["api x", "apix"]
+        row = slots._bar("chats", list(names), "apix", 200)[0]
+        marks = [f for f in row.split(" " * slots._BAR_GAP)
+                 if f.strip().startswith(slots._BAR_MARK[0])]
+        self.assertEqual(len(marks), 1,
+                         f"two names were repaired into one marked row: {row!r}")
+        self.assertTrue(row.rstrip().endswith(f"{slots._BAR_MARK[0]}apix"),
+                        f"the mark landed on the repaired name: {row!r}")
+
     def test_a_hostile_name_is_contained_before_the_width_arithmetic(self):
         """#472, at the position it was filed about: a row that sized itself from a raw
         name. `tui.width` — never `len` — measures what `contain.one_line` already made

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -126,6 +126,23 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
     def test_no_names_at_all_is_no_row(self):
         self.assertEqual(slots._bar("chats", [], "api.1", 200), [])
 
+    def test_a_row_you_are_not_on_still_lists_and_still_counts(self):
+        """`here` naming nothing in the list is a real state — the workspace bar draws it
+        for a frame whose recorded workspace has been deleted — and it must not become an
+        unmarked row that silently claims you are somewhere. Nothing is marked, and the
+        narrow rungs say how many there are without claiming a position."""
+        wide = self._row(200, here="nowhere")
+        self.assertNotIn(slots._BAR_MARK[0], wide)
+        for name in self.NAMES:
+            self.assertIn(name, wide)
+        self.assertEqual(self._row(16, here="nowhere").strip(), "chats  3")
+
+    def test_the_only_chat_is_never_counted_as_plus_zero(self):
+        """The count is of the OTHERS, so one name has none. `+0` would be a field that
+        is always false and always drawn."""
+        row = self._row(20, names=["averylongchatname.1"], here="averylongchatname.1")
+        self.assertNotIn("+0", row)
+
     def test_a_hostile_name_is_contained_before_the_width_arithmetic(self):
         """#472, at the position it was filed about: a row that sized itself from a raw
         name. `tui.width` — never `len` — measures what `contain.one_line` already made
@@ -241,6 +258,14 @@ class ABarIsPlaceableByConfig(unittest.TestCase):
         self.assertTrue(slots.drawable("chats"))
         self.assertTrue(slots.drawable("workspaces"))
         self.assertFalse(slots.drawable("changes"))
+
+    def test_places_refuses_anything_that_is_not_a_name(self):
+        """It is asked of a value read out of a committed `charter.toml`, on the import
+        path of every charter command — so a TOML array or a table reaching
+        `Registry.on_edge`'s comparison must be a `False` here rather than a traceback
+        that takes `charter --version` down with it."""
+        for junk in (None, 3, True, ["chats"], {"use": "chats"}):
+            self.assertFalse(builtins.places(junk), repr(junk))
 
     def test_a_provider_cannot_answer_for_a_bars_name(self):
         """`drawable`'s own rule, extended to the bars: a distribution declaring `chats`

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -1,0 +1,287 @@
+"""Phase 5 Stage 5b, Task 7: the two bars — what they draw, how they give way, and why
+neither is on every operator's frame.
+
+**The bar is a READOUT and never the mechanism** (§3.6), and every decision here follows
+from that one sentence. The palette reaches every chat and every workspace in two
+keystrokes at every width — including the widths where neither bar can be drawn at all —
+so a bar is allowed to degrade to a count and then to nothing, and `layout._DROP_ORDER`
+gives both up before `top`.
+
+**Neither is placed by default, and that is a decision with a measurement behind it
+rather than an omission.** `frame/builtins.build` carries the argument; the short of it is
+that a plane with one chat is the ordinary, permanent state (the same fact that keeps
+`changes` a section rather than a pane), and each placed pane is ~7 of a switch's 41 tmux
+invocations — measured at ~360 ms on tmux 3.7c and ~395 ms at the 3.2 floor. So the bars
+ship as components a `[[frame.component]]` table can place, and
+:class:`ABarIsPlaceableByConfig` is what says that route actually works end to end rather
+than leaving two components nothing could ever ask for.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import config, instance, tui
+from charter.frame.component import Fixed
+from charter.frame import builtins, layout, slots, state
+from tests._isolation import PersonaIso
+from tests.test_frame_chat_switch import _plant
+
+
+class TheLadderGivesUpWholeThings(unittest.TestCase):
+    """`slots._bar` alone, against a list of names and a width — no plane underneath it.
+
+    Split out for `slots._fit_fields`' reason: the arithmetic is the thing that has to be
+    right at three widths, and a test that needed a frame to ask it would be measuring the
+    fixture as much as the ladder.
+    """
+
+    NAMES = ["api.1", "api.2", "api.3"]
+
+    def _row(self, width, names=None, here="api.2", **kw):
+        rows = slots._bar("chats", list(names or self.NAMES), here, width, **kw)
+        self.assertLessEqual(len(rows), 1, "a bar is one row or it is none")
+        return rows[0] if rows else ""
+
+    def test_a_wide_row_shows_every_name_with_the_one_you_are_in_marked(self):
+        row = self._row(200)
+        for name in self.NAMES:
+            self.assertIn(name, row)
+        self.assertIn(f"{slots._BAR_MARK[0]}api.2", row)
+        self.assertNotIn(f"{slots._BAR_MARK[0]}api.1", row)
+
+    def test_the_two_marks_are_the_same_width_so_the_names_do_not_shift(self):
+        """A mark that moved the names beside it would make the row jump every time the
+        operator switched — `overlay._MARK`'s own rule, and why both entries are ASCII."""
+        self.assertEqual(tui.width(slots._BAR_MARK[0]),
+                         tui.width(slots._BAR_MARK[1]))
+        widths = {tui.width(self._row(200, here=n)) for n in self.NAMES}
+        self.assertEqual(len(widths), 1, "the row changed width when the mark moved")
+
+    def test_a_row_with_no_room_for_every_name_keeps_yours_and_counts_the_rest(self):
+        row = self._row(30)
+        self.assertIn("*api.2", row)
+        self.assertIn("+2", row)
+        self.assertNotIn("api.1", row)
+        self.assertNotIn("api.3", row)
+
+    def test_a_row_with_no_room_for_a_name_says_where_you_are_and_how_many(self):
+        """§3.6's "marks only", and a count IS the mark: `2/3` says where you are, which
+        three dots do not."""
+        self.assertEqual(self._row(16).strip(), "chats  2/3")
+
+    def test_a_row_with_no_room_for_the_count_draws_nothing_at_all(self):
+        """Rather than a fragment of one. A bar that could not say anything true says
+        nothing — nothing is lost but the reminder (§3.6)."""
+        self.assertEqual(self._row(11), "")
+
+    def test_no_name_is_ever_shown_in_part_at_any_width(self):
+        """**The property §3.6 asks `slots._NAME_MIN_W` to guarantee, asserted directly.**
+
+        That constant is a floor against TRUNCATION, and this ladder never truncates —
+        every rung drops whole names — so the guarantee is unconditional here rather than
+        conditional on a width, and writing the floor as an `if` would be a line no input
+        could reach. Asked at every width from 0 to 200 so there is no gap between the
+        three widths the spec names.
+
+        Asserted on the row's FIELDS rather than by substring search: every name shares a
+        prefix with the heading and with each other, so `name[:3] in row` answers yes for
+        rows that are perfectly correct. Splitting the row on its own gap and asking what
+        each field IS is the property; anything else is a coincidence about spelling.
+        """
+        names = ["api-staging.1", "api-standby.2", "api.3"]
+        counts = {f"+{n}" for n in range(1, len(names) + 1)}
+        positions = {f"{i}/{len(names)}" for i in range(1, len(names) + 1)}
+        for width in range(0, 201):
+            row = slots._bar("chats", list(names), "api-standby.2", width)
+            text = row[0] if row else ""
+            self.assertLessEqual(tui.width(text), width, repr(text))
+            if not text:
+                continue
+            head, _, body = text.strip().partition(" ")
+            self.assertEqual(head, "chats", repr(text))
+            for field in body.split(" " * slots._BAR_GAP):
+                field = field.strip()
+                if not field:
+                    continue
+                bare = field[len(slots._BAR_MARK[0]):] \
+                    if field.startswith(slots._BAR_MARK[0]) else field
+                self.assertIn(bare, {*names, *counts, *positions},
+                              f"{width}: {field!r} is not a whole name, a count or a "
+                              f"position — {text!r}")
+
+    def test_one_chat_carries_the_add_affordance_and_two_do_not(self):
+        row = self._row(120, names=["api.1"], here="api.1", note=slots.ADD_CHAT)
+        self.assertIn(slots.ADD_CHAT, row)
+        self.assertNotIn(slots.ADD_CHAT, self._row(120))
+
+    def test_the_affordance_is_dropped_before_any_name_is(self):
+        """It is a reminder and the names are the readout, so it goes first."""
+        row = self._row(28, names=["api.1"], here="api.1", note=slots.ADD_CHAT)
+        self.assertIn("api.1", row)
+        self.assertNotIn(slots.ADD_CHAT, row)
+
+    def test_no_names_at_all_is_no_row(self):
+        self.assertEqual(slots._bar("chats", [], "api.1", 200), [])
+
+    def test_a_hostile_name_is_contained_before_the_width_arithmetic(self):
+        """#472, at the position it was filed about: a row that sized itself from a raw
+        name. `tui.width` — never `len` — measures what `contain.one_line` already made
+        one line of."""
+        hostile = "z" * 20 + " " + "y" * 20
+        for width in (200, 80, 40):
+            row = slots._bar("chats", ["api.1", hostile], "api.1", width)
+            text = row[0] if row else ""
+            self.assertEqual(text, "".join(text.splitlines()), repr(text))
+            self.assertLessEqual(tui.width(tui.strip_ansi(text)), width, repr(text))
+
+
+class TheChatBarReadsThePlane(PersonaIso, unittest.TestCase):
+    """`slots.chats_bar` over a real frame directory."""
+
+    def setUp(self):
+        super().setUp()
+        self._env = mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"},
+                                    clear=False)
+        self._env.start()
+        self.addCleanup(self._env.stop)
+
+    def test_the_bar_hides_the_second_name_when_there_is_one_chat_and_says_how(self):
+        """Stage 5b's exit criterion, first half: "the chat bar is absent with one chat".
+        Absent means it stops being a list — it still says which chat you are in and how
+        to get a second, because a row that vanished would leave an operator with no way
+        to learn the feature exists."""
+        _plant("api.1", workspace="api")
+        row = slots.chats_bar("api.1", 200)[0]
+        self.assertIn("api.1", row)
+        self.assertIn(slots.ADD_CHAT, row)
+        self.assertIn("charter <harness>", row,
+                      "the affordance must name something that works today")
+
+    def test_the_bar_lists_both_chats_when_there_are_two(self):
+        """The other half: "present with two"."""
+        _plant("api.1", workspace="api")
+        _plant("api.2", workspace="api")
+        row = slots.chats_bar("api.2", 200)[0]
+        self.assertIn("api.1", row)
+        self.assertIn("*api.2", row)
+        self.assertNotIn(slots.ADD_CHAT, row)
+
+    def test_only_this_workspaces_chats_are_on_the_bar(self):
+        _plant("api.1", workspace="api")
+        _plant("web.1", workspace="web")
+        row = slots.chats_bar("api.1", 200)[0]
+        self.assertNotIn("web.1", row)
+
+    def test_a_plane_it_cannot_read_draws_no_row_rather_than_raising(self):
+        with mock.patch("os.scandir", side_effect=OSError("nope")):
+            self.assertEqual(slots.chats_bar("", 200), [])
+
+
+class TheWorkspaceBarReadsTheFrame(PersonaIso, unittest.TestCase):
+    def test_it_marks_the_workspace_the_FRAME_is_on_not_this_process(self):
+        """#512: a panel is a child of a tmux server shared between every frame on the
+        machine, so a bar resolving locally would mark another plane's workspace."""
+        for name in ("alpha", "beta"):
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        state.frame_dir("f1", create=True)
+        state.record_workspace("f1", "beta")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""}, clear=False):
+            row = slots.workspaces_bar("f1", 200)[0]
+        self.assertIn("*beta", row)
+        self.assertIn("alpha", row)
+        self.assertNotIn("*alpha", row)
+
+
+class ABarIsPlaceableByConfig(unittest.TestCase):
+    """**The route that makes these components real rather than dead code.**
+
+    Neither bar has a committed `[frame] slots` word — adding one would put it on every
+    operator's frame, which `frame/builtins.build` measures the cost of — so the only way
+    to ask for one is a `[[frame.component]]` table. Before `builtins.places` existed that
+    form refused them: the branch asked `cid in SLOT_OF`, so a component charter
+    registers, sizes and can draw fell through to the provider check and was refused for
+    having no installed distribution behind it.
+    """
+
+    TABLES = {"frame": {"component": [
+        {"use": "chats", "edge": "top", "size": 1},
+        {"use": "workspaces", "edge": "top", "size": 1},
+        {"use": "identity"},
+        {"use": "attention"},
+    ]}}
+
+    def test_a_component_table_places_both_bars_at_the_geometry_they_declare(self):
+        frame = instance.frame_of(self.TABLES)
+        placed = {p["use"]: (p["edge"], p["size"]) for p in frame["components"]}
+        self.assertEqual(placed["chats"], ("top", Fixed(1)))
+        self.assertEqual(placed["workspaces"], ("top", Fixed(1)))
+
+    def test_a_table_naming_an_edge_the_bar_does_not_declare_is_refused(self):
+        """A built-in's edge is derived at import (`layout._derive`), so a different one
+        could only be read, validated, stored and ignored — the convincing empty this form
+        is written against. Refused whole, #535."""
+        cfg = {"frame": {"component": [{"use": "chats", "edge": "bottom", "size": 1}]}}
+        self.assertIsNone(instance.component_tables(cfg["frame"]))
+
+    def test_a_sidebar_part_is_still_not_placeable(self):
+        """`places` answers off `Registry.on_edge`, which excludes a composite's parts —
+        so `changes` stays a section. A part that could be placed as well would be drawn
+        twice, once in its own pane and once inside the sidebar's."""
+        for part in ("personas", "todos", "changes"):
+            self.assertFalse(builtins.places(part), part)
+            cfg = {"frame": {"component": [{"use": part, "edge": "right", "size": 4}]}}
+            self.assertIsNone(instance.component_tables(cfg["frame"]), part)
+
+    def test_a_panel_process_can_draw_a_bar_it_was_handed_by_name(self):
+        """`slots.drawable` is the one answer four callers share, and a bar has to be in
+        it or `charter panel chats --session <fid>` refuses rather than painting."""
+        self.assertTrue(slots.drawable("chats"))
+        self.assertTrue(slots.drawable("workspaces"))
+        self.assertFalse(slots.drawable("changes"))
+
+    def test_a_provider_cannot_answer_for_a_bars_name(self):
+        """`drawable`'s own rule, extended to the bars: a distribution declaring `chats`
+        must not become the answer to a question about charter's own component."""
+        with mock.patch.object(builtins, "supplies", return_value=False):
+            self.assertTrue(slots.drawable("chats"))
+
+
+class BothBarsGoWhenTheRowsRunOut(unittest.TestCase):
+    """§3.6 asks that both bars "join `layout._DROP_ORDER`, above `top`".
+
+    **Taken literally that instruction changed nothing**, and this class is what says so.
+    That constant was read by nothing: `visible_slots` spelled its order out by hand as
+    `s != "right"` and `s != "top"`, so a bar added to the list would have survived
+    exactly the shortage that took the identity row — the wrong way round for a readout
+    the palette makes redundant. `layout._ROW_DROPS` derives the row-edge half from it, so
+    the list is now the mechanism and these assertions are about behaviour rather than
+    about a tuple.
+    """
+
+    ALL = ["chats", "workspaces", "top", "bottom", "repos", "right"]
+
+    def _kept(self, cols, rows):
+        frame = config.FRAME
+        return layout.visible_slots(list(self.ALL), cols, rows,
+                                    frame["min_cols"], frame["min_rows"])
+
+    def test_a_roomy_terminal_keeps_both_bars(self):
+        self.assertEqual(self._kept(200, 50), self.ALL)
+
+    def test_a_short_terminal_gives_up_both_bars_with_the_identity_row(self):
+        kept = self._kept(200, 16)
+        for gone in ("chats", "workspaces", "top", "right"):
+            self.assertNotIn(gone, kept)
+        self.assertIn("bottom", kept,
+                      "the attention strip is the one slot that never goes")
+
+    def test_the_drop_list_is_what_decides_and_not_a_second_copy_of_it(self):
+        """The property that makes `_DROP_ORDER` a constant: every row-edge name in it is
+        one a short terminal actually loses. Deleting an entry has to change this."""
+        kept = self._kept(200, 16)
+        for name in layout._ROW_DROPS:
+            self.assertNotIn(name, kept, f"{name} is in _ROW_DROPS and survived")
+        self.assertEqual(layout._ROW_DROPS, ("chats", "workspaces", "top"))

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -1,0 +1,644 @@
+"""Phase 5 Stage 5b, Task 4 and Task 6: switching between the chats of one workspace.
+
+Two halves, and they are separated the way the code is. `frame/chats.py` decides —
+which chats a workspace holds, which one you are in, and whether a name may be switched
+to — and touches no tmux, so everything in :class:`TheRosterIsTheDirectory` and
+:class:`TheCheckSaysWhichRefusalFired` runs against a plane and nothing else.
+`commands_frame.cmd_chat` performs, and :class:`TheSwitchIsFourStepsInOneOrder` measures
+the argv it sends with a fake server underneath it.
+
+**The order the four steps go in is the only thing that makes the panels correct**, and
+it is asserted as an order rather than as a set: `select-window` first, because a
+background window keeps stale geometry on tmux 3.7c and on tmux 3.2 alike and tmux
+resizes it AT the switch; then the teardown, then the split, so the new panels are born
+in a window that has already been resized. `tests/test_frame_tmux_integration
+.SwitchingBetweenChatsMovesTheClientAndThePanels` is where that is measured against a
+real server with a real attached client, because it is the half a fake cannot make a
+claim about.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import commands_frame, config, contain, instance
+from charter.frame import chats, choose, state, tmuxctl
+from tests._isolation import PersonaIso
+# The one list of hostile display strings this suite has, imported rather than retyped:
+# a second copy is one that stops growing when somebody finds a ninth shape.
+from tests.test_frame_pickers import HOSTILE
+
+
+def _plant(fid: str, *, workspace: str, pane: str = "%1",
+           harness: str = "Claude Code") -> None:
+    """Make *fid* look like a chat charter launched into *workspace*.
+
+    The production writers, never a hand-written file: `record_workspace` is what
+    `frame_workspace` reads back and `record_identity` is what `state.identity` does, so
+    a test that stopped agreeing with either of them fails here rather than passing
+    against its own fixture.
+    """
+    state.frame_dir(fid, create=True)
+    state.record_workspace(fid, workspace)
+    state.record_harness_pane(fid, pane)
+    state.record_identity(fid, {"CHARTER_HARNESS": harness})
+
+
+class TheRosterIsTheDirectory(PersonaIso, unittest.TestCase):
+    """Spec §3.5: there is no per-workspace index of chats, so `.charter/frame/` is the
+    list. What that costs and what it buys are both measured here."""
+
+    def test_a_workspaces_chats_are_the_directories_that_name_it(self):
+        _plant("api.1", workspace="api")
+        _plant("api.2", workspace="api")
+        _plant("web.1", workspace="web")
+        self.assertEqual(chats.of_workspace("api"), ["api.1", "api.2"])
+        self.assertEqual(chats.of_workspace("web"), ["web.1"])
+
+    def test_membership_is_the_recorded_workspace_and_never_the_ids_prefix(self):
+        """Spec §3.2's rename property, and the one that makes the id a NAME rather than
+        a pointer. A workspace renamed under two live chats keeps both: their ids still
+        spell the old name and their `workspace` file is what says where they belong."""
+        _plant("old.1", workspace="old")
+        _plant("old.2", workspace="old")
+        for fid in ("old.1", "old.2"):
+            state.record_workspace(fid, "renamed")
+        self.assertEqual(chats.of_workspace("renamed"), ["old.1", "old.2"])
+        self.assertEqual(chats.of_workspace("old"), [])
+
+    def test_an_old_shape_frame_is_not_a_chat(self):
+        """`{workspace}-{pid}` is Stage 5a's other id shape and it is still launchable.
+        `state._launcher_pid` is the discriminator — asked once, in `chats.is_chat`, so
+        a bar cannot offer to `select-window` at a frame that is a whole tmux session."""
+        _plant("api-4242", workspace="api")
+        _plant("api.1", workspace="api")
+        self.assertFalse(chats.is_chat("api-4242"))
+        self.assertTrue(chats.is_chat("api.1"))
+        self.assertEqual(chats.of_workspace("api"), ["api.1"])
+
+    def test_a_directory_name_outside_the_id_alphabet_is_not_a_chat(self):
+        """A name off `os.scandir` is whatever is on disk, and it goes on to a palette
+        row, a `frame-chat` argv and a tmux `-t`. `chats.ID_RE` is that alphabet, asked
+        where the name enters charter's vocabulary rather than at each of the three
+        places it leaves it."""
+        root = state._root()
+        root.mkdir(parents=True, exist_ok=True)
+        for hostile in ("api.1;kill-server", "api 1", "api\t1"):
+            (root / hostile).mkdir()
+            state.record_workspace(hostile, "api")
+        _plant("api.1", workspace="api")
+        self.assertEqual(chats.of_workspace("api"), ["api.1"])
+
+    def test_the_order_is_the_ordinal_and_not_the_directorys(self):
+        """Ordinal order, so `api.1` stays leftmost on the bar where an operator learned
+        to look for it. Ten sorts after two, which string order would not do."""
+        for n in (10, 2, 1, 3):
+            _plant(f"api.{n}", workspace="api")
+        self.assertEqual(chats.of_workspace("api"),
+                         ["api.1", "api.2", "api.3", "api.10"])
+
+    def test_a_chat_whose_ordinal_cannot_be_read_sorts_last_rather_than_vanishing(self):
+        """The migration and corruption case. A chat charter cannot read the ordinal of
+        is still a chat whose window may be on screen, so it is ordered rather than
+        dropped — dropping it would leave it out of the picker while it is running."""
+        _plant("api.2", workspace="api")
+        _plant("api.notanumber", workspace="api")
+        self.assertEqual(chats.of_workspace("api"), ["api.2", "api.notanumber"])
+
+    def test_the_roster_marks_the_chat_asking_and_carries_each_ones_harness(self):
+        _plant("api.1", workspace="api", harness="Claude Code")
+        _plant("api.2", workspace="api", harness="Codex")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"}, clear=False):
+            roster = chats.roster("api.2")
+        self.assertEqual([(c.id, c.harness, c.active) for c in roster],
+                         [("api.1", "Claude Code", False),
+                          ("api.2", "Codex", True)])
+
+    def test_the_chat_asking_is_in_its_own_roster_even_with_no_record(self):
+        """A frame whose `workspace` file could not be read is still the chat you are
+        typing in. A bar that omitted the active chat would draw a list the operator is
+        not in."""
+        _plant("api.1", workspace="api")
+        state.frame_dir("api.9", create=True)     # no `workspace` written at all
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"}, clear=False):
+            roster = chats.roster("api.9")
+        self.assertEqual([c.id for c in roster], ["api.1", "api.9"])
+        self.assertTrue(roster[-1].active)
+
+    def test_others_is_the_roster_without_you(self):
+        _plant("api.1", workspace="api")
+        _plant("api.2", workspace="api")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"}, clear=False):
+            self.assertEqual(chats.others("api.1"), ["api.2"])
+            self.assertEqual(chats.others("api.2"), ["api.1"])
+
+    def test_a_frame_root_that_cannot_be_scanned_offers_no_chats_and_does_not_raise(self):
+        """A bar that could not scan draws nothing; it does not take the panel down with
+        it. `os.scandir` on a plane that has never launched a frame is the ordinary form
+        of this, and it is the same answer."""
+        self.assertEqual(chats.of_workspace("api"), [])
+        with mock.patch("os.scandir", side_effect=OSError("nope")):
+            self.assertEqual(chats.of_workspace("api"), [])
+
+    def test_the_harness_comes_from_the_frames_own_record_not_this_process(self):
+        """`state.identity`, never `os.environ` — a palette is a `run-shell` child of a
+        server shared between every frame on the machine, so this process's own
+        `$CHARTER_HARNESS` may be another chat's."""
+        _plant("api.1", workspace="api", harness="Codex")
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "Something Else"},
+                             clear=False):
+            self.assertEqual(chats.harness_of("api.1"), "Codex")
+        self.assertEqual(chats.harness_of("api.404"), "")
+
+
+class TheCheckSaysWhichRefusalFired(PersonaIso, unittest.TestCase):
+    """Every refusal names itself, because an assertion about a bare `ok is False` cannot
+    tell two guards in sequence apart — this repository's commonest defect, and the
+    reason the deletion sweep asks for the reason rather than the refusal."""
+
+    def setUp(self):
+        super().setUp()
+        _plant("api.1", workspace="api")
+        _plant("api.2", workspace="api")
+        self._env = mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"},
+                                    clear=False)
+        self._env.start()
+        self.addCleanup(self._env.stop)
+
+    def test_a_name_outside_the_alphabet_is_refused_as_a_name(self):
+        out = chats.check("api.1", "api.2;kill-server")
+        self.assertFalse(out.ok)
+        self.assertIn("cannot name a chat", out.message)
+
+    def test_an_empty_name_is_refused_as_a_name_rather_than_as_unknown(self):
+        self.assertIn("cannot name a chat", chats.check("api.1", "").message)
+
+    def test_an_unknown_chat_is_refused_with_the_ones_this_workspace_has(self):
+        out = chats.check("api.1", "api.7")
+        self.assertFalse(out.ok)
+        self.assertIn("no chat 'api.7' here", out.message)
+        self.assertIn("api.2", out.message)
+
+    def test_a_chat_of_another_workspace_is_unknown_here(self):
+        _plant("web.1", workspace="web")
+        self.assertIn("no chat 'web.1' here", chats.check("api.1", "web.1").message)
+
+    def test_switching_to_the_chat_you_are_in_is_refused_and_says_so(self):
+        """Refused rather than performed: it would tear this chat's panels down and split
+        them again for no change on screen, which is ~90 ms of blank panes nobody asked
+        for."""
+        out = chats.check("api.1", "api.1")
+        self.assertFalse(out.ok)
+        self.assertIn("already in chat 'api.1'", out.message)
+
+    def test_a_chat_with_no_usable_pane_record_is_refused_with_the_fix(self):
+        """#475's boundary: this value comes off disk and is about to be a tmux `-t`."""
+        state.record_harness_pane("api.2", "%1;kill-server")
+        out = chats.check("api.1", "api.2")
+        self.assertFalse(out.ok)
+        self.assertIn("no usable record", out.message)
+        self.assertIn("relaunch that chat", out.message)
+
+    def test_a_switch_that_may_go_ahead_names_where_it_is_going(self):
+        out = chats.check("api.1", "api.2")
+        self.assertTrue(out.ok)
+        self.assertEqual(out.message, "chat → api.2")
+
+    def test_every_message_is_one_line_whatever_the_name_carried(self):
+        """A message is a line of charter's own output and reaches `display-message`,
+        which is a tmux FORMAT. `contain.one_line` is what stops a name forging a second
+        line of it (#453)."""
+        for hostile in ("api\n✗ nope", "api x", "api\x1b[31mR", "api#(touch /tmp/x)"):
+            msg = chats.check("api.1", hostile).message
+            self.assertEqual(msg, contain.one_line(msg))
+            self.assertNotIn("\n", msg)
+
+
+class TheChatDoorwaySaysWhyBeforeTheKeypress(PersonaIso, unittest.TestCase):
+    """`choose.pin_reason`'s rule, one noun over: an operator cannot ask about an option
+    they cannot see (#512), so the doorway carries the reason and the picker is not
+    opened over a list of one row that is yourself."""
+
+    def setUp(self):
+        super().setUp()
+        self._env = mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"},
+                                    clear=False)
+        self._env.start()
+        self.addCleanup(self._env.stop)
+
+    def test_one_chat_means_no_picker_and_the_row_says_how_to_get_a_second(self):
+        _plant("api.1", workspace="api")
+        reason = choose.pin_reason(choose.CHAT, "api.1")
+        self.assertEqual(reason, chats.ONLY_CHAT)
+        self.assertIn("charter <harness>", reason)
+
+    def test_two_chats_means_the_doorway_opens(self):
+        _plant("api.1", workspace="api")
+        _plant("api.2", workspace="api")
+        self.assertEqual(choose.pin_reason(choose.CHAT, "api.1"), "")
+
+    def test_the_chat_you_are_in_is_the_marked_row(self):
+        _plant("api.1", workspace="api")
+        _plant("api.2", workspace="api")
+        rows = choose.roster(choose.CHAT, "api.2").rows
+        marked = [r.title for r in rows if r.title.startswith(choose.MARK[0])]
+        self.assertEqual(marked, [f"{choose.MARK[0]}api.2"])
+
+    def test_a_chats_row_carries_its_harness_and_the_other_nouns_carry_nothing(self):
+        _plant("api.1", workspace="api", harness="Claude Code")
+        _plant("api.2", workspace="api", harness="Codex")
+        notes = {r.title[len(choose.MARK[0]):]: r.note
+                 for r in choose.roster(choose.CHAT, "api.1").rows}
+        self.assertEqual(notes, {"api.1": "Claude Code", "api.2": "Codex"})
+        self.assertEqual(choose._note(choose.WORKSPACE, "api"), "")
+
+    def test_no_launch_pin_can_refuse_a_chat_doorway(self):
+        """`$CHARTER_SESSION_ID` IS a chat's identity and is set on every frame, so an
+        entry in `choose.PIN` for `chat` would refuse the doorway on every frame there
+        has ever been."""
+        self.assertNotIn(choose.CHAT, choose.PIN)
+
+    def test_a_chat_row_id_can_never_be_an_action_id(self):
+        from charter.frame import component
+        _plant("api.1", workspace="api")
+        _plant("api.2", workspace="api")
+        ids = ([choose.OPEN_ID.format(choose.CHAT)]
+               + [r.id for r in choose.roster(choose.CHAT, "api.1").rows])
+        for rid in ids:
+            self.assertFalse(component.usable_id(rid),
+                             f"{rid!r} is a usable action id, so a provider shipping an "
+                             f"action called `chat` could take the keypress")
+
+
+class AHostileChatRendersAsOneRowAndRunsNothing(PersonaIso, unittest.TestCase):
+    """Task 6, step 4, measured against the values that actually reach the surface.
+
+    **There is no `label` file in this stage, so this measures what there IS.** Spec §3.5
+    asks for one per chat; nothing here writes one (renaming a chat is not a task in this
+    stage) and a reader with no writer is a line no test can turn red. What a chat is
+    called today is two strings off disk with two alphabets, and both are exercised:
+
+    * the **id**, which is a DIRECTORY NAME under `.charter/frame/` and therefore whatever
+      is on disk. It is held to `chats.ID_RE` where it enters charter's vocabulary, so a
+      hostile one is not a chat at all and contributes no row.
+    * the **harness**, which is read out of the frame's `identity` file, has an OPEN
+      alphabet (it is a harness's own display name) and goes in the row's note. It is
+      contained where it is drawn — `overlay.Surface.render`, immediately before
+      `tui.width` measures it (#472) — and never anywhere else.
+
+    The hostile values are injected through `state.record_identity`, the production
+    writer, so a test that stopped agreeing with it fails here rather than passing against
+    its own fixture.
+    """
+
+    #: A pane narrow enough that the two-column layout has to squeeze, so the width
+    #: arithmetic is exercised rather than trivially satisfied — `test_frame_pickers`'
+    #: own size, for the same reason.
+    SIZE = (44, 12)
+
+    def setUp(self):
+        super().setUp()
+        self._env = mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"},
+                                    clear=False)
+        self._env.start()
+        self.addCleanup(self._env.stop)
+        for i, bad in enumerate(HOSTILE, start=1):
+            _plant(f"api.{i}", workspace="api", pane=f"%{i}", harness=bad)
+
+    def _drawn(self) -> list[str]:
+        from charter.frame import palette
+        roster = choose.roster(choose.CHAT, "api.1")
+        surface = palette.Palette(catalogue=roster.rows, label=choose.CHAT)
+        return surface.render(*self.SIZE)
+
+    def test_every_chat_is_exactly_one_row_however_its_harness_is_spelled(self):
+        roster = choose.roster(choose.CHAT, "api.1")
+        self.assertEqual(len(roster.rows), len(HOSTILE))
+        self.assertEqual(len({r.id for r in roster.rows}), len(HOSTILE),
+                         "two chats sharing a row id is one chat that cannot be chosen")
+
+    def test_the_drawn_pane_is_exactly_as_tall_as_the_pane(self):
+        drawn = self._drawn()
+        self.assertEqual(len(drawn), self.SIZE[1])
+        for line in drawn:
+            self.assertEqual(line, "".join(line.splitlines()), repr(line))
+
+    def test_no_hostile_byte_reaches_the_pane(self):
+        """Asserted per LINE rather than on a join of them, so the separator this test is
+        about cannot be one the test itself put there."""
+        for line in self._drawn():
+            for bad in ("\n", "\r", " ", " ", "", "\x1b[31m"):
+                self.assertNotIn(bad, line, repr(line))
+
+    def test_the_column_arithmetic_sees_the_contained_harness_not_the_raw_one(self):
+        """#472 exactly. `tui.width` — never `len` — measures what `contain.one_line` has
+        already made one line of, so a note holding a separator cannot make a row wider
+        than the pane."""
+        from charter import tui
+        state.record_identity("api.1", {"CHARTER_HARNESS":
+                                        "z" * 30 + " " + "y" * 30})
+        for line in self._drawn():
+            self.assertLessEqual(tui.width(tui.strip_ansi(line)), self.SIZE[0],
+                                 repr(line))
+
+    def _switch_argvs(self) -> list[list[str]]:
+        state.record_server("api.1", commands_frame.SOCKET)
+        state.record_server("api.2", commands_frame.SOCKET)
+        fake = _FakeServer()
+        with mock.patch.object(tmuxctl, "run", fake), \
+             mock.patch.object(commands_frame.tmuxctl, "run", fake), \
+             mock.patch.object(tmuxctl, "version", lambda: (3, 7)), \
+             mock.patch.object(commands_frame.tmuxctl, "version", lambda: (3, 7)), \
+             mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "api.1"}, clear=False):
+            commands_frame.cmd_chat(mock.Mock(chat_id="api.2", chat="api.1"))
+        self.assertTrue(fake.calls, "nothing was sent, so this measures nothing")
+        return fake.calls
+
+    def test_a_harness_name_reaches_a_command_line_only_as_an_e_VALUE(self):
+        """**The stronger property, stated as it is actually true — and the spec's
+        version of it is not.**
+
+        Task 6 step 4 asks that a display string "never reaches a tmux argv or a tmux
+        format string at all". The second half is the one that matters and it holds
+        absolutely (see the test below). The FIRST half cannot: `_relayout_pane_env`
+        replays what the LAUNCH put on `-e` onto every pane a re-layout splits, and
+        `CHARTER_HARNESS` has been in `layout.CARRIABLE` since #411 — so a chat's harness
+        name is on the `split-window` command line of every panel that chat ever gets,
+        with or without this switch.
+
+        That is not the same risk and this test is what says so. `-e NAME=VALUE` is one
+        argv ELEMENT, handed to `execve` and never parsed by tmux, so a newline or an
+        escape sequence in it is an odd environment variable and nothing more. What
+        §7.3's measurement is about is a display string reaching a place tmux EVALUATES —
+        and the value half of a `-e` is not one.
+
+        So the property pinned here is the exact one: a hostile harness name appears in a
+        tmux argv only as `-e CHARTER_HARNESS=<it>`, and never as a command word, a
+        target, or an option value of any other kind.
+        """
+        for argv in self._switch_argvs():
+            for i, word in enumerate(argv):
+                for bad in HOSTILE:
+                    if bad not in word:
+                        continue
+                    self.assertEqual(word, f"CHARTER_HARNESS={bad}",
+                                     f"{bad!r} reached a tmux command line as {word!r}")
+                    self.assertEqual(argv[i - 1], "-e",
+                                     f"{word!r} was not the value half of a `-e`")
+
+    def test_no_display_string_reaches_a_tmux_FORMAT(self):
+        """The half that holds absolutely, and the one §7.3 measured the cost of.
+
+        `rename-window 'chat#{pane_pid}X'` stores the name **already expanded** —
+        `chat4327X` on 3.7c, `chat49359X` on 3.2 — and `#{E:@opt}` expands a `#{...}`
+        sitting in a user option's value. So a display string inside a `#{…}` would be a
+        format injection on the first hop. Every `#{…}` this switch sends is a literal
+        charter wrote itself.
+        """
+        for argv in self._switch_argvs():
+            for word in argv:
+                if "#{" not in word:
+                    continue
+                for bad in HOSTILE:
+                    self.assertNotIn(bad, word,
+                                     f"{bad!r} is inside the tmux format {word!r}")
+                self.assertIn(word, ("#{pane_id}",
+                                     "#{window_width}:#{window_height}"),
+                              f"an unexpected tmux format reached the switch: {word!r}")
+
+    def test_a_chat_id_outside_the_alphabet_is_refused_before_it_becomes_an_argv(self):
+        """"Runs nothing" is the other half, and it is asked of the ID rather than of the
+        note: the id is the only one of the two that a switch ever puts on a command
+        line."""
+        for bad in HOSTILE:
+            out = chats.check("api.1", bad)
+            self.assertFalse(out.ok, f"{bad!r} was accepted as a chat")
+            self.assertIn("cannot name a chat", out.message)
+            self.assertEqual(out.message, "".join(out.message.splitlines()),
+                             repr(out.message))
+
+
+class _FakeServer:
+    """A tmux that records what it was asked and answers what a test told it to.
+
+    Everything `cmd_chat` sends goes through `tmuxctl.run`, so one patch is the whole
+    server. `_relayout` and `_split_panels` go through it too, which is what makes the
+    ORDER of the four steps assertable in one list.
+    """
+
+    def __init__(self, *, select_rc: int = 0):
+        self.calls: list[list[str]] = []
+        self.select_rc = select_rc
+
+    def __call__(self, what, argv, **kw):
+        import subprocess
+        self.calls.append(list(argv))
+        rc, out = 0, ""
+        verb = self._verb(argv)
+        if verb == "select-window":
+            rc = self.select_rc
+        elif verb == "split-window":
+            out = "%9"
+        elif verb == "display-message":
+            out = "80:24"
+        return subprocess.CompletedProcess(argv, rc, out, "")
+
+    @staticmethod
+    def _verb(argv) -> str:
+        """The tmux command word — the first element after the socket flags.
+
+        Spelled by scanning rather than by index, because `tmuxctl.server_argv` puts a
+        different number of elements in front of it for `-L` and `-S`.
+        """
+        for i, word in enumerate(argv):
+            if word in ("-L", "-S", "-f"):
+                continue
+            if i and argv[i - 1] in ("-L", "-S", "-f"):
+                continue
+            if word.startswith("-") or word.endswith("tmux"):
+                continue
+            return word
+        return ""
+
+    def verbs(self) -> list[str]:
+        return [self._verb(a) for a in self.calls]
+
+
+class TheSwitchIsFourStepsInOneOrder(PersonaIso, unittest.TestCase):
+    """Task 4, against a fake server: what `cmd_chat` sends, and in which order.
+
+    The ORDER is the requirement. `select-window` has to come first because tmux resizes
+    the target window at the switch and never before it (measured on 3.7c and on 3.2), so
+    a split issued earlier is a pane born at a width that is not its window's — the
+    defect `panel._component_text`'s `width=slots._width()` guard exists for. And the
+    teardown has to come after the select for the same measurement read the other way:
+    the window being left is the one that is now stale.
+    """
+
+    def setUp(self):
+        super().setUp()
+        _plant("api.1", workspace="api", pane="%1")
+        _plant("api.2", workspace="api", pane="%2")
+        state.record_server("api.1", commands_frame.SOCKET)
+        state.record_server("api.2", commands_frame.SOCKET)
+        state.record_panes("api.1", panels={"top": "%3", "bottom": "%4"})
+        self.fake = _FakeServer()
+        self._patches = [
+            mock.patch.object(tmuxctl, "run", self.fake),
+            mock.patch.object(commands_frame.tmuxctl, "run", self.fake),
+            mock.patch.object(tmuxctl, "version", lambda: (3, 7)),
+            mock.patch.object(commands_frame.tmuxctl, "version", lambda: (3, 7)),
+            mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "api.1",
+                                         "CHARTER_WORKSPACE": "api"}, clear=False),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def _switch(self, target="api.2"):
+        return commands_frame.cmd_chat(
+            mock.Mock(chat_id=target, chat="api.1"))
+
+    def test_the_client_is_moved_before_anything_is_torn_down_or_split(self):
+        self._switch()
+        verbs = self.fake.verbs()
+        self.assertIn("select-window", verbs)
+        first = verbs.index("select-window")
+        for later in ("kill-pane", "split-window"):
+            if later in verbs:
+                self.assertLess(first, verbs.index(later),
+                                f"{later} was issued before the window had been "
+                                f"selected, so it acted on stale geometry")
+
+    def test_the_window_is_named_by_the_targets_own_harness_pane(self):
+        self._switch()
+        sel = next(a for a in self.fake.calls
+                   if _FakeServer._verb(a) == "select-window")
+        self.assertEqual(sel[-2:], ["-t", "%2"])
+
+    def test_the_chat_being_left_loses_its_panels(self):
+        self._switch()
+        killed = [a[-1] for a in self.fake.calls
+                  if _FakeServer._verb(a) == "kill-pane"]
+        self.assertEqual(sorted(killed), ["%3", "%4"])
+        self.assertEqual(state.panes("api.1"), {})
+
+    def test_the_chat_being_entered_gets_panels_and_a_bump(self):
+        before = state.version("api.2")
+        self._switch()
+        self.assertIn("split-window", self.fake.verbs())
+        self.assertTrue(state.panes("api.2"))
+        self.assertNotEqual(state.version("api.2"), before)
+
+    def test_a_window_that_is_gone_costs_a_sentence_and_no_panels(self):
+        """The one refusal `chats.check` deliberately does not guess at. Nothing is torn
+        down: the teardown is below the select for exactly this case."""
+        self.fake.select_rc = 1
+        said = []
+        with mock.patch.object(commands_frame, "_say_on_screen",
+                               lambda fid, msg, *a, **k: said.append(msg)):
+            self._switch()
+        self.assertEqual(len(said), 1)
+        self.assertIn("has no window any more", said[0])
+        self.assertNotIn("kill-pane", self.fake.verbs())
+        self.assertEqual(state.panes("api.1"), {"top": "%3", "bottom": "%4"})
+
+    def test_a_refused_name_never_reaches_tmux_at_all(self):
+        said = []
+        with mock.patch.object(commands_frame, "_say_on_screen",
+                               lambda fid, msg, *a, **k: said.append(msg)):
+            self._switch("api.9")
+        self.assertEqual(self.fake.calls, [])
+        self.assertIn("no chat 'api.9' here", said[0])
+
+    def test_the_switch_lays_out_the_same_with_the_window_resized_hook_removed(self):
+        """Task 4, step 5, and the measurement behind it: on tmux 3.2 —
+        `tmuxctl.FLOOR` — `set-hook -w window-resized` answers `invalid option`, rc=1.
+        The hook does not exist there.
+
+        **Charter does still install it above `tmuxctl.RESIZE_HOOK_FLOOR`, and that is
+        not what this is about.** `_relayout` arms it for the window's own later resizes,
+        which is a different event from the switch. What the switch may not do is *rely*
+        on it to correct geometry it did not assert itself — so the property is that the
+        panels come out identical with the hook and without it, which is what a 3.2
+        operator gets.
+        """
+        def panes_at(version):
+            state.record_panes("api.2", panels={})
+            with mock.patch.object(tmuxctl, "version", lambda: version), \
+                 mock.patch.object(commands_frame.tmuxctl, "version",
+                                   lambda: version):
+                self.fake.calls.clear()
+                self._switch()
+            hooked = any("window-resized" in " ".join(a) for a in self.fake.calls)
+            splits = [a for a in self.fake.calls
+                      if _FakeServer._verb(a) == "split-window"]
+            return sorted(state.panes("api.2")), len(splits), hooked
+
+        at_37 = panes_at((3, 7))
+        # Put the panels back where the 3.7 pass found them, so the second pass starts
+        # from the same frame rather than from the one the first left behind.
+        state.record_panes("api.1", panels={"top": "%3", "bottom": "%4"})
+        at_32 = panes_at((3, 2))
+        self.assertEqual(at_37[:2], at_32[:2],
+                         "the switch laid the target out differently without the hook")
+        self.assertTrue(at_37[2], "3.7 should still arm the hook for later resizes")
+        self.assertFalse(at_32[2],
+                         "the hook does not exist at the floor and must not be sent")
+
+    def test_the_target_gets_its_own_visible_arrangement_and_not_this_chats(self):
+        """`_visible_now(target, …)` — the chat being entered draws what IT was told to
+        hide, not what the chat being left was."""
+        frame = config.FRAME
+        arrangement = instance.frame_arrangement(frame)
+        state.record_hidden("api.2", [n for n in arrangement if n != "top"])
+        self._switch()
+        self.assertEqual(sorted(state.panes("api.2")), ["top"])
+
+    def test_the_presser_chat_is_the_one_left_not_the_session_variable(self):
+        """One bind text is shared by every frame on the socket, so `$CHARTER_SESSION_ID`
+        cannot tell two chats of one workspace apart — `--chat` can, and it is what
+        decides whose panels are torn down."""
+        state.record_panes("api.2", panels={"top": "%7"})
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "api.2"}, clear=False):
+            commands_frame.cmd_chat(mock.Mock(chat_id="api.1", chat="api.2"))
+        killed = [a[-1] for a in self.fake.calls
+                  if _FakeServer._verb(a) == "kill-pane"]
+        self.assertEqual(killed, ["%7"])
+
+
+class ThePaletteStartsTheSwitchRatherThanPerformingIt(PersonaIso, unittest.TestCase):
+    """§4g: a row returns having started. The palette's pane is killed the instant it has
+    invoked, and `kill-pane` hands SIGHUP to that pane's process group — so a switch that
+    ran in the palette's own process would be racing its own teardown for three of its
+    four tmux calls."""
+
+    def setUp(self):
+        super().setUp()
+        _plant("api.1", workspace="api", pane="%1")
+        _plant("api.2", workspace="api", pane="%2")
+        self._env = mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"},
+                                    clear=False)
+        self._env.start()
+        self.addCleanup(self._env.stop)
+
+    def test_the_palette_spawns_frame_chat_detached_with_the_target_on_the_argv(self):
+        spawned = []
+        with mock.patch.object(commands_frame.builtin_actions, "_spawn",
+                               lambda argv, *, fid: spawned.append((argv, fid))):
+            commands_frame._start_chat_switch("api.1", "api.2")
+        self.assertEqual(len(spawned), 1)
+        argv, fid = spawned[0]
+        self.assertEqual(argv[-2:], ["frame-chat", "api.2"])
+        self.assertEqual(fid, "api.1")
+
+    def test_choose_switch_to_decides_and_does_not_perform(self):
+        """`choose.switch_to` is asked in the palette's own process, which may make no
+        tmux call — so for `chat` it returns the check and `_draw_palette` starts the
+        command. The other three nouns still perform."""
+        with mock.patch.object(tmuxctl, "run") as ran:
+            out = choose.switch_to(choose.CHAT, "api.1", "api.2")
+        self.assertTrue(out.ok)
+        ran.assert_not_called()

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -645,6 +645,25 @@ class TheSwitchIsFourStepsInOneOrder(PersonaIso, unittest.TestCase):
         self.assertNotIn("kill-pane", self.fake.verbs())
         self.assertEqual(state.panes("api.1"), {"top": "%3", "bottom": "%4"})
 
+    def test_outside_a_frame_it_touches_no_tmux_at_all(self):
+        """**Found by hand against the real server, not by a test.** `_say_on_screen`'s
+        `-t <fid>` with an empty target resolves to whichever session on the SHARED
+        `-L charter` server was attached most recently — so `charter frame-chat api.2`
+        typed in an ordinary shell drew charter's refusal across another operator's frame.
+
+        Unlike `cmd_toggle`'s deleted `if not fid`, this refusal is not free: that command
+        emits nothing with an empty id and its guard was an equivalent mutant, and this
+        one issues a real tmux command aimed at a session it has no business naming.
+        """
+        said = []
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": ""}, clear=False), \
+             mock.patch.object(commands_frame, "_say_on_screen",
+                               lambda fid, msg, *a, **k: said.append(msg)):
+            self.assertEqual(
+                commands_frame.cmd_chat(mock.Mock(chat_id="api.2", chat="")), 0)
+        self.assertEqual(self.fake.calls, [])
+        self.assertEqual(said, [], "a refusal was aimed at a frame this is not in")
+
     def test_a_refused_name_never_reaches_tmux_at_all(self):
         said = []
         with mock.patch.object(commands_frame, "_say_on_screen",

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -134,6 +134,42 @@ class TheRosterIsTheDirectory(PersonaIso, unittest.TestCase):
             self.assertEqual(chats.others("api.1"), ["api.2"])
             self.assertEqual(chats.others("api.2"), ["api.1"])
 
+    def test_a_loose_file_under_the_frame_root_is_not_a_chat(self):
+        """The directory is the list, and a file in it is not a directory. `exit`, a
+        temp file a write was interrupted mid-`os.replace`, anything — none of them has a
+        frame directory's shape and none may become a row."""
+        _plant("api.1", workspace="api")
+        (state._root() / "api.2").write_text("not a chat\n")
+        self.assertEqual(chats.of_workspace("api"), ["api.1"])
+
+    def test_a_chat_with_no_recorded_workspace_belongs_to_none(self):
+        """`frame_workspace` answers `None` for the migration case and the corrupt one,
+        and `None` is not a workspace name — so the chat is in nobody's list rather than
+        in everybody's."""
+        _plant("api.1", workspace="api")
+        state.frame_dir("api.2", create=True)
+        self.assertEqual(chats.of_workspace("api"), ["api.1"])
+
+    def test_the_roster_invents_nothing_for_a_frame_that_is_not_a_chat(self):
+        """`roster` folds the asking frame in so a chat whose record is unreadable is
+        still on its own bar — but only when it IS a chat. An old `{workspace}-{pid}`
+        frame, or no frame at all, must not become a row that `select-window` would be
+        aimed at."""
+        _plant("api.1", workspace="api")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"}, clear=False):
+            self.assertEqual([c.id for c in chats.roster("")], ["api.1"])
+            self.assertEqual([c.id for c in chats.roster("api-4242")], ["api.1"])
+            # And it is not folded in twice when the scan already found it.
+            self.assertEqual([c.id for c in chats.roster("api.1")], ["api.1"])
+
+    def test_a_harness_recorded_as_whitespace_is_no_harness(self):
+        """`state.identity` does not strip — it hands back what the file holds — so a
+        note of three spaces would be a column of blank that reads as a harness charter
+        could not name. Empty says the honest thing."""
+        _plant("api.1", workspace="api")
+        state.record_identity("api.1", {"CHARTER_HARNESS": "   "})
+        self.assertEqual(chats.harness_of("api.1"), "")
+
     def test_a_frame_root_that_cannot_be_scanned_offers_no_chats_and_does_not_raise(self):
         """A bar that could not scan draws nothing; it does not take the panel down with
         it. `os.scandir` on a plane that has never launched a frame is the ordinary form
@@ -172,8 +208,14 @@ class TheCheckSaysWhichRefusalFired(PersonaIso, unittest.TestCase):
         self.assertFalse(out.ok)
         self.assertIn("cannot name a chat", out.message)
 
-    def test_an_empty_name_is_refused_as_a_name_rather_than_as_unknown(self):
-        self.assertIn("cannot name a chat", chats.check("api.1", "").message)
+    def test_an_absent_name_is_refused_as_a_name_rather_than_as_unknown(self):
+        """Both spellings of absent, and `None` is the one that would be a `TypeError`
+        out of `re.fullmatch` rather than a refusal. `charter frame-chat` cannot produce
+        it — argparse gives a string — but this is the one rule two callers share, and a
+        rule that raises for one of the ways of being asked nothing is not one."""
+        for absent in ("", None):
+            self.assertIn("cannot name a chat",
+                          chats.check("api.1", absent).message, repr(absent))
 
     def test_an_unknown_chat_is_refused_with_the_ones_this_workspace_has(self):
         out = chats.check("api.1", "api.7")
@@ -596,6 +638,31 @@ class TheSwitchIsFourStepsInOneOrder(PersonaIso, unittest.TestCase):
         state.record_hidden("api.2", [n for n in arrangement if n != "top"])
         self._switch()
         self.assertEqual(sorted(state.panes("api.2")), ["top"])
+
+    def test_a_chat_charter_cannot_relayout_still_gets_the_client_moved(self):
+        """The two re-layouts are attempted independently, and the client's move is not
+        conditional on either. A chat charter has no usable pane record for cannot have
+        its panels moved — but abandoning the switch over it would leave the operator on
+        the window they asked to leave, which is the worse of the two failures."""
+        state.record_harness_pane("api.1", "not-a-pane")
+        self._switch()
+        verbs = self.fake.verbs()
+        self.assertIn("select-window", verbs)
+        self.assertNotIn("kill-pane", verbs)
+        self.assertTrue(state.panes("api.2"),
+                        "the target lost its panels because the chat being left could "
+                        "not be tidied")
+
+    def test_a_tmux_whose_version_charter_cannot_read_moves_the_client_and_no_panes(self):
+        """`_relayout_target` refuses on an unreadable version because every builder
+        below it takes one. The switch itself needs none — `select-window` has been in
+        tmux forever — so the client still moves and nothing is split blind."""
+        with mock.patch.object(tmuxctl, "version", lambda: None), \
+             mock.patch.object(commands_frame.tmuxctl, "version", lambda: None):
+            self._switch()
+        verbs = self.fake.verbs()
+        self.assertEqual(verbs, ["select-window"])
+        self.assertEqual(state.panes("api.1"), {"top": "%3", "bottom": "%4"})
 
     def test_the_presser_chat_is_the_one_left_not_the_session_variable(self):
         """One bind text is shared by every frame on the socket, so `$CHARTER_SESSION_ID`

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -745,6 +745,38 @@ class TheSwitchIsFourStepsInOneOrder(PersonaIso, unittest.TestCase):
         self.assertIn("select-window", self.fake.verbs(),
                       "a padded id was not trimmed back to a real chat")
 
+    def test_a_pane_record_that_vanishes_between_the_check_and_the_send(self):
+        """**The one survivor CI's first sweep left, and it was a real hazard rather than
+        an equivalent.** `cmd_chat` reads the target's pane a second time — the check
+        answered about the record a moment ago — and with an `or ""` fallback a record
+        that had gone in between became `select-window -t ""`. An empty tmux target is
+        not nothing: it resolves to the CURRENT window, so charter would report a switch
+        that did not happen and then tear this chat's panels down around it.
+
+        Driven by making the SECOND read answer differently from the first, which is the
+        only shape that can tell a re-read from a carried value.
+        """
+        real = state.harness_pane
+        seen = []
+
+        def racing(fid):
+            seen.append(fid)
+            if fid == "api.2" and seen.count("api.2") > 1:
+                return None
+            return real(fid)
+
+        said = []
+        with mock.patch.object(state, "harness_pane", racing), \
+             mock.patch.object(commands_frame.state, "harness_pane", racing), \
+             mock.patch.object(chats.state, "harness_pane", racing), \
+             mock.patch.object(commands_frame, "_say_on_screen",
+                               lambda fid, msg, *a, **k: said.append(msg)):
+            self.assertEqual(self._switch(), 0)
+        self.assertEqual(self.fake.calls, [],
+                         "an empty `-t` target reached tmux")
+        self.assertEqual(len(said), 1)
+        self.assertIn("stopped being one while charter was switching", said[0])
+
     def test_a_refused_name_never_reaches_tmux_at_all(self):
         said = []
         with mock.patch.object(commands_frame, "_say_on_screen",

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -107,6 +107,25 @@ class TheRosterIsTheDirectory(PersonaIso, unittest.TestCase):
         _plant("api.notanumber", workspace="api")
         self.assertEqual(chats.of_workspace("api"), ["api.2", "api.notanumber"])
 
+    def test_an_ordinal_too_long_to_convert_sorts_last_rather_than_raising(self):
+        """`int("9" * 5000)` raises `ValueError` on CPython — the int-str conversion
+        limit, not an overflow — and unbounded that exception comes out of `sorted`, in a
+        panel's render path.
+
+        **Not through the directory**, which cannot hold a name that long (`NAME_MAX` is
+        255 on every filesystem this runs on, so `mkdir` answers `ENAMETOOLONG` first).
+        Through the fid `roster` folds in, which is `$CHARTER_SESSION_ID` — a value from
+        the environment, not from a directory listing, and the one input to this sort with
+        no length bound in front of it.
+        """
+        _plant("api.2", workspace="api")
+        huge = "api." + "9" * 5000
+        self.assertTrue(chats.is_chat(huge),
+                        "if this stopped being a chat the sort would never see it and "
+                        "this test would be measuring the wrong guard")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"}, clear=False):
+            self.assertEqual([c.id for c in chats.roster(huge)], ["api.2", huge])
+
     def test_the_roster_marks_the_chat_asking_and_carries_each_ones_harness(self):
         _plant("api.1", workspace="api", harness="Claude Code")
         _plant("api.2", workspace="api", harness="Codex")

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -12,7 +12,7 @@ it is asserted as an order rather than as a set: `select-window` first, because 
 background window keeps stale geometry on tmux 3.7c and on tmux 3.2 alike and tmux
 resizes it AT the switch; then the teardown, then the split, so the new panels are born
 in a window that has already been resized. `tests/test_frame_tmux_integration
-.SwitchingBetweenChatsMovesTheClientAndThePanels` is where that is measured against a
+.SwitchingBetweenChatsMovesTheClientAndThePanes` is where that is measured against a
 real server with a real attached client, because it is the half a fake cannot make a
 claim about.
 """

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -126,6 +126,56 @@ class TheRosterIsTheDirectory(PersonaIso, unittest.TestCase):
         with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"}, clear=False):
             self.assertEqual([c.id for c in chats.roster(huge)], ["api.2", huge])
 
+    def test_the_sort_key_reads_the_LAST_dot_and_refuses_what_is_not_an_ordinal(self):
+        """`_order`, at the four inputs that tell its clauses apart — the sweep found all
+        four unpinned because every earlier test used a plain `api.<n>`.
+
+        * `a.b.3` — `rpartition` takes the LAST dot and reads `3`; `partition` takes the
+          first and reads `b.3`, which is not an ordinal at all.
+        * `12345` — a name that is all digits and has NO dot. Without the `sep` clause it
+          sorts as ordinal 12,345 instead of last, which puts a chat charter never minted
+          in the middle of the bar.
+        * `api.x` — a short non-digit tail. Without `tail.isdigit()` this reaches
+          `int("x")` and the sort raises.
+        * `api.99999` — exactly `_MAX_ORDINAL_DIGITS` digits, so `<=` draws it as an
+          ordinal and `<` sorts it last.
+        """
+        self.assertEqual(chats._order("a.b.3"), (0, 3, "a.b.3"))
+        self.assertEqual(chats._order("12345"), (1, 0, "12345"))
+        self.assertEqual(chats._order("api.x"), (1, 0, "api.x"))
+        edge = "api." + "9" * chats._MAX_ORDINAL_DIGITS
+        self.assertEqual(chats._order(edge), (0, int("9" * chats._MAX_ORDINAL_DIGITS),
+                                              edge))
+        over = "api." + "9" * (chats._MAX_ORDINAL_DIGITS + 1)
+        self.assertEqual(chats._order(over), (1, 0, over))
+        # And through the list, which is where the ordering is actually read.
+        for fid in ("a.b.3", "12345", "api.x", "api.2"):
+            _plant(fid, workspace="w")
+        self.assertEqual(chats.of_workspace("w"),
+                         ["api.2", "a.b.3", "12345", "api.x"])
+
+    def test_a_chat_with_no_pane_record_at_all_is_refused_rather_than_raising(self):
+        """`state.harness_pane` answers ``None`` for a frame that has none — a chat
+        launched by a charter that predates the record — and `re.fullmatch(None)` is a
+        `TypeError`, not a refusal. The earlier test wrote a BAD pane string, which is a
+        different input and left the fallback unpinned."""
+        _plant("w.1", workspace="w")
+        state.frame_dir("w.2", create=True)
+        state.record_workspace("w.2", "w")
+        self.assertIsNone(state.harness_pane("w.2"))
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "w"}, clear=False):
+            out = chats.check("w.1", "w.2")
+        self.assertFalse(out.ok)
+        self.assertIn("no usable record", out.message)
+
+    def test_a_harness_with_a_TRAILING_space_is_trimmed_too(self):
+        """`.strip()`, not `.lstrip()`. The earlier test recorded three spaces, for which
+        both answer `""` — so the half that matters on a real value was unpinned. A note
+        is a column beside a name, and a trailing space in it moves nothing visible and
+        makes two identical harnesses compare unequal."""
+        _plant("w.1", workspace="w", harness="  Codex  ")
+        self.assertEqual(chats.harness_of("w.1"), "Codex")
+
     def test_the_roster_marks_the_chat_asking_and_carries_each_ones_harness(self):
         _plant("api.1", workspace="api", harness="Claude Code")
         _plant("api.2", workspace="api", harness="Codex")
@@ -314,6 +364,22 @@ class TheChatDoorwaySaysWhyBeforeTheKeypress(PersonaIso, unittest.TestCase):
                  for r in choose.roster(choose.CHAT, "api.1").rows}
         self.assertEqual(notes, {"api.1": "Claude Code", "api.2": "Codex"})
         self.assertEqual(choose._note(choose.WORKSPACE, "api"), "")
+
+    def test_only_a_chat_row_carries_a_harness_even_when_the_names_collide(self):
+        """`_note`'s `if noun == CHAT`, at the one input that can tell it from an
+        unconditional lookup.
+
+        `chats.harness_of` answers `""` for a name with no frame directory, so on an
+        ordinary plane dropping the branch changes nothing — which is why the sweep found
+        it unpinned. A workspace and a chat CAN share a name (`chats.is_chat` accepts a
+        name with no dot; `workspace.valid_name` accepts one), and then an unconditional
+        lookup puts a chat's harness in a workspace row's note.
+        """
+        _plant("shared", workspace="api", harness="Codex")
+        self.assertEqual(choose._note(choose.CHAT, "shared"), "Codex")
+        self.assertEqual(choose._note(choose.WORKSPACE, "shared"), "",
+                         "a workspace row borrowed a chat's harness")
+        self.assertEqual(choose._note(choose.PERSONA, "shared"), "")
 
     def test_no_launch_pin_can_refuse_a_chat_doorway(self):
         """`$CHARTER_SESSION_ID` IS a chat's identity and is set on every frame, so an
@@ -664,6 +730,21 @@ class TheSwitchIsFourStepsInOneOrder(PersonaIso, unittest.TestCase):
         self.assertEqual(self.fake.calls, [])
         self.assertEqual(said, [], "a refusal was aimed at a frame this is not in")
 
+    def test_an_absent_or_padded_chat_id_is_refused_rather_than_raising(self):
+        """`(… or "").strip()`, both halves. `None` reaches `str.strip` as an
+        `AttributeError` without the fallback, and a padded id passes `ID_RE` only once
+        the trailing space is gone — `lstrip` leaves it and the name is refused as
+        unknown, which is a different sentence for a name that is really fine."""
+        said = []
+        with mock.patch.object(commands_frame, "_say_on_screen",
+                               lambda fid, msg, *a, **k: said.append(msg)):
+            commands_frame.cmd_chat(mock.Mock(chat_id=None, chat="api.1"))
+            self.assertIn("cannot name a chat", said[-1])
+            self.assertEqual(self.fake.calls, [])
+            commands_frame.cmd_chat(mock.Mock(chat_id="  api.2  ", chat="api.1"))
+        self.assertIn("select-window", self.fake.verbs(),
+                      "a padded id was not trimmed back to a real chat")
+
     def test_a_refused_name_never_reaches_tmux_at_all(self):
         said = []
         with mock.patch.object(commands_frame, "_say_on_screen",
@@ -777,6 +858,58 @@ class ThePaletteStartsTheSwitchRatherThanPerformingIt(PersonaIso, unittest.TestC
         argv, fid = spawned[0]
         self.assertEqual(argv[-2:], ["frame-chat", "api.2"])
         self.assertEqual(fid, "api.1")
+
+    def test_the_palette_starts_nothing_for_a_chat_the_check_refused(self):
+        """**`if out.ok and noun == choose.CHAT`, both halves, through the real
+        `_draw_palette`.** The sweep found the whole `if` and its `out.ok` conjunct
+        unpinned: every other case here calls `_start_chat_switch` directly, so none of
+        them would notice the palette spawning a switch for a name `chats.check` has just
+        refused — the chat you are already in, or one whose window record is unusable.
+
+        Driven with `palette.own_the_tty` faked out the way `tests/test_frame_pickers.py`
+        drives it, so the row travels the path a keypress does.
+        """
+        from types import SimpleNamespace
+
+        from charter.frame import palette
+
+        def pane(*rows):
+            """`tests/test_frame_pickers._pane`: one row per surface, in order — the
+            doorway first, which is what opens the picker and puts its roster where
+            `_chosen_name` looks, then the name."""
+            def fake(surface, *, then=None, **kw):
+                chosen = None
+                for row in rows:
+                    chosen = row
+                    if row is None or then is None or then(row) is None:
+                        break
+                return chosen
+            return fake
+
+        doorway = next(r for r in choose.open_rows("api.1")
+                       if choose.noun_of(r) == choose.CHAT)
+
+        def row_for(name):
+            roster = choose.roster(choose.CHAT, "api.1")
+            return next(r for r in roster.rows if roster.name_of(r) == name)
+
+        for target, expect in (("api.1", 0), ("api.2", 1)):
+            with self.subTest(target=target):
+                spawned = []
+                with mock.patch.dict(os.environ,
+                                     {"CHARTER_SESSION_ID": "api.1"}, clear=False), \
+                     mock.patch.object(commands_frame.builtin_actions, "_spawn",
+                                       lambda argv, *, fid: spawned.append(argv)), \
+                     mock.patch.object(commands_frame, "_say_on_screen"), \
+                     mock.patch.object(commands_frame, "_close_palette"), \
+                     mock.patch.object(palette, "own_the_tty",
+                                       pane(doorway, row_for(target))):
+                    rc = commands_frame.cmd_palette(
+                        SimpleNamespace(client="/dev/ttys7", pane=True))
+                self.assertEqual(rc, 0)
+                self.assertEqual(len(spawned), expect,
+                                 f"the palette started {len(spawned)} switch(es) for "
+                                 f"{target!r}")
 
     def test_choose_switch_to_decides_and_does_not_perform(self):
         """`choose.switch_to` is asked in the palette's own process, which may make no

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -24,7 +24,7 @@ import unittest
 from unittest import mock
 
 from charter import commands_frame, config, contain, instance
-from charter.frame import chats, choose, state, tmuxctl
+from charter.frame import chats, choose, slots, state, tmuxctl
 from tests._isolation import PersonaIso
 # The one list of hostile display strings this suite has, imported rather than retyped:
 # a second copy is one that stops growing when somebody finds a ninth shape.
@@ -468,6 +468,45 @@ class AHostileChatRendersAsOneRowAndRunsNothing(PersonaIso, unittest.TestCase):
                 self.assertIn(word, ("#{pane_id}",
                                      "#{window_width}:#{window_height}"),
                               f"an unexpected tmux format reached the switch: {word!r}")
+
+    def test_every_chat_is_still_reachable_at_200_80_and_40_columns(self):
+        """**Stage 5b's first exit criterion**: every chat reachable in ≤2 keystrokes at
+        200, 80 and 40 columns — *including* the widths where no bar can be drawn.
+
+        Two keystrokes is `F2` and then either an arrow or a filter; what has to be true
+        at every width is that the row is in the surface and still maps back to its own
+        chat. Asserted through `Roster.name_of`, which is what
+        `commands_frame._chosen_name` calls — matching on the drawn title instead would be
+        matching on a string `Surface.render` has already contained, and would pass while
+        the switch went to the wrong chat or to none.
+
+        The chat bar draws nothing at all at 40 columns for this many chats, which is the
+        point: the palette is a full pane (§4k) and does not care how wide the frame is.
+        """
+        from charter.frame import overlay, palette
+        roster = choose.roster(choose.CHAT, "api.1")
+        self.assertEqual(len(roster.rows), len(HOSTILE))
+        for cols in (200, 80, 40):
+            with self.subTest(cols=cols):
+                surface = palette.Palette(catalogue=roster.rows, label=choose.CHAT)
+                drawn = surface.render(cols, 20)
+                self.assertEqual(len(drawn), 20)
+                for row in roster.rows:
+                    self.assertIsNotNone(roster.name_of(row))
+                # And typing narrows to exactly one of them, which is the second keystroke.
+                surface.handle(overlay.Event(overlay.KEY, "2"), 20)
+                self.assertEqual([r.id for r in surface.rows], ["chat:n1"],
+                                 f"typing `2` at {cols} columns did not reach api.2")
+                self.assertEqual(roster.name_of(surface.rows[0]), "api.2")
+        # And the width at which the BAR gives up its names is not a width at which the
+        # picker gives up anything — which is the whole of "the bar is a readout and the
+        # palette is the mechanism".
+        from charter import tui
+        narrow = slots.chats_bar("api.1", 40)
+        self.assertTrue(all("api.8" not in ln for ln in narrow),
+                        f"the bar still listed every chat at 40 columns: {narrow!r}")
+        for ln in narrow:
+            self.assertLessEqual(tui.width(ln), 40)
 
     def test_a_chat_id_outside_the_alphabet_is_refused_before_it_becomes_an_argv(self):
         """"Runs nothing" is the other half, and it is asked of the ID rather than of the

--- a/tests/test_frame_palette_names.py
+++ b/tests/test_frame_palette_names.py
@@ -325,9 +325,10 @@ class TheRosterIsNeverReadUntilSomethingIsTyped(_Frame, unittest.TestCase):
                        if choose.noun_of(r) == choose.WORKSPACE)
         commands_frame._picker(doorway, self.FID, opened)
         self.assertEqual((self.ws.call_count, self.pe.call_count), (1, 1))
-        # One roster per noun, in `choose.NOUNS` order — `change` is the third and last.
+        # One roster per noun, in `choose.NOUNS` order — `chat` is the fourth and last.
         self.assertEqual([r.noun for r in opened],
-                         [choose.WORKSPACE, choose.PERSONA, choose.CHANGE])
+                         [choose.WORKSPACE, choose.PERSONA, choose.CHANGE,
+                          choose.CHAT])
 
 
 class FindingNothingIsAnANSWERAndNotAMissingOne(unittest.TestCase):

--- a/tests/test_frame_pickers.py
+++ b/tests/test_frame_pickers.py
@@ -146,7 +146,8 @@ class APickerRowIsNotAnAction(_Frame, unittest.TestCase):
         opens = {r.id: choose.noun_of(r) for r in choose.open_rows(self.FID)}
         self.assertEqual(opens, {"pick:workspace": choose.WORKSPACE,
                                  "pick:persona": choose.PERSONA,
-                                 "pick:change": choose.CHANGE})
+                                 "pick:change": choose.CHANGE,
+                                 "pick:chat": choose.CHAT})
         for stranger in ("frame.detach", "density.full", "workspace:n0", "acme.deploy"):
             self.assertIsNone(choose.noun_of(overlay.Row(id=stranger, title="x")))
 

--- a/tests/test_frame_switch.py
+++ b/tests/test_frame_switch.py
@@ -277,18 +277,19 @@ class ThePaletteOffersAPickerForEach(PersonaIso, unittest.TestCase):
         state.frame_dir(self.FID, create=True)
         state.record_identity(self.FID, {"CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
 
-    def test_the_palette_opens_with_the_three_pickers_then_charters_own_actions(self):
+    def test_the_palette_opens_with_the_pickers_then_charters_own_actions(self):
         """The order is fixed and the pickers are first, so an operator who presses `F2`
         and Enter without reading opens a list rather than detaching their harness.
 
-        Three since `change` joined `choose.NOUNS`, and it is LAST of the three: a change
-        is the narrowest thing a frame is looking at, so it sits after the plane and the
-        person looking at it."""
+        Four since Phase 5's `chat` joined `choose.NOUNS`, and it is LAST: the first
+        three move what THIS frame is looking at — the plane, the person looking, and the
+        piece of work, narrowest last — while a chat is a sibling frame, which is a
+        different kind of thing rather than a narrower one."""
         _plane_workspaces("alpha")
         ids = [r.id for r in _rows(self.FID)]
-        self.assertEqual(ids[:4], ["pick:workspace", "pick:persona", "pick:change",
-                                   "frame.detach"])
-        self.assertTrue(any(i.startswith("density.") for i in ids[4:7]), ids)
+        self.assertEqual(ids[:5], ["pick:workspace", "pick:persona", "pick:change",
+                                   "pick:chat", "frame.detach"])
+        self.assertTrue(any(i.startswith("density.") for i in ids[5:8]), ids)
 
     def test_each_doorway_says_which_name_the_frame_is_on(self):
         """So the palette still answers "which workspace am I on" without opening

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -106,7 +106,7 @@ from charter.frame import slots as frame_slots
 from charter.frame import state, tmuxctl
 
 from tests import _tmuxreap
-from tests._isolation import PersonaIso, child_plane_env, run_hook
+from tests._isolation import PersonaIso, make_plane, run_hook
 from tests._planeguard import allow_background_children
 # Imported rather than re-declared: a second copy of the stub that keeps a launch's
 # detached `frame-gather` child off the developer's real plane is a copy that can drift
@@ -5306,6 +5306,25 @@ class SwitchingBetweenChatsMovesTheClientAndThePanes(_ChatsOnOneSession,
     BIG = (200, 50)
     SMALL = (100, 30)
 
+    def setUp(self) -> None:
+        super().setUp()
+        # **The panels this class's switch splits are REAL `charter panel` children**, and
+        # `layout.panel_command` builds their argv with `-P` (#390) — so this checkout has
+        # to reach them on `$PYTHONPATH`, exactly as `PanelIntegration` and
+        # `FourEdgeIntegration` already arrange for their own.
+        #
+        # Set into `os.environ` and set HERE, before this class's first tmux command, and
+        # both halves matter. A live re-layout hands `tmuxctl.run` no client environment
+        # at all (`_relayout`'s `env=None`), so there is nowhere to pass one; and the
+        # first tmux command is what STARTS this class's server, whose environment is what
+        # every pane it later creates inherits. Set afterwards it would reach the test
+        # process and no pane, and the panels would die with `No module named charter` —
+        # which is what `test_a_placed_chat_bar_…` caught, because it is the only test
+        # here that asserts on what a panel actually PAINTED rather than on its geometry.
+        self.enterContext(mock.patch.dict(
+            os.environ, {"PYTHONPATH": _importable_env(os.environ)["PYTHONPATH"]},
+            clear=False))
+
     def _resize(self, fd: int, cols: int, rows: int) -> None:
         """Change the pty's size the way a terminal emulator does — `TIOCSWINSZ`, which
         is what makes tmux resize the client and, at the switch, the window."""
@@ -5460,6 +5479,75 @@ class SwitchingBetweenChatsMovesTheClientAndThePanes(_ChatsOnOneSession,
                                      "#{pane_id}").stdout.split(),
                       "killing the chat's panel took its harness with it")
 
+    def test_a_placed_chat_bar_is_split_by_the_switch_and_paints_both_chats(self):
+        """**The end-to-end nobody else in this branch makes**, and the one a unit test
+        cannot: a plane that places `chats` with a `[[frame.component]]` table gets a real
+        pane split for it by the switch, running a real `charter panel chats` process, and
+        that process paints both chats with the active one marked.
+
+        Every link in that chain was a separate gate before this branch —
+        `instance.component_tables` refused the id for not being in `builtins.SLOT_OF`,
+        `slots.drawable` refused the name for the same reason, and `panel._run` would then
+        have held the pane open painting `unknown slot`. Asserting on what is ON THE PANE
+        is what says all three opened; asserting that a pane exists would pass with
+        `unknown slot` drawn in it.
+        """
+        # **The panel has to read the plane the frames are IN**, which is this case's own
+        # throwaway root — not a second one. `child_plane_env` hands out a fresh empty
+        # plane, and a `charter panel chats` pointed at that one scans an empty
+        # `.charter/frame/`, finds no sibling, and draws a perfectly correct one-chat bar
+        # for a workspace that has two. (It did exactly that, which is the second thing
+        # this test caught.) `make_plane` puts a `charter.toml` at `PersonaIso`'s own
+        # root, which is what makes a CHILD resolve the same plane this process has —
+        # `PersonaIso` alone only redirects `config` in memory.
+        plane = make_plane(self)
+        one, two, fd = self._two_chats_and_a_client()
+        frame = dict(config.FRAME)
+        frame["components"] = instance.frame_components(
+            {"frame": {"component": [{"use": "chats", "edge": "top", "size": 1},
+                                     {"use": "identity"}]}})
+        frame["slots"] = [p["use"] for p in frame["components"]]
+        with mock.patch.object(commands_frame, "SOCKET", self.SOCKET_NAME), \
+             mock.patch.object(config, "FRAME", frame), \
+             mock.patch.dict(os.environ,
+                             {"CHARTER_SESSION_ID": f"{self.WS}.1",
+                              "CHARTER_WORKSPACE": self.WS,
+                              "CHARTER_ROOT": str(plane)}, clear=False):
+            for chat in (f"{self.WS}.1", f"{self.WS}.2"):
+                state.record_workspace(chat, self.WS)
+                state.record_identity(chat, {"CHARTER_SESSION_ID": chat,
+                                             "CHARTER_ROOT": str(plane),
+                                             "CHARTER_WORKSPACE": self.WS})
+            self.assertEqual(
+                commands_frame.cmd_chat(
+                    SimpleNamespace(chat_id=f"{self.WS}.2", chat=f"{self.WS}.1")), 0)
+            pane = state.panes(f"{self.WS}.2").get("chats")
+            self.assertIsNotNone(
+                pane, "the switch split no pane for a placed `chats` — it split "
+                      f"{sorted(state.panes(f'{self.WS}.2'))}")
+            drew = self._wait_for_text(pane, f"{self.WS}.1")
+        self.assertIn(f"{self.WS}.1", drew, f"the chat bar painted {drew!r}")
+        self.assertIn(f"*{self.WS}.2", drew,
+                      f"the chat bar did not mark the chat switched to: {drew!r}")
+        self.assertNotIn("unknown slot", drew)
+
+    def _wait_for_text(self, pane: str, needle: str) -> str:
+        """What *pane* is showing once *needle* is on it, or whatever it ends up showing.
+
+        A panel is a real process that starts, imports `charter.frame` and paints —
+        `--once` is not what production runs — so this polls rather than sleeps, and
+        returns the last capture either way, so a failure says what WAS drawn rather than
+        only that something was not.
+        """
+        seen = ""
+        deadline = time.monotonic() + _DEADLINE
+        while time.monotonic() < deadline:
+            seen = self._srv("capture-pane", "-p", "-t", pane).stdout
+            if needle in seen:
+                return seen
+            time.sleep(0.1)
+        return seen
+
     def test_each_chat_keeps_its_own_escape_hatch_across_a_switch(self):
         """Stage 5b's exit criterion: `F12` returns to the harness from any chat.
 
@@ -5521,16 +5609,20 @@ class SwitchingBetweenChatsMovesTheClientAndThePanes(_ChatsOnOneSession,
             self._wait_until(lambda: self._size_of(self._window_of(one))[0]
                              == self.SMALL[0]))
 
-        # The panels this splits are REAL `charter panel` children, so they are handed a
-        # throwaway plane — `tests._planeguard` refuses the spawn otherwise, and it is
-        # right to: a panel resolving the developer's own plane would rewrite its caches.
+        # The panels this splits are REAL `charter panel` children, so they are pointed
+        # at THIS case's own throwaway plane — `tests._planeguard` refuses the spawn
+        # otherwise, and it is right to: a panel resolving the developer's own plane
+        # would rewrite its caches. `make_plane` rather than `child_plane_env` for the
+        # reason `test_a_placed_chat_bar_…` records: a panel must read the plane the
+        # frames are IN, and a second empty plane is one it can read nothing out of.
+        #
         # BOTH halves are needed and they are two different things. The `-e` is what the
         # PANE's process gets, and `_relayout_pane_env` builds it out of `state.identity`
         # — which is why the root is recorded there. `$CHARTER_ROOT` in this process is
         # what the tmux CLIENT inherits, because a live re-layout hands `tmuxctl.run` no
         # client environment at all (`_relayout`'s `env=None`), and that is what the
         # guard resolves a spawn's plane from.
-        plane, _child = child_plane_env(self)
+        plane = make_plane(self)
         with mock.patch.object(commands_frame, "SOCKET", self.SOCKET_NAME), \
              mock.patch.dict(os.environ,
                              {"CHARTER_SESSION_ID": f"{self.WS}.1",

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -80,6 +80,7 @@ one does.
 
 from __future__ import annotations
 
+import fcntl
 import os
 import pty
 import re
@@ -87,9 +88,11 @@ import select
 import shutil
 import signal
 import socket
+import struct
 import subprocess
 import sys
 import tempfile
+import termios
 import threading
 import time
 import unittest
@@ -103,7 +106,7 @@ from charter.frame import slots as frame_slots
 from charter.frame import state, tmuxctl
 
 from tests import _tmuxreap
-from tests._isolation import PersonaIso, run_hook
+from tests._isolation import PersonaIso, child_plane_env, run_hook
 from tests._planeguard import allow_background_children
 # Imported rather than re-declared: a second copy of the stub that keeps a launch's
 # detached `frame-gather` child off the developer's real plane is a copy that can drift
@@ -4961,20 +4964,14 @@ class FocusEventsIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase
             "session-scoped, reached the sibling here — this probe measures nothing")
 
 
-class ChatsAreWindowsOnOneWorkspaceSession(_TmuxServerFixture, PersonaIso):
-    """Phase 5 Stage 5a, against a real server: a workspace is a SESSION and a chat is a
-    WINDOW in it.
+class _ChatsOnOneSession:
+    """Opening real chats as real windows of one workspace's session.
 
-    Every claim here is one a mock cannot make. Whether `new-window -n` pins a name and
-    whether a pane can take it back; whether a window user option survives that; whether
-    a pane-scoped `pane-died[1] kill-window` leaves its siblings alone and still ends the
-    session when it is the last window; and whether a per-window `-e` really beats a
-    session-wide `set-environment` in the pane's own environment.
-
-    **Re-run against tmux 3.2 — `tmuxctl.FLOOR` — as well as 3.7c**, by putting a 3.2
-    built from the release tarball first on `$PATH` and running this module: every
-    assertion below passed identically on both, so nothing here carries a version gate.
-    The two versions' answers are quoted in the tests that turn on them.
+    A mixin rather than a base class with tests in it, for `_TmuxServerFixture`'s own
+    reason: `unittest` collects an inherited test as the subclass's own, so a second
+    class about chats would re-run every one of Stage 5a's against its own server for
+    nothing. What is shared is the FIXTURE — the production builders, the cleanup, and
+    the two readings every chat test needs — and nothing else.
     """
 
     #: The workspace these chats belong to — the tmux SESSION's name, and the part of each
@@ -5035,6 +5032,24 @@ class ChatsAreWindowsOnOneWorkspaceSession(_TmuxServerFixture, PersonaIso):
                 return True
             time.sleep(0.05)
         return False
+
+
+class ChatsAreWindowsOnOneWorkspaceSession(_ChatsOnOneSession, _TmuxServerFixture,
+                                           PersonaIso):
+    """Phase 5 Stage 5a, against a real server: a workspace is a SESSION and a chat is a
+    WINDOW in it.
+
+    Every claim here is one a mock cannot make. Whether `new-window -n` pins a name and
+    whether a pane can take it back; whether a window user option survives that; whether
+    a pane-scoped `pane-died[1] kill-window` leaves its siblings alone and still ends the
+    session when it is the last window; and whether a per-window `-e` really beats a
+    session-wide `set-environment` in the pane's own environment.
+
+    **Re-run against tmux 3.2 — `tmuxctl.FLOOR` — as well as 3.7c**, by putting a 3.2
+    built from the release tarball first on `$PATH` and running this module: every
+    assertion below passed identically on both, so nothing here carries a version gate.
+    The two versions' answers are quoted in the tests that turn on them.
+    """
 
     def test_two_chats_in_one_workspace_are_two_windows_on_one_session(self):
         """The shape, end to end. One session named for the workspace, one window per
@@ -5263,6 +5278,249 @@ class ChatsAreWindowsOnOneWorkspaceSession(_TmuxServerFixture, PersonaIso):
             "run-shell", "-b", "-t", self.WS,
             f"printenv CHARTER_SESSION_ID > {seen}").returncode, 0)
         self.assertEqual(_await_text(seen), "session-wide")
+
+
+class SwitchingBetweenChatsMovesTheClientAndThePanes(_ChatsOnOneSession,
+                                                     _NeedsAttachedClient,
+                                                     _TmuxServerFixture, PersonaIso):
+    """Phase 5 Stage 5b, Task 4: every claim the switch rests on, against a REAL attached
+    client whose size this test changes.
+
+    **A mock cannot make any of these**, which is why the module's own fake server is
+    only ever asked about ARGV and ORDER (`tests/test_frame_chat_switch.py`). Whether a
+    background window keeps stale geometry, whether `select-window` corrects it by the
+    time the very next command runs, whether a pane split before that switch is born at
+    the wrong width, and whether `select-pane` on another window's pane drags the client
+    with it — all four are facts about tmux, and the design is wrong if any of them is
+    not what it was measured to be.
+
+    **Re-run against tmux 3.2 — `tmuxctl.FLOOR` — as well as 3.7c**, by putting a 3.2
+    built from the release tarball first on `$PATH`. Every assertion below was identical
+    on both, so nothing here carries a version gate; the two numbers are quoted in the
+    tests that turn on them.
+    """
+
+    #: The client's size before and after the resize each test makes. Two shapes rather
+    #: than one because the whole property is that a background window keeps the FIRST
+    #: while the client is at the SECOND — so a single size would measure nothing.
+    BIG = (200, 50)
+    SMALL = (100, 30)
+
+    def _resize(self, fd: int, cols: int, rows: int) -> None:
+        """Change the pty's size the way a terminal emulator does — `TIOCSWINSZ`, which
+        is what makes tmux resize the client and, at the switch, the window."""
+        fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+
+    def _window_of(self, pane: str) -> str:
+        return self._srv("display-message", "-p", "-t", pane,
+                         "#{window_id}").stdout.strip()
+
+    def _current_window(self) -> str:
+        return self._srv("display-message", "-p", "-t", f"{self.WS}:",
+                         "#{window_id}").stdout.strip()
+
+    def _size_of(self, window: str) -> tuple[int, int]:
+        out = self._srv("display-message", "-p", "-t", window,
+                        "#{window_width}:#{window_height}").stdout.strip()
+        w, _, h = out.partition(":")
+        return int(w), int(h)
+
+    def _two_chats_and_a_client(self):
+        """Two chats on one session, a real client attached at :data:`BIG`, **both**
+        windows already at that size, and the client sitting on the first chat.
+
+        Returns the two panes and the client's pty fd. The attach is
+        `_NeedsAttachedClient`'s, so a machine tmux will not attach a client on skips
+        rather than asserting about a switch nothing was there to see.
+
+        **Both windows are visited once on purpose.** A window is created at the SESSION's
+        size (80x24 here, `layout.session_argv`'s own), so a second chat that has never
+        been selected is already stale — which would make every test below pass for the
+        wrong reason, measuring "a window nobody looked at kept its birth size" instead of
+        "a window that WAS correct went stale when the client moved". Selecting each once
+        puts both at the client's size, so the only staleness left is the one the resize
+        creates.
+        """
+        one, _ = self._chat(f"{self.WS}.1", first=True)
+        two, _ = self._chat(f"{self.WS}.2", first=False)
+        _name, fd, _screen = self._attach_pty(self.WS)
+        self._resize(fd, *self.BIG)
+        for pane in (two, one):
+            self._srv("select-window", "-t", pane)
+            self.assertTrue(
+                self._wait_until(lambda p=pane: self._size_of(self._window_of(p))[0]
+                                 == self.BIG[0]),
+                "the client never took the size this test set, so nothing below "
+                "measures what it claims to")
+        self.assertEqual(self._current_window(), self._window_of(one))
+        return one, two, fd
+
+    def test_a_background_chats_window_keeps_stale_geometry_until_the_switch(self):
+        """§7.4, re-measured on this tree because the whole design turns on it.
+
+        With the client resized 200x50 → 100x30 the ACTIVE chat's window follows and the
+        background chat's does not — it is still 200 columns wide. Identical on tmux 3.7c
+        and tmux 3.2. That is why panels may not simply be left running in a background
+        chat: they are not idle, they are rendering at a width that is not their
+        window's.
+        """
+        one, two, fd = self._two_chats_and_a_client()
+        self._resize(fd, *self.SMALL)
+        self.assertTrue(
+            self._wait_until(lambda: self._size_of(self._window_of(one))[0]
+                             == self.SMALL[0]),
+            "the active window never followed the client's resize")
+        self.assertEqual(self._size_of(self._window_of(two))[0], self.BIG[0],
+                         "the background window followed the resize on this tmux — the "
+                         "stale-geometry premise this design rests on is gone and the "
+                         "decision should be re-argued")
+
+    def test_select_window_corrects_that_geometry_by_the_very_next_command(self):
+        """And this is why the switch splits panels AFTER the select and not before.
+
+        No sleep, no hook, no poll: the invocation immediately after `select-window`
+        already reports the target window at the client's own size. Measured 200x50 →
+        100x29 on tmux 3.7c and identically on tmux 3.2 — which matters because
+        `set-hook -w window-resized` does not exist at all on 3.2 (`invalid option`,
+        rc=1), so there is nothing there to repair a window charter did not correct
+        itself.
+        """
+        one, two, fd = self._two_chats_and_a_client()
+        self._resize(fd, *self.SMALL)
+        self.assertTrue(
+            self._wait_until(lambda: self._size_of(self._window_of(one))[0]
+                             == self.SMALL[0]))
+        self.assertEqual(self._srv("select-window", "-t", two).returncode, 0)
+        self.assertEqual(self._size_of(self._window_of(two))[0], self.SMALL[0],
+                         "the target window was still stale on the command after the "
+                         "switch, so panels split here would be born at the wrong width")
+
+    def test_a_pane_split_before_the_switch_is_born_at_the_wrong_width(self):
+        """The defect the ordering exists to avoid, demonstrated rather than argued.
+
+        Split into the background chat while it is still stale and the new pane is 200
+        columns wide in a window the client will draw at 100. `panel._component_text`'s
+        `width=slots._width()` guard is what that would have reached.
+        """
+        one, two, fd = self._two_chats_and_a_client()
+        self._resize(fd, *self.SMALL)
+        self.assertTrue(
+            self._wait_until(lambda: self._size_of(self._window_of(one))[0]
+                             == self.SMALL[0]))
+        early = self._srv("split-window", "-d", "-t", two, "-l", "3",
+                          "-P", "-F", "#{pane_id}", "sleep", "600")
+        self.assertEqual(early.returncode, 0, early.stderr)
+        self.addCleanup(_kill_pid, self._pane_pid_on(early.stdout.strip()))
+        stale_width = int(self._srv("display-message", "-p", "-t",
+                                    early.stdout.strip(),
+                                    "#{pane_width}").stdout.strip())
+
+        self.assertEqual(self._srv("select-window", "-t", two).returncode, 0)
+        late = self._srv("split-window", "-d", "-t", two, "-l", "3",
+                         "-P", "-F", "#{pane_id}", "sleep", "600")
+        self.assertEqual(late.returncode, 0, late.stderr)
+        self.addCleanup(_kill_pid, self._pane_pid_on(late.stdout.strip()))
+        fresh_width = int(self._srv("display-message", "-p", "-t",
+                                    late.stdout.strip(),
+                                    "#{pane_width}").stdout.strip())
+
+        self.assertEqual(stale_width, self.BIG[0])
+        self.assertEqual(fresh_width, self.SMALL[0])
+
+    def test_select_pane_on_another_windows_pane_does_not_move_the_client(self):
+        """**The measurement that makes the switch safe to run DETACHED.**
+
+        `_close_palette` runs in the palette's own process, after `cmd_chat` has been
+        started, and aims `select-pane` at the harness of the chat being LEFT. If that
+        moved the client, the two processes would be racing for which window the operator
+        ends on. It does not: current window `@0` before and `@0` after, on tmux 3.7c and
+        on tmux 3.2. The pane it names becomes its own window's active pane and nothing
+        else happens.
+        """
+        one, two, _fd = self._two_chats_and_a_client()
+        before = self._current_window()
+        self.assertEqual(self._srv("select-pane", "-t", two).returncode, 0)
+        self.assertEqual(self._current_window(), before,
+                         "`select-pane` dragged the client to another window on this "
+                         "tmux — the palette's own close would then undo every switch")
+
+    def test_kill_pane_works_on_the_window_the_client_has_just_left(self):
+        """The teardown half. The chat being left is a background window by the time its
+        panels are killed, and tmux is as happy to close a pane there as anywhere."""
+        one, two, _fd = self._two_chats_and_a_client()
+        extra = self._srv("split-window", "-d", "-t", one, "-l", "3",
+                          "-P", "-F", "#{pane_id}", "sleep", "600")
+        self.assertEqual(extra.returncode, 0, extra.stderr)
+        panel = extra.stdout.strip()
+        self.assertEqual(self._srv("select-window", "-t", two).returncode, 0)
+        self.assertEqual(self._srv("kill-pane", "-t", panel).returncode, 0)
+        self.assertNotIn(panel, self._srv("list-panes", "-a", "-F",
+                                          "#{pane_id}").stdout.split())
+        self.assertIn(one, self._srv("list-panes", "-a", "-F",
+                                     "#{pane_id}").stdout.split(),
+                      "killing the chat's panel took its harness with it")
+
+    def test_the_whole_command_moves_the_client_and_re_lays_out_the_target(self):
+        """`commands_frame.cmd_chat` end to end on a real server with a real client.
+
+        The client starts on chat one with a panel pane; the switch is run; the client
+        ends on chat two, chat one has lost its panel, and chat two has gained panes that
+        are the CLIENT's width rather than the stale one. This is the exit criterion
+        "switching between chats loses nothing" expressed as the smallest thing that can
+        fail.
+        """
+        one, two, fd = self._two_chats_and_a_client()
+        # A stand-in panel for chat one, recorded exactly as `_draw_panels` records one,
+        # so the teardown path is charter's own rather than this test's.
+        extra = self._srv("split-window", "-d", "-t", one, "-l", "3",
+                          "-P", "-F", "#{pane_id}", "sleep", "600")
+        self.assertEqual(extra.returncode, 0, extra.stderr)
+        state.record_panes(f"{self.WS}.1", panels={"top": extra.stdout.strip()})
+        # Resized while chat two is in the background, which is the case a bare
+        # `select-window` would leave broken on tmux 3.2.
+        self._resize(fd, *self.SMALL)
+        self.assertTrue(
+            self._wait_until(lambda: self._size_of(self._window_of(one))[0]
+                             == self.SMALL[0]))
+
+        # The panels this splits are REAL `charter panel` children, so they are handed a
+        # throwaway plane — `tests._planeguard` refuses the spawn otherwise, and it is
+        # right to: a panel resolving the developer's own plane would rewrite its caches.
+        # BOTH halves are needed and they are two different things. The `-e` is what the
+        # PANE's process gets, and `_relayout_pane_env` builds it out of `state.identity`
+        # — which is why the root is recorded there. `$CHARTER_ROOT` in this process is
+        # what the tmux CLIENT inherits, because a live re-layout hands `tmuxctl.run` no
+        # client environment at all (`_relayout`'s `env=None`), and that is what the
+        # guard resolves a spawn's plane from.
+        plane, _child = child_plane_env(self)
+        with mock.patch.object(commands_frame, "SOCKET", self.SOCKET_NAME), \
+             mock.patch.dict(os.environ,
+                             {"CHARTER_SESSION_ID": f"{self.WS}.1",
+                              "CHARTER_WORKSPACE": self.WS,
+                              "CHARTER_ROOT": str(plane)}, clear=False):
+            for chat in (f"{self.WS}.1", f"{self.WS}.2"):
+                state.record_workspace(chat, self.WS)
+                state.record_identity(chat, {"CHARTER_SESSION_ID": chat,
+                                             "CHARTER_ROOT": str(plane),
+                                             "CHARTER_WORKSPACE": self.WS})
+            rc = commands_frame.cmd_chat(
+                SimpleNamespace(chat_id=f"{self.WS}.2", chat=f"{self.WS}.1"))
+        self.assertEqual(rc, 0)
+
+        self.assertEqual(self._current_window(), self._window_of(two),
+                         "the client did not end on the chat that was switched to")
+        self.assertEqual(state.panes(f"{self.WS}.1"), {},
+                         "the chat that was left kept its panels, so they are now "
+                         "rendering at a width that is not their window's")
+        self.assertNotIn(extra.stdout.strip(),
+                         self._srv("list-panes", "-a", "-F",
+                                   "#{pane_id}").stdout.split())
+        for pane in state.panes(f"{self.WS}.2").values():
+            width = int(self._srv("display-message", "-p", "-t", pane,
+                                  "#{pane_width}").stdout.strip())
+            self.assertLessEqual(width, self.SMALL[0],
+                                 "a panel was born at the background window's stale "
+                                 "width")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -101,7 +101,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, config, hooks, instance, statusline, todos
-from charter.frame import gather, layout, notify
+from charter.frame import gather, layout, notify, overlay
 from charter.frame import slots as frame_slots
 from charter.frame import state, tmuxctl
 
@@ -5459,6 +5459,44 @@ class SwitchingBetweenChatsMovesTheClientAndThePanes(_ChatsOnOneSession,
         self.assertIn(one, self._srv("list-panes", "-a", "-F",
                                      "#{pane_id}").stdout.split(),
                       "killing the chat's panel took its harness with it")
+
+    def test_each_chat_keeps_its_own_escape_hatch_across_a_switch(self):
+        """Stage 5b's exit criterion: `F12` returns to the harness from any chat.
+
+        The hatch is a WINDOW option (`overlay.arm_hatch_argv`: `set-option -w -t <pane>`,
+        which resolves to that pane's own window), so one chat per window is one hatch per
+        chat for free — and the switch must not disturb either. The case that could have
+        broken it is `_close_palette`, which re-arms the option on the chat being LEFT
+        while the client is already on the chat being entered: window-scoped, that touches
+        the old chat's window and nothing else. A global write would have handed one
+        chat's hatch the other's harness pane, which is the "last launched wins" trap
+        `conf_text` names for `mouse` and `history-limit`.
+        """
+        one, two, _fd = self._two_chats_and_a_client()
+        for pane in (one, two):
+            armed = overlay.arm_hatch_argv(self.SOCKET_NAME, harness=pane)
+            self.assertIsNotNone(armed)
+            self.assertEqual(_run(armed).returncode, 0)
+        self.assertEqual(self._srv("select-window", "-t", two).returncode, 0)
+        # And the palette's own close, aimed at the chat that was left.
+        commands_frame._close_palette(self.SOCKET_NAME, harness=one,
+                                      overlay_pane=self._spare_pane(one))
+        for pane in (one, two):
+            hatch = self._srv("display-message", "-p", "-t", pane,
+                              f"#{{{overlay.HATCH_OPTION}}}").stdout.strip()
+            self.assertIn(pane, hatch,
+                          f"chat window for {pane} lost its own hatch: {hatch!r}")
+
+    def _spare_pane(self, near: str) -> str:
+        """A throwaway pane in *near*'s window, for `_close_palette` to kill.
+
+        It needs a real overlay pane id or `overlay.close_argvs` refuses outright and the
+        test would measure a command that was never sent.
+        """
+        made = self._srv("split-window", "-d", "-t", near, "-l", "3",
+                         "-P", "-F", "#{pane_id}", "sleep", "600")
+        self.assertEqual(made.returncode, 0, made.stderr)
+        return made.stdout.strip()
 
     def test_the_whole_command_moves_the_client_and_re_lays_out_the_target(self):
         """`commands_frame.cmd_chat` end to end on a real server with a real client.


### PR DESCRIPTION
Phase 5 **Stage 5b**, tasks **4, 6 and 7** of
`docs/superpowers/plans/2026-08-28-phase5-workspace-and-chat-tabs.md`. **Task 5 (harness
selection at chat creation) is not in this branch** — see *What is not here*.

Stage 5a made a workspace a tmux session and a chat a window in it. This is the half that
lets you move between them.

---

## What changed

`F2` → `chat` lists this workspace's chats, marks the one you are typing in, and names the
harness each is running. Choosing one puts the client on that chat's window and moves the
frame's panels with it. Typing the chat's name at the top level reaches the same row
without the doorway, so a chat is **two keystrokes at every width** — including widths
where no bar can be drawn at all. `charter frame-chat <id>` is the same switch by hand.

### Task 4 — the switch

Four steps, each an existing path (§3.7):

1. `select-window` at the **target chat's own harness pane**. A pane id resolves to that
   pane's window on 3.7c and 3.2 alike, so charter needs no window-id record beside the
   pane record `state.record_harness_pane` already keeps — nothing new to keep in step.
2. `_apply_arrangement(left, want=[])` — the panels of the chat being left come down.
3. `_apply_arrangement(entered, want=_visible_now(...))` — the new panels are split into
   the window **tmux has just resized**.
4. The bump is step 3's own last line, so the panels repaint into a shape that has already
   settled (#411/#412).

**The order is the correctness**, and it is measured rather than argued. Re-measured on
this tree, on 3.7c and at the 3.2 floor, byte-identical:

| | measured |
|---|---|
| a background window after the client resizes 200x50 → 100x30 | still **200** columns |
| the same window on the command **immediately after** `select-window` | **100** — no sleep, no hook, no poll |
| a pane split into it *before* the switch | born **200** wide, in a window drawn at 100 |
| a pane split into it *after* | 100 |

That last pair is the defect `panel._component_text`'s `width=slots._width()` guard exists
for, and it is why the switch never asks for a `window-resized` hook — which does not
exist at `tmuxctl.FLOOR` (`invalid option`, rc=1).

**The switch is detached, and one more measurement is what makes that safe.**
`_close_palette` runs in the palette's own process *after* `cmd_chat` has started, and
aims `select-pane` at the chat being **left**. Measured on both versions: `select-pane -t
%N` on a pane in another window of the same session does **not** move the client (current
window `@0` before and `@0` after). Without that, the two processes would be racing for
which window the operator ends on.

### Task 6 — the chat picker, and the containment

`chat` is a fourth noun in `choose.NOUNS`, last: the first three move what *this* frame is
looking at by writing a file its own panels read; a chat is a sibling frame. Row ids are
`pick:chat` / `chat:n<N>`, so the `:` keeps them out of the action namespace
`component._ID_RE` governs and a provider shipping an action called `chat` cannot take the
keypress.

`frame/chats.py` is the reading half — which chats a workspace holds, which one you are in,
and whether a name may be switched to. **No tmux call and no subprocess**, `frame/switch.py`'s
own rule and for its own reason: it is asked on a panel's repaint path and when the palette
opens.

**Refusals name themselves**: a name outside the id alphabet, a chat this workspace does not
have (with the ones it does listed), the chat you are already in, a chat with no usable
pane record, and — from `cmd_chat`, because only tmux can answer it — a chat whose window
has gone. The last one is checked **after** `select-window` and **before** any teardown, so
a dead chat costs a sentence and no panes.

### Task 7 — the two bars

`chats` and `workspaces` are components, `edge="top"`, `size=Fixed(1)`. One shared ladder,
so two bars on adjacent rows cannot give up their names at different widths:

```
  chats   api.1  *api.2   api.3        every name
  chats  *api.2  +2                     yours whole, the rest counted
  chats  2/3                            where you are, and how many
  (nothing)                             no room for even that
```

Every rung drops **whole** names. That is stronger than §3.6's `slots._NAME_MIN_W` floor
and makes it unnecessary: the floor guards against a truncation this renderer never
performs, so written as an `if` it would be a line no input could reach — the equivalent
mutant the sweep asks be deleted rather than documented. `TheLadderGivesUpWholeThings
.test_no_name_is_ever_shown_in_part_at_any_width` pins the property directly, at every
width from 0 to 200.

---

## Three findings that correct the spec

### 1. A switch is ~360 ms, not ~16 ms — and chaining is not worth 3.3×

§7.7 timed nine commands: one `select-window`, four chained `kill-pane`, four chained
`split-window`. **Charter's one live pane-mutation path issues 41.** The other thirty-two
are not incidental — `_disarm_panel_respawn` before each kill, `_arm_panel_respawn` after
each split, the panel mark, the pane surface and border options, `_install_resize_hook`,
and `_reassert_sizes`, which exists precisely because a `kill-pane` or a `split-window -l`
makes tmux redistribute every surviving pane.

Measured end to end — `cmd_chat` between two real chats, real attached client at 200x50,
four panels, six switches alternating direction:

```
tmux 3.7c   median 360.2 ms   min 282.2   max 600.3   41 invocations
tmux 3.2    median 394.7 ms   min 330.2   max 428.4   41 invocations
one tmux invocation, median 6.18 ms (3.7c) / 6.70 ms (3.2)
```

**§3.7's decision stands and is not close** — 41 invocations once per switch against 758 MB
of panel processes permanently drawing at wrong widths is not a trade this reopens. What
changes is the adversary's answer: "comfortably inside the band where a terminal reads as
instant" is no longer true at 360 ms, and the honest statement is that a switch is
perceptible.

**And it changes Task 4 step 4.** "Chaining is worth 3.3× here and is not optional" was
derived from the nine-command model. The eight commands a chain would collapse are under a
fifth of the forty-one, so chaining them buys ~10 %. The rest is in the other thirty-three,
which means the real optimisation is collapsing the whole of `_relayout` into one
invocation — a change to the funnel a density change and every toggle key also go through,
and not one to make at the end of a stage. **I followed the funnel and did not chain**, and
this is the measurement that says why. Appended to the spec as §7.10.

### 2. `layout._DROP_ORDER` was read by nothing

§3.6 says "Both join `layout._DROP_ORDER`, **above `top`**". Taken literally that changes
nothing: `grep -rn _DROP_ORDER charter/` at `7dcf09c` returns the definition and one
docstring mention, and `visible_slots` spells the order out by hand as `s != "right"` then
`s != "top"`. Both bars would have survived exactly the shortage that takes the identity
row — backwards, for a readout the palette makes redundant.

`layout._ROW_DROPS` derives the row-edge half from `_DROP_ORDER` now, so the constant is
the mechanism and an entry deleted from it changes what a short terminal draws. Appended as
§7.11.

### 3. A registered component with no slot name could not be placed by anything

Neither bar has a committed `[frame] slots` word — adding one would put it on every
operator's frame — so the only way to ask for one is a `[[frame.component]]` table. That
form refused them: `instance.component_tables` asked `cid in builtins.SLOT_OF` where it
meant *is this one charter places*, so a component charter registers, sizes and can draw
fell through to the provider branch and was refused for having no installed distribution
behind it. `slots.drawable` had the same gap.

`builtins.places(cid, reg=None)` is that question asked directly — off `Registry.on_edge`,
so a composite's parts (`personas`, `todos`, `changes`) stay excluded for free. Charter's
own components are now exactly as placeable as a provider's. **Without this the two bars
would have been dead code wearing a feature's name.**

---

## The decision I want your word on: neither bar ships placed

I did not put them in `FRAME_SLOTS`. The argument is the measurement above plus the
precedent already in the tree:

- A plane with **one chat** is the ordinary, permanent state — the same fact
  `frame/builtins.py` already uses to keep `changes` a sidebar section rather than a pane
  ("a plane with no cross-repo change is the ordinary, permanent state").
- Each placed pane costs a permanent row off the harness, a ~24 MB panel process, and
  **about seven of every switch's 41 tmux invocations** — so a bar on by default makes
  every switch measurably slower for everyone, forever, to draw a name `F2` already
  reaches in two keystrokes.
- §3.6's own sentence is that the bar is a readout and the palette is the mechanism.
  Nothing is unreachable without them.

So they ship as components a plane places deliberately, which is also the only way any
component gets a toggle key:

```toml
[[frame.component]]
use = "chats"
edge = "top"
size = 1
key = "F9"
```

**My recommendation is that `chats` joins the shipped default in Stage 5c, not here** —
when the row carries every chat's token gauge and activity mark (Task 8 step 5) and is
therefore saying something no other surface says. Today it would draw a name the operator
already knows. If you want it on now, it is two lines in `instance.FRAME_SLOTS` plus the
three tables pinned to agree with it, and I will do it.

---

## Verification

**Full suite: 8719 tests, OK** locally on python3.14, and green in CI on **3.11, 3.12,
3.13 and 3.14** — four environments, not two.

**Real tmux, both versions.** New class `tests/test_frame_tmux_integration
.SwitchingBetweenChatsMovesTheClientAndThePanes` — 7 tests with a real forked `tmux attach`
client whose pty this test resizes. Passes on **tmux 3.7c and on tmux 3.2** built from the
release tarball; Stage 5a's `ChatsAreWindowsOnOneWorkspaceSession` passes on both too after
its fixture was lifted into a `_ChatsOnOneSession` mixin (no test moved, no assertion
changed). Every claim in it is one a mock cannot make: stale background geometry,
`select-window` correcting it by the next command, a pane split too early being born at the
wrong width, `select-pane` not dragging the client, `kill-pane` on the window just left,
each chat keeping its own `@charter_hatch` across a switch, and `cmd_chat` end to end.

**Mutation testing — 37 mutations, 37 RED**, in three passes: 16 on the guards this
branch adds, 18 re-running exactly what CI's first sweep reported as survivors, and 3 on
the `pane_of` read that replaced the last of them. Green unmutated baseline first, each
mutation asserted to have changed the file, each restored and the restore verified by
**sha256**, every child under `PYTHONDONTWRITEBYTECODE=1`. One per guard this branch adds:

| file | guard deleted or inverted |
|---|---|
| `frame/chats.py` | the id alphabet where a directory name enters; the version discriminator; membership by recorded workspace; the ordinal bound before `int()`; refusing a switch to the chat you are in; the pane record held to tmux's own shape |
| `commands_frame.py` | `select-window` before the teardown; a dead window costing no panes; outside a frame, touching no tmux |
| `frame/slots.py` | the ladder's rung 2 before rung 3; containment before the width arithmetic; a bar with no room drawing nothing; a charter component with no slot name being drawable |
| `frame/layout.py` | the bars going with the identity row rather than after it |
| `instance.py` | a registered built-in with no slot name being placeable |
| `frame/builtins.py` | a sidebar part not being placeable |

**Deletion sweep — CI's sharded gate, read twice.**

The first run said **`5 unpinned, 22 in masked cluster(s), 0 platform-deferred, 1
unresolved, 0 not applied, 59 pinned`** — 27 survivors. I read all 27 rather than filing
them as debt, and every one decomposed into a line I could delete or a test I could
sharpen. The second run reads **`88 pinned, 1 survivor, 1 unresolved`**, and neither of
the two is this branch's:

| what it found | verdict | what I did |
|---|---|---|
| `_bar`'s `contain.one_line` on its `head` and on its `note` (2) | **equivalent** | deleted — both are charter's own literals (`"chats"`, `"workspaces"`, `ADD_CHAT`), so the call was provably its own argument. The NAMES are still contained, which is where the open alphabet is |
| `_bar`'s `if len(names) > 1` on the count (2) | **unreachable** | deleted — with one name `joined` IS `marked[at]`, so the rung above asks exactly what rung 2 asks and always answers first. `+0` could be built and never returned |
| `builtins.places`' `isinstance(cid, str)` (2) | **equivalent** | deleted — `Registry.on_edge` yields components whose id is always a string, so `c.id == cid` is already False for a TOML array |
| `chats.roster`'s `fid and` | **equivalent** | deleted — `is_chat("")` is already False |
| `chats.of_workspace`'s `e.is_dir()` | **masked** | deleted — a loose file has no `workspace` file inside it, so `frame_workspace` already refuses it. A guard passing because a different guard caught it |
| `cmd_chat`'s `contain.one_line(target)` | **equivalent** | deleted — `chats.check` has already held it to `ID_RE`, whose alphabet holds nothing `one_line` touches |
| eight `shift-boundary` in `_bar` (`<=`→`<`, `>=`→`>`) | unpinned | every one was a test measuring at a ROUND width. Each rung is now asserted at the exact width it fills and at one cell narrower, computed off the row |
| `at >= 0`, twice | unpinned | pinned by marking the FIRST chat, whose index is 0 — every earlier test marked the middle one |
| `_order`'s four clauses | unpinned | `a.b.3` (last dot, not first), `12345` (digits, no dot), `api.x` (a short non-digit tail, which reaches `int()`), and a tail of exactly `_MAX_ORDINAL_DIGITS` |
| `harness_of`'s `.strip()` | unpinned | a TRAILING space — the old test used only spaces, for which `lstrip` answers identically |
| `_note`'s branch | unpinned | a workspace and a chat that share a name, which is the one input that tells it from an unconditional lookup |
| `_draw_palette`'s `out.ok` (2) | unpinned | through the real palette, with a chat `chats.check` refuses |
| `cmd_chat`'s `or ""` and `.strip()` (2) | unpinned | `None`, and a padded id |
| `cmd_chat`'s `state.harness_pane(target) or ""` | **a real hazard** | see below |

**The last one was worth the whole exercise.** That read is the SECOND — `chats.check`
asked about the same record a moment earlier — so a record that had gone in between (a
reap, a relaunch) became `select-window -t ""`. An empty tmux target is not nothing: it
resolves to the CURRENT window, so charter would have reported a switch that did not
happen and then torn this chat's panels down around it. `chats.pane_of` is that read now,
held to `tmuxctl.PANE_ID_RE`, asked once by the check and once by the switch, and a
vanished record is a sentence rather than a `-t ""`.

**The two the second run still names are not this branch's:**

- **`charter/news.py:658` `_BODY_BUDGET = 100_000` (survived).** Not in this diff at all —
  `git grep _BODY_BUDGET HEAD -- charter/news.py` is empty. It arrived on `main` in
  `db87d2e` (#672) while this branch was open, and the sweep runs on the PR's MERGE
  commit, so it swept that change too.
- **`chats.ID_RE`'s `retune-string` (unresolved).** A shard timeout, which the sweep
  classes as neither green nor red because machine load must not become evidence. Measured
  by hand on this tree: replacing `[A-Za-z0-9._-]+` with the empty-range
  `[B-Ab-a1-0._-]+` is **RED**.

**The one test in this branch that asserts on what a panel PAINTED found two holes a unit
test could not**, and both were in the fixture rather than the product — which is exactly
why it is here. `test_a_placed_chat_bar_is_split_by_the_switch_and_paints_both_chats`
failed twice before it passed:

1. the panels died with `No module named charter`. `layout.panel_command` builds their
   argv with `-P` (#390), so the checkout has to reach them on `$PYTHONPATH` — and it has
   to be set before the class's FIRST tmux command, because that command starts the server
   whose environment every later pane inherits. Every other panel-splitting test in this
   class had the same hole and could not see it: they assert on pane WIDTHS, which a dead
   pane still reports.
2. the bar then painted a perfectly correct **one-chat** row for a workspace with two,
   because `child_plane_env` hands out a fresh empty plane and the panel was scanning that
   one's `.charter/frame/`. `make_plane` points the child at the plane the frames are
   actually in.

**And one defect no test found — I found it by typing the command.** `charter frame-chat
api.2` in an ordinary shell reached `_say_on_screen`, whose `-t <fid>` with an empty target
resolves to whichever session on the SHARED `-L charter` server was attached most recently
— so charter's refusal was drawn across another operator's frame. Guarded the way
`cmd_switch` guards it, and pinned by asserting **no tmux call and no message** rather than
a return code: unlike `cmd_toggle`'s deleted `if not fid`, this one is not free, because
this command does emit something with an empty id.

**Two guards I deleted rather than documented**, both found by asking what could redden them:

- `chats._order`'s `head and` — `rpartition` answers `("", "", name)` for a name with no
  separator, so the empty separator already refuses `api5`; the only name the head test
  could tell apart is `.5`, whose ordinal is as good an answer as sorting it last.
- a second `try` around `DirEntry.is_dir()` in `of_workspace` — only a race could turn it
  red. The scan and the question share one `except OSError` now.

**And one guard the spec asked for that I did not write**: `slots._NAME_MIN_W` in the bar
ladder. See Task 7 above.

---

## What is not here, and why

**Task 5 — harness selection at chat creation.** `F2` → pick a harness → a new tab is not
built. It has no Stage 5b exit criterion, and it is not a prerequisite for anything here:
`charter <harness>` in the workspace opens a second chat from a shell (Stage 5a), which is
what the chat bar's affordance names rather than a palette row that does not exist. Doing
it properly means either duplicating ~70 lines of `cmd_launch`'s hook-arming — the drift
this repo hates — or extracting them from the function 5a has just rewritten, and I would
rather that landed on its own with its own review than at the end of this branch.

**The bar is eventually consistent with a sibling's launch.** A new chat's launch bumps its
own frame, not its siblings', so a bar already on screen learns about it at that chat's next
`state.bump` — which §5 step 2 anticipates ("the old chat's `chats` component repaints on
the next `state.bump`"). A switch bumps both chats, so any switch resynchronises. Fixing it
means bumping every sibling from the launch path, which belongs with Task 5.

**A cold chat is still not a thing, and Stage 5c should know it before Task 9.** §3.3
decides a chat has three states — live, cold, gone — but after 5a there is no cold: a chat
id carries no launcher pid, so `state.reap` abstains on nothing and deletes any chat
directory whose window is absent, at every launch and at every launch's exit. "The record
exists, the window does not" survives only until the next `charter <harness>` anywhere on
the machine. Task 9 ("reopening restores the workspace, the persona, the harness and the
cwd") therefore has no record left to reopen from unless reap learns to keep a chat the
operator closed deliberately. Nothing in this branch depends on it; it is named here so it
is not discovered inside Task 9.

**No version bump, no stamping, no tag.** News entry at
`docs/news/unreleased-switching-between-the-chats-of-one-workspace.md`, `version:
unreleased`.
