### PR TITLE
Charter's own plane can place a component charter ships, and eight tests stop reading "draws every edge" as "draws nothing else" (#701)

### DIFF
--- a/docs/news/unreleased-charters-own-plane-can-place-a-component-charter-ships.md
+++ b/docs/news/unreleased-charters-own-plane-can-place-a-component-charter-ships.md
@@ -1,0 +1,85 @@
+---
+version: unreleased
+headline: charter's own plane can place a component charter ships — eight tests stopped reading "this plane draws every edge" as "this plane draws nothing else"
+---
+
+Adding the two bars `docs/frame.md` documents to this repository's own `charter.toml` —
+copying the snippet out of charter's own documentation, into charter's own control plane —
+turned **eight** tests red:
+
+```
+FAIL test_the_committed_slots_line_names_every_slot_charter_can_draw
+     ['bottom','chats','repos','right','top','workspaces'] != ['bottom','repos','right','top']
+```
+
+Take the two tables out and all eight pass. **A feature charter ships could not be used on
+the plane that ships it**, which is [#661](https://github.com/diazoxide/charter/issues/661)
+exactly — the `size` key that could not be committed — one layer up.
+
+## The class name was already the right claim
+
+`CharterOwnPlaneDrawsEveryEdgeItShips`. That is a **superset**: *this plane exercises every
+slot charter can draw*, and it is what stops a shipped edge going undrawn on the only plane
+anybody runs the suite on. `assertEqual` says something stronger and different — *this
+plane draws these and nothing else* — which is not a property charter wants, and it is not
+the one the class is named for. A second class said the same thing in its own name:
+`test_charters_own_plane_still_draws_every_panel_it_draws_today`, where *today* is doing
+the work and today moves.
+
+Every case now drops what charter does not ship and compares what is left, so the
+expectation is *charter's four are all still here, in the shipped split order, on their
+shipped edges, at their shipped sizes* — and a plane may place a component of its own
+between them.
+
+## What did not get relaxed
+
+Permitting extras is the easy half and, on its own, would have thrown the property away.
+Three things had to survive, and each was verified by breaking this plane's file on purpose
+and watching the red arrive:
+
+* **A shipped edge going undrawn.** Delete the `repos` table from `charter.toml`: eight
+  cases go red naming `repos`. Set `visible = false` on it instead: nine do, one of them
+  naming `(use='repos')` in its subtest.
+* **The split order, which is the geometry**
+  ([#488](https://github.com/diazoxide/charter/issues/488)/[#500](https://github.com/diazoxide/charter/issues/500)).
+  `repos` before `right` draws the table at the full window width from 95 columns up;
+  after it, the table needs a 118-column terminal before it is drawn at all. Move the
+  `repos` table after `sidebar` and seven cases go red. The order is asserted as a
+  subsequence — *drop what charter does not ship, then compare* — which carries the
+  membership and the order in one line and still names the whole list when it fails.
+* **The set being read rather than written out.** The superset comes off
+  `instance.FRAME_SLOTS` and `instance.frame_components({})`, so the slot charter ships
+  next is covered without a new test. The literals stay where a literal is the point: the
+  shipped default is pinned against them in a different class, and the "this frame resolves
+  to what it always resolved to" class keeps its own on purpose — a change to charter's
+  four *should* come and update that line by hand. Both of those reds are wanted. The only
+  red that was not is the one an operator's own `[[frame.component]]` used to cause.
+
+## Five of the eight were not in the report
+
+The issue named three. Running the whole suite rather than the two frame modules found
+five more, in two files the report did not reach — including the regression test written
+for [#662](https://github.com/diazoxide/charter/issues/662), the fix for #661. The defect
+had been copied into its own cure.
+
+That is the shape worth naming: the feature was exercised only against synthetic configs
+and never against a real plane using it, which is how #660 shipped a `size` key that
+dropped a whole arrangement and how
+[#690](https://github.com/diazoxide/charter/issues/690) shipped a documented snippet that
+turned the frame off. Every test in this repository that reads the committed
+`charter.toml` off disk was enumerated and read; eight compared it with a shipped constant
+by equality, and all eight are here.
+
+One of them was doing less than it looked, and now says so out loud. An arrangement is
+refused **whole** ([#535](https://github.com/diazoxide/charter/issues/535)) — one value
+charter cannot read drops every table back to `slots` — and this plane's `slots` line
+resolves to the same four panels its tables do. So a `charter.toml` whose arrangement
+charter could no longer read fell back silently and every assertion about the resolved
+frame went on passing. Verified: put an unreadable `bg` on one table and two cases catch
+it, one of them reporting `this plane declares its arrangement`.
+
+Nothing to adopt, and nothing changed in `charter/`. `charter.toml` is unchanged too —
+whether this plane carries the bars is its operator's line to write, and the tests no
+longer have an opinion about it.
+
+[#701](https://github.com/diazoxide/charter/issues/701).

--- a/tests/test_a_pinned_repo_strip_keeps_its_height.py
+++ b/tests/test_a_pinned_repo_strip_keeps_its_height.py
@@ -490,6 +490,15 @@ class TheCommittedFileIsReadAtABoundaryAndNotInTheArithmetic(unittest.TestCase):
         plane that later commits the same key for real is running the case this test
         already ran, and the day charter's own frame gains a pin this stays green rather
         than needing to be rewritten.
+
+        **`slot_sizes`' answer is compared over the shipped slots and not whole (#701),
+        for the same reason this test reads the real file at all.** An operator whose
+        `[[frame.component]]` places something charter did not ship — the two bars
+        `docs/frame.md` documents — gets an extra key here, and asserting the dict whole
+        made that arrangement a failure. Which is #661 itself, said about a test instead
+        of about `repos_rows`: charter's own plane could not use a feature charter ships.
+        The property is unchanged — the fixed strips stay 1 and 22, and `repos` stays the
+        6 rows it was HANDED rather than the 15 the file now pins.
         """
         cfg = tomllib.loads(_COMMITTED.read_text(encoding="utf-8"))
         tables = cfg["frame"]["component"]
@@ -506,9 +515,10 @@ class TheCommittedFileIsReadAtABoundaryAndNotInTheArithmetic(unittest.TestCase):
                 layout.repos_rows(content_rows=4, window_rows=50,
                                   slots=["top", "bottom", "repos"]),
                 4)
+            sizes = layout.slot_sizes(resolved["slots"], window_rows=50, content_rows=6)
             self.assertEqual(
-                layout.slot_sizes(resolved["slots"], window_rows=50, content_rows=6),
-                {"top": 1, "bottom": 1, "repos": 6, "right": 22})
+                {s: n for s, n in sizes.items() if s in instance.FRAME_SLOTS},
+                {"top": 1, "bottom": 1, "repos": 6, "right": 22}, sizes)
 
     def test_the_number_the_arithmetic_was_handed_is_the_number_it_used(self):
         """The other half, and it is what stops the two tests above being satisfied by a

--- a/tests/test_component_config.py
+++ b/tests/test_component_config.py
@@ -264,6 +264,13 @@ class TheOperatorsOwnPlane(unittest.TestCase):
     copy that agrees with the real thing until somebody edits one of them. That is the
     whole failure mode: the change #535 shipped removed the repo table from charter's own
     plane and every fixture in the suite went on describing a frame that had one.
+
+    **Every case here asks whether a panel charter SHIPS is still drawn, never whether
+    this plane draws only those (#701).** The three cases that already read that way —
+    the repo table by name, the split order, the committed names resolving — are the
+    shape; the first one was an equality, and an equality is a claim about the
+    OPERATOR's file rather than about charter. It made `[[frame.component]]` unusable on
+    the plane that ships it: adding either bar `docs/frame.md` documents turned this red.
     """
 
     def setUp(self) -> None:
@@ -272,10 +279,27 @@ class TheOperatorsOwnPlane(unittest.TestCase):
         self.cfg = tomllib.loads(CHARTER_TOML.read_text())
 
     def test_charters_own_plane_still_draws_every_panel_it_draws_today(self):
-        got = instance.frame_components(self.cfg)
-        self.assertEqual([(p["use"], p["edge"], p["visible"]) for p in got],
-                         [("identity", "top", True), ("attention", "bottom", True),
-                          ("repos", "bottom", True), ("sidebar", "right", True)])
+        """Every panel the SHIPPED frame places, on its shipped edge, visible, in the
+        shipped split order — with this plane's own components allowed to sit between
+        them.
+
+        *want* comes off `instance.frame_components({})` rather than a literal, which is
+        the same reason the class name says *today*: today moves, and the day charter
+        ships a fifth panel this should follow it rather than need a new literal.
+        `SlotsIsShorthandForPlacingBuiltIns.test_the_shipped_default_places_every_panel_charter_draws`
+        is where that default is pinned against literals, so deriving here is not both
+        sides moving together.
+
+        Filtered by `use` and not by the whole tuple, so a `repos` this plane moved to
+        another edge or hid survives the filter and reddens the comparison naming
+        itself — rather than being dropped as *not one of ours* and reported as a length
+        mismatch."""
+        want = [(p["use"], p["edge"], p["visible"])
+                for p in instance.frame_components({})]
+        shipped = {use for use, _, _ in want}
+        got = [(p["use"], p["edge"], p["visible"])
+               for p in instance.frame_components(self.cfg)]
+        self.assertEqual([t for t in got if t[0] in shipped], want, got)
 
     def test_charters_own_plane_still_has_its_repo_table(self):
         """Said separately from the list above, and on purpose. The assertion that shape

--- a/tests/test_component_id_is_the_currency.py
+++ b/tests/test_component_id_is_the_currency.py
@@ -457,6 +457,19 @@ class TheRespawnHookStillOnlyArmsNamesCharterCanDraw(unittest.TestCase):
                 self.assertIsNone(self._armed(hostile))
 
 
+#: The slots charter SHIPS, written out — the literal `CharterOwnConfigIsUnchanged` keeps
+#: on purpose, and the one every case in it filters this plane's answer down to.
+#:
+#: A LITERAL here and not `instance.FRAME_SLOTS`, unlike
+#: `test_frame_config.CharterOwnPlaneDrawsEveryEdgeItShips`, and the two want different
+#: things. That class asks *does this plane still draw every edge charter ships* — a
+#: question about a set that MOVES, so it has to read the set. This class asks *does the
+#: frame still resolve to what it resolved to* across a refactor, so a change to the
+#: shipped four SHOULD come and update this line by hand. Both reds are wanted; only the
+#: red an operator's own `[[frame.component]]` used to cause was not (#701).
+_SHIPPED_SLOTS = ["top", "bottom", "repos", "right"]
+
+
 class CharterOwnConfigIsUnchanged(unittest.TestCase):
     """charter's own committed `charter.toml` resolves to the frame it always drew.
 
@@ -464,14 +477,32 @@ class CharterOwnConfigIsUnchanged(unittest.TestCase):
     test. This reads the file off disk and pins the whole resolved arrangement — the slot
     list, the component ids behind it, and every rectangle — so a refactor that speaks a
     new vocabulary has to keep answering in the old one.
+
+    **Pins what charter ships, over the plane's answer — never the plane's answer whole
+    (#701).** Every case below drops what `_SHIPPED_SLOTS` does not name and compares
+    what is left, so charter's four keep their ids, their edges, their sizes and their
+    split order, and this plane may also place a component of its own between them.
+    Asserted whole, these four were a claim that charter's own operator may not use
+    `[[frame.component]]` for anything charter did not ship — which is the feature this
+    class's own file exists to place. Adding either bar `docs/frame.md` documents turned
+    all four red, and #661 is the same defect one layer down: a read of the committed
+    file that turned a legal arrangement into a failure.
+
+    What survives the filter is the whole property: a refactor that loses `repos`, moves
+    it off `bottom`, hides it, re-keys it or splits it after the sidebar still reddens
+    every case it used to.
     """
 
     def setUp(self):
         self.cfg = tomllib.loads(_COMMITTED.read_text(encoding="utf-8"))
 
     def test_the_slot_list_is_the_one_that_is_committed(self):
-        self.assertEqual(instance.frame_of(self.cfg)["slots"],
-                         ["top", "bottom", "repos", "right"])
+        """The shipped four, in the shipped order, as a SUBSEQUENCE of what this plane
+        resolves — *drop what charter does not ship, then compare*, which carries the
+        membership and the order in one assertion and still names the whole list on a
+        failure."""
+        got = instance.frame_of(self.cfg)["slots"]
+        self.assertEqual([s for s in got if s in _SHIPPED_SLOTS], _SHIPPED_SLOTS, got)
 
     def test_the_arrangement_it_declares_resolves_to_the_frame_it_always_drew(self):
         """This plane writes its arrangement out, and the tables must still answer the
@@ -487,42 +518,72 @@ class CharterOwnConfigIsUnchanged(unittest.TestCase):
         the geometry (#488/#500): `repos` before `right` draws the table at the full
         window width from 95 columns up; reversed, it is split off a harness the sidebar
         has already narrowed and needs 118. That reversal is exactly what this class
-        caught when the tables were first written."""
+        caught when the tables were first written.
+
+        `assertIsNotNone` is the load-bearing line and is not a formality: an arrangement
+        is refused WHOLE (#535), and this plane's `slots` list resolves to the same four
+        panels its tables do — so a file whose arrangement charter can no longer read
+        falls back to `slots` and every other assertion in this class goes on passing.
+        That silent fallback is how #690 shipped a documented snippet that turned the
+        frame off.
+
+        The edge and visibility are asked of the shipped four only. A component with no
+        committed slot name is in no derived table at all — `SLOT_EDGE` would `KeyError`
+        on `chats` — because its rectangle is read back off this arrangement instead
+        (`layout._placed_here`, #687); and whether the plane's OWN component starts
+        hidden is the operator's line to write, not charter's to pin."""
         got = instance.component_tables(self.cfg.get("frame"))
         self.assertIsNotNone(got, "this plane declares its arrangement")
-        self.assertEqual([c["slot"] for c in got], ["top", "bottom", "repos", "right"])
-        for c in got:
+        shipped = [c for c in got if c["slot"] in _SHIPPED_SLOTS]
+        self.assertEqual([c["slot"] for c in shipped], _SHIPPED_SLOTS,
+                         [c["slot"] for c in got])
+        for c in shipped:
             with self.subTest(use=c["use"]):
                 self.assertEqual(c["edge"], layout.SLOT_EDGE[c["slot"]])
                 self.assertEqual(c["visible"], True)
 
     def test_every_placement_is_the_built_in_it_always_was(self):
-        got = instance.frame_components(self.cfg)
-        self.assertEqual([(p["use"], p["slot"], p["edge"], p["visible"]) for p in got],
-                         [("identity", "top", "top", True),
-                          ("attention", "bottom", "bottom", True),
-                          ("repos", "repos", "bottom", True),
-                          ("sidebar", "right", "right", True)])
+        """Filtered by the component ID rather than by the whole tuple: a `repos` this
+        plane moved, hid or re-keyed stays in the filtered list and reddens the
+        comparison naming itself, instead of being dropped as *not one of ours* and
+        reported as a length that does not match."""
+        want = [("identity", "top", "top", True),
+                ("attention", "bottom", "bottom", True),
+                ("repos", "repos", "bottom", True),
+                ("sidebar", "right", "right", True)]
+        shipped = {use for use, _, _, _ in want}
+        got = [(p["use"], p["slot"], p["edge"], p["visible"])
+               for p in instance.frame_components(self.cfg)]
+        self.assertEqual([t for t in got if t[0] in shipped], want, got)
 
     def test_the_frame_it_splits_is_byte_for_byte_the_frame_it_split(self):
         """The whole launch argv, not a summary of it. `slot_sizes` and `panel_argvs`
         are where a re-keyed table would show up first, and they are asserted against
-        literals rather than against the tables under test."""
+        literals rather than against the tables under test.
+
+        `panel_argvs` is one `split-window` per slot in the order it was handed, which is
+        what `zip(…, strict=True)` says out loud — so pairing each argv with its slot and
+        then keeping the shipped ones asserts the argv AND its position, and a length
+        that stopped matching is a `ValueError` here rather than four argvs silently
+        compared against the wrong four slots."""
         f = instance.frame_of(self.cfg)
         with mock.patch.dict(config.FRAME, f):
             sizes = layout.slot_sizes(f["slots"], window_rows=50, content_rows=6)
-            self.assertEqual(sizes, {"top": 1, "bottom": 1, "repos": 6, "right": 22})
+            self.assertEqual({s: n for s, n in sizes.items() if s in _SHIPPED_SLOTS},
+                             {"top": 1, "bottom": 1, "repos": 6, "right": 22}, sizes)
             argvs = layout.panel_argvs(slots=f["slots"], session="f-1", socket="/sock",
                                        harness_pane="%0", sizes=sizes)
-        self.assertEqual([a[a.index("split-window") + 1:] for a in argvs], [
-            ["-t", "%0", "-v", "-b", "-l", "1", "-P", "-F", "#{pane_id}", "--",
-             *layout.panel_command(slot="top", session="f-1")],
-            ["-t", "%0", "-v", "-l", "1", "-P", "-F", "#{pane_id}", "--",
-             *layout.panel_command(slot="bottom", session="f-1")],
-            ["-t", "%0", "-v", "-l", "6", "-P", "-F", "#{pane_id}", "--",
-             *layout.panel_command(slot="repos", session="f-1")],
-            ["-t", "%0", "-h", "-l", "22", "-P", "-F", "#{pane_id}", "--",
-             *layout.panel_command(slot="right", session="f-1")],
+        split = [(slot, a[a.index("split-window") + 1:])
+                 for slot, a in zip(f["slots"], argvs, strict=True)]
+        self.assertEqual([p for p in split if p[0] in _SHIPPED_SLOTS], [
+            ("top", ["-t", "%0", "-v", "-b", "-l", "1", "-P", "-F", "#{pane_id}", "--",
+                     *layout.panel_command(slot="top", session="f-1")]),
+            ("bottom", ["-t", "%0", "-v", "-l", "1", "-P", "-F", "#{pane_id}", "--",
+                        *layout.panel_command(slot="bottom", session="f-1")]),
+            ("repos", ["-t", "%0", "-v", "-l", "6", "-P", "-F", "#{pane_id}", "--",
+                       *layout.panel_command(slot="repos", session="f-1")]),
+            ("right", ["-t", "%0", "-h", "-l", "22", "-P", "-F", "#{pane_id}", "--",
+                       *layout.panel_command(slot="right", session="f-1")]),
         ])
 
 

--- a/tests/test_frame_config.py
+++ b/tests/test_frame_config.py
@@ -175,20 +175,51 @@ class CharterOwnPlaneDrawsEveryEdgeItShips(unittest.TestCase):
     has is filtered to nothing here, which reads on screen the same way as a list missing
     one. And the whole set is required rather than a membership check on today's newest
     name — the next slot has the same problem and should not need a new test.
+
+    **A SUPERSET, and never an equality (#701).** The class name is the claim: *this
+    plane draws every edge charter ships*. `assertEqual` said something stronger and
+    different — *this plane draws these and nothing else* — which is not a property
+    charter wants, and it made a shipped FEATURE unusable on the plane that ships it.
+    Adding the two bars `docs/frame.md` documents (`chats`, `workspaces` — components
+    with no `[frame] slots` word at all, #687) turned these red, so charter's own
+    operator and CI on every branch were pinned to the shipped default forever. That is
+    #661 one file over: a config read that turned an operator's legal choice into a
+    failure, and #662 fixed it by asking the question the code was actually about.
+
+    What the superset keeps that a bare *"extras are allowed"* would have given away:
+    both cases below still go RED when this plane stops drawing an edge charter ships —
+    the case the class exists for — and the second still pins the split order, because
+    the order is the geometry. Neither is a membership check on a name written out here:
+    the expectation comes off `instance.FRAME_SLOTS`, so the slot charter ships next is
+    already covered.
     """
 
     def test_the_committed_slots_line_names_every_slot_charter_can_draw(self):
+        """Every shipped slot appears. The missing ones are computed and asserted empty
+        rather than written `assertLessEqual(set(…), set(…))`, so a failure NAMES the
+        edge that went dark instead of printing two sets to diff by eye."""
         got = instance.frame_of(tomllib.loads(_COMMITTED.read_text()))["slots"]
-        self.assertEqual(sorted(got), sorted(instance.FRAME_SLOTS), got)
+        self.assertEqual([s for s in instance.FRAME_SLOTS if s not in got], [],
+                         f"this plane draws {got}, and charter ships "
+                         f"{list(instance.FRAME_SLOTS)}")
 
     def test_the_committed_order_is_the_one_the_geometry_wants(self):
         """The list is the SPLIT order, so it is the geometry (#488/#500): a slot listed
         later sits higher, and a `repos` listed after `right` is inset by the sidebar's
         23 columns and needs a 118-column terminal before it draws a table at all. The
         shipped default is the order charter measured; this file having the same set in a
-        different order would be a frame nobody chose."""
+        different order would be a frame nobody chose.
+
+        A SUBSEQUENCE, not an equality: the shipped slots, in the shipped order, with the
+        plane's own components allowed to sit between them. Written as *drop what the
+        shipped frame does not name, then compare* — one assertion that carries both the
+        order and the membership, and that still reddens on the reversal it was written
+        for (`repos` after `right` filters to `[… 'right', 'repos']`, which is not the
+        shipped list). What it deliberately no longer says is *and nothing else*, which
+        is what a plane placing `chats` between `top` and `bottom` breaks and should."""
         got = instance.frame_of(tomllib.loads(_COMMITTED.read_text()))["slots"]
-        self.assertEqual(got, instance.frame_of({})["slots"])
+        shipped = instance.frame_of({})["slots"]
+        self.assertEqual([s for s in got if s in shipped], shipped, got)
 
 
 class HotkeyIsNotAFreeString(unittest.TestCase):


### PR DESCRIPTION
Closes #701.

Adding the two bars `docs/frame.md` documents to this repository's own `charter.toml` —
the snippet from charter's own documentation, on charter's own control plane — turned
**eight** tests red. Take the two tables out and all eight pass. **A feature charter ships
could not be used on the plane that ships it**, which is #661 exactly, one layer up.

## The property each test is actually about

`CharterOwnPlaneDrawsEveryEdgeItShips` is already the right claim: a **superset** — *this
plane exercises every slot charter can draw* — and it is what stops a shipped edge going
undrawn on the only plane anybody runs the suite on. `assertEqual` said something stronger
and different: *this plane draws these and nothing else*, which is neither what the class
name claims nor a property charter wants. `test_charters_own_plane_still_draws_every_panel_it_draws_today`
said the same thing in its own name — *today* is doing the work, and today moves.

Every case now drops what charter does not ship and compares what is left, so charter's
four keep their ids, edges, sizes and split order, and a plane may place a component of
its own between them.

## Five of the eight were not in the report

The issue named three. Running the whole suite rather than the two frame modules found
five more, in two files the report did not reach:

| file | tests |
|---|---|
| `tests/test_frame_config.py` | 2 (reported) |
| `tests/test_component_config.py` | 1 (reported) |
| `tests/test_component_id_is_the_currency.py` | **4** |
| `tests/test_a_pinned_repo_strip_keeps_its_height.py` | **1** |

The last one is the regression test written for **#662, the fix for #661** — the defect
had been copied into its own cure.

Every test in this repository that reads the committed `charter.toml` off disk was
enumerated and read (four files; every other test writes its own fixture into a temp
plane). Eight compared it with a shipped constant by equality, and all eight are here.

## What did not get relaxed

Permitting extras is the easy half and on its own throws the property away. Each of the
three was verified by breaking this plane's file on purpose:

| mutation to `charter.toml` | reds |
|---|---|
| `repos` table deleted | **8**, each naming `repos` |
| `repos` set `visible = false` | **9**, one naming `(use='repos')` in its subtest |
| `repos` moved after `sidebar` | **7** — the split order (#488/#500) still bites |
| unreadable `bg` on one table (arrangement refused whole, #535) | **2** |

The superset is read off `instance.FRAME_SLOTS` and `instance.frame_components({})`, so
the slot charter ships next is covered without a new test. Literals stay where a literal
is the point: the shipped default is pinned against them in a different class, and
`CharterOwnConfigIsUnchanged` keeps its own on purpose — a change to charter's four
*should* come and update that line by hand. Both of those reds are wanted; the only red
that was not is the one an operator's own `[[frame.component]]` used to cause.

## One case was doing less than it looked

An arrangement is refused **whole** (#535) — one value charter cannot read drops every
table back to `slots` — and this plane's `slots` line resolves to the same four panels its
tables do. So a `charter.toml` whose arrangement charter could no longer read fell back
silently and every assertion about the resolved frame went on passing. That is how #690
shipped a documented snippet that turned the frame off. It is now stated in the docstring
and verified: an unreadable `bg` on one table is caught by two cases, one reporting
`this plane declares its arrangement`.

## Verification

- **Full suite with both bars added to `charter.toml`: 8930 tests, `OK`.**
- **Full suite with `charter.toml` reverted (this branch's state): 8930 tests, `OK`.**
- `charter.toml` was reverted and is byte-identical to `HEAD` (sha256 checked). Whether
  this plane carries the bars is its operator's line to write.
- Hand deletion sweep, since this diff is tests-only and the gate charges `charter/` (it
  would plan 0 mutations and report a worthless `no survivors`). Five mutations applied to
  real source lines in `charter/`, sha256 verified on apply **and** restore plus
  `git diff --quiet` after each, so a timeout could not leave a mutant on disk: four
  killed. The fifth — reordering `FRAME_SLOTS` — survives these four modules, was verified
  to survive **identically with the tests at `HEAD`** (so it is pre-existing and neither
  introduced nor widened here), and is killed by the full suite in `test_frame_density`.

Nothing under `charter/` changed. News entry staged at `version: unreleased`; no version
bump, no stamp, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy