### PR TITLE
A fact written down twice is now held to one copy of it (#669, #670)

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -69,7 +69,7 @@ jobs:
           # #508's entire defect, out of the sweep's reach. `sweep.reach()` says so in the
           # report rather than letting a smaller sweep read like a clean one.
           python-version: "3.12"
-      # The selection map is one trace of the whole suite — 350 s measured, and the
+      # The selection map is one trace of the whole suite and, per `SHARD_FIXED_COSTS`, the
       # largest fixed cost a shard pays. It is content-addressed on the tree it measured,
       # so this step saves it once here and every shard below restores it instead of
       # measuring it again. A fork's pull request cannot write this cache and will simply

--- a/docs/news/unreleased-a-fact-written-twice-is-held-to-one-copy.md
+++ b/docs/news/unreleased-a-fact-written-twice-is-held-to-one-copy.md
@@ -1,0 +1,49 @@
+---
+version: unreleased
+headline: A number written down twice is now held to one copy of it
+---
+
+Two defects, one shape: a fact recorded in two places, in prose, in neither of which
+anything could check it. Both were found by reading rather than by a failure, which is the
+tell — nothing in the repository was able to fail.
+
+**`pad` had two ranges (#669).** `docs/frame.md` said `` `0` to `5` `` where it explains
+the key and `` `0`–`8` `` four hundred lines down, in the list of values that take an
+arrangement out of play. The second is the harmful one, because it is the sentence about
+*refusal*: `pad = 6` on the documentation's word does not clamp and does not warn — an
+arrangement charter cannot draw is refused **whole**, so the operator loses their entire
+`[[frame.component]]` block and the frame falls back to `slots`.
+
+The text was corrected. The defect was the test. It asked
+
+```python
+self.assertIn(f"`0` to `{instance.FRAME_PANE_PAD_MAX}`", md)
+```
+
+and the *right* copy satisfied it, so the wrong one was never in its reach. An assertion
+that one occurrence exists cannot see a second one that disagrees. It now reads every range
+`docs/frame.md` states and holds each of them to the constant, and a second check asks
+`pane_pad` itself about every number the file prints beside `pad` — so a copy phrased
+"capped at `8`" rather than as a range is red too.
+
+**The selection map's trace cost had two figures (#670).** `SHARD_FIXED`'s budget note in
+`tools/sweep.py` said the trace costs 250 s; `sweep.yml`'s cache step said 350 s, about the
+same trace. Neither was asserted. It survived because nothing downstream turns on it — the
+twelve-minute `SHARD_FIXED` covers either reading — so it was only a number a reader would
+quote, with no way to know which one to quote.
+
+Re-measured across nine cache-miss runs on `ubuntu-latest`, where the tool prints its own
+`selection map: … in Ns`: 242, 252, 257, 276, 277, 279, 280, 282, 285 seconds. 250 was
+honest when it was written against 7,693 tests and the suite has grown past it; 350 matches
+no run at all.
+
+The itemisation is now data rather than a bulleted comment — `SHARD_FIXED_COSTS`, quoting
+the trace at the ceiling of that spread, because a budget is sized against the slow run —
+and `sweep.yml`'s comment names the constant instead of restating a figure. What is
+asserted is not the digits: the budget must cover the costs it is written from, the map
+must still be the largest of them, and **any duration the workflow's comments quote must be
+one the tool states**. A third copy is then either right or red.
+
+Nothing an operator runs changes. Both fixes are the same correction to the same habit: an
+assertion about *presence* was standing in for one about a *value*, and a check that counts
+occurrences is exactly that.

--- a/docs/news/unreleased-a-green-sweep-is-not-no-survivors.md
+++ b/docs/news/unreleased-a-green-sweep-is-not-no-survivors.md
@@ -70,10 +70,10 @@ now warmed once and restored by every shard in seconds, so a second machine cost
 baseline and not its own trace. That the map was cached was the premise for sharding, and
 it was not true before: the workflow had no cache step at all, so every run rebuilt it.
 
-The exact figure is written down twice and not identically: `SHARD_FIXED`'s budget note in
-`tools/sweep.py` says 250 s and `sweep.yml`'s cache step says 350 s. The 12-minute
-`SHARD_FIXED` covers either reading, so nothing downstream turns on which is right — but
-neither number is one to quote until somebody re-measures, so this entry does not.
+The figure: **about 285 seconds**, and under five restored from the cache. Nine cache-miss
+runs on `ubuntu-latest` measured 242 to 285 s, and the trace is quoted at the top of that
+range because a budget is sized against the slow run. It is written down once now, in
+`SHARD_FIXED_COSTS`, which `sweep.yml`'s cache comment names rather than restates (#670).
 
 The budget is written for the case where the cache misses anyway, because a fork's pull
 request cannot write one and a budget that only holds on a hit fails on exactly the runs

--- a/tests/test_frame_pane_style.py
+++ b/tests/test_frame_pane_style.py
@@ -1133,8 +1133,98 @@ class TheDocumentedExampleIsRunThroughCharter(unittest.TestCase):
             with self.subTest(word=word):
                 self.assertIn(f"`{word}`", md)
         self.assertIn("`bright` forms", md)
-        self.assertIn(f"`0` to `{instance.FRAME_PANE_PAD_MAX}`", md)
 
+
+#: Every bound `docs/frame.md` writes as a range, in the two spellings the file uses:
+#: `` `0` to `5` `` and the dash form `` `0`–`5` ``. Version numbers (tmux `3.2` to `3.6`)
+#: are dotted and are deliberately not matched — a range in this file is a range of cells,
+#: which is a thing charter enforces, and that is what may not drift.
+_STATED_RANGE = re.compile(r"`(\d+)`\s*(?:to|through|[-–—])\s*`(\d+)`")
+
+
+def stated_ranges(prose: str) -> list[tuple[int, int]]:
+    """**Every** range *prose* states — not the first one, and not whether one exists.
+
+    That distinction is the whole of #669. `docs/frame.md` gave `pad` two ranges four
+    hundred lines apart — `` `0` to `5` `` and `` `0`–`8` `` — and the test asked
+    ``assertIn(f"`0` to `{FRAME_PANE_PAD_MAX}`", md)``, which the *right* copy satisfied.
+    An assertion that one occurrence exists cannot see a second, wrong one; the wrong one
+    was the sentence about refusal, so `pad = 6` on the documentation's word silently cost
+    the operator their whole `[[frame.component]]` block.
+    """
+    return [(int(a), int(b)) for a, b in _STATED_RANGE.findall(prose)]
+
+
+class EveryStatementOfThePadBoundIsHeldToTheConstant(unittest.TestCase):
+    """#669. `FRAME_PANE_PAD_MAX` is written out in prose more than once, and every copy
+    has to agree with the constant — all of them, not one of them.
+
+    Scoped to `docs/frame.md`, the way `test_readme_states_the_ceilings` is scoped to the
+    README: it is the file an operator reads to learn what they may write, and the file the
+    enforcement sentence lives in. A news entry records what a release said and is not held
+    to a constant that may move after it.
+    """
+
+    MD = Path(__file__).resolve().parents[1] / "docs" / "frame.md"
+
+    def setUp(self) -> None:
+        self.md = self.MD.read_text()
+
+    def test_the_reader_finds_the_second_copy_the_old_assertion_could_not(self):
+        """The control, and the reason `stated_ranges` is a function.
+
+        Run over the exact pair #669 reported — the right copy and the wrong one. `assertIn`
+        on the first was green with the second sitting in the same file, so a reader that
+        returned only the first would rebuild the defect."""
+        both = ("`0` to `5`. Five is not a round number picked by hand …\n"
+                "… and so are a `bg` that is not one of the seventeen words, a `pad` "
+                "outside `0`–`8`, and a `size` charter cannot give the component")
+        self.assertEqual(stated_ranges(both), [(0, 5), (0, 8)])
+        self.assertEqual(stated_ranges("On tmux 3.2 to 3.6"), [])
+        self.assertEqual(stated_ranges("On tmux `3.2` to `3.6`"), [])
+
+    def test_the_documentation_states_the_bound_at_all(self):
+        """The vacuity control: the assertion below is green on a file that says nothing."""
+        self.assertTrue(stated_ranges(self.md),
+                        "docs/frame.md states no range — the `pad` bound went missing")
+
+    def test_every_range_the_documentation_states_is_the_pad_range(self):
+        """The fix. Each copy is checked, so the enforcement sentence at the bottom of the
+        file is in reach whatever the copy up by the `pad` prose says.
+
+        `pad` is the only bound this file states as a range of cells. A second one arriving
+        is a reason to teach this test the second constant — never a reason to go back to
+        asking whether one of them appears somewhere."""
+        want = (0, instance.FRAME_PANE_PAD_MAX)
+        wrong = [r for r in stated_ranges(self.md) if r != want]
+        self.assertEqual(
+            wrong, [],
+            f"docs/frame.md states {wrong} where charter enforces {want}. #669 was two "
+            "copies of this range disagreeing, and the harmful copy was the sentence about "
+            "refusal: an arrangement charter cannot draw is refused WHOLE, so a `pad` the "
+            "documentation invited costs the operator the entire `[[frame.component]]` "
+            "block and the frame falls back to `slots`.")
+
+    def test_no_number_the_documentation_prints_beside_pad_is_one_charter_refuses(self):
+        """The copy that is not written as a range — "a `pad` of `8`", "capped at `8`" —
+        held to `pane_pad` itself rather than to a spelling of the constant.
+
+        The rule this puts on the file: do not print an integer in a sentence about `pad`
+        that charter would refuse. Asked of the enforcing function, so it moves when
+        `FRAME_PANE_PAD_MAX` moves. The fenced examples are excluded because
+        `TheDocumentedExampleIsRunThroughCharter` resolves those through `instance` itself,
+        which is a stronger question than this one."""
+        prose = re.sub(r"```.*?```", "", self.md, flags=re.S)
+        sentences = [s for s in re.split(r"(?<=[.!?])\s+", " ".join(prose.split()))
+                     if "`pad`" in s]
+        self.assertTrue(sentences, "docs/frame.md no longer mentions `pad`")
+        for sentence in sentences:
+            for number in re.findall(r"`(\d+)`", sentence):
+                with self.subTest(number=number):
+                    self.assertIsNotNone(
+                        instance.pane_pad(int(number)),
+                        f"docs/frame.md prints `{number}` as a `pad` and charter refuses it "
+                        f"(the cap is {instance.FRAME_PANE_PAD_MAX}): …{sentence[:140]}")
 
 
 class TheLiveChromeToggleDoesNotEraseAPanesOwnColour(PersonaIso, unittest.TestCase):

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -16,6 +16,7 @@ import hashlib
 import io
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -2533,6 +2534,91 @@ class TheSweepIsSplitAcrossMachinesAndNothingIsDropped(unittest.TestCase):
         self.assertIn("225 mutations", loud)
         self.assertIn("still swept", loud)
         self.assertIn("nothing here is dropped", loud)
+
+
+#: Every duration a piece of prose quotes in seconds. The shape the workflow's comments
+#: used — ``350 s``, ``250 s``, ``about 240 seconds`` — and deliberately not minutes, so
+#: `timeout-minutes: 30` (a YAML key, not a claim about a measurement) is not one.
+#:
+#: A function rather than a regex inlined into an assertion, because the assertion below
+#: is green on an empty list and would therefore be green against a reader that matched
+#: nothing at all. `TheWorkflowQuotesNoCostTheToolDoesNotState` proves the reader first.
+_DURATION = re.compile(r"\b(\d+)\s?(?:s\b|seconds\b)")
+
+
+def durations_stated(prose: str) -> list[int]:
+    return [int(n) for n in _DURATION.findall(prose)]
+
+
+class TheWorkflowQuotesNoCostTheToolDoesNotState(unittest.TestCase):
+    """#670: one measurement, written down twice and not identically.
+
+    `SHARD_FIXED`'s itemisation said the selection map costs **250 s** and `sweep.yml`'s
+    cache step said **350 s**, about the same trace, and *neither was asserted* — so
+    nothing in the repository was able to notice. It survived because nothing downstream
+    turns on it: `SHARD_FIXED` is twelve minutes and the itemised total fits under it at
+    either reading, so no arithmetic moved and no run failed. It was only a number a
+    reader would quote, with no way to know which one to quote.
+
+    Re-measured across nine cache-miss runs on `ubuntu-latest` — the tool prints its own
+    ``selection map: … in Ns`` — the trace is 242 to 285 s. 250 was honest when #630 wrote
+    it and the suite has grown past it; 350 matches no run at all.
+
+    **The fix is the second copy, not the digits.** `SHARD_FIXED_COSTS` is now the one
+    place the itemisation is written, `sweep.yml` names the constant instead of quoting a
+    figure, and this class holds any duration the workflow's comments *do* quote to one
+    the tool states. A third copy is then either right or red.
+    """
+
+    WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "sweep.yml"
+
+    def test_the_reader_finds_the_copy_this_class_is_about(self):
+        """The control, and the reason the reader is a function.
+
+        The assertion below is satisfied by an empty list, which is the same shape of
+        defect as #669 next door — an assertion about absence standing in for one about a
+        value. This one runs the reader over the exact line #670 reported."""
+        self.assertEqual(
+            durations_stated("# The selection map is one trace of the whole suite — "
+                             "350 s measured, and the"), [350])
+        self.assertEqual(durations_stated("under 5 s, and about 240 seconds"), [5, 240])
+        self.assertEqual(durations_stated("timeout-minutes: 30"), [])
+        self.assertEqual(durations_stated("python-version: \"3.12\""), [])
+
+    def test_every_duration_the_workflow_quotes_is_one_the_tool_states(self):
+        stated = set(sweep.SHARD_FIXED_COSTS.values())
+        loose = [n for n in durations_stated(self.WORKFLOW.read_text()) if n not in stated]
+        self.assertEqual(
+            loose, [],
+            f"sweep.yml quotes {loose} s, which `SHARD_FIXED_COSTS` does not state. That "
+            "is the #670 shape: a cost written down in two files, in words, in neither of "
+            "which anything can check it. Name the constant in the comment instead, or "
+            "move the measurement into `SHARD_FIXED_COSTS` and let the comment cite it.")
+
+    def test_the_budget_covers_the_itemisation_it_is_written_from(self):
+        """`SHARD_FIXED`'s note claims to be the no-cache figure rounded up past the items.
+        Asserted, so a re-measurement that outgrows the budget is red here rather than in
+        a shard that gets cancelled at `timeout-minutes` and reports nothing at all."""
+        itemised = sum(sweep.SHARD_FIXED_COSTS.values())
+        self.assertLess(itemised, sweep.SHARD_FIXED,
+                        "the fixed costs no longer fit the fixed-cost budget")
+        self.assertLess(sweep.SHARD_FIXED, sweep.SHARD_BUDGET,
+                        "a shard would have no time left to measure a mutation in")
+
+    def test_the_itemisation_names_every_cost_and_the_map_is_the_largest(self):
+        """A dict is a source of truth only while it is complete: drop an entry and the
+        sum still fits the budget, silently, which is how a shard comes to be sized
+        against a cost it no longer counts. And "the largest fixed cost a shard pays" is
+        the claim `sweep.yml`'s cache step makes about the map — held to the numbers."""
+        self.assertEqual(sorted(sweep.SHARD_FIXED_COSTS), [
+            "checkout at fetch-depth 0, and the interpreter",
+            "the sandbox clone",
+            "the selection map, traced",
+            "the unmutated baseline",
+        ])
+        self.assertEqual(max(sweep.SHARD_FIXED_COSTS,
+                             key=sweep.SHARD_FIXED_COSTS.__getitem__),
+                         "the selection map, traced")
 
 
 class EverySurvivorLandsOnTheLineItIsAbout(unittest.TestCase):

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -2154,22 +2154,42 @@ def gate_exit_code(gate: Gate, enforce: bool) -> int:
 #: survivors it had already printed, nothing the merge step can read.
 SHARD_BUDGET = 40 * 60
 
-#: What a shard pays before it measures its first mutation. Measured on `ubuntu-latest`
-#: and not on a workstation, because that is where the budget has to hold:
+#: What a shard pays before it measures its first mutation, itemised, in seconds. Measured
+#: on `ubuntu-latest` and not on a workstation, because that is where the budget has to
+#: hold.
 #:
-#: * checkout at ``fetch-depth: 0`` and the interpreter — 3 s;
-#: * the selection map, traced — **250 s**, and restored from cache — under 5 s;
-#: * the sandbox clone — about 15 s;
-#: * the unmutated baseline — about 240 s, the same 7,693 tests `test.yml` runs in 4 min.
+#: **Data and not a bulleted comment, which is what #670 cost.** The largest of these was
+#: written in prose here and written again in `sweep.yml`'s cache step, and the two copies
+#: said 250 and 350 for a month with nothing able to notice: a figure two files state in
+#: words drifts, and neither copy was in reach of an assertion. This dict is the one place
+#: it is written, `test_sweep` holds the workflow's comments to it, and `sweep.yml` names
+#: the constant instead of quoting a number.
+#:
+#: The map figure is nine cache-miss traces on `ubuntu-latest` (242, 252, 257, 276, 277,
+#: 279, 280, 282, 285 s — the tool prints its own `selection map: … in Ns`), taken at the
+#: ceiling because a budget is sized against the slow run. 250 was honest when #630 wrote
+#: it against 7,693 tests and the suite has grown since; 350 never matched a run.
+#:
+#: The baseline is the whole suite once, the same run `test.yml` makes in about four
+#: minutes; the clone is the sandbox `git clone` of this checkout.
+SHARD_FIXED_COSTS = {
+    "checkout at fetch-depth 0, and the interpreter": 3,
+    "the selection map, traced": 285,
+    "the sandbox clone": 15,
+    "the unmutated baseline": 240,
+}
+
+#: What a shard pays before it measures its first mutation, as one number.
 #:
 #: The baseline is the expensive half and it is not negotiable: a shard that skips it
 #: cannot tell a survivor from a tree that was already red, which is the spec's second way
 #: a sweep lies. So every shard buys its own — the marginal cost of a machine.
 #:
-#: The map is the half that CAN be shared, and `sweep.yml` warms it once for all of them.
-#: This constant is deliberately the NO-CACHE figure anyway, and rounded up past even
-#: that: a pull request from a fork cannot write that cache, and a budget that only holds
-#: when the cache hits is a budget that fails on exactly the runs nobody is watching.
+#: The map is the half that CAN be shared, and `sweep.yml` warms it once for all of them;
+#: restored from that cache it costs under 5 s. This constant is deliberately the NO-CACHE
+#: figure anyway, and rounded up past even `sum(SHARD_FIXED_COSTS.values())`: a pull
+#: request from a fork cannot write that cache, and a budget that only holds when the cache
+#: hits is a budget that fails on exactly the runs nobody is watching.
 SHARD_FIXED = 12 * 60
 
 #: What one mutation costs a shard. Read off the runs that ran out of time rather than off


### PR DESCRIPTION
Two defects with the same shape: a fact recorded in two places, in prose, in neither of which anything could check it. Both were found by reading rather than by a failure — which is the tell. Neither is a behaviour change; both are the same correction to the same habit, an assertion about **presence** standing in for one about a **value**.

## #669 — `pad` had two ranges, and the test could only see the right one

`docs/frame.md` said `` `0` to `5` `` where it explains the key and `` `0`–`8` `` four hundred lines down, in the list of values that take an arrangement out of play. The second is the harmful one: it is the sentence about *refusal*, and an arrangement charter cannot draw is refused **whole**, so a `pad = 6` the documentation invited costs the operator their entire `[[frame.component]]` block and drops the frame back to `slots`.

The prose was corrected before this branch. **The defect was the test.** It asked

```python
self.assertIn(f"`0` to `{instance.FRAME_PANE_PAD_MAX}`", md)
```

and the *right* copy satisfied it, so the wrong one was never in its reach. An assertion that one occurrence exists cannot see a second one that disagrees.

`EveryStatementOfThePadBoundIsHeldToTheConstant` replaces it:

* `stated_ranges()` returns **every** range the file states — both spellings, `to` and the dash form — and each is held to `(0, FRAME_PANE_PAD_MAX)`;
* a second check asks `instance.pane_pad` itself about every backticked integer in a sentence mentioning `` `pad` ``, so a copy phrased "capped at `8`" rather than as a range is red too;
* a checker self-test runs the reader over the exact pair #669 reported, because the assertion is green on an empty list and would pass against a reader that matched nothing;
* a vacuity control, and dotted version numbers (tmux `3.2` to `3.6`) are deliberately not matched.

Reintroducing the `` `0`–`8` `` sentence reddens both checks.

## #670 — the trace cost had two figures, re-measured

`SHARD_FIXED`'s budget note in `tools/sweep.py` said the selection map costs **250 s**; `sweep.yml`'s cache step said **350 s**, about the same trace. Neither was asserted. It survived because nothing downstream turns on it — twelve-minute `SHARD_FIXED` covers either reading — so it was only a number a reader would quote, with no way to know which one to quote.

**Measured, not guessed.** Nine cache-miss `Size the sweep` runs on `ubuntu-latest`, where the tool prints its own `selection map: … in Ns` and the log confirms `Cache not found`:

| run | traced |
|---|---|
| 33280305239 | 242 s |
| 33282629763 | 252 s |
| 33281856274 | 257 s |
| 33280291240 | 276 s |
| 33284539956 | 277 s |
| 33284902446 | 279 s |
| 33282911560 | 280 s |
| 33281082952 | 282 s |
| 33282891144 | 285 s |

250 was honest when #630 wrote it against 7,693 tests and the suite has grown past it. **350 matches no run at all** — it was a typo in the same commit that wrote 250, corroborated by the sibling `SECONDS_A_MUTATION` note, whose 515 s no-cache fixed cost only adds up at 250.

The itemisation is now `SHARD_FIXED_COSTS` — data, not a bulleted comment — with the trace at 285, the ceiling of that spread, because a budget is sized against the slow run. `sweep.yml`'s comment names the constant instead of restating a figure (one line changed, line 72).

What is asserted is not the digits:

* the budget covers the costs it is written from, and still leaves a shard time to measure a mutation in;
* the itemisation names all four costs, and the map is still the largest of them — the claim the workflow comment makes about it;
* **any duration the workflow's comments quote must be one the tool states.** Reintroducing `350 s` on line 72 goes red with the diagnosis.

The reader is a function with its own control test, for the same reason as above: the workflow quotes no duration today, so the assertion is green on an empty list.

Nothing downstream moves — `sum(SHARD_FIXED_COSTS.values())` is 543 against `SHARD_FIXED` of 720, and `per_shard()` is still 28.

## Also

`docs/news/unreleased-a-green-sweep-is-not-no-survivors.md` said the two figures had not been reconciled and declined to quote one. It now states the re-measured figure, which is what #670 asked for.

## Verification

* Full suite: 8,785 tests, green, `env -u PYTHONSAFEPATH python3 -m unittest discover -s tests`.
* Both #669 checks proved red against the original `` `0`–`8` `` text; the #670 check proved red against the original `350 s` line.
* No `charter/**` file is touched, so the deletion sweep has nothing to mutate on this branch.

Closes #669.
Closes #670.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy