### PR TITLE
A repo pane that draws no table has nowhere to scroll, so the wheel stops repainting it (#664)

### DIFF
--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -533,13 +533,42 @@ class _Viewport:
 
         Indexed by the PANE's row, not the table's: `_repos` puts a heading on row 0 and
         the table under it, and the three one-line answers it draws instead of a table
-        (`_unknown_lines`, `_empty_lines`, `_too_narrow_lines`) publish nothing at all. So
-        a click on the heading, on a message, or below the last row lands on ``None`` and
-        is not a selection — which is the same rule `events.Dispatcher._on_canvas` applies
-        to the pad, one axis over: cells the component did not draw a row into are not
-        cells it was clicked in.
+        (`_unknown_lines`, `_empty_lines`, `_too_narrow_lines`) publish nothing at all —
+        through :meth:`blank`, which is the one call that says so, because such a paint
+        has a bound to record as well. So a click on the heading, on a message, or below
+        the last row lands on ``None`` and is not a selection — which is the same rule
+        `events.Dispatcher._on_canvas` applies to the pad, one axis over: cells the
+        component did not draw a row into are not cells it was clicked in.
         """
         self._rows = tuple(rows)
+
+    def blank(self) -> None:
+        """What a paint that drew NO TABLE leaves behind: no map, and nowhere to scroll.
+
+        **The two halves of a paint are recorded together, because a paint that recorded
+        one and not the other is the defect this method exists to make unwriteable.**
+        `_repos` has four ways out and three of them draw a single sentence instead of a
+        table (`_too_narrow_lines`, `_unknown_lines`, `_empty_lines`). Each cleared the
+        click map and none of them touched the bound, so a pane that had been scrolled and
+        then lost its table — the terminal narrowed below `statusline._LEFT_W`, the gather
+        cache went away, the workspace's last clone was removed — kept whatever
+        :meth:`settle` recorded for the TALLER table that was there before. The handler
+        reads that bound and nothing else (§4f), so every wheel notch over the sentence
+        answered truthy and the panel repainted a byte-identical line, once per notch:
+        motion the operator can see is not happening, charged to their terminal, which is
+        the exact cost :func:`_scroll_limit`'s own docstring refuses one paragraph over.
+
+        **Zero and not "leave the bound alone", because zero is what the arithmetic
+        already answers for this pane.** `_scroll_limit` answers 0 for any budget at or
+        below one row, and a pane drawing one sentence has no rows for a table at all — so
+        this is that function's answer for the shape rather than a second rule beside it.
+        The offset goes with it through :meth:`settle`'s own clamp, which is the same
+        thing that happens to a table starved to no rows by a resize (that path reaches
+        `settle` and always did); the two shapes now agree instead of differing by which
+        line `_repos` returned from.
+        """
+        self.publish(())
+        self.settle(0)
 
     def repo_at(self, row: int):
         """The repo on pane row *row*, or ``None`` — the paint the operator was looking at.
@@ -2168,6 +2197,14 @@ def _repos(fid: str) -> str:
       three one-line answers below publish nothing, which is what makes a click on
       `gathering this workspace's repos…` not a selection.
 
+    **All four ways out record BOTH, and the three that draw no table say so in one call**
+    (:meth:`_Viewport.blank`). They used to clear the map and leave the bound where the
+    last table put it, so a pane whose terminal had narrowed, whose cache had gone or whose
+    workspace had lost its last clone still answered every wheel notch truthy — repainting
+    one static sentence, once per notch, off a bound for a table that was no longer on
+    screen. That is the same stale-bound reading the `settle` below is unconditional for;
+    the guard was on the one path that already reached it, and these three went round it.
+
     `state.selection` is read here and handed to :func:`_table_lines`, which is what draws
     the chosen row in reverse video. One extra file read per repaint of a pane that is not
     animated — it repaints on a version bump or a resize, and a click is a version bump
@@ -2191,7 +2228,7 @@ def _repos(fid: str) -> str:
         # needs rather than what the table needs — see :func:`_too_narrow_lines`. Asked of
         # :func:`pad_of` and not subtracted back out of `w`, because `pad_of` is the one
         # that knows whether the pad was afforded at all.
-        VIEWPORT.publish(())
+        VIEWPORT.blank()
         return "\n".join(_too_narrow_lines(w, pad_of("repos")))
     from . import gather
     # `gather.cached`, never `gather.read` (#512). The two differ by exactly one thing:
@@ -2217,14 +2254,14 @@ def _repos(fid: str) -> str:
     # hook refreshes it after that (`notify.plane_changed`).
     data = gather.cached(fid)
     if data is None:
-        VIEWPORT.publish(())
+        VIEWPORT.blank()
         return "\n".join(_unknown_lines(w))
     repos = data.get("repos") or []
     if not repos:
         # Gathered, and there is nothing in it. Said out loud rather than left as an
         # empty bordered rectangle — see :func:`_empty_lines`. No heading: `▪ repos 0`
         # above "no clones in demo" is the same fact twice in a two-row pane.
-        VIEWPORT.publish(())
+        VIEWPORT.blank()
         return "\n".join(_empty_lines(_frame_workspace(fid), w))
     # The heading takes the first row and the table spends what is left. Asked for fewer
     # ROWS rather than sliced afterwards, so what survives at `terse` (or in a pane a

--- a/docs/news/unreleased-a-pane-with-no-table-in-it-has-nowhere-to-scroll.md
+++ b/docs/news/unreleased-a-pane-with-no-table-in-it-has-nowhere-to-scroll.md
@@ -1,0 +1,46 @@
+---
+version: unreleased
+headline: A repo pane that draws no table stops answering the wheel with a repaint
+---
+
+*"The table went away and the wheel kept doing something. Nothing moved, but the pane kept
+flickering."*
+
+The `repos` pane draws one of four things. Three of them are a single sentence rather than a
+table — the terminal is too narrow for one, nothing has gathered this workspace yet, or the
+workspace has no clones:
+
+```
+ ▪ repos 0
+   ⋯ gathering this workspace's repos…
+```
+
+Each of those three cleared the map that turns a click into a repo, so a click on the
+sentence has never selected anything. **None of them cleared the SCROLL BOUND.** The handler
+that receives a wheel notch is handed no context by contract — it cannot see how many rows
+the table has or how tall the pane is — so it reads the bound the last paint recorded and
+nothing else. On a pane that had been scrolled and then lost its table, that bound was still
+the one belonging to the taller table that used to be there. Every notch moved an offset over
+rows that were no longer on screen, answered *repaint me*, and the panel redrew one static
+line, once per notch.
+
+That is the cost this pane's own arithmetic refuses one function over: *motion the operator
+can see is not happening, charged to their terminal.* The scroll bound is deliberately 0 on
+the ordinary plane, and asserted as a number rather than as "nothing visibly moved", because
+a wheel that quietly did nothing because two numbers happened to cancel is indistinguishable
+from one that was dropped. This is the same reading arriving through the one door that never
+told it anything.
+
+**A paint that drew no table now records both halves in one call** — no click map, and
+nowhere to scroll. Zero is not a new rule: it is what the bound arithmetic already answers
+for a pane with no rows to give a table, so a pane starved to nothing by a resize (which
+always did reach this) and a pane whose cache went away now agree instead of differing by
+which line the renderer returned from.
+
+Nothing changes for a pane that has a table in it, at any offset or pane height.
+
+**Why it survived review.** The property was written down and a test asserted it — *the
+bound is settled on every paint, not only the ones that draw rows* — but the assertion was
+placed on the one path that already reached the settle, and the three that returned above it
+went round both. A guard checked where it can be seen is not a guard on where the property
+lives.

--- a/tests/test_the_repo_table_scrolls_and_selects.py
+++ b/tests/test_the_repo_table_scrolls_and_selects.py
@@ -697,6 +697,56 @@ class ThePaneWiresItAllTogether(PersonaIso, unittest.TestCase):
         self._paint(rows=1)
         self.assertEqual(slots.VIEWPORT.limit, 0)
 
+    def test_a_pane_that_drew_no_table_leaves_no_bound_either(self):
+        """**The case above, on the three ways out that never reached `settle`.** Each
+        cleared the click map and left the BOUND where the last table put it, so the one
+        property `_repos` claims for every paint held on exactly the path that already had
+        it — the guard was written where the assertion could see it rather than where the
+        property lives.
+
+        Three separate paints and not one loop over a helper: they are three different
+        reasons for a pane to have no table, each reached by its own line, and a helper
+        would let one of them stop being exercised without anything going red. Asserted as
+        the value 0, because a bound the handler can still move against is the whole defect
+        whatever its size — and the OFFSET with it, since `settle` is what carries one down
+        with the other."""
+        rows = [_row(f"r{i}") for i in range(20)]
+
+        gather.save(FID, _data(rows))
+        self._paint(rows=8)
+        self.assertGreater(slots.VIEWPORT.limit, 0, "the table had room to move")
+        self._paint(cols=40, rows=8)                       # narrower than `_LEFT_W`
+        self.assertEqual((slots.VIEWPORT.limit, slots.VIEWPORT.offset), (0, 0))
+
+        gather.save(FID, _data(rows))
+        self._paint(rows=8)
+        gather.discard(FID)                                # nothing has gathered yet
+        self._paint(rows=8)
+        self.assertEqual((slots.VIEWPORT.limit, slots.VIEWPORT.offset), (0, 0))
+
+        gather.save(FID, _data(rows))
+        self._paint(rows=8)
+        gather.save(FID, _data([]))                        # gathered, and no clones
+        self._paint(rows=8)
+        self.assertEqual((slots.VIEWPORT.limit, slots.VIEWPORT.offset), (0, 0))
+
+    def test_the_wheel_over_a_pane_with_no_table_repaints_nothing(self):
+        """The cost that bound is read for, at the surface that reads it. A notch on a pane
+        drawing one static sentence answered truthy, so the panel repainted a byte-identical
+        line once per notch — `_scroll_limit`'s own "motion the operator can see is not
+        happening, charged to their terminal", reached through the one paint that never told
+        it anything.
+
+        Driven through the component's real handler rather than through `VIEWPORT.move`, so
+        what is pinned is what a wheel report actually costs this frame."""
+        gather.save(FID, _data([_row(f"r{i}") for i in range(20)]))
+        self._paint(rows=8)
+        gather.discard(FID)
+        self._paint(rows=8)
+        on_event = builtins.build(FID).get("repos").on_event
+        self.assertFalse(on_event(overlay.Event(overlay.SCROLL, "down")),
+                         "there is nothing on this pane to scroll")
+
     def test_a_worktree_removed_under_a_scrolled_table_clamps_it_on_the_next_paint(self):
         """The stale-offset clamp, in the unit that changed. `charter worktree remove`
         takes rows off the bottom of this table without touching the repo list, so a bound


### PR DESCRIPTION
Found by an adversarial review of the frame work merged in the last 24 hours.

## What is wrong

`slots._repos` has four ways out. Three of them draw a single sentence instead of a table —
the pane is narrower than `statusline._LEFT_W`, nothing has gathered this workspace yet, or
the workspace has no clones. Each of the three cleared the click map and **none of them
touched the scroll bound**:

```python
cap = _table_cap(fid, w)
if cap <= 0:
    VIEWPORT.publish(())          # map cleared, bound untouched
    return ...
data = gather.cached(fid)
if data is None:
    VIEWPORT.publish(())          # map cleared, bound untouched
    return ...
if not repos:
    VIEWPORT.publish(())          # map cleared, bound untouched
    return ...
budget = min(_height() - 1, cap)
offset = VIEWPORT.settle(_scroll_limit(_content_rows(data), budget))   # the only settle
```

`builtins._repos_events` is handed no ctx by contract (§4f), so it reads that bound and
nothing else. On a pane that had been scrolled and then lost its table, the bound was still
the one belonging to the taller table that used to be there — so every wheel notch moved an
offset over rows that were not on screen, answered *repaint me*, and the panel redrew one
static line, once per notch.

That is the cost `_scroll_limit`'s own docstring refuses one function over: *motion the
operator can see is not happening, charged to their terminal*.

Reproduced before the fix — 20 repos into an 8-row pane, then the table taken away:

```
  after too-narrow paint: limit = 14 (was 14)
  after unknown paint:    limit = 14 (was 14)
  after empty paint:      limit = 14 (was 14)
  scroll answered:        True
```

## Why it survived review

The property is written down and a test asserts it. `_repos`' own docstring says the settle
is unconditional, and `test_a_starved_pane_puts_the_window_back_rather_than_keeping_a_stale_bound`
pins it — by starving the pane to one row, which is a path that **reaches** the settle. The
three paths that return above it went round the guard and round the assertion together. A
guard checked where it can be seen is not a guard on where the property lives.

## The fix

`_Viewport.blank()` records both halves of a paint that drew no table — no map, and nowhere
to scroll — and the three early returns go through it.

Zero is not a new rule. `_scroll_limit` already answers 0 for any budget at or below one
row, so a pane starved to nothing by a resize (which always did reach `settle`) and a pane
whose cache went away now agree, instead of differing by which line the renderer returned
from.

## Verification

- Two cases added to `tests/test_the_repo_table_scrolls_and_selects.py`: the bound **and**
  the offset are 0 after each of the three paints, and a real wheel report driven through
  `builtins._repos_events` answers falsy on a pane with no table.
- Full suite: **8835 tests, OK**, including the real-tmux `test_a_real_click_reaches_the_real_repo_table`.
- Hand-verified by deletion, sha256 on apply and restore (the sweep gate charges `charter/`
  and this does touch it, but the by-hand check is the one I stand behind):

  | mutation | sha256 of `charter/frame/slots.py` | result |
  |---|---|---|
  | baseline | `b9977bce…` | 90 tests OK |
  | `VIEWPORT.blank()` → `VIEWPORT.publish(())` | `f484d4e7…` | **2 failures** |
  | `settle(0)` dropped out of `blank` | `d14690ef…` | **2 failures** |
  | restored | `b9977bce…` | 90 tests OK |

Nothing changes for a pane that has a table in it, at any offset or pane height.

News entry carries `version: unreleased`. No version bump, no stamp, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy