### PR TITLE
The sweep stops asking regex questions that have no answer, and says when it declines one (#698)

### DIFF
--- a/docs/news/unreleased-the-sweep-says-what-it-did-not-ask.md
+++ b/docs/news/unreleased-the-sweep-says-what-it-did-not-ask.md
@@ -1,0 +1,65 @@
+---
+version: unreleased
+headline: The deletion sweep stops asking regex questions that have no answer, and says when it declines one
+---
+
+More than half of every regular expression in charter was being asked a mutation question
+that could not be answered — and the answer came back as `no verdict`, which is the one
+outcome the gate exists to make a reviewer stop on.
+
+## The mutant was not a program
+
+`retune-string` re-spells a string constant: same length, same character classes, a
+different value. For a digit that is `0 -> 1` and `9 -> 0`, and **inside a character class
+that inverts the range**:
+
+```
+retune(r"\$[0-9]+")  ->  r"\$[1-0]+"
+re.compile(...)      ->  re.error: bad character range 1-0
+```
+
+So the module raises while it is being imported, every selected test module fails to load,
+**zero tests run**, and the sweep — correctly — refuses to call that a pin. What a reviewer
+sees is `no verdict: 2 not measured` beside a report advising them to re-run on a quieter
+machine. No machine and no timeout can ever clear it.
+
+Measured over `charter/` and `tools/`: **56 of the 108** patterns in the tree retune into
+something `re.compile` refuses. Not two lines on one branch — every one of them was a
+question waiting to be asked the day its line moved.
+
+## The rule it needed was already written, for its neighbour
+
+`retune` has always left the character after a backslash alone, and says why: `\d -> \e`
+is `re.error: bad escape`, "a red for a reason that has nothing to do with the property,
+which is the one outcome this whole file exists to refuse". A character range is that same
+hazard one step over, and so is the letter after `(?` — `(?i) -> (?j)` is `unknown
+extension ?j`, four of those in `charter/hooks.py` alone.
+
+All three are one rule: **a character that says what kind of thing comes next is syntax,
+and the syntax is not the value this operator asks about.**
+
+Which end of a range moves is the interesting half. Holding both would keep the pattern
+valid by making the mutation a no-op — and a character class is the whole of many patterns
+here, so that would withdraw the question rather than fix it. The low end moves and the
+high end holds: `[0-9] -> [1-9]` is a valid pattern that stops matching `0`, which is a
+question a test can answer. With the three rules the 56 become **1**.
+
+## And the one that is left is reported, not dropped
+
+A mutation the tool declines is a question it did not ask, and the one thing it may not do
+is decline one in silence — that is the same failure as a shard that never reported,
+arriving from inside the plan instead of from a runner.
+
+So the last one (a `\x1f -> \x2g` hex escape in `charter/tui.py`) is still planned, still
+sharded, and still reported. It gets a verdict of its own — `withheld` — with the reason
+beside it, a row in the gate table, and a line in the check's own name: `no survivors,
+1 withheld`.
+
+**Its own bucket and not folded into `unresolved`**, because the two say opposite things
+about what the tool knows. `unresolved` is *I looked and could not tell*. `withheld` is *I
+decided not to ask, and here is why*. Collapsing them makes a deliberate, bounded,
+explained subtraction read as a timeout — and a `no verdict` that cannot be cleared is how
+the signal a reviewer must stop on gets spent.
+
+It never fails the gate, for the same reason a question the interpreter puts out of reach
+does not. It is loud so that it is not a finding about nothing either.

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -450,6 +450,131 @@ class TheStringShape(unittest.TestCase):
         nothing to do with the property — the definition of a false pin."""
         self.assertEqual(sweep.retune(r"^Ran (\d+) tests?"), r"^Sbo (\d+) uftut?")
 
+    def test_a_retuned_pattern_is_still_a_pattern(self):
+        """#698. `retune` shifts a digit `0 -> 1` and `9 -> 0`, and inside a character
+        class that INVERTS the range: `[0-9] -> [1-0]` is `re.error: bad character
+        range`. The module then raises on import, no test runs at all, and the sweep
+        reports `no verdict` on a question it could have asked properly.
+
+        Measured over `charter/` and `tools/` before this rule: **56 of the 108**
+        patterns in the tree retuned into something `re.compile` refuses.
+        """
+        for shipped in (r"\$[0-9]+", r"@[0-9]+", "[A-Za-z0-9._-]+", "(?i)^core=",
+                        "^[a-z0-9][a-z0-9._-]*$", r"\bagentId:\s*([0-9a-f]{6,})"):
+            with self.subTest(shipped=shipped):
+                moved = sweep.retune(shipped, regex=True)
+                self.assertNotEqual(moved, shipped,
+                                    "the question was withdrawn, not kept")
+                re.compile(moved)          # must not raise
+
+    def test_the_low_end_of_a_range_moves_and_the_high_end_holds(self):
+        """WHICH end moves is the whole reason the rule names one. Holding both would
+        keep the pattern valid by making the mutation a no-op — and a character class is
+        the whole of many patterns here, so that would withdraw the question rather than
+        fix it. `[0-9] -> [1-9]` is a valid pattern that stops matching `0`."""
+        self.assertEqual(sweep.retune(r"@[0-9]+", regex=True), r"@[1-9]+")
+        self.assertEqual(sweep.retune("[A-Za-z]", regex=True), "[B-Zb-z]")
+
+    def test_the_letter_after_an_inline_group_is_left_alone(self):
+        """`(?i) -> (?j)` is `unknown extension ?j`. The same rule as the backslash, one
+        step over: a character that says what KIND of thing comes next is syntax, and
+        the syntax is not the value this operator asks about."""
+        self.assertEqual(sweep.retune("(?i)^core", regex=True), "(?i)^dpsf")
+        re.compile(sweep.retune("(?P<n>x)", regex=True))
+
+    def test_the_regex_rules_are_off_for_a_string_that_is_not_one(self):
+        """A separator that happens to spell `[a-b]` has no syntax to protect, and holding
+        a character in it would weaken the mutation for nothing. The caller says which
+        strings are patterns — `regex_positions` knows and `retune` does not guess.
+
+        And a `-` OUTSIDE a class is not a range in either mode: `a-b` is two literals and
+        a dash, so both ends move and the two answers agree. The rule is about a character
+        class, not about every dash in a string."""
+        self.assertEqual(sweep.retune("[a-b]"), "[b-c]")
+        self.assertEqual(sweep.retune("[a-b]", regex=True), "[b-b]")
+        self.assertEqual(sweep.retune("a-b"), sweep.retune("a-b", regex=True))
+
+    def test_a_pattern_the_rules_cannot_keep_valid_is_withheld_not_dropped(self):
+        """The backstop, and the reason the shift rules may be approximate. A `\\x1f`
+        retunes to `\\x2g`, which is not a hex escape — the one case left in `charter/`
+        today. It is planned, declined, and REPORTED: a question not asked in silence is
+        the same failure as a shard that never reported."""
+        muts = _mutations(
+            'import re\n'
+            'P = re.compile("[\\\\x00-\\\\x1f]")\n')
+        offered = [m for m in muts if m.operator == "retune-string"]
+        self.assertEqual(len(offered), 1)
+        self.assertTrue(offered[0].withheld.startswith("the retuned pattern"),
+                        offered[0].withheld)
+
+    def test_a_pattern_that_survives_the_rules_carries_no_refusal(self):
+        """The control: the backstop must not decline what the rules already fixed."""
+        muts = _mutations(
+            'import re\n'
+            'P = re.compile(r"[0-9]+")\n')
+        offered = [m for m in muts if m.operator == "retune-string"]
+        self.assertEqual([m.withheld for m in offered], [""])
+
+    def test_only_the_pattern_argument_of_an_re_call_is_a_pattern(self):
+        """`re.split` takes a regex and `str.split` takes a separator; they share a name,
+        which is why this is keyed on the module and not on `READERS`."""
+        tree = ast.parse('import re\nre.split("[a-b]", s)\n"[a-b]".split(x)\n')
+        found = sweep.regex_positions(tree)
+        consts = [n for n in ast.walk(tree)
+                  if isinstance(n, ast.Constant) and n.value == "[a-b]"]
+        self.assertEqual(len(consts), 2)
+        self.assertEqual([id(c) in found for c in consts], [True, False])
+
+    def test_a_class_that_ended_really_ended(self):
+        """The `not in_class` guard on `[`, which decides where the class STOPS. Inside a
+        class a `[` is a literal, so treating it as an opening one leaves the scan still
+        inside a class after the real `]` has closed it — and the next `x-y` in ordinary
+        pattern text, where a dash is a literal dash, gets read as a range and held."""
+        self.assertEqual(sweep.retune("[^[]x-y", regex=True), "[^[]y-z")
+
+    def test_a_string_that_is_not_a_pattern_is_never_withheld_for_being_a_bad_one(self):
+        """The backstop asks `re.compile` only where the program does. A comparison
+        operand that happens to spell a character class has no regex syntax to be wrong
+        about, and withholding its mutation would subtract a question for a reason that
+        does not apply to it."""
+        muts = _mutations(
+            'def f(x):\n'
+            '    return x == "[0-9] items"\n')
+        offered = [m for m in muts if m.operator == "retune-string"]
+        self.assertEqual([m.withheld for m in offered], [""])
+        self.assertEqual([m.after for m in offered], ["'[1-0] jufnt'"])
+
+    def test_a_withheld_mutation_never_reaches_a_sandbox(self):
+        """It has its verdict before anything is applied, and that is the point: running
+        it would measure an import error. The box raises if it is touched at all."""
+        class _Untouchable:
+            def clean_failures(self, modules):
+                raise AssertionError("a withheld mutation was measured")
+
+            def apply(self, mutation):
+                raise AssertionError("a withheld mutation reached the tree")
+
+        m = sweep.Mutation(path="p.py", line=1, end_line=1, operator="retune-string",
+                           question="q", before="a", after="b", symbol="f",
+                           withheld="the retuned pattern is not one re.compile accepts")
+        verdict, outcome, full = sweep.decide(_Untouchable(), m, ["tests.test_x"])
+        self.assertEqual(verdict, "withheld")
+        self.assertIn("re.compile", outcome.detail)
+        self.assertFalse(outcome.conclusive)
+        self.assertIsNone(full)
+
+    def test_a_withheld_verdict_gets_its_own_bucket_and_fails_nothing(self):
+        """Its own bucket and not `unresolved`: the two say opposite things about what
+        the tool knows, and a deliberate subtraction that rendered as a timeout is how a
+        branch comes to sit behind a `no verdict` no re-run can clear (#693)."""
+        m = sweep.Mutation(path="p.py", line=1, end_line=1, operator="retune-string",
+                           question="q", before="a", after="b", symbol="f",
+                           withheld="not a pattern")
+        gate = sweep.classify([sweep.Result(m, "withheld", None, None, [], None)])
+        self.assertEqual(len(gate.withheld), 1)
+        self.assertEqual((gate.unresolved, gate.unapplied, gate.actionable), ([], [], []))
+        self.assertEqual(sweep.headline(gate), "no survivors, 1 withheld")
+
     def test_a_string_with_nothing_to_move_offers_no_mutation(self):
         muts = _mutations("""
             def f(x):

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -262,6 +262,17 @@ class Mutation:
     #: somebody to write a test for a line that is already covered, and the first person
     #: who chases one and finds that out stops believing the tool.
     origin: str = ""
+    #: Why this mutation was never run, or ``""`` for the ordinary case (#698).
+    #:
+    #: **A mutation the tool declines is a question it did not ask, and the one thing it
+    #: may not do is decline one in silence** — that is the same failure as a shard that
+    #: never reported, arriving from inside the plan instead of from a runner. So a
+    #: declined mutation is still planned, still sharded and still reported; it simply
+    #: carries its reason here and gets its verdict without a sandbox. `unevaluated` and
+    #: `reach` are the two subtractions that came before this one, and the difference is
+    #: that those remove a POSITION the operator never reaches while this removes a
+    #: mutant the operator did produce — which is exactly the one worth counting.
+    withheld: str = ""
 
     @property
     def tag(self) -> str:
@@ -609,7 +620,73 @@ def _shift_char(ch: str) -> str:
     return ch
 
 
-def retune(text: str) -> str:
+def _regex_shape(text: str) -> set[int]:
+    """The indices in *text* that spell a regex's SHAPE rather than its value.
+
+    :func:`retune`'s backslash rule, generalised to the two other places where shifting a
+    character does not produce a different pattern but an unparseable one. The rule they
+    are all three instances of: **a character that says what kind of thing comes next is
+    part of the syntax, and the syntax is not the value this operator asks about.**
+
+    * the character after a ``\\`` — `\\d` -> `\\e` is ``re.error: bad escape``. That one is
+      applied in :func:`retune` itself, on every string, because an escape is an escape in
+      a replacement template too.
+    * the character after ``(?`` — `(?i)` -> `(?j)` is ``unknown extension ?j``, and
+      `(?P<n>` -> `(?Q<n>` the same. Four of these in `charter/hooks.py` alone.
+    * the HIGH end of a ``[a-b]`` range — `[0-9]` -> `[0-0]`… or rather `[1-0]`, which is
+      ``bad character range``. The LOW end is left shiftable on purpose and is the whole
+      reason this function names *which* end: `[0-9]` -> `[1-9]` is a valid pattern and a
+      genuinely different one (it stops matching `0`), so the question survives. Holding
+      both ends would keep the pattern valid by making the mutation a no-op, which is the
+      same as not asking — and a character class is the whole of many patterns in this
+      tree, so that would withdraw the question for most of them.
+
+    **Measured over `charter/` and `tools/` before choosing.** 108 string constants are
+    compiled as regexes. Under the escape rule alone, **56 of them** retune into something
+    `re.compile` refuses — more than half of every pattern in the tree, each one a question
+    that could never be answered and, since #698, a `no verdict` on the day its line moved.
+    With these two rules the 56 become **1** (a `\\x1f` -> `\\x2g` hex escape in
+    `charter/tui.py`), and the 20 patterns whose retune was already a no-op are unchanged.
+    That last one is left to the backstop in :func:`mutations_for` rather than chased with
+    a fourth rule: the rules recover questions, and the backstop is what makes being wrong
+    about them safe.
+
+    A `[` inside a class is a literal and a `]` first in a class is too, so the scan tracks
+    both; getting that wrong cannot produce a bad mutation, only a missed or a needless
+    hold, because nothing here is offered without `re.compile` agreeing it is a pattern.
+    """
+    held: set[int] = set()
+    i, n, in_class = 0, len(text), False
+    while i < n:
+        ch = text[i]
+        if ch == "\\":
+            i += 2                      # `retune` holds the escaped character itself
+            continue
+        if not in_class and ch == "(" and i + 1 < n and text[i + 1] == "?":
+            held.add(i + 2)
+            i += 3
+            continue
+        if not in_class and ch == "[":
+            in_class = True
+            i += 1
+            if i < n and text[i] == "^":
+                i += 1
+            if i < n and text[i] == "]":    # a `]` first in a class is a literal `]`
+                i += 1
+            continue
+        if in_class and ch == "]":
+            in_class = False
+            i += 1
+            continue
+        if in_class and i + 2 < n and text[i + 1] == "-" and text[i + 2] != "]":
+            held.add(i + 2)
+            i += 3
+            continue
+        i += 1
+    return held
+
+
+def retune(text: str, *, regex: bool = False) -> str:
     """*text*, re-spelled: same length, same character classes, a different value.
 
     **This is the principled general form the spec said a string constant did not have,
@@ -630,11 +707,20 @@ def retune(text: str) -> str:
     and shifting the neighbour turns a working pattern into `re.error: bad escape \\e`.
     That is a red for a reason that has nothing to do with the property, which is the one
     outcome this whole file exists to refuse.
+
+    **`regex` widens that same rule to the two other places a shift changes a pattern's
+    shape instead of its value** — the letter after `(?`, and the high end of a `[a-b]`
+    range. See :func:`_regex_shape` for both, for which end of a range moves and why, and
+    for the measurement that says this is 56 of the 108 patterns in the tree rather than a
+    tidy-up. It is a keyword and it is off by default because a string is only a regex
+    where the program compiles one: `read_positions` knows that and this function does not,
+    so the caller says so rather than this one guessing from the bytes.
     """
+    shape = _regex_shape(text) if regex else frozenset()
     out: list[str] = []
     escaped = False
-    for ch in text:
-        out.append(ch if escaped else _shift_char(ch))
+    for i, ch in enumerate(text):
+        out.append(ch if escaped or i in shape else _shift_char(ch))
         escaped = ch == "\\" and not escaped
     return "".join(out)
 
@@ -728,6 +814,50 @@ def unevaluated(tree: ast.AST) -> set[int]:
         # and keeps the `"left"`.
         for part in ast.walk(annotation):
             out.add(id(part))
+    return out
+
+
+#: The `re` functions whose FIRST argument is a pattern. `split` is here and `str.split`
+#: is not, which is the whole reason this is keyed on the module: the two share a name and
+#: only one of them takes a regex.
+_RE_PATTERN_ARG = frozenset({
+    "compile", "match", "search", "fullmatch", "sub", "subn", "split", "findall",
+    "finditer",
+})
+
+
+def regex_positions(tree: ast.AST) -> set[int]:
+    """The ids of the string constants the program compiles as a REGEX.
+
+    Two callers and one reason between them: a pattern's *shape* is not the value
+    `retune-string` asks about, so :func:`retune` needs to know which strings are patterns
+    (`_regex_shape`), and `mutations_for` needs to know which mutants have to survive
+    `re.compile` before they may be offered at all.
+
+    **`re.<fn>(…)` spelled that way, and nothing cleverer.** Not `READERS`, which holds
+    `match`, `search` and `split` because `str` has them too — `"a,b".split(",")` takes a
+    separator and `re.split(r"[,;]", s)` takes a pattern, and treating the first as a regex
+    would hold characters in a string that has no syntax to protect. Not `RE.match(s)`
+    either: the pattern there is the receiver's own constant, which was already recognised
+    where `re.compile` was called on it, and the argument is the subject.
+
+    The first positional argument only, because that is where every function in
+    :data:`_RE_PATTERN_ARG` takes its pattern. A `pattern=` keyword is legal and nobody in
+    this tree writes one; missing it costs a question asked in the older, blunter way,
+    which the backstop then declines — a bounded loss that says so, rather than a rule
+    guessing at an argument's role from its name.
+    """
+    out: set[int] = set()
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and node.args
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "re"
+                and node.func.attr in _RE_PATTERN_ARG):
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            out.add(id(first))
     return out
 
 
@@ -888,6 +1018,7 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
     parents = _parents(tree)
     docstrings = _docstrings(tree)
     reads = read_positions(tree)
+    patterns = regex_positions(tree)
     modules = module_names(tree)
     in_fstring = {id(part) for node in ast.walk(tree) if isinstance(node, ast.JoinedStr)
                   for part in ast.walk(node) if part is not node}
@@ -1037,7 +1168,7 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
                 and id(node) in reads and id(node) not in docstrings:
             raw = node.value if isinstance(node.value, str) \
                 else node.value.decode("latin-1")
-            moved = retune(raw)
+            moved = retune(raw, regex=id(node) in patterns)
             if moved != raw:
                 if id(node) in in_fstring:
                     # A literal segment of an f-string, including a `{x:<28}` FORMAT SPEC,
@@ -1194,6 +1325,41 @@ def _is_empty_literal(node: ast.AST) -> bool:
     return isinstance(node, ast.Constant) and node.value in ("", 0, None)
 
 
+def _not_a_pattern(node: ast.AST, replacement: str, is_pattern: bool) -> str:
+    """Why *replacement* may not be offered here, or ``""`` when it may.
+
+    **The backstop, and the reason the shift rules are allowed to be approximate.**
+    `_regex_shape` keeps a retuned pattern parseable in the three places this tool knows
+    how; a fourth it does not know about would produce a mutant `re.compile` refuses, the
+    module would raise on import, every selected test would fail to load, and the sweep
+    would report `no verdict` on a question it could have declined to ask. That is #698: a
+    `retune-string` on a `[0-9]` pattern produced a `[1-0]` one, and a reviewer had to read a
+    CI log and a stack trace to find out that the tool had asked something unanswerable.
+
+    So the two layers hold each other up. The shift rules recover the question where they
+    can — measured, 56 patterns to 1 — and this refuses to offer what is left, by name,
+    so being wrong about a rule costs a question rather than a verdict.
+
+    `ast.literal_eval` and not a strip of the quotes: *replacement* is a `repr`, and the
+    one thing this must not do is guess at its own encoding. Anything it cannot read back
+    is not a pattern it can vouch for and is left alone — the mutation goes out as it
+    always did, and `re.compile` in the sandbox is nobody's problem but the suite's.
+    """
+    if not is_pattern:
+        return ""
+    try:
+        value = ast.literal_eval(replacement)
+    except (ValueError, SyntaxError):
+        return ""
+    if not isinstance(value, str):
+        return ""
+    try:
+        re.compile(value)
+    except re.error as why:
+        return f"the retuned pattern is not one re.compile accepts ({why})"
+    return ""
+
+
 def mutations_for(path: str, source: bytes, lines: set[int]) -> list[Mutation]:
     """Every mutation this file offers on the lines the branch is answerable for."""
     try:
@@ -1202,6 +1368,11 @@ def mutations_for(path: str, source: bytes, lines: set[int]) -> list[Mutation]:
         return []
     sp = _Spans(source)
     raw = _fstring_segments(tree)
+    # The one place a mutant is checked for being a PROGRAM before it is offered (#698).
+    # `_regex_shape` keeps a retuned pattern parseable where the tool can see how; this is
+    # what happens when it could not — a `\x1f` -> `\x2g` hex escape is the one case left
+    # in `charter/` today. Withheld and not dropped: see `Mutation.withheld`.
+    patterns = regex_positions(tree)
     out: list[Mutation] = []
     seen: set[tuple[int, int, str, str]] = set()
     for node, replacement, operator, question in _iter_operators(tree, sp):
@@ -1221,6 +1392,7 @@ def mutations_for(path: str, source: bytes, lines: set[int]) -> list[Mutation]:
         if key in seen:
             continue
         seen.add(key)
+        refused = _not_a_pattern(node, replacement, id(node) in patterns)
         mutated = sp.splice(node, replacement)
         try:
             ast.parse(mutated, filename=path)
@@ -1241,7 +1413,7 @@ def mutations_for(path: str, source: bytes, lines: set[int]) -> list[Mutation]:
             path=path, line=node.lineno, end_line=node.end_lineno or node.lineno,
             operator=operator, question=question, before=before, after=replacement,
             symbol=_enclosing(tree, node), source=mutated, span=sp.span(node),
-            origin=hashlib.sha256(source).hexdigest()))
+            origin=hashlib.sha256(source).hexdigest(), withheld=refused))
     out.sort(key=lambda m: (m.path, m.line, m.operator, m.after))
     return out
 
@@ -1816,6 +1988,13 @@ def decide(box, mutation: Mutation, modules: list[str]) -> tuple[str, Outcome, O
       suite for 1800s instead of failing, and reading that as green would have pinned a
       guard on a timeout.
     """
+    # Before anything is measured, and before a sandbox is touched: a mutation the plan
+    # declined has its verdict already (#698, `Mutation.withheld`). It is answered here
+    # rather than filtered out of the plan so that it is sharded, serialised and counted
+    # like every other one — a question not asked is a fact about the sweep, and the only
+    # way to report it is to carry it.
+    if mutation.withheld:
+        return "withheld", Outcome(False, 0, mutation.withheld, conclusive=False), None
     # Measured BEFORE the mutation goes anywhere near the tree.
     clean = box.clean_failures(modules) if modules else frozenset()
     try:
@@ -2055,6 +2234,7 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
     unresolved = [r for r in results if r.verdict == "unresolved"]
     pinned = [r for r in results if r.verdict == "pinned"]
     unapplied = [r for r in results if r.verdict == "unapplied"]
+    withheld = [r for r in results if r.verdict == "withheld"]
     pairs = pairs or []
     out: list[str] = []
     w = out.append
@@ -2073,6 +2253,8 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
     w(f"UNRESOLVED        : {len(unresolved)}")
     if unapplied:
         w(f"NOT APPLIED       : {len(unapplied)}  (a defect in this tool, not a finding)")
+    if withheld:
+        w(f"WITHHELD          : {len(withheld)}  (questions this tool declined to ask)")
     w(f"wall clock        : {elapsed / 60:.1f} min")
     w("")
 
@@ -2089,6 +2271,22 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
             m = r.mutation
             w(f"  {m.path}:{m.line}  [{m.operator}]  "
               f"{r.subset.detail if r.subset else ''}")
+        w("")
+
+    if withheld:
+        w("-" * 86)
+        w("WITHHELD — these questions were not asked, and here is why")
+        w("-" * 86)
+        w("Not a verdict and not a timeout: the mutant would not have been a program, so")
+        w("running it would have measured an import error rather than the guard. Each line")
+        w("below is one question this sweep is NOT answering — read the count, not the")
+        w("silence. A rule in `_regex_shape` is what turns one of these back into a")
+        w("question that can be asked.")
+        for r in sorted(withheld, key=lambda r: (r.mutation.path, r.mutation.line)):
+            m = r.mutation
+            w(f"  {m.path}:{m.line}  [{m.operator}]  {m.withheld}")
+            w(f"    shipped : {_oneline(m.before, 70)}")
+            w(f"    mutant  : {_oneline(m.after, 70)}")
         w("")
 
     if unresolved:
@@ -2202,6 +2400,7 @@ def as_json(results: list[Result]) -> str:
         "operator": r.mutation.operator, "symbol": r.mutation.symbol,
         "question": r.mutation.question,
         "before": r.mutation.before, "after": r.mutation.after,
+        "withheld": r.mutation.withheld,
         "verdict": r.verdict,
         # `detail` and not only the verdict: a run that went red says WHICH test went red,
         # and that is the first thing anyone asks of a mutation reported as pinned.
@@ -2248,6 +2447,15 @@ class Gate:
       this repository hits it repeatedly, and "I could not look" must never render as
       "nothing to see".
     * ``unapplied`` — the mutation never reached the tree (#586). A defect in the tool.
+    * ``withheld`` — the mutation was never offered, because the mutant was not a program
+      (#698). **Its own bucket and not folded into `unresolved`**, because the two say
+      opposite things about what the tool knows: `unresolved` is "I looked and could not
+      tell", and this is "I decided not to ask, and here is why". Collapsing them would
+      make a deliberate, bounded, explained subtraction read as a timeout — which is how
+      #693 came to sit behind a `no verdict` that no re-run could ever clear. It never
+      fails the gate, for the same reason `reach()` does not: a question not asked is not
+      a finding about the branch. It is loud in the report so that it is not a finding
+      about nothing either.
     """
 
     unpinned: list[Result] = dataclasses.field(default_factory=list)
@@ -2255,6 +2463,7 @@ class Gate:
     platform: list[Result] = dataclasses.field(default_factory=list)
     unresolved: list[Result] = dataclasses.field(default_factory=list)
     unapplied: list[Result] = dataclasses.field(default_factory=list)
+    withheld: list[Result] = dataclasses.field(default_factory=list)
     pinned: int = 0
 
     @property
@@ -2278,6 +2487,8 @@ def classify(results: list[Result]) -> Gate:
             gate.unresolved.append(r)
         elif r.verdict == "unapplied":
             gate.unapplied.append(r)
+        elif r.verdict == "withheld":
+            gate.withheld.append(r)
         elif r.verdict == "survived":
             if platform_caveat(r.mutation):
                 gate.platform.append(r)
@@ -2523,8 +2734,15 @@ def headline(gate: Gate, missing: int = 0, shards: int = 1) -> str:
     never planned as a sweep that was planned and lost.
     """
     conclusion = gate_conclusion(gate, missing)
+    # Said in the check's NAME when there is one, and said BESIDE "no survivors" rather
+    # than instead of it (#698). A withheld mutation does not put the branch in doubt —
+    # nothing about it was measured and found wanting, and nothing about it could not be
+    # measured either; the tool declined to ask and can say why. Turning a clean sweep
+    # into `no verdict` over that would spend the one signal a reviewer must stop on, and
+    # #693 is what it costs when `no verdict` stops meaning "look at this".
+    aside = f", {len(gate.withheld)} withheld" if gate.withheld else ""
     if conclusion == CLEAN:
-        return "no survivors"
+        return f"no survivors{aside}"
     found = _plural(len(gate.actionable), "survivor", "survivors")
     unsure = []
     if missing:
@@ -2536,10 +2754,10 @@ def headline(gate: Gate, missing: int = 0, shards: int = 1) -> str:
     if gate.unresolved:
         unsure.append(f"{len(gate.unresolved)} not measured")
     if conclusion == SURVIVORS:
-        return f"{found}, {'; '.join(unsure)}" if unsure else found
+        return (f"{found}, {'; '.join(unsure)}{aside}" if unsure else f"{found}{aside}")
     if gate.actionable:
-        return f"no verdict: {found} so far, {'; '.join(unsure)}"
-    return f"no verdict: {'; '.join(unsure)}"
+        return f"no verdict: {found} so far, {'; '.join(unsure)}{aside}"
+    return f"no verdict: {'; '.join(unsure)}{aside}"
 
 
 #: How many annotations of one LEVEL, per step, GitHub will draw before it stops. Not per
@@ -2696,6 +2914,9 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float | None,
     w(f"| platform-deferred | {len(gate.platform)} | the clause may be unreachable on "
       f"{sys.platform}; never fails this gate |")
     w(f"| unresolved | {len(gate.unresolved)} | no verdict — timed out, not measured |")
+    if gate.withheld:
+        w(f"| withheld | {len(gate.withheld)} | the mutant was not a program, so the "
+          "question was not asked |")
     if reach():
         w(f"| not asked about | — | {reach()} |")
     w(f"| not applied | {len(gate.unapplied)} | the edit never reached the tree — a bug "
@@ -2705,6 +2926,21 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float | None,
         w(f"> **Reporting only.** This job blocks nothing; it {verdict} with `--enforce`. "
           "The spec's own staging argument says a gate whose numbers nobody has seen gets "
           "disabled the first time it is inconvenient, so the numbers come first.")
+        w("")
+    if gate.withheld:
+        w("### Withheld — questions this sweep did not ask")
+        w("")
+        w(f"{len(gate.withheld)} mutation(s) were planned and then declined: the mutant "
+          "would not have been a program, so running it would have measured an import "
+          "error rather than the guard. This is **not** `no verdict` — the tool knows "
+          "what it did and why — but it is a question nobody answered, and a sweep that "
+          "subtracted questions in silence would read exactly like a clean one.")
+        w("")
+        w("| line | operator | why |")
+        w("|---|---|---|")
+        for r in sorted(gate.withheld, key=lambda r: (r.mutation.path, r.mutation.line)):
+            m = r.mutation
+            w(f"| `{m.path}:{m.line}` | `{m.operator}` | {m.withheld} |")
         w("")
     if missing:
         w("### Did not report — this page is not a count")
@@ -2787,7 +3023,11 @@ def results_from_json(payload: str) -> list[Result]:
     for row in json.loads(payload):
         m = Mutation(path=row["path"], line=row["line"], end_line=row["end_line"],
                      operator=row["operator"], question=row["question"],
-                     before=row["before"], after=row["after"], symbol=row["symbol"])
+                     before=row["before"], after=row["after"], symbol=row["symbol"],
+                     # `.get`, and it is the one field read that way: a shard built by an
+                     # older sweep than the merge has no such key, and a merge that raised
+                     # on it would turn a mixed-version run into no report at all.
+                     withheld=row.get("withheld", ""))
         # `null` means the evidence pass never ran, which is not the same as running and
         # finding nothing: `_summary_rows` tells "nothing measured executes this file"
         # from "N modules execute it and not one names the symbol" by exactly that field,
@@ -3149,7 +3389,8 @@ def _say(args, gate: Gate, log, missing: int = 0, shards: int = 1) -> None:
     log("")
     log(f"gate: {len(gate.unpinned)} unpinned, {len(gate.masked)} in masked cluster(s), "
         f"{len(gate.platform)} platform-deferred, {len(gate.unresolved)} unresolved, "
-        f"{len(gate.unapplied)} not applied, {gate.pinned} pinned")
+        f"{len(gate.unapplied)} not applied, {len(gate.withheld)} withheld, "
+        f"{gate.pinned} pinned")
     log(f"gate: {headline(gate, missing, shards)}")
     if not args.enforce:
         log("gate: reporting only — nothing here blocks. Pass --enforce to make it.")


### PR DESCRIPTION
Closes #698. Found on #693, whose gate read `no verdict: 2 not measured` while its three
siblings read `no survivors`.

## The mutant was not a program

`retune` shifts a digit `0 -> 1` and `9 -> 0`, which **inside a character class inverts the
range**:

```
retune(r"\$[0-9]+")  ->  r"\$[1-0]+"
re.compile(...)      ->  re.error: bad character range 1-0
```

`charter/commands_frame.py` then raises while it is being imported, every selected test
module fails to load, **zero tests run**, and the sweep — correctly — refuses to call that
a pin. What the reviewer got was `no verdict` beside prose advising a quieter machine and a
bigger timeout. Neither could ever have cleared it; the second of the two mutations
finished in 32 seconds.

**Measured over `charter/` and `tools/` before choosing a fix: 56 of the 108 patterns in
the tree** retune into something `re.compile` refuses. Not two lines on one branch — more
than half of every regex here was a question waiting to come back unanswerable the day its
line moved. `tmuxctl.PANE_ID_RE` is `r"%[0-9]+"` and is one of them.

## The rule was already written, for its neighbour

`retune` has always left the character after a backslash alone, and says why: `\d -> \e` is
`re.error: bad escape`, "a red for a reason that has nothing to do with the property, which
is the one outcome this whole file exists to refuse."

`_regex_shape` puts the other two beside it as one rule — **a character that says what kind
of thing comes next is syntax, and the syntax is not the value this operator asks about**:

| shape | without the rule | with it |
|---|---|---|
| `\d` | `\e` — bad escape | held (already) |
| `(?i)` | `(?j)` — unknown extension | held |
| `[0-9]` | `[1-0]` — bad character range | `[1-9]` |

**Which end of a range moves is the half worth stating.** Holding both would keep the
pattern valid by making the mutation a no-op — and a character class is the whole of many
patterns here, so that would withdraw the question rather than fix it. The low end moves
and the high end holds: `[0-9] -> [1-9]` is valid, different (it stops matching `0`), and
answerable.

**56 become 1**, and the 20 patterns whose retune was already a no-op are unchanged.

## The one that is left is withheld, not dropped

A mutation the tool declines is a question it did not ask, and declining one in silence is
the same failure as a shard that never reported — arriving from inside the plan instead of
from a runner. `#680`'s author flagged this gap and it was judged out of scope then; with
this change it stops being optional.

So the residue (a `\x1f -> \x2g` hex escape in `charter/tui.py`) is still planned, still
sharded, and still reported. It carries its reason, gets a verdict of its own, and shows up
in three places: the gate table, the text report's own `WITHHELD` section, and the check's
**name** — `no survivors, 1 withheld`.

**Its own bucket and not folded into `unresolved`**, because the two say opposite things
about what the tool knows: `unresolved` is *I looked and could not tell*; `withheld` is *I
decided not to ask, and here is why*. Collapsing them makes a deliberate, bounded, explained
subtraction read as a timeout — which is how #693 came to sit behind a `no verdict` no
re-run could clear. It never fails the gate, for the same reason a question the interpreter
puts out of reach does not.

The two layers hold each other up: the shift rules recover the question where the tool can
see how, and the backstop refuses what is left **by name**, so being wrong about a rule
costs a question rather than a verdict.

## Verification

- Full suite green on 3.14: **8924 tests, OK** (349 of them `tests/test_sweep.py`).
- The two mutations that produced `no verdict` now produce `r"\$[1-9]+"` and `r"@[1-9]+"` —
  and applying the first to `main` **reddens five tests**, so the question is not merely
  askable, it is answered.
- Whole-tree check with the new code: 2,845 `retune-string` mutations across `charter/` and
  `tools/`, **1 withheld**, named with its reason.
- Hand deletion sweep, restores verified with sha256 **and** `git diff --quiet`. Eight
  guards, all RED — four were survivors on the first pass and grew tests, including the
  `not in_class` guard on `[` (which decides where a class *stops*: without it `[^[]x-y`
  reads the trailing `x-y` as a range) and the runner short-circuit (asserted with a box
  that raises if a withheld mutation touches it).

That mid-run `git diff --quiet` is not decoration: a run killed at a tool timeout left a
mutant on disk during this work, and the check caught it on the next invocation rather than
letting the following run adopt it as a baseline. Same family as the bug being fixed — a
sweep that cannot tell you what it did not do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy