### PR TITLE
The deletion sweep keeps the two triggers a required check can speak for (#646)

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1,4 +1,53 @@
 name: deletion sweep
+
+# **`push:` is deliberately absent, and #646 is the issue that asks for it by name.**
+#
+# The hole #646 reports is real: two pushes produced no `synchronize` event, no sweep ran,
+# and the checks list simply had no sweep row — which reads exactly like a sweep that found
+# nothing. #630 spent a whole workflow teaching this gate to say `no survivors` rather than
+# wearing a silent green tick; a run that never happened says nothing at all, and that is
+# the fourth state none of the three careful ones can be told apart from.
+#
+# **A workflow that did not run cannot report that it did not run.** Nothing added to this
+# file can close that, because every line here is code that only executes on the runs that
+# already happen. Only something outside the run can speak for a missing one, and on GitHub
+# that is a required status check — which is #561, and a repository setting rather than a
+# commit.
+#
+# Adding `push:` here does not close the hole, and it quietly widens it. Measured on this
+# repository rather than read out of the documentation:
+#
+#   * **The two events sweep different trees.** On `pull_request`, `github.sha` is the merge
+#     commit and `--base` is the pull request's base sha — the tree that will land. A `push`
+#     run has neither: `BASE_SHA` is empty, so `sweep.py` takes its own default of the
+#     merge-base with `origin/main` and charges the branch TIP. Both answers are defensible.
+#     They are not the same answer, and under `push:` they would arrive on the same pull
+#     request under the same check names.
+#   * **That is what makes it worse rather than better.** The remedy #646 settles on is to
+#     require this workflow's `collect` job, so that a missing row BLOCKS instead of passing
+#     silently. The moment `push:` can also produce that check, its presence stops proving
+#     the pull-request-scoped sweep ran — a push-scoped run of a different tree satisfies it.
+#     The one-line fix reintroduces one level down the exact defect it was reached for.
+#   * **The cost is not the cost of `test.yml`.** That workflow carries both triggers, and
+#     every pull request there runs its matrix twice — once on the head sha, once on the
+#     merge commit. Four cheap jobs, twice, is affordable. This gate is eight parallel jobs
+#     and up to forty minutes on a large diff (#639: 443 mutations), and `push:` would spend
+#     that on every push of every branch, PR or not.
+#
+# `workflow_dispatch` stays. It has the same missing merge commit, and it is a hazard of
+# degree rather than of kind: somebody has to ask for it, once, on purpose — which is the
+# whole reason it is here.
+#
+# **The job to require is `collect`, and that was measured too.** Its check is named
+# `Add up what the shards found`, it runs under `always()`, and across twelve consecutive
+# real runs it concluded `success` every time — including the two whose `plan` job concluded
+# `cancelled` because a newer push superseded them. `plan` is therefore the wrong context to
+# require: `cancelled` blocks, so requiring `Size the sweep` would block every pull request
+# that got a second push. `verdict` is the wrong one for the reason stated on the job itself
+# — its name is the answer, so it is different on every branch.
+#
+# `tests/test_workflows.py` holds the trigger set and those two job properties, so a future
+# `push:` is a deliberate act that meets an assertion rather than a one-line convenience.
 on:
   pull_request:
   workflow_dispatch:      # so a branch can be re-swept without a noise commit

--- a/docs/news/unreleased-the-sweep-keeps-the-two-triggers-a-required-check-can-speak-for.md
+++ b/docs/news/unreleased-the-sweep-keeps-the-two-triggers-a-required-check-can-speak-for.md
@@ -1,0 +1,55 @@
+---
+version: unreleased
+headline: The deletion sweep keeps the two triggers a required check can speak for, and says why `push:` is not a third
+---
+
+#646 asks whether `sweep.yml` should gain a `push:` trigger, and calls it a decision rather
+than a patch. The decision is **no**, the file now argues it where somebody reaching for that
+one-line change will read it, and `tests/test_workflows.py` holds the trigger set so that
+overturning it meets an assertion.
+
+The hole is real. Two pushes produced no `synchronize` event, so the gate never ran, and the
+checks list simply had **no sweep row**. #630 spent a whole workflow teaching this gate to say
+`no survivors` rather than wearing a silent green tick, because GitHub's conclusion vocabulary
+cannot carry the difference. A run that never happened says nothing at all — a fourth state,
+underneath the three that were so carefully separated, and indistinguishable from the clean
+one.
+
+**A workflow that did not run cannot report that it did not run.** Nothing added to that file
+closes this, because every line in it is code that executes only on the runs that already
+happen. Only something outside the run can speak for a missing one, and on GitHub that is a
+required status check — which is #561, and a repository setting rather than a commit.
+
+**Adding `push:` would not close it and would quietly widen it.** The two events sweep
+different trees: on `pull_request`, `github.sha` is the merge commit and `--base` is the pull
+request's base sha — the tree that will land; a `push` run has neither, so `sweep.py` takes its
+own default of the merge-base with `origin/main` and charges the branch *tip*. Both answers
+are defensible and they are not the same answer. Once `push:` can also publish the check that
+#646's remedy requires, the presence of that check stops proving the pull-request-scoped sweep
+ran — a push-scoped run of a different tree satisfies it. The fix people reach for reopens the
+same defect one level below itself.
+
+The cost is the smaller argument but not a small one. `test.yml` carries both triggers and
+every pull request runs its matrix twice, on the head sha and on the merge commit; four cheap
+jobs, twice, is affordable. This gate is eight parallel jobs and up to forty minutes on a large
+diff (#639: 443 mutations), and `push:` would spend that on every push of every branch, pull
+request or not. `workflow_dispatch` stays: it has the same missing merge commit and is a hazard
+of degree rather than of kind, because somebody has to ask for it, once, on purpose.
+
+**Which job the operator should require was measured rather than reasoned.** `collect` — the
+check named `Add up what the shards found` — runs under `always()` and concluded `success` on
+twelve consecutive real runs, *including the two whose `plan` job concluded `cancelled`*
+because a newer push superseded them. That is what makes it absent exactly when the workflow
+did not fire, which is the whole property #646 needs. `Size the sweep` is the wrong context: a
+`cancelled` required check blocks, so requiring it would block every pull request that got a
+second push. `verdict` is wrong for the reason stated on the job itself — its name *is* the
+answer, so it is different on every branch, and a required context nothing ever reports again
+blocks forever rather than passing.
+
+A new test holds all three: the trigger set, `collect`'s fixed name and its `always()`, and the
+fact that the jobs whose names interpolate — `verdict` and the sharded `sweep` — can never be
+required. The reader it uses is exercised in both directions, because one that called every job
+requirable would make the `verdict` assertion vacuously true and one that called none would
+satisfy the `collect` assertion by finding no jobs at all.
+
+Nothing here changes a repository setting. #561 remains open and needs the owner, as it says.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2342,5 +2342,122 @@ class TheJobThisIsAboutIsTheOneThatCanPublish(unittest.TestCase):
                          {("release.yml", "owner/act")})
 
 
+# ------------------------------------------ what can speak for a run that never happened
+
+def requirable(workflow: object) -> dict[str, str]:
+    """Job key -> the check-run name it publishes, for the jobs that can be *required*.
+
+    Branch protection matches a required status check by NAME and by nothing else, so a job
+    has to answer two questions to be one: what name does it publish, and does that name
+    hold still. A job with no `name:` publishes its key; one with a `name:` publishes that.
+
+    A name carrying `${{ }}` publishes a different string on every branch. Requiring it
+    would protect a branch against a string that never appears again — and a required
+    context nothing ever reports does not pass, it blocks forever. Two jobs in `sweep.yml`
+    are deliberately in that class: `verdict`, whose name IS the answer (#630), and the
+    sharded `sweep` job, whose name counts shards. Neither is a mistake and neither is a
+    candidate.
+
+    A job with no body at all is a workflow somebody is still writing, and it names no
+    check yet — the same half-written case `beside_the_publishing_identity` handles rather
+    than crashing on.
+    """
+    out: dict[str, str] = {}
+    for key, job in workflow["jobs"].items():
+        if not isinstance(job, dict):
+            continue
+        name = job.get("name", key)
+        if "${{" not in name:
+            out[key] = name
+    return out
+
+
+class TheSweepsAbsenceIsSomethingOnlyARequiredCheckCanSay(unittest.TestCase):
+    """#646 and #561 are one defect seen from two heights, and this holds the code half.
+
+    #561: *a check that never ran reports CLEAN*. #646: *a branch with no gate run looks
+    identical to one whose gate found nothing*. Neither can be answered from inside the
+    workflow, because every line of a workflow is code that runs only on the runs that
+    already happen — so the answer is a required status check, which is a repository
+    setting and not a commit.
+
+    What IS in this repository's gift is keeping that setting meaningful, and there are
+    exactly two ways a commit can quietly hollow it out. Add `push:` to `sweep.yml` and the
+    required check can be satisfied by a run that swept the branch tip instead of the merge
+    result — the hole reopened one level below the fix. Or rename the job that check names,
+    or take away the `always()` that makes it report at all.
+
+    So the trigger set and the two properties of `collect` are pinned here, and `requirable`
+    is exercised in both directions: a reader that called everything requirable would make
+    the `verdict` assertion vacuous, and one that called nothing requirable would satisfy
+    the `collect` assertion by finding no jobs at all.
+    """
+
+    def sweep(self) -> dict:
+        return load((GITHUB / "workflows" / "sweep.yml").read_text())
+
+    NAMES = [
+        ("a job with no name of its own publishes its key",
+         "jobs:\n  collect:\n    runs-on: ubuntu-latest\n", {"collect": "collect"}),
+        ("a job with a fixed name publishes that name",
+         'jobs:\n  c:\n    name: Add up what the shards found\n', {"c": "Add up what"
+                                                                   " the shards found"}),
+        ("a name that interpolates an output is not a context anything can require",
+         'jobs:\n  verdict:\n    name: "${{ needs.collect.outputs.headline }}"\n', {}),
+        ("a name that interpolates a matrix value is not one either",
+         "jobs:\n  sweep:\n    name: Sweep shard ${{ matrix.shard }} of 8\n", {}),
+        ("the fixed names survive beside the moving ones",
+         "jobs:\n  plan:\n    name: Size the sweep\n  v:\n    name: ${{ x }}\n",
+         {"plan": "Size the sweep"}),
+        ("a job nobody has finished writing names no check yet",
+         "jobs:\n  half:\n", {}),
+    ]
+
+    def test_a_job_names_a_required_context_only_when_that_name_holds_still(self):
+        for label, text, expected in self.NAMES:
+            with self.subTest(label):
+                self.assertEqual(requirable(load(text)), expected, label)
+
+    def test_the_sweep_runs_on_the_two_triggers_it_can_answer_for(self):
+        """The assertion the header of `sweep.yml` argues at length, and #646 asks to
+        overturn. `pull_request` is the only trigger that hands this gate a merge commit
+        and a base sha — the tree that will land, which is what "scoped to added lines"
+        means. `workflow_dispatch` is a human asking, once.
+
+        A `push:` here would let the required `collect` check be reported by a run that
+        swept the branch TIP against the merge-base instead, under the same name — so the
+        check's presence would stop proving that the pull-request-scoped sweep ever ran.
+        Overturning this is a decision; it is not a line somebody adds in passing.
+        """
+        self.assertEqual(set(self.sweep()["on"]), {"pull_request", "workflow_dispatch"})
+
+    def test_the_context_to_require_is_the_job_that_reports_whatever_the_shards_did(self):
+        """`collect` is the one job in this workflow fit to be a required check, and both
+        halves of that were measured on real runs rather than reasoned from the file.
+
+        Its name is fixed, so branch protection can name it. And it runs under `always()`,
+        which is why it reports at all when the shards die (#626) and when a newer push
+        cancels the run (#654): across twelve consecutive runs it concluded `success` every
+        time, including the two whose `plan` job concluded `cancelled`. That is what makes
+        it absent EXACTLY when the workflow did not fire, which is the whole property #646
+        needs — a `cancelled` required context blocks, so requiring `Size the sweep`
+        instead would block every pull request that got a second push.
+        """
+        jobs = self.sweep()["jobs"]
+        self.assertEqual(requirable(self.sweep())["collect"],
+                         "Add up what the shards found")
+        self.assertEqual(jobs["collect"]["if"], "always()")
+
+    def test_the_job_whose_name_is_the_answer_can_never_be_a_required_check(self):
+        """The `verdict` job says this about itself already; this is that comment with
+        teeth. Its name is `no survivors` on one branch and `114 survivors, 1 not measured`
+        on the next, so requiring it would demand a context that never reports twice — and
+        a required context nothing reports blocks forever rather than passing.
+        """
+        names = requirable(self.sweep())
+        self.assertNotIn("verdict", names)
+        self.assertNotIn("sweep", names)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes the code half of **#646**. **#561 stays open** — it is a repository setting and needs the owner. The measurements for that decision are in the thread below, taken against github.com on a throwaway branch that has since been deleted.

## The decision #646 asks for: no `push:` trigger

#646 argues both sides and calls it a decision rather than a patch. The answer is **no**, and `sweep.yml` now carries the argument where somebody reaching for that one-line change will read it.

**A workflow that did not run cannot report that it did not run.** Every line in that file is code that executes only on the runs that already happen. Only something outside the run can speak for a missing one, and on GitHub that is a required status check.

**`push:` would not close the hole and would quietly widen it.** The two events sweep different trees — `pull_request` gives a merge commit and a base sha (the tree that will land); a `push` run has neither, so `sweep.py` falls back to the merge-base with `origin/main` and charges the branch *tip*. Once `push:` can also publish the check that #646's own remedy requires, the presence of that check stops proving the pull-request-scoped sweep ran. The one-line fix reopens the same defect one level below itself.

The cost is the smaller argument but not a small one: eight parallel jobs and up to forty minutes on a large diff (#639: 443 mutations), on every push of every branch.

## Which job to require, measured rather than reasoned

| context | verdict |
|---|---|
| `Add up what the shards found` (`collect`) | **the one to require** — `always()`, and `success` on 12 consecutive real runs |
| `Size the sweep` (`plan`) | wrong — `cancelled` on 2 of those 12 (superseded runs), and a `cancelled` required check blocks |
| `no survivors` / … (`verdict`) | wrong — its name *is* the answer, different on every branch |

## What the test pins

`requirable()` plus three assertions: the trigger set, `collect`'s fixed name and its `always()`, and that the interpolating job names (`verdict`, the sharded `sweep`) can never be a required context. The reader is exercised in both directions — one that called every job requirable would make the `verdict` assertion vacuous, one that called none would satisfy the `collect` assertion by finding no jobs at all.

## Deletion sweep

**14 mutations, 14 pinned, 0 survivors.** Six on the `requirable` reader (`drop-if`, `drop-isinstance`, `no-fallback`, and the `"jobs"`/`"name"` key literals) and eight on the assertions' own key and job-name literals.

Run as `tools/sweep.py --gate --path tests`. The default `--path charter` plans **zero** mutations on a workflow-and-tests diff and reports a clean that means nothing — three agents have now hit that trap this session, and it is worth saying out loud in a PR description.

Full suite: 8805 tests, OK.