### PR TITLE
The tab bar draws the tabs that fit, not only the one you are already on (#758)

### DIFF
--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2592,6 +2592,63 @@ def _tab_columns(start: int, drawn) -> dict:
     return cols
 
 
+def _page(fields: list[str], at: int, room: int) -> tuple[int, int]:
+    """The half-open run of *fields* the tab at index *at* is drawn with, inside *room*.
+
+    :func:`_bar`'s windowed rung. *fields* are the already-marked, already-contained tab
+    texts; the answer is a slice of them wide enough to draw, with room left for the two
+    counts that stand for what it leaves out.
+
+    **The pages do not depend on *at*, and that is the whole design.** The list is cut
+    into consecutive pages left to right — greedily, as many whole names as fit, then the
+    next page from where that one stopped — and this returns whichever page the marked tab
+    falls in. So the page is a pure function of the NAMES and the WIDTH, and switching to a
+    tab that is on the page redraws that page unchanged with only the `*` moved.
+
+    That property is what makes a windowed strip safe to click, and the alternative is
+    where it was measured. A window CENTRED on the marked tab moves every column each time
+    the operator switches, so the cell they just pressed holds a different name a moment
+    later: on this project's own fifteen workspaces at 160 columns, six of the nine drawn
+    tabs answer a second press at the identical column with a SECOND, different workspace.
+    `_Tabs.switch_to`'s "the tab you are on is not news" cannot catch that — the name at
+    that column really did change — so a double-click would switch twice, which is the one
+    thing that rule exists to stop. Pages cannot: a drawn tab is by construction on the
+    current page, so switching to it cannot turn the page.
+
+    **Anchoring to the previous window would buy the same steadiness and would have to be
+    remembered.** A panel is one long-lived process per slot, so state does survive an
+    ordinary repaint — but not `cmd_respawn`, not the respawn hook a dead pane fires, and
+    not a density change that re-splits the panels. The row would then depend on history
+    the operator cannot see, and two frames showing the same plane at the same width could
+    disagree. Pages need nothing remembered.
+
+    **Both counts are paid for before a name is, and the trailing one is sized for the
+    worst case.** The leading `+N` is exactly ``+start``, which is known before the page is
+    built. The trailing one is not: whether it is drawn at all depends on where the page
+    ends, which is what is being computed. Reserving the widest count the list can produce
+    breaks that circle for the price of at most a cell or two on the final page, where the
+    reserve is spent on a count that is never drawn. The alternative is an iteration whose
+    fixed point is not obvious, to save a column.
+
+    At least one field per page, always, so a name wider than the whole row cannot spin
+    this. Such a page overflows, and :func:`_bar` measures the row it composed and gives
+    the rung up rather than drawing it — the ladder's own rule, one rung down.
+    """
+    # The widest count either end can carry: every name but one left out. Measured with
+    # `tui.width` for this module's own reason, even though charter mints the digits.
+    tail = _BAR_GAP + tui.width(f"+{len(fields) - 1}")
+    start = 0
+    while True:
+        budget = room - tail - (_BAR_GAP + tui.width(f"+{start}") if start else 0)
+        used, stop = tui.width(fields[start]), start + 1
+        while stop < len(fields) and used + _BAR_GAP + tui.width(fields[stop]) <= budget:
+            used += _BAR_GAP + tui.width(fields[stop])
+            stop += 1
+        if at < stop:
+            return start, stop
+        start = stop
+
+
 def _bar(head: str, names: list[str], here: str, width: int, *,
          note: str = "") -> list[str]:
     """One bar row: *head*, then *names* with *here* marked, inside *width* columns.
@@ -2604,10 +2661,18 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     **The ladder, and every rung drops a whole thing rather than truncating one.**
 
     1. **Every name in full**, *here* marked. What a wide row shows.
-    2. **The one you are in, in full, plus a count of the rest** (`+2`). The others go
-       WHOLE, which is `_fit_fields`' own discipline one row over: a list cut off
-       mid-name is a list where `api-staging` and `api-standby` are the same string, and
-       half a name is worse than an honest count.
+    2. **The PAGE the one you are in falls on, plus a count at each end** (`+5  …  +9`).
+       Every name on the row goes WHOLE, which is `_fit_fields`' own discipline one row
+       over: a list cut off mid-name is a list where `api-staging` and `api-standby` are
+       the same string, and half a name is worse than an honest count. :func:`_page` is
+       the cut and carries why it is a page rather than a window centred on *here*.
+
+       **This rung used to draw the marked name alone**, and on a real plane that made
+       the whole bar inert: fifteen workspaces need 274 columns for rung 1, so every
+       width an operator actually runs at drew `*harness-wrapper  +14` — one tab, the one
+       they were already on, which `_Tabs.switch_to` correctly refuses. The bar was
+       clickable and reached nothing. A page reaches five more at 120 columns, seven at
+       160 and nine at 200.
     3. **`n/N` alone** — which position you are in and how many there are. This is the
        rung §3.6 calls "marks only", and a count IS what a mark per chat degenerates to
        once there is no room to draw one per chat. It says strictly more: `2/3` tells you
@@ -2641,11 +2706,18 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     bar clickable at all and is the same discipline `_repos` keeps for the table's rows:
     the handler resolves a click against WHAT WAS DRAWN rather than against what it
     thinks would have been. Only the names actually on the row get columns — the heading,
-    the gaps, the `+N`, the `n/N` and the affordance are cells this bar drew no tab into
-    and a click on one of them switches nothing. **The rungs that draw NOTHING publish
-    too**, and that is the half `_Viewport.blank` exists for one axis over: a bar that
-    kept its last map through a resize down to `2/3`, or down to no row at all, would
+    the gaps, BOTH `+N` counts, the `n/N` and the affordance are cells this bar drew no
+    tab into and a click on one of them switches nothing. **The rungs that draw NOTHING
+    publish too**, and that is the half `_Viewport.blank` exists for one axis over: a bar
+    that kept its last map through a resize down to `2/3`, or down to no row at all, would
     switch to a tab the operator can see is not on screen.
+
+    **The windowed rung sharpens that rather than softening it.** It draws a different
+    slice of the names at every width, so a map kept across a resize would answer with a
+    name that is genuinely somewhere else on the row — not merely absent from it. The map
+    is published from the composition itself (`row`'s *before*, and :func:`_tab_columns`
+    walking the fields the rung actually joined), so there is no second walk of the ladder
+    to disagree with the first.
     """
     # **`head` and `note` are NOT contained, and the deletion sweep is what settled it.**
     # Both are charter's own literals — `"chats"`, `"workspaces"`, :data:`ADD_CHAT` — and
@@ -2655,7 +2727,7 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     # contained, below, which is where the open alphabet actually is.
     lead = _inset() + head + " " * _BAR_GAP
 
-    def row(body: str = "", drawn=()) -> list[str]:
+    def row(body: str = "", drawn=(), before: str = "") -> list[str]:
         """This rung's row, and the column map for the tabs it actually drew.
 
         **Every way out of the ladder goes through here**, which is what keeps "the map
@@ -2666,9 +2738,17 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
 
         An empty *body* is the rung that draws nothing — rung 4, and a bar with no names.
         It still publishes, for the reason the docstring above gives.
+
+        *before* is what a rung draws between the heading and its FIRST tab — the leading
+        `+3` of the windowed rung, and nothing else today. It is passed rather than glued
+        onto *body* by the caller because the map is measured from where the first tab
+        starts: a rung that composed its own prefix would be publishing columns three
+        cells left of the names it drew, which is a click landing on the tab beside the one
+        the operator pressed. Every other rung starts its tabs at the lead and says so by
+        not passing it.
         """
-        TABS.publish(_tab_columns(tui.width(lead), drawn), here)
-        return [lead + body] if body else []
+        TABS.publish(_tab_columns(tui.width(lead + before), drawn), here)
+        return [lead + before + body] if body else []
 
     if not names:
         return row()
@@ -2692,20 +2772,28 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     if tui.width(joined) <= room:
         return row(joined, zip(names, marked))
     if at >= 0:
-        # **No `if len(names) > 1` on the count, and it is unreachable rather than merely
-        # untested.** With ONE name `joined` IS `marked[at]` and the count is empty, so
-        # the rung above asks exactly what this one asks and always answers first: a `+0`
-        # can be built here and can never be returned. The sweep found the conditional as
-        # a survivor for that reason.
-        rest = f"{' ' * _BAR_GAP}+{len(names) - 1}"
-        if tui.width(marked[at]) + tui.width(rest) <= room:
-            # The count is NOT a tab. `+2` stands for names that are not on the row, so
-            # there is nothing there to switch to and saying so is better than picking one
-            # of them — `_Viewport.publish`'s rule for `…(+N more)`, one axis over. The
-            # one name this rung draws is the one you are already on, so this rung is
-            # inert by construction, which is honest rather than a gap: the palette is
-            # what reaches the other names at a width that cannot draw them.
-            return row(marked[at] + rest, [(names[at], marked[at])])
+        # **No `if len(names) > 1` here, and it is unreachable rather than merely
+        # untested.** With ONE name the page is that name, both counts are absent, and the
+        # body this composes IS `joined` — so the rung above asks exactly what this one
+        # asks and always answers first. The sweep found the old conditional as a survivor
+        # for that reason and the shape has not changed.
+        first, last = _page(marked, at, room)
+        # Neither count is a tab. `+9` stands for names that are not on the row, so there
+        # is nothing there to switch to and saying so is better than picking one of them —
+        # `_Viewport.publish`'s rule for `…(+N more)`, one axis over. **Two of them, and
+        # the left one is what a windowed strip owes the operator**: a single trailing
+        # `+14` beside a page that starts in the middle of the list says the names on the
+        # row are the FIRST fourteen, which is false. `+5  *harness-wrapper  …  +9` says
+        # where in the plane's fifteen this page sits, which is the readout `n/N` gives
+        # one rung down and the reason that rung was worth keeping.
+        before = f"+{first}{' ' * _BAR_GAP}" if first else ""
+        after = f"{' ' * _BAR_GAP}+{len(names) - last}" if last < len(names) else ""
+        body = (" " * _BAR_GAP).join(marked[first:last]) + after
+        # Measured, not assumed. :func:`_page` puts at least one name on a page, so a name
+        # wider than the whole row composes a body that overflows — and this ladder gives a
+        # rung up rather than drawing part of anything.
+        if tui.width(before + body) <= room:
+            return row(body, zip(names[first:last], marked[first:last]), before=before)
     counted = f"{at + 1}/{len(names)}" if at >= 0 else str(len(names))
     if tui.width(counted) <= room:
         return row(counted)

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2510,8 +2510,8 @@ class _Tabs:
         *columns* maps a column of the component's OWN canvas — the rectangle `ctx.width`
         describes, which is what `events.Dispatcher._on_canvas` delivers a click in — to
         the name of the tab drawn there. Absent means the operator clicked a cell this
-        bar drew no tab into: the heading, the gap between two tabs, the `+14`, the
-        `n/N`, the empty space past the last name. `events.Dispatcher._on_canvas` applies
+        bar drew no tab into: the heading, the gap between two tabs, EITHER `+N` count,
+        the `n/N`, the empty space past the last name. `events.Dispatcher._on_canvas` applies
         the identical rule one axis over for the pad, and `_Viewport.publish` applies it
         for the table's heading row.
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -159,10 +159,18 @@ reach a panel at all — tmux gives your typing to the active pane, which is the
 
 Clicking the tab you are already on does nothing at all, rather than tearing the panels down
 and putting them back to arrive where you were. So does clicking the heading, the gap between
-two names, the `+14` where names did not fit, or the empty space past the last tab: those are
-cells no tab was drawn into, and charter will not pick the nearest name for you. On a bar
-narrow enough that only your own name is drawn, nothing on it is clickable — `F2` is what
-reaches the rest at any width, which is what the bar being a readout means.
+two names, either `+N` count where names did not fit, or the empty space past the last tab:
+those are cells no tab was drawn into, and charter will not pick the nearest name for you. On
+a bar narrow enough that only your own name is drawn, nothing on it is clickable — `F2` is
+what reaches the rest at any width, which is what the bar being a readout means.
+
+**The names on a narrow bar do not move when you switch between them.** Where the whole list
+does not fit, the bar cuts it into pages and draws the page yours falls on — and that cut is
+decided by the names and the width alone, never by which one you are on. So clicking a tab
+redraws the same row with the `*` moved and every other tab still where you pressed it, which
+is what makes a double-click harmless: the second press lands on the tab you just arrived at,
+and that one does nothing. It also means the names a click can reach are the ones on your
+page; `F2` is what reaches the other pages.
 
 **Focus events are on inside a frame charter launched, and off inside your own tmux.** tmux
 ships `focus-events` off, and it is a server-wide setting; charter turns it on for its own
@@ -297,8 +305,12 @@ already in.
 
 `chats` and `workspaces` are one-row components: the chat bar names every chat in this
 workspace with yours marked, and the workspace bar does the same for the plane. Where the
-names do not all fit the bar keeps yours whole and counts the rest (`*api.2  +2`); narrower
-still it says only where you are (`2/3`). It never shows half a name.
+names do not all fit the bar draws the page yours falls on and counts what is off each end
+(`+5  *harness-wrapper   news-dispatch-guard  …  +7`); narrower still it says only where you
+are (`2/3`). It never shows half a name.
+
+Fifteen workspaces need 274 columns to fit on one row, so on a real terminal the bar is
+usually drawing a page. At 120 columns it draws six of them, at 160 eight, at 200 ten.
 
 **They are tabs: with `mouse = true`, clicking a name switches to it.** A chat tab does
 exactly what `F2` → `chat` does — the same command, the same five refusals, the same

--- a/docs/news/unreleased-the-tab-bar-draws-the-tabs-that-fit.md
+++ b/docs/news/unreleased-the-tab-bar-draws-the-tabs-that-fit.md
@@ -1,0 +1,84 @@
+---
+version: unreleased
+headline: The tab bars draw the tabs that fit, instead of only the one you are already on
+---
+
+*"Trying to click on workspace or chats to switch — seems not working?"*
+
+That report is what made both bars clickable. It did not make this one work. Fifteen
+workspaces need **274 columns** to fit on one row, and no terminal is 274 columns wide, so
+the `workspaces` bar fell to the rung below and drew:
+
+```
+  workspaces  *harness-wrapper  +14
+```
+
+One tab, and it is the one you are standing on. Clicking the tab you are on does nothing —
+deliberately, so a double-click cannot tear four panels down twice — so the bar was clickable
+and reached nothing at all. From the operator's chair that is the same screen as before.
+
+**The bar now draws the names that fit.**
+
+```
+  workspaces   authority-audit   autonomy   charter-update-skill   default   fleet  *harness-wrapper  +9
+```
+
+That is the same plane at 120 columns: six tabs, five of them somewhere to go. At 160 it
+draws eight, at 200 ten. The count at the end stands for the names that are not on the row,
+and there is one at each end when the row starts partway down the list:
+
+```
+  workspaces  +5  *harness-wrapper   news-dispatch-guard   opencode-integration   plane-shape  +6
+```
+
+Two counts rather than one, because a lone trailing `+14` beside a row that begins in the
+middle of the list says these are the *first* names, which is false. `+5 … +6` says where in
+the plane's fifteen you are looking, which is what the `n/N` rung one step narrower has always
+said and is worth keeping when there is room for names as well.
+
+**The names do not move when you switch between them, and that is a decision with a
+measurement behind it.** Where the whole list does not fit, charter cuts it into pages and
+draws the page yours falls on — and the cut is made from the names and the width alone. Which
+name is marked never enters it. So clicking a tab redraws the identical row with the `*`
+moved, and every other tab is still exactly where you pressed it.
+
+The obvious alternative is a window *centred* on the name you are on, which slides one step
+each time you switch. It reads well and it is unsafe: the cell you just pressed holds a
+different name a moment later, so a second press switches again, to a third workspace.
+Measured on this project's own fifteen workspaces at 160 columns, six of the nine tabs a
+centred strip draws do exactly that. "The tab you are on does nothing" cannot save you from
+it, because the name under your pointer genuinely changed. Pages cannot go wrong that way: a
+tab you can click is by construction on the page you are on, so clicking it cannot turn the
+page.
+
+Nothing is remembered between paints to make this work, which is the other half of the same
+choice. A panel that anchored its window to wherever it was last time would lose that anchor
+to a respawn, to a dead pane coming back, or to a density change re-splitting the panels — and
+the row would then depend on history you cannot see, with two frames on the same plane at the
+same width disagreeing about what they draw.
+
+**What a click on the wrong cell still does, which is nothing.** The heading, the gap between
+two names, *both* counts, the empty space past the last tab, and the tab you are already on.
+Charter resolves a click against the columns the paint actually wrote, and a windowed row
+makes that stricter rather than looser: the bar draws a different slice of the names at every
+width, so a map kept across a resize would answer with a name that is somewhere else on the
+row rather than merely absent from it. The map is published by the pass that composed the row,
+on every rung, including the rungs that draw no tab at all.
+
+**Both bars, one ladder.** `chats` and `workspaces` sit on adjacent rows of the same frame and
+degrade through the same code, so they cannot give their names up at two different widths. The
+chat bar reaches the page later — two chats called `harness-wrapper.1` and `harness-wrapper.2`
+fit on one row from 47 columns up — but it reaches it: four chats of a workspace called
+`relations-and-delegations` need 127 columns, and at 80 that bar now draws two of them with a
+`+2` instead of one and a `+3`.
+
+**What has not changed.** You still need `[frame] mouse = true` and you still have to place a
+bar with a `[[frame.component]]` table; neither is on by default. The names a click can reach
+are the ones on your page, and `F2` is what reaches every chat and every workspace at every
+width — including the widths where neither bar can be drawn at all. That is what "the bar is a
+readout" has always meant, and it is why the bar is allowed to show you part of the list.
+
+Verified on a real tmux — 3.7c and the 3.2 floor — with a real client on a real pty and a real
+`charter panel` process holding the bar's pane: on a plane with fifteen workspaces at 120
+columns, a click on a neighbour's tab switches the frame, and the same click a second time
+switches nothing.

--- a/docs/news/unreleased-the-tab-bars-are-tabs.md
+++ b/docs/news/unreleased-the-tab-bars-are-tabs.md
@@ -44,7 +44,7 @@ side of it:
   selected would draw a second mark nothing on the machine could act on.
 
 **What a click on the wrong cell does, which is nothing — deliberately, in four places.** The
-heading. The gap between two names. The `+14` where the names did not fit, which stands for
+heading. The gap between two names. A `+N` where the names did not fit, which stands for
 names that are not on the row at all. And the empty space past the last tab. Charter resolves
 a click against the columns the paint actually wrote, published by the same pass that drew the
 row, so a cell no tab was drawn into is not a cell a tab was clicked in — it will not pick the
@@ -52,11 +52,13 @@ nearest name for you. **Clicking the tab you are already on does nothing too**, 
 tearing four panels down and splitting them again to arrive where you were; it is also what
 stops a double-click switching twice.
 
-**One consequence to know before you place a bar on a narrow frame.** Where the row has room
-for only your own name and a count, the only tab drawn is the one you are on — so nothing on
-that bar is clickable. That is honest rather than broken: `F2` reaches every chat and every
-workspace in two keystrokes at every width, which is what "the bar is a readout" has always
-meant.
+**One consequence to know before you place a bar on a narrow frame.** Where the whole list
+does not fit, the row draws the page yours falls on and counts what is off each end — so the
+names a click can reach are the ones on that page, and on a row narrow enough to hold only
+your own name there is nothing on the bar to click at all. That is honest rather than broken:
+`F2` reaches every chat and every workspace in two keystrokes at every width, which is what
+"the bar is a readout" has always meant. *The tab bars draw the tabs that fit* in this same
+release has how the page is chosen and why it does not move under your pointer.
 
 **You need `[frame] mouse = true`, and you need to have placed a bar.** Neither is on by
 default and this entry does not change that: with mouse off, tmux asks your terminal to report

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -534,3 +534,113 @@ class ARealClickOnTheChatBarMovesTheClient(_ARealFrameWithBars, unittest.TestCas
         time.sleep(2.0)
         self.assertEqual(self._current_window(self.WS), window)
         self.assertEqual(self._active(), self.harness)
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealClickOnAWINDOWEDWorkspaceBarMovesTheFrame(_ARealFrameWithBars,
+                                                     unittest.TestCase):
+    """The rung an operator's plane actually draws, clicked on a real terminal.
+
+    **Every other case in this file clicks rung 1**, where every name is on the row —
+    which needs 274 columns for the fifteen workspaces this project's own plane has. So
+    the cases above pass on a bar no operator can produce, and the report that produced
+    them (*"seems not working?"*) survived them: the rung a 120-column terminal reaches
+    drew one tab, the one the frame was already on, and clicking it is correctly nothing.
+
+    This is that plane. Fifteen real workspace names, a 120-column window, and a click on a
+    tab that is only on the row because the rung draws a PAGE rather than the marked name
+    alone. Nothing here is a narrower unit of the same thing: the columns the operator's
+    pointer lands in are read off the pane tmux painted, so a page whose map was published
+    from the wrong starting column — the leading `+N` displaces every tab right of it —
+    fails here and passes every unit test that asks `slots.TABS` where it put something.
+    """
+
+    #: The fifteen this plane has. Real names rather than even-width ones: the cut is
+    #: greedy over the widths names actually have, and `relations-and-delegations` (25
+    #: cells) against `todos` (5) is what makes the page boundary land where it does.
+    NAMES = sorted([
+        "authority-audit", "autonomy", "charter-update-skill", "default", "fleet",
+        "harness-wrapper", "news-dispatch-guard", "opencode-integration", "plane-shape",
+        "relations-and-delegations", "showcase", "statusline-improvements", "todos",
+        "tracking-github-issues", "user-reporting",
+    ])
+    #: The workspace this frame is on, and one that shares its page at :data:`COLS`. Both
+    #: are asserted to be on the drawn row in `setUp` rather than assumed, so a change to
+    #: the cut fails loudly here instead of silently clicking empty cells.
+    HERE = "harness-wrapper"
+    THERE = "authority-audit"
+
+    def setUp(self) -> None:
+        super().setUp()
+        for name in self.NAMES:
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        self.fid = state.frame_id("tabbarwin", os.getpid())
+        state.frame_dir(self.fid, create=True)
+        state.record_workspace(self.fid, self.HERE)
+        self.harness = self._start_session(self.fid)
+        state.record_server(self.fid, self.socket)
+        state.record_harness_pane(self.fid, self.harness)
+        self._source_conf(self.fid)
+        self.bar = self._split_bar(self.harness, "workspaces", self.fid)
+        self.assertEqual(self._tmux("select-pane", "-t", self.harness).returncode, 0)
+        self.fd = self._attach(self.fid)
+        self.assertTrue(
+            _await(lambda: f"*{self.HERE}" in self._bar_row(self.bar)),
+            f"the bar never painted: {self._bar_row(self.bar)!r}")
+        row = self._bar_row(self.bar)
+        self.assertNotIn(self.NAMES[-1], row,
+                         f"{COLS} columns drew every name, so this measures rung 1 and "
+                         f"not the windowed rung: {row!r}")
+        self.assertIn(f" {self.THERE}", row,
+                      f"the page does not hold the tab this case clicks: {row!r}")
+        self.assertEqual(self._active(), self.harness)
+
+    def test_a_click_on_a_tab_the_old_rung_never_drew_moves_the_frame(self):
+        """The operator's report, at the operator's width. Before the windowed rung this
+        row was `workspaces  *harness-wrapper  +14` and this click had nothing to land
+        on."""
+        self._click(self.bar, col=self._column_of(self.bar, f" {self.THERE}"))
+        self.assertTrue(
+            _await(lambda: state.frame_workspace(self.fid) == self.THERE),
+            f"the click never reached the switch: "
+            f"{state.frame_workspace(self.fid)!r} — row {self._bar_row(self.bar)!r}")
+
+    def test_the_page_does_not_move_under_the_pointer_when_the_frame_switches(self):
+        """**The double-click property, through a real terminal.** The cut is made from the
+        names and the width alone, so the row that comes back after the switch holds the
+        same names in the same columns with only the `*` moved — and a second press at the
+        cell that just switched lands on the tab the frame has arrived at, which does
+        nothing.
+
+        A window centred on the marked name would have slid one step here, putting a third
+        workspace under that cell; `slots._Tabs.switch_to` could not refuse it, because the
+        name at that column really would have changed.
+        """
+        before = self._bar_row(self.bar)
+        col = self._column_of(self.bar, f" {self.THERE}")
+        self._click(self.bar, col=col)
+        self.assertTrue(
+            _await(lambda: state.frame_workspace(self.fid) == self.THERE),
+            "the first click never switched, so there is no repaint to measure")
+        self.assertTrue(
+            _await(lambda: f"*{self.THERE}" in self._bar_row(self.bar)),
+            f"the bar never redrew the mark: {self._bar_row(self.bar)!r}")
+        after = self._bar_row(self.bar)
+        self.assertEqual([n for n in self.NAMES if n in after],
+                         [n for n in self.NAMES if n in before],
+                         f"the page moved under the pointer:\n  {before!r}\n  {after!r}")
+        self._click(self.bar, col=col)
+        time.sleep(2.0)
+        self.assertEqual(state.frame_workspace(self.fid), self.THERE,
+                         "the second press at the same column switched a second time")
+
+    def test_neither_overflow_count_is_a_tab(self):
+        """`+9` stands for names that are not on the row. It is the field an operator is
+        most likely to try, and it has to do nothing rather than pick one of them."""
+        row = self._bar_row(self.bar)
+        counts = [f.strip() for f in row.split("  ") if f.strip().startswith("+")]
+        self.assertTrue(counts, f"this row carries no count to click: {row!r}")
+        for count in counts:
+            self._click(self.bar, col=self._column_of(self.bar, count))
+        time.sleep(2.0)
+        self.assertEqual(state.frame_workspace(self.fid), self.HERE)

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -60,12 +60,60 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         widths = {tui.width(self._row(200, here=n)) for n in self.NAMES}
         self.assertEqual(len(widths), 1, "the row changed width when the mark moved")
 
-    def test_a_row_with_no_room_for_every_name_keeps_yours_and_counts_the_rest(self):
+    def test_a_row_with_no_room_for_every_name_draws_the_page_yours_is_on(self):
+        """The names that FIT, not the one you are on and a count of everything else.
+
+        The rung this replaces drew `*api.2  +2`, whose only tab is the one the operator
+        is already standing on — correct, and inert. What the row can hold is drawn
+        instead, and the rest is counted at whichever end it fell off.
+        """
         row = self._row(30)
         self.assertIn("*api.2", row)
-        self.assertIn("+2", row)
-        self.assertNotIn("api.1", row)
+        self.assertIn("api.1", row, "the row had room for a neighbour and drew none")
         self.assertNotIn("api.3", row)
+        self.assertIn("+1", row, "the name left off the row was not counted")
+
+    def test_both_ends_are_counted_so_a_page_says_where_in_the_list_it_sits(self):
+        """A single trailing `+N` beside a page that starts in the middle of the list
+        claims the names on the row are the FIRST N — which a windowed strip makes false.
+
+        Measured on a list long enough to have a page with names on both sides of it.
+        """
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        row = self._row(80, names=names, here="workspace-07")
+        self.assertIn("*workspace-07", row)
+        counts = [f.strip() for f in row.split(" " * slots._BAR_GAP)
+                  if f.strip().startswith("+")]
+        self.assertEqual(len(counts), 2, f"one end went uncounted: {row!r}")
+        left, right = counts
+        drawn = [n for n in names if n in row]
+        self.assertEqual(int(left[1:]) + len(drawn) + int(right[1:]), len(names),
+                         f"the two counts and the drawn names are not the list: {row!r}")
+        self.assertEqual(names[int(left[1:])], drawn[0],
+                         f"the leading count does not name where the page starts: {row!r}")
+
+    def test_the_page_is_the_same_page_for_every_name_on_it(self):
+        """**Why it is a page and not a window centred on the marked name.** The cut is a
+        function of the names and the width alone, so switching to a tab that is ON the row
+        redraws the identical row with only the `*` moved — which is what makes the column
+        the operator pressed still mean the same thing an instant later.
+
+        A centred window does not have this property, and the difference is not
+        theoretical: measured on this project's own fifteen workspaces at 160 columns, six
+        of the nine tabs a centred strip draws answer a second press at the identical
+        column with a second, different workspace. `_Tabs.switch_to` cannot refuse that —
+        the name at that column really did change — so a double-click would switch twice.
+        """
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        for width in (60, 80, 120, 160, 200):
+            row = self._row(width, names=names, here="workspace-07")
+            drawn = [n for n in names if n in row]
+            self.assertIn("workspace-07", drawn, f"{width}: nothing was drawn")
+            for name in drawn:
+                again = self._row(width, names=names, here=name)
+                self.assertEqual([n for n in names if n in again], drawn,
+                                 f"{width}: switching to {name} moved the page:\n"
+                                 f"  {row!r}\n  {again!r}")
 
     def test_a_row_with_no_room_for_a_name_says_where_you_are_and_how_many(self):
         """§3.6's "marks only", and a count IS the mark: `2/3` says where you are, which
@@ -338,15 +386,47 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         for col in self._cells(row, "api.2"):
             self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
 
-    def test_the_overflow_count_resolves_to_nothing(self):
-        """Rung 2's `+2` stands for names that are NOT on the row, so there is nothing
-        there to switch to — `…(+N more)`'s rule one axis over. On a plane with fifteen
-        workspaces that field is a `+14`, and it is the one an operator is most likely to
-        try: it answers falsy, and the palette is what reaches those names."""
-        row = self._draw(30, here="api.2")
-        self.assertIn("+2", row, f"this width is not rung 2: {row!r}")
-        for col in self._cells(row, "+2"):
-            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+    def test_neither_overflow_count_resolves_to_anything(self):
+        """A `+N` stands for names that are NOT on the row, so there is nothing there to
+        switch to — `…(+N more)`'s rule one axis over. **Both ends**, and the LEADING one
+        is the new half: it sits between the heading and the first tab, so a map measured
+        from the lead rather than from where the tabs actually start would hand its cells
+        to the first name on the page — a click landing one tab off where the operator
+        pressed."""
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        row = self._draw(80, names=names, here="workspace-07")
+        counts = [f.strip() for f in row.split(" " * slots._BAR_GAP)
+                  if f.strip().startswith("+")]
+        self.assertEqual(len(counts), 2, f"this width is not a page in the middle: {row!r}")
+        for count in counts:
+            for col in self._cells(row, count):
+                self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+
+    def test_a_page_that_starts_in_the_middle_still_maps_its_tabs_where_they_are(self):
+        """The leading count moves every tab right of where a bar without one puts them.
+
+        **This is the case a map measured from the heading gets wrong**, and it gets it
+        wrong quietly: every tab answers with its LEFT neighbour, which is a real name and
+        a plausible switch. Asked on the drawn row, one column at a time, so the answer
+        follows the paint rather than a second walk of the same arithmetic.
+
+        The marked name is the one tab with no answer of its own
+        (`test_the_tab_you_are_already_on_resolves_to_nothing`), and it is excluded here
+        rather than the page being drawn for a `here` that names nothing — the windowed
+        rung is only reached when the marked name is IN the list, which is the whole point
+        of it drawing the page that name falls on.
+        """
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        here = "workspace-07"
+        row = self._draw(80, names=names, here=here)
+        self.assertTrue(row.lstrip().split("  ")[1].startswith("+"),
+                        f"this row has no leading count to displace anything: {row!r}")
+        drawn = [n for n in names if n in row and n != here]
+        self.assertTrue(drawn, f"no switchable tab on the page: {row!r}")
+        for name in drawn:
+            for col in self._cells(row, name):
+                self.assertEqual(slots.TABS.switch_to(col), name,
+                                 f"column {col} of {row!r}")
 
     def test_the_rung_that_says_only_where_you_are_has_no_tabs_at_all(self):
         """`2/3` is a position, not a name, and there is no name on the row to click."""
@@ -409,6 +489,102 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         for col in range(at, at + tui.width(drawn)):
             self.assertEqual(slots.TABS.switch_to(col), raw,
                              f"column {col} of {row!r} carries the drawn name")
+
+    def test_a_second_press_on_the_column_you_just_switched_from_does_nothing(self):
+        """**The double-click property, asserted across the repaint that a switch causes**
+        rather than against one paint.
+
+        `test_the_tab_you_are_already_on_resolves_to_nothing` asks whether the marked tab
+        is inert on the row in front of it. This asks the thing an operator can actually
+        do wrong: press a tab, let the frame switch and repaint, press the same cell again.
+        The answer has to be nothing — and it is only nothing because the page did not
+        move. A window centred on the marked name would put a DIFFERENT workspace under
+        that cell, and the second press would switch to it.
+
+        Every drawn tab, at five widths, including the widths where the page has names on
+        both sides of it.
+        """
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        for width in (60, 80, 120, 160, 200):
+            row = self._draw(width, names=names, here="workspace-07")
+            for name in [n for n in names if n in row and n != "workspace-07"]:
+                for col in self._cells(row, name):
+                    # Redrawn each time round: the strip is one object, so the paint the
+                    # first press resolves against has to be the one in front of it.
+                    self._draw(width, names=names, here="workspace-07")
+                    self.assertEqual(slots.TABS.switch_to(col), name)
+                    after = self._draw(width, names=names, here=name)
+                    self.assertIsNone(
+                        slots.TABS.switch_to(col),
+                        f"{width}: pressing column {col} twice switched twice — "
+                        f"{name} then {slots.TABS.switch_to(col)}\n"
+                        f"  before {row!r}\n  after  {after!r}")
+
+
+class ThisPlaneIsWhyTheRungIsWindowed(unittest.TestCase):
+    """The fifteen workspaces this repository's own plane has, at the widths it is run at.
+
+    **The measurement #725 shipped with, kept as a test.** That change made both bars
+    clickable and the `workspaces` bar stayed inert on the plane it was reported from:
+    those names need 274 columns for rung 1, so every real width fell to a rung whose only
+    drawn tab was the one the operator was already on. "Clickable" and "reaches nothing"
+    are the same screen.
+
+    Written against the real names rather than a fixture of even-width ones, because the
+    greedy cut is about the widths names actually have — `relations-and-delegations` is 25
+    cells and `todos` is 5, and a page of uniform names would measure neither.
+    """
+
+    NAMES = sorted([
+        "authority-audit", "autonomy", "charter-update-skill", "default", "fleet",
+        "harness-wrapper", "news-dispatch-guard", "opencode-integration", "plane-shape",
+        "relations-and-delegations", "showcase", "statusline-improvements", "todos",
+        "tracking-github-issues", "user-reporting",
+    ])
+    HERE = "harness-wrapper"
+
+    def setUp(self):
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+
+    def _switchable(self, width):
+        rows = slots._bar("workspaces", list(self.NAMES), self.HERE, width)
+        row = rows[0] if rows else ""
+        self.assertLessEqual(tui.width(row), width, repr(row))
+        return row, {slots.TABS.switch_to(col) for col in range(width)} - {None}
+
+    def test_rung_one_still_needs_two_hundred_and_seventy_four_columns(self):
+        """The number the whole change is about. Measured off the ladder, so it follows
+        the inset and the gap if either moves."""
+        widest = next(w for w in range(400)
+                      if len(slots._bar("workspaces", list(self.NAMES), self.HERE, w)) == 1
+                      and all(n in slots._bar("workspaces", list(self.NAMES),
+                                              self.HERE, w)[0] for n in self.NAMES))
+        self.assertEqual(widest, 274)
+
+    def test_every_real_width_now_reaches_workspaces_the_operator_is_not_on(self):
+        """120, 160 and 200 columns. Before this change each of them drew
+        `*harness-wrapper  +14` and switched to nothing at all."""
+        for width, least in ((120, 5), (160, 7), (200, 9)):
+            row, switchable = self._switchable(width)
+            self.assertNotIn(self.HERE, switchable,
+                             "the tab you are on is not somewhere to switch to")
+            self.assertGreaterEqual(
+                len(switchable), least,
+                f"{width} columns reaches {len(switchable)} workspaces: {row!r}")
+
+    def test_the_narrowest_frame_that_draws_a_name_still_says_where_in_the_list_it_is(self):
+        """A page of one is inert — there is nothing on it but the name you are on — and
+        that is the rung this replaced, arrived at honestly. It still carries both counts,
+        so it says strictly more than the `*harness-wrapper  +14` it replaces: which of
+        the fifteen this is."""
+        row, switchable = self._switchable(60)
+        self.assertIn(f"{slots._BAR_MARK[0]}{self.HERE}", row)
+        counts = [f.strip() for f in row.split(" " * slots._BAR_GAP)
+                  if f.strip().startswith("+")]
+        self.assertEqual(sum(int(c[1:]) for c in counts),
+                         len(self.NAMES) - len([n for n in self.NAMES if n in row]),
+                         f"the counts do not add up to what is off the row: {row!r}")
 
 
 class TheChatBarReadsThePlane(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -92,6 +92,47 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         self.assertEqual(names[int(left[1:])], drawn[0],
                          f"the leading count does not name where the page starts: {row!r}")
 
+    def test_a_page_is_cut_inside_the_room_its_own_leading_count_has_left(self):
+        """**The leading `+N` is paid for before a name is, and this is where that shows.**
+
+        A page after the first is cut inside `room` MINUS that count, so the row it goes on
+        to compose fits the pane. Cut inside the whole room instead and the row comes out
+        one name too wide — the ladder measures it, gives the entire rung up, and a name
+        with a perfectly good page is drawn as `3/15`, with nothing on the bar to click.
+        The deletion sweep found that reserve unpinned and this is the case it asked for.
+
+        Asked as the property that failure breaks, which is **widening the pane never takes
+        a name away**. The reserve is what keeps the ladder monotone: without it a wider
+        room cuts a page one name longer, the leading count that page has to carry was
+        never budgeted for, the row overflows and the whole rung is given up. Measured on
+        the mutant — with these fifteen names the row is drawn at 31 columns, gone at 42
+        through 45, and back at 46. A bar that loses its names when the pane gets bigger is
+        a bug an operator reports as a flicker.
+
+        Every name of the list, at every width from 0 to 200, plus the narrowest row for
+        three of them written out — one near the start, one in the middle, one at the end,
+        because the leading count is two cells wide for some and three for others.
+        """
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        for here in names:
+            drawn = [w for w in range(201)
+                     if here in self._row(w, names=names, here=here)]
+            self.assertTrue(drawn, f"{here} is drawn at no width at all")
+            missing = [w for w in range(min(drawn), 201) if w not in drawn]
+            self.assertEqual(missing, [],
+                             f"{here} was drawn at {min(drawn)} columns and gone at "
+                             f"{missing[:3]} — the pane got wider and lost a name")
+        for here, expected in (("workspace-02", "chats  +2  *workspace-02  +12"),
+                               ("workspace-07", "chats  +7  *workspace-07  +7"),
+                               ("workspace-13", "chats  +13  *workspace-13  +1")):
+            narrowest = min(w for w in range(201)
+                            if here in self._row(w, names=names, here=here))
+            row = self._row(narrowest, names=names, here=here)
+            self.assertEqual(row.strip(), expected)
+            self.assertEqual(tui.width(row), narrowest,
+                             "the row does not fill the width it is first drawn at, so "
+                             "this measures no boundary")
+
     def test_the_page_is_the_same_page_for_every_name_on_it(self):
         """**Why it is a page and not a window centred on the marked name.** The cut is a
         function of the names and the width alone, so switching to a tab that is ON the row


### PR DESCRIPTION
Closes #758.

#725 made both bars clickable and the report that produced it survived. Fifteen
workspaces need **274 columns** for rung 1, so every real width fell to the rung that
draws `*harness-wrapper  +14` — one tab, the one the frame is already on, which
`_Tabs.switch_to` correctly refuses. Clickable, correct, and reaching nothing.

That rung now draws the **page** the marked name falls on, with a count at each end.

## Measured, on this project's own fifteen workspaces

Rows painted by a real tmux, captured off the pane with `capture-pane`:

| width | before | after | tabs a click can reach |
|---|---|---|---|
| 120 | `workspaces  *harness-wrapper  +14` | `workspaces   authority-audit   autonomy   charter-update-skill   default   fleet  *harness-wrapper  +9` | 0 → **5** |
| 160 | `workspaces  *harness-wrapper  +14` | `… +  news-dispatch-guard   opencode-integration  +7` | 0 → **7** |
| 200 | `workspaces  *harness-wrapper  +14` | `… +  plane-shape   relations-and-delegations  +5` | 0 → **9** |

Rung 1 still needs 274 columns; nothing above the windowed rung changed.

## A page, not a window centred on the marked name

The cut is a pure function of the **names and the width** — which name is marked never
enters it — so switching to a tab that is on the row redraws the same row with only the
`*` moved.

A centred window slides one step per switch, which puts a **different name under the cell
the operator just pressed**. Measured on the same fifteen names at 160 columns: six of the
nine tabs a centred strip draws answer a second press at the identical column with a
second, different workspace. `_Tabs.switch_to`'s "the tab you are on is not news" cannot
refuse that, because the name at that column really did change — so a double-click would
switch twice, which is the one thing that rule exists to stop.

An **anchored** window (only move when the marked name would leave it) has the right
behaviour and has to be remembered. A panel is one long-lived process per slot, so an
anchor survives an ordinary repaint — but not `cmd_respawn`, not the respawn hook a dead
pane fires, and not a density change re-splitting the panels. The row would then depend on
history the operator cannot see. Pages get the same steadiness with nothing remembered.

## Two counts, not one

`+5  *harness-wrapper  …  +9`. A lone trailing `+14` beside a page that begins in the
middle of the list says the names on the row are the *first* fourteen, which is false. The
leading count is what makes the row say where in the list it sits — the readout the `n/N`
rung one step narrower has always given.

Neither count is a tab, at either end.

## The map still describes exactly what was drawn

`row()` takes the leading `+N` as its own argument rather than having the caller glue it
onto the body, because a map measured from the heading would hand every tab's cells to its
**left neighbour** — a real name and a plausible switch. Every rung still publishes,
including the rungs that draw no tab: a windowed row makes `_Viewport.blank`'s rule
sharper, since a stale map now answers with a name that is *elsewhere on the row* rather
than merely absent from it.

## Scope

`charter/frame/slots.py` only. `builtins.py`, `switch.py`, `chats.py` and
`commands_frame.py` are untouched — `TABS.publish` and `_Tabs.switch_to` keep their
signatures and their rules, so `_bar_events` needs to know nothing about pages.

`chats` gets this because there is one `_bar` for both bars, by that function's own stated
design ("so the two cannot degrade differently"). There is no second code path to add. It
reaches the rung later — two chats named `harness-wrapper.N` fit from 47 columns — but it
does reach it: four chats of `relations-and-delegations` need 127.

## Verification

- Full suite green (9082 tests).
- New real-tmux class `ARealClickOnAWINDOWEDWorkspaceBarMovesTheFrame`: fifteen real
  workspace names, a 120-column window, a real client on a real pty, a real
  `charter panel workspaces` holding the bar's pane, and a real detached
  `charter frame-switch` started from its handler. Clicking a neighbour's tab switches the
  frame; the page does not move under the pointer; the same click a second time switches
  nothing; neither count is a tab. Green on **tmux 3.7c and the 3.2 floor**.
- Every other case in that file clicks rung 1, which needs 274 columns — i.e. a bar no
  operator can produce. That is why the new class exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy