### PR TITLE
`charter` on its own opens the frame, once the plane names a harness (§4a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ you use. The browser lane additionally shells out to `npx`. That is the whole li
   owns the rectangles; charter fills the edges and never draws in the agent's own pane.
   `charter frame -- <cmd>` does it for a command charter has never met, and `--no-frame`
   (or piping the output anywhere) skips the frame entirely and carries the real exit code.
+  Name the one you use — `[harness] default = "claude"` — and the command is just
+  `charter`.
   → [docs/frame.md](docs/frame.md)
 - **An unattended run that stops to ask a question.** Every git operation authenticates
   with that repo's own forge CLI token over HTTPS — never an SSH key, never signing —

--- a/charter.toml
+++ b/charter.toml
@@ -128,3 +128,17 @@ key = "F7"
 # Track main instead of the last release. `charter update` installs straight from git;
 # nothing is published, and PEP 610 gives `charter --version` the exact commit.
 channel = "dev"
+
+[harness]
+# Bare `charter` opens the frame with this harness — the same command as `charter
+# claude`, which still works and is what this expands to. Claude Code and not one of the
+# other two, and the reason is not preference: it is the only harness that writes its
+# session id where charter can read it (`state.record_harness_session`, whose one caller
+# is Claude Code's own `statusLine` hook), so it is the only one with a context gauge in
+# the top bar. codex and opencode both carry a `status-bar` deficit saying charter cannot
+# render into their chrome at all.
+#
+# A plane that writes no default keeps argparse's usage message, which is what charter does
+# for every plane but this one. And `charter 2>&1 | head` still prints that usage rather
+# than exec-ing the harness: a script probing for charter must not start a session.
+default = "claude"

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -1723,8 +1723,13 @@ def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
     from . import config
 
     declared = config.HARNESS
+    # Truthiness, not `is not None`, and the same test `doctor` makes of the same key.
+    # `contain.readable` never returns a blank string, so on anything `harness_of` produced
+    # the two are the same question — but `config.HARNESS` is a module attribute anything
+    # in-process can assign, and a planted `{"refused": ""}` would otherwise print a
+    # refusal naming nothing at all instead of falling through to the usage message.
     refused = declared.get("refused")
-    if refused is not None:
+    if refused:
         util.err(f'charter: [harness] default = "{refused}" in '
                  f'{util.short_path(config.ROOT / "charter.toml")} is not a harness '
                  f'charter can launch — one of: '

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -20,6 +20,7 @@ from . import (
     contain,
     harness,
     hooks,
+    instance,
     statusline,
     toolgate,
     util,
@@ -1673,8 +1674,81 @@ def _record_crash(exc: BaseException, subcommand: str) -> None:
         pass
 
 
+def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
+    """Bare ``charter``: the plane's ``[harness] default``, or today's usage error.
+
+    Returns the argv to parse and, when charter is finished here, a return code. Expressed
+    as a REWRITE of argv rather than as a dispatch of its own — bare ``charter`` on a plane
+    that defaults to Claude Code becomes exactly `["claude"]`, and every splitter, flag and
+    branch below it then runs on the same tokens a typed `charter claude` produces. A
+    second path into `cmd_launch` would be a second set of answers about the workspace
+    picker, `$CHARTER_HARNESS`, `--probe` and the frame, all of which are already settled
+    for the typed form.
+
+    **Four things stop it, and each is reachable on its own.**
+
+    *A subcommand was typed.* Nothing here runs, `--version` included. It is a flag on the
+    root parser (`_VersionAction`), so ``charter --version`` is a non-empty argv and never
+    reaches this function at all — the version action still exits 0 from inside
+    `parse_args`, which is what `commands_update._handoff` reads back.
+
+    *The plane declared a value charter cannot launch.* Reported here, loudly, naming the
+    value and the words that would work. `instance.harness_of` recorded it at the config
+    boundary; this is the reader that can say so on the command the key is *for*. Silence
+    would be the whole defect: a refused default degrades to no default, which renders as
+    argparse's usage message — byte-identical to what a plane that declared nothing gets,
+    so the operator who committed ``default = "clyde"`` would watch charter behave exactly
+    as though their key were not there. Checked BEFORE the tty rule below, because a
+    committed file being wrong is not a fact about anybody's terminal.
+
+    *The plane declared nothing.* Today's behaviour, unchanged: argparse's own usage error
+    on exit 2. Charter does not guess a harness for somebody who never named one — not
+    "whatever is installed" (a plane with two of them has no answer, and the answer would
+    change when a colleague installed a third) and not "the one last used" (a machine-local
+    memory deciding what a committed command runs).
+
+    *Stdout is not a terminal.* Also today's behaviour, and this is the one that has to be
+    a test rather than a comment. `commands_frame.cmd_launch` returns `bypass(argv)` when
+    stdout is not a tty — it `os.execvp`s the harness in place of charter. Today bare
+    `charter` is argparse's usage error, exit 2 with no side effect, so ``charter 2>&1 |
+    head`` is a probe that costs nothing. Rewrite argv unconditionally and, on a plane that
+    sets a default, that pipeline execs Claude Code — correct against every config anyone
+    tested, wrong the first time a script asks whether charter is installed (#687, #690).
+    Stdout, and stdout alone, because that is the exact stream `cmd_launch` branches on: a
+    second, looser condition here is how the two come to disagree about what "interactive"
+    means.
+    """
+    if argv:
+        return argv, None
+    from . import config
+
+    declared = config.HARNESS
+    refused = declared.get("refused")
+    if refused is not None:
+        util.err(f'charter: [harness] default = "{refused}" in '
+                 f'{util.short_path(config.ROOT / "charter.toml")} is not a harness '
+                 f'charter can launch — one of: '
+                 f'{", ".join(instance.launchable_harnesses())}. Nothing was started.')
+        return argv, 2
+    default = declared.get("default")
+    # Two conditions, two statements, and deliberately not one `or`. They are different
+    # facts — a file that said nothing, and a terminal that is not one — with different
+    # reasons in the docstring above, and an arm two inputs can both satisfy is an arm
+    # neither of them ends up testing.
+    if not default:
+        return argv, None
+    if not sys.stdout.isatty():
+        return argv, None
+    return [default], None
+
+
 def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
+    # First, so what it returns is then hoisted, split and parsed exactly as the same
+    # tokens typed by hand would be. See `_bare_launch`.
+    argv, rc = _bare_launch(argv)
+    if rc is not None:
+        return rc
     argv = _hoist_persona_memory(argv)
     argv, exec_command = _split_exec_command(argv)
     argv, frame_rest = _split_frame_argv(argv)

--- a/charter/config.py
+++ b/charter/config.py
@@ -590,6 +590,13 @@ def derive(root: Path, start: Path | None = None) -> dict:
     #: charter does not recognise degrades to exactly that.
     d["UPDATE"] = _instance.update_of(cfg)
 
+    #: What bare ``charter`` launches — ``{"default": None, "refused": None}`` unless the
+    #: plane opts in with ``[harness] default``. ``default`` is a name out of charter's own
+    #: registry or ``None``; ``refused`` names a declared value that is not one, so the two
+    #: are never confused with each other. See `instance.harness_of`, and `cli.main` for
+    #: the tty rule that decides whether the default is acted on at all.
+    d["HARNESS"] = _instance.harness_of(cfg)
+
     #: Root for worktrees, or ``None`` for the per-workspace ``.worktrees/`` default.
     d["WORKTREES_ROOT"] = worktrees_root_for(root, cfg)
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -266,11 +266,15 @@ def check_control_plane_config() -> Result:
     # plane whose declared layout is not the layout it has. This is the only place that
     # can say so; the resolver itself runs inside `derive`, where there is nobody to tell.
     from . import contain, instance as _instance
+    # Parsed ONCE, for both of the silently-ignored-key rows below. `CONFIG_ERROR` is None
+    # by the branch above, so this normally cannot raise — but `doctor` is the command
+    # somebody runs when charter is already misbehaving, and a row that raises reports on
+    # nothing at all.
     try:
-        _declared = _instance.worktrees_of(_instance.load(_config.ROOT))
+        _cfg = _instance.load(_config.ROOT)
     except Exception:
-        _declared = None
-    why = contain.plane_adjacent_refusal(_config.ROOT, _declared)
+        _cfg = {}
+    why = contain.plane_adjacent_refusal(_config.ROOT, _instance.worktrees_of(_cfg))
     if why:
         return Result(
             "charter.toml",
@@ -289,6 +293,28 @@ def check_control_plane_config() -> Result:
             detail=f"{len(forge_errors)} [[forge]] block(s) failed to resolve",
             hint=f"{shown} — those hosts are NOT covered by the one-credential guard or "
                  f"git-policy until fixed (other declared/default hosts still are).",
+        )
+    # A committed `[harness] default` naming something charter cannot launch degrades to no
+    # default at all (`instance.harness_of`) — and that renders as argparse's usage message,
+    # which is exactly what a plane declaring nothing gets. So bare `charter` on a plane with
+    # a typo behaves as though the key were absent, the same silently-ignored-setting shape
+    # the `[plane] worktrees` branch above is about. `cli.main` says so on the bare launch
+    # itself; this says so to anybody who runs `doctor` instead, and to every OTHER command,
+    # where nothing else would.
+    #
+    # Read from `instance.load` rather than `config.HARNESS`, the way the worktrees branch
+    # reads `instance.worktrees_of`: this row is about the FILE, and `derive` already ran
+    # before anybody could have fixed it.
+    _refused = _instance.harness_of(_cfg).get("refused")
+    if _refused:
+        return Result(
+            "charter.toml",
+            WARN,
+            detail=f'[harness] default = "{_refused}" is not a harness charter can launch',
+            hint=f"Bare `charter` prints the usage message until it names one of: "
+                 f"{', '.join(_instance.launchable_harnesses())} — which is also what a "
+                 f"plane that declares no default gets, so the key currently reads as "
+                 f"absent. `charter <harness>` is unaffected.",
         )
     if not _config.HAS_CONTROL_PLANE:
         # NOT ok. Every check below reports green against a plane that does not exist —

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -2015,3 +2015,123 @@ def update_of(cfg: dict) -> dict:
                 out["channel"] = known       # the constant, not the file's string
                 break
     return out
+
+
+#: Every ``[harness]`` setting, in the shape :data:`FRAME_FIELDS` documents: keyed by the
+#: name :func:`harness_of` returns it under, paired with ``(default, toml_key)``. One key
+#: today, and the shape is the point — a second one cannot be added to a defaults dict and
+#: forgotten in a spellings dict.
+#:
+#: ``default = "claude"`` is what makes bare ``charter`` launch the frame, and its shipped
+#: default is ``None`` rather than a harness name. That is the whole decision of the
+#: section: a plane that has said nothing keeps argparse's usage output, because guessing
+#: a harness for somebody who never named one is charter choosing what runs on their
+#: machine. ``[persona] default`` and ``[workspace] default`` spell the same idea with the
+#: same word, which is why this section is ``[harness]`` and this key is ``default``.
+#:
+#: **The direction of the fallback is the opposite of :data:`UPDATE_FIELDS`', and both are
+#: the conservative one.** ``update`` degrades to ``stable`` because *something* has to be
+#: installed and the safe answer exists; here the safe answer is to run NOTHING, so an
+#: unreadable value degrades to no default at all — and is reported rather than swallowed,
+#: because a plane that declared a harness and gets the usage message is indistinguishable
+#: from a plane that declared none. See :func:`harness_of`.
+HARNESS_FIELDS = {
+    "default": (None, "default"),
+}
+
+#: The plain ``{key: default}`` view of :data:`HARNESS_FIELDS`.
+HARNESS_DEFAULTS = {key: default for key, (default, _toml_key) in HARNESS_FIELDS.items()}
+
+
+def launchable_harnesses() -> tuple[str, ...]:
+    """Every word ``[harness] default`` may name, in registration order.
+
+    Each registered harness's :attr:`~charter.harness.base.Harness.cli_name` — the word an
+    operator types after ``charter`` — read from the registry rather than written down
+    here. That is the whole reason `harness/registry.py` exists: *"iterating KINDS means a
+    harness added to it is covered everywhere the day it is registered, never a hardcoded
+    literal in `init` or `doctor` that someone has to remember to update."* A tuple of
+    three strings in this module would be exactly that literal, and it would go stale
+    silently — the plane would refuse a harness charter can launch, and say the name is
+    unknown.
+
+    So this is deliberately NOT the shape :data:`FRAME_SLOTS` and :data:`UPDATE_CHANNELS`
+    use. Those are closed sets this module OWNS and nothing else can extend; these names
+    belong to another module, and copying them here would be a second registry.
+
+    ``frame`` is not on this list, even though `charter frame` is registered by the same
+    loop in `cli._add_frame_parsers`. It is the escape hatch for a command charter has
+    never met and carries no command of its own, so a plane defaulting to it would get
+    ``charter frame: nothing to run`` on every bare ``charter`` — a default that cannot
+    launch is not a default. A harness with an empty ``cli_name`` is off the list for the
+    same reason: the attribute's own docstring says empty means charter cannot launch it.
+
+    Imported inside the function, the way `config.worktrees_root_for` imports `contain`:
+    this module is imported by every command including ``charter --version``, and the
+    harness package is only needed by the one caller below.
+    """
+    from .harness import registry
+
+    return tuple(h.cli_name for h in registry.all() if h.cli_name)
+
+
+def harness_of(cfg: dict) -> dict:
+    """The ``[harness]`` section merged over :data:`HARNESS_DEFAULTS`.
+
+    Same contract as :func:`frame_of` and :func:`update_of`, for the same reason: this
+    module is imported by every command including ``charter --version``, so a hand-edited
+    charter.toml must degrade rather than raise.
+
+    ``default`` is matched against :func:`launchable_harnesses` and **the registry's own
+    string is what is stored, never the object the file supplied** — :func:`update_of`'s
+    rule, and it holds here for a sharper reason than there. This value becomes
+    ``argv[0]`` of a `charter` invocation that `cli.main` then dispatches, and charter.toml
+    is COMMITTED: it arrives from somebody else's machine (README.md's containment rule).
+    Nothing an operator can type is passed through — the value is only ever *compared*, and
+    what survives the comparison is a constant out of charter's own registry.
+
+    **The refusal is recorded, not swallowed, and that is the one place this differs from
+    the two sections above.** A misspelt ``[frame] chrome`` degrades to a shipped default
+    and the frame still draws; a misspelt ``[update] channel`` degrades to ``stable`` and
+    charter still installs. A misspelt ``[harness] default`` degrades to *no default*,
+    which renders as argparse's usage message — byte-identical to what a plane that
+    declared nothing gets. So the operator who committed ``default = "clyde"`` would see
+    charter behaving exactly as though their key were not there, which is the failure shape
+    #535 refuses an arrangement whole to avoid: a declared thing silently not in force.
+    ``refused`` carries it out to the two readers that can say so — `cli.main`, on the bare
+    launch the key is *for*, and `doctor.check_control_plane_config`, which is where
+    `config.worktrees_root_for`'s own silently-ignored key is named for the same reason.
+
+    ``refused`` is a key in the returned dict and not in :data:`HARNESS_FIELDS`, because it
+    is not a SETTING — nothing in ``[harness]`` is spelled ``refused``. That is
+    :func:`frame_of`'s own arrangement with ``components``, and it is set on every path so
+    a caller never has to ask which one it came back from.
+
+    The value is rendered through :func:`contain.readable` and never handed on raw: it is
+    an identifier a sentence is about to tell somebody to go and fix, and it comes out of a
+    committed file, where a newline forges a second line of charter's own report and an
+    invisible codepoint names nothing at all.
+    """
+    out = dict(HARNESS_DEFAULTS)
+    # Set before every early return, `frame_of`'s rule for `components`: a key present on
+    # one path and absent on another is two shapes for one answer, and the caller would be
+    # reading a `KeyError` on exactly the planes that declare no `[harness]` section.
+    out["refused"] = None
+    section = cfg.get("harness")
+    if not isinstance(section, dict):
+        return out
+    toml_key = HARNESS_FIELDS["default"][1]
+    if toml_key not in section:
+        return out
+    value = section[toml_key]
+    for known in launchable_harnesses():
+        if value == known:
+            out["default"] = known       # the registry's constant, not the file's string
+            return out
+    # `tomllib` can hand this a list, a table, an int or a bool, and every one of them
+    # reaches here rather than through a preceding `isinstance` check: a value of the wrong
+    # TYPE is as declared, and as not in force, as a misspelt string, and reporting only
+    # the strings would leave `default = ["claude"]` in the silent bucket this whole
+    # function exists to empty.
+    out["refused"] = contain.readable(value)
+    return out

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -89,6 +89,13 @@ share = "local"                  # "local" | "commit" | "push". Default: "local"
 [workspace]
 default = "default"              # Default: "default".
 
+# What bare `charter` opens. Opt-in; absent, `charter` on its own prints the usage list.
+[harness]
+default = "claude"               # "claude" | "opencode" | "codex" — the word you would
+                                  # have typed after `charter`. No default: charter does
+                                  # not pick one for you. A name it does not know is
+                                  # REPORTED, not ignored — see "Bare `charter`" below.
+
 # Which charter this plane tracks. Opt-in; absent, you track published releases.
 [update]
 channel = "stable"               # "stable" | "dev". Default: "stable". A CLOSED set:
@@ -400,6 +407,50 @@ until it is resolved.
 verifies the target *before* writing the lock, so you cannot pin colleagues to a build you
 have not run; `--push` commits and pushes, and everyone conforms on their next session.
 charter only ever *shows* you that command — it never bumps on its own.
+
+## `[harness].default` — bare `charter`
+
+**Opt-in.** Absent, `charter` on its own prints the usage list, exactly as it always has.
+
+```toml
+[harness]
+default = "claude"
+```
+
+With it, `charter` is `charter claude`. Not "like" it — charter rewrites the command into
+that one and runs it, so the workspace picker, `--no-frame`, `--probe`, `--workspace` and
+everything else the launcher does are the same behaviours, not a second set of them. Every
+subcommand keeps working untouched, `charter claude` included.
+
+The value is one of the words you would type after `charter`: `claude`, `opencode`,
+`codex` — whatever `charter harness list` shows, read out of charter's own registry rather
+than a list in this page, so a harness added to charter becomes a legal default the day it
+is registered.
+
+**Charter does not pick one for you.** No default and you get the usage message, not
+"whatever is installed" (a machine with two of them has no answer, and the answer would
+change the day a colleague installed a third) and not "the one you ran last" (a
+machine-local memory deciding what a committed command does). Naming it is one line.
+
+**A name charter cannot launch is reported, not ignored.**
+
+```
+$ charter
+✗ charter: [harness] default = "clyde" in ~/plane/charter.toml is not a harness charter
+  can launch — one of: claude, opencode, codex. Nothing was started.
+```
+
+That is the whole reason this key is checked where it is read rather than where it is
+used. A refused value falls back to *no default*, and no default renders as the usage
+message — the same output a plane that declared nothing gets. Silently, you could not tell
+a typo from a key you never wrote. `charter doctor` carries the same warning on its
+`charter.toml` row, for the plane where somebody else committed the typo.
+
+**`charter | head` still prints usage.** Bare `charter` starts a harness only when stdout
+is a terminal. Piped or redirected, it prints the usage message and exits 2, which is what
+it did before this key existed — so a script that runs `charter 2>&1 | head` to find out
+whether charter is installed gets an answer instead of an agent session. `charter claude`
+into a pipe is unaffected: it runs the harness bare, as it always did.
 
 ## `[update].channel` — the dev channel
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -5,8 +5,17 @@ middle, charter's own panels on the edges. It works on every harness, which is t
 a status line is Claude Code's own surface, and Codex and opencode have none at all.
 
     charter claude               # or codex, opencode
+    charter                      # the same thing, on a plane with [harness] default
     charter frame -- <cmd>       # anything charter has never met
     charter claude --no-frame    # bare, no frame at all
+
+`charter` on its own opens the frame once the plane says which harness it means —
+`[harness] default = "claude"` in `charter.toml`, documented in
+[control-plane.md](control-plane.md#harnessdefault--bare-charter). It is a rewrite of the
+command rather than a route of its own: `charter` becomes `charter claude` and everything
+below applies to it unchanged. A plane that names no default keeps the usage list, and so
+does `charter` with its output piped or redirected — a script asking whether charter is
+installed must not get a harness session instead of an answer.
 
 `claude`, `codex` and `opencode` are top-level commands (`charter claude`), never nested
 under `frame` (`charter frame claude`) — `charter frame` is its own, separate escape hatch

--- a/docs/news/unreleased-charter-on-its-own-opens-the-frame.md
+++ b/docs/news/unreleased-charter-on-its-own-opens-the-frame.md
@@ -1,0 +1,73 @@
+---
+version: unreleased
+headline: '`charter` on its own opens the frame, once your plane says which harness it means'
+---
+
+The command was `charter claude`, every time, for the whole life of the frame. Now it is:
+
+```toml
+[harness]
+default = "claude"
+```
+
+and then `charter`.
+
+That is the entire feature. `charter` with no subcommand is rewritten into `charter
+claude` and run — not something like it, the same command — so the workspace picker,
+`--no-frame`, `--probe`, `--workspace`, the chat it opens and the exit code it carries back
+are all the ones you already have. `charter claude` still works, and so does every other
+subcommand.
+
+## Charter does not pick a harness for you
+
+A plane that writes no `[harness] default` gets exactly what it got yesterday: the usage
+list. That is a decision, not an omission. The two obvious guesses are both worse than
+asking:
+
+- *whatever is installed* — a machine with `claude` and `codex` on it has no answer, and
+  the answer changes the day a colleague installs a third;
+- *the one you ran last* — a file on your laptop deciding what a command in a committed
+  file does.
+
+Naming it is one line, and once named it is in the repo where the rest of the plane's
+shape lives.
+
+**`claude`, where a plane has no strong feeling, and the reason is measurable.** It is the
+only harness that writes its session id somewhere charter can read — the only caller of
+`record_harness_session` is Claude Code's own `statusLine` hook — which makes it the only
+harness with a context gauge in the top bar. Codex and opencode both carry a `status-bar`
+deficit that says charter cannot render into their chrome at all. A bare command that
+quietly cost you the gauge would be charter choosing for you without saying so.
+
+## A name charter cannot launch is reported, not ignored
+
+```
+$ charter
+✗ charter: [harness] default = "clyde" in ~/plane/charter.toml is not a harness charter
+  can launch — one of: claude, opencode, codex. Nothing was started.
+```
+
+A refused value falls back to *no default*, and no default prints the usage message —
+which is the same output a plane that declared nothing gets. Left silent, a typo would be
+indistinguishable from a key you never wrote, and you would go looking in the wrong place
+for the reason your new command does nothing. `charter doctor` says the same thing on its
+`charter.toml` row, for the plane where somebody else committed the typo and you are the
+one running into it.
+
+The legal names come out of charter's own harness registry rather than a list somewhere,
+so a harness added to charter is a legal default the day it is added.
+
+## `charter | head` still prints usage, and that is the part that needed care
+
+Bare `charter` opens a frame only when its output is a terminal. Piped or redirected, it
+prints the usage message and exits 2 — which is what it did before this key existed.
+
+The reason is that charter's launcher, with output that is not a terminal, does not build
+a frame at all: it `exec`s the harness in place of itself. Until now bare `charter` was an
+argument-parsing error, so `charter 2>&1 | head` was a free way for a script to ask whether
+charter is installed. Without this rule, that pipeline would have started an agent session
+on any plane that set a default — correct against every configuration anyone tested, wrong
+the first time something automated went looking for charter.
+
+`charter claude` into a pipe is unchanged: it still runs the harness bare, exactly as
+before.

--- a/docs/news/unreleased-charter-on-its-own-opens-the-frame.md
+++ b/docs/news/unreleased-charter-on-its-own-opens-the-frame.md
@@ -1,6 +1,6 @@
 ---
 version: unreleased
-headline: '`charter` on its own opens the frame, once your plane says which harness it means'
+headline: `charter` on its own opens the frame, once your plane says which harness it means
 ---
 
 The command was `charter claude`, every time, for the whole life of the frame. Now it is:

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -311,9 +311,14 @@ def _guard_os(name: str, *, arg: int = 0, both: bool = False) -> None:
 
 #: The settings no test may read off the developer's own ``charter.toml``.
 #:
-#: One name, and it is a list rather than a special case for exactly one reason: the next
-#: opt-in setting to arrive has the same shape, and the day it arrives is the day it should
-#: be guarded, not the day someone re-derives this argument from a red CI run.
+#: It is a list rather than a special case for exactly one reason: the next opt-in setting
+#: to arrive has the same shape, and the day it arrives is the day it should be guarded,
+#: not the day someone re-derives this argument from a red CI run. ``HARNESS`` is that next
+#: setting, added on the day it arrived. ``[harness] default`` is opt-in and brand new, so
+#: for its whole life `config.HARNESS` is ``{"default": None, …}`` on every machine — and
+#: charter's own dogfood plane declares ``default = "claude"``, which is the ``channel =
+#: "dev"`` situation exactly: a test asserting "bare charter prints usage" would pass in CI
+#: and fail on the one machine whose file says otherwise.
 #:
 #: Not every `config.DERIVED` name belongs here, and the boundary is what the value is a
 #: fact ABOUT. ``ROOT``, ``STATE_DIR`` and the paths under them are facts about the
@@ -324,7 +329,7 @@ def _guard_os(name: str, *, arg: int = 0, both: bool = False) -> None:
 #: run it. Values that are dicts, and only dicts: the refusal works by handing back an
 #: object that will not answer, and a `str` or a `Path` cannot be made to refuse without
 #: breaking the formatting of every message that legitimately quotes it.
-_GUARDED_SETTINGS = ("UPDATE",)
+_GUARDED_SETTINGS = ("UPDATE", "HARNESS")
 
 
 class RealPlaneRead(BaseException):

--- a/tests/test_bare_charter_opens_the_frame.py
+++ b/tests/test_bare_charter_opens_the_frame.py
@@ -1,0 +1,493 @@
+"""Bare ``charter`` launches the frame — §4a of the IDE spec.
+
+`charter claude` becomes `charter`, on a plane that says which harness it means. Three
+things are new and each is tested here rather than described:
+
+* a ``[harness]`` section in `charter.toml`, with one key, ``default``;
+* a refusal at the CONFIG boundary for a value charter cannot launch, carried out to the
+  two readers that can report it rather than degrading into silence;
+* an argv REWRITE in `cli.main`, gated on stdout being a terminal.
+
+**The third is the whole reason this needed care, and it has its own class.**
+`commands_frame.cmd_launch` returns `bypass(argv)` — an `os.execvp` — when stdout is not a
+tty. Today bare `charter` is argparse's own usage error: exit 2, nothing started, so
+``charter 2>&1 | head`` is a free probe for "is charter installed". Rewrite argv
+unconditionally and, on a plane that sets a default, that pipeline execs Claude Code. It
+would be correct against every config anybody tested and wrong the first time a script
+looked for charter — #687 and #690's exact shape, twice over. `TheNonTtyPathStartsNothing`
+is that hazard as a test.
+
+The refusal cases assert the REASON, not merely that the value was not honoured: a
+`default` that came back `None` proves nothing on its own, because that is also what a
+plane declaring nothing gets — which is precisely the confusion `refused` exists to end.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stderr
+from unittest import mock
+
+from charter import cli, commands_frame, config, doctor, harness, instance
+from charter.harness.base import Harness
+from tests._isolation import PersonaIso
+
+
+class TheSectionIsReadAtTheConfigBoundary(unittest.TestCase):
+    """`instance.harness_of` — pure, no plane, no filesystem."""
+
+    def test_a_plane_that_declares_nothing_gets_no_default(self):
+        """The shipped answer, and the decision the whole section turns on: charter does
+        not guess a harness for somebody who never named one."""
+        self.assertEqual(instance.harness_of({}), {"default": None, "refused": None})
+
+    def test_a_declared_harness_is_the_default(self):
+        got = instance.harness_of({"harness": {"default": "claude"}})
+        self.assertEqual(got, {"default": "claude", "refused": None})
+
+    def test_every_registered_harness_can_be_the_default(self):
+        """Not just `claude`. `opencode` and `codex` are launchers too, and a plane that
+        runs one of them is entitled to the same command."""
+        for name in ("claude", "opencode", "codex"):
+            with self.subTest(name=name):
+                got = instance.harness_of({"harness": {"default": name}})
+                self.assertEqual(got["default"], name)
+                self.assertIsNone(got["refused"])
+
+    def test_what_is_stored_is_the_registrys_own_string_not_the_files(self):
+        """`update_of`'s belt-and-braces rule, and it bites harder here: this value
+        becomes `argv[0]` of a charter invocation, out of a file that arrives from
+        somebody else's machine. No object originating in charter.toml reaches the CLI."""
+        supplied = "".join(["cla", "ude"])          # equal to, and not, the constant
+        self.assertIsNot(supplied, "claude")
+        got = instance.harness_of({"harness": {"default": supplied}})
+        self.assertIs(got["default"], instance.launchable_harnesses()[0])
+
+    def test_an_unknown_name_is_refused_and_the_refusal_names_it(self):
+        """The grill this feature was built against. `default = None` is also what a plane
+        that declared nothing gets, so a test asserting only that would pass against a
+        charter which threw the key away — which is the defect, not the fix."""
+        got = instance.harness_of({"harness": {"default": "clyde"}})
+        self.assertIsNone(got["default"])
+        self.assertEqual(got["refused"], "clyde")
+
+    def test_the_frame_escape_hatch_is_not_a_launchable_default(self):
+        """`charter frame` is registered by the same loop in `cli._add_frame_parsers`, and
+        it carries no command of its own — `charter frame -- <cmd>`. A plane defaulting to
+        it would get `charter frame: nothing to run` on every bare `charter`."""
+        got = instance.harness_of({"harness": {"default": "frame"}})
+        self.assertIsNone(got["default"])
+        self.assertEqual(got["refused"], "frame")
+        self.assertNotIn("frame", instance.launchable_harnesses())
+
+    def test_a_value_of_the_wrong_type_is_refused_and_named_too(self):
+        """`tomllib` hands back lists, tables, ints and bools. A value of the wrong TYPE is
+        as declared, and as not in force, as a misspelt string — reporting only the strings
+        would leave these in the silent bucket the `refused` key exists to empty."""
+        for value in (["claude"], {"name": "claude"}, 3, True, 1.5):
+            with self.subTest(value=value):
+                got = instance.harness_of({"harness": {"default": value}})
+                self.assertIsNone(got["default"])
+                self.assertTrue(got["refused"], f"{value!r} was refused without saying so")
+
+    def test_a_case_or_whitespace_variant_is_refused_rather_than_normalised(self):
+        """A closed set, matched exactly — `UPDATE_CHANNELS`'s posture. Trimming and
+        lowercasing here would be charter guessing what a committed file meant."""
+        for value in ("Claude", "CLAUDE", " claude", "claude ", "claude-code", ""):
+            with self.subTest(value=value):
+                self.assertIsNone(instance.harness_of({"harness": {"default": value}})["default"])
+
+    def test_a_refused_value_cannot_forge_a_second_report_line(self):
+        """It is printed into charter's own stderr report and into a `doctor` row. A
+        newline there writes a line that looks exactly as much like charter's output as
+        the real one — `contain.readable`'s whole subject."""
+        got = instance.harness_of({"harness": {"default": "claude\n✓ charter: pwned"}})
+        self.assertIsNone(got["default"])
+        self.assertNotIn("\n", got["refused"])
+        self.assertTrue(got["refused"].isascii())
+
+    def test_a_refused_value_that_renders_as_nothing_still_names_something(self):
+        """`contain.readable` over `contain.one_line`, for its own stated reason: this
+        sentence tells somebody to go and fix an identifier, and a row naming an invisible
+        codepoint names nobody (#498)."""
+        got = instance.harness_of({"harness": {"default": "ㅤㅤ"}})
+        self.assertTrue(got["refused"].strip(), "the refusal named nothing at all")
+
+    def test_a_section_that_is_not_a_section_degrades_rather_than_raising(self):
+        """`instance` is imported by every command including `charter --version`."""
+        for section in ("claude", ["claude"], 7, None, True):
+            with self.subTest(section=section):
+                self.assertEqual(instance.harness_of({"harness": section}),
+                                 {"default": None, "refused": None})
+
+    def test_a_section_with_no_default_key_is_not_a_refusal(self):
+        """Declaring `[harness]` and nothing in it is declaring nothing. A `refused` here
+        would put a `doctor` warning on a plane that did nothing wrong."""
+        self.assertEqual(instance.harness_of({"harness": {"nothing": "here"}}),
+                         {"default": None, "refused": None})
+
+    def test_the_defaults_view_and_the_fields_table_cannot_drift(self):
+        """`FRAME_FIELDS`'s shape, and its whole reason for existing."""
+        self.assertEqual(set(instance.HARNESS_DEFAULTS), set(instance.HARNESS_FIELDS))
+        self.assertIsNone(instance.HARNESS_DEFAULTS["default"])
+        self.assertEqual(instance.HARNESS_FIELDS["default"][1], "default")
+
+    def test_refused_is_not_a_setting_and_is_absent_from_the_fields_table(self):
+        """It rides out in the returned dict the way `frame_of` carries `components`:
+        nothing in `[harness]` is spelled `refused`, so a plane writing it declares
+        nothing."""
+        self.assertNotIn("refused", instance.HARNESS_FIELDS)
+        self.assertIsNone(instance.harness_of({"harness": {"refused": "claude"}})["default"])
+
+
+class TheLegalNamesComeFromTheRegistry(unittest.TestCase):
+    """`launchable_harnesses` reads `harness.KINDS` rather than listing three words.
+
+    `harness/registry.py`'s own rule — *"a harness added to KINDS is covered everywhere the
+    day it is registered, never a hardcoded literal someone has to remember to update"*. A
+    tuple in `instance.py` would go stale silently, and the symptom would be charter
+    refusing a harness charter can launch.
+    """
+
+    def test_a_harness_registered_today_is_a_legal_default_today(self):
+        class _Fictional(Harness):
+            name = "zzz-fictional"
+            cli_name = "zzz"
+            binary = "zzz"
+
+        with mock.patch.dict(harness.registry.KINDS, {"zzz-fictional": _Fictional}):
+            self.assertIn("zzz", instance.launchable_harnesses())
+            self.assertEqual(instance.harness_of({"harness": {"default": "zzz"}})["default"],
+                             "zzz")
+
+    def test_a_harness_charter_cannot_launch_is_not_a_legal_default(self):
+        """An empty `cli_name` is the attribute's own spelling of "charter cannot launch
+        this". A default naming one would rewrite argv to `[""]`."""
+        class _Unlaunchable(Harness):
+            name = "zzz-unlaunchable"
+            cli_name = ""
+            binary = ""
+
+        with mock.patch.dict(harness.registry.KINDS,
+                             {"zzz-unlaunchable": _Unlaunchable}):
+            self.assertNotIn("", instance.launchable_harnesses())
+            self.assertIsNone(instance.harness_of({"harness": {"default": ""}})["default"])
+
+    def test_the_names_are_the_words_an_operator_types(self):
+        """`cli_name`, never `name`: `charter claude` is the command, `claude-code` is the
+        harness's identity in `$CHARTER_HARNESS`. A plane writing the identity gets a
+        refusal that names it rather than a launcher that does not exist."""
+        self.assertEqual(instance.launchable_harnesses(),
+                         tuple(h.cli_name for h in harness.all() if h.cli_name))
+        self.assertIsNone(instance.harness_of({"harness": {"default": "claude-code"}})["default"])
+
+
+class TheSectionReachesConfig(PersonaIso):
+    """`config.HARNESS` is derived from the plane's own charter.toml, like `config.UPDATE`."""
+
+    def _declare(self, text: str) -> None:
+        (self.tmp / "charter.toml").write_text(text)
+        config.use(self.tmp)
+
+    def test_a_plane_that_declares_a_default_derives_it(self):
+        self._declare('schema = 1\n[harness]\ndefault = "claude"\n')
+        self.assertEqual(config.HARNESS, {"default": "claude", "refused": None})
+
+    def test_a_plane_that_declares_nothing_derives_no_default(self):
+        self._declare("schema = 1\n")
+        self.assertEqual(config.HARNESS, {"default": None, "refused": None})
+
+    def test_a_refused_declaration_reaches_config_as_a_refusal(self):
+        self._declare('schema = 1\n[harness]\ndefault = "clyde"\n')
+        self.assertEqual(config.HARNESS, {"default": None, "refused": "clyde"})
+
+    def test_harness_is_one_of_the_settings_the_test_harness_isolates(self):
+        """`config.DERIVED` is the source of truth for what `config.use` swaps. A setting
+        absent from it is a setting no test can isolate — and this one is declared by
+        charter's own dogfood plane, so an unisolated test would assert against whatever
+        the machine running the suite happens to commit."""
+        self.assertIn("HARNESS", config.DERIVED)
+
+    def test_a_malformed_charter_toml_still_derives_a_usable_harness_setting(self):
+        """`derive` swallows a parse error into `CONFIG_ERROR` and carries on, and every
+        setting must still have a shape. A `KeyError` out of `cli.main` on a broken plane
+        would be a crash report filed against charter for a typo in a TOML file."""
+        (self.tmp / "charter.toml").write_text("this is not = valid = toml\n")
+        config.use(self.tmp)
+        self.assertIsNotNone(config.CONFIG_ERROR)
+        self.assertEqual(config.HARNESS, {"default": None, "refused": None})
+
+
+class _Recorder:
+    """Stands in for `commands_frame.cmd_launch` and keeps the args it was handed."""
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def __call__(self, args) -> int:
+        self.calls.append(args)
+        return 0
+
+
+class _BareLaunchCase(unittest.TestCase):
+    """Drives `cli.main`, with the launcher replaced and the plane's setting stated.
+
+    Everything below goes through `cli.main` rather than `_bare_launch`, because the claim
+    is about the COMMAND — that bare `charter` reaches the same handler `charter claude`
+    reaches, having crossed the same three argv splitters. A test of the helper alone would
+    still pass if `main` stopped calling it.
+    """
+
+    def setUp(self) -> None:
+        # argparse writes its usage error straight to `sys.stderr`, and half the cases
+        # below want that to happen — off a buffer it would land in the suite's own output.
+        self.enterContext(redirect_stderr(io.StringIO()))
+        self.launch = _Recorder()
+        self.enterContext(mock.patch.object(commands_frame, "cmd_launch", self.launch))
+        # The exec `bypass` would make, pinned as never-happens rather than inferred from
+        # `cmd_launch` not being called. It is the actual side effect the hazard is about.
+        self.exec = self.enterContext(
+            mock.patch("os.execvp", side_effect=AssertionError("charter exec'd a harness")))
+        self.err = self.enterContext(mock.patch("charter.util.err"))
+
+    def _declare(self, **harness_setting):
+        return mock.patch.object(config, "HARNESS",
+                                 {"default": None, "refused": None, **harness_setting})
+
+    def _messages(self) -> str:
+        return "\n".join(str(c.args[0]) for c in self.err.call_args_list)
+
+
+class TheBareCommandLaunchesTheDeclaredHarness(_BareLaunchCase):
+
+    def test_bare_charter_on_a_terminal_reaches_the_launcher(self):
+        with self._declare(default="claude"), \
+             mock.patch("sys.stdout.isatty", return_value=True):
+            rc = cli.main([])
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(self.launch.calls), 1)
+        self.assertEqual(self.launch.calls[0].harness, "claude")
+
+    def test_it_is_the_same_call_typing_the_harness_makes(self):
+        """The design in one assertion: bare `charter` is a REWRITE of argv, not a second
+        route into `cmd_launch`. Anything the typed form settles — the workspace picker,
+        `--probe`, `--no-frame`, `rest` — is settled identically here, because the same
+        namespace arrives at the same function."""
+        with self._declare(default="claude"), \
+             mock.patch("sys.stdout.isatty", return_value=True):
+            cli.main([])
+            cli.main(["claude"])
+        bare, typed = self.launch.calls
+        self.assertEqual(vars(bare), vars(typed))
+
+    def test_the_declared_harness_is_the_one_launched(self):
+        """Not "whatever is installed" and not "the one last used" — the plane's word."""
+        for name in ("claude", "opencode", "codex"):
+            with self.subTest(name=name):
+                self.launch.calls.clear()
+                with self._declare(default=name), \
+                     mock.patch("sys.stdout.isatty", return_value=True):
+                    cli.main([])
+                self.assertEqual(self.launch.calls[0].harness, name)
+
+
+class TheNonTtyPathStartsNothing(_BareLaunchCase):
+    """#687/#690's shape, closed before it shipped.
+
+    `cmd_launch` execs the harness in place of charter when stdout is not a tty. Bare
+    `charter` is a usage error today — exit 2, no side effect — so a script may pipe it to
+    ask whether charter is there. That must stay true on a plane that sets a default.
+    """
+
+    def test_a_piped_bare_charter_prints_usage_and_execs_nothing(self):
+        with self._declare(default="claude"), \
+             mock.patch("sys.stdout.isatty", return_value=False):
+            with self.assertRaises(SystemExit) as caught:
+                cli.main([])
+        self.assertEqual(caught.exception.code, 2)
+        self.assertEqual(self.launch.calls, [], "a pipe reached the launcher")
+        self.exec.assert_not_called()
+
+    def test_the_usage_text_is_the_one_argparse_already_printed(self):
+        """Not a new message that happens to exit 2. The claim is that this path is
+        UNCHANGED, so the assertion is against argparse's own output on the real parser."""
+        buf = io.StringIO()
+        with self._declare(default="claude"), \
+             mock.patch("sys.stdout.isatty", return_value=False), \
+             mock.patch.object(sys, "stderr", buf):
+            with self.assertRaises(SystemExit):
+                cli.main([])
+        self.assertIn("usage: charter", buf.getvalue())
+        self.assertIn("the following arguments are required: command", buf.getvalue())
+
+    def test_the_typed_form_is_untouched_by_the_tty_rule(self):
+        """The gate belongs to the BARE command only. `charter claude` piped still reaches
+        `cmd_launch`, which is where the bypass decision has always lived — moving that
+        decision up here would change what the typed command does."""
+        with self._declare(default="claude"), \
+             mock.patch("sys.stdout.isatty", return_value=False):
+            cli.main(["claude"])
+        self.assertEqual(len(self.launch.calls), 1)
+
+
+class APlaneThatDeclaredNothingKeepsTodaysUsage(_BareLaunchCase):
+
+    def test_bare_charter_on_a_terminal_still_prints_usage(self):
+        """The other half of the design: charter does not guess. A tty is present and a
+        harness is installed, and charter still refuses to pick one."""
+        with self._declare(), mock.patch("sys.stdout.isatty", return_value=True):
+            with self.assertRaises(SystemExit) as caught:
+                cli.main([])
+        self.assertEqual(caught.exception.code, 2)
+        self.assertEqual(self.launch.calls, [])
+        self.exec.assert_not_called()
+
+
+class ARefusedDefaultIsReportedNotSwallowed(_BareLaunchCase):
+    """The grill: a committed `default = "clyde"` must fail loudly.
+
+    It degrades to no default, and no default renders as argparse's usage message — which
+    is byte-identical to what a plane declaring nothing gets. So the operator who made the
+    typo would watch charter behave exactly as though their key were not there.
+    """
+
+    def test_the_refusal_is_printed_and_names_the_value(self):
+        with self._declare(refused="clyde"), \
+             mock.patch("sys.stdout.isatty", return_value=True):
+            rc = cli.main([])
+        self.assertEqual(rc, 2)
+        self.assertIn("clyde", self._messages())
+        self.assertEqual(self.launch.calls, [])
+        self.exec.assert_not_called()
+
+    def test_the_refusal_names_the_words_that_would_work(self):
+        """A refusal that does not say what to write instead sends somebody to the docs
+        for a list charter is already holding."""
+        with self._declare(refused="clyde"), \
+             mock.patch("sys.stdout.isatty", return_value=True):
+            cli.main([])
+        said = self._messages()
+        for name in instance.launchable_harnesses():
+            self.assertIn(name, said)
+
+    def test_it_is_reported_off_a_terminal_too(self):
+        """A committed file being wrong is not a fact about anybody's terminal, so the
+        refusal is checked before the tty rule. Still exit 2 and still nothing started,
+        which is what makes it safe to report on the piped path."""
+        with self._declare(refused="clyde"), \
+             mock.patch("sys.stdout.isatty", return_value=False):
+            rc = cli.main([])
+        self.assertEqual(rc, 2)
+        self.assertIn("clyde", self._messages())
+        self.exec.assert_not_called()
+
+    def test_a_typed_subcommand_is_not_blocked_by_a_broken_default(self):
+        """The key decides one command. A plane cannot lose `charter status` — or
+        `charter claude` — to a typo in a section neither of them reads."""
+        with self._declare(refused="clyde"), \
+             mock.patch("sys.stdout.isatty", return_value=True):
+            cli.main(["claude"])
+        self.assertEqual(len(self.launch.calls), 1)
+        self.assertEqual(self._messages(), "")
+
+
+class EveryOtherCommandIsUnchanged(_BareLaunchCase):
+
+    def test_version_is_not_swallowed_by_the_default(self):
+        """`--version` is a flag on the ROOT parser, so it is a non-empty argv and the
+        rewrite never sees it. `commands_update._handoff` runs the newly installed
+        `charter --version` and reads the last word back — a bare launch here would hang
+        an upgrade inside a harness."""
+        buf = io.StringIO()
+        with self._declare(default="claude"), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch.object(sys, "stdout", buf):
+            with self.assertRaises(SystemExit) as caught:
+                cli.main(["--version"])
+        self.assertEqual(caught.exception.code, 0)
+        self.assertIn("charter", buf.getvalue())
+        self.assertEqual(self.launch.calls, [])
+
+    def test_help_is_not_swallowed_by_the_default(self):
+        buf = io.StringIO()
+        with self._declare(default="claude"), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch.object(sys, "stdout", buf):
+            with self.assertRaises(SystemExit) as caught:
+                cli.main(["--help"])
+        self.assertEqual(caught.exception.code, 0)
+        self.assertIn("usage: charter", buf.getvalue())
+        self.assertEqual(self.launch.calls, [])
+
+    def test_a_core_subcommand_still_dispatches_to_its_own_handler(self):
+        called = []
+        with self._declare(default="claude"), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("charter.commands.cmd_status", lambda a: called.append(a) or 0):
+            rc = cli.main(["status"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(called), 1)
+        self.assertEqual(self.launch.calls, [])
+
+    def test_an_unknown_command_is_still_an_unknown_command(self):
+        """The gap signal (`report gap`) rides on argparse's refusal of an unrecognised
+        first token. A default must not turn a typo into a launch."""
+        with self._declare(default="claude"), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch.object(sys, "stderr", io.StringIO()):
+            with self.assertRaises(SystemExit):
+                cli.main(["frobnicate"])
+        self.assertEqual(self.launch.calls, [])
+
+    def test_the_harness_flags_still_reach_the_typed_launcher(self):
+        """`_split_frame_argv` runs AFTER the rewrite, so it is still the thing that peels
+        a harness's own argv off — and the rewrite produces a token it already handles."""
+        with self._declare(default="claude"), \
+             mock.patch("sys.stdout.isatty", return_value=True):
+            cli.main(["claude", "--no-frame", "-p", "hi"])
+        args = self.launch.calls[0]
+        self.assertTrue(args.no_frame)
+        self.assertEqual(args.rest, ["-p", "hi"])
+
+
+class DoctorNamesASilentlyIgnoredDefault(PersonaIso):
+    """The second reader, for the operator who runs `doctor` rather than bare `charter`.
+
+    `config.worktrees_root_for`'s precedent, in its own words: a value refused inside
+    `derive` has nobody to tell, so `doctor` asks the same question of the file and names
+    it. Every other command on a plane with this typo says nothing at all.
+    """
+
+    def _declare(self, text: str):
+        (self.tmp / "charter.toml").write_text(text)
+        config.use(self.tmp)
+        return doctor.check_control_plane_config()
+
+    def test_a_refused_default_is_a_warning_that_names_the_value(self):
+        result = self._declare('schema = 1\n[harness]\ndefault = "clyde"\n')
+        self.assertEqual(result.status, doctor.WARN)
+        self.assertIn("clyde", result.detail)
+        self.assertIn("[harness]", result.detail)
+
+    def test_the_warning_says_what_the_plane_gets_instead(self):
+        """"Ignored" is the fact an operator cannot see for themselves — the usage message
+        they are getting is the same one a plane with no key gets."""
+        result = self._declare('schema = 1\n[harness]\ndefault = "clyde"\n')
+        for name in instance.launchable_harnesses():
+            self.assertIn(name, result.hint)
+
+    def test_a_usable_default_is_not_warned_about(self):
+        """The precondition. A check that warns about everything is a check nobody reads,
+        and one that stopped running looks exactly like one that found nothing."""
+        result = self._declare('schema = 1\n[harness]\ndefault = "claude"\n')
+        self.assertEqual(result.status, doctor.OK)
+
+    def test_a_plane_that_declares_nothing_is_not_warned_about(self):
+        result = self._declare("schema = 1\n")
+        self.assertEqual(result.status, doctor.OK)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
§4a of `docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md`. The operator's ask, in their words: `charter claude` → `charter`.

```toml
[harness]
default = "claude"
```

and then `charter`.

## What this is

Bare `charter` is **rewritten** into `charter claude` in `cli.main` and run. Not a second route into `cmd_launch` — the same argv, through the same three splitters, into the same handler, so the workspace picker, `--no-frame`, `--probe`, `--workspace`, the chat it opens and the exit code it carries back are the behaviours the typed form already has rather than a second set of answers about them. `TheBareCommandLaunchesTheDeclaredHarness.test_it_is_the_same_call_typing_the_harness_makes` asserts that as an equality on the two namespaces.

Every existing subcommand is untouched, `charter claude`, `charter opencode` and `charter status` included.

## There was no `[harness]` section at all

Zero references in `instance.py`, so this is a new config section plus a new dispatch mode, not three lines. It follows `[update]`'s shape rather than inventing a second one: a `HARNESS_FIELDS` table paired `(default, toml_key)`, a `harness_of` reader, a closed set matched exactly, and **the matched constant stored rather than the file's own string** — which matters more here than it does for `channel`, because this value becomes `argv[0]` of a charter invocation, out of a file that arrives from somebody else's machine.

The legal names come from `harness.KINDS` (`instance.launchable_harnesses`), not a literal — `registry.py`'s own rule, *"a harness added to KINDS is covered everywhere the day it is registered"*. A tuple of three words in `instance.py` would go stale silently, and the symptom would be charter refusing a harness charter can launch. `frame` is excluded: the escape hatch carries no command of its own, so a plane defaulting to it would get `nothing to run` on every bare `charter`.

## The three grills

**Where does an unknown `default` get refused?** At the boundary, in `harness_of`, and it is *recorded* rather than swallowed. A refused value degrades to no default, and no default renders as argparse's usage message — byte-identical to what a plane declaring nothing gets. Silently, `default = \"clyde\"` would be indistinguishable from a key nobody wrote. Two readers say so:

```
$ charter
✗ charter: [harness] default = \"clyde\" in ~/plane/charter.toml is not a harness charter
  can launch — one of: claude, opencode, codex. Nothing was started.
```

and `doctor.check_control_plane_config`, which is exactly where `config.worktrees_root_for`'s own silently-ignored key is named, for the reason that function's docstring already gives: *\"the resolver itself runs inside `derive`, where there is nobody to tell.\"* `instance` still never raises — it is imported by every command including `charter --version`.

The refused value is rendered through `contain.readable` before it reaches a report line. It is a committed identifier a sentence is telling somebody to go and fix, so a newline must not forge a second line of charter's own output and an invisible codepoint must not name nobody (#498).

**What does `charter --version` do?** Nothing new. It is a flag on the root parser, so `[\"--version\"]` is a non-empty argv and the rewrite never sees it — `_bare_launch` returns on its first line. Pinned, because `commands_update._handoff` runs the newly installed `charter --version` and reads the last word back: a bare launch there would hang an upgrade inside a harness. `--help` likewise.

**Is `[harness]` the right section name?** `[persona] default` and `[workspace] default` already spell this exact idea with this exact word, and `[update]` is the shape for a validated closed set. Both followed; nothing new invented.

## The hazard

`cmd_launch` returns `bypass(argv)` — an `os.execvp` — when stdout is not a tty. Bare `charter` is argparse's usage error today, exit 2 with no side effect, so `charter 2>&1 | head` is a free probe for \"is charter installed\". Rewrite argv unconditionally and, on a plane that sets a default, that pipeline execs Claude Code: correct against every config anyone tested, wrong the first time something automated goes looking for charter. #687 and #690's exact shape, twice over.

**The non-tty path keeps printing usage, and it is a test.** `TheNonTtyPathStartsNothing` pins that the launcher is not reached, that `os.execvp` is never called, and that the text is argparse's own — not a new message that happens to exit 2. Stdout and stdout alone, because that is the stream `cmd_launch` branches on; a second, looser condition here is how the two would come to disagree about what interactive means.

The two gates (`not default`, `not sys.stdout.isatty()`) are two statements rather than one `or`, deliberately: they are different facts with different reasons, and an arm two inputs can both satisfy is an arm neither of them ends up testing.

## `claude`, verified rather than inherited

§2.8's reasoning holds on this tree. `record_harness_session` has exactly one caller — `statusline.py:2835` — and it needs `payload[\"session_id\"]`, which only Claude Code's `statusLine` hook supplies; `charter statusline --watch`, the remedy the other two are given, carries no payload. Codex and opencode both declare a `status-bar` deficit. So Claude Code is the only harness with a context gauge and the only one a future resume (§4e) could restore.

## Verification

- **Suite: 8972 tests, green** (`python3 -m unittest discover -s tests`), stdlib `unittest`, no new dependency.
- **Hand-run on charter's own plane** (§7's rule), under a real pty with `claude` off `\$PATH` so nothing is started: bare `charter` and `charter claude` are byte-identical (exit 127, same message). Piped, bare `charter` is the usage list and exit 2.
- **Nine hand-applied mutations, all red.** Each gate deleted in turn — the tty gate, the no-default gate, the refusal report, the `_bare_launch` call, the typed-argv guard, `refused` not being recorded, the `cli_name` filter, storing the file's own string, and the doctor row. The repo's own `tools/sweep.py` runs on this diff in CI.
- `config.HARNESS` joins `_planeguard._GUARDED_SETTINGS` **on the day it arrives**, which is what that list's own comment asks for: it is opt-in, and charter's dogfood plane now declares it, so an unisolated test would assert against whatever the machine running the suite commits.

## Not in scope

`charter -w foo` (§4k), the `workspaces` bar (§4b) and `charter status` learning about open/live (§4m) are their own stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy