### PR TITLE
Opening a second chat stops leaving the first one's panels running behind it (#688)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1488,9 +1488,16 @@ def _chat_being_left(socket: str, *, beside: str) -> str:
     # `None` when *beside*'s own window is not in the listing, and it needs no branch of
     # its own: no session id is ever `None`, so the second lookup below matches nothing
     # and answers "". A sentinel that cannot collide is one guard rather than two.
-    session = next((s[0] for s in seats if s[2].strip() == beside), None)
-    chat = next((s[2].strip() for s in seats
-                 if s[0] == session and s[1] == "1"), "")
+    session = next((s[0] for s in seats if s[2] == beside), None)
+    chat = next((s[2] for s in seats if s[0] == session and s[1] == "1"), "")
+    # **Not stripped, and that is the guard rather than a missing one.** `splitlines`
+    # has already taken the line terminator and the fields are cut on tabs, so there is
+    # no whitespace here tmux put in — only whitespace somebody put in the OPTION, and
+    # `_FRAME_ID_RE`'s alphabet holds none. Stripping would turn ` demo.1 ` into a chat
+    # charter then tears the panels off, which is normalising a value the one rule below
+    # is there to refuse. It is also the `strip`/`lstrip` shape `_live_chats`' own
+    # docstring names: truthy for exactly the same strings, so no test can tell the two
+    # apart — a question with one answer, not asked.
     return chat if chat != beside and _FRAME_ID_RE.fullmatch(chat) else ""
 
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1433,6 +1433,67 @@ def _live_chats(socket: str) -> set[str] | None:
     return {name for name in names if name}
 
 
+#: What :func:`_chat_being_left` asks of every window on a server, in one call.
+#:
+#: Three fields and all of them tmux's own: which SESSION a window is in, whether it is
+#: that session's current one, and which chat it draws. Ids and an option, never names —
+#: a window name is not an identity (`_CHAT_OPTION`), and a session NAME is worse than
+#: useless as a `-t` target here because tmux parses `api.2` as ``window.pane``, so a
+#: workspace with a dot in it would resolve to somebody else's window or to none.
+#:
+#: `\t` because none of the three can contain one: `#{session_id}` is `$<digits>`,
+#: `#{window_active}` is `0` or `1`, and a chat id is held to `_FRAME_ID_RE`'s alphabet
+#: on the way back out.
+_WINDOW_SEAT_FORMAT = f"#{{session_id}}\t#{{window_active}}\t#{{{_CHAT_OPTION}}}"
+
+
+def _chat_being_left(socket: str, *, beside: str) -> str:
+    """The chat currently on screen in the same tmux session as chat *beside* — or ``""``.
+
+    **What a launch has to know before it takes the client somewhere else** (#688).
+    `cmd_chat` tears the panels of the chat it leaves down, and #668 calls that a
+    correctness rule rather than a saving: a background window keeps STALE geometry
+    (§7.4, measured identically on tmux 3.7c and 3.2), so panels left running in one are
+    not idle, they are rendering at a width that is no longer their window's. The launch
+    path is what CREATES that situation — `layout.chat_window_argv` opens the second chat
+    with `new-window -d` and the launcher then selects it — and it kept no such rule.
+
+    One `list-windows -a`, and the whole of the reason it is not two: the new chat's own
+    window is in that answer too, so its `@charter_chat` gives the SESSION without a
+    second round trip, and nothing here ever hands tmux a name to resolve. That matters
+    beyond tidiness — see :data:`_WINDOW_SEAT_FORMAT` for what `-t <workspace>` does to a
+    workspace whose name contains a dot.
+
+    ``""`` for every way this can fail to answer, because the caller does one thing with
+    all of them: leave the other chat alone. A server that would not list its windows, a
+    *beside* whose window is not in the list, a session whose current window carries no
+    chat at all (the operator's own shell, on their own server), and *beside* itself —
+    the launch that created the session, whose only window is already current.
+
+    Held to `_FRAME_ID_RE` on the way out, at #475's boundary: this value came off a tmux
+    option, and it is about to be a state directory's name and the key `state.harness_pane`
+    is read under.
+    """
+    out = tmuxctl.run("finding the chat this launch is leaving",
+                      tmuxctl.server_argv(socket, "list-windows", "-a", "-F",
+                                          _WINDOW_SEAT_FORMAT),
+                      timeout=5, report=False)
+    # No branch on the return code: a listing that failed has an empty stdout, so it
+    # falls out below as "no seats and therefore no answer" — the same sentence, said
+    # once. Exactly three fields per row, because `#{@charter_chat}` is an option and an
+    # option's value is whatever somebody set: one holding a tab of its own would
+    # otherwise have its first half read as a chat id.
+    seats = [line.split("\t") for line in out.stdout.splitlines()]
+    seats = [s for s in seats if len(s) == 3]
+    # `None` when *beside*'s own window is not in the listing, and it needs no branch of
+    # its own: no session id is ever `None`, so the second lookup below matches nothing
+    # and answers "". A sentinel that cannot collide is one guard rather than two.
+    session = next((s[0] for s in seats if s[2].strip() == beside), None)
+    chat = next((s[2].strip() for s in seats
+                 if s[0] == session and s[1] == "1"), "")
+    return chat if chat != beside and _FRAME_ID_RE.fullmatch(chat) else ""
+
+
 def _frame_is_live(socket: str, fid: str) -> bool:
     """Is the frame *fid* still running on *socket*? One question, one place — #408.
 
@@ -2590,10 +2651,19 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     _arm_panel_respawn(socket, fid=fid, panes=panes, env=None)
     tmuxctl.run("focusing the harness pane",
                 tmuxctl.server_argv(socket, "select-pane", "-t", harness_pane))
+    # Read before the select takes the operator off it, for the private path's reason
+    # (#688). Ordinarily nothing: the window they are on is one of THEIR windows and
+    # carries no `@charter_chat`, so this answers `""` and nothing of theirs is touched —
+    # the same promise every other line on this path makes. It is a chat only when the
+    # operator already had a charter frame open in this session, which is exactly the
+    # case the rule is about.
+    leaving = _chat_being_left(socket, beside=fid)
     # `select-window`, never `attach`: the operator has a client already, on this very
     # server. A second attach IS the nesting this path exists to remove.
-    tmuxctl.run("switching to the frame",
-                tmuxctl.server_argv(socket, "select-window", "-t", window_id))
+    selected = tmuxctl.run("switching to the frame",
+                           tmuxctl.server_argv(socket, "select-window", "-t", window_id))
+    if selected.returncode == 0:
+        _drop_panels(socket, leaving)
 
     code = _wait_for_harness(socket, harness_pane)
     if code is None:
@@ -3793,9 +3863,25 @@ def cmd_launch(args) -> int:
             # must not be dragged onto a half-built window — and this is where that is
             # paid back. A no-op for the launch that created the session, whose only
             # window is already current.
-            tmuxctl.run("selecting the chat",
-                        tmuxctl.server_argv(SOCKET, "select-window", "-t", harness_pane),
-                        env=env)
+            # Which chat the client is on right now, read BEFORE the select takes them
+            # off it (#688). `new-window -d` did not move them, so the session's current
+            # window is still the chat being left. A no-op for the launch that created
+            # the session, whose only window is the one it just built.
+            leaving = _chat_being_left(SOCKET, beside=fid)
+            selected = tmuxctl.run(
+                "selecting the chat",
+                tmuxctl.server_argv(SOCKET, "select-window", "-t", harness_pane),
+                env=env)
+            # And the chat the client has just left loses its panels — `cmd_chat` step 2's
+            # rule, applied where the situation is made rather than only where it is
+            # managed. Gated on the select having WORKED, which here is what the return
+            # code honestly says: both windows are in one session by construction (this
+            # launch created its own in `session`), so unlike #684's cross-session case
+            # there is no way for `select-window` to succeed against a window the client
+            # cannot be moved to. A teardown ahead of a failed select would kill the
+            # panels of the chat the operator is still looking at.
+            if selected.returncode == 0:
+                _drop_panels(SOCKET, leaving)
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
             # after every slot has been drawn, the LAST panel drawn — not the harness —
@@ -4590,6 +4676,38 @@ def _apply_arrangement(fid: str, *, where, want: list[str],
     # by construction — where the menu was a SNAPSHOT on disk that a switch had to rewrite
     # or it went on naming the level the frame had left.
     state.bump(fid)
+
+
+def _drop_panels(socket: str, chat: str) -> None:
+    """Tear the panels of *chat* down, because the client has just left its window.
+
+    **`cmd_chat` step 2's call, made on the path that creates the situation the switch
+    exists to manage** (#688). #668 states the rule and enforced it on the switch only: a
+    background window keeps STALE geometry, so panels left running in one are not idle,
+    they are rendering at a width that is no longer their window's — the exact defect
+    `panel._component_text`'s `width=slots._width()` guard exists for. `charter claude`
+    twice in one workspace left four panel processes doing that per abandoned chat, each
+    polling `state.version` at `panel.TICK`, until an `F2` round trip happened to tidy
+    them.
+
+    **The socket is compared rather than trusted**, and that is #684's class rather than
+    belt and braces: `_relayout_target` resolves the server from the frame's OWN record,
+    while the chat this is about was found by reading a window on *socket* — and pane ids
+    are PER-SERVER, so a record that disagreed would aim `kill-pane` at a real, live,
+    unrelated pane on the other server. A disagreement means charter cannot say where this
+    chat is, and the answer to that is to leave it alone.
+
+    Every refusal is a quiet no-op: this is a window nobody is looking at, and a launch
+    that has just built a frame must not fail over tidying one.
+    """
+    # No `if not chat` in front of this: `_relayout_target` reads the pane record through
+    # `state.frame_dir`, which resolves through `contain.child` and refuses `""` outright,
+    # so the empty answer is already the refusal below. A guard that passes only because a
+    # different guard caught it is the shape this repository deletes.
+    where = _relayout_target(chat)
+    if where is None or where[0] != socket:
+        return
+    _apply_arrangement(chat, where=where, want=[])
 
 
 def _hidden_now(fid: str, frame: dict) -> list[str]:

--- a/docs/news/unreleased-opening-a-second-chat-tidies-the-first.md
+++ b/docs/news/unreleased-opening-a-second-chat-tidies-the-first.md
@@ -1,0 +1,52 @@
+---
+version: unreleased
+headline: Opening a second chat stops leaving the first one's panels running behind it
+---
+
+`charter claude` twice in one workspace left four panel processes running in a background
+window. Not idle: each was polling `state.version` at `panel.TICK` and rendering against a
+width its window no longer had.
+
+## The rule, and where it was kept
+
+`cmd_chat` — the `F2` switch — tears the panels of the chat it leaves down, and #668's own
+text is emphatic that this is **not a saving**:
+
+> A background window keeps STALE geometry (§7.4, measured identically on 3.7c and 3.2),
+> so panels left running there are not idle, they are rendering at a width that is no
+> longer their window's, which is the exact defect `panel._component_text`'s
+> `width=slots._width()` guard exists for.
+
+The launch path had no such rule — and the launch path is what *creates* the situation the
+switch exists to manage. `layout.chat_window_argv` opens the second chat with
+`new-window -d` and the launcher then selects it, leaving the first chat behind, panels
+and all, until an `F2` round trip happened to tidy them.
+
+## What it does now
+
+The launcher reads which chat the client is on **before** its own `select-window`, and
+tears that one down **after** — the same order `cmd_chat` uses, for the same reason: the
+window being left is stale from the moment the client moves, and a teardown ahead of a
+select that failed would kill the panels of the chat the operator is still looking at.
+
+Both launch paths keep it. Inside an operator's own tmux the window they were on is
+ordinarily one of *theirs* and carries no `@charter_chat` at all, so nothing happens — the
+same promise the rest of that path makes; it is a chat only when the operator already had
+a charter frame open in that session, which is exactly the case the rule is about.
+
+## The reading takes no target
+
+Which chat is on screen is asked as one `list-windows -a` over tmux's own ids — the
+session id, `#{window_active}`, and the `@charter_chat` option — and the new chat's own
+row is what identifies the session, so there is no second round trip and **no name is ever
+handed to tmux to resolve.**
+
+That last part is not tidiness. tmux parses a target on `.` as `window.pane`, so
+`-t api.2` asks about a pane index of some other window rather than about the session
+called `api.2` — and a workspace named `api.2` is one an operator is entitled to create.
+Measured on 3.7c and 3.2; there is a real-tmux test for that name specifically.
+
+And the teardown compares the server it read the window on against the server the chat's
+own record names, because pane ids are per-server: a record that disagreed would aim
+`kill-pane` at a real, live, unrelated pane on the other tmux. A disagreement means
+charter cannot say where that chat is, and the answer to that is to leave it alone.

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -2397,8 +2397,15 @@ class ALaunchTakesThePanelsOfTheChatItLeaves(PersonaIso, unittest.TestCase):
     def test_a_chat_id_outside_the_alphabet_answers_nothing(self):
         """#475\'s rule where this value enters charter\'s vocabulary: it came off a tmux
         option and it is about to be a state directory\'s name and the key
-        `state.harness_pane` is read under."""
-        for hostile in ("../../etc", "demo 9", "demo.9;kill-server", "demo\x1b[31m"):
+        `state.harness_pane` is read under.
+
+        ` demo.9 ` is in the list on purpose: the field is NOT stripped, so a value
+        somebody padded is refused rather than normalised into a real chat charter would
+        then tear the panels off. A `\\r` cannot be tested here and that is a fact about
+        the reader rather than a gap — `splitlines` treats it as a line terminator, so it
+        becomes a row boundary before this ever sees it."""
+        for hostile in ("../../etc", "demo 9", "demo.9;kill-server", "demo\x1b[31m",
+                        " demo.9 "):
             with self.subTest(hostile=hostile):
                 fake = _SeatReader(f"$0\t1\t{hostile}\n$0\t0\tdemo.1")
                 with mock.patch("charter.commands_frame.subprocess.run",

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1458,7 +1458,7 @@ class _FakeTmux:
 
     def __init__(self, *, pane_id="%7", exit_code=None, race_death_status=None,
                 still_live=False, pre_existing_sessions=frozenset(),
-                pre_existing_chats=frozenset(), list_windows_rc=0,
+                pre_existing_chats=frozenset(), current_chat=None, list_windows_rc=0,
                 panel_pane_ids=None, pane_capture="",
                 session_rc=0, source_rc=0, env_set_rc=0, write_hook_rc=0,
                 teardown_hook_rc=0, panel_rc=0, select_rc=0, attach_rc=0, dm_rc=0,
@@ -1478,6 +1478,10 @@ class _FakeTmux:
         #: already has one chat open, which is what makes a launch into it the SECOND
         #: chat rather than the first.
         self.pre_existing_chats = frozenset(pre_existing_chats)
+        #: Which chat the client is sitting on when this launch begins — the one #688's
+        #: teardown is about. ``None`` means the launch's own, which is what a first chat
+        #: of a workspace ends up being.
+        self.current_chat = current_chat
         #: A server that answers `list-sessions` and then refuses `list-windows` — the
         #: one state in which charter cannot tell which chats are live and must not reap.
         self.list_windows_rc = list_windows_rc
@@ -1618,6 +1622,13 @@ class _FakeTmux:
             return subprocess.CompletedProcess(cmd, self.capture_rc,
                                                stdout=self.pane_capture if self.capture_rc == 0 else "",
                                                stderr="" if self.capture_rc == 0 else "no such pane")
+        if "kill-pane" in cmd or "resize-pane" in cmd:
+            # What tearing a chat's panels down issues (#688). One knob for the pair
+            # because they only ever appear together — `_relayout` with `want=[]` kills
+            # every panel and then re-asserts what is left, which is nothing.
+            return subprocess.CompletedProcess(cmd, self.kill_rc, stdout="",
+                                               stderr="" if self.kill_rc == 0
+                                               else "no such pane")
         if "kill-session" in cmd:
             self.kill_session_called = True
             return subprocess.CompletedProcess(cmd, self.kill_rc, stdout="",
@@ -1639,6 +1650,14 @@ class _FakeTmux:
             else:
                 live = {self.session} if self.still_live else set()
             return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(live), stderr="")
+        if commands_frame._WINDOW_SEAT_FORMAT in cmd:
+            # `_chat_being_left` (#688): every window's session, whether it is that
+            # session's current one, and which chat it draws. Told apart from
+            # `_live_chats` by the FORMAT and answered BEFORE the generic `list-windows`
+            # branch, because both carry `@charter_chat` and they are different
+            # questions — one is "what is alive", this one is "what is on screen".
+            return subprocess.CompletedProcess(cmd, self.list_windows_rc,
+                                               stdout=self._seats(), stderr="")
         if "list-windows" in cmd:
             if self.list_windows_rc != 0:
                 return subprocess.CompletedProcess(cmd, self.list_windows_rc, stdout="",
@@ -1652,6 +1671,21 @@ class _FakeTmux:
                 live.add(self.fid)
             return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(live), stderr="")
         raise AssertionError(f"unexpected tmux command in test: {cmd}")
+
+    def _seats(self) -> str:
+        """One row per window of this session, in `_WINDOW_SEAT_FORMAT`'s three fields.
+
+        `current_chat` is which chat the CLIENT is on when this launch starts, and
+        ``None`` means "this launch's own", which is the first-chat-of-a-workspace case:
+        the session it created has exactly one window. A test that wants the second-chat
+        case names the first chat, which is also what it puts in `pre_existing_chats`.
+        """
+        current = self.current_chat if self.current_chat is not None else self.fid
+        rows = [(chat, chat == current) for chat in sorted(self.pre_existing_chats)]
+        if self.fid:
+            rows.append((self.fid, self.fid == current))
+        return "\n".join(f"$0\t{'1' if active else '0'}\t{chat}"
+                          for chat, active in rows)
 
 
 def _is_chrome(cmd: list[str]) -> bool:
@@ -2226,6 +2260,163 @@ class TwoChatsAreTwoCharterSessions(PersonaIso, unittest.TestCase):
         self.assertEqual(toolgate.frozen_tools("release", "demo.1"), {"Bash"},
                          "one chat's ceiling moved when another chat froze its own")
         self.assertEqual(toolgate.frozen_tools("release", "demo.2"), {"Bash", "Read"})
+
+
+class _SeatReader:
+    """A tmux that answers `_WINDOW_SEAT_FORMAT` with exactly the text a test hands it.
+
+    Separate from `_FakeTmux`, which MODELS a server: this one is for the rows a real
+    server cannot produce — a value with a tab in it, a short line — which is the only way
+    to reach `_chat_being_left`\'s own parsing guards. Anything else raises, so a test
+    cannot pass by exercising a path it did not mean to.
+    """
+
+    def __init__(self, stdout: str, rc: int = 0):
+        self.stdout, self.rc = stdout, rc
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+        if commands_frame._WINDOW_SEAT_FORMAT in cmd:
+            return subprocess.CompletedProcess(cmd, self.rc, stdout=self.stdout,
+                                               stderr="")
+        raise AssertionError(f"unexpected tmux command in test: {cmd}")
+
+
+class ALaunchTakesThePanelsOfTheChatItLeaves(PersonaIso, unittest.TestCase):
+    """#688: opening a second chat left the first one's panels running.
+
+    #668 states the rule and its own text calls it a correctness rule rather than a
+    saving: a background window keeps STALE geometry (§7.4, measured identically on tmux
+    3.7c and 3.2), so four panel processes left in one are not idle — each is polling
+    `state.version` at `panel.TICK` and rendering against a width its window no longer
+    has. `cmd_chat` kept the rule and the launch path did not, which is the path that
+    CREATES the situation the switch exists to manage: `layout.chat_window_argv` opens the
+    second chat with `new-window -d` and the launcher then selects it, leaving the first
+    behind, panels and all, until an `F2` round trip happened to tidy them.
+
+    Driven through a whole `cmd_launch` rather than through a helper, because the claim is
+    about ordering inside that function — which chat is read, when, and whether the
+    teardown is gated on the select having worked.
+    """
+
+    def _first_chat_open(self, **kw) -> _FakeTmux:
+        """A workspace that already has `demo.1` open, with the client on it and two
+        panels recorded — the state a second `charter claude` finds."""
+        state.record_server("demo.1", commands_frame.SOCKET)
+        state.record_harness_pane("demo.1", "%1")
+        state.record_panes("demo.1", panels={"top": "%3", "bottom": "%4"})
+        return _FakeTmux(exit_code=0, pre_existing_sessions={"demo"},
+                         pre_existing_chats={"demo.1"}, current_chat="demo.1", **kw)
+
+    @staticmethod
+    def _killed(fake) -> list[str]:
+        return [c[-1] for c in fake.calls if "kill-pane" in c]
+
+    def test_the_chat_the_client_was_on_loses_its_panels(self):
+        fake = self._first_chat_open()
+        self.assertEqual(_launch(fake), 0)
+        self.assertEqual(sorted(self._killed(fake)), ["%3", "%4"],
+                         "the chat this launch took the client off kept its panels, "
+                         "which are now rendering at a width that is not their window\'s")
+        self.assertEqual(state.panes("demo.1"), {},
+                         "the abandoned chat\'s pane map still names panes charter killed")
+
+    def test_the_first_chat_of_a_workspace_leaves_nothing_behind(self):
+        """The control, and the one that keeps this from being a teardown of whatever
+        happens to be current. A launch that CREATED the session has one window and it is
+        its own."""
+        fake = _FakeTmux(exit_code=0)
+        self.assertEqual(_launch(fake), 0)
+        self.assertEqual(self._killed(fake), [])
+
+    def test_the_teardown_comes_after_the_select_and_not_before_it(self):
+        """`cmd_chat`\'s order, for `cmd_chat`\'s reason read the other way: the window
+        being left is stale from the moment the client moves, and a teardown ahead of the
+        select would be tearing down the chat the operator is still looking at."""
+        fake = self._first_chat_open()
+        _launch(fake)
+        selects = [i for i, c in enumerate(fake.calls) if "select-window" in c]
+        killed = [i for i, c in enumerate(fake.calls) if "kill-pane" in c]
+        self.assertTrue(selects and killed)
+        self.assertLess(selects[0], killed[0],
+                        "panels were killed before the client had been moved off them")
+
+    def test_a_select_that_failed_tears_nothing_down(self):
+        """The gate is the select having WORKED. Here the return code is an honest answer
+        — both windows are in one session by construction, this launch having created its
+        own there — so unlike #684\'s cross-session case there is no way for it to succeed
+        against a window the client cannot reach."""
+        fake = self._first_chat_open(select_rc=1)
+        _launch(fake)
+        self.assertEqual(self._killed(fake), [],
+                         "the client never moved and charter tore down the chat it is "
+                         "still sitting on")
+        self.assertEqual(state.panes("demo.1"), {"top": "%3", "bottom": "%4"})
+
+    def test_a_chat_recorded_against_the_other_server_is_left_alone(self):
+        """#684\'s class, one command over. `_relayout_target` resolves the server from
+        the frame\'s OWN record while this chat was found by reading a window on charter\'s
+        server — and pane ids are PER-SERVER, so a record that disagrees would aim
+        `kill-pane` at a real, live, unrelated pane on somebody else\'s tmux."""
+        fake = self._first_chat_open()
+        state.record_server("demo.1", OPERATOR_SOCKET)
+        _launch(fake)
+        self.assertEqual(self._killed(fake), [])
+        self.assertEqual(state.panes("demo.1"), {"top": "%3", "bottom": "%4"})
+
+    def test_a_chat_with_no_usable_pane_record_is_left_alone(self):
+        """`_relayout_target`\'s own refusal, reached from here: nothing off disk is used
+        as a pane id until it has tmux\'s own shape (#475)."""
+        fake = self._first_chat_open()
+        state.record_harness_pane("demo.1", "%1;kill-server")
+        _launch(fake)
+        for cmd in fake.calls:
+            self.assertNotIn("%1;kill-server", cmd)
+        self.assertEqual(self._killed(fake), [])
+
+    def test_a_seat_row_that_is_not_three_fields_answers_nothing(self):
+        """`@charter_chat` is an OPTION and an option\'s value is whatever somebody set.
+        A value holding a tab of its own would split into four fields, and without the
+        count filter the first half would be read as a chat id and torn down.
+
+        Asked of the reader directly, because there is no way to get a malformed row past
+        a real tmux and every route from the top would refuse for a different reason —
+        which is the "a guard that passes because a different guard caught it" shape.
+        """
+        for rows in ("$0\t1\tdemo.9\textra\n$0\t0\tdemo.1",
+                     "$0\t1\n$0\t0\tdemo.1",
+                     ""):
+            with self.subTest(rows=rows):
+                fake = _SeatReader(rows)
+                with mock.patch("charter.commands_frame.subprocess.run",
+                                side_effect=fake):
+                    self.assertEqual(
+                        commands_frame._chat_being_left("charter", beside="demo.1"), "")
+
+    def test_a_chat_id_outside_the_alphabet_answers_nothing(self):
+        """#475\'s rule where this value enters charter\'s vocabulary: it came off a tmux
+        option and it is about to be a state directory\'s name and the key
+        `state.harness_pane` is read under."""
+        for hostile in ("../../etc", "demo 9", "demo.9;kill-server", "demo\x1b[31m"):
+            with self.subTest(hostile=hostile):
+                fake = _SeatReader(f"$0\t1\t{hostile}\n$0\t0\tdemo.1")
+                with mock.patch("charter.commands_frame.subprocess.run",
+                                side_effect=fake):
+                    self.assertEqual(
+                        commands_frame._chat_being_left("charter", beside="demo.1"), "")
+
+    def test_the_chat_is_asked_for_by_id_and_never_by_a_session_name(self):
+        """The reading is `list-windows -a` over tmux\'s own ids, and nothing on this path
+        ever hands tmux a name to resolve — `-t <workspace>` parses `api.2` as
+        ``window.pane``, so a workspace with a dot in its name would aim the question at
+        somebody else\'s window or at none."""
+        fake = self._first_chat_open()
+        _launch(fake)
+        seat = [c for c in fake.calls if commands_frame._WINDOW_SEAT_FORMAT in c]
+        self.assertEqual(len(seat), 1, "the seat was read more than once, or not at all")
+        self.assertIn("-a", seat[0], "the read was scoped to a target rather than to "
+                                     "every window on the server")
 
 
 class Launch(PersonaIso, unittest.TestCase):
@@ -4579,7 +4770,7 @@ class _FakeOperatorTmux:
 
     def __init__(self, *, window_id="@3", pane_id="%7", polls_alive=1, exit_code=0,
                  pane_vanishes=False, window_size=(200, 50),
-                 pre_existing_windows=("zsh",), list_windows_rc=0,
+                 pre_existing_windows=("zsh",), current_chat="", list_windows_rc=0,
                  new_window_rc=0, arm_rc=0, chrome_rc=0, respawn_rc=0, panel_rc=0,
                  panel_pane_ids=None, resize_hook_rc=0, select_rc=0, kill_rc=0,
                  pane_capture="", capture_rc=0, chat_option_rc=0, chat_list_rc=0):
@@ -4596,6 +4787,10 @@ class _FakeOperatorTmux:
         self.capture_rc = capture_rc
         self.window_size = window_size
         self.pre_existing_windows = list(pre_existing_windows)
+        #: What the window the operator is currently on draws. ``""`` — the default — is
+        #: one of THEIR windows, which carries no `@charter_chat` at all; a test that
+        #: wants #688's case names a charter chat they already had open here.
+        self.current_chat = current_chat
         self.list_windows_rc = list_windows_rc
         self.new_window_rc = new_window_rc
         self.arm_rc = arm_rc
@@ -4621,6 +4816,13 @@ class _FakeOperatorTmux:
 
     def __call__(self, cmd, **kwargs):
         self.calls.append(list(cmd))
+        if commands_frame._WINDOW_SEAT_FORMAT in cmd:
+            # `_chat_being_left` (#688). Before the generic `list-windows` branch, for
+            # `_FakeTmux._seats`' reason: both formats carry `@charter_chat` and they are
+            # different questions. The window the operator is ON is one of THEIRS unless
+            # a test says otherwise, which is why the default row draws no chat at all.
+            return self._ok(cmd, stdout=f"$0\t1\t{self.current_chat}\n"
+                                        f"$0\t0\t{_frame_id()}")
         if "list-windows" in cmd:
             if self.list_windows_rc != 0:
                 return subprocess.CompletedProcess(
@@ -4637,7 +4839,13 @@ class _FakeOperatorTmux:
                 return subprocess.CompletedProcess(
                     cmd, self.chat_list_rc, stdout="",
                     stderr=f"error connecting to {OPERATOR_SOCKET} (No such file)")
-            live = [] if chats else list(self.pre_existing_windows)
+            # A chat the operator already has open is a LIVE chat, so it belongs in the
+            # `@charter_chat` answer as well as in the seat listing — without it the
+            # launch's own opening `state.reap` deletes that chat's directory and #688's
+            # teardown then has no record to act on, which is a fixture failing rather
+            # than the rule.
+            live = ([self.current_chat] if self.current_chat else []) if chats \
+                else list(self.pre_existing_windows)
             if self.window_killed is False and any("new-window" in c for c in self.calls):
                 live.append(_frame_id())
             return self._ok(cmd, stdout="\n".join(live))
@@ -4715,6 +4923,14 @@ class _FakeOperatorTmux:
             self.window_killed = True
             return subprocess.CompletedProcess(cmd, self.kill_rc, stdout="",
                                                stderr="" if self.kill_rc == 0 else "no window")
+        if "kill-pane" in cmd or "resize-pane" in cmd:
+            # Tearing a charter chat's panels down (#688) — `_relayout` with `want=[]`
+            # kills every panel and re-asserts what is left, which is nothing. Answered
+            # rather than raised because it IS charter's own window either way: these are
+            # panes charter split, in a window charter created.
+            return subprocess.CompletedProcess(cmd, self.kill_rc, stdout="",
+                                               stderr="" if self.kill_rc == 0
+                                               else "no such pane")
         raise AssertionError(f"unexpected tmux command on the operator's server: {cmd}")
 
 
@@ -5046,6 +5262,46 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         self.assertEqual(armed[0][:3], ["tmux", "-S", OPERATOR_SOCKET])
         self.assertEqual(armed[0][armed[0].index("-t") + 1], "%9")
         self.assertIn(f"--frame {_frame_id()}", armed[0][-1])
+
+    def test_a_charter_chat_the_operator_was_on_loses_its_panels(self):
+        """#688 on this path too. The rule is about the window the client is leaving, and
+        it does not become a different rule because the server is somebody else\'s: an
+        operator with two charter frames open in one session was leaving the first one\'s
+        panels running at a width its window no longer has."""
+        state.record_server("op.1", OPERATOR_SOCKET)
+        state.record_harness_pane("op.1", "%1")
+        state.record_panes("op.1", panels={"top": "%3"})
+        fake = _FakeOperatorTmux(exit_code=0, current_chat="op.1")
+        self.assertEqual(_launch_inside(fake), 0)
+        self.assertIn(["tmux", "-S", OPERATOR_SOCKET, "kill-pane", "-t", "%3"],
+                      fake.calls,
+                      "the charter chat this launch took the operator off kept its "
+                      "panels")
+        self.assertEqual(state.panes("op.1"), {})
+
+    def test_a_select_that_failed_tears_nothing_down_here_either(self):
+        """The gate is the same on both paths and for the same reason: a teardown ahead of
+        a select that did not happen kills the panels of the frame the operator is still
+        looking at."""
+        state.record_server("op.1", OPERATOR_SOCKET)
+        state.record_harness_pane("op.1", "%1")
+        state.record_panes("op.1", panels={"top": "%3"})
+        fake = _FakeOperatorTmux(exit_code=0, current_chat="op.1", select_rc=1)
+        _launch_inside(fake)
+        self.assertEqual([c for c in fake.calls if "kill-pane" in c], [],
+                         "the operator never moved and charter tore down the frame they "
+                         "are still sitting on")
+        self.assertEqual(state.panes("op.1"), {"top": "%3"})
+
+    def test_one_of_the_operators_own_windows_is_never_touched(self):
+        """The control, and the promise this whole path is built on. Their window carries
+        no `@charter_chat`, so there is nothing here charter may act on — and the default
+        fixture is exactly that, which is why every other test in this class stayed green
+        while this rule was added."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        self.assertEqual(_launch_inside(fake), 0)
+        self.assertEqual([c for c in fake.calls if "kill-pane" in c], [],
+                         "charter killed a pane in a window that is not its own")
 
     def test_a_finished_frame_leaves_no_directory_behind_on_this_path(self):
         """The CLOSING reap, and it needs a fixture the opening one cannot satisfy.

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -5095,6 +5095,126 @@ class _ChatsOnOneSession:
         return False
 
 
+class TheChatALaunchIsLeavingIsReadFromTmux(_ChatsOnOneSession, _TmuxServerFixture,
+                                            PersonaIso):
+    """#688: which chat the client is on, and whether charter can name it without naming
+    a session.
+
+    **A mock cannot make either claim.** `#{window_active}` is tmux's own word for "the
+    session's current window", and `-t <session name>` is how a target gets parsed — a
+    workspace called `api.2` is read as ``window.pane``, so a question aimed that way lands
+    on somebody else's window or on none. The reading here is `list-windows -a` over ids
+    and an option, and this is where that is measured rather than argued.
+
+    Verified on tmux 3.7c and on tmux 3.2 (`tmuxctl.FLOOR`); the answers were identical,
+    so nothing here carries a version gate.
+    """
+
+    def test_the_active_window_is_the_one_the_session_is_on(self):
+        one, _ = self._chat(f"{self.WS}.1", first=True)
+        two, _ = self._chat(f"{self.WS}.2", first=False)
+        self.assertEqual(
+            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.2"),
+            f"{self.WS}.1",
+            "the chat a second launch would be leaving was not the one on screen")
+        self._srv("select-window", "-t", two)
+        self.assertEqual(
+            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.1"),
+            f"{self.WS}.2",
+            "`#{window_active}` did not follow the select on this tmux, so the whole "
+            "reading is measuring something else")
+        self.assertTrue(one)
+
+    def test_the_only_chat_of_a_session_answers_nothing(self):
+        """A launch that CREATED the session has one window and it is its own — there is
+        nothing to leave, and the `chat != beside` filter is what says so."""
+        self._chat(f"{self.WS}.1", first=True)
+        self.assertEqual(
+            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.1"), "")
+
+    def test_a_chat_in_another_session_is_never_the_one_being_left(self):
+        """The session comes from the new chat's OWN row rather than from a name, so a
+        window that is current in a different session cannot be mistaken for this one's."""
+        self._chat(f"{self.WS}.1", first=True)
+        r = self._srv("new-session", "-d", "-s", "elsewhere", "-P", "-F",
+                      "#{pane_id}", "--", *_gate_argv(
+                          os.path.join(self._gate_dir, "gate-elsewhere"), "exit 0"))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.addCleanup(_kill_pid, self._pane_pid_on(r.stdout.strip()))
+        named = commands_frame._chat_option_argv(socket=self.SOCKET_NAME,
+                                                 harness_pane=r.stdout.strip(),
+                                                 chat="other.1")
+        self.assertEqual(_run(named).returncode, 0)
+        self.assertEqual(
+            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.1"), "")
+
+    def test_a_workspace_whose_name_holds_a_dot_is_still_answered(self):
+        """The reason nothing here is a `-t <session>`: tmux parses a target on `.` as
+        ``window.pane``, so `display-message -t api.2` resolves to a pane INDEX of some
+        other window rather than to the session called `api.2`. Measured on 3.7c: the
+        session is found, the window is not, and the answer is whatever was current.
+
+        This class's own reading takes no target at all, so a workspace an operator is
+        perfectly entitled to name is answered like any other."""
+        r = self._srv("new-session", "-d", "-s", "api.2", "-n", "api.2.1", "-P", "-F",
+                      "#{pane_id}", "--", *_gate_argv(
+                          os.path.join(self._gate_dir, "gate-dotted"), "exit 0"))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        first = r.stdout.strip()
+        self.addCleanup(_kill_pid, self._pane_pid_on(first))
+        self.assertEqual(_run(commands_frame._chat_option_argv(
+            socket=self.SOCKET_NAME, harness_pane=first, chat="api.2.1")).returncode, 0)
+        # A second window of that session, made the way `_chat_being_left`'s caller would
+        # have to reach it — off the FIRST window's pane id, never off the session's name.
+        window = self._srv("display-message", "-p", "-t", first,
+                           "#{window_id}").stdout.strip()
+        r2 = self._srv("new-window", "-d", "-a", "-t", window, "-P", "-F", "#{pane_id}",
+                       "--", *_gate_argv(os.path.join(self._gate_dir, "gate-dotted2"),
+                                         "exit 0"))
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+        self.addCleanup(_kill_pid, self._pane_pid_on(r2.stdout.strip()))
+        self.assertEqual(_run(commands_frame._chat_option_argv(
+            socket=self.SOCKET_NAME, harness_pane=r2.stdout.strip(),
+            chat="api.2.2")).returncode, 0)
+        self.assertEqual(
+            commands_frame._chat_being_left(self.SOCKET_NAME, beside="api.2.2"),
+            "api.2.1")
+
+    def test_a_window_carrying_no_chat_is_not_one_to_tear_down(self):
+        """The operator's-tmux case: the window they were on is one of THEIRS and carries
+        no `@charter_chat` at all, so this answers `""` and nothing of theirs is touched."""
+        pane, _ = self._chat(f"{self.WS}.1", first=True)
+        window = self._srv("display-message", "-p", "-t", pane,
+                           "#{window_id}").stdout.strip()
+        r = self._srv("new-window", "-a", "-t", window, "-P", "-F", "#{pane_id}",
+                      "--", *_gate_argv(os.path.join(self._gate_dir, "gate-theirs"),
+                                        "exit 0"))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.addCleanup(_kill_pid, self._pane_pid_on(r.stdout.strip()))
+        self.assertEqual(
+            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.1"), "",
+            "charter would have torn down a window that is not a chat")
+
+    def test_the_panels_of_the_chat_left_behind_really_stop(self):
+        """The other half, end to end against real panes: `_drop_panels` kills them and
+        rewrites the map, so nothing is left rendering at a width its window no longer
+        has."""
+        pane, _ = self._chat(f"{self.WS}.1", first=True)
+        panels = {}
+        for slot in ("top", "bottom"):
+            r = self._srv("split-window", "-d", "-t", pane, "-P", "-F", "#{pane_id}",
+                          "--", *_gate_argv(
+                              os.path.join(self._gate_dir, f"gate-{slot}"), "exit 0"))
+            self.assertEqual(r.returncode, 0, r.stderr)
+            panels[slot] = r.stdout.strip()
+        state.record_panes(f"{self.WS}.1", panels=panels)
+        commands_frame._drop_panels(self.SOCKET_NAME, f"{self.WS}.1")
+        alive = self._srv("list-panes", "-t", pane, "-F", "#{pane_id}").stdout.split()
+        for slot, panel in panels.items():
+            self.assertNotIn(panel, alive, f"the {slot} panel is still running")
+        self.assertEqual(state.panes(f"{self.WS}.1"), {})
+
+
 class ChatsAreWindowsOnOneWorkspaceSession(_ChatsOnOneSession, _TmuxServerFixture,
                                            PersonaIso):
     """Phase 5 Stage 5a, against a real server: a workspace is a SESSION and a chat is a
@@ -5712,126 +5832,6 @@ class SwitchingBetweenChatsMovesTheClientAndThePanes(_ChatsOnOneSession,
             self.assertLessEqual(width, self.SMALL[0],
                                  "a panel was born at the background window's stale "
                                  "width")
-
-
-class TheChatALaunchIsLeavingIsReadFromTmux(_ChatsOnOneSession, _TmuxServerFixture,
-                                            PersonaIso):
-    """#688: which chat the client is on, and whether charter can name it without naming
-    a session.
-
-    **A mock cannot make either claim.** `#{window_active}` is tmux's own word for "the
-    session's current window", and `-t <session name>` is how a target gets parsed — a
-    workspace called `api.2` is read as ``window.pane``, so a question aimed that way lands
-    on somebody else's window or on none. The reading here is `list-windows -a` over ids
-    and an option, and this is where that is measured rather than argued.
-
-    Verified on tmux 3.7c and on tmux 3.2 (`tmuxctl.FLOOR`); the answers were identical,
-    so nothing here carries a version gate.
-    """
-
-    def test_the_active_window_is_the_one_the_session_is_on(self):
-        one, _ = self._chat(f"{self.WS}.1", first=True)
-        two, _ = self._chat(f"{self.WS}.2", first=False)
-        self.assertEqual(
-            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.2"),
-            f"{self.WS}.1",
-            "the chat a second launch would be leaving was not the one on screen")
-        self._srv("select-window", "-t", two)
-        self.assertEqual(
-            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.1"),
-            f"{self.WS}.2",
-            "`#{window_active}` did not follow the select on this tmux, so the whole "
-            "reading is measuring something else")
-        self.assertTrue(one)
-
-    def test_the_only_chat_of_a_session_answers_nothing(self):
-        """A launch that CREATED the session has one window and it is its own — there is
-        nothing to leave, and the `chat != beside` filter is what says so."""
-        self._chat(f"{self.WS}.1", first=True)
-        self.assertEqual(
-            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.1"), "")
-
-    def test_a_chat_in_another_session_is_never_the_one_being_left(self):
-        """The session comes from the new chat's OWN row rather than from a name, so a
-        window that is current in a different session cannot be mistaken for this one's."""
-        self._chat(f"{self.WS}.1", first=True)
-        r = self._srv("new-session", "-d", "-s", "elsewhere", "-P", "-F",
-                      "#{pane_id}", "--", *_gate_argv(
-                          os.path.join(self._gate_dir, "gate-elsewhere"), "exit 0"))
-        self.assertEqual(r.returncode, 0, r.stderr)
-        self.addCleanup(_kill_pid, self._pane_pid_on(r.stdout.strip()))
-        named = commands_frame._chat_option_argv(socket=self.SOCKET_NAME,
-                                                 harness_pane=r.stdout.strip(),
-                                                 chat="other.1")
-        self.assertEqual(_run(named).returncode, 0)
-        self.assertEqual(
-            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.1"), "")
-
-    def test_a_workspace_whose_name_holds_a_dot_is_still_answered(self):
-        """The reason nothing here is a `-t <session>`: tmux parses a target on `.` as
-        ``window.pane``, so `display-message -t api.2` resolves to a pane INDEX of some
-        other window rather than to the session called `api.2`. Measured on 3.7c: the
-        session is found, the window is not, and the answer is whatever was current.
-
-        This class's own reading takes no target at all, so a workspace an operator is
-        perfectly entitled to name is answered like any other."""
-        r = self._srv("new-session", "-d", "-s", "api.2", "-n", "api.2.1", "-P", "-F",
-                      "#{pane_id}", "--", *_gate_argv(
-                          os.path.join(self._gate_dir, "gate-dotted"), "exit 0"))
-        self.assertEqual(r.returncode, 0, r.stderr)
-        first = r.stdout.strip()
-        self.addCleanup(_kill_pid, self._pane_pid_on(first))
-        self.assertEqual(_run(commands_frame._chat_option_argv(
-            socket=self.SOCKET_NAME, harness_pane=first, chat="api.2.1")).returncode, 0)
-        # A second window of that session, made the way `_chat_being_left`'s caller would
-        # have to reach it — off the FIRST window's pane id, never off the session's name.
-        window = self._srv("display-message", "-p", "-t", first,
-                           "#{window_id}").stdout.strip()
-        r2 = self._srv("new-window", "-d", "-a", "-t", window, "-P", "-F", "#{pane_id}",
-                       "--", *_gate_argv(os.path.join(self._gate_dir, "gate-dotted2"),
-                                         "exit 0"))
-        self.assertEqual(r2.returncode, 0, r2.stderr)
-        self.addCleanup(_kill_pid, self._pane_pid_on(r2.stdout.strip()))
-        self.assertEqual(_run(commands_frame._chat_option_argv(
-            socket=self.SOCKET_NAME, harness_pane=r2.stdout.strip(),
-            chat="api.2.2")).returncode, 0)
-        self.assertEqual(
-            commands_frame._chat_being_left(self.SOCKET_NAME, beside="api.2.2"),
-            "api.2.1")
-
-    def test_a_window_carrying_no_chat_is_not_one_to_tear_down(self):
-        """The operator's-tmux case: the window they were on is one of THEIRS and carries
-        no `@charter_chat` at all, so this answers `""` and nothing of theirs is touched."""
-        pane, _ = self._chat(f"{self.WS}.1", first=True)
-        window = self._srv("display-message", "-p", "-t", pane,
-                           "#{window_id}").stdout.strip()
-        r = self._srv("new-window", "-a", "-t", window, "-P", "-F", "#{pane_id}",
-                      "--", *_gate_argv(os.path.join(self._gate_dir, "gate-theirs"),
-                                        "exit 0"))
-        self.assertEqual(r.returncode, 0, r.stderr)
-        self.addCleanup(_kill_pid, self._pane_pid_on(r.stdout.strip()))
-        self.assertEqual(
-            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.1"), "",
-            "charter would have torn down a window that is not a chat")
-
-    def test_the_panels_of_the_chat_left_behind_really_stop(self):
-        """The other half, end to end against real panes: `_drop_panels` kills them and
-        rewrites the map, so nothing is left rendering at a width its window no longer
-        has."""
-        pane, _ = self._chat(f"{self.WS}.1", first=True)
-        panels = {}
-        for slot in ("top", "bottom"):
-            r = self._srv("split-window", "-d", "-t", pane, "-P", "-F", "#{pane_id}",
-                          "--", *_gate_argv(
-                              os.path.join(self._gate_dir, f"gate-{slot}"), "exit 0"))
-            self.assertEqual(r.returncode, 0, r.stderr)
-            panels[slot] = r.stdout.strip()
-        state.record_panes(f"{self.WS}.1", panels=panels)
-        commands_frame._drop_panels(self.SOCKET_NAME, f"{self.WS}.1")
-        alive = self._srv("list-panes", "-t", pane, "-F", "#{pane_id}").stdout.split()
-        for slot, panel in panels.items():
-            self.assertNotIn(panel, alive, f"the {slot} panel is still running")
-        self.assertEqual(state.panes(f"{self.WS}.1"), {})
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -5714,5 +5714,125 @@ class SwitchingBetweenChatsMovesTheClientAndThePanes(_ChatsOnOneSession,
                                  "width")
 
 
+class TheChatALaunchIsLeavingIsReadFromTmux(_ChatsOnOneSession, _TmuxServerFixture,
+                                            PersonaIso):
+    """#688: which chat the client is on, and whether charter can name it without naming
+    a session.
+
+    **A mock cannot make either claim.** `#{window_active}` is tmux's own word for "the
+    session's current window", and `-t <session name>` is how a target gets parsed — a
+    workspace called `api.2` is read as ``window.pane``, so a question aimed that way lands
+    on somebody else's window or on none. The reading here is `list-windows -a` over ids
+    and an option, and this is where that is measured rather than argued.
+
+    Verified on tmux 3.7c and on tmux 3.2 (`tmuxctl.FLOOR`); the answers were identical,
+    so nothing here carries a version gate.
+    """
+
+    def test_the_active_window_is_the_one_the_session_is_on(self):
+        one, _ = self._chat(f"{self.WS}.1", first=True)
+        two, _ = self._chat(f"{self.WS}.2", first=False)
+        self.assertEqual(
+            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.2"),
+            f"{self.WS}.1",
+            "the chat a second launch would be leaving was not the one on screen")
+        self._srv("select-window", "-t", two)
+        self.assertEqual(
+            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.1"),
+            f"{self.WS}.2",
+            "`#{window_active}` did not follow the select on this tmux, so the whole "
+            "reading is measuring something else")
+        self.assertTrue(one)
+
+    def test_the_only_chat_of_a_session_answers_nothing(self):
+        """A launch that CREATED the session has one window and it is its own — there is
+        nothing to leave, and the `chat != beside` filter is what says so."""
+        self._chat(f"{self.WS}.1", first=True)
+        self.assertEqual(
+            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.1"), "")
+
+    def test_a_chat_in_another_session_is_never_the_one_being_left(self):
+        """The session comes from the new chat's OWN row rather than from a name, so a
+        window that is current in a different session cannot be mistaken for this one's."""
+        self._chat(f"{self.WS}.1", first=True)
+        r = self._srv("new-session", "-d", "-s", "elsewhere", "-P", "-F",
+                      "#{pane_id}", "--", *_gate_argv(
+                          os.path.join(self._gate_dir, "gate-elsewhere"), "exit 0"))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.addCleanup(_kill_pid, self._pane_pid_on(r.stdout.strip()))
+        named = commands_frame._chat_option_argv(socket=self.SOCKET_NAME,
+                                                 harness_pane=r.stdout.strip(),
+                                                 chat="other.1")
+        self.assertEqual(_run(named).returncode, 0)
+        self.assertEqual(
+            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.1"), "")
+
+    def test_a_workspace_whose_name_holds_a_dot_is_still_answered(self):
+        """The reason nothing here is a `-t <session>`: tmux parses a target on `.` as
+        ``window.pane``, so `display-message -t api.2` resolves to a pane INDEX of some
+        other window rather than to the session called `api.2`. Measured on 3.7c: the
+        session is found, the window is not, and the answer is whatever was current.
+
+        This class's own reading takes no target at all, so a workspace an operator is
+        perfectly entitled to name is answered like any other."""
+        r = self._srv("new-session", "-d", "-s", "api.2", "-n", "api.2.1", "-P", "-F",
+                      "#{pane_id}", "--", *_gate_argv(
+                          os.path.join(self._gate_dir, "gate-dotted"), "exit 0"))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        first = r.stdout.strip()
+        self.addCleanup(_kill_pid, self._pane_pid_on(first))
+        self.assertEqual(_run(commands_frame._chat_option_argv(
+            socket=self.SOCKET_NAME, harness_pane=first, chat="api.2.1")).returncode, 0)
+        # A second window of that session, made the way `_chat_being_left`'s caller would
+        # have to reach it — off the FIRST window's pane id, never off the session's name.
+        window = self._srv("display-message", "-p", "-t", first,
+                           "#{window_id}").stdout.strip()
+        r2 = self._srv("new-window", "-d", "-a", "-t", window, "-P", "-F", "#{pane_id}",
+                       "--", *_gate_argv(os.path.join(self._gate_dir, "gate-dotted2"),
+                                         "exit 0"))
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+        self.addCleanup(_kill_pid, self._pane_pid_on(r2.stdout.strip()))
+        self.assertEqual(_run(commands_frame._chat_option_argv(
+            socket=self.SOCKET_NAME, harness_pane=r2.stdout.strip(),
+            chat="api.2.2")).returncode, 0)
+        self.assertEqual(
+            commands_frame._chat_being_left(self.SOCKET_NAME, beside="api.2.2"),
+            "api.2.1")
+
+    def test_a_window_carrying_no_chat_is_not_one_to_tear_down(self):
+        """The operator's-tmux case: the window they were on is one of THEIRS and carries
+        no `@charter_chat` at all, so this answers `""` and nothing of theirs is touched."""
+        pane, _ = self._chat(f"{self.WS}.1", first=True)
+        window = self._srv("display-message", "-p", "-t", pane,
+                           "#{window_id}").stdout.strip()
+        r = self._srv("new-window", "-a", "-t", window, "-P", "-F", "#{pane_id}",
+                      "--", *_gate_argv(os.path.join(self._gate_dir, "gate-theirs"),
+                                        "exit 0"))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.addCleanup(_kill_pid, self._pane_pid_on(r.stdout.strip()))
+        self.assertEqual(
+            commands_frame._chat_being_left(self.SOCKET_NAME, beside=f"{self.WS}.1"), "",
+            "charter would have torn down a window that is not a chat")
+
+    def test_the_panels_of_the_chat_left_behind_really_stop(self):
+        """The other half, end to end against real panes: `_drop_panels` kills them and
+        rewrites the map, so nothing is left rendering at a width its window no longer
+        has."""
+        pane, _ = self._chat(f"{self.WS}.1", first=True)
+        panels = {}
+        for slot in ("top", "bottom"):
+            r = self._srv("split-window", "-d", "-t", pane, "-P", "-F", "#{pane_id}",
+                          "--", *_gate_argv(
+                              os.path.join(self._gate_dir, f"gate-{slot}"), "exit 0"))
+            self.assertEqual(r.returncode, 0, r.stderr)
+            panels[slot] = r.stdout.strip()
+        state.record_panes(f"{self.WS}.1", panels=panels)
+        commands_frame._drop_panels(self.SOCKET_NAME, f"{self.WS}.1")
+        alive = self._srv("list-panes", "-t", pane, "-F", "#{pane_id}").stdout.split()
+        for slot, panel in panels.items():
+            self.assertNotIn(panel, alive, f"the {slot} panel is still running")
+        self.assertEqual(state.panes(f"{self.WS}.1"), {})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #688.

## The rule, kept in one place and not the other

`cmd_chat` tears the panels of the chat it leaves down, and #668's own text is emphatic:

> Not a saving — a correctness rule. A background window keeps STALE geometry (§7.4,
> measured identically on 3.7c and 3.2), so panels left running there are not idle, they
> are rendering at a width that is no longer their window's.

The launch path had no such rule — and it is the path that *creates* the situation the
switch exists to manage. `layout.chat_window_argv` opens the second chat with
`new-window -d` and the launcher then selects it, leaving the first behind: four panel
processes per abandoned chat, each polling `state.version` at `panel.TICK`, until an `F2`
round trip happened to tidy them.

## What it does now

Both launch paths read which chat the client is on **before** their own `select-window`,
and tear that one down **after** — `cmd_chat`'s order, for `cmd_chat`'s reason: the window
being left is stale from the moment the client moves, and a teardown ahead of a select
that failed would kill the panels of the chat the operator is still looking at.

Inside an operator's own tmux the window they were on ordinarily carries no
`@charter_chat` at all, so nothing of theirs is touched. It is a chat only when they
already had a charter frame open in that session — which is the case the rule is about.

## The reading takes no target, and that is load-bearing

One `list-windows -a` over tmux's own ids — `#{session_id}`, `#{window_active}`,
`@charter_chat` — with the new chat's own row identifying the session, so there is no
second round trip and **no name is ever handed to tmux to resolve.**

tmux parses a target on `.` as `window.pane`. Measured on 3.7c:

```
$ tmux -L … new-window -d -a -t api.2 …
can't specify pane here          rc=1
$ tmux -L … set-environment -t api.2 FOO bar   # rc 0
$ tmux -L … show-environment -t api  FOO
FOO=bar                          # it landed on a DIFFERENT workspace's session
```

`instance.WORKSPACE_NAME_RE` allows dots, so `api.2` is a workspace an operator may
create. This change asks its question in a way that is immune to that; the launcher's own
remaining `-t <session>` uses are filed separately (#695).

And the teardown compares the server it read the window on against the server the chat's
own record names, because pane ids are per-server — a record that disagreed would aim
`kill-pane` at a real, live, unrelated pane on the other tmux. That is #684's class, one
command over.

## Verification

- Full suite green on 3.14: **OK**.
- New real-tmux class `TheChatALaunchIsLeavingIsReadFromTmux`, run on 3.7c and on 3.2:
  `#{window_active}` really does follow a select, a session's only chat answers nothing, a
  chat in another session is never mistaken for this one's, a window carrying no chat is
  left alone, a **dotted workspace name** is still answered, and the panels really stop.
- Hand deletion sweep, applied and restored with sha256 **and** `git diff --quiet` checked
  on every restore. Ten guards, all RED:

| deleted line | reddens |
|---|---|
| the teardown, private path | `test_the_chat_the_client_was_on_loses_its_panels`, `..._comes_after_the_select...` |
| the select-worked gate, private path | `test_a_select_that_failed_tears_nothing_down` |
| the teardown, operator path | `test_a_charter_chat_the_operator_was_on_loses_its_panels` |
| the select-worked gate, operator path | `test_a_select_that_failed_tears_nothing_down_here_either` |
| `_drop_panels`' socket comparison | `test_a_chat_recorded_against_the_other_server_is_left_alone` |
| `_drop_panels`' `where is None` half | `test_a_chat_with_no_usable_pane_record_is_left_alone` |
| the not-myself filter | `test_the_only_chat_of_a_session_answers_nothing` + 3 |
| the id alphabet | `test_a_chat_id_outside_the_alphabet_answers_nothing` |
| the field-count filter | `test_a_seat_row_that_is_not_three_fields_answers_nothing` |
| the `#{window_active}` test | `test_the_active_window_is_the_one_the_session_is_on` |

  Six survivors on the first pass. Two were genuine equivalents and the **lines were
  deleted** rather than tested — `if not chat` was masked by `_relayout_target`'s own
  containment refusal, and `if out.returncode != 0` said what an empty stdout already
  said. A third was removed by dropping a branch entirely: the "session not found"
  sentinel is now `None`, which no session id can equal, so the second lookup answers ""
  with no `if` of its own. The remaining three grew tests.

## Merging

This branch, #691 (#685), #693 (#684) and the #686 branch merge cleanly against each other
in every pairwise order — checked with `git merge-tree`. The one place they all touch is
the tail of `tests/test_frame_tmux_integration.py`, and each new class is anchored beside
the class it is about rather than appended, so there is nothing to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy