### PR TITLE
A panel pane exists once per placed component, because the window is asked rather than the record (#714)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -497,6 +497,48 @@ _PANEL_OPTION = "@charter_panel"
 #: palette's, and the operator's own.
 _PANEL_MARK = "1"
 
+#: WHICH component a panel draws, said to tmux beside :data:`_PANEL_OPTION` — and the two
+#: are separate options rather than one because they answer two different questions, only
+#: one of which a `bind` line reads.
+#:
+#: `_PANEL_OPTION` is a truth-value: `conf_text`'s `MouseDown1Pane` bind format-expands it
+#: and tmux decides where a click goes on whether it reads true. Folding the component's
+#: id into that value would have worked by accident — every id `component.usable_id`
+#: admits is a true format value — right up to the first id spelled `0`, which that
+#: alphabet does not forbid and which would have made one component's panel the only one
+#: in the frame that steals the keyboard. Two options, so naming a component cannot change
+#: the routing answer.
+#:
+#: **This is what makes #714's reconciliation possible at all.** `state.record_panes`
+#: cannot be the authority on which pane draws which component, because a wrong record is
+#: that defect's failure mode: the file is rewritten whole on every re-layout, so the
+#: moment a second pane is split for a component the first one's id is gone from it and no
+#: reader that goes through `state.panes` can see that pane again — `_drop_panels`
+#: included. tmux still can. A pane carrying this option answers "which component am I"
+#: out of the SERVER, which is the one place a wrong file does not reach.
+#:
+#: The value is held to `component.usable_id` on the way out (:func:`_panel_slot_argv`)
+#: and again on the way back (:func:`_window_panels`) — the same alphabet
+#: `frame/component.py` already holds every id that reaches a `bind` line to. Measured on
+#: tmux 3.7c and at `tmuxctl.FLOOR`: a user option's VALUE is not re-expanded when a
+#: format reads it — ``set-option -p @charter_panel_slot '#{pane_id}'`` comes back out of
+#: ``list-panes -F '#{@charter_panel_slot}'`` as those literal ten characters — so the
+#: guard is about what charter compares against `want` and what it will kill a pane over,
+#: not about tmux's parser.
+_PANEL_SLOT_OPTION = "@charter_panel_slot"
+
+#: The one `list-panes` format :func:`_window_panels` asks the window with, held beside the
+#: two option names it is built from so the reader and the writers cannot drift apart.
+#:
+#: A single space between the three, and that is safe rather than lucky: `_PANE_ID_RE`'s
+#: `%N` and `component.usable_id`'s alphabet both exclude it, so the only field that could
+#: ever contain one is a slot value charter did not write — which fails `usable_id` on the
+#: way back in and is discarded there. An unset option expands to the empty string on both
+#: tmux 3.7c and `tmuxctl.FLOOR` (measured), so the line for an unmarked pane is `%0` and
+#: two empty fields, and `str.split(" ")` — never bare `.split()`, which collapses them —
+#: is what keeps that three fields rather than one.
+_PANEL_LIST_FORMAT = f"#{{pane_id}} #{{{_PANEL_OPTION}}} #{{{_PANEL_SLOT_OPTION}}}"
+
 
 def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
               toggles: dict | None = None) -> str:
@@ -2369,6 +2411,35 @@ def _panel_mark_argv(*, socket: str, pane_id: str) -> list[str]:
                                _PANEL_OPTION, _PANEL_MARK)
 
 
+def _panel_slot_argv(*, socket: str, pane_id: str, slot: str) -> list[str] | None:
+    """`set-option -p`: say WHICH component this panel draws — or ``None`` for a name
+    charter will not put on a pane.
+
+    The write half of :data:`_PANEL_SLOT_OPTION`, issued from `_split_panels`' funnel one
+    line after :func:`_panel_mark_argv` and for the same funnel reason: a panel that
+    reached the screen without it is a panel `_reconcile_panels` cannot name, and a panel
+    charter cannot name is one it will never kill (see there).
+
+    **Unlike :func:`_panel_mark_argv` this one CAN decline, because its value is not
+    charter's own constant.** A slot name arrives from `[[frame.component]]` — a committed
+    file — by way of a density level's list or `_drawable_slots`, and every guard between
+    here and there is a guard on a different question (`frame_slots.drawable` asks whether
+    anything can DRAW it). `component.usable_id` is the alphabet `frame/component.py`
+    holds an id to before it may reach a `bind` line, asked here rather than re-spelled,
+    so a name charter would not let near tmux's parser does not get onto a pane either.
+
+    Declining is not silent about its consequence: the pane is still split, still marked,
+    still drawn and still recorded — it is only unnameable to a later reconciliation,
+    which is exactly the position every pane split by a charter older than #714 is in, and
+    :func:`_reconcile_panels` treats both the same way. That is the safe direction: a pane
+    charter cannot identify is left running, never guessed at and never killed.
+    """
+    if not component.usable_id(slot):
+        return None
+    return tmuxctl.server_argv(socket, "set-option", "-p", "-t", pane_id,
+                               _PANEL_SLOT_OPTION, slot)
+
+
 def _resurface_argvs(*, socket: str, pane_id: str, chrome, bg=None,
                      pane_borders: bool = False) -> list[list[str]]:
     """:func:`_surface_argvs` for a pane that is ALREADY DRAWN — with the unsets.
@@ -2882,6 +2953,192 @@ def _window_settled(socket: str, harness_pane: str,
     return _window_still(socket, harness_pane, measured)
 
 
+def _window_panels(socket: str, harness_pane: str) -> dict[str, str | None] | None:
+    """What panes *harness_pane*'s WINDOW actually has, and which component each of
+    charter's own draws — **asked of tmux, never of `state.panes`** (#714).
+
+    ``{pane id: mark}`` in tmux's own order, with three distinguishable answers per pane
+    and a fourth for the whole window:
+
+    * ``None`` — this pane does not carry :data:`_PANEL_OPTION`. It is the harness's, the
+      palette overlay's (`frame/overlay.py` splits one and never marks it), or one the
+      operator split themselves. **Not charter's to kill**, and that is the single
+      discriminator constraint 1 of #714 rests on.
+    * ``""`` — a panel charter split, by a charter that did not yet write
+      :data:`_PANEL_SLOT_OPTION` (anything before #714), or one whose slot name
+      :func:`_panel_slot_argv` declined. Charter's pane, and charter cannot say which
+      component it is.
+    * ``"<id>"`` — a panel charter split for that component, said by the pane itself.
+    * ``None`` from the whole function — charter could not ask. `list-panes` exited
+      non-zero (a harness pane that has gone), or answered something that is not this
+      window's pane list. Callers fall back to the record, which is exactly the behaviour
+      that shipped before this function existed.
+
+    **The window, and only the window.** `list-panes -t %N` resolves a pane target to its
+    containing window on tmux 3.7c and at `tmuxctl.FLOOR` alike — measured by adding a
+    second window to the session and re-reading, which returned the same three lines — so
+    a frame with several chats reconciles one chat's window per call and cannot reach
+    another's. That scoping is the same one `_install_resize_hook` relies on, and it is
+    what makes this safe to run inside an operator's own tmux at all.
+
+    **The harness pane is the proof that the answer is real.** tmux lists the window
+    containing the target, so the target is always in its own answer; a reply that does
+    not contain it is not this window's pane list, whatever its exit code said. That is
+    not belt and braces over the return code — it is what tells a truthful empty window
+    (impossible) from a stub, a truncated read, or a `tmuxctl.run` that answered something
+    else, and it is what makes the whole reconciliation degrade to "charter cannot tell"
+    rather than to "charter's window has no panes", which would be a licence to split
+    duplicates and a licence to kill.
+
+    **The mark is compared against the constant, not read as a tmux truth-value, and the
+    asymmetry with `conf_text`'s bind is deliberate.** That bind is generous — `2`, `on`
+    and even `off` all read TRUE (see :data:`_PANEL_MARK`) — because being wrong there
+    costs a click going to the wrong pane. Being wrong here costs a pane. `_PANEL_MARK` is
+    charter's own literal, written by exactly one function, so a pane carrying anything
+    else is a pane charter did not write and the safe answer is that it is not charter's.
+
+    `report=False`: a frame whose harness pane has gone is a frame this cannot be asked
+    about, and both callers are on paths (`cmd_resize`'s hook child, a `run-shell`
+    keypress) whose only remaining screen is the agent's own.
+    """
+    p = tmuxctl.run("asking which panes this frame's window already has",
+                    tmuxctl.server_argv(socket, "list-panes", "-t", harness_pane,
+                                        "-F", _PANEL_LIST_FORMAT),
+                    report=False)
+    if p.returncode != 0:
+        return None
+    found: dict[str, str | None] = {}
+    for line in p.stdout.splitlines():
+        # Exactly three, split on the single space the format joins them with — see
+        # :data:`_PANEL_LIST_FORMAT` for why that is a property of the two alphabets
+        # rather than an assumption about the values.
+        fields = line.split(" ")
+        if len(fields) != 3:
+            continue
+        pane_id, mark, slot = fields
+        # #475's rule on the way IN from tmux's stdout, the same way `_split_panels`
+        # applies it to `split-window`'s: these ids become `kill-pane -t` arguments below.
+        if not _PANE_ID_RE.fullmatch(pane_id):
+            continue
+        if mark != _PANEL_MARK:
+            found[pane_id] = None
+            continue
+        found[pane_id] = slot if component.usable_id(slot) else ""
+    if harness_pane not in found:
+        return None
+    return found
+
+
+def _reconcile_panels(socket: str, *, harness_pane: str, want: list[str],
+                      panels: dict[str, str]) -> dict[str, str]:
+    """Make the panes this window HAS agree with the components *want* names, and answer
+    with the ``{slot: pane id}`` that survived. **The whole of #714.**
+
+    Two directions, one walk, and they were two different bugs with one cause:
+
+    * a component `want` names that already has a pane nobody recorded is **adopted**,
+      instead of getting a second pane split for it. Six panel panes where there should
+      have been two, each holding a ~24 MB `charter panel` process and each drawing
+      correct content, is what the other answer looked like on a real frame;
+    * a component `want` no longer names loses its pane, **whether or not the record
+      still points at it**. That direction is how the first orphans were made: a
+      `charter.toml` edited twice in a session left `state.panes` naming only the newest
+      pane per component, so the previous one was already unreachable to the kill loop
+      that ran here, to `_drop_panels`, and to every other reader of `state.panes`.
+
+    **Why the record cannot be the authority, stated once.** `state.record_panes` writes
+    the map whole on every re-layout. Splitting a second pane for a component therefore
+    *deletes* the first one's id — not corrupts it, deletes it — and after that no reader
+    that goes through `state.panes` can see the pane at all. A reconciliation built on the
+    record would be built on the thing that is wrong. So the window is read
+    (:func:`_window_panels`) and the record is demoted to what it is good for: naming
+    panes split by a charter that predates :data:`_PANEL_SLOT_OPTION`, and choosing WHICH
+    of several panes for one component is the one to keep.
+
+    **What may be killed, as a rule rather than a list.** A pane is killed only if charter
+    itself said so — either the pane carries :data:`_PANEL_SLOT_OPTION` naming a component
+    (tmux's word), or `state.panes` names it for a slot (charter's own record of a
+    `split-window` it ran). Everything else is left running: the harness pane, the palette
+    overlay, a pane the operator split, and — the case worth naming — a pane carrying
+    :data:`_PANEL_OPTION` but no component id, which is every panel of a frame launched by
+    a charter older than this one and not otherwise recorded. Charter can see that such a
+    pane is its own and cannot see which component it is; killing it would be a positional
+    guess on a window whose panes have moved, which is the guess that kills the wrong
+    pane. It is left alone, and one re-layout later every pane charter splits carries an
+    id, so the frame heals forward rather than being repaired by guesswork.
+
+    **The record still chooses, and that is why it is walked first.** Where a component
+    has both a recorded pane and unrecorded ones, the recorded one is the survivor: it is
+    the one the resize hook, the respawn hooks and `layout.repos_cols`' ordering already
+    agree about, so keeping it makes the reconciliation a no-op for a healthy frame —
+    `keep` comes out in exactly the order and with exactly the contents the loop this
+    replaced produced. A recorded id tmux does not list is dropped instead of kept, so a
+    pane that has gone gets its component re-split rather than leaving a hole nothing
+    fills; that is only ever done when the window could actually be read.
+
+    Adopted panes are not re-armed for respawn. A pane split for component `x` was armed
+    for `x` at its creation (`_arm_panel_respawn`) and a re-layout does not change which
+    component it draws, so the hook it carries is already the right one; re-arming would
+    be a second writer of a fact that has not changed.
+    """
+    live = _window_panels(socket, harness_pane)
+    keep: dict[str, str] = {}
+    doomed: list[tuple[str, str]] = []
+    # Which pane ids the record spoke for at all — the set the window walk below defers
+    # to, so one pane cannot be decided twice.
+    recorded: set[str] = set()
+    for slot, pane_id in panels.items():
+        # #475, on the value that is about to become a `kill-pane -t` argument. `panels`
+        # is `state.panes(fid)`, JSON on disk, so a truncated write or a hand edit reaches
+        # here: a `%1;kill-server` in that file armed `kill-server` on every window resize
+        # for the life of a window once already.
+        if not _PANE_ID_RE.fullmatch(pane_id):
+            continue
+        # The harness pane is the one pane `state.record_panes` deliberately never holds
+        # (see its docstring), so a record naming it is a record charter did not write —
+        # and this loop's other branch would `kill-pane` it, taking the agent's own
+        # rectangle down along with the panel the operator was dropping.
+        if pane_id == harness_pane:
+            continue
+        recorded.add(pane_id)
+        if live is not None and pane_id not in live:
+            # The record points at a pane this window does not have. Neither kept (there
+            # is nothing to keep) nor killed (there is nothing to kill) — dropping it is
+            # what puts the component back in `_relayout`'s `missing` list.
+            continue
+        # No `and slot not in keep` here, unlike the window walk below: `panels` is a
+        # dict, so a slot cannot arrive twice and a second check would be one no input
+        # could ever reach.
+        if slot in want:
+            keep[slot] = pane_id
+            continue
+        doomed.append((slot, pane_id))
+    for pane_id, mark in (live or {}).items():
+        if pane_id in recorded:
+            # Already decided by the record, above, which is where a component with both
+            # a recorded pane and unrecorded ones picks its survivor.
+            continue
+        if not mark:
+            # `None` — not charter's pane at all — and `""` — charter's, but from a
+            # charter that could not say which component. One outcome for two facts, and
+            # it is the same outcome for the same reason: charter will not kill a pane it
+            # cannot name.
+            continue
+        if mark in want and mark not in keep:
+            # The adoption. Without it this is the split that made the duplicates.
+            keep[mark] = pane_id
+        else:
+            doomed.append((mark, pane_id))
+    for slot, pane_id in doomed:
+        # Disarm before killing, always: `kill-pane` on an armed panel fires its own
+        # `pane-died` hook, and `cmd_respawn` brings back the panel the operator just
+        # dropped, one respawn life poorer. See :func:`_disarm_panel_respawn`.
+        _disarm_panel_respawn(socket, pane_id=pane_id)
+        tmuxctl.run(f"closing the {slot} panel",
+                    tmuxctl.server_argv(socket, "kill-pane", "-t", pane_id))
+    return keep
+
+
 def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
                  env: dict | None, v: tuple[int, int],
                  pane_env: dict[str, str] | None = None,
@@ -2900,14 +3157,40 @@ def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     the checkout instead of the install, which is how both panels once came up reading
     `Pane is dead (status 2)`. Nothing about that is specific to charter's own server;
     inside an operator's tmux the cwd is the same cwd, so the hole is the same hole.
+
+    **The reconciliation runs here as well as in `_relayout`, and #697's `_dress_window`
+    is the precedent rather than a caution** (:func:`_reconcile_panels`). On both launch
+    paths this window was created by the launch two dozen lines above — `new-session` on
+    charter's own server, `new-window` inside an operator's — so it holds the harness pane
+    and nothing else, and the reconciliation correctly finds nothing to adopt and nothing
+    to kill. That is precisely the shape #686 cost a release: the window options were
+    right at launch and issued from a branch a re-layout could skip, and "this path
+    happens not to need it" is what made it possible to be wrong on the other one. "One
+    pane per placed component in this window" is a property of `_draw_panels`, not of one
+    of its two callers, so both callers assert it. The cost is one `list-panes` per launch
+    — one round trip, ~5ms against a real tmux 3.7c, beside the several dozen calls a
+    launch already makes.
+
+    **And it is handed NO record, which is the whole difference between the two callers.**
+    A re-layout's `state.panes` describes the frame that is running; a launch's describes
+    whatever held this frame id last. Frame ids are reused — a chat is `<session>.<n>` and
+    a workspace relaunched after its server died gets the same one — so the file in the
+    frame's directory can name panes of a server that no longer exists, and believing it
+    here would mean a launch that split no panel at all and recorded a map of dead ids.
+    Only the window's own answer is admissible at launch, and it is authoritative:
+    `_reconcile_panels` drops a recorded id the window does not have, so even a `panels`
+    passed here would be discarded the moment tmux could be asked — passing ``{}`` is that
+    same conclusion made structural instead of depending on `list-panes` succeeding.
     """
     # The window's own options first, and before any `split-window`: `remain-on-exit` has
     # to be armed before a panel can be born into a window that would throw its corpse
     # away (#408), which is the ordering this call site inherits from where these three
     # used to live (`_dress_window`, #686).
     _dress_window(socket, fid=fid, harness_pane=harness_pane, env=env, v=v)
-    panes = _split_panels(socket, slots=slots, fid=fid, harness_pane=harness_pane,
-                          env=env, pane_env=pane_env, sizes=sizes, v=v)
+    panes = _reconcile_panels(socket, harness_pane=harness_pane, want=slots, panels={})
+    panes.update(_split_panels(socket, slots=[s for s in slots if s not in panes],
+                               fid=fid, harness_pane=harness_pane,
+                               env=env, pane_env=pane_env, sizes=sizes, v=v))
     _install_resize_hook(socket, harness_pane=harness_pane, panes=panes, v=v, env=env,
                          fid=fid)
     # Written down, because a frame's shape can now be CHANGED while it runs (the density
@@ -3075,6 +3358,19 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
             # is still clicked, it just costs the operator an `F12` afterwards.
             tmuxctl.run("marking a panel so a click on it stays where it points",
                         _panel_mark_argv(socket=socket, pane_id=pane_id), env=env)
+            # And WHICH panel it is, on the same pane and out of the same funnel (#714,
+            # `_panel_slot_argv`). The mark above says a pane is charter's; this says what
+            # charter meant by it, which is the half `state.panes` cannot be trusted for —
+            # that file is rewritten whole on every re-layout, so a component whose pane
+            # got split twice has one id recorded and the other invisible to every reader
+            # that goes through it. Written where the pane is CREATED rather than by a
+            # later pass, because a later pass is a thing to forget: `_reconcile_panels`
+            # will not kill a pane it cannot name, so a panel that missed this is a panel
+            # that can be orphaned exactly once more. `None` for a name charter will not
+            # put on a pane — see there for why that is not silent about its cost.
+            slot_argv = _panel_slot_argv(socket=socket, pane_id=pane_id, slot=slot)
+            if slot_argv is not None:
+                tmuxctl.run("saying which component a panel draws", slot_argv, env=env)
             # The pane surface, on the pane that was just created and on no other — the
             # one place charter has a panel's `%N` in hand. The harness pane is never an
             # argument (`_surface_argvs`), which is how ADR 0018's boundary holds by
@@ -4155,9 +4451,9 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
               window_cols: int, window_rows: int) -> dict[str, str]:
     """Make the running frame's panes match *want*, and return the map that resulted.
 
-    Dress the window, kill what is no longer wanted, split what is newly wanted, re-arm
-    the hooks, re-assert every size. In that order, and each step is here for a measured
-    reason:
+    Dress the window, reconcile the panes it already has against *want*, split what is
+    still missing, re-arm the hooks, re-assert every size. In that order, and each step is
+    here for a measured reason:
 
     * **Dress the window first, and unconditionally** (#686, :func:`_dress_window`). What
       belongs to the WINDOW — `remain-on-exit`, the frame's chrome, #657's rules round the
@@ -4168,6 +4464,17 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
       leaves the first's panels alive and recorded, so the first `F2` back has nothing to
       split. First rather than last because `remain-on-exit` has to be armed ahead of any
       pane charter creates, and this function creates some further down.
+    * **Ask the WINDOW which panes it has, not the record** (#714,
+      :func:`_reconcile_panels`). *panels* used to be the whole answer: a slot in it and
+      in *want* was kept, a slot in it and not in *want* was killed, and a slot in *want*
+      and not in it was split. All three go wrong together the moment the record is wrong,
+      and the record is rewritten whole on every re-layout — so a `charter.toml` edited
+      twice in one session left `state.panes` naming only the newest pane per component
+      and the older ones unreachable to every reader of it, this loop included. Six panel
+      panes where there should have been two, each holding a ~24 MB process and each
+      drawing correct content, is what that looked like on a real frame. The record is
+      still read, and still chooses which of several panes for one component survives; it
+      is no longer the only thing that can see a pane.
     * **Disarm before killing.** See :func:`_disarm_panel_respawn` — otherwise the panel
       charter just closed comes straight back, one respawn life poorer.
     * **Split off the HARNESS pane, never off a sibling panel.** `_draw_panels` already
@@ -4210,25 +4517,12 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
     # no corpse, because that option decides what happens when a pane's COMMAND exits and
     # not what happens when tmux is told to close it.
     _dress_window(socket, fid=fid, harness_pane=harness_pane, env=None, v=v)
-    keep: dict[str, str] = {}
-    for slot, pane_id in panels.items():
-        # Checked ABOVE the `want` branch, not inside the kill branch — #475. `panels` is
-        # `state.panes(fid)`, read back out of the frame's directory on disk, so it is
-        # not tmux's own word for a pane any more whichever branch it takes. The guard
-        # used to sit below the `continue`, which meant every slot the new density KEPT
-        # went into `keep` unexamined and straight on to a `resize-pane -t` and a hook —
-        # a `%1;kill-server` in that file armed `kill-server` on every window resize for
-        # the life of the window. The property is that nothing off disk is used as a pane
-        # id until it has tmux's own shape, and a guard on one branch of a loop is a
-        # guard on the wrong thing.
-        if not _PANE_ID_RE.fullmatch(pane_id):
-            continue
-        if slot in want:
-            keep[slot] = pane_id
-            continue
-        _disarm_panel_respawn(socket, pane_id=pane_id)
-        tmuxctl.run(f"closing the {slot} panel",
-                    tmuxctl.server_argv(socket, "kill-pane", "-t", pane_id))
+    # The kill loop that used to be written out here lives in `_reconcile_panels` now,
+    # with the window's own answer alongside the record — see this function's second
+    # bullet and that function's docstring for what the record could not see (#714). It
+    # is shared with `_draw_panels` for #697's reason, so a pane per placed component is a
+    # property of both paths rather than of this one.
+    keep = _reconcile_panels(socket, harness_pane=harness_pane, want=want, panels=panels)
 
     missing = [s for s in want if s not in keep]
     # The table pane's width is not the window's, and a re-layout is where the two come

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -312,6 +312,16 @@ order is split order, so the bar named last is split off last.
 Both are the first things a short terminal gives up — before the identity row, because the
 palette reaches everything they show and nothing is lost but the reminder.
 
+**You can edit the arrangement while the frame is running**, which is when you can see what
+you are arranging. The file is re-read at the next re-layout — a density row or a
+component's own key, `F2` back into the chat, or a terminal resize that changes the frame's
+shape — and the running frame is made to match it: a component you added gets a pane, one
+you removed loses its pane, and one that already has a pane keeps the pane it has. Charter
+works that out by asking tmux which panes this window holds and which components they draw,
+not by consulting its own notes, so a frame that has been rearranged several times in one
+session still ends up with exactly one panel per component. Panes you split yourself are
+not part of that reckoning and are never touched.
+
 ## Inside a tmux you already have
 
 **Run from inside an existing tmux session, the frame does not nest.** Charter reads

--- a/docs/news/unreleased-a-panel-exists-once-per-placed-component.md
+++ b/docs/news/unreleased-a-panel-exists-once-per-placed-component.md
@@ -1,0 +1,75 @@
+---
+version: unreleased
+headline: Editing a running frame's arrangement stops duplicating every panel it places
+---
+
+Adding two `[[frame.component]]` tables to a plane whose frame was already running left
+**six panel panes where there should have been two**, and the frame's own state recorded
+only the newest of each:
+
+```
+%366 152x1 panel workspaces --session harness-wrapper.1
+%367 152x1 panel workspaces --session harness-wrapper.1
+%368 152x1 panel workspaces --session harness-wrapper.1
+%369 152x1 panel chats      --session harness-wrapper.1
+%370 152x1 panel chats      --session harness-wrapper.1
+%371 152x1 panel chats      --session harness-wrapper.1
+
+.charter/frame/harness-wrapper.1/panes:
+  {"top":"%362","bottom":"%363","repos":"%364","right":"%365",
+   "workspaces":"%368","chats":"%371"}
+```
+
+The four orphans were still running and still drawing, each holding a ~24 MB `charter
+panel` process, and they had squeezed that operator's harness from 38 rows to 30 with
+panes whose cause was invisible from the screen. Nothing in charter would ever have reaped
+them.
+
+## The cause is a file, not a loop
+
+`state.record_panes` rewrites the pane map **whole** on every re-layout. Splitting a second
+pane for a component therefore *deletes* the first one's id — and after that no reader that
+goes through `state.panes` can see that pane at all: not the kill loop that would have
+dropped it, not the teardown a chat switch runs, not the resize path.
+
+So a re-layout asked the record three questions and got the wrong answer to all three at
+once. It is also why removing a component from `charter.toml` sometimes left its panel
+running: the same reconciliation in the other direction, blind for the same reason.
+
+## The window is asked now, not the record
+
+Every pane charter splits already carried `@charter_panel`, the mark that keeps a click on
+a panel from stealing the keyboard. It says a pane is *a* panel and not *which*, so it
+grows a second option beside it — `@charter_panel_slot`, carrying the component's id — and
+a re-layout now asks tmux which panes this window has and which components they draw:
+
+```
+$ tmux list-panes -t %362 -F '#{pane_id} #{@charter_panel} #{@charter_panel_slot}'
+%362
+%366 1 workspaces
+%368 1 workspaces
+```
+
+A component the arrangement still wants and a pane already exists for is **adopted**
+instead of split again. A component it no longer names loses its pane whether or not the
+record can still see it. The record is still read — it decides which of several panes for
+one component survives, so a healthy frame reconciles to exactly what it already had — but
+it is no longer the only thing that can see a pane.
+
+## What is never killed
+
+A pane charter did not split. The mark is the whole discriminator, and it is compared
+against charter's own literal rather than read as a tmux truth value, because the cost of
+being wrong here is a pane rather than a click: your own splits, the palette's overlay and
+the harness itself carry no mark and are left alone, at any arrangement and at `want=[]`.
+
+**A frame launched by an older charter keeps its panels.** Its panes carry the mark and no
+component id, so charter can see they are its own and cannot see which component each one
+is — and a positional guess on a window whose panes have moved is exactly how you kill the
+wrong pane. Those panes are left running, the frame is no worse off than it was, and its
+record still drops a component's panel the way it always did. Every pane split from this
+version on carries an id, so a frame heals forward rather than being repaired by guesswork.
+
+Cost: one `tmux list-panes` per re-layout and per launch — a single round trip, ~5 ms
+against a real tmux 3.7c — and one `set-option -p` per panel as it is created. Measured on
+tmux 3.7c and at charter's 3.2 floor; identical on both.

--- a/tests/test_a_panel_pane_exists_once_per_placed_component.py
+++ b/tests/test_a_panel_pane_exists_once_per_placed_component.py
@@ -1,0 +1,824 @@
+"""#714: one pane per placed component, decided by asking tmux rather than the record.
+
+Adding two `[[frame.component]]` tables to a plane whose frame was already running left
+**six panel panes where there should have been two**, and the frame's own state recorded
+only the newest of each::
+
+    %366 %367 %368  panel workspaces --session harness-wrapper.1
+    %369 %370 %371  panel chats      --session harness-wrapper.1
+
+    .charter/frame/harness-wrapper.1/panes:
+      {"top":"%362", ..., "workspaces":"%368", "chats":"%371"}
+
+The four orphans were still running, each holding a ~24 MB `charter panel` process and
+each drawing correct content, and they had squeezed the operator's harness from 38 rows to
+30. Nothing in charter would ever have reaped them.
+
+**The cause is one sentence and it is about a file, not about a loop.**
+`state.record_panes` rewrites the pane map WHOLE on every re-layout. Splitting a second
+pane for a component therefore deletes the first one's id, and after that no reader that
+goes through `state.panes` can see that pane at all — not `_relayout`'s kill loop, not
+`_drop_panels`, not `cmd_resize`. A re-layout built on the record is built on the thing
+that is wrong, which is why `_reconcile_panels` reads the WINDOW.
+
+Six properties, one class each:
+
+**A panel says which component it is** (`ThePaneSaysWhichComponentItIs`). `_PANEL_OPTION`
+from #634 marks a pane as *a panel* and does not name *which*, so the mark grows a second
+option beside it (`_PANEL_SLOT_OPTION`) rather than the reconciliation guessing from
+position. A positional match on a window whose panes have moved is the guess that kills
+the wrong pane, and `frame/layout.py`'s module docstring already measures what "indices
+move" costs.
+
+**The window is asked, and a reply charter cannot trust is no reply**
+(`TheWindowIsAskedNotTheRecord`). `list-panes` is the authority; a non-zero exit, or an
+answer that does not contain the harness pane charter targeted, degrades to exactly the
+behaviour that shipped before this — the record alone — rather than to "this window has no
+panes", which would be a licence both to split duplicates and to kill.
+
+**Nothing charter did not split is ever killed** (`OnlyWhatCharterSplitIsEverKilled`).
+The discriminator is the mark, not position and not proximity: the harness pane, the
+palette overlay, and a pane the operator split themselves all survive a reconciliation
+that kills everything else in the window. So does a panel from a charter old enough to
+carry the mark but no component id — charter can see it is its own and cannot see which
+component it is, and the safe answer to that is to leave it running.
+
+**Both directions, on a real tmux** (`TheReproductionOnARealServer`). The issue's own
+acceptance test: a running frame, a `charter.toml` edited to add a component and then to
+remove it, with a re-layout after each, ending with exactly one pane per placed component.
+Run against tmux 3.7c and against 3.2 — `tmuxctl.FLOOR` — by putting a 3.2 built from the
+release tarball first on `$PATH`; identical on both, so nothing here carries a version
+gate.
+
+**And it survives the record being wrong** (`TheRecordIsNoLongerTheOnlyThingThatSees`),
+which is the defect rather than a hardening exercise: the state file is planted in the
+exact shape the operator's frame was measured in, and the frame comes back to one pane per
+component from there.
+
+**Both callers split only what is left** (`BothCallersSplitOnlyWhatTheWindowIsMissing`).
+The duplicate pane is a `split-window`, so a reconciliation that returned the right map
+while its caller went on splitting anyway would have fixed nothing — asserted through
+`_relayout` and through `_draw_panels`, which is where "is `_relayout` the right home" is
+answered: neither on its own, the way #697 made `_dress_window` a step both run.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import commands_frame, config, instance
+from charter.frame import layout, state, tmuxctl
+
+from tests import _tmuxreap
+from tests._isolation import PersonaIso, make_plane
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: One socket for this module, carrying this process's pid so an interrupted run's server
+#: is reaped by the next one rather than collided with (`tests/_tmuxreap.py`).
+SOCKET = _tmuxreap.name("panel-reconcile")
+
+#: This checkout, for the `$PYTHONPATH` a real `charter panel` child needs: its argv comes
+#: from `util.self_relaunch_argv()` and carries `-P`, which strips exactly the cwd entry
+#: `-m` would otherwise have used to find this tree (#390).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: The plane this test PROCESS started in — the developer's real one, captured before any
+#: `setUp` repoints `config`. Read only to refuse to run against it.
+_REAL_STATE_DIR = Path(config.STATE_DIR)
+
+#: The four charter ships, plus the two the operator added to the live frame. Written as
+#: committed `[[frame.component]]` tables rather than as resolved placements, because what
+#: is under test is what editing that FILE does to a running frame.
+_BASE_TABLES = [{"use": "identity"}, {"use": "attention"},
+                {"use": "repos"}, {"use": "sidebar"}]
+_ADDED_TABLES = _BASE_TABLES + [{"use": "workspaces"}, {"use": "chats"}]
+
+
+def _a_dead_pid() -> int:
+    """A real pid that has exited and been reaped — `tests/test_component_toggle_keys.py`'s
+    helper, repeated for the reason that copy states. `state.reap` keeps any frame
+    directory whose trailing number is a live pid, and a hand-written `-1` reads as pid 1,
+    which never exits."""
+    p = subprocess.Popen([sys.executable, "-c", "pass"])
+    p.wait()
+    return p.pid
+
+
+class _Tmux:
+    """A recording stand-in for `tmuxctl.run` that can answer `list-panes`.
+
+    `tests/test_component_toggle_keys.py`'s fake with the one query this defect is about
+    added. *window* is the reply `list-panes` gives, as ``{pane id: (mark, slot)}`` in
+    tmux's own order — which is a pane's two option VALUES, exactly as a real server hands
+    them back, so a test states what the server says rather than what charter concluded.
+    ``None`` makes the call fail, which is the "charter could not ask" case.
+    """
+
+    def __init__(self, *, window=None, size="200:50", new_panes=("%90", "%91", "%92")):
+        self.window = window
+        self.size = size
+        self.new_panes = list(new_panes)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, action, argv, *, env=None, timeout=None, report=True):
+        self.calls.append(list(argv))
+        out = ""
+        if "list-panes" in argv:
+            if self.window is None:
+                return subprocess.CompletedProcess(argv, 1, stdout="",
+                                                   stderr="can't find pane\n")
+            out = "".join(f"{p} {mark} {slot}\n"
+                          for p, (mark, slot) in self.window.items())
+        elif "display-message" in argv:
+            out = self.size
+        elif "split-window" in argv:
+            out = self.new_panes.pop(0) if self.new_panes else ""
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+    def killed(self) -> list[str]:
+        return [c[c.index("kill-pane") + 2] for c in self.calls if "kill-pane" in c]
+
+    def split(self) -> list[str]:
+        return [c[c.index("panel") + 1] for c in self.calls
+                if "split-window" in c and "panel" in c]
+
+
+def _pane(slot: str | None = None, *, charters: bool = True) -> tuple[str, str]:
+    """One `_Tmux` window entry: the two option values a pane of this kind really has.
+
+    `charters=False` is a pane charter never marked — the harness's, the palette
+    overlay's, or one the operator split; *slot* ``None`` is a panel from a charter that
+    marked panes without naming them.
+    """
+    return ((commands_frame._PANEL_MARK if charters else ""), slot or "")
+
+
+class ThePaneSaysWhichComponentItIs(PersonaIso, unittest.TestCase):
+    """#634's mark says a pane is A panel. It does not say WHICH, and that gap is why
+    `_relayout` could not tell an orphan from a stranger.
+
+    The alternative was a positional match — "the third pane from the top is `chats`" —
+    and it is refused rather than deferred: `frame/layout.py`'s module docstring measures
+    that tmux renumbers pane INDICES on every split, so a window whose panes have moved
+    (any window a re-layout has ever touched) would hand a positional matcher the wrong
+    pane, and what it does with the wrong pane is `kill-pane`.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # The split funnel sizes each pane through the resolved ARRANGEMENT
+        # (`layout._size_of`), so a component this plane has not placed cannot be split at
+        # all — `_drawable_slots`' own guarantee one level up. The two extra tables are
+        # therefore needed here as well as in the classes that are about them.
+        self.enterContext(mock.patch.dict(
+            config.FRAME, instance.frame_of({"frame": {"component": _ADDED_TABLES}}),
+            clear=True))
+
+    def test_the_mark_alone_cannot_name_a_component(self):
+        """The control for this whole file: if the mark ever grew a component id of its
+        own, the second option would be dead weight and every test below would be
+        asserting about a mechanism nothing needs."""
+        argv = commands_frame._panel_mark_argv(socket="s", pane_id="%3")
+        self.assertEqual(argv[-2:], [commands_frame._PANEL_OPTION,
+                                     commands_frame._PANEL_MARK])
+        self.assertNotIn("chats", argv)
+
+    def test_a_panel_is_told_which_component_it_draws(self):
+        argv = commands_frame._panel_slot_argv(socket="s", pane_id="%3", slot="chats")
+        self.assertEqual(argv[-4:], ["-t", "%3",
+                                     commands_frame._PANEL_SLOT_OPTION, "chats"])
+        self.assertEqual(argv[:6], ["tmux", "-L", "s", "set-option", "-p", "-t"])
+
+    def test_the_two_options_are_different_names(self):
+        """Two options rather than one value doing both jobs. `conf_text`'s
+        `MouseDown1Pane` bind format-expands `_PANEL_OPTION` and routes a click on
+        whether it reads TRUE; a component id spelled `0` is a perfectly legal id
+        (`component._ID_RE`) and a FALSE format value, so folding the two together would
+        have made that one component's panel the only pane in the frame that steals the
+        keyboard."""
+        self.assertNotEqual(commands_frame._PANEL_OPTION,
+                            commands_frame._PANEL_SLOT_OPTION)
+        self.assertEqual(commands_frame._PANEL_MARK, "1")
+
+    def test_a_name_charter_would_not_put_on_a_bind_line_is_refused(self):
+        """The value reaches a comparison against `want` and a decision to `kill-pane`, so
+        it is held to the alphabet `frame/component.py` holds every id that reaches tmux
+        config text to — asked of `component.usable_id` rather than re-spelled. Each of
+        these is a name `instance.frame_of` would already have refused; this is the guard
+        that stops one arriving by some other route from being written onto a pane and
+        read back as though charter had put it there."""
+        for name in ("chats\nkill-server", "chats kill-server", "#{pane_id}",
+                     "CHATS", "", "chats;kill-server"):
+            with self.subTest(name=name):
+                self.assertIsNone(
+                    commands_frame._panel_slot_argv(socket="s", pane_id="%3", slot=name))
+
+    def test_a_panel_charter_cannot_name_is_still_split_marked_and_drawn(self):
+        """What declining costs and what it does not, at the funnel rather than at the
+        builder. The pane is still created, still carries `_PANEL_OPTION`, and still gets
+        its surface — a component charter cannot name is not a component charter refuses
+        to draw. What it loses is the ability to be reconciled later, which is exactly the
+        position every panel of a pre-#714 frame is in, and `_reconcile_panels` treats
+        both the same way: left running, never guessed at.
+
+        Sized explicitly, because that is what lets a name the arrangement never placed
+        reach this funnel at all — `_panel_died_hook_argv`'s rule, one function over: what
+        decides is the value that arrives, never where it came from."""
+        fake = _Tmux(new_panes=("%20",))
+        with mock.patch.object(commands_frame.tmuxctl, "run", fake):
+            panes = commands_frame._split_panels(
+                "s", slots=["CHATS"], fid="f", harness_pane="%1", env=None,
+                pane_env=None, sizes={"CHATS": 1}, v=(3, 7))
+        self.assertEqual(panes, {"CHATS": "%20"}, fake.calls)
+        self.assertEqual([c for c in fake.calls
+                          if commands_frame._PANEL_SLOT_OPTION in c], [],
+                         "a name charter would not put on a bind line was written onto "
+                         "a pane and will be read back as though charter had meant it")
+        self.assertIn(["tmux", "-L", "s", "set-option", "-p", "-t", "%20",
+                       commands_frame._PANEL_OPTION, commands_frame._PANEL_MARK],
+                      fake.calls, "the pane charter could not name lost its panel mark "
+                                  "too, so a click on it now steals the keyboard")
+
+    def test_every_pane_the_split_funnel_creates_is_told(self):
+        """`_split_panels` is the one place a panel pane comes out of, on both launch
+        paths and every re-layout (#634's own funnel argument, one option over). A pane
+        that reached the screen without this is a pane `_reconcile_panels` cannot name,
+        and therefore one it will never kill — so it can be orphaned exactly once more."""
+        fake = _Tmux(new_panes=("%20", "%21"))
+        with mock.patch.object(commands_frame.tmuxctl, "run", fake):
+            panes = commands_frame._split_panels(
+                "s", slots=["workspaces", "chats"], fid="f", harness_pane="%1",
+                env=None, pane_env=None, v=(3, 7))
+        self.assertEqual(panes, {"workspaces": "%20", "chats": "%21"})
+        said = {c[c.index("-t") + 1]: c[-1] for c in fake.calls
+                if "set-option" in c and c[-2] == commands_frame._PANEL_SLOT_OPTION}
+        self.assertEqual(said, {"%20": "workspaces", "%21": "chats"})
+
+
+class TheWindowIsAskedNotTheRecord(PersonaIso, unittest.TestCase):
+    """`_window_panels`: what tmux says, and what charter does when it cannot be sure.
+
+    Every case below is a REPLY — a `list-panes` exit code and its bytes — because that is
+    the whole of this function's input, and because the reply shapes that matter are the
+    ones a stub, a truncated read or an older tmux can produce.
+    """
+
+    def _asked(self, *, window=None, stdout=None, rc=0, harness="%1"):
+        def fake(_action, argv, **_kw):
+            if stdout is not None:
+                return subprocess.CompletedProcess(argv, rc, stdout=stdout, stderr="")
+            body = "".join(f"{p} {m} {s}\n" for p, (m, s) in (window or {}).items())
+            return subprocess.CompletedProcess(argv, rc, stdout=body, stderr="")
+        with mock.patch.object(commands_frame.tmuxctl, "run", fake):
+            return commands_frame._window_panels("s", harness)
+
+    def test_it_asks_the_window_through_the_harness_pane(self):
+        """Scoped to the harness pane's own window, which is what keeps a frame with
+        several chats from reconciling another chat's window — measured on tmux 3.7c and
+        at `tmuxctl.FLOOR` that `list-panes -t %N` resolves a pane target to its window
+        and lists that window alone."""
+        seen: list[list[str]] = []
+
+        def fake(_action, argv, **_kw):
+            seen.append(list(argv))
+            return subprocess.CompletedProcess(argv, 0, stdout="%1  \n", stderr="")
+
+        with mock.patch.object(commands_frame.tmuxctl, "run", fake):
+            commands_frame._window_panels("s", "%1")
+        self.assertEqual(seen, [["tmux", "-L", "s", "list-panes", "-t", "%1",
+                                 "-F", commands_frame._PANEL_LIST_FORMAT]])
+
+    def test_a_marked_pane_answers_with_its_component(self):
+        got = self._asked(window={"%1": _pane(charters=False),
+                                  "%4": _pane("chats"), "%5": _pane("workspaces")})
+        self.assertEqual(got, {"%1": None, "%4": "chats", "%5": "workspaces"})
+
+    def test_an_unmarked_pane_is_not_charters(self):
+        """`None`, distinctly — the operator's own pane and the palette overlay both land
+        here, and it is the only answer that must never become a kill."""
+        self.assertEqual(self._asked(window={"%1": _pane(charters=False),
+                                             "%9": _pane(charters=False)}),
+                         {"%1": None, "%9": None})
+
+    def test_a_panel_from_an_older_charter_is_charters_but_unnamed(self):
+        """The migration case, and `""` rather than `None` because the two are different
+        facts: this pane IS charter's, and charter cannot say which component it is."""
+        self.assertEqual(self._asked(window={"%1": _pane(charters=False),
+                                             "%4": _pane(None)}),
+                         {"%1": None, "%4": ""})
+
+    def test_a_slot_value_charter_would_not_have_written_is_not_read_back(self):
+        """The read-side half of `_panel_slot_argv`'s guard. A pane option is a pane
+        option: anything with `set-option -p` rights can put a value there, and this one
+        decides which component a pane is believed to be — which decides whether it is
+        kept, adopted or killed. Downgraded to "charter's, unnamed", which is the answer
+        that never kills."""
+        self.assertEqual(self._asked(window={"%1": _pane(charters=False),
+                                             "%4": ("1", "#{pane_id}")}),
+                         {"%1": None, "%4": ""})
+
+    def test_a_mark_that_is_not_charters_own_constant_is_not_charters_pane(self):
+        """Compared against `_PANEL_MARK`, not read as a tmux truth-value — and the
+        asymmetry with `conf_text`'s bind is deliberate. That bind is generous (`2`, `on`
+        and even `off` all read TRUE) because being wrong there costs a click going to
+        the wrong pane. Being wrong here costs a pane."""
+        self.assertEqual(self._asked(window={"%1": _pane(charters=False),
+                                             "%4": ("on", "chats")}),
+                         {"%1": None, "%4": None})
+
+    def test_a_reply_charter_could_not_get_is_no_reply(self):
+        """A non-zero exit ends it, and the reply's BYTES are not read as a consolation —
+        which is why this case carries a perfectly well-formed body. tmux prints what it
+        can before it fails, and a partial pane list read as a whole one is a window
+        charter believes has fewer panes than it does: a licence to split a duplicate for
+        every pane the failure cut off."""
+        self.assertIsNone(self._asked(rc=1, stdout="%1  \n%4 1 chats\n"))
+
+    def test_a_reply_without_the_pane_charter_asked_about_is_no_reply(self):
+        """tmux lists the window CONTAINING the target, so the target is always in its own
+        answer. A reply that does not contain it is not this window's pane list, whatever
+        its exit code said — and this is what makes the whole reconciliation degrade to
+        "charter cannot tell" (the record alone, which is what shipped) rather than to
+        "this window has no panes", which is a licence to split duplicates and to kill."""
+        self.assertIsNone(self._asked(window={"%4": _pane("chats")}))
+
+    def test_a_line_that_is_not_three_fields_is_dropped(self):
+        """`str.split(" ")` and not bare `.split()`: an unmarked pane's line is a pane id
+        and two EMPTY fields, which whitespace-splitting collapses to one."""
+        self.assertEqual(self._asked(stdout="%1  \nnonsense\n%4 1 chats\n"),
+                         {"%1": None, "%4": "chats"})
+
+    def test_a_pane_id_that_is_not_tmuxs_own_shape_is_dropped(self):
+        """#475's rule applied on the way IN from tmux's stdout, the same way
+        `_split_panels` applies it to `split-window`'s: these ids become `kill-pane -t`
+        arguments."""
+        self.assertEqual(self._asked(stdout="%1  \n%2;kill-server 1 chats\n"),
+                         {"%1": None})
+
+
+class OnlyWhatCharterSplitIsEverKilled(PersonaIso, unittest.TestCase):
+    """Constraint 1 of #714, asserted from the other end: everything in the window is
+    unwanted, and the reconciliation still kills only what charter itself said was a
+    panel of a component.
+
+    Each case below is an input that reaches exactly one refusal, so no two of them can
+    stand in for each other.
+    """
+
+    def _reconcile(self, *, window, want, panels=None, harness="%1"):
+        fake = _Tmux(window=window)
+        with mock.patch.object(commands_frame.tmuxctl, "run", fake):
+            keep = commands_frame._reconcile_panels(
+                "s", harness_pane=harness, want=want, panels=panels or {})
+        return keep, fake
+
+    def test_the_harness_pane_is_never_killed(self):
+        keep, fake = self._reconcile(window={"%1": _pane(charters=False)}, want=[])
+        self.assertEqual(keep, {})
+        self.assertEqual(fake.killed(), [])
+
+    def test_a_record_that_names_the_harness_pane_does_not_kill_it(self):
+        """`state.record_panes` deliberately never holds the harness pane, so a record
+        naming it is a record charter did not write — a hand edit, or a truncated write
+        over a file that is JSON on disk. Without the guard the loop's other branch
+        `kill-pane`s it, taking the agent's own rectangle down along with the panel the
+        operator was dropping. Reachable by nothing else here: this pane is unmarked, so
+        the window walk leaves it alone on its own account."""
+        keep, fake = self._reconcile(window={"%1": _pane(charters=False)},
+                                     want=[], panels={"top": "%1"})
+        self.assertEqual(keep, {})
+        self.assertEqual(fake.killed(), [])
+
+    def test_a_pane_the_operator_split_themselves_is_never_killed(self):
+        """Unmarked and unrecorded — which is every pane in an operator's own tmux, and
+        the palette's overlay pane on charter's own server (`frame/overlay.py` splits one
+        and never marks it). The window says nothing about it, so charter says nothing to
+        it."""
+        keep, fake = self._reconcile(
+            window={"%1": _pane(charters=False), "%7": _pane(charters=False)}, want=[])
+        self.assertEqual(fake.killed(), [])
+        self.assertEqual(keep, {})
+
+    def test_a_panel_from_an_older_charter_is_left_running_rather_than_guessed_at(self):
+        """The migration answer, and it is the SAFE direction rather than the complete
+        one. A frame launched before this change has panels carrying `_PANEL_OPTION` and
+        no component id; charter can see they are its own and cannot see which component
+        each is. Killing one would be a positional guess on a window whose panes have
+        moved. It is left running — the frame is no worse off than it was — and one
+        re-layout later every pane charter splits carries an id, so it heals forward."""
+        keep, fake = self._reconcile(
+            window={"%1": _pane(charters=False), "%4": _pane(None)}, want=[])
+        self.assertEqual(fake.killed(), [])
+        self.assertEqual(keep, {})
+
+    def test_an_older_charters_panel_is_still_reachable_through_the_record(self):
+        """…and the record is what makes the migration case merely *incomplete* rather
+        than *broken*: a frame from before #714 whose record is still correct drops a
+        component's pane exactly as it always did. That is the direction removal has
+        always worked in, and it must not regress on the frames that are running today."""
+        keep, fake = self._reconcile(
+            window={"%1": _pane(charters=False), "%4": _pane(None)},
+            want=[], panels={"chats": "%4"})
+        self.assertEqual(fake.killed(), ["%4"])
+        self.assertEqual(keep, {})
+
+    def test_a_record_id_that_is_not_tmuxs_own_shape_reaches_no_argv(self):
+        """#475, on the value that is about to become a `kill-pane -t` argument. A
+        `%1;kill-server` in that file armed `kill-server` on every window resize for the
+        life of a window once already.
+
+        On a window charter could NOT read, which is the only state in which this guard is
+        the one that decides: with a reply in hand the id is discarded a line later for not
+        being in it, and a guard that passes only because a different guard caught it is
+        not a guard. Here the record is all there is — exactly as it was before #714 — and
+        an unchecked value goes straight to `kill-pane`."""
+        keep, fake = self._reconcile(window=None, want=[],
+                                     panels={"top": "%1;kill-server"})
+        self.assertEqual(keep, {})
+        self.assertEqual(fake.killed(), [])
+        self.assertEqual([c for c in fake.calls if any("kill-server" in a for a in c)],
+                         [], "a value off disk reached a tmux argv unchecked")
+
+    def test_a_panel_of_a_component_that_is_gone_is_killed_and_disarmed_first(self):
+        """The control for every refusal above: with the same window and the same call,
+        a pane charter DID name is closed — so none of those tests is passing because the
+        reconciliation kills nothing at all.
+
+        Disarmed before it is killed, and in that order: `kill-pane` on an armed panel
+        fires its own `pane-died` hook, and `cmd_respawn` brings back the panel the
+        operator just dropped, one respawn life poorer."""
+        keep, fake = self._reconcile(
+            window={"%1": _pane(charters=False), "%4": _pane("chats")}, want=[])
+        self.assertEqual(keep, {})
+        self.assertEqual(fake.killed(), ["%4"])
+        order = [c[3] for c in fake.calls if c[3] in ("set-hook", "kill-pane")]
+        self.assertEqual(order, ["set-hook", "kill-pane"])
+
+
+class TheRecordIsNoLongerTheOnlyThingThatSees(PersonaIso, unittest.TestCase):
+    """The defect itself: `state.panes` is wrong, and the frame still comes back to one
+    pane per placed component.
+
+    The record is planted in the shape the operator's live frame was measured in — the
+    newest pane per component and nothing else — because "the reconciliation must survive
+    the record being wrong" is not a hardening exercise here, it is the failure mode.
+    """
+
+    def _reconcile(self, *, window, want, panels):
+        fake = _Tmux(window=window)
+        with mock.patch.object(commands_frame.tmuxctl, "run", fake):
+            keep = commands_frame._reconcile_panels(
+                "s", harness_pane="%1", want=want, panels=panels)
+        return keep, fake
+
+    def test_an_unrecorded_pane_for_a_wanted_component_is_adopted_not_duplicated(self):
+        """The whole of the growth half. Without this the component is `missing`, a
+        second pane is split for it, the record is rewritten around the new id, and the
+        pane that was already there is invisible to every reader from then on."""
+        keep, fake = self._reconcile(
+            window={"%1": _pane(charters=False), "%4": _pane("chats")},
+            want=["chats"], panels={})
+        self.assertEqual(keep, {"chats": "%4"})
+        self.assertEqual(fake.killed(), [])
+
+    def test_the_measured_frame_comes_back_to_one_pane_per_component(self):
+        """`%366`-`%371`, and the record from the issue verbatim. Six panes, two
+        components, one recorded each; four orphans still drawing."""
+        window = {"%1": _pane(charters=False), "%362": _pane("identity")}
+        window.update({p: _pane("workspaces") for p in ("%366", "%367", "%368")})
+        window.update({p: _pane("chats") for p in ("%369", "%370", "%371")})
+        keep, fake = self._reconcile(
+            window=window, want=["identity", "workspaces", "chats"],
+            panels={"identity": "%362", "workspaces": "%368", "chats": "%371"})
+        self.assertEqual(keep, {"identity": "%362",
+                                "workspaces": "%368", "chats": "%371"},
+                         "the recorded pane is the survivor, so the resize hook and the "
+                         "respawn hooks still agree about which pane is which")
+        self.assertEqual(sorted(fake.killed()), ["%366", "%367", "%369", "%370"])
+        self.assertEqual(fake.split(), [], fake.calls)
+
+    def test_a_component_no_longer_placed_loses_a_pane_the_record_lost_too(self):
+        """The removal half, which is the same reconciliation in the other direction and
+        was broken today for the same reason — and is how the first orphan pair was made.
+        Neither pane is in the record; `want` no longer names the component; both go."""
+        keep, fake = self._reconcile(
+            window={"%1": _pane(charters=False),
+                    "%4": _pane("chats"), "%5": _pane("chats")},
+            want=["repos"], panels={"repos": "%9"})
+        self.assertEqual(keep, {}, "a recorded pane the window does not have was kept")
+        self.assertEqual(sorted(fake.killed()), ["%4", "%5"])
+
+    def test_a_recorded_pane_the_window_no_longer_has_is_dropped_not_kept(self):
+        """A record can be wrong in the other direction too — it can name a pane that has
+        gone (the operator closed it, the panel's window was rebuilt). Kept, it is a hole
+        nothing ever fills, because the component looks present to `_relayout`'s `missing`
+        and to every size re-assertion. Dropped, the component is split again."""
+        keep, fake = self._reconcile(
+            window={"%1": _pane(charters=False)}, want=["chats"],
+            panels={"chats": "%4"})
+        self.assertEqual(keep, {})
+        self.assertEqual(fake.killed(), [],
+                         "charter aimed a kill at a pane that is not there")
+
+    def test_nothing_is_dropped_on_a_window_charter_could_not_read(self):
+        """`_window_panels` answering `None` is not "the window is empty". Every recorded
+        pane is still honoured and nothing is adopted, which is exactly the behaviour that
+        shipped before this — a re-layout that cannot ask tmux is no worse than one that
+        never could."""
+        keep, fake = self._reconcile(window=None, want=["chats"],
+                                     panels={"chats": "%4", "repos": "%5"})
+        self.assertEqual(keep, {"chats": "%4"})
+        self.assertEqual(fake.killed(), ["%5"])
+
+
+class BothCallersSplitOnlyWhatTheWindowIsMissing(PersonaIso, unittest.TestCase):
+    """The same property one level up, through the two real functions that split panes —
+    because the duplicate pane is their `split-window`, and a reconciliation that returned
+    the right map while its caller went on splitting anyway would fix nothing.
+
+    `_draw_panels` as well as `_relayout`, which is the answer to "is `_relayout` the right
+    home": neither, on its own. The reconciliation is a shared step both callers run, the
+    way #697 made `_dress_window` one — and the two are handed different things, because a
+    launch's `state.panes` describes whatever held this frame id last while a re-layout's
+    describes the frame that is running.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"rl-{_a_dead_pid()}"
+        self.enterContext(mock.patch.dict(
+            config.FRAME, instance.frame_of({"frame": {"component": _ADDED_TABLES}})))
+
+    def _relayout(self, *, window, want, panels):
+        fake = _Tmux(window=window)
+        with mock.patch.object(commands_frame.tmuxctl, "run", fake):
+            keep = commands_frame._relayout(
+                "s", fid=self.fid, harness_pane="%1", panels=panels, want=want,
+                v=(3, 7), window_cols=200, window_rows=50)
+        return keep, fake
+
+    def test_a_component_whose_pane_is_already_there_is_not_split_again(self):
+        keep, fake = self._relayout(
+            window={"%1": _pane(charters=False), "%4": _pane("chats")},
+            want=["chats"], panels={})
+        self.assertEqual(fake.split(), [], fake.calls)
+        self.assertEqual(keep, {"chats": "%4"})
+
+    def test_a_component_with_no_pane_anywhere_is_still_split(self):
+        """The control: adoption must not become a reason never to split. A frame that
+        genuinely lacks a component's pane still gets one."""
+        keep, fake = self._relayout(window={"%1": _pane(charters=False)},
+                                    want=["chats"], panels={})
+        self.assertEqual(fake.split(), ["chats"], fake.calls)
+        self.assertEqual(keep, {"chats": "%90"})
+
+    def test_a_launch_into_a_window_that_already_holds_a_panel_adopts_it(self):
+        """The same property on the LAUNCH path, which is why the reconciliation lives in
+        `_draw_panels` rather than only in `_relayout` (#697's precedent, one function
+        over). Both launch paths open their own window two dozen lines earlier, so today
+        this finds nothing — and "this path happens not to need it" is precisely the shape
+        #686 cost a release. Driven here at the one input that can tell the difference: a
+        window that already holds a marked panel for a slot the launch is about to draw."""
+        fake = _Tmux(window={"%1": _pane(charters=False), "%4": _pane("chats")})
+        with mock.patch.object(commands_frame.tmuxctl, "run", fake):
+            panes = commands_frame._draw_panels(
+                "s", slots=["chats", "identity"], fid=self.fid, harness_pane="%1",
+                env=None, v=(3, 7))
+        self.assertEqual(fake.split(), ["identity"], fake.calls)
+        self.assertEqual(panes, {"chats": "%4", "identity": "%90"})
+        self.assertEqual(state.panes(self.fid), panes,
+                         "the adopted pane is missing from the record, so the next "
+                         "re-layout cannot see it either")
+
+    def test_a_launch_does_not_believe_a_record_left_by_whatever_held_this_id(self):
+        """Frame ids are reused — a chat is `<session>.<n>`, and a workspace relaunched
+        after its server died gets the same one — so the pane map in the frame's directory
+        can name panes of a server that no longer exists. A launch that believed it would
+        split no panel at all and record a map of dead ids."""
+        state.record_panes(self.fid, panels={"chats": "%77", "identity": "%78"})
+        fake = _Tmux(window={"%1": _pane(charters=False)})
+        with mock.patch.object(commands_frame.tmuxctl, "run", fake):
+            panes = commands_frame._draw_panels(
+                "s", slots=["chats", "identity"], fid=self.fid, harness_pane="%1",
+                env=None, v=(3, 7))
+        self.assertEqual(fake.split(), ["chats", "identity"], fake.calls)
+        self.assertEqual(panes, {"chats": "%90", "identity": "%91"})
+        self.assertEqual(fake.killed(), [],
+                         "a launch aimed a kill at a pane recorded by a frame that is "
+                         "over")
+
+    def test_the_surviving_order_is_the_recorded_one(self):
+        """`_relayout` hands `list(keep) + missing` to `layout.repos_cols`, so the order
+        `keep` comes out in is load-bearing (#500 round 3): it has to be the order the
+        panes are really in, which for a healthy frame is the record's. The record is
+        walked before the window for that reason as well as for choosing survivors."""
+        keep, _ = self._relayout(
+            window={"%1": _pane(charters=False), "%2": _pane("identity"),
+                    "%3": _pane("attention"), "%4": _pane("chats")},
+            want=["chats", "identity", "attention"],
+            panels={"identity": "%2", "attention": "%3"})
+        self.assertEqual(list(keep), ["identity", "attention", "chats"])
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class TheReproductionOnARealServer(PersonaIso, unittest.TestCase):
+    """#714's own acceptance test, against a real tmux: a running frame, a `charter.toml`
+    edited to add two components and then to remove them, with a re-layout after each.
+
+    **Nothing here is a fake.** The panes are split by charter's own `_split_panels`,
+    which means real `charter panel` children pointed at a throwaway plane; the marks are
+    the ones production writes; the re-layout is the real `_relayout`; and what is
+    asserted is `list-panes` on a real server afterwards. A mock cannot make this claim:
+    the whole defect is about what a pane option survives and what a state file forgets,
+    and both of those are facts about tmux and the filesystem rather than about charter's
+    control flow.
+
+    Re-run against tmux 3.2 (`tmuxctl.FLOOR`) as well as 3.7c by putting a 3.2 built from
+    the release tarball first on `$PATH`. Identical on both, so nothing here is gated on a
+    version.
+    """
+
+    WS = "recon"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertNotEqual(
+            Path(config.STATE_DIR), _REAL_STATE_DIR,
+            "this test runs charter's real re-layout, whose state this would write into "
+            "the developer's own control plane")
+        self.addCleanup(self._teardown_socket)
+        self.fid = f"{self.WS}.1"
+        self.plane = make_plane(self)
+        # Both halves, and they are two different things (the same pair
+        # `test_frame_tmux_integration`'s own switch test carries): the `-e` payload is
+        # built from `state.identity` and is what each PANEL's process gets, while
+        # `$CHARTER_ROOT` in THIS process is what the tmux client inherits — a live
+        # re-layout hands `tmuxctl.run` no client environment at all (`_relayout`'s
+        # `env=None`), so the server's own environment is this process's.
+        self.enterContext(mock.patch.dict(os.environ, {
+            "CHARTER_ROOT": str(self.plane), "CHARTER_WORKSPACE": self.WS,
+            "CHARTER_SESSION_ID": self.fid,
+            # The panel argv carries `-P` (#390), which strips exactly the entry `-m`
+            # would have used to find this checkout; `$PYTHONPATH` is the substitute the
+            # suite already uses for a panel spawned out of a working tree.
+            "PYTHONPATH": os.pathsep.join(
+                [str(_REPO_ROOT), os.environ.get("PYTHONPATH", "")]).rstrip(os.pathsep),
+        }, clear=False))
+        state.record_workspace(self.fid, self.WS)
+        state.record_identity(self.fid, {"CHARTER_SESSION_ID": self.fid,
+                                         "CHARTER_ROOT": str(self.plane),
+                                         "CHARTER_WORKSPACE": self.WS})
+        made = self._srv("new-session", "-d", "-s", self.WS, "-x", "200", "-y", "50",
+                         "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+        self.assertEqual(made.returncode, 0, made.stderr)
+        self.harness = made.stdout.strip()
+        state.record_harness_pane(self.fid, self.harness)
+        self.v = tmuxctl.version()
+        self.assertIsNotNone(self.v, "charter could not read this tmux's version")
+
+    def _teardown_socket(self) -> None:
+        """`kill-server` FIRST and unlink second, never two `addCleanup` calls in that
+        order — `addCleanup` runs LIFO, so the second spelling unlinks the socket and then
+        reconnects to nothing, leaving a server behind with `remain-on-exit` armed on its
+        window (`_dress_window` arms it, so every test here has it)."""
+        self._srv("kill-server")
+        (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
+
+    def _srv(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(["tmux", "-L", SOCKET, *args],
+                              capture_output=True, text=True, timeout=15)
+
+    def _window(self) -> dict[str, str]:
+        """`{pane id: component}` for every pane charter marked, read off the real server
+        with charter's own format — so this measures what a later reconciliation would
+        see rather than what this test believes."""
+        out = self._srv("list-panes", "-t", self.harness, "-F",
+                        commands_frame._PANEL_LIST_FORMAT)
+        self.assertEqual(out.returncode, 0, out.stderr)
+        found = {}
+        for line in out.stdout.splitlines():
+            pane_id, mark, slot = line.split(" ")
+            if mark == commands_frame._PANEL_MARK:
+                found[pane_id] = slot
+        return found
+
+    def _drawn(self) -> list[str]:
+        return sorted(self._window().values())
+
+    def _edit_charter_toml(self, tables) -> None:
+        """What editing the plane's `[[frame.component]]` tables does to a process that
+        has already resolved them — `config.FRAME` is the resolved arrangement every
+        re-layout reads, so this is that edit at the boundary charter actually feels it
+        at."""
+        self.enterContext(mock.patch.dict(
+            config.FRAME, instance.frame_of({"frame": {"component": tables}}),
+            clear=True))
+
+    def _relayout(self, want) -> dict[str, str]:
+        panes = commands_frame._relayout(
+            SOCKET, fid=self.fid, harness_pane=self.harness, panels=state.panes(self.fid),
+            want=want, v=self.v, window_cols=200, window_rows=50)
+        state.record_panes(self.fid, panels=panes)
+        return panes
+
+    def _draw(self, slots) -> dict[str, str]:
+        panes = commands_frame._draw_panels(
+            SOCKET, slots=slots, fid=self.fid, harness_pane=self.harness, env=None,
+            v=self.v, pane_env=commands_frame._relayout_pane_env(self.fid, self.v))
+        return panes
+
+    def test_adding_two_components_and_removing_them_leaves_one_pane_each(self):
+        """The reproduction, end to end. Three edits — added, reverted, added again — is
+        what the operator's session actually did, and it is what turned two panels into
+        six."""
+        self._edit_charter_toml(_BASE_TABLES)
+        self._draw(["identity", "attention"])
+        self.assertEqual(self._drawn(), ["attention", "identity"])
+
+        # Edit one: the two tables go in, and the frame is re-laid-out.
+        self._edit_charter_toml(_ADDED_TABLES)
+        self._relayout(["identity", "attention", "workspaces", "chats"])
+        self.assertEqual(self._drawn(),
+                         ["attention", "chats", "identity", "workspaces"])
+
+        # Edit two: reverted. The panes of a component nothing places any more go with it
+        # — the direction that was broken, and the direction that made the first orphans.
+        self._edit_charter_toml(_BASE_TABLES)
+        self._relayout(["identity", "attention"])
+        self.assertEqual(self._drawn(), ["attention", "identity"])
+
+        # Edit three: added again. One pane each, not three.
+        self._edit_charter_toml(_ADDED_TABLES)
+        self._relayout(["identity", "attention", "workspaces", "chats"])
+        self.assertEqual(self._drawn(),
+                         ["attention", "chats", "identity", "workspaces"])
+        self.assertEqual(sorted(state.panes(self.fid)),
+                         ["attention", "chats", "identity", "workspaces"])
+
+    def test_a_frame_whose_record_lost_a_pane_does_not_grow_a_second_one(self):
+        """The measured state, planted on a real server: the panes exist, the record does
+        not name them. Without the reconciliation this is where the second set of panes
+        appears — `_relayout` finds the components missing and splits."""
+        self._edit_charter_toml(_ADDED_TABLES)
+        want = ["identity", "attention", "workspaces", "chats"]
+        before = self._draw(want)
+        self.assertEqual(len(before), 4)
+        # Exactly what `record_panes` leaves behind after a second split for a component:
+        # the newest id per component, and nothing at all about the older panes.
+        state.record_panes(self.fid, panels={"identity": before["identity"]})
+
+        self._relayout(want)
+        self.assertEqual(self._drawn(),
+                         ["attention", "chats", "identity", "workspaces"],
+                         "a component the record had lost was split a second time")
+        self.assertEqual(set(self._window()), set(before.values()),
+                         "the panes that came back are new ones, so the old ones were "
+                         "orphaned rather than adopted")
+
+    def test_a_component_removed_from_the_config_loses_a_pane_the_record_lost(self):
+        """The removal direction with the record in the state the field measured — which
+        is how the first orphan pair was made, and the reason the issue calls this "the
+        same reconciliation in the other direction, broken today for the same reason".
+
+        A clean add-then-remove works either way, because a correct record can see the
+        pane it is about to kill. This is the case that cannot: the tables come out of
+        `charter.toml` while the panes they made are invisible to `state.panes`."""
+        self._edit_charter_toml(_ADDED_TABLES)
+        want = ["identity", "attention", "workspaces", "chats"]
+        before = self._draw(want)
+        state.record_panes(self.fid, panels={"identity": before["identity"]})
+
+        self._edit_charter_toml(_BASE_TABLES)
+        self._relayout(["identity", "attention"])
+        self.assertEqual(self._drawn(), ["attention", "identity"],
+                         "a component nothing places any more kept its pane, which is "
+                         "still running and still drawing")
+
+    def test_a_pane_the_operator_split_survives_a_relayout_that_drops_everything(self):
+        """Constraint 1, on a real server and at the sharpest moment: `want` is empty, so
+        every panel in this window is going, and the pane the operator split for
+        themselves is in the middle of them. It is unmarked — measured on tmux 3.7c and at
+        `tmuxctl.FLOOR`, a pane option is NOT inherited by a pane split off the one
+        carrying it, so even a pane split out of a PANEL comes out unmarked — and it is
+        still there afterwards, with its process alive."""
+        self._edit_charter_toml(_ADDED_TABLES)
+        self._draw(["identity", "attention", "workspaces", "chats"])
+        theirs = self._srv("split-window", "-d", "-t", self.harness, "-l", "3",
+                           "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+        self.assertEqual(theirs.returncode, 0, theirs.stderr)
+        mine = theirs.stdout.strip()
+
+        self._relayout([])
+        alive = self._srv("list-panes", "-t", self.harness,
+                          "-F", "#{pane_id} #{pane_dead}").stdout.split("\n")
+        self.assertIn(f"{mine} 0", alive,
+                      "charter killed a pane it did not split")
+        self.assertIn(f"{self.harness} 0", alive, "charter killed the harness pane")
+        self.assertEqual(self._drawn(), [], f"a panel outlived `want=[]`: {alive}")

--- a/tests/test_a_panel_pane_exists_once_per_placed_component.py
+++ b/tests/test_a_panel_pane_exists_once_per_placed_component.py
@@ -207,6 +207,32 @@ class ThePaneSaysWhichComponentItIs(PersonaIso, unittest.TestCase):
                             commands_frame._PANEL_SLOT_OPTION)
         self.assertEqual(commands_frame._PANEL_MARK, "1")
 
+    def test_the_option_name_is_spelled_out_because_a_rename_costs_a_release(self):
+        """**The one case in this file allowed to compare the constant against text**, and
+        the sweep is what asked for it: every other case here builds its expectation out of
+        `_PANEL_SLOT_OPTION`, so all of them pass with the constant respelled to anything
+        at all.
+
+        The spelling is a promise across VERSIONS, which is what makes it worth an
+        assertion rather than a convention. A pane carries this option for as long as it
+        lives, and the whole of #714 is a charter reading back what an earlier charter
+        wrote onto a pane that is still running. Rename it and every panel of every live
+        frame answers `""` again — charter's pane, unnameable, never killed and never
+        adopted — which is this defect returning for one release per rename, silently,
+        on exactly the frames that were already up.
+
+        It also has to stay inside charter's own `@charter_` namespace: this option is
+        written on the operator's own server as well as charter's (`_split_panels` does
+        not gate on which), and charter compares it and closes panes on it. A name outside
+        that namespace is a name something else on their server may also be using.
+        """
+        self.assertEqual(commands_frame._PANEL_SLOT_OPTION, "@charter_panel_slot")
+        self.assertEqual(
+            commands_frame._panel_slot_argv(socket="s", pane_id="%1",
+                                            slot="chats")[-2],
+            "@charter_panel_slot")
+        self.assertIn("#{@charter_panel_slot}", commands_frame._PANEL_LIST_FORMAT)
+
     def test_a_name_charter_would_not_put_on_a_bind_line_is_refused(self):
         """The value reaches a comparison against `want` and a decision to `kill-pane`, so
         it is held to the alphabet `frame/component.py` holds every id that reaches tmux

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -561,7 +561,14 @@ class AHostileChatRendersAsOneRowAndRunsNothing(PersonaIso, unittest.TestCase):
                 self.assertIn(word, ("#{pane_id}",
                                      "#{window_width}:#{window_height}",
                                      "#{session_id}\t#{window_id}",
-                                     "#{window_id}"),
+                                     "#{window_id}",
+                                     # #714's reconciliation asks the window which panes
+                                     # it holds and which components they draw. Named by
+                                     # the PRODUCTION constant rather than re-spelled, so
+                                     # this allow-list cannot be widened by a rename it
+                                     # never saw — the same reason `test_frame_launcher`'s
+                                     # fake matches the two pane options on theirs.
+                                     commands_frame._PANEL_LIST_FORMAT),
                               f"an unexpected tmux format reached the switch: {word!r}")
 
     def test_every_chat_is_still_reachable_at_200_80_and_40_columns(self):

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1459,7 +1459,7 @@ class _FakeTmux:
     def __init__(self, *, pane_id="%7", exit_code=None, race_death_status=None,
                 still_live=False, pre_existing_sessions=frozenset(),
                 pre_existing_chats=frozenset(), current_chat=None, list_windows_rc=0,
-                panel_pane_ids=None, pane_capture="",
+                panel_pane_ids=None, window_panes=None, pane_capture="",
                 session_rc=0, source_rc=0, env_set_rc=0, write_hook_rc=0,
                 teardown_hook_rc=0, panel_rc=0, select_rc=0, attach_rc=0, dm_rc=0,
                 kill_rc=0, arm_rc=0, hatch_rc=0, mark_rc=0, chrome_rc=0,
@@ -1490,6 +1490,17 @@ class _FakeTmux:
         # `split-window`'s own handler below for why that matters for every other test
         # in this class).
         self.panel_pane_ids = panel_pane_ids or {}
+        #: `{harness pane: {panel pane id: component}}` — which panes each WINDOW already
+        #: holds, which is the question #714's reconciliation asks tmux before it splits
+        #: or kills anything (`_window_panels`). A window this fake knows nothing about
+        #: answers with its harness pane alone, which is what a window a launch has just
+        #: created really contains; a test that plants a chat's panels with
+        #: `state.record_panes` states them here too, or it is describing a server where
+        #: the record names panes the window does not have.
+        #:
+        #: Grown as `split-window` hands ids out, so the panes a launch creates are in the
+        #: answer to a later `list-panes` without any test having to say so twice.
+        self.window_panes = {h: dict(p) for h, p in (window_panes or {}).items()}
         self.session_rc = session_rc
         self.source_rc = source_rc
         self.env_set_rc = env_set_rc
@@ -1569,13 +1580,28 @@ class _FakeTmux:
             return subprocess.CompletedProcess(cmd, self.hatch_rc, stdout="",
                                                stderr="" if self.hatch_rc == 0
                                                else "cannot set")
-        if commands_frame._PANEL_OPTION in cmd:
-            # The panel mark (#634). Matched on the PRODUCTION constant, like the hatch
-            # option above, so a rename is answered here rather than raising "unexpected
-            # tmux command" in every test that draws a panel.
+        if (commands_frame._PANEL_OPTION in cmd
+                or commands_frame._PANEL_SLOT_OPTION in cmd):
+            # The panel mark (#634) and, beside it, which component that panel draws
+            # (#714). Matched on the PRODUCTION constants, like the hatch option above,
+            # so a rename is answered here rather than raising "unexpected tmux command"
+            # in every test that draws a panel. One knob for the pair: both are `-p`
+            # writes on a pane charter has just created, both are reported and neither is
+            # fatal, so a test that wants to fail one wants the same consequence from the
+            # other.
             return subprocess.CompletedProcess(cmd, self.mark_rc, stdout="",
                                                stderr="" if self.mark_rc == 0
                                                else "cannot set")
+        if "list-panes" in cmd:
+            # #714's reconciliation asking the window what it holds. The target is always
+            # in its own answer — tmux lists the window CONTAINING it — and it is a pane
+            # charter never marked, so it comes back with both options empty. Everything
+            # else in the window is a panel charter split, carrying the mark and its
+            # component (`self.window_panes`). A window this fake knows nothing about is
+            # therefore a window holding only its harness, which is what a launch's brand
+            # new one really contains.
+            return subprocess.CompletedProcess(cmd, 0, stderr="", stdout=self._panes(
+                cmd[cmd.index("-t") + 1]))
         if _is_chrome(cmd):
             return subprocess.CompletedProcess(cmd, self.chrome_rc, stdout="",
                                                stderr="" if self.chrome_rc == 0
@@ -1612,6 +1638,13 @@ class _FakeTmux:
             # order, so a test can name exactly which slot(s) it wants a real id for.
             slot = cmd[cmd.index("panel") + 1] if "panel" in cmd else None
             pane_id = self.panel_pane_ids.get(slot, "") if self.panel_rc == 0 else ""
+            if pane_id:
+                # A pane split off the harness joins that harness's WINDOW, which is what
+                # a later `list-panes` has to report (#714). Recorded here rather than
+                # restated by each test, so the fake cannot answer that a window lacks a
+                # pane this same fake just created in it.
+                self.window_panes.setdefault(cmd[cmd.index("-t") + 1],
+                                             {})[pane_id] = slot
             return subprocess.CompletedProcess(cmd, self.panel_rc,
                                                stdout=f"{pane_id}\n" if pane_id else "",
                                                stderr="" if self.panel_rc == 0 else "no space for a new pane")
@@ -1671,6 +1704,16 @@ class _FakeTmux:
                 live.add(self.fid)
             return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(live), stderr="")
         raise AssertionError(f"unexpected tmux command in test: {cmd}")
+
+    def _panes(self, harness: str) -> str:
+        """`list-panes -F` output for *harness*'s window, in `_PANEL_LIST_FORMAT`'s three
+        fields — built from the production constants rather than typed, so a rename of
+        either pane option is answered here instead of silently producing a reply
+        `_window_panels` reads as "not charter's pane"."""
+        rows = [f"{harness}  "]
+        rows += [f"{pane} {commands_frame._PANEL_MARK} {slot}"
+                 for pane, slot in self.window_panes.get(harness, {}).items()]
+        return "\n".join(rows) + "\n"
 
     def _seats(self) -> str:
         """One row per window of this session, in `_WINDOW_SEAT_FORMAT`'s three fields.
@@ -2306,8 +2349,13 @@ class ALaunchTakesThePanelsOfTheChatItLeaves(PersonaIso, unittest.TestCase):
         state.record_server("demo.1", commands_frame.SOCKET)
         state.record_harness_pane("demo.1", "%1")
         state.record_panes("demo.1", panels={"top": "%3", "bottom": "%4"})
+        # And the same two panes on the SERVER, because that is where #714's
+        # reconciliation looks for them: a record naming panes the window does not hold
+        # describes a chat whose panels are already gone, which is a different fixture and
+        # not this one.
         return _FakeTmux(exit_code=0, pre_existing_sessions={"demo"},
-                         pre_existing_chats={"demo.1"}, current_chat="demo.1", **kw)
+                         pre_existing_chats={"demo.1"}, current_chat="demo.1",
+                         window_panes={"%1": {"%3": "top", "%4": "bottom"}}, **kw)
 
     @staticmethod
     def _killed(fake) -> list[str]:
@@ -4796,7 +4844,8 @@ class _FakeOperatorTmux:
                  pane_vanishes=False, window_size=(200, 50),
                  pre_existing_windows=("zsh",), current_chat="", list_windows_rc=0,
                  new_window_rc=0, arm_rc=0, chrome_rc=0, respawn_rc=0, panel_rc=0,
-                 panel_pane_ids=None, resize_hook_rc=0, select_rc=0, kill_rc=0,
+                 panel_pane_ids=None, window_panes=None, resize_hook_rc=0,
+                 select_rc=0, kill_rc=0,
                  pane_capture="", capture_rc=0, chat_option_rc=0, chat_list_rc=0):
         self.window_id = window_id
         self.pane_id = pane_id
@@ -4822,6 +4871,10 @@ class _FakeOperatorTmux:
         self.respawn_rc = respawn_rc
         self.panel_rc = panel_rc
         self.panel_pane_ids = panel_pane_ids or {}
+        #: `{harness pane: {panel pane id: component}}` — what each WINDOW holds, which is
+        #: what #714's reconciliation asks the server before it splits or kills anything.
+        #: `_FakeTmux` carries the identical knob for the identical reason; see there.
+        self.window_panes = {h: dict(v) for h, v in (window_panes or {}).items()}
         self.resize_hook_rc = resize_hook_rc
         self.select_rc = select_rc
         self.kill_rc = kill_rc
@@ -4887,8 +4940,21 @@ class _FakeOperatorTmux:
         if "remain-on-exit" in cmd:
             return subprocess.CompletedProcess(cmd, self.arm_rc, stdout="",
                                                stderr="" if self.arm_rc == 0 else "cannot set")
-        if commands_frame._PANEL_OPTION in cmd:
+        if (commands_frame._PANEL_OPTION in cmd
+                or commands_frame._PANEL_SLOT_OPTION in cmd):
+            # The panel mark and, beside it, which component that panel draws (#714).
             return self._ok(cmd)
+        if "list-panes" in cmd:
+            # #714's reconciliation asking a window what it holds. The target is always in
+            # its own answer (tmux lists the window CONTAINING it) and is a pane charter
+            # never marked; everything else is a panel charter split, carrying the mark
+            # and its component. A window this fake knows nothing about therefore holds
+            # only its harness, which is what a window this launch just opened contains.
+            harness = cmd[cmd.index("-t") + 1]
+            rows = [f"{harness}  "] + [
+                f"{pane} {commands_frame._PANEL_MARK} {slot}"
+                for pane, slot in self.window_panes.get(harness, {}).items()]
+            return self._ok(cmd, stdout="\n".join(rows) + "\n")
         if _is_chrome(cmd):
             return subprocess.CompletedProcess(cmd, self.chrome_rc, stdout="",
                                                stderr="" if self.chrome_rc == 0
@@ -4933,6 +4999,10 @@ class _FakeOperatorTmux:
         if "split-window" in cmd:
             slot = cmd[cmd.index("panel") + 1] if "panel" in cmd else None
             pane = self.panel_pane_ids.get(slot, "") if self.panel_rc == 0 else ""
+            if pane:
+                # A pane split off the harness joins that harness's window, and a later
+                # `list-panes` has to say so (#714).
+                self.window_panes.setdefault(cmd[cmd.index("-t") + 1], {})[pane] = slot
             return subprocess.CompletedProcess(cmd, self.panel_rc,
                                                stdout=f"{pane}\n" if pane else "",
                                                stderr="" if self.panel_rc == 0 else "no space")
@@ -5295,7 +5365,10 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         state.record_server("op.1", OPERATOR_SOCKET)
         state.record_harness_pane("op.1", "%1")
         state.record_panes("op.1", panels={"top": "%3"})
-        fake = _FakeOperatorTmux(exit_code=0, current_chat="op.1")
+        # And on the SERVER, where #714's reconciliation looks for it: a record naming a
+        # pane the window does not hold is a chat whose panel has already gone.
+        fake = _FakeOperatorTmux(exit_code=0, current_chat="op.1",
+                                 window_panes={"%1": {"%3": "top"}})
         self.assertEqual(_launch_inside(fake), 0)
         self.assertIn(["tmux", "-S", OPERATOR_SOCKET, "kill-pane", "-t", "%3"],
                       fake.calls,


### PR DESCRIPTION
Closes #714.

Adding two `[[frame.component]]` tables to a plane whose frame was already running left
**six panel panes where there should have been two**, and the frame's own state recorded
only the newest of each. The four orphans were still running, still drawing, each holding
a ~24 MB `charter panel` process, and they had squeezed the operator's harness from 38
rows to 30. Nothing in charter would ever have reaped them.

## The cause is a file, not a loop

`state.record_panes` rewrites the pane map **whole** on every re-layout. Splitting a
second pane for a component therefore *deletes* the first one's id — and after that no
reader that goes through `state.panes` can see that pane at all: not `_relayout`'s kill
loop, not `_drop_panels`, not `cmd_resize`.

That is also why **removing** a component from `charter.toml` sometimes left its panel
running. Same reconciliation, other direction, blind for the same reason. A clean
add-then-remove always worked; it is the case where the record has already lost the pane
that cannot.

## The window is asked now

`@charter_panel` (#634) says a pane is **a** panel and not **which**, so it grows
`@charter_panel_slot` beside it, carrying the component's id, written from
`_split_panels`' single funnel. `_window_panels` reads both back off one
`list-panes -t <harness>`; `_reconcile_panels` adopts a pane the arrangement still wants
instead of splitting a second one, and drops a pane it no longer wants whether or not the
record can still see it.

The record is still read, and still chooses which of several panes for one component
survives — so a healthy frame reconciles to exactly the map and the order it already had,
which is what keeps `layout.repos_cols`' ordering and the respawn hooks agreeing.

## Answers to the three questions in the issue

**Does a pane carry enough to say which component it is?** No — `_PANEL_OPTION` is a
truth-value the mouse bind format-expands, and it names no component. So the mark grows a
second option rather than the reconciliation going positional. Two options and not one
value doing both jobs: a component id spelled `0` is a legal id (`component._ID_RE`) and a
FALSE format value, so folding them together would have made that one component's panel
the only pane in the frame that steals the keyboard. Positional matching was refused
outright — `frame/layout.py`'s module docstring already measures that tmux renumbers pane
indices on every split, and what a positional matcher does with the wrong pane is
`kill-pane`.

**What happens to a frame launched by an older charter?** Its panels carry the mark and no
component id. Charter can see they are its own and cannot see which component each is, so
they are **left running** — never guessed at, never killed. Such a frame is no worse off
than it was: its record still drops a component's panel exactly as it always did, and
every pane split from this version on carries an id, so the frame heals forward at its
next re-layout rather than being repaired by guesswork. Pinned by two tests, one for the
"left alone" half and one for the "still reachable through the record" half.

**Is `_relayout` the right home?** Neither caller on its own. The reconciliation is a
shared step `_draw_panels` and `_relayout` both run, the way #697 made `_dress_window` one
— "this path happens not to need it" is what made #686 possible. The launch is handed **no
record**, and that difference is load-bearing: frame ids are reused (`<session>.<n>`), so
the file in the frame's directory can name panes of a server that no longer exists.

## What is never killed

A pane charter did not split. The mark is the whole discriminator and it is compared
against charter's own literal rather than read as a tmux truth-value — the asymmetry with
`conf_text`'s generous bind is deliberate, because being wrong there costs a click and
being wrong here costs a pane. The harness pane, the palette overlay and a pane the
operator split themselves all survive a reconciliation with `want=[]` that kills every
panel around them (asserted on a real server). A record naming the harness pane — which
`state.record_panes` deliberately never writes — is refused separately.

A reply charter cannot trust is no reply: a non-zero exit, or an answer that does not
contain the harness pane charter targeted, degrades to the record alone (exactly what
shipped before) rather than to "this window has no panes", which would be a licence both
to split duplicates and to kill.

## Verification

### The arrangement space, measured on both trees

A fix believed from the shapes I happened to think of is a fix believed from the wrong
thing, so the arrangement space was walked on a real tmux — **on `origin/main` as well as
on this branch, with the same script**, because a measurement that never goes red proves
nothing.

The component pool is read out of the registry and filtered by what `instance.frame_of`
actually *places*, which is not what it accepts: `todos`, `changes` and `personas` are the
sidebar's children, and a plane naming one at top level silently gets the shipped
arrangement back — a pool built from "frame_of did not raise" would have been the default
frame five times over. Four survivors were walked (`chats`, `top`, `repos`, `right`: a
plane-placed component, both edges, and the content-sized slot `repos_fits` can drop out
of `missing`), giving all 16 arrangements and all 256 ordered transitions, each in four
states of the pane record — intact, one entry dropped, **newest-only (the field's own
shape)**, and empty. 1024 runs per tree, each a real window with real `charter panel`
children and a pane the operator split for themselves sitting in the middle of it.

Counted off `#{pane_start_command}`, **not** off the option this fix adds — a fixture
built from the mechanism under test is a fixture that agrees with it.

```
origin/main   1024 runs, 656 bad   (0 of them with the record intact)
this branch   1024 runs,   0 bad
```

Both directions show up on main and neither survives here:

```
BAD  ['chats'] -> ['chats'] (record empty):      duplicate panes {'chats': ['%281', '%282']}
BAD  ['chats'] -> ['top']   (record drop-one):   orphaned components ['chats']
BAD  ['chats','top','right'] -> ['chats','top','repos','right'] (record empty):
        duplicate panes {'chats': [...], 'top': [...], 'right': [...]}
```

All 656 come from the three damaged-record modes, and **zero** from the intact one —
which is the defect stated as a measurement: a correct record always worked, and the
record is what stops being correct.

### The rest

- **The reproduction is also a real-tmux test.** `TheReproductionOnARealServer` drives
  `_draw_panels`/`_relayout` against a real server: the add/revert/add cycle, the record
  planted in the shape the operator's frame was measured in (growth *and* removal), and
  the operator's own pane surviving `want=[]`. With the window read stubbed out, the
  growth case returns `['attention','attention','chats','chats','identity','identity',
  'workspaces','workspaces']` and the removal case keeps the panes it should have dropped.
- **tmux 3.7c and the 3.2 floor**, by putting a 3.2 built from the release tarball first on
  `$PATH`. New module: 38/38 on both. `test_frame_tmux_integration`: 95/95 on 3.7c; its 8
  failures on 3.2 are identical on `origin/main` and are that module's own 3.7-only border
  cases.
- **Full suite**: green.
- **Deletion sweep**: CI reports **41 pinned, 0 survived** across every line this branch
  adds. The one survivor of the first run — the option's own spelling, which any name would
  have done for — is fixed in the second commit with the reason it has to be stable across
  versions. Re-checked by hand with `python3 -B` and every `__pycache__` cleared:
  **20/20 pinned**, no survivors. Two `unresolved` entries in the CI report are in
  `charter/instance.py`, which this branch does not touch.

## Cost

One `list-panes` per re-layout and per launch — **4.9 ms** measured against a real tmux
3.7c over 40 calls — and one `set-option -p` per panel as it is created.

## Adjacent, and deliberately not in here

- **#748** (roster drawn twice on ~1 launch in 6) is a startup ordering race between the
  detached gather's `state.bump` and `record_panes`, not a pane-identity question, and this
  cannot close it: `_sidebar_live` asks whether `right` is live from inside a panel
  process, about a sibling pane that on the shipped frame is split *last*, so `top`'s first
  paint can precede that pane existing at all. What this branch does carry is a correction
  to `_sidebar_live`'s docstring, which argued from "tmux itself cannot be asked either" —
  a sentence `@charter_panel_slot` makes false. Note for whoever takes #748: the extra
  `list-panes` shifts every panel's start ~5 ms later relative to the gather's bump, so
  re-measure the rate against this branch rather than against the 8-launch sample.
- **#730** (repo strip keeps the height of the workspace you left) is a missing call rather
  than a broken path: `_relayout` already re-asserts every size on its way out, and
  `frame/switch.py::to_workspace` re-gathers and bumps without going through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
