### PR TITLE
A provider's `ctx.chrome` colour reaches its pane instead of printing as text (#707)

### DIFF
--- a/charter.toml
+++ b/charter.toml
@@ -105,6 +105,31 @@ bg  = "brightblack"
 pad = 1
 key = "F5"
 
+# The two tab strips, between the identity row and the work area: what plane, then
+# which workspace, then which chat inside it. Split order is the geometry (#488).
+#
+# Neither ships placed (`instance.FRAME_SLOTS`) and that is deliberate — a plane with one
+# chat is the ordinary permanent state, and each costs a row, a ~24 MB process and about
+# seven of every switch's tmux calls. This plane opts in because its operator wants them.
+#
+# `workspaces` draws `switch.workspaces()` — EVERY directory under `workspaces/`, with the
+# current one marked. It is a listing, not a project switcher, and it stays one until open
+# and live are real states (the IDE spec, 4c). Placed here anyway at the operator's
+# request, with that limit stated rather than discovered.
+[[frame.component]]
+use  = "workspaces"
+edge = "top"
+size = 1
+bg   = "brightblack"
+pad  = 1
+
+[[frame.component]]
+use  = "chats"
+edge = "top"
+size = 1
+bg   = "brightblack"
+pad  = 1
+
 [[frame.component]]
 use = "attention"
 bg  = "brightblack"

--- a/charter/frame/chrome.py
+++ b/charter/frame/chrome.py
@@ -1,4 +1,15 @@
-"""The frame's paint: filling a row to the pane's edge, and highlighting one.
+"""The frame's paint: filling a row to the pane's edge, highlighting one, and deciding
+what a stranger's row may keep of it.
+
+**The vocabulary and the containment of that vocabulary are one module, deliberately.**
+:func:`recipes` is what a provider is handed so it can match the rest of the frame;
+:func:`contain_row` is what `registry.Registry.draw` runs over what the provider hands
+back. Written apart, the two were each asserted and disagreed from the day the recipes
+landed (#604) against an escaping that had shipped two days before them (#550): charter
+served ``ctx.chrome['heading']`` and then escaped it into the literal text
+``\\x1b[1mMetrics\\x1b[0m`` on the way to the pane (#707). :func:`served_params` is the one
+list both read, so a role added to :func:`_role_values` is served and admitted on the same
+commit or on neither.
 
 **Everything here takes a FINISHED row** — a string some `tui` node has already
 composed and clamped — and hands back a string that must not go back through `tui`.
@@ -37,7 +48,7 @@ import os
 import re
 from types import MappingProxyType
 
-from .. import tui
+from .. import contain, tui
 from . import pane
 
 #: Reverse video on, and everything off. `_OFF` is a FULL reset rather than SGR 27
@@ -237,6 +248,190 @@ def recipes() -> MappingProxyType:
     out = {role: (sgr if live else "") for role, sgr in _role_values().items()}
     out["inset"] = slots._inset()
     return MappingProxyType(out)
+
+
+def served_params() -> frozenset[int]:
+    """Every SGR parameter charter's own recipes are made of, read as NUMBERS.
+
+    **Derived from :func:`_role_values`, never spelled beside it.** A second list of the
+    numbers is exactly how a role comes to be *served and not admitted* — a provider
+    handed a colour that is escaped on the way out, which is #707 — or *admitted and not
+    served*, which is a vocabulary charter enforces and nobody documents. One source, and
+    a role added above widens this on the same commit.
+    """
+    out: set[int] = set()
+    for value in _role_values().values():
+        for m in _SGR.finditer(value):
+            out.update(int(p or "0") for p in m.group(1).split(";"))
+    return frozenset(out)
+
+
+def is_recipe(params: str, served: frozenset[int]) -> bool:
+    """True when every parameter in the SGR list *params* is one of *served*.
+
+    **The vocabulary is a parameter and not a call, because this is on the repaint
+    path.** Every escape in every row of every foreign pane asks this, and
+    :func:`served_params` builds a set out of a function-level import — measured at 4.2µs,
+    which is 1.2ms per repaint of one 24-row pane carrying a dozen escapes a row, against
+    `render`'s own measured 4 816µs. So :func:`contain_row` asks once and hands the answer
+    down. Required rather than defaulted: a second way of getting the vocabulary is how
+    one caller comes to be asking about a different one.
+
+    **This is not "did charter hand this exact string over", and that distinction is the
+    whole design of :func:`contain_row`.** A string carries no provenance: the row a
+    provider returns is text, and ``ctx.chrome["heading"]`` and a hard-coded
+    ``"\\x1b[1m"`` are the same six characters by the time charter sees them. Asking
+    which one it was is unanswerable, and answering it by matching the recipe's spelling
+    would be this repo's own recurring defect (#547, #558, #537, #498, #577, #594) in the
+    file that is about that defect.
+
+    So the question asked is what the escape DOES, and it is asked of the parameters as
+    numbers the way :func:`resets_everything` asks its own. Measured, the spellings that
+    a substring match against `_role_values()` gets wrong::
+
+        spelling         params    equals a served recipe   every parameter served
+        '\\x1b[1m'        '1'       True                     True
+        '\\x1b[01m'       '01'      False   <- MISSED         True
+        '\\x1b[1;32m'     '1;32'    False   <- MISSED         True
+        '\\x1b[m'         ''        False   <- MISSED         True   (empty is 0)
+        '\\x1b[38;5;236m' '38;5;2…' False                     False
+        '\\x1b[41m'       '41'      False                     False
+
+    The two ``MISSED`` rows are a provider composing charter's own vocabulary in a legal
+    spelling charter does not happen to write, and there is no argument for escaping
+    those and keeping ``\\x1b[1m``: bold is bold. The two false rows are the property
+    doing its job — a cube index and a background colour are colours charter did not get
+    from the operator's palette, which is `instance.FRAME_CHROME`'s rule reaching the one
+    place a stranger's code would otherwise sit outside it.
+    """
+    return all(int(p or "0") in served for p in params.split(";"))
+
+
+def _pieces(row: str, served: frozenset[int]):
+    """*row* as ``(text, keep)`` pairs: what charter passes through, and what it escapes.
+
+    A non-recipe SGR yields no pair of its own — it stays inside the surrounding text and
+    is escaped with it, which is what makes ``\\x1b[38;5;236m`` come out as the six
+    visible characters of its own escape rather than as a colour with a hole in it.
+
+    **A row with no recipe in it yields exactly one pair, the whole row**, which is what
+    makes :func:`contain_row` answer such a row with `contain.one_line`'s own string,
+    character for character. The containment did not change for anything outside the
+    vocabulary; it grew a hole exactly the size of it.
+    """
+    pos = 0
+    for m in _SGR.finditer(row):
+        if is_recipe(m.group(1), served):
+            yield row[pos:m.start()], False
+            yield m.group(0), True
+            pos = m.end()
+    yield row[pos:], False
+
+
+def _escaped(piece: str, budget: int) -> str:
+    """*piece* with nothing in it that can forge a row — `contain.one_line`, or its answer.
+
+    `str.isprintable()` is a C-level scan, and it is false for a SUPERSET of what
+    `contain.one_line` rewrites: every *Other* and *Separator* category, against
+    `one_line`'s `_INVISIBLE` five (``Cc``, ``Cf``, ``Cs``, ``Zl``, ``Zp``) plus whitespace
+    that is not an ASCII space. Superset is the direction that makes this safe — printable
+    implies `one_line` would change nothing, so such a piece inside its budget IS its own
+    containment, and a `Co` or a `Zs` merely falls through to the slow path and gets the
+    same answer a character at a time. `tui.sanitize` takes the same shortcut against the
+    same question, and this is on the same repaint path.
+    `TheBudgetNeedsNoSecondGuard` puts one of each through both.
+    """
+    # **The deletion sweep reports this line, twice, and it is right to.** A shortcut
+    # cannot change an OUTPUT — that is what makes it a shortcut — so `collapse-ifexp`
+    # and `shift-boundary` on it are equivalent mutants by construction and no test can
+    # ever pin them. What it changes is cost, and the numbers are why it stays. One
+    # 24-row foreign pane, `registry._fit` end to end, with the shortcut and without::
+    #
+    #     24 rows of 300 plain characters   340 us   without: 750 us   (was 512 us)
+    #     24 rows, 4 escapes each           323 us   without: 397 us   (was  73 us)
+    #     24 rows, no escape at all         205 us   without: 268 us   (was  65 us)
+    #
+    # The first row is the one that decides it: without the shortcut a long plain row
+    # costs MORE than the `contain.one_line` this whole function replaces, so #707 would
+    # have bought a provider its colour by making every text-heavy pane slower than it
+    # was. `tui.sanitize` and `tui.width` carry the same shortcut against the same kind
+    # of scan and for the same reason.
+    return (piece if len(piece) <= budget and piece.isprintable()
+            else contain.one_line(piece, limit=budget))
+
+
+def contain_row(row: str, *, limit: int) -> str:
+    """*row* from a foreign component, contained: charter's own vocabulary and nothing else.
+
+    **The containment stays and the channel opens, and those are not in tension.** What
+    `registry.Registry.draw` has to prevent is a stranger's row moving the cursor out of
+    its own rectangle, erasing a pane it does not own, or naming a colour the operator's
+    palette never chose. None of those is an SGR from :func:`served_params` — an SGR
+    costs zero columns and says nothing about position, and charter's seven roles are
+    plain attributes and the sixteen palette names. Everything else in the row goes
+    through `contain.one_line` exactly as the whole row used to: a cursor move, an OSC
+    title string, a bare BEL and a newline all come out as their own visible escape.
+
+    So this is the same guarantee with one hole cut in it, and the hole is the size of
+    the vocabulary charter already publishes. Before it, `docs/frame.md`'s own worked
+    example — a provider writing ``ctx.chrome['heading']`` — reached the pane as the
+    literal text ``\\x1b[1mMetrics\\x1b[0m`` (#707): charter served a colour channel and
+    then stripped it, and the two halves each had a test while the round trip had none.
+
+    **Under `NO_COLOR`, or a pane that is not a terminal, every escape is escaped again.**
+    :func:`recipes` already serves the empty string there, so a component built on the
+    recipes emits no SGR at all and this line changes nothing for it. What it catches is
+    the component that hard-coded ``\\x1b[1m``: §3.2's rule is that charter emits no SGR
+    from the frame, and passing one through on a provider's behalf is charter asking
+    somebody else to paint — the half of that promise `no_colour`'s own docstring is
+    about.
+
+    *limit* is `registry.LINE_LIMIT`, and it bounds the CHARACTERS, which
+    `tui.truncate`'s visible-width clamp cannot: a line of a million combining marks
+    measures zero cells. **A kept escape spends that budget like anything else**, and the
+    one break below is what that costs: an SGR's parameter list is unbounded, so
+    ``\\x1b[`` + ``1;`` four hundred times + ``m`` is every parameter in the vocabulary
+    and is no colour any operator will ever see. It is taken whole or not at all, because
+    half of ``\\x1b[1m`` is a bare ESC and manufacturing one is the single thing an
+    escape-aware containment must never do.
+
+    **What it costs, measured, because this is the repaint path.** One 24-row foreign
+    pane, `registry._fit` end to end, against the `contain.one_line`-over-the-whole-row it
+    replaces::
+
+        24 rows, 4 escapes each (the docs' own example)   323 us   was   73 us
+        24 rows, 12 escapes each (deliberately dense)     914 us   was  457 us
+        24 rows, no escape at all                         205 us   was   65 us
+        24 rows of 300 plain characters                   340 us   was  510 us
+
+    The last row is not a typo: :func:`_escaped`'s `isprintable()` scan is faster than
+    `one_line`'s per-character loop, so a long plain row now costs less than it did. The
+    worst case is half a millisecond against `render`'s own measured 4 816 us — a tenth of
+    what the pane already spends to have rows at all — and it is paid only by a pane
+    charter did not write. The hoist that made it that rather than four times that is
+    :func:`is_recipe`'s: the vocabulary is built once here and not once per escape.
+
+    **An ``if used >= limit: break`` above that line was written first and then deleted**,
+    and the reason is the sweep's rather than tidiness: it was there to stop
+    `contain.one_line` being handed a negative limit — which slices from the END of the
+    string rather than refusing — and it could not, because :func:`_pieces` strictly
+    alternates and a kept piece is appended only when it FITS. So an escaped piece is
+    always preceded either by nothing or by a kept piece that left ``used <= limit``, and
+    the subtraction is never negative. `TheBudgetNeedsNoSecondGuard` pins that property
+    without the guard, over every row a fuzz could build.
+    """
+    if not colour_ok():
+        return contain.one_line(row, limit=limit)
+    served = served_params()
+    out: list[str] = []
+    used = 0
+    for piece, keep in _pieces(row, served):
+        text = piece if keep else _escaped(piece, limit - used)
+        if keep and used + len(text) > limit:
+            break
+        out.append(text)
+        used += len(text)
+    return "".join(out)
 
 
 def plain(row: str) -> str:

--- a/charter/frame/registry.py
+++ b/charter/frame/registry.py
@@ -63,6 +63,7 @@ from types import MappingProxyType
 from typing import Any, Mapping
 
 from .. import contain, tui
+from . import chrome
 from .component import (API_VERSION, EDGES, Component, ComponentError, Content,
                         Fill)
 
@@ -182,15 +183,22 @@ def _fit(lines, *, width: int, height: int, escape: bool) -> tuple[str, ...]:
 
     ``escape`` is provenance and not a preference — see :meth:`Registry.draw`.
 
-    `contain.one_line` runs BEFORE the width arithmetic, which is the order the rest of
+    The containment runs BEFORE the width arithmetic, which is the order the rest of
     charter uses for the same reason: an escape sequence is a zero-width instruction to
     the terminal, so measuring first would measure a string that is not what the terminal
     is about to do, and clipping first would cut an escape in half.
+
+    `chrome.contain_row` rather than `contain.one_line`, and the difference is exactly
+    the seven roles `chrome.recipes` hands the component that drew these lines: an SGR
+    out of charter's own published vocabulary comes through, everything else — a cursor
+    move, an OSC title string, a cube index, a newline — comes out as the characters of
+    its own escape, which is what the whole row used to get. #707 is what the stricter
+    form cost: charter served a colour channel and then stripped it.
     """
     out = []
     for line in lines[:max(height, 0)]:
         if escape:
-            line = contain.one_line(line, limit=LINE_LIMIT)
+            line = chrome.contain_row(line, limit=LINE_LIMIT)
         out.append(tui.truncate(line, width))
     return tuple(out)
 
@@ -631,14 +639,34 @@ class Registry:
         otherwise — a provider's module is ordinary Python.
 
         **Escaping is decided by who wrote the line, not by the caller.** A provider's
-        rows are escaped: they carry committed plane values — repo names, branch names,
+        rows are contained: they carry committed plane values — repo names, branch names,
         todo text — and they reach a terminal, where an escape sequence is an instruction
         and not a character, so a row of one could move the cursor out of its own
         rectangle and draw over the pane beside it. Charter's own renderers already
         contain their committed values at the point they interpolate them and then add
-        charter's own colour markup on top, so escaping their output here would corrupt
+        charter's own colour markup on top, so containing their output here would corrupt
         charter's markup while protecting nothing. The width and the row count are
         applied to both: the rectangle is the frame's, whoever drew inside it.
+
+        **What a provider's row keeps is the vocabulary charter served it, and nothing
+        else** (`chrome.contain_row`, #707). Containment was `contain.one_line` over the
+        whole row, which escaped every SGR — including the seven `ctx.chrome` recipes
+        charter had handed that same component one call earlier, so `docs/frame.md`'s own
+        worked example reached the pane as the literal text ``\\x1b[1mMetrics\\x1b[0m``.
+        The two halves each had a test and the round trip had none, which is the defect
+        underneath the defect.
+
+        The channel opens no further than that vocabulary, and the argument is what the
+        escaping was FOR: an SGR from `chrome.served_params` costs zero columns, says
+        nothing about position, and names only a plain attribute or one of the sixteen
+        slots in the operator's own palette. It cannot reach the pane beside it and it
+        cannot pick a colour charter did not pick. Everything a row can do that is not
+        that — a cursor move, an erase, an OSC title string, a 24-bit triple, a newline —
+        is still escaped into the characters of its own escape. **And it is asked as a
+        property of the SGR parameters rather than by matching the recipe's text**: a
+        string carries no provenance, so "did charter serve this" is unanswerable, while
+        "is this inside charter's vocabulary" is the question that was actually worth
+        asking (`chrome.is_recipe`).
         """
         c = self.get(cid)
         try:

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1186,6 +1186,24 @@ unchanged: the keys never disappear, so a component built on them does not break
 There is no `surface` or `focus` recipe, because there is nothing to hand over — those two
 are tmux pane options and no renderer can write one.
 
+**Those eight are also the whole of what survives the trip.** Charter contains every row a
+component outside its own tree returns, before it reaches the terminal — and containment
+means an escape comes out as the visible characters of itself, so `\x1b[2J` prints as
+`\x1b[2J` instead of erasing somebody's pane. **What is exempt is the vocabulary above, and
+it is exempt as a property rather than as a spelling**: an SGR whose every parameter is one
+of these roles' comes through, however you spelled it. `\x1b[1m`, `\x1b[01m` and `\x1b[m`
+are all charter's own vocabulary; so is `\x1b[1;32m`, which is two of the roles in one
+escape and something charter never writes itself.
+
+Everything else does not. A colour outside your palette's sixteen — `\x1b[38;5;236m`,
+`\x1b[38;2;30;60;90m`, a background like `\x1b[41m` — a cursor move, an erase, an OSC title
+string, a newline: each arrives as its own text. And one parameter charter does not serve
+takes the whole escape with it, so `\x1b[1;41m` is contained entire rather than half-kept.
+Under `NO_COLOR`, or a pane that is not a terminal, nothing is exempt: the recipes are
+already empty there, so a component built on them is unaffected, and one that hard-coded an
+escape has it contained like any other — charter emits no SGR from the frame, including on
+somebody else's behalf.
+
 **What charter does not promise is that your pane looks like its own.** A component that
 ignores the recipes and paints something else will not match, and charter will not make it:
 it does not overdraw your heading, and it does not take a row out of your rectangle to fit

--- a/docs/news/unreleased-a-providers-colour-reaches-its-pane.md
+++ b/docs/news/unreleased-a-providers-colour-reaches-its-pane.md
@@ -1,0 +1,44 @@
+---
+version: unreleased
+headline: A provider's `ctx.chrome` colour now reaches its pane instead of printing as text
+---
+
+Charter hands a component a mapping of the frame's own recipes — `ctx.chrome['heading']`,
+`['ok']`, `['inset']` — so a pane written by somebody else can match the rest of the frame
+without charter drawing over it. `docs/frame.md` has a worked example that writes them.
+For a component that came from an installed distribution, none of it worked: the row
+arrived in the pane as the literal text `\x1b[1mMetrics\x1b[0m`.
+
+Both halves were right on their own. Charter contains what a foreign component returns,
+because a row reaches a terminal where an escape is an instruction rather than a character
+— a cursor move in one could draw over the pane beside it. The containment was
+`contain.one_line` over the whole row, which escapes every escape, including the seven
+charter had handed that same component one call earlier. So charter served a colour channel
+and then stripped it, and told providers to use it.
+
+**The containment stays and the vocabulary is cut out of it.** An SGR from charter's own
+recipes costs zero columns, says nothing about position, and names only a plain attribute
+or one of the sixteen slots in your palette — it cannot reach the pane beside it and it
+cannot pick a colour charter did not pick. Everything else a row can do is still contained:
+a cursor move, an erase, an OSC title string, a 24-bit triple, a background colour, a
+newline. One parameter outside the vocabulary takes the whole escape with it, so `\x1b[1;41m`
+is contained entire rather than half-kept. Under `NO_COLOR`, or a pane that is not a
+terminal, nothing is exempt — the recipes are already empty there, and passing an escape
+through on a provider's behalf would be charter emitting SGR from the frame after promising
+not to.
+
+**It is asked of the SGR parameters as numbers, not by matching the recipes' text.** A
+string carries no provenance: `ctx.chrome['heading']` and a hard-coded `"\x1b[1m"` are the
+same six characters by the time charter sees the row, so "did charter serve this" is
+unanswerable. "Is this inside charter's vocabulary" is answerable and is the question worth
+asking — and it gets `\x1b[01m`, `\x1b[m` and `\x1b[1;32m` right, which a match against the
+recipes' spelling would have escaped for being spelled a way charter does not happen to
+write.
+
+**The test that was missing asserts the round trip.** One test pinned that the recipes are
+served and another pinned that a foreign row is contained; nothing spanned them, which is
+why the two halves could disagree from the day the recipes landed, with everything green.
+The new one installs a real distribution whose renderer reads `ctx.chrome`, draws it
+through the registry, and asserts the escape that comes out is the escape that went in —
+and that the same renderer run as one of charter's own components produces the identical
+row.

--- a/personas/_dispatch/2026-08.EasyDMARCs-MacBook-Pro-6.jsonl
+++ b/personas/_dispatch/2026-08.EasyDMARCs-MacBook-Pro-6.jsonl
@@ -332,3 +332,6 @@
 {"agent": "Explore", "ts": "2026-08-30T17:29:58+00:00"}
 {"event": "advice", "ts": "2026-08-30T18:42:09+00:00"}
 {"event": "advice", "ts": "2026-08-30T19:02:42+00:00"}
+{"agent": "general-purpose", "ts": "2026-08-30T19:14:57+00:00"}
+{"agent": "general-purpose", "ts": "2026-08-30T19:15:25+00:00"}
+{"agent": "general-purpose", "ts": "2026-08-30T19:15:54+00:00"}

--- a/tests/test_frame_provider_recipes.py
+++ b/tests/test_frame_provider_recipes.py
@@ -15,6 +15,15 @@ outright that it is not a sandbox. What charter *can* guarantee is the three thi
 already guarantees, and they are asserted here rather than restated: the provider's paint
 stops at its rectangle, its failure costs its pane and not the session, and its output is
 contained before it reaches the terminal.
+
+**And the ROUND TRIP, which is the assertion this file was missing** (#707). Two halves
+were each pinned here — that the recipes are served, and that a foreign row is
+contained — and nothing spanned them, so from the day #604 landed charter handed a provider
+``ctx.chrome`` and
+then escaped it back into the literal text ``\\x1b[1mMetrics\\x1b[0m`` on the way to the
+pane, with every test green. `TheRecipeSurvivesToThePane` below installs a real
+distribution whose renderer writes the recipes and asserts what arrives in the pane,
+because a property that spans two mechanisms cannot be asserted at either end of it.
 """
 
 from __future__ import annotations
@@ -26,9 +35,10 @@ import unittest
 from types import MappingProxyType
 from unittest import mock
 
-from charter import statusline, tui
-from charter.frame import chrome, ctx, registry, slots
+from charter import contain, statusline, tui
+from charter.frame import chrome, component, ctx, registry, slots
 from tests._isolation import PersonaIso
+from tests.test_component_providers import CID, ENTRY, MODULE, _SitePackages, _source
 
 #: One SGR escape with its parameter list captured — the shape `chrome._SGR` matches.
 _SGR = re.compile(r"\x1b\[([0-9;]*)m")
@@ -297,7 +307,23 @@ class AProviderThatIgnoresTheRecipesHarmsNothingOutsideItsPane(unittest.TestCase
 
     A provider whose rows carry a background and no reset is the case that matters, because
     it is the one this whole spec makes normal: components are about to start painting.
+
+    **Colour is LIVE for every case here, and that is the harder half rather than the
+    tidier one.** `chrome.contain_row` escapes every escape when `colour_ok()` is false
+    (§3.2), so a case that let the suite's own piped stdout decide would be asserting
+    containment with the containment's own reason turned off — and would have gone on
+    passing if the vocabulary hole #707 opened had been cut the whole width of SGR. With a
+    tty and no `NO_COLOR`, `\\x1b[41m` is escaped because 41 is not a parameter charter
+    serves, which is the property.
     """
+
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.tty = _tty()
+        self.tty.start()
+        self.addCleanup(self.tty.stop)
 
     def test_a_foreign_row_is_clipped_to_its_rectangle(self):
         """`Registry._fit` contains and clips every foreign row. A row wider than the pane
@@ -355,6 +381,413 @@ class AProviderThatIgnoresTheRecipesHarmsNothingOutsideItsPane(unittest.TestCase
              mock.patch.object(panel.sys.stdout, "flush"):
             panel._write("BODY")
         self.assertEqual("".join(wrote).split("\x1b[2J", 1)[1], "BODY")
+
+
+class TheRecipeSurvivesToThePane(unittest.TestCase):
+    """#707, and the assertion that would have caught it: the ROUND TRIP.
+
+    Everything above this class asserts one END of the channel — `chrome.recipes` serves
+    the escapes, `registry._fit` contains a foreign row — and both stayed green for every
+    day a provider's ``ctx.chrome['heading']`` arrived in the pane as the six visible
+    characters of its own escape. Neither half was wrong on its own; the property that
+    spans them was never asked for.
+
+    **So this asks for it end to end, through a real installed distribution.** The module
+    under `sys.path` is written by `_SitePackages` exactly as
+    `tests.test_component_providers` writes one, its renderer reads `ctx.chrome` the way
+    `docs/frame.md`'s worked example tells a provider to, and the assertion is the tuple
+    `Registry.draw` answers — which is what `frame/panel.py` joins and writes into the
+    pane. A fixture that registered the component directly and reached into `_foreign`
+    would be asserting charter's plumbing rather than the seam a provider actually
+    arrives through.
+    """
+
+    def setUp(self):
+        self.site = _SitePackages(self)
+        self.env = mock.patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.tty = _tty()
+        self.tty.start()
+        self.addCleanup(self.tty.stop)
+
+    def _drew(self, render: str) -> tuple[str, ...]:
+        """The rows a real installed provider whose renderer is *render* put in its pane.
+
+        A registry per call, not one per case. `Registry.place` answers what is already
+        registered rather than re-importing — a component keeps the rectangle it went onto
+        the frame in — so a case that varies the renderer across subtests would draw the
+        FIRST one seven times and pass on six roles it never exercised.
+        """
+        self.site.install("acme-charter", "1.4.0", {CID: ENTRY},
+                          {MODULE: _source(render=render)})
+        r = registry.Registry()
+        r.place(CID)
+        return r.draw(CID, ctx.build((), width=60, height=4, fid="fr-1", snapshot={}))
+
+    def test_the_worked_example_in_the_docs_reaches_the_pane_as_colour(self):
+        """`docs/frame.md`'s own provider, verbatim in shape: inset, heading, reset, muted.
+
+        The literal text `\\x1b[1mMetrics\\x1b[0m` is what this used to answer, so the
+        negative is asserted beside the positive — a row that is neither is a third
+        failure, and only naming both tells them apart.
+        """
+        drew = self._drew(
+            "lambda ctx: [ctx.chrome['inset'] + ctx.chrome['heading'] + 'Metrics' "
+            "+ ctx.chrome['reset'] + ctx.chrome['muted'] + ' 12' + ctx.chrome['reset']]")
+        served = chrome.recipes()
+        self.assertEqual(
+            drew,
+            (f"{served['inset']}{served['heading']}Metrics{served['reset']}"
+             f"{served['muted']} 12{served['reset']}",))
+        self.assertNotIn("\\x1b", "".join(drew))
+
+    def test_every_role_charter_serves_survives_the_trip(self):
+        """One case per role rather than one case for `heading`. A vocabulary is a set,
+        and a hole in it is exactly the shape of a role that was added to `recipes` and
+        not to what the containment admits."""
+        served = chrome.recipes()
+        for role in ("heading", "muted", "selected", "ok", "warn", "bad", "reset"):
+            with self.subTest(role=role):
+                drew = self._drew(f"lambda ctx: [ctx.chrome[{role!r}] + 'x']")
+                self.assertEqual(drew, (f"{served[role]}x",))
+
+    def test_the_provider_row_is_the_row_charters_own_component_would_have_drawn(self):
+        """§7's exit criterion, and the reason the round trip is the assertion: a
+        component drawn with the recipes is INDISTINGUISHABLE from a built-in at the same
+        size. The same renderer is run once as a provider and once as charter's own, and
+        the two tuples must be equal — which they were not, because only one of them was
+        contained."""
+        drew = self._drew("lambda ctx: [ctx.chrome['heading'] + 'Metrics' "
+                          "+ ctx.chrome['reset']]")
+        own = registry.Registry()
+        own.register(component.Component(
+            id="builtin.metrics", title="Metrics", edge="right",
+            size=component.Fixed(12), needs=(),
+            render=lambda c: [c.chrome["heading"] + "Metrics" + c.chrome["reset"]]))
+        self.assertEqual(
+            drew,
+            own.draw("builtin.metrics",
+                     ctx.build((), width=60, height=4, fid="fr-1", snapshot={})))
+
+    def test_a_provider_that_hard_codes_an_escape_charter_does_not_serve_is_contained(self):
+        """The other side of the same trip, asserted here rather than only at `_fit`: the
+        hole is the size of the vocabulary and no larger. A cube index is a colour charter
+        never picked, so it arrives as the characters of its own escape."""
+        drew = self._drew(r"lambda ctx: ['\x1b[38;5;236mcube']")
+        self.assertEqual(drew, ("\\x1b[38;5;236mcube",))
+
+    def test_under_no_color_the_provider_emits_nothing_and_carries_nothing(self):
+        """Both halves of §3.2 at once. `recipes` serves the empty string, so a component
+        built on it writes no escape — and a component that hard-coded one has it escaped,
+        because charter passing an SGR through on a provider's behalf is charter asking
+        somebody else to paint."""
+        with mock.patch.dict(os.environ, {"NO_COLOR": "1"}):
+            drew = self._drew(
+                r"lambda ctx: [ctx.chrome['heading'] + 'served', '\x1b[1mhard']")
+        self.assertEqual(drew, ("served", "\\x1b[1mhard"))
+
+
+class TheContainmentAdmitsCharterSVocabularyAndNothingElse(unittest.TestCase):
+    """What `chrome.contain_row` lets through, asked of the SGR parameters as numbers.
+
+    **Every case here is a row a provider could legally return**, and the split is the
+    one #707 argued: an escape that costs zero columns and names an attribute or a slot in
+    the operator's own palette cannot reach the pane beside it or forge a colour charter
+    did not pick, and everything else can. Matching the recipes' SPELLING would put the
+    first three kept cases on the wrong side — which is this repo's own recurring defect,
+    in the file that is about it.
+    """
+
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.tty = _tty()
+        self.tty.start()
+        self.addCleanup(self.tty.stop)
+
+    def _fit(self, row: str) -> str:
+        return registry._fit([row], width=120, height=1, escape=True)[0]
+
+    def test_a_spelling_charter_does_not_write_is_still_the_vocabulary(self):
+        """`\\x1b[01m` is bold with a leading zero and `\\x1b[m` is a reset with no
+        parameter at all. Neither is a string `chrome._role_values` contains, and both do
+        exactly what a recipe does."""
+        for row in ("\x1b[01mbold", "\x1b[mreset", "\x1b[0;1mboth"):
+            with self.subTest(row=row):
+                self.assertEqual(self._fit(row), row)
+
+    def test_two_roles_in_one_escape_are_two_parameters_and_not_a_new_colour(self):
+        """A provider composing `heading` and `ok` into one escape wrote `\\x1b[1;32m`,
+        which charter never writes and which says only what charter serves."""
+        self.assertEqual(self._fit("\x1b[1;32mgreen heading"), "\x1b[1;32mgreen heading")
+
+    def test_a_colour_outside_the_operators_palette_does_not_survive(self):
+        """The three ways to name a colour charter did not get from the sixteen, each
+        arriving as the characters of its own escape."""
+        for row, seen in (("\x1b[38;5;236mcube", "\\x1b[38;5;236mcube"),
+                          ("\x1b[38;2;30;60;90mtrue", "\\x1b[38;2;30;60;90mtrue"),
+                          ("\x1b[41mbackground", "\\x1b[41mbackground")):
+            with self.subTest(row=row):
+                self.assertEqual(self._fit(row), seen)
+
+    def test_one_served_parameter_beside_one_that_is_not_carries_neither(self):
+        """The arm a per-parameter check needs and a per-escape one misses: `\\x1b[1;41m`
+        is bold AND a background charter never picked, and half an escape is not a thing
+        that can be kept."""
+        self.assertEqual(self._fit("\x1b[1;41mmixed"), "\\x1b[1;41mmixed")
+
+    def test_nothing_that_moves_the_cursor_or_talks_to_the_terminal_survives(self):
+        """The whole reason the containment exists, and it is untouched: these are what a
+        row would use to draw over the pane beside it, and none of them is an SGR."""
+        for row in ("\x1b[2Jerase", "\x1b[10Aup", "\x1b]0;title\x07osc", "\x1bcreset",
+                    "a\x07bell", "two\nlines", "tab\there"):
+            with self.subTest(row=row):
+                self.assertNotIn("\x1b", self._fit(row))
+                self.assertNotIn("\x07", self._fit(row))
+
+    def test_charters_own_rows_are_still_not_contained_at_all(self):
+        """`escape` is provenance. A built-in's markup goes through untouched, including
+        the colours charter picked for its own panes, which containing would corrupt while
+        protecting nothing."""
+        row = "\x1b[38;5;236mcharter's own\x1b[0m"
+        self.assertEqual(registry._fit([row], width=120, height=1, escape=False)[0], row)
+
+    def test_with_colour_off_the_vocabulary_is_empty(self):
+        """§3.2 is a statement about what charter emits, not about what it serves — so it
+        has to reach the containment as well as the recipes."""
+        with mock.patch.dict(os.environ, {"NO_COLOR": ""}):
+            self.assertEqual(self._fit("\x1b[1mbold"), "\\x1b[1mbold")
+
+    def test_a_pane_that_is_not_a_terminal_is_the_same_answer(self):
+        with _tty(False):
+            self.assertEqual(self._fit("\x1b[1mbold"), "\\x1b[1mbold")
+
+
+class TheVocabularyIsTheRolesAndNotASecondListOfThem(unittest.TestCase):
+    """`chrome.served_params` is derived from `chrome._role_values`, and #707 is what a
+    second list costs: a role served at one end and unknown at the other."""
+
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.tty = _tty()
+        self.tty.start()
+        self.addCleanup(self.tty.stop)
+
+    def test_every_role_charter_serves_is_admitted_by_the_containment(self):
+        """The property the two halves have to share, asked directly. A role that stopped
+        being admitted would fail here as well as in the round trip above — one of them is
+        the seam and this one is the reason."""
+        for role, value in chrome._role_values().items():
+            with self.subTest(role=role):
+                served = chrome.served_params()
+                for m in _SGR.finditer(value):
+                    self.assertTrue(chrome.is_recipe(m.group(1), served), value)
+
+    def test_a_role_added_upstream_widens_the_vocabulary_without_a_second_edit(self):
+        """The control, and the whole argument for deriving it. A magenta role appears in
+        `_role_values` alone and the containment admits it on the same breath — so the
+        drift #707 was cannot happen by somebody forgetting the other list."""
+        self.assertFalse(chrome.is_recipe("35", chrome.served_params()))
+        with mock.patch.object(chrome, "_role_values",
+                               return_value={"brand": "\x1b[35m"}):
+            self.assertTrue(chrome.is_recipe("35", chrome.served_params()))
+
+    def test_the_vocabulary_is_the_seven_roles_and_stops_there(self):
+        """Pinned as a set rather than left implicit: widening it is a widening of what a
+        stranger's code may put on an operator's screen, and it should cost a test change
+        and the conversation that goes with it."""
+        self.assertEqual(sorted(chrome.served_params()), [0, 1, 2, 7, 31, 32, 33])
+
+    def test_the_inset_is_not_in_it_because_it_is_not_an_escape(self):
+        """The one recipe that is spaces. It survives containment the way every other
+        space does, which is why it is not in the vocabulary and does not need to be."""
+        self.assertNotIn("\x1b", chrome.recipes()["inset"])
+
+
+class TheCharacterBudgetSurvivesTheHoleThatWasCutInIt(unittest.TestCase):
+    """`registry.LINE_LIMIT` bounds CHARACTERS, and `tui.truncate`'s width clamp cannot:
+    a combining mark measures zero cells. Opening the vocabulary put escapes on the
+    keeping side of that budget, and both of `contain_row`'s breaks are what that costs.
+    """
+
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.tty = _tty()
+        self.tty.start()
+        self.addCleanup(self.tty.stop)
+
+    def test_a_row_of_invisibles_is_still_bounded(self):
+        """The bound the width clamp cannot give: a million combining marks fit any pane
+        and cost the repaint a million characters."""
+        got = chrome.contain_row("́" * 5000, limit=64)
+        self.assertLessEqual(len(got), 65)
+
+    def test_a_row_whose_budget_runs_out_mid_way_keeps_none_of_the_tail(self):
+        row = "\n" * 20 + "\x1b[1m" + "TAIL"
+        got = chrome.contain_row(row, limit=16)
+        self.assertNotIn("TAIL", got)
+        self.assertLessEqual(len(got), 17)
+
+    def test_an_unbounded_parameter_list_is_in_the_vocabulary_and_still_refused(self):
+        """The `keep` break. An SGR's parameter list has no length limit, so
+        `\\x1b[` + `1;` half a million times + `m` is every parameter charter serves and is
+        no colour anyone will ever see. Taken whole or not at all — a slice of it is a
+        bare ESC, which is the one thing this must never manufacture."""
+        row = "\x1b[" + "1;" * 400 + "1m" + "after"
+        self.assertTrue(chrome.is_recipe(row[2:row.index("m")], chrome.served_params()))
+        got = chrome.contain_row(row, limit=64)
+        self.assertNotIn("\x1b", got)
+        self.assertLessEqual(len(got), 65)
+
+    def test_a_recipe_that_lands_exactly_on_the_budget_is_still_inside_it(self):
+        """**The boundary, and not only the direction** — the deletion sweep asked for
+        this one by name. `used + len(text) > limit` and `>= limit` differ on exactly one
+        row: an escape whose last character lands ON the limit. It is inside the budget,
+        and reading it as outside would drop a recipe from every row that happened to end
+        there, which is a vocabulary that narrows by one escape with no rule behind it.
+        The row one character longer is the control, so the case pins where the line is
+        rather than only that there is one.
+        """
+        self.assertEqual(chrome.contain_row("\x1b[1m", limit=4), "\x1b[1m")
+        self.assertEqual(chrome.contain_row("\x1b[1m", limit=3), "")
+
+    def test_a_recipe_that_fits_the_budget_is_kept_whole(self):
+        """The control for the break above: the same shape under the limit comes through,
+        so the refusal is about the budget and not about the parameter list."""
+        row = "\x1b[1;1;1m" + "after"
+        self.assertEqual(chrome.contain_row(row, limit=64), row)
+
+    def test_the_limit_reaches_the_containment_from_the_registry(self):
+        """`registry._fit` is the only caller in production and it passes `LINE_LIMIT`.
+        Asserted rather than assumed, because a default spelled here as well would be the
+        second, weaker copy this repo deletes."""
+        long_row = "́" * (registry.LINE_LIMIT * 2)
+        self.assertLessEqual(len(registry._fit([long_row], width=10, height=1,
+                                               escape=True)[0]),
+                             registry.LINE_LIMIT + 1)
+
+
+class TheBudgetNeedsNoSecondGuard(unittest.TestCase):
+    """The property an `if used >= limit: break` was written for, pinned without it.
+
+    That guard was there so `contain.one_line` could not be handed a NEGATIVE limit —
+    which it reads as a slice from the end of the string, answering with the tail of what
+    it was hiding. It could not happen: `chrome._pieces` strictly alternates escaped and
+    kept pieces, and a kept piece is appended only when it FITS, so every escaped piece
+    starts from a `used` that is at most the limit. The guard was deleted and this is what
+    keeps the reasoning honest — the deletion sweep's own shape, and the same one
+    `chrome.fill` and `slots.inset_rows` already carry.
+    """
+
+    #: Rows are built from these, so a case is a real mixture of what a provider returns:
+    #: two recipes, two colours outside the vocabulary, an unbounded parameter list, the
+    #: whitespace controls `one_line` expands four-to-one, and ordinary text.
+    #:
+    #: **The last two are what `chrome._escaped`'s fast path is judged on.**
+    #: `str.isprintable()` is false for every *Other* and *Separator* category, and
+    #: `contain.one_line` rewrites a narrower set — its `_INVISIBLE` five plus whitespace
+    #: that is not an ASCII space. U+00A0 is `Zs` and IS rewritten; U+E000 is `Co` and is
+    #: NOT. Both fall off the fast path, and both have to come back exactly what `one_line`
+    #: answers, which is what makes the equivalence case a test of the shortcut rather than
+    #: of the common case it shortcuts.
+    _ALPHABET = ("\x1b[1m", "\x1b[0m", "\x1b[41m", "\x1b[38;5;9m", "\x1b[1;1;1;1;1;1m",
+                 "\n", "\t", "\x07", "a", "́", "\xa0", "\ue000")
+
+    def setUp(self):
+        # `colour_ok` answering a plain `True`, and NOT `_tty()` like every other class
+        # here. These cases make about 27 000 calls, and a `Mock` records every one of
+        # them: measured, the same fixture through `mock.patch.object` spends 2.2s where
+        # this spends a fifth of it, and the recorded calls are a list that only grows.
+        # What the cases are about is the budget, and the answer this pins is the one
+        # `NoColourReachesTheRecipesToo` and the containment class already assert for real.
+        self.env = mock.patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.live = mock.patch.object(chrome, "colour_ok", lambda: True)
+        self.live.start()
+        self.addCleanup(self.live.stop)
+
+    def _rows(self):
+        """Every row of up to three pieces of :data:`_ALPHABET` — exhaustive, not sampled.
+
+        1 111 rows, so the property is *proved* over the shape rather than sampled from
+        it. A random fuzz would make a failure depend on a seed, and a containment defect
+        that reproduces once a week is a defect nobody can bisect.
+
+        Three is where the alternation is complete rather than an arbitrary stopping
+        point: a row of three already yields five pieces — escaped, kept, escaped, kept,
+        escaped — which is every position `contain_row`'s loop can be in. A fourth adds
+        rows and no new shape, at ten times the cost on a suite that runs on every push.
+        """
+        from itertools import product
+        for n in range(4):
+            for parts in product(self._ALPHABET, repeat=n):
+                yield "".join(parts)
+
+    def test_one_line_is_never_handed_a_negative_limit(self):
+        limits = []
+        real = contain.one_line
+
+        def spy(value, limit=contain.DISPLAY_LIMIT):
+            limits.append(limit)
+            return real(value, limit)
+
+        with mock.patch.object(chrome.contain, "one_line", side_effect=spy):
+            for row in self._rows():
+                for limit in (1, 3, 8, 64):
+                    chrome.contain_row(row, limit=limit)
+        self.assertTrue(limits, "the spy saw nothing — the fixture stopped testing")
+        self.assertEqual([x for x in limits if x < 0], [])
+
+    def test_the_answer_is_never_longer_than_the_budget_and_its_ellipsis(self):
+        """The bound the deleted guard was also credited with. One clipped piece is the
+        most a row can have — after it, the next piece is a kept escape that no longer
+        fits — so `limit + 1` is the whole of it."""
+        for row in self._rows():
+            for limit in (1, 3, 8, 64):
+                got = chrome.contain_row(row, limit=limit)
+                if len(got) > limit + 1:
+                    self.fail(f"{row!r} at {limit} came back {got!r}")
+
+    def test_no_answer_ever_carries_half_an_escape(self):
+        """The one thing an escape-aware containment must never manufacture. A bare ESC in
+        a pane is an introducer for whatever character follows it."""
+        for row in self._rows():
+            for limit in (1, 3, 8, 64):
+                got = chrome.contain_row(row, limit=limit)
+                if "\x1b" in _SGR.sub("", got):
+                    self.fail(f"{row!r} at {limit} came back {got!r}")
+
+    def test_a_row_with_no_recipe_in_it_is_contained_exactly_as_it_always_was(self):
+        """**The strongest statement this change can make**: for a row carrying none of
+        charter's own vocabulary, `chrome.contain_row` answers `contain.one_line`'s own
+        string, character for character. The containment did not become cleverer or
+        weaker — it grew a hole exactly the size of the roles charter publishes, and
+        anything outside that hole is treated by the same function it always was.
+
+        It is also what pins `chrome._escaped`'s `isprintable()` fast path, which exists
+        because this is on the repaint path: a piece that skips `one_line`'s per-character
+        loop has to come out identical, and both shapes are in the alphabet above.
+        """
+        served = chrome.served_params()
+        checked = 0
+        for row in self._rows():
+            if any(chrome.is_recipe(m.group(1), served) for m in _SGR.finditer(row)):
+                continue
+            checked += 1
+            for limit in (1, 3, 8, 64):
+                got, was = (chrome.contain_row(row, limit=limit),
+                            contain.one_line(row, limit=limit))
+                if got != was:
+                    self.fail(f"{row!r} at {limit}: {got!r} is no longer {was!r}")
+        self.assertGreater(checked, 100,
+                           "the filter took every row — this case stopped testing")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #707.

`docs/frame.md` shows a provider writing `ctx.chrome['heading']` into a row. `registry.py`
escaped every foreign row with `contain.one_line`, so that row reached the pane as the
literal text `\x1b[1mMetrics\x1b[0m`. Charter served a colour channel, stripped it, and
documented it. Verified round trip before the fix:

```
served heading: '\x1b[1m'
drawn:          ('  \\x1b[1mMetrics\\x1b[0m',)
```

## What changed

The containment stays; a hole is cut in it exactly the size of the vocabulary charter
already publishes. `chrome.contain_row` passes an SGR through when **every one of its
parameters is one of `chrome.served_params()`** — the numbers `chrome._role_values()` is
made of — and escapes everything else through `contain.one_line`, which is what the whole
row used to get.

That is safe on the axis the escaping was written for. An SGR costs zero columns and says
nothing about position, so it cannot reach the pane beside it; and the seven roles are
plain attributes and the sixteen names in the operator's own palette, so it cannot name a
colour charter did not pick. A cursor move, an erase, an OSC title string, a cube index, a
24-bit triple, a background colour, a newline: each still arrives as the characters of its
own escape. One parameter outside the vocabulary takes the whole escape with it, so
`\x1b[1;41m` is contained entire rather than half-kept. Under `NO_COLOR` or a pane that is
not a terminal nothing is exempt, because §3.2's rule is about what charter *emits*, not
only about what it serves.

## The spelling-versus-property trap, and why the question changed

The issue asks charter to tell *its own recipe echoed back* from *an escape a provider
invented*, and notes that matching the recipe's text is not the same as knowing charter
served it. That is right, and it is unanswerable: a row is a string, and
`ctx.chrome['heading']` and a hard-coded `"\x1b[1m"` are the same six characters by the
time `draw` sees them. There is no provenance to recover.

So the question asked is the one that is answerable and is the one that matters — *is what
this escape does inside charter's vocabulary* — and it is asked of the parameters as
numbers, the way `chrome.resets_everything` already asks its own:

```
spelling         params    equals a served recipe   every parameter served
'\x1b[1m'        '1'       True                     True
'\x1b[01m'       '01'      False   <- MISSED         True
'\x1b[1;32m'     '1;32'    False   <- MISSED         True
'\x1b[m'         ''        False   <- MISSED         True   (empty is 0)
'\x1b[38;5;236m' '38;5;2…' False                     False
'\x1b[41m'       '41'      False                     False
```

The three `MISSED` rows are a provider composing charter's own vocabulary in a legal
spelling charter does not happen to write, and escaping those while keeping `\x1b[1m` would
be the string-match defect this repo has now met six times.

## The deliverable is the spanning test

One test pinned that the recipes are *served* and another pinned that a foreign row is
*contained*; nothing spanned them, which is the defect underneath the defect.
`TheRecipeSurvivesToThePane` installs a real distribution (the same `_SitePackages` fixture
`test_component_providers` uses — a real `.dist-info` on `sys.path`, nothing stubbed) whose
renderer reads `ctx.chrome`, draws it through the registry, and asserts what arrives:

* the docs' own worked example comes out as colour, and *not* as `\\x1b`;
* every one of the seven roles survives, one case each;
* the identical renderer run as one of charter's own components produces the **same tuple**
  — §7's exit criterion, which is what "indistinguishable from a built-in" has to mean;
* a hard-coded cube index still arrives as text;
* under `NO_COLOR` the recipes are empty *and* a hard-coded `\x1b[1m` is escaped.

Plus `TheBudgetNeedsNoSecondGuard`, which proves over every row of up to three pieces of a
ten-symbol alphabet (1 111 rows × 6 limits, exhaustive rather than sampled) that the answer
never exceeds `limit + 1`, never carries half an escape, and — for a row with no recipe in
it — **is `contain.one_line`'s own string character for character**. The containment did not
become cleverer or weaker.

## What the sweep found

**A deleted guard.** An `if used >= limit: break` was written first and removed. It was
there to stop `contain.one_line` being handed a negative limit, and it could not: `_pieces`
strictly alternates and a kept piece is appended only when it fits, so an escaped piece
always starts from `used <= limit`. A 71 711-call fuzz confirmed no negative limit is
reachable without it and that the `limit + 1` bound holds. `TheBudgetNeedsNoSecondGuard`
pins the property without the guard.

**Two survivors on the guard that stayed, both now pinned.** `tools/sweep.py` reported a
masked cluster on `keep and used + len(text) > limit`:

* *drop-conjunct* — dropping the `keep` half. Caught by
  `test_a_row_with_no_recipe_in_it_is_contained_exactly_as_it_always_was`, which the sweep
  ran before it existed.
* *shift-boundary* — `>` becoming `>=`. This was a genuinely missing test rather than an
  equivalent mutant: it drops an escape whose last character lands *on* the limit, which
  is inside the budget. `test_a_recipe_that_lands_exactly_on_the_budget_is_still_inside_it`
  now pins the boundary and the row one character longer as its control.

Every remaining arm was mutated by hand as well, each caught by a test with an input that
reaches only it — including the `isprintable()` fast path, whose removal correctly changes
nothing, which is why it is written as one expression the way `tui.sanitize` writes the
same shortcut rather than as a guard no test could turn red.

## Cost, measured

This is the repaint path, so: one 24-row foreign pane through `registry._fit`, against the
`contain.one_line`-over-the-whole-row it replaces.

```
24 rows, 4 escapes each (the docs' own example)   323 us   was   73 us
24 rows, 12 escapes each (deliberately dense)     914 us   was  457 us
24 rows, no escape at all                         205 us   was   65 us
24 rows of 300 plain characters                   340 us   was  510 us
```

The last row is not a typo — `_escaped`'s `isprintable()` scan beats `one_line`'s
per-character loop, the same shortcut `tui.sanitize` takes. The worst case is half a
millisecond against `render`'s own measured 4 816 us, paid only by a pane charter did not
write. A first cut was four times that because `served_params()` was called per escape;
`is_recipe` now takes the vocabulary as a parameter and `contain_row` builds it once.

## Contract, stated

`docs/frame.md` now says what survives the trip and what does not, so the two halves of the
seam are documented in one place instead of contradicting each other in two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
