### PR TITLE
`_screenshot` waits for the whole frame to arrive, instead of for the first rule (#719)

### DIFF
--- a/docs/news/unreleased-the-frames-screenshot-waits-for-the-whole-frame.md
+++ b/docs/news/unreleased-the-frames-screenshot-waits-for-the-whole-frame.md
@@ -1,0 +1,106 @@
+---
+version: unreleased
+headline: The frame's screenshot tests stop photographing a half-painted frame
+---
+
+`ChromeIsOneColour` is the only place in this suite that looks at what an operator looks
+at, and on a loaded machine it was photographing frames that had not finished arriving.
+The messages it produced never said so. They said this:
+
+```
+AssertionError: Lists differ: [(1, 9, 100, ['default', 'default']), …34 more…] != []
+```
+
+— a rule at row 1, running from column 9 to column 100, with an unpainted pane on each
+side of it. Every panel in that screenshot had been handed `window-style bg=brightblack`
+before the client ever attached, so a settled screen cannot have a `default` pane next to
+a rule. It reads exactly like a #514 regression, and it sends the next person to audit
+`pane_border_options`, which is correct. That is what made this the more dangerous of the
+two flakes found in this class (#713 was the other), and why it was split out rather than
+bundled.
+
+**The gate measured the wrong fact.** The frame is drawn by a client on the inner server
+writing into a pty that the OUTER server reads, and `_screenshot` stopped at the first
+capture that contained **any** rule:
+
+```python
+if _rule_states(shot):
+    break
+```
+
+tmux emits a redraw borders first, so the first capture with a rule in it is routinely a
+capture with the borders drawn and the pane surfaces not yet arrived. Idle, the whole paint
+lands between two polls and nothing notices. Loaded, the outer server is descheduled
+part-way through reading it, the gate is satisfied by the fragment, and the test asserts
+about a screen that was never the frame. "Some rules exist" and "this frame has finished
+arriving" are different questions, and only the second one was ever wanted.
+
+**The fix is an ordering, not a wait** (#650's rule; no `sleep` was added and no deadline
+was lengthened). Once the frame's paint is demonstrably under way, a short mark is TYPED
+into the harness pane — whose program is `cat`, whose pty echoes it — and the shot is the
+first capture that holds the mark. A pty is a stream: the mark's bytes are written after
+the redraw's and cannot overtake them, so the mark on the outer pane's screen is proof the
+outer server consumed the whole redraw first. It survives tmux's one escape from that
+ordering as well: a client whose terminal cannot keep up has its pending output
+**discarded**, and while it is in that state the mark is discarded with it — tmux then
+invalidates and redraws the entire screen, so the mark still cannot arrive without the
+frame it marks.
+
+A rule is still waited for, and it is now the precondition rather than the answer: tmux
+composes a whole-screen redraw in one pass into one buffer, so one border cell reaching the
+outer server proves the rest of that frame is already written and ordered ahead of anything
+typed next. Typed any earlier, the mark would be part of the pane content that same redraw
+is still drawing, and would prove only that one pane had arrived.
+
+**Three candidate gates were measured rather than argued, 600 shots each under load.**
+
+| gate | wrong at this loop's 0.1s cadence | at 0.01s |
+|---|---|---|
+| any rule has appeared (what was there) | 29/600 | 30/600 |
+| every row of the capture is full width | 10/600 | 6/600 |
+| two captures in a row are identical | 0/600 | **5/600** |
+| the typed mark has come back | **0/600** | **0/600** |
+
+"Every pane is non-empty" is not on that list because it cannot be asked here: every pane
+in these tests runs `cat` and writes nothing, so a painted pane is a rectangle of spaces.
+Its nearest measurable cousin — every row of the capture arrived at full width — is cheap
+and wrong: it catches a paint truncated at a row boundary and misses one that stopped after
+the borders. And "it stopped changing" is a duration wearing a fact's clothes: it is right
+only while the gap between two polls is longer than the longest pause inside a paint, which
+is a fact about the machine's load and not about the frame — halve the cadence and it
+starts being wrong.
+
+**Measured end to end, both worktrees run at once under one load**, three legs each,
+135 runs per worktree per binary, 14-core darwin, `python3.14`.
+
+| binary | leg | runs | failed |
+|---|---|---|---|
+| tmux 3.7c | `main` | 135 | **6** |
+| tmux 3.7c | this branch | 135 | **0** |
+| tmux 3.2 | `main` | 135 | **18** |
+| tmux 3.2 | this branch | 135 | **0** |
+
+Every one of `main`'s 24 failures is one of #719's own two:
+`test_no_shipped_design_leaves_a_seam_between_two_panes_of_one_colour` (19) and
+`test_an_unsurfaced_rule_really_does_leave_a_seam_between_painted_panes` (5) — the two
+messages the issue was filed with, and neither of them about colour. The tmux 3.2 leg
+needed #716's four deterministic floor failures patched out of the way first, or the
+surfaced screenshots never run at all; that patch is measurement scaffolding and is not in
+this branch.
+
+Per screenshot rather than per run, which is the more sensitive instrument: `main` stopped
+at a screen that was not the one the frame settled to on **5 of 716** shots on 3.7c and
+**8 of 263** on 3.2; this branch on **0 of 960** and **0 of 264**.
+
+Two claims the mark makes are now asserted rather than promised. It reaches the shot
+through the nested client and its cells read as the harness pane's own background, so
+nothing this class reads off a screenshot can see it. And the ordering itself is measured
+on this tmux rather than argued from tmux's source: six rounds repaint a pane and type a
+mark behind the repaint, and the screen carrying each mark carries exactly one background
+and a new one — a screen caught between two paints carries both, which is the frame this
+was photographing.
+
+The module's deterministic tmux 3.2 failures are unchanged, four in this class and all of
+them #716's.
+
+Nothing to adopt — no production behaviour changed.

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -4355,6 +4355,25 @@ def _rule_glyphs(text: str) -> set:
 #: cannot see them and they are asked about by name.
 _INDICATOR_GLYPHS = frozenset("←→↑↓")
 
+#: The mark `_screenshot` types into the frame once the frame's own paint is on its way,
+#: and waits to see come back — the fact that says the whole of that paint has arrived.
+#: See `_screenshot` for why an ordering is the only honest answer to "is this frame
+#: finished" and #719 for what asking "are there rules yet" instead cost.
+#:
+#: **Every character is chosen so the frame it marks still reads exactly as it did.** It
+#: is typed into the HARNESS pane — the one pane charter never paints — so its cells
+#: carry that pane's own background and `_painted`, `_seams`, `_harness_edges` and
+#: `_rule_rows` see what they saw before it. It is outside the Box Drawing block, so
+#: `_rule_glyphs` and `_rule_states` cannot mistake it for chrome, and outside
+#: `_INDICATOR_GLYPHS`. And it is fenced in tildes because a hostname cannot contain one:
+#: `test_the_frame_draws_every_rule_the_same_inside_the_operators_own_tmux` asserts this
+#: machine's name is NOT on the screen, and a mark that could pass for a hostname would
+#: turn that assertion into one about the mark.
+#:
+#: `test_the_paint_mark_arrives_and_reads_as_the_harnesss_own_background` is that
+#: paragraph, asserted rather than promised.
+_PAINT_MARK = "~painted~"
+
 
 class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
     """#514, asked of the SCREEN: charter's own frame must draw every rule the same.
@@ -4449,6 +4468,13 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
           horizontal rule in two colours and is the defect the operator reported third.
         * ``"pane"`` — ``"panel"`` plus `_harness_rule_argvs` on the harness pane, which is
           what charter does above the floor now.
+
+        **The shot carries `_PAINT_MARK`, and every caller here reads a marked frame.**
+        The mark is what says the frame has finished arriving — see the gate at the end of
+        this method, and #719 for the frame this returned before it. Its cells are the
+        harness pane's own, so nothing this class reads off a screenshot can see it;
+        `test_the_paint_mark_arrives_and_reads_as_the_harnesss_own_background` is that
+        claim, measured.
         """
         session = f"f{int(arm)}{int(hostile)}{int(bool(surface))}{design[0]}-{self._pane_counter}"
         self._pane_counter += 1
@@ -4532,8 +4558,46 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         # before there is anything to read, and how long that takes is the machine's
         # business. Gives up quietly — `_control` is what turns "nothing rendered" into a
         # skip that says so.
+        #
+        # **What is polled for is an ORDERING, and #719 is what polling for "are there
+        # rules yet" cost.** The frame is drawn by a client on the inner server writing
+        # into a pty the OUTER server reads, and a redraw goes down that pty borders
+        # first — so the first capture holding a rule is routinely a capture holding the
+        # borders and none of the pane surfaces behind them. Idle, the whole paint lands
+        # between two polls and nothing notices; loaded, the outer server is descheduled
+        # part-way through reading it and the gate is satisfied by the fragment. Measured
+        # on this machine, 600 shots under load: **29 of them stopped at a screen that was
+        # not the screen the frame settled to.** What came back then was a frame with
+        # rules and `default` panes — which every assertion here reads as charter having
+        # changed colour, and none of them as tmux having been interrupted.
+        #
+        # So the gate below asks a question with a yes: a mark is TYPED into the frame
+        # once its paint is demonstrably under way, and the shot is the first capture that
+        # holds the mark. A pty is a stream; the mark's bytes are written after the
+        # redraw's and cannot overtake them, so the mark on the outer pane's screen is
+        # proof the outer server consumed the whole redraw first. It holds through tmux's
+        # one escape from that ordering as well: a client whose terminal cannot keep up
+        # has its pending output DISCARDED, and while it is in that state the mark is
+        # discarded with it — tmux then invalidates and redraws the entire screen, so the
+        # mark still cannot arrive without the frame it marks.
+        #
+        # **A rule is still waited for, and it is now the precondition rather than the
+        # answer.** tmux composes a whole-screen redraw in one pass into one buffer, so a
+        # single border cell reaching the outer server proves the rest of that frame is
+        # already written and ordered ahead of anything typed next. Typed before that, the
+        # mark would be part of the pane content the first redraw is still drawing, and it
+        # would prove only that ONE pane had arrived.
+        #
+        # Not a `sleep` and not a longer deadline (#650's rule, and #713's): the deadline
+        # bounds how long "it never painted" takes to report and is never spent by a
+        # machine that painted. The alternative that looks cheaper — stop when two
+        # captures in a row are identical — is a duration wearing a fact's clothes, and it
+        # measures as one: wrong on 0 of 600 shots at this loop's 0.1s cadence and on 5 of
+        # 600 at 0.01s, because what it really asks is whether a paint stalled for longer
+        # than the gap between two polls.
         deadline = time.time() + 10
         shot = ""
+        typed = False
         while time.time() < deadline:
             # `-N` keeps the trailing spaces on each row, and without it a SURFACE is
             # invisible to this harness: every pane here runs `cat` and writes nothing, so
@@ -4544,8 +4608,19 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
             got = self._outer("capture-pane", "-p", "-e", "-N", "-t", host)
             if got.returncode == 0:
                 shot = got.stdout
-            if _rule_states(shot):
-                break
+            if typed:
+                if _PAINT_MARK in shot:
+                    break
+            elif _rule_states(shot):
+                # Into the harness, whose program is `cat` and whose pty echoes what is
+                # typed at it — the same `cat` every pane in this module runs, so nothing
+                # here needs a pane built differently from the frame's own. `-l` sends the
+                # string as literal characters rather than as key names.
+                self.assertEqual(
+                    self._srv("send-keys", "-l", "-t", harness,
+                              _PAINT_MARK).returncode, 0,
+                    "tmux would not type the paint mark into the frame")
+                typed = True
             time.sleep(0.1)
         self._outer("kill-session", "-t", host)
         self._srv("kill-session", "-t", session)
@@ -4784,6 +4859,151 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
                          "a server was rebuilt in the middle of this test, so the next "
                          "`new-session` on it was a client racing a process that had "
                          "already decided to exit")
+
+    def test_the_paint_mark_arrives_and_reads_as_the_harnesss_own_background(self):
+        """`_PAINT_MARK`'s two claims, asked of a real screenshot rather than promised.
+
+        **It arrives.** The gate `_screenshot` ends on waits for this string to come back
+        through the nested client, and it gets there by being typed at the harness pane's
+        `cat`, whose pty echoes it. On a tmux or a pty where that did not hold, every
+        screenshot in this class would spend its whole deadline and hand back whatever the
+        last capture happened to be — which is the reading #719 is about, restored by a
+        different route. So this is red, and loudly, rather than 20 tests going quiet.
+
+        **And it changes nothing this class reads.** Its cells are the harness pane's —
+        the one pane charter never paints — so they carry that pane's own background,
+        which is `default`: the very reading `_harness_edges` uses to find the harness at
+        all. None of its characters is a box-drawing glyph or a `pane-border-indicators`
+        arrow, so `_rule_states`, `_rule_glyphs` and `_rule_rows` cannot mistake it for
+        chrome, and `_painted` still finds exactly one painted background on a surfaced
+        frame — which this asks for first, and skips on if this machine cannot render one.
+
+        **`arm=False`, and that is not laziness** — the same argument
+        `test_neither_server_this_class_uses_is_ever_rebuilt_mid_test` makes. This is
+        about the mark and the harness's own background, and neither is charter's; arming
+        would put charter's chrome argvs on the path, which at `tmuxctl.FLOOR` fail over
+        an option tmux 3.2 does not have (#716) and would make this report somebody else's
+        failure. The panels are still painted either way — `_screenshot` paints a
+        *surface* whether or not the rules are armed — so the reading is the same one.
+        """
+        self.assertEqual(
+            set(_PAINT_MARK) & (_RULE_GLYPHS | _INDICATOR_GLYPHS), set(),
+            "the paint mark is made of characters this class reads as chrome, so every "
+            "screenshot it marks has a rule on it that tmux never drew")
+        shot = self._screenshot(arm=False, surface=self._SURFACE, design="bare")
+        painted = self._painted(shot)
+        cells = _sgr_runs(shot, carry=True)
+        at = "".join(ch for _state, ch in cells).find(_PAINT_MARK)
+        self.assertNotEqual(at, -1,
+                            "the mark `_screenshot` waits for is not on the screen it "
+                            "returned, so the gate gave up on its deadline rather than "
+                            "fired and this shot is not a photograph of a finished frame")
+        self.assertEqual(
+            {dict(cells[i][0])["bg"] for i in range(at, at + len(_PAINT_MARK))},
+            {"default"},
+            "the paint mark is drawn over a background of its own rather than the "
+            f"harness's, so a screenshot carrying it has a background beside {painted} "
+            "on it and `_painted` is reading the mark")
+
+    def test_what_the_frame_drew_before_the_mark_is_on_the_screen_no_later_than_it(self):
+        """The ordering `_screenshot`'s gate rests on, measured on this tmux rather than
+        argued from tmux's source — the whole reason the mark is a FACT and not a wait.
+
+        A frame reaches the outer server down ONE pty, as a stream. The inner client
+        composes a redraw and writes it; anything typed into the frame after that is
+        composed after it and goes into the same stream behind it. So a capture that holds
+        the mark cannot be a capture missing what the frame drew before the mark was
+        typed. That is the whole of the gate, and it is what "some rules have appeared"
+        never said.
+
+        Six rounds, each painting the panel a colour the round before it did not use, so a
+        tmux that answered out of order has six draws to do it in. Each round asserts that
+        the screen carrying that round's mark carries ONE background and that it is a new
+        one: a screen caught between two paints carries both, which is exactly the shape
+        #719 photographed — borders from the new frame, panes still from the old.
+
+        Its own session and its own two panes, at tmux's own border defaults: nothing here
+        is about charter's chrome, and a frame styled by `_chrome_argvs` would put a
+        background on the rules for this to have to reason about.
+        """
+        session = f"ord-{self._pane_counter}"
+        self._pane_counter += 1
+        r = self._srv("new-session", "-d", "-s", session, "-x", "100", "-y", "24",
+                      "-P", "-F", "#{pane_id}", "--", "cat")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness = r.stdout.strip()
+        self.assertEqual(self._srv("set", "-t", session, "status", "off").returncode, 0)
+        r = self._srv("split-window", "-t", harness, "-P", "-F", "#{pane_id}",
+                      "--", "cat")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        panel = r.stdout.strip()
+        # The harness holds the keyboard, so the panel is painted from `window-style`
+        # rather than `window-active-style` and one option is enough to move it.
+        self.assertEqual(self._srv("select-pane", "-t", harness).returncode, 0)
+        host = f"host-{session}"
+        r = self._outer("new-session", "-d", "-s", host, "-x", "100", "-y", "24",
+                        "--", "tmux", "-L", self.SOCKET_NAME, "attach", "-t", session)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self._outer("set", "-t", host, "status", "off")
+
+        def outer_screen() -> str:
+            got = self._outer("capture-pane", "-p", "-e", "-N", "-t", host)
+            return got.stdout if got.returncode == 0 else ""
+
+        try:
+            # The client has to be painting before a round can mean anything: until then
+            # a mark typed at the harness is part of the content the FIRST redraw is
+            # still drawing, and would prove only that one pane had arrived. Same
+            # precondition `_screenshot`'s gate arms on, for the same reason.
+            deadline = time.monotonic() + _DEADLINE
+            shot = ""
+            while not _rule_states(shot) and time.monotonic() < deadline:
+                shot = outer_screen()
+                time.sleep(0.05)
+            if not _rule_states(shot):
+                raise unittest.SkipTest(
+                    "this machine rendered no pane border through a nested tmux client "
+                    "at all, so there is no frame here whose arrival to order anything "
+                    "against")
+            was = None
+            for round_, colour in enumerate(("red", "green", "yellow", "blue",
+                                             "magenta", "cyan")):
+                self.assertEqual(
+                    self._srv("set", "-p", "-t", panel, "window-style",
+                              f"bg={colour}").returncode, 0)
+                mark = f"~{round_}~"
+                self.assertEqual(
+                    self._srv("send-keys", "-l", "-t", harness, mark).returncode, 0,
+                    "tmux would not type this round's mark into the frame")
+                deadline = time.monotonic() + _DEADLINE
+                shot = ""
+                while mark not in shot and time.monotonic() < deadline:
+                    shot = outer_screen()
+                    time.sleep(0.05)
+                self.assertIn(mark, shot,
+                              f"round {round_}'s mark never came back through the nested "
+                              "client, so nothing here was ordered against anything")
+                painted = {dict(state)["bg"]
+                           for state, _ch in _sgr_runs(shot, carry=True)} - {"default"}
+                if not painted and was is None:
+                    raise unittest.SkipTest(
+                        "this tmux painted no pane background through a nested client, "
+                        f"so `bg={colour}` is not something this machine can see arrive")
+                self.assertEqual(
+                    len(painted), 1,
+                    f"round {round_} typed its mark after `bg={colour}` and the screen "
+                    f"that came back carrying the mark is painted "
+                    f"{painted or 'nothing at all'} — a screen caught between two "
+                    "paints carries both, which is the frame #719 photographed")
+                self.assertNotEqual(
+                    painted, was,
+                    f"round {round_}'s screen is still painted the colour round "
+                    f"{round_ - 1} left, so `bg={colour}` had not arrived when its own "
+                    "mark did and the mark is not ordered behind the paint")
+                was = painted
+        finally:
+            self._outer("kill-session", "-t", host)
+            self._srv("kill-session", "-t", session)
 
     #: The colour every panel in a surfaced screenshot is painted, and the only
     #: non-default background on the screen — the harness pane is never painted, and every


### PR DESCRIPTION
Closes #719.

`ChromeIsOneColour` photographs the frame through a nested tmux client — an inner server
holds the frame, an outer server holds one pane whose program is a client attached to it,
and `capture-pane` on that outer pane is the operator's screen. `_screenshot` stopped at
the first capture that contained **any** rule:

```python
if _rule_states(shot):
    break
```

tmux emits a redraw borders-first, so on a loaded machine that is routinely a capture with
the borders drawn and the pane surfaces not yet arrived. The failures it produced named
colour, not tmux — a rule with an unpainted pane on each side of it, on a frame whose every
panel had been handed `window-style bg=brightblack` before the client attached. That reads
exactly like a #514 regression and sends the next reader to audit `pane_border_options`,
which is correct. Which is why #713 called this the more dangerous of the two, and why
fixing #713 made it **more** visible rather than less.

## The fact the gate now waits on

"Some rules exist" and "this frame has finished arriving" are different questions. The gate
now asks the second one, and it asks it as an **ordering** rather than as a duration.

Once the frame's paint is demonstrably under way, a short mark is *typed* into the harness
pane — whose program is `cat`, whose pty echoes it — and the shot is the first capture that
holds the mark. A pty is a stream: the mark's bytes are written after the redraw's and
cannot overtake them, so the mark on the outer pane's screen is proof the outer server
consumed the whole redraw first. tmux's one escape from that ordering keeps it: a client
whose terminal cannot keep up has its pending output **discarded**, and while it is in that
state the mark is discarded with it — tmux then invalidates and redraws the entire screen,
so the mark still cannot arrive without the frame it marks.

Waiting for a rule is still there, as the **precondition** rather than the answer. tmux
composes a whole-screen redraw in one pass into one buffer, so one border cell reaching the
outer server proves the rest of that frame is already written and ordered ahead of anything
typed next. Typed any earlier, the mark would be part of the pane content that same redraw
is still drawing, and would prove only that one pane had arrived.

No `sleep`, no lengthened deadline. The deadline only bounds how long "it never painted"
takes to report.

## Candidates, measured rather than assumed

600 shots each, under load, on the same construction these tests use. A gate is *wrong* on
a shot when the capture it stops at is not the capture the frame settles to.

| gate | at this loop's 0.1s cadence | at 0.01s |
|---|---|---|
| any rule has appeared (what was there) | 29/600 | 30/600 |
| every row of the capture arrived at full width | 10/600 | 6/600 |
| two captures in a row are identical | 0/600 | **5/600** |
| the typed mark has come back | **0/600** | **0/600** |

*"Every declared pane exists and is non-empty"* cannot be asked here at all: every pane in
these tests runs `cat` and writes nothing, so a painted pane is a rectangle of spaces. Its
nearest measurable cousin — every row of the capture arrived at full width — is cheap and
wrong: it catches a paint truncated at a row boundary and misses one that stopped after the
borders.

*"It stopped changing"* is a duration wearing a fact's clothes. It is right only while the
gap between two polls is longer than the longest pause inside a paint — a fact about the
machine's load, not about the frame. Halve the cadence and it starts being wrong.

I also looked for a paint counter to wait on in tmux's own formats. `#{client_written}` /
`#{client_discarded}` are the inner server's view of bytes handed to its client, which is
the wrong side of the pty: they say nothing about what the outer server has *consumed*.

## Rates

Both worktrees run at once under one load, three legs each, 14-core darwin, `python3.14`.

| binary | runs each | `main` failed | this branch |
|---|---|---|---|
| tmux 3.7c | 135 | **6** | **0** |
| tmux 3.2 | 135 | **18** | **0** |
| tmux 3.2, re-run against `main` once #716/#717/#718 landed | 45 | **9** | **0** |

Every one of `main`'s 33 failures is one of #719's own two:
`test_no_shipped_design_leaves_a_seam_between_two_panes_of_one_colour` (24) and
`test_an_unsurfaced_rule_really_does_leave_a_seam_between_painted_panes` (9) — the two
messages the issue was filed with, and neither of them about colour.

The first tmux 3.2 campaign needed #716's floor failures patched out of the way so the
surfaced screenshots could run at all; the third needed nothing, because by then #716 had
shipped. The floor reproduces this far more readily than 3.7c does — it paints the nested
client more slowly, so the fragment is on screen for longer.

Per screenshot rather than per run, which is the more sensitive instrument — a shot counts
as wrong when the capture the gate stopped at is not the capture the frame settled to:
`main` on **5 of 716** shots on 3.7c and **8 of 263** on 3.2, this branch on **0 of 960**
and **0 of 264**.

## Tests

* `test_the_paint_mark_arrives_and_reads_as_the_harnesss_own_background` — the mark reaches
  the shot through the nested client, and its cells read as the harness pane's own
  background, so nothing this class reads off a screenshot can see it. Red and loud if the
  echo ever stops working, instead of 20 tests quietly spending their deadline.
* `test_what_the_frame_drew_before_the_mark_is_on_the_screen_no_later_than_it` — the
  ordering itself, measured on this tmux rather than argued from tmux's source. Six rounds
  repaint a pane and type a mark behind the repaint; the screen carrying each mark carries
  exactly one background and a new one. A screen caught between two paints carries both,
  which is the frame this was photographing.

## Verification

* Full suite green on tmux 3.7c: 9091 tests, `OK (skipped=1)`.
* Green at `~/.local/share/charter-testing/tmux-3.2` too, now that #716/#717/#718 have
  landed: the whole `test_frame_tmux_integration` module is 102 tests, `OK (skipped=9)`,
  and both new tests run there rather than skip.
* Rebased onto `main` after #716/#717/#718 merged. **No conflict** — their edits to
  `_screenshot` are the `_chrome_argvs` call and `_hostile`, mine are the poll loop at the
  end of it and two new tests.
* **Tests only.** A tests-only diff plans 0 mutations under `--path charter`, so the
  sweep's `no survivors` says nothing. Hand-verified two ways instead: `git diff --quiet --
  charter tools hooks skills personas charter.toml pyproject.toml` exits 0, and a sha256
  over all 96 files under `charter/` is identical to the parent commit's
  (`0a9f789fb02faf7f7b528922c3f845aafb1d53ee90d3716540f457a43bd94d32`).
* No `sleep` was added, no deadline widened, no assertion weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
