### PR TITLE
The pad-bound guard reads the bound instead of the backticks, the chat-bar snippet stops turning the frame off, and a bar takes the height it is given (#689) (#690) (#687)

### DIFF
--- a/charter/instance.py
+++ b/charter/instance.py
@@ -1523,22 +1523,41 @@ def _built_in_size(c, value):
 
     **A committed value is accepted exactly where something reads it, and refused
     everywhere else — which is the rule :func:`component_tables` already keeps for
-    ``edge``, not a new one.** `layout._derive` turns each component's declared size into
-    :data:`layout.SLOT_SIZE` once, at import, and `layout._size_of` answers `top`,
-    `bottom` and `right` out of that table on every launch. There is no per-plane
-    override between `charter.toml` and `split-window` for those three, so a ``size`` that
-    disagreed with the declaration would be a value read, validated, stored and then
-    ignored — the convincing empty the whole form is written against. It may therefore
-    only ECHO, which is what it could do before.
+    ``edge``, not a new one.** The question is therefore *is this number read at launch*,
+    and it is asked of :data:`frame.builtins.SLOT_OF` — the table that decides it —
+    rather than of the component's declared policy CLASS.
 
-    ``repos`` is the exception because it is the one placed built-in charter declares
-    ``Content()``, and a `Content` height is not in that table at all: `layout.slot_sizes`
-    routes it to `layout.repos_rows`, which is recomputed from the RESOLVED config on
-    every launch and on every `window-resized` (`commands_frame._reassert_sizes`). So
-    there is somewhere for a number to be read, and pinning it is what makes the strip a
-    fixed height instead of one that collapses to two rows on a two-repo plane.
+    ``SLOT_OF`` is the whole of it because `layout._PLACED` is literally
+    ``[c for c in every built-in if c.id in SLOT_OF]`` and `layout._derive` keys
+    :data:`layout.SLOT_SIZE` off it, so *in ``SLOT_OF``* and *in ``SLOT_SIZE``* are the
+    same set said twice. `tests/…_pinned_repo_strip…` asserts that equivalence for every
+    registered component, because this function reads the cheap one and the launch path
+    reads the other.
 
-    The pin is `Fixed`, and `component.Fixed` is asked rather than re-checked: it refuses
+    * **In ``SLOT_OF`` — `identity`, `attention`, `sidebar`.** `layout._size_of` answers
+      `top`, `bottom` and `right` out of `SLOT_SIZE`, derived once at import, and there is
+      no per-plane override between `charter.toml` and `split-window` for them. A ``size``
+      disagreeing with the declaration would be a value read, validated, stored and then
+      ignored — the convincing empty the whole form is written against. It may only ECHO.
+    * **In ``SLOT_OF`` and ``Content()`` — `repos`.** A `Content` height is not in
+      `SLOT_SIZE` as anything but a floor: `layout.slot_sizes` routes it to
+      `layout.repos_rows`, recomputed from the RESOLVED config on every launch and every
+      `window-resized` (`commands_frame._reassert_sizes`). There is somewhere for a number
+      to be read, and pinning it (#660) is what makes the strip a fixed height instead of
+      one that collapses to two rows on a two-repo plane.
+    * **Not in ``SLOT_OF`` — `chats`, `workspaces` (#687).** These are `Fixed(1)` and are
+      placeable only from a ``[[frame.component]]`` table, so they were never *placed* and
+      never entered `SLOT_SIZE`. `layout._size_of` misses the table and falls through to
+      `layout._placed_here` → `layout._policy_cells`, which reads the committed policy off
+      this resolved arrangement on every launch and hands it to ``split-window -l``.
+      **Their number is read.** They took the echo branch anyway until #687, on a reason —
+      "it could only be ignored" — that was measurably false for them: ``size = 2`` on a
+      chat bar reached `_built_in_size`, came back ``None``, and took the operator's ENTIRE
+      arrangement out of play (#535) in silence (see :data:`_HOTKEY_RE`'s note). Charter's
+      own bar on `top` may now pick a height exactly as a provider's component on `top`
+      already could.
+
+    The value is `Fixed`, and `component.Fixed` is asked rather than re-checked: it refuses
     a `bool`, a non-int and anything below one cell in `component.cells`, which is the one
     place that rule is written. Asked inside a ``try`` because this runs while a committed
     file is being resolved — on the path of `charter --version` as much as `charter frame`
@@ -1549,17 +1568,31 @@ def _built_in_size(c, value):
     ``not isinstance(value, bool)`` stays on the echo branch and is not redundant beside
     it: ``True == 1`` in Python, so without it a ``size = true`` on `identity` or
     `attention` — both `Fixed(1)` — would compare equal and be accepted as the number
-    nobody wrote. Four separate shapes of that trap have been caught in this suite.
+    nobody wrote. Four separate shapes of that trap have been caught in this suite. It is
+    not needed on the two branches that build a `Fixed`, because `Fixed` refuses a `bool`
+    itself.
+
+    A policy that is neither `Content` nor `Fixed` — `Fill()`, which `personas` declares —
+    has no number to echo and no height to pin, and is refused rather than asked for a
+    ``.n`` it does not have.
     """
+    from .frame import builtins as _builtins
     from .frame.component import ComponentError, Content, Fixed
     if isinstance(c.size, Content):
         try:
             return Fixed(value)
         except ComponentError:
             return None
-    if isinstance(c.size, Fixed) and value == c.size.n and not isinstance(value, bool):
-        return c.size
-    return None
+    if not isinstance(c.size, Fixed):
+        return None
+    if c.id in _builtins.SLOT_OF:
+        if value == c.size.n and not isinstance(value, bool):
+            return c.size
+        return None
+    try:
+        return Fixed(value)
+    except ComponentError:
+        return None
 
 
 def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None:
@@ -1788,12 +1821,15 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
             if "edge" in table and table["edge"] != c.edge:
                 return None
             # The one key on a built-in that a plane may do more with than echo, and
-            # :func:`_built_in_size` is where that asymmetry is argued: `top`, `bottom`
-            # and `right` are read out of a table `layout` derives at IMPORT, so a
-            # different number there could only be ignored; `repos` is `Content()` and its
-            # height is recomputed from this resolved arrangement on every launch and
-            # every resize, so a number there is read. `None` is refused the way every
-            # other unusable value in this loop is — whole arrangement, #535.
+            # :func:`_built_in_size` is where that asymmetry is argued: `identity`,
+            # `attention` and `sidebar` are read out of a table `layout` derives at
+            # IMPORT, so a different number there could only be ignored; `repos` is
+            # `Content()` and its height is recomputed from this resolved arrangement on
+            # every launch and every resize; `chats` and `workspaces` are in no derived
+            # table at all, so `layout._placed_here` reads their number off this
+            # arrangement too (#687). A number is honoured where it is READ. `None` is
+            # refused the way every other unusable value in this loop is — whole
+            # arrangement, #535.
             #
             # `None` rather than `c.size` for a table that names no size, and that is this
             # function's own #547 rule kept: `_built_in_placement` already declares what a

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -279,15 +279,35 @@ still it says only where you are (`2/3`). It never shows half a name.
 unfinished: on the ordinary plane there is one chat, and a row saying so permanently costs
 a row off your harness, a 24 MB panel process, and about seven of every switch's 41 tmux
 commands — to draw a name `F2` already reaches in two keystrokes. Turn one on with a
-`[[frame.component]]` table, which is also how it gets a key of its own:
+`[[frame.component]]` table, which is also how it gets a key of its own.
+
+**`[[frame.component]]` replaces your whole arrangement rather than adding to it**, so the
+bar goes in a list of every panel you want — charter's four and then the bar. A file that
+names only the bar gets a frame that is only the bar:
 
 ```toml
 [[frame.component]]
-use = "chats"
+use = "identity"
+
+[[frame.component]]
+use = "attention"
+
+[[frame.component]]
+use = "repos"
+
+[[frame.component]]
+use = "sidebar"
+
+[[frame.component]]
+use  = "chats"
 edge = "top"
 size = 1
-key = "F9"
+key  = "F9"
 ```
+
+Those first four are the shipped frame written out longhand, and
+[Writing the arrangement out](#writing-the-arrangement-out) says what each of them is. File
+order is split order, so the bar named last is split off last.
 
 Both are the first things a short terminal gives up — before the identity row, because the
 palette reaches everything they show and nothing is lost but the reminder.
@@ -936,12 +956,25 @@ id**, which is the vocabulary the frame reasons in, and not a `slots` name. The 
 Mixing the vocabularies is refused rather than half-understood, so a file says which of the
 two it is written in.
 
+**An arrangement is the whole list, every time.** These tables do not add to the shipped
+frame, they replace it — so every example below writes all four out, and so must your file.
+Naming one panel gets you a frame with one panel in it.
+
 A component can be kept in the arrangement and not drawn:
 
 ```toml
 [[frame.component]]
-use = "repos"
+use = "identity"
+
+[[frame.component]]
+use = "attention"
+
+[[frame.component]]
+use     = "repos"
 visible = false
+
+[[frame.component]]
+use = "sidebar"
 ```
 
 That is the one thing `slots` cannot express. Deleting a name from `slots` loses its
@@ -1019,14 +1052,25 @@ round-trip.
 
 `size` is the same for three of the four: `size = 1` on identity, `size = 1` on the
 attention strip, `size = 22` on the sidebar, and any other number takes the arrangement
-out of play for the reason above.
+out of play for the reason above. **That reason is about those three and not about
+built-ins in general** — the two bars are a built-in charter derives nothing for, and they
+take a real height like any component a package supplies (see below).
 
-**`size` on the repo table is the one exception, and it pins the strip's height.**
+**`size` on the repo table pins the strip's height.**
 
 ```toml
 [[frame.component]]
+use = "identity"
+
+[[frame.component]]
+use = "attention"
+
+[[frame.component]]
 use  = "repos"
 size = 15
+
+[[frame.component]]
+use = "sidebar"
 ```
 
 The table is the one panel charter sizes to its content — one row per repo, so a plane
@@ -1042,13 +1086,22 @@ It is a number of cells: a whole number, at least 1. Anything else — `0`, a ne
 `true`, a string, a float — takes the arrangement out of play like every other value
 charter cannot honour.
 
+**The chat and workspace bars take a real height too, by the same rule.** Charter places
+neither of them by default, so neither has a slot whose geometry is derived at import;
+their height is read off your arrangement at every launch, exactly like the repo table's
+pin. So `size = 3` on `chats` gives you a three-row bar. They draw one row of names — the
+rest is empty surface, which is a thing you may want under a `bg` and is otherwise a waste
+of rows. The same whole-number rule applies: anything charter cannot turn into cells takes
+the arrangement out of play.
+
 **Your pin is still capped so your session keeps its 12 rows.** tmux does not refuse an
 over-large pane height, it grants it out of the neighbour, and the neighbour is your agent
 session — `size = 40` in a 20-row window would leave it one row tall. So a pin is what the
 strip *wants*, and what the window can spare is decided afterwards, exactly as it already
 is for a fourteen-repo plane on a short terminal. On a terminal with room, you get your
 number; on one without, you get what is left, and the strip is dropped entirely below the
-95 columns its table needs.
+width its table needs — the one
+[When the terminal is too small](#when-the-terminal-is-too-small) names.
 
 `bg` and `pad` are the two keys that have no `slots` equivalent at all: they say how a pane
 *looks*, not where it sits, so they only exist in the long form.
@@ -1067,7 +1120,7 @@ With that installed, your arrangement can place it:
 
 ```toml
 [[frame.component]]
-use  = "identity"
+use = "identity"
 
 [[frame.component]]
 use  = "acme.metrics"
@@ -1075,11 +1128,19 @@ edge = "right"
 size = 12
 
 [[frame.component]]
-use  = "attention"
+use = "attention"
+
+[[frame.component]]
+use = "repos"
+
+[[frame.component]]
+use = "sidebar"
 ```
 
 File order is split order here as everywhere else, so `acme.metrics` is split off before
-the attention strip and the strip is inset beside it.
+the attention strip and the strip is inset beside it. Charter's own four are written out
+again because this list is the whole arrangement — leaving one out is how you turn it off,
+not how you leave it alone.
 
 **`edge` and `size` are required here, and they win.** Required, because the only way to
 ask a package where it would like to sit is to import it — and your config is resolved by

--- a/docs/news/unreleased-a-guard-that-reads-prose-says-what-it-cannot-read.md
+++ b/docs/news/unreleased-a-guard-that-reads-prose-says-what-it-cannot-read.md
@@ -1,0 +1,113 @@
+---
+version: unreleased
+headline: The guard on the documented `pad` bound stops matching backticks and starts matching the bound — plus the chat-bar snippet that turned every other panel off
+---
+
+Three findings from an adversarial review of last week's frame work. They share a shape:
+each one is a rule that was written down correctly and then enforced, or documented,
+against something that is not the rule.
+
+**A guard for "a check matched a spelling instead of a property" matched a spelling
+instead of a property.**
+
+[#669](https://github.com/diazoxide/charter/issues/669) was two copies of the `pad` bound
+disagreeing in `docs/frame.md`, and the harmful copy was the sentence about *refusal* — an
+arrangement charter cannot draw is refused whole, so a `pad` the documentation invited
+costs the operator their entire `[[frame.component]]` block. The fix added a checker that
+read every range the file stated and held each to `FRAME_PANE_PAD_MAX`. Measured against
+it, appending one line at a time:
+
+```
+"a pad outside 0 to 12 is refused"        -> OK        <- wrong bound, suite green
+"pad is capped at 12"                     -> OK        <- wrong bound, suite green
+"a `pad` outside `0`-`12` is refused"     -> FAILED    <- only this spelling was caught
+```
+
+Both readers required the digits to be **backticked**, and the second additionally
+required the number and the literal `` `pad` `` to be in the same sentence. Neither is a
+property of the bound; both are properties of the markup. #669's own harmful sentence,
+written without backticks, went straight through.
+
+Two things changed. The reader is scoped by **the word `pad`** — `pad`, `pads`, `padded`,
+`padding`, and not `trackpad` — over the paragraph that names it and one sentence either
+side of it, so a bound stated a paragraph away is in reach. And a number is a *count of
+cells* unless it is part of a version: `3.2` and `3.7c` are excluded because a dot has a
+digit on the far side of it, not because a number is followed by a dot. That second
+lookahead was its own defect — `(?![.\d])` skips every integer that ends an English
+sentence, so `The maximum` `` `pad` `` `is 12.` was invisible to the old reader too.
+
+**The attack is now the test.** Nineteen restatements of the bound, with the number left
+as a hole, live beside the reader as data. Each is run with a number charter refuses,
+where it must be red, and again with `FRAME_PANE_PAD_MAX` in the hole, where it must be
+green — a reader that fails everything catches nothing, and templating the corpus means it
+survives the constant moving.
+
+**And the limits are written down and run.** No reader of English prose is complete, so
+the shapes this one cannot catch — a bound spelled in words, a bound in a paragraph that
+never names the key — are a second list, executed by a test that goes red if one of them
+starts being caught. The signal means *someone widened the reader*, and the answer is to
+move the line into the corpus, never to narrow the reader back. A guard that overstates
+its reach is the thing this project refuses.
+
+**The snippet for turning the chat bar on built a frame with only the chat bar.**
+
+[#690](https://github.com/diazoxide/charter/issues/690). `[[frame.component]]` supersedes
+`slots` and replaces the arrangement whole, so the four-line example under *"Turn one on
+with a `[[frame.component]]` table"* resolved to exactly this:
+
+```
+slots      : ['chats']
+components : ['chats']
+```
+
+No identity row, no attention strip, no repo table, no sidebar. The caveat existed, seven
+hundred lines further down in the toggle-keys section, which is not where the reader is
+being told to write the table. Four snippets in the file had that shape; all four now list
+the whole arrangement, because a sentence of warning above a fence is not read by someone
+who stops at the fence. Every `[[frame.component]]` example in `docs/frame.md` is now
+resolved through `instance.frame_of` by the suite and has to come back as the frame it
+prints.
+
+**`size = 2` on the chat bar took the whole arrangement out of play, on a reason that was
+false for the chat bar.**
+
+[#687](https://github.com/diazoxide/charter/issues/687). The boundary's rule is *a
+committed value is accepted exactly where something reads it* — and it was implemented by
+asking which size **policy class** the component declared, which is a different question.
+`chats` and `workspaces` declare `Fixed(1)`, so they took the echo-only branch, on the
+stated grounds that their geometry is derived at import and a different number could only
+be ignored.
+
+That is true of `identity`, `attention` and `sidebar`. It is not true of the two bars.
+Charter places neither by default, so neither is in `layout._PLACED`, neither enters
+`SLOT_SIZE`, and `layout._size_of` answers them out of `_placed_here` → `_policy_cells` —
+a live read of the committed number on every launch, which reaches tmux as `split-window
+-l`. Measured: a `size` on a bar is read; the boundary refused it anyway, and refusing it
+dropped **every** `[[frame.component]]` table the plane had, in silence.
+
+So the reason was right and the implementation was asking the wrong question. The
+condition is membership of `builtins.SLOT_OF` now — the table that decides whether
+`layout` derives a component's geometry — and a test holds `SLOT_OF` and `SLOT_SIZE` to
+being the same set for every registered component, because `instance` reads the cheap one
+on purpose and must not reach `frame/layout.py` at module scope.
+
+```toml
+[[frame.component]]
+use  = "chats"
+edge = "top"
+size = 3        # a three-row bar, drawn where a one-row bar was refused
+```
+
+Nothing else widens: `0`, a negative, `true`, `"3"` and `3.0` are refused by
+`component.Fixed` as before, and `identity`, `attention` and `sidebar` still take their own
+number and nothing else.
+
+**Still open, and named rather than fixed here:** a refused `[frame]` value is reported
+nowhere — a dropped `slots` entry and a rejected `history-limit` are exactly as quiet — so
+the fix is one surface for the whole section rather than a special case for `size`. #687
+files that half separately.
+
+[#689](https://github.com/diazoxide/charter/issues/689),
+[#690](https://github.com/diazoxide/charter/issues/690) and
+[#687](https://github.com/diazoxide/charter/issues/687), all three found by an adversarial
+review of work merged in the previous 24 hours.

--- a/tests/test_a_pinned_repo_strip_keeps_its_height.py
+++ b/tests/test_a_pinned_repo_strip_keeps_its_height.py
@@ -12,9 +12,13 @@ echo a number charter had already declared, and since `repos` declares no number
 Four claims are pinned here, and they are separable on purpose:
 
 * **the config boundary** decides which built-ins may carry a `size` that means
-  something, and `repos` is the only one — every other placed built-in is `Fixed` in its
-  own declaration, `layout` derives that into `SLOT_SIZE` at import, and a per-plane
-  number there could only be ignored;
+  something, and the question it asks is *is this number READ at launch* — every built-in
+  charter PLACES by default is `Fixed` in its own declaration, `layout` derives that into
+  `SLOT_SIZE` at import, and a per-plane number there could only be ignored. #687 corrects
+  the earlier form of that sentence, which said "every other placed built-in is `Fixed`"
+  and was read as being about every built-in: `chats` and `workspaces` are placeable and
+  are not PLACED, so nothing derives their geometry and `layout._placed_here` reads their
+  committed number on every launch;
 * **the arithmetic** replaces the CONTENT term and leaves the floor and the cap alone, so
   the harness keeps `layout.HARNESS_MIN_ROWS` however large a number was committed —
   measured on tmux 3.7c, an over-large `-y` is not refused, it is granted out of the
@@ -85,12 +89,25 @@ class TheConfigBoundaryDecidesWhichBuiltInsMayCarryASize(unittest.TestCase):
     """A committed number is honoured exactly where something reads it.
 
     Not "on the components charter feels like allowing it on": the rule is mechanical and
-    is the same one `edge` already keeps. `layout._derive` turns each component's declared
-    size into `SLOT_SIZE` once, at import, and `_size_of` answers `top`, `bottom` and
-    `right` out of that table forever after — so a number on those three has nowhere to be
-    read. `repos` is `Content()`, which never enters that table: `slot_sizes` routes it to
-    `repos_rows`, which is handed the resolved arrangement's number at every launch and
-    again on every `window-resized` (`commands_frame._slot_sizes`).
+    is the same one `edge` already keeps. `layout._derive` turns each PLACED component's
+    declared size into `SLOT_SIZE` once, at import, and `_size_of` answers `top`, `bottom`
+    and `right` out of that table forever after — so a number on those three has nowhere to
+    be read. `repos` is `Content()`, which never enters that table as more than a floor:
+    `slot_sizes` routes it to `repos_rows`, which is handed the resolved arrangement's
+    number at every launch and again on every `window-resized`
+    (`commands_frame._slot_sizes`).
+
+    **#687: `is it read` and `what policy did it declare` are two questions, and the
+    boundary was asking the second.** `chats` and `workspaces` declare `Fixed(1)` and took
+    the echo branch on the reasoning quoted above — which is measurably false for them:
+    charter places neither by default, so neither is in `layout._PLACED`, neither enters
+    `SLOT_SIZE`, and `_size_of` answers them out of `_placed_here` → `_policy_cells`, a
+    live read of the committed number on every launch. `size = 2` on a chat bar was
+    refused on the grounds that it could only be ignored, and refusing it took the
+    operator's ENTIRE arrangement out of play (#535) in silence. The condition is
+    membership of `builtins.SLOT_OF` now, and
+    `test_the_table_the_boundary_asks_is_the_table_the_launch_path_reads` is the assertion
+    that the cheap question and the expensive one have the same answer.
     """
 
     def test_the_repo_table_resolves_a_committed_size_to_a_fixed_policy(self):
@@ -140,6 +157,83 @@ class TheConfigBoundaryDecidesWhichBuiltInsMayCarryASize(unittest.TestCase):
                                  [component.Fixed(echo)])
                 self.assertIsNone(instance.component_tables(
                     {"component": [{"use": use, "size": other}]}))
+
+    def test_the_table_the_boundary_asks_is_the_table_the_launch_path_reads(self):
+        """#687's load-bearing link, asserted rather than assumed.
+
+        `_built_in_size` decides on ``c.id in builtins.SLOT_OF``, and the property it is
+        deciding about is *is this component's slot in `layout.SLOT_SIZE`* — the table
+        that makes a committed number unreadable. They are the same set because
+        `layout._PLACED` is filtered by `SLOT_OF` and `_derive` keys the table off it,
+        and that is exactly the kind of two-step nobody re-checks.
+
+        `instance` reads the cheap one deliberately: it is imported by every command and
+        must not reach `frame/layout.py` at module scope (`FRAME_PANE_PAD_MAX`'s note
+        makes the same trade). This is the test that keeps the trade honest — split the
+        two and it goes red here rather than in an operator's frame.
+        """
+        for c in builtins.build().all():
+            with self.subTest(component=c.id):
+                self.assertEqual(
+                    c.id in builtins.SLOT_OF,
+                    builtins.SLOT_OF.get(c.id, c.id) in layout.SLOT_SIZE,
+                    f"`{c.id}` is in one of SLOT_OF/SLOT_SIZE and not the other, so "
+                    "`instance._built_in_size` is now asking a different question from "
+                    "the one `layout._size_of` answers.")
+
+    def test_a_bar_charter_derives_no_geometry_for_takes_the_height_it_is_given(self):
+        """#687. The two bars are `Fixed(1)` and are placeable only from a
+        `[[frame.component]]` table, so charter places neither and `layout` derives
+        nothing for either — their height is read off the resolved arrangement at every
+        launch, exactly like the repo table's pin.
+
+        The echo is asserted beside the non-echo for the same reason it is above: a
+        boundary that accepted everything would pass a test that only tried `3`.
+        """
+        for use in ("chats", "workspaces"):
+            for n in (1, 2, 3, 12):
+                with self.subTest(use=use, n=n):
+                    kept = instance.component_tables(
+                        {"component": [{"use": use, "edge": "top", "size": n}]})
+                    self.assertIsNotNone(
+                        kept, f"`size = {n}` on `{use}` took the whole arrangement out of "
+                        "play (#535) — and #687 measured that the number IS read: "
+                        "`layout._placed_here` hands it to `split-window -l`.")
+                    self.assertEqual([p["size"] for p in kept], [component.Fixed(n)])
+
+    def test_a_bar_still_refuses_a_value_that_is_not_a_number_of_cells(self):
+        """Widening which built-ins may carry a number is not widening what a number is.
+
+        `Fixed` is asked rather than re-checked, so `0`, a negative, a `bool`, a string
+        and a float are refused by `component.cells` — the one place that rule is written.
+        `True` is in the list because ``True == 1`` and both bars declare `Fixed(1)`: the
+        branch that once compared it away is gone, and `Fixed` has to be the thing that
+        catches it now."""
+        for value in (0, -1, True, False, "3", 3.0, [3]):
+            with self.subTest(value=value):
+                self.assertIsNone(instance.component_tables(
+                    {"component": [{"use": "chats", "edge": "top", "size": value}]}))
+
+    def test_the_height_a_bar_carries_reaches_split_window(self):
+        """The refusal was argued from the launch path, so the launch path is where the
+        acceptance is checked — not at the boundary that resolved it.
+
+        This is the measurement #687 filed: `_size_of` misses `SLOT_SIZE`, falls through
+        to `_placed_here` → `_policy_cells`, and `slot_sizes` hands the number to tmux as
+        `-l`. A committed `3` that stopped at the placement would be the inert value the
+        whole form is written against."""
+        tables = [{"use": u} for u in ("identity", "attention", "repos", "sidebar")]
+        tables.append({"use": "chats", "edge": "top", "size": 3})
+        frame = instance.frame_of({"frame": {"component": tables}})
+        self.assertIn("chats", frame["slots"])
+        with mock.patch.dict(config.FRAME, frame):
+            self.assertEqual(layout._size_of("chats"), 3)
+            sizes = layout.slot_sizes(frame["slots"], window_rows=48, content_rows=4)
+            self.assertEqual(sizes["chats"], 3)
+            argvs = layout.panel_argvs(slots=frame["slots"], session="s", socket="k",
+                                       harness_pane="%1", sizes=sizes)
+            bar, = [a for a in argvs if "chats" in a]
+            self.assertEqual(bar[bar.index("-l") + 1], "3")
 
     def test_a_component_with_no_number_to_echo_is_refused_rather_than_raising(self):
         """The third size policy, asked of the one component that really has it.

--- a/tests/test_frame_pane_style.py
+++ b/tests/test_frame_pane_style.py
@@ -1135,15 +1135,151 @@ class TheDocumentedExampleIsRunThroughCharter(unittest.TestCase):
         self.assertIn("`bright` forms", md)
 
 
-#: Every bound `docs/frame.md` writes as a range, in the two spellings the file uses:
-#: `` `0` to `5` `` and the dash form `` `0`–`5` ``. Version numbers (tmux `3.2` to `3.6`)
-#: are dotted and are deliberately not matched — a range in this file is a range of cells,
-#: which is a thing charter enforces, and that is what may not drift.
-_STATED_RANGE = re.compile(r"`(\d+)`\s*(?:to|through|[-–—])\s*`(\d+)`")
+class EveryDocumentedArrangementIsAWholeArrangement(unittest.TestCase):
+    """#690. **`[[frame.component]]` REPLACES the arrangement, so a snippet that lists one
+    table is an instruction to turn everything else off.**
+
+    The reported one was the chat bar: *"Turn one on with a `[[frame.component]]` table"*
+    over a fence naming `chats` and nothing else. Pasted into a plane's `charter.toml`,
+    that resolves to a frame whose entire contents are the chat bar — no identity row, no
+    attention strip, no repo table, no sidebar — because a component list is the whole
+    arrangement (`instance.component_tables`) and not an addition to the shipped one. The
+    caveat existed, seven hundred lines further down in the toggle-keys section, which is
+    not where the reader is being told to write the table.
+
+    The property asked here is the operator's, not the prose's: **paste any fence in this
+    file and you still have charter's four panels.** A sentence of warning above the fence
+    would fix the report and could not be checked, because a reader who stops at the code
+    block never reads it; a fence that lists the whole arrangement cannot be misread and
+    is exactly what this asserts.
+
+    Related and asserted together: #687 — a `size` charter refuses on ANY table in the
+    list takes the whole arrangement out of play in silence, so a documented number is
+    checked here by resolving it, not by reading it.
+    """
+
+    MD = Path(__file__).resolve().parents[1] / "docs" / "frame.md"
+
+    #: Charter's own four, in the vocabulary `use` speaks. Written out rather than read
+    #: from `builtins.SLOT_OF` on purpose: this is what the DOCUMENTATION must show an
+    #: operator, and a fifth built-in becoming placeable by default is a documentation
+    #: change, not something this test should absorb silently.
+    SHIPPED = ("identity", "attention", "repos", "sidebar")
+
+    def _fences(self) -> list[tuple[int, str]]:
+        """Every ```toml fence in `docs/frame.md` that writes a component table, with the
+        line it starts on so a failure says where to look."""
+        md = self.MD.read_text()
+        return [(md[:m.start()].count("\n") + 1, m.group(1))
+                for m in re.finditer(r"```toml\n(.*?)```", md, re.S)
+                if "[[frame.component]]" in m.group(1)]
+
+    def test_the_documentation_carries_arrangements_to_check(self):
+        """The vacuity control: both loops below pass on a file with no examples in it,
+        and a snippet quietly deleted is exactly how this check would stop meaning
+        anything."""
+        self.assertGreaterEqual(len(self._fences()), 7,
+                                "docs/frame.md lost `[[frame.component]]` examples")
+
+    def test_every_documented_arrangement_lists_charters_own_four(self):
+        """#690 itself. Asked of every fence, because the reported one was not special —
+        it was the first of four partial lists in the file."""
+        for line, body in self._fences():
+            import tomllib
+            uses = [t.get("use")
+                    for t in tomllib.loads(body)["frame"]["component"]]
+            with self.subTest(line=line):
+                missing = [c for c in self.SHIPPED if c not in uses]
+                self.assertEqual(
+                    missing, [], f"docs/frame.md:{line} shows a `[[frame.component]]` "
+                    f"arrangement that omits {missing}. An operator who pastes it turns "
+                    f"those panels OFF — the list replaces the frame rather than adding "
+                    f"to it — and the frame they get is {uses}.")
+
+    def test_every_arrangement_of_charters_own_resolves_to_what_it_shows(self):
+        """Stronger than reading the fence: resolved through the real `instance.frame_of`,
+        so a documented `size`, `bg`, `pad`, `edge` or `key` charter would refuse is red
+        here rather than in an operator's terminal.
+
+        A refusal is what makes this worth running. `component_tables` refuses an
+        arrangement WHOLE (#535) and says nothing about it (`instance.py`'s `_HOTKEY_RE`
+        note), so a documented number charter cannot honour does not cost the reader the
+        line they got wrong — it costs them every panel in the file.
+
+        Fences naming a component no installed distribution supplies are skipped: the
+        provider example is about a package that does not exist on this machine, and
+        `frame_of` is right to refuse it. Its SHAPE is still checked by the test above.
+        """
+        import tomllib
+
+        from charter.frame import builtins as _builtins
+        ours = {c.id for c in _builtins.build().all()}
+        checked = 0
+        for line, body in self._fences():
+            cfg = tomllib.loads(body)
+            uses = [t.get("use") for t in cfg["frame"]["component"]]
+            if not set(uses) <= ours:
+                continue
+            checked += 1
+            with self.subTest(line=line):
+                got = [p["use"] for p in instance.frame_of(cfg)["components"]]
+                self.assertEqual(
+                    got, uses, f"docs/frame.md:{line} does not resolve to the arrangement "
+                    f"it prints. An empty list here means charter REFUSED the whole thing "
+                    f"and fell back to `slots`, which is what an operator pasting it would "
+                    f"silently get.")
+        self.assertGreaterEqual(checked, 6, "nothing was resolved — the skip ate the loop")
+
+
+#: A number written as a number of CELLS, and not a component of a version.
+#:
+#: The distinction is the one that matters, and it is a property rather than a markup
+#: spelling: ``3.2`` and ``3.7c`` are tmux versions this file names constantly, and a
+#: digit with a decimal point and another digit on the far side of it is one of those.
+#: Everything else — `` `5` ``, ``5``, ``5.`` at the end of a sentence, ``5,`` in a list —
+#: is a count, and is held to `instance.pane_pad`.
+#:
+#: The two negative lookaheads are not one lookahead, and the lookbehinds mirror them.
+#: ``(?![.\d])`` — which is what #675 shipped inside its backtick-anchored reader —
+#: refuses a number followed by ANY dot, so it silently skips every number that ends a
+#: sentence: "The maximum `pad` is 12." was invisible to it. ``(?!\.\d)`` refuses only a
+#: dot with a digit after it, which is what "this is a version" actually means; ``(?!\d)``
+#: is separately what stops `12` being read out of `120`.
+_CELL_COUNT = r"(?<!\d)(?<!\d\.)(\d+)(?!\d)(?!\.\d)"
+
+#: A bound written as a RANGE, in every spelling this file could plausibly use, with the
+#: backticks OPTIONAL. #689: the backticks were the whole match before, so the same
+#: sentence #669 filed — "a `pad` outside `0`-`8` is refused" — went green the moment its
+#: digits were written bare. Markup is not the property; the pair of numbers is.
+_STATED_RANGE = re.compile(
+    r"(?:(?P<between>between)\s+)?`?" + _CELL_COUNT + r"`?\s*"
+    r"(?:(?(between)and|(?!))|to|through|[-–—])\s*`?" + _CELL_COUNT + r"`?")
+
+#: `pad`, `pads`, `padded`, `padding` — the word, in the forms prose actually uses, and
+#: NOT the literal `` `pad` ``. The leading lookbehind is what keeps ``trackpad`` (which
+#: this file says once, about mouse wheels) out of the reader's scope.
+_PAD_WORD = re.compile(r"(?<![A-Za-z])pad(?:s|ded|ding)?(?![A-Za-z])", re.I)
+
+_NUMBER = re.compile(_CELL_COUNT)
+_SENTENCE = re.compile(r"(?<=[.!?])\s+")
+_FENCE = re.compile(r"```.*?```", re.S)
+_HEADING = re.compile(r"(?m)^#{1,6} .*$")
+
+
+def prose_of(md: str) -> str:
+    """*md* with its fenced blocks and its headings taken out.
+
+    Fences go because `TheDocumentedExampleIsRunThroughCharter` and
+    `EveryDocumentedArrangementIsAWholeArrangement` put every one of them through
+    `instance.frame_of` itself, which is a stronger question than any reader of English.
+    Headings go so that flattening the file cannot glue a heading to the sentence under it.
+    """
+    return _HEADING.sub("", _FENCE.sub("", md))
 
 
 def stated_ranges(prose: str) -> list[tuple[int, int]]:
-    """**Every** range *prose* states — not the first one, and not whether one exists.
+    """**Every** range of cells *prose* states — not the first one, and not whether one
+    exists.
 
     That distinction is the whole of #669. `docs/frame.md` gave `pad` two ranges four
     hundred lines apart — `` `0` to `5` `` and `` `0`–`8` `` — and the test asked
@@ -1151,8 +1287,131 @@ def stated_ranges(prose: str) -> list[tuple[int, int]]:
     An assertion that one occurrence exists cannot see a second, wrong one; the wrong one
     was the sentence about refusal, so `pad = 6` on the documentation's word silently cost
     the operator their whole `[[frame.component]]` block.
+
+    Unscoped on purpose: a range of bare cell counts is a thing this file states about
+    `pad` and about nothing else, so the reader does not have to work out what a sentence
+    is about before it can hold the pair to the constant. A second such bound arriving is
+    a reason to teach this function the second constant.
     """
-    return [(int(a), int(b)) for a, b in _STATED_RANGE.findall(prose)]
+    return [(int(m.group(2)), int(m.group(3)))
+            for m in _STATED_RANGE.finditer(" ".join(prose.split()))]
+
+
+def pad_numbers(prose: str) -> list[tuple[int, str]]:
+    """Every cell count *prose* offers as a `pad`, with the text it was read out of.
+
+    **Scope is the property "this text is about `pad`", and it is two readings unioned**,
+    because #689 is what one narrow reading costs. #675 scoped this to *a sentence
+    containing the literal* `` `pad` ``, so "A pane may carry a `pad`. Charter caps it at
+    `12`." was green: the number and the word were one sentence apart.
+
+    * **the paragraph** that names a `pad` word — the document's own unit of topic, so a
+      bound stated five sentences below the word is still in reach;
+    * **one sentence either side** of each `pad` word, over the file FLATTENED — so a
+      bound stated in the paragraph after the one that names the key is in reach too.
+
+    **What this cannot catch, said plainly rather than implied away.** No reader of English
+    prose is complete, and these are the shapes that get past this one:
+
+    * a bound written in WORDS — "charter caps a `pad` at twelve" has no integer in it;
+    * a bound more than one sentence from any form of the word `pad`, in a paragraph that
+      never says it — "the inset ceiling is 12", alone, under a heading about insets;
+    * anything inside a fenced block, which `prose_of` removes — those are resolved
+      through `instance.frame_of` instead, which is stricter than this;
+    * a wrong bound stated somewhere other than `docs/frame.md`.
+
+    `TheReaderIsAttackedWithTheSpellingsThatBeatTheLastOne` runs the corpus that IS in
+    reach, and `test_the_shapes_this_reader_is_blind_to_are_the_ones_written_down` runs
+    the ones that are not, so both halves of that claim are measured rather than asserted.
+
+    **The cost, accepted knowingly.** Scoping by proximity instead of by markup means an
+    incidental integer near a `pad` sentence is a false red. `docs/frame.md` carries none
+    today (measured), and the rule it puts on the file is writable: an incidental number
+    beside the `pad` prose is spelled in words or moved. The judgement #689 named is that
+    this noise is cheaper than a reader that misses the sentence #669 was filed about.
+    """
+    scoped: list[str] = []
+    for paragraph in re.split(r"\n\s*\n", prose):
+        flat = " ".join(paragraph.split())
+        if flat and _PAD_WORD.search(flat):
+            scoped.append(flat)
+    sentences = _SENTENCE.split(" ".join(prose.split()))
+    near = {i + offset
+            for i, s in enumerate(sentences) if _PAD_WORD.search(s)
+            for offset in (-1, 0, 1)}
+    scoped += [sentences[i] for i in sorted(near) if 0 <= i < len(sentences)]
+    # One entry per NUMBER, quoting the shortest text it was found in: the two readings
+    # overlap by design — a sentence is inside its paragraph — and a caller wants the
+    # number once, with the tightest quotation of where it came from for its message.
+    where: dict[int, str] = {}
+    for text in scoped:
+        for n in (int(x) for x in _NUMBER.findall(text)):
+            if n not in where or len(text) < len(where[n]):
+                where[n] = text
+    return sorted(where.items())
+
+
+#: Restatements of the `pad` bound, one per plausible spelling, with the number left as a
+#: hole. **This tuple is the attack, kept as data so the next person inherits it rather
+#: than repeating it.**
+#:
+#: #689 was measured by appending restatements of a WRONG bound to `docs/frame.md` and
+#: watching the suite stay green. Three of these are that reviewer's own three, verbatim;
+#: the rest are the same defect in the spellings a documentation edit would plausibly
+#: reach for. Each one is run twice — with `FRAME_PANE_PAD_MAX` in the hole, where it must
+#: be GREEN, and with a number charter refuses, where it must be RED — because a reader
+#: that fails everything catches nothing.
+#:
+#: Adding a spelling here is the cheap half of a fix. If one arrives that neither reader
+#: catches, widen the reader; if it cannot be widened without noise, add it to
+#: `_OUT_OF_REACH` instead, so the gap is written down rather than absent.
+_BOUND_RESTATEMENTS = (
+    # The three from #689's own reproduction table.
+    "The `pad` key insets a pane's content. Values from 0 to {n} are accepted.",
+    "A pane may carry a `pad`. Charter caps it at `{n}`.",
+    "Any `pad` outside 0-{n} refuses the whole arrangement.",
+    # #669's own refusal sentence, in the spelling that was caught and the two that were not.
+    "A `pad` outside `0`-`{n}` is refused.",
+    "A `pad` outside `0`–`{n}` is refused.",
+    "a pad outside 0 to {n} is refused",
+    # A cap rather than a range — the phrasing #675 claimed was already red.
+    "pad is capped at {n}",
+    "The maximum `pad` is {n}.",
+    "The pad ceiling is {n}.",
+    "Charter refuses a `pad` over {n}.",
+    "Padding is limited to {n} cells.",
+    "A padded pane may inset by as much as {n} cells.",
+    # The same bound one paragraph away from the word, which sentence scope cannot see.
+    "A pane may carry a `pad`.\n\nCharter caps it at `{n}`.",
+    # And the same bound several sentences BELOW the word inside one paragraph, which the
+    # sentence window cannot see either. This is the line the paragraph reading exists
+    # for: delete that reading and every other line here is still caught.
+    ("A pane may carry a `pad`. It is one number, and it means both sides. "
+     "It comes out of the pane's own width rather than your terminal's. "
+     "Charter caps it at `{n}`."),
+    # Range spellings this file does not use today but an edit could.
+    "`pad` accepts `0` through `{n}`.",
+    "A `pad` between 0 and {n} is honoured.",
+    "Pads run 0—{n}.",
+    # Not a sentence at all.
+    "| `pad` | `0` to `{n}` | how many cells |",
+    "`pad = {n}` is accepted.",
+    "Give the sidebar a `pad` of {n}.",
+)
+
+#: The shapes neither reader catches, kept as data for the same reason the corpus above
+#: is: a limit that is measured cannot quietly stop being true, and a guard that overstates
+#: its reach is the thing this project refuses.
+#:
+#: If a line here starts being caught — because someone widened `pad_numbers` — the test
+#: that runs it goes RED. That is the intended signal, and the fix is to move the line up
+#: into `_BOUND_RESTATEMENTS`, not to re-narrow the reader.
+_OUT_OF_REACH = (
+    # A bound spelled in words has no integer for any of this to hold to the constant.
+    "Charter caps a `pad` at twelve.",
+    # A bound in a paragraph that never names the key, more than one sentence from one.
+    "The inset ceiling is {n}. It is not a round number. It was picked to fit.",
+)
 
 
 class EveryStatementOfThePadBoundIsHeldToTheConstant(unittest.TestCase):
@@ -1180,13 +1439,51 @@ class EveryStatementOfThePadBoundIsHeldToTheConstant(unittest.TestCase):
                 "… and so are a `bg` that is not one of the seventeen words, a `pad` "
                 "outside `0`–`8`, and a `size` charter cannot give the component")
         self.assertEqual(stated_ranges(both), [(0, 5), (0, 8)])
-        self.assertEqual(stated_ranges("On tmux 3.2 to 3.6"), [])
-        self.assertEqual(stated_ranges("On tmux `3.2` to `3.6`"), [])
+
+    def test_a_version_is_not_a_range_of_cells_and_a_full_stop_is_not_a_decimal_point(self):
+        """The two halves of `_CELL_COUNT`, which is where #689's second defect lived.
+
+        Version ranges must stay out: this file says "on tmux 3.2 to 3.6" and dropping the
+        backtick requirement without the dotted-number rule reads that as `2` to `3`. That
+        is the reason #689 gives for why the obvious widening is not a one-character fix,
+        so it is asserted rather than trusted.
+
+        And a number that ENDS a sentence must stay in. #675's reader excluded any digit
+        followed by a dot, which is every count at the end of an English sentence — so
+        "The maximum `pad` is 12." was invisible to it, and that is a spelling a
+        documentation edit reaches for constantly."""
+        for versions in ("On tmux 3.2 to 3.6", "On tmux `3.2` to `3.6`",
+                         "Measured on 3.1c, 3.2 and 3.7c", "at the 3.2 floor"):
+            with self.subTest(versions=versions):
+                self.assertEqual(stated_ranges(versions), [])
+                self.assertEqual(pad_numbers(f"A `pad`. {versions}"), [])
+        self.assertEqual([n for n, _ in pad_numbers("The maximum `pad` is 12.")], [12])
+        self.assertEqual(stated_ranges("Pads run 0—12."), [(0, 12)])
+        # 395 ms is a bare count and IS in reach — the reader excludes versions, not
+        # every number that happens to sit near one. This is the noise `pad_numbers`
+        # documents as the price of scoping by proximity, shown rather than described.
+        self.assertEqual([n for n, _ in pad_numbers("A `pad`. median 395 ms on 3.7c")],
+                         [395])
+
+    def test_the_word_and_not_the_markup_puts_a_sentence_in_scope(self):
+        """`pad` unbackticked, `padding`, `padded`, `pads` — all the same key. And
+        `trackpad`, which this file says once about mouse wheels, is not: the reader is
+        scoped by the WORD, so a lookbehind is what keeps that sentence's numbers out."""
+        for spelling in ("a pad of 12", "padding of 12", "a padded 12", "pads of 12",
+                         "a `pad` of 12"):
+            with self.subTest(spelling=spelling):
+                self.assertEqual([n for n, _ in pad_numbers(spelling)], [12])
+        self.assertEqual(pad_numbers("the horizontal wheel a trackpad reports, 12 of them"),
+                         [])
 
     def test_the_documentation_states_the_bound_at_all(self):
-        """The vacuity control: the assertion below is green on a file that says nothing."""
-        self.assertTrue(stated_ranges(self.md),
+        """The vacuity control: the assertions below are green on a file that says
+        nothing, so the file is asked to still be saying it."""
+        prose = prose_of(self.md)
+        self.assertTrue(stated_ranges(prose),
                         "docs/frame.md states no range — the `pad` bound went missing")
+        self.assertTrue(pad_numbers(prose),
+                        "docs/frame.md prints no number about `pad` any more")
 
     def test_every_range_the_documentation_states_is_the_pad_range(self):
         """The fix. Each copy is checked, so the enforcement sentence at the bottom of the
@@ -1196,7 +1493,7 @@ class EveryStatementOfThePadBoundIsHeldToTheConstant(unittest.TestCase):
         is a reason to teach this test the second constant — never a reason to go back to
         asking whether one of them appears somewhere."""
         want = (0, instance.FRAME_PANE_PAD_MAX)
-        wrong = [r for r in stated_ranges(self.md) if r != want]
+        wrong = [r for r in stated_ranges(prose_of(self.md)) if r != want]
         self.assertEqual(
             wrong, [],
             f"docs/frame.md states {wrong} where charter enforces {want}. #669 was two "
@@ -1205,26 +1502,111 @@ class EveryStatementOfThePadBoundIsHeldToTheConstant(unittest.TestCase):
             "documentation invited costs the operator the entire `[[frame.component]]` "
             "block and the frame falls back to `slots`.")
 
-    def test_no_number_the_documentation_prints_beside_pad_is_one_charter_refuses(self):
-        """The copy that is not written as a range — "a `pad` of `8`", "capped at `8`" —
-        held to `pane_pad` itself rather than to a spelling of the constant.
+    def test_no_number_the_documentation_offers_as_a_pad_is_one_charter_refuses(self):
+        """The copy that is not written as a range — "a `pad` of 8", "capped at 8" — held
+        to `pane_pad` itself rather than to a spelling of the constant.
 
-        The rule this puts on the file: do not print an integer in a sentence about `pad`
-        that charter would refuse. Asked of the enforcing function, so it moves when
-        `FRAME_PANE_PAD_MAX` moves. The fenced examples are excluded because
-        `TheDocumentedExampleIsRunThroughCharter` resolves those through `instance` itself,
-        which is a stronger question than this one."""
-        prose = re.sub(r"```.*?```", "", self.md, flags=re.S)
-        sentences = [s for s in re.split(r"(?<=[.!?])\s+", " ".join(prose.split()))
-                     if "`pad`" in s]
-        self.assertTrue(sentences, "docs/frame.md no longer mentions `pad`")
-        for sentence in sentences:
-            for number in re.findall(r"`(\d+)`", sentence):
-                with self.subTest(number=number):
-                    self.assertIsNotNone(
-                        instance.pane_pad(int(number)),
-                        f"docs/frame.md prints `{number}` as a `pad` and charter refuses it "
-                        f"(the cap is {instance.FRAME_PANE_PAD_MAX}): …{sentence[:140]}")
+        The rule this puts on the file: **do not print a bare integer in prose about
+        `pad` that charter would refuse.** An incidental number that lands there is
+        spelled in words or moved, which is the noise `pad_numbers` documents as the price
+        of scoping by proximity rather than by markup."""
+        refused = [(n, text) for n, text in pad_numbers(prose_of(self.md))
+                   if instance.pane_pad(n) is None]
+        self.assertEqual(
+            refused, [],
+            f"docs/frame.md offers {sorted({n for n, _ in refused})} as a `pad` and charter "
+            f"refuses it (the cap is {instance.FRAME_PANE_PAD_MAX}): "
+            + " | ".join(f"…{t[:120]}" for _, t in refused[:3]))
+
+
+class TheReaderIsAttackedWithTheSpellingsThatBeatTheLastOne(unittest.TestCase):
+    """#689. **The fix for #669 was itself an instance of #669**: a guard that matched a
+    markup spelling where the property was a bound, filed against a defect that was a guard
+    matching a spelling where the property was a bound. Fifth measured instance in this
+    repository of a fix for a class of bug containing that bug.
+
+    So the reader above is not asserted to work — it is ATTACKED, the way the reviewer
+    attacked #675's: a restatement of a wrong bound is appended to the real
+    `docs/frame.md`, the readers are run over the result, and it has to come out red. The
+    corpus is `_BOUND_RESTATEMENTS` and lives beside the readers as data, so the next
+    person inherits the attack rather than repeating it.
+
+    Both directions are run. A reader that fails everything catches nothing, so every
+    spelling is run again with `FRAME_PANE_PAD_MAX` in the hole and must be GREEN — which
+    is also what makes the corpus survive the constant moving.
+    """
+
+    MD = Path(__file__).resolve().parents[1] / "docs" / "frame.md"
+
+    def _verdict(self, appended: str) -> list[str]:
+        """What the two readers say about `docs/frame.md` with *appended* added to it."""
+        prose = prose_of(f"{self.MD.read_text()}\n\n{appended}\n")
+        want = (0, instance.FRAME_PANE_PAD_MAX)
+        found = [f"range {r}" for r in stated_ranges(prose) if r != want]
+        found += [f"number {n}" for n, _ in pad_numbers(prose)
+                  if instance.pane_pad(n) is None]
+        return found
+
+    def test_the_shipped_documentation_is_green(self):
+        """The control the whole class rests on: every red below has to be caused by the
+        appended sentence and not by the file it was appended to."""
+        self.assertEqual(self._verdict(""), [])
+
+    def test_a_wrong_bound_is_caught_in_every_spelling_the_corpus_carries(self):
+        """The attack. Three of these are #689's own reproduction table, which #675 left
+        green; the rest are the same defect in the spellings an edit would reach for.
+
+        Three wrong numbers each, and they are not decoration: `MAX + 1` is the off-by-one
+        an edit makes, and a large one is the copy that came from a different constant."""
+        for template in _BOUND_RESTATEMENTS:
+            for wrong in (instance.FRAME_PANE_PAD_MAX + 1,
+                          instance.FRAME_PANE_PAD_MAX + 7, 97):
+                sentence = template.format(n=wrong)
+                with self.subTest(sentence=sentence):
+                    self.assertTrue(
+                        self._verdict(sentence),
+                        f"docs/frame.md can state a `pad` bound of {wrong} as "
+                        f"{sentence!r} and both readers stay green. That is #689 again: "
+                        "the reader is matching something other than the bound.")
+
+    def test_the_same_spellings_with_the_right_bound_stay_green(self):
+        """The other direction, and the reason the corpus is templated rather than
+        literal. A reader that reds on every sentence containing a number would pass the
+        test above while being useless, and it would make the file uneditable."""
+        for template in _BOUND_RESTATEMENTS:
+            sentence = template.format(n=instance.FRAME_PANE_PAD_MAX)
+            with self.subTest(sentence=sentence):
+                self.assertEqual(
+                    self._verdict(sentence), [],
+                    f"{sentence!r} states the bound charter enforces and the reader "
+                    "called it wrong — a false red makes this check the kind that gets "
+                    "deleted rather than fixed.")
+
+    def test_an_enumeration_is_caught_number_by_number(self):
+        """Not a bound at all: a list of the values that are allowed. Every member is held
+        to `pane_pad`, so the one over the cap is the one that reds — which is the
+        difference between asking the enforcing function and asking about a range."""
+        cap = instance.FRAME_PANE_PAD_MAX
+        listing = "A `pad` may be " + ", ".join(str(i) for i in range(cap + 3)) + "."
+        self.assertTrue(self._verdict(listing))
+        honest = "A `pad` may be " + ", ".join(str(i) for i in range(cap + 1)) + "."
+        self.assertEqual(self._verdict(honest), [])
+
+    def test_the_shapes_this_reader_is_blind_to_are_the_ones_written_down(self):
+        """**The honesty test.** `pad_numbers` says in its docstring what it cannot catch,
+        and this runs those shapes to prove the list is the real one rather than a
+        disclaimer. A guard that overstates its reach is the thing this project refuses.
+
+        Going red here means a shape moved from *out of reach* to *caught* — someone
+        widened the reader. That is good news: move the line into `_BOUND_RESTATEMENTS`.
+        It must never be answered by narrowing the reader back."""
+        for template in _OUT_OF_REACH:
+            sentence = template.format(n=instance.FRAME_PANE_PAD_MAX + 7)
+            with self.subTest(sentence=sentence):
+                self.assertEqual(
+                    self._verdict(sentence), [],
+                    f"{sentence!r} is listed as out of reach and was caught. Move it into "
+                    "_BOUND_RESTATEMENTS and shorten the docstring's list of limits.")
 
 
 class TheLiveChromeToggleDoesNotEraseAPanesOwnColour(PersonaIso, unittest.TestCase):


### PR DESCRIPTION
Closes #689, #690, #687.

## #689 — a fix for "a guard matched a spelling instead of a property" matched a spelling instead of a property

#675 closed #669 by reading every range `docs/frame.md` states and holding each to `FRAME_PANE_PAD_MAX`. It does not work. Both readers required the digits to be **backticked**, and the number-scan additionally required the number and the literal `` `pad` `` to be in the **same sentence**. Neither is a property of the bound. #669's own harmful refusal sentence, written without backticks, went straight through.

Measured on the merged guard, one line appended at a time:

```
"a pad outside 0 to 12 is refused"        -> OK       <- wrong bound, suite green
"pad is capped at 12"                     -> OK       <- wrong bound, suite green
"a `pad` outside `0`-`12` is refused"     -> FAILED   <- only this spelling was caught
```

**What the readers ask now.**

* Scope is **the word `pad`** — `pad`, `pads`, `padded`, `padding`, and a lookbehind that keeps `trackpad` out — over the *paragraph* that names it **and** one *sentence* either side of each mention, flattened across paragraph breaks. Two readings unioned, and the sweep below shows both are load-bearing.
* A number is a **count of cells** unless a dot has a digit on the far side of it. #675's `(?![.\d])` was its own second defect: it refuses a number followed by *any* dot, so it silently skipped every integer that ends an English sentence — `The maximum` `` `pad` `` `is 12.` was invisible to it.
* Ranges are read unscoped, with the backticks optional, in `to` / `through` / `-` / `–` / `—` / `between … and` forms. The tmux version ranges the file states (`3.2 to 3.6`) are excluded by the dotted-number rule, which is the reason #689 gives for why the obvious widening is not a one-character fix — so it is asserted rather than trusted.

**The attack is in the test as data.** `_BOUND_RESTATEMENTS` is nineteen restatements of the bound with the number left as a hole, including #689's own three verbatim. Each is appended to the real `docs/frame.md` and run twice: with a number charter refuses, where it must be **red**, and with `FRAME_PANE_PAD_MAX`, where it must be **green** — a reader that fails everything catches nothing, and templating the corpus means it survives the constant moving.

**The limits are written down and executed.** `_OUT_OF_REACH` carries the shapes neither reader catches — a bound spelled in words, a bound in a paragraph that never names the key — and a test runs them. Going red there means someone *widened* the reader; the answer is to move the line into the corpus, never to narrow the reader back. The false-positive cost (an incidental integer beside the `pad` prose) is stated in the same docstring, and the one instance in the file was removed.

## #690 — the snippet for turning the chat bar on built a frame with only the chat bar

`[[frame.component]]` replaces the arrangement whole, so the documented four-line table resolved to `slots: ['chats']`, `components: ['chats']` — no identity row, attention strip, repo table or sidebar. Four snippets in `docs/frame.md` had that shape (the chat bar, `visible = false`, the repo pin, the provider example); all four now list the whole arrangement, because a sentence of warning above a fence is not read by someone who stops at the fence.

`EveryDocumentedArrangementIsAWholeArrangement` resolves **every** `[[frame.component]]` fence in the file through the real `instance.frame_of` and holds it to the frame it prints — so a documented `size`, `bg`, `pad`, `edge` or `key` charter would refuse is red here rather than in an operator's terminal.

## #687 — a `size` on a bar was refused on a reason that is false for that bar

The boundary's rule is *a committed value is accepted exactly where something reads it*. It was implemented by asking which size **policy class** the component declared. `chats` and `workspaces` are `Fixed(1)`, so they took the echo-only branch on the stated grounds that their geometry is derived at import and a different number could only be ignored.

True of `identity`, `attention` and `sidebar`. **False for the two bars.** Charter places neither by default, so neither is in `layout._PLACED`, neither enters `SLOT_SIZE`, and `layout._size_of` answers them out of `_placed_here` → `_policy_cells` — a live read of the committed number that reaches tmux as `split-window -l` (measured). So the refusal was wrong, not just its reason, and refusing it dropped **every** `[[frame.component]]` table the plane had, in silence (#535 + the silent-refusal gap `instance.py` already names).

The condition is membership of `builtins.SLOT_OF` now — the table that decides whether `layout` derives a component's geometry. `instance` reads that cheap table deliberately, because it is imported by every command and must not reach `frame/layout.py` at module scope; `test_the_table_the_boundary_asks_is_the_table_the_launch_path_reads` holds `SLOT_OF` and `SLOT_SIZE` to being the same set for every registered component, so splitting them is red here rather than in a frame.

Nothing else widens: `0`, a negative, `true`, `"3"`, `3.0` are refused by `component.Fixed` as before, and the three derived built-ins still take their own number and nothing else. **Not** fixed here: a refused `[frame]` value is reported nowhere. That is the whole section's gap, not `size`'s, and #687 files it separately.

## Verification

* `python3 -m unittest discover -s tests` — **8856 tests, OK** (env -u PYTHONSAFEPATH).
* **Hand-run deletion sweep.** The pad guard's diff is tests + docs, so `tools/sweep.py --gate` plans no mutations there and its verdict would be worth nothing. Eleven mutations applied by hand, run, restored, with sha256 taken on every file before and after:

| mutation | verdict |
|---|---|
| number matcher back to #675's backtick+dot form | killed (16 failures) |
| range reader requires backticks again | killed |
| pad scope back to the literal `` `pad` `` | killed (19) |
| drop the paragraph reading | killed (3) |
| drop the sentence window, keep the same sentence | killed (3) |
| readers report nothing at all (vacuity control) | killed (41) |
| chat-bar snippet back to the bar alone | killed |
| a documented snippet charter refuses (`pad = 9`) | killed |
| `_built_in_size` back to the policy-class question | killed (7) |
| `_built_in_size` lets every built-in take any number | killed (3) |
| `SLOT_OF` and `SLOT_SIZE` stop agreeing | killed (4) |

**11 mutations, 0 survivors, 0 restore mismatches** — all five touched files byte-identical afterwards. The paragraph reading survived the first run; a corpus line that only it catches was added rather than the reading deleted, and it is killed now.

* `dependencies = []` untouched; stdlib only; `unittest` throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy