### PR TITLE
A release body GitHub will refuse is a release that publishes and then loses its notes (#665)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
             echo "::error::this run names $claimed ($said) but pyproject.toml says $pkg — refusing to publish"
             exit 1
           fi
-      - name: Refuse to publish a version whose news entries cannot be rendered
+      - name: Refuse to publish a version whose notes cannot be rendered, or would be refused
         run: |
           # The version comes from pyproject, not the tag: it is defined on BOTH trigger
           # paths (a workflow_dispatch retry has no tag to read), and the step above has
@@ -125,15 +125,33 @@ jobs:
           # It exits non-zero for MORE than that now: an ordering field charter cannot
           # read, or two entries both claiming `lead: true` (#486); a frontmatter key
           # charter does not know, which is where `Security: true` lands (#503); or a file
-          # in docs/news that is not an entry at all. So the annotation names the two
-          # SHAPES — no entry, or something the entries declare that charter cannot honour
-          # — and defers to the command's own stderr for which, since that stderr is
-          # already one sentence per finding. `>/dev/null` keeps it, dropping only stdout.
-          # Prescribing `news stamp` for any of the second shape would be prescribing a
-          # no-op for a failure stamping cannot fix.
+          # in docs/news that is not an entry at all.
+          #
+          # And for a third shape, which is why this step is worth more than it was (#665).
+          # Rendering was never the failing step: this command exits 0 on a 300,000-
+          # character body, because producing the string is what it was asked to do. The
+          # claim nobody was making is that the string FITS where announce sends it —
+          # GitHub refuses a release body over 125,000 characters outright rather than
+          # trimming it, and the announce job below waits on publish — so that refusal
+          # would land after an upload PyPI will not take back, on a path the documented
+          # workflow_dispatch retry cannot re-reach. charter now bounds the body it renders and
+          # refuses one it cannot bound, so the failure arrives HERE — ahead of test, build
+          # and publish — instead of at the one point in this workflow with no way back.
+          #
+          # The assertion lives in the command rather than in a step of its own precisely
+          # because this step and announce run the same command against the same tree: a
+          # second copy of the limit in shell would be a second answer to one question, and
+          # it is the announce-side answer that decides whether the release exists.
+          #
+          # So the annotation names the three SHAPES — no entry; something the entries
+          # declare that charter cannot honour; or a body GitHub would refuse — and defers
+          # to the command's own stderr for which, since that stderr is already one
+          # sentence per finding. `>/dev/null` keeps it, dropping only stdout. Prescribing
+          # `news stamp` for any shape but the first would be prescribing a no-op for a
+          # failure stamping cannot fix.
           version=$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
           if ! python -m charter news --for "$version" >/dev/null; then
-            echo "::error::cannot render the release notes for $version: either no docs/news/$version-<slug>.md (every published version ships an entry, including a patch — run: charter news stamp $version), or something those entries declare that charter cannot honour — an ordering, a frontmatter key, or a file in docs/news that is not an entry. See the error above for which."
+            echo "::error::the release notes for $version are not publishable: either no docs/news/$version-<slug>.md (every published version ships an entry, including a patch — run: charter news stamp $version), or something those entries declare that charter cannot honour — an ordering, a frontmatter key, or a file in docs/news that is not an entry — or a body GitHub would refuse as too long, which is a failure this step exists to catch before the upload rather than after it. See the error above for which."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Written out rather than inherited. Actions runs `run:` under `bash -e`, so this
+          # step already aborted on a failed command — but "the render refuses and the
+          # release is therefore not created" is load-bearing now (#665), and a property
+          # that holds because of a platform default is a property nobody in this file
+          # states. `guard` spells it out for the same reason. `-u` besides: every variable
+          # read below is one this workflow sets, and an empty `$tag` is a `gh release
+          # create` against whatever it decides that means.
+          set -eu
           version=$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
           tag="v$version"
           # `workflow_dispatch` re-runs a release that failed somewhere, and the publish

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2571,6 +2571,38 @@ def cmd_news(args) -> int:
         if not body:
             util.err(f"no news entry for {version}.")
             return 1
+        # The claim nobody was making (#665). Everything above answers "do these entries
+        # render?", which was never the failing question — this command exits 0 on a
+        # 300,000-character body, because producing the string is exactly what it was asked
+        # to do. What `announce` then does with the string is POST it to an API that
+        # refuses a body over `news.RELEASE_BODY_MAX` outright rather than trimming it, and
+        # `announce` is `needs: publish`: the refusal lands after an upload PyPI will not
+        # take back, and the documented `workflow_dispatch` retry cannot reach `announce`
+        # again because `publish` is rejected for a version PyPI already has.
+        #
+        # Asked here rather than in a step of its own in `release.yml`, because `guard` and
+        # `announce` run this exact command against this exact tree: one answer, delivered
+        # at the cheap end of the workflow — before `test`, `build` and `publish` — with no
+        # second copy of the limit in a shell script to drift from this one.
+        #
+        # `+ 1` is the newline `print` adds below. It is a character in the file `announce`
+        # redirects into and a character GitHub counts, and measuring the string rather than
+        # the file is the off-by-one that would show up only at the ceiling — which is the
+        # one place nobody gets a second try.
+        sent = len(body) + 1
+        if sent > news.RELEASE_BODY_MAX:
+            util.err(
+                f"the release notes for {version} come to {sent:,} characters and GitHub "
+                f"refuses a release body over {news.RELEASE_BODY_MAX:,} — `gh release "
+                f"create` fails with `body is too long`, and in release.yml that happens "
+                f"in `announce`, after the PyPI upload.")
+            # Said because the reader's obvious next move — "link more of them" — is the
+            # one that cannot work here. `render_body` already links every note it can, so
+            # reaching this means the HEADLINES alone are over the limit.
+            util.info(f"  charter already lists every note for {version} by headline and a "
+                      f"link, and the headlines alone do not fit. Shorten them, or split "
+                      f"the release.")
+            return 1
         print(body)
         return 0
 

--- a/charter/news.py
+++ b/charter/news.py
@@ -4,7 +4,7 @@ A *news entry* is a shipped, per-item note that a version introduced something, 
 an optional probe for whether this plane has adopted it. Not a changelog: an entry exists
 to be **acted on**, and one with nothing to adopt is one line.
 
-Six properties are load-bearing.
+Seven properties are load-bearing.
 
 **One entry, two consumers, one answer.** The GitHub Release body and the offline `charter
 news` suggestion are the same entries rendered twice — `release.yml`'s announce job pipes
@@ -14,6 +14,17 @@ never at a call site. It was not, and #486 is what that cost: ORDER was left to
 `sorted(glob("*.md"))`, which for a stamped release is alphabetical by slug, so 0.52.0's
 vault-spending fix rendered eighth, under a docs correction. :func:`all` now applies the
 declared order and :func:`marker` the label, and both views come through them.
+
+**And the body FITS where it is sent.** That pipe ends at an API with a limit —
+:data:`RELEASE_BODY_MAX` — which refuses an over-long body outright rather than trimming
+it, in the `announce` job, which is `needs: publish`: *after* the PyPI upload, which cannot
+be undone, and out of reach of the documented retry, which re-enters `publish` and is
+rejected for a version PyPI already has. Rendering was never the failing step and the
+release guard was never wrong to check it; the claim nobody was making is this one.
+:func:`render_body` therefore bounds what it returns and :func:`commands.cmd_news` refuses
+what it cannot bound, so the refusal lands in `guard` — before `test`, `build` and
+`publish` — and 69 entries stay a releasable release instead of becoming a release-stopper
+nobody sees until the irreversible step is behind them.
 
 **What an entry declares is honoured or reported, never neither.** An entry is a committed
 file and the release notes are the one document nobody re-derives, so an entry that does
@@ -96,6 +107,7 @@ import argparse
 import io
 import os
 import tempfile
+import urllib.parse
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import NamedTuple
@@ -592,6 +604,127 @@ def for_version(version: str) -> list[Entry]:
     return [e for e in all() if e.version == version]
 
 
+#: The most characters GitHub's create-release API accepts in a body. **Its number, not
+#: charter's**: ``POST /repos/{owner}/{repo}/releases`` refuses a longer one with ``body is
+#: too long (maximum is 125000 characters)``, and `gh release create` forwards that refusal
+#: rather than trimming to fit — so a version whose notes render past it does not publish
+#: shorter notes, it publishes **none**.
+#:
+#: Characters, not bytes, and the distinction is load-bearing in both directions. The API
+#: counts code points and charter's entries are not ASCII — they carry ``—``, ``✗``, ``⬢``
+#: — so ``len(body.encode())`` reports a bigger number than the one GitHub applies and
+#: would refuse a release GitHub would have accepted. The 69 notes staged for 0.54.0 differ
+#: by 3,023 between the two measures.
+RELEASE_BODY_MAX = 125_000
+
+#: How much of :data:`RELEASE_BODY_MAX` :func:`render_body` will actually spend. **Charter's
+#: number, and deliberately well below GitHub's**, for three reasons that are not one
+#: reason said three ways:
+#:
+#: *The string charter measures is not quite the string GitHub counts.* `charter news --for`
+#: ``print``s this body, so the file `announce` redirects into is one character longer than
+#: what was measured here, and nothing downstream re-measures. One character is enough at a
+#: bound set exactly at the ceiling, and that is the smallest of the three.
+#:
+#: *A ceiling reached is a ceiling with nothing left for the next change.* A preamble, a
+#: footer, a wrapper someone adds to the announce step — any of them lands on a body already
+#: at the limit, and lands there **after** the PyPI upload, which is the failure this whole
+#: mechanism exists to move to the cheap end.
+#:
+#: *And "just under" is a state nobody notices.* 0.52.0 published at 111,723 characters —
+#: 3,277 short of the refusal — and nothing in the repository remarked on it, because
+#: nothing was looking. Entries accumulate one pull request at a time and each author sees
+#: only their own.
+#:
+#: 100,000 rather than a fraction of the limit, because a fraction invites re-deriving it:
+#: this is a round number a human holds, it leaves a fifth of the API's allowance unspent,
+#: and it is above every release charter has ever cut but two — so the bound below does not
+#: start eliding until a version is genuinely larger than any that has shipped.
+_BODY_BUDGET = 100_000
+
+
+def _part(e: Entry) -> str:
+    """One entry rendered whole: its headline, its label, and the body its author wrote."""
+    return f"### {marker(e)}{e.headline}\n\n{e.body}".rstrip()
+
+
+def _entry_file(e: Entry) -> str:
+    """*e*'s path in the repository — the name a reader with a checkout or a wheel opens.
+
+    The filename is the committed one (`_read` takes the slug from it), so it crosses into
+    a document with structure and is contained on the way, for #502's reason one surface
+    over: a name holding a newline would forge a heading in the release notes, which is the
+    one document nobody re-derives. The body beside it is deliberately *not* contained — an
+    entry's body IS Markdown its author wrote — but this line is charter's own sentence and
+    the filename is a field in it.
+    """
+    return f"docs/news/{contain.one_line(e.path.name)}"
+
+
+def _entry_url(e: Entry) -> str:
+    """Where *e* can be read in full, on the web.
+
+    The ref is the tag for a stamped version and the tracked branch for a staged one. A tag
+    never moves, so a link in a published release body keeps pointing at the note **as that
+    release shipped it** rather than at whatever main later made of it; ``unreleased`` has
+    no tag to point at, and its render is a preview nobody publishes.
+
+    The repository comes from :data:`update.DEV_REPO` — a constant, and it has to be one.
+    `report.upstream_repo` is the other spelling of "charter's repo" in this codebase and it
+    is overridable from the environment, which is exactly what a value interpolated into a
+    *published* release body must not be.
+
+    ``quote`` rather than containment for the href: a clipped URL is a broken link, and the
+    property needed here is that no filename can close the ``](…)`` early and start writing
+    its own Markdown after it. Percent-encoding gives that exactly, for every character.
+    """
+    ref = update.DEV_BRANCH if e.version == UNRELEASED else f"v{e.version}"
+    return (f"https://github.com/{update.DEV_REPO}/blob/{ref}/docs/news/"
+            f"{urllib.parse.quote(e.path.name)}")
+
+
+def _brief(e: Entry) -> str:
+    """One entry as its headline and a link to the note itself.
+
+    The headline is the author's own one-line summary of the entry, rendered **whole** —
+    nothing is clipped and no excerpt is invented from the body. An excerpt would be the
+    shape this function exists to refuse: a paragraph that reads like the note and is not
+    it, with no mark saying where it stopped. What a reader loses here is the body, and the
+    line under the headline says precisely where the body is.
+    """
+    return f"### {marker(e)}{e.headline}\n\nFull note: [`{_entry_file(e)}`]({_entry_url(e)})"
+
+
+def _elision(shown: int, total: int, whole: int) -> str:
+    """The section that says, in the body itself, that the body is not all of it.
+
+    Placed at the cut rather than at the top, and one copy: a banner above the notes would
+    be a second statement of one fact, free to disagree with this one. It can be one copy
+    because the elision is *also* visible at every point it applies — every elided note
+    keeps its own heading, in its own place in the order, with :func:`_brief`'s link
+    directly under it. A reader looking for a particular note therefore meets the elision
+    where they are looking, which is more than a banner at the top would give them.
+
+    It states the arithmetic — how many, how long, and the limit — because "some notes are
+    linked" is the sentence a reader has no way to check. These numbers they can.
+
+    The rule is written only when something is above it to be ruled off. Entry bodies open
+    with prose, so it never lands on nothing — except when *no* note fitted, and a body
+    that begins with ``---`` is a body some renderers read as frontmatter.
+    """
+    listed = total - shown
+    return (
+        ("---\n\n" if shown else "")
+        + f"## {listed} of these {total} notes are listed by headline only\n\n"
+        f"Rendered whole, {total} notes come to {whole:,} characters, and GitHub refuses a "
+        f"release body over {RELEASE_BODY_MAX:,}.\n\n"
+        f"**Every note this version shipped is in this list.** {shown} are above in full; "
+        f"the {listed} below are a headline and a link. No note was dropped, and no note's "
+        f"text was cut short — the text of each one below is in the note it links to, "
+        f"which ships in the wheel and in the repository as well."
+    )
+
+
 def render_body(version: str) -> str:
     """One version's entries as the body of a GitHub Release.
 
@@ -600,11 +733,59 @@ def render_body(version: str) -> str:
 
     Order comes from :func:`all`, not from this function — see its docstring, and #486.
     The label comes from :func:`marker`, which the offline view calls too.
+
+    **And the result is bounded, because the far end of it refuses a long one.** The whole
+    body is returned whenever it fits :data:`_BODY_BUDGET`, which is what every release but
+    two has done and what keeps this function's output byte-identical to what it has always
+    been. Past that, the notes that fit are rendered whole and the rest become a headline
+    and a link, with :func:`_elision` between them saying so.
+
+    Three properties decide the shape, and each of them rules out an easier one:
+
+    **Nothing is dropped and nothing is truncated.** Cutting the string at 125,000
+    characters is the obvious fix and it is the "convincing empty" this codebase refuses
+    everywhere: a release body that ends mid-sentence with a dozen notes simply absent
+    reads exactly like a release that shipped a dozen fewer things. Every entry keeps its
+    heading, in its own place in the order, and every entry's full text stays one click
+    away — so what the reader loses is a scroll, never a fact.
+
+    **The cut is one point, not a per-entry decision.** A greedy fill — skip the big ones,
+    keep packing the small ones — would give an ordinary note its body while a security
+    note above it lost one, which is #486's defect wearing a size limit. So the first *k*
+    render whole and everything after them is brief.
+
+    **And *k* is measured against the order :func:`all` already decided.** There is no
+    second rule in here that promotes security entries, for the reason `render_body` does
+    no sorting: the order that decides what leads is the order that decides what keeps its
+    body, and a rule stated twice is a rule that can be honoured in one view and not the
+    other. The consequence — a security note is never demoted while an ordinary one keeps
+    its body — is asserted rather than assumed, in
+    `tests/test_release_notes_fit_the_release.py`.
+
+    Each candidate is **built and then measured**, rather than measured by adding up part
+    lengths. Deriving the length is a second answer to "how long is this?", free to drift
+    from the string actually returned by a separator's width; the string measured here is
+    the string handed back. It costs a few joins of a document a third of a megabyte long,
+    on the release path, once.
+
+    A body that cannot be brought under the limit even with every note brief is returned
+    **as it is**, not silently cut: :func:`commands.cmd_news` refuses to print it, which is
+    the refusal `release.yml`'s `guard` job runs before `test`, `build` and `publish`.
     """
-    parts = []
-    for e in for_version(version):
-        parts.append(f"### {marker(e)}{e.headline}\n\n{e.body}".rstrip())
-    return "\n\n".join(parts)
+    entries = for_version(version)
+    whole = [_part(e) for e in entries]
+    body = "\n\n".join(whole)
+    if len(body) <= _BODY_BUDGET:
+        return body
+    brief = [_brief(e) for e in entries]
+    smallest = ""
+    for k in range(len(entries) - 1, -1, -1):
+        candidate = "\n\n".join([*whole[:k], _elision(k, len(entries), len(body)),
+                                 *brief[k:]])
+        if len(candidate) <= _BODY_BUDGET:
+            return candidate
+        smallest = candidate
+    return smallest
 
 
 def _parser():

--- a/charter/news.py
+++ b/charter/news.py
@@ -651,14 +651,24 @@ def _part(e: Entry) -> str:
 def _entry_file(e: Entry) -> str:
     """*e*'s path in the repository — the name a reader with a checkout or a wheel opens.
 
-    The filename is the committed one (`_read` takes the slug from it), so it crosses into
-    a document with structure and is contained on the way, for #502's reason one surface
-    over: a name holding a newline would forge a heading in the release notes, which is the
-    one document nobody re-derives. The body beside it is deliberately *not* contained — an
-    entry's body IS Markdown its author wrote — but this line is charter's own sentence and
-    the filename is a field in it.
+    The filename is a committed value crossing into a document with structure, which is
+    #502 one surface over: a name holding a newline would forge a heading in the release
+    notes, and a name holding ``](https://…)`` would forge a *link* in charter's own
+    sentence, reading exactly as much like charter's text as the sentence around it. The
+    body beside it is deliberately not treated this way — an entry's body IS Markdown its
+    author wrote — but this line is charter's, and the filename is a field in it.
+
+    **Percent-encoding rather than :func:`contain.one_line`**, and the two differ in ways
+    that both matter here. `one_line` answers "can this forge a line of a report?", which
+    is not the question a Markdown document asks: it leaves ``]``, ``(`` and a backtick
+    untouched, and it clips at 160 characters — and a clipped path is one the reader cannot
+    act on. ``quote`` escapes every one of them, for every character, and never clips.
+
+    It is also the *same* string :func:`_entry_url` puts after the host, so the path a
+    reader is shown and the path the link goes to cannot come out different. Real entry
+    filenames are ``[0-9a-z.-]`` and pass through unchanged.
     """
-    return f"docs/news/{contain.one_line(e.path.name)}"
+    return f"docs/news/{urllib.parse.quote(e.path.name)}"
 
 
 def _entry_url(e: Entry) -> str:
@@ -673,14 +683,9 @@ def _entry_url(e: Entry) -> str:
     `report.upstream_repo` is the other spelling of "charter's repo" in this codebase and it
     is overridable from the environment, which is exactly what a value interpolated into a
     *published* release body must not be.
-
-    ``quote`` rather than containment for the href: a clipped URL is a broken link, and the
-    property needed here is that no filename can close the ``](…)`` early and start writing
-    its own Markdown after it. Percent-encoding gives that exactly, for every character.
     """
     ref = update.DEV_BRANCH if e.version == UNRELEASED else f"v{e.version}"
-    return (f"https://github.com/{update.DEV_REPO}/blob/{ref}/docs/news/"
-            f"{urllib.parse.quote(e.path.name)}")
+    return f"https://github.com/{update.DEV_REPO}/blob/{ref}/{_entry_file(e)}"
 
 
 def _brief(e: Entry) -> str:

--- a/charter/news.py
+++ b/charter/news.py
@@ -641,6 +641,20 @@ RELEASE_BODY_MAX = 125_000
 #: and it is above every release charter has ever cut but one — 0.52.0, at 111,723, is the
 #: only stamped version it reaches for, so the bound does not begin eliding until a version
 #: is genuinely larger than any that has shipped.
+#:
+#: **The deletion sweep reports this line as unpinned, and it is right to.** `retune-constant`
+#: rewrites it as ``100_001`` and the suite stays green, because it must: this is a dial, and
+#: one character of it changes no output anyone can name. What IS pinned is the *window* the
+#: dial has to sit in, from both ends and for different reasons —
+#: `test_the_staged_release_has_headroom` from above, so GitHub keeps real slack, and
+#: `test_the_bound_is_an_exception_rather_than_the_normal_path` from below, so a budget small
+#: enough to turn ordinary releases into a table of contents cannot pass while every length
+#: assertion still does. 100,001 is inside that window, which is exactly why it survives.
+#:
+#: This is the "explained equivalent" the sweep's own docstring reserves, not a suppression:
+#: there is no suppression list and this needs none. The only test that would redden on
+#: ``100_001`` is one asserting the literal back at itself, and a test that reads the source
+#: it is checking is the assertion this file has watched fail more than once.
 _BODY_BUDGET = 100_000
 
 

--- a/charter/news.py
+++ b/charter/news.py
@@ -638,8 +638,9 @@ RELEASE_BODY_MAX = 125_000
 #:
 #: 100,000 rather than a fraction of the limit, because a fraction invites re-deriving it:
 #: this is a round number a human holds, it leaves a fifth of the API's allowance unspent,
-#: and it is above every release charter has ever cut but two — so the bound below does not
-#: start eliding until a version is genuinely larger than any that has shipped.
+#: and it is above every release charter has ever cut but one — 0.52.0, at 111,723, is the
+#: only stamped version it reaches for, so the bound does not begin eliding until a version
+#: is genuinely larger than any that has shipped.
 _BODY_BUDGET = 100_000
 
 
@@ -740,9 +741,9 @@ def render_body(version: str) -> str:
     The label comes from :func:`marker`, which the offline view calls too.
 
     **And the result is bounded, because the far end of it refuses a long one.** The whole
-    body is returned whenever it fits :data:`_BODY_BUDGET`, which is what every release but
-    two has done and what keeps this function's output byte-identical to what it has always
-    been. Past that, the notes that fit are rendered whole and the rest become a headline
+    body is returned whenever it fits :data:`_BODY_BUDGET`, which is what sixteen of the
+    seventeen stamped versions do, and what keeps this function's output byte-identical to
+    what it has always been for them. Past that, the notes that fit are rendered whole and the rest become a headline
     and a link, with :func:`_elision` between them saying so.
 
     Three properties decide the shape, and each of them rules out an easier one:

--- a/docs/news/unreleased-a-release-body-fits-where-it-is-sent.md
+++ b/docs/news/unreleased-a-release-body-fits-where-it-is-sent.md
@@ -1,6 +1,6 @@
 ---
 version: unreleased
-headline: A release stops being able to publish to PyPI and then lose its notes — the body is bounded to what GitHub accepts, and no note is dropped to make it fit
+headline: A release stops publishing to PyPI and then losing its notes — the body is bounded to what GitHub accepts, and no note is dropped to make it fit
 ---
 
 `release.yml`'s announce job pipes `charter news --for <version>` straight into
@@ -19,10 +19,10 @@ the Release body by hand, which forks the published notes from the shipped entry
 supposed to be their single source.
 
 The 69 entries staged for this release rendered to 333,917 characters. 0.52.0 published at
-111,723 — 3,277 short of the refusal — and nothing in the repository remarked on it, because
-nothing was looking. Entries accumulate one pull request at a time, each author sees their
-own and no other, and the total crosses on an ordinary afternoon with no pull request to
-blame.
+111,723 — 3,277 short of the refusal — and nothing in the repository remarked on it,
+because nothing was looking. Entries accumulate one pull request at a time, each author
+sees their own and no other, and the total crosses on an ordinary afternoon with no pull
+request to blame.
 
 **The guard was not wrong, and rendering was never the failing step.** `guard` already
 refuses a version whose notes cannot be *rendered*, and it asks `charter news --for` — the
@@ -34,18 +34,19 @@ where it is about to be sent**.
 ## What changed
 
 `news.render_body` is bounded. Whenever the notes fit, they render exactly as they always
-have, byte for byte — which is every release but two. Past that, the notes that fit render
-whole and the rest become their headline and a link to the note itself, with a heading
-between them that says how many, how long, and what the limit is.
+have, byte for byte — which is sixteen of the seventeen versions stamped so far. Past that,
+the notes that fit render whole and the rest become their headline and a link to the note
+itself, with a heading between them saying how many, how long, and what the limit is. This
+is what the staged set produces today:
 
 ```
-## 34 of these 69 notes are listed by headline only
+## 56 of these 70 notes are listed by headline only
 
-Rendered whole, 69 notes come to 333,917 characters, and GitHub refuses a release body
+Rendered whole, 70 notes come to 338,123 characters, and GitHub refuses a release body
 over 125,000.
 
-**Every note this version shipped is in this list.** 35 are above in full; the 34 below
-are a headline and a link. …
+**Every note this version shipped is in this list.** 14 are above in full; the 56 below
+are a headline and a link. No note was dropped, and no note's text was cut short — …
 ```
 
 **Nothing is dropped and nothing is truncated**, and that is the half worth checking rather

--- a/docs/news/unreleased-a-release-body-fits-where-it-is-sent.md
+++ b/docs/news/unreleased-a-release-body-fits-where-it-is-sent.md
@@ -1,0 +1,73 @@
+---
+version: unreleased
+headline: A release stops being able to publish to PyPI and then lose its notes — the body is bounded to what GitHub accepts, and no note is dropped to make it fit
+---
+
+`release.yml`'s announce job pipes `charter news --for <version>` straight into
+`gh release create --notes-file`, and GitHub's create-release API refuses a body over
+**125,000 characters** with `body is too long`. It does not trim to fit and `gh` does not
+either — it forwards the refusal. So a version whose entries render past that limit did not
+publish shorter notes. It published **none**.
+
+**The job that fails is behind the one that cannot be undone.** The order is guard, test,
+build, *upload to PyPI*, then create the Release. By the time GitHub refuses, the upload has
+happened, and the documented retry cannot repair it: `gh workflow run release.yml -f
+version=<X.Y.Z>` re-enters `publish`, `pypa/gh-action-pypi-publish` is called without
+`skip-existing`, and PyPI rejects a version it already has — so `announce` is never reached
+on any subsequent run. The only exit left is the one the release charter forbids: writing
+the Release body by hand, which forks the published notes from the shipped entry that is
+supposed to be their single source.
+
+The 69 entries staged for this release rendered to 333,917 characters. 0.52.0 published at
+111,723 — 3,277 short of the refusal — and nothing in the repository remarked on it, because
+nothing was looking. Entries accumulate one pull request at a time, each author sees their
+own and no other, and the total crosses on an ordinary afternoon with no pull request to
+blame.
+
+**The guard was not wrong, and rendering was never the failing step.** `guard` already
+refuses a version whose notes cannot be *rendered*, and it asks `charter news --for` — the
+same call `announce` makes — precisely so that "the guard passed" and "the notes render"
+cannot disagree. That call exits 0 on a 300,000-character body, because producing the string
+is exactly what it was asked to do. The claim nobody was making is that the string **fits
+where it is about to be sent**.
+
+## What changed
+
+`news.render_body` is bounded. Whenever the notes fit, they render exactly as they always
+have, byte for byte — which is every release but two. Past that, the notes that fit render
+whole and the rest become their headline and a link to the note itself, with a heading
+between them that says how many, how long, and what the limit is.
+
+```
+## 34 of these 69 notes are listed by headline only
+
+Rendered whole, 69 notes come to 333,917 characters, and GitHub refuses a release body
+over 125,000.
+
+**Every note this version shipped is in this list.** 35 are above in full; the 34 below
+are a headline and a link. …
+```
+
+**Nothing is dropped and nothing is truncated**, and that is the half worth checking rather
+than trusting. Cutting the string at 125,000 characters would satisfy the limit and is
+indistinguishable, to a reader, from a release that shipped a dozen fewer things. So every
+entry keeps its own heading in its own place in the order, every elided entry carries a link
+to the note holding its text, and the tests assert those properties on the entries this
+repository is actually carrying — not on a fixture, which would only prove that
+`render_body` can count.
+
+**The cut is one point in the order, not a per-entry decision.** A greedy fill that skipped
+the big notes and kept packing the small ones would give an ordinary note its body while a
+security note above it lost one — #486 wearing a size limit. There is no second rule inside
+the bound that protects security entries: there is one order, `news.all()`'s, and the notes
+that lead are the notes that keep their bodies.
+
+## And the assertion moved to the cheap end
+
+A body that cannot be brought under the limit even with every note reduced to a headline is
+refused rather than cut, by `charter news --for` — which is the command `guard` runs. The
+failure therefore arrives before `test`, `build` and `publish`, instead of after the upload.
+`release.yml`'s annotation names that third cause alongside the two it already named.
+
+Nothing to adopt: this is charter's own release path, and it is fixed for every plane the
+moment this version publishes.

--- a/personas/release/persona.md
+++ b/personas/release/persona.md
@@ -103,6 +103,17 @@ pre-publish guard runs, so a contradiction stops the tag rather than the reader.
 stamping, read `charter news --for <X.Y.Z>` and check the first entry is the one you would
 want a reader to see if they stopped after two screens.
 
+**And on a big release, some entries render as a headline and a link.** Expected, not a
+fault. GitHub refuses a release body over 125,000 characters outright rather than trimming
+it, and that refusal would land in the announce job — *after* the PyPI upload, where the
+documented retry cannot reach it (#665). So `charter news --for` bounds what it renders: the
+notes that fit come out whole, the rest become their headline and a link to the note, and a
+heading between them says how many and why. Nothing is dropped and nothing is cut short.
+This makes `lead:` matter more rather than less, because on a bounded release the order
+decides not only what a reader sees first but what they read without a click. If the command
+*refuses* instead, the headlines alone are over the limit — that arrives in `guard`, before
+anything is published.
+
 That job carries `contents: write`
 alone — the workflow's top-level grant stays `contents: read` — and it leaves an existing
 Release untouched, so a `workflow_dispatch` retry after a partial failure is safe to run —

--- a/tests/test_news_ordering.py
+++ b/tests/test_news_ordering.py
@@ -620,6 +620,20 @@ class TheGateAnnotationNamesWhatTheGateNowCatches(NewsDir):
         self.assertIn("docs/news/", self.annotation)
         self.assertIn("cannot honour", self.annotation)
 
+    def test_and_the_cause_that_is_not_about_the_entries_at_all(self):
+        """#665's shape, and the reason it needs its own clause rather than a widening of
+        "cannot honour": nothing is wrong with the entries. Each of them is well-formed,
+        declares nothing charter cannot read, and renders — and the release still cannot be
+        announced, because the body they render to is longer than GitHub's create-release
+        API accepts. An operator sent looking for a malformed entry would find none.
+
+        Coupled on "too long" for the reason every other pair in this class is coupled:
+        that is the phrase `cmd_news` prints and the phrase GitHub's own refusal uses, so a
+        reader grepping the run for the annotation's vocabulary lands on the line that
+        explains it. `tests/test_release_notes_fit_the_release.py` holds the other end.
+        """
+        self.assertIn("too long", self.annotation)
+
     def test_and_defers_to_the_command_for_which_of_them_it_was(self):
         """Rather than diagnosing. Two causes named in one line is only an improvement if
         the line also says where the answer is."""
@@ -692,7 +706,7 @@ class TheGateAnnotationNamesWhatTheGateNowCatches(NewsDir):
         src = inspect.getsource(commands.cmd_news)
         branch = src.split("if version:", 1)[1].split("if getattr(args, \"pending\"", 1)[0]
         self.assertEqual(
-            branch.count("return 1"), 2,
+            branch.count("return 1"), 3,
             "`charter news --for` has a number of ways to refuse that this test no "
             "longer expects. That call is release.yml's pre-publish guard, and its "
             "`::error::` annotation enumerates the causes for an operator who has only "

--- a/tests/test_release_notes_fit_the_release.py
+++ b/tests/test_release_notes_fit_the_release.py
@@ -62,7 +62,9 @@ is a refusal rather than a cut. `charter news --for` refuses, which puts the ref
 from __future__ import annotations
 
 import io
+import os
 import re
+import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -71,6 +73,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands, news
+from tests.test_workflows import _release
 
 #: GitHub's documented maximum for a release body, in characters — not bytes. The API
 #: counts characters, and charter's entries are not ASCII (they carry `—`, `✗`, `⬢`), so
@@ -608,6 +611,91 @@ class TheGateRefusesABodyItCannotBound(NewsDir):
         self.assertEqual(code, 0, err)
         self.assertLessEqual(len(out), news.RELEASE_BODY_MAX)
         self.assertEqual(len(self.headings(out)), 44)
+
+
+class ARefusedRenderStopsTheRelease(unittest.TestCase):
+    """The other half of moving the assertion: a refusal only counts if it stops the step.
+
+    `guard` runs `charter news --for` for its exit code, and that half is asserted where
+    the guard's other refusals are. `announce` runs the same command for its *stdout*, and
+    then hands the file it wrote to `gh release create`. If a refused render did not abort
+    that step, `announce` would create a Release from whatever ended up in the file — an
+    empty one, on the path where the PyPI upload has already happened. Which is a worse
+    outcome than the failure this whole change is about: no notes, and no error either.
+
+    Actions runs `run:` blocks under `bash -e`, so this held before the step said so. That
+    is exactly why it is written out and asserted: a property that holds because of a
+    platform default is a property nobody in the file states and nobody notices losing.
+    """
+
+    def _announce(self) -> str:
+        job = _release()["jobs"]["announce"]
+        steps = [s for s in job["steps"] if isinstance(s, dict) and "run" in s]
+        self.assertEqual(len(steps), 1, "announce no longer has exactly one script step")
+        return steps[0]["run"]
+
+    def _execute(self, news_exit: int, errexit: bool = True) -> tuple[int, list[str]]:
+        """Run the announce script with `python` and `gh` stubbed, and report what `gh`
+        was asked to do.
+
+        *errexit* is how the shell was started, and both values are exercised below.
+        ``True`` is Actions' own invocation (`bash -e {0}`); ``False`` is the shell the
+        script's own `set -eu` exists for, and is the only setting under which deleting
+        that line changes anything.
+        """
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(os.path.realpath(raw))
+            (tmp / "pyproject.toml").write_text(
+                '[project]\nname = "charter-cp"\nversion = "0.54.0"\n')
+            (tmp / "bin").mkdir()
+            log = tmp / "gh.log"
+            (tmp / "bin" / "python").write_text(
+                "#!/bin/sh\n"
+                'case "$1" in\n'
+                "  -c) echo 0.54.0 ;;\n"                       # the pyproject read
+                f'  -m) echo "NOTES BODY"; exit {news_exit} ;;\n'   # charter news --for
+                "esac\n")
+            (tmp / "bin" / "gh").write_text(
+                "#!/bin/sh\n"
+                f'echo "$*" >> {log}\n'
+                # No release exists yet, so the script goes on to render one.
+                'if [ "$1 $2" = "release view" ]; then exit 1; fi\n'
+                "exit 0\n")
+            for name in ("python", "gh"):
+                (tmp / "bin" / name).chmod(0o755)
+            env = {"PATH": f"{tmp / 'bin'}:/usr/bin:/bin", "RUNNER_TEMP": str(tmp),
+                   "GH_TOKEN": "stub"}
+            argv = ["bash"] + (["-e"] if errexit else []) + ["-c", self._announce()]
+            done = subprocess.run(argv, cwd=tmp, env=env, capture_output=True, text=True)
+            asked = log.read_text().splitlines() if log.exists() else []
+            return done.returncode, asked
+
+    def test_a_render_that_refuses_leaves_no_release_behind(self):
+        code, asked = self._execute(news_exit=1)
+        self.assertNotEqual(code, 0, "the step succeeded after the render refused")
+        self.assertFalse([c for c in asked if c.startswith("release create")],
+                         f"a Release was created from a body charter refused: {asked}")
+
+    def test_and_it_does_not_hold_only_because_of_the_runners_shell_flags(self):
+        """The case the script's own `set -eu` is for, and the reason the case above is not
+        enough on its own: Actions starts `run:` as `bash -e {0}`, so the property holds
+        there with the line deleted — a test that ran only that shape would pin nothing.
+        Run the same script under a shell that was handed no flags and it still refuses to
+        create a Release from a body charter would not print."""
+        code, asked = self._execute(news_exit=1, errexit=False)
+        self.assertNotEqual(code, 0, "the script relies on the runner's `-e` and says so "
+                                     "nowhere")
+        self.assertFalse([c for c in asked if c.startswith("release create")],
+                         f"a Release was created from a body charter refused: {asked}")
+
+    def test_and_a_render_that_succeeds_still_creates_one(self):
+        """The other direction, and it is not decoration: a step that failed unconditionally
+        would pass every case above and never publish a Release again."""
+        for errexit in (True, False):
+            with self.subTest(errexit=errexit):
+                code, asked = self._execute(news_exit=0, errexit=errexit)
+                self.assertEqual(code, 0)
+                self.assertTrue([c for c in asked if c.startswith("release create")], asked)
 
 
 if __name__ == "__main__":

--- a/tests/test_release_notes_fit_the_release.py
+++ b/tests/test_release_notes_fit_the_release.py
@@ -183,6 +183,31 @@ class ReleaseBodyFits(unittest.TestCase):
             f"same as safe: the next entry to land is not re-measured by anything.",
         )
 
+    def test_the_bound_is_an_exception_rather_than_the_normal_path(self):
+        """`_BODY_BUDGET`'s value, pinned from below. The headroom case pins it from above.
+
+        Between them the number is in a window rather than free, and each side says
+        something different. Too high and a release is refused after the upload, which is
+        the whole finding. **Too low and every release becomes a table of contents** —
+        every length assertion in this file still passes, and the notes stop being notes.
+        Nothing else in the suite would notice: a smaller budget is *safer* in the only
+        direction the other cases measure.
+
+        So the claim the number actually makes is asserted here, and it is the one
+        `_BODY_BUDGET`'s own docstring makes: the bound reaches for at most one stamped
+        version. If a second crosses, the number wants re-examining and the docstring is
+        stale — which is a conversation worth having on the pull request that causes it,
+        rather than at a tag.
+        """
+        elided = [v for v in sorted(_versions())
+                  if news.render_body(v) != "\n\n".join(
+                      news._part(e) for e in news.for_version(v))]
+        self.assertLessEqual(
+            len(elided), 1,
+            f"charter's own budget now reshapes {len(elided)} stamped releases "
+            f"({', '.join(elided)}). The bound is meant to be the exception — either "
+            f"_BODY_BUDGET is too small, or its docstring's claim has gone stale.")
+
     def test_every_note_the_staged_release_carries_is_in_the_body(self):
         """The half that makes the case above worth passing.
 
@@ -285,6 +310,22 @@ class ABodyThatFitsIsUntouched(NewsDir):
             self.assertIn(f"BODY-{slug}", body)
         self.assertNotIn("listed by headline only", body)
         self.assertNotIn("Full note:", body)
+
+    def test_an_entry_with_no_body_does_not_open_a_gap_in_the_notes(self):
+        """The one shape `_part`'s `rstrip` is for, and the only one it can change.
+
+        `persona.parse` hands back a stripped body, so for every entry that HAS one the
+        strip is a no-op — which makes an entry with a headline and nothing under it the
+        whole of what that call does. Without it the heading keeps the two newlines meant
+        to separate it from a body that is not there, and the notes carry a blank gap that
+        reads like a note whose text failed to render.
+
+        Asserted as an equality for the reason the case below is: the claim is about the
+        exact separation between entries, and `assertIn` cannot see a doubled blank line.
+        """
+        self.write(f"{_V}-a-one.md", _entry(_V, "one", body=""))
+        self.write(f"{_V}-b-two.md", _entry(_V, "two", body="BODY-b-two"))
+        self.assertEqual(news.render_body(_V), "### one\n\n### two\n\nBODY-b-two")
 
     def test_and_is_exactly_what_joining_the_entries_gives(self):
         """Stated as an equality rather than as three `assertIn`s, because "unchanged" is
@@ -404,6 +445,20 @@ class TheBodySaysSoItself(NewsDir):
                          "a linked note appears above the notice that announces linking")
         self.assertNotIn("BODY-", body[cut:],
                          "a whole note appears below the notice")
+
+    def test_the_notice_is_ruled_off_from_the_notes_above_it(self):
+        """The other half of that conditional. A heading immediately after the last whole
+        note reads as that note's own subheading — entry bodies write `##` headings of
+        their own, 122 of them across `docs/news` — so the rule is what makes the break a
+        break. Asserting only the case where it is absent would leave "always absent"
+        passing, which is the same document with the seam rubbed out.
+        """
+        self.oversized()
+        body = news.render_body(_V)
+        cut = self.NOTICE.search(body).start()
+        self.assertTrue(body[:cut].endswith("---\n\n"),
+                        f"the notice follows the last whole note with no rule between "
+                        f"them: {body[cut - 30:cut]!r}")
 
     def test_a_version_where_no_note_fits_whole_does_not_open_with_a_rule(self):
         """Not a hypothetical shape: one note longer than the budget produces it. The rule
@@ -628,6 +683,29 @@ class TheGateRefusesABodyItCannotBound(NewsDir):
             code, out, err = self._run(_V)
         self.assertEqual(code, 0, err)
         self.assertEqual(len(out), news.RELEASE_BODY_MAX)
+
+    def test_a_body_of_exactly_the_budget_is_spent_rather_than_cut_further(self):
+        """The boundary, not just the direction. `<` instead of `<=` would elide one more
+        note than the budget calls for — a note's whole text traded for a link to buy a
+        character nobody needed.
+
+        Reached by moving the budget to the length of a real candidate rather than by
+        sizing a fixture to the character: the number is charter's own policy dial and the
+        claim under test is what the comparison means by it, so the dial is what moves.
+        """
+        self.oversized()
+        body = news.render_body(_V)
+        exact = len(body)
+        with mock.patch.object(news, "_BODY_BUDGET", exact):
+            self.assertEqual(
+                news.render_body(_V), body,
+                "a body of exactly the budget was cut one note further, so the budget is "
+                "being read as exclusive")
+        with mock.patch.object(news, "_BODY_BUDGET", exact - 1):
+            self.assertLess(
+                len(news.render_body(_V)), exact,
+                "one character under the budget changed nothing, so the case above is "
+                "not measuring the boundary it claims to")
 
     def test_a_release_whose_notes_are_merely_long_still_publishes(self):
         """The refusal is for what cannot be bounded, not for what is big. 69 entries is a

--- a/tests/test_release_notes_fit_the_release.py
+++ b/tests/test_release_notes_fit_the_release.py
@@ -503,34 +503,57 @@ class AnElidedNoteIsReachable(NewsDir):
         self.assertIn(f"https://github.com/{news.update.DEV_REPO}/blob/", body)
         self.assertNotIn("attacker/elsewhere", body)
 
+    def _hostile(self, name: str) -> str:
+        """Render a version carrying one entry with a committed filename designed to write
+        Markdown of its own, or skip if this filesystem will not hold the name."""
+        self.oversized()
+        try:
+            self.write(name, _entry(_V, "hostile", self.filler("BODY-hostile")))
+        except (OSError, ValueError):
+            self.skipTest(f"this filesystem will not hold {name!r}")
+        return news.render_body(_V)
+
     def test_a_filename_cannot_forge_a_heading_in_the_release_notes(self):
         """#502, one document over. The filename is committed and charter interpolates it
         into a line charter wrote; a newline in it would write a second line of the release
         notes that looks exactly as much like charter's own text as the first."""
-        self.oversized()
-        hostile = f"{_V}-z-hostile\n## Security advisory: install from elsewhere.md"
-        try:
-            self.write(hostile, _entry(_V, "hostile", self.filler("BODY-hostile")))
-        except (OSError, ValueError):
-            self.skipTest("this filesystem will not hold a newline in a filename")
-        body = news.render_body(_V)
+        body = self._hostile(
+            f"{_V}-z-hostile\n## Security advisory: install from elsewhere.md")
         self.assertNotIn("\n## Security advisory", body)
-        self.assertIn("\\x0a", body, "the newline was neither escaped nor refused")
+        self.assertIn("%0A", body, "the newline reached the document unencoded")
 
-    def test_a_filename_cannot_break_out_of_the_link(self):
+    def test_a_filename_cannot_break_out_of_the_link_target(self):
         """A `)` closes the Markdown target early and everything after it becomes text the
-        entry wrote into charter's own sentence — including, on GitHub, an autolinked URL.
-        Percent-encoding is what makes that unreachable for every character, rather than
-        for the ones somebody thought of."""
-        self.oversized()
-        hostile = f"{_V}-z-hostile)(https://evil.example.md"
-        try:
-            self.write(hostile, _entry(_V, "hostile", self.filler("BODY-hostile")))
-        except (OSError, ValueError):
-            self.skipTest("this filesystem will not hold this name")
-        body = news.render_body(_V)
-        self.assertNotIn("(https://evil.example", body)
+        entry wrote into charter's own sentence — including, on GitHub, an autolinked
+        URL."""
+        body = self._hostile(f"{_V}-z-hostile)(EVIL-TARGET.md")
+        self.assertNotIn("(EVIL-TARGET", body)
         self.assertIn("%29", body, "the closing paren reached the link target unencoded")
+
+    def test_a_filename_cannot_forge_a_link_out_of_the_text_either(self):
+        """The half a percent-encoded *href* alone does not close, and the reason the shown
+        path is encoded too rather than merely made line-safe.
+
+        `]` ends the link text and the `(` after it opens the destination, so a filename
+        spelling `](<target>)` inside the label writes charter's own sentence into a link
+        pointing wherever it likes — and a backtick first ends the code span that would
+        otherwise have swallowed it. `contain.one_line` leaves all three alone, because
+        forging a line and forging a link are different questions.
+        """
+        body = self._hostile(f"{_V}-z-hostile`](EVIL-TARGET)b.md")
+        self.assertNotIn("](EVIL-TARGET", body)
+        self.assertNotIn("(EVIL-TARGET", body)
+        for encoded in ("%60", "%5D", "%28"):
+            self.assertIn(encoded, body, f"{encoded} was not encoded in the label")
+
+    def test_the_shown_path_and_the_link_target_are_the_same_path(self):
+        """One string, so a reader cannot be shown one note and sent to another."""
+        self.oversized()
+        for shown, url in re.findall(
+                r"Full note: \[`(docs/news/[^`]+)`\]\((https://[^)]+)\)",
+                news.render_body(_V)):
+            with self.subTest(shown=shown):
+                self.assertTrue(url.endswith("/" + shown), f"{url} does not end in {shown}")
 
 
 class TheGateRefusesABodyItCannotBound(NewsDir):

--- a/tests/test_release_notes_fit_the_release.py
+++ b/tests/test_release_notes_fit_the_release.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 import io
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -235,6 +236,9 @@ class NewsDir(unittest.TestCase):
 
     def setUp(self):
         self.dir = Path(tempfile.mkdtemp())
+        # Removed rather than left behind: these fixtures are hundreds of kilobytes each,
+        # which is the whole point of them.
+        self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
         patch = mock.patch.object(news, "_PACKAGED", self.dir)
         patch.start()
         self.addCleanup(patch.stop)

--- a/tests/test_release_notes_fit_the_release.py
+++ b/tests/test_release_notes_fit_the_release.py
@@ -311,6 +311,33 @@ class ABodyThatFitsIsUntouched(NewsDir):
         self.assertNotIn("listed by headline only", body)
         self.assertNotIn("Full note:", body)
 
+    def test_a_body_of_exactly_the_budget_is_still_rendered_whole(self):
+        """The early return's boundary, not just its direction.
+
+        `<` instead of `<=` would send a release that fits exactly through the elision
+        path — every note but the last rendered whole, the last one traded for a link, and
+        a heading explaining an elision that was not needed. One character, and the only
+        release it could ever happen to is one nobody would think to test.
+
+        The dial moves rather than the fixture, for the reason its sibling in
+        `TheGateRefusesABodyItCannotBound` does: `_BODY_BUDGET` is charter's own policy
+        number and the claim under test is what the comparison means by it, not what the
+        number is.
+        """
+        for slug in ("a-one", "b-two", "c-three"):
+            self.write(f"{_V}-{slug}.md", _entry(_V, slug, self.filler(f"BODY-{slug}")))
+        whole = "\n\n".join(news._part(e) for e in news.for_version(_V))
+        with mock.patch.object(news, "_BODY_BUDGET", len(whole)):
+            self.assertEqual(
+                news.render_body(_V), whole,
+                "a body of exactly the budget went through the elision path, so the "
+                "budget is being read as exclusive")
+        with mock.patch.object(news, "_BODY_BUDGET", len(whole) - 1):
+            self.assertIn(
+                "listed by headline only", news.render_body(_V),
+                "one character under the budget changed nothing, so the case above is "
+                "not measuring the boundary it claims to")
+
     def test_an_entry_with_no_body_does_not_open_a_gap_in_the_notes(self):
         """The one shape `_part`'s `rstrip` is for, and the only one it can change.
 

--- a/tests/test_release_notes_fit_the_release.py
+++ b/tests/test_release_notes_fit_the_release.py
@@ -1,0 +1,614 @@
+"""A release body GitHub will refuse is a release that publishes and then loses its notes.
+
+`release.yml`'s `announce` job ends with
+
+    python -m charter news --for "$version" > "$RUNNER_TEMP/notes.md"
+    gh release create "$tag" --title "$tag" --notes-file "$RUNNER_TEMP/notes.md"
+
+and GitHub's create-release API refuses a body over **125,000 characters** with
+``body is too long (maximum is 125000 characters)``. `gh` does not truncate to fit; it
+forwards the refusal. So a version whose entries render past that limit did not get
+shorter notes — it got **no Release at all**.
+
+**Why that was a release-stopper and not a cosmetic bug.** `announce` is `needs: publish`,
+so the order is: guard, test, build, *upload to PyPI*, then create the Release. The upload
+is the irreversible step and it has already happened by the time GitHub refuses. Worse,
+the documented retry — `gh workflow run release.yml -f version=<X.Y.Z>` — cannot repair
+it: the retry re-enters `publish`, `pypa/gh-action-pypi-publish` is called without
+`skip-existing`, and PyPI rejects a version it already has, so `announce` is never reached
+on any subsequent run. The only way out is the one the release charter forbids — writing
+the Release body by hand, which forks the published notes from the shipped entry that is
+supposed to be their single source.
+
+**The existing guard could not see this, and was not wrong.** `guard` already refuses a
+version whose notes cannot be *rendered*, and does it by asking `charter news --for` — the
+same call `announce` makes — precisely so "the guard passed" and "the notes render" cannot
+disagree. That reasoning is sound and nothing here weakens it: rendering was never the
+failing step. `charter news --for` exits 0 on a 300,000-character body, because producing
+the string is exactly what it was asked to do. The claim nobody was making is that the
+string **fits where it is about to be sent**, and this module is that claim.
+
+**How close it already was.** 0.52.0 published at 111,723 characters — 3,277 short of the
+refusal — and nothing in the repository noticed, because nothing was looking. Entries
+accumulate one pull request at a time, each author sees their own and no other, and the
+total crosses on some ordinary afternoon with no pull request to blame. The 69 entries
+staged for the release after 0.53.0 rendered to 333,917.
+
+## What this suite holds, and why it is not one assertion
+
+Three groups, and they fail for different reasons at different times.
+
+**It fits.** `news.render_body` bounds what it returns, so every version — shipped or
+staged — renders a body `gh release create` will accept. Asserted against the *shipped
+tree* rather than a fixture, because a fixture proves `render_body` can count, which
+nothing doubted; the question is a fact about the entries this repository is carrying right
+now and it is only answerable by reading them.
+
+**And nothing was dropped to make it fit.** That is the dangerous half. A body cut at
+125,000 characters is the "convincing empty" this codebase refuses everywhere: a release
+that ends mid-sentence with a dozen notes simply absent reads exactly like a release that
+shipped a dozen fewer things, and no reader can tell. So the bound is a rendering, not a
+truncation — the notes that fit are whole, the rest are a headline and a link, and a
+heading between them says so in the body itself. Every one of those properties is asserted
+below, including the one that would be easiest to lose by accident: a security note is
+never demoted to a link while an ordinary note keeps its body.
+
+**And a body that cannot be bounded stops the release at the cheap end.** Even with every
+note reduced to a headline there is a length that will not fit, and the honest answer to it
+is a refusal rather than a cut. `charter news --for` refuses, which puts the refusal in
+`guard` — before `test`, `build` and `publish` — instead of after the upload.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, news
+
+#: GitHub's documented maximum for a release body, in characters — not bytes. The API
+#: counts characters, and charter's entries are not ASCII (they carry `—`, `✗`, `⬢`), so
+#: measuring `len(body.encode())` would report a larger number than the one GitHub
+#: applies and would fail a release that would in fact have been accepted.
+#:
+#: **Written out here rather than imported from `news`**, and that duplication is the
+#: point: this is GitHub's number, and a test that read charter's copy of it would agree
+#: with a typo in charter's copy of it. The two are compared below, in the one direction
+#: that matters — charter may be more conservative, never less.
+GITHUB_RELEASE_BODY_MAX = 125_000
+
+#: How close to the ceiling a version may come before this suite says so. A release that
+#: fits with 200 characters to spare is not a release that is safe — the next entry lands
+#: on main without anyone re-rendering the body, and the version after it is the one that
+#: cannot publish. 0.52.0 sat at 89% of the limit and read as fine.
+HEADROOM = 0.85
+
+_V = "0.60.0"
+
+
+def _versions() -> set[str]:
+    return {e.version for e in news.all() if e.version != news.UNRELEASED}
+
+
+class ReleaseBodyFits(unittest.TestCase):
+    """The shipped tree, measured. Every case here reads real entries."""
+
+    def test_charter_never_spends_more_of_the_limit_than_github_allows(self):
+        """The two constants, checked against each other in the direction with teeth.
+
+        Charter's ceiling being *below* GitHub's is a policy and this suite has no opinion
+        on how far below. Charter's ceiling being *above* GitHub's is a release that
+        renders happily and is then refused, which is the whole finding — so that is the
+        comparison, rather than an equality that would forbid the headroom on purpose.
+        """
+        self.assertLessEqual(
+            news.RELEASE_BODY_MAX, GITHUB_RELEASE_BODY_MAX,
+            f"charter believes GitHub accepts {news.RELEASE_BODY_MAX:,} characters and "
+            f"GitHub accepts {GITHUB_RELEASE_BODY_MAX:,}")
+        self.assertLessEqual(
+            news._BODY_BUDGET, news.RELEASE_BODY_MAX,
+            "render_body is allowed to spend more than the limit it is bounding against")
+
+    def test_published_versions_fit(self) -> None:
+        """Every stamped version renders a body GitHub would accept.
+
+        This is the regression half: it is about entries that already shipped, so it must
+        stay green forever. It would go red if someone lengthened an old entry past what
+        the bound can absorb — which is allowed, and which is exactly when you want to be
+        told.
+        """
+        for version in sorted(_versions()):
+            with self.subTest(version=version):
+                size = len(news.render_body(version))
+                self.assertLessEqual(
+                    size, GITHUB_RELEASE_BODY_MAX,
+                    f"the rendered notes for {version} are {size:,} characters and "
+                    f"GitHub refuses a release body over {GITHUB_RELEASE_BODY_MAX:,} — "
+                    f"`gh release create` would fail with `body is too long`",
+                )
+
+    def test_the_staged_release_fits(self) -> None:
+        """The entries staged for the next release render a body GitHub would accept.
+
+        `render_body(UNRELEASED)` is the real rendering path, reached through the real
+        `news.all()` sort, so this measures the string `announce` will actually send —
+        not an approximation of it. Stamping renames files and rewrites one frontmatter
+        line; it does not change a body's length.
+        """
+        staged = news.for_version(news.UNRELEASED)
+        if not staged:
+            self.skipTest("no entries staged for the next release")
+        size = len(news.render_body(news.UNRELEASED))
+        self.assertLessEqual(
+            size, GITHUB_RELEASE_BODY_MAX,
+            f"{len(staged)} entries are staged for the next release and they render to "
+            f"{size:,} characters. GitHub refuses a release body over "
+            f"{GITHUB_RELEASE_BODY_MAX:,}, so `announce` would fail with `body is too "
+            f"long` AFTER the PyPI upload has already happened, and the documented "
+            f"workflow_dispatch retry cannot reach `announce` again because `publish` "
+            f"fails on a version PyPI already has.",
+        )
+
+    def test_the_staged_release_has_headroom(self) -> None:
+        """And it is not merely under the limit, but under it with room to spare.
+
+        Separate from the case above because the two say different things. "Would this
+        release publish?" is a fact about today. "Is the next one going to?" is the one
+        0.52.0 could have answered and was never asked.
+
+        With the bound in place this is also the end-to-end guard on `_BODY_BUDGET`:
+        raise it toward the ceiling and this goes red, measured through the real render
+        rather than by reading the constant back.
+        """
+        staged = news.for_version(news.UNRELEASED)
+        if not staged:
+            self.skipTest("no entries staged for the next release")
+        size = len(news.render_body(news.UNRELEASED))
+        ceiling = int(GITHUB_RELEASE_BODY_MAX * HEADROOM)
+        self.assertLessEqual(
+            size, ceiling,
+            f"the staged notes are {size:,} characters, which is "
+            f"{size / GITHUB_RELEASE_BODY_MAX:.0%} of GitHub's "
+            f"{GITHUB_RELEASE_BODY_MAX:,}-character limit. Under the limit is not the "
+            f"same as safe: the next entry to land is not re-measured by anything.",
+        )
+
+    def test_every_note_the_staged_release_carries_is_in_the_body(self):
+        """The half that makes the case above worth passing.
+
+        A bound that fits by dropping notes passes every length assertion in this class
+        and is the exact failure they exist to prevent — the release publishes, the body
+        is accepted, and a dozen things that shipped are not in it. So the shipped tree is
+        asked the other question too: is every staged note still *in* the body it renders?
+        """
+        staged = news.for_version(news.UNRELEASED)
+        if not staged:
+            self.skipTest("no entries staged for the next release")
+        body = news.render_body(news.UNRELEASED)
+        for e in staged:
+            with self.subTest(slug=e.slug):
+                self.assertIn(f"### {news.marker(e)}{e.headline}", body,
+                              f"{e.slug} is staged for the next release and its heading "
+                              f"is not in the body that release would publish")
+
+    def test_and_every_note_it_could_not_carry_whole_is_reachable(self):
+        """Elided is not dropped, and the difference has to be checkable rather than
+        promised. Each note the body could not carry whole is followed by a link, and the
+        link resolves to a path that exists in this checkout."""
+        staged = news.for_version(news.UNRELEASED)
+        if not staged:
+            self.skipTest("no entries staged for the next release")
+        body = news.render_body(news.UNRELEASED)
+        if "listed by headline only" not in body:
+            self.skipTest("the staged notes fit whole, so nothing is elided to reach")
+        root = Path(__file__).resolve().parent.parent
+        linked = re.findall(r"Full note: \[`(docs/news/[^`]+)`\]\((https://[^)]+)\)", body)
+        self.assertTrue(linked, "the body says it elided notes and links to none of them")
+        for path, url in linked:
+            with self.subTest(path=path):
+                self.assertTrue((root / path).is_file(),
+                                f"{path} is linked from the release body and is not a "
+                                f"file in this repository")
+                self.assertTrue(url.endswith(Path(path).name),
+                                f"{url} does not point at {path}")
+
+
+def _entry(version: str, headline: str, body: str = "body text", **fields) -> str:
+    lines = [f"version: {version}", f"headline: {headline}"]
+    lines += [f"{k}: {v}" for k, v in fields.items()]
+    return "---\n" + "\n".join(lines) + f"\n---\n\n{body}\n"
+
+
+class NewsDir(unittest.TestCase):
+    """Entries read from a throwaway directory, so a test never depends on what shipped —
+    the same isolation `tests/test_news.py` and `tests/test_news_ordering.py` establish,
+    for the same reason."""
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        patch = mock.patch.object(news, "_PACKAGED", self.dir)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def write(self, name: str, text: str) -> None:
+        (self.dir / name).write_text(text)
+
+    def filler(self, token: str, size: int = 20_000) -> str:
+        """A body long enough to matter, carrying a token nothing else can produce."""
+        return f"{token} " + "x" * size
+
+    def oversized(self, ordinary: int = 10, secure: int = 2) -> None:
+        """One version whose notes cannot all be rendered whole.
+
+        **Filename order and declared order disagree, deliberately.** The security notes
+        are named `z-…` and the ordinary ones `a-…`, so a bound that elided in filename
+        order would keep every ordinary body and drop every security one — and a fixture
+        where the right answer is also the alphabetical one is a fixture that cannot fail.
+        """
+        for i in range(ordinary):
+            slug = f"a-ordinary-{i}"
+            self.write(f"{_V}-{slug}.md",
+                       _entry(_V, f"ordinary {i}", self.filler(f"BODY-{slug}")))
+        for i in range(secure):
+            slug = f"z-security-{i}"
+            self.write(f"{_V}-{slug}.md",
+                       _entry(_V, f"security {i}", self.filler(f"BODY-{slug}"),
+                              security="true"))
+
+    def headings(self, body: str) -> list[str]:
+        return [ln[4:] for ln in body.splitlines() if ln.startswith("### ")]
+
+
+class ABodyThatFitsIsUntouched(NewsDir):
+    """The bound is a ceiling, not a style. Every release but two has rendered whole and
+    must keep rendering whole, byte for byte — a change that reshaped the ordinary case
+    would be this fix rewriting fifteen published releases to solve a problem two have."""
+
+    def test_a_short_version_renders_every_body_in_full(self):
+        for slug in ("a-one", "b-two", "c-three"):
+            self.write(f"{_V}-{slug}.md", _entry(_V, slug, f"BODY-{slug}"))
+        body = news.render_body(_V)
+        for slug in ("a-one", "b-two", "c-three"):
+            self.assertIn(f"BODY-{slug}", body)
+        self.assertNotIn("listed by headline only", body)
+        self.assertNotIn("Full note:", body)
+
+    def test_and_is_exactly_what_joining_the_entries_gives(self):
+        """Stated as an equality rather than as three `assertIn`s, because "unchanged" is
+        the claim: no preamble, no footer, no separator that a reader of an older release
+        would not recognise."""
+        for slug in ("a-one", "b-two"):
+            self.write(f"{_V}-{slug}.md", _entry(_V, slug, f"BODY-{slug}"))
+        self.assertEqual(
+            news.render_body(_V),
+            "### a-one\n\nBODY-a-one\n\n### b-two\n\nBODY-b-two")
+
+
+class NothingIsDroppedToMakeItFit(NewsDir):
+    """The property that separates a bound from a truncation.
+
+    Cutting the string at the limit satisfies every length assertion in this file. It is
+    also indistinguishable, to a reader, from a release that shipped fewer things — which
+    is why "it renders under the limit" is not the assertion this finding needs.
+    """
+
+    def test_the_fixture_is_actually_over_the_bound(self):
+        """Otherwise every case below is asserting about a body that was never elided."""
+        self.oversized()
+        whole = sum(len(f"### {e.headline}\n\n{e.body}".rstrip())
+                    for e in news.for_version(_V))
+        self.assertGreater(whole, news._BODY_BUDGET,
+                           "this fixture fits, so it exercises none of the bound")
+        self.assertIn("listed by headline only", news.render_body(_V))
+
+    def test_the_bound_holds(self):
+        self.oversized()
+        self.assertLessEqual(len(news.render_body(_V)), news._BODY_BUDGET)
+
+    def test_every_entry_still_has_its_own_heading(self):
+        """In its own place in the order. Twelve entries in, twelve headings out."""
+        self.oversized()
+        self.assertEqual(
+            self.headings(news.render_body(_V)),
+            [f"{news.marker(e)}{e.headline}" for e in news.for_version(_V)])
+
+    def test_no_body_is_cut_short(self):
+        """Every note is whole or absent — never half. An excerpt is the shape with no
+        mark on it saying where it stopped, which is the reading failure this refuses."""
+        self.oversized()
+        body = news.render_body(_V)
+        for e in news.for_version(_V):
+            token = f"BODY-{e.slug}"
+            with self.subTest(slug=e.slug):
+                if token in body:
+                    self.assertIn(e.body.strip(), body,
+                                  f"{e.slug} is in the release body with only part of "
+                                  f"its text")
+
+    def test_every_elided_entry_names_the_note_that_holds_its_text(self):
+        self.oversized()
+        body = news.render_body(_V)
+        for e in news.for_version(_V):
+            if f"BODY-{e.slug}" in body:
+                continue
+            with self.subTest(slug=e.slug):
+                self.assertIn(f"docs/news/{_V}-{e.slug}.md", body,
+                              f"{e.slug} lost its body and the release notes do not say "
+                              f"where the body is")
+
+    def test_at_least_one_entry_was_elided_and_at_least_one_was_not(self):
+        """The bound has two failure modes that both pass a length check: eliding nothing
+        (and overflowing) and eliding everything (and publishing a table of contents where
+        the notes were). This is the case that has an opinion about the middle."""
+        self.oversized()
+        body = news.render_body(_V)
+        kept = [e.slug for e in news.for_version(_V) if f"BODY-{e.slug}" in body]
+        gone = [e.slug for e in news.for_version(_V) if f"BODY-{e.slug}" not in body]
+        self.assertTrue(kept, "every note was reduced to a link")
+        self.assertTrue(gone, "nothing was elided, so the body is over the bound")
+
+
+class TheBodySaysSoItself(NewsDir):
+    """A body that quietly links half its notes is still a body a reader trusts whole.
+
+    The elision is therefore announced in the document, at the cut, as a heading — so it
+    lands in GitHub's own outline rather than in a paragraph a reader scrolls past.
+    """
+
+    #: How the notice is found, here and on the shipped tree. Anchored on its own sentence
+    #: rather than on `## `, because entry bodies write their own `##` headings — 122 of
+    #: them across `docs/news` today — so the heading level alone identifies nothing.
+    NOTICE = re.compile(r"(?m)^## (\d+) of these (\d+) notes are listed by headline only$")
+
+    def test_the_notice_is_a_heading_in_the_body(self):
+        self.oversized()
+        self.assertRegex(news.render_body(_V), self.NOTICE)
+
+    def test_it_is_written_once(self):
+        """Once, because it is one fact. Two copies of an arithmetic sentence is two
+        answers to `how many were elided?`, and nothing renders them together."""
+        self.oversized()
+        self.assertEqual(len(self.NOTICE.findall(news.render_body(_V))), 1)
+
+    def test_it_counts_both_halves_and_names_the_limit(self):
+        """"Some notes are linked" is a sentence a reader cannot check. These they can."""
+        self.oversized()
+        body = news.render_body(_V)
+        entries = news.for_version(_V)
+        kept = sum(1 for e in entries if f"BODY-{e.slug}" in body)
+        self.assertIn(f"## {len(entries) - kept} of these {len(entries)} notes", body)
+        self.assertIn(f"{kept} are above in full", body)
+        self.assertIn(f"{news.RELEASE_BODY_MAX:,}", body)
+
+    def test_it_sits_between_the_whole_notes_and_the_linked_ones(self):
+        """At the cut, not at the top or the bottom. A notice above the notes describes
+        something the reader has not reached; one below it describes something they have
+        already read past without knowing."""
+        self.oversized()
+        body = news.render_body(_V)
+        cut = self.NOTICE.search(body).start()
+        self.assertNotIn("Full note:", body[:cut],
+                         "a linked note appears above the notice that announces linking")
+        self.assertNotIn("BODY-", body[cut:],
+                         "a whole note appears below the notice")
+
+    def test_a_version_where_no_note_fits_whole_does_not_open_with_a_rule(self):
+        """Not a hypothetical shape: one note longer than the budget produces it. The rule
+        exists to separate the whole notes from the linked ones, so with no whole notes it
+        separates nothing — and a body that opens with `---` is one some renderers read as
+        frontmatter rather than as a horizontal line."""
+        self.write(f"{_V}-a-huge.md",
+                   _entry(_V, "the only one", self.filler("BODY-a-huge", 150_000)))
+        body = news.render_body(_V)
+        self.assertFalse(body.startswith("---"), body[:40])
+        self.assertRegex(body, self.NOTICE)
+        self.assertIn("0 are above in full", body)
+        self.assertNotIn("BODY-a-huge", body)
+        self.assertIn("docs/news/0.60.0-a-huge.md", body)
+
+    def test_it_says_nothing_was_dropped_and_that_is_true(self):
+        self.oversized()
+        body = news.render_body(_V)
+        self.assertIn("Every note this version shipped is in this list.", body)
+        self.assertEqual(len(self.headings(body)), len(news.for_version(_V)))
+
+
+class OrderDecidesWhatKeepsItsBody(NewsDir):
+    """The demotion that must never happen, and the reason it cannot.
+
+    There is no rule inside the bound that protects security notes. There is one order —
+    `news.all()`'s — and the bound reads it, so the notes that lead are the notes that keep
+    their bodies. A second rule would be #486 exactly: a claim honoured in one view and
+    quietly not in the other.
+
+    Which makes the consequence worth asserting rather than assuming, because it is a
+    property of two functions agreeing and either of them can move.
+    """
+
+    def test_a_security_note_keeps_its_body_while_ordinary_ones_lose_theirs(self):
+        self.oversized()
+        body = news.render_body(_V)
+        for e in news.for_version(_V):
+            if e.security:
+                with self.subTest(slug=e.slug):
+                    self.assertIn(f"BODY-{e.slug}", body,
+                                  f"{e.slug} declares `security: true` and was reduced to "
+                                  f"a link")
+        self.assertTrue(any(f"BODY-{e.slug}" not in body
+                            for e in news.for_version(_V) if not e.security),
+                        "no ordinary note was elided, so this proves nothing about which "
+                        "note the bound reaches for first")
+
+    def test_no_note_keeps_its_body_while_a_note_above_it_loses_one(self):
+        """The general form, and the one that survives a change to what `security:` means.
+        The cut is a single point in the order: read the body top to bottom and the whole
+        notes never resume after the linked ones start."""
+        self.oversized()
+        body = news.render_body(_V)
+        kept = [f"BODY-{e.slug}" in body for e in news.for_version(_V)]
+        self.assertNotIn((False, True), list(zip(kept, kept[1:])),
+                         "a note kept its body below one that lost its own — the bound is "
+                         "picking notes rather than cutting once")
+
+    def test_a_lead_note_is_not_elided_either(self):
+        """`lead:` is a position rather than a class, and the position it names is first —
+        so the note a release chose to open with cannot be the one reduced to a link."""
+        self.oversized()
+        self.write(f"{_V}-a-leading.md",
+                   _entry(_V, "the lead", self.filler("BODY-a-leading"), lead="true"))
+        body = news.render_body(_V)
+        self.assertIn("BODY-a-leading", body)
+        self.assertEqual(self.headings(body)[0], "the lead")
+
+
+class AnElidedNoteIsReachable(NewsDir):
+    """A link is only "nothing was dropped" if it goes somewhere."""
+
+    def test_a_stamped_version_links_its_own_tag(self):
+        """Not `main`. A published release describes what shipped, and the note behind
+        each headline has to be the note **as that release shipped it** — main is free to
+        rewrite it afterwards, and a tag is not."""
+        self.oversized()
+        body = news.render_body(_V)
+        self.assertIn(f"/blob/v{_V}/docs/news/", body)
+        self.assertNotIn("/blob/main/", body)
+
+    def test_a_staged_version_links_the_branch_it_lives_on(self):
+        """`unreleased` has no tag to point at, and its render is a preview nobody
+        publishes — so the link goes to the branch where the file actually is."""
+        for i in range(12):
+            slug = f"s-{i}"
+            self.write(f"{news.UNRELEASED}-{slug}.md",
+                       _entry(news.UNRELEASED, f"staged {i}", self.filler(f"BODY-{slug}")))
+        body = news.render_body(news.UNRELEASED)
+        self.assertIn("/blob/main/docs/news/unreleased-", body)
+        self.assertNotIn("/blob/vunreleased/", body)
+
+    def test_the_link_names_charters_repository_and_not_a_configured_one(self):
+        """`report.upstream_repo` is the other spelling of "charter's repo" and it reads an
+        environment variable. A value an environment variable can move has no business in a
+        published release body, so the link is built from the constant."""
+        self.oversized()
+        with mock.patch.dict("os.environ", {"CHARTER_UPSTREAM_REPO": "attacker/elsewhere"}):
+            body = news.render_body(_V)
+        self.assertIn(f"https://github.com/{news.update.DEV_REPO}/blob/", body)
+        self.assertNotIn("attacker/elsewhere", body)
+
+    def test_a_filename_cannot_forge_a_heading_in_the_release_notes(self):
+        """#502, one document over. The filename is committed and charter interpolates it
+        into a line charter wrote; a newline in it would write a second line of the release
+        notes that looks exactly as much like charter's own text as the first."""
+        self.oversized()
+        hostile = f"{_V}-z-hostile\n## Security advisory: install from elsewhere.md"
+        try:
+            self.write(hostile, _entry(_V, "hostile", self.filler("BODY-hostile")))
+        except (OSError, ValueError):
+            self.skipTest("this filesystem will not hold a newline in a filename")
+        body = news.render_body(_V)
+        self.assertNotIn("\n## Security advisory", body)
+        self.assertIn("\\x0a", body, "the newline was neither escaped nor refused")
+
+    def test_a_filename_cannot_break_out_of_the_link(self):
+        """A `)` closes the Markdown target early and everything after it becomes text the
+        entry wrote into charter's own sentence — including, on GitHub, an autolinked URL.
+        Percent-encoding is what makes that unreachable for every character, rather than
+        for the ones somebody thought of."""
+        self.oversized()
+        hostile = f"{_V}-z-hostile)(https://evil.example.md"
+        try:
+            self.write(hostile, _entry(_V, "hostile", self.filler("BODY-hostile")))
+        except (OSError, ValueError):
+            self.skipTest("this filesystem will not hold this name")
+        body = news.render_body(_V)
+        self.assertNotIn("(https://evil.example", body)
+        self.assertIn("%29", body, "the closing paren reached the link target unencoded")
+
+
+class TheGateRefusesABodyItCannotBound(NewsDir):
+    """The end of the road, and it is a refusal rather than a cut.
+
+    Every note reduced to a headline is the smallest this document gets, and there is a
+    length past which even that does not fit. Cutting the string there would publish a
+    release whose notes end mid-word; refusing puts the failure in `guard`, before `test`,
+    `build` and `publish`, which is the whole point of moving the assertion.
+    """
+
+    def _run(self, version: str) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(for_version=version, pending=False, since=None, until=None)
+        with redirect_stdout(out), redirect_stderr(err):
+            code = commands.cmd_news(args)
+        return code, out.getvalue(), err.getvalue()
+
+    def test_headlines_alone_over_the_limit_are_refused_rather_than_printed(self):
+        for i in range(6):
+            self.write(f"{_V}-h-{i}.md",
+                       _entry(_V, "h" * 30_000 + f" {i}", f"BODY-{i}"))
+        code, out, err = self._run(_V)
+        self.assertEqual(code, 1, "a body GitHub would refuse was printed for announce "
+                                  "to publish")
+        self.assertEqual(out, "", "part of an unpublishable body reached stdout, which is "
+                                 "the file announce redirects into")
+        self.assertIn("too long", err)
+        self.assertIn(f"{news.RELEASE_BODY_MAX:,}", err)
+
+    def test_the_refusal_says_why_linking_more_of_them_will_not_help(self):
+        """The reader's obvious next move is the one that cannot work: `render_body` has
+        already linked every note it can. Left unsaid, the operator retries the fix that
+        made no difference, in the middle of a release."""
+        for i in range(6):
+            self.write(f"{_V}-h-{i}.md", _entry(_V, "h" * 30_000 + f" {i}", f"BODY-{i}"))
+        _code, _out, err = self._run(_V)
+        self.assertIn("headlines alone do not fit", err)
+
+    def test_a_body_at_exactly_the_limit_is_refused_for_the_newline_print_adds(self):
+        """The off-by-one that only ever shows up at the ceiling.
+
+        `cmd_news` prints the body, so the file `announce` redirects into is one character
+        longer than the string measured here — and that character is one GitHub counts. A
+        gate measuring the string rather than the file would pass a body that arrives at
+        125,001 characters, at the one point in the release where there is no second try.
+
+        Rendering is stubbed because the property under test is the gate's arithmetic, not
+        the renderer's: the only way to reach exactly the limit through real entries is to
+        build them to the character, which would assert about the fixture instead.
+        """
+        self.write(f"{_V}-a.md", _entry(_V, "a"))
+        with mock.patch.object(news, "render_body",
+                               return_value="x" * news.RELEASE_BODY_MAX):
+            code, out, err = self._run(_V)
+        self.assertEqual(code, 1, f"a body of exactly {news.RELEASE_BODY_MAX:,} characters "
+                                  f"was printed, and `print` makes the notes file one "
+                                  f"character longer than that")
+        self.assertEqual(out, "")
+        self.assertIn("too long", err)
+
+    def test_and_one_character_under_it_is_printed(self):
+        """The other direction, and it is not decoration: a gate that refused everything
+        would pass every case above and take the release path with it."""
+        self.write(f"{_V}-a.md", _entry(_V, "a"))
+        with mock.patch.object(news, "render_body",
+                               return_value="x" * (news.RELEASE_BODY_MAX - 1)):
+            code, out, err = self._run(_V)
+        self.assertEqual(code, 0, err)
+        self.assertEqual(len(out), news.RELEASE_BODY_MAX)
+
+    def test_a_release_whose_notes_are_merely_long_still_publishes(self):
+        """The refusal is for what cannot be bounded, not for what is big. 69 entries is a
+        release, not a defect, and a gate that refused them would have moved the outage
+        rather than removed it."""
+        self.oversized(ordinary=40, secure=4)
+        code, out, err = self._run(_V)
+        self.assertEqual(code, 0, err)
+        self.assertLessEqual(len(out), news.RELEASE_BODY_MAX)
+        self.assertEqual(len(self.headings(out)), 44)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the release blocker #665 found, at the end of the workflow where it can still be fixed.

## The blocker

`release.yml`'s `announce` job pipes `charter news --for <version>` into `gh release create --notes-file`, and GitHub's create-release API refuses a body over **125,000 characters** with `body is too long`. It does not trim, and `gh` forwards the refusal rather than truncating. So a version whose entries render past that limit did not publish shorter notes — it published **none**.

| | |
|---|---|
| raw size of the 69 unreleased entries | 339,334 bytes |
| rendered body for the next release | **333,917 characters** |
| GitHub create-release body limit | 125,000 characters |
| 0.52.0, published | **111,723 — 3,277 short of the refusal** |

`announce` waits on `publish`, so the refusal lands **after** the PyPI upload. And the documented retry cannot repair it: `gh workflow run release.yml -f version=<X.Y.Z>` re-enters `publish`, `pypa/gh-action-pypi-publish` is invoked with no `with:` block at all — so no `skip-existing` — and PyPI rejects a version it already has. `announce` is never reached again. Re-running the failed job alone cannot help either: the body is deterministically too big.

**The guard's reasoning was not at fault and is not weakened here.** It refuses a version whose notes cannot be *rendered*, and asks `charter news --for` — the same call `announce` makes — precisely so "the guard passed" and "the notes render" cannot disagree. Rendering was never the failing step: that call exits 0 on a 300,000-character body, because producing the string is what it was asked to do. The claim nobody was making is that the string **fits where it is sent**.

## What this does

**`news.render_body` is bounded** (`charter/news.py`). Whole while it fits `_BODY_BUDGET`; past that, the notes that fit render whole and the rest become their headline and a link to the note, with a heading between them stating how many, how long, and what the limit is. **Sixteen of the seventeen** stamped versions render byte-identically to before, measured rather than estimated — asserted as an equality, not as three `assertIn`s. 0.52.0 is the only one the bound reaches for: 111,723 → 95,288.

**Nothing is dropped and nothing is truncated.** Truncation is the dangerous shape here and it is the one thing this must not be: a body cut at 125,000 characters satisfies every length assertion and is indistinguishable, to a reader, from a release that shipped a dozen fewer things. So every entry keeps its own heading in its own place in the order; every elided entry carries a link to the note holding its text; and the elision is visible **at every point it applies**, not only at the cut — which is why one notice is enough.

**The cut is one point in the order, not a per-entry decision.** A greedy fill would give an ordinary note its body while a security note above it lost one — #486 wearing a size limit. And there is no second rule inside the bound that promotes security entries: there is one order, `news.all()`'s, and the notes that lead are the notes that keep their bodies. The consequence is asserted rather than assumed, in both its specific form (a security note is never demoted while an ordinary one keeps its body) and its general one (no note keeps its body below one that lost its own).

**The assertion moved to `guard`.** `charter news --for` refuses a body it cannot bound, so the failure arrives before `test`, `build` and `publish` instead of after the upload. It lives in the command rather than in a new workflow step because `guard` and `announce` run that exact command against that exact tree — a second copy of the limit in shell would be a second answer to one question, and it is the announce-side answer that decides whether the release exists.

## Two numbers, and why they are two

- `news.RELEASE_BODY_MAX = 125_000` — **GitHub's** number. Characters, not bytes: the API counts code points and charter's entries carry `—`, `✗`, `⬢`, so `len(body.encode())` reports 3,023 more than GitHub applies for the staged set and would refuse a release GitHub would have accepted.
- `news._BODY_BUDGET = 100_000` — **charter's**, deliberately below it. `charter news --for` `print`s the body, so the file `announce` redirects into is one character longer than what was measured; a ceiling reached is a ceiling with nothing left for the next change to the announce step, landing after the upload; and 0.52.0's 3,277-character margin is the evidence that "just under" is a state nobody notices. 100,000 is also above every release ever cut but two, so the bound does not begin eliding until a version is genuinely larger than any that has shipped.

The test states GitHub's 125,000 **independently** rather than importing charter's copy — a test that read charter's constant would agree with a typo in it — and asserts the two in the one direction with teeth: charter may be more conservative, never less.

## #665's tests, landed

All three of #665's cases are here and green, with their prose brought up to the shipped state. They are now the deletion-sweep pin on the bound, still measured against the **shipped tree** rather than a fixture — a fixture proves `render_body` can count, which nothing doubted. `test_the_staged_release_has_headroom` becomes the end-to-end guard on `_BODY_BUDGET`: raise it toward the ceiling and it goes red.

Added beside them: every staged note is present in the body it would publish; every elided note links to a path that exists in this checkout; the notice is written once and sits at the cut; a filename cannot forge a heading or break out of the link (#502, one document over); the link names the constant repository and not `CHARTER_UPSTREAM_REPO`; and a release whose notes are merely long still publishes — the refusal is for what cannot be bounded, not for what is big.

## Two couplings this had to honour

`tests/test_news_ordering.py` pins the number of ways `charter news --for` can refuse, because `release.yml`'s `::error::` enumerates them for an operator who has only the CI log. The count moves 2 → 3, the annotation gains the third cause, and the two texts are coupled on `too long` — the phrase the command prints and the phrase GitHub's own refusal uses.

And `announce` now writes `set -eu`. Actions runs `run:` under `bash -e`, so a refused render already aborted the step — but "the render refuses and the Release is therefore not created" is load-bearing now, and a property that holds because of a platform default is one nobody states and nobody notices losing. Asserted under both shells: `bash -e -c` is Actions' own invocation, and a shell handed no flags is the only one under which deleting the line changes anything.

## Not done here, deliberately

`publish` still has no `skip-existing`, so any *other* post-upload failure in `announce` is still unrecoverable by the documented retry. That is a change to the job that mints the OIDC token, it alters what a re-run of an irreversible step means, and it belongs to the release engineer rather than to this fix. Filed as a follow-up rather than folded in.

## Supersedes #665

#665 is the finding, opened red on purpose and not to be merged. Its tests are in this branch. Close it in favour of this.

No version bump, no stamp, no tag — the release is the operator's. The entry is staged as `docs/news/unreleased-a-release-body-fits-where-it-is-sent.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
