### PR TITLE
The chats and workspaces bars are tabs you can click, not captions that list names

### DIFF
--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -413,10 +413,9 @@ def _bar_events(fid: str, command: tuple[str, ...]):
         # `builtin_actions._spawn` and not a `Popen` of this module's own — one answer to
         # "how does a frame surface start work that must outlive it", shared with every
         # palette row and with `commands_frame._start_chat_switch`, which starts this
-        # exact argv for the exact same switch. `start_new_session=True` matters here for
-        # a reason the palette's does not have: a panel pane is torn down and split again
-        # by the switch it just started, and a child in this pane's process group would
-        # take the SIGHUP that arrives with the teardown.
+        # exact argv for the exact same switch. Its `start_new_session=True` and its three
+        # `DEVNULL` streams are its own docstring's argument and are not re-argued here:
+        # what a second copy would buy is a second place for them to stop agreeing.
         _spawn(util.self_relaunch_argv(*command, name), fid=fid)
         return False
 

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -16,11 +16,12 @@ below wraps a renderer `frame/slots.py` already had, unchanged; those declaratio
 statement of what the renderers already do, not a new arrangement, and the before/after
 render at 200x50 and 80x24 was byte-identical.
 
-**Phase 5's two bars are the first entries here that are not that**, and they change no
+**Phase 5's two bars are the first entries here that are not that**, and they changed no
 output either — for a different reason. `chats` and `workspaces` are registered and NOT
 placed (see :func:`build`), so nothing draws them until a plane writes a
 `[[frame.component]]` table naming one. :func:`places` is the question that makes that
-route work at all.
+route work at all. A plane that has placed one gets a clickable bar; every other plane's
+frame is byte-identical to what it was, because there is no such pane on it.
 
 **The slot names survive as SHORTHAND, because they are committed** (:data:`SLOT_OF`).
 `[frame] slots = ["top", "bottom", "repos", "right"]` sits in charter.toml on every plane
@@ -61,15 +62,25 @@ not the same as what the slice names suggest.**
   `…(+N more)` line can say how many are hidden; a component built on the `todos` slice
   alone would report zero hidden todos with no way to know it was wrong.
 
-**One of them takes EVENTS, and it is the first thing anywhere that does.** #607 built the
-whole path — the decoder, the dispatcher, `DELIVERED` — and shipped it with no consumer:
-every one of these six declared `events = ()`, so a release went by in which a provider
-could declare `scroll`, pass validation, and be the only thing on the machine receiving
-anything. `repos` declares `scroll` and `click` and :func:`_repos_events` receives them,
-which makes charter's own panel the worked example rather than the exception — the same
-sequencing §4b asks for and the same reason charter's panels went through the component
-seam first. What that handler does and does not do is its own docstring; the short of it is
-that a click SELECTS and never chooses, because a pointer event can arrive unpaired.
+**Three of them take EVENTS, and `repos` was the first thing anywhere that did.** #607
+built the whole path — the decoder, the dispatcher, `DELIVERED` — and shipped it with no
+consumer: every one of these components declared `events = ()`, so a release went by in
+which a provider could declare `scroll`, pass validation, and be the only thing on the
+machine receiving anything. `repos` declares `scroll` and `click` and :func:`_repos_events`
+receives them, which makes charter's own panel the worked example rather than the exception
+— the same sequencing §4b asks for and the same reason charter's panels went through the
+component seam first. What that handler does and does not do is its own docstring; the
+short of it is that a click SELECTS and never chooses, because a pointer event can arrive
+unpaired.
+
+**The two bars are the second and third, and a click on one of them SWITCHES.** They
+shipped with the same empty declaration and the same consequence one surface over: an
+operator placed both, clicked a tab, and nothing happened, because a bar with no
+`on_event` is a caption that happens to list names. :func:`_bar_events` is what receives
+them now. The difference from the table is argued at that function rather than here, and
+it turns on the two things a bar does not have: an intermediate "selected" state to
+confirm, and a keyboard to confirm it with (`key` is a kind `events.DELIVERED` does not
+carry, because the harness owns the keyboard).
 
 **Registration order is split order** (`registry.Registry`), so the four placed components
 are registered in the order charter splits their panes off the harness: identity,
@@ -226,12 +237,17 @@ def _panel(slot: str):
     return render
 
 
-#: Which mouse button selects a row. One, and it is named rather than "whatever came":
+#: Which mouse button charter acts on. One, and it is named rather than "whatever came":
 #: middle-click is paste on every terminal an operator has ever used and right-click opens
 #: their emulator's own menu, so acting on either would be charter taking a gesture that
 #: already means something else. `overlay._SGR_BUTTONS` is where the three get their names,
 #: and the ones §4f named no kind for never arrive here at all.
-_SELECT_BUTTON = "left"
+#:
+#: **One constant for the table and for both bars**, because "which button did the operator
+#: mean" is one question — a second answer to it would be a frame where the same gesture
+#: works on one pane and does nothing on the next, which is the thing an operator reports
+#: as a bug and is right to.
+_ACT_BUTTON = "left"
 
 
 def _repos_events(fid: str):
@@ -283,7 +299,7 @@ def _repos_events(fid: str):
         if ev.kind == overlay.SCROLL:
             return _slots.VIEWPORT.move(
                 _slots.SCROLL_ROWS if ev.name == "down" else -_slots.SCROLL_ROWS)
-        if not ev.pressed or ev.name != _SELECT_BUTTON:
+        if not ev.pressed or ev.name != _ACT_BUTTON:
             return False
         name = _slots.VIEWPORT.repo_at(ev.row)
         if name is None or name == state.selection(fid):
@@ -291,6 +307,118 @@ def _repos_events(fid: str):
         state.record_selection(fid, name)
         state.bump(fid)
         return True
+
+    return on_event
+
+
+#: What a click on the `chats` bar starts, and what a click on `workspaces` starts — the
+#: arguments in front of the name, which goes LAST on both commands (`cli._wire`).
+#:
+#: **The existing front door for each noun, and neither is a shortcut past it.** A chat
+#: switch is `commands_frame.cmd_chat` — `chats.check`'s five refusals, `_pane_place`'s
+#: cross-session reading (#684), `select-window`, and the two re-layouts — and a workspace
+#: switch is `cmd_switch` over `switch.to_workspace`'s three. Every one of those refusals
+#: reaches the operator through `_say_on_screen`, which is a `display-message` on the
+#: frame's own client; a panel process has no such surface, and a click that silently did
+#: nothing is exactly the report this feature answers.
+#:
+#: Spelled as the argv rather than called in-process for a second reason: what these start
+#: is slow and is not this loop's to wait on. A chat switch is 41 tmux invocations and
+#: ~360 ms measured; a workspace switch re-gathers the plane. `panel._watch` is a paint
+#: loop, and a handler that blocked it would freeze the pane it was clicked on.
+_CHAT_SWITCH = ("frame-chat",)
+_WORKSPACE_SWITCH = ("frame-switch", "--workspace")
+
+
+def _bar_events(fid: str, command: tuple[str, ...]):
+    """A tab bar's handler: a left click on a tab switches this frame to it.
+
+    **A click here SWITCHES, where a click on the repo table only ever SELECTS, and that
+    difference is a decision rather than a drift.** §4i's rule is that the irreversible
+    half of an interaction is never driven by a pointer event, because one can arrive
+    unpaired — a drag begun on a pane border delivers exactly one release. Three things
+    put a tab bar on the other side of that rule:
+
+    * **The unpaired event is the RELEASE, and this acts on the PRESS.** That is
+      :func:`_repos_events`' own reading of §4i, kept here word for word: a press is
+      delivered because the pointer was over this pane when the button went down, which
+      is the operator pointing at this tab. A drag that began elsewhere and happens to
+      release over the bar delivers only a release and switches nothing, which is right —
+      they never pointed here.
+    * **A switch is reversible by the same gesture that made it.** The tab you left is
+      still on the bar, one click away; nothing is created, nothing is destroyed, and no
+      work is started. `switch.to_workspace` moves a lock and says so, and clicking back
+      moves it back. That is the property §4i is actually about, and it holds.
+    * **There is no chooser for a select-then-confirm bar to be confirmed with.** On the
+      table, selecting is a real intermediate state (a highlighted row, a detail on the
+      attention strip) and `Enter` in the palette is the chooser. A bar has no such
+      state — the tab you are on IS the selection, drawn with `slots._BAR_MARK` — and
+      `key` is in `component.EVENT_KINDS` but deliberately NOT in `events.DELIVERED`,
+      because the harness owns the keyboard and tmux routes typing to the active pane. So
+      a bar that "selected" would draw a second mark nothing on the machine could act on:
+      a feature that cannot be finished, which is the dead code `places` refuses to ship
+      under a feature's name.
+
+    **A click on the tab you are already on does nothing**, and that rule lives in
+    `slots._Tabs.switch_to` rather than here — see it for why, and for the two other
+    things that answer nothing: the `+14` overflow, which stands for names that are not
+    on the row, and every cell this bar drew no tab into.
+
+    **It answers falsy even when it started a switch**, which is the one place this reads
+    differently from the table's handler. Truthy means *repaint me* (§4f), and nothing
+    this process can see has changed: the switch happens in another process and ends in a
+    `state.bump` of its own — `switch.to_workspace`'s last line, `_apply_arrangement`'s —
+    which is the version this panel's poll is already watching. Answering truthy would
+    buy one immediate repaint of a byte-identical row, which is the cost
+    `slots._Viewport.move` refuses in as many words.
+
+    **No `ev.kind` test**, unlike the table's handler: `chats` and `workspaces` declare
+    `click` and nothing else, and `events.Dispatcher._deliver` drops a kind the component
+    did not declare before it ever reaches here. A branch on a kind that cannot arrive is
+    a line no input could turn red.
+
+    **`scroll` is not declared, and that is not an omission.** A bar is one row with
+    nothing to scroll; a handler for it could only ever answer False, and the wheel is not
+    a gesture to hang a switch on. `events.Dispatcher.open` charges the same
+    `overlay.MOUSE_ON` for one pointer kind as for two, so declaring it would cost nothing
+    and mean nothing — which is precisely what makes it wrong to declare.
+
+    *command* is which of the two switches this bar starts (:data:`_CHAT_SWITCH`,
+    :data:`_WORKSPACE_SWITCH`). One handler and two lines of data rather than two
+    handlers, because everything above is true of both bars and a second copy would be
+    two places for it to stop being true.
+
+    *fid* is closed over for :func:`_repos_events`' reason and is handed to
+    `builtin_actions._spawn` as the child's own `$CHARTER_SESSION_ID`: this process was
+    TOLD which frame it draws (`charter panel chats --session <fid>`), and one tmux server
+    is shared by every frame on the machine, so a child left to read that variable out of
+    an inherited environment could act on another operator's frame.
+
+    **No `--chat` on the chat switch, unlike the palette's row.** `_pressers_chat` prefers
+    that option because a palette's `bind` text is shared by every frame on the socket and
+    `#{@charter_chat}` is the only thing that can tell two chats of one session apart. A
+    panel has no such ambiguity and `_spawn` states the id outright, so the option would be
+    a second spelling of a value the environment already carries — provably equal, which
+    the deletion sweep reports and this repository deletes.
+    """
+    def on_event(ev):
+        from .. import util
+        from . import slots as _slots
+        from .builtin_actions import _spawn
+        if not ev.pressed or ev.name != _ACT_BUTTON:
+            return False
+        name = _slots.TABS.switch_to(ev.col)
+        if name is None:
+            return False
+        # `builtin_actions._spawn` and not a `Popen` of this module's own — one answer to
+        # "how does a frame surface start work that must outlive it", shared with every
+        # palette row and with `commands_frame._start_chat_switch`, which starts this
+        # exact argv for the exact same switch. `start_new_session=True` matters here for
+        # a reason the palette's does not have: a panel pane is torn down and split again
+        # by the switch it just started, and a child in this pane's process group would
+        # take the SIGHUP that arrives with the teardown.
+        _spawn(util.self_relaunch_argv(*command, name), fid=fid)
+        return False
 
     return on_event
 
@@ -463,10 +591,26 @@ def build(fid: str = "") -> Registry:
     # `slots.chats_bar` reads `.charter/frame/` and `slots.workspaces_bar` reads
     # `workspaces/`, and a declaration naming a slice `ctx` carries would make the frame's
     # cost budget describe a cost that is not there — `identity`'s own reasoning, above.
+    #
+    # **Both declare `click`, and that is what makes them tab bars rather than captions.**
+    # They shipped registered `needs=()` with no `events`/`on_event` at all, so a click
+    # reached the pane, was decoded, and landed on no consumer — the report this closes was
+    # "I clicked a tab and nothing happened", which is what a readout with no handler looks
+    # like from the outside. `_bar_events` is what receives them and why a click here
+    # SWITCHES where a click on the table only selects.
+    #
+    # `click` alone rather than `("scroll", "click")` like `repos`: a bar is one row and
+    # there is nothing to scroll it to, so a `scroll` declaration could only reach a
+    # handler that always answered False. `repos` declares both because it moves a
+    # viewport; the shared reason that constant's comment gives — one `MOUSE_ON` serves
+    # both — is why declaring the second one costs nothing, never a reason to declare one
+    # that does nothing.
     reg.register(Component(
         id="chats", title="chats", edge="top", size=Fixed(1),
-        needs=(), render=_chats))
+        needs=(), render=_chats,
+        events=("click",), on_event=_bar_events(fid, _CHAT_SWITCH)))
     reg.register(Component(
         id="workspaces", title="workspaces", edge="top", size=Fixed(1),
-        needs=(), render=_workspaces))
+        needs=(), render=_workspaces,
+        events=("click",), on_event=_bar_events(fid, _WORKSPACE_SWITCH)))
     return reg

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2548,7 +2548,8 @@ class _Tabs:
         already answers ``None`` for it. A guard in front of that is a line no input can
         make observable, which is exactly what the deletion sweep reports as a survivor.
         """
-        return None if self._cols.get(col) == self._here else self._cols.get(col)
+        name = self._cols.get(col)
+        return None if name == self._here else name
 
 
 #: The one tab strip this process's bar draws into. See :class:`_Tabs` for why there is

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2449,6 +2449,148 @@ _BAR_MARK = ("*", " ")
 _BAR_GAP = 2
 
 
+class _Tabs:
+    """Which name each COLUMN of a bar's row is about, and which of them you are on.
+
+    :class:`_Viewport` one axis over, and it exists for the reason that class states for
+    the repo table: a pointer event arrives as a NUMBER (`frame/events.py`), and the only
+    thing that knows what is at that number is the pass that composed the row. For a
+    table the number is a row; a bar is horizontal, so here it is a column.
+
+    **A bar needs it MORE than the table does, because the ladder is not invertible.**
+    :func:`_bar` has four rungs and three of them draw a different set of names — every
+    name, or the one you are on plus a count of the rest, or `2/3`, or nothing at all —
+    so "which name is at column 40" is not a question anything downstream can work back
+    to from the names and the width. It would have to re-walk the ladder, which is a
+    second answer to what is on the row, and the two disagree the moment a repaint lands
+    between the paint and the click.
+
+    **One object at module scope rather than one per bar.** `panel.run` resolves a
+    component name once and draws that one component for the life of the process, so a
+    process drawing the chat bar never draws the workspace bar and "which bar is this"
+    has exactly one answer here — :class:`_Viewport`'s own argument, and a key for it
+    would be the same second, weaker one. Tests reach the same object and :meth:`forget`
+    is what puts it back.
+
+    **The map and the mark are written by ONE call**, which is what `_Viewport.blank`
+    exists to enforce for the pair that class holds. A bar that published its columns and
+    left a stale *here* behind would answer "you are already there" for a tab the
+    operator can see is not marked, and the reverse would switch to a tab that has since
+    stopped being drawn. There is no way to write down one half here, so there is nothing
+    for a second method to keep in step.
+
+    **Columns are a mapping and not a tuple, and that is where the bounds check went.**
+    `_Viewport.repo_at` spells `0 <= row < len(...)` and argues it, because a tuple
+    indexed with a negative number answers the LAST row — a wrong answer that hides a
+    wrong reading. A mapping has no such answer to give: a column nothing drew into is
+    absent whether it is `-1`, `4096` or the two cells of a :data:`_BAR_GAP`, so the
+    property is structural rather than guarded. That is `builtins.places`' finding in a
+    different shape — a guard no input can make observable is a line the deletion sweep
+    reports and this repository deletes.
+    """
+
+    __slots__ = ("_cols", "_here")
+
+    def __init__(self) -> None:
+        self._cols: dict[int, str] = {}
+        self._here = ""
+
+    def forget(self) -> None:
+        """Back to a bar nobody has drawn — for a test, and only a test.
+
+        `_Viewport.forget`'s reason exactly: production never calls it, because a panel
+        process is born here and the object dies with the process, and the alternative
+        for a test is reaching into ``__slots__`` by name.
+        """
+        self.publish({}, "")
+
+    def publish(self, columns: dict, here: str) -> None:
+        """Record what the paint that just happened put on each column, and where you are.
+
+        *columns* maps a column of the component's OWN canvas — the rectangle `ctx.width`
+        describes, which is what `events.Dispatcher._on_canvas` delivers a click in — to
+        the name of the tab drawn there. Absent means the operator clicked a cell this
+        bar drew no tab into: the heading, the gap between two tabs, the `+14`, the
+        `n/N`, the empty space past the last name. `events.Dispatcher._on_canvas` applies
+        the identical rule one axis over for the pad, and `_Viewport.publish` applies it
+        for the table's heading row.
+
+        *here* is the name this frame is ON, taken from the same paint that drew the
+        mark. Not re-resolved when a click arrives: `switch.current_workspace` reads the
+        plane, and a handler is handed no ctx by contract (§4f) precisely so it does not
+        grow a second reading of a plane the repaint is about to read anyway. It is also
+        the only reading that can agree with the `*` the operator was looking at.
+
+        **RAW names, never the drawn ones.** :func:`_bar` runs `contain.one_line` over
+        every name before it measures one (#472), and that is a REPAIR — what comes out
+        is display text and what goes into `switch.to_workspace` or `charter frame-chat`
+        has to be the name on disk. The mark is matched on the raw name for the same
+        reason one function down; this is that decision arriving at the other end.
+        """
+        self._cols = dict(columns)
+        self._here = here
+
+    def switch_to(self, col: int):
+        """The tab a click at canvas column *col* should switch this frame to, or ``None``.
+
+        **The rule lives here rather than in the handler**, which is `_Viewport.move`'s
+        choice for its own answer: "a click on the tab you are already on does nothing"
+        becomes a property of one object with one test instead of an agreement between a
+        renderer and a handler that could stop holding. Re-selecting what is already
+        selected is not news — the same sentence `frame/builtins._repos_events` keeps for
+        the table — and here it is worth more, because re-switching is not free: a chat
+        switch is 41 tmux invocations and ~360 ms of panes being torn down and split
+        again, all of it to arrive where you already were.
+
+        **One comparison, and there is deliberately no `name is None` beside it.** A
+        column nothing drew into is absent from the mapping, so ``get`` answers ``None``,
+        and ``None`` is never a name any caller publishes — so the expression below
+        already answers ``None`` for it. A guard in front of that is a line no input can
+        make observable, which is exactly what the deletion sweep reports as a survivor.
+        """
+        return None if self._cols.get(col) == self._here else self._cols.get(col)
+
+
+#: The one tab strip this process's bar draws into. See :class:`_Tabs` for why there is
+#: exactly one; `frame/builtins._bar_events` is the other half, and it holds no state of
+#: its own so that the handler and the renderer cannot come to disagree about which tab is
+#: where.
+TABS = _Tabs()
+
+
+def _tab_columns(start: int, drawn) -> dict:
+    """Which canvas column each drawn tab owns — the map :meth:`_Tabs.publish` takes.
+
+    *drawn* is the ``(name, field)`` pairs the rung actually put on the row, in the order
+    it put them: the raw name a click switches to, and the text that was drawn for it.
+    *start* is the column the first field begins in. So this walks the composition once
+    more rather than guessing at it, and the two things that could have been guessed wrong
+    are settled here in one place: **the mark belongs to the tab it marks** (it is drawn
+    against that name and there is nothing else it could be a click on), and **the
+    :data:`_BAR_GAP` between two tabs belongs to neither** — those cells are separator,
+    the operator can see they are empty, and picking the nearer name for them would be the
+    clamp `events.Dispatcher._on_canvas` refuses one rectangle out.
+
+    ``tui.width`` and never ``len``, for the reason every other measurement in this module
+    gives: a field is display text that has already been through `contain.one_line`, and
+    the column a name ENDS in is a question about cells.
+
+    The walk starts one gap behind *start* and pays the gap at the top of every iteration,
+    so there is no "first field is different" branch to get wrong or to test — the same
+    trade `builtin_actions._SELECT_STEPS` makes when it writes its two starting points
+    down as data rather than deriving them from a sign.
+    """
+    cols: dict[int, str] = {}
+    at = start - _BAR_GAP
+    for name, field in drawn:
+        at += _BAR_GAP
+        width = tui.width(field)
+        for col in range(at, at + width):
+            cols[col] = name
+        at += width
+    return cols
+
+
 def _bar(head: str, names: list[str], here: str, width: int, *,
          note: str = "") -> list[str]:
     """One bar row: *head*, then *names* with *here* marked, inside *width* columns.
@@ -2493,9 +2635,42 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     *note* is an extra field drawn after the names when there is room for it whole — the
     "add chat" affordance, and nothing else today. Dropped first, before any name, because
     it is a reminder and the names are the readout.
+
+    **Every rung publishes its own column map** (:data:`TABS`), which is what makes the
+    bar clickable at all and is the same discipline `_repos` keeps for the table's rows:
+    the handler resolves a click against WHAT WAS DRAWN rather than against what it
+    thinks would have been. Only the names actually on the row get columns — the heading,
+    the gaps, the `+N`, the `n/N` and the affordance are cells this bar drew no tab into
+    and a click on one of them switches nothing. **The rungs that draw NOTHING publish
+    too**, and that is the half `_Viewport.blank` exists for one axis over: a bar that
+    kept its last map through a resize down to `2/3`, or down to no row at all, would
+    switch to a tab the operator can see is not on screen.
     """
+    # **`head` and `note` are NOT contained, and the deletion sweep is what settled it.**
+    # Both are charter's own literals — `"chats"`, `"workspaces"`, :data:`ADD_CHAT` — and
+    # no caller can hand this an open-alphabet one, so a `contain.one_line` on either is a
+    # call whose result is provably its argument. The sweep found both as survivors for
+    # exactly that reason: no input could make the mutation differ. The NAMES are
+    # contained, below, which is where the open alphabet actually is.
+    lead = _inset() + head + " " * _BAR_GAP
+
+    def row(body: str = "", drawn=()) -> list[str]:
+        """This rung's row, and the column map for the tabs it actually drew.
+
+        **Every way out of the ladder goes through here**, which is what keeps "the map
+        describes the row" a property of one line rather than an agreement between six
+        returns. `_repos` learnt that the expensive way: three of its four exits cleared
+        the click map and none of them cleared the scroll bound, and `_Viewport.blank` is
+        the method that finding produced.
+
+        An empty *body* is the rung that draws nothing — rung 4, and a bar with no names.
+        It still publishes, for the reason the docstring above gives.
+        """
+        TABS.publish(_tab_columns(tui.width(lead), drawn), here)
+        return [lead + body] if body else []
+
     if not names:
-        return []
+        return row()
     # **Which row is yours is decided on the RAW names; only the drawing uses the
     # contained ones.** `choose.Roster` makes the same split one surface over and for the
     # same reason: `contain.one_line` is a repair, so two names that differ only in what
@@ -2503,24 +2678,18 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     # follow the repair rather than the identity. Neither caller can reach that today
     # (`chats.ID_RE` and `workspace.valid_name` both refuse the characters `one_line`
     # touches), which is exactly why it is written as an index now rather than found as a
-    # bug by whichever caller stops.
+    # bug by whichever caller stops. The same split reaches :data:`TABS`, which is handed
+    # the raw name beside the drawn field: a click has to switch to what is on disk.
     at = names.index(here) if here in names else -1
     shown = [contain.one_line(n) for n in names]
     marked = [f"{_BAR_MARK[0] if i == at else _BAR_MARK[1]}{n}"
               for i, n in enumerate(shown)]
-    # **`head` and `note` are NOT contained, and the deletion sweep is what settled it.**
-    # Both are charter's own literals — `"chats"`, `"workspaces"`, :data:`ADD_CHAT` — and
-    # no caller can hand this an open-alphabet one, so a `contain.one_line` on either is a
-    # call whose result is provably its argument. The sweep found both as survivors for
-    # exactly that reason: no input could make the mutation differ. The NAMES are
-    # contained, one line up, which is where the open alphabet actually is.
-    lead = _inset() + head + " " * _BAR_GAP
     room = width - tui.width(lead)
     joined = (" " * _BAR_GAP).join(marked)
     if note and tui.width(joined) + _BAR_GAP + tui.width(note) <= room:
-        return [lead + joined + " " * _BAR_GAP + note]
+        return row(joined + " " * _BAR_GAP + note, zip(names, marked))
     if tui.width(joined) <= room:
-        return [lead + joined]
+        return row(joined, zip(names, marked))
     if at >= 0:
         # **No `if len(names) > 1` on the count, and it is unreachable rather than merely
         # untested.** With ONE name `joined` IS `marked[at]` and the count is empty, so
@@ -2529,11 +2698,17 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
         # a survivor for that reason.
         rest = f"{' ' * _BAR_GAP}+{len(names) - 1}"
         if tui.width(marked[at]) + tui.width(rest) <= room:
-            return [lead + marked[at] + rest]
+            # The count is NOT a tab. `+2` stands for names that are not on the row, so
+            # there is nothing there to switch to and saying so is better than picking one
+            # of them — `_Viewport.publish`'s rule for `…(+N more)`, one axis over. The
+            # one name this rung draws is the one you are already on, so this rung is
+            # inert by construction, which is honest rather than a gap: the palette is
+            # what reaches the other names at a width that cannot draw them.
+            return row(marked[at] + rest, [(names[at], marked[at])])
     counted = f"{at + 1}/{len(names)}" if at >= 0 else str(len(names))
     if tui.width(counted) <= room:
-        return [lead + counted]
-    return []
+        return row(counted)
+    return row()
 
 
 #: What the chat bar says instead of a second name when this workspace has one chat.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -121,7 +121,7 @@ component declares `click` or `scroll` asks *its own* terminal to report, so if 
 that panel's pane (with your tmux prefix, say), your terminal starts reporting and native
 selection goes for as long as it is the active pane. Selecting the harness back — or `F12`
 — ends it. Panels that declare neither ask for nothing and change nothing, which is three
-of the four panels charter ships.
+of the four panels charter ships — and the two bars, if you place one, are not among them.
 
 **The repo table is the fourth: it scrolls and it selects.** Roll the wheel over it and the
 window moves down the list; click a row and that repo is selected, its row drawn in reverse
@@ -147,6 +147,22 @@ Three things follow that are worth saying plainly rather than leaving you to fin
   only route on a plane with `mouse = false`, which is the default, and charter will not
   bind a bare arrow key to change it: a `bind -n Up` is server-wide and would take the arrow
   before your harness sees it.
+
+**The tab bars are the exception to "a click only selects", and they say why.** Click a name
+on the `chats` or `workspaces` bar and the frame *switches* to it — there is no in-between
+state to confirm, because the tab you are on *is* the selection and the `*` beside it is how
+you can see that. The three things that make a click safe to switch on here are the same
+three that keep it a mere selection on the table: charter acts on the **press**, which is the
+half that is never delivered unpaired; a switch is undone by the identical click on the tab
+you came from; and nothing else could ever finish the gesture, because a keypress does not
+reach a panel at all — tmux gives your typing to the active pane, which is the harness.
+
+Clicking the tab you are already on does nothing at all, rather than tearing the panels down
+and putting them back to arrive where you were. So does clicking the heading, the gap between
+two names, the `+14` where names did not fit, or the empty space past the last tab: those are
+cells no tab was drawn into, and charter will not pick the nearest name for you. On a bar
+narrow enough that only your own name is drawn, nothing on it is clickable — `F2` is what
+reaches the rest at any width, which is what the bar being a readout means.
 
 **Focus events are on inside a frame charter launched, and off inside your own tmux.** tmux
 ships `focus-events` off, and it is a server-wide setting; charter turns it on for its own
@@ -283,6 +299,13 @@ already in.
 workspace with yours marked, and the workspace bar does the same for the plane. Where the
 names do not all fit the bar keeps yours whole and counts the rest (`*api.2  +2`); narrower
 still it says only where you are (`2/3`). It never shows half a name.
+
+**They are tabs: with `mouse = true`, clicking a name switches to it.** A chat tab does
+exactly what `F2` → `chat` does — the same command, the same five refusals, the same
+sentence on your screen when one fires — and a workspace tab does what `charter frame-switch
+--workspace <name>` does. *Mouse is off by default* above has the rules a click follows and
+why a tab switches where a repo row only selects; the short of it is that clicking the tab
+you are on, the `+N`, or anything that is not a drawn name does nothing at all.
 
 **Neither is drawn unless a plane places it**, and that is deliberate rather than
 unfinished: on the ordinary plane there is one chat, and a row saying so permanently costs

--- a/docs/news/unreleased-the-tab-bars-are-tabs.md
+++ b/docs/news/unreleased-the-tab-bars-are-tabs.md
@@ -1,0 +1,71 @@
+---
+version: unreleased
+headline: The chat and workspace bars are tabs you can click, not captions that list names
+---
+
+*"I put both bars on my plane, clicked a tab, and nothing happened."*
+
+Nothing was going to. `chats` and `workspaces` shipped as components a plane could place, and
+both were registered with no `events` and no `on_event` at all — so tmux routed the report to
+the pane, charter decoded it, and the dispatcher dropped it for a kind the component had never
+declared. A bar with no handler is a caption that happens to list names.
+
+**Both bars declare `click` now, and a click switches.**
+
+```
+  workspaces   alpha  *harness-wrapper   showcase   todos          <- click `alpha`
+  chats       *api.1   api.2                                       <- click `api.2`
+```
+
+A chat tab runs exactly the switch `F2` → `chat` runs — the same command, the same five
+refusals, the same sentence on your own screen when one fires. A workspace tab runs
+`charter frame-switch --workspace <name>`. Neither is a shortcut past those: the click starts
+the command charter already had, which is what puts a refusal somewhere you can read it. A
+panel has no status line of its own, and a click that silently does nothing is the report this
+entry is answering.
+
+**A click on the repo table only ever *selects*, and a click on a tab *switches*. That is a
+decision, and it is worth the paragraph.** The rule the table keeps is that nothing
+irreversible rides on a pointer event, because one can arrive unpaired — a drag begun on a
+pane border delivers exactly one release, measured. Three things put a tab bar on the other
+side of it:
+
+- **Charter acts on the press, and the press is never the unpaired half.** A press is
+  delivered because the pointer was over that pane when the button went down. A drag that
+  began elsewhere and happens to release over the bar delivers only a release, and switches
+  nothing.
+- **A switch is undone by the identical gesture.** The tab you left is still on the bar, one
+  click away. Nothing is created, nothing is destroyed, nothing is started.
+- **Nothing could ever finish a select-then-confirm gesture here.** On the table, "selected"
+  is a real state — a highlighted row, its detail on the attention strip — and `Enter` in the
+  palette is what chooses. A bar has no such state: the tab you are on *is* the selection, and
+  the `*` beside it is how you see that. And a keypress does not reach a panel at all, because
+  tmux gives your typing to the active pane and that pane is your harness. A bar that merely
+  selected would draw a second mark nothing on the machine could act on.
+
+**What a click on the wrong cell does, which is nothing — deliberately, in four places.** The
+heading. The gap between two names. The `+14` where the names did not fit, which stands for
+names that are not on the row at all. And the empty space past the last tab. Charter resolves
+a click against the columns the paint actually wrote, published by the same pass that drew the
+row, so a cell no tab was drawn into is not a cell a tab was clicked in — it will not pick the
+nearest name for you. **Clicking the tab you are already on does nothing too**, rather than
+tearing four panels down and splitting them again to arrive where you were; it is also what
+stops a double-click switching twice.
+
+**One consequence to know before you place a bar on a narrow frame.** Where the row has room
+for only your own name and a count, the only tab drawn is the one you are on — so nothing on
+that bar is clickable. That is honest rather than broken: `F2` reaches every chat and every
+workspace in two keystrokes at every width, which is what "the bar is a readout" has always
+meant.
+
+**You need `[frame] mouse = true`, and you need to have placed a bar.** Neither is on by
+default and this entry does not change that: with mouse off, tmux asks your terminal to report
+from the *active* pane's request alone, so a click on a panel is not an event charter drops —
+it is an event that never happens. What it no longer costs is your keyboard: clicking a tab
+acts where you pointed and leaves you typing in the harness.
+
+Verified end to end on a real tmux — 3.7c and the 3.2 floor — with a real client on a real
+pty, a real `charter panel` process holding the bar's pane, and a real detached `charter
+frame-chat` / `charter frame-switch` started by that panel out of its own handler: the client
+lands on the other chat's window, the frame lands on the other workspace, the bar repaints
+with the mark moved, and the keyboard never leaves the harness.

--- a/tests/test_a_click_on_a_tab_bar_switches.py
+++ b/tests/test_a_click_on_a_tab_bar_switches.py
@@ -1,0 +1,309 @@
+"""A click on the `chats` or `workspaces` bar switches this frame — and the four gestures
+that deliberately do not.
+
+The report this answers is *"I put both bars on my plane, clicked a tab, and nothing
+happened."* Nothing was going to: both components shipped registered `needs=()` with no
+``events``/``on_event`` at all, so tmux routed the report to the pane, `frame/events.py`
+decoded it, and `Dispatcher._deliver` dropped it for a kind the component had not
+declared. A bar with no handler is a caption that happens to list names.
+
+**The design question this branch had to answer, and where the answer lives.** `repos` —
+charter's first pointer consumer — holds a rule that a click SELECTS and never chooses,
+because a pointer event can arrive unpaired (§4i). A tab bar is on the other side of that
+rule and `frame/builtins._bar_events` argues why in full; the three cases at
+:class:`AClickIsTheWholeGesture` are that argument as assertions: it acts on the PRESS
+(which is never the unpaired half), the switch is reversible by the same gesture, and
+there is no chooser a select-then-confirm bar could be confirmed with — `key` is a kind
+`events.DELIVERED` does not carry, because the harness owns the keyboard.
+
+**Everything the click starts is an existing front door.** It does not switch in this
+process: it starts `charter frame-chat <id>` or `charter frame-switch --workspace <name>`
+detached, which is the same argv `commands_frame._start_chat_switch` and a hand-typed
+switch already use. That is what puts every refusal on the operator's screen — a panel
+process has no `display-message` surface of its own, and a click that silently did
+nothing is the report this feature is answering.
+
+The column half — which name is at which column, and which cells are not a tab at all —
+is `tests/test_frame_bars.AClickResolvesAgainstWhatWasDrawn`. The real-tmux half is
+`tests/test_a_real_click_on_a_real_tab_bar_switches.py`.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import commands_frame, config, util
+from charter.frame import (builtin_actions, builtins, chats, component, events, overlay,
+                           slots, state)
+
+from tests._isolation import PersonaIso
+from tests.test_frame_chat_switch import _plant
+
+
+def _press(col: int, *, name: str = "left", pressed: bool = True):
+    """One decoded left-button press at *col* of the component's own canvas.
+
+    `overlay.Event` and not a stand-in: `events.Dispatcher._on_canvas` hands the handler
+    exactly this, with the operator's `[frame] pad` already subtracted, so a case that
+    invented its own record would be asserting against a shape nothing produces.
+    """
+    return overlay.Event(overlay.CLICK, name, row=0, col=col, pressed=pressed)
+
+
+class _ABarThatWasDrawn(PersonaIso):
+    """A plane with something to switch between, and the bar drawn over it.
+
+    **The bar is DRAWN before every click**, never hand-published, because the column map
+    is the paint's own output (`slots._bar`) and a case that published a map by hand would
+    be measuring a fixture. Which column to click therefore comes from the row that was
+    painted, exactly as it does for the operator.
+    """
+
+    #: Wide enough for every rung-1 name. Narrow rungs have their own cases in
+    #: `test_frame_bars`; this file is about what happens after a tab is resolved.
+    WIDTH = 200
+
+    def setUp(self):
+        super().setUp()
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+        self.spawned = []
+        self.enterContext(mock.patch.object(
+            builtin_actions, "_spawn",
+            side_effect=lambda argv, *, fid: self.spawned.append((argv, fid))))
+
+    def _handler(self, cid: str, fid: str):
+        """*cid*'s handler out of the REAL registry, closed over *fid*.
+
+        `builtins.build(fid)` rather than a handler reached directly, so every case here
+        also asserts that `Component.__post_init__` accepted the declaration: it refuses
+        an `on_event` with no `events` and `events` with no `on_event`, so a component
+        that lost either half fails at this line rather than in an assertion about a
+        gesture.
+        """
+        return builtins.build(fid).get(cid).on_event
+
+    def _column_of(self, row: str, field: str) -> int:
+        at = row.index(field)
+        self.assertNotIn(field, row[at + 1:], f"{field!r} is not unique in {row!r}")
+        return at
+
+
+class AClickOnAChatTabStartsTheChatSwitch(_ABarThatWasDrawn, unittest.TestCase):
+    """The `chats` bar, over a real frame directory."""
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"},
+                                          clear=False))
+        for chat in ("api.1", "api.2", "api.3"):
+            _plant(chat, workspace="api")
+        self.row = slots.chats_bar("api.1", self.WIDTH)[0]
+        self.on_event = self._handler("chats", "api.1")
+
+    def test_a_press_on_another_chats_tab_starts_the_switch_to_it(self):
+        self.on_event(_press(self._column_of(self.row, " api.3")))
+        self.assertEqual(
+            self.spawned, [(util.self_relaunch_argv("frame-chat", "api.3"), "api.1")])
+
+    def test_it_starts_exactly_what_the_palette_row_starts(self):
+        """One switch, two front doors. `commands_frame._start_chat_switch` is what a
+        palette row runs, and a bar that assembled its own argv would be a second answer
+        to how a chat switch is performed — the shape `frame/slots.drawable` exists to
+        stop one question having two."""
+        self.on_event(_press(self._column_of(self.row, " api.2")))
+        commands_frame._start_chat_switch("api.1", "api.2")
+        by_click, by_palette = self.spawned
+        self.assertEqual(by_click, by_palette)
+
+    def test_the_child_is_told_which_frame_it_is_rather_than_inheriting_one(self):
+        """`_spawn`'s `fid=` is the child's own `$CHARTER_SESSION_ID`. One tmux server is
+        shared by every frame on the machine, so a child left to read that variable out of
+        an inherited environment can act on somebody else's frame — the trap
+        `state.record_identity` measures. The panel was TOLD which frame it draws
+        (`charter panel chats --session <fid>`), so it is the one process that knows."""
+        self.on_event(_press(self._column_of(self.row, " api.2")))
+        self.assertEqual([fid for _argv, fid in self.spawned], ["api.1"])
+
+    def test_no_chat_option_rides_along_with_it(self):
+        """The palette's row carries `--chat` because a `bind` text is shared by every
+        frame on the socket and `#{@charter_chat}` is the only thing that tells two chats
+        of one session apart. A panel has no such ambiguity and `_spawn` states the id
+        outright, so the option would be a second spelling of a value the environment
+        already carries — provably equal, which the sweep reports and this repo deletes."""
+        self.on_event(_press(self._column_of(self.row, " api.2")))
+        self.assertNotIn("--chat", self.spawned[0][0])
+
+    def test_only_this_planes_own_chat_directories_are_on_the_bar(self):
+        """**Membership is read from the plane, never from a live session name** (#684).
+        A chat of another workspace shares the tmux server and may share a session name;
+        what decides is `state.frame_workspace`, a file in this plane's own
+        `.charter/frame/`. So there is no column for it and no argv that could name it."""
+        _plant("web.1", workspace="web")
+        row = slots.chats_bar("api.1", self.WIDTH)[0]
+        self.assertNotIn("web.1", row)
+        for col in range(0, self.WIDTH):
+            self.assertNotEqual(slots.TABS.switch_to(col), "web.1", f"column {col}")
+
+    def test_a_tab_the_command_will_refuse_is_still_handed_to_the_command(self):
+        """**The refusal belongs where it can be SAID**, which is not here.
+
+        A chat on another tmux server is in this workspace's roster — the roster is the
+        `workspace` file, and that file says nothing about where a chat is running — and
+        `chats.check` refuses it, because pane ids are per-server and `select-window`
+        would aim at a real, live, unrelated pane and be told it worked (#684). Refusing
+        in the handler instead would be a second, weaker copy of that rule AND would be
+        silent: a panel has no `display-message` surface, so the operator would be back to
+        clicking a tab and watching nothing happen. `cmd_chat` refuses with a sentence on
+        the frame's own client.
+        """
+        state.record_server("api.1", "charter")
+        state.record_server("api.3", "somebody-elses")
+        self.on_event(_press(self._column_of(self.row, " api.3")))
+        self.assertEqual(
+            self.spawned, [(util.self_relaunch_argv("frame-chat", "api.3"), "api.1")])
+        refused = chats.check("api.1", "api.3")
+        self.assertFalse(refused.ok)
+        self.assertIn("not on this frame's tmux server", refused.message)
+
+
+class AClickOnAWorkspaceTabStartsTheWorkspaceSwitch(_ABarThatWasDrawn,
+                                                    unittest.TestCase):
+    """The `workspaces` bar, over a real plane."""
+
+    def setUp(self):
+        super().setUp()
+        for name in ("alpha", "beta", "gamma"):
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        state.frame_dir("f1", create=True)
+        state.record_workspace("f1", "beta")
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""},
+                                          clear=False))
+        self.row = slots.workspaces_bar("f1", self.WIDTH)[0]
+        self.on_event = self._handler("workspaces", "f1")
+
+    def test_a_press_on_another_workspaces_tab_starts_the_switch_to_it(self):
+        self.on_event(_press(self._column_of(self.row, " gamma")))
+        self.assertEqual(
+            self.spawned,
+            [(util.self_relaunch_argv("frame-switch", "--workspace", "gamma"), "f1")])
+
+    def test_the_name_goes_last_so_it_cannot_be_read_as_a_flag(self):
+        """`frame-switch` takes the workspace as the VALUE of `--workspace`, and
+        `frame-chat` takes the chat as a positional — two shapes, one rule this handler
+        depends on: the name is the last argument on both, so `_bar_events` can hold the
+        difference as a prefix and nothing else."""
+        self.on_event(_press(self._column_of(self.row, " alpha")))
+        self.assertEqual(self.spawned[0][0][-1], "alpha")
+
+    def test_the_workspace_this_frame_is_on_is_the_FRAMEs_and_not_this_processs(self):
+        """#512, arriving at the click. The mark comes from `state.workspace_for(fid)` and
+        the map is published beside it in the same paint, so the tab that answers "you are
+        already here" is the one the operator can see marked — never one this panel
+        process would have resolved for itself out of a shared server's environment."""
+        self.assertIn("*beta", self.row)
+        for col in range(0, self.WIDTH):
+            self.assertNotEqual(slots.TABS.switch_to(col), "beta", f"column {col}")
+        self.assertEqual(self.spawned, [])
+
+
+class AClickIsTheWholeGesture(_ABarThatWasDrawn, unittest.TestCase):
+    """Which pointer events act, which do not, and what a handler answers afterwards.
+
+    **This is §4i kept rather than waived.** The rule is that the irreversible half of an
+    interaction never rides on a pointer event, because one can arrive unpaired — a drag
+    begun on a pane border delivers exactly one release, measured. A switch rides on a
+    click here, and these cases are the three reasons that is sound rather than an
+    exception: the PRESS is what is acted on and a press is never the unpaired half; the
+    switch is undone by the same gesture that made it, because the tab you left is still
+    on the bar; and no `key` reaches a panel at all, so a bar that merely SELECTED would
+    draw a second mark nothing on the machine could act on.
+    """
+
+    def setUp(self):
+        super().setUp()
+        for name in ("alpha", "beta"):
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        state.frame_dir("f1", create=True)
+        state.record_workspace("f1", "alpha")
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""},
+                                          clear=False))
+        self.row = slots.workspaces_bar("f1", self.WIDTH)[0]
+        self.beta = self._column_of(self.row, " beta")
+        self.component = builtins.build("f1").get("workspaces")
+        self.on_event = self.component.on_event
+
+    def test_the_press_acts_and_the_release_does_not(self):
+        """`_repos_events`' reading of §4i, kept word for word. A click arrives twice and
+        either half can arrive alone; the press is where the operator POINTED, so a drag
+        that began elsewhere and happens to release over the bar delivers only a release
+        and switches nothing."""
+        self.on_event(_press(self.beta, pressed=False))
+        self.assertEqual(self.spawned, [], "an unpaired release switched the frame")
+        self.on_event(_press(self.beta))
+        self.assertEqual(len(self.spawned), 1)
+
+    def test_the_middle_and_right_buttons_are_left_to_the_terminal(self):
+        """Middle-click is paste on every terminal an operator has ever used and
+        right-click opens their emulator's own menu, so acting on either would be charter
+        taking a gesture that already means something else."""
+        for button in ("middle", "right"):
+            self.on_event(_press(self.beta, name=button))
+        self.assertEqual(self.spawned, [])
+
+    def test_a_switch_is_reversible_by_the_same_gesture_that_made_it(self):
+        """**The §4i property, asserted rather than asserted-about.** What makes a click
+        an acceptable carrier here is that the tab you left is still on the bar: switching
+        back is the identical gesture on the identical column, and nothing was created,
+        destroyed or started along the way."""
+        self.on_event(_press(self.beta))
+        state.record_workspace("f1", "beta")
+        back = slots.workspaces_bar("f1", self.WIDTH)[0]
+        self.assertIn("*beta", back)
+        self.on_event(_press(self._column_of(back, " alpha")))
+        self.assertEqual(
+            [argv[-1] for argv, _fid in self.spawned], ["beta", "alpha"],
+            "the way back is not the same gesture on the same bar")
+
+    def test_there_is_no_keypress_a_selection_could_have_been_confirmed_with(self):
+        """**Why a bar switches where the table selects.** A select-then-choose bar needs
+        a chooser, and a panel has none: `key` is in `component.EVENT_KINDS` — a provider
+        may declare it — and deliberately NOT in `events.DELIVERED`, because tmux routes
+        typing to the ACTIVE pane and that pane is the harness charter exists to protect.
+        So a second mark on this bar would be a state nothing could ever act on."""
+        self.assertIn("key", component.EVENT_KINDS)
+        self.assertNotIn("key", events.DELIVERED)
+
+    def test_the_handler_answers_falsy_even_when_it_started_a_switch(self):
+        """Truthy means *repaint me* (§4f), and nothing this process can see has changed:
+        the switch happens in another process and ends in a `state.bump` of its own, which
+        is the version this panel's poll already watches. Answering truthy would buy one
+        immediate repaint of a byte-identical row — the cost `slots._Viewport.move`
+        refuses in as many words."""
+        self.assertFalse(self.on_event(_press(self.beta)))
+        self.assertEqual(len(self.spawned), 1, "the case measured nothing")
+        self.assertFalse(self.on_event(_press(0)))
+
+    def test_both_bars_declare_click_and_nothing_else(self):
+        """`scroll` is absent deliberately: a bar is one row with nothing to scroll to, so
+        a handler for it could only ever answer False. `events.Dispatcher.open` charges the
+        same `overlay.MOUSE_ON` for one pointer kind as for two — which is why declaring
+        the second costs nothing, and never a reason to declare one that does nothing."""
+        for cid in ("chats", "workspaces"):
+            c = builtins.build("f1").get(cid)
+            self.assertEqual(c.events, ("click",), cid)
+            self.assertEqual(events.wanted(c), ("click",), cid)
+            self.assertIsNotNone(c.on_event, cid)
+
+    def test_a_wheel_notch_never_reaches_the_handler(self):
+        """The declaration is what decides, and `Dispatcher._deliver` is where it is
+        applied — a kind the component did not declare is dropped before the handler is
+        reached, which is why `_bar_events` carries no `ev.kind` branch of its own."""
+        d = events.Dispatcher(self.component)
+        for direction in ("up", "down"):
+            self.assertFalse(
+                d._deliver(overlay.Event(overlay.SCROLL, direction, row=0,
+                                         col=self.beta)))
+        self.assertEqual(self.spawned, [])

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -1,0 +1,482 @@
+"""A click on a REAL tab bar, in a REAL tmux, moves the frame — and leaves the keyboard.
+
+The report this answers is *"I put both bars on my plane, clicked a tab, and nothing
+happened."* Nothing about that could have been settled by a unit test: every link in it is
+a claim about tmux or about a separate process.
+`tests/test_a_click_on_a_tab_bar_switches.py` says what the handler does with an event and
+`tests/test_frame_bars.py` says what the renderer publishes; only this can say that a
+report injected into a client's terminal becomes a switch at all.
+
+Everything here is real: a real tmux server, a real attached client on a real pty, real
+`charter panel` processes holding their own panes, the frame's own private config sourced
+from `commands_frame.conf_text` rather than hand-written, and — the link no fake can stand
+in for — a real detached `charter frame-switch` / `charter frame-chat` child, started by
+the panel process out of its own event handler. What that buys, link by link:
+
+* that `charter panel workspaces` builds a dispatcher for a bar at all, which it did not
+  before this change: both bars declared `events = ()`, so `events.wanted` answered `()`,
+  `panel._run` built no dispatcher, and the pane's terminal was never even asked to report;
+* that the pane really asks (`overlay.MOUSE_ON` written to fd 1 by a process nobody in
+  this test can monkey-patch);
+* that tmux routes the report to the pane under the pointer, in that pane's own cells, and
+  **leaves the keyboard on the harness** — #634's `MouseDown1Pane` rebind, which is what
+  makes a clickable bar something an operator can use rather than a trap;
+* that the handler's `_spawn` really starts a charter that really performs the switch, in
+  a plane the child resolves for itself — a link that is three processes long and whose
+  failure mode (`No module named charter`, a plane resolved from a cwd) is silent.
+
+**`mouse = true`, because that is the regime this feature is for.** With charter's flag
+off, tmux asks the terminal to report from the ACTIVE pane's own request alone, and the
+active pane here is a `cat` — so nothing would be sent, nothing would arrive, and a green
+test would be measuring an empty room. `docs/frame.md` states that half to the operator.
+
+**Verified on tmux 3.7c and at the 3.2 floor** (`tmuxctl.FLOOR`), by putting a 3.2 built
+from the release tarball first on `$PATH`. Identical on both, so nothing here carries a
+version gate.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import itertools
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import termios
+import time
+import unittest
+from pathlib import Path
+
+from charter import commands_frame, config
+from charter.frame import layout, state, tmuxctl
+
+from tests import _tmuxreap
+from tests._isolation import PersonaIso, make_plane
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: How many servers this module has started. **A socket per TEST, not per class or per
+#: run**, and the reason is what this file is about: a click starts a DETACHED charter that
+#: goes on making tmux calls after the case that clicked has finished asserting — a chat
+#: switch is ~20 of them. On a shared socket the next case kills that server, starts its
+#: own, and the previous case's child then aims `select-pane -t %1` at a pane id that
+#: exists again and belongs to something else. Measured: running both classes together on
+#: one socket failed `_active()` in the second class's `setUp` with the bar selected
+#: instead of the harness, and neither class fails alone. A dead socket answers a stray
+#: child with an error and nothing else.
+_SERVERS = itertools.count()
+
+_DEADLINE = 30.0
+
+_TERM_CANDIDATES = tuple(dict.fromkeys(
+    ([os.environ["TERM"]] if os.environ.get("TERM", "dumb") != "dumb" else [])
+    + ["xterm-256color", "screen", "vt100"]))
+
+#: Wide enough for rung 1 — every name whole, which is the rung a click is about. The
+#: narrow rungs draw no tab to click and `tests/test_frame_bars.py` is where that is said.
+COLS = 120
+
+
+def _await(predicate, timeout: float = _DEADLINE) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
+
+
+def _fork_pty(rows: int, cols: int) -> tuple[int, int]:
+    """`pty.fork` with the window size set BEFORE the exec — #648's fix, borrowed.
+
+    A client born at the kernel's 80x24 default attaching to a wider session makes tmux
+    resize the window, which is a SIGWINCH in every pane. Here that would repaint the bar
+    for a reason no case asked for, which is exactly the noise these cases have to be
+    free of.
+    """
+    master, slave = os.openpty()
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+    pid = os.fork()
+    if pid == 0:
+        os.close(master)
+        os.login_tty(slave)
+        return 0, -1
+    os.close(slave)
+    return pid, master
+
+
+class _ARealFrameWithBars(PersonaIso):
+    """One real frame whose panels are bars, on a plane a CHILD charter can also find.
+
+    **`make_plane` and not merely `PersonaIso`'s root**, and the reason is the whole
+    point of this file: the switch is performed by a `charter frame-switch` process the
+    PANEL starts, which resolves its own plane. `PersonaIso` redirects `config` in this
+    interpreter and writes no `charter.toml`, so such a child would go looking for a plane
+    of its own and — on the machine this was written on — find the operator's live one
+    (#527). A plane a test claims to have has to be one a subprocess can find.
+    """
+
+    #: The workspace this frame starts on, and the one it is clicked onto. Literals, so a
+    #: case cannot be satisfied by whatever the plane happens to contain.
+    HERE = "alpha"
+    THERE = "beta"
+
+    def setUp(self) -> None:
+        super().setUp()
+        v = tmuxctl.version()
+        if v is None or v < tmuxctl.FLOOR:
+            self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}."
+                          f"{tmuxctl.FLOOR[1]}; this machine has {v}")
+        self.socket = _tmuxreap.name(f"tabbar{next(_SERVERS)}")
+        self.socket_path = os.path.join(os.environ.get("TMUX_TMPDIR") or "/tmp",
+                                        f"tmux-{os.getuid()}", self.socket)
+        self.addCleanup(self._teardown_socket)
+        self.plane = make_plane(self, self._plane_toml())
+        for name in (self.HERE, self.THERE):
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+
+        existing = os.environ.get("PYTHONPATH", "")
+        parts = [str(_REPO_ROOT)] + ([existing] if existing else [])
+        self.env = dict(os.environ, CHARTER_ROOT=str(self.plane),
+                        PYTHONPATH=os.pathsep.join(parts))
+        self.env.pop("CHARTER_HOME", None)
+        # **`$CHARTER_WORKSPACE` is deliberately absent from the pane environment.** It is
+        # a PIN: `switch.to_workspace` refuses outright when the launch carried one,
+        # because that value sits in every panel pane's process environment and no file
+        # charter writes can take it out. A fixture that set it would make every case here
+        # measure the refusal.
+        self.env.pop("CHARTER_WORKSPACE", None)
+
+    def _tmux(self, *args: str, env=None) -> subprocess.CompletedProcess:
+        """One tmux command against THIS case's own server."""
+        return subprocess.run(["tmux", "-L", self.socket, *args], capture_output=True,
+                              text=True, timeout=20, env=env)
+
+    def _plane_toml(self) -> str:
+        """The plane's `charter.toml` — what a CHILD process reads to know this frame.
+
+        The bars are placed with a `[[frame.component]]` table, which is the only form
+        that can place one (neither has a committed `[frame] slots` spelling), so this is
+        also the config an operator writes to get what these cases click on.
+        """
+        return ("schema = 1\n"
+                '[[frame.component]]\nuse = "workspaces"\nedge = "top"\nsize = 1\n'
+                '[[frame.component]]\nuse = "chats"\nedge = "top"\nsize = 1\n')
+
+    # -- the frame ---------------------------------------------------------- #
+
+    def _start_session(self, fid: str, session: str | None = None) -> str:
+        """A session whose first window's only pane is a `cat` standing in for a harness."""
+        started = self._tmux("-f", "/dev/null", "new-session", "-d", "-s", session or fid,
+                        "-x", str(COLS), "-y", "24", "-P", "-F", "#{pane_id}", "cat",
+                        env=self.env)
+        self.assertEqual(started.returncode, 0, started.stderr)
+        return started.stdout.strip()
+
+    def _source_conf(self, fid: str) -> None:
+        """charter's OWN frame config, `mouse = true`.
+
+        Asking `conf_text` for the text rather than writing `set mouse on` by hand is what
+        makes the `MouseDown1Pane` rebind (#634) part of what is under test — a
+        hand-written config would leave tmux's default binding in place and the "keyboard
+        stays on the harness" case below would be measuring a config this file invented.
+        """
+        conf = str(self.tmp / f"{fid}.conf")
+        with open(conf, "w") as fh:
+            fh.write(commands_frame.conf_text(hotkey=config.FRAME["hotkey"], mouse=True,
+                                              history_limit=100, session=fid))
+        sourced = self._tmux("source-file", conf)
+        self.assertEqual(sourced.returncode, 0, sourced.stderr)
+
+    def _split_bar(self, harness: str, name: str, fid: str) -> str:
+        """One real `charter panel <name>` pane, marked the way its launcher marks it.
+
+        `layout.panel_command` and `commands_frame._panel_mark_argv` are called rather
+        than re-spelled: the argv is what the launcher really sends, and that mark is what
+        the `MouseDown1Pane` bind asks about.
+        """
+        argv = layout.panel_command(slot=name, session=fid)
+        r = self._tmux("split-window", "-t", harness, "-v", "-l", "1",
+                  "-P", "-F", "#{pane_id}", "--", *argv, env=self.env)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pane = r.stdout.strip()
+        marked = subprocess.run(
+            commands_frame._panel_mark_argv(socket=self.socket, pane_id=pane),
+            capture_output=True, text=True, timeout=20)
+        self.assertEqual(marked.returncode, 0, marked.stderr)
+        return pane
+
+    def _attach(self, session: str) -> int:
+        size = self._window_size(session)
+        self.assertNotEqual(size, (-1, -1), "tmux would not say how big its window is")
+        cols, rows = size
+        refusals = []
+        for term in _TERM_CANDIDATES:
+            pid, fd = _fork_pty(rows=rows, cols=cols)
+            if pid == 0:
+                try:
+                    os.environ["TERM"] = term
+                    os.environ["CHARTER_ROOT"] = str(self.plane)
+                    os.execvp("tmux",
+                              ["tmux", "-L", self.socket, "attach", "-t", session])
+                finally:
+                    os._exit(127)
+            if _await(lambda: bool(self._tmux("list-clients", "-t", session,
+                                              "-F", "#{client_name}").stdout.strip()),
+                      timeout=10.0):
+                self.addCleanup(self._reap, pid, fd)
+                self.assertTrue(
+                    _await(lambda: self._window_size(session) == size),
+                    "attaching the client resized the window, so every panel took a "
+                    "SIGWINCH the cases below would read as an event")
+                return fd
+            refusals.append(term)
+            self._reap(pid, fd)
+        self.skipTest("no tmux client will attach on this machine, and a pointer needs "
+                      "one — tried TERM=" + ", ".join(refusals))
+
+    @staticmethod
+    def _reap(pid: int, fd: int) -> None:
+        for call in (lambda: os.kill(pid, 9), lambda: os.waitpid(pid, 0),
+                     lambda: os.close(fd)):
+            try:
+                call()
+            except OSError:
+                pass
+
+    def _teardown_socket(self) -> None:
+        said = self._tmux("display-message", "-p", "#{socket_path}")
+        was_running = said.returncode == 0
+        path = said.stdout.strip()
+        self._tmux("kill-server")
+        for candidate in {self.socket_path,
+                          path if path.startswith("/") else self.socket_path}:
+            try:
+                os.unlink(candidate)
+            except OSError:
+                pass
+        if not was_running:
+            return
+        self.assertTrue(path.startswith("/"), "tmux would not say where its socket is")
+        self.assertFalse(os.path.exists(path), f"{path} survived this test's teardown")
+
+    # -- reading the frame back --------------------------------------------- #
+
+    def _shown(self, pane: str) -> str:
+        return self._tmux("capture-pane", "-p", "-t", pane).stdout
+
+    def _bar_row(self, pane: str) -> str:
+        return self._shown(pane).split("\n")[0].rstrip()
+
+    def _window_size(self, session: str) -> tuple[int, int]:
+        r = self._tmux("display-message", "-p", "-t", session,
+                  "#{window_width} #{window_height}")
+        said = r.stdout.split()
+        if r.returncode != 0 or len(said) != 2:
+            return (-1, -1)
+        return int(said[0]), int(said[1])
+
+    def _rect(self, pane: str) -> tuple[int, int]:
+        r = self._tmux("display-message", "-p", "-t", pane, "#{pane_left} #{pane_top}")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        left, top = (int(n) for n in r.stdout.split())
+        return left, top
+
+    def _active(self) -> str:
+        return self._tmux("display-message", "-p", "#{pane_id}").stdout.strip()
+
+    def _current_window(self, session: str) -> str:
+        return self._tmux("display-message", "-p", "-t", f"{session}:",
+                     "#{window_id}").stdout.strip()
+
+    def _window_of(self, pane: str) -> str:
+        return self._tmux("display-message", "-p", "-t", pane, "#{window_id}").stdout.strip()
+
+    def _click(self, pane: str, *, col: int, row: int = 0, button: int = 0) -> None:
+        """One left press and its release, at the pane's own cell, through the client.
+
+        Both halves are sent because that is what a terminal sends. Only the press is
+        acted on — `frame/builtins._bar_events`' reading of §4i — and sending only the
+        press would leave this measuring a gesture no mouse makes.
+        """
+        left, top = self._rect(pane)
+        wcol, wrow = left + col + 1, top + row + 1
+        os.write(self.fd, b"\x1b[<%d;%d;%dM" % (button, wcol, wrow))
+        os.write(self.fd, b"\x1b[<%d;%d;%dm" % (button, wcol, wrow))
+
+    def _column_of(self, pane: str, field: str) -> int:
+        """Which column of *pane* the drawn *field* starts in — read off the pane.
+
+        Off the PANE and never off `slots.TABS`: that object lives in the panel's process
+        and not in this one, and asking charter where it put something and then clicking
+        there would be a test that agrees with itself. This is the column the operator's
+        eye lands on.
+        """
+        row = self._bar_row(pane)
+        at = row.index(field)
+        self.assertNotIn(field, row[at + 1:], f"{field!r} is not unique in {row!r}")
+        return at
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealClickOnTheWorkspaceBarMovesTheFrame(_ARealFrameWithBars, unittest.TestCase):
+    """The `workspaces` bar: click a name, the frame is on that workspace.
+
+    **Three processes and none of them is this one.** The bar is painted by a `charter
+    panel workspaces` child, the click is decoded there, and the switch is performed by a
+    `charter frame-switch` child that panel starts. The only thing between them and this
+    test is the plane on disk — so these passing is the proof that the whole chain is real
+    rather than an artefact of one interpreter.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.fid = state.frame_id("tabbar", os.getpid())
+        state.frame_dir(self.fid, create=True)
+        state.record_workspace(self.fid, self.HERE)
+        self.harness = self._start_session(self.fid)
+        state.record_server(self.fid, self.socket)
+        state.record_harness_pane(self.fid, self.harness)
+        self._source_conf(self.fid)
+        self.bar = self._split_bar(self.harness, "workspaces", self.fid)
+        # **The harness is put back in front, and that is the regime, not tidiness.**
+        # `split-window` selects the pane it made, and a frame whose bar was the ACTIVE
+        # pane would be reporting the mouse because THAT pane asked — the `mouse = false`
+        # route `docs/frame.md` describes, which would make every case below pass with
+        # charter's flag off. `commands_frame._split_panels` ends the same way.
+        self.assertEqual(self._tmux("select-pane", "-t", self.harness).returncode, 0)
+        self.fd = self._attach(self.fid)
+        self.assertTrue(
+            _await(lambda: f"*{self.HERE}" in self._bar_row(self.bar)),
+            f"the bar never painted: {self._bar_row(self.bar)!r}")
+        self.assertEqual(self._active(), self.harness,
+                         "the harness is not the active pane, so a report reaching the "
+                         "bar would prove nothing about `[frame] mouse`")
+
+    def test_clicking_a_tab_moves_the_frame_to_that_workspace(self):
+        """The report, answered end to end. Nothing here writes the frame's workspace and
+        nothing resizes anything, so a frame that moved moved because of the click."""
+        self._click(self.bar, col=self._column_of(self.bar, f" {self.THERE}"))
+        self.assertTrue(
+            _await(lambda: state.frame_workspace(self.fid) == self.THERE),
+            f"the click never reached the switch: "
+            f"{state.frame_workspace(self.fid)!r}")
+
+    def test_the_bar_repaints_with_the_mark_on_the_workspace_it_moved_to(self):
+        """The switch ends in a `state.bump`, which is the version this panel's poll was
+        already watching — so the mark follows with no repaint of this test's own."""
+        self._click(self.bar, col=self._column_of(self.bar, f" {self.THERE}"))
+        self.assertTrue(
+            _await(lambda: f"*{self.THERE}" in self._bar_row(self.bar)),
+            f"the bar never redrew the mark: {self._bar_row(self.bar)!r}")
+
+    def test_the_click_leaves_the_keyboard_on_the_harness(self):
+        """The property `mouse = true` used to take away and #634 gave back, asserted
+        against a BAR rather than the repo table. A tab you cannot click without losing
+        your prompt is not a tab an operator will click twice."""
+        self._click(self.bar, col=self._column_of(self.bar, f" {self.THERE}"))
+        self.assertTrue(_await(
+            lambda: state.frame_workspace(self.fid) == self.THERE))
+        self.assertEqual(self._active(), self.harness,
+                         "clicking the workspace bar moved the keyboard off the harness")
+
+    def test_clicking_the_workspace_you_are_already_on_moves_nothing(self):
+        """Re-switching would re-gather the plane and bump the frame to arrive exactly
+        where it already was. The rule is `slots._Tabs.switch_to`'s; this is it holding
+        through a real terminal, a real pane and a real handler."""
+        before = self._bar_row(self.bar)
+        self._click(self.bar, col=self._column_of(self.bar, f"*{self.HERE}"))
+        time.sleep(2.0)
+        self.assertEqual(state.frame_workspace(self.fid), self.HERE)
+        self.assertEqual(self._bar_row(self.bar), before)
+
+    def test_clicking_the_heading_moves_nothing(self):
+        """`  workspaces  ` is about no workspace. It is a field the operator can see and
+        click, so "nothing happens" has to be what happens rather than the nearest name
+        being picked for them."""
+        self._click(self.bar, col=0)
+        time.sleep(2.0)
+        self.assertEqual(state.frame_workspace(self.fid), self.HERE)
+
+    def test_clicking_past_the_last_tab_moves_nothing(self):
+        """The empty right-hand end of the row — the `+N` overflow's neighbour, and the
+        commonest miss."""
+        self._click(self.bar, col=COLS - 2)
+        time.sleep(2.0)
+        self.assertEqual(state.frame_workspace(self.fid), self.HERE)
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealClickOnTheChatBarMovesTheClient(_ARealFrameWithBars, unittest.TestCase):
+    """The `chats` bar: click a name, the client is on that chat's window.
+
+    **This is the half that moves a CLIENT rather than a file**, and it is the one #684 is
+    about: membership comes from this plane's own chat directories (`state.frame_workspace`,
+    a file), the target is a recorded pane ID and never a session NAME, and `cmd_chat`
+    establishes where both chats actually are before it aims anything anywhere — because
+    `select-window` at another session's pane returns 0 and moves that session while this
+    client stays put.
+    """
+
+    WS = "alpha"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.here, self.there = f"{self.WS}.1", f"{self.WS}.2"
+        self.harness = self._start_session(self.here, session=self.WS)
+        second = self._tmux("new-window", "-t", self.WS, "-P", "-F", "#{pane_id}",
+                       "cat", env=self.env)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.other_harness = second.stdout.strip()
+        for chat, pane in ((self.here, self.harness),
+                           (self.there, self.other_harness)):
+            state.frame_dir(chat, create=True)
+            state.record_workspace(chat, self.WS)
+            state.record_server(chat, self.socket)
+            state.record_harness_pane(chat, pane)
+            state.record_identity(chat, {"CHARTER_SESSION_ID": chat,
+                                         "CHARTER_ROOT": str(self.plane)})
+        self._source_conf(self.WS)
+        self.assertEqual(self._tmux("select-window", "-t", self.harness).returncode, 0)
+        self.bar = self._split_bar(self.harness, "chats", self.here)
+        self.assertEqual(self._tmux("select-pane", "-t", self.harness).returncode, 0)
+        self.fd = self._attach(self.WS)
+        self.assertTrue(
+            _await(lambda: self.there in self._bar_row(self.bar)),
+            f"the chat bar never painted both chats: {self._bar_row(self.bar)!r}")
+        self.assertEqual(self._active(), self.harness)
+
+    def test_clicking_the_other_chats_tab_moves_the_client_to_its_window(self):
+        """`select-window` at the target chat's own harness PANE — a pane id resolves to
+        that pane's window, which is why charter keeps no window-id record beside the pane
+        record it already has. The client following is the whole switch."""
+        self._click(self.bar, col=self._column_of(self.bar, f" {self.there}"))
+        self.assertTrue(
+            _await(lambda: self._current_window(self.WS)
+                   == self._window_of(self.other_harness)),
+            "the click never moved the client to the other chat's window")
+
+    def test_the_click_leaves_the_keyboard_on_a_harness(self):
+        """A chat switch moves the WINDOW, and the pane the operator types in afterwards
+        is the new chat's harness — never the bar they clicked."""
+        self._click(self.bar, col=self._column_of(self.bar, f" {self.there}"))
+        self.assertTrue(
+            _await(lambda: self._current_window(self.WS)
+                   == self._window_of(self.other_harness)))
+        self.assertEqual(self._active(), self.other_harness,
+                         "clicking the chat bar left the keyboard on a panel")
+
+    def test_clicking_the_chat_you_are_in_moves_nothing(self):
+        """`chats.check` refuses a switch to the chat you are already in — a teardown and
+        a split for no change on screen — but the click never gets that far: the bar knows
+        which tab is marked, so the gesture costs nothing at all rather than costing an
+        interpreter start and a refusal."""
+        window = self._current_window(self.WS)
+        self._click(self.bar, col=self._column_of(self.bar, f"*{self.here}"))
+        time.sleep(2.0)
+        self.assertEqual(self._current_window(self.WS), window)
+        self.assertEqual(self._active(), self.harness)

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -443,6 +443,13 @@ class ARealClickOnTheChatBarMovesTheClient(_ARealFrameWithBars, unittest.TestCas
         self._source_conf(self.WS)
         self.assertEqual(self._tmux("select-window", "-t", self.harness).returncode, 0)
         self.bar = self._split_bar(self.harness, "chats", self.here)
+        # **The bar is recorded as this chat's panel, which is what makes the switch tear
+        # it down** — `cmd_chat`'s step 2 is `_apply_arrangement(<chat being left>,
+        # want=[])`, and `state.panes` is the record it reads to know which pane to kill.
+        # Without this line the teardown is a no-op and the case below measures a switch
+        # that never touched the pane its own click came from, which is the one thing
+        # about this path that is not like the palette's.
+        state.record_panes(self.here, panels={"chats": self.bar})
         self.assertEqual(self._tmux("select-pane", "-t", self.harness).returncode, 0)
         self.fd = self._attach(self.WS)
         self.assertTrue(
@@ -469,6 +476,36 @@ class ARealClickOnTheChatBarMovesTheClient(_ARealFrameWithBars, unittest.TestCas
                    == self._window_of(self.other_harness)))
         self.assertEqual(self._active(), self.other_harness,
                          "clicking the chat bar left the keyboard on a panel")
+
+    def test_the_switch_runs_to_the_end_after_killing_the_pane_it_started_from(self):
+        """**The whole switch, from a click on a pane the switch then destroys.**
+
+        Step 2 of a chat switch is `_apply_arrangement(<chat being left>, want=[])`, and
+        on a frame where a bar is one of the panels that means killing the very pane the
+        click came from — the one whose process started the child. Nothing else in this
+        file reaches past that point: the client has already moved by then. What is
+        asserted here is step THREE, the chat being ENTERED getting its panels, which is
+        the switch having run to its end rather than having stopped when its own parent
+        went away.
+
+        **What this does NOT pin, said rather than implied.** `_spawn`'s
+        `start_new_session=True` looks like the thing that makes this work, and it was
+        written up that way first; measured with `start_new_session=False` the case is
+        still green, so the SIGHUP is not what this case is about and the comment claiming
+        it has been deleted from `_bar_events` rather than left as a story. `_spawn` is
+        used because it is the one answer to how a frame surface starts detached work, not
+        because this case can tell it apart from a bare `Popen`.
+        """
+        self._click(self.bar, col=self._column_of(self.bar, f" {self.there}"))
+        self.assertTrue(
+            _await(lambda: self.bar not in self._tmux(
+                "list-panes", "-a", "-F", "#{pane_id}").stdout.split()),
+            "the chat that was left kept the bar pane, so the teardown this case is "
+            "about did not run and nothing below is measured")
+        self.assertTrue(
+            _await(lambda: bool(state.panes(self.there))),
+            "the switch stopped when the pane that started it was killed — its own "
+            f"teardown took it with it: {state.panes(self.there)!r}")
 
     def test_clicking_the_chat_you_are_in_moves_nothing(self):
         """`chats.check` refuses a switch to the chat you are already in — a teardown and

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -469,13 +469,30 @@ class ARealClickOnTheChatBarMovesTheClient(_ARealFrameWithBars, unittest.TestCas
 
     def test_the_click_leaves_the_keyboard_on_a_harness(self):
         """A chat switch moves the WINDOW, and the pane the operator types in afterwards
-        is the new chat's harness — never the bar they clicked."""
+        is the new chat's harness — never the bar they clicked, and never a panel.
+
+        **Asked once the switch has SETTLED, and the first version asked too early.** The
+        client moving is step 1 of four; step 3 splits the entered chat's own panels, and
+        `split-window` selects the pane it makes — `commands_frame._split_panels` re-selects
+        the harness at the end, for the same reason this case exists. Between those two
+        moments the active pane really is a panel, for a few hundred milliseconds. Measured
+        rather than reasoned: this file was green on the machine it was written on and
+        failed on CI's 3.13 runner with `'%4' != '%1'`, which is that window. So the case
+        waits for `state.panes` — the record step 3 writes last — before it asks.
+        """
         self._click(self.bar, col=self._column_of(self.bar, f" {self.there}"))
         self.assertTrue(
             _await(lambda: self._current_window(self.WS)
-                   == self._window_of(self.other_harness)))
-        self.assertEqual(self._active(), self.other_harness,
-                         "clicking the chat bar left the keyboard on a panel")
+                   == self._window_of(self.other_harness)),
+            "the click never moved the client to the other chat's window")
+        self.assertTrue(
+            _await(lambda: bool(state.panes(self.there))),
+            "the switch never finished laying the entered chat out, so the pane it "
+            "leaves selected is not the one this case is about")
+        self.assertTrue(
+            _await(lambda: self._active() == self.other_harness),
+            f"clicking the chat bar left the keyboard on {self._active()} rather than "
+            f"the entered chat's harness {self.other_harness}")
 
     def test_the_switch_runs_to_the_end_after_killing_the_pane_it_started_from(self):
         """**The whole switch, from a click on a pane the switch then destroys.**

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -23,7 +23,7 @@ import os
 import unittest
 from unittest import mock
 
-from charter import config, instance, tui
+from charter import config, contain, instance, tui
 from charter.frame.component import Fixed
 from charter.frame import builtins, layout, slots, state
 from tests._isolation import PersonaIso
@@ -233,6 +233,182 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
             text = row[0] if row else ""
             self.assertEqual(text, "".join(text.splitlines()), repr(text))
             self.assertLessEqual(tui.width(tui.strip_ansi(text)), width, repr(text))
+
+
+class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
+    """`slots.TABS` — the column map every rung of `slots._bar` publishes.
+
+    **The map is measured off the ROW, never off the map.** Each case below finds the
+    columns it clicks by looking for the field in the string `_bar` returned, which is the
+    thing the operator points at; asking `TABS` where it put something and then asking
+    `TABS` what is there would agree with itself whatever the ladder did. The fixtures are
+    ASCII on purpose, so a character index into that string IS a terminal column — the one
+    case that is about a name needing repair says so and measures with `tui.width`.
+
+    **A bar is horizontal, so the map is per column, and the ladder is why it has to exist
+    at all**: three of the four rungs draw a different set of names and the fourth draws
+    none, so "which name is at column 40" cannot be recomputed from the names and the
+    width without re-walking the ladder — a second answer that disagrees with the first
+    the moment a repaint lands between the paint and the click.
+    """
+
+    NAMES = ["api.1", "api.2", "api.3"]
+
+    def setUp(self):
+        # The strip is one object at module scope (`slots._Tabs`), so a case that did not
+        # clear it would be reading the previous case's paint — and one that left a map
+        # behind would hand it to whatever renders next.
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+
+    def _draw(self, width, names=None, here="api.2", note=""):
+        rows = slots._bar("chats", list(names or self.NAMES), here, width, note=note)
+        return rows[0] if rows else ""
+
+    def _cells(self, row, field):
+        """Every column *field* occupies in *row*, taken from the drawn row itself."""
+        at = row.index(field)
+        self.assertNotIn(field, row[at + 1:], f"{field!r} is not unique in {row!r}")
+        return range(at, at + len(field))
+
+    def test_every_tab_on_a_wide_row_resolves_to_its_own_name(self):
+        """The whole feature, at the rung that draws every name: point at a tab, get that
+        tab. `here` is a name that is NOT in the list so no tab is the current one and
+        every one of them has an answer — the current-tab rule has its own case below."""
+        row = self._draw(200, here="nowhere")
+        for name in self.NAMES:
+            for col in self._cells(row, name):
+                self.assertEqual(slots.TABS.switch_to(col), name,
+                                 f"column {col} of {row!r}")
+
+    def test_the_mark_belongs_to_the_tab_it_marks(self):
+        """A tab is its mark and its name together — the operator sees one field, and
+        clicking either half of it means the same thing.
+
+        Asserted on BOTH marks, because they are different characters in the same cell:
+        the inactive `_BAR_MARK[1]` is the blank in front of a name you can switch to, and
+        the active `_BAR_MARK[0]` is the `*`. The second is measured by drawing the same
+        names with `here` somewhere else, which moves no column (the two marks are the
+        same width — `test_the_two_marks_are_the_same_width…`), so the star's own cell can
+        be asked about while it belongs to a tab that is not the current one.
+        """
+        row = self._draw(200, here="api.2")
+        blank = self._cells(row, " api.3").start
+        self.assertEqual(slots.TABS.switch_to(blank), "api.3",
+                         "the blank mark in front of an inactive tab is not part of it")
+        star = self._cells(row, "*api.2").start
+        self.assertIsNone(slots.TABS.switch_to(star), "the tab you are on switched")
+        self._draw(200, here="nowhere")
+        self.assertEqual(slots.TABS.switch_to(star), "api.2",
+                         "the marked tab's own mark column belongs to no tab")
+
+    def test_the_gap_between_two_tabs_resolves_to_nothing(self):
+        """Separator cells the operator can see are empty. Picking the nearer name for
+        them would be the clamp `events.Dispatcher._on_canvas` refuses one rectangle out —
+        a click on a cell nothing was drawn into is not a click on a neighbour."""
+        row = self._draw(200, here="nowhere")
+        end = self._cells(row, "api.1").stop
+        for col in range(end, end + slots._BAR_GAP):
+            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+
+    def test_the_heading_resolves_to_nothing(self):
+        """`  chats  ` is about no chat, exactly as the repo table's heading row is about
+        no repo (`slots._repos` publishes `None` for it)."""
+        row = self._draw(200, here="nowhere")
+        # Up to the first tab's own MARK column, not to its name: the mark belongs to the
+        # tab (`test_the_mark_belongs_to_the_tab_it_marks`), so a heading measured to the
+        # first letter would assert the opposite of that case one cell over.
+        for col in range(self._cells(row, " api.1").start):
+            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+
+    def test_the_empty_space_past_the_last_tab_resolves_to_nothing(self):
+        """Most of a wide bar is blank. A click out there has to answer falsy rather than
+        land on the last name, which is what a map running to the pane's width — or an
+        index counting from the end — would do."""
+        row = self._draw(200, here="nowhere")
+        for col in range(len(row), 200):
+            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+
+    def test_the_tab_you_are_already_on_resolves_to_nothing(self):
+        """Re-selecting what is already selected is not news — `_repos_events`' sentence,
+        and here it is worth more: a re-switch is a real teardown and split (~360 ms for a
+        chat) arriving exactly where the operator already was. It is also what keeps a
+        double-click from switching twice."""
+        row = self._draw(200, here="api.2")
+        for col in self._cells(row, "api.2"):
+            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+
+    def test_the_overflow_count_resolves_to_nothing(self):
+        """Rung 2's `+2` stands for names that are NOT on the row, so there is nothing
+        there to switch to — `…(+N more)`'s rule one axis over. On a plane with fifteen
+        workspaces that field is a `+14`, and it is the one an operator is most likely to
+        try: it answers falsy, and the palette is what reaches those names."""
+        row = self._draw(30, here="api.2")
+        self.assertIn("+2", row, f"this width is not rung 2: {row!r}")
+        for col in self._cells(row, "+2"):
+            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+
+    def test_the_rung_that_says_only_where_you_are_has_no_tabs_at_all(self):
+        """`2/3` is a position, not a name, and there is no name on the row to click."""
+        row = self._draw(16, here="api.2")
+        self.assertEqual(row.strip(), "chats  2/3", repr(row))
+        for col in range(0, 200):
+            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+
+    def test_a_narrowed_bar_forgets_the_tabs_it_is_no_longer_drawing(self):
+        """**The `_Viewport.blank` half, one axis over.** A pane that drew every name and
+        then narrowed to a count — or to nothing at all — must not go on answering for the
+        tabs that were there: a click would switch to a name the operator can see is not on
+        screen. Every rung publishes, including the two that draw no tab."""
+        wide = self._draw(200, here="nowhere")
+        col = self._cells(wide, "api.3").start
+        self.assertEqual(slots.TABS.switch_to(col), "api.3")
+        for width in (30, 16, 11):
+            self._draw(width, here="api.2")
+            self.assertIsNone(slots.TABS.switch_to(col),
+                              f"width {width} kept a stale tab")
+
+    def test_a_bar_with_no_names_at_all_publishes_no_tabs(self):
+        """`chats.roster` answers with the chat asking and nothing else for a frame root it
+        could not scan, and `_bar` answers `[]` for an empty list — so this is the
+        unreadable-plane path, and it must leave nothing clickable behind either."""
+        self._draw(200, here="nowhere")
+        self.assertEqual(slots._bar("chats", [], "api.1", 200), [])
+        for col in range(0, 200):
+            self.assertIsNone(slots.TABS.switch_to(col), f"column {col}")
+
+    def test_the_add_chat_affordance_is_not_a_tab(self):
+        """It is a reminder naming a command, not a name to switch to."""
+        row = self._draw(120, names=["api.1"], here="nowhere", note=slots.ADD_CHAT)
+        self.assertIn(slots.ADD_CHAT, row)
+        for col in self._cells(row, slots.ADD_CHAT):
+            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+
+    def test_a_column_nothing_drew_answers_nothing_however_far_out(self):
+        """A mapping has no answer to give for a column outside it — which is where
+        `_Viewport.repo_at`'s bounds check went. `-1` is the one that matters: a tuple
+        would have answered with the LAST tab, hiding a wrong reading behind a plausible
+        name, and the row's last column IS a tab here so that wrong answer is available."""
+        row = self._draw(200, here="nowhere")
+        self.assertEqual(slots.TABS.switch_to(len(row) - 1), "api.3",
+                         "the last drawn column is not a tab, so -1 measures nothing")
+        for col in (-1, -99, 10_000):
+            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+
+    def test_the_map_carries_the_name_on_disk_and_not_the_repaired_one(self):
+        """`contain.one_line` is a REPAIR for drawing (#472), and what a click has to hand
+        `charter frame-chat` or `switch.to_workspace` is the name in the directory. The two
+        are one string for every name either caller can produce today, which is exactly why
+        this asks with a name that needs repairing rather than waiting for a caller to stop
+        refusing one."""
+        raw = "api\t1"
+        row = slots._bar("chats", [raw, "api.2"], "api.2", 200)[0]
+        drawn = contain.one_line(raw)
+        self.assertNotEqual(drawn, raw, "this name needs no repair, so it measures none")
+        at = row.index(drawn)
+        for col in range(at, at + tui.width(drawn)):
+            self.assertEqual(slots.TABS.switch_to(col), raw,
+                             f"column {col} of {row!r} carries the drawn name")
 
 
 class TheChatBarReadsThePlane(PersonaIso, unittest.TestCase):

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -769,6 +769,12 @@ class NoCharterEscapesThroughTheExecFamily(unittest.TestCase):
             "than a fixture provider's, and a mouse report still has to be put on a real "
             "client's terminal for tmux to route it anywhere. `os._exit`s in its "
             "`finally`.",
+        "tests/test_a_real_click_on_a_real_tab_bar_switches.py:execvp":
+            "The same `tmux attach` inside a `pty.fork` child, for the sibling reason "
+            "again: that file exercises the pointer against the two BARS, whose click "
+            "starts a real detached charter, and a mouse report still has to be put on a "
+            "real client's terminal for tmux to route it anywhere. `os._exit`s in its "
+            "`finally`.",
     }
 
     _WATCHED = ("execl", "execle", "execlp", "execlpe", "execv", "execve", "execvp",


### PR DESCRIPTION
*"I put both bars on my plane, clicked a tab, and nothing happened."*

Nothing was going to. `chats` and `workspaces` shipped registered `needs=()` with **no `events` and no `on_event` at all**, so tmux routed the report to the pane, `frame/events.py` decoded it, and `Dispatcher._deliver` dropped it for a kind the component had never declared. A bar with no handler is a caption that happens to list names.

Both declare `click` now, and `builtins._bar_events` receives it.

## A click SWITCHES here, where a click on the repo table only SELECTS

That is the design question this branch had to answer, and the answer is written at `_bar_events` rather than left implicit. §4i's rule is that the irreversible half of an interaction never rides on a pointer event, because one can arrive unpaired — a drag begun on a pane border delivers exactly one release. Three things put a tab bar on the other side of it:

1. **The unpaired event is the RELEASE, and this acts on the PRESS.** That is `_repos_events`' own reading of §4i, kept word for word. A press is delivered because the pointer was over that pane when the button went down. A drag that began elsewhere and happens to release over the bar delivers only a release and switches nothing.
2. **A switch is reversible by the identical gesture.** The tab you left is still on the bar, one click away. Nothing is created, destroyed or started.
3. **There is no chooser a select-then-confirm bar could be confirmed with.** On the table, "selected" is a real intermediate state — a highlighted row, a detail on the attention strip — and `Enter` in the palette chooses. A bar has no such state: the tab you are on *is* the selection and `_BAR_MARK` is how you see it. And `key` is in `component.EVENT_KINDS` but deliberately **not** in `events.DELIVERED`, because the harness owns the keyboard. A bar that merely selected would draw a second mark nothing on the machine could ever act on — dead code wearing a feature's name.

## Columns are mapped, never guessed

`slots._Tabs` is `_Viewport` one axis over: every rung of `slots._bar` publishes a column→name map beside the row it composed, and the handler resolves against **what was drawn**. It has to be published rather than recomputed, because the ladder is not invertible — three of its four rungs draw a different set of names.

Four things answer nothing, each with a case: the heading, the `_BAR_GAP` between two tabs, the `+N` overflow (it stands for names that are *not* on the row), and the empty space past the last tab. **A click on the tab you are already on answers nothing too** — that rule lives in `_Tabs.switch_to`, which is `_Viewport.move`'s choice for the same reason, and it is also what stops a double-click switching twice.

**Every rung publishes, including the two that draw no tab.** A bar that kept its map through a resize down to `2/3` would switch to a name the operator can see is gone — the defect `_Viewport.blank` exists for, one axis over.

## The switch is the front door charter already had

The handler starts `charter frame-chat <id>` or `charter frame-switch --workspace <name>` **detached**, which is byte-for-byte the argv `commands_frame._start_chat_switch` starts (asserted). Not a shortcut past `chats.check`'s five refusals or `switch.to_workspace`'s three: every one of them reaches the operator through `_say_on_screen`, and a panel has no such surface of its own. Refusing in the handler would be a second, weaker copy of those rules **and would be silent** — which is the report this PR is answering.

Cross-session and cross-plane are #684's, unchanged and now depended on: membership comes from this plane's own chat directories (`state.frame_workspace`, a file), the target is a recorded **pane id** and never a session name, and `cmd_chat` asks tmux where both chats actually are before aiming anything.

The handler answers **falsy even when it started a switch**: the switch bumps the frame from its own process, which is the version this panel's poll already watches, so truthy would buy one repaint of a byte-identical row.

`scroll` is not declared — a bar is one row and a handler for it could only ever answer False.

## Verification

- `python3 -m unittest discover -s tests` green (8930).
- **Real tmux, 3.7c and the 3.2 floor**, run twice each: `tests/test_a_real_click_on_a_real_tab_bar_switches.py` — a real client on a real pty, `mouse = true` sourced from `conf_text` (so #634's `MouseDown1Pane` rebind is under test), a real `charter panel` process holding the bar's pane, and a real detached `charter frame-switch`/`frame-chat` started by that panel out of its own handler. The frame lands on the other workspace, the client lands on the other chat's window, the bar repaints with the mark moved, and **the keyboard stays on the harness**.
- Red-first: with the two production files reverted, the new unit modules error on `slots.TABS` (29) and the real-tmux module fails 5 of 9.

## Known limit, on this plane specifically

`workspaces` needs **274 columns** to draw all fifteen names here; below that it is `*harness-wrapper  +14`, whose only tab is the one you are on — so on any ordinary terminal that bar is correct and inert. `chats` (two short ids) is fine at every realistic width. Making rung 2 draw the names that *fit* rather than only the marked one is a change to the ladder and is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy