### PR TITLE
A chat you have just opened stops being deleted by the next chat you open (#685)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2608,6 +2608,9 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     else:
         state.record_exit(fid, code)
         _close_window()
+    # Given up before this path's own closing reap, for the reason `cmd_launch` gives at
+    # its own (#685): the marker is held for the LAUNCH, and this launch is over.
+    state.clear_claim(fid)
     _reap_this_server(socket)
     return code
 
@@ -3822,6 +3825,13 @@ def cmd_launch(args) -> int:
                 # never actually reached the server despite reporting success).
                 code = _query_pane_dead_status(SOCKET, harness_pane)
 
+    # The claim is given up before the reap that exists to collect it (#685). The marker
+    # `state.new_chat_id` wrote says "a launcher is still working on this directory", and
+    # this one no longer is: `state.exit_code` has already been read above, so the #383
+    # window the marker covers is behind it. Left in place it would refuse the one thing
+    # only the CLOSING reap can do — remove this frame's own directory — by naming a
+    # process that is, necessarily, still alive.
+    state.clear_claim(fid)
     after_sessions = _live_sessions(SOCKET)
     after_chats = _live_chats(SOCKET)
     live_after = after_sessions | (after_chats or set())

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -119,6 +119,16 @@ _CHAT_SEP = "."
 #: refusal a caller can report rather than a hang nobody can see.
 _CHAT_ORDINAL_MAX = 10_000
 
+#: The file :func:`new_chat_id` writes its own pid into as it claims a directory, and the
+#: third keep-rule :func:`reap` reads it back through (#685).
+#:
+#: A plain name beside `server` and `workspace`, not a dotfile: everything in a frame's
+#: directory is charter's own bookkeeping and nothing here hides from `ls`. It is read by
+#: `reap` alone — no bar, no panel and no palette asks who claimed a chat — which is why
+#: the reader below is private and there is no `record_launcher` in this module's public
+#: surface for a second caller to reach for.
+_CLAIM_FILE = "launcher"
+
 
 def _root() -> Path:
     return Path(config.STATE_DIR) / "frame"
@@ -143,6 +153,16 @@ def new_chat_id(workspace: str) -> str | None:
     this name mine?". Here ``FileExistsError`` is the claim failing, and the answer to it
     is ``n+1``. Two allocators racing the same workspace cannot both win, because
     ``mkdir`` is one syscall and the kernel picks.
+
+    **Winning the `mkdir` is only half of it, and the other half is :func:`_record_claim`**
+    (#685). A claim has to survive until it is a chat, and for hundreds of milliseconds
+    after this returns it is a directory with no window, no `server` marker and — unlike
+    the `{workspace}-{pid}` ids this replaced — no pid in its name, which is to say a
+    directory every one of :func:`reap`'s rules said was dead. A sibling launcher runs a
+    reap on the way in to its own claim, so the loser of the race deleted the winner's
+    directory and then claimed the same ordinal: the silent collision the paragraph above
+    says the design makes impossible, arriving one layer down. The pid goes in the
+    directory as its first byte, and `reap` reads it.
 
     **A scan is not a substitute.** Reading the directory and taking ``max + 1`` gives
     two racers the same answer, and the loser silently adopts the winner's frame
@@ -189,8 +209,49 @@ def new_chat_id(workspace: str) -> str | None:
             # ENAMETOOLONG for an id no `mkdir` will take, a full filesystem, a
             # permission the plane does not have. None of those gets better at `n+1`.
             return None
+        # And the claim is SAID, immediately, in the directory the `mkdir` just made
+        # (#685). Winning the `mkdir` is only half of "cannot both win": the other half
+        # is that the winner's directory survives long enough to become a chat, and
+        # between this line and the `new-window` hundreds of milliseconds later the
+        # claim passed all three of `reap`'s keep-rules — no window yet, no `server`
+        # marker yet, and a chat id carries no launcher pid for the third to abstain in
+        # favour of. A sibling launcher's reap (every launch runs one) deleted it, and
+        # both launchers then held `api.1`: one `exit` file, one `panes` map, one pane
+        # record, and a switch aimed at whichever wrote last. Reproduced.
+        _record_claim(d)
         return d.name
     return None
+
+
+def _record_claim(d: Path) -> None:
+    """Write this process's pid into the directory :func:`new_chat_id` has just claimed.
+
+    **What the old `{workspace}-{pid}` id shape said in its NAME, said in a file.** That
+    shape got `reap`'s launcher rule for free — the pid was in the name, so the `mkdir`
+    that made the directory also made it un-reapable — and Stage 5a spent it deliberately:
+    `_launcher_pid`'s `-`-vs-`.` answer is the version discriminator, and widening it to
+    read `api.1` as pid 1 would hand every chat ``launchd`` and keep every dead one
+    forever. Nothing replaced the guard it removed. This does, in the one place that can:
+    the allocator, on the path that has already made the directory.
+
+    **The first byte written into a claimed directory, and that ordering is the guard
+    rather than a tidiness.** `reap` reads this file to decide, so between the `mkdir` and
+    this write there is a directory it can see and no pid it can read — which is why
+    :func:`reap` keeps an EMPTY frame directory outright. Those two rules meet exactly:
+    the directory is empty until this lands, and marked from the moment it does. Any later
+    writer (`record_server`, `record_workspace`, `bump`) would leave a window in between
+    where the directory holds something and says nothing, which is the window this closes.
+
+    Never raises, like every other writer here: a claim that could not be marked is a
+    directory a sibling's reap may delete out from under this launch — the defect above —
+    but a launch is not worth failing over a file, and the empty-directory rule still
+    covers the instant this was called at. Written with `config.write_for` at 0700's
+    dispatch for `record_server`'s reason: this is charter's own state.
+    """
+    try:
+        config.write_for(d / _CLAIM_FILE, f"{os.getpid()}\n")
+    except OSError:
+        return
 
 
 def frame_dir(fid: str, *, create: bool = False) -> Path | None:
@@ -345,6 +406,34 @@ def clear_exit(fid: str) -> None:
         # Same must-not-raise promise the rest of this module makes: a launch is not
         # worth failing over a file that could not be deleted, and the stale-code
         # reading below is the caller's own to notice.
+        return
+
+
+def clear_claim(fid: str) -> None:
+    """Give up the claim :func:`new_chat_id` made on *fid*'s directory (#685).
+
+    **The marker is held for the LAUNCH, not for the life of the process**, and this is
+    the half that makes those two different. `_record_claim` says "a launcher is still
+    working on this directory"; a launcher that has read its harness's exit code and is
+    about to return is not, and its own last `reap` — the one whose whole job is to remove
+    the frame it just finished — would otherwise be refused by a marker naming a process
+    that is still, necessarily, alive.
+
+    Called at the END of a launch and nowhere else, which is why the window this protects
+    stays protected: the #383 hazard is a SIBLING's reap landing between a harness dying
+    and its own launcher reading `exit`, and that launcher has not reached here yet.
+
+    Nothing is lost when it is never called — a launcher killed outright leaves the marker
+    behind and its pid dies with it, so the next reap removes the directory on the pid rule
+    exactly as it does for an old `{workspace}-{pid}` frame. Never raises and never
+    creates, like :func:`clear_exit` beside it.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return
+    try:
+        (d / _CLAIM_FILE).unlink(missing_ok=True)
+    except OSError:
         return
 
 
@@ -1268,6 +1357,37 @@ def _launcher_pid(name: str) -> int | None:
     return pid if pid > 0 else None
 
 
+def _claiming_pid(d: Path) -> int | None:
+    """The pid :func:`_record_claim` wrote into *d*, or ``None``.
+
+    :func:`_launcher_pid`'s counterpart, asked of the FILE rather than of the name, and
+    the same answer means the same thing in both: "this directory carries no claim about
+    any process". ``None`` is the ordinary answer for every frame directory an older
+    charter left behind and for every old-shape `{workspace}-{pid}` frame, both of which
+    go on being decided by the rules that already decided them.
+
+    A `Path`, not a frame id, because its one caller is :func:`reap` — which is walking
+    `os.scandir`'s own entries and has the directory in hand. Resolving a name back into a
+    path here would be `frame_dir`'s containment asked a second time about a value that
+    never left this module.
+
+    Held to the same shape :func:`_launcher_pid` holds its own to: digits, and greater
+    than zero, because ``0`` is "every process in my group" to ``kill(2)`` rather than a
+    process. Anything else on disk — a truncated write, a hand-edited file, a directory
+    where the file should be — is no claim at all, which is the safe direction: a chat
+    whose marker cannot be read is reaped like one that never had one, exactly as it is
+    today.
+    """
+    try:
+        val = (d / _CLAIM_FILE).read_text().strip()
+    except (OSError, ValueError):
+        return None
+    if not val.isdigit():
+        return None
+    pid = int(val)
+    return pid if pid > 0 else None
+
+
 def _launcher_is_alive(pid: int) -> bool:
     """Is the process *pid* names still running? Asks; never signals anything.
 
@@ -1417,6 +1537,24 @@ def reap(live: set[str], *, server: str) -> list[str]:
     whose launcher is still a live process is one somebody may still come back to, and
     is left alone — no age, no timestamps, no extra file, nothing to keep in sync.
 
+    **A CHAT id carries no pid, so that question is asked of a file instead** (#685,
+    :func:`_record_claim`). Stage 5a's ids are `{workspace}.{n}`, and the paragraph above
+    is the whole reason: reading `api.1` as pid 1 would hand every chat ``launchd`` and
+    keep every dead one forever. What Stage 5a did not do was replace the guard that
+    removed. Without it a directory `new_chat_id` had just claimed passed every rule here
+    — no window yet (`@charter_chat` is set hundreds of milliseconds later, after
+    `_spawn_gather`, the tmux.conf write and `new-window`), no `server` marker yet
+    (`record_server` runs after the claim), and no pid in the name by design — so a
+    SIBLING launcher's reap deleted it and both launchers went on holding `api.1`. Two
+    live chats, one `exit` file, one `panes` map, one pane record. Reproduced.
+
+    The claim marker restores the old shape's guard exactly, including its two failure
+    directions and the price of each: a recycled pid keeps one directory until that
+    process ends, and a launcher misread as dead costs a real exit code. It also restores
+    for chats the #383 protection the paragraph above describes — a chat whose harness has
+    exited is now kept until its launcher has read the code, where before Stage 5b it was
+    reapable the instant its window went away.
+
     Both ways of being wrong point the same way, deliberately. A pid the OS has recycled
     onto an unrelated process reads as "alive" and costs one directory's cleanup, deferred
     until that process ends and some later launch reaps it — bounded, silent, and measured
@@ -1439,14 +1577,48 @@ def reap(live: set[str], *, server: str) -> list[str]:
     for d in sorted(root.iterdir()):
         if not d.is_dir() or d.name in live:
             continue
-        # Two independent reasons to keep a directory, and BOTH must be absent before
-        # anything is deleted. They answer different questions and neither implies the
-        # other: the frame may belong to the OTHER tmux server (#381), or its launcher
-        # may still be running on this one (#383).
+        # Four independent reasons to keep a directory, and ALL must be absent before
+        # anything is deleted. They answer different questions and none implies another:
+        # the frame may belong to the OTHER tmux server (#381), its launcher may still be
+        # running on this one (#383), or the directory may be a claim that is not a frame
+        # yet (#685) — either because its marker has not landed (it holds nothing at all)
+        # or because it has (a live pid is in it).
         owner = frame_server(d.name)
         if owner is not None and owner != server:
             continue
-        pid = _launcher_pid(d.name)
+        try:
+            claimed = next(d.iterdir(), None) is None
+        except OSError:
+            # A directory this process cannot list is one it has no reading of, and
+            # `rmtree` would not have emptied it either. Kept, on the same side every
+            # unreadable answer in this module falls: no proof, no deletion.
+            continue
+        if claimed:
+            # **Nothing in it yet, so its claimer is between two syscalls.**
+            # `new_chat_id` creates the directory and `_record_claim` writes the pid as
+            # the very first byte into it, so an EMPTY frame directory is a claim caught
+            # in the microseconds between the two — the only window the marker itself
+            # cannot cover, and the reason the marker has to be the first write rather
+            # than merely an early one. Every frame that has ever run holds `server`,
+            # `workspace` and `version` at minimum, so nothing this keeps is a frame.
+            #
+            # It costs an ordinal rather than bytes, and that is the honest price: a
+            # directory left empty by an `rmtree` that half-failed is now kept, and
+            # `new_chat_id` skips its name for good. One name out of
+            # `_CHAT_ORDINAL_MAX`, against a collision that hands two live chats one
+            # `exit` file.
+            continue
+        pid = _claiming_pid(d)
+        if pid is None:
+            # The claim's own record first and the NAME second, never both at once: a
+            # chat's launcher is in the file (#685) and an old `{workspace}-{pid}` frame's
+            # is in its id, and no directory carries the two. `is None` rather than
+            # falsiness, and that is the difference between a guard and an accident: pid
+            # `0` is a value this reads off disk, `kill(2)` takes it as "every process in
+            # my group" and would answer alive, and a `0` that fell through to the name
+            # would be a corrupt marker being saved by a rule that is about something
+            # else. `_claiming_pid` refuses it on its own terms.
+            pid = _launcher_pid(d.name)
         if pid is not None and _launcher_is_alive(pid):
             continue
         shutil.rmtree(d, ignore_errors=True)

--- a/docs/news/unreleased-a-claim-outlives-the-next-launchs-reap.md
+++ b/docs/news/unreleased-a-claim-outlives-the-next-launchs-reap.md
@@ -1,0 +1,78 @@
+---
+version: unreleased
+headline: A chat you have just opened stops being deleted by the next chat you open
+---
+
+Opening two chats in one workspace — `charter claude` twice, the feature's own headline
+use — could hand both of them the same state directory. One `exit` file, one `panes` map,
+one harness-pane record between two running agents: the roster showed one chat where two
+were live, and a switch aimed at whichever launcher had written last.
+
+## What was actually happening
+
+A chat's id is claimed, not computed. `state.new_chat_id` walks upwards from 1 and the
+`mkdir` **is** the allocation, so two launchers racing one workspace cannot both be told
+they won — the kernel picks. That much held.
+
+What did not hold is that the winner's directory had to survive long enough to become a
+chat. Between the claim and the `new-window` that gives the chat its window there are
+hundreds of milliseconds: a background gather is spawned, the frame's environment is
+resolved, its identity is recorded, its `tmux.conf` is written. Through all of it the
+claim was a directory that passed every one of `state.reap`'s keep-rules:
+
+| keep rule | why it missed |
+|---|---|
+| the chat is in the live list | its window — and its `@charter_chat` — does not exist yet |
+| the directory names another tmux server | `record_server` runs *after* the claim, so it named none |
+| the launcher in the id is still alive | a chat id is `{workspace}.{n}` and carries no pid, by design |
+
+And **every launch runs a reap immediately before its own claim.** So the second
+`charter claude` deleted the first one's directory on its way in, then claimed the same
+ordinal. Reproduced:
+
+```python
+first  = state.new_chat_id("api")        # -> 'api.1'   (launcher 1, mid-launch)
+state.reap(set(), server=SOCKET)         # -> removed ['api.1']   (launcher 2)
+second = state.new_chat_id("api")        # -> 'api.1'   (launcher 2)
+```
+
+The old `{workspace}-{pid}` id shape had closed this for free, because the pid was in the
+name and the `mkdir` that made the directory also made it un-reapable. Stage 5a spent that
+guard deliberately — reading `api.1` as pid 1 would hand every chat `launchd`, which never
+exits, and `reap` is the only thing bounding `.charter/frame/` — and nothing replaced it.
+
+## What replaces it
+
+The claim says whose it is, in the directory it just made. `new_chat_id` writes its own
+pid as the **first byte** into the directory it claimed, and `reap` keeps any directory
+whose claiming launcher is still running.
+
+First byte, not merely early: `reap` reads that file to decide, so between the `mkdir` and
+the write there would be a directory it can see and no pid it can read. The two rules meet
+exactly — a frame directory holding *nothing at all* is kept too, because that is a claim
+caught between its two syscalls and never a frame (every frame that has run holds
+`server`, `workspace` and `version` at minimum).
+
+Both ways of being wrong point the same way, as they did for the old shape: a pid the OS
+has recycled keeps one directory until that process ends, measured in bytes; reading a
+live launcher as dead costs a real exit code.
+
+The claim is held for the **launch**, not for the life of the launcher, and giving it up
+is the half that keeps `.charter/frame/` bounded: a launcher that has read its harness's
+exit code releases the marker before its own last reap, so a finished chat still leaves
+nothing behind. A launcher killed outright never gets there, and needs no cleanup — its
+pid dies with it and the next reap removes the directory on the pid rule, exactly as it
+already does for a `{workspace}-{pid}` frame.
+
+## And it gives chats back a guard they had quietly lost
+
+`reap` runs at every launch, and the set it is handed names what tmux reported live at
+that instant. A frame outlives its session: between a harness exiting and its launcher
+reading the exit code, the window is already gone from that list while `cmd_launch` is
+still one line away from the answer. For `{workspace}-{pid}` frames the pid rule covered
+that window — it is why the rule exists. Chats had no such cover, so a sibling launch
+landing in it deleted the `exit` file before it was read, `exit_code` answered `None`,
+and a harness that had genuinely failed was reported to the caller as a success.
+
+The claim marker closes that for chats too, with no new file to keep in sync and no
+timestamp anywhere.

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -3367,6 +3367,23 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(state.harness_pane(fake.fid), fake.pane_id)
 
+    def test_a_finished_chat_leaves_no_directory_behind(self):
+        """The bounding property the comment above depends on, asserted rather than
+        assumed.
+
+        Since #685 a claim carries its launcher's pid, so a SIBLING's reap cannot delete
+        it mid-launch — and that pid is this very process's, alive by construction. `reap`
+        would therefore keep this frame's directory for as long as the launcher lived if
+        the launcher did not give the claim up on its way out (`state.clear_claim`), and
+        the closing reap would have nothing left that only it can do.
+        """
+        fake = _FakeTmux(exit_code=0)
+        self.assertEqual(_launch(fake), 0)
+        self.assertFalse(state.frame_dir(fake.fid).exists(),
+                         "the finished chat's directory outlived its launch — the claim "
+                         "was never given up, and the process that made it is still "
+                         "running")
+
     def test_the_panels_are_told_the_frames_identity_too(self):
         """#411's other half, and the one that outlives the tmux floor. A panel splits off
         a server another launcher may have started, so `$CHARTER_WORKSPACE` and

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -28,6 +28,23 @@ def _a_dead_pid() -> int:
     return p.pid
 
 
+def _claimed_by_a_departed_launcher(workspace: str) -> str:
+    """A chat claimed exactly as a launcher claims one, by a launcher that has exited.
+
+    `state.new_chat_id` — the production allocator, marker and all — with the one fact
+    these tests are about stated rather than inherited: **which process made the claim.**
+    Since #685 the claim carries its launcher's pid, so a chat this test process claims
+    for itself is one this test process keeps alive; that is the fix, and it is exactly
+    what makes an unstated pid the wrong fixture for "the launcher is gone".
+
+    `_a_dead_pid`'s own argument, one layer along: a real pid that has exited, never a
+    large made-up number that could name somebody else's live process and quietly change
+    what a test proves.
+    """
+    with mock.patch.object(os, "getpid", _a_dead_pid):
+        return state.new_chat_id(workspace)
+
+
 class FrameId(unittest.TestCase):
     def test_the_id_carries_the_workspace_and_the_pid(self):
         fid = state.frame_id("harness-wrapper", 4242)
@@ -226,17 +243,23 @@ class TheDotIsTheVersionDiscriminator(PersonaIso, unittest.TestCase):
         self.assertEqual(state.reap(set(), server="charter"), [old])
 
     def test_a_chat_is_kept_by_the_liveness_list_alone(self):
-        """The whole of a chat's bounding rule: no pid abstains in its favour, so the set
-        `reap` is handed decides. `commands_frame._live_chats` is what fills it."""
-        chat = state.new_chat_id("api")
+        """The whole of a chat's bounding rule once its launcher is gone: nothing in the
+        NAME abstains in its favour, so the set `reap` is handed decides. `_live_chats`
+        is what fills it."""
+        chat = _claimed_by_a_departed_launcher("api")
         state.bump(chat)
         self.assertEqual(state.reap({chat}, server="charter"), [])
         self.assertTrue(state.frame_dir(chat).exists())
 
     def test_a_chat_whose_window_is_gone_is_removed_with_no_launcher_process_alive(self):
         """The other half, and the one the dash would have broken: nothing in the name
-        can keep this directory, so an absent chat id really does reap."""
-        chat = state.new_chat_id("api")
+        can keep this directory, so an absent chat id really does reap.
+
+        The launcher is a departed one (#685) rather than this test process, and that is
+        the difference between measuring the dot and measuring the claim: a chat whose
+        launcher is still running is kept on purpose now, so a fixture that left the pid
+        unstated would pass this file's own fix off as a regression."""
+        chat = _claimed_by_a_departed_launcher("api")
         state.bump(chat)
         self.assertEqual(state.reap(set(), server="charter"), [chat])
         self.assertFalse(state.frame_dir(chat).exists())
@@ -276,6 +299,138 @@ class TheDotIsTheVersionDiscriminator(PersonaIso, unittest.TestCase):
         chat = state.new_chat_id("api")
         state.record_harness_pane(chat, "%4")
         self.assertFalse(state.is_live(chat, pane="%4"))
+
+
+class AClaimSurvivesASiblingsReap(PersonaIso, unittest.TestCase):
+    """#685: winning the `mkdir` is only half of "two allocators cannot both win".
+
+    The other half is that the winner's directory survives long enough to become a chat.
+    Between `new_chat_id` returning and `new-window` there are hundreds of milliseconds —
+    `_spawn_gather`, `_frame_env`, `record_identity`, the tmux.conf write — during which
+    the claim had a window in no list, no `server` marker, and (Stage 5a, on purpose) no
+    launcher pid in its name. Every one of `reap`'s rules said dead, and every launch runs
+    a reap immediately before its own claim, so the loser of the race deleted the winner's
+    directory and then claimed the same ordinal.
+    """
+
+    def test_a_sibling_launch_does_not_un_claim_an_ordinal_just_handed_out(self):
+        """The reported reproduction, kept in its reported order: claim, a sibling's
+        reap, claim again."""
+        first = state.new_chat_id("api")
+        self.assertEqual(state.reap(set(), server="charter"), [],
+                         "a sibling's reap deleted a directory this process had just "
+                         "claimed and was still launching into")
+        second = state.new_chat_id("api")
+        self.assertNotEqual(first, second,
+                            "two live chats were handed one state directory")
+
+    def test_the_two_chats_keep_two_pane_records_rather_than_one(self):
+        """What the collision COST, rather than that it happened. One directory means one
+        `panes` map, one `exit` file and one harness pane — so a switch aims at whichever
+        launcher wrote last, and the roster shows one chat where two are running."""
+        first = state.new_chat_id("api")
+        state.reap(set(), server="charter")
+        second = state.new_chat_id("api")
+        state.record_harness_pane(first, "%11")
+        state.record_harness_pane(second, "%22")
+        self.assertEqual(state.harness_pane(first), "%11")
+        self.assertEqual(state.harness_pane(second), "%22")
+
+    def test_a_chats_exit_code_survives_a_reap_that_beats_its_own_launcher(self):
+        """#383's protection, which Stage 5a's id shape had silently spent for chats.
+
+        `Reap.test_a_sibling_exit_code_survives_a_reap_that_beats_its_own_launcher` is the
+        same property for a `{workspace}-{pid}` frame, where the NAME carried the pid. A
+        chat's does not, so without the claim marker a chat whose harness had just exited
+        — absent from the live list, its launcher one line from `exit_code` — lost the
+        number it was about to read, and `cmd_launch` returned 0 for a harness that
+        failed.
+        """
+        chat = state.new_chat_id("api")
+        state.record_exit(chat, 42)
+        state.reap({"some-other-chat"}, server="charter")
+        self.assertEqual(state.exit_code(chat), 42,
+                         "reap deleted a live launcher's chat directory, and with it the "
+                         "exit code that launcher had not read yet")
+
+    def test_a_claim_with_nothing_in_it_yet_is_kept(self):
+        """The one window the marker itself cannot cover, and why the marker has to be the
+        FIRST byte written into a claimed directory rather than merely an early one.
+
+        Between `claim_private_dir`'s `mkdir` and `_record_claim`'s write there is a
+        directory `reap` can see and no pid it can read. An empty frame directory is
+        therefore a claim caught between two syscalls — never a frame, since every frame
+        that has run holds `server`, `workspace` and `version` at minimum.
+        """
+        d = state.frame_dir("api.7", create=True)
+        self.assertEqual(list(d.iterdir()), [], "the fixture is not the empty case")
+        self.assertEqual(state.reap(set(), server="charter"), [])
+        self.assertTrue(d.is_dir(), "a claim was deleted between its two syscalls")
+
+    def test_a_claim_a_launcher_no_longer_holds_is_reaped_like_any_other(self):
+        """The keep-rule is the launcher's liveness and not the marker's presence, which
+        is what stops #685's fix from making `.charter/frame/` unbounded — the failure the
+        dot in the id exists to prevent, arriving through the file instead."""
+        chat = _claimed_by_a_departed_launcher("api")
+        self.assertEqual(state.reap(set(), server="charter"), [chat])
+
+    @unittest.skipIf(os.name != "posix" or os.geteuid() == 0,
+                     "root reads a mode-000 directory anyway, so there is no unlistable "
+                     "directory here to measure against")
+    def test_a_directory_that_cannot_be_listed_is_kept_rather_than_raised_over(self):
+        """`reap` runs on the launch path and may not raise there, and asking whether a
+        directory is empty is the one question in it that opens a directory rather than a
+        file. Every other reading here already answers `None` for a path it cannot read;
+        this one had to be given the same posture explicitly.
+
+        Kept rather than removed, on the side every unreadable answer in this module falls
+        on: `rmtree` would not have emptied it either, so deleting on no evidence would be
+        a report of work that did not happen."""
+        chat = _claimed_by_a_departed_launcher("api")
+        d = state.frame_dir(chat)
+        state.bump(chat)
+        d.chmod(0o000)
+        self.addCleanup(d.chmod, 0o700)
+        self.assertEqual(state.reap(set(), server="charter"), [])   # must not raise
+        self.assertTrue(d.is_dir())
+
+    def test_a_launcher_that_has_finished_gives_the_claim_up(self):
+        """`state.clear_claim` — the half that keeps this fix from making
+        `.charter/frame/` unbounded. The marker is held for the LAUNCH, not for the life
+        of the process, and a launcher that has read its harness's exit code is done with
+        it: without this its own closing reap would be refused by a pid that is,
+        necessarily, still alive."""
+        chat = state.new_chat_id("api")
+        state.bump(chat)
+        self.assertEqual(state.reap(set(), server="charter"), [],
+                         "the claim did not keep the directory, so this test cannot say "
+                         "anything about giving it up")
+        state.clear_claim(chat)
+        self.assertEqual(state.reap(set(), server="charter"), [chat])
+
+    def test_giving_up_a_claim_that_was_never_made_is_a_no_op(self):
+        """Never raises and never creates, like `clear_exit` beside it: this runs on the
+        launch path, where a directory an older charter left — or one whose marker could
+        not be written — must degrade rather than take the launch down."""
+        state.bump("f-1")
+        state.clear_claim("f-1")            # no marker to remove
+        state.clear_claim("nothing.9")      # no directory at all
+        self.assertFalse(state.frame_dir("nothing.9").exists(),
+                         "giving up a claim created the directory it was asked about")
+        with mock.patch("charter.frame.state.Path.unlink",
+                        side_effect=OSError("read-only")):
+            state.clear_claim("f-1")        # must not raise
+
+    def test_a_marker_that_is_not_a_pid_keeps_nothing(self):
+        """A truncated write, a hand-edited file, a `0` — `kill(2)`'s "every process in my
+        group" rather than a process. Each is no claim about any process at all, and the
+        safe direction is the one the module already takes for an unreadable record: the
+        chat reaps exactly as it did before there was a marker."""
+        for junk in ("0", "-1", "notapid", "", "12 34"):
+            with self.subTest(junk=junk):
+                chat = state.new_chat_id("api")
+                (state.frame_dir(chat) / state._CLAIM_FILE).write_text(junk)
+                self.assertEqual(state.reap(set(), server="charter"), [chat])
 
 
 class TheIdIsANameAndNotAPointer(PersonaIso, unittest.TestCase):
@@ -428,6 +583,17 @@ class WriteFailureIsNotFatal(PersonaIso, unittest.TestCase):
         with mock.patch("charter.frame.state.os.replace", side_effect=OSError("disk full")):
             state.bump("f-1")  # the write fails silently (Finding 1)
         self.assertEqual(state.version("f-1"), before)
+
+    def test_a_claim_whose_marker_cannot_be_written_is_still_a_claim(self):
+        """#685's marker is written on the launch path, so it takes the same posture as
+        every other writer here: a filesystem that will not take the file costs the claim
+        its keep-rule, never the launch. The ordinal still comes back and the directory is
+        still this launcher's."""
+        with mock.patch("charter.frame.state.config.write_for",
+                        side_effect=OSError("disk full")):
+            chat = state.new_chat_id("api")   # must not raise
+        self.assertEqual(chat, "api.1")
+        self.assertTrue(state.frame_dir(chat).is_dir())
 
 
 class ExitCode(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -394,6 +394,29 @@ class AClaimSurvivesASiblingsReap(PersonaIso, unittest.TestCase):
         self.assertEqual(state.reap(set(), server="charter"), [])   # must not raise
         self.assertTrue(d.is_dir())
 
+    def test_the_claim_is_a_plain_file_inside_the_directory_it_claimed(self):
+        """Both halves of where the marker goes, because both are load-bearing.
+
+        INSIDE the claimed directory, so `reap` removing that directory removes the marker
+        with it and there is nothing outside the frame root to keep in step — the property
+        that makes this "no new file to keep in sync" rather than one more thing to reap.
+
+        And the FIRST thing in it, which is what makes the empty-directory rule and the
+        pid rule meet with no gap between them: a frame directory holding anything at all
+        is one whose claimer has already said who it is.
+
+        Named plainly beside `server` and `workspace` rather than as a dotfile:
+        everything under a frame's directory is charter's own bookkeeping and none of it
+        hides from `ls`.
+        """
+        chat = state.new_chat_id("api")
+        d = state.frame_dir(chat)
+        self.assertEqual([p.name for p in d.iterdir()], ["launcher"],
+                         "the claim is not the only thing in a just-claimed directory, "
+                         "so `reap`'s empty-directory rule and its pid rule no longer "
+                         "meet")
+        self.assertEqual((d / "launcher").read_text().strip(), str(os.getpid()))
+
     def test_a_launcher_that_has_finished_gives_the_claim_up(self):
         """`state.clear_claim` — the half that keeps this fix from making
         `.charter/frame/` unbounded. The marker is held for the LAUNCH, not for the life
@@ -415,6 +438,10 @@ class AClaimSurvivesASiblingsReap(PersonaIso, unittest.TestCase):
         state.bump("f-1")
         state.clear_claim("f-1")            # no marker to remove
         state.clear_claim("nothing.9")      # no directory at all
+        # And a name `contain.child` refuses to shape into one — `$CHARTER_SESSION_ID` is
+        # a value from the environment, so "there is no directory" and "there could not
+        # be one" are two different answers and both have to be no-ops here.
+        state.clear_claim("../../etc")
         self.assertFalse(state.frame_dir("nothing.9").exists(),
                          "giving up a claim created the directory it was asked about")
         with mock.patch("charter.frame.state.Path.unlink",


### PR DESCRIPTION
Closes #685. Reproduced first, then fixed:

```
launcher 1 claimed: api.1
launcher 2's reap removed: ['api.1']
launcher 2 claimed: api.1
harness_pane(first) -> %22
AssertionError: 'api.1' == 'api.1' : two live chats were handed one state directory
```

## What was wrong

`state.new_chat_id` claims a chat's ordinal with a `mkdir`, so two allocators racing one
workspace cannot both be told they won. What was missing is the other half: **the
winner's directory has to survive long enough to become a chat.**

Between the claim and the `new-window` that gives the chat its window there are hundreds
of milliseconds — `_spawn_gather`, `_frame_env`, `record_identity`, the tmux.conf write —
and through all of them the claim passed every one of `state.reap`'s keep-rules:

| keep rule | why it missed |
|---|---|
| the chat is in the live list | its window, and its `@charter_chat`, does not exist yet |
| the directory names another server | `record_server` runs *after* the claim |
| the launcher in the id is alive | a chat id is `{workspace}.{n}` and carries no pid, by design |

And every launch runs a reap immediately before its own claim. So the second
`charter claude` in a workspace deleted the first one's directory on the way in and then
claimed the same ordinal: one `exit` file, one `panes` map, one harness-pane record
between two running agents.

The old `{workspace}-{pid}` shape closed this for free — the pid was in the name, so the
`mkdir` that made the directory also made it un-reapable. Stage 5a spent that guard
deliberately (`api.1` would read as pid 1, `launchd`, which never exits) and nothing
replaced it.

## The fix

`new_chat_id` writes its own pid as the **first byte** into the directory it claimed, and
`reap` keeps a directory whose claiming launcher is still running.

First byte, not merely early: `reap` reads that file to decide, so between the `mkdir` and
the write there would be a directory it can see and no pid it can read. The two rules meet
with no gap — a frame directory holding *nothing at all* is kept too, because that is a
claim caught between its two syscalls and never a frame (every frame that has run holds
`server`, `workspace` and `version` at minimum).

`state.clear_claim` is the other half: the marker is held for the **launch**, not for the
life of the process, so a launcher that has read its harness's exit code gives it up
before its own closing reap — the one reap that can remove this frame's own directory, and
which a pid that is necessarily still alive would otherwise refuse. A launcher killed
outright never gets there and needs no cleanup: its pid dies with it.

## It also gives chats back #383

`reap` runs at every launch on the list tmux reported live at that instant. Between a
harness exiting and its launcher reading the exit code, the window is already gone from
that list while `cmd_launch` is one line from the answer. The pid rule covered that window
for `{workspace}-{pid}` frames — it is why the rule exists. Chats had no cover, so a
sibling launch landing in it deleted the `exit` file before it was read, `exit_code`
answered `None`, and a harness that had genuinely failed was reported as a success.

## Verification

- Full suite green on 3.14: **8853 tests, OK**.
- Hand deletion sweep, applied and restored with sha256 checked on every restore. Every
  new guard goes RED when deleted:

| deleted line | reddens |
|---|---|
| the `_record_claim` call | `test_a_chats_exit_code_survives_a_reap_that_beats_its_own_launcher`, `test_a_claim_a_launcher_no_longer_holds_is_reaped_like_any_other` |
| the empty-claim keep rule | `test_a_claim_with_nothing_in_it_yet_is_kept` |
| the claim-pid read | `test_a_sibling_launch_does_not_un_claim_an_ordinal_just_handed_out` + 2 |
| the name-pid fallback | `test_an_old_frame_id_still_parses_and_still_reports_liveness_by_pid` |
| `_claiming_pid`'s `isdigit` guard | `test_a_marker_that_is_not_a_pid_keeps_nothing` |
| `_claiming_pid`'s `> 0` guard | same, `junk='0'` |
| `_record_claim`'s never-raise | `test_a_claim_whose_marker_cannot_be_written_is_still_a_claim` |
| `reap`'s unlistable-dir catch | `test_a_directory_that_cannot_be_listed_is_kept_rather_than_raised_over` |
| `clear_claim` on either launch path | `test_a_finished_chat_leaves_no_directory_behind`, `..._on_this_path` |

The `> 0` guard was a survivor on the first pass — masked by an `or` whose falsiness was
doing the work — which is why the two keep-rules are now asked as `is None` rather than
chained. That is the "a guard that passes because a different guard caught it" shape, and
it is fixed rather than suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy