### PR TITLE
A retry can finish a release but can no longer quietly become one (#558)

### DIFF
--- a/.claude/agents/release.md
+++ b/.claude/agents/release.md
@@ -130,6 +130,18 @@ so on the retry path it was skipped — and a skipped step reports success, whic
 retry could publish with its version cross-check never having run. Passing the version is
 what gives the guard a claim it can refuse.
 
+**`--ref main` is refused when the version is not on PyPI yet, and that is not pedantry.**
+Naming a version is a claim about a string; publishing is an act on a commit. A dispatch
+from `main` for a version PyPI has never seen is not finishing a release, it is *beginning*
+one, from a tree no tag names — `skip-existing` skips nothing, because there is nothing
+there to skip. That is the window #558 opened with: between the bump merging and the tag
+being pushed, `main` carries a version that has never been published, and the
+`pyproject.toml` sitting beside it agrees with whatever you type. So `guard` asks PyPI
+whether the version is already there, and refuses when it is not — or when PyPI does not
+answer, since the last step before an irreversible act does not guess. A run standing on
+`v<X.Y.Z>` is asked nothing: what it uploads is the tree that tag names, and an ordinary
+release cannot be stopped by pypi.org being down.
+
 **Until #673 that retry could not repair anything that failed after the upload.** `announce`
 is `needs: publish`, so the retry re-entered `publish`, PyPI rejected a version it already
 had, and `announce` was unreachable on that version forever — the only exit being the one
@@ -149,7 +161,8 @@ operator's, not the workflow's:
   forever; use it unless the fix is on main. `--ref main` works only until main's
   `pyproject.toml` bumps past the version being retried, since `guard` compares the input
   against the tree it is handed — so a deterministic failure is repaired promptly or not at
-  all.
+  all. And it works only *after* the upload landed, per the rule above: before that there is
+  no release to finish and `guard` will not let main's tree become the one PyPI keeps.
 
 Whatever the retry does, PyPI keeps the artifacts it already holds. A published version is
 one immutable thing, and a rebuild will not be the same bytes anyway: `docs/news/` ships

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,19 @@ name: release
 # you want for a transient failure and what stays available afterwards. Re-pushing a
 # deleted tag is NOT a retry: it arrives here as `push`, gets the strict path, and is
 # refused at the upload — deliberately, see `publish`.
+#
+# What makes `--ref main` safe is a sentence, and `guard` now holds it (the rest of #558).
+# "The dispatch retry is not there to publish, it is there to FINISH a publish that may
+# already have happened" is true of every run it was written for and of no run that has to
+# be refused — because if PyPI does NOT already hold the version, that run is not
+# finishing anything, it IS the publish, and `--ref main` makes it the publish of whatever
+# main holds at that moment: the tagged tree plus everything merged since, or a version
+# with no tag cut at all. It passes every version check by agreeing with the pyproject
+# beside it, and `skip-existing` skips nothing, because there is nothing there to skip.
+# So the run that is not standing on `v<X.Y.Z>` has to show that it cannot be the first
+# upload of that version, and the check asks PyPI rather than assuming. A run standing on
+# the tag asks nobody: the tree it publishes is the one the tag names, which is the whole
+# property, and it holds without the network.
 on:
   push:
     tags: ["v*"]
@@ -96,7 +109,7 @@ jobs:
       # a run and an irreversible upload to report success without ever having run. That
       # is #558 exactly, and `tests/test_workflows.py` fails if an `if:` reappears in this
       # job. Whatever a new trigger needs, it is not a condition on the refusal.
-      - name: Compare the version this run names against pyproject.toml
+      - name: Compare the version this run names against pyproject.toml, and refuse a run that would be its first upload from off the tag
         id: version-check
         env:
           # Empty on the tag path, set on the dispatch path. Which one is authoritative is
@@ -140,6 +153,53 @@ jobs:
           if [ "$claimed" != "$pkg" ]; then
             echo "::error::this run names $claimed ($said) but pyproject.toml says $pkg — refusing to publish"
             exit 1
+          fi
+          # Everything above compares one version STRING against another, and PyPI is handed
+          # a COMMIT. Which commit is a question none of it asks (#558).
+          #
+          # On the tag path the two questions are one: `github.ref` IS `refs/tags/v$pkg`, so
+          # every job checks out the tree that tag names and nothing else can be built. Below
+          # is the same statement for the other path, where they came apart.
+          #
+          # `workflow_dispatch` takes any ref, and the retry this file documents may legitimately
+          # be `--ref main`, because the #665 shape is a release whose `announce` fails for a
+          # reason still true of the tagged tree — you cannot repair that from the tag. #673
+          # made that retry work by passing `skip-existing` on this trigger, resting on one
+          # sentence: the dispatch retry is not there to publish, it is there to FINISH a
+          # publish that may already have happened. True of every run it was written for. But
+          # nothing made it true: if PyPI does not already hold $pkg then that run is not
+          # finishing anything, `skip-existing` skips nothing because there is nothing there to
+          # skip, and main's tree becomes what $pkg means on PyPI, forever, with no tag naming
+          # it. That is #558's opening scenario — the window between a bump merging and the tag
+          # being pushed — surviving both of its fixes: #560 made the run STATE a version, and a
+          # stated version is not a tagged tree.
+          #
+          # So a run standing on `v$pkg` is asked nothing further: what it uploads is the tree
+          # that tag names, which is the property, and it holds offline. A run standing anywhere
+          # else must show it CANNOT be the first upload of $pkg — and that is asked of PyPI,
+          # which is the only place the answer lives. Refusing on an unclear answer rather than
+          # assuming one: this is the last step before an act with no way back, and re-running
+          # `guard` is free.
+          project=$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["name"])')
+          if [ "${GITHUB_REF_TYPE:-}" = "tag" ] && [ "${GITHUB_REF_NAME:-}" = "v$pkg" ]; then
+            echo "standing on v$pkg — what this run uploads is the tree that tag names, and no other check is needed"
+          else
+            standing="${GITHUB_REF_TYPE:-<no ref type>} ${GITHUB_REF_NAME:-<none>}"
+            echo "not standing on v$pkg (this run is on $standing) — so it may only finish a release, never begin one; asking PyPI whether $project $pkg is already there"
+            status=$(curl -sS -o /dev/null -w '%{http_code}' --retry 3 --max-time 30 "https://pypi.org/pypi/$project/$pkg/json") || status="000"
+            case "$status" in
+              200)
+                echo "PyPI already has $project $pkg, so this run cannot be its first upload — publish will skip the files PyPI holds and announce can finish the release"
+                ;;
+              404)
+                echo "::error::this run would be the FIRST upload of $project $pkg and it is not standing on v$pkg — what it would upload is whatever $standing holds right now, which no tag names and PyPI will never let go of — dispatch on the tag instead: gh workflow run release.yml --ref v$pkg -f version=$pkg — refusing to publish"
+                exit 1
+                ;;
+              *)
+                echo "::error::could not ask PyPI whether it already has $project $pkg (HTTP $status), and this run is not standing on v$pkg, so whether it would be that version's first upload is unknown — re-run this job, or dispatch on the tag: gh workflow run release.yml --ref v$pkg -f version=$pkg — refusing to publish on a guess"
+                exit 1
+                ;;
+            esac
           fi
       - name: Refuse to publish a version whose notes cannot be rendered, or would be refused
         run: |

--- a/docs/news/unreleased-a-retry-cannot-become-the-publish.md
+++ b/docs/news/unreleased-a-retry-cannot-become-the-publish.md
@@ -1,0 +1,94 @@
+---
+version: unreleased
+headline: A release retried by hand can finish a publish, and can no longer quietly become one
+---
+
+`release.yml` has two ways to reach an upload PyPI cannot take back: push a version tag, or
+run the workflow by hand. The point of #558 was that the second carried weaker checks than
+the first. One part of that closed already — a hand-run release has to name the version it
+is publishing, and the step that asks can no longer be skipped. This is the part underneath
+it, and it decides *what gets uploaded* rather than what gets typed.
+
+## Naming a version is a claim about a string
+
+Every check in `guard` compared one version against another version: the tag, or the
+`version` input, against `pyproject.toml`. All of those are numbers, and agreeing about a
+number is not agreeing about a commit — but a commit is what PyPI receives and keeps.
+
+On the tag path the two questions are one. `github.ref` **is** `refs/tags/v0.53.0`, so every
+job checks out the tree that tag names and nothing else can be built.
+
+On the hand-run path they came apart, because `workflow_dispatch` takes any ref. The
+documented recovery includes:
+
+```
+gh workflow run release.yml --ref main -f version=0.53.0
+```
+
+and that command is genuinely needed. When a release fails *after* the upload — the shape
+#665 described, where the notes cannot be turned into a GitHub Release — the fix lives on
+`main` and the tagged tree cannot carry it. So the retry rests on one sentence, written into
+the workflow when that recovery was built: *the dispatch retry is not there to publish, it is
+there to finish a publish that may already have happened.*
+
+Nothing made that sentence true. If PyPI does not already hold the version, such a run is not
+finishing anything — it **is** the publish. `skip-existing` skips nothing, because there is
+nothing there to skip. And what it publishes is whatever `main` holds at that moment: the
+tagged tree plus everything merged since, or a version with no tag cut at all. It passes every
+check, because the `pyproject.toml` sitting in that tree agrees with the number you typed.
+
+That last case is the scenario #558 opened with, surviving both of its fixes: between a
+version bump merging to `main` and the tag being pushed, `main` carries a version that has
+never been published. Requiring the run to state a version made it state one. It did not make
+the statement true of anything but a file the run had already chosen.
+
+## So an off-tag run has to prove it cannot be the first upload
+
+`guard` now asks one more question, and only of the runs that need it:
+
+- **Standing on `v<X.Y.Z>`** — a tag push, or `--ref v<X.Y.Z>` — nothing further is asked.
+  What the run uploads is the tree that tag names. That is the whole property, and it holds
+  with no network: an ordinary release cannot be stopped by pypi.org being unreachable.
+- **Standing anywhere else** — the run may only *finish* a release, so `guard` asks PyPI
+  whether the version is already there. If it is, the upload is a no-op and the recovery
+  proceeds exactly as before. If it is not, the run is refused, and the refusal hands back
+  the dispatch that would have been accepted.
+- **PyPI does not answer** — refused as well. An answer that did not arrive is not a yes,
+  and this is the last step before an act with no way back, where re-running `guard` costs a
+  minute and being wrong costs a version number permanently.
+
+```
+::error::this run would be the FIRST upload of charter-cp 0.53.0 and it is not standing on
+v0.53.0 — what it would upload is whatever branch main holds right now, which no tag names
+and PyPI will never let go of — dispatch on the tag instead: gh workflow run release.yml
+--ref v0.53.0 -f version=0.53.0 — refusing to publish
+```
+
+Nothing about the `--ref main` recovery changes for the case it was written for. What changes
+is that the assumption it was resting on is now checked rather than described.
+
+## What the tests hold
+
+`tests/test_workflows.py` pulls the check's own script out of the YAML and runs it against a
+synthetic tree, on both triggers, with `curl` stubbed — which is also the only way to exercise
+the answers that are hard to arrange for real: a version PyPI has never seen, and PyPI not
+answering at all. Runs are sorted into tables by which of the two things they get wrong, and
+every refusal is asserted by **the reason it gives** as well as by its exit code.
+
+Two of those assertions are about the absence of a call rather than its result, and both are
+properties rather than bookkeeping. A run standing on the tag must reach the network *not at
+all* — otherwise a release could be blocked by an outage that has no bearing on whether the
+tree is the tagged one. And a run refused for its version must be refused before any lookup,
+so the check does not fail differently when PyPI is slow.
+
+There is also an assertion about the tables rather than the script: an allowed run either
+stands on the tag for the version it publishes, or has been told by PyPI that the version is
+already there. The cheapest way back to green after a change like this is a permissive row,
+and that is now itself a failure.
+
+## Still not held here
+
+The `pypi` environment has no protection rule — no required reviewer, no wait timer — so
+nothing pauses between the build and the upload on either path, and its deployment-branch
+policy is unset, so any ref may deploy to it. Those are repository settings rather than lines
+in a file, and no test in this suite can hold them.

--- a/personas/release/persona.md
+++ b/personas/release/persona.md
@@ -129,6 +129,18 @@ so on the retry path it was skipped — and a skipped step reports success, whic
 retry could publish with its version cross-check never having run. Passing the version is
 what gives the guard a claim it can refuse.
 
+**`--ref main` is refused when the version is not on PyPI yet, and that is not pedantry.**
+Naming a version is a claim about a string; publishing is an act on a commit. A dispatch
+from `main` for a version PyPI has never seen is not finishing a release, it is *beginning*
+one, from a tree no tag names — `skip-existing` skips nothing, because there is nothing
+there to skip. That is the window #558 opened with: between the bump merging and the tag
+being pushed, `main` carries a version that has never been published, and the
+`pyproject.toml` sitting beside it agrees with whatever you type. So `guard` asks PyPI
+whether the version is already there, and refuses when it is not — or when PyPI does not
+answer, since the last step before an irreversible act does not guess. A run standing on
+`v<X.Y.Z>` is asked nothing: what it uploads is the tree that tag names, and an ordinary
+release cannot be stopped by pypi.org being down.
+
 **Until #673 that retry could not repair anything that failed after the upload.** `announce`
 is `needs: publish`, so the retry re-entered `publish`, PyPI rejected a version it already
 had, and `announce` was unreachable on that version forever — the only exit being the one
@@ -148,7 +160,8 @@ operator's, not the workflow's:
   forever; use it unless the fix is on main. `--ref main` works only until main's
   `pyproject.toml` bumps past the version being retried, since `guard` compares the input
   against the tree it is handed — so a deterministic failure is repaired promptly or not at
-  all.
+  all. And it works only *after* the upload landed, per the rule above: before that there is
+  no release to finish and `guard` will not let main's tree become the one PyPI keeps.
 
 Whatever the retry does, PyPI keeps the artifacts it already holds. A published version is
 one immutable thing, and a rebuild will not be the same bytes anyway: `docs/news/` ships

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1558,15 +1558,34 @@ class _Run(NamedTuple):
     ref: str | None = None        # GITHUB_REF_NAME, unset when None
     claimed: str | None = None    # the `version` input, unset when None
     says: str = ""                # what its refusal must name, when it refuses
+    #: GITHUB_REF_TYPE, unset when None. `branch` and `tag` are the only values GitHub
+    #: writes here, and the difference decides whether this run's commit is the one its
+    #: version's tag names or whatever that ref held when the run started.
+    ref_type: str | None = None
+    #: What PyPI answers when asked whether it already holds this version — the HTTP
+    #: status a stubbed `curl` reports. `"200"` already there, `"404"` not there, `"000"`
+    #: or a 5xx unreachable. **None means the run must never ask**, and every case that
+    #: says None has that asserted, because a release that needs the network to publish a
+    #: tagged tree is a release the network can stop.
+    pypi: str | None = None
 
 
-def _execute(script: str, run: _Run, packaged: str = "0.53.0") -> tuple[int, str]:
+class _Result(NamedTuple):
+    code: int
+    said: str
+    asked: list[str]      # the argv of every `curl` the script ran, in order
+
+
+def _execute(script: str, run: _Run, packaged: str = "0.53.0") -> _Result:
     """Actually run the check's script, in a tree whose pyproject says `packaged`.
 
     Reading the YAML proves the step has no `if:`; only running it proves the step
     refuses. `python` is a shim onto this interpreter because the step's own comment says
     why the workflow pins one: it needs `tomllib`, which is 3.11+, and the runner's
-    default `python` is a version nobody chose.
+    default `python` is a version nobody chose. `curl` is a shim for a different reason:
+    the check asks PyPI a question, this suite reaches no network, and stubbing the answer
+    is also the only way to exercise the answers that are hard to arrange for real — a
+    version PyPI has never seen, and PyPI not answering at all.
     """
     with tempfile.TemporaryDirectory() as raw:
         tmp = Path(os.path.realpath(raw))
@@ -1576,14 +1595,32 @@ def _execute(script: str, run: _Run, packaged: str = "0.53.0") -> tuple[int, str
         shim = tmp / "bin" / "python"
         shim.write_text(f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n')
         shim.chmod(0o755)
+        log = tmp / "curl-calls"
+        answers = run.pypi and run.pypi != "000"
+        # A stub that models the two flags the script depends on rather than ignoring its
+        # argv, because a stub that answers whatever it is asked cannot fail when the
+        # question changes. Real `curl` writes the response body to stdout unless `-o`
+        # redirects it, and writes `-w`'s format after that — so a script that dropped
+        # either flag would read a status it never received, and here it reads one too.
+        curl = tmp / "bin" / "curl"
+        curl.write_text(
+            "#!/bin/sh\n"
+            f'printf "%s\\n" "$*" >> {shlex.quote(str(log))}\n'
+            'case "$*" in *" -o "*) ;; *) printf \'{"info": {}}\' ;; esac\n'
+            + (f'case "$*" in *"%{{http_code}}"*) printf "%s" {shlex.quote(run.pypi)} ;; esac\n'
+               "exit 0\n" if answers else "exit 7\n"))
+        curl.chmod(0o755)
         env = {"PATH": f"{tmp / 'bin'}:/usr/bin:/bin", "GITHUB_EVENT_NAME": run.event}
         if run.ref is not None:
             env["GITHUB_REF_NAME"] = run.ref
+        if run.ref_type is not None:
+            env["GITHUB_REF_TYPE"] = run.ref_type
         if run.claimed is not None:
             env["CLAIMED_VERSION"] = run.claimed
         done = subprocess.run(["bash", "-e", "-c", script], cwd=tmp, env=env,
                               capture_output=True, text=True)
-        return done.returncode, done.stdout + done.stderr
+        asked = log.read_text().splitlines() if log.exists() else []
+        return _Result(done.returncode, done.stdout + done.stderr, asked)
 
 
 class TheVersionCheckRunsOnEveryTriggerThatCanPublish(unittest.TestCase):
@@ -1601,43 +1638,109 @@ class TheVersionCheckRunsOnEveryTriggerThatCanPublish(unittest.TestCase):
     `publish` transitively behind it. The behaviour says the check is worth running: its
     script is executed, on both triggers, and refused when the run cannot name what it is
     publishing — no input, the wrong input, a trigger the check was never taught.
+
+    And then the rest of #558, which those halves do not reach. Naming a version is a claim
+    about a string; publishing is an act on a commit. On the tag path they are one question
+    because `github.ref` *is* the tag. On the dispatch path they came apart, and #673 leaned
+    on the gap: `skip-existing` is passed on that trigger because "the dispatch retry is not
+    there to publish, it is there to finish a publish that may already have happened". True
+    of every run it was written for — and nothing made it true. If PyPI does not already
+    hold the version, that run is not finishing anything, it IS the publish, and from
+    `--ref main` it publishes whatever the default branch holds, under a version no tag
+    names. So a run that is not standing on `v<version>` has to show it cannot be that
+    version's first upload, and the tables below are sorted by which of those two things a
+    run gets wrong.
     """
 
-    #: Runs that must be refused, and what each refusal must say. The message is asserted
-    #: because it is what makes the sweep honest: delete any one of the three refusals in
-    #: the script and the surviving ones still exit non-zero, so an exit-code-only test
-    #: would stay green while the run stopped being told what it did wrong.
+    #: Runs that must be refused for not naming what they publish, and what each refusal
+    #: must say. The message is asserted because it is what makes the sweep honest: delete
+    #: any one refusal in the script and the surviving ones still exit non-zero, so an
+    #: exit-code-only test would stay green while the run stopped being told what it did
+    #: wrong. Every case is refused before the ref is looked at, so every one carries
+    #: `pypi=None` — asserted, not assumed: a run refused for its version asks nobody.
     REFUSED = [
         _Run("a dispatch that names no version", "workflow_dispatch", "main", "",
-             says="did not say which version it publishes"),
+             says="did not say which version it publishes", ref_type="branch"),
         _Run("a dispatch with no input at all", "workflow_dispatch", "main", None,
-             says="did not say which version it publishes"),
+             says="did not say which version it publishes", ref_type="branch"),
         _Run("a dispatch naming the wrong version", "workflow_dispatch", "main", "0.52.0",
-             says="but pyproject.toml says 0.53.0"),
+             says="but pyproject.toml says 0.53.0", ref_type="branch"),
         _Run("a dispatch from a tag-shaped branch, still naming nothing",
              "workflow_dispatch", "v0.53.0", None,
-             says="did not say which version it publishes"),
+             says="did not say which version it publishes", ref_type="branch"),
+        _Run("a dispatch standing on the right tag but naming the wrong version",
+             "workflow_dispatch", "v0.53.0", "0.52.0",
+             says="but pyproject.toml says 0.53.0", ref_type="tag"),
         _Run("a tag that disagrees with the packaged version", "push", "v0.52.0", None,
-             says="but pyproject.toml says 0.53.0"),
+             says="but pyproject.toml says 0.53.0", ref_type="tag"),
         _Run("a tag push with no ref name", "push", "", None,
-             says="did not say which version it publishes"),
+             says="did not say which version it publishes", ref_type="tag"),
         _Run("a trigger nobody taught this check", "schedule", "main", "0.53.0",
-             says="does not know what that run claims to publish"),
+             says="does not know what that run claims to publish", ref_type="branch"),
         _Run("a repository_dispatch", "repository_dispatch", "main", "0.53.0",
-             says="does not know what that run claims to publish"),
+             says="does not know what that run claims to publish", ref_type="branch"),
         _Run("no event at all", "", "main", "0.53.0",
-             says="does not know what that run claims to publish"),
+             says="does not know what that run claims to publish", ref_type="branch"),
     ]
 
-    #: Runs that must be allowed: exactly the two ways to state the packaged version.
+    #: Runs that name the packaged version correctly — every refusal above is satisfied —
+    #: and would still be the FIRST upload of it while standing somewhere that is not its
+    #: tag. This is the half #560 left open and #673 built on. The first case is the
+    #: window #558 opened with: a bump merged to main, no tag pushed yet, and a dispatch
+    #: that agrees with the `pyproject.toml` sitting beside it.
+    WOULD_BE_THE_FIRST_UPLOAD = [
+        _Run("a dispatch from main in the window before the tag is pushed",
+             "workflow_dispatch", "main", "0.53.0", says="FIRST upload of charter-cp 0.53.0",
+             ref_type="branch", pypi="404"),
+        _Run("a dispatch from a branch someone named after the tag",
+             "workflow_dispatch", "v0.53.0", "0.53.0",
+             says="FIRST upload of charter-cp 0.53.0", ref_type="branch", pypi="404"),
+        _Run("a dispatch whose ref type is not set at all", "workflow_dispatch",
+             "v0.53.0", "0.53.0", says="FIRST upload of charter-cp 0.53.0", ref_type=None,
+             pypi="404"),
+        _Run("a dispatch standing on some other version's tag", "workflow_dispatch",
+             "v0.52.0", "0.53.0", says="FIRST upload of charter-cp 0.53.0",
+             ref_type="tag", pypi="404"),
+        _Run("a push that reaches here from a branch rather than a tag", "push",
+             "v0.53.0", None, says="FIRST upload of charter-cp 0.53.0", ref_type="branch",
+             pypi="404"),
+    ]
+
+    #: Same runs, except PyPI does not answer. Whether the run would be a first upload is
+    #: then unknown, and the last step before an irreversible act does not guess.
+    PYPI_DID_NOT_ANSWER = [
+        _Run("PyPI is unreachable", "workflow_dispatch", "main", "0.53.0",
+             says="could not ask PyPI", ref_type="branch", pypi="000"),
+        _Run("PyPI answers 503", "workflow_dispatch", "main", "0.53.0",
+             says="could not ask PyPI", ref_type="branch", pypi="503"),
+        _Run("PyPI answers something nobody expected", "push", "v0.53.0", None,
+             says="could not ask PyPI", ref_type="branch", pypi="418"),
+    ]
+
+    #: Off the tag and allowed, because PyPI already holds the version — so this run cannot
+    #: be its first upload and `skip-existing` has something to skip. This is #673's
+    #: `--ref main` recovery, and it must keep working: a check that closed #558 by making
+    #: a half-finished release unfinishable would have moved the defect, not fixed it.
+    FINISHING = [
+        _Run("the #665 recovery: the upload landed, announce did not", "workflow_dispatch",
+             "main", "0.53.0", ref_type="branch", pypi="200"),
+        _Run("the same recovery from a branch named after the tag", "workflow_dispatch",
+             "v0.53.0", "0.53.0", ref_type="branch", pypi="200"),
+    ]
+
+    #: Runs that must be allowed with nobody asked at all: they stand on the tag for the
+    #: version they publish, so what they upload is the tree that tag names. `pypi=None`
+    #: is asserted here, and it is a property rather than bookkeeping — the ordinary
+    #: release must not be stoppable by PyPI's API being down.
     ACCEPTED = [
-        _Run("a tag naming the packaged version", "push", "v0.53.0", None),
-        _Run("a dispatch naming the packaged version", "workflow_dispatch", "main",
-             "0.53.0"),
-        _Run("a dispatch naming it with the tag's leading v", "workflow_dispatch", "main",
-             "v0.53.0"),
+        _Run("a tag naming the packaged version", "push", "v0.53.0", None,
+             ref_type="tag"),
+        _Run("a dispatch standing on the tag it is retrying", "workflow_dispatch",
+             "v0.53.0", "0.53.0", ref_type="tag"),
+        _Run("a dispatch naming it with the tag's leading v", "workflow_dispatch",
+             "v0.53.0", "v0.53.0", ref_type="tag"),
         _Run("a tag run carrying a stale input from an earlier dispatch", "push",
-             "v0.53.0", "9.9.9"),
+             "v0.53.0", "9.9.9", ref_type="tag"),
     ]
 
     def setUp(self):
@@ -1697,11 +1800,21 @@ class TheVersionCheckRunsOnEveryTriggerThatCanPublish(unittest.TestCase):
 
     def test_the_publish_job_still_names_the_environment_pypi(self):
         """Trusted Publishing's OIDC claim carries this name, so it is load-bearing for
-        the upload — and it is also where the other half of #558 hangs: a required
-        reviewer on this environment is a repository setting, not a line in this file, so
-        no test here can assert it. What this can hold is that the name is still there for
-        the rule to attach to."""
+        the upload — and it is also where the last piece of #558 hangs: a required
+        reviewer on this environment, and a deployment-branch policy narrowing which refs
+        may deploy to it, are repository settings rather than lines in this file, so no
+        test here can assert them. What this can hold is that the name is still there for
+        the rules to attach to."""
         self.assertEqual(self.jobs["publish"]["environment"]["name"], "pypi")
+
+    def test_the_tag_the_check_reconstructs_is_the_tag_this_workflow_triggers_on(self):
+        """The check builds `v$pkg` and asks whether the run is standing on it, which is
+        the right question only while `v<version>` is what this project tags. Change the
+        convention under `on: push:` without changing the check and the tag path starts
+        sending itself down the off-tag branch — so the two are asserted together rather
+        than left to agree by habit."""
+        self.assertEqual(self.release["on"]["push"]["tags"], ["v*"])
+        self.assertIn('= "v$pkg"', self.check["run"])
 
     # ----------------------------------------------------------------- the behaviour
 
@@ -1712,42 +1825,137 @@ class TheVersionCheckRunsOnEveryTriggerThatCanPublish(unittest.TestCase):
         `build` on the strength of nobody having thought about it."""
         declared = set(self.release["on"])
         self.assertEqual(declared, {"push", "workflow_dispatch"})
-        for table in (self.ACCEPTED, self.REFUSED):
+        for table in (self.ACCEPTED, self.REFUSED, self.WOULD_BE_THE_FIRST_UPLOAD,
+                      self.PYPI_DID_NOT_ANSWER):
             for trigger in declared:
                 self.assertIn(trigger, {run.event for run in table},
                               f"{trigger} has no case in one of the tables")
 
-    def test_the_check_refuses_a_run_that_cannot_name_what_it_publishes(self):
+    def _refuses(self, table):
         script = self.check["run"]
-        for run in self.REFUSED:
+        for run in table:
             with self.subTest(run=run.name):
-                code, said = _execute(script, run)
-                self.assertNotEqual(code, 0, f"{run.name} was allowed to publish:\n{said}")
-                self.assertIn("::error::", said, "refused without annotating the log")
-                self.assertIn(run.says, said,
+                r = _execute(script, run)
+                self.assertNotEqual(r.code, 0,
+                                    f"{run.name} was allowed to publish:\n{r.said}")
+                self.assertIn("::error::", r.said, "refused without annotating the log")
+                self.assertIn(run.says, r.said,
                               f"{run.name} was refused, but for a different reason than "
                               f"the one this case exists to exercise")
 
+    def test_the_check_refuses_a_run_that_cannot_name_what_it_publishes(self):
+        self._refuses(self.REFUSED)
+
+    def test_a_run_refused_for_its_version_never_asks_anybody_anything(self):
+        """The refusals above come first, and they are the cheap ones. A run with no
+        version to check has nothing to look up, and a check that went to the network
+        before finishing the arithmetic it can do offline would fail differently when PyPI
+        is slow than when it is not."""
+        script = self.check["run"]
+        for run in self.REFUSED:
+            with self.subTest(run=run.name):
+                self.assertIsNone(run.pypi, "this table is the offline one")
+                self.assertEqual(_execute(script, run).asked, [])
+
+    def test_a_run_that_would_be_a_versions_first_upload_from_off_its_tag_is_refused(self):
+        """The rest of #558. Every run here names the packaged version correctly, so every
+        refusal above is satisfied — and PyPI has never seen this version, so the run is
+        not finishing a release, it is beginning one, from a ref no tag names."""
+        self._refuses(self.WOULD_BE_THE_FIRST_UPLOAD)
+
+    def test_a_run_that_cannot_find_out_whether_it_would_be_the_first_is_refused(self):
+        """Fail closed on the unknown. A network answer that did not arrive is not a
+        `404` and not a `200`, and the step that reads it is the last one before an act
+        with no way back — where re-running `guard` costs a minute and being wrong costs
+        a version number forever."""
+        self._refuses(self.PYPI_DID_NOT_ANSWER)
+
+    def test_a_run_finishing_a_release_pypi_already_holds_is_allowed_off_the_tag(self):
+        """#673's `--ref main` recovery, kept working. It is the reason this check asks
+        PyPI instead of simply demanding the tag: when `announce` fails for a reason still
+        true of the tagged tree, the fix is on main and the tag cannot carry it. What the
+        check refuses is that same command run when it would publish rather than finish."""
+        script = self.check["run"]
+        for run in self.FINISHING:
+            with self.subTest(run=run.name):
+                r = _execute(script, run)
+                self.assertEqual(r.code, 0, f"{run.name} was refused:\n{r.said}")
+                self.assertEqual(len(r.asked), 1, "asked PyPI more than once")
+
     def test_the_check_allows_a_run_that_names_the_packaged_version(self):
         """The other direction, and it is not decoration: a check that refused everything
-        would pass every case above and take the release path with it."""
+        would pass every case above and take the release path with it.
+
+        `asked == []` is the second half and it is a property, not bookkeeping: a run
+        standing on `v0.53.0` publishes the tree that tag names whatever PyPI says, so an
+        ordinary release must not be stoppable by pypi.org being unreachable. The network
+        is reached on exactly the path that cannot answer the question without it."""
         script = self.check["run"]
         for run in self.ACCEPTED:
             with self.subTest(run=run.name):
-                code, said = _execute(script, run)
-                self.assertEqual(code, 0, f"{run.name} was refused:\n{said}")
-                self.assertIn("pyproject=0.53.0", said)
+                r = _execute(script, run)
+                self.assertEqual(r.code, 0, f"{run.name} was refused:\n{r.said}")
+                self.assertIn("pyproject=0.53.0", r.said)
+                self.assertEqual(r.asked, [],
+                                 "a run standing on the tag asked PyPI's permission to "
+                                 "publish the tree that tag names")
+
+    def test_the_question_put_to_pypi_names_what_this_run_would_publish(self):
+        """Both halves of it read from `pyproject.toml`. A URL with the project or the
+        version written into it would answer about some other release and be impossible to
+        tell apart from this one on a green run."""
+        script = self.check["run"]
+        r = _execute(script, self.FINISHING[0])
+        self.assertEqual(len(r.asked), 1, r.asked)
+        self.assertIn("https://pypi.org/pypi/charter-cp/0.53.0/json", r.asked[0])
+        r = _execute(script, self.FINISHING[0]._replace(claimed="9.9.9"), packaged="9.9.9")
+        self.assertIn("https://pypi.org/pypi/charter-cp/9.9.9/json", r.asked[0])
+
+    def test_the_refusal_names_the_dispatch_that_would_have_been_accepted(self):
+        """A refusal that leaves an operator mid-release without the next command is a
+        refusal they will route around, and the route around this one is irreversible."""
+        script = self.check["run"]
+        for run in self.WOULD_BE_THE_FIRST_UPLOAD + self.PYPI_DID_NOT_ANSWER:
+            with self.subTest(run=run.name):
+                self.assertIn(
+                    "gh workflow run release.yml --ref v0.53.0 -f version=0.53.0",
+                    _execute(script, run).said,
+                    "the refusal does not name the dispatch that would be accepted")
+
+    def test_no_accepted_run_reaches_the_upload_without_the_tag_or_pypi_saying_so(self):
+        """The tables themselves, before they are executed. Every other test is a claim
+        about the script; this is a claim about the tables — that the cheap way back to
+        green after this change is not to add a permissive row. An allowed run either
+        stands on the tag for the version it publishes, or has been told by PyPI that the
+        version is already there."""
+        for run in self.ACCEPTED:
+            with self.subTest(run=run.name):
+                self.assertEqual((run.ref_type, run.ref), ("tag", "v0.53.0"),
+                                 "an accepted run that is not standing on the tag for the "
+                                 "version it publishes uploads a tree no tag names (#558)")
+                self.assertIsNone(run.pypi, "and it must not need PyPI's answer to do it")
+        for run in self.FINISHING:
+            with self.subTest(run=run.name):
+                self.assertEqual(run.pypi, "200",
+                                 "an off-tag run is allowed only where PyPI has already "
+                                 "made this run's upload a no-op (#558, #673)")
 
     def test_the_check_reads_the_packaged_version_from_pyproject_and_not_from_a_guess(self):
         """The comparison is against the file being published, whatever it says. Pinning
         `0.53.0` in the tables above would otherwise be indistinguishable from a script
-        that had the answer written into it."""
+        that had the answer written into it — and that goes for the tag it reconstructs as
+        much as for the version it compares."""
         script = self.check["run"]
-        code, said = _execute(script, _Run("a tag", "push", "v9.9.9"), packaged="9.9.9")
-        self.assertEqual(code, 0, said)
-        code, said = _execute(script, _Run("the same tag", "push", "v9.9.9"),
-                              packaged="0.53.0")
-        self.assertNotEqual(code, 0, said)
+        on_tag = _Run("a tag", "push", "v9.9.9", ref_type="tag")
+        self.assertEqual(_execute(script, on_tag, packaged="9.9.9").code, 0)
+        self.assertNotEqual(_execute(script, on_tag, packaged="0.53.0").code, 0)
+        # And the tag it demands is built from the version, not written down: standing on
+        # v0.53.0 while publishing 9.9.9 is off-tag, and off-tag runs are asked about PyPI.
+        r = _execute(script, _Run("a dispatch on the wrong tag", "workflow_dispatch",
+                                  "v0.53.0", "9.9.9", ref_type="tag", pypi="404"),
+                     packaged="9.9.9")
+        self.assertNotEqual(r.code, 0, r.said)
+        self.assertIn("FIRST upload of charter-cp 9.9.9", r.said)
 
 
 # ------------------------------------------------- what a pinned action then names (#473)


### PR DESCRIPTION
Closes the code half of #558 that #560 left open. **The `pypi` environment-protection half is still a repository setting and still needs the owner** — measured again below, it has not changed.

## What was still divergent

#560 made a `workflow_dispatch` run name the version it publishes and made the step that asks unskippable. That is a claim about a **string**. Publishing is an act on a **commit**.

On the tag path those are the same question — `github.ref` **is** `refs/tags/v0.53.0`, so every job checks out the tree that tag names and nothing else can be built. On the dispatch path they are not, because `workflow_dispatch` takes any ref.

#673 then built on that gap. `publish` passes `skip-existing` on the dispatch trigger, and the workflow says why:

> A `workflow_dispatch` run is not here to publish. It is here to FINISH a publish that may already have happened.

True of every run it was written for. Nothing made it true. If PyPI does **not** already hold the version:

- the run is not finishing anything — it **is** the publish;
- `skip-existing` skips nothing, because there is nothing there to skip;
- `--ref main` uploads whatever the default branch holds — the tagged tree plus everything merged since, or a version with no tag cut at all;
- and it passes every check, because the `pyproject.toml` in that tree agrees with the number typed.

That last case is #558's opening paragraph, still live: *between the merge and the tag, `main` carries a version that has never been published.* #560 made such a run **state** a version. A stated version is not a tagged tree.

## What this changes

`guard` asks one further question, and only of the runs that need it.

| the run is | asked | outcome |
|---|---|---|
| standing on `v<X.Y.Z>` — a tag push, or `--ref v<X.Y.Z>` | **nothing** | allowed; what it uploads is the tree that tag names |
| standing anywhere else, PyPI has the version | is it already there? | allowed — it can only finish, `skip-existing` has something to skip |
| standing anywhere else, PyPI does not | is it already there? | **refused**, naming the dispatch that would be accepted |
| standing anywhere else, PyPI does not answer | is it already there? | **refused** — the last step before an irreversible act does not guess |

```
::error::this run would be the FIRST upload of charter-cp 0.53.0 and it is not standing
on v0.53.0 — what it would upload is whatever branch main holds right now, which no tag
names and PyPI will never let go of — dispatch on the tag instead: gh workflow run
release.yml --ref v0.53.0 -f version=0.53.0 — refusing to publish
```

**#673's `--ref main` recovery keeps working, unchanged, for the case it was written for.** That is deliberate and it is why this asks PyPI instead of simply demanding the tag: when `announce` fails for a reason still true of the tagged tree (the #665 shape), the fix is on `main` and the tag cannot carry it. What is refused is that same command run when it would *publish* rather than *finish*. The precondition #673 documented is now checked rather than described.

**The tag path reaches the network not at all**, and that is asserted rather than incidental. A run standing on `v0.53.0` publishes the tree that tag names whatever PyPI says, so an ordinary release must not be stoppable by pypi.org being unreachable. The network is touched on exactly the path that cannot answer the question without it.

No job-graph change: `guard → test → build → publish → announce` is untouched, as are every `uses:` pin, its trailing tag, `.github/publish-closure.json`, and #673's `skip-existing` expression.

## How the tests hold it

`tests/test_workflows.py` already pulled this step's script out of the YAML and executed it. It now also stubs `curl` — which is the only way to exercise the two answers that are hard to arrange for real, a version PyPI has never seen and PyPI not answering at all — and the stub **models the two flags the script depends on** rather than answering whatever it is asked. That was not a nicety: with a stub that ignored its argv, deleting `-w '%{http_code}'` from the real command left the suite **green** (see N7 below). A stub that answers any question cannot fail when the question changes.

Runs are sorted into tables by which of the two things they get wrong, and each refusal is asserted by **the reason it gives** as well as by its exit code. Two assertions are about the *absence* of a call: a run standing on the tag asks nobody, and a run refused for its version is refused before any lookup — so the check does not fail differently when PyPI is slow.

<details>
<summary><b>Deletion sweep</b> — 19 mutations, <code>tests/test_workflows.py</code> + <code>tests/test_a_half_finished_release_can_be_finished.py</code> (83 tests). Both survivors decomposed.</summary>

| # | deleted / mutated | result | what died |
|---|---|---|---|
| N1 | the whole off-tag branch — an off-tag run is asked nothing again | **RED** — failures=21 | `test_a_run_that_would_be_a_versions_first_upload_from_off_its_tag_is_refused` (+2) |
| N2 | the `404` arm — a first upload from off the tag is refused for the wrong reason | **RED** — failures=6 | `test_a_run_that_would_be_a_versions_first_upload_from_off_its_tag_is_refused`, `test_the_check_reads_the_packaged_version_from_pyproject_and_not_from_a_guess` |
| N3 | the `*)` arm — an unanswered PyPI walks past | **RED** — failures=6 | `test_a_run_that_cannot_find_out_whether_it_would_be_the_first_is_refused`, `test_the_refusal_names_the_dispatch_that_would_have_been_accepted` |
| N4 | the ref TYPE half — a branch named `v0.53.0` counts as the tag | **RED** — failures=9 | `test_a_run_that_would_be_a_versions_first_upload_from_off_its_tag_is_refused` (+2) |
| N5 | the ref NAME half — any tag at all counts as this version's tag | **RED** — failures=4 | `test_a_run_that_would_be_a_versions_first_upload_from_off_its_tag_is_refused` (+2) |
| N6 | the version in the PyPI question written down instead of read | **RED** — failures=1 | `test_the_question_put_to_pypi_names_what_this_run_would_publish` |
| N7 | `curl` stops reporting the status (`-w` dropped) | **RED** — failures=8 | `test_a_run_finishing_a_release_pypi_already_holds_is_allowed_off_the_tag` (+2) |
| N7b | `curl` stops redirecting the body (`-o` dropped) — the status is read out of JSON | **RED** — failures=8 | `test_a_run_finishing_a_release_pypi_already_holds_is_allowed_off_the_tag` (+2) |
| N8 | the unreachable case stops becoming a status — bash aborts unannotated | **RED** — failures=2 | `test_a_run_that_cannot_find_out_whether_it_would_be_the_first_is_refused` (+1) |
| N9 | the tag path asks PyPI too — a release an outage can stop | **RED** — failures=7 | `test_the_check_allows_a_run_that_names_the_packaged_version` (+2) |
| N10 | an accepted table row relaxed back to a branch — the cheap way to green | **RED** — failures=2 | `test_no_accepted_run_reaches_the_upload_without_the_tag_or_pypi_saying_so` (+1) |
| N11 | a finishing row relaxed to a version PyPI does not have | **RED** — failures=2 | `test_a_run_finishing_a_release_pypi_already_holds_is_allowed_off_the_tag` (+1) |
| N12 | N2 **plus** the shared reason assertion removed | **RED** — failures=1 | `test_the_check_reads_the_packaged_version_from_pyproject_and_not_from_a_guess` |
| **N12b** | N2 **plus both** places the reason is asserted removed | **GREEN** | — **survivor, by design** |
| N13 | N9 **plus** the no-network-on-the-tag assertion removed | **RED** — failures=3 | `test_a_run_finishing_a_release_pypi_already_holds_is_allowed_off_the_tag` (+1) |
| P1 | *prior guard:* the #558 `if:` gate back on the version check | **RED** — failures=1 | `test_no_step_in_the_guard_job_can_be_skipped` |
| P2 | *prior:* the refusal of a run naming nothing | **RED** — failures=4 | `test_the_check_refuses_a_run_that_cannot_name_what_it_publishes` |
| P3 | *prior:* the refusal of a run naming a version pyproject disagrees with | **RED** — failures=5 | `test_a_run_refused_for_its_version_never_asks_anybody_anything` (+1) |
| P4 | *prior:* the `*)` arm refusing a trigger nobody taught the check | **RED** — failures=3 | `test_the_check_refuses_a_run_that_cannot_name_what_it_publishes` |
| P5 | *prior:* `required: true` off the dispatch input | **RED** — failures=1 | `test_the_dispatch_path_has_to_say_what_it_is_retrying` |
| P6 | *prior:* `publish` stops waiting on the guard | **RED** — failures=1 | `test_the_job_graph_from_the_trigger_to_the_release_is_intact` |
| P7 | *prior (#673):* `skip-existing` becomes unconditional | **RED** — failures=2 | `test_a_tag_push_is_still_refused_a_version_pypi_already_has` (+1) |

**Two survivors, both measured rather than assumed.**

**N7 was a real hole and is fixed here.** With the first version of the `curl` stub — which ignored its argv and answered whatever it was asked — deleting `-w '%{http_code}'` from the workflow left the whole suite green, while the real command would have read an empty status and refused every off-tag retry. The stub now models `-o` and `-w`, and both mutations are red. Recorded because it is the same shape as #672: *a guard that a value renders is not a guard that it fits.*

**N12b is a survivor by design, and it is what the message assertions buy.** Delete the `404` arm and the `*)` arm still exits non-zero on the same input, and still names the retry command — so an exit-code-only test, and even a test asserting the command is offered, stays green while the operator is told PyPI could not be reached when in fact PyPI answered clearly. Only the two assertions on the *reason* catch it. `assertRaises(SomeError)` is an assertion about type, and type is not the property.
</details>

<details>
<summary><b>Two environments, two more parsers</b></summary>

```
########## ENV A: python3.14, charter/claude vars unset ##########
Ran 8809 tests in 416.492s
OK

########## ENV B: python3.12, this shell's environment ##########
Ran 8809 tests in 419.612s
OK

########## after rebase onto 13d70cd ##########
Ran 8833 tests in 417.339s
OK

Python 3.14.4 / Python 3.12.13
```

The YAML is not taken on this repository's own reader's word:

```
$ actionlint .github/workflows/release.yml
exit=0

$ ruby -ryaml     # a third parser, reading the same file
triggers: ["push", "workflow_dispatch"]   push tags: ["v*"]
job guard     needs="-"          job-level if=nil
job test      needs="guard"      job-level if=nil
job build     needs="test"       job-level if=nil
job publish   needs="build"      job-level if=nil
job announce  needs="publish"    job-level if=nil
guard steps with if: 0
version-check env: {"CLAIMED_VERSION"=>"${{ github.event.inputs.version }}"}
publish skip-existing: {"skip-existing"=>"${{ github.event_name == 'workflow_dispatch' }}"}
```

And the endpoint the check asks was verified against the real PyPI, since the suite only ever sees a stub:

```
$ curl -sS -o /dev/null -w '%{http_code}\n' https://pypi.org/pypi/charter-cp/0.53.0/json
200
$ curl -sS -o /dev/null -w '%{http_code}\n' https://pypi.org/pypi/charter-cp/99.99.99/json
404
```
</details>

## Coordination

- **#673 / #676** landed in this file while this was being written, and the first draft of this change collided with it head-on: it required the dispatch to stand on the tag, which would have removed the `--ref main` recovery #676 exists to provide. Rebased and reworked so the two compose — #676's recovery is preserved exactly, and its stated precondition is what this enforces. `publish` and the job graph are untouched.
- **#561 / #646** own "what *requires* a check". Nothing here is required by branch protection, so this is a stronger check that still nothing demands. That dependency is theirs, not narrowed by this.

## Still open on #558, and still the owner's

Measured today, unchanged:

```
$ gh api repos/diazoxide/charter/environments/pypi
  protection_rules: []          # no required reviewer, no wait timer
  deployment_branch_policy: null # every branch and tag may deploy to `pypi`
```

Nothing pauses between `build` and the upload on either path. Both are repository settings rather than lines in a file, and no test in this suite can hold them. Worth noting that the second one is the platform-side statement of the property this PR enforces in the tree: a deployment-branch policy admitting only `v*` tags would say the same thing from GitHub's side, and would keep saying it if this check were ever deleted.

## Checks

- [x] `python3 -m unittest discover -s tests` passes — both environments above
- [x] A test fails without this change — the sweep above, 19 mutations, both survivors decomposed
- [x] Nothing reports success for a state it did not read back ([ADR 0013](../docs/adr/0013-success-is-checked-divergence-is-named.md)) — the whole point: "PyPI already holds this" stops being an assumption
- [x] Docs updated — `release.yml`'s header, `personas/release/persona.md`, `.claude/agents/release.md`
- [x] `docs/news/unreleased-a-retry-cannot-become-the-publish.md`, `version: unreleased`
- [x] No new runtime dependencies — stdlib only, `unittest`, `dependencies = []` untouched
- [x] No version bump, no stamp, no tag, no publish
- [x] No ADR contradicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
