### PR TITLE
A chat you switch back into is dressed again, instead of keeping whatever it had (#686)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2775,6 +2775,11 @@ def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     `Pane is dead (status 2)`. Nothing about that is specific to charter's own server;
     inside an operator's tmux the cwd is the same cwd, so the hole is the same hole.
     """
+    # The window's own options first, and before any `split-window`: `remain-on-exit` has
+    # to be armed before a panel can be born into a window that would throw its corpse
+    # away (#408), which is the ordering this call site inherits from where these three
+    # used to live (`_dress_window`, #686).
+    _dress_window(socket, fid=fid, harness_pane=harness_pane, env=env, v=v)
     panes = _split_panels(socket, slots=slots, fid=fid, harness_pane=harness_pane,
                           env=env, pane_env=pane_env, sizes=sizes, v=v)
     _install_resize_hook(socket, harness_pane=harness_pane, panes=panes, v=v, env=env,
@@ -2787,6 +2792,84 @@ def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     return panes
 
 
+def _dress_window(socket: str, *, fid: str, harness_pane: str, env: dict | None,
+                  v: tuple[int, int] | None) -> None:
+    """Assert everything about a frame that belongs to its WINDOW rather than to a pane.
+
+    `remain-on-exit -w`, the five `_CHROME` window options, and #657's two `-p` rules
+    around the harness. Three calls' worth of scope semantics, measured on tmux 3.7c and
+    identical on 3.2:
+
+    * ``set-option -w -t %0 pane-border-lines double`` writes window `@0` and shows as
+      ``[]`` on a pane of any other window;
+    * ``set-option -p -t %0 pane-border-style …`` writes pane `%0` and shows as ``[]``
+      both on `%1` and on `show -w -t %0`.
+
+    Nothing is server- or session-scoped, so **every chat's window has to be told
+    separately** — and until #686 that only ever happened at that chat's own launch.
+
+    **Called on every re-layout, not only when a pane is created, and that is the whole
+    of #686.** These three used to live inside `_split_panels`, which `_relayout` calls
+    behind `if missing:`. A switch into a chat that still holds every drawable panel has
+    nothing missing, so it wrote geometry and hooks and **not one option** — measured with
+    the repo's own `_FakeServer` driving the real `cmd_chat` at 200x50: `select-window`,
+    two `display-message`, four hook calls, five `resize-pane`, `select-pane`, and no
+    `set-option` at all. It is reachable in one step: `cmd_launch` creates the second
+    chat's window with `new-window -d` and selects it, leaving chat 1's panels alive and
+    still recorded, so the operator's first `F2` back into chat 1 finds nothing missing.
+
+    **What is NOT hoisted is as deliberate as what is.** The per-pane calls —
+    `_panel_mark_argv`, `_surface_argvs` — stay in the split loop, because that is the one
+    place charter has a panel's own `%N` in hand and `window-style` is a pane option. And
+    the harness's INTERIOR is never painted at any version or level: `_harness_rule_argvs`
+    cannot emit `window-style`, which is ADR 0018's boundary made structural rather than
+    remembered. #657's own design point is that the harness's rules are charter's and its
+    interior is the agent's; making the rules apply everywhere must not blur that.
+
+    Reported but not fatal, like the splits: a frame whose borders kept tmux's own colours
+    looks wrong, it does not fail. `remain-on-exit` is armed FIRST and this function is
+    called before any `split-window`, so no panel is ever born into a window that would
+    throw its corpse away and its respawn hook with it (#408).
+    """
+    tmuxctl.run("keeping the frame's own dead panes long enough to bring them back",
+                _panel_remain_on_exit_argv(socket=socket, harness_pane=harness_pane),
+                env=env)
+    # The frame's own word for its chrome, resolved through `_current_chrome` so a live
+    # `charter frame-chrome` is what a re-layout re-asserts rather than the configured
+    # value the frame launched with. `_split_panels` resolves it the same way for the pane
+    # scope; one resolver, so the two cannot disagree.
+    chrome = _current_chrome(fid)
+    # Above `tmuxctl.PANE_BORDER_FLOOR` the rules are each pane's own
+    # (`_pane_border_pairs`, set beside that pane's surface in `_split_panels`) and the
+    # WINDOW's stay bare — which is #631: a frame-wide border surface is one value for
+    # every rule, so a panel whose colour is not the frame's got rules in a colour it does
+    # not wear. Below the floor those two options have no pane scope at all, so the
+    # frame-wide answer is the only one that can be given and it is given here. One or the
+    # other, never both.
+    #
+    # The rules carry the frame's surface from the ARRANGEMENT rather than from any slot
+    # list: `instance.border_bg` reads `config.FRAME`, which is the same thing `cmd_chrome`
+    # reads on the live path — the agreement #610 is about, made by construction rather
+    # than by two call sites matching.
+    pane_borders = _pane_borders_wanted(v)
+    for argv in _chrome_argvs(
+            socket=socket, harness_pane=harness_pane,
+            surface=None if pane_borders else instance.border_bg(config.FRAME, chrome)):
+        tmuxctl.run("styling the frame's own rules", argv, env=env)
+    # And the three rules AROUND the harness, which above the floor are the harness's own
+    # cells and are therefore the one part of the frame the loop above no longer reaches
+    # (`_harness_rule_argvs`, #657). Left unset by #631 they were the terminal's own
+    # background while the panel on the far side of the very same rule was surfaced, so one
+    # horizontal rule came out in two colours — reported off a screenshot three times, and
+    # reproduced through a nested client at 100x24: 78 rule cells carrying an explicit
+    # `ESC[49m` beside 22 cells of `ESC[100m`.
+    for argv in _harness_rule_argvs(
+            socket=socket, harness_pane=harness_pane, pane_borders=pane_borders,
+            surface=instance.agreed_border_bg(config.FRAME, chrome)):
+        tmuxctl.run("styling the rules around the pane charter does not paint", argv,
+                    env=env)
+
+
 def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
                   env: dict | None, pane_env: dict[str, str] | None,
                   sizes: dict[str, int] | None = None,
@@ -2797,20 +2880,18 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     a live re-layout (`_relayout`) can add panes to a frame that already has some without
     re-installing hooks per batch or overwriting the map it is in the middle of building.
 
-    **The one funnel every panel pane charter creates comes out of, which is why
-    `remain-on-exit` is armed here** — before the first `split-window`, so no panel is
-    ever born into a window that would throw its corpse away and its respawn hook with it
-    (`_panel_remain_on_exit_argv`, #408). Both launch paths and every density change
-    reach panels through this function; arming at the call sites instead is what left the
-    operator's server covered on one of two.
+    **What belongs to the WINDOW is not here, and #686 is why it moved out**
+    (:func:`_dress_window` — `remain-on-exit -w`, the five `_CHROME` options, the two
+    harness rules). Those are properties of the frame, not of a pane being created, and
+    this function is only ever called when there is a pane to create: `_relayout` calls it
+    behind `if missing:`, so a switch into a chat that still holds every drawable panel
+    wrote **zero** window and pane options — geometry and hooks re-asserted, not one
+    border option, measured with the repo's own `_FakeServer` driving the real `cmd_chat`
+    at 200x50. What was right about arming them here is the FUNNEL, and that survives: it
+    is the same funnel one level up, in `_draw_panels` and `_relayout`, where it runs
+    whether or not a pane is being split.
 
-    **The frame's own chrome is armed at the same point, for that same reason** (#514,
-    `_chrome_argvs`). A pane border belongs to the window, not to the pane that was just
-    split off, so every rule in the frame is drawn from one set of window options — and
-    the only way for the two servers to agree about them is for one call site to set them
-    on both.
-
-    **And the pane SURFACE is set here too, one pane at a time** (`_surface_argvs`). It
+    **The pane SURFACE is still here, one pane at a time** (`_surface_argvs`). It
     is the same funnel and the same argument, one scope down: `window-style` is a PANE
     option, so unlike the border it has to be set on each panel as it appears — which is
     also exactly why the harness pane never gets it. Both launch paths and every density
@@ -2829,9 +2910,6 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     separately and earlier (`_remain_on_exit_argv`), so the exit code does not ride on
     this.
     """
-    tmuxctl.run("keeping the frame's own dead panes long enough to bring them back",
-                _panel_remain_on_exit_argv(socket=socket, harness_pane=harness_pane),
-                env=env)
     # The word, resolved once for the whole batch, through `_current_chrome` rather than
     # off `config.FRAME` — which is the difference a live `charter frame-chrome` makes.
     # The configured value says what a frame STARTS at; a frame the operator has since
@@ -2840,44 +2918,10 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     # one it launched with. One resolver, so the palette's mark and this pane's option
     # cannot disagree. `instance.chrome_options` is still what turns the word into
     # styles, so a value charter does not know produces no commands at all, which is
-    # `off`.
+    # `off`. `_dress_window` resolves the same word for the WINDOW's options; both ask
+    # `_current_chrome`, so the pane scope and the window scope cannot answer differently.
     chrome = _current_chrome(fid)
-    # And the chrome those panes will be bordered with, armed at the same moment and for
-    # the same reason: this is the one funnel both launch paths and every density change
-    # reach panels through, so a rule cannot come out styled one way on charter's own
-    # server and another way on the operator's (#514, `_chrome_argvs`). Reported but not
-    # fatal, like the splits themselves — a frame whose borders kept tmux's own colours
-    # is a frame that looks wrong, not one that fails.
-    #
-    # The rules carry the frame's SURFACE, from the arrangement rather than from `slots`:
-    # this function is handed only the slots being split, which on a density change is the
-    # ones being ADDED (`_relayout` passes `missing`), so a rule colour derived from that
-    # list would change every time a panel appeared. `instance.border_bg` reads
-    # `config.FRAME`, which is the same thing `cmd_chrome` reads on the live path — the
-    # agreement #610 is about, made by construction rather than by two call sites matching.
-    # Above `tmuxctl.PANE_BORDER_FLOOR` the rules are each pane's own (`_pane_border_pairs`,
-    # set beside that pane's surface below) and the WINDOW's stay bare — which is #631: a
-    # frame-wide border surface is one value for every rule, so a panel whose colour is not
-    # the frame's got rules in a colour it does not wear. Below the floor those two options
-    # have no pane scope at all, so the frame-wide answer is the only one that can be given
-    # and it is given here. One or the other, never both.
     pane_borders = _pane_borders_wanted(v)
-    for argv in _chrome_argvs(
-            socket=socket, harness_pane=harness_pane,
-            surface=None if pane_borders else instance.border_bg(config.FRAME, chrome)):
-        tmuxctl.run("styling the frame's own rules", argv, env=env)
-    # And the three rules AROUND the harness, which above the floor are the harness's own
-    # cells and are therefore the one part of the frame the loop above no longer reaches
-    # (`_harness_rule_argvs`). Left unset by #631 they were the terminal's own background
-    # while the panel on the far side of the very same rule was surfaced, so one horizontal
-    # rule came out in two colours — reported off a screenshot three times. Its INTERIOR is
-    # untouched at every version and every level: `window-style` is not one of the two
-    # option names that function can emit. Reported but not fatal, like the rules above.
-    for argv in _harness_rule_argvs(
-            socket=socket, harness_pane=harness_pane, pane_borders=pane_borders,
-            surface=instance.agreed_border_bg(config.FRAME, chrome)):
-        tmuxctl.run("styling the rules around the pane charter does not paint", argv,
-                    env=env)
     panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=socket,
                                     harness_pane=harness_pane, env=pane_env,
                                     sizes=sizes)
@@ -4001,6 +4045,16 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
     # `env=None` throughout: see `_relayout_pane_env` for why a live re-layout has
     # no client environment to decide.
     pane_env = _relayout_pane_env(fid, v)
+    # **Unconditionally, and before anything is killed or split** (#686). What belongs to
+    # the window is a property of the FRAME, not of a pane being created, so it is asserted
+    # on every re-layout rather than only on the ones that happen to add a pane. Behind
+    # `if missing:` — where these calls lived, inside `_split_panels` — a switch into a
+    # chat that still holds every drawable panel wrote no window or pane option at all, and
+    # that chat is one `charter claude` away: the second launch selects its own new window
+    # and leaves the first's panels alive and recorded, so the first `F2` back has nothing
+    # missing. Before the kill loop for `_draw_panels`' reason: `remain-on-exit` is armed
+    # ahead of any pane charter creates, and a re-layout creates panes further down.
+    _dress_window(socket, fid=fid, harness_pane=harness_pane, env=None, v=v)
     keep: dict[str, str] = {}
     for slot, pane_id in panels.items():
         # Checked ABOVE the `want` branch, not inside the kill branch — #475. `panels` is

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4054,6 +4054,9 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
     # and leaves the first's panels alive and recorded, so the first `F2` back has nothing
     # missing. Before the kill loop for `_draw_panels`' reason: `remain-on-exit` is armed
     # ahead of any pane charter creates, and a re-layout creates panes further down.
+    # It costs the kills nothing — measured on 3.7c, `kill-pane` destroys a pane on a
+    # window with `remain-on-exit on` outright, leaving no corpse: the option decides
+    # what happens when a pane's COMMAND exits, not when tmux is told to close it.
     _dress_window(socket, fid=fid, harness_pane=harness_pane, env=None, v=v)
     keep: dict[str, str] = {}
     for slot, pane_id in panels.items():

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4006,9 +4006,19 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
               window_cols: int, window_rows: int) -> dict[str, str]:
     """Make the running frame's panes match *want*, and return the map that resulted.
 
-    Kill what is no longer wanted, split what is newly wanted, re-arm the hooks, re-assert
-    every size. In that order, and each step is here for a measured reason:
+    Dress the window, kill what is no longer wanted, split what is newly wanted, re-arm
+    the hooks, re-assert every size. In that order, and each step is here for a measured
+    reason:
 
+    * **Dress the window first, and unconditionally** (#686, :func:`_dress_window`). What
+      belongs to the WINDOW — `remain-on-exit`, the frame's chrome, #657's rules round the
+      harness — is a property of the frame rather than of a pane being created, and it
+      used to be issued from inside the split below. Behind `if missing:` that meant a
+      re-layout of a frame already holding everything it wants wrote no option at all,
+      which is one `charter claude` away: the second launch selects its own new window and
+      leaves the first's panels alive and recorded, so the first `F2` back has nothing to
+      split. First rather than last because `remain-on-exit` has to be armed ahead of any
+      pane charter creates, and this function creates some further down.
     * **Disarm before killing.** See :func:`_disarm_panel_respawn` — otherwise the panel
       charter just closed comes straight back, one respawn life poorer.
     * **Split off the HARNESS pane, never off a sibling panel.** `_draw_panels` already
@@ -4045,18 +4055,11 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
     # `env=None` throughout: see `_relayout_pane_env` for why a live re-layout has
     # no client environment to decide.
     pane_env = _relayout_pane_env(fid, v)
-    # **Unconditionally, and before anything is killed or split** (#686). What belongs to
-    # the window is a property of the FRAME, not of a pane being created, so it is asserted
-    # on every re-layout rather than only on the ones that happen to add a pane. Behind
-    # `if missing:` — where these calls lived, inside `_split_panels` — a switch into a
-    # chat that still holds every drawable panel wrote no window or pane option at all, and
-    # that chat is one `charter claude` away: the second launch selects its own new window
-    # and leaves the first's panels alive and recorded, so the first `F2` back has nothing
-    # missing. Before the kill loop for `_draw_panels`' reason: `remain-on-exit` is armed
-    # ahead of any pane charter creates, and a re-layout creates panes further down.
-    # It costs the kills nothing — measured on 3.7c, `kill-pane` destroys a pane on a
-    # window with `remain-on-exit on` outright, leaving no corpse: the option decides
-    # what happens when a pane's COMMAND exits, not when tmux is told to close it.
+    # Unconditionally, and above the kill loop — see this function's own first bullet for
+    # both halves of why (#686). Being above it costs the kills nothing: measured on 3.7c,
+    # `kill-pane` destroys a pane on a window with `remain-on-exit on` outright and leaves
+    # no corpse, because that option decides what happens when a pane's COMMAND exits and
+    # not what happens when tmux is told to close it.
     _dress_window(socket, fid=fid, harness_pane=harness_pane, env=None, v=v)
     keep: dict[str, str] = {}
     for slot, pane_id in panels.items():

--- a/docs/news/unreleased-a-chat-you-switch-back-into-gets-its-borders-back.md
+++ b/docs/news/unreleased-a-chat-you-switch-back-into-gets-its-borders-back.md
@@ -1,0 +1,67 @@
+---
+version: unreleased
+headline: A chat you switch back into is dressed again, instead of keeping whatever it had
+---
+
+Switching into a chat whose panels were still running re-asserted its geometry and its
+hooks and **not one window or pane option**. Charter's own border chrome, and #657's rules
+around the harness, applied at a chat's launch and never again.
+
+## The gate
+
+`_relayout` only calls the split when a slot is missing, and the three window-level calls
+lived inside that split:
+
+```python
+if missing:
+    keep.update(_split_panels(...))   # ← remain-on-exit -w, five _CHROME options,
+                                      #   #657's two harness rules, all in here
+```
+
+So a re-layout of a frame that already holds everything it wants wrote nothing. Measured
+with the repo's own fake server driving the real `cmd_chat` at 200x50, target holding
+every drawable panel:
+
+```
+select-window -t %2
+display-message -p -t %1 #{window_width}:#{window_height}
+set-hook -p -u -t %3 pane-died ; kill-pane -t %3
+…
+resize-pane -t %10 -y 1 ; resize-pane -t %11 -y 1 ; resize-pane -t %2 -y 44
+select-pane -t %2
+```
+
+Eleven calls, no `set-option` among them. Re-measured against a real server on tmux 3.7c
+and on tmux 3.2 by stripping the options off a chat's window and switching into it: every
+one of them still unset afterwards.
+
+## It is one `charter claude` away
+
+The second chat of a workspace is created with `new-window -d` and then selected, so the
+first chat is left with its panels **alive and still recorded**. The operator's first `F2`
+back into it therefore has nothing missing — and that is the entry that used to write
+nothing. (The next leave tears those panels down, so the staleness is one screen deep,
+which is exactly deep enough to be the screen somebody reports.)
+
+The visible case is a chat surfaced by a charter predating #657, re-entered while its
+panels are alive: the rule cells over the harness carry an explicit `ESC[49m` while the
+cells beside them, over a surfaced panel, carry `ESC[100m` — one horizontal rule in two
+colours, which is the screenshot that was reported three times.
+
+## The fix, and the distinction it keeps
+
+The window's own options move up one level, into `_dress_window`, and both callers run it
+unconditionally — `_draw_panels` at launch and `_relayout` on every re-layout, before
+anything is killed or split (`remain-on-exit` still has to be armed ahead of any pane
+charter creates).
+
+What did **not** move is as deliberate as what did. The per-pane calls — the panel mark
+and each pane's `window-style` — stay in the split loop, because that is the one place
+charter has a panel's own `%N` in hand. And the harness's **interior** is still never
+painted at any version or level: the function that writes its rules cannot emit
+`window-style` at all. #657's design point was that the harness's rules are charter's and
+its interior is the agent's; making the rules apply everywhere had to leave that intact,
+and there is now a real-tmux test that says so.
+
+Cost: about eight tmux calls on a re-layout that previously made none of them, against the
+~6 ms already measured for the batch.

--- a/tests/test_frame_border_surface.py
+++ b/tests/test_frame_border_surface.py
@@ -659,8 +659,15 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
     ``bg = None`` and the whole suite stayed green — a per-pane colour that production
     never resolves is a feature that does nothing on a real frame and a test file that
     says it works. The *surface* argument has exactly that shape, so it is driven through
-    exactly that funnel: `_split_panels`, which both launch paths and every density change
-    come through, with only `tmuxctl.run` faked.
+    exactly that funnel, with only `tmuxctl.run` faked.
+
+    **The funnel is `_draw_panels` since #686, and it is two functions rather than one.**
+    A window's options (`_dress_window`) and each pane's (`_split_panels`) were one call
+    for as long as a window option was only ever written when a pane was created — which
+    is exactly the assumption #686 found to be false, because `_relayout` calls the split
+    behind `if missing:`. Driving `_split_panels` alone here would now measure the pane
+    half and report the window half as absent, so this drives the level both halves hang
+    off, in the order `_draw_panels` calls them.
     """
 
     def _issued(self, frame: dict, slots: list[str], *, fid="f-1",
@@ -676,6 +683,8 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         with mock.patch.dict(config.FRAME, frame), \
                 mock.patch.object(commands_frame.tmuxctl, "run", fake_run), \
                 mock.patch.dict(os.environ, {}, clear=True):
+            commands_frame._dress_window("sock", fid=fid, harness_pane="%1",
+                                         env=None, v=v)
             commands_frame._split_panels("sock", slots=slots, fid=fid,
                                          harness_pane="%1", env=None, pane_env=None, v=v)
         return seen
@@ -877,10 +886,14 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
         return self._styles(self._launch_calls(frame, level, v))
 
     def _launch_calls(self, frame, level, v=None):
-        """What `_split_panels` — the funnel both launch paths and every density change
+        """What `_draw_panels` — the funnel both launch paths and every density change
         come through — actually issues, with the frame's live word recorded rather than
         the resolver stubbed out. A reconstruction of the expression would agree with the
-        live path by being written twice, which is the thing #610 is about."""
+        live path by being written twice, which is the thing #610 is about.
+
+        `_draw_panels` and not `_split_panels` since #686: the window's own options moved
+        up a level (`_dress_window`) so that a re-layout which adds no pane still asserts
+        them, and the two halves are only both in view from here."""
         calls: list[list[str]] = []
         state.record_chrome(self.FID, level)
 
@@ -891,6 +904,8 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
         with mock.patch.object(config, "FRAME", frame), \
                 mock.patch.object(commands_frame.tmuxctl, "run", fake_run), \
                 mock.patch.dict(os.environ, {}, clear=True):
+            commands_frame._dress_window("s", fid=self.FID, harness_pane="%1",
+                                         env=None, v=v)
             commands_frame._split_panels("s", slots=["top"], fid=self.FID,
                                          harness_pane="%1", env=None, pane_env=None, v=v)
         return calls
@@ -1058,6 +1073,99 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
             commands_frame.cmd_chrome(type("A", (), {"level": "dark"})())
         for argv in calls:
             self.assertNotIn("; kill-server", argv)
+
+
+class ARelayoutThatAddsNoPaneStillAssertsTheWindowsOwnOptions(PersonaIso,
+                                                              unittest.TestCase):
+    """#686: the frame's window options are a property of the FRAME, not of a split.
+
+    They used to be issued from inside `_split_panels`, which `_relayout` calls behind
+    `if missing:`. So a re-layout of a frame that already holds every slot it wants — a
+    switch back into a chat whose panels are still running, which is one `charter claude`
+    away — re-asserted geometry and hooks and **not one option**. Measured before the
+    fix, with the repo's own `_FakeServer` driving the real `cmd_chat` at 200x50: eleven
+    tmux calls, no `set-option` among them.
+
+    Nothing asserted this either way. `test_frame_chat_switch`'s switch tests and
+    `test_frame_tmux_integration`'s both plant an EMPTY pane map for the target, so both
+    exercised only the `missing != []` branch.
+    """
+
+    FID = "f-relayout"
+
+    def _calls(self, *, panels, want, v=(3, 7)) -> list[list[str]]:
+        seen: list[list[str]] = []
+        spare = iter(f"%{n}" for n in range(30, 99))
+
+        def fake_run(_why, argv, **_kw):
+            seen.append(list(argv))
+            out = next(spare) if "split-window" in argv else "80"
+            return subprocess.CompletedProcess(argv, 0, stdout=out + "\n", stderr="")
+
+        frame = _resolved(*["brightblack"] * 4, chrome="dark")
+        with mock.patch.object(config, "FRAME", frame), \
+                mock.patch.object(commands_frame.tmuxctl, "run", fake_run), \
+                mock.patch.dict(os.environ, {}, clear=True):
+            commands_frame._relayout("sock", fid=self.FID, harness_pane="%1",
+                                     panels=panels, want=want, v=v,
+                                     window_cols=200, window_rows=50)
+        return seen
+
+    @staticmethod
+    def _options(calls, flag) -> dict[str, str]:
+        """The `_CHROME` window options only — `remain-on-exit` is window-scoped too and
+        has its own test, so folding it in here would let one of the two stand in for the
+        other."""
+        return {a[-2]: a[-1] for a in calls
+                if "set-option" in a and flag in a and "-u" not in a
+                and a[-2] in dict(commands_frame._CHROME)}
+
+    def test_a_relayout_with_nothing_missing_still_writes_the_window_options(self):
+        panels = {"top": "%3", "bottom": "%4"}
+        calls = self._calls(panels=panels, want=list(panels))
+        self.assertNotIn("split-window", [a[3] for a in calls if len(a) > 3],
+                         "the fixture split something, so this is the branch that "
+                         "already worked")
+        self.assertEqual(self._options(calls, "-w"), dict(commands_frame._CHROME),
+                         "a re-layout that added no pane wrote no window option, so "
+                         "#657's rules and #514's chrome do not apply after a switch")
+
+    def test_it_writes_the_two_rules_around_the_harness_as_well(self):
+        """#657's own two `-p` writes, which are the ones the reported screenshot is
+        about: unset, the 78 rule cells over the harness carry an explicit `ESC[49m`
+        while the cells beside them over a surfaced panel carry `ESC[100m` — one
+        horizontal rule in two colours."""
+        panels = {"top": "%3", "bottom": "%4"}
+        calls = self._calls(panels=panels, want=list(panels))
+        want = f"{commands_frame._CHROME_STYLE},bg=brightblack"
+        harness = [a for a in calls if "set-option" in a and "-p" in a
+                   and a[a.index("-t") + 1] == "%1"]
+        self.assertEqual([a[-1] for a in harness], [want, want],
+                         "the rules around the pane charter does not paint were not "
+                         "re-asserted")
+
+    def test_it_re_arms_remain_on_exit_on_the_window(self):
+        """Armed before any pane charter creates (#408), which on this path means before
+        the kill-and-split loop rather than only when that loop has work."""
+        panels = {"top": "%3"}
+        calls = self._calls(panels=panels, want=list(panels))
+        self.assertTrue([a for a in calls
+                         if "set-option" in a and "remain-on-exit" in a],
+                        "a frame's dead panels would be thrown away with their respawn "
+                        "hooks after a re-layout that added no pane")
+
+    def test_a_relayout_that_does_add_a_pane_is_unchanged(self):
+        """The control. Moving these calls up a level must not stop them happening on the
+        path that already had them, and must not double them."""
+        added = self._calls(panels={"top": "%3"}, want=["top", "bottom"])
+        none_added = self._calls(panels={"top": "%3", "bottom": "%4"},
+                                 want=["top", "bottom"])
+        self.assertEqual(self._options(added, "-w"), self._options(none_added, "-w"))
+        for calls in (added, none_added):
+            names = [a[-2] for a in calls if "set-option" in a and "-w" in a
+                     and a[-2] in dict(commands_frame._CHROME)]
+            self.assertEqual(len(names), len(set(names)),
+                             "a window option was written twice in one re-layout")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -698,6 +698,38 @@ class TheSwitchIsFourStepsInOneOrder(PersonaIso, unittest.TestCase):
         self.assertTrue(state.panes("api.2"))
         self.assertNotEqual(state.version("api.2"), before)
 
+    def test_a_target_that_kept_its_panels_still_has_its_rules_re_asserted(self):
+        """#686. Every switch test in this file — and in
+        `tests/test_frame_tmux_integration.py` — plants an EMPTY pane map for the target,
+        so all of them exercised the `missing != []` branch and none of them looked at a
+        border option. This plants the other branch.
+
+        It is one `charter claude` away: the second chat's window is created with
+        `new-window -d` and selected, so chat 1 keeps its panels alive **and recorded**,
+        and the operator's first `F2` back into chat 1 finds nothing missing. Before this
+        fix that switch wrote zero window and zero pane options — geometry and hooks
+        re-asserted, not one of `_CHROME`'s five, not #657's two, not `remain-on-exit`.
+        """
+        want = commands_frame._drawable_slots(
+            80, 24, commands_frame._visible_now("api.2", config.FRAME))
+        self.assertTrue(want, "the fixture has nothing to keep, so nothing is measured")
+        state.record_panes("api.2",
+                           panels={s: f"%{20 + i}" for i, s in enumerate(want)})
+        self._switch()
+        self.assertNotIn("split-window", self.fake.verbs(),
+                         "the target was missing a slot after all, so this is the branch "
+                         "that already worked")
+        options = [a[-2] for a in self.fake.calls
+                   if _FakeServer._verb(a) == "set-option" and "-u" not in a]
+        for name, _value in commands_frame._CHROME:
+            self.assertIn(name, options,
+                          f"the window's {name} was never asserted on the chat being "
+                          f"switched into")
+        harness = [a for a in self.fake.calls
+                   if _FakeServer._verb(a) == "set-option" and "-p" in a
+                   and a[a.index("-t") + 1] == "%2"]
+        self.assertTrue(harness, "#657's rules around the harness were not re-asserted")
+
     def test_a_window_that_is_gone_costs_a_sentence_and_no_panels(self):
         """The one refusal `chats.check` deliberately does not guess at. Nothing is torn
         down: the teardown is below the select for exactly this case."""

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -5714,5 +5714,112 @@ class SwitchingBetweenChatsMovesTheClientAndThePanes(_ChatsOnOneSession,
                                  "width")
 
 
+class ASwitchDressesTheWindowItEntersEvenWithNothingToSplit(_ChatsOnOneSession,
+                                                            _TmuxServerFixture,
+                                                            PersonaIso):
+    """#686, against a real server: the options are *present on the window* afterwards.
+
+    The argv half is `tests/test_frame_border_surface.py`'s. What only a real tmux can say
+    is that the writes landed — nothing here is server- or session-scoped, so every chat's
+    window has to be told separately, and until this fix the only thing that ever told one
+    was that chat's own launch.
+
+    **The fixture is the one a mock cannot plant honestly**: a chat holding every panel it
+    wants, with the options stripped off it. That is the shipping state of a chat surfaced
+    by a charter predating #657/#631 and re-entered while its panels are alive, and it is
+    also one `charter claude` away on this charter — the second launch selects its own new
+    window and leaves the first's panels running and recorded.
+
+    Verified on tmux 3.7c and on tmux 3.2 (`tmuxctl.FLOOR`). Which options exist differs
+    between them — `pane-border-indicators` is 3.7's — so this asserts about the ones THIS
+    tmux has rather than about a list, the way `EveryBorderOptionThisTmuxHasIsPinned`
+    already does.
+    """
+
+    def _has(self, name: str) -> bool:
+        """Does this tmux have *name* as a window option at all? Probed, never inferred
+        from a version string — this module's own rule."""
+        return self._srv("set-option", "-w", "-t", self.pane, name,
+                         "off").returncode == 0
+
+    def _shown(self, scope: str, name: str) -> str:
+        return self._srv("show-options", scope, "-t", self.pane,
+                         name).stdout.strip()
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.one, _ = self._chat(f"{self.WS}.1", first=True)
+        self.pane, _ = self._chat(f"{self.WS}.2", first=False)
+        for chat in (f"{self.WS}.1", f"{self.WS}.2"):
+            state.record_workspace(chat, self.WS)
+            state.record_chrome(chat, "dark")
+        # Every drawable panel already split into the target's window — the branch
+        # `if missing:` skipped, and the one no existing switch test plants.
+        want = commands_frame._drawable_slots(
+            80, 24, commands_frame._visible_now(f"{self.WS}.2", config.FRAME))
+        self.assertTrue(want, "nothing is drawable at this size, so nothing is measured")
+        panels = {}
+        for slot in want:
+            r = self._srv("split-window", "-d", "-t", self.pane, "-P", "-F",
+                          "#{pane_id}", "--", *_gate_argv(
+                              os.path.join(self._gate_dir, f"gate-{slot}"), "exit 0"))
+            self.assertEqual(r.returncode, 0, r.stderr)
+            panels[slot] = r.stdout.strip()
+        state.record_panes(f"{self.WS}.2", panels=panels)
+        self.kept = panels
+        self.names = [n for n, _ in commands_frame._CHROME if self._has(n)]
+        self.assertTrue(self.names, "this tmux has none of the options under test")
+        for name in self.names:
+            self._srv("set-option", "-w", "-u", "-t", self.pane, name)
+        for name in instance.PANE_BORDER_OPTIONS:
+            self._srv("set-option", "-p", "-u", "-t", self.pane, name)
+
+    def _switch(self) -> None:
+        with mock.patch.object(commands_frame, "SOCKET", self.SOCKET_NAME), \
+             mock.patch.object(commands_frame, "_say_on_screen",
+                               lambda fid, msg, *a, **k: self.fail(msg)), \
+             mock.patch.dict(os.environ,
+                             {"CHARTER_SESSION_ID": f"{self.WS}.1",
+                              "CHARTER_WORKSPACE": self.WS}, clear=False):
+            self.assertEqual(commands_frame.cmd_chat(
+                SimpleNamespace(chat_id=f"{self.WS}.2", chat=f"{self.WS}.1")), 0)
+
+    def test_the_fixture_really_has_nothing_left_to_split(self):
+        """Without this the class would be measuring the branch that already worked."""
+        before = self._srv("list-panes", "-t", self.pane, "-F", "#{pane_id}").stdout.split()
+        self._switch()
+        self.assertEqual(
+            self._srv("list-panes", "-t", self.pane, "-F", "#{pane_id}").stdout.split(),
+            before, "the switch split or killed something, so `missing` was not empty")
+
+    def test_the_windows_own_options_are_set_after_the_switch(self):
+        self.assertEqual([self._shown("-w", n) for n in self.names], [""] * len(self.names),
+                         "the fixture never stripped the options")
+        self._switch()
+        for name in self.names:
+            with self.subTest(option=name):
+                self.assertTrue(self._shown("-w", name),
+                                f"{name} is still unset on the window charter just "
+                                f"switched into")
+
+    def test_the_rules_around_the_harness_are_set_after_the_switch(self):
+        """#657's two `-p` writes — the ones the reported screenshot is about."""
+        self._switch()
+        self.assertTrue([self._shown("-p", n) for n in instance.PANE_BORDER_OPTIONS
+                         if self._shown("-p", n)],
+                        "the rules around the pane charter does not paint were never "
+                        "re-asserted, so a horizontal rule stays two colours")
+
+    def test_the_harnesss_interior_is_still_never_painted(self):
+        """#657's own design point, kept while making its rules apply: the harness's
+        RULES are charter's and its INTERIOR is the agent's (ADR 0018). A re-layout that
+        now dresses the window on every pass must not start painting inside it."""
+        self._switch()
+        for name in instance.chrome_option_names():
+            with self.subTest(option=name):
+                self.assertEqual(self._shown("-p", name), "",
+                                 f"charter painted the harness pane's {name}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -5341,6 +5341,113 @@ class ChatsAreWindowsOnOneWorkspaceSession(_ChatsOnOneSession, _TmuxServerFixtur
         self.assertEqual(_await_text(seen), "session-wide")
 
 
+class ASwitchDressesTheWindowItEntersEvenWithNothingToSplit(_ChatsOnOneSession,
+                                                            _TmuxServerFixture,
+                                                            PersonaIso):
+    """#686, against a real server: the options are *present on the window* afterwards.
+
+    The argv half is `tests/test_frame_border_surface.py`'s. What only a real tmux can say
+    is that the writes landed — nothing here is server- or session-scoped, so every chat's
+    window has to be told separately, and until this fix the only thing that ever told one
+    was that chat's own launch.
+
+    **The fixture is the one a mock cannot plant honestly**: a chat holding every panel it
+    wants, with the options stripped off it. That is the shipping state of a chat surfaced
+    by a charter predating #657/#631 and re-entered while its panels are alive, and it is
+    also one `charter claude` away on this charter — the second launch selects its own new
+    window and leaves the first's panels running and recorded.
+
+    Verified on tmux 3.7c and on tmux 3.2 (`tmuxctl.FLOOR`). Which options exist differs
+    between them — `pane-border-indicators` is 3.7's — so this asserts about the ones THIS
+    tmux has rather than about a list, the way `EveryBorderOptionThisTmuxHasIsPinned`
+    already does.
+    """
+
+    def _has(self, name: str) -> bool:
+        """Does this tmux have *name* as a window option at all? Probed, never inferred
+        from a version string — this module's own rule."""
+        return self._srv("set-option", "-w", "-t", self.pane, name,
+                         "off").returncode == 0
+
+    def _shown(self, scope: str, name: str) -> str:
+        return self._srv("show-options", scope, "-t", self.pane,
+                         name).stdout.strip()
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.one, _ = self._chat(f"{self.WS}.1", first=True)
+        self.pane, _ = self._chat(f"{self.WS}.2", first=False)
+        for chat in (f"{self.WS}.1", f"{self.WS}.2"):
+            state.record_workspace(chat, self.WS)
+            state.record_chrome(chat, "dark")
+        # Every drawable panel already split into the target's window — the branch
+        # `if missing:` skipped, and the one no existing switch test plants.
+        want = commands_frame._drawable_slots(
+            80, 24, commands_frame._visible_now(f"{self.WS}.2", config.FRAME))
+        self.assertTrue(want, "nothing is drawable at this size, so nothing is measured")
+        panels = {}
+        for slot in want:
+            r = self._srv("split-window", "-d", "-t", self.pane, "-P", "-F",
+                          "#{pane_id}", "--", *_gate_argv(
+                              os.path.join(self._gate_dir, f"gate-{slot}"), "exit 0"))
+            self.assertEqual(r.returncode, 0, r.stderr)
+            panels[slot] = r.stdout.strip()
+        state.record_panes(f"{self.WS}.2", panels=panels)
+        self.kept = panels
+        self.names = [n for n, _ in commands_frame._CHROME if self._has(n)]
+        self.assertTrue(self.names, "this tmux has none of the options under test")
+        for name in self.names:
+            self._srv("set-option", "-w", "-u", "-t", self.pane, name)
+        for name in instance.PANE_BORDER_OPTIONS:
+            self._srv("set-option", "-p", "-u", "-t", self.pane, name)
+
+    def _switch(self) -> None:
+        with mock.patch.object(commands_frame, "SOCKET", self.SOCKET_NAME), \
+             mock.patch.object(commands_frame, "_say_on_screen",
+                               lambda fid, msg, *a, **k: self.fail(msg)), \
+             mock.patch.dict(os.environ,
+                             {"CHARTER_SESSION_ID": f"{self.WS}.1",
+                              "CHARTER_WORKSPACE": self.WS}, clear=False):
+            self.assertEqual(commands_frame.cmd_chat(
+                SimpleNamespace(chat_id=f"{self.WS}.2", chat=f"{self.WS}.1")), 0)
+
+    def test_the_fixture_really_has_nothing_left_to_split(self):
+        """Without this the class would be measuring the branch that already worked."""
+        before = self._srv("list-panes", "-t", self.pane, "-F", "#{pane_id}").stdout.split()
+        self._switch()
+        self.assertEqual(
+            self._srv("list-panes", "-t", self.pane, "-F", "#{pane_id}").stdout.split(),
+            before, "the switch split or killed something, so `missing` was not empty")
+
+    def test_the_windows_own_options_are_set_after_the_switch(self):
+        self.assertEqual([self._shown("-w", n) for n in self.names], [""] * len(self.names),
+                         "the fixture never stripped the options")
+        self._switch()
+        for name in self.names:
+            with self.subTest(option=name):
+                self.assertTrue(self._shown("-w", name),
+                                f"{name} is still unset on the window charter just "
+                                f"switched into")
+
+    def test_the_rules_around_the_harness_are_set_after_the_switch(self):
+        """#657's two `-p` writes — the ones the reported screenshot is about."""
+        self._switch()
+        self.assertTrue([self._shown("-p", n) for n in instance.PANE_BORDER_OPTIONS
+                         if self._shown("-p", n)],
+                        "the rules around the pane charter does not paint were never "
+                        "re-asserted, so a horizontal rule stays two colours")
+
+    def test_the_harnesss_interior_is_still_never_painted(self):
+        """#657's own design point, kept while making its rules apply: the harness's
+        RULES are charter's and its INTERIOR is the agent's (ADR 0018). A re-layout that
+        now dresses the window on every pass must not start painting inside it."""
+        self._switch()
+        for name in instance.chrome_option_names():
+            with self.subTest(option=name):
+                self.assertEqual(self._shown("-p", name), "",
+                                 f"charter painted the harness pane's {name}")
+
+
 class SwitchingBetweenChatsMovesTheClientAndThePanes(_ChatsOnOneSession,
                                                      _NeedsAttachedClient,
                                                      _TmuxServerFixture, PersonaIso):
@@ -5712,113 +5819,6 @@ class SwitchingBetweenChatsMovesTheClientAndThePanes(_ChatsOnOneSession,
             self.assertLessEqual(width, self.SMALL[0],
                                  "a panel was born at the background window's stale "
                                  "width")
-
-
-class ASwitchDressesTheWindowItEntersEvenWithNothingToSplit(_ChatsOnOneSession,
-                                                            _TmuxServerFixture,
-                                                            PersonaIso):
-    """#686, against a real server: the options are *present on the window* afterwards.
-
-    The argv half is `tests/test_frame_border_surface.py`'s. What only a real tmux can say
-    is that the writes landed — nothing here is server- or session-scoped, so every chat's
-    window has to be told separately, and until this fix the only thing that ever told one
-    was that chat's own launch.
-
-    **The fixture is the one a mock cannot plant honestly**: a chat holding every panel it
-    wants, with the options stripped off it. That is the shipping state of a chat surfaced
-    by a charter predating #657/#631 and re-entered while its panels are alive, and it is
-    also one `charter claude` away on this charter — the second launch selects its own new
-    window and leaves the first's panels running and recorded.
-
-    Verified on tmux 3.7c and on tmux 3.2 (`tmuxctl.FLOOR`). Which options exist differs
-    between them — `pane-border-indicators` is 3.7's — so this asserts about the ones THIS
-    tmux has rather than about a list, the way `EveryBorderOptionThisTmuxHasIsPinned`
-    already does.
-    """
-
-    def _has(self, name: str) -> bool:
-        """Does this tmux have *name* as a window option at all? Probed, never inferred
-        from a version string — this module's own rule."""
-        return self._srv("set-option", "-w", "-t", self.pane, name,
-                         "off").returncode == 0
-
-    def _shown(self, scope: str, name: str) -> str:
-        return self._srv("show-options", scope, "-t", self.pane,
-                         name).stdout.strip()
-
-    def setUp(self) -> None:
-        super().setUp()
-        self.one, _ = self._chat(f"{self.WS}.1", first=True)
-        self.pane, _ = self._chat(f"{self.WS}.2", first=False)
-        for chat in (f"{self.WS}.1", f"{self.WS}.2"):
-            state.record_workspace(chat, self.WS)
-            state.record_chrome(chat, "dark")
-        # Every drawable panel already split into the target's window — the branch
-        # `if missing:` skipped, and the one no existing switch test plants.
-        want = commands_frame._drawable_slots(
-            80, 24, commands_frame._visible_now(f"{self.WS}.2", config.FRAME))
-        self.assertTrue(want, "nothing is drawable at this size, so nothing is measured")
-        panels = {}
-        for slot in want:
-            r = self._srv("split-window", "-d", "-t", self.pane, "-P", "-F",
-                          "#{pane_id}", "--", *_gate_argv(
-                              os.path.join(self._gate_dir, f"gate-{slot}"), "exit 0"))
-            self.assertEqual(r.returncode, 0, r.stderr)
-            panels[slot] = r.stdout.strip()
-        state.record_panes(f"{self.WS}.2", panels=panels)
-        self.kept = panels
-        self.names = [n for n, _ in commands_frame._CHROME if self._has(n)]
-        self.assertTrue(self.names, "this tmux has none of the options under test")
-        for name in self.names:
-            self._srv("set-option", "-w", "-u", "-t", self.pane, name)
-        for name in instance.PANE_BORDER_OPTIONS:
-            self._srv("set-option", "-p", "-u", "-t", self.pane, name)
-
-    def _switch(self) -> None:
-        with mock.patch.object(commands_frame, "SOCKET", self.SOCKET_NAME), \
-             mock.patch.object(commands_frame, "_say_on_screen",
-                               lambda fid, msg, *a, **k: self.fail(msg)), \
-             mock.patch.dict(os.environ,
-                             {"CHARTER_SESSION_ID": f"{self.WS}.1",
-                              "CHARTER_WORKSPACE": self.WS}, clear=False):
-            self.assertEqual(commands_frame.cmd_chat(
-                SimpleNamespace(chat_id=f"{self.WS}.2", chat=f"{self.WS}.1")), 0)
-
-    def test_the_fixture_really_has_nothing_left_to_split(self):
-        """Without this the class would be measuring the branch that already worked."""
-        before = self._srv("list-panes", "-t", self.pane, "-F", "#{pane_id}").stdout.split()
-        self._switch()
-        self.assertEqual(
-            self._srv("list-panes", "-t", self.pane, "-F", "#{pane_id}").stdout.split(),
-            before, "the switch split or killed something, so `missing` was not empty")
-
-    def test_the_windows_own_options_are_set_after_the_switch(self):
-        self.assertEqual([self._shown("-w", n) for n in self.names], [""] * len(self.names),
-                         "the fixture never stripped the options")
-        self._switch()
-        for name in self.names:
-            with self.subTest(option=name):
-                self.assertTrue(self._shown("-w", name),
-                                f"{name} is still unset on the window charter just "
-                                f"switched into")
-
-    def test_the_rules_around_the_harness_are_set_after_the_switch(self):
-        """#657's two `-p` writes — the ones the reported screenshot is about."""
-        self._switch()
-        self.assertTrue([self._shown("-p", n) for n in instance.PANE_BORDER_OPTIONS
-                         if self._shown("-p", n)],
-                        "the rules around the pane charter does not paint were never "
-                        "re-asserted, so a horizontal rule stays two colours")
-
-    def test_the_harnesss_interior_is_still_never_painted(self):
-        """#657's own design point, kept while making its rules apply: the harness's
-        RULES are charter's and its INTERIOR is the agent's (ADR 0018). A re-layout that
-        now dresses the window on every pass must not start painting inside it."""
-        self._switch()
-        for name in instance.chrome_option_names():
-            with self.subTest(option=name):
-                self.assertEqual(self._shown("-p", name), "",
-                                 f"charter painted the harness pane's {name}")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -3599,7 +3599,16 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         was missing. It is a shape the launcher really passes, not one invented here —
         `_drawable_slots` answers `[]` below its size floors and `cmd_launch` calls
         straight through with it.
+
+        **Two calls since #686, and that is exactly what these tests are for.** The window
+        half moved out of `_split_panels` (`_dress_window`) so that a re-layout adding no
+        pane still asserts it — and with `slots=()` this fixture adds no pane either, so
+        driving the split alone would leave charter's own window at tmux's default
+        `remain-on-exit` and the assertions below would be measuring nothing. Called in
+        `_draw_panels`' own order.
         """
+        commands_frame._dress_window(OP_SOCKET_PATH, fid="charter-demo-1",
+                                     harness_pane=harness_pane, env=None, v=None)
         return commands_frame._split_panels(
             OP_SOCKET_PATH, slots=list(slots), fid="charter-demo-1",
             harness_pane=harness_pane, env=None, pane_env=None)


### PR DESCRIPTION
Closes #686.

## The gate

`_relayout` splits only when a slot is missing, and three window-level calls lived inside
that split — `remain-on-exit -w`, the five `_CHROME` options, and #657's two rules around
the harness. A re-layout of a frame that already holds everything it wants therefore wrote
**nothing**.

Measured with the repo's own fake server driving the real `cmd_chat` at 200x50, target
holding every drawable panel: eleven tmux calls, not one `set-option` among them.

Re-measured against a **real** server by stripping the options off a chat's window and
switching into it — on `main`:

```
BEFORE window: {'pane-border-style': '', 'pane-active-border-style': '', …}
AFTER  window: {'pane-border-style': '', 'pane-active-border-style': '', …}
AFTER  harness rules: {'pane-border-style': '', 'pane-active-border-style': ''}
VERDICT: FAIL
```

and on this branch, tmux 3.7c and tmux 3.2 alike, every option this tmux has comes back
set.

## It is one `charter claude` away

The second chat's window is created with `new-window -d` and then selected, so the first
chat is left with its panels alive **and still recorded** — the operator's first `F2` back
into it has nothing missing. (The next leave tears them down, so the staleness is one
screen deep, which is exactly deep enough to be the screen somebody reports.)

The visible case is a chat surfaced by a charter predating #657, re-entered while its
panels are alive: 78 rule cells over the harness carrying an explicit `ESC[49m` beside 22
cells of `ESC[100m` over a surfaced panel — one horizontal rule in two colours.

## The fix, and the distinction it keeps

The window's own options move up one level into `_dress_window`, and both callers run it
unconditionally: `_draw_panels` at launch and `_relayout` on every re-layout, **before**
anything is killed or split, because `remain-on-exit` still has to be armed ahead of any
pane charter creates (#408). Above the kill loop costs nothing — measured on 3.7c,
`kill-pane` destroys a pane on a window with `remain-on-exit on` and leaves no corpse.

What did **not** move is as deliberate as what did:

- the per-pane calls (the panel mark, each pane's `window-style`) stay in the split loop,
  which is the one place charter has a panel's own `%N` in hand;
- the harness's **interior** is still never painted at any version or level —
  `_harness_rule_argvs` cannot emit `window-style` at all. #657's design point is that the
  harness's rules are charter's and its interior is the agent's (ADR 0018), and there is
  now a real-tmux test asserting exactly that after a switch.

## Coverage that did not exist

The issue is right that nothing asserted this either way: every switch test in the tree
plants an **empty** pane map for the target, so all of them exercised `missing != []`.
This adds the other branch at three levels — `_relayout` directly, `cmd_chat` through the
fake server, and a real tmux — plus a control at each showing the `missing != []` path is
unchanged and that no window option is now written twice.

Two existing fixtures moved with the code: `test_frame_border_surface`'s two "what the
funnel issues" helpers, and `test_frame_tmux_integration._panel_funnel`. All three drove
`_split_panels` as *the* funnel; it is two functions now, and driving one of them would
have measured the pane half while reporting the window half as absent. The second of those
is the sharper case — it is called with `slots=()` on purpose, so after the split it added
no pane *and* asserted no option, and its two `remain-on-exit` tests went red honestly.

## Verification

- Full suite green on 3.14.
- Real tmux 3.7c and tmux 3.2, both for the new integration class and for the standalone
  before/after measurement above.
- Hand deletion sweep, applied and restored with sha256 and `git diff --quiet` checked on
  every restore: deleting `_relayout`'s `_dress_window` call reddens four tests across
  three files (unit, fake-server switch, real tmux); deleting `_draw_panels`' reddens six.

## Merging

This branch, #691 (#685), #693 (#684) and #696 (#688) merge cleanly against each other in
every pairwise order, and all four merge cleanly onto current `main` in sequence — checked
with `git merge-tree` and with a real four-way merge. Each new integration class is
anchored beside the class it is about rather than appended to the file's tail, so they do
not collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy