### PR TITLE
The frame's chrome carries a floor per option, so tmux 3.2 stops being told about one it does not have (#716)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2002,16 +2002,44 @@ _CHROME_STYLE = "fg=default,dim"
 #: `_CHROME_STYLE` — derived from this table the way `instance.chrome_option_names`
 #: derives its own, so a sixth border-style option added here is not the one rule left
 #: with a seam through it.
-_CHROME: tuple[tuple[str, str], ...] = (
-    ("pane-border-style", _CHROME_STYLE),
-    ("pane-active-border-style", _CHROME_STYLE),
-    ("pane-border-indicators", "off"),
-    ("pane-border-lines", "single"),
-    ("pane-border-status", "off"),
+#:
+#: **The third field is the oldest tmux charter will issue that option to, and it is a
+#: FIELD rather than a check for #716's reason.** `pane-border-indicators` does not exist
+#: at `tmuxctl.FLOOR` — it arrived in 3.3 — and pinning a name tmux does not have is not
+#: degraded but refused, so this table shipped for a release making **every launch on the
+#: supported floor** print `charter frame: styling the frame's own rules failed — … invalid
+#: option: pane-border-indicators`. That was the third time charter got this wrong in one
+#: file: `pane-border-style` at pane scope has `tmuxctl.PANE_BORDER_FLOOR` and
+#: `window-resized` has `tmuxctl.RESIZE_HOOK_FLOOR`, each a bespoke check of its own, and
+#: a third bespoke check would leave the FOURTH just as easy to add unguarded. A row here
+#: cannot be written without a floor, `_chrome_argvs` cannot read one without applying it,
+#: and `tests/test_frame_tmux_integration.py`'s
+#: `EveryBorderOptionThisTmuxHasIsPinned` measures every floor in it against the binary
+#: it is running on — in both directions, so a floor set too high goes red on the tmux
+#: that has the option and a floor set too low goes red on the tmux that does not.
+#:
+#: `tmuxctl.FLOOR` means "everywhere charter supports", and it is measured rather than
+#: assumed: all four of these answer `show -w` with rc 0 on a real tmux 3.2.
+_CHROME: tuple[tuple[str, str, tuple[int, int]], ...] = (
+    ("pane-border-style", _CHROME_STYLE, tmuxctl.FLOOR),
+    ("pane-active-border-style", _CHROME_STYLE, tmuxctl.FLOOR),
+    ("pane-border-indicators", "off", tmuxctl.BORDER_INDICATORS_FLOOR),
+    ("pane-border-lines", "single", tmuxctl.FLOOR),
+    ("pane-border-status", "off", tmuxctl.FLOOR),
 )
 
 
-def _chrome_argvs(*, socket: str, harness_pane: str,
+def _chrome_values() -> dict[str, str]:
+    """`{option: charter's answer}` for every row of :data:`_CHROME`, floors dropped.
+
+    The one reading of that table that is about WHAT charter pins rather than about which
+    tmuxes get told — `dict(_CHROME)` said once, now that a row is three fields wide, so
+    the callers that only want the two do not each re-spell the unpacking.
+    """
+    return {name: value for name, value, _floor in _CHROME}
+
+
+def _chrome_argvs(*, socket: str, harness_pane: str, v: tuple[int, int] | None,
                   surface: str | None = None) -> list[list[str]]:
     """`set-option -w`: charter's own answer for every option tmux draws a border from.
 
@@ -2084,12 +2112,29 @@ def _chrome_argvs(*, socket: str, harness_pane: str,
     a colour charter chose, so it is not what `NO_COLOR` is about, while a background is
     exactly what it is about. Asked through `chrome.no_colour` so there is one reading of
     the variable (#547), the same way `_surface_argvs` asks.
+
+    ***v* is this tmux's version, and every row of `_CHROME` is filtered through its own
+    floor by it (#716).** REQUIRED rather than defaulted, because a default is the shape
+    the defect had: `pane-border-indicators` does not exist below
+    `tmuxctl.BORDER_INDICATORS_FLOOR`, and a caller that could forget to say which tmux it
+    is talking to is a caller that goes on issuing it there. Both production call sites
+    already hold the answer for `_pane_borders_wanted`, so this asks for nothing new — it
+    only stops the question being skipped.
+
+    ``None`` — charter could not read a version — is taken as `tmuxctl.FLOOR`, and that is
+    the opposite of `_pane_borders_wanted`'s ``None`` for a stated reason rather than by
+    inconsistency. There the unknown answers *False* because the failure below its floor is
+    SILENT and destructive (a `set -p` that writes the window). Here every failure is loud
+    and harmless — `run` reports it and the launch continues — so the useful answer is the
+    supported baseline: pin everything every tmux charter supports has, and leave the one
+    option that arrived after it to a tmux that says so.
     """
     rule = (f"{_CHROME_STYLE},{surface}"
             if surface and not chrome_mod.no_colour() else _CHROME_STYLE)
+    known = v if v is not None else tmuxctl.FLOOR
     return [tmuxctl.server_argv(socket, "set-option", "-w", "-t", harness_pane, name,
                                 rule if value == _CHROME_STYLE else value)
-            for name, value in _CHROME]
+            for name, value, floor in _CHROME if known >= floor]
 
 
 def _pane_borders_wanted(v: tuple[int, int] | None) -> bool:
@@ -2978,8 +3023,12 @@ def _dress_window(socket: str, *, fid: str, harness_pane: str, env: dict | None,
     # reads on the live path — the agreement #610 is about, made by construction rather
     # than by two call sites matching.
     pane_borders = _pane_borders_wanted(v)
+    # The same *v*, handed on rather than re-read: `_chrome_argvs` drops the rows of
+    # `_CHROME` this tmux has no such option for (#716), and a second `tmux -V` here would
+    # be a second subprocess for one unchanging fact — and one more place for the two
+    # readings to disagree.
     for argv in _chrome_argvs(
-            socket=socket, harness_pane=harness_pane,
+            socket=socket, harness_pane=harness_pane, v=v,
             surface=None if pane_borders else instance.border_bg(config.FRAME, chrome)):
         tmuxctl.run("styling the frame's own rules", argv, env=env)
     # And the three rules AROUND the harness, which above the floor are the harness's own
@@ -4949,7 +4998,13 @@ def cmd_chrome(args) -> int:
     # one `tmux -V`; this path is a keypress that already spawns a process, and it is not
     # a refusal — an unreadable version answers the frame-wide design, which is correct on
     # every tmux (`_pane_borders_wanted`).
-    pane_borders = _pane_borders_wanted(tmuxctl.version())
+    #
+    # Kept in a name rather than passed straight in, because `_chrome_argvs` below needs
+    # the same answer for a different question (#716: which rows of `_CHROME` this tmux has
+    # an option for). Two `version()` calls would be two subprocesses for one unchanging
+    # fact on a path that is a keypress, and two answers that could disagree.
+    v = tmuxctl.version()
+    pane_borders = _pane_borders_wanted(v)
     for slot, pane_id in panes.items():
         # `_PANE_ID_RE` is #475's rule applied to a value that arrived off DISK and is
         # about to be a tmux argv — the same check `_relayout_target` makes of the harness
@@ -4983,7 +5038,7 @@ def cmd_chrome(args) -> int:
     harness = state.harness_pane(fid) or ""
     if _PANE_ID_RE.fullmatch(harness):
         for argv in _chrome_argvs(
-                socket=socket, harness_pane=harness,
+                socket=socket, harness_pane=harness, v=v,
                 surface=None if pane_borders
                 else instance.border_bg(config.FRAME, level)):
             tmuxctl.run("styling the frame's own rules", argv)

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -139,6 +139,31 @@ PANE_ENV_FLOOR = (3, 0)
 #: shade on one row of cells, not a frame.
 PANE_BORDER_FLOOR = (3, 7)
 
+#: The first tmux release that has `pane-border-indicators` AT ALL — one of the five
+#: options `commands_frame._CHROME` pins so the operator's own `.tmux.conf` cannot decide
+#: part of the frame's chrome (#514).
+#:
+#: **VERSION read out of tmux's own published CHANGES** (github.com/tmux/tmux, "CHANGES
+#: FROM 3.2a TO 3.3"): "Add an option (pane-border-indicators) to select how the active
+#: pane is shown on the pane border (colour, arrows or both)." **Confirmed by running both
+#: sides**: `show -w pane-border-indicators` is rc 0 on a real 3.7c and answers `invalid
+#: option: pane-border-indicators`, rc 1, on a real 3.2 built from source on this machine —
+#: which is the whole of #716. `_CHROME`'s other four are rc 0 on that same 3.2, measured
+#: the same way, which is why this is the only entry in that table floored above `FLOOR`.
+#:
+#: HIGHER than `FLOOR`, and a separate constant for `RESIZE_HOOK_FLOOR`'s reason exactly —
+#: it is the same failure as that one, in an option rather than a hook. An operator on 3.2
+#: is explicitly still allowed to launch (`below_floor_message` warns, does not refuse),
+#: and pinning a name that tmux does not have is not degraded but REFUSED: :func:`run`
+#: reports it, so before this constant existed **every launch on the supported floor**
+#: printed `charter frame: styling the frame's own rules failed — … invalid option:
+#: pane-border-indicators` to the operator's stderr. What is lost below the line is one
+#: hostile setting left inherited — `pane-border-indicators arrows` marks the active
+#: pane's borders with `←`/`↓` and its neighbours' not — on a tmux that has no such
+#: setting to inherit. Nothing at all, in other words, which is why the gate is a version
+#: and the option stays in the table.
+BORDER_INDICATORS_FLOOR = (3, 3)
+
 #: The session-scoped tmux environment variable carrying the interpreter that runs
 #: charter from inside a frame — `"$CHARTER_PY" -m charter …`, never a bare `charter`
 #: off `$PATH`. Defined HERE, not in either of the two modules that build text around it

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -387,6 +387,9 @@ the sentence above:
   five of the options tmux draws a border from — both border styles, plus
   `pane-border-lines`, `pane-border-indicators` and `pane-border-status` — so every rule in
   the frame is one colour and the frame looks the same in your tmux as in charter's own.
+  Each is pinned only on a tmux that has it: `pane-border-indicators` arrived in tmux 3.3,
+  and on 3.2 charter pins the other four and says nothing about a name that release does
+  not know.
   With `[frame] chrome` left at its default this is the only place charter overrides a
   preference of yours rather than deferring to it; setting `chrome` adds a second — a
   background on charter's own panel panes, and never on the pane your harness runs in — and

--- a/docs/news/unreleased-a-frame-on-tmux-3-2-stops-reporting-its-own-failure.md
+++ b/docs/news/unreleased-a-frame-on-tmux-3-2-stops-reporting-its-own-failure.md
@@ -1,0 +1,35 @@
+---
+version: unreleased
+headline: A frame on tmux 3.2 stops reporting its own failure on every launch
+---
+
+Every `charter claude` on tmux 3.2 printed this, and then came up fine:
+
+```
+✗ charter frame: styling the frame's own rules failed — `tmux -L charter set-option -w
+  -t %0 pane-border-indicators off`: invalid option: pane-border-indicators
+```
+
+3.2 is charter's supported floor. `pane-border-indicators` arrived in tmux **3.3**, so
+that line was charter naming an option the operator's tmux has never had — on every
+single launch, for as long as the frame has pinned its own chrome. Nothing was broken:
+the frame drew, the other four border options were pinned, and the one that could not be
+pinned does not exist on 3.2 to be inherited from anyone's `.tmux.conf`. What the
+operator got was a report of a failure with no consequence, in the two seconds before the
+terminal switched to the alternate screen.
+
+Each of the five options charter pins now carries the oldest tmux it may be issued to, and
+a launch issues the ones this tmux actually has. On 3.3 and newer nothing changes — all
+five are pinned exactly as before. On 3.2 four are pinned and the fifth is not mentioned.
+
+**The floor is a field of the table now, not a fourth check.** This was the third time
+charter had shipped a tmux capability with no version behind it — pane-scoped border
+styles and the `window-resized` hook each already had a gate written for them alone, and
+a third one would have left the fourth just as easy to add unguarded. So an option cannot
+be added to the frame's chrome without stating the tmux it needs, and there is a test that
+runs the real binary and checks every floor in that table against it in both directions:
+a floor set too low goes red on the tmux that lacks the option, and one set too high goes
+red on the tmux that has it.
+
+Nothing to adopt — upgrading is the whole of it, and it applies to frames launched after
+upgrading rather than to one already running.

--- a/tests/test_frame_border_surface.py
+++ b/tests/test_frame_border_surface.py
@@ -41,6 +41,28 @@ from tests._isolation import PersonaIso
 
 _STYLES = ("pane-border-style", "pane-active-border-style")
 
+#: A tmux old enough to have every option `_CHROME` names — the version the cases that are
+#: about the SURFACE are asked at, so a row dropped for its own floor cannot quietly change
+#: what they measure. DERIVED from the table rather than written as a number, because a
+#: sixth option floored higher than any of today's five must move this with it or those
+#: cases start measuring four options and still passing.
+_EVERY_CHROME_OPTION = max(floor for _n, _v, floor in commands_frame._CHROME)
+
+
+def _pinned_at(v) -> dict[str, str]:
+    """`{option: charter's answer}` for the rows of `_CHROME` a tmux *v* is told about.
+
+    The cases below are about the frame's SURFACE — which value reaches which option — and
+    several of them run the funnel at `None`, `tmuxctl.FLOOR` and above it to prove the
+    per-pane writes appear only above `tmuxctl.PANE_BORDER_FLOOR`. #716 made the SET of
+    options depend on that same *v*, and this is that dependency said once so those cases
+    keep asking their own question. Whether the set is the right one is
+    `AnOptionThisTmuxDoesNotHaveIsNeverIssued`'s, measured against the real binaries by
+    `tests/test_frame_tmux_integration.py`'s `EveryBorderOptionThisTmuxHasIsPinned`.
+    """
+    known = v if v is not None else tmuxctl.FLOOR
+    return {name: value for name, value, floor in commands_frame._CHROME if known >= floor}
+
 
 def _frame(*bgs, **rest) -> dict:
     """A `[frame]` mapping whose arrangement names one component per *bgs* entry — `None`
@@ -191,20 +213,20 @@ class TheRuleIsDrawnInIt(unittest.TestCase):
     """`commands_frame._chrome_argvs` — the five `set-option -w`s, with the surface in
     the two that are styles."""
 
-    def _tails(self, surface=None):
+    def _tails(self, surface=None, v=_EVERY_CHROME_OPTION):
         return [a[a.index("set-option"):]
                 for a in commands_frame._chrome_argvs(socket="s", harness_pane="%1",
-                                                      surface=surface)]
+                                                      v=v, surface=surface)]
 
-    def _values(self, surface=None):
-        return {a[-2]: a[-1] for a in self._tails(surface)}
+    def _values(self, surface=None, v=_EVERY_CHROME_OPTION):
+        return {a[-2]: a[-1] for a in self._tails(surface, v=v)}
 
     def test_no_surface_is_byte_identical_to_the_frame_charter_shipped(self):
         """The `off` invariant, and the reason the border needs no `-u` where the pane
         surface does: these two options are charter's own at EVERY level (#514 pins them
         with or without a surface), so "no surface" is a value rather than an absence, and
         it is the value that was there before this parameter existed."""
-        self.assertEqual(self._values(), dict(commands_frame._CHROME))
+        self.assertEqual(self._values(), commands_frame._chrome_values())
 
     def test_the_surface_is_appended_to_the_styles_and_to_nothing_else(self):
         got = self._values("bg=brightblack")
@@ -212,7 +234,7 @@ class TheRuleIsDrawnInIt(unittest.TestCase):
             with self.subTest(option=name):
                 self.assertEqual(got[name],
                                  f"{commands_frame._CHROME_STYLE},bg=brightblack")
-        for name, value in commands_frame._CHROME:
+        for name, value in commands_frame._chrome_values().items():
             if name not in _STYLES:
                 with self.subTest(option=name):
                     self.assertEqual(got[name], value,
@@ -241,7 +263,8 @@ class TheRuleIsDrawnInIt(unittest.TestCase):
         with mock.patch.object(
                 commands_frame, "_CHROME",
                 commands_frame._CHROME + (("pane-border-status-style",
-                                           commands_frame._CHROME_STYLE),)):
+                                           commands_frame._CHROME_STYLE,
+                                           tmuxctl.FLOOR),)):
             self.assertEqual(self._values("bg=blue")["pane-border-status-style"],
                              f"{commands_frame._CHROME_STYLE},bg=blue")
 
@@ -260,10 +283,10 @@ class TheRuleIsDrawnInIt(unittest.TestCase):
         one is still charter putting colour on their screen."""
         with mock.patch.dict(os.environ, {"NO_COLOR": ""}, clear=True):
             self.assertEqual(self._values("bg=brightblack"),
-                             dict(commands_frame._CHROME))
+                             commands_frame._chrome_values())
         with mock.patch.dict(os.environ, {}, clear=True):
             self.assertNotEqual(self._values("bg=brightblack"),
-                                dict(commands_frame._CHROME))
+                                commands_frame._chrome_values())
 
     def test_no_operator_string_reaches_a_style_value(self):
         """The boundary asserted end to end rather than at the table: whatever a committed
@@ -274,11 +297,78 @@ class TheRuleIsDrawnInIt(unittest.TestCase):
         hostile = "bg=#{?#{==:1,1},colour196,colour46}"
         for level in ("dark", hostile):
             argvs = commands_frame._chrome_argvs(
-                socket="s", harness_pane="%1",
+                socket="s", harness_pane="%1", v=_EVERY_CHROME_OPTION,
                 surface=instance.border_bg(_frame(hostile, hostile), level))
             for argv in argvs:
                 for word in argv:
                     self.assertNotIn("#", word)
+
+
+class AnOptionThisTmuxDoesNotHaveIsNeverIssued(unittest.TestCase):
+    """#716: every row of `_CHROME` carries the oldest tmux it may be issued to, and
+    `_chrome_argvs` applies it.
+
+    **The defect was one option and the class of defect is a missing gate.**
+    `pane-border-indicators` arrived in tmux 3.3 and charter's floor is 3.2, so the table
+    shipped issuing, on every launch a 3.2 operator makes, a `set-option` tmux answers
+    `invalid option: pane-border-indicators`, rc 1 — which `tmuxctl.run` reports. Not a
+    degraded frame: a working frame that tells the operator something of charter's failed,
+    every single time they start one.
+
+    It was the THIRD time in this file. `pane-border-style` at pane scope is gated by
+    `tmuxctl.PANE_BORDER_FLOOR` and `window-resized` by `tmuxctl.RESIZE_HOOK_FLOOR`, each
+    with a check written for it alone. So the floor is a field of the table rather than a
+    fourth check: a row cannot be added without one, and the two cases below are what
+    reads it.
+
+    The other direction — that a floor written here matches what a real tmux actually
+    has — cannot be asked of a table, only of a binary, and is
+    `tests/test_frame_tmux_integration.py`'s `EveryBorderOptionThisTmuxHasIsPinned`.
+    """
+
+    #: The option the defect was reported for, and the only row floored above
+    #: `tmuxctl.FLOOR` today. Named once here rather than in each case below.
+    OPTION = "pane-border-indicators"
+
+    def _names(self, v):
+        return [a[-2] for a in commands_frame._chrome_argvs(socket="s", harness_pane="%1",
+                                                            v=v)]
+
+    def test_charters_own_floor_is_below_the_option_that_needs_a_gate(self):
+        """The premise, asserted rather than assumed — without it every case below is
+        vacuous. A charter whose `FLOOR` rises to 3.3 can delete this whole gate, and this
+        is the line that says so."""
+        self.assertLess(tmuxctl.FLOOR, tmuxctl.BORDER_INDICATORS_FLOOR,
+                        "charter's floor now has `pane-border-indicators`, so the floor "
+                        "field on that row no longer gates anything")
+
+    def test_a_tmux_at_the_options_own_floor_is_told_about_it(self):
+        self.assertIn(self.OPTION, self._names(tmuxctl.BORDER_INDICATORS_FLOOR),
+                      "the option is not issued to the very tmux release that added it")
+
+    def test_a_tmux_below_it_is_not(self):
+        """#716 itself: the launch on `tmuxctl.FLOOR` that printed `styling the frame's
+        own rules failed`. The other four are still issued, because the fix is a gate on
+        one row and not a frame with no chrome."""
+        got = self._names(tmuxctl.FLOOR)
+        self.assertNotIn(self.OPTION, got,
+                         "charter still pins an option this tmux has no such name for, "
+                         "so every launch on the supported floor reports its own failure")
+        self.assertEqual([n for n, _v, f in commands_frame._CHROME if f <= tmuxctl.FLOOR],
+                         got, "a row this tmux DOES have was dropped with it")
+
+    def test_an_unreadable_version_takes_the_supported_floor(self):
+        """`None` is "charter could not find out", and here it answers `tmuxctl.FLOOR` —
+        the opposite of `_pane_borders_wanted`'s `None`, for a reason rather than by
+        inconsistency (see `_chrome_argvs`). Every failure on this path is loud and
+        recoverable, so the useful guess is the baseline charter supports: pin what every
+        supported tmux has, and leave the rest to a tmux that says what it is.
+
+        Both halves are asserted, because the two ways to get this wrong differ from each
+        other and not from the middle: issuing nothing would leave the operator's own
+        config deciding all five, and issuing everything is the defect back again."""
+        self.assertEqual(self._names(None), self._names(tmuxctl.FLOOR))
+        self.assertTrue(self._names(None), "an unreadable version pinned nothing at all")
 
 
 class APanelDrawsItsOwnEdgesAndTheHarnessKeepsItsOwn(unittest.TestCase):
@@ -691,7 +781,7 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
 
     def _rules(self, issued: list[list[str]]) -> dict[str, str]:
         return {a[-2]: a[-1] for a in issued
-                if "set-option" in a and "-w" in a and a[-2] in dict(commands_frame._CHROME)}
+                if "set-option" in a and "-w" in a and a[-2] in commands_frame._chrome_values()}
 
     def test_a_launch_below_the_floor_draws_its_rules_in_the_agreed_colour(self):
         """The frame-wide design, which is all a tmux without pane-scoped border options
@@ -715,7 +805,7 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         style and every panel pane that was actually split gets its own two options."""
         frame = _resolved(*["brightblack"] * 4, chrome="dark")
         issued = self._issued(frame, ["top", "bottom", "repos", "right"], v=(3, 7))
-        self.assertEqual(self._rules(issued), dict(commands_frame._CHROME),
+        self.assertEqual(self._rules(issued), commands_frame._chrome_values(),
                          "the window carries a surface above the floor, so a rule is "
                          "being coloured in two places")
         want = f"{commands_frame._CHROME_STYLE},bg=brightblack"
@@ -755,7 +845,7 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         for v in (None, (3, 2), (3, 7)):
             with self.subTest(v=v):
                 issued = self._issued({}, ["top", "bottom"], v=v)
-                self.assertEqual(self._rules(issued), dict(commands_frame._CHROME))
+                self.assertEqual(self._rules(issued), _pinned_at(v))
                 self.assertEqual([a for a in issued if "set-option" in a and "-p" in a
                                   and a[-2] in instance.PANE_BORDER_OPTIONS], [])
 
@@ -1054,7 +1144,7 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
                                 clear=True):
             self.assertEqual(
                 commands_frame.cmd_chrome(type("A", (), {"level": "dark"})()), 0)
-        self.assertEqual([a[-2] for a in calls if a[-2] in dict(commands_frame._CHROME)],
+        self.assertEqual([a[-2] for a in calls if a[-2] in commands_frame._chrome_values()],
                          [])
         self.assertTrue([a for a in calls if "window-style" in a],
                         "the panes were not repainted either")
@@ -1118,7 +1208,7 @@ class ARelayoutThatAddsNoPaneStillAssertsTheWindowsOwnOptions(PersonaIso,
         other."""
         return {a[-2]: a[-1] for a in calls
                 if "set-option" in a and flag in a and "-u" not in a
-                and a[-2] in dict(commands_frame._CHROME)}
+                and a[-2] in commands_frame._chrome_values()}
 
     def test_a_relayout_with_nothing_missing_still_writes_the_window_options(self):
         panels = {"top": "%3", "bottom": "%4"}
@@ -1126,7 +1216,7 @@ class ARelayoutThatAddsNoPaneStillAssertsTheWindowsOwnOptions(PersonaIso,
         self.assertNotIn("split-window", [a[3] for a in calls if len(a) > 3],
                          "the fixture split something, so this is the branch that "
                          "already worked")
-        self.assertEqual(self._options(calls, "-w"), dict(commands_frame._CHROME),
+        self.assertEqual(self._options(calls, "-w"), commands_frame._chrome_values(),
                          "a re-layout that added no pane wrote no window option, so "
                          "#657's rules and #514's chrome do not apply after a switch")
 
@@ -1163,7 +1253,7 @@ class ARelayoutThatAddsNoPaneStillAssertsTheWindowsOwnOptions(PersonaIso,
         self.assertEqual(self._options(added, "-w"), self._options(none_added, "-w"))
         for calls in (added, none_added):
             names = [a[-2] for a in calls if "set-option" in a and "-w" in a
-                     and a[-2] in dict(commands_frame._CHROME)]
+                     and a[-2] in commands_frame._chrome_values()]
             self.assertEqual(len(names), len(set(names)),
                              "a window option was written twice in one re-layout")
 

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -792,7 +792,7 @@ class TheSwitchIsFourStepsInOneOrder(PersonaIso, unittest.TestCase):
                          "that already worked")
         options = [a[-2] for a in self.fake.calls
                    if _FakeServer._verb(a) == "set-option" and "-u" not in a]
-        for name, _value in commands_frame._CHROME:
+        for name in commands_frame._chrome_values():
             self.assertIn(name, options,
                           f"the window's {name} was never asserted on the chat being "
                           f"switched into")

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -389,6 +389,13 @@ class Conf(unittest.TestCase):
         self.assertIn("bind -n M-m run-shell", text)
 
 
+#: A tmux old enough to have every option `commands_frame._CHROME` names, so the cases in
+#: `Chrome` below are asked about all of them rather than about whichever subset the
+#: floor field lets through (#716). DERIVED from the table: a sixth option floored higher
+#: than today's five moves this with it instead of quietly leaving those cases short.
+_EVERY_CHROME_OPTION = max(floor for _n, _v, floor in commands_frame._CHROME)
+
+
 class Chrome(unittest.TestCase):
     """The frame's own pane-border settings (#514) — the builder alone; the launch paths
     that issue them are pinned in `Launch` and `LaunchInsideTmux` below, and what tmux
@@ -402,9 +409,16 @@ class Chrome(unittest.TestCase):
     """
 
     def _argvs(self, **kw):
-        """The real builder, with the arguments a launch would hand it."""
+        """The real builder, with the arguments a launch would hand it.
+
+        *v* defaults to a tmux that has every option in the table, because none of these
+        cases is about #716's floor field — they are about sameness and scope, and a
+        subset would let one of them pass by not asking. The floor itself is
+        `tests/test_frame_border_surface.py`'s `AnOptionThisTmuxDoesNotHaveIsNeverIssued`.
+        """
         return commands_frame._chrome_argvs(
-            **{"socket": "charter", "harness_pane": "%7", **kw})
+            **{"socket": "charter", "harness_pane": "%7", "v": _EVERY_CHROME_OPTION,
+               **kw})
 
     def test_both_border_styles_are_given_the_same_answer(self):
         """#514 itself. Setting one and leaving the other is what makes a rule change
@@ -2981,7 +2995,7 @@ class Launch(PersonaIso, unittest.TestCase):
         which a hand-written list here would not notice."""
         fake = _FakeTmux(exit_code=0)
         self.assertEqual(_launch(fake), 0)
-        self.assertEqual(_chrome_values(fake.calls), dict(commands_frame._CHROME))
+        self.assertEqual(_chrome_values(fake.calls), commands_frame._chrome_values())
         for cmd in [c for c in fake.calls if _is_chrome(c)]:
             self.assertEqual(cmd[cmd.index("-t") + 1], fake.pane_id, cmd)
             self.assertNotIn("-g", cmd, cmd)
@@ -5097,7 +5111,7 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         answers is the shape that produced a two-coloured rule in the first place."""
         fake = _FakeOperatorTmux(exit_code=0)
         self.assertEqual(_launch_inside(fake), 0)
-        self.assertEqual(_chrome_values(fake.calls), dict(commands_frame._CHROME))
+        self.assertEqual(_chrome_values(fake.calls), commands_frame._chrome_values())
 
     def test_the_chrome_here_reaches_charters_own_window_and_no_other(self):
         """The boundary, stated where it costs something — and it is the TARGET rather

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -4415,15 +4415,44 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         self._outer("kill-server")
         (Path("/tmp") / f"tmux-{os.getuid()}" / self._outer_socket).unlink(missing_ok=True)
 
-    def _hostile(self) -> None:
+    def _has_option(self, name: str) -> bool:
+        """Does THIS tmux have *name* as a window option at all?
+
+        Probed, never inferred from a version string — this module's own rule, and the
+        same question `ASwitchDressesTheWindowItEntersEvenWithNothingToSplit._has` asks of
+        the same table. `show-options -wg <name>` answers rc 1 and `invalid option:
+        <name>` on a tmux that does not have it (measured on a real 3.2, for
+        `pane-border-indicators`) and rc 0 on one that does.
+        """
+        return self._srv("show-options", "-wg", name).returncode == 0
+
+    def _hostile(self) -> list[str]:
         """Somebody else's `.tmux.conf`, applied the way theirs is: `-wg`, reaching every
-        window on the server charter is a guest on."""
+        window on the server charter is a guest on. Returns the names that landed.
+
+        **Only the settings THIS tmux has, probed rather than assumed** — the rule this
+        module already follows in `ASwitchDressesTheWindowItEntersEvenWithNothingToSplit.
+        _has`. `pane-border-indicators` arrived in tmux 3.3 and charter's floor is 3.2
+        (`tmuxctl.BORDER_INDICATORS_FLOOR`), and nobody's `.tmux.conf` can hand charter a
+        hostile value for an option their tmux has no name for: at the floor this method
+        asserted rc 0 on `set -wg pane-border-indicators arrows` and reported the TEST's
+        own config failing as though it were charter's (#716).
+        """
+        applied = []
         for name, value in (("pane-border-style", "fg=blue"),
                             ("pane-active-border-style", "fg=red,bold"),
                             ("pane-border-indicators", "arrows"),
                             ("pane-border-lines", "double"),
                             ("pane-border-status", "top")):
+            if not self._has_option(name):
+                continue
             self.assertEqual(self._srv("set", "-wg", name, value).returncode, 0)
+            applied.append(name)
+        self.assertTrue(applied, "this tmux has none of the five settings an operator's "
+                                 "own config would hand charter, so nothing hostile was "
+                                 "applied and the frame under test is not a guest in "
+                                 "anything")
+        return applied
 
     def _screenshot(self, *, arm: bool, hostile: bool = False,
                     surface: str | None = None, design: str = "pane",
@@ -4479,9 +4508,13 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         if hostile:
             self._hostile()
         if arm:
-            # The production argv, never a hand-retyped `set-option` — see `_run`.
+            # The production argv, never a hand-retyped `set-option` — see `_run`. `v` is
+            # the real `tmux -V`, which is what a launch hands it: below
+            # `tmuxctl.BORDER_INDICATORS_FLOOR` the builder drops the row this tmux has no
+            # such option for, so the rc-0 assertion below is about charter's argv rather
+            # than about which release the developer happens to be on (#716).
             for cmd in commands_frame._chrome_argvs(
-                    socket=self.SOCKET_NAME, harness_pane=harness,
+                    socket=self.SOCKET_NAME, harness_pane=harness, v=tmuxctl.version(),
                     surface=surface if design == "window" else None):
                 self.assertEqual(_run(cmd).returncode, 0, cmd)
             # The production argv for the harness's OWN three edges, which above the floor
@@ -4587,9 +4620,10 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
     def test_the_frame_draws_every_rule_the_same_inside_the_operators_own_tmux(self):
         """The second server path, where charter's assumptions do not hold: the borders
         are not tmux's defaults here, they are the operator's own config, which charter
-        would otherwise inherit whole. All five settings, because colour is only the most
-        visible of them — their `pane-border-status top` writes this machine's hostname
-        into every rule and takes a row the frame's own arithmetic never budgeted for."""
+        would otherwise inherit whole. Every one of the five settings this tmux HAS,
+        because colour is only the most visible of them — their `pane-border-status top`
+        writes this machine's hostname into every rule and takes a row the frame's own
+        arithmetic never budgeted for."""
         self._control(hostile=True)
         shot = self._screenshot(arm=True, hostile=True)
         states = _rule_states(shot)
@@ -4600,9 +4634,15 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         self.assertNotIn(socket.gethostname().split(".")[0], shot,
                          "`pane-border-status` is still on, so the frame's rules are "
                          "carrying this machine's hostname")
-        self.assertEqual(set(shot) & _INDICATOR_GLYPHS, set(),
-                         "`pane-border-indicators` is still theirs, so charter's frame "
-                         "marks its active pane's borders and not its others")
+        # Asked only where there is something to ask about. Below
+        # `tmuxctl.BORDER_INDICATORS_FLOOR` no `.tmux.conf` can set this option, so no
+        # glyph can be on this screen and the line would pass for a reason that is not
+        # charter's — an assertion nobody can read the strength of. Skipping it there is
+        # naming what cannot be measured; the tmux that HAS the option still measures it.
+        if self._has_option("pane-border-indicators"):
+            self.assertEqual(set(shot) & _INDICATOR_GLYPHS, set(),
+                             "`pane-border-indicators` is still theirs, so charter's "
+                             "frame marks its active pane's borders and not its others")
         # The whole property in one line: the frame drawn inside their tmux is the same
         # frame, cell for cell of chrome, as the one drawn on charter's own server.
         # Colour alone would not catch a `pane-border-lines double` — every rule would
@@ -4770,12 +4810,14 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         #
         # **`arm=False` for both, and that is not laziness.** This test is about the two
         # servers' lifetimes and nothing else, and `arm=True` would put charter's own
-        # chrome argvs on its path — which at `tmuxctl.FLOOR` fail over an option tmux
-        # 3.2 does not have (`pane-border-indicators`, a separate defect this class
-        # already reports through three other tests). A lifecycle test that goes red for
-        # that reason is a test reporting somebody else's failure, which is the whole
-        # thing #694 and #713 are about. Unarmed builds and kills exactly the same
-        # sessions.
+        # chrome argvs on its path — a whole second subject, whose own failures this case
+        # would then report as a lifetime one. (Until #716 that was not hypothetical: at
+        # `tmuxctl.FLOOR` those argvs carried `pane-border-indicators`, which tmux 3.2 does
+        # not have, so an armed lifecycle test went red over an option. The argvs are now
+        # floored per option and would pass here — the reason to stay unarmed is the
+        # subject, not the defect.) A test that goes red for somebody else's failure is
+        # the whole thing #694 and #713 are about. Unarmed builds and kills exactly the
+        # same sessions.
         self._screenshot(arm=False)
         after_one = pids()
         self._screenshot(arm=False, focus=0)
@@ -5008,7 +5050,8 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         self.assertEqual(r.returncode, 0, r.stderr)
         harness = r.stdout.strip()
         for cmd in commands_frame._chrome_argvs(socket=self.SOCKET_NAME,
-                                                harness_pane=harness):
+                                                harness_pane=harness,
+                                                v=tmuxctl.version()):
             _run(cmd)
         for cmd in commands_frame._harness_rule_argvs(
                 socket=self.SOCKET_NAME, harness_pane=harness, surface="bg=brightblack",
@@ -5059,7 +5102,8 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         self.assertEqual(r.returncode, 0, r.stderr)
         harness = r.stdout.strip()
         for cmd in commands_frame._chrome_argvs(socket=self.SOCKET_NAME,
-                                                harness_pane=harness):
+                                                harness_pane=harness,
+                                                v=tmuxctl.version()):
             self.assertEqual(_run(cmd).returncode, 0, cmd)
         for cmd in commands_frame._harness_rule_argvs(
                 socket=self.SOCKET_NAME, harness_pane=harness, surface="bg=brightblack",
@@ -5096,6 +5140,15 @@ class EveryBorderOptionThisTmuxHasIsPinned(_TmuxServerFixture, PersonaIso,
     charter's chrome and charter never gave an answer", and a hand-written list of five
     names cannot see the sixth option a later tmux adds. `show-options -wg` is tmux
     itself saying what it draws a border from.
+
+    **And since #716 it is where the table's FLOORS are measured, which is the same
+    sentence read the other way.** Each row of `_CHROME` carries the oldest tmux charter
+    will issue it to, and a floor is a claim about a binary: `pane-border-indicators` is
+    3.3's, so on a real 3.2 charter must issue four options and on 3.7c five. Only a tmux
+    can settle that, and the tmux that can settle it is whichever one this run is on —
+    which is why every case below asks the binary rather than a version string, and why
+    `test_every_floor_in_the_table_is_what_this_tmux_actually_has` asks in BOTH
+    directions.
     """
 
     def _window_options(self) -> dict[str, str]:
@@ -5110,6 +5163,17 @@ class EveryBorderOptionThisTmuxHasIsPinned(_TmuxServerFixture, PersonaIso,
             out[name] = value
         return out
 
+    def _pinned_here(self) -> dict[str, str]:
+        """`{option: value}` charter would really issue on THIS tmux.
+
+        Read off the production builder rather than off the table, so #716's floor field
+        is applied here exactly as a launch applies it instead of being restated in a
+        test that would then agree with itself. `harness_pane` and `socket` reach only the
+        argv's other words, which nothing below looks at.
+        """
+        return {argv[-2]: argv[-1] for argv in commands_frame._chrome_argvs(
+            socket=self.SOCKET_NAME, harness_pane="%0", v=tmuxctl.version())}
+
     def test_no_pane_border_option_is_left_for_the_operators_config_to_decide(self):
         """Every `pane-*border*` window option this tmux has, pinned by `_CHROME`.
 
@@ -5118,8 +5182,13 @@ class EveryBorderOptionThisTmuxHasIsPinned(_TmuxServerFixture, PersonaIso,
         `off`, so nothing renders it. The first assertion re-establishes that condition
         instead of trusting it — turn the status on and this test starts demanding the
         format be pinned too.
+
+        **Asked of what charter ISSUES here, not of what the table names** (#716). An
+        option pinned in the table and floored above this tmux is one the operator's own
+        config still decides, which is precisely the defect this case is named for — so a
+        floor set too high goes red here, on the tmux that has the option.
         """
-        pinned = dict(commands_frame._CHROME)
+        pinned = self._pinned_here()
         self.assertEqual(pinned.get("pane-border-status"), "off",
                          "`pane-border-status` is no longer off, so `pane-border-format` "
                          "renders and must be pinned as well")
@@ -5135,10 +5204,44 @@ class EveryBorderOptionThisTmuxHasIsPinned(_TmuxServerFixture, PersonaIso,
     def test_every_option_charter_pins_is_one_this_tmux_actually_has(self):
         """The other direction. A misspelt option name is refused by `set-option`, and a
         launch treats that refusal as non-fatal — so the typo would leave the real option
-        inherited and the frame wrong, with nothing but a warning to show for it."""
+        inherited and the frame wrong, with nothing but a warning to show for it.
+
+        **This is #716 itself, on the floor.** Before the table carried floors, charter
+        issued `pane-border-indicators` on tmux 3.2 — which has no such option — so every
+        launch there printed `charter frame: styling the frame's own rules failed … invalid
+        option`. Asking about what charter ISSUES on this tmux, rather than about every
+        name in the table, is what turns this from "the developer is on 3.7c" into a
+        measurement that means the same thing on both.
+        """
         theirs = self._window_options()
-        for name in dict(commands_frame._CHROME):
+        pinned = self._pinned_here()
+        self.assertTrue(pinned, "charter pins nothing at all on this tmux")
+        for name in pinned:
             self.assertIn(name, theirs, f"{name} is not a window option on this tmux")
+
+    def test_every_floor_in_the_table_is_what_this_tmux_actually_has(self):
+        """`_CHROME`'s floors, checked against the binary rather than against tmux's own
+        CHANGES — the shape `ChromeIsOneColour.test_the_floor_agrees_with_what_this_tmux_
+        actually_does` already gives `tmuxctl.PANE_BORDER_FLOOR`.
+
+        **Both directions, per row.** A floor set too LOW is #716 back again — charter
+        issues a name this tmux does not have and reports its own failure on every launch.
+        A floor set too HIGH is quieter and no better: the operator's own `.tmux.conf`
+        goes on deciding an option their tmux really does have, which is the whole of
+        #514. Neither can be seen without a tmux, and each of the two binaries this suite
+        is run against sees a different half: 3.2 is where the low direction bites and
+        3.7c is where the high one does.
+        """
+        v = tmuxctl.version()
+        if v is None:
+            raise unittest.SkipTest("no readable tmux version to check the floors against")
+        theirs = self._window_options()
+        for name, _value, floor in commands_frame._CHROME:
+            with self.subTest(option=name, floor=floor):
+                self.assertEqual(
+                    name in theirs, v >= floor,
+                    f"tmux {v} {'has' if name in theirs else 'does not have'} `{name}`, "
+                    f"which is not what its floor {floor} in `_CHROME` says")
 
 
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
@@ -5910,9 +6013,9 @@ class ASwitchDressesTheWindowItEntersEvenWithNothingToSplit(_ChatsOnOneSession,
     window and leaves the first's panels running and recorded.
 
     Verified on tmux 3.7c and on tmux 3.2 (`tmuxctl.FLOOR`). Which options exist differs
-    between them — `pane-border-indicators` is 3.7's — so this asserts about the ones THIS
-    tmux has rather than about a list, the way `EveryBorderOptionThisTmuxHasIsPinned`
-    already does.
+    between them — `pane-border-indicators` arrived in 3.3
+    (`tmuxctl.BORDER_INDICATORS_FLOOR`) — so this asserts about the ones THIS tmux has
+    rather than about a list, the way `EveryBorderOptionThisTmuxHasIsPinned` already does.
     """
 
     def _has(self, name: str) -> bool:
@@ -5946,7 +6049,7 @@ class ASwitchDressesTheWindowItEntersEvenWithNothingToSplit(_ChatsOnOneSession,
             panels[slot] = r.stdout.strip()
         state.record_panes(f"{self.WS}.2", panels=panels)
         self.kept = panels
-        self.names = [n for n, _ in commands_frame._CHROME if self._has(n)]
+        self.names = [n for n in commands_frame._chrome_values() if self._has(n)]
         self.assertTrue(self.names, "this tmux has none of the options under test")
         for name in self.names:
             self._srv("set-option", "-w", "-u", "-t", self.pane, name)


### PR DESCRIPTION
Closes #716.

## The failure

`commands_frame._CHROME` pinned `pane-border-indicators`. That option arrived in tmux
**3.3**; charter's declared floor is **3.2**, where the write is refused:

```
$ tmux-3.2 -L probe set -w -t s pane-border-indicators off
invalid option: pane-border-indicators
rc=1
```

`tmuxctl.run` reports every non-zero return, so **every launch on the supported floor**
printed to the operator's stderr:

```
✗ charter frame: styling the frame's own rules failed — `tmux -L charter set-option -w
  -t %0 pane-border-indicators off`: invalid option: pane-border-indicators
```

Not a test defect and not a degraded frame — an operator on a version charter says it
supports, told that something of charter's failed, every single time they start a session.

**Reproduced and re-measured as a real launch**, not only through the suite: a `charter
frame -- …` driven under a pty on a real tmux 3.2 built from source, with the socket
patched to a throwaway so nothing of the operator's is touched.

| | before | after |
|---|---|---|
| tmux 3.2 launcher stderr | the line above | *(nothing)* |
| tmux 3.7c launcher stderr | *(nothing)* | *(nothing)* |

## The fix — a floor per option, not a third bespoke check

`pane-border-style` at pane scope already had `tmuxctl.PANE_BORDER_FLOOR`, and
`window-resized` already had `tmuxctl.RESIZE_HOOK_FLOOR`, each with a check written for
itself alone. A third one would have left the *fourth* just as easy to add unguarded. So
the floor is a **field of the table**:

```python
_CHROME: tuple[tuple[str, str, tuple[int, int]], ...] = (
    ("pane-border-style",        _CHROME_STYLE, tmuxctl.FLOOR),
    ("pane-active-border-style", _CHROME_STYLE, tmuxctl.FLOOR),
    ("pane-border-indicators",   "off",         tmuxctl.BORDER_INDICATORS_FLOOR),
    ("pane-border-lines",        "single",      tmuxctl.FLOOR),
    ("pane-border-status",       "off",         tmuxctl.FLOOR),
)
```

- A row cannot be written without a floor — the tuple is three wide and every reader
  unpacks three.
- `_chrome_argvs` cannot read one without applying it, and takes `v` as a **required**
  keyword: a default is the shape the defect had. Both production call sites already read
  the version for `_pane_borders_wanted`, so no extra `tmux -V` is spent.
- An unreadable version answers `tmuxctl.FLOOR` — the supported baseline. Deliberately the
  opposite of `_pane_borders_wanted`'s `None`, and the docstring says why: there the
  failure below the floor is silent and destructive (a `set -p` that writes the window);
  here every failure is loud and recoverable.

`tmuxctl.BORDER_INDICATORS_FLOOR = (3, 3)` is read out of tmux's own published CHANGES
("CHANGES FROM 3.2a TO 3.3": *"Add an option (pane-border-indicators) to select how the
active pane is shown on the pane border"*) **and** confirmed by running both sides — rc 0
on 3.7c, `invalid option` rc 1 on 3.2. The other four are rc 0 on that same 3.2, measured
the same way, which is why this is the only row floored above `FLOOR`.

## What stops the next one

`EveryBorderOptionThisTmuxHasIsPinned` now checks **every floor in the table against the
running binary, in both directions**:

- a floor set too **low** goes red on the tmux that does not have the option — #716 again;
- a floor set too **high** goes red on the tmux that does — that is #514, the operator's
  own `.tmux.conf` deciding part of the frame's chrome.

Its two existing cases now ask what charter *issues* on this tmux rather than what the
table *names*, which is what makes them mean the same thing on 3.2 and on 3.7c.
`tests/test_frame_border_surface.py` gains `AnOptionThisTmuxDoesNotHaveIsNeverIssued` for
the argv-level property, including the arm an unreadable version reaches.

## Test-side changes in the same file

Three of the five failures were the tests inheriting the same assumption:

- `ChromeIsOneColour._hostile` applied `set -wg pane-border-indicators arrows` and asserted
  rc 0 — the **test's own** `.tmux.conf` failing, reported as charter's. It now applies
  only the settings this tmux has, probed the way `_has` already does, and asserts that at
  least one landed.
- `_screenshot` hands the production builder the real `tmux -V`, which is what a launch
  hands it.
- The `_INDICATOR_GLYPHS` assertion is made only where there is something to assert: on a
  tmux with no such option no glyph can be on the screen and the line would pass for a
  reason that is not charter's.

## Verification

Hand-run against both binaries — CI installs no tmux, so all 95 real-tmux tests skip there
and a green gate says nothing about any of this.

| | tmux 3.2 (`tmuxctl.FLOOR`) | tmux 3.7c |
|---|---|---|
| `tests.test_frame_tmux_integration` before | 8 failures | 0 |
| after this PR alone | 3 failures (#717's two, #718's one) | 0 |
| after #716+#717+#718 together | **0 failures** | 0 |

- Full suite on 3.7c: `Ran 9080 tests — OK`.
- Deletion sweep (`tools/sweep.py --gate`, scoped to `charter/`): **4 mutations applied,
  4 pinned, 0 survived, 0 unresolved.** Every line this diff adds to `charter/` goes red
  when deleted.

## Notes for review

- Splitting the eight floor failures into three issues was #713's agent's call; this is the
  only one of the three that is charter's own, in production. #717 and #718 are test-only
  and ship separately.
- #719 is open against `ChromeIsOneColour._screenshot`'s polling and will touch the same
  region of this file; whichever of the two lands second rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy