### PR TITLE
A one-row pane's history is read whole, instead of to a depth that assumed tmux's dead-pane marker is one row (#718)

### DIFF
--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -2042,8 +2042,11 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
     _BAD_SLOT_STDERR = (f"charter panel: unknown slot '{_BAD_SLOT}' "
                         f"(known: {', '.join(sorted(frame_slots.SLOTS))})")
 
-    #: How wide the one-row pane below is. Named because the reason's WRAPPED height is
-    #: derived from it, and a width written twice would let the two drift.
+    #: How wide the one-row pane below is. Narrow on purpose: the 74-column reason has to
+    #: WRAP for the pane's single row to be scrolled away by the write itself, which is the
+    #: fixture's own load-bearing half (see the test's docstring). It is a constant here
+    #: rather than a number in one call because the reason's own length is compared against
+    #: it in prose, and a width written twice would let the two drift.
     _PANE_COLS = 40
 
     #: A pane program that waits for a gate file, prints *stderr text* and exits 2 — the
@@ -2058,7 +2061,11 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
     def _capture(self, target: str, *history: str) -> str:
         """What `capture-pane` reports for *target* — the VISIBLE screen by default,
         which is the whole point: it is what an operator sees without knowing to scroll
-        a one-row pane's history. Pass `"-S", "-<n>"` to look into that history instead."""
+        a one-row pane's history. Pass `"-S", "-"` — the start of the history — to look
+        into that instead. A `"-S", "-<n>"` window is available too and is deliberately
+        not used: how many rows back a thing sits depends on how the RUNNING TMUX chose to
+        draw its own dead-pane marker, which is one row on 3.7c and two at
+        `tmuxctl.FLOOR` (#718)."""
         return _tmux("capture-pane", "-p", *history, "-t", target).stdout
 
     def _dead(self, target: str) -> str:
@@ -2230,15 +2237,24 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
                          "a pane that small no longer loses a newline-terminated write, "
                          "so `panel._hold` is solving a problem that no longer exists: "
                          f"{visible!r}")
-        # One row deeper than the reason's own wrapped height. `-3` today, exactly as it
-        # was written by hand — but DERIVED, because the reason names every key of
-        # `frame_slots.SLOTS` and therefore grows whenever charter ships a slot. Measured
-        # while `changes` was briefly a slot: the sentence went from two wrapped rows to
-        # three, this history window stopped reaching the row carrying the slot name, and
-        # the case went red for the LENGTH of a message rather than for the property it
-        # is named for. That is the failure this arithmetic removes.
-        depth = -(-len(self._BAD_SLOT_STDERR) // self._PANE_COLS) + 1
-        with_history = self._capture("panel-oldshape", "-S", f"-{depth}")
+        # **The WHOLE history, and the depth arithmetic that used to be here is gone**
+        # (#718). That line read `-(-len(reason) // cols) + 1`: the reason's own wrapped
+        # height, DERIVED because the sentence names every key of `frame_slots.SLOTS` and
+        # grows whenever charter ships a slot — plus one row for tmux's `Pane is dead (…)`
+        # marker. The derived half was right and is the reason this comment existed; the
+        # `+ 1` was a hard-coded constant that is not a constant at all but a tmux
+        # RENDERING decision. Measured, same program, same 40-column pane: 3.7c truncates
+        # `Pane is dead (status 0, <date>)` to the pane's width and spends ONE row, while
+        # tmux 3.2 wraps it onto TWO — so `-3` reached the slot name on 3.7c and stopped
+        # one row short of it on the floor, and the case went red for how another program
+        # draws its own text.
+        #
+        # `-S -` is the start of the pane's history (rc 0 on 3.7c and on `tmuxctl.FLOOR`,
+        # measured), and it removes the question rather than re-tuning the number for one
+        # more tmux. Nothing here needed the bound: the assertion below is that the reason
+        # REACHED the pane at all — the "it is one row up" claim belongs to the visible
+        # capture above, which is where it is made.
+        with_history = self._capture("panel-oldshape", "-S", "-")
         self.assertIn(self._BAD_SLOT, with_history,
                       "the reason never reached the pane AT ALL — that is a different "
                       "failure from the one #382 fixes, and `_hold` would not cure it: "


### PR DESCRIPTION
Closes #718. Test-only — **no line of `charter/` changes** (verified below).

## The failure

```
FAIL: PanelIntegration.test_the_same_reason_on_stderr_alone_is_scrolled_out_of_a_one_row_pane
AssertionError: 'nosuchslot' not found in ' (known: bottom, repos, right, top)\n\n
Pane is dead (status 2, Sun Aug 30 23:45\n:29 2026)\n'
```

The test writes a 75-character reason into a 40-column one-row pane and reads it back at a
depth it derived:

```python
depth = -(-len(self._BAD_SLOT_STDERR) // self._PANE_COLS) + 1   # 2 + 1 = 3
```

The derived half was right and was the whole point of the comment above it — the reason
names every key of `frame_slots.SLOTS`, so it grows whenever charter ships a slot. **The
`+ 1` was the other half hard-coded, and it is not a constant.** It is one row of tmux's
own `remain-on-exit` marker, and how many rows that takes is a rendering decision:

```
tmux 3.7c   ' … \n\nPane is dead (status 0, Sun Aug 30 23:47\n'          <- truncated: 1 row
tmux 3.2    ' … \n\nPane is dead (status 0, Sun Aug 30 23:47\n:17 2026)\n' <- wrapped:  2 rows
```

So `-3` reached the row carrying the slot name on 3.7c and stopped one row short of it on
charter's own floor, and the case went red for how *another program* draws *its own* text.

**Nothing of charter's is involved**: the reason reaches the pane on both tmuxes, and
`panel._hold` is not what this measures.

## The fix

`capture-pane -S -` — the start of the history — removes the question rather than
re-tuning the number for one more tmux. Verified rc 0 on both binaries.

Nothing here needed the bound. The assertion is that the reason **reached the pane at
all**; the "it is one row up" claim belongs to the visible capture above it, which is
where it is still made, unchanged:

```python
visible = self._capture("panel-oldshape")
self.assertNotIn(self._BAD_SLOT, visible, …)          # unchanged — the property
with_history = self._capture("panel-oldshape", "-S", "-")
self.assertIn(self._BAD_SLOT, with_history, …)        # "it reached the pane at all"
```

The comment that argued the derived half is kept and finished — it now records the
measurement above and says why a `-S -<n>` window is deliberately *not* used. `_capture`'s
own docstring and `_PANE_COLS`' record the same.

## Verification

Hand-run against both binaries — CI installs no tmux, so all 95 real-tmux tests skip there.

| | tmux 3.2 (`tmuxctl.FLOOR`) | tmux 3.7c |
|---|---|---|
| `tests.test_frame_tmux_integration` before | 8 failures | 0 |
| after this PR alone | 7 failures (#716's five, #717's two) | 0 |
| after #716+#717+#718 together | **0 failures** | 0 |

`PanelIntegration` itself: 5 tests OK on 3.2 and on 3.7c, nothing skipped either side.

**Deletion sweep:** this branch plans 0 mutations — it adds no line to `charter/`.
Hand-verified instead: `git diff --quiet origin/main -- charter/` exits 0, and the sha256
over every `charter/**/*.py` is `6bef9a29…b659f99` on this branch and on `origin/main`
alike.

## Note for review

#719 is open against `ChromeIsOneColour._screenshot` in this same file; it touches a
different class from this PR, so they should not collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy