### PR TITLE
A workspace with a dot in its name works, instead of failing in two directions (#695)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -820,7 +820,8 @@ def _charter_py_env_argv(*, socket: str, session: str) -> list[str]:
     write would hand frame N's interpreter to frame N-1 — the same "last launched wins"
     trap `conf_text`'s docstring already names for `mouse`/`history-limit`.
     """
-    return tmuxctl.server_argv(socket, "set-environment", "-t", session, _CHARTER_PY_ENV,
+    return tmuxctl.server_argv(socket, "set-environment", "-t", session,
+                               _CHARTER_PY_ENV,
                                sys.executable)
 
 
@@ -876,7 +877,8 @@ def _exit_path_env_argv(*, socket: str, session: str, frame_root: str) -> list[s
     reports a number that was never its own. The hook appends the chat itself, from the
     window option `_chat_option_argv` writes; see `_pane_died_write_hook_argv`.
     """
-    return tmuxctl.server_argv(socket, "set-environment", "-t", session, _EXIT_PATH_ENV,
+    return tmuxctl.server_argv(socket, "set-environment", "-t", session,
+                               _EXIT_PATH_ENV,
                                frame_root)
 
 
@@ -5791,7 +5793,27 @@ def _say_on_screen(fid: str, message: str, client: str | None = None) -> None:
     if client:
         argv += ["-c", client]
     else:
-        argv += ["-t", fid]
+        # **The frame's own PANE, and never its id** (#695). A chat id is
+        # `{workspace}.{ordinal}` and tmux parses a `-t` on the dot, so
+        # `-t harness-wrapper.2` is not the window of that name: measured on 3.7c it
+        # resolves to session
+        # `harness-wrapper`, its CURRENT window, and `2` as a pane index — and
+        # `-t harness-wrapper.9` answers rc 0 with pane index 0 rather than failing. The
+        # session half happens to be the right screen, which is why nothing has ever been
+        # seen to go wrong here; the target has never once meant what it was spelled to
+        # mean, and the day a workspace is called `api.2` beside one called `api` it means
+        # a different operator's frame. There is no spelling that fixes a window: tmux
+        # takes `session:window` and this side has no session in hand — so the answer is
+        # the record charter already keeps of where this frame's harness runs, which is a
+        # `%N` and cannot be parsed as anything else.
+        pane = state.harness_pane(fid) or ""
+        if not _PANE_ID_RE.fullmatch(pane):
+            # No usable record and no client: there is nothing this can be aimed at that is
+            # certainly this frame. Silence rather than `-t <fid>`, which is how a refusal
+            # came to be drawn across somebody else's frame — the same direction the empty
+            # id above is refused for, and one an operator loses only a sentence to.
+            return
+        argv += ["-t", pane]
     # One prefix for every outcome. Every refusal `switch.py` produces already reads as
     # one ("cannot switch: …", "no workspace 'x' — have: …"), and a second word saying so
     # only ate columns off a status line tmux truncates without saying it did — measured

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -55,7 +55,26 @@ from .. import config, contain
 #: Anything outside this becomes an underscore. Only used to MINT an id in
 #: :func:`frame_id` — never to rewrite one handed to :func:`frame_dir`, which resolves
 #: through :func:`charter.contain.child` instead and refuses rather than rewrites.
-_UNSAFE = re.compile(r"[^A-Za-z0-9._-]")
+#:
+#: **The `.` is not in it, and that is #695 rather than tidiness.** A workspace may be
+#: called `api.2` — `instance.WORKSPACE_NAME_RE` accepts a dot and this does not narrow
+#: what an operator may call anything — but the name this function MINTS goes on to be a
+#: tmux SESSION (`commands_frame.cmd_launch`), and a session name is not a string tmux
+#: reads as a string. Measured:
+#:
+#: * tmux 3.7c keeps the dot and then splits on it in every `-t`: `new-window -t api.2`
+#:   answers ``can't specify pane here`` rc 1, so a dotted workspace could never open its
+#:   SECOND chat; `set-environment -t api.2` answers rc **0** and writes on session
+#:   `api`, which is another workspace's frame told it is this one.
+#: * tmux 3.2 — `tmuxctl.FLOOR` — does not even keep it: ``new-session -s api.2`` creates
+#:   a session actually named ``api_2``. So charter asked for one name and got another,
+#:   and every later `-t` missed the session it had just made.
+#:
+#: A trailing `:` disambiguates the target on 3.7c and does nothing on 3.2, so the fix
+#: cannot live at the target. It lives here, where charter chooses the identifier: the
+#: workspace keeps its own name, and the thing derived from it is spelled in an alphabet
+#: tmux reads back the way it was written — which is what 3.2 was going to do anyway.
+_UNSAFE = re.compile(r"[^A-Za-z0-9_-]")
 
 
 def workspace_prefix(workspace: str) -> str:

--- a/docs/news/unreleased-a-workspace-with-a-dot-in-its-name-works.md
+++ b/docs/news/unreleased-a-workspace-with-a-dot-in-its-name-works.md
@@ -1,0 +1,72 @@
+---
+version: unreleased
+headline: A workspace with a dot in its name can open a second chat, and stops writing its identity on another workspace's frame
+---
+
+`charter workspace create api.2` is a name charter accepts. Opening a second chat in that
+workspace returned 1 with nothing to explain it, and the frame's own identity was written
+onto a *different* workspace's tmux session at rc 0.
+
+## A session name is not a string tmux reads as a string
+
+tmux parses a `-t` argument as `session:window.pane`, so a dot in a name is a separator
+before it is a character. `state.workspace_prefix` turns a workspace into the tmux session
+name, and the two tmux versions charter supports disagree about what happens next:
+
+**tmux 3.7c keeps the dot and then splits on it.**
+
+```
+$ tmux … new-window -d -a -t api.2 -n api.2.2 …
+can't specify pane here                                   rc=1
+$ tmux … set-environment -t api.2 CHARTER_SESSION_ID api.2.1
+                                                          rc=0
+$ tmux … show-environment -t api CHARTER_SESSION_ID
+CHARTER_SESSION_ID=api.2.1        ← a sibling workspace's session
+```
+
+The first is `cmd_launch` adding the workspace's second chat, so a dotted workspace was a
+one-chat workspace. The second is the silent-success class again — `$CHARTER_SESSION_ID`
+is what the hotkey bind and every palette action resolve themselves from, so that is one
+frame's identity handed to another, reported as having worked.
+
+**tmux 3.2 — the floor — does not keep it at all.** `new-session -s api.2` creates a
+session actually named `api_2`, so charter asked for one name and got another, and every
+later target missed the session it had just made.
+
+## Why the fix is not at the target
+
+A trailing `:` disambiguates on 3.7c — `-t 'api.2:'` resolves the session and lands
+correctly. On 3.2 it answers `can't find session: api.2`, because there is no such session
+to find. A rule that works on one of two supported versions is not a rule.
+
+So the fix is where charter *chooses the identifier*: `workspace_prefix` no longer mints a
+dot. The workspace keeps its own name — `WORKSPACE_NAME_RE` is untouched and nothing an
+operator may call a thing has been narrowed — and the session derived from it is `api_2`,
+which is what 3.2 was going to spell anyway and which 3.7c gives back unchanged.
+
+**Narrowing the alphabet instead would have been the cheaper edit and the worse one.** It
+is shared with the change-slug alphabet, and a plane that already had such a workspace
+would not get a refusal — it would get a workspace that stops resolving, `frame_workspace`
+answering `None` and `workspace_dir` refusing, and the thing simply vanishing. Measured on
+this machine: 15 workspaces across six clones, none with a dot. Nothing is gained by
+forbidding the input and something real is risked.
+
+## And one dot fewer in a chat id
+
+A chat of `api.2` is now `api_2.1` rather than `api.2.1`, so the only dot in a chat id is
+`state._CHAT_SEP` — the ordinal separator. `chats._order` reads an ordinal off the last
+dot, and now there is only one to read.
+
+## The refusal that could not reach the screen
+
+`_say_on_screen` aimed `display-message -t <chat id>`, and a chat id is *always* dotted.
+Measured on 3.7c, charter's own shape: `-t harness-wrapper.2` resolves to session
+`harness-wrapper`, its **current** window, and `2` as a pane index — and
+`-t harness-wrapper.9` answers rc 0 with pane index 0 rather than failing. The session half
+happened to be the right screen, which is why nothing was ever seen to go wrong; the target
+never once meant what it was spelled to mean.
+
+There is no spelling that fixes a window — `session:window` needs the session, and this
+side has none in hand — so it now aims at the record charter already keeps of where the
+frame's harness runs, which is a `%N` and cannot be parsed as anything else. A frame whose
+pane record is unusable is told nothing rather than told on somebody else's screen.

--- a/tests/test_frame_palette.py
+++ b/tests/test_frame_palette.py
@@ -690,6 +690,10 @@ class WhatReachesTheOperatorsScreen(PersonaIso, unittest.TestCase):
         super().setUp()
         state.frame_dir(self.FID, create=True)
         state.record_server(self.FID, "charter")
+        # A frame HAS one, and since #695 it is what a message without a client is aimed
+        # at — the record charter already keeps of where this frame's harness runs, whose
+        # `%N` tmux cannot read as anything but a pane.
+        state.record_harness_pane(self.FID, "%4")
 
     def test_what_is_put_on_screen_is_inert_before_tmux_ever_parses_it(self):
         """`display-message`'s argument is a tmux FORMAT (its own docs say so), and what
@@ -702,20 +706,42 @@ class WhatReachesTheOperatorsScreen(PersonaIso, unittest.TestCase):
         self.assertNotIn("x #(touch /tmp/pwned) y", argv)
         self.assertIn("charter: x ##(touch /tmp/pwned) y", argv)
 
-    def test_a_named_client_is_told_and_an_unnamed_one_is_the_session(self):
+    def test_a_named_client_is_told_and_an_unnamed_one_is_the_frames_own_pane(self):
         """Measured against tmux 3.7c with two real ptys on one session: `-t <session>`
         drew on the most recently attached client regardless of who pressed, and `-c` drew
         on exactly the named one. The palette carries the presser's own client from the
-        hotkey bind, so a refusal reaches the terminal that asked for it."""
+        hotkey bind, so a refusal reaches the terminal that asked for it.
+
+        With no client the target is the frame's own PANE and never its id (#695). A chat
+        id is `{workspace}.{ordinal}` and tmux splits a `-t` on the dot, so
+        `-t harness-wrapper.2` is not the window of that name: measured on 3.7c it resolves
+        to session `harness-wrapper`, its CURRENT window, and `2` as a pane index. The
+        session half happened to be the right screen, which is why nothing was ever seen to
+        go wrong — the target has never once meant what it was spelled to mean."""
         with mock.patch.object(commands_frame.tmuxctl, "run") as run:
             commands_frame._say_on_screen(self.FID, "hello", "/dev/ttys7")
         self.assertIn("-c", run.call_args[0][1])
         self.assertIn("/dev/ttys7", run.call_args[0][1])
         with mock.patch.object(commands_frame.tmuxctl, "run") as run:
             commands_frame._say_on_screen(self.FID, "hello")
-        self.assertNotIn("-c", run.call_args[0][1])
-        self.assertIn("-t", run.call_args[0][1])
-        self.assertIn(self.FID, run.call_args[0][1])
+        argv = run.call_args[0][1]
+        self.assertNotIn("-c", argv)
+        self.assertEqual(argv[argv.index("-t") + 1], "%4")
+        self.assertNotIn(self.FID, argv,
+                         "a frame id reached tmux as a target, where the dot in it is a "
+                         "separator and not a character")
+
+    def test_a_frame_with_no_usable_pane_record_is_told_nothing_at_all(self):
+        """The direction the refusal falls, and it is the same one an empty id already
+        falls: there is nothing here that can be aimed at that is CERTAINLY this frame, and
+        `-t <fid>` is how a refusal came to be drawn across somebody else's. An operator
+        loses a sentence; the alternative is another operator gaining one."""
+        for record in ("", "not-a-pane", "%1;kill-server"):
+            with self.subTest(record=record):
+                state.record_harness_pane(self.FID, record)
+                with mock.patch.object(commands_frame.tmuxctl, "run") as run:
+                    commands_frame._say_on_screen(self.FID, "hello")
+                self.assertEqual(run.call_count, 0, run.call_args)
 
 
 if __name__ == "__main__":                          # pragma: no cover

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -115,13 +115,21 @@ class ChatIdIsAllocated(PersonaIso, unittest.TestCase):
 
     def test_a_workspace_spelled_like_a_chat_id_does_not_collide_with_one(self):
         """Workspace `api.2` and chat 2 of workspace `api` are two different names, and
-        the allocator has to keep them that way: `api.2`'s own chats are `api.2.1`,
-        `api.2.2`, and the directory `api.2` belongs to whichever allocator claimed it.
-        Pinned as literals, because the point is which strings come out."""
+        the allocator has to keep them that way. Since #695 it keeps them apart by not
+        minting the dot at all: `api.2`'s chats are `api_2.1`, `api_2.2`, so the only dot
+        in a chat id is the ordinal separator and nothing has to be told which one it is.
+
+        Pinned as literals, because the point is which strings come out — and because the
+        prefix is a tmux SESSION name, where a dot is a target separator on 3.7c and is
+        rewritten to `_` outright on 3.2. Charter now spells what 3.2 was going to spell
+        anyway, on both."""
         self.assertEqual(state.new_chat_id("api"), "api.1")
         self.assertEqual(state.new_chat_id("api"), "api.2")
-        self.assertEqual(state.new_chat_id("api.2"), "api.2.1")
+        self.assertEqual(state.new_chat_id("api.2"), "api_2.1")
         self.assertEqual(state.new_chat_id("api"), "api.3")
+        self.assertNotEqual(state.workspace_prefix("api.2"), "api.2",
+                            "the identifier charter derives still carries a dot, which is "
+                            "a tmux target separator")
 
     def test_a_taken_ordinal_is_skipped_rather_than_adopted(self):
         """A directory already holding another chat's record is not an id to hand out.
@@ -151,8 +159,8 @@ class ChatIdIsAllocated(PersonaIso, unittest.TestCase):
         self.assertEqual(state.workspace_prefix("api_"), "api")
         self.assertEqual(state.workspace_prefix("_api"), "api",
                          "the leading end too, so `_launcher_pid` still finds a head")
-        self.assertEqual(state.workspace_prefix("a.p-i"), "a.p-i",
-                         "and only at the ENDS: the three characters are ordinary inside "
+        self.assertEqual(state.workspace_prefix("a.p-i"), "a_p-i",
+                         "and only at the ENDS: `-` and `_` are ordinary inside "
                          "a name, or `harness-wrapper` would come back as `harness`")
         self.assertEqual(state.new_chat_id("api."), "api.1")
         self.assertEqual(state.workspace_prefix("..."), "frame",

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -5224,6 +5224,110 @@ class TheChatALaunchIsLeavingIsReadFromTmux(_ChatsOnOneSession, _TmuxServerFixtu
         self.assertEqual(state.panes(f"{self.WS}.1"), {})
 
 
+class AWorkspaceNamedWithADotIsStillAWorkspace(_TmuxServerFixture, PersonaIso,
+                                              unittest.TestCase):
+    """#695, against a real server: a session NAME is not a string tmux reads as a string.
+
+    `instance.WORKSPACE_NAME_RE` accepts a dot, so `api.2` is a workspace
+    `charter workspace create` takes — and `state.workspace_prefix` turns a workspace into
+    the tmux SESSION name. Two facts about tmux, neither of which a mock can produce, and
+    which disagree with each other:
+
+    * **3.7c keeps the dot and then splits on it.** `-t api.2` is `window.pane`, so
+      `new-window` answers `can't specify pane here` rc 1 and `set-environment` answers rc
+      **0** onto a sibling session called `api`.
+    * **3.2 — `tmuxctl.FLOOR` — does not keep it at all.** `new-session -s api.2` creates
+      a session named `api_2`, so charter asked for one name and got another and every
+      later target missed.
+
+    That disagreement is the whole reason the fix is in what charter MINTS rather than in
+    how it spells a target: a trailing `:` disambiguates on 3.7c and finds nothing on 3.2.
+    So this class asserts the property both versions can hold — the identifier charter
+    derives is one tmux gives back unchanged, and the frame works.
+
+    The sibling session called `api` is not decoration: on 3.7c it is what `-t api.2`
+    resolves TO once tmux has split the name, so without it the wrong target would merely
+    fail instead of quietly working on another workspace's frame.
+    """
+
+    WS = "api.2"
+    SIBLING = "api"
+
+    def _session(self, name: str) -> str:
+        r = self._srv("new-session", "-d", "-s", name, "-n", f"{name}.1", "-P", "-F",
+                      "#{pane_id}", "--", *_gate_argv(
+                          os.path.join(self._gate_dir, f"gate-{name}"), "exit 0"))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pane = r.stdout.strip()
+        self.addCleanup(_kill_pid, self._srv("display-message", "-p", "-t", pane,
+                                             "#{pane_pid}").stdout.strip())
+        return pane
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.prefix = state.workspace_prefix(self.WS)
+        self.pane = self._session(self.prefix)
+        self._session(self.SIBLING)
+
+    def test_tmux_gives_back_the_name_charter_asked_for(self):
+        """The property both versions can hold, and the one a dotted name cannot. Read out
+        of `list-sessions` rather than assumed: on 3.2 a dotted name comes back rewritten,
+        which is how charter came to target a session that was never there."""
+        self.assertNotIn(".", self.prefix,
+                         "charter is still minting a dot into a tmux session name")
+        names = self._srv("list-sessions", "-F", "#{session_name}").stdout.split()
+        self.assertIn(self.prefix, names)
+
+    def test_a_second_chat_can_be_opened_in_it(self):
+        """The reachable defect. `layout.chat_window_argv` is the production builder, and
+        with a dotted session name it answered `can't specify pane here` rc 1 on 3.7c — so
+        `charter claude` a second time in that workspace returned 1 with nothing to explain
+        it, and the workspace was a one-chat workspace for good."""
+        chat = f"{self.prefix}.2"
+        cmd = layout.chat_window_argv(socket=self.SOCKET_NAME, session=self.prefix,
+                                      chat=chat, cwd=self._gate_dir,
+                                      harness_argv=_gate_argv(
+                                          os.path.join(self._gate_dir, "gate-2"),
+                                          "exit 0"))
+        r = _run(cmd)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.addCleanup(_kill_pid, self._srv("display-message", "-p", "-t",
+                                             r.stdout.strip(),
+                                             "#{pane_pid}").stdout.strip())
+        self.assertEqual(
+            sorted(self._srv("list-windows", "-t", self.prefix,
+                             "-F", "#{window_name}").stdout.split()),
+            sorted([f"{self.prefix}.1", chat]))
+
+    def test_the_frames_identity_lands_on_its_own_session(self):
+        """`$CHARTER_SESSION_ID` is what the hotkey bind and every palette action resolve
+        themselves from. With a dotted session name `set-environment` answered rc **0** and
+        wrote it on session `api` — another workspace's frame, told it was this one."""
+        cmd = commands_frame._session_id_env_argv(socket=self.SOCKET_NAME,
+                                                  session=self.prefix,
+                                                  chat=f"{self.prefix}.1")
+        self.assertEqual(_run(cmd).returncode, 0)
+        mine = self._srv("show-environment", "-t", self.prefix, "CHARTER_SESSION_ID")
+        self.assertEqual(mine.stdout.strip(), f"CHARTER_SESSION_ID={self.prefix}.1")
+        theirs = self._srv("show-environment", "-t", self.SIBLING, "CHARTER_SESSION_ID")
+        self.assertNotEqual(theirs.returncode, 0,
+                            "this frame's identity was written on another workspace's "
+                            "session")
+
+    def test_the_reattach_line_charter_prints_is_one_that_works(self):
+        """The launcher's own advice, run. An operator who cannot reattach to a detached
+        agent has lost it, and a hint that fails is worse than none."""
+        self.assertEqual(self._srv("has-session", "-t", self.prefix).returncode, 0)
+
+    def test_a_chat_id_carries_exactly_one_dot_and_it_is_the_ordinal(self):
+        """What the mint buys beyond the target: the only dot left in a chat id is
+        `state._CHAT_SEP`, so `chats._order`'s `rpartition` reads an ordinal rather than
+        whichever dot happened to be last."""
+        chat = state.new_chat_id(self.WS)
+        self.assertEqual(chat, f"{self.prefix}.1")
+        self.assertEqual(chat.count("."), 1)
+
+
 class ChatsAreWindowsOnOneWorkspaceSession(_ChatsOnOneSession, _TmuxServerFixture,
                                            PersonaIso):
     """Phase 5 Stage 5a, against a real server: a workspace is a SESSION and a chat is a


### PR DESCRIPTION
Closes #695.

`instance.WORKSPACE_NAME_RE` is `^[A-Za-z0-9][A-Za-z0-9._-]*$`, so `api.2` is a workspace
`charter workspace create` takes. `state.workspace_prefix` turns a workspace into a tmux
**session** name — and tmux parses a `-t` argument as `session:window.pane`, so a dot in
that name is a separator before it is a character.

## Two versions, two different wrong things

**tmux 3.7c keeps the dot and then splits on it.** With a sibling session called `api`:

```
$ tmux … new-window -d -a -t api.2 -n api.2.2 …
can't specify pane here                                          rc=1
$ tmux … set-environment -t api.2 CHARTER_SESSION_ID api.2.1      rc=0
$ tmux … show-environment -t api CHARTER_SESSION_ID
CHARTER_SESSION_ID=api.2.1        ← a different workspace's session
```

The first is `cmd_launch` adding the workspace's **second** chat, so a dotted workspace was
a one-chat workspace and the launcher returned 1 with nothing to explain it. The second is
#684's silent-success class one command over: `$CHARTER_SESSION_ID` is what the hotkey bind
and every palette action resolve themselves from.

**tmux 3.2 — `tmuxctl.FLOOR` — does not keep it at all.**

```
$ tmux3.2 … new-session -d -s api.2 …
$ tmux3.2 … list-sessions -F '#{session_name}'
api_2
```

Charter asked for one name and got another, and every later target missed the session it
had just made.

## Why the fix is not at the target

A trailing `:` is tmux's own way to say "this is a session", and it works — **on 3.7c**.
On 3.2 it answers `can't find session: api.2`, because there is no such session to find. A
rule that holds on one of two supported versions is not a rule, so this went through a
first implementation and back out again.

The fix is where charter **chooses the identifier**: `workspace_prefix` no longer mints a
dot. The workspace keeps its own name, nothing an operator may call a thing is narrowed,
and the session derived from it is `api_2` — which is what 3.2 was going to spell anyway
and which 3.7c gives back unchanged. A chat of it is `api_2.1`, so the only dot left in a
chat id is `state._CHAT_SEP`, the ordinal separator `chats._order` reads off the last dot.

## The fork you asked me to measure, and which way I went

**Do not narrow `WORKSPACE_NAME_RE`.** It is the cheaper edit and the worse one: the
alphabet is shared with the change-slug alphabet, and a plane that already had such a
workspace would not get a refusal — it would get one that *stops resolving*,
`frame_workspace` answering `None` and `workspace_dir` refusing, and the thing simply
vanishing. Measured on this machine before deciding: **15 workspaces across six clones,
none with a dot.** So nothing is gained by forbidding the input and something real is
risked, where naming the derived identifier correctly costs one character class and fixes
the cause.

## The refusal that could not reach the screen

`_say_on_screen` aimed `display-message -t <chat id>`, and a chat id is *always* dotted —
this session is `harness-wrapper.1`. Measured on 3.7c against charter's own shape:

```
-t harness-wrapper.1  -> [harness-wrapper | harness-wrapper.1 | pane 1]  rc=0
-t harness-wrapper.2  -> [harness-wrapper | harness-wrapper.1 | pane 2]  rc=0   ← not window .2
-t harness-wrapper.9  -> [harness-wrapper | harness-wrapper.1 | pane 0]  rc=0
```

The `.N` is read as a pane index every time and the window is always the session's
**current** one. The session half happened to be the right screen, which is why nothing was
ever seen to go wrong — the target never once meant what it was spelled to mean.

There is no spelling that fixes a *window* (`session:window` needs the session, and this
side has none in hand), so it now aims at the record charter already keeps of where the
frame's harness runs: a `%N`, which tmux cannot read as anything else. A frame whose pane
record is unusable is told **nothing** rather than told on somebody else's screen — the
same direction an empty frame id is already refused for.

## Verification

- Full suite green on 3.14: **8919 tests, OK**.
- New real-tmux class `AWorkspaceNamedWithADotIsStillAWorkspace`, run on **3.7c and 3.2**:
  tmux gives back the name charter asked for; the second chat opens; the identity lands on
  its own session and not the sibling's; the printed reattach line is one that works; and a
  chat id carries exactly one dot.
- Hand deletion sweep, restores verified with sha256 **and** `git diff --quiet`. Three
  guards, all RED — two were survivors on the first pass (nothing asserted what
  `_say_on_screen` targets at all) and grew tests.
- Merges cleanly with #699.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy