### PR TITLE
A workspace you already have open is focused rather than added to, and a chat keeps the session id a resume will need (§4e, §4k)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1547,6 +1547,119 @@ def _chat_being_left(socket: str, *, beside: str) -> str:
     return chat if chat != beside and _FRAME_ID_RE.fullmatch(chat) else ""
 
 
+#: What :func:`_workspace_to_focus` asks of every pane on a server, in one call.
+#:
+#: Two fields, both of them tmux's OWN ids and neither of them a name —
+#: :data:`_WINDOW_SEAT_FORMAT`'s rule one noun over, and here it is the whole correctness
+#: argument rather than a target-grammar convenience. One tmux server serves every plane
+#: on this machine (:data:`SOCKET`), session names are bare workspace names, and `default`
+#: is a name EVERY plane has, so `#{session_name}` cannot say whose session it is.
+#: `#{pane_id}` can: a pane id is minted by the server, and the only plane holding one is
+#: the plane whose launcher wrote it down (`state.record_harness_pane`).
+#:
+#: `\t` because neither can contain one: `#{session_id}` is `$<digits>` and `#{pane_id}`
+#: is `%<digits>`, both tmux's own and neither settable by anyone.
+_PANE_SEAT_FORMAT = "#{session_id}\t#{pane_id}"
+
+
+def _workspace_to_focus(socket: str, *, ws: str) -> tuple[str, str] | None:
+    """``(tmux session id, chat id)`` for THIS PLANE's live *ws* when somebody is looking
+    at it — otherwise ``None``, meaning "open a chat as you always did".
+
+    **§4k, and §3.3 is why it is spelled this way.** `charter -w foo` used to mean "add a
+    chat to `foo`" unconditionally, and §2.3 measured what that does to a workspace
+    somebody already has open: both clients of a tmux session share one current window, so
+    the `select-window` that puts THIS launch on its new chat drags the other client off
+    the chat they were reading, and `_drop_panels` then tears that chat's panels down.
+    §2.10 measured the alternative and there is not one — tmux has no per-client current
+    window inside a session on 3.7c or at the 3.2 floor, and the only mechanism that does
+    not drag is a session GROUP, which would stop a workspace being a tmux session.
+    So the drag is not fixed; the reason to drag is removed. A workspace somebody is
+    already in is FOCUSED — one more client on the session they are on, looking at the
+    window they are on — and a workspace nobody is in opens a chat exactly as before.
+
+    **Matched on this plane's own chat directories, never on a live session name, and
+    that inversion is §3.3's.** `cmd_launch` already asks `if session in live_sessions:`
+    and that question is unanswerable across planes: `_live_sessions` returns every
+    session on the machine, `default` is `DEFAULT_WORKSPACE_FALLBACK` and therefore a name
+    every plane has, and `config.STATE_DIR` is the only thing that is per-plane. Reading
+    the answer off a name would make an existing collision into the ADVERTISED behaviour —
+    `charter -w default` in one plane attaching to another plane's frame. So the question
+    starts on disk: `chats.of_workspace` is `.charter/frame/` under THIS plane's state
+    directory, and `state.harness_pane` is a `%N` this plane's own launcher wrote down.
+
+    **The residual, stated rather than hidden, and it is narrower than it first looks.**
+    A pane id is unique on a running server but restarts at `%0` when that server does, so
+    a `%3` recorded for a chat that is over can later name a different live pane. Within
+    ONE plane that is already closed by the caller: `cmd_launch` reaps immediately above
+    this, and a chat directory whose id tmux no longer reports live is removed — so the
+    only directories reaching here are ones the server still lists. Across two planes it
+    is not, because that liveness list is by CHAT ID and chat ids collide exactly as
+    session names do: `new_chat_id` counts from 1 on each plane's own disk, so `shared.1`
+    is the id both planes mint first. What it costs is one focus of a frame that is not
+    yours, on a machine running two planes, across a tmux server restart, for a workspace
+    both planes have, on a pane id that came back round. Closing it needs a plane marker
+    on the window — a second option written at launch and a schema both halves agree on —
+    which is a stage, not a line. What is closed today is the case §3.3 names: a plane
+    that has never opened `ws` has no directory for it, reaches no tmux call at all, and
+    can never focus anybody.
+
+    **Three answers, and the two tmux calls are asked in the order that makes most
+    launches pay for neither.** No chat directory for *ws* on this plane — the ordinary
+    first launch — returns before `list-panes`. No live pane among the ones this plane
+    recorded — every chat of *ws* is cold — returns before `list-clients`. And a live
+    session nobody is attached to returns ``None`` as well, deliberately: with no client
+    on it there is nobody to drag, so a launch there SHOULD add its chat and select it,
+    which is the behaviour that shipped and the one an operator reopening a detached
+    workspace wants.
+
+    Measured on tmux 3.7c and at the 3.2 floor, identically on both: `list-panes -a` lists
+    every pane on the server with its own session id; `list-clients -t $N` takes a session
+    ID as its target, prints one line per attached client, and exits 0 with nothing on
+    stdout when none is attached (rc 1 only for a session id the server does not have).
+
+    **Nothing off tmux is re-checked on the way out and that is deliberate**, unlike
+    `_chat_being_left`, which holds its answer to `_FRAME_ID_RE` because `@charter_chat`
+    is a user OPTION and its value is whatever somebody set. Both fields here are tmux's
+    own built-in ids; a shape check over them would be a guard no input can reach, which
+    is the shape this repository's deletion sweep exists to delete rather than document.
+    The chat id returned is this plane's own directory name and never came from tmux at
+    all. The recorded pane ids are not held to `tmuxctl.PANE_ID_RE` for the mirror-image
+    reason: they are only ever COMPARED against what tmux just said, never sent to it, so
+    a value that is not a pane id matches nothing and is refused by the comparison itself.
+    """
+    mine: dict[str, str] = {}
+    for chat in chats.of_workspace(ws):
+        pane = state.harness_pane(chat)
+        if pane is not None:
+            mine[pane] = chat
+    if not mine:
+        return None
+    out = tmuxctl.run("finding this plane's live chats in this workspace",
+                      tmuxctl.server_argv(socket, "list-panes", "-a", "-F",
+                                          _PANE_SEAT_FORMAT),
+                      timeout=5, report=False)
+    # No branch on the return code, for `_chat_being_left`'s reason: a listing that failed
+    # has an empty stdout and falls out below as "no seats and therefore no answer", which
+    # is the same sentence said once. Exactly two fields per row, so a server that answers
+    # something other than this format cannot have half a row read as a pane id.
+    seats = [line.split("\t") for line in out.stdout.splitlines()]
+    seat = next((s for s in seats if len(s) == 2 and s[1] in mine), None)
+    if seat is None:
+        return None
+    clients = tmuxctl.run("asking whether anybody is looking at that workspace",
+                          tmuxctl.server_argv(socket, "list-clients", "-t", seat[0],
+                                              "-F", "#{client_name}"),
+                          timeout=5, report=False)
+    # Both halves, and they are two different facts: a non-zero return is a server that
+    # would not answer (or a session it no longer has, between the two calls), and an
+    # empty answer is a session with no client on it. Either way nobody is being dragged,
+    # so either way this launch opens its own chat.
+    if clients.returncode != 0 or not clients.stdout.strip():
+        return None
+    return seat[0], mine[seat[1]]
+
+
 def _frame_is_live(socket: str, fid: str) -> bool:
     """Is the frame *fid* still running on *socket*? One question, one place — #408.
 
@@ -3514,6 +3627,56 @@ def _pin_workspace(ws: str, fid: str, picked: bool) -> None:
               f"releases it.")
 
 
+def _focus_workspace(session_id: str, chat: str, *, ws: str, picked: bool) -> int:
+    """Attach to a workspace this plane already has open, and start nothing — §4k.
+
+    The other half of :func:`_workspace_to_focus`, and everything it does NOT do is the
+    point: no `new_chat_id`, no directory, no `new-window`, no `select-window` and no
+    `_drop_panels`. Somebody is reading a chat in this workspace; this launch joins them
+    on it. §2.4's geometry race between two clients of one session is untouched and §5
+    says so out loud — this removes the reason to have two clients on different windows,
+    not the cost of having two.
+
+    **`-t <session id>`, never the workspace's name.** Measured on tmux 3.7c and at the
+    3.2 floor: `attach -t $N` attaches to that session, and a second client attaching to a
+    session does not move its current window — so a focus is guaranteed not to be the drag
+    it exists to avoid. The id came from the pane THIS plane recorded
+    (:func:`_workspace_to_focus`); a name would have come from a namespace every plane on
+    the machine shares.
+
+    **The pointer is still written, and #518 is why.** `_pin_workspace` is what tells the
+    launching terminal which workspace it answered for, so an operator who picked one at
+    the prompt and was focused into it is not asked again next launch. It is written under
+    the chat being focused rather than under a new id, because that chat is the frame
+    session the pointer is about — and it names the same workspace that chat is already
+    in, so the write is the same value it already held.
+
+    **No `env=` on the attach, and that is the difference from `cmd_launch`'s own.** That
+    one carries `_frame_env(fid, h)` because it is the launch that MADE the frame and the
+    client it attaches is that frame's. This launch made nothing: the session already
+    carries its own `CHARTER_SESSION_ID` (`_session_id_env_argv`) and each window its own
+    `-e` overlay, and handing this client a frame identity charter invented for a chat it
+    did not open would put a second answer next to the right one.
+
+    Returns 0 for a clean detach — the workspace is still running and that is not a
+    failure — and `attach`'s own code for a refusal, reported rather than folded away, the
+    same way `cmd_launch`'s own attach is.
+    """
+    _pin_workspace(ws, chat, picked)
+    attach_cmd = tmuxctl.server_argv(SOCKET, "attach", "-t", session_id)
+    attached = tmuxctl.interact(attach_cmd)
+    if attached.returncode != 0:
+        tmuxctl.report_failure("attaching to the frame", attach_cmd, attached)
+        return attached.returncode
+    # The same sentence a launch that detached prints, and true for the same reason: this
+    # client left, the session did not. Named by the WORKSPACE, because that is what an
+    # operator types — the `$id` above is charter's own way of being sure which one.
+    util.info(f"charter frame: detached — the harness is still running.\n"
+              f"  reattach with: tmux -L {SOCKET} attach -t "
+              f"{state.workspace_prefix(ws)}")
+    return 0
+
+
 def cmd_launch(args) -> int:
     """One launcher, shared by every registered harness and by `charter frame --`."""
     if getattr(args, "probe", False):
@@ -3637,6 +3800,32 @@ def cmd_launch(args) -> int:
                     tmuxctl.server_argv(SOCKET, "set", "-g", "remain-on-exit", "on"))
     if can_reap:
         state.reap(live_before, server=SOCKET)
+
+    # **Open or focus** (§4k), and it is asked HERE — after the reap, before the
+    # allocation — for both of its neighbours' reasons. After the reap, so the chat
+    # directories `_workspace_to_focus` reads are the ones that survived it rather than
+    # ones about to be deleted; before `new_chat_id`, so a launch that focuses claims no
+    # ordinal, makes no directory and writes no state at all. A focus is a READ and an
+    # `attach`, and nothing else.
+    #
+    # **Only for a launch that asked for nothing but the workspace, and that gate is not
+    # a nicety.** Attaching answers "put me in `foo`". It cannot answer "run THIS in
+    # `foo`", and a focus taken over one would silently discard an argv the operator
+    # typed: `charter frame -- <cmd>` is the escape hatch for a command charter has never
+    # met, and `charter claude --resume <id>` carries the operator's own flags through
+    # `rest` into `launch_argv`. Both must still open a chat and run what they named — a
+    # launcher that swallowed a command and attached instead would be wrong in the one
+    # direction this module refuses everywhere else, silently.
+    #
+    # **`rest` alone, and an `h is not None` beside it would be a guard nothing can
+    # reach.** An unregistered harness means `argv = rest`, and `if not argv:` above has
+    # already ended the launch with "nothing to run" — so by here a launch with no `h` is
+    # a launch with a non-empty `rest`, and the second half of that condition could never
+    # decide anything. The deletion sweep found it as a survivor for exactly that reason.
+    if not rest:
+        focus = _workspace_to_focus(SOCKET, ws=ws)
+        if focus is not None:
+            return _focus_workspace(*focus, ws=ws, picked=picked)
 
     # AFTER the reap, for the reason the paragraph above gives about the directory: the
     # allocation IS a `mkdir`, so an id claimed before the reap would be a directory the

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1655,7 +1655,16 @@ def _workspace_to_focus(socket: str, *, ws: str) -> tuple[str, str] | None:
     # would not answer (or a session it no longer has, between the two calls), and an
     # empty answer is a session with no client on it. Either way nobody is being dragged,
     # so either way this launch opens its own chat.
-    if clients.returncode != 0 or not clients.stdout.strip():
+    #
+    # **`.split()` and NOT `.strip()`, and the deletion sweep is what settled it.** The
+    # only question here is "is there a client at all", and `strip()` asked it in a form
+    # no test can pin: `s.strip()` and `s.lstrip()` are truthy for exactly the same
+    # strings, so the mutation is invisible — the equivalent mutant `_live_chats`' own
+    # docstring names. A bare `.split()` asks the real question once, on tmux's own
+    # newline-separated output: no non-whitespace token, no client. It has no half to
+    # mutate, and deleting it IS pinnable, because a server answering a bare newline then
+    # reads as one client with a blank name.
+    if clients.returncode != 0 or not clients.stdout.split():
         return None
     return seat[0], mine[seat[1]]
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2543,6 +2543,12 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
 #: in this workspace joins the session as a second window, which is what Stage 5a shipped
 #: — rather than a palette row this stage does not have. A reminder naming something that
 #: does not work is worse than no reminder.
+#:
+#: **Read from INSIDE the frame, which is what keeps it true.** A charter started in a
+#: frame's own pane has `$TMUX` set, so it takes `commands_frame._launch_in_operator_tmux`
+#: and adds a window to the session it is already in. From a terminal OUTSIDE the frame
+#: the same command now focuses that workspace instead of adding to it (§4k, open-or-
+#: focus) — a different question, asked somewhere this row is not on screen.
 ADD_CHAT = "+ charter <harness> opens another"
 
 

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -536,6 +536,13 @@ def record_harness_session(fid: str, sid: str) -> bool:
     Same atomic-write, never-raise shape as :func:`record_harness_pane`, and for the same
     reason: a frame whose harness session could not be recorded simply draws no gauge,
     which is the safe direction — no gauge rather than a wrong one.
+
+    **Two files, because one file was serving two purposes.** See
+    :data:`_KEPT_SESSION_FILE`: `session` is the GAUGE's mapping and :func:`clear_shape`
+    deletes it; the sibling is the same id kept as this chat's own durable state, and
+    `clear_shape` does not list it. Written on the same branch and from the same value, so
+    the two can only ever disagree by the sibling being ABSENT — never by holding a
+    different id.
     """
     sid = (sid or "").strip()
     if not sid or harness_session(fid) == sid:
@@ -549,6 +556,7 @@ def record_harness_session(fid: str, sid: str) -> bool:
         os.replace(tmp, d / "session")
     except OSError:
         return False
+    _record_kept_session(d, sid)
     return True
 
 
@@ -570,6 +578,83 @@ def harness_session(fid: str) -> str | None:
         return None
     try:
         return (d / "session").read_text().strip() or None
+    except (OSError, ValueError):
+        return None
+
+
+#: The DURABLE half of :func:`record_harness_session` — the harness's own session id,
+#: kept as this chat's state rather than as the gauge's mapping.
+#:
+#: **One file was answering two questions, and only one of them is over when a frame is.**
+#: :func:`clear_shape` deletes `session` for a reason that is still right and is written
+#: out at that line: the token-usage history the gauge reads is keyed by the HARNESS's
+#: session id and lives outside the frame directory, so a `session` inherited by the next
+#: frame to claim this id draws the previous session's `ctx 78%` as its own, forever —
+#: *"a gauge reading somebody else's 78% is worse than either"*. That argument is about a
+#: READING. It is not an argument about the identifier, which is exactly what resuming
+#: that harness needs and the only thing charter records that can ask for the conversation
+#: back (`docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md` §4e).
+#:
+#: So the id is written twice and deleted once. Nothing reads this file yet, and that is
+#: the whole of the stage: reopen (§6 stage 5) is what reads it, and it cannot be written
+#: retroactively for a chat that has already been cleared — which is why this ships first
+#: and alone.
+#:
+#: **The ordering hazard §4e states, restated where it can be acted on.** Keeping the id
+#: is only "no behaviour change" while nothing relaunches into an existing chat directory.
+#: The moment a reopen does, `session` comes back from this file and the gauge starts
+#: reading a stale history again — so the gauge's own gate (`exit_code(fid) is None`)
+#: must ship BEFORE reopen, not with it.
+#:
+#: **`.durable` and not a dotfile**, like `server`, `workspace` and `claim` beside it:
+#: everything in a frame's directory is charter's own bookkeeping and none of it hides
+#: from `ls`. The stem is shared with `session` on purpose — the two are one fact with
+#: two lifetimes, and a name that did not say so would be a second concept.
+_KEPT_SESSION_FILE = "session.durable"
+
+
+def _record_kept_session(d: Path, sid: str) -> None:
+    """Write :data:`_KEPT_SESSION_FILE` into the frame directory *d*.
+
+    *d* rather than a *fid*, because the only caller has already resolved it — asking
+    `frame_dir` a second time would be a second chance to get a different answer for a
+    file whose whole contract is that it holds the same id as the one just written.
+
+    Never raises, like everything else here, and its failure is quieter than
+    :func:`record_harness_session`'s: the gauge's own mapping has already landed, so a
+    chat that could not keep the durable copy still draws its context reading and simply
+    cannot be resumed later. Returning nothing rather than a bool is the same statement —
+    there is no caller that could do anything with the answer.
+    """
+    tmp = d / "session.durable.tmp"
+    try:
+        config.write_for(tmp, f"{sid}\n")
+        os.replace(tmp, d / _KEPT_SESSION_FILE)
+    except OSError:
+        return
+
+
+def kept_harness_session(fid: str) -> str | None:
+    """The DURABLE harness session id for *fid*, or ``None`` when there is not one.
+
+    :func:`harness_session`'s twin over :data:`_KEPT_SESSION_FILE`, and the difference
+    between them is only ever visible after a :func:`clear_shape`: before one they hold
+    the same id, after one this is the one still standing.
+
+    ``None`` for every reason :func:`harness_session` answers ``None``, plus one that is
+    this file's own and worth naming rather than discovering: **a chat whose harness was
+    already running when this charter was installed.** Its `session` was written by the
+    previous version, so the no-op guard in :func:`record_harness_session` returns before
+    the sibling is ever written, and the sibling first appears when that harness's own
+    session id next changes. There is no back-fill and there should not be — reading
+    `session` as a stand-in would be reading exactly the file whose deletion this pair
+    exists to survive.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        return (d / _KEPT_SESSION_FILE).read_text().strip() or None
     except (OSError, ValueError):
         return None
 
@@ -1061,6 +1146,14 @@ def clear_shape(fid: str) -> None:
       new one — which it never will, because it is over. `slots.py`'s rule is that a gauge
       reading zero is worse than no gauge; a gauge reading somebody else's 78% is worse
       than either.
+
+      **The ID survives this and the READING does not**, and the two used to be one file.
+      :data:`_KEPT_SESSION_FILE` is the same value written beside `session` and is
+      deliberately not in the list below: the paragraph above is an argument about a
+      *number drawn on screen*, and it says nothing against keeping the identifier a
+      resume needs. Adding that file to this list is the one edit that would silently
+      take resume away, which is why it is named here rather than only where it is
+      written.
 
     * ``selection`` is the same keypress or the same click said about a ROW
       (:func:`record_selection`), and it inherits with the mildest of these consequences

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -238,8 +238,9 @@ Charter never touches `~/.tmux.conf` — the frame's settings go into a private 
 charter's own (`tmux -L charter`), one server shared by every frame on the machine. On it,
 a **workspace is a session** and a **chat is a window** in that session: `charter claude`
 in a workspace that already has one open adds a second chat beside it rather than starting
-a second session, and the two run side by side with their own harnesses, their own personas
-and their own tool ceilings. A chat's id is `<workspace>.<n>` — allocated, so two of them
+a second session (unless somebody is attached to it — see below), and the two run side by
+side with their own harnesses, their own personas and their own tool ceilings. A chat's id
+is `<workspace>.<n>` — allocated, so two of them
 can never land on the same state — and it is what `$CHARTER_SESSION_ID` holds inside that
 chat.
 
@@ -247,10 +248,29 @@ One chat's harness dying ends **that chat's window** and nothing else; the other
 the workspace keep running. When the last chat's window goes, so does the session, which is
 what returns `charter claude` to your shell.
 
-The cost of one session, said plainly: a tmux session has one current window, so two
-terminals attached to the same workspace look at the same chat. Opening a second chat from
-a second terminal moves both. That is what "one workspace, several chats" means — the
-chats are independent, the *view* is the session's.
+**Opening a workspace you already have open puts you in it rather than beside it.** A tmux
+session has one current window, so two terminals attached to one workspace look at the same
+chat — and a second launch that added a chat and selected it therefore pulled whoever was
+already there off what they were reading. So it does not. `charter -w foo` from a second
+terminal, while somebody is attached to `foo`, **attaches you to what they are looking at**;
+nothing is started and nothing moves. Where nobody is attached — you closed the terminal, or
+never had one — the same command opens a chat exactly as before. It is `code <path>`'s
+behaviour: the flag means one thing whether or not the workspace happens to be running.
+
+To open a *second* chat in a workspace you are already in, run `charter <harness>` from
+inside the frame — that is the add-chat affordance the chat bar names, and it is unchanged.
+
+**A launch that names something to run still runs it.** Attaching answers "put me in
+`foo`"; it cannot answer "run *this* in `foo`", so `charter frame -- <cmd>` and
+`charter claude --resume <id>` open a chat and run what you typed, attached client or not.
+Only a launch that asked for nothing but the workspace is answered by focusing one.
+
+Which workspace is yours is decided on **this plane's own chat directories, never on a
+session name**. One tmux server serves every plane on the machine and session names are bare
+workspace names, so `default` — a name every plane has — names one session that any of them
+might have opened. Charter matches on the pane id its own launcher wrote down for a chat in
+`.charter/frame/`, which the server minted and only one plane holds. A workspace this plane
+has never opened is never focused, whatever another plane happens to be calling its own.
 
 ### Switching between them
 

--- a/docs/news/unreleased-a-chats-harness-session-id-outlives-the-gauge-that-reads-it.md
+++ b/docs/news/unreleased-a-chats-harness-session-id-outlives-the-gauge-that-reads-it.md
@@ -1,0 +1,40 @@
+---
+version: unreleased
+headline: A chat keeps the harness session id a resume will need, without the context gauge ever reading a stale one
+---
+
+Charter records the harness's own session id at `.charter/frame/<fid>/session`, written by
+Claude Code's `statusLine` hook. It is the only thing charter records that could ever ask a
+harness for its conversation back — and `state.clear_shape` deletes it on every launch that
+claims a chat id, with its reason written at the line: *"a gauge reading somebody else's 78%
+is worse than either."*
+
+**Both requirements are right, and one file was serving two purposes.** The usage history
+the context gauge reads is keyed by that session id and lives *outside* the frame directory,
+so deleting the mapping is the only thing suppressing a stale gauge today — that argument is
+about a number drawn on screen and it stands. It is not an argument about the identifier.
+
+So the id is written twice and deleted once. `record_harness_session` writes a durable
+sibling, `session.durable`, from the same value on the same branch; `clear_shape` does not
+list it. The two can only ever disagree by the sibling being *absent* — never by holding a
+different id.
+
+**Nothing reads it yet, and that is the stage rather than an omission.** Reopening a chat
+into its own existing directory is what reads it, and the id cannot be written retroactively
+for a chat whose `session` a launch has already cleared — so this has to land first, on its
+own, ahead of everything that uses it.
+
+**The ordering hazard, stated here so the next person does not have to find it again.**
+Keeping the id is "no behaviour change" only while nothing relaunches into an existing chat
+directory. The moment a reopen does, `session` comes back and the gauge starts reading a
+history that belongs to a run that is over. The gauge's gate — `state.exit_code(fid) is
+None`, one `stat`, already written and already correct — **must ship before reopen, not with
+it**. It is deliberately not in this change: a gate is a behaviour change and this is not.
+
+One thing that is neither back-filled nor guessed at: a chat whose harness was already
+running when this charter was installed keeps a `session` written by the previous version,
+so the sibling first appears when that harness's own session id next changes. Reading
+`session` as a stand-in would be reading exactly the file whose deletion this pair exists to
+survive.
+
+Nothing to adopt — no production behaviour changed, and no surface draws anything new.

--- a/docs/news/unreleased-opening-a-workspace-you-already-have-open-puts-you-in-it.md
+++ b/docs/news/unreleased-opening-a-workspace-you-already-have-open-puts-you-in-it.md
@@ -1,0 +1,79 @@
+---
+version: unreleased
+headline: Opening a workspace somebody already has open attaches to it instead of dragging them off what they were reading
+---
+
+`charter -w foo` used to mean "add a chat to `foo`" whatever `foo` was doing. Where
+somebody was already attached, that was measurably destructive: both clients of a tmux
+session share one current window, so the `select-window` that put the *new* launch on its
+new chat pulled the *existing* client onto it too, and charter then tore down the panels of
+the chat that client had been reading.
+
+**There is no small fix for the drag.** Measured with real ptys on tmux 3.7c and at the 3.2
+floor alike: a client on `chat1`, then `new-window -d` plus `select-window`, lands that
+client on `chat2` — identically on both. tmux has no per-client current window inside one
+session. The one mechanism that does not drag is a session *group*, and adopting groups
+would stop a workspace being a tmux session, which is what everything since chats has been
+built on.
+
+So charter stops making the situation instead of fixing it. **A workspace somebody is
+already attached to is focused, not added to**: your terminal attaches to the session they
+are on, looking at the window they are on. Nothing is started, no chat id is claimed, no
+directory is made, and no window is selected. Where nobody is attached — you closed the
+terminal, or never had one — the same command opens a chat exactly as it did before, because
+there is nobody there to drag.
+
+Measured on 3.7c and at the 3.2 floor, identically on both: a second client attaching to a
+session does **not** move that session's current window, which is the fact that makes
+focusing safe where adding was not.
+
+To open a second chat in a workspace you are already in, run `charter <harness>` from inside
+the frame. That is what the chat bar's own `+ charter <harness> opens another` names, and it
+is unchanged — a charter started in a frame's pane is inside a tmux and takes the window
+path, not this one.
+
+**A launch that names something to run still runs it.** Attaching answers "put me in `foo`";
+it cannot answer "run *this* in `foo`", and a focus taken over one would silently throw away
+an argv you typed. So `charter frame -- <cmd>` — the escape hatch for a command charter has
+never met — and `charter claude --resume <id>` both open a chat and run what they named,
+attached client or not. Only a launch that asked for nothing but the workspace is answered
+by focusing one.
+
+## Which workspace is yours is read off this plane's disk, never off a session name
+
+One tmux server serves **every plane on this machine** and session names are bare workspace
+names, so `default` — a name every plane has whether anybody chose it or not — names one
+session that any of them might have opened. A focus decided on that name would have turned
+an existing cross-plane collision into charter's advertised behaviour: `charter -w default`
+in one plane attaching to another plane's frame.
+
+So the question starts on disk. Charter looks for a chat directory of *this* plane's for
+that workspace, takes the `%<pane>` id its own launcher wrote down for it, and asks tmux
+whether that pane is live and which `$<session>` holds it — ids the server minted, which
+only one plane can be holding. A plane that has never opened a workspace has no directory
+for it, makes no tmux call at all, and can never focus anybody.
+
+The residual is stated rather than hidden: pane ids restart at `%0` when a tmux server does,
+so a pane id recorded for a chat that is over can, after a `kill-server`, name another
+plane's live pane. Closing that needs a plane marker on the window, which is a stage rather
+than a line.
+
+## Verification
+
+Two planes on one machine, one tmux server, and one workspace name they share — including
+the same chat id, `shared.1`, which both planes mint first — is the arrangement the flaw
+exists in, and a single-plane test is structurally blind to it. The plane that opened the
+workspace focuses it; the plane that did not focuses nothing, though its workspace name, its
+chat id and the live session's name all match. Both wrong implementations were run against
+that test and both go red: matching on the session name, and matching on the chat id.
+
+And a whole `cmd_launch`, twice, against a real server with a real attached client and two
+real plane roots — identical on 3.7c and at the 3.2 floor. On this branch the second launch
+attaches to `$0`, adds no window and leaves the client on `shared.1`; on `main` the same
+second launch adds `shared.2` and moves the attached client onto it. The third launch, from
+the other plane, opens its own chat on both.
+
+Run by hand on **tmux 3.7c and on tmux 3.2** — 29/29 on each. CI installs no tmux, so none
+of it runs there.
+
+Nothing to adopt.

--- a/tests/test_a_chats_harness_session_outlives_its_gauge.py
+++ b/tests/test_a_chats_harness_session_outlives_its_gauge.py
@@ -56,6 +56,25 @@ class TheIdIsWrittenTwice(PersonaIso, unittest.TestCase):
         self.assertEqual(state.harness_session(FID), SID)
         self.assertEqual(state.kept_harness_session(FID), SID)
 
+    def test_the_name_on_disk_is_the_contract_and_not_an_implementation_detail(self):
+        """**The spelling is load-bearing across VERSIONS, which is why it is asserted
+        rather than read back through the constant.** Every other test here goes through
+        `state._KEPT_SESSION_FILE`, so a rename would move writer and reader together and
+        no test would notice — the deletion sweep found exactly that and was right to.
+
+        But this file is durable state in a directory a much newer charter reopens (§5's
+        "survive a schema change across a long-lived chat directory"). Renaming it after
+        this ships silently loses the id for every chat already recorded, and the operator
+        sees a resume that quietly does not resume. So the name is pinned as bytes, and
+        changing it is a deliberate act with a red test in front of it.
+
+        The exact-set assertion is the second half: `record_harness_session` leaves the two
+        files it writes and no `.tmp` beside them, so a half-finished atomic write cannot
+        be mistaken for state either."""
+        state.record_harness_session(FID, SID)
+        self.assertEqual(sorted(p.name for p in _dir().iterdir()),
+                         ["session", "session.durable"])
+
     def test_the_two_files_can_only_disagree_by_the_sibling_being_absent(self):
         """One branch, one value, so there is no path on which the sibling holds a
         DIFFERENT id from `session` — the failure mode a second writer would have."""

--- a/tests/test_a_chats_harness_session_outlives_its_gauge.py
+++ b/tests/test_a_chats_harness_session_outlives_its_gauge.py
@@ -1,0 +1,234 @@
+"""The harness's own session id is written twice and deleted once — §4e, reduced form.
+
+One file was serving two purposes. `state.record_harness_session` records the id Claude
+Code's own token-usage history is keyed by, and `state.clear_shape` deletes it with its
+reason written at the line: *"a gauge reading somebody else's 78% is worse than either"*.
+That reason is about a NUMBER DRAWN ON SCREEN and it is still right. It is not an argument
+about the identifier, which is the only thing charter records that could ever ask a
+harness for its conversation back.
+
+So the id gets a durable sibling (`state._KEPT_SESSION_FILE`) that `clear_shape` does not
+list, and **nothing else changes**: the gauge's own file is written, cleared and read
+exactly as it was. `ZeroBehaviourChange` is the half of this module that says so, and it
+is not decoration — the stage's whole claim is that it can ship on its own, ahead of the
+gauge gate and ahead of reopen (§6 stages 2, 5 and 6 in that order).
+
+Nothing in `charter/` reads the sibling yet. That is the stage, not an omission: reopen is
+what reads it, and it cannot be written retroactively for a chat whose `session` a launch
+has already cleared — which is why this ships first and alone.
+
+No tmux anywhere in this module. Every fact here is a file in a plane's own state
+directory.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import config
+from charter.frame import state
+from tests._isolation import PersonaIso
+
+#: A chat id in the shape `state.new_chat_id` mints, so nothing here is testing a name
+#: charter could not produce.
+FID = "demo.1"
+
+#: A harness session id shaped like Claude Code's own — a UUID, which is what
+#: `statusline.main` reads off the JSON payload on its stdin and hands to
+#: `record_harness_session`.
+SID = "9f1c2a44-7b0e-4d21-9b3a-1f2e3d4c5b6a"
+
+
+def _dir():
+    """The frame directory for :data:`FID`, created — the plane-side view every
+    assertion here is made against."""
+    d = state.frame_dir(FID, create=True)
+    assert d is not None
+    return d
+
+
+class TheIdIsWrittenTwice(PersonaIso, unittest.TestCase):
+    """`record_harness_session` lands both files from one value."""
+
+    def test_the_durable_sibling_is_written_beside_the_gauges_own_file(self):
+        self.assertTrue(state.record_harness_session(FID, SID))
+        self.assertEqual(state.harness_session(FID), SID)
+        self.assertEqual(state.kept_harness_session(FID), SID)
+
+    def test_the_two_files_can_only_disagree_by_the_sibling_being_absent(self):
+        """One branch, one value, so there is no path on which the sibling holds a
+        DIFFERENT id from `session` — the failure mode a second writer would have."""
+        state.record_harness_session(FID, SID)
+        state.record_harness_session(FID, "a-second-session")
+        self.assertEqual(state.harness_session(FID), "a-second-session")
+        self.assertEqual(state.kept_harness_session(FID), "a-second-session")
+
+    def test_the_id_is_stripped_the_same_way_on_both_sides(self):
+        state.record_harness_session(FID, f"  {SID}\n")
+        self.assertEqual(state.kept_harness_session(FID), SID)
+
+    def test_no_id_writes_neither_file(self):
+        self.assertFalse(state.record_harness_session(FID, "   "))
+        self.assertIsNone(state.harness_session(FID))
+        self.assertIsNone(state.kept_harness_session(FID))
+
+    def test_an_id_a_frame_directory_cannot_be_made_for_writes_neither(self):
+        """`frame_dir` REFUSES rather than rewrites (`contain.child`), and the sibling is
+        written after that refusal has already been taken, so there is no second chance
+        for a name to reach the filesystem through this pair."""
+        self.assertFalse(state.record_harness_session("../escape", SID))
+        self.assertIsNone(state.kept_harness_session("../escape"))
+        self.assertEqual(sorted(p.name for p in config.STATE_DIR.glob("**/session*")), [])
+
+
+class TheSiblingSurvivesTheClear(PersonaIso, unittest.TestCase):
+    """The property the whole stage exists for."""
+
+    def test_clear_shape_takes_the_gauges_file_and_leaves_the_id(self):
+        state.record_harness_session(FID, SID)
+        state.clear_shape(FID)
+        self.assertIsNone(state.harness_session(FID),
+                          "the gauge's mapping must still be destroyed — #413")
+        self.assertEqual(state.kept_harness_session(FID), SID,
+                         "the identifier a resume needs must survive")
+
+    def test_the_file_clear_shape_deletes_is_not_the_file_it_keeps(self):
+        """Named against the list itself, not only against its effect. Adding
+        `_KEPT_SESSION_FILE` to `clear_shape`'s tuple is a one-word edit that would take
+        resume away with nothing on screen to say so, and this is what goes red for it."""
+        d = _dir()
+        state.record_harness_session(FID, SID)
+        state.clear_shape(FID)
+        left = sorted(p.name for p in d.iterdir())
+        self.assertIn(state._KEPT_SESSION_FILE, left)
+        self.assertNotIn("session", left)
+
+    def test_a_second_clear_leaves_it_alone_too(self):
+        """`clear_shape` runs on every launch that claims an id, so "survives one" is not
+        the claim — "is never in the list" is."""
+        state.record_harness_session(FID, SID)
+        for _ in range(3):
+            state.clear_shape(FID)
+        self.assertEqual(state.kept_harness_session(FID), SID)
+
+
+class ZeroBehaviourChange(PersonaIso, unittest.TestCase):
+    """What a reviewer has to be able to check in one place: the gauge's half is
+    untouched, so this stage can land ahead of the gate §4e settles."""
+
+    def test_the_return_value_still_means_the_gauge_moved(self):
+        """`statusline.main` repaints the frame's panels on a `True`, several times per
+        turn. A second writer that changed what `True` means would repaint on every
+        status-line render."""
+        self.assertTrue(state.record_harness_session(FID, SID))
+        self.assertFalse(state.record_harness_session(FID, SID),
+                         "an unchanged id is still not a change")
+
+    def test_a_sibling_that_cannot_be_written_does_not_take_the_gauge_down(self):
+        """The durable write is the LAST thing that happens and its failure is quieter
+        than the gauge's own: the mapping has already landed, so this chat still draws
+        its context reading and simply cannot be resumed later."""
+        real = config.write_for
+
+        def refuse_the_sibling(path, text, **kw):
+            if path.name.startswith("session.durable"):
+                raise OSError("no room for the durable copy")
+            return real(path, text, **kw)
+
+        with mock.patch.object(config, "write_for", refuse_the_sibling):
+            self.assertTrue(state.record_harness_session(FID, SID))
+        self.assertEqual(state.harness_session(FID), SID)
+        self.assertIsNone(state.kept_harness_session(FID))
+
+    def test_a_chat_already_running_when_this_charter_arrived_gets_no_back_fill(self):
+        """The migration gap, pinned rather than discovered. Its `session` was written by
+        the previous version, so the no-op guard returns before the sibling is reached and
+        the sibling first appears when that harness's own session id next changes. Reading
+        `session` as a stand-in would be reading exactly the file whose deletion this pair
+        exists to survive."""
+        d = _dir()
+        (d / "session").write_text(f"{SID}\n")
+        self.assertFalse(state.record_harness_session(FID, SID))
+        self.assertIsNone(state.kept_harness_session(FID))
+        self.assertTrue(state.record_harness_session(FID, "the-next-session"))
+        self.assertEqual(state.kept_harness_session(FID), "the-next-session")
+
+
+class ItDoesNotOUTLIVETheChatItself(PersonaIso, unittest.TestCase):
+    """The other end of "durable", and #731 is why it is asserted rather than assumed.
+
+    #731 is a recycled chat id inheriting the PREVIOUS frame's workspace pointer and lock:
+    `state.new_chat_id` frees an ordinal the moment its frame DIRECTORY is reaped, while
+    `.charter/sessions/<fid>.workspace` and `.lock` live somewhere else entirely and are
+    left behind — so `charter claude --workspace alpha` can come up labelled `gamma`.
+
+    **This file cannot do that, and the reason is structural rather than careful.** It
+    lives INSIDE `.charter/frame/<fid>/`, which is the very directory whose absence frees
+    the ordinal — `reap` removes it whole. So "the id is free" and "the durable session id
+    is gone" are one event, not two, and there is no window in which a new chat can be
+    handed an old one's harness session.
+
+    That is the invariant a resume has to rest on, so it is pinned here rather than left as
+    a property the design happens to have. It is also the exact contrast with #731: the
+    defect there is a per-chat file kept OUTSIDE the directory that decides the chat's
+    lifetime, and the fix is to reap it with the frame — not to spread this file the same
+    way.
+    """
+
+    def test_a_recycled_ordinal_cannot_inherit_the_previous_chats_durable_id(self):
+        state.record_harness_session(FID, SID)
+        self.assertEqual(state.kept_harness_session(FID), SID)
+        # The whole of what frees the ordinal, and the whole of what removes the file.
+        self.assertEqual(state.reap(set(), server=state.frame_server(FID) or ""), [FID])
+        self.assertEqual(state.new_chat_id("demo"), FID,
+                         "the ordinal is only free because the directory went")
+        self.assertIsNone(state.kept_harness_session(FID),
+                          "a new chat must not be handed the previous chat's session id")
+
+    def setUp(self) -> None:
+        super().setUp()
+        # `reap` keeps a directory whose recorded server is not the one being reaped, and
+        # a chat's own launcher writes that marker — so the fixture writes it too.
+        state.frame_dir(FID, create=True)
+        state.record_server(FID, "charter")
+        state.record_workspace(FID, "demo")
+
+
+class TheReaderAnswersNoneRatherThanRaising(PersonaIso, unittest.TestCase):
+    """`kept_harness_session`'s own arms — `harness_session`'s, one file over, because a
+    reader on a panel's repaint path may never take a frame down with it."""
+
+    def test_never_recorded(self):
+        _dir()
+        self.assertIsNone(state.kept_harness_session(FID))
+
+    def test_no_such_frame_directory(self):
+        self.assertIsNone(state.kept_harness_session("nothing-here.7"))
+
+    def test_an_id_that_is_not_a_frame_directorys_name(self):
+        self.assertIsNone(state.kept_harness_session("../escape"))
+
+    def test_a_file_that_cannot_be_read(self):
+        """A directory where the file should be — an `IsADirectoryError`, which is an
+        `OSError`, and the only way to make this read fail without root."""
+        (_dir() / state._KEPT_SESSION_FILE).mkdir()
+        self.assertIsNone(state.kept_harness_session(FID))
+
+    def test_a_file_that_is_not_text(self):
+        """The `ValueError` half of the same clause, and it is reachable rather than
+        defensive: `UnicodeDecodeError` IS a `ValueError`, and this file is bytes on disk
+        that some other process may have put there."""
+        (_dir() / state._KEPT_SESSION_FILE).write_bytes(b"\xff\xfe not utf-8 \xff")
+        self.assertIsNone(state.kept_harness_session(FID))
+
+    def test_a_file_holding_only_whitespace(self):
+        """`or None`, and it is the same rule `harness_session` keeps: "recorded nothing"
+        and "not recorded" are one answer, because every caller does the same thing with
+        both."""
+        (_dir() / state._KEPT_SESSION_FILE).write_text("   \n")
+        self.assertIsNone(state.kept_harness_session(FID))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_second_launch_focuses_instead_of_dragging.py
+++ b/tests/test_a_second_launch_focuses_instead_of_dragging.py
@@ -216,6 +216,15 @@ class TheFocusDecision(PersonaIso, unittest.TestCase):
         fake = _FakeServer(panes=[], panes_rc=1, clients=["/dev/ttys001"])
         self.assertIsNone(self._decide(fake))
 
+    def test_a_client_list_that_is_only_whitespace_is_no_client(self):
+        """A server answering a bare newline has told us about no clients, and reading it
+        as one would focus a workspace nobody is looking at — the exact launch that SHOULD
+        open a chat and select it. Pins `.split()`, which is what asks "is there a client"
+        in a form a test can go red on (see the comment at the line)."""
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$3\t%0"], clients=["", "   "])
+        self.assertIsNone(self._decide(fake))
+
     def test_a_server_that_will_not_list_that_sessions_clients_focuses_nothing(self):
         """A session the server no longer has between the two calls answers rc 1 — and a
         launch that cannot tell whether anybody is there opens its own chat, which is the

--- a/tests/test_a_second_launch_focuses_instead_of_dragging.py
+++ b/tests/test_a_second_launch_focuses_instead_of_dragging.py
@@ -1,0 +1,563 @@
+"""`charter -w foo` opens or focuses — §4k, and §3.3 is why it is matched the way it is.
+
+**The defect this replaces has no small fix.** Both clients of a tmux session share one
+current window (§2.10, measured on 3.7c and at the 3.2 floor alike), so a second launch's
+`select-window` drags the client that was already there onto the new chat, and
+`_drop_panels` then tears down the panels it was reading. The only mechanism that does not
+drag is a session group, which would stop a workspace being a tmux session — the
+foundation everything since #488 rests on. So charter stops making the situation instead
+of fixing it: **a workspace somebody already has open is attached to, not added to.**
+
+**And it is matched on this plane's own chat directories, never on a live session name.**
+One tmux server serves every plane on this machine, session names are bare workspace names,
+and `default` is a name EVERY plane has (§2.13). `charter -w default` in one plane already
+adds a window to another plane's session today; open-or-focus matched on a name would make
+that the *advertised* behaviour. `_workspace_to_focus` therefore starts on disk — this
+plane's `.charter/frame/` — and asks tmux only about `%<pane>` and `$<session>` ids, which
+are minted by the server and cannot be two planes' at once.
+
+`TwoPlanesOnOneMachine` is the test §7 asks for and the only one here that can fail for
+§3.3's reason: a single plane cannot be confused with anybody, so a single-plane test is
+structurally blind to it. It runs against a REAL tmux and is skipped, never failed, where
+the machine has none — which per §2.12 is every CI job charter has.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import pty
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config, workspace
+from charter.frame import state
+from tests import _tmuxreap
+from tests._isolation import PersonaIso
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: This module's own server, unique per test PROCESS — `tests/_tmuxreap.py`'s namespace,
+#: so a run the deletion sweep kills mid-flight is recognised and collected by the next
+#: one rather than left running for days.
+SOCKET = _tmuxreap.name("open-or-focus")
+
+#: The FALLBACK path for :data:`SOCKET`'s file. tmux is the authority on its own socket
+#: path and the teardown asks it; this copy of tmux's rule is spent only on the teardown
+#: that has no server left to ask, and nothing is ever asserted about it.
+SOCKET_PATH = os.path.join(os.environ.get("TMUX_TMPDIR") or "/tmp",
+                           f"tmux-{os.getuid()}", SOCKET)
+
+#: The workspace name BOTH planes have. Any shared name reproduces §2.13; `default` is
+#: the one every plane has whether anybody chose it or not.
+SHARED = "shared"
+
+_DEADLINE = 20.0
+
+_TERM_CANDIDATES = tuple(dict.fromkeys(
+    ([os.environ["TERM"]] if os.environ.get("TERM", "dumb") != "dumb" else [])
+    + ["xterm-256color", "screen", "vt100"]))
+
+
+@contextlib.contextmanager
+def _plane(root: Path):
+    """Resolve every charter path against *root* for the duration — one plane of the two.
+
+    `config.use`/`config.restore` is the same seam `PersonaIso` uses; entering it twice
+    with two roots inside one test process is what "two planes on one machine" means when
+    the machine is a test runner.
+    """
+    previous = config.use(root)
+    try:
+        yield
+    finally:
+        config.restore(previous)
+
+
+def _completed(argv, rc=0, out="", err=""):
+    return subprocess.CompletedProcess(argv, rc, stdout=out, stderr=err)
+
+
+class _FakeServer:
+    """The three answers a focus decision reads, and a record of everything it asked.
+
+    Deliberately not `tests/test_frame_launcher._FakeTmux`: that fake models a whole
+    launch, and every test here is about the handful of calls that happen BEFORE a launch
+    would start anything. What this fake is for is the half a real server cannot show —
+    which questions were asked, in which order, and which were not asked at all.
+    """
+
+    def __init__(self, *, panes=(), clients=(), panes_rc=0, clients_rc=0,
+                 sessions=(), chats=()):
+        #: `#{session_id}\t#{pane_id}` rows, exactly as `list-panes -a -F` prints them.
+        self.panes = list(panes)
+        #: One `#{client_name}` per client attached to the session asked about.
+        self.clients = list(clients)
+        self.panes_rc = panes_rc
+        self.clients_rc = clients_rc
+        self.sessions = list(sessions)
+        self.chats = list(chats)
+        self.calls: list[list[str]] = []
+        #: What `list-clients -t` was aimed at, so a test can assert it was an id.
+        self.clients_target = None
+
+    @staticmethod
+    def _lines(rows) -> str:
+        """What tmux prints for *rows*: one per line with a trailing newline, and NOTHING
+        at all for none — not a bare `"\\n"`, which is what a naive join produces and what
+        would make "no clients attached" look like one client with a blank name."""
+        return "".join(f"{r}\n" for r in rows)
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+        if "list-panes" in cmd:
+            return _completed(cmd, self.panes_rc, self._lines(self.panes))
+        if "list-clients" in cmd:
+            self.clients_target = cmd[cmd.index("-t") + 1]
+            return _completed(cmd, self.clients_rc, self._lines(self.clients))
+        if "list-sessions" in cmd:
+            return _completed(cmd, 0, self._lines(self.sessions))
+        if "list-windows" in cmd:
+            return _completed(cmd, 0, self._lines(self.chats))
+        return _completed(cmd, 0)
+
+    def asked(self, verb: str) -> int:
+        return sum(1 for c in self.calls if verb in c)
+
+
+def _a_chat(fid: str, *, ws: str, pane: str | None,
+            server: str = commands_frame.SOCKET) -> None:
+    """A chat directory on THIS plane, in the shape a launcher leaves one.
+
+    *server* is named rather than assumed because the real-tmux class below runs on a
+    server of its own: a `server` marker naming charter's production socket would be a
+    fixture asserting something about a machine's live frames.
+    """
+    state.frame_dir(fid, create=True)
+    state.record_workspace(fid, ws)
+    state.record_server(fid, server)
+    if pane is not None:
+        state.record_harness_pane(fid, pane)
+
+
+class TheFocusDecision(PersonaIso, unittest.TestCase):
+    """`_workspace_to_focus` — three answers, and which calls each one costs."""
+
+    def _decide(self, fake):
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake):
+            return commands_frame._workspace_to_focus(commands_frame.SOCKET, ws=SHARED)
+
+    def test_a_workspace_this_plane_has_never_opened_reaches_no_tmux_call_at_all(self):
+        """The ordinary first launch, and the property that keeps this free: with no chat
+        directory there is nothing to compare against, so the decision is made on disk and
+        the server is never asked anything."""
+        fake = _FakeServer(panes=["$0\t%0"], clients=["/dev/ttys001"])
+        self.assertIsNone(self._decide(fake))
+        self.assertEqual(fake.calls, [])
+
+    def test_a_chat_with_no_recorded_pane_reaches_no_tmux_call_either(self):
+        """A directory a launcher never got as far as recording a pane in has nothing
+        that could identify it on the server — a chat id would, and a chat id is exactly
+        what two planes can both hold (§3.3)."""
+        _a_chat("shared.1", ws=SHARED, pane=None)
+        fake = _FakeServer(panes=["$0\t%0"], clients=["/dev/ttys001"])
+        self.assertIsNone(self._decide(fake))
+        self.assertEqual(fake.calls, [])
+
+    def test_a_recorded_pane_that_is_not_live_stops_before_asking_about_clients(self):
+        """Every chat of this workspace is cold. There is nothing to focus, and the
+        second question is not worth a subprocess."""
+        _a_chat("shared.1", ws=SHARED, pane="%4")
+        fake = _FakeServer(panes=["$0\t%0", "$1\t%2"], clients=["/dev/ttys001"])
+        self.assertIsNone(self._decide(fake))
+        self.assertEqual(fake.asked("list-panes"), 1)
+        self.assertEqual(fake.asked("list-clients"), 0)
+
+    def test_a_live_workspace_with_nobody_attached_is_opened_rather_than_focused(self):
+        """Deliberate, and it is the launch an operator reopening a detached workspace
+        makes: with no client on the session there is nobody to drag, so the chat is
+        added and selected exactly as it shipped."""
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$0\t%0"], clients=[])
+        self.assertIsNone(self._decide(fake))
+        self.assertEqual(fake.asked("list-clients"), 1)
+
+    def test_a_live_workspace_somebody_is_looking_at_is_focused(self):
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"])
+        self.assertEqual(self._decide(fake), ("$3", "shared.1"))
+
+    def test_the_session_is_targeted_by_its_id_and_never_by_its_name(self):
+        """#693's rule, and here it is the correctness argument rather than a convenience:
+        a session NAME is a name every plane on the machine may have."""
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"])
+        self._decide(fake)
+        self.assertEqual(fake.clients_target, "$3")
+
+    def test_only_this_workspaces_chats_are_considered(self):
+        """`chats.of_workspace` reads each directory's own `workspace` file, so a live
+        chat of a DIFFERENT workspace on this same plane focuses nothing."""
+        _a_chat("elsewhere.1", ws="elsewhere", pane="%0")
+        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"])
+        self.assertIsNone(self._decide(fake))
+        self.assertEqual(fake.calls, [])
+
+    def test_a_server_that_will_not_list_its_panes_focuses_nothing(self):
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=[], panes_rc=1, clients=["/dev/ttys001"])
+        self.assertIsNone(self._decide(fake))
+
+    def test_a_server_that_will_not_list_that_sessions_clients_focuses_nothing(self):
+        """A session the server no longer has between the two calls answers rc 1 — and a
+        launch that cannot tell whether anybody is there opens its own chat, which is the
+        behaviour that shipped."""
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"], clients_rc=1)
+        self.assertIsNone(self._decide(fake))
+
+    def test_a_row_with_too_few_fields_is_not_read_as_a_pane(self):
+        """`_chat_being_left`'s rule: exactly the field count the format asks for, so a
+        server answering something else cannot have half a row read as a pane id."""
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$3"], clients=["/dev/ttys001"])
+        self.assertIsNone(self._decide(fake))
+
+    def test_a_row_with_too_many_fields_is_not_read_as_a_pane_either(self):
+        """Its own case, because the two halves of one field-count check are two
+        different servers: a row that is short raises where a row that is long merely
+        lies, and only the second can be mistaken for a match."""
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$3\t%0\textra"], clients=["/dev/ttys001"])
+        self.assertIsNone(self._decide(fake))
+
+    def test_a_server_that_cannot_be_listed_is_not_reported_on_every_launch(self):
+        """`report=False` on both calls, for `_live_sessions`' own reason: on a machine
+        with no charter server running yet, "could not list the panes" is the ORDINARY
+        answer, and charter must not print an error in front of every launch that happens
+        to be the first one."""
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=[], panes_rc=1)
+        said = io.StringIO()
+        with redirect_stderr(said):
+            self.assertIsNone(self._decide(fake))
+        self.assertEqual(said.getvalue(), "")
+
+    def test_a_session_whose_clients_cannot_be_listed_is_not_reported_either(self):
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$3\t%0"], clients_rc=1)
+        said = io.StringIO()
+        with redirect_stderr(said):
+            self.assertIsNone(self._decide(fake))
+        self.assertEqual(said.getvalue(), "")
+
+    def test_a_recorded_pane_that_is_not_a_pane_id_matches_nothing(self):
+        """The recorded value is COMPARED against tmux's answer and never sent to it, so
+        a state file holding something that is not a pane id is refused by the comparison
+        itself rather than by a shape check that could never fire."""
+        _a_chat("shared.1", ws=SHARED, pane="; kill-server")
+        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"])
+        self.assertIsNone(self._decide(fake))
+
+
+class TheFocusItself(PersonaIso, unittest.TestCase):
+    """`_focus_workspace` — the attach, and the two things around it."""
+
+    def _focus(self, fake, *, picked=False):
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake):
+            return commands_frame._focus_workspace("$3", "shared.1", ws=SHARED,
+                                                   picked=picked)
+
+    def test_a_workspace_the_operator_picked_is_still_written_down(self):
+        """#518's property survives the new branch: an operator who answered the picker
+        and was focused into their answer must not be asked again next launch. Written
+        under the chat being focused, which is the frame session the pointer is about."""
+        fake = _FakeServer()
+        self.assertEqual(self._focus(fake, picked=True), 0)
+        self.assertEqual(workspace.is_locked("shared.1"), SHARED)
+
+    def test_a_launch_that_answered_nothing_writes_no_pointer(self):
+        """The other half of `_pin_workspace`'s own rule, carried over unchanged: a launch
+        that resolved silently must not move any terminal's workspace."""
+        fake = _FakeServer()
+        self.assertEqual(self._focus(fake), 0)
+        self.assertIsNone(workspace.is_locked("shared.1"))
+
+    def test_a_detach_says_the_harness_is_still_running(self):
+        """The same sentence a launch that detached prints, and true for the same reason:
+        this client left, the session did not. Silence here would return an operator to
+        their shell with agents running and nothing saying so."""
+        said = io.StringIO()
+        with redirect_stderr(said):
+            self._focus(_FakeServer())
+        self.assertIn("still running", said.getvalue())
+        self.assertIn(f"attach -t {SHARED}", said.getvalue())
+
+
+class TheLaunchTakesTheDecision(PersonaIso, unittest.TestCase):
+    """`cmd_launch`'s own branch: what a focused launch does, and what it does not."""
+
+    def _launch(self, fake, *, workspace=SHARED, harness="claude", rest=()):
+        args = SimpleNamespace(harness=harness, rest=list(rest), no_frame=False,
+                               workspace=workspace, pick=False)
+        stripped = {k: v for k, v in os.environ.items()
+                    if k not in ("TMUX", "TMUX_PANE")}
+        with mock.patch.dict(os.environ, stripped, clear=True), \
+             mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
+             mock.patch("charter.commands_frame.shutil.which",
+                        side_effect=lambda n, *a, **k: f"/usr/bin/{n}"), \
+             mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("sys.stdin.isatty", return_value=False):
+            return commands_frame.cmd_launch(args)
+
+    def test_a_focused_launch_attaches_by_session_id_and_returns_zero(self):
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"],
+                           sessions=[SHARED], chats=["shared.1"])
+        self.assertEqual(self._launch(fake), 0)
+        attaches = [c for c in fake.calls if "attach" in c]
+        self.assertEqual(len(attaches), 1)
+        self.assertEqual(attaches[0][-2:], ["-t", "$3"])
+
+    def test_a_focused_launch_claims_no_ordinal_and_makes_no_directory(self):
+        """The whole reason the branch sits between the reap and `new_chat_id`: a focus is
+        a read and an `attach`. Nothing is allocated, so nothing has to be given back if
+        the operator detaches a second later."""
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        before = sorted(p.name for p in (config.STATE_DIR / "frame").iterdir())
+        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"],
+                           sessions=[SHARED], chats=["shared.1"])
+        self._launch(fake)
+        after = sorted(p.name for p in (config.STATE_DIR / "frame").iterdir())
+        self.assertEqual(before, after)
+
+    def test_a_focused_launch_starts_no_window_and_selects_nothing(self):
+        """`new-window` plus `select-window` IS the drag (§2.3). A focus must issue
+        neither — that is the whole of what makes it not one."""
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"],
+                           sessions=[SHARED], chats=["shared.1"])
+        self._launch(fake)
+        for verb in ("new-window", "new-session", "select-window", "split-window"):
+            self.assertEqual(fake.asked(verb), 0, verb)
+
+    def test_a_launch_that_focuses_nothing_still_opens_a_chat(self):
+        """The negative control, and it must be a launch that could have focused: same
+        plane, same workspace, same live session — only nobody attached."""
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$3\t%0"], clients=[],
+                           sessions=[SHARED], chats=["shared.1"])
+        with mock.patch("charter.commands_frame._spawn_gather"):
+            self._launch(fake)
+        self.assertEqual(fake.asked("new-window"), 1)
+
+    def test_a_command_the_operator_named_is_run_rather_than_swallowed(self):
+        """`charter frame -- <cmd>` is the escape hatch for a command charter has never
+        met, and attaching cannot answer it: a focus here would silently discard the argv
+        the operator typed. Same workspace, same live session, same attached client — the
+        only difference is that this launch named something to RUN."""
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"],
+                           sessions=[SHARED], chats=["shared.1"])
+        with mock.patch("charter.commands_frame._spawn_gather"):
+            self._launch(fake, harness=None, rest=["--", "htop"])
+        self.assertEqual(fake.asked("new-window"), 1)
+        self.assertIn("htop", sum((c for c in fake.calls if "new-window" in c), []))
+
+    def test_a_harness_the_operator_passed_flags_to_is_run_rather_than_swallowed(self):
+        """`charter claude --resume <id>` is the same fact one harness over: `rest` is the
+        operator's own flags, `launch_argv` carries them, and a focus would drop them."""
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"],
+                           sessions=[SHARED], chats=["shared.1"])
+        with mock.patch("charter.commands_frame._spawn_gather"):
+            self._launch(fake, rest=["--resume", "abc123"])
+        self.assertEqual(fake.asked("new-window"), 1)
+        self.assertIn("abc123", sum((c for c in fake.calls if "new-window" in c), []))
+
+    def test_the_attach_failure_is_reported_rather_than_folded_into_a_zero(self):
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+
+        class _RefusesToAttach(_FakeServer):
+            def __call__(self, cmd, **kwargs):
+                if "attach" in cmd:
+                    self.calls.append(list(cmd))
+                    return _completed(cmd, 3)
+                return super().__call__(cmd, **kwargs)
+
+        fake = _RefusesToAttach(panes=["$3\t%0"], clients=["/dev/ttys001"],
+                               sessions=[SHARED], chats=["shared.1"])
+        self.assertEqual(self._launch(fake), 3)
+
+
+def _tmux(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["tmux", "-L", SOCKET, *args], capture_output=True, text=True,
+                          timeout=15)
+
+
+def _await(predicate, timeout: float = _DEADLINE) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class TwoPlanesOnOneMachine(unittest.TestCase):
+    """§7's acceptance shape, reduced to the one question this stage decides.
+
+    Two plane roots, one tmux server, and one workspace name they share — which is the
+    only arrangement in which §3.3's flaw exists to be found. Everything asserted here is
+    read back off a real server: the pane ids it minted, the session ids it minted, and
+    the clients it reports.
+
+    **Not `cmd_launch` end to end**, deliberately. A whole launch here would bring panel
+    processes, hooks and an attach into a test whose subject is a decision taken before
+    any of them; `TheLaunchTakesTheDecision` above already pins that the launcher takes
+    this decision and what it does with each answer. What a mock cannot supply is tmux's
+    own vocabulary, and that is exactly what this class asks for.
+    """
+
+    def setUp(self) -> None:
+        self.addCleanup(self._teardown_socket)
+        self.plane_a = Path(tempfile.mkdtemp(prefix="ide-plane-a-"))
+        self.plane_b = Path(tempfile.mkdtemp(prefix="ide-plane-b-"))
+        for p in (self.plane_a, self.plane_b):
+            self.addCleanup(shutil.rmtree, p, True)
+        # One session named for the workspace both planes have — which is what charter's
+        # own launcher would create, and the collision §2.13 measures on this machine.
+        self.assertEqual(_tmux("new-session", "-d", "-s", SHARED, "-n", "c1",
+                               "sleep 300").returncode, 0)
+        seats = _tmux("list-panes", "-a", "-F", "#{session_id}\t#{pane_id}").stdout
+        self.session_id, self.pane = seats.split()[0], seats.split()[1]
+        # The window carries the chat id a launcher would have written on it — which is
+        # the SECOND name both planes have. `new_chat_id` counts from 1 on each plane's
+        # own disk, so `shared.1` is not plane A's id, it is the id both planes mint
+        # first. Without this the fixture would let an implementation that matched on
+        # `@charter_chat` pass for the wrong reason.
+        self.assertEqual(_tmux("set-option", "-w", "-t", self.pane,
+                               commands_frame._CHAT_OPTION, "shared.1").returncode, 0)
+        # Plane A opened it: its chat directory records the pane the server minted.
+        with _plane(self.plane_a):
+            _a_chat("shared.1", ws=SHARED, pane=self.pane, server=SOCKET)
+        # Plane B has a chat directory for the SAME workspace under the SAME chat id —
+        # `new_chat_id` counts from 1 on each plane's own disk, so this is what two planes
+        # that both opened `shared` actually look like — but its own chat is over, and the
+        # pane it recorded is not on this server.
+        with _plane(self.plane_b):
+            _a_chat("shared.1", ws=SHARED, pane="%9000", server=SOCKET)
+
+    def _teardown_socket(self) -> None:
+        """End the server and unlink its socket, in that order and in one cleanup —
+        `tests/test_frame_tmux_integration.py::_TmuxServerFixture`'s rule, which measures
+        why the reverse order leaves the real server running."""
+        said = _tmux("display-message", "-p", "#{socket_path}")
+        path = said.stdout.strip()
+        _tmux("kill-server")
+        for candidate in {SOCKET_PATH, path if path.startswith("/") else SOCKET_PATH}:
+            try:
+                os.unlink(candidate)
+            except OSError:
+                pass
+
+    def _attach(self):
+        """A real client on `SHARED`, or a skip naming what tmux refused."""
+        refusals = []
+        for term in _TERM_CANDIDATES:
+            pid, fd = pty.fork()
+            if pid == 0:
+                try:
+                    os.environ["TERM"] = term
+                    os.execvp("tmux", ["tmux", "-L", SOCKET, "attach", "-t", SHARED])
+                finally:
+                    os._exit(127)
+            if _await(lambda: _tmux("list-clients", "-t", SHARED,
+                                    "-F", "#{client_name}").stdout.strip() != ""):
+                self.addCleanup(self._reap_pty, pid, fd)
+                return fd
+            refusals.append(f"TERM={term}")
+            self._reap_pty(pid, fd)
+        self.skipTest("no tmux client can attach on this machine, and open-or-focus is "
+                      "a decision about an ATTACHED client — tried " + ", ".join(refusals))
+
+    def _reap_pty(self, pid: int, fd: int) -> None:
+        try:
+            os.kill(pid, 9)
+            os.waitpid(pid, 0)
+        except OSError:
+            pass
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+    def _clients(self) -> list[str]:
+        return [c for c in _tmux("list-clients", "-t", SHARED,
+                                 "-F", "#{client_name}").stdout.split() if c]
+
+    def _current_window(self) -> str:
+        return _tmux("display-message", "-p", "-t", SHARED, "#{window_name}").stdout.strip()
+
+    # -- the decision, on a real server ------------------------------------------------
+
+    def test_the_plane_that_opened_it_focuses_it(self):
+        self._attach()
+        with _plane(self.plane_a):
+            got = commands_frame._workspace_to_focus(SOCKET, ws=SHARED)
+        self.assertEqual(got, (self.session_id, "shared.1"))
+
+    def test_the_other_plane_focuses_nothing_though_every_NAME_matches(self):
+        """**§3.3, and it is the only test here that two planes are needed for.** Plane B
+        has a workspace called `shared`, a chat directory called `shared.1`, and a live
+        tmux session called `shared` with a client on it. Every NAME lines up. The one
+        thing that does not is the pane its own launcher wrote down — which is the only
+        fact on this machine that belongs to one plane and not the other."""
+        self._attach()
+        with _plane(self.plane_b):
+            self.assertIsNone(commands_frame._workspace_to_focus(SOCKET, ws=SHARED))
+
+    def test_the_plane_that_opened_it_focuses_nothing_while_nobody_is_attached(self):
+        with _plane(self.plane_a):
+            self.assertIsNone(commands_frame._workspace_to_focus(SOCKET, ws=SHARED))
+
+    # -- the tmux facts §4k rests on ---------------------------------------------------
+
+    def test_a_second_client_attaching_by_session_id_does_not_move_the_first(self):
+        """The measurement that makes focusing safe where adding a chat is not. Both
+        clients share one current window (§2.10), so the question is whether ATTACHING
+        moves it — and it does not, on 3.7c and at the 3.2 floor alike."""
+        self._attach()
+        was = self._current_window()
+        _tmux("new-window", "-d", "-t", SHARED, "-n", "c2", "sleep 300")
+        self.assertEqual(self._current_window(), was, "`new-window -d` moved the client")
+        second = self._attach()
+        self.assertEqual(len(self._clients()), 2)
+        self.assertEqual(self._current_window(), was)
+        self.assertGreater(second, 0)
+
+    def test_selecting_the_new_chat_is_what_drags_the_client(self):
+        """The control, and without it the test above is satisfied by a client that was
+        never movable. This is §2.3 reproduced on this machine: the launcher's own
+        `select-window` moves the client that was already there onto the new chat."""
+        self._attach()
+        was = self._current_window()
+        _tmux("new-window", "-d", "-t", SHARED, "-n", "c2", "sleep 300")
+        _tmux("select-window", "-t", f"{SHARED}:c2")
+        self.assertTrue(_await(lambda: self._current_window() == "c2"),
+                        "tmux did not drag the attached client — §2.10 no longer holds")
+        self.assertNotEqual(self._current_window(), was)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -763,6 +763,11 @@ class NoCharterEscapesThroughTheExecFamily(unittest.TestCase):
             "to be put on a real client's terminal for tmux to route it — so neither "
             "`focus`/`blur` nor `click`/`scroll` can be exercised without a real one. "
             "`os._exit`s in its `finally`.",
+        "tests/test_a_second_launch_focuses_instead_of_dragging.py:execvp":
+            "The same `tmux attach` inside a `pty.fork` child, for the reason open-or-"
+            "focus is ABOUT: the decision it takes is 'is a client attached to this "
+            "workspace', and only a real client on a real terminal makes that true. "
+            "`os._exit`s in its `finally`.",
         "tests/test_a_real_click_reaches_the_real_repo_table.py:execvp":
             "The same `tmux attach` inside a `pty.fork` child, for the sibling reason: "
             "that file exercises the pointer against charter's OWN `repos` panel rather "


### PR DESCRIPTION
Two stages of `docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md`, both from
§6's "Ready now" list: **the durable session id (§4e, reduced form)** and **open-or-focus
(§4k)**.

**One PR, and here is the case for it.** They share no code, no file and no test: §4e is
`charter/frame/state.py` and a new test module; §4k is `charter/commands_frame.py`, `docs/frame.md`
and a second new test module. Neither reads the other. Two PRs would have been two
five-minute reviews of two things nobody has to hold in their head at once — but they are
also the two halves of one delivery decision, and the ordering hazard §4e states (below) is
the kind of note that gets lost when it is filed on its own. Read either half alone; the
diff does not interleave them.

---

## Stage A — the durable session id (§4e, reduced form)

Charter records the harness's own session id at `.charter/frame/<fid>/session`, written by
Claude Code's `statusLine` hook. `state.clear_shape` deletes it, with its reason at the
line: *"a gauge reading somebody else's 78% is worse than either."*

**Both requirements are right and one file was serving two purposes.** The usage history
the gauge reads is keyed by that id and lives outside the frame directory, so deleting the
mapping is the only thing suppressing a stale gauge today — that argument is about a number
drawn on screen and it stands. It is not an argument about the identifier, which is the only
thing charter records that could ever ask a harness for its conversation back.

So `record_harness_session` writes a durable sibling, `session.durable`, from the same value
on the same branch, and `clear_shape` does not list it. The two can only ever disagree by
the sibling being **absent** — never by holding a different id. `clear_shape` and the gauge
are untouched.

**Nothing reads it, and that is the stage.** Reopen (§6 stage 5) is what reads it, and the
id cannot be written retroactively for a chat whose `session` a launch has already cleared —
so it has to land first, alone.

### ⚠ The ordering hazard, restated so it does not get lost

Keeping the id is "no behaviour change" **only while nothing relaunches into an existing
chat directory**. The moment a reopen does, `session` comes back from this file and the
gauge starts reading a history belonging to a run that is over.

**The gauge's gate must ship before reopen, not with it.** §4e settled what that gate is:
`state.exit_code(fid) is None` — one `stat`, already written and already correct — and
*not* a liveness check, because `state.is_live` for a chat has no launcher pid and falls to
`pane_matches`, which is `False` for every panel, always. It is deliberately not in this PR:
a gate is a behaviour change and this is not.

One migration case, pinned rather than discovered: a chat whose harness was already running
when this charter arrives keeps a `session` written by the previous version, so the no-op
guard returns before the sibling is reached and the sibling first appears when that harness's
session id next changes. There is no back-fill and there should not be — reading `session`
as a stand-in would be reading exactly the file whose deletion this pair exists to survive.

---

## Stage B — open-or-focus (§4k)

`charter -w foo` meant "add a chat to `foo`" whatever `foo` was doing. Where somebody was
attached, that was destructive: both clients of a tmux session share one current window, so
the `select-window` that put the new launch on its new chat pulled the existing client onto
it, and `_drop_panels` then tore down the panels they were reading.

§2.10 says the drag has no small fix, and I re-measured it: on 3.7c and at the 3.2 floor
alike, tmux has no per-client current window inside one session, and the only non-dragging
mechanism is a session group, which would stop a workspace being a tmux session.

**So the reason to drag is removed rather than the drag fixed.** A workspace whose session
already has an attached client is **focused** — one more client on the session they are on,
looking at the window they are on. Nothing is started, no ordinal is claimed, no directory is
made, no window is selected. A workspace nobody is attached to opens a chat exactly as
before: there is nobody there to drag.

### §3.3, which is the whole reason this is not ten lines

One tmux server serves **every plane on this machine**, session names are bare workspace
names, and `default` is a name every plane has. A focus decided on a name would have made an
existing cross-plane collision into charter's *advertised* behaviour.

`_workspace_to_focus` therefore **starts on disk** — `chats.of_workspace(ws)` under this
plane's own `config.STATE_DIR` — takes the `%<pane>` id this plane's own launcher wrote
down, and asks tmux only for `#{session_id}` and `#{pane_id}`. #693's rule: ids the server
minted, never names from a namespace every plane shares. A plane that has never opened a
workspace has no directory for it, **makes no tmux call at all**, and can never focus
anybody.

The residual is stated in the code rather than hidden: pane ids restart at `%0` when a tmux
server does. Within one plane that is already closed by the reap `cmd_launch` runs
immediately above this. Across two planes it is not, because that liveness list is by chat
id and chat ids collide exactly as session names do (`new_chat_id` counts from 1 on each
plane's own disk, so `shared.1` is the id both planes mint first). Closing it needs a plane
marker on the window — a stage, not a line.

### Two things it deliberately does not do

* **A launch that names something to run still runs it.** Attaching answers "put me in
  `foo`"; it cannot answer "run *this* in `foo`". `charter frame -- <cmd>` and
  `charter claude --resume <id>` both open a chat and run what they named, attached client
  or not — a launcher that swallowed an argv the operator typed and attached instead would
  be wrong in the one direction this module refuses everywhere else, silently.
* **Adding a chat from inside the frame is unchanged.** A charter started in a frame's own
  pane has `$TMUX` set and takes `_launch_in_operator_tmux`, so `+ charter <harness> opens
  another` — what the chat bar tells you — still does exactly that.

§2.4's geometry race between two clients of one session is untouched, and §5 already says
so: this removes the reason to have two clients on different windows, not the cost of having
two.

---

## Verification

**None of this runs in CI** — there is no tmux there, so a green gate says nothing about
either stage (§2.12).

* **The two-plane acceptance test (§7).** `TwoPlanesOnOneMachine` stands up two plane roots
  against one real tmux server with one workspace name they share — *and* the same chat id,
  `shared.1`, which both planes mint first. The plane that opened it focuses it; the plane
  that did not focuses nothing, though its workspace name, its chat id and the live session's
  name all match. **Both wrong implementations were run against that test and both go red**:
  matching on the session name, and matching on the chat id (disk ∩ live). A single-plane
  test cannot fail for §3.3's reason at all.
* **A whole `cmd_launch`, by hand, on a real server with a real attached client**, on this
  branch and on `main`, on both tmux versions and identical on each:

  | | second launch, plane A | third launch, plane B |
  |---|---|---|
  | `main` | adds `shared.2`, **moves the attached client onto it** | adds a window to plane A's session |
  | this branch | `attach -t $0`, no window, client stays on `shared.1` | adds a window to plane A's session |

  (Plane B's column is the pre-existing cross-plane collision §3.3 names. It is unchanged —
  this PR neither fixes it nor makes it the advertised path.)
* **The tmux facts, measured on 3.7c and at the 3.2 floor, identically on both:**
  `list-panes -a` lists every pane on the server with its own session id; `list-clients -t $N`
  takes a session *id*, prints one line per attached client, exits 0 with nothing on stdout
  when none is attached and rc 1 for a session the server does not have; `attach -t $N`
  attaches; and **a second client attaching to a session does not move its current window** —
  which is the fact that makes focusing safe where adding was not. The drag itself is
  asserted as a control in the same class, so "the client did not move" cannot pass for a
  client that was never movable.
* **Both new modules on both versions**: 29/29 and 18/18 on tmux 3.7c, and the same at the
  3.2 floor with it first on `$PATH`.
* **Full suite**: 9048 tests, `OK (skipped=1)`. The first full run caught something worth naming:
  `test_plane_spawn_guard.NoCharterEscapesThroughTheExecFamily` refuses any `os.exec*` in
  the tree that is not written down with a reason, and the new module's `pty.fork` +
  `os.execvp("tmux", …)` was one. It is registered with its reason now, beside the five
  other real-tmux modules that fork a client the same way — it execs tmux, never charter,
  and `os._exit`s in its `finally`.
* **Deletion sweep, decomposed by hand and never a bare count.** Every line this branch adds
  that refuses, clamps, defers or falls back was deleted one at a time — 23 mutations, each
  run on its own, **zero survivors**. Each alternative arm has an input that reaches only it:
  the `list-clients` return code and the empty client list are two separate tests, and the
  field-count check is two (a short row raises where a long row merely lies, and only the
  second can be mistaken for a match). Two of the 22 are not deletions but the wrong DESIGN,
  because that is what these two stages are actually at risk of: putting `session.durable`
  in `clear_shape`'s list, and keeping it outside the frame directory (#731's shape). Both
  go red.

  Run with `python3 -B` and `PYTHONDONTWRITEBYTECODE=1` over a purged `__pycache__`, so no
  colour here comes from a stale `.pyc` served to a same-second restore.

  **The sweep found one real defect in my own gate and it is fixed rather than documented.**
  The "only a launch that asked for nothing but the workspace" condition was first written
  `if h is not None and not rest:` — and `h is not None` is unreachable there: an
  unregistered harness means `argv = rest`, and `if not argv:` above has already ended the
  launch with "nothing to run". It is `if not rest:` now, with the reason written at the
  line.

  **And CI's own sweep found two more, which are fixed rather than argued with.**

  * `clients.stdout.strip()` was the `strip`/`lstrip` equivalent mutant `_live_chats`'
    own docstring names — truthy for exactly the same strings, so no test could tell the
    two apart. The question here was only ever "is there a client at all", so it is
    `clients.stdout.split()` now: one question, asked once on tmux's own newline-separated
    output, with no half to mutate — and deleting it IS pinnable, because a server
    answering a bare newline then reads as one client with a blank name.
  * `_KEPT_SESSION_FILE = "session.durable"` survived because every test reads through the
    constant, so a rename moved writer and reader together. That is the right code and the
    wrong test coverage: the name is **durable state in a directory a much newer charter
    reopens**, so renaming it after this ships silently loses the id for every chat already
    recorded. It is pinned as bytes now, together with the fact that the write leaves those
    two files and no `.tmp` beside them.

## The three findings routed to me tonight — #731, #733, #735

**I am taking none of them into this PR**, and the reasoning is more useful than the verdict.

### #731 — a recycled chat id inherits the previous frame's workspace pointer and lock

**My design does not make this impossible, and saying it did would be conflating two
different session ids.** #731 is about the CHAT id (`<workspace>.<n>`, `$CHARTER_SESSION_ID`)
being recycled while `.charter/sessions/<fid>.workspace` and `.lock` outlive the frame
directory whose removal freed the ordinal. Stage A is about the HARNESS's own session id
(Claude Code's UUID), and it lives *inside* `.charter/frame/<fid>/`.

That difference is the whole answer, and it is now **asserted rather than left as a property
the design happens to have** — `ItDoesNotOUTLIVETheChatItself` reaps a chat, allocates the
ordinal again, and requires the durable id to be gone. `state.new_chat_id` frees an ordinal
by the absence of that directory and `reap` removes it whole, so "the id is free" and "the
durable id is gone" are one event, not two. There is no window in which a new chat is handed
an old one's harness session. The deletion sweep pins it from the other side: **moving the
durable file out of the frame directory — #731's exact shape — goes red on that test.**

So #731 is not made impossible by Stage A; it is made *contrastable* by it, and the contrast
says which of the two candidate fixes in the issue is right. **Reap the session pointer with
the frame.** The alternative offered there — "make an explicit `--workspace` outrank a
pointer it did not write" — fixes only launches that carry the flag; a bare `charter` (which
#715 has just made the ordinary way to open the frame) still inherits, and the identity row
still lies. It is a small, well-specified job in `state.reap` + `workspace.py`, and it wants
its own reproduction and its own tests — `reap`'s keep-rules carry ~60 tests and §6 already
calls that file "not a stage — a redesign".

**One disclosure: this PR adds one new caller of the file #731 is about.** `_focus_workspace`
calls `_pin_workspace`, which calls `workspace.set_active(ws, session_id=<chat>)` — so a
*picked* focus writes `sessions/<chat>.workspace` and `.lock`, exactly as every picked launch
already does. It cannot introduce a mismatch (it writes the workspace that chat is already
in) but it is one more occasion for the leak, and it should be counted when #731 is fixed.

### #733 — `F2 → workspace` strands a chat

**Different job, and I recommend refusing it here.** It is about `F2 → workspace` breaking
the invariant that a chat's workspace is its tmux session's name — `frame/switch.py`, the
palette's chat doorway and `cmd_chat`, none of which this PR touches.

**But it interacts with open-or-focus and that is worth having on the issue as evidence.**
`_workspace_to_focus` reads `chats.of_workspace`, so it inherits #733's membership gap. In
the stranded state the issue describes — `alpha.1` moved to `gamma`, still a window of tmux
session `alpha` — `charter -w gamma` now finds a live chat for `gamma` (that is `alpha.1`)
and attaches to the session holding it, whose current window is `alpha.2`. So the operator
asking for `gamma` lands looking at `alpha`'s chat. Before this PR they would have got a new
tmux session named `gamma` instead.

I deliberately did **not** guard that at my seam. The only guard available is "refuse unless
the chat's session is the one named for `ws`", which is a session-NAME comparison — the one
thing §3.3 forbids — and it would paper over #733 rather than fix it. It is a fourth
consequence of the same broken invariant and belongs on #733.

### #735 — a corrupt `gather.json` says "gathering…" forever

**Not mine.** It is a repo-panel message (`frame/slots.py`, `frame/gather.py`) plus a palette
row over an existing command (`frame/builtin_actions.py`). No overlap with either stage.

## Conflicts

Rebased onto `origin/main` at 67d9121 (#715, bare `charter` — §4a) with **no conflicts**;
bare `charter` rewrites argv to `charter claude` with an empty `rest`, so it focuses, which
is the IDE behaviour that stage was for. **#724** (`fix/714-reconcile-panels`) was read
before pushing: it works in `_draw_panels`/`_relayout`/`_split_panels` and adds
`_window_panels`/`_reconcile_panels`, all of it below `cmd_launch`'s early branching; a trial
merge is clean. Its test changes are concentrated in `test_frame_launcher.py`'s `_FakeTmux`,
which is why both new test modules here are new files rather than additions to it.

Nothing here touches a version file or `docs/news/0.54.0-*`. Two news entries, both
`version: unreleased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
