### PR TITLE
A chat switch that cannot move you stops reporting success and tearing your panels down (#684)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -252,6 +252,38 @@ _WINDOW_SIZE_FORMAT = "#{window_width}:#{window_height}"
 #: the pane after the side panels have been put back where they belong.
 _PANE_WIDTH_FORMAT = "#{pane_width}"
 
+#: The format that says WHERE a pane is — the session and the window it belongs to, as
+#: tmux's own ids rather than as names (#684).
+#:
+#: Both halves, in one ask, because both are needed at the same instant and by the same
+#: caller: `cmd_chat` has to know the target is in the session it is switching WITHIN
+#: before it selects anything, and has to know which window to expect the client on
+#: afterwards. Ids and never `#{session_name}`/`#{window_name}`: a name is not an
+#: identity (`_CHAT_OPTION` records the measurement — `allow-rename on` let a pane's own
+#: output rename its window), the ids are what tmux hands back for its own targets, and
+#: `#{session_id}` is about to be one.
+#:
+#: `:` is the separator because neither id can contain it: tmux spells them `$<digits>`
+#: and `@<digits>`, which is exactly what :data:`_SESSION_ID_RE` and :data:`_WINDOW_ID_RE`
+#: hold them to on the way back.
+_PANE_PLACE_FORMAT = "#{session_id}:#{window_id}"
+
+#: The format that says which window a SESSION is on right now — what a switch has to
+#: read back before it may believe the client moved. Measured on tmux 3.7c and 3.2:
+#: `display-message -p -t $N` resolves to that session's CURRENT window, so this is the
+#: reading `select-window`'s return code is not.
+_WINDOW_ID_FORMAT = "#{window_id}"
+
+#: tmux's own shapes for a session and a window, held to for :data:`_PANE_ID_RE`'s reason
+#: and at its boundary: both come back through text tmux re-parsed, and the session id
+#: goes straight back out as a `-t` target. A format that expanded to nothing — which is
+#: what tmux answers for a target it cannot resolve, with rc **0** and no stderr (measured
+#: on 3.7c) — fails these rather than becoming an empty target, and an empty `-t` resolves
+#: to the CURRENT window, which is the exact shape #668's own last commit closed for
+#: `select-window`.
+_SESSION_ID_RE = re.compile(r"\$[0-9]+")
+_WINDOW_ID_RE = re.compile(r"@[0-9]+")
+
 #: How long `_wait_for_harness` leaves between asks. There is no `attach` to block on
 #: inside an operator's tmux — the operator is already attached, to their own server —
 #: so the launcher watches the pane instead, and this is the cost of that: one local
@@ -4831,6 +4863,75 @@ def cmd_toggle(args) -> int:
     return 0
 
 
+def _pane_place(socket: str, pane: str | None) -> tuple[str, str] | None:
+    """Which tmux SESSION and WINDOW *pane* is in, as ids — or ``None`` (#684).
+
+    **The question `chats.py` cannot ask and `select-window`'s return code does not
+    answer.** `chats.of_workspace` decides membership from a FILE — `state.frame_workspace`,
+    which `charter workspace use` rewrites and `switch.to_workspace` rewrites again — so
+    two chats can share a roster while their windows are in two different tmux sessions.
+    The session is where a chat actually lives (`cmd_launch` makes the workspace the
+    session), it is not written down anywhere charter can read, and it moves at runtime.
+    So it is asked of tmux, at the moment it matters.
+
+    ``None`` for every way that can fail to answer, because the caller does the same thing
+    with each: refuse, and touch nothing. A *pane* is required rather than a name, and
+    checked here rather than at the call site, for the reason `_relayout_target` checks the
+    same record: the value arrives off disk, and `display-message -p -t ""` does not fail —
+    **measured on tmux 3.7c: an unresolvable target answers rc 0, empty stdout and no
+    stderr**, and an EMPTY target resolves to the current window, which would have this
+    function report the asker's own place as the target's and agree that a switch may
+    proceed.
+
+    That measurement is also why the return code alone is not the guard: it is the same
+    rc-0-on-the-wrong-thing shape as `select-window -t %N` succeeding against another
+    session's pane, which is #684 itself.
+    """
+    if not _PANE_ID_RE.fullmatch(pane or ""):
+        return None
+    p = tmuxctl.run("asking which window a chat is in",
+                    tmuxctl.server_argv(socket, "display-message", "-p", "-t", pane,
+                                        _PANE_PLACE_FORMAT))
+    # **The SHAPE of what came back, and deliberately not the return code.** A status of
+    # 0 is what an unresolvable target answers with here, so branching on it would be the
+    # same mistake one noun over from the one this whole function exists to correct. Both
+    # halves are held: the session id is about to be a `-t` target (#475's rule at #475's
+    # boundary), and a window id that came back empty beside a session id that did not is
+    # an answer charter has no reading of — treated as "no window", which is the sentence
+    # it would get anyway one line later, said for the right reason.
+    sid, _, wid = p.stdout.strip().partition(":")
+    if not _SESSION_ID_RE.fullmatch(sid) or not _WINDOW_ID_RE.fullmatch(wid):
+        return None
+    return sid, wid
+
+
+def _session_window(socket: str, session: str) -> str:
+    """The window *session* is on right now, as tmux reported it.
+
+    What "did the client actually move" is asked as. `select-window` sets the SESSION's
+    current window and the clients attached to it follow, so this is the reading that says
+    whether the switch happened — and it is a different fact from `select-window`'s exit
+    status, which is 0 for a window of a session the asker is not in (measured on tmux
+    3.7c: `select-window -t %N` against another session returned 0 and moved THAT session,
+    while the asking client stayed exactly where it was).
+
+    *session* is `#{session_id}`, held to :data:`_SESSION_ID_RE` by the only thing that
+    produces one here (:func:`_pane_place`) before it ever reaches this. A session NAME
+    would be the wrong currency twice over: it is renameable, and `-t api.1` is parsed by
+    tmux as ``window.pane`` rather than as a name with a dot in it.
+    """
+    # Whatever came back, unexamined, and that is the honest shape rather than a missing
+    # guard. The one caller compares this against a window id `_pane_place` has ALREADY
+    # held to `_WINDOW_ID_RE`, so equality already implies this is one — and an answer
+    # tmux could not resolve (rc 0, empty stdout, measured on 3.7c) compares unequal and
+    # is read as "the client did not move", which is the safe direction because what
+    # follows a move is a teardown. A regex here would be a second guard for what the
+    # comparison already decides, and the deletion sweep is where that shows up.
+    return tmuxctl.run("asking which chat this client is on now",
+                       tmuxctl.server_argv(socket, "display-message", "-p", "-t",
+                                           session, _WINDOW_ID_FORMAT)).stdout.strip()
+
+
 #: How long the palette waits, at SHUTDOWN, for an action's ``run`` to have returned.
 #:
 #: **Not a wait for the work — a wait for the START.** §4g's fire-and-report says ``run``
@@ -4854,10 +4955,24 @@ def cmd_chat(args) -> int:
 
     **Four steps, and every one of them is an existing path** (spec §3.7):
 
+    0. **Where both chats are, asked of tmux, before anything is aimed anywhere** (#684,
+       :func:`_pane_place`). Not one of the four, and it is here because every one of them
+       assumes something no record on disk can promise: that the target's window is a
+       window this client can be moved to. `chats.of_workspace` matches a workspace FILE,
+       which `charter workspace use` and `switch.to_workspace` both rewrite, so two chats
+       can share a roster with their windows in two different tmux sessions — and
+       `select-window` at another session's pane returns **0**, moves that session, and
+       leaves this client exactly where it was. Steps 1 and 2 then reported a switch that
+       had not happened and tore down the panels of the chat still on screen.
     1. `select-window` at the target chat's own harness PANE. A pane id resolves to that
        pane's window — measured on tmux 3.7c and on tmux 3.2 — which is why charter needs
        no window-id record beside the pane record it already keeps
        (`state.record_harness_pane`), and why there is no second thing to keep in step.
+       Its status is checked and is **not** what says the switch worked: step 0's reading,
+       taken again afterwards, is (:func:`_session_window`). A command that exits 0 having
+       acted on the wrong target is indistinguishable from one that acted on the right
+       one, so the teardown below is gated on the client having moved rather than on a
+       return code.
     2. :func:`_apply_arrangement` with ``want=[]`` on the chat being left, which tears its
        panels down. Not a saving — a correctness rule. A background window keeps STALE
        geometry (§7.4, measured identically on 3.7c and 3.2), so panels left running there
@@ -4937,6 +5052,47 @@ def cmd_chat(args) -> int:
         _say_on_screen(fid, f"cannot switch: chat '{target}' stopped being one while "
                             "charter was switching to it")
         return 0
+    # **Where the two chats actually are, asked of tmux before anything is aimed at
+    # anything** (#684). `chats.check` has established that both are chats of one
+    # workspace and — since this issue — that both are on one tmux SERVER, and neither of
+    # those is "in one tmux session". `cmd_launch` makes the workspace the session, but
+    # the record membership is read from is a FILE that moves: `charter workspace use
+    # beta` typed inside chat `api.1` repoints it, `switch.to_workspace` repoints it
+    # again, and after one of those `of_workspace("beta")` returns `api.1` — a window of
+    # session `api` — beside `beta.1`, in one roster.
+    here_place = _pane_place(socket, chats.pane_of(fid))
+    there_place = _pane_place(socket, pane)
+    if there_place is None:
+        # The window is gone, learnt BEFORE anything is selected rather than from
+        # `select-window`'s status afterwards. Same sentence it used to be said with, one
+        # step earlier, and the step is what makes it honest: `display-message` answers rc
+        # 0 with nothing for a target it cannot resolve, so this is the reading that says
+        # the window is absent rather than the one that says a command exited.
+        _say_on_screen(fid, f"cannot switch: chat '{target}' has no window any more")
+        return 0
+    if here_place is None:
+        # The asker's own window cannot be found, so there is no session to compare
+        # against and no way to tell afterwards whether the client moved. Refused rather
+        # than guessed at, because the guess costs the panels of the chat the operator is
+        # still looking at — `_relayout_target(fid)` is about to be handed the same
+        # record, and a switch that cannot establish where it is standing must not tear
+        # anything down.
+        _say_on_screen(fid, "cannot switch: charter cannot find this chat's own window, "
+                            "so it cannot tell whether a switch would move this client")
+        return 0
+    if here_place[0] != there_place[0]:
+        # **The refusal #684 is about, and it is about an identity rather than a name.**
+        # Measured on tmux 3.7c, own socket: `select-window -t %N` where `%N` is a window
+        # of ANOTHER session returns **0** and moves that session's current window, while
+        # the asking client does not move at all. So the status check below could never
+        # have caught this, and what followed it was `_apply_arrangement(fid, want=[])` —
+        # charter tearing down the panels of the chat still on screen, having reported a
+        # switch that did not happen. That is verbatim the failure #668's own last commit
+        # says it closed, closed there for the `select-window -t ""` spelling only.
+        _say_on_screen(fid, f"cannot switch: chat '{target}' is a window of another tmux "
+                            "session, so selecting it would move that session and leave "
+                            "this client here")
+        return 0
     selected = tmuxctl.run("switching to the chat",
                            tmuxctl.server_argv(socket, "select-window", "-t", pane))
     if selected.returncode != 0:
@@ -4952,6 +5108,17 @@ def cmd_chat(args) -> int:
         # survivor for that reason. `_say_on_screen`'s own `inert_format` is what makes
         # this a tmux format's business rather than this line's.
         _say_on_screen(fid, f"cannot switch: chat '{target}' has no window any more")
+        return 0
+    if _session_window(socket, here_place[0]) != there_place[1]:
+        # **The teardown is gated on the client having MOVED, not on a command having
+        # exited 0** (#684). The session check above is what stops charter selecting
+        # somebody else's window; this is what stops it acting as though a selection
+        # worked. They are two different properties and the second is the one the panels
+        # ride on: everything below this line assumes the window the operator is looking
+        # at is the target's, and `want=[]` on that assumption is the defect rather than a
+        # tidy-up. A refusal here leaves both chats exactly as they were.
+        _say_on_screen(fid, f"cannot switch: tmux selected chat '{target}' but this "
+                            "client did not move, so this chat keeps its panels")
         return 0
     here = _relayout_target(fid)
     if here is not None:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -263,10 +263,14 @@ _PANE_WIDTH_FORMAT = "#{pane_width}"
 #: output rename its window), the ids are what tmux hands back for its own targets, and
 #: `#{session_id}` is about to be one.
 #:
-#: `:` is the separator because neither id can contain it: tmux spells them `$<digits>`
-#: and `@<digits>`, which is exactly what :data:`_SESSION_ID_RE` and :data:`_WINDOW_ID_RE`
-#: hold them to on the way back.
-_PANE_PLACE_FORMAT = "#{session_id}:#{window_id}"
+#: `\t` is the separator, and it is not `:` for the deletion sweep's reason. Neither id can
+#: contain either character — tmux spells them `$<digits>` and `@<digits>`, which is what
+#: :data:`_SESSION_ID_RE` and :data:`_WINDOW_ID_RE` hold them to on the way back — but a
+#: split on `:` has to be spelled `partition` or `rpartition`, and with exactly one
+#: separator by construction those two are the same program: a question no test can ever
+#: answer. `split("\t")` and a field COUNT says the same thing and is a guard a test can
+#: redden, which is also how `_WINDOW_SEAT_FORMAT` asks it.
+_PANE_PLACE_FORMAT = "#{session_id}\t#{window_id}"
 
 #: The format that says which window a SESSION is on right now — what a switch has to
 #: read back before it may believe the client moved. Measured on tmux 3.7c and 3.2:
@@ -4899,7 +4903,10 @@ def _pane_place(socket: str, pane: str | None) -> tuple[str, str] | None:
     # boundary), and a window id that came back empty beside a session id that did not is
     # an answer charter has no reading of — treated as "no window", which is the sentence
     # it would get anyway one line later, said for the right reason.
-    sid, _, wid = p.stdout.strip().partition(":")
+    fields = p.stdout.strip().split("\t")
+    if len(fields) != 2:
+        return None
+    sid, wid = fields
     if not _SESSION_ID_RE.fullmatch(sid) or not _WINDOW_ID_RE.fullmatch(wid):
         return None
     return sid, wid

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -279,12 +279,20 @@ _PANE_PLACE_FORMAT = "#{session_id}\t#{window_id}"
 _WINDOW_ID_FORMAT = "#{window_id}"
 
 #: tmux's own shapes for a session and a window, held to for :data:`_PANE_ID_RE`'s reason
-#: and at its boundary: both come back through text tmux re-parsed, and the session id
-#: goes straight back out as a `-t` target. A format that expanded to nothing — which is
-#: what tmux answers for a target it cannot resolve, with rc **0** and no stderr (measured
-#: on 3.7c) — fails these rather than becoming an empty target, and an empty `-t` resolves
-#: to the CURRENT window, which is the exact shape #668's own last commit closed for
-#: `select-window`.
+#: and at its boundary: both come back through text tmux re-parsed. A format that expanded
+#: to nothing — which is what tmux answers for a target it cannot resolve, with rc **0**
+#: and no stderr (measured on 3.7c) — fails these rather than becoming an empty target,
+#: and an empty `-t` resolves to the CURRENT window, which is the exact shape #668's own
+#: last commit closed for `select-window`.
+#:
+#: **The two are not load-bearing in the same way, and saying which is which is the point
+#: of writing them down separately.** The SESSION id goes straight back out as a `-t`
+#: target (`_session_window`), so its whole alphabet is #475's rule and every part of it
+#: is asserted — the sigil, the digits, and that `$0;kill-server` never reaches a command
+#: line. The WINDOW id is only ever COMPARED, against a reading taken from the same tmux a
+#: moment later, so beyond telling a window id from a session id its strictness decides
+#: nothing that the comparison does not already decide. A sweep that reports `r"@[0-9]+"`
+#: widened to `r".+"` as a survivor is right, and this is the answer to it.
 _SESSION_ID_RE = re.compile(r"\$[0-9]+")
 _WINDOW_ID_RE = re.compile(r"@[0-9]+")
 

--- a/charter/frame/chats.py
+++ b/charter/frame/chats.py
@@ -279,6 +279,19 @@ def check(fid: str, chat: str) -> Outcome:
       which is a re-layout an operator did not ask for and ~90 ms of blank panes; and the
       row is drawn with `choose.MARK` beside it, so the operator can see they are already
       there before they press it.
+    * **not on this frame's tmux server** — and this one is about an IDENTITY where every
+      rule above it is about a name (#684). A workspace's chats are the directories whose
+      `workspace` file names it, and that file says nothing about where the chat is
+      RUNNING: charter has two servers (its own `-L charter` and, inside an operator's
+      tmux, theirs), a chat can be open on each, and `state.frame_server` is the record
+      that tells them apart. Pane ids are per-server — `%3` on one is somebody else's pane
+      on the other — so a switch that crossed servers would aim a `select-window` at a
+      real, live, unrelated pane and be told it worked. Compared as recorded, with no
+      default filled in for a missing marker: every chat this charter launches records one
+      on both paths, so an absent value is a truncated record rather than a migration
+      (`of_workspace` already keeps old `{workspace}-{pid}` frames out of the roster
+      entirely), and "charter cannot tell" is the same answer as "somewhere else" for a
+      switch that is about to move a client.
     * **no usable harness pane** — the target's window cannot be named. `select-window`
       is aimed at the chat's own harness pane (measured on tmux 3.7c and 3.2: a pane id
       resolves to that pane's window), and `state.harness_pane` is the record that holds
@@ -294,6 +307,13 @@ def check(fid: str, chat: str) -> Outcome:
     for the row and once for the switch — would be two answers to it. `cmd_chat` selects
     the window and reports what tmux said, which is the reading that is true at the
     instant it matters rather than the instant the palette opened.
+
+    **Nor is the tmux SESSION, for the same reason and with a sharper edge** (#684). The
+    server above is a record and belongs here; which session a chat's window is in is a
+    fact only tmux holds, it moves while the palette is open, and `cmd_launch` makes the
+    workspace the session while membership here is read from a file `charter workspace
+    use` can repoint. `cmd_chat` asks it (`commands_frame._pane_place`) at the one moment
+    it decides anything, and refuses there.
     """
     shown = contain.one_line(chat)
     if not ID_RE.fullmatch(chat or ""):
@@ -303,6 +323,9 @@ def check(fid: str, chat: str) -> Outcome:
         return Outcome(False, f"no chat '{shown}' here — have: {_some(names)}")
     if chat == fid:
         return Outcome(False, f"already in chat '{shown}'")
+    if state.frame_server(chat) != state.frame_server(fid):
+        return Outcome(False, f"chat '{shown}' is not on this frame's tmux server, so "
+                              "charter cannot move this client to its window")
     if pane_of(chat) is None:
         return Outcome(False, f"charter has no usable record of chat {shown}'s harness "
                               "pane, so it cannot find its window — relaunch that chat")

--- a/docs/news/unreleased-a-switch-that-did-not-happen-stops-being-reported-as-one.md
+++ b/docs/news/unreleased-a-switch-that-did-not-happen-stops-being-reported-as-one.md
@@ -1,0 +1,74 @@
+---
+version: unreleased
+headline: A chat switch that cannot move you stops reporting success and tearing your panels down
+---
+
+`F2 → chat → <name>` could leave you exactly where you were, with the panels of the chat
+you were looking at killed around you. Charter thought it had switched, because tmux told
+it so.
+
+## A command that exits 0 on the wrong target
+
+`cmd_chat` aims `select-window` at the target chat's own harness pane, and then checks the
+return code. Measured on real tmux 3.7c, own socket, two sessions with the client in the
+first:
+
+```
+$ tmux -L … select-window -t %3        # %3 is a window of session B; client is in session A
+rc=0
+after:  A current=@0   B current=@2    # session B moved. The client did not.
+```
+
+So the check could never fire. What followed it was `_apply_arrangement(fid, want=[])` —
+the teardown of the chat being left, which #668 rightly calls a correctness rule — applied
+to the chat still on screen. Reproduced end to end against a real server on 3.7c and on
+tmux 3.2, driving the real `cmd_chat`: nothing said, the client never moved, and both
+panels of the chat in front of the operator gone.
+
+## Why two chats of one workspace can be in two tmux sessions
+
+Because membership is a **file**. `chats.of_workspace` lists the frame directories whose
+`workspace` file names the workspace, and that file moves at runtime: `charter workspace
+use beta` typed at the agent rewrites it — *"it moves the panels too"* is a documented
+promise — and the workspace picker rewrites it again. The tmux **session**, meanwhile, is
+fixed at launch: `cmd_launch` makes the workspace the session and a chat one window in it.
+
+So after one `F2 → workspace → beta` inside chat `api.1`, the roster for `beta` holds
+`api.1` (a window of session `api`) beside `beta.1` (a window of session `beta`), and
+every check charter had said yes.
+
+## What it asks now
+
+The guard wanted a property, not a spelling, and there are two of them.
+
+**Which server** is a record, so `chats.check` asks it: charter runs frames on its own
+`-L charter` and, inside an operator's tmux, on theirs, and pane ids are per-server — `%3`
+recorded by a chat on one names a real, live, unrelated pane on the other. No default is
+filled in for a missing marker; every chat this charter launches records one on both
+paths.
+
+**Which session** is a fact only tmux holds and it moves while the palette is open, so
+`cmd_chat` asks it, of both chats, before it aims anything anywhere. Same session: switch.
+Different: refuse, with a sentence, having selected nothing — so the other session's screen
+is left alone too.
+
+And the teardown is gated on the client having **moved**, read back from tmux, rather than
+on a command having exited 0. Those are two different facts and the panels ride on the
+second one.
+
+## The reading is the guard, not the status
+
+`display-message -p` against a target tmux cannot resolve answers **rc 0, empty stdout and
+no stderr** — measured on 3.7c. So the placement readings are held to their shape
+(`$<digits>`, `@<digits>`) rather than to their exit status, which is the same
+rc-0-on-the-wrong-thing this whole entry is about, one command over. An empty `-t` target
+is not nothing either: it resolves to the current window, which would have charter report
+the asker's own place as the target's.
+
+## One consequence worth knowing about
+
+A chat whose own harness-pane record is unreadable now refuses the switch instead of
+moving the client anyway. That reversal is deliberate: the record that says where to tear
+down is the record that says which session this client is in, so without it charter can
+neither check the target nor tell afterwards whether anything moved — and selecting anyway
+means aiming at a pane that may belong to somebody else's session.

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -560,7 +560,7 @@ class AHostileChatRendersAsOneRowAndRunsNothing(PersonaIso, unittest.TestCase):
                                      f"{bad!r} is inside the tmux format {word!r}")
                 self.assertIn(word, ("#{pane_id}",
                                      "#{window_width}:#{window_height}",
-                                     "#{session_id}:#{window_id}",
+                                     "#{session_id}\t#{window_id}",
                                      "#{window_id}"),
                               f"an unexpected tmux format reached the switch: {word!r}")
 
@@ -670,7 +670,7 @@ class _FakeServer:
         fmt, target = argv[-1], self._target(argv)
         if fmt == commands_frame._PANE_PLACE_FORMAT:
             seat = self.place.get(target)
-            return f"{seat[0]}:{seat[1]}" if seat else ""
+            return f"{seat[0]}\t{seat[1]}" if seat else ""
         if fmt == commands_frame._WINDOW_ID_FORMAT:
             return self.current.get(target, "")
         if fmt == commands_frame._PANE_WIDTH_FORMAT:
@@ -1079,6 +1079,27 @@ class TheSwitchEstablishesTheWindowItIsMovingTo(PersonaIso, unittest.TestCase):
         commands_frame.cmd_chat(mock.Mock(chat_id="beta.1", chat="api.1"))
         self.assertNotIn("select-window", self.fake.verbs())
         self.assertIn("has no window any more", self.said[0])
+
+    def test_a_placement_that_is_not_two_fields_answers_nothing(self):
+        """The reading is `split("\\t")` and a field COUNT rather than a `partition`, and
+        that is the deletion sweep's doing: with exactly one separator by construction,
+        `partition` and `rpartition` are the same program and no test could ever tell them
+        apart. A count says the same thing and is a guard a test can redden — which is
+        also how `_chat_being_left` asks it (#688).
+
+        Asked of the reader directly, because a real tmux cannot be made to answer with
+        the wrong number of fields."""
+        for answer in ("$0", "", "$0\t@1\textra"):
+            with self.subTest(answer=answer):
+                with mock.patch.object(
+                        tmuxctl, "run",
+                        lambda *a, **k: __import__("subprocess").CompletedProcess(
+                            [], 0, answer, "")), \
+                     mock.patch.object(
+                        commands_frame.tmuxctl, "run",
+                        lambda *a, **k: __import__("subprocess").CompletedProcess(
+                            [], 0, answer, "")):
+                    self.assertIsNone(commands_frame._pane_place("sock", "%1"))
 
     def test_the_placement_reading_never_makes_a_target_of_a_non_pane(self):
         """#475's rule at the boundary the placement reading adds, asserted of the reader

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -1080,6 +1080,27 @@ class TheSwitchEstablishesTheWindowItIsMovingTo(PersonaIso, unittest.TestCase):
         self.assertNotIn("select-window", self.fake.verbs())
         self.assertIn("has no window any more", self.said[0])
 
+    def test_a_session_id_that_is_not_tmuxs_own_never_becomes_a_target(self):
+        """#475\'s rule, on the one value of the placement that goes back OUT to tmux.
+
+        `_pane_place`\'s session id is what `_session_window` sends as `-t` afterwards, so
+        its ALPHABET is load-bearing and not decoration — `$0;kill-server` in that position
+        is the shape that already cost this project a `kill-server` armed on every window
+        resize. The window id beside it is only ever compared, which is why its own
+        strictness is not asserted here and its docstring says so.
+
+        Driven through a whole switch as well as through the reader, because the property
+        is "it never reaches tmux", not "the function returned None".
+        """
+        self.fake.place["%2"] = ("$0;kill-server", "@1")
+        self.assertIsNone(commands_frame._pane_place("sock", "%2"))
+        commands_frame.cmd_chat(mock.Mock(chat_id="beta.1", chat="api.1"))
+        for argv in self.fake.calls:
+            self.assertNotIn("$0;kill-server", argv,
+                             "a session id charter did not recognise reached a tmux "
+                             "command line")
+        self.assertIn("has no window any more", self.said[0])
+
     def test_a_placement_that_is_not_two_fields_answers_nothing(self):
         """The reading is `split("\\t")` and a field COUNT rather than a `partition`, and
         that is the deletion sweep's doing: with exactly one separator by construction,

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -26,6 +26,7 @@ from unittest import mock
 from charter import commands_frame, config, contain, instance
 from charter.frame import chats, choose, slots, state, tmuxctl
 from tests._isolation import PersonaIso
+from tests._tmuxsocket import OPERATOR_SOCKET
 # The one list of hostile display strings this suite has, imported rather than retyped:
 # a second copy is one that stops growing when somebody finds a ninth shape.
 from tests.test_frame_pickers import HOSTILE
@@ -312,6 +313,32 @@ class TheCheckSaysWhichRefusalFired(PersonaIso, unittest.TestCase):
         self.assertIn("no usable record", out.message)
         self.assertIn("relaunch that chat", out.message)
 
+    def test_a_chat_on_the_other_tmux_server_is_refused(self):
+        """#684, the half that is a record rather than a reading of tmux.
+
+        Charter runs frames on two servers — its own `-L charter` and, inside an
+        operator's tmux, theirs — and a workspace can hold a chat on each, because
+        membership here is the `workspace` FILE and says nothing about where a chat runs.
+        Pane ids are per-server, so `%3` recorded by a chat on one server names a real,
+        live, unrelated pane on the other, and the `select-window` charter would send
+        would be told it worked."""
+        state.record_server("api.1", commands_frame.SOCKET)
+        state.record_server("api.2", OPERATOR_SOCKET)
+        out = chats.check("api.1", "api.2")
+        self.assertFalse(out.ok)
+        self.assertIn("not on this frame's tmux server", out.message)
+
+    def test_a_chat_whose_server_charter_never_recorded_is_refused_too(self):
+        """No default is filled in for a missing marker. Every chat this charter launches
+        records one on both paths, and `of_workspace` keeps pre-chat `{workspace}-{pid}`
+        frames out of the roster entirely — so an absent value is a truncated record, and
+        "charter cannot tell" is the same answer as "somewhere else" for something about
+        to move a client."""
+        state.record_server("api.1", commands_frame.SOCKET)
+        out = chats.check("api.1", "api.2")
+        self.assertFalse(out.ok)
+        self.assertIn("not on this frame's tmux server", out.message)
+
     def test_a_switch_that_may_go_ahead_names_where_it_is_going(self):
         out = chats.check("api.1", "api.2")
         self.assertTrue(out.ok)
@@ -532,7 +559,9 @@ class AHostileChatRendersAsOneRowAndRunsNothing(PersonaIso, unittest.TestCase):
                     self.assertNotIn(bad, word,
                                      f"{bad!r} is inside the tmux format {word!r}")
                 self.assertIn(word, ("#{pane_id}",
-                                     "#{window_width}:#{window_height}"),
+                                     "#{window_width}:#{window_height}",
+                                     "#{session_id}:#{window_id}",
+                                     "#{window_id}"),
                               f"an unexpected tmux format reached the switch: {word!r}")
 
     def test_every_chat_is_still_reachable_at_200_80_and_40_columns(self):
@@ -592,11 +621,27 @@ class _FakeServer:
     Everything `cmd_chat` sends goes through `tmuxctl.run`, so one patch is the whole
     server. `_relayout` and `_split_panels` go through it too, which is what makes the
     ORDER of the four steps assertable in one list.
+
+    **It carries a placement, and since #684 that is not decoration.** A pane belongs to a
+    window and a window to a session, `select-window` sets the SESSION's current window,
+    and a fake that answered one format for every `display-message` could not tell the
+    switch that worked from the one that moved somebody else's session — which is the
+    whole defect. So: :attr:`place` says where each pane is, :attr:`current` says which
+    window each session is on, and `select-window` moves the target pane's session rather
+    than a boolean. A test that wants the broken shape states it by putting the target in
+    another session, the way the real server put it there.
     """
 
     def __init__(self, *, select_rc: int = 0):
         self.calls: list[list[str]] = []
         self.select_rc = select_rc
+        #: ``{pane id: (session id, window id)}`` — what `#{session_id}:#{window_id}`
+        #: reports for a pane. A pane that is not here is one tmux cannot resolve, and
+        #: tmux answers that with rc 0 and empty output (measured on 3.7c), which is why
+        #: this fake answers it the same way rather than with a non-zero status.
+        self.place = {"%1": ("$0", "@0"), "%2": ("$0", "@1")}
+        #: ``{session id: window id}`` — the window each session is currently on.
+        self.current = {"$0": "@0"}
 
     def __call__(self, what, argv, **kw):
         import subprocess
@@ -605,11 +650,37 @@ class _FakeServer:
         verb = self._verb(argv)
         if verb == "select-window":
             rc = self.select_rc
+            if rc == 0:
+                seat = self.place.get(self._target(argv))
+                if seat is not None:
+                    self.current[seat[0]] = seat[1]
         elif verb == "split-window":
             out = "%9"
         elif verb == "display-message":
-            out = "80:24"
+            out = self._display(argv)
         return subprocess.CompletedProcess(argv, rc, out, "")
+
+    def _display(self, argv) -> str:
+        """What tmux would print for the format charter actually sent.
+
+        Told apart by the FORMAT, never by the order the calls arrive in: the switch asks
+        three different questions of `display-message` and a fake that answered them all
+        with one string would let any of them stand in for the others.
+        """
+        fmt, target = argv[-1], self._target(argv)
+        if fmt == commands_frame._PANE_PLACE_FORMAT:
+            seat = self.place.get(target)
+            return f"{seat[0]}:{seat[1]}" if seat else ""
+        if fmt == commands_frame._WINDOW_ID_FORMAT:
+            return self.current.get(target, "")
+        if fmt == commands_frame._PANE_WIDTH_FORMAT:
+            return "80"
+        return "80:24"
+
+    @staticmethod
+    def _target(argv) -> str:
+        """The `-t` argument, or ``""`` — what tmux would be aiming at."""
+        return argv[argv.index("-t") + 1] if "-t" in argv else ""
 
     @staticmethod
     def _verb(argv) -> str:
@@ -829,29 +900,49 @@ class TheSwitchIsFourStepsInOneOrder(PersonaIso, unittest.TestCase):
         self._switch()
         self.assertEqual(sorted(state.panes("api.2")), ["top"])
 
-    def test_a_chat_charter_cannot_relayout_still_gets_the_client_moved(self):
-        """The two re-layouts are attempted independently, and the client's move is not
-        conditional on either. A chat charter has no usable pane record for cannot have
-        its panels moved — but abandoning the switch over it would leave the operator on
-        the window they asked to leave, which is the worse of the two failures."""
+    def test_a_chat_whose_own_pane_record_is_broken_switches_nothing(self):
+        """**This test's property changed with #684, and the change is the finding.**
+
+        It used to say the client moves even when the chat being LEFT cannot be tidied,
+        on the argument that leaving the operator where they asked not to be is the worse
+        of two failures. That argument held while the only cost of not knowing where you
+        are standing was an untidy background window. It does not hold now: the record
+        that says where to tear down (`state.harness_pane(fid)`) is the same record that
+        says which tmux SESSION this client is in, and without it charter can neither
+        check that the target is a window this client can be moved to nor tell afterwards
+        whether it moved. Selecting anyway would aim `select-window` at a pane that may
+        belong to another session — which returns 0 and moves that session's screen.
+
+        So one broken record now refuses the whole switch, with a sentence, and touches
+        no tmux beyond the two readings that failed."""
         state.record_harness_pane("api.1", "not-a-pane")
-        self._switch()
-        verbs = self.fake.verbs()
-        self.assertIn("select-window", verbs)
-        self.assertNotIn("kill-pane", verbs)
-        self.assertTrue(state.panes("api.2"),
-                        "the target lost its panels because the chat being left could "
-                        "not be tidied")
+        said = []
+        with mock.patch.object(commands_frame, "_say_on_screen",
+                               lambda fid, msg, *a, **k: said.append(msg)):
+            self._switch()
+        self.assertEqual(len(said), 1)
+        self.assertIn("cannot find this chat's own window", said[0])
+        self.assertNotIn("select-window", self.fake.verbs())
+        self.assertEqual(state.panes("api.1"), {"top": "%3", "bottom": "%4"})
 
     def test_a_tmux_whose_version_charter_cannot_read_moves_the_client_and_no_panes(self):
         """`_relayout_target` refuses on an unreadable version because every builder
         below it takes one. The switch itself needs none — `select-window` has been in
-        tmux forever — so the client still moves and nothing is split blind."""
+        tmux forever, and the placement readings around it are `display-message` — so the
+        client still moves and nothing is split blind.
+
+        This is what keeps "the two re-layouts are attempted independently, and the
+        client's move is not conditional on either" pinned: both re-layouts are refused
+        here and the switch still happens."""
         with mock.patch.object(tmuxctl, "version", lambda: None), \
              mock.patch.object(commands_frame.tmuxctl, "version", lambda: None):
             self._switch()
         verbs = self.fake.verbs()
-        self.assertEqual(verbs, ["select-window"])
+        self.assertIn("select-window", verbs)
+        self.assertEqual([v for v in verbs if v not in ("display-message",
+                                                        "select-window")], [],
+                         "something was split or killed on a tmux charter could not "
+                         "read the version of")
         self.assertEqual(state.panes("api.1"), {"top": "%3", "bottom": "%4"})
 
     def test_the_presser_chat_is_the_one_left_not_the_session_variable(self):
@@ -864,6 +955,175 @@ class TheSwitchIsFourStepsInOneOrder(PersonaIso, unittest.TestCase):
         killed = [a[-1] for a in self.fake.calls
                   if _FakeServer._verb(a) == "kill-pane"]
         self.assertEqual(killed, ["%7"])
+
+
+class TheSwitchEstablishesTheWindowItIsMovingTo(PersonaIso, unittest.TestCase):
+    """#684: `select-window` at another session's pane returns **0**.
+
+    Measured on real tmux 3.7c, own socket: two sessions A and B, the client in A,
+    `select-window -t %N` where `%N` is a window of B — rc **0**, B's current window
+    changed, A's did not, the client did not move. So the status check that follows it
+    could never have told a switch from a no-op, and what came next was
+    `_apply_arrangement(fid, want=[])`: charter tearing down the panels of the chat still
+    on screen, having reported a switch that did not happen.
+
+    Reachable because membership is a FILE. `chats.of_workspace` matches
+    `state.frame_workspace`, which `charter workspace use <other>` typed at the agent
+    rewrites ("it moves the panels too" is a documented promise) and which
+    `switch.to_workspace` rewrites again — so after one `F2 → workspace → beta` inside
+    chat `api.1`, `of_workspace("beta")` returns `api.1` (a window of tmux session `api`)
+    beside `beta.1`, in one roster, and `chats.check` says ok.
+
+    The fixture is that plane: both chats say workspace `beta`, both are on charter's own
+    server, and their windows are in two different tmux sessions — which is the one fact
+    only tmux holds.
+    """
+
+    def setUp(self):
+        super().setUp()
+        _plant("api.1", workspace="beta", pane="%1")
+        _plant("beta.1", workspace="beta", pane="%2")
+        for fid in ("api.1", "beta.1"):
+            state.record_server(fid, commands_frame.SOCKET)
+        state.record_panes("api.1", panels={"top": "%3", "bottom": "%4"})
+        self.fake = _FakeServer()
+        # `api.1`'s window is in session `$0`; `beta.1`'s is in session `$1` — which is
+        # what `cmd_launch` builds, one tmux session per workspace, and what no record on
+        # disk can say.
+        self.fake.place = {"%1": ("$0", "@0"), "%2": ("$1", "@7")}
+        self.fake.current = {"$0": "@0", "$1": "@7"}
+        for p in (mock.patch.object(tmuxctl, "run", self.fake),
+                  mock.patch.object(commands_frame.tmuxctl, "run", self.fake),
+                  mock.patch.object(tmuxctl, "version", lambda: (3, 7)),
+                  mock.patch.object(commands_frame.tmuxctl, "version", lambda: (3, 7)),
+                  mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "api.1",
+                                               "CHARTER_WORKSPACE": "beta"},
+                                  clear=False)):
+            p.start()
+            self.addCleanup(p.stop)
+        # Every refusal in `cmd_chat` goes to the screen and nowhere else, so this is
+        # where a test reads one.
+        self.said: list[str] = []
+        said = mock.patch.object(commands_frame, "_say_on_screen",
+                                 lambda fid, msg, *a, **k: self.said.append(msg))
+        said.start()
+        self.addCleanup(said.stop)
+
+    def test_the_roster_really_does_offer_the_other_sessions_chat(self):
+        """The premise, asserted rather than assumed: without this the tests below would
+        be measuring a switch nothing would ever have attempted."""
+        self.assertEqual(chats.of_workspace("beta"), ["api.1", "beta.1"])
+        self.assertTrue(chats.check("api.1", "beta.1").ok,
+                        "the reading half already refuses this, so the tmux half is not "
+                        "what this class is about any more")
+
+    def test_a_cross_session_switch_selects_nothing_and_says_why(self):
+        commands_frame.cmd_chat(mock.Mock(chat_id="beta.1", chat="api.1"))
+        self.assertNotIn("select-window", self.fake.verbs(),
+                         "charter aimed a select-window at another session's window, "
+                         "which returns 0 and moves that session")
+        self.assertEqual(len(self.said), 1)
+        self.assertIn("another tmux session", self.said[0])
+
+    def test_it_does_not_tear_down_the_panels_of_the_chat_on_screen(self):
+        """The cost the refusal exists to stop. `want=[]` on `api.1` is what used to
+        follow the rc-0 reading."""
+        commands_frame.cmd_chat(mock.Mock(chat_id="beta.1", chat="api.1"))
+        self.assertNotIn("kill-pane", self.fake.verbs())
+        self.assertEqual(state.panes("api.1"), {"top": "%3", "bottom": "%4"})
+
+    def test_the_other_sessions_current_window_is_left_where_it_was(self):
+        """Not only "this client did not move" — the OTHER session's screen is also
+        untouched, which is what a `select-window` sent anyway would have changed."""
+        commands_frame.cmd_chat(mock.Mock(chat_id="beta.1", chat="api.1"))
+        self.assertEqual(self.fake.current, {"$0": "@0", "$1": "@7"})
+
+    def test_the_same_two_chats_in_one_session_switch_normally(self):
+        """The control. Nothing about the workspace record changed — only which tmux
+        session the target's window is in — so a refusal that fired here would be
+        refusing the ordinary case."""
+        self.fake.place["%2"] = ("$0", "@1")
+        commands_frame.cmd_chat(mock.Mock(chat_id="beta.1", chat="api.1"))
+        self.assertEqual(self.said, [])
+        self.assertIn("select-window", self.fake.verbs())
+        self.assertEqual(state.panes("api.1"), {})
+
+    def test_a_target_whose_window_is_gone_is_learnt_before_anything_is_selected(self):
+        """`display-message -p` against a target tmux cannot resolve answers rc **0**,
+        empty stdout and no stderr (measured on 3.7c) — so the reading, not the status,
+        is what says the window is absent. Learnt one step earlier than it used to be,
+        which is what makes it a fact about the window rather than about a command."""
+        self.fake.place["%2"] = ("$0", "@1")
+        del self.fake.place["%2"]
+        commands_frame.cmd_chat(mock.Mock(chat_id="beta.1", chat="api.1"))
+        self.assertNotIn("select-window", self.fake.verbs())
+        self.assertEqual(len(self.said), 1)
+        self.assertIn("has no window any more", self.said[0])
+
+    def test_an_answer_missing_its_session_is_read_as_no_window(self):
+        """Both halves of the placement are held, and each says a different thing when it
+        is missing. Asserted on the SENTENCE rather than on "it refused": with the session
+        half unchecked an empty string would go on to be compared against this chat's real
+        session id, refuse for looking like another session, and pass a test that only
+        asked whether something was refused."""
+        self.fake.place["%2"] = ("", "@1")
+        commands_frame.cmd_chat(mock.Mock(chat_id="beta.1", chat="api.1"))
+        self.assertNotIn("select-window", self.fake.verbs())
+        self.assertIn("has no window any more", self.said[0])
+
+    def test_an_answer_missing_its_window_is_read_as_no_window_too(self):
+        """The other half. Unchecked, an empty window id reaches the reading taken after
+        the select — where it would refuse for "this client did not move", which is a
+        different fact said about a switch that should never have been attempted."""
+        self.fake.place["%2"] = ("$0", "")
+        commands_frame.cmd_chat(mock.Mock(chat_id="beta.1", chat="api.1"))
+        self.assertNotIn("select-window", self.fake.verbs())
+        self.assertIn("has no window any more", self.said[0])
+
+    def test_the_placement_reading_never_makes_a_target_of_a_non_pane(self):
+        """#475's rule at the boundary the placement reading adds, asserted of the reader
+        itself.
+
+        Asked of `_pane_place` directly and not through a switch, because every route into
+        it from `cmd_chat` goes past a guard that would refuse first (`chats.check`'s pane
+        record, `chats.pane_of`'s own `PANE_ID_RE`) — a test driven from the top would
+        pass on THOSE and say nothing about this one, which is exactly the "a guard that
+        passes because a different guard caught it" shape.
+
+        The value matters because `display-message -p` does not fail on a bad target: an
+        empty `-t` resolves to the CURRENT window, so `""` would have this function report
+        the asker's own place as the target's and agree that the switch may go ahead. And
+        `None` — what `chats.pane_of` answers for an unusable record — is not even a
+        string `subprocess` can put in an argv."""
+        for bad in (None, "", "not-a-pane", "%1;kill-server", " %1"):
+            with self.subTest(bad=bad):
+                self.fake.calls.clear()
+                self.assertIsNone(commands_frame._pane_place("sock", bad))
+                self.assertEqual(self.fake.calls, [],
+                                 "a value that is not a pane id reached tmux as a target")
+
+    def test_a_select_that_reports_success_without_moving_tears_nothing_down(self):
+        """The gate is on the client having MOVED, not on a command having exited 0 —
+        the two are different facts and this is the one the panels ride on. Driven by a
+        server that accepts the `select-window` and leaves the session where it was,
+        which is what tmux itself does whenever the target is not this session's."""
+        self.fake.place["%2"] = ("$0", "@1")
+        real_call = self.fake.__call__
+
+        def deaf(what, argv, **kw):
+            before = dict(self.fake.current)
+            out = real_call(what, argv, **kw)
+            self.fake.current = before          # the select "worked" and moved nothing
+            return out
+
+        with mock.patch.object(tmuxctl, "run", deaf), \
+             mock.patch.object(commands_frame.tmuxctl, "run", deaf):
+            commands_frame.cmd_chat(mock.Mock(chat_id="beta.1", chat="api.1"))
+        self.assertIn("select-window", self.fake.verbs())
+        self.assertNotIn("kill-pane", self.fake.verbs())
+        self.assertEqual(state.panes("api.1"), {"top": "%3", "bottom": "%4"})
+        self.assertEqual(len(self.said), 1)
+        self.assertIn("did not move", self.said[0])
 
 
 class ThePaletteStartsTheSwitchRatherThanPerformingIt(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -101,7 +101,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, config, hooks, instance, statusline, todos
-from charter.frame import gather, layout, notify, overlay
+from charter.frame import chats, gather, layout, notify, overlay
 from charter.frame import slots as frame_slots
 from charter.frame import state, tmuxctl
 
@@ -5712,6 +5712,129 @@ class SwitchingBetweenChatsMovesTheClientAndThePanes(_ChatsOnOneSession,
             self.assertLessEqual(width, self.SMALL[0],
                                  "a panel was born at the background window's stale "
                                  "width")
+
+
+class ASwitchAcrossSessionsIsRefusedRatherThanReported(_TmuxServerFixture, PersonaIso,
+                                                       unittest.TestCase):
+    """#684, against a real server: `select-window` at another session's pane returns 0.
+
+    **A mock cannot make this claim.** Every other guard in `cmd_chat` is about a value
+    charter read; this one is about what tmux DOES with a target it accepts, and the whole
+    defect is that accepting it and acting on it look identical from charter's side.
+    Measured here rather than quoted: the return code, both sessions' current windows, and
+    whether the panels of the chat still on screen are alive afterwards.
+
+    **Re-run against tmux 3.2 — `tmuxctl.FLOOR` — as well as 3.7c**, by putting a 3.2
+    built from the release tarball first on `$PATH`. Identical on both, so nothing here
+    carries a version gate.
+
+    The plane is the one `charter workspace use beta` typed inside chat `api.1` produces:
+    two chats whose `workspace` files both say `beta`, on one server, in two different
+    tmux sessions. `chats.of_workspace` reads the file, so both land in one roster and
+    `chats.check` says ok — which is what makes this reachable rather than hypothetical.
+    """
+
+    WS = "beta"
+
+    def _chat_in_its_own_session(self, session: str, chat: str) -> str:
+        """One chat as `cmd_launch` builds the FIRST chat of a workspace: its own tmux
+        session, its window named for the chat, the production records beside it."""
+        conf = os.path.join(self._gate_dir, f"{chat}.conf")
+        Path(conf).write_text(commands_frame._PLACEHOLDER_CONF)
+        gate = os.path.join(self._gate_dir, f"gate-{chat}")
+        r = _run(layout.session_argv(session=session, conf=conf, chat=chat,
+                                     socket=self.SOCKET_NAME, cols=80, rows=24,
+                                     harness_argv=_gate_argv(gate, "exit 0"),
+                                     env={"CHARTER_SESSION_ID": chat}))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pane = r.stdout.strip()
+        self.addCleanup(_kill_pid, self._srv("display-message", "-p", "-t", pane,
+                                             "#{pane_pid}").stdout.strip())
+        state.record_server(chat, self.SOCKET_NAME)
+        state.record_harness_pane(chat, pane)
+        state.record_workspace(chat, self.WS)
+        state.bump(chat)
+        return pane
+
+    def _current_window(self, session: str) -> str:
+        return self._srv("display-message", "-p", "-t", f"{session}:",
+                         "#{window_id}").stdout.strip()
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.one = self._chat_in_its_own_session("api", "api.1")
+        self.two = self._chat_in_its_own_session("beta", "beta.1")
+        # Two real panels on the chat the operator is looking at — what a wrongful
+        # teardown kills, and the only way to tell "charter refused" from "charter had
+        # nothing to tear down".
+        panels = {}
+        for slot in ("top", "bottom"):
+            p = self._srv("split-window", "-d", "-t", self.one, "-P", "-F",
+                          "#{pane_id}", "--", *_gate_argv(
+                              os.path.join(self._gate_dir, f"gate-{slot}"), "exit 0"))
+            self.assertEqual(p.returncode, 0, p.stderr)
+            panels[slot] = p.stdout.strip()
+        state.record_panes("api.1", panels=panels)
+        self.panels = panels
+
+    def _switch(self) -> list[str]:
+        said: list[str] = []
+        with mock.patch.object(commands_frame, "SOCKET", self.SOCKET_NAME), \
+             mock.patch.object(commands_frame, "_say_on_screen",
+                               lambda fid, msg, *a, **k: said.append(msg)), \
+             mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "api.1",
+                                          "CHARTER_WORKSPACE": self.WS}, clear=False):
+            self.assertEqual(
+                commands_frame.cmd_chat(SimpleNamespace(chat_id="beta.1",
+                                                        chat="api.1")), 0)
+        return said
+
+    def test_tmux_really_does_accept_the_wrong_target(self):
+        """The control this whole class rests on, measured on THIS tmux rather than
+        quoted from the report. If `select-window` ever starts refusing a pane of another
+        session, the guard above it is guarding nothing and the decision should be
+        re-argued."""
+        before = self._current_window("api")
+        r = self._srv("select-window", "-t", self.two)
+        self.assertEqual(r.returncode, 0,
+                         "select-window refused another session's pane on this tmux")
+        self.assertEqual(self._current_window("api"), before,
+                         "the asking session moved after all, which would make that "
+                         "return code an honest answer")
+
+    def test_the_two_chats_share_a_roster_and_not_a_session(self):
+        """The premise. Both files say `beta`, so both are in one roster; their windows
+        are in two sessions, which is the fact no file holds."""
+        self.assertEqual(chats.of_workspace(self.WS), ["api.1", "beta.1"])
+        self.assertNotEqual(
+            self._srv("display-message", "-p", "-t", self.one,
+                      "#{session_id}").stdout.strip(),
+            self._srv("display-message", "-p", "-t", self.two,
+                      "#{session_id}").stdout.strip())
+
+    def test_the_switch_is_refused_and_both_sessions_stay_where_they_were(self):
+        api_before, beta_before = (self._current_window("api"),
+                                   self._current_window("beta"))
+        said = self._switch()
+        self.assertEqual(len(said), 1, said)
+        self.assertIn("another tmux session", said[0])
+        self.assertEqual(self._current_window("api"), api_before)
+        self.assertEqual(self._current_window("beta"), beta_before,
+                         "charter moved a session it is not in")
+
+    def test_the_panels_of_the_chat_on_screen_are_still_running(self):
+        """The cost. Before this refusal the rc-0 reading was followed by
+        `_apply_arrangement(fid, want=[])`, which killed these panes — the panels of the
+        chat the operator was still looking at, torn down over a switch that never
+        happened."""
+        self._switch()
+        alive = self._srv("list-panes", "-t", self.one, "-F",
+                          "#{pane_id}").stdout.split()
+        for slot, pane in self.panels.items():
+            self.assertIn(pane, alive, f"the {slot} panel of the chat on screen was "
+                                       f"killed by a switch that did not happen")
+        self.assertEqual(state.panes("api.1"), self.panels,
+                         "charter rewrote the pane map of a chat it did not leave")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #684.

## Reproduced against a real server first

Driving the real `cmd_chat` on `main`, two chats whose `workspace` files both say `beta`,
their windows in two tmux sessions:

```
CROSS-SESSION (main)
  said            : []
  api current     : @0 -> @0        <- the client never moved
  api.1 panes     : ['%0']          <- its two panels are gone
  VERDICT: FAIL
```

and on this branch, on tmux 3.7c and on tmux 3.2 alike:

```
CROSS-SESSION
  said            : ["cannot switch: chat 'beta.1' is a window of another tmux session, …"]
  api current     : @0 -> @0
  beta current    : @1 -> @1        <- the other session was not moved either
  api.1 panes     : ['%0', '%2', '%3']
  VERDICT: PASS
SAME-SESSION
  api current     : @0 -> @2  target window: @2
  api.1 panes     : ['%0']          <- the ordinary switch still tears down what it leaves
  VERDICT: PASS
```

## Why the return code could not catch it

```
$ tmux -L … select-window -t %3     # %3 is a window of session B; client is in session A
rc=0
after:  A current=@0   B current=@2
```

A command that exits 0 having acted on the wrong target is indistinguishable from one that
acted on the right one. `chats.check`'s last refusal guarded that the pane **record** was
well-formed, never that the pane was somewhere this client could be moved to.

## Reachable, not hypothetical

`chats.of_workspace` matches `state.frame_workspace` — a FILE. `charter workspace use beta`
typed inside chat `api.1` rewrites it ("it moves the panels too" is a documented promise)
and `switch.to_workspace` rewrites it again. The tmux session is fixed at launch. So one
`F2 → workspace → beta` puts `api.1` and `beta.1` in one roster with their windows in two
sessions, and every check said yes.

## The two properties

- **Server** — a record, so `chats.check` asks it. Pane ids are per-server: `%3` recorded by
  a chat on charter's own socket names a real, live, unrelated pane on the operator's. No
  default is filled in for a missing marker; every chat this charter launches records one
  on both paths, and `of_workspace` keeps pre-chat `{ws}-{pid}` frames out of the roster.
- **Session** — a fact only tmux holds, which moves while the palette is open, so `cmd_chat`
  asks it of both chats before aiming anything. Refusing *before* the select is what keeps
  charter from moving somebody else's session.

And the teardown is gated on the client having **moved** — read back from tmux — rather
than on `select-window`'s status.

## The reading is the guard, not the status

Measured on 3.7c: `display-message -p` against an unresolvable target answers **rc 0, empty
stdout, no stderr**. So the placement readings are held to their shape (`$<digits>`,
`@<digits>`) rather than to their exit code — the same mistake this issue is about, one
command over. An empty `-t` is not nothing either: it resolves to the current window.

## The audit the review asked for

Every other place in `commands_frame` that targets a pane or window was walked. Findings
are in the report; two are worth naming here:

- `_say_on_screen`'s `-t <fid>` is a **name**-shaped target that works today only by
  accident of tmux's fallback (a chat id starts with its session's name, and tmux resolves
  `api.1` to session `api`). Sound in the reachable configuration; noted, not changed here.
- `layout.chat_window_argv`'s `-t <session>` genuinely breaks for a workspace whose name
  contains a dot — `new-window -t api.2` answers `can't specify pane here`, rc 1, so a
  second chat can never be opened in that workspace. Separate defect, filed separately.

## One deliberate reversal

A chat whose own harness-pane record is unreadable now refuses the switch instead of moving
the client anyway. The previous argument ("leaving the operator where they asked not to be
is the worse failure") held while the only cost of not knowing where you stand was an
untidy background window. That record is what says which session this client is in.
`TheSwitchIsFourStepsInOneOrder.test_a_chat_whose_own_pane_record_is_broken_switches_nothing`
carries the reasoning.

## Verification

- Full suite green on 3.14: **8858 tests, OK**.
- New real-tmux class `ASwitchAcrossSessionsIsRefusedRatherThanReported`, run on 3.7c and
  on 3.2. It measures `select-window`'s rc against another session's pane on *this* tmux
  first, so the guard cannot outlive the behaviour it is for.
- Hand deletion sweep, applied and restored with sha256 **and** `git diff --quiet` checked
  on every restore. All ten guards go RED; two survivors on the first pass were fixed at
  the source rather than papered over — `_session_window`'s shape check was subsumed by the
  comparison it feeds (deleted), and `_pane_place`'s pane-id check was masked by
  `chats.pane_of` on every route from the top (now asserted of the reader directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy