### PR TITLE
A panel a plane placed is re-asserted after a resize, so it stops taking the repo table's rows (#668)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1159,32 +1159,6 @@ def _panel_died_hook_argv(*, socket: str, panel_pane: str, slot: str,
                                action)
 
 
-#: Which `resize-pane` flag re-asserts a slot's dimension, **for every slot
-#: :func:`_reassert_sizes` asserts one for**: `-y` (rows) for the horizontal strips, `-x`
-#: (columns) for the side column — the same axis `layout.py`'s own `-v`/`-h` split
-#: direction already encodes for the same slots, read here rather than re-derived a third
-#: way. The SIZE that goes with it is `layout.slot_sizes`', not `SLOT_SIZE`'s, since
-#: `repos`' is a function of its content and of the window (#488).
-#:
-#: **`repos` is deliberately absent, and #515 is the whole of it.** The issue asked for
-#: the second bottom pane to be in this map and that would be wrong — not because its
-#: axis is in doubt (it is rows; its width is whatever the harness column leaves it, and
-#: no `resize-pane -x` ever set that), but because tmux's `resize-pane` moves exactly ONE
-#: boundary. In a vertical stack of N panes only N-1 heights can be asserted; assert them
-#: all and the outcome depends on the order they are asserted in. Measured on tmux 3.7c
-#: at 200x50, asserting `top`, `bottom` and `repos` in split order: the table came back
-#: **1** row tall and the attention strip **6** — the two sizes swapped panes, and the
-#: harness kept whatever tmux's own proportional redistribution had left it.
-#:
-#: So the pane left out is the one whose height is already a function of all the others
-#: (`layout.VARIABLE_ROW_SLOTS`), the HARNESS is told its height explicitly
-#: (`layout.harness_rows`), and the table lands on exactly `layout.repos_rows`' answer
-#: without anything naming it. Putting `repos` back in this map is a mutation
-#: `tests/test_frame_density.py::ResizeRecomputesForBothDimensions
-#: ::test_the_fixed_strips_are_re_asserted_at_their_own_constant_height` turns red — it
-#: asserts the whole set of `-y`s issued, not merely that each one present is right.
-_RESIZE_FLAG = {"top": "-y", "bottom": "-y", "right": "-x"}
-
 #: Every real pane id tmux ever reports, held in `tmuxctl` because a SECOND module
 #: now interpolates one into text tmux re-parses (`frame/overlay.py`'s escape
 #: hatch), and two copies of one guard is the drift this repo keeps paying for.
@@ -4097,16 +4071,27 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
 def _apply_sizes(socket: str, *, panes: dict[str, str], sizes: dict[str, int],
                  flag: str) -> None:
     """`resize-pane <flag>` every slot in *panes* that *sizes* has a number for and
-    :data:`_RESIZE_FLAG` gives exactly *flag*.
+    `layout.resize_flag` answers exactly *flag* about.
 
     One loop, called twice by :func:`_reassert_sizes` — once for the columns and once for
     the rows — rather than one loop over both, because the two are separated by a
     MEASUREMENT that only the first one makes truthful (:func:`_variable_pane_cols`).
 
-    `layout.VARIABLE_ROW_SLOTS` is not in :data:`_RESIZE_FLAG` at all, which is what leaves
-    the table pane as the stack's dependent one — see that constant's own comment for the
-    tmux measurement, and note that a second check for it here would be a guard no mutation
-    could turn red, because this one already catches it.
+    **The axis is asked of `layout`, not read out of a map here, and that map was the last
+    hand-written table of per-slot facts charter had.** `layout` derives every other one
+    (`SLOT_EDGE`, `SLOT_SIZE`, `_COLUMN_SLOTS`, `_FIXED_ROW_SLOTS`, `VARIABLE_ROW_SLOTS`)
+    from what each component declares, exactly so a component charter did not write is
+    answered rather than missing — and this module's `{"top": "-y", "bottom": "-y",
+    "right": "-x"}` was the one that was not. Once Phase 5 made a `[[frame.component]]`
+    table reachable, a placed component travelling under its own id was SIZED by
+    `layout.slot_sizes`, CHARGED to the harness by `layout.harness_rows`, and then never
+    re-asserted here at all: the harness's own `-y` took those rows out of a neighbour and
+    the variable row slot absorbed the error. See `layout.resize_flag` for the measurement.
+
+    `layout.VARIABLE_ROW_SLOTS` gets no flag from that function at all, which is what
+    leaves the table pane as the stack's dependent one — see its docstring for the tmux
+    measurement, and note that a second check for it here would be a guard no mutation
+    could turn red, because that one already catches it.
 
     Every pane id is checked before it is used, even though both callers of
     :func:`_reassert_sizes` already checked theirs. `_panel_died_hook_argv`'s own rule
@@ -4119,7 +4104,7 @@ def _apply_sizes(socket: str, *, panes: dict[str, str], sizes: dict[str, int],
     an integration failure worth printing over the agent's own screen.
     """
     for slot, pane_id in panes.items():
-        if _RESIZE_FLAG.get(slot) != flag or slot not in sizes:
+        if layout.resize_flag(slot) != flag or slot not in sizes:
             continue
         if not _PANE_ID_RE.fullmatch(pane_id):
             continue
@@ -4253,12 +4238,13 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str], harness_pan
     order left the table 1 row tall and the attention strip 6 — the two sizes swapped
     panes, and the harness kept whatever tmux's own redistribution had given it.
 
-    So this asserts every slot :data:`_RESIZE_FLAG` names — which is every slot whose size
-    is a CONSTANT, and deliberately not `layout.VARIABLE_ROW_SLOTS` — plus
-    `layout.harness_rows` on the harness itself. The table's size is already a function of
-    all the others, so it lands on exactly `repos_rows`' answer without being asserted. In
-    a stack of N panes only N-1 heights are free; asserting all N is what made the result
-    depend on the order.
+    So this asserts every slot `layout.resize_flag` gives an axis — which is every slot
+    whose size is a CONSTANT, **including one this plane placed under its own id**, and
+    deliberately not `layout.VARIABLE_ROW_SLOTS` — plus `layout.harness_rows` on the
+    harness itself. The table's size is already a function of all the others, so it lands
+    on exactly `repos_rows`' answer without being asserted. In a stack of N panes only N-1
+    heights are free; asserting all N is what made the result depend on the order, and
+    asserting N-2 is what left a placed bar holding the table's rows.
 
     *harness_pane* is checked like every other id here and for the same reason: it is read
     off disk (`state.harness_pane`) by `cmd_resize`, which is exactly the shape #475 was.

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -666,6 +666,58 @@ def column_sizes(slots: list[str] | tuple[str, ...]) -> dict[str, int]:
     return out
 
 
+def resize_flag(slot) -> str | None:
+    """Which ``resize-pane`` axis re-asserts *slot*'s size, or ``None`` for a pane tmux is
+    never told the size of — `commands_frame._apply_sizes`' filter.
+
+    **Derived, because a hand-written table of per-slot facts is what this module stopped
+    keeping.** :data:`SLOT_EDGE`, :data:`SLOT_SIZE`, :data:`_COLUMN_SLOTS`,
+    :data:`_FIXED_ROW_SLOTS` and :data:`VARIABLE_ROW_SLOTS` are all `_derive`'s, built once
+    at import from what each component declares, precisely so that a component charter did
+    not write answers the same questions through the same two readers (:func:`_edge_of`,
+    :func:`_size_of`) rather than being missing from a literal. `commands_frame` kept a
+    sixth such table in its own module — ``{"top": "-y", "bottom": "-y", "right": "-x"}`` —
+    and it was the one nothing derived.
+
+    **What that cost, once Phase 5 made a `[[frame.component]]` table reachable.** A placed
+    component travels under its own id (`chats`, `workspaces`, a provider's), which is in
+    no literal here; :func:`slot_sizes` sizes it, :func:`harness_rows` CHARGES the harness
+    for its rows, and `_apply_sizes` then issued no `resize-pane` for it at all. So the
+    harness's explicit ``-y`` took those rows out of a neighbour and the one pane nothing
+    asserts — the variable row slot — absorbed the whole error. Measured on tmux 3.7c, a
+    frame with `chats` placed at `size = 1`, grown from 200x40 to 200x90 and put through
+    the real `window-resized` handler::
+
+        want   top 1   chats 1   harness 76   repos 7   bottom 1
+        got    top 1   chats 7   harness 76   repos 1   bottom 1
+
+    which is #515's own failure — two sizes swapping panes — in the one place #515 did not
+    reach. It is stable rather than transient: three further resizes with no window change
+    reproduced it exactly.
+
+    **``None`` for the variable row slot, and that is the same decision it always was.**
+    tmux's `resize-pane` moves exactly ONE boundary, so in a stack of N panes only N-1
+    heights are free; assert all N and the outcome depends on the order. The pane left out
+    is the one whose height is already a function of every other (:data:`VARIABLE_ROW_SLOTS`),
+    the harness is told its height explicitly (:func:`harness_rows`), and the table lands on
+    exactly :func:`repos_rows`' answer without anything naming it. Measured on tmux 3.7c at
+    200x50, asserting `top`, `bottom` and `repos` in split order: the table came back **1**
+    row tall and the attention strip **6**.
+
+    **``None`` for a name nothing placed**, which is :func:`_edge_of`'s own contract read
+    one step on: a slot charter knows nothing about falls out of both edge tests rather
+    than being assigned an axis, and `_apply_sizes` skips it exactly as the literal's
+    ``.get`` used to. The axis for the two it does know is the same one `panel_argvs`
+    already encodes as `-v`/`-h` at split time, asked of the same :func:`_edge_of`.
+    """
+    if _key(slot) in VARIABLE_ROW_SLOTS:
+        return None
+    edge = _edge_of(slot)
+    if edge in _COLUMN_EDGES:
+        return "-x"
+    return "-y" if edge in _ROW_EDGES else None
+
+
 def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int,
                pinned_rows: int | None = None) -> dict[str, int]:
     """Every slot in *slots* mapped to the size it should be given — rows for the

--- a/docs/news/unreleased-a-panel-your-plane-placed-keeps-its-height-through-a-resize.md
+++ b/docs/news/unreleased-a-panel-your-plane-placed-keeps-its-height-through-a-resize.md
@@ -1,0 +1,57 @@
+---
+version: unreleased
+headline: A panel your plane placed keeps its height through a window resize, instead of taking the repo table's rows
+---
+
+*"I put the chat bar on my frame, dragged the terminal, and the repo table vanished."*
+
+It did not vanish — it was squeezed to one row while the one-line bar grew to seven, and it
+stayed that way until the frame was relaunched.
+
+Charter re-applies every pane's size after a window resize, because tmux redistributes all of
+them proportionally on its own. **Which axis re-asserts which panel was the last per-slot
+fact charter had not derived**: it was a literal in `commands_frame`, keyed by the four
+committed slot names —
+
+```python
+{"top": "-y", "bottom": "-y", "right": "-x"}
+```
+
+— while every other such fact (which splits cost columns, which strips are a fixed height,
+which one takes what its content needs) is built at import from what each component
+*declares*, precisely so that a component charter did not write is answered rather than
+missing from a list.
+
+A panel placed by a `[[frame.component]]` table travels under its own id — `chats`,
+`workspaces`, or a component someone else's package supplies. None of those is in that
+literal. So the arithmetic sized the panel, the arithmetic charged the harness for its rows,
+and then **nothing told tmux about it**. The harness's own explicit height took those rows out
+of whichever neighbour tmux picked, and the one pane charter deliberately never asserts — the
+repo table, which is the stack's remainder by design — absorbed the entire error.
+
+Measured against real tmux 3.7c: a frame with `chats` placed at `size = 1`, grown from 200x40
+to 200x90 and put through the real `window-resized` handler.
+
+```
+want    top 1    chats 1    harness 76    repos 7    bottom 1
+got     top 1    chats 7    harness 76    repos 1    bottom 1
+```
+
+That is charter's own two-sizes-swapping-panes failure — the one the three-strip frame was
+fixed for — in the one place that fix could not reach, because at the time there was nothing
+a plane could place that was not already in the list. It is stable rather than transient:
+three further resizes with no window change reproduced it exactly.
+
+**The axis is derived now**, from the same edge the splitter already reads: columns for a
+side panel, rows for a horizontal strip, and nothing at all for the repo table, which stays
+the dependent pane it has always been (in a stack of N panes only N-1 heights are free, and
+asserting all N is what makes the outcome depend on the order). A component charter does not
+know about still gets no axis rather than a default, which is the same
+filter-don't-refuse degrade the rest of the frame's geometry already makes.
+
+Nothing moves for a frame that places only charter's own four panels — the derivation answers
+exactly what the literal did for `top`, `bottom`, `right` and `repos`.
+
+**If you had placed a bar or a provider's panel, this is why your frame drifted.** The
+symptom is always the same shape: the panel with no `-y` grows to whatever the proportional
+redistribution gave it, and the repo table pays.

--- a/tests/test_a_pinned_repo_strip_keeps_its_height.py
+++ b/tests/test_a_pinned_repo_strip_keeps_its_height.py
@@ -19,10 +19,10 @@ Four claims are pinned here, and they are separable on purpose:
   the harness keeps `layout.HARNESS_MIN_ROWS` however large a number was committed —
   measured on tmux 3.7c, an over-large `-y` is not refused, it is granted out of the
   neighbour;
-* **the mechanism does not move.** `repos` stays the one variable-row slot and stays out
-  of `commands_frame._RESIZE_FLAG`, so it is still the stack's dependent pane and tmux is
-  still asked to move exactly N-1 boundaries in an N-pane stack. A pin changes the number
-  the other panes are sized around, and nothing about how they are asserted;
+* **the mechanism does not move.** `repos` stays the one variable-row slot and stays the
+  one slot `layout.resize_flag` gives no axis, so it is still the stack's dependent pane
+  and tmux is still asked to move exactly N-1 boundaries in an N-pane stack. A pin changes
+  the number the other panes are sized around, and nothing about how they are asserted;
 * **the plane is read at a boundary and the arithmetic is handed the answer** (#661).
   `layout.repos_rows` is charter's one provably pure geometry function and its tests are
   written to that property; the first cut of this feature read `config.FRAME` from inside
@@ -248,10 +248,10 @@ class APinChangesTheNumberAndNotTheMechanism(unittest.TestCase):
     registry. Two things are wrong with it. `slot_sizes` would then answer `repos` from
     `_size_of`, which reads `SLOT_SIZE["repos"]` — the shipped FLOOR, `1`, not the
     committed number — so the pinned strip would come out one row tall. And it would buy
-    nothing at the tmux end: `_RESIZE_FLAG` has no `repos` entry, adding one would assert
-    N heights in an N-pane stack, and that is the measured failure (`top`, `bottom`,
-    `repos` in split order at 200x50 left the table 1 row and the strip 6 — the two sizes
-    swapped panes). The strip has to stay the dependent pane whether its height is
+    nothing at the tmux end: `layout.resize_flag` gives `repos` no axis, and giving it one
+    would assert N heights in an N-pane stack, which is the measured failure (`top`,
+    `bottom`, `repos` in split order at 200x50 left the table 1 row and the strip 6 — the
+    two sizes swapped panes). The strip has to stay the dependent pane whether its height is
     content-derived or committed.
     """
 
@@ -265,12 +265,19 @@ class APinChangesTheNumberAndNotTheMechanism(unittest.TestCase):
             self.assertIs(layout._is_fixed_row("repos"), False)
 
     def test_the_pinned_strip_is_still_the_pane_tmux_is_never_told_the_height_of(self):
-        """In a stack of N panes only N-1 heights are free. `_RESIZE_FLAG` names the
-        three whose size is a constant; the strip lands on its number because everything
-        else was asserted around it, which is the same mechanism a content-sized strip
-        already uses."""
-        self.assertNotIn("repos", commands_frame._RESIZE_FLAG)
-        self.assertEqual(sorted(commands_frame._RESIZE_FLAG), ["bottom", "right", "top"])
+        """In a stack of N panes only N-1 heights are free. `layout.resize_flag` gives an
+        axis to the slots whose size is a constant and none to the table, so the strip
+        lands on its number because everything else was asserted around it — the same
+        mechanism a content-sized strip already uses.
+
+        Asked of the function, not of a literal set of names: the axis is derived now, so
+        a test spelling out `["bottom", "right", "top"]` would go red the day a plane
+        places a component charter did not write — which is a frame this has to answer
+        for, not one it refuses."""
+        with mock.patch.dict(config.FRAME, _arrangement(size=15)):
+            self.assertIsNone(layout.resize_flag("repos"))
+            self.assertEqual([layout.resize_flag(s) for s in SLOTS],
+                             ["-y", "-y", None, "-x"])
 
     def test_a_pin_does_not_move_the_shipped_geometry_tables(self):
         """`SLOT_SIZE["repos"]` is the FLOOR and stays it: `repos_rows` reads it as the

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -1461,6 +1461,29 @@ class ResizeRecomputesForBothDimensions(PersonaIso, unittest.TestCase):
         the two below the harness trade rows with each other and never with it."""
         self.assertEqual(self._heights("200:50"), {"%1": 1, "%2": 1, "%0": 38})
 
+    def test_a_strip_this_plane_placed_is_re_asserted_like_charters_own(self):
+        """**A component travelling under its own id, which is what Phase 5 made
+        reachable.** `chats` is not one of the four committed slot names, so the
+        hand-written `{"top": "-y", "bottom": "-y", "right": "-x"}` this call site used to
+        filter on had no entry for it and `_apply_sizes` issued nothing at all — while
+        `layout.slot_sizes` sized it and `layout.harness_rows` charged the harness for its
+        rows anyway. The harness's own `-y` then took those rows out of a neighbour, and
+        the one pane nothing asserts absorbed the error: measured on tmux 3.7c, a frame
+        with `chats` placed and grown from 200x40 to 200x90 came back with the bar 7 rows
+        tall and the six-repo table 1 — #515's two-sizes-swapping-panes, in the one place
+        #515 did not reach, and stable across further resizes rather than transient.
+
+        Asserted as the whole map, like the case above, so a bar that is asserted at the
+        wrong height fails here too and not only one that is skipped. `%4` is one row and
+        the harness gives up two for it — its own row and its border."""
+        tables = [{"use": "identity"}, {"use": "chats", "edge": "top", "size": 1},
+                  {"use": "attention"}, {"use": "repos"}, {"use": "sidebar"}]
+        panels = {"top": "%1", "chats": "%4", "bottom": "%2", "repos": "%5", "right": "%3"}
+        with mock.patch.dict(config.FRAME,
+                             instance.frame_of({"frame": {"component": tables}})):
+            self.assertEqual(self._heights("200:50", panels=panels),
+                             {"%1": 1, "%4": 1, "%2": 1, "%0": 36})
+
     def test_a_table_pane_that_stays_is_shrunk_to_the_one_row_it_can_draw(self):
         """The panel draws no table below `statusline._LEFT_W`, so every row past the
         first was blank — and came out of the harness.

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -17,8 +17,9 @@ import sys
 import unittest
 from unittest import mock
 
-from charter import util
+from charter import config, util
 from charter.frame import layout
+from charter.frame.component import Fixed
 from tests._tmuxsocket import OPERATOR_SOCKET
 
 
@@ -506,7 +507,8 @@ class ColumnSizesIsTheHalfThatCanBeAppliedFirst(unittest.TestCase):
 
     Pinned here rather than only through that caller, and `tools/sweep.py` is why: deleting
     the edge filter left the whole suite green, because `_apply_sizes` filters again by
-    `_RESIZE_FLAG` on its way to the `-x` and swallowed every extra entry. Two guards in
+    `layout.resize_flag` on its way to the `-x` and swallowed every extra entry. Two
+    guards in
     sequence, the second hiding the first. This asks the function its own question.
     """
 
@@ -536,6 +538,71 @@ class ColumnSizesIsTheHalfThatCanBeAppliedFirst(unittest.TestCase):
         degrades rather than refusing for exactly that reason."""
         self.assertEqual(layout.column_sizes(["sideways", "right"]),
                          {"right": layout.SLOT_SIZE["right"]})
+
+
+class ResizeFlagIsDerivedLikeEveryOtherPerSlotFact(unittest.TestCase):
+    """`resize_flag` — which axis re-asserts a slot's size after a window resize.
+
+    **`commands_frame` kept this as a literal, and it was the last per-slot table charter
+    had not derived.** Every other one here (`SLOT_EDGE`, `SLOT_SIZE`, `_COLUMN_SLOTS`,
+    `_FIXED_ROW_SLOTS`, `VARIABLE_ROW_SLOTS`) is `_derive`'s, built at import from what
+    each component declares, so a component charter did not write is ANSWERED rather than
+    missing. `{"top": "-y", "bottom": "-y", "right": "-x"}` was not — and once a
+    `[[frame.component]]` table could place a component under its own id, that component
+    was sized by `slot_sizes`, charged to the harness by `harness_rows`, and then never
+    re-asserted at all, so the harness's own `-y` took its rows out of a neighbour and the
+    variable row slot absorbed the whole error.
+
+    Asked of the function on names it can only answer by deriving, which is the property.
+    `tests/test_frame_density` asserts the same fact through the caller that issues the
+    `resize-pane`, and `tests/test_frame_tmux_integration` against a real server.
+    """
+
+    def test_the_shipped_slots_get_the_axis_their_split_already_uses(self):
+        """One fact, two consumers: `panel_argvs` splits `-v`/`-h` off the same edge this
+        reads. A `-x` on a horizontal strip would assert a WIDTH on a full-width pane."""
+        self.assertEqual([layout.resize_flag(s) for s in ("top", "bottom", "right")],
+                         ["-y", "-y", "-x"])
+
+    def test_the_variable_row_slot_gets_no_axis_at_all(self):
+        """In a stack of N panes only N-1 heights are free (#515), so the pane left out is
+        the one whose height is already a function of every other. Asserted as `None` and
+        not as "not -y": an axis of any kind here is the measured failure."""
+        self.assertIsNone(layout.resize_flag("repos"))
+
+    def test_a_component_this_plane_placed_is_answered_from_its_own_edge(self):
+        """The case the literal could not have. `chats` is in no shipped table, so the
+        answer comes from the placement — and a component on `left` or `right` gets the
+        columns axis by the same route, which is what stops a provider's side panel being
+        the same defect one axis over."""
+        arrangement = {"components": [
+            {"slot": "chats", "edge": "top", "size": Fixed(1)},
+            {"slot": "acme.metrics", "edge": "right", "size": Fixed(30)}]}
+        with mock.patch.dict(config.FRAME, arrangement):
+            self.assertEqual(layout.resize_flag("chats"), "-y")
+            self.assertEqual(layout.resize_flag("acme.metrics"), "-x")
+
+    def test_a_name_nothing_placed_gets_no_axis_rather_than_a_default(self):
+        """`_edge_of`'s own contract read one step on: a name charter knows nothing about
+        falls out of both edge tests instead of being assigned a side, which is the same
+        filter-don't-refuse degrade `slot_sizes` and `column_sizes` already make."""
+        self.assertIsNone(layout.resize_flag("sideways"))
+
+    def test_every_slot_the_harness_is_charged_rows_for_is_one_tmux_is_told_about(self):
+        """**The invariant the defect broke, stated as the relation rather than as a
+        list.** `harness_rows` subtracts a row for every horizontal strip in the map, so
+        each of those has to be a strip something re-asserts — or the harness's explicit
+        height takes rows nothing puts back. The one exception is the variable row slot,
+        which is the remainder by construction."""
+        arrangement = {"components": [
+            {"slot": "chats", "edge": "top", "size": Fixed(1)}]}
+        placed = ["top", "chats", "bottom", "repos", "right"]
+        with mock.patch.dict(config.FRAME, arrangement):
+            sizes = layout.slot_sizes(placed, window_rows=50, content_rows=6)
+            charged = [s for s in sizes if layout._edge_of(s) not in layout._COLUMN_EDGES]
+            self.assertEqual(charged, ["top", "chats", "bottom", "repos"])
+            self.assertEqual([s for s in charged if layout.resize_flag(s) is None],
+                             list(layout.VARIABLE_ROW_SLOTS))
 
 
 class SlotSizesAnswersEverySlotAtOnce(unittest.TestCase):

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -1618,10 +1618,10 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
         is asked of tmux.
 
         Which is also why the obvious alternative is not what shipped. Calling a pinned
-        table a FIXED row and adding it to `_RESIZE_FLAG` would assert all N heights, and
-        that is the measured failure `_reassert_sizes`' own docstring carries: at 200x50,
-        asserting `top`, `bottom` and `repos` in split order left the table 1 row and the
-        attention strip 6, the two sizes having swapped panes.
+        table a FIXED row and giving it a `layout.resize_flag` axis would assert all N
+        heights, and that is the measured failure `_reassert_sizes`' own docstring
+        carries: at 200x50, asserting `top`, `bottom` and `repos` in split order left the
+        table 1 row and the attention strip 6, the two sizes having swapped panes.
 
         `repos_rows_wanted` is stubbed to a number the pin must beat and one it must not
         lose to — 2 clones and 30 — because a pin that were quietly still content-sized
@@ -1672,6 +1672,67 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
                                  f"the harness has {harness} rows, so the rows the pin "
                                  f"took came from somewhere the arithmetic does not "
                                  f"describe")
+
+    def test_a_bar_this_plane_placed_does_not_take_the_tables_rows(self):
+        """A `[[frame.component]]` table placing `chats`, driven against real tmux — the
+        case the hand-written `{"top": "-y", "bottom": "-y", "right": "-x"}` in
+        `commands_frame` could not have, because a placed component travels under its own
+        id and was in no such literal.
+
+        `layout.slot_sizes` sized the bar and `layout.harness_rows` charged the harness
+        for its rows; `_apply_sizes` then issued no `resize-pane` for it at all, so the
+        harness's explicit `-y` took those rows out of a neighbour and the one pane
+        nothing asserts absorbed the whole error. That remainder is tmux's arithmetic and
+        not charter's, which is why it is asked of tmux here rather than of the argv.
+
+        The window is GROWN first, so every pane arrives proportionally scaled — which is
+        the state a `window-resized` hook actually fires in and the state in which the
+        defect was measured (200x40 -> 200x90 left the bar 7 rows and the six-repo table
+        1). Both numbers are asserted, because a bar re-asserted at the wrong height and a
+        bar not re-asserted at all are different defects with the same symptom.
+        """
+        fid = state.frame_id("placed-bar", os.getpid())
+        r = _tmux("new-session", "-d", "-s", "placed-bar", "-x", "120", "-y", "40",
+                  "-P", "-F", "#{pane_id}")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness_pane = r.stdout.strip()
+        panes = {}
+        for slot, args in (("top", ("-v", "-b", "-l", "1")),
+                           ("chats", ("-v", "-b", "-l", "1")),
+                           ("bottom", ("-v", "-l", "1")),
+                           ("repos", ("-v", "-l", "6"))):
+            out = _tmux("split-window", "-t", harness_pane, *args,
+                        "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+            self.assertEqual(out.returncode, 0, out.stderr)
+            panes[slot] = out.stdout.strip()
+
+        placed = instance.frame_of({"frame": {"component": [
+            {"use": "identity"}, {"use": "chats", "edge": "top", "size": 1},
+            {"use": "attention"}, {"use": "repos"}, {"use": "sidebar"}]}})
+        self.assertIn("chats", placed["slots"],
+                      "the arrangement did not place the bar, so nothing below is about "
+                      "a placed component")
+
+        self.assertEqual(_tmux("resize-window", "-t", "placed-bar",
+                               "-x", "120", "-y", "90").returncode, 0)
+        with mock.patch.dict(config.FRAME, placed), \
+                mock.patch("charter.frame.slots.repos_rows_wanted", return_value=6):
+            commands_frame._reassert_sizes(SOCKET, fid=fid, panes=panes,
+                                           harness_pane=harness_pane,
+                                           window_cols=120, window_rows=90)
+
+        bar = _tmux("display-message", "-p", "-t", panes["chats"],
+                    "#{pane_height}").stdout.strip()
+        self.assertEqual(bar, "1",
+                         f"the placed bar is {bar} rows where it committed 1 — tmux was "
+                         f"never told its height, so it kept whatever the window resize "
+                         f"scaled it to")
+        table = _tmux("display-message", "-p", "-t", panes["repos"],
+                      "#{pane_height}").stdout.strip()
+        self.assertEqual(table, "6",
+                         f"the table pane is {table} rows on a six-clone plane — it is "
+                         f"the stack's dependent pane, so it is where the rows nothing "
+                         f"put back are taken from")
 
     def test_the_table_panes_width_is_tmuxs_answer_and_not_the_recorded_order(self):
         """#510, against the one authority there is.


### PR DESCRIPTION
Found by an adversarial review of the frame work merged in the last 24 hours. **Reproduced against real tmux 3.7c, before and after.**

## What is wrong

`commands_frame._RESIZE_FLAG` was the last hand-written table of per-slot facts charter had:

```python
_RESIZE_FLAG = {"top": "-y", "bottom": "-y", "right": "-x"}
```

Every other one — `SLOT_EDGE`, `SLOT_SIZE`, `_COLUMN_SLOTS`, `_FIXED_ROW_SLOTS`,
`VARIABLE_ROW_SLOTS` — is `layout._derive`'s, built at import from what each component
*declares*, precisely so a component charter did not write is **answered** rather than
missing from a literal. This one lived in a different module and was not.

#668 Task 7 made that reachable. A `[[frame.component]]` table places a component under its
own id — `chats`, `workspaces`, or a provider's — and none of those is in the literal. So:

- `layout.slot_sizes` **sizes** it,
- `layout.harness_rows` **charges the harness** for its rows (via `_edge_of`, which does
  answer for it),
- `_apply_sizes` filters on `_RESIZE_FLAG.get(slot)` and issues **nothing**.

The harness's explicit `-y` then takes those rows out of whichever neighbour tmux picks, and
the one pane charter deliberately never asserts — the repo table, the stack's remainder by
design — absorbs the whole error.

## Reproduction (real tmux 3.7c)

A frame with `chats` placed at `size = 1`, grown 200x40 → 200x90, through the real
`window-resized` handler:

```
want    top 1    chats 1    harness 76    repos 7    bottom 1
got     top 1    chats 7    harness 76    repos 1    bottom 1
```

The bar draws one line and six blank rows; `capture-pane` on the table pane returns a single
line where six clones should be. That is #515's own **two sizes swapping panes**, in the one
place #515 could not reach — at the time, nothing a plane could place was outside the list.

It is **stable, not transient**: three further `cmd_resize` calls with no window change
reproduced it exactly. It stays wrong until relaunch, or until a re-layout re-splits that pane.

**Scope is wider than the two bars.** Any component placed under its own id is affected,
including a provider's on `left`/`right`, whose `-x` is dropped the same way.

## The fix

`layout.resize_flag(slot)` derives the axis from the same `_edge_of` the splitter's `-v`/`-h`
already reads:

- `-x` for a side panel, `-y` for a horizontal strip;
- `None` for `layout.VARIABLE_ROW_SLOTS` — unchanged, and the reason is unchanged: in a stack
  of N panes only N-1 heights are free, so the pane left out is the one whose height is
  already a function of every other;
- `None` for a name nothing placed — `_edge_of`'s own contract read one step on, the same
  filter-don't-refuse degrade `slot_sizes` and `column_sizes` already make.

**Nothing moves for a frame that places only charter's own four panels.** The derivation
answers exactly what the literal did for `top`, `bottom`, `right` and `repos`.

## Verification

Three levels, and the middle one is the invariant rather than a list of names:

| test | what it pins |
|---|---|
| `test_frame_layout.ResizeFlagIsDerivedLikeEveryOtherPerSlotFact` | the axis per slot, a placed component's, an unknown name's — **and the relation**: every slot `harness_rows` charges rows for is one something re-asserts, bar the variable one |
| `test_frame_density::test_a_strip_this_plane_placed_is_re_asserted_like_charters_own` | the whole `-y` map `cmd_resize` issues, with a bar placed |
| `test_frame_tmux_integration::test_a_bar_this_plane_placed_does_not_take_the_tables_rows` | a real five-pane stack, really grown, really re-asserted — asserts **both** the bar's height and the table's, because a bar re-asserted at the wrong height and one not re-asserted at all are different defects with the same symptom |

Two existing tests pinned the literal by name (`sorted(_RESIZE_FLAG) == ["bottom","right","top"]`).
Both are moved onto the property — a list of names would go red the day a plane places
something, which is a frame this has to answer for rather than one it refuses.

Hand-verified by deletion, sha256 on apply and restore:

| state | sha256 of `charter/frame/layout.py` | result |
|---|---|---|
| fix | `4e90e69c…` | 8840 tests OK |
| `resize_flag` body replaced by the old literal | `f7b3525b…` | 3 unit/argv failures + **real-tmux red: bar 6 rows, table 1** |
| restored | `4e90e69c…` | OK |

Full suite: **8840 tests, OK**.

News entry carries `version: unreleased`. No version bump, no stamp, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy