### PR TITLE
The deletion sweep applies the edit it printed, and stops asking a question that has one answer (#655)

### DIFF
--- a/docs/news/unreleased-the-sweep-applies-the-edit-it-describes.md
+++ b/docs/news/unreleased-the-sweep-applies-the-edit-it-describes.md
@@ -1,0 +1,138 @@
+---
+version: unreleased
+headline: The deletion sweep applies the edit it printed, and stops asking a question that has one answer
+---
+
+#655 proposed a third verdict for the deletion sweep. Beside `pinned` and `survived` it
+wanted **`indistinguishable`** — for the mutant no honest test can redden, produced by a
+rule the tool can check rather than by a suppression list a person maintains. Its author
+was careful to say it was a proposal, and careful to name the measurement that should come
+first:
+
+> across the last N branches, how many survivors are decidably-equivalent by a rule, versus
+> how many are the genuine "the test asserts too little" case the report is designed to
+> surface? If the answer is "almost all are the genuine case", the right fix is nothing at
+> all.
+
+**The measurement was run, and the answer is "almost all are the genuine case".** So there
+is no third verdict. What the measurement did turn up is a defect in the tool that would
+have made `--enforce` unusable on its first day, and that is what this changes.
+
+## The measurement
+
+Every sweep result GitHub still holds an artifact for was collected: 136 shard files from
+54 completed runs across 2026-08-28 and 2026-08-30, on ten branches that produced a
+survivor. That is 3,044 mutation records, 1,285 distinct mutations, and **461 distinct
+survivors.**
+
+| operator | survivors | | operator | survivors |
+|---|---:|---|---|---:|
+| `uncontain` | 109 | | `shift-boundary` | 25 |
+| `drop-if` | 70 | | `drop-conjunct` | 15 |
+| `retune-string` | 62 | | `retune-constant` | 10 |
+| `swap-synonym` | 51 | | `drop-isinstance` | 7 |
+| `no-fallback` | 45 | | `drop-comprehension-if` | 5 |
+| `collapse-ifexp` | 33 | | `unclamp` | 3 |
+| `narrow-except` | 26 | | | |
+
+Of those 461, the number a **rule** could have called equivalent is **one**. Not a small
+fraction — one line, `change.py:142`.
+
+And the three cases #655 names are not among the decidable ones:
+
+**`path.partition("/")` -> `rpartition("/")`** (eight survivors) is equivalent only if a
+GitHub `path_with_namespace` really does hold exactly one slash. Nothing in
+`charter/forge/github.py` constrains it — the value arrives as
+`repo.get("path_with_namespace") or ""` — so the constraint lives in a remote API's
+contract, not in the code. A tool that asserts it is a suppression list with a rule's
+manners, and it is exactly the thing #370 refuses: an exception nothing re-checks when the
+code moves.
+
+**`GIT_TIMEOUT = 20 -> 21`** would have to be decided from the evidence the sweep already
+collects — "N modules execute this file and not one names the symbol". But that sentence is
+the report's *loudest finding*, not an equivalence: turning it into a reason to stop asking
+inverts the tool, and it would be lifted by renaming the constant.
+
+**`_BODY_BUDGET = 100_000 -> 100_001`** is the one offered as the sharpest case, against
+`RELEASE_BODY_MAX = 125_000` beside it, which is pinned. The two really are different, and
+the difference is not decidability: GitHub's number is pinned by a test that names GitHub's
+number, and charter's is pinned from both ends by a *window* — `test_the_staged_release_has_headroom`
+from above and `test_the_bound_is_an_exception_rather_than_the_normal_path` from below —
+which `100_001` sits inside. No rule can compute that window. A reader can, and
+`_BODY_BUDGET`'s own docstring already does, which is the remedy that scales: a comment,
+at the line, saying why.
+
+So: **no new verdict, no suppression list, and the report keeps saying what it says.**
+
+## What the measurement found instead: the mutant was not always the edit
+
+While counting survivors, one shape kept reading oddly. `charter/commands.py:975` was
+reported like this:
+
+```
+shipped : (pattern or "").strip
+mutant  : pattern or "".lstrip
+```
+
+The question printed beside it is "is `how much` pinned?". The mutation applied does not
+move how much is stripped — it **deletes the strip on every path but one**, because
+`ast` node positions exclude the parentheses a programmer wrote around a subexpression, so
+`sp.text` of the receiver is `pattern or ""` and splicing it back rebuilds the expression.
+
+Measured over `charter/` and `tools/`: **144 of 8,903 expression mutations spliced
+something other than the edit they described.** 137 are that receiver, one spelling or
+another. The remaining seven are worse:
+
+```python
+(vc or {}).get("config", {})    ->    vc or {}["config"]
+```
+
+`{}["config"]` is a `KeyError`. So the suite goes red, and the fallback is recorded as
+**pinned** — a guard certified as tested by a crash that has nothing to do with it. That is
+the false pin the whole file is built to prevent, four times in `charter/`, plus two
+`unclamp` sites and one `uncontain`.
+
+This is the failure `--enforce` could not have survived. A blocked branch whose author is
+sent to write a test for a property the mutation never perturbed has no move to make, which
+is the same dead end #632 closed for the unkillable annotation — arriving from the other
+direction.
+
+**Fixed as a property, not as a list of sites.** `parenthesised` spells any replacement
+whose top node binds loosely enough to re-associate, and `LOOSE`/`TIGHT` between them name
+every subclass of `ast.expr` — asserted in the suite, so the day Python grows a new
+expression the tests say so rather than the tool guessing. (They said so immediately: on
+3.14, PEP 750's `TemplateStr` and `Interpolation` are two nodes that did not exist when
+this was written.) Re-measured after the change: **0 of 9,189.**
+
+It also *recovers* questions the sweep had been dropping in silence. A receiver spread
+over two lines — an implicitly concatenated pair of f-strings, say — produced a mutant
+that did not parse, and `mutations_for` skips those without a word. Brackets make them
+parse: **25 mutations across the tree are asked for the first time.**
+
+## And one question that only ever had one answer
+
+`SYNONYMS` justifies each pair by the single axis it moves. `split`/`rsplit` moves nothing
+when no `maxsplit` is given: `s.split(sep)` and `s.rsplit(sep)` return the same list for
+every string and every separator, because the only thing the `r` decides is which end runs
+out of splits first and with an unlimited budget neither does. That is verified
+exhaustively in the suite over every string of up to five characters from an alphabet
+containing the separator, for `str` and `bytes` and the no-argument whitespace form.
+
+67 of the 98 `split`/`rsplit` call sites in `charter/` and `tools/` pass no `maxsplit`. Each
+was a mutation that could never be killed by anybody — #630's own self-sweep already listed
+`split(".")[-1]` against `rsplit(".")[-1]` among the sixteen it said nobody could close —
+and every one becomes a *permanent* survivor now that the receiver's brackets survive the
+splice, because until now the lost parentheses were accidentally making the mutant a
+different program.
+
+**It is answered where #632 answered its sibling: the mutation is not offered.** A survivor
+no test can kill is a false positive, and the place to fix a false positive is the question,
+not the answer. Not a verdict, not an entry on a list — the operator declines, in one
+predicate, with the reason in its docstring where a reader can disagree with it. The 31
+sites that *do* pass a `maxsplit` are untouched and stay a real question.
+
+Together the two changes move the whole-tree count from **11,277 to 11,235**: 67
+withdrawn because they had one answer, 25 recovered because they now parse.
+`swap-synonym` itself goes from 975 to 909 — 67 refused, one of them handed back.
+
+The gate still blocks nothing. `--enforce` is still absent, deliberately.

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -119,7 +119,7 @@ class TheConjunctShape(unittest.TestCase):
                         out[name] = placed
         """)
         self.assertEqual(_afters(muts, "drop-conjunct"),
-                         ["isinstance(name, str)", "name not in SLOT_SIZE"])
+                         ["(name not in SLOT_SIZE)", "isinstance(name, str)"])
 
     def test_a_three_part_guard_drops_one_part_at_a_time_and_keeps_the_rest(self):
         muts = _mutations("""
@@ -128,7 +128,7 @@ class TheConjunctShape(unittest.TestCase):
                     return 1
         """)
         self.assertEqual(_afters(muts, "drop-conjunct"),
-                         ["a and b", "a and c", "b and c"])
+                         ["(a and b)", "(a and c)", "(b and c)"])
 
     def test_a_single_condition_offers_no_conjunct_mutation(self):
         muts = _mutations("""
@@ -149,7 +149,7 @@ class TheClampShape(unittest.TestCase):
                 n = max(1, height - _CHROME_ROWS)
                 return n
         """)
-        self.assertEqual(_afters(muts, "unclamp"), ["1", "height - _CHROME_ROWS"])
+        self.assertEqual(_afters(muts, "unclamp"), ["(height - _CHROME_ROWS)", "1"])
 
     def test_a_nested_clamp_offers_the_inner_variable_on_its_own(self):
         """`self._top = max(0, min(top, max(0, len(self.rows) - n)))` is unpinned, and
@@ -743,14 +743,14 @@ class TheBoundaryShape(unittest.TestCase):
                     return sel
                 return top
         """)
-        self.assertEqual(_afters(muts, "shift-boundary"), ["(sel) <= (top)"])
+        self.assertEqual(_afters(muts, "shift-boundary"), ["((sel) <= (top))"])
 
     def test_an_inclusive_comparison_is_offered_one_notch_narrower(self):
         muts = _mutations("""
             def f(n, cap):
                 return n <= cap
         """)
-        self.assertEqual(_afters(muts, "shift-boundary"), ["(n) < (cap)"])
+        self.assertEqual(_afters(muts, "shift-boundary"), ["((n) < (cap))"])
 
     def test_a_chain_moves_one_link_and_respells_the_rest(self):
         """`0 <= i < n` is ONE node. Moving one link means writing the whole chain back
@@ -761,14 +761,14 @@ class TheBoundaryShape(unittest.TestCase):
                 return 0 <= i < n
         """)
         self.assertEqual(sorted(_afters(muts, "shift-boundary")),
-                         ["(0) < (i) < (n)", "(0) <= (i) <= (n)"])
+                         ["((0) < (i) < (n))", "((0) <= (i) <= (n))"])
 
     def test_a_link_that_is_not_a_boundary_is_carried_through_untouched(self):
         muts = _mutations("""
             def f(a, b, c):
                 return a < b == c
         """)
-        self.assertEqual(_afters(muts, "shift-boundary"), ["(a) <= (b) == (c)"])
+        self.assertEqual(_afters(muts, "shift-boundary"), ["((a) <= (b) == (c))"])
 
     def test_every_comparison_operator_python_has_is_spelled(self):
         """`CMP_TEXT` is subscripted directly, with no fallback, so an operator missing
@@ -862,12 +862,15 @@ class TheSynonymShape(unittest.TestCase):
         """`shlex.split` and `re.split` live in a namespace with no `rsplit` in it at all,
         so the swap is an `AttributeError` rather than a question about which end was
         searched. The pair is justified by two methods on one TYPE, and a module is not an
-        instance of anything. Measured on `charter/`: eight such call sites."""
+        instance of anything. Measured on `charter/`: eight such call sites.
+
+        The `maxsplit` on the second call is what keeps it a question at all rather than
+        scenery — see :func:`sweep.indistinguishable`."""
         muts = _mutations("""
             import shlex
 
             def f(command, name):
-                return shlex.split(command), name.split(",")
+                return shlex.split(command), name.split(",", 1)
         """)
         self.assertEqual(_afters(muts, "swap-synonym"), ["name.rsplit"])
 
@@ -887,6 +890,270 @@ class TheSynonymShape(unittest.TestCase):
         for name, (other, axis) in sweep.SYNONYMS.items():
             self.assertTrue(axis and isinstance(axis, str), name)
             self.assertNotEqual(name, other)
+
+
+class TheMutantIsTheEditDescribed(unittest.TestCase):
+    """`parenthesised` (#655): the mutation applied is the mutation the report prints.
+
+    Measured over `charter/` and `tools/` before this existed: **144 of 8,903 expression
+    mutations spliced something else**, because an `ast` node's span excludes the
+    parentheses a programmer put around it. `(x or "").strip()` became
+    ``x or "".lstrip()`` — not a swap of which end is stripped but a deletion of the
+    strip on every path but one — and `(vc or {}).get("config", {})` became
+    ``vc or {}["config"]``, which is a `KeyError` and therefore a FALSE PIN, the failure
+    this whole file exists to prevent.
+
+    The shapes below are the real ones from that measurement, and each is written to die
+    if the mutant stops standing exactly where it was put.
+    """
+
+    def _every_splice_stands_where_it_was_put(self, source: str, least: int = 1) -> None:
+        """The property, not an example of it: bracketing the mutant changes nothing.
+
+        A splice that re-associates is exactly a splice whose result would parse
+        DIFFERENTLY with brackets around it, so this is the whole claim and it needs no
+        table of precedences to state. Two splices are not expressions at all and are
+        skipped rather than fudged: a statement deletion, and an f-string's literal text.
+        """
+        blob = textwrap.dedent(source).lstrip("\n").encode("utf-8")
+        tree = ast.parse(blob)
+        sp = sweep._Spans(blob)
+        raw = {sp.span(part) for node in ast.walk(tree)
+               if isinstance(node, ast.JoinedStr)
+               for part in node.values if isinstance(part, ast.Constant)}
+        muts = sweep.mutations_for(
+            "charter/x.py", blob, set(range(1, len(blob.splitlines()) + 2)))
+        self.assertGreaterEqual(len(muts), least)
+        checked = 0
+        for m in muts:
+            if m.span in raw:
+                continue
+            try:
+                ast.parse(m.after, mode="eval")
+            except SyntaxError:
+                continue
+            a, b = m.span
+            bracketed = blob[:a] + b"(" + m.after.encode("utf-8") + b")" + blob[b:]
+            with self.subTest(mutation=str(m)):
+                self.assertEqual(
+                    ast.dump(ast.parse(m.source)), ast.dump(ast.parse(bracketed)),
+                    f"{m.tag}: the mutant re-associates — the program it makes is not "
+                    f"the edit the report describes ({m.before!r} -> {m.after!r})")
+            checked += 1
+        self.assertGreater(checked, 0)
+
+    def test_a_grouped_receiver_keeps_its_grouping(self):
+        """137 of the 144 are this line, in one spelling or another: the receiver is an
+        `or` chain, its parentheses are grouping rather than syntax, and `ast` does not
+        put them in the span. The mutant the report called "which side is stripped"
+        stripped neither side."""
+        muts = _mutations("""
+            def f(p):
+                return (p.stderr or p.stdout or "").strip()
+        """)
+        self.assertEqual(_afters(muts, "swap-synonym"),
+                         ['(p.stderr or p.stdout or "").lstrip'])
+        self._every_splice_stands_where_it_was_put("""
+            def f(p):
+                return (p.stderr or p.stdout or "").strip()
+        """)
+
+    def test_a_fallback_on_a_grouped_receiver_does_not_become_a_key_error(self):
+        """The false pin, which is the half that matters. `vc or {}["config"]` evaluates
+        the subscript only when `vc` is falsy, and `{}["config"]` raises — so the suite
+        goes red for a crash and the fallback is certified as tested. Four sites in
+        `charter/` are exactly this."""
+        muts = _mutations("""
+            def f(vc):
+                return (vc or {}).get("config", {})
+        """)
+        self.assertIn('(vc or {})["config"]', _afters(muts, "no-fallback"))
+
+    def test_a_fallback_written_as_an_or_keeps_its_receiver_grouped_too(self):
+        """The other `no-fallback` spelling, `d.get(k) or ()`, builds the same subscript
+        from the same receiver — and a test that only covered `d.get(k, v)` left this one
+        unpinned. Found by deleting the line."""
+        muts = _mutations("""
+            def f(vc):
+                return (vc or {}).get("config") or {}
+        """)
+        self.assertIn('(vc or {})["config"]', _afters(muts, "no-fallback"))
+
+    def test_a_conjunct_that_is_itself_an_or_keeps_its_grouping(self):
+        """`and` binds tighter than `or`, so a half spelled `a or b` joined back with
+        ` and ` reads as `a or (b and c)` — a different condition from the one dropped.
+        Also found by deleting the line: the two-conjunct fixtures could not reach it,
+        because a lone survivor gets its brackets from the outer spelling instead."""
+        muts = _mutations("""
+            def f(a, b, c, d):
+                if (a or b) and c and d:
+                    return 1
+        """)
+        self.assertIn("((a or b) and c)", _afters(muts, "drop-conjunct"))
+
+    def test_a_clamp_dropped_inside_a_tighter_expression_keeps_its_grouping(self):
+        """`2 * max(0, inner - w)` -> `2 * inner - w` is not the clamp dropped, it is
+        arithmetic rewritten."""
+        muts = _mutations("""
+            def f(inner, w):
+                return 2 * max(0, inner - w)
+        """)
+        self.assertIn("(inner - w)", _afters(muts, "unclamp"))
+
+    def test_a_containment_dropped_beside_a_concatenation_keeps_its_grouping(self):
+        muts = _mutations("""
+            def f(detail):
+                return contain.one_line(detail[-1] if detail else "no output") + "!"
+        """)
+        self.assertEqual(_afters(muts, "uncontain"),
+                         ['(detail[-1] if detail else "no output")'])
+
+    def test_an_fstring_format_spec_is_text_and_never_grows_brackets(self):
+        """A format spec's span holds raw bytes and not an expression, so `retune-string`
+        splices text there. `x-y` happens to parse as a `BinOp`, and bracketing it would
+        put `(y-z)` inside the string — a corruption, not a mutation.
+
+        BOTH arms, for the reason the width-literal case above gives at length: PEP 701
+        landed in 3.12, and before it an f-string's internal positions are approximate, so
+        `span_is_sound` refuses the segment and there is nothing here to protect. That is
+        `sweep.reach`'s declared gap rather than a different answer to this question."""
+        muts = _mutations("""
+            def f(v):
+                return f"{v:x-y}"
+        """)
+        if sys.version_info >= (3, 12):
+            self.assertEqual(_afters(muts, "retune-string"), ["y-z"])
+            self.assertIn('f"{v:y-z}"', _by(muts, "retune-string")[0].source.decode())
+        else:
+            self.assertEqual(_by(muts, "retune-string"), [])
+
+    def test_text_that_is_not_an_expression_is_returned_untouched(self):
+        """A statement deletion splices nothing, or `pass`. Neither is an expression and
+        neither may grow brackets."""
+        self.assertEqual(sweep.parenthesised(""), "")
+        self.assertEqual(sweep.parenthesised("pass"), "pass")
+        self.assertEqual(sweep.parenthesised("<39"), "<39")
+
+    def test_a_bracket_already_around_the_whole_expression_is_not_doubled(self):
+        """`drop-conjunct` spells each half and then the join is spelled again, so this
+        runs twice over the same text. `((prog != "export"))` is a mutant nobody reads."""
+        self.assertEqual(sweep.parenthesised("(a and b)"), "(a and b)")
+        self.assertEqual(sweep.parenthesised("(a) and b"), "((a) and b)")
+
+    def test_a_tight_expression_is_left_alone(self):
+        for text in ("name", "d[k]", "f(x)", "p.stem", '"lit"', "[1, 2]", "{}"):
+            self.assertEqual(sweep.parenthesised(text), text)
+
+    def test_every_expression_python_has_is_either_loose_or_tight(self):
+        """The same protection `CMP_TEXT` gets, for the same reason: an expression node
+        in neither tuple would be treated as tight by default, and a splice that
+        re-associates is a mutation that is not the mutation the report describes. This
+        fails on the day Python grows a new expression, rather than on the day somebody's
+        survivor turns out to be a different program."""
+        self.assertEqual(set(ast.expr.__subclasses__()),
+                         set(sweep.LOOSE) | set(sweep.TIGHT))
+        self.assertEqual(set(sweep.LOOSE) & set(sweep.TIGHT), set())
+
+    def test_every_shape_in_the_table_stands_where_it_was_put(self):
+        """The property over one module carrying every operator that splices source text
+        back into the tree, each in a position tight enough to rebuild it."""
+        self._every_splice_stands_where_it_was_put("""
+            BUDGET = 3 + 4
+
+            def f(p, vc, detail, xs, n, cap, w):
+                a = 2 * max(0, n - w)
+                b = (p.stderr or "").strip()
+                c = (vc or {}).get("config", {})
+                d = contain.one_line(detail[-1] if detail else "x") + "!"
+                e = 2 * (n if cap else n - 1)
+                g = 2 * ((vc or {}).get("k") or ())
+                h = -(n if cap else n - 1)
+                if isinstance(n, int) and n - 1 < cap:
+                    return a, b, c, d, e, g, h
+                return (p.name or "").lower()
+        """, least=10)
+
+
+class TheMutantThatAsksNothing(unittest.TestCase):
+    """`indistinguishable` (#655): a mutation that cannot be killed is not offered.
+
+    #655 proposed a third verdict beside `pinned`/`survived` for the mutant no honest
+    test can redden. The measurement it asked for first refuses it: across every sweep
+    result this repository still holds — 461 distinct survivors on ten branches — the
+    number a rule could decide is one. `path.partition("/")` is equivalent only if a
+    GitHub `path_with_namespace` holds one slash, which is a fact about a remote API and
+    not about the code; `GIT_TIMEOUT = 20 -> 21` would have to be decided from "no
+    covering test names the symbol", which is the report's loudest FINDING and is lifted
+    by renaming the constant.
+
+    What is decidable is answered where #632 answered its sibling — the operator does not
+    offer the mutation. A survivor no test can kill is a false positive, and the place to
+    fix a false positive is the question, not the answer.
+    """
+
+    def test_a_split_with_no_maxsplit_is_not_offered(self):
+        muts = _mutations("""
+            def f(path):
+                return path.split("/")
+        """)
+        self.assertEqual(_by(muts, "swap-synonym"), [])
+
+    def test_an_rsplit_with_no_maxsplit_is_not_offered_either(self):
+        muts = _mutations("""
+            def f(path):
+                return path.rsplit("/")
+        """)
+        self.assertEqual(_by(muts, "swap-synonym"), [])
+
+    def test_the_whitespace_form_is_the_same_function_too(self):
+        muts = _mutations("""
+            def f(text):
+                return text.split()
+        """)
+        self.assertEqual(_by(muts, "swap-synonym"), [])
+
+    def test_a_maxsplit_makes_it_a_question_again(self):
+        muts = _mutations("""
+            def f(path):
+                return path.split("/", 1)
+        """)
+        self.assertEqual(_afters(muts, "swap-synonym"), ["path.rsplit"])
+
+    def test_a_maxsplit_passed_by_keyword_counts_too(self):
+        muts = _mutations("""
+            def f(path):
+                return path.split("/", maxsplit=1)
+        """)
+        self.assertEqual(_afters(muts, "swap-synonym"), ["path.rsplit"])
+
+    def test_the_pair_really_is_one_function_without_a_maxsplit(self):
+        """The evidence for the rule rather than a restatement of it. Exhaustive over
+        every string of up to five characters drawn from an alphabet that CONTAINS the
+        separator, for `str` and for `bytes`, plus the no-argument whitespace form."""
+        import itertools
+        for n in range(6):
+            for letters in itertools.product("ab.", repeat=n):
+                s = "".join(letters)
+                self.assertEqual(s.split(), s.rsplit(), s)
+                for sep in (".", "a", "ab"):
+                    self.assertEqual(s.split(sep), s.rsplit(sep), (s, sep))
+                    self.assertEqual(s.encode().split(sep.encode()),
+                                     s.encode().rsplit(sep.encode()), (s, sep))
+        self.assertNotEqual("a.b.c".split(".", 1), "a.b.c".rsplit(".", 1))
+
+    def test_a_pair_that_does_move_its_axis_is_untouched(self):
+        muts = _mutations("""
+            def f(name):
+                return name.lower()
+        """)
+        self.assertEqual(_afters(muts, "swap-synonym"), ["name.upper"])
+
+    def test_the_refusal_names_the_reason_rather_than_dropping_it_silently(self):
+        call = ast.parse('x.split(",")', mode="eval").body
+        self.assertIn("maxsplit", sweep.indistinguishable("split", "rsplit", call))
+        self.assertEqual(sweep.indistinguishable("lower", "upper", call), "")
+        with_max = ast.parse('x.split(",", 1)', mode="eval").body
+        self.assertEqual(sweep.indistinguishable("split", "rsplit", with_max), "")
 
 
 class TheNonDecimalConstantShape(unittest.TestCase):
@@ -1505,7 +1772,11 @@ class TwoGuardsCanHideBehindEachOther(unittest.TestCase):
         how the harness asks that question."""
         muts = sweep.mutations_for("charter/frame/layout.py", self.SRC, set(range(1, 9)))
         a = next(m for m in muts if m.operator == "no-fallback")
-        b = next(m for m in muts if m.operator == "drop-conjunct")
+        # The half this test is about, named rather than taken by sort order: it is
+        # `name not in SLOT_SIZE` whose consequence hides behind the fallback, and the
+        # mutation that asks about it is the one that KEEPS `isinstance`.
+        b = next(m for m in muts
+                 if m.operator == "drop-conjunct" and "isinstance" in m.after)
         combined = sweep.compose(self.SRC, (a, b))
         self.assertIsNotNone(combined)
         text = combined.decode()

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -314,6 +314,120 @@ class _Spans:
         return self.source[:a] + rep + b"\n" * max(0, lost) + self.source[b:]
 
 
+#: Expression nodes whose source text **re-associates** with whatever it is spliced next
+#: to. `ast` positions do not include the grouping parentheses a programmer wrote, so
+#: `sp.text` of the `x or ""` inside `(x or "").strip()` is `x or ""` — and splicing that
+#: back somewhere tighter silently rebuilds the expression. See :func:`parenthesised`.
+LOOSE = (ast.BoolOp, ast.NamedExpr, ast.BinOp, ast.UnaryOp, ast.Lambda, ast.IfExp,
+         ast.Await, ast.Yield, ast.YieldFrom, ast.Compare, ast.Tuple)
+
+#: And the ones that do not: a name, a call, a subscript, a display, a literal. Their
+#: source text already carries its own delimiters, so it means the same thing wherever it
+#: lands.
+#:
+#: `Starred` and `Slice` are here because a parenthesis around either is a `SyntaxError`,
+#: and both are unreachable by construction rather than by luck: :func:`parenthesised`
+#: only ever sees text that ``ast.parse(..., mode="eval")`` accepted, and `*a` and `a:b`
+#: are not expressions that mode can parse. `TheSpliceIsTheEditDescribed` asserts that
+#: these two tuples between them name **every** subclass of `ast.expr`, which is the same
+#: protection `CMP_TEXT` gets and for the same reason — the day Python grows a new
+#: expression node, the suite says so rather than the tool quietly guessing.
+#:
+#: The tail is PEP 750's template strings, which 3.14 added and 3.12 — the version the
+#: gate pins — does not have. They are the ``t"…"`` analogues of `JoinedStr` and
+#: `FormattedValue`, delimited by their own quotes and braces, so they are tight for the
+#: same reason those are. Reached through `getattr` because naming them outright is an
+#: `AttributeError` on the interpreter CI actually runs, and the completeness test is
+#: what keeps the conditional honest rather than a guess: on 3.14 it demands them, on
+#: 3.12 there is nothing to demand.
+TIGHT = (ast.Dict, ast.Set, ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp,
+         ast.Call, ast.FormattedValue, ast.JoinedStr, ast.Constant, ast.Attribute,
+         ast.Subscript, ast.Name, ast.List, ast.Starred, ast.Slice) + tuple(
+    t for t in (getattr(ast, "TemplateStr", None), getattr(ast, "Interpolation", None))
+    if t is not None)
+
+
+def parenthesised(text: str) -> str:
+    """*text*, spelled so that splicing it cannot rebuild the expression around it.
+
+    **The mutant has to be the edit the report describes.** Measured over `charter/` and
+    `tools/` before this existed: 144 of 8,903 expression mutations spliced something
+    else. The shape is everywhere — `(x or "").strip()` is 137 of them — and it comes
+    from one fact about `ast`: a node's span excludes the parentheses the programmer put
+    around it, because they are grouping and not syntax. So `sp.text` of the receiver in
+    `(p.stderr or p.stdout or "").strip()` is `p.stderr or p.stdout or ""`, and the
+    `swap-synonym` mutant built from it reads ``p.stderr or p.stdout or "".lstrip()`` —
+    which does not swap which end is stripped, it deletes the strip on every path but
+    one.
+
+    Two ways that lies, and they are the two failures this file is built around:
+
+    * **A survivor answering a question nobody asked.** The report prints "is `how much`
+      pinned?" beside a mutant that dropped the normalisation entirely. Under
+      ``--enforce`` that is a blocked branch whose author is sent to write a test for a
+      property the mutation never perturbed.
+    * **A false pin**, which is worse and is the one this file exists to prevent.
+      ``(vc or {}).get("config", {})`` becomes ``vc or {}["config"]``, and `{}["config"]`
+      is a `KeyError` — so the suite goes red for a crash and the fallback is certified
+      as tested. Four sites in this tree are exactly that.
+
+    The rule is a property of Python, not a list of the shapes that happened to be
+    caught: an expression whose top node is in :data:`LOOSE` binds more weakly than
+    something it could be spliced beside, so it is wrapped; one in :data:`TIGHT` carries
+    its own delimiters and is left alone. Text that is not an expression at all — the
+    empty string of a statement deletion, the ``pass`` that replaces it, the raw
+    ``{:<28}`` of an f-string's format spec — does not parse here and is returned
+    untouched, which is the only correct answer for a splice that is not an expression.
+    """
+    try:
+        top = ast.parse(text, mode="eval").body
+    except SyntaxError:
+        return text
+    if not isinstance(top, LOOSE):
+        return text
+    # Idempotent, because two operators reach this with text that has already been
+    # through it: `drop-conjunct` spells each half and then :func:`mutations_for` spells
+    # the join. `((prog != "export"))` is a mutant nobody can read.
+    #
+    # A bracket already around the WHOLE expression is the only thing that pushes its
+    # first token off line one, column zero, and that holds because of what reaches here:
+    # a node's own source text, which by definition starts where the node starts, or a
+    # replacement built by joining such texts. Neither can begin with whitespace or a
+    # comment. `(a) and b` is the case this must NOT match and does not — the `and`
+    # begins at column zero however many brackets sit inside it.
+    #
+    # A `text.startswith("(")` was written beside this and the deletion sweep took it:
+    # with the column test present it is a second answer to the same question, and a
+    # guard nothing can redden is a line this file's own rule says to delete.
+    if (top.lineno, top.col_offset) > (1, 0):
+        return text
+    return f"({text})"
+
+
+def _spell(sp: "_Spans", node: ast.AST) -> str:
+    """*node*'s source, safe to interpolate into a replacement built around it.
+
+    The outer half of :func:`parenthesised` is applied once, in :func:`mutations_for`, to
+    every replacement. That cannot reach an operand spliced INTO the middle of one —
+    ``f"{receiver}.{other}"`` produces a `swap-synonym` mutant whose top node is an
+    `Attribute` however loose the receiver is — so an operand is spelled here instead.
+    """
+    return parenthesised(sp.text(node))
+
+
+def _fstring_segments(tree: ast.AST) -> set[int]:
+    """The ids of the constants that are an f-string's *literal text*.
+
+    These are the one place a replacement is raw bytes rather than an expression: the
+    span holds no quotes, so `retune-string` splices `<28` -> `<39` as text. Running
+    :func:`parenthesised` over that would be a category error and occasionally a
+    corruption — a segment spelling `a-b` parses as a `BinOp` and would come back
+    `(b-c)`, parentheses and all, inside the string.
+    """
+    return {id(part) for node in ast.walk(tree) if isinstance(node, ast.JoinedStr)
+            for part in node.values if isinstance(part, ast.Constant)}
+
+
 def _sole_statement(parent_body: list[ast.stmt], node: ast.AST) -> bool:
     return len(parent_body) == 1 and parent_body[0] is node
 
@@ -416,6 +530,66 @@ SYNONYMS = {
 #: the double `resolve()` two lines away. A test that never sees a symlink, a relative path
 #: or a trailing separator cannot tell the mutant from the shipped line.
 NORMALISERS = ("resolve", "absolute", "expanduser", "casefold")
+
+
+def indistinguishable(name: str, other: str, call: ast.Call) -> str:
+    """Why re-spelling a call to *name* as *other* would be the SAME PROGRAM, or ``""``.
+
+    #655 asks for a third verdict beside `pinned`/`survived`, for the mutant no honest
+    test can redden. The measurement it asked for first says no: across every sweep this
+    repository still holds a result for — 461 distinct survivors on ten branches — the
+    number a rule could decide is **one**, and the cases the proposal names are not
+    decidable at all. `path.partition("/")` is equivalent only if a GitHub
+    `path_with_namespace` really does hold one slash, which is a fact about a remote API
+    and not about the code; a tool asserting it is a suppression list with a rule's
+    manners. `GIT_TIMEOUT = 20 -> 21` would have to be decided from "no covering test
+    names the symbol", which is the report's *loudest finding* and not an equivalence —
+    and it would be lifted by renaming the constant.
+
+    So there is no third verdict here, and the one genuinely decidable case is answered
+    where #632 answered its sibling: the mutation is **not offered**. A survivor no test
+    can kill is a false positive, and the place to fix a false positive is the question,
+    not the answer. `unevaluated` took the same line about a forward reference under PEP
+    563, for the same reason — under ``--enforce`` an unkillable mutant is a blocked
+    branch whose author has no move to make, so the operator must not offer it at all.
+
+    **`split` and `rsplit` are one function when no `maxsplit` is given.** Not "usually",
+    not "on the values this project happens to pass" — `str.split(sep)` and
+    `str.rsplit(sep)` return the same list for every string and every separator, because
+    the only thing the `r` decides is which end runs out of splits first and with an
+    unlimited budget neither does. Verified exhaustively over every string of up to six
+    characters from an alphabet containing the separator, for `str` and `bytes`, and for
+    the no-argument whitespace form. `SYNONYMS` justifies a pair by the axis it moves;
+    with `maxsplit` absent this pair moves nothing, so the mutation asks nothing and its
+    survival says nothing.
+
+    Measured over `charter/` and `tools/`: 67 of the 98 `split`/`rsplit` call sites the
+    table would mutate pass no `maxsplit`, against 31 that do and stay a real question.
+    Two of them turned up as survivors in the corpus above; every one of the 67 becomes a
+    permanent survivor the moment :func:`parenthesised` lands, because until now the
+    receiver's lost parentheses were accidentally making the mutant a different program.
+
+    The rule is about the arguments and not about the receiver, so what it claims is
+    exactly what it can check. On a receiver that is not a `str` the mutant is not
+    equivalent, it is an `AttributeError` — `re.Pattern` has `split` and no `rsplit` —
+    and that is a FALSE PIN, the failure this file exists to prevent. Three sites in this
+    tree are that shape (`_BACKTICK_RE.split`, `_OPERATOR_SPLIT_RE.split` twice) and all
+    three pass no `maxsplit`, so this rule happens to withdraw them; a compiled pattern
+    split with a `maxsplit` would still be offered and would still crash. That gap is
+    named here rather than papered over, because the fix for it is a receiver-type
+    question this pass cannot answer and `SYNONYMS`' own comment on `index`/`rindex`
+    already measures by hand.
+
+    Nothing in this tree defines a `split` or an `rsplit` of its own. If something ever
+    does, the cost of this rule is one question not asked, which is the direction this
+    file errs in everywhere else.
+    """
+    if {name, other} != {"split", "rsplit"}:
+        return ""
+    if len(call.args) >= 2 or any(k.arg == "maxsplit" for k in call.keywords):
+        return ""
+    return ("`split` and `rsplit` are the same function with no `maxsplit`, so the "
+            "mutant is the shipped program")
 
 
 def _shift_char(ch: str) -> str:
@@ -792,7 +966,7 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
                 and isinstance(node.test.op, ast.And) and len(node.test.values) > 1:
             for i, part in enumerate(node.test.values):
                 rest = [v for j, v in enumerate(node.test.values) if j != i]
-                kept = " and ".join(sp.text(v) for v in rest)
+                kept = " and ".join(_spell(sp, v) for v in rest)
                 yield (node.test, kept, "drop-conjunct",
                        f"is the `{_oneline(sp.text(part), 48)}` half pinned?")
 
@@ -835,10 +1009,10 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
         if isinstance(node, ast.BoolOp) and isinstance(node.op, ast.Or) \
                 and len(node.values) == 2 and _is_get(node.values[0]):
             call = node.values[0]
-            yield (node, f"{sp.text(call.func.value)}[{sp.text(call.args[0])}]",
+            yield (node, f"{_spell(sp, call.func.value)}[{sp.text(call.args[0])}]",
                    "no-fallback", "is the fallback pinned?")
         if _is_get(node) and len(node.args) == 2:
-            yield (node, f"{sp.text(node.func.value)}[{sp.text(node.args[0])}]",
+            yield (node, f"{_spell(sp, node.func.value)}[{sp.text(node.args[0])}]",
                    "no-fallback", "is the fallback pinned?")
 
         # `A or B` where B is an empty literal — `placed or []`, `paint or _paint`.
@@ -932,8 +1106,12 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
                 and node.func.attr in SYNONYMS \
                 and _receiver_root(node.func.value) not in modules:
             other, axis = SYNONYMS[node.func.attr]
-            yield (node.func, f"{sp.text(node.func.value)}.{other}", "swap-synonym",
-                   f"is `{axis}` pinned, or does `{other}` pass the same tests?")
+            # A swap that produces the same program asks nothing, and #655's answer is
+            # that such a mutation is not offered rather than given a verdict of its own.
+            if not indistinguishable(node.func.attr, other, node):
+                yield (node.func, f"{_spell(sp, node.func.value)}.{other}",
+                       "swap-synonym",
+                       f"is `{axis}` pinned, or does `{other}` pass the same tests?")
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
                 and node.func.id in SYNONYMS and not node.keywords \
                 and len(node.args) == 1 and not any(
@@ -1023,6 +1201,7 @@ def mutations_for(path: str, source: bytes, lines: set[int]) -> list[Mutation]:
     except SyntaxError:
         return []
     sp = _Spans(source)
+    raw = _fstring_segments(tree)
     out: list[Mutation] = []
     seen: set[tuple[int, int, str, str]] = set()
     for node, replacement, operator, question in _iter_operators(tree, sp):
@@ -1033,6 +1212,11 @@ def mutations_for(path: str, source: bytes, lines: set[int]) -> list[Mutation]:
         before = sp.text(node)
         if before.strip() == replacement.strip():
             continue
+        # Spelled AFTER the no-op check above and in one place for every operator, so
+        # that a shape added to the table below cannot forget it. `parenthesised` is a
+        # no-op on a replacement that is already tight, which is most of them.
+        if id(node) not in raw:
+            replacement = parenthesised(replacement)
         key = (node.lineno, node.col_offset, operator, replacement)
         if key in seen:
             continue


### PR DESCRIPTION
Closes #655.

#655 asked for a third verdict — **`indistinguishable`**, beside `pinned` and `survived` — for the mutant no honest test can redden. Its author asked for a measurement first, and said that if almost all survivors turn out to be the genuine "the test asserts too little" case, **the right fix is nothing at all.**

**The measurement was run before any code was written. It says exactly that.** So there is no third verdict. What it turned up instead is a defect that would have made `--enforce` unusable on its first day, and that is what this fixes.

## The measurement

Every sweep result GitHub still holds an artifact for: **136 shard files from 54 completed runs**, 2026-08-28 to 2026-08-30, **ten branches** that produced a survivor. 3,044 mutation records, 1,285 distinct mutations, **461 distinct survivors**, decomposed:

| operator | survivors | | operator | survivors |
|---|---:|---|---|---:|
| `uncontain` | 109 | | `shift-boundary` | 25 |
| `drop-if` | 70 | | `drop-conjunct` | 15 |
| `retune-string` | 62 | | `retune-constant` | 10 |
| `swap-synonym` | 51 | | `drop-isinstance` | 7 |
| `no-fallback` | 45 | | `drop-comprehension-if` | 5 |
| `collapse-ifexp` | 33 | | `unclamp` | 3 |
| `narrow-except` | 26 | | | |

**Survivors a rule could have called equivalent: 1 of 461.** One line, `change.py:142`.

And the three cases the issue names are not decidable *by a tool*:

- **`path.partition("/")` → `rpartition("/")`** (8 survivors). Equivalent only if a GitHub `path_with_namespace` holds exactly one slash. Nothing in `charter/forge/github.py` constrains it — the value arrives as `repo.get("path_with_namespace") or ""` — so the constraint lives in a remote API's contract, not in the code. A tool asserting it is a suppression list with a rule's manners, and #370's objection lands on it unchanged: nothing re-checks the entry when the code moves.
- **`GIT_TIMEOUT = 20 → 21`**. The only evidence available is "N modules execute this file and not one names the symbol" — which is the report's **loudest finding**, not an equivalence. Turning it into a reason to stop asking inverts the tool, and it would be lifted by renaming the constant.
- **`_BODY_BUDGET = 100_000 → 100_001`**, offered as the sharpest case against the pinned `RELEASE_BODY_MAX = 125_000` beside it. The two really are different, but not in decidability: GitHub's number is pinned by a test naming GitHub's number, and charter's is pinned from both ends by a **window** (`test_the_staged_release_has_headroom` above, `test_the_bound_is_an_exception_rather_than_the_normal_path` below) that `100_001` sits inside. No rule can compute that window. A reader can — and `_BODY_BUDGET`'s docstring already does, which is the remedy that scales.

## What the measurement found instead

While counting survivors, one shape kept reading wrong. `charter/commands.py:975`:

```
shipped : (pattern or "").strip
mutant  : pattern or "".lstrip
```

The report prints "is `how much` pinned?" beside a mutant that does not move how much is stripped — it **deletes the strip on every path but one**, because an `ast` node's span excludes the parentheses a programmer wrote, so `sp.text` of the receiver is `pattern or ""` and splicing it back rebuilds the expression.

**144 of 8,903 expression mutations across `charter/` and `tools/` spliced something other than the edit they described.** 137 are that receiver. The other seven are worse:

```python
(vc or {}).get("config", {})    ->    vc or {}["config"]
```

`{}["config"]` is a `KeyError`, so the suite goes red and the fallback is recorded as **pinned** — a guard certified as tested by a crash. That is the false pin the file exists to prevent, at four `no-fallback` sites plus two `unclamp` and one `uncontain`.

This is the dead end `--enforce` could not have survived: a blocked branch whose author is sent to write a test for a property the mutation never perturbed. Same shape as #632, from the other direction.

### Fixed as a property, not a list of sites

`parenthesised` spells any replacement whose top node binds loosely enough to re-associate. `LOOSE` and `TIGHT` between them name **every** subclass of `ast.expr`, asserted in the suite the way `CMP_TEXT` is — and that test earned its keep immediately: on 3.14, PEP 750's `TemplateStr` and `Interpolation` are two expression nodes that did not exist when the tuple was written.

Re-measured tree-wide after the change: **0 of 9,189.** It also *recovers* questions: a receiver spread over two lines produced a mutant that did not parse and was skipped in silence, and brackets make it parse — **25 mutations are asked for the first time.**

## And one question that only ever had one answer

`SYNONYMS` justifies a pair by the axis it moves. **`split`/`rsplit` moves nothing when no `maxsplit` is given** — `s.split(sep)` and `s.rsplit(sep)` return the same list for every string and every separator, verified exhaustively in the suite over `str`, `bytes` and the whitespace form.

**67 of the 98** such call sites in `charter/` and `tools/` pass no `maxsplit`. Every one becomes a *permanent* survivor the moment the receiver's brackets survive the splice — until now the lost parentheses were accidentally making the mutant a different program. (#630's own self-sweep already listed `split(".")[-1]` against `rsplit(".")[-1]` among the sixteen it said nobody could close.)

**Answered where #632 answered its sibling: the mutation is not offered.** A survivor no test can kill is a false positive, and the place to fix a false positive is the question, not the answer. One predicate, the reason in its docstring where a reader can disagree with it. The 31 sites that *do* pass a `maxsplit` stay a real question.

Whole-tree count: **11,277 → 11,235** (67 withdrawn, 25 recovered). `swap-synonym`: 975 → 909.

## Verification

**The gate cannot see this change.** `DEFAULT_PATHS = ("charter",)` and every line here is in `tools/sweep.py`, so a green `Add up what the shards found` on this branch would plan 0 mutations and prove nothing. It is not quoted as evidence.

Swept by hand instead — 22 mutations of the new guards, each applied, the full `tests.test_sweep` run, then restored, with sha256 checked on both ends:

- **First pass: 19 pinned, 3 SURVIVED.**
  - `text.startswith("(")` in the idempotence guard — a second answer to the same question. Deleted, per §4: an equivalent mutant and a dead line are one finding.
  - `no-fallback`'s **or-form** receiver was unspelled with everything still green — only the default-form `d.get(k, v)` had a test. Test added.
  - `drop-conjunct`'s operand spelling had no test that could reach it: a two-conjunct fixture gets its brackets from the outer spelling instead, so it needs a **three**-conjunct guard whose surviving half is an `or`. Test added.
- **Second pass: 22 of 22 pinned**, `tools/sweep.py` restored byte-identical (`706e369054c1…` in and out).

Full suite: **8,805 tests, OK** on 3.14; `tests.test_sweep` 342 tests. Nine existing assertions changed because the spelling of a mutant changed, and each was re-derived rather than loosened. `.github/workflows/sweep.yml` is untouched.

`--enforce` is still absent, deliberately. This is groundwork for a decision nobody has taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy