### PR TITLE
A sweep survivor says which of a line's mutants survived, so a fail-open hole stops reading like an equivalent prefilter (#721)

### DIFF
--- a/docs/news/unreleased-a-sweep-survivor-says-which-mutant-survived.md
+++ b/docs/news/unreleased-a-sweep-survivor-says-which-mutant-survived.md
@@ -73,6 +73,18 @@ for — and the edit is **appended**:
 charter/hooks.py:3658:drop-conjunct -> text.startswith("$(", i)
 ```
 
+## The first version of this fix contained the bug it fixes
+
+`after` is everything the mutant **keeps**, so `drop-conjunct` siblings share a long
+*prefix* — and a tag that truncated the edit at 40 characters put two of them straight
+back onto one line. The instance is in `tools/sweep.py` itself: `_regex_shape`'s
+four-conjunct guard, whose middle two replacements agree for their first 40 characters.
+
+Not truncating is not the answer either — replacements reach **7,149 characters** in this
+tree. So the shortening stays and carries a six-hex digest of the whole replacement, and
+the fixture that catches it is that same four-conjunct guard, copied into
+`tests/test_sweep.py`.
+
 ## The check that is worth more than the six fixes
 
 `tests/test_sweep.py` now asserts the rule on the table rather than on the operators that

--- a/docs/news/unreleased-a-sweep-survivor-says-which-mutant-survived.md
+++ b/docs/news/unreleased-a-sweep-survivor-says-which-mutant-survived.md
@@ -1,0 +1,86 @@
+---
+version: unreleased
+headline: A sweep survivor says which of a line's mutants survived, instead of a line two opposite findings share
+---
+
+The deletion sweep reported a `drop-conjunct` survivor by printing the original line:
+
+```
+charter/hooks.py:3658 [drop-conjunct] c == "$" and text.startswith("$(", i)
+```
+
+That line is the same whichever conjunct was dropped, and **the two mean opposite
+things**. Dropping the first half removes a cheap prefilter in front of the test that
+decides: the mutant is genuinely equivalent and dismissing it is correct. Dropping the
+second half is a fail-open hole.
+
+Two real ones, in a security guard, were dismissed as the first — for **two full sweep
+runs** — and only found on a third pass, when somebody checked which half had actually
+gone. Both were verified against a real `bash`, with **150,585** and **119,278**
+distinguishing inputs. Neither is an edge case, and neither could be told from an
+equivalent prefilter by anything the report printed (#721).
+
+## The reason was computed all along, and one stream threw it away
+
+`mutations_for` already yields a `question` with every mutant — *what a survivor would
+mean* — and `drop-conjunct`'s names the half that went. The gate summary prints it. The
+**per-mutation progress line** did not:
+
+```python
+def __str__(self) -> f"{path}:{line} [{operator}] {before}"   # question dropped
+```
+
+`before` is the mutated **node**, which for `drop-conjunct` is the whole condition. And
+the progress log is exactly what is left to read when a shard is reclaimed before it can
+emit a summary — which is what happened to the two shards that mattered. The two streams
+now say the same thing.
+
+## The rule that says where else this lives
+
+> Ambiguity appears exactly where the mutated node is **larger than the thing being
+> varied**, because `before` *is* the node.
+
+Applied to the table, over `charter/` and `tools/`: **1,410 nodes** offer more than one
+mutant, and every one of them rendered as a single line and a single tag. For **77** of
+them no field distinguished the siblings at all —
+
+- **`unclamp`** (58 nodes) — both mutants printed identically *and shared one question*,
+  while asking opposite things: `max(a, b) -> a` asks whether anything requires the value
+  to clear the floor, `-> b` whether anything requires the floor at all. Worse than the
+  case that prompted the issue, and nothing had tripped over it.
+- **`drop-term`** (11) — the same shape on a module constant's `A + B`, and in nobody's
+  list of suspects.
+- **`shift-boundary`** (8 of the 13 chained comparisons) — one node, two edges, and
+  `" " <= c <= "~"` carries the same `(<= vs <)` pair on both.
+
+Each question now names its own operand, term or edge. `collapse-ifexp` (767) and
+`disable-branch` (253) had questions that differed and still were not *self-locating* —
+"is this branch pinned?" against "is the other branch pinned?" can only be decoded with
+the operator table open, which the reviewer holding the report does not have. They name
+the branch now, by keyword and by the direction the condition was forced.
+
+`drop-comprehension-if`, `narrow-except` and `no-fallback` were never affected: they
+mutate the individual node, so the line already differed.
+
+## `tag` too, because the lists are not only the log
+
+`Mutation.tag` was `path:line:operator`, and it is what the not-applied and no-verdict
+lists render. Sibling mutants collided there as well, so a fix touching only the progress
+line would have left those ambiguous. The prefix is unchanged — it is what a reader greps
+for — and the edit is **appended**:
+
+```
+charter/hooks.py:3658:drop-conjunct -> text.startswith("$(", i)
+```
+
+## The check that is worth more than the six fixes
+
+`tests/test_sweep.py` now asserts the rule on the table rather than on the operators that
+cost something: **an operator yielding more than one mutant for one node must give them
+distinct questions, distinct tags and distinct report lines.** It runs over a fixture
+holding one instance of every shape the table recognises, and a second test reads the
+operator names straight out of `_iter_operators`, so a shape added there and not added to
+the fixture fails rather than going quietly unmeasured.
+
+That check would have caught `unclamp` and `drop-term` before either cost anybody a run,
+which is the general form of what this took two sweeps to find by accident.

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -2111,6 +2111,18 @@ class TwoMutantsOfOneNodeAreNeverReportedAlike(unittest.TestCase):
         self.assertTrue(gone.tag.endswith("(deleted)"),
                         "a deletion has no `after` to name, and an empty discriminator "
                         "would put every deletion on one line back")
+        # Both survivors this branch's own self-sweep found, pinned. A `drop-conjunct`
+        # replacement is short far more often than not — p90 is 25 characters — and a
+        # digest on one of those is noise the reader has to decode for nothing.
+        short = dataclasses.replace(m, after="a and b")
+        self.assertTrue(short.tag.endswith(" -> a and b"), short.tag)
+        edge = dataclasses.replace(m, after="x" * 48)
+        self.assertTrue(edge.tag.endswith(" -> " + "x" * 48),
+                        "48 characters is short ENOUGH, and a boundary one notch in "
+                        "digests an edit that would have fitted: " + edge.tag)
+        over = dataclasses.replace(m, after="x" * 49)
+        self.assertRegex(over.tag, r"…#[0-9a-f]{6}$")
+        self.assertEqual(len(over.tag.split(" -> ", 1)[1]), 48)
 
     def test_a_long_edit_is_shortened_without_becoming_its_siblings_tag(self):
         """The first fix for #721 contained #721, and this fixture line is why it was

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1959,10 +1959,12 @@ class TwoMutantsOfOneNodeAreNeverReportedAlike(unittest.TestCase):
         SPAN = ROWS + COLS
 
 
-        def render(rows, name, d, path, text, x, y, ch):
+        def render(rows, name, d, path, text, x, y, ch, i, n, in_class):
             if not isinstance(name, str):
                 return []
             if name and name not in d:
+                return []
+            if in_class and i + 2 < n and text[i + 1] == "-" and text[i + 2] != "]":
                 return []
             if text.startswith("focus:"):
                 return []
@@ -2109,6 +2111,33 @@ class TwoMutantsOfOneNodeAreNeverReportedAlike(unittest.TestCase):
         self.assertTrue(gone.tag.endswith("(deleted)"),
                         "a deletion has no `after` to name, and an empty discriminator "
                         "would put every deletion on one line back")
+
+    def test_a_long_edit_is_shortened_without_becoming_its_siblings_tag(self):
+        """The first fix for #721 contained #721, and this fixture line is why it was
+        caught. `after` is everything the mutant KEEPS, so `drop-conjunct` siblings share
+        a long PREFIX — `_regex_shape`'s four-conjunct guard in `tools/sweep.py` has two
+        whose replacements agree for their first 48 characters — and a plain truncation
+        merged them back onto one line. Not truncating is not the answer either:
+        replacements reach 7,149 characters in this tree. So the shortening stays and
+        carries a digest of the whole replacement."""
+        four = [ms for (_, operator), ms in self.siblings().items()
+                if operator == "drop-conjunct" and len(ms) == 4]
+        self.assertEqual(len(four), 1, "the fixture's four-conjunct guard is gone, and "
+                                       "with it the only case that catches this")
+        ms = four[0]
+        edits = [m.tag.split(" -> ", 1)[1] for m in ms]
+        self.assertLess(
+            len({e[:40] for e in edits}), len(ms),
+            "no two of these tags share their visible prefix any more, so this no longer "
+            "measures what a plain truncation did to them: " + " | ".join(sorted(edits)))
+        self.assertEqual(len(set(edits)), 4,
+                         "two mutants of one line render as one tag again")
+        for m in ms:
+            with self.subTest(after=m.after):
+                self.assertLessEqual(
+                    len(m.tag.split(" -> ", 1)[1]), 48,
+                    "the discriminator is bounded, or a 7,149-character replacement "
+                    "puts a bullet list past anything a reader will read")
 
     def test_the_progress_line_says_what_the_gate_summary_says(self):
         """The asymmetry that hid the two holes: the gate summary printed `question` and

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1928,6 +1928,201 @@ class TwoGuardsCanHideBehindEachOther(unittest.TestCase):
 # Evidence, caching, and the report
 # ======================================================================================
 
+class TwoMutantsOfOneNodeAreNeverReportedAlike(unittest.TestCase):
+    """#721, asserted on the whole operator table rather than on the two that cost money.
+
+    `Mutation.before` is the mutated NODE, so **ambiguity appears exactly where the node
+    is larger than the thing being varied**: every `drop-conjunct` mutant of
+    `if A and B:` prints the same line, and the two mean opposite things. Dropping the
+    cheap prefilter is genuinely equivalent and correctly dismissed; dropping the test
+    that decides is a fail-open hole. Two of those, in a security guard, were read as the
+    first across two full sweep runs and only caught on a third — 150,585 and 119,278
+    distinguishing inputs, both verified against a real `bash`. A report line satisfied by
+    two mutants meaning different things discriminates neither, and that is worse than
+    printing nothing, because it supplies a wrong reading.
+
+    So the property is the table's and not one operator's: **an operator yielding more
+    than one mutant for one node must give them distinct questions, distinct tags and
+    distinct report lines.** That is what would have caught `unclamp` — whose two mutants
+    printed identically AND carried one question, while asking whether the floor is pinned
+    and whether the value is — before anybody was bitten by it, and `drop-term`, which had
+    the same shape and was in nobody's table.
+    """
+
+    #: One instance of every shape the table can recognise, so that the property below is
+    #: measured over all of them and not over the ones somebody remembered. The seven
+    #: shapes that yield siblings for one node are all here; the rest are here so that an
+    #: operator added to `_iter_operators` without a line here fails the coverage test.
+    FIXTURE = """
+        LIMIT = 28
+        MODE = 0o600
+        SPAN = ROWS + COLS
+
+
+        def render(rows, name, d, path, text, x, y, ch):
+            if not isinstance(name, str):
+                return []
+            if name and name not in d:
+                return []
+            if text.startswith("focus:"):
+                return []
+            if x == 1:
+                head = 1
+            else:
+                head = 2
+            width = max(1, LIMIT - head)
+            if 0 <= x < width:
+                return []
+            if " " <= ch <= "~":
+                return []
+            kept = [r for r in rows if r]
+            label = contain.one_line(text)
+            slot = d.get(name) or ()
+            other = d.get(name, "-")
+            tail = "left" if y else "right"
+            try:
+                value = int(text)
+            except ValueError:
+                return []
+            return [label.lower(), path.resolve(), kept, slot, other, tail, value, width]
+    """
+
+    def siblings(self) -> dict[tuple, list]:
+        """Every group of mutants sharing one node and one operator.
+
+        Keyed on the byte span, which is the node — not on the line, because two nodes on
+        one line are two questions and are entitled to read alike.
+        """
+        groups: dict[tuple, list] = {}
+        for m in _mutations(self.FIXTURE):
+            groups.setdefault((m.span, m.operator), []).append(m)
+        return {k: v for k, v in groups.items() if len(v) > 1}
+
+    def test_no_sibling_pair_shares_a_question_a_tag_or_a_report_line(self):
+        """The whole issue, in one assertion, over every shape that has siblings.
+
+        Three fields and not one: `question` is what the gate summary prints, `__str__` is
+        what the per-mutation progress line prints — the stream that is all a reclaimed
+        shard leaves behind, and the stream that hid the two holes — and `tag` is what the
+        not-applied and no-verdict lists render.
+        """
+        self.assertTrue(self.siblings(), "the fixture offers no sibling group at all")
+        for (_, operator), ms in sorted(self.siblings().items()):
+            for field, read in (("question", lambda m: m.question),
+                                ("tag", lambda m: m.tag),
+                                ("report line", str)):
+                with self.subTest(operator=operator, line=ms[0].line, field=field):
+                    seen = {read(m) for m in ms}
+                    self.assertEqual(
+                        len(seen), len(ms),
+                        f"{operator} yields {len(ms)} mutants for one node and only "
+                        f"{len(seen)} distinct {field}s, so a survivor reported this way "
+                        f"is satisfied by mutants meaning different things: "
+                        + "  ||  ".join(sorted(seen)))
+
+    def test_every_shape_that_yields_siblings_is_in_the_fixture(self):
+        """A guard on the guard. The assertion above is only as general as this list, and
+        a fixture that quietly stopped covering `unclamp` would still pass it.
+
+        `retune-constant` is here because a module-level constant written in a base other
+        than ten is offered twice — once by the module-constant rule as `n + 1` in decimal,
+        once by the non-decimal rule re-spelled in its own base. Those two are the same
+        VALUE, so it is a question asked twice rather than an ambiguity, and it is left
+        alone here: this test pins that the two are told apart, not that both exist.
+        """
+        self.assertEqual(
+            sorted({operator for _, operator in self.siblings()}),
+            ["collapse-ifexp", "disable-branch", "drop-conjunct", "drop-term",
+             "retune-constant", "shift-boundary", "unclamp"])
+
+    def test_the_fixture_exercises_every_operator_the_table_names(self):
+        """An operator added to `_iter_operators` and not to the fixture is a shape this
+        property was never asserted over — which is how `unclamp` and `drop-term` came to
+        be live instances of #721 that nothing had tripped over. The table names its
+        operators as literals in the yielded tuple, so it can be read without running a
+        sweep."""
+        table = set()
+        tree = ast.parse(Path(sweep.__file__).read_text(encoding="utf-8"))
+        fn = next(n for n in ast.walk(tree)
+                  if isinstance(n, ast.FunctionDef) and n.name == "_iter_operators")
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Yield) and isinstance(node.value, ast.Tuple):
+                name = node.value.elts[2]
+                self.assertIsInstance(name, ast.Constant)
+                table.add(name.value)
+        self.assertGreater(len(table), 10)
+        self.assertEqual(sorted(table - {m.operator for m in _mutations(self.FIXTURE)}),
+                         [])
+
+    def test_the_clamp_question_names_the_operand_the_mutant_keeps(self):
+        """`unclamp` was the worst instance and the one no field could disambiguate:
+        `max(a, b) -> a` asks whether anything requires the value to clear the floor,
+        `-> b` whether anything requires the floor at all, and both used to read "is the
+        clamp pinned, or only its inner value?"."""
+        self.assertEqual(
+            sorted(m.question for m in _by(_mutations("""
+                def f(h):
+                    return max(1, h - 3)
+            """), "unclamp")),
+            ["is the clamp pinned, or is `1` always the answer?",
+             "is the clamp pinned, or is `h - 3` always the answer?"])
+
+    def test_a_branch_question_locates_itself_without_the_operator_table_open(self):
+        """"is this branch pinned?" against "is the other branch pinned?" are two
+        different strings and still not a legible reason: which is which is knowable only
+        with `_iter_operators` open, and the reviewer holding the report does not have it.
+        The spec asks that a survivor's reason be legible, so each one now names the branch
+        it is about — by keyword for the conditional expression, by the direction the
+        condition was forced for the statement."""
+        self.assertEqual(
+            sorted(m.question for m in _by(_mutations("""
+                def f(y):
+                    return "left" if y else "right"
+            """), "collapse-ifexp")),
+            ['is the `else` branch pinned, or is `"left"` always the answer?',
+             'is the `if` branch pinned, or is `"right"` always the answer?'])
+        forced = sorted(m.question for m in _by(_mutations("""
+            def f(y):
+                if y:
+                    return 1
+                else:
+                    return 2
+        """), "disable-branch"))
+        self.assertEqual(forced, [
+            "is the rest of the chain pinned, or does nothing change when this condition "
+            "always holds?",
+            "is this branch pinned, or does nothing change when its condition never "
+            "holds?"])
+
+    def test_the_tag_keeps_its_prefix_and_adds_what_tells_siblings_apart(self):
+        """`tag` is rendered into the not-applied and no-verdict lists and into the
+        `NotApplied` message, and `path:line:operator` is what a reader greps for — so the
+        edit is appended rather than substituted for it."""
+        m = sweep.Mutation(path="charter/hooks.py", line=3658, end_line=3658,
+                           operator="drop-conjunct",
+                           question='is the `c == "$"` half pinned?',
+                           before='c == "$" and text.startswith("$(", i)',
+                           after='text.startswith("$(", i)', symbol="_scan")
+        self.assertTrue(m.tag.startswith("charter/hooks.py:3658:drop-conjunct"))
+        self.assertIn('text.startswith("$(", i)', m.tag)
+        gone = dataclasses.replace(m, after="")
+        self.assertTrue(gone.tag.endswith("(deleted)"),
+                        "a deletion has no `after` to name, and an empty discriminator "
+                        "would put every deletion on one line back")
+
+    def test_the_progress_line_says_what_the_gate_summary_says(self):
+        """The asymmetry that hid the two holes: the gate summary printed `question` and
+        the per-mutation log did not, so a shard reclaimed before it could emit a summary
+        left behind the one stream that could not be read."""
+        m = sweep.Mutation(path="charter/hooks.py", line=3658, end_line=3658,
+                           operator="drop-conjunct",
+                           question='is the `c == "$"` half pinned?',
+                           before='c == "$" and text.startswith("$(", i)',
+                           after='text.startswith("$(", i)', symbol="_scan")
+        self.assertIn('is the `c == "$"` half pinned?', str(m))
+        self.assertIn("charter/hooks.py:3658 [drop-conjunct]", str(m))
+
+
 class TheReportSaysWhatTheTestsAsserted(unittest.TestCase):
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp(prefix="charter-sweep-ev-"))

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -276,10 +276,35 @@ class Mutation:
 
     @property
     def tag(self) -> str:
-        return f"{self.path}:{self.line}:{self.operator}"
+        """`path:line:operator`, and then the edit that makes this one not its sibling.
+
+        The prefix is unchanged, because it is what a reader greps for; the discriminator
+        is appended rather than substituted. What is appended is the one field that is
+        different by construction: :func:`mutations_for` de-duplicates on
+        ``(line, col, operator, replacement)``, so two mutants that survive that key
+        together differ in `after` and in nothing else the report round-trips. Without it
+        a single `if A and B:` renders both of its `drop-conjunct` mutants as one string
+        in the not-applied and no-verdict lists, and a list that names two different
+        mutations identically discriminates neither (#721).
+        """
+        edit = _oneline(self.after, 40) or "(deleted)"
+        return f"{self.path}:{self.line}:{self.operator} -> {edit}"
 
     def __str__(self) -> str:
-        return f"{self.path}:{self.line} [{self.operator}] {_oneline(self.before)}"
+        """The per-mutation progress line's whole account of one mutation.
+
+        `before` is the mutated NODE, and **ambiguity appears exactly where the node is
+        larger than the thing being varied** — for `drop-conjunct` it is the whole
+        condition, identical for every conjunct. `question` is the field that says which
+        one went, and until #721 only the gate summary printed it. A shard reclaimed
+        before it could emit a summary leaves this log as the only record, and it read the
+        same whether the dropped half was a cheap prefilter (equivalent, and correctly
+        dismissed) or the test that decides. Two fail-open holes in a security guard were
+        read as the first and dismissed across two full sweep runs on exactly that. The
+        two streams now say the same thing, which is the property that failed.
+        """
+        return (f"{self.path}:{self.line} [{self.operator}] "
+                f"{_oneline(self.before, 72)} — {self.question}")
 
 
 def _oneline(s: str, limit: int = 96) -> str:
@@ -1046,9 +1071,14 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
             yield (value, str(value.value + 1), "retune-constant",
                    f"is `{target}`'s value pinned, or would any number do?")
         if isinstance(value, ast.BinOp) and isinstance(value.op, ast.Add):
-            for side in (value.left, value.right):
-                yield (value, sp.text(side), "drop-term",
-                       f"is every term of `{target}` pinned?")
+            # The question names the term that WENT, not "every term": the mutated node
+            # is the whole sum, so both mutants of `A + B` print identically, and until
+            # #721 they carried one question too — the `unclamp` shape, where no field at
+            # all told a reviewer which of two opposite claims had survived.
+            for kept, gone in ((value.left, value.right), (value.right, value.left)):
+                yield (value, sp.text(kept), "drop-term",
+                       f"is the `{_oneline(sp.text(gone), 40)}` term of `{target}` "
+                       f"pinned?")
 
     for node in ast.walk(tree):
 
@@ -1071,8 +1101,17 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
         # happen and a mutation that reddens the suite for that reason is a false pin —
         # the one outcome worse than no signal.
         if isinstance(node, ast.If) and node.orelse:
-            yield (node.test, "False", "disable-branch", "is this branch pinned?")
-            yield (node.test, "True", "disable-branch", "is the other branch pinned?")
+            # "this" and "the other" are two different questions and they are also not
+            # self-locating: which is which is knowable only by reading this file, and the
+            # reviewer holding the report does not have it open. Naming the direction the
+            # condition was forced makes each one checkable against the printed line,
+            # which is what #721 asks of a question that has to carry the disambiguation.
+            yield (node.test, "False", "disable-branch",
+                   "is this branch pinned, or does nothing change when its condition "
+                   "never holds?")
+            yield (node.test, "True", "disable-branch",
+                   "is the rest of the chain pinned, or does nothing change when this "
+                   "condition always holds?")
 
         # The same refusal in expression clothes: `[x for x in xs if C]`. Round two's
         # first finding, `harness_rows`' `if _edge_of(slot) not in _COLUMN_EDGES`, lives
@@ -1115,9 +1154,16 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
                 and node.func.id in ("max", "min") and len(node.args) == 2 \
                 and not node.keywords:
+            # The operand the mutant collapses to, named. This was the worst instance of
+            # #721 in the table and the one nothing had tripped over: both mutants of
+            # `max(a, b)` print identically AND shared one question, while asking opposite
+            # things — `-> a` asks whether anything requires the value to clear the floor,
+            # `-> b` whether anything requires the floor at all. No field distinguished
+            # them, so a survivor here could not be read at all, only guessed at.
             for arg in node.args:
                 yield (node, sp.text(arg), "unclamp",
-                       "is the clamp pinned, or only its inner value?")
+                       f"is the clamp pinned, or is `{_oneline(sp.text(arg), 40)}` "
+                       f"always the answer?")
 
         # `except E:` — narrowed to something nothing raises. `_component_text`'s
         # `except Exception` was round two's finding 4.
@@ -1156,10 +1202,16 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
         # `a if C else b` — collapsed to each side. `_policy_cells`' `else 1` was round
         # three's fifth finding and is exactly this.
         if isinstance(node, ast.IfExp):
+            # Technically two questions and practically one: "this" and "the other" are
+            # only decodable with this function open, and 767 nodes in `charter/` carry
+            # the pair. The branch that went is named by keyword and the branch that
+            # stayed by its own text, so the report is readable on its own (#721).
             yield (node, sp.text(node.body), "collapse-ifexp",
-                   "is the other branch pinned?")
+                   f"is the `else` branch pinned, or is "
+                   f"`{_oneline(sp.text(node.body), 40)}` always the answer?")
             yield (node, sp.text(node.orelse), "collapse-ifexp",
-                   "is this branch pinned?")
+                   f"is the `if` branch pinned, or is "
+                   f"`{_oneline(sp.text(node.orelse), 40)}` always the answer?")
 
         # ------------------------------------------------------------------------------
         # String and regex constants (#569). The general form is :func:`retune`.
@@ -1226,9 +1278,15 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
                 parts = [spelled[0]]
                 for o, right in zip(ops, spelled[1:]):
                     parts += [o, right]
+                # WHICH boundary, because a chained comparison is one node with two
+                # edges: `" " <= c <= "~"` yields two mutants that print identically and,
+                # when both edges spell the same operator, carried the same question as
+                # well — 8 of the 13 chained comparisons in `charter/` and `tools/` (#721).
+                edge = (f"{_oneline(sp.text(operands[i]), 24)} {swap[0]} "
+                        f"{_oneline(sp.text(operands[i + 1]), 24)}")
                 yield (node, " ".join(parts), "shift-boundary",
-                       f"is the boundary pinned, or only the direction ({swap[0]} vs "
-                       f"{swap[1]})?")
+                       f"is `{edge}`'s boundary pinned, or only the direction "
+                       f"({swap[0]} vs {swap[1]})?")
 
         # `x.lower()` -> `x.upper()`, `sorted(xs)` -> `list(xs)`, and the rest of
         # :data:`SYNONYMS`. The mutant is type-correct by construction, so a red here is a

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -286,8 +286,24 @@ class Mutation:
         a single `if A and B:` renders both of its `drop-conjunct` mutants as one string
         in the not-applied and no-verdict lists, and a list that names two different
         mutations identically discriminates neither (#721).
+
+        **Truncating alone re-created the very bug, one line inside its fix.** `after` is
+        everything the mutant KEEPS, so for `drop-conjunct` it is nearly the whole
+        condition and its siblings share a long prefix: `_regex_shape`'s own four-conjunct
+        guard on line 706 of this file has two mutants whose replacements agree for their
+        first 48 characters, and a cut there put them back on one line. Replacements run
+        to 7,149 characters in this tree, so not cutting is not an option either — the
+        digest is of the WHOLE replacement, so the tag stays short and still names exactly
+        one mutant.
         """
-        edit = _oneline(self.after, 40) or "(deleted)"
+        flat = " ".join(self.after.split())
+        if not flat:
+            edit = "(deleted)"
+        elif len(flat) <= 48:
+            edit = flat
+        else:
+            edit = flat[:40] + "…#" + hashlib.sha256(
+                self.after.encode("utf-8")).hexdigest()[:6]
         return f"{self.path}:{self.line}:{self.operator} -> {edit}"
 
     def __str__(self) -> str:


### PR DESCRIPTION
Closes #721.

## What the report could not say

`Mutation.before` is the mutated **node**, so wherever the node is larger than the thing
being varied, every mutant of it prints the same line:

```
charter/hooks.py:3658 [drop-conjunct] c == "$" and text.startswith("$(", i)
```

Dropping the first half removes a cheap prefilter and is genuinely equivalent. Dropping
the second is a fail-open hole. Two of those, in a security guard, were read as the first
across **two full sweep runs** — 150,585 and 119,278 distinguishing inputs, both verified
against a real `bash`.

## Where the fix lands

Per @diazoxide's correcting comment: the information was already computed. `mutations_for`
yields a `question` per mutant, the gate summary prints it, and `__str__` dropped it —
and `__str__` is the per-mutation progress line, which is all a shard reclaimed before it
can emit a summary leaves behind. That is the stream that hid these two.

- **`__str__` carries the question**, so the progress log and the gate summary agree.
- **`tag` keeps `path:line:operator` and appends the edit.** It is *appended*, not
  substituted — the prefix is what a reader greps for. `tag` is not load-bearing as an
  identifier: it is not in the JSON, not a merge or resume key, and appears in exactly
  three places (`NotApplied`'s message, the not-applied list, the no-verdict list).
- **Six question fixes**, below.

## Which operators were affected — measured over `charter/` and `tools/`

**1,410 nodes** offer more than one mutant, and every one rendered as one line and one
tag. For **77** of them no field distinguished the siblings at all:

| operator | sibling nodes | question collided | in the issue's table? |
|---|---|---|---|
| `collapse-ifexp` | 767 | no, but not self-locating | yes |
| `drop-conjunct` | 306 | no | yes (the one that cost) |
| **`disable-branch`** | **253** | no, but not self-locating | **no — found here** |
| `unclamp` | 58 | **yes, all 58** | yes ("worst") |
| `shift-boundary` | 13 | **yes, 8 of 13** | yes (chained only) |
| **`drop-term`** | **11** | **yes, all 11** | **no — found here** |
| `retune-constant` | 2 | no | no — see below |

Two beyond the five named. **`disable-branch`** is `collapse-ifexp`'s shape ("is this
branch pinned?" / "is the other branch pinned?", decodable only with `_iter_operators`
open) at 253 nodes. **`drop-term`** is `unclamp`'s shape — both mutants of a module
constant's `A + B` printed identically *and* carried one question. `drop-comprehension-if`,
`narrow-except` and `no-fallback` are unaffected, as the issue predicted.

`unclamp`, `drop-term` and `shift-boundary` now name their own operand, term and edge;
`collapse-ifexp` and `disable-branch` name the branch by keyword and by the direction the
condition was forced.

## The first version of this fix contained the bug it fixes

`after` is everything the mutant **keeps**, so `drop-conjunct` siblings share a long
*prefix*, and truncating the tag's edit at 40 characters merged two of them again. The
instance is in `tools/sweep.py` itself — `_regex_shape`'s four-conjunct guard on line 706,
whose middle two replacements agree for 40 characters. It was the only collision left in
the tree after the first commit, and it was found by re-measuring rather than by reasoning.

Not truncating is not the answer either: replacements reach **7,149** characters here
(p50 = 7, p90 = 25, p99 = 72). So the edit is verbatim up to 48 characters and otherwise
cut to 40 with a six-hex digest of the whole replacement. That same four-conjunct guard is
now in the test fixture, where a plain truncation fails two tests.

## The deliverable

`TwoMutantsOfOneNodeAreNeverReportedAlike` asserts the rule on the **table**, not on the
operators that cost something: *an operator yielding more than one mutant for one node
must give them distinct questions, distinct tags and distinct report lines.* It runs over
one fixture holding an instance of every shape `_iter_operators` recognises, and a
companion test reads the operator names straight out of that function's AST — so a shape
added there and not added to the fixture fails rather than going quietly unmeasured.

**Verified red.** Eight collisions reintroduced one at a time, each confirmed to fail and
`tools/sweep.py` restored byte-identical after: `unclamp`, `drop-term` and
`shift-boundary` questions collapsed back to one string; `collapse-ifexp` and
`disable-branch` wording back to "this"/"the other"; `tag` with no discriminator; `tag`
truncated with no digest; `__str__` without the question.

## Verification

- `tests.test_sweep` — **361 tests, OK**. Plus the 634 tests in the eleven other modules
  that import `tools.sweep`, and the news/packaging tests.
- **Tree-wide re-measure**: over all **11,338** mutations `charter/` and `tools/` offer,
  **zero** colliding questions, tags or report lines. Before: 1,410 colliding tags and
  report lines, 77 colliding questions.
- **The sweep, on itself.** `tools/sweep.py --path tools --plan` offers **6 mutations** on
  this diff. Run by hand against `tests.test_sweep` in a clone: the first pass found **2
  survivors** in this PR's own new code (`len(flat) <= 48 -> False`, and the `<=`/`<`
  boundary). Both are now pinned, and the second pass is **0 survivors**.
- **Hand-verified** the sandbox round trip, since the gate's own numbers do not cover
  `tools/`: `sha256` on the sandbox file pristine (equal to `mutation.origin`), after
  `apply` (different), and after `restore` (equal again); the operator's checkout
  unchanged by sha256; `git diff --quiet` exit 0 and `git status --porcelain` empty.
- **Plan order is unchanged.** `question`, `tag` and `__str__` are inputs to none of
  `mutations_for`'s dedup key `(line, col, operator, replacement)` or its sort key
  `(path, line, operator, after)` — confirmed by diffing the ordered
  `(path, line, operator, after)` list produced by `origin/main`'s `sweep.py` and this
  branch's over the same sources (261 mutations of `charter/instance.py`: identical). So
  `shard_of`'s round-robin membership does not move.

## Two things this PR does *not* do

- **`retune-constant` offers a module-level non-decimal constant twice** — `STATE_FILE_MODE
  = 0o600` yields both `385` (module-constant rule, decimal) and `0o601` (non-decimal rule).
  Same value, so it is a question asked **twice**, not an ambiguity — and the `385` spelling
  is what the operator table's own comment calls "a mutation nobody can check at a glance".
  2 instances in `charter/`. Left alone: it changes the plan, and it is a different defect.
  Worth its own issue.
- **A killed shard still cannot be told from a reclaimed one.** The progress line is
  emitted *after* `decide` returns and `--json` is written once at the end, so the mutation
  that consumed a runner is precisely the one with no line. This PR improves what the
  surviving lines say — each now names its mutant exactly — but "the last mutation this
  shard *started*" is not recorded anywhere, and unlike #721's question it is not
  information that already exists and is being dropped. That is a behaviour change, and it
  belongs with the runaway-mutation work rather than here.

## Not touched

Version files and `docs/news/0.54.0-*`. The news entry is `version: unreleased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy