### PR TITLE
The frame stops freezing for four seconds to say it moved, and stops spinning after the work ends (#729, #727)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -792,12 +792,15 @@ def _add_frame_parsers(sub) -> None:
     # `conf_text` — and, with `--pane`, by tmux's own `split-window`; never typed by an
     # operator.
     #
-    # Its `client` argument is `#{client_name}`, expanded by tmux INSIDE the bind's
-    # `run-shell` text before this process starts — never queried after the fact (see
-    # `cmd_palette`'s own docstring for why: `list-clients` cannot tell WHO pressed the
-    # key, only who is attached, and picking among several guessed wrong). `nargs="?"`
-    # because the pane half is started by charter itself with whatever the bind carried,
-    # and an empty client is a `display-message -t <session>` rather than a refusal.
+    # Its `client` positional is ACCEPTED AND IGNORED, and is kept for one reason only:
+    # a bind installed by a charter from before #729 is still sitting in a running
+    # server's key table across the upgrade, and it fires this command with a
+    # `#{client_name}` in it. Dropping the positional would make F2 on every such frame
+    # fail to parse. Nothing reads it: an outcome is now written to the frame's own state
+    # and drawn by its attention panel (`commands_frame._say_on_screen`), which every
+    # client attached to that frame sees, so there is no longer a per-client screen to
+    # choose between. `nargs="?"` is what lets the new bind, which carries no client at
+    # all, parse through the same parser.
     #
     # `--pane` says "you ARE the palette" rather than "open one". One subcommand and not
     # two, because they are two halves of one keypress and two spellings would be two

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -644,33 +644,35 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
     a window created `-e CHARTER_SESSION_ID=chat-A` in it: the window's own PANE reported
     `chat-A` and a `run-shell` fired against that session reported `session-wide`. This
     bind's action IS a `run-shell`, so the variable would hand every chat's keypress the
-    same frame. The window option does not: like `#{client_name}` beside it, it is
-    expanded in the context of whoever's keypress is firing the bind, so `F2` in chat two
-    opens chat two's palette. `cmd_palette` falls back to `$CHARTER_SESSION_ID` when the
+    same frame. The window option does not: it is expanded in the context of whoever's
+    keypress is firing the bind — the same property `#{client_name}` was carried here for
+    until #729 removed the need for it — so `F2` in chat two opens chat two's palette. `cmd_palette` falls back to `$CHARTER_SESSION_ID` when the
     option is empty, which is what a frame launched by an older charter — its window
     carrying no such option, its bind text replaced by this one the moment a newer frame
     launches on the shared server — still resolves through.
 
-    `"#{client_name}"` is a THIRD thing this same bind carries, for a DIFFERENT
-    reason: which of possibly several clients attached to one frame should be TOLD when
-    an action refuses. Format expansion resolves `#{client_name}` in the context of
-    whoever's keypress is firing the bind — verified by hand with two real ptys attached
-    to one session, pressing the hotkey from each in turn: each press's own `run-shell`
-    resolved its OWN presser's client name, never the other one's, regardless of which
-    was attached first. `charter frame-palette` receives it as a plain argv value (`args
-    .client` in `cmd_palette`), carries it to the palette's own pane, and hands it to
-    `display-message -c`. Earlier, this module queried `list-clients` and guessed the
-    first one reported when several clients were attached — confirmed wrong, on the menu
-    this replaced: pressing the hotkey on the SECOND-attached client drew on the FIRST
-    client's screen, worse than tmux's own unscoped default single-client guess this
-    module was replacing. Carrying the presser by name removes the guess entirely rather
-    than making it a better one.
+    **This bind used to carry `"#{client_name}"` as a third value, and does not any
+    more** (#729). It named which of several clients attached to one frame should be TOLD
+    when an action refuses, and it was threaded from here through `args.client` and the
+    palette pane's own relaunch argv for exactly one consumer: `display-message -c`. That
+    consumer is gone. An outcome is now written to the frame's own state and drawn by its
+    attention panel (`_say_on_screen`), which is a PANE — so every client attached to the
+    frame sees it, and "which client pressed the key" stopped being a question that has
+    to be answered rather than being answered better. The value is not merely unused, it
+    is unnecessary: the surface it was selecting between no longer has variants.
 
-    **What the palette does NOT carry it for, and this is a real difference from the
-    menu.** A `display-menu` was drawn per client; the palette is a PANE (§4k), and a
+    `charter frame-palette` still ACCEPTS the positional (`cli.py`, `nargs="?"`), and that
+    is not vestigial — a bind installed by a charter that predates this change is still
+    sitting in a running server's key table across the upgrade and fires the command with
+    a client name in it, exactly as `--chat`'s own optionality is there for. Accepting and
+    ignoring it is what keeps `F2` working on those frames; emitting it is what stopped.
+
+    **The palette was never per-client anyway, and that is the difference from the menu it
+    replaced.** A `display-menu` was drawn per client; the palette is a PANE (§4k), and a
     pane belongs to the window, so with two clients attached to one frame both of them
     see it. That is the price of the surface being something charter draws rather than
-    something tmux draws, and it is the same price every other panel already pays.
+    something tmux draws, it is the same price every other panel already pays, and the
+    outcome line has now been moved onto the same footing as the surface that produces it.
 
     The last line is `frame/overlay.hatch_bind()` — **the escape hatch**, and it is here
     rather than beside the hotkey because it is the one bind that must keep working when
@@ -725,8 +727,9 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
     Code (or codex, or whatever the operator ran) on every plane that has a charter.toml.
 
     These are frame-agnostic for the same reason the hotkey bind above is, and they carry
-    no `#{client_name}`: a toggle changes the FRAME, not what one client is looking at, so
-    unlike the palette there is nothing here to draw on a particular presser's screen.
+    no client name: a toggle changes the FRAME, not what one client is looking at, so
+    there is nothing here to draw on a particular presser's screen — which since #729 is
+    true of the palette's bind as well, and for the same reason.
     `cmd_toggle` resolves which frame from `$CHARTER_SESSION_ID` when the key fires.
 
     **Both halves of a toggle line are refused rather than escaped, and each on its own
@@ -749,7 +752,7 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
     arrangement — `source-file` returns 0 and `list-keys -T root` reads all four binds
     back, the palette's, both toggles' and the hatch's, byte for byte::
 
-        bind-key -T root F2  run-shell "\\"\\$CHARTER_PY\\" -m charter frame-palette \\"#{client_name}\\""
+        bind-key -T root F2  run-shell "\\"\\$CHARTER_PY\\" -m charter frame-palette"
         bind-key -T root F7  run-shell "\\"\\$CHARTER_PY\\" -m charter frame-toggle repos"
         bind-key -T root F12 run-shell -C "#{@charter_hatch}"
         bind-key -T root M-s run-shell "\\"\\$CHARTER_PY\\" -m charter frame-toggle right"
@@ -780,7 +783,7 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
         "set -g remain-on-exit on",
         "set -g focus-events on",
         f"bind -n {hotkey} run-shell "
-        f"'\"${_CHARTER_PY_ENV}\" -m charter frame-palette \"#{{client_name}}\" "
+        f"'\"${_CHARTER_PY_ENV}\" -m charter frame-palette "
         f"--chat \"#{{{_CHAT_OPTION}}}\"'",
         f"bind -n {tmuxctl.WHEEL_KEY} if-shell -F -t = '#{{mouse_any_flag}}'"
         " 'send-keys -M' 'copy-mode -e; send-keys -M'",
@@ -5467,7 +5470,7 @@ def _open_palette(args) -> int:
         return 0
     argv = overlay.open_argv(
         socket, harness=harness,
-        command=util.self_relaunch_argv("frame-palette", getattr(args, "client", "") or "",
+        command=util.self_relaunch_argv("frame-palette",
                                         "--pane"),
         env=_relayout_pane_env(fid, v))
     if argv is None:
@@ -5525,7 +5528,6 @@ def _draw_palette(args) -> int:
     reg = builtin_actions.build(fid, current_density=_current_density(fid),
                                 current_chrome=_current_chrome(fid))
     snapshot = gather.cached(fid) or {}
-    client = getattr(args, "client", "")
     opened: list[choose.Roster] = []
     try:
         surface = palette.Palette(
@@ -5543,17 +5545,24 @@ def _draw_palette(args) -> int:
             out = choose.switch_to(noun, fid, name)
             if out.ok and noun == choose.CHAT:
                 _start_chat_switch(fid, name)
-            _say_on_screen(fid, out.message, client)
+            # **Which frame's row, and it is not always this one.** The notice is drawn by
+            # a panel out of a frame's own state, so it has to be written to the frame the
+            # operator will be LOOKING at a moment from now. A chat switch that took moves
+            # the client to a sibling frame — `choose.py`'s "the frame IS the chat" — and
+            # a chat's name IS its frame id, so that is the id to write. Every other
+            # outcome, refused chat switches included, leaves the operator on this frame.
+            shown_on = name if (out.ok and noun == choose.CHAT) else fid
+            _say_on_screen(shown_on, out.message, ok=out.ok)
             return 0
         if choose.noun_of(chosen) is not None:
             # A picker row that never opened its picker: `_picker` refused it, which it
             # does for exactly one reason and always with that reason in the row's note.
-            _say_on_screen(fid, chosen.note, client)
+            _say_on_screen(fid, chosen.note)
             return 0
         inv = reg.invoke(chosen.id, fid=fid, snapshot=snapshot)
         inv.join(timeout=_ACTION_START_GRACE)
         if not inv.started:
-            _say_on_screen(fid, inv.reason, client)
+            _say_on_screen(fid, inv.reason)
     finally:
         _close_palette(socket, harness=harness,
                        overlay_pane=os.environ.get("TMUX_PANE", ""))
@@ -5760,66 +5769,68 @@ def cmd_switch(args) -> int:
         out = switch.to_persona(fid, persona_name)
     else:
         return 0
-    _say_on_screen(fid, out.message)
+    _say_on_screen(fid, out.message, ok=out.ok)
     return 0
 
 
-def _say_on_screen(fid: str, message: str, client: str | None = None) -> None:
+def _say_on_screen(fid: str, message: str, *, ok: bool = False) -> None:
     """Put one line on the frame's own screen. Best effort, never raises.
 
-    **The message is a tmux FORMAT.** `display-message`'s own docs say so, and
-    `tmuxctl.inert_format`'s measurement — a `#(...)` runs during format evaluation
-    whether or not the thing goes on to display — applies here word for word. Every
-    caller's *message* already carries contained names (`contain.one_line`, in
-    `switch.py` and in `frame/actions.py`'s own `_reason`), which closes the newline half;
-    `inert_format` closes the `#` half. Both, because they are different properties: one
-    line, and inert.
+    **On charter's own attention row, not on the tmux client's message line** (#729).
+    This was `display-message -d 4000` and it moved for two separately measured reasons,
+    either of which is on its own enough:
 
-    A leading `-` would make tmux read the message as a flag of its own and refuse the
-    whole command — the same measured failure `inert_format` guards against — so the same
-    guard is what runs here rather than a second one that "does the same thing".
+    * **It froze the screen for exactly as long as it spoke.** A tmux client does not
+      redraw its PANES while a message is up. Measured with an outer terminal mirroring an
+      inner session, on tmux 3.7c and at the 3.2 floor alike: the pane's content changed
+      at 0.02s and the operator's screen did not catch up until 4.03s. The freeze tracks
+      `-d` linearly (`-d 200` → 0.20s, `-d 750` → 0.74s), so those four seconds bought
+      nothing and hid the repaint the message existed to announce — every workspace,
+      persona and chat switch, on an operation `docs/frame.md` measures at a third of a
+      second.
+    * **It could not name the screen it drew on.** `-t` is `display-message`'s target for
+      FORMAT evaluation, not its client; the client is `-c`, and with no `-c` tmux picks
+      its own current client. Measured on both versions with two sessions on one server
+      and a terminal attached to each: a message aimed at `-t <a pane of session sa>` was
+      drawn on `sb`'s terminal and not on `sa`'s at all. `cmd_chat`'s own guard already
+      recorded this leak by hand for an EMPTY target and read it as a property of the
+      emptiness — it is not. A well-formed `%N` naming the right frame's own harness pane
+      leaks identically, because the pane was never what chose the screen. On a control
+      plane with eleven frames on one socket, that is a refusal about one frame drawn
+      across another operator's.
 
-    *client* is `#{client_name}` where a caller has one: the palette carries the presser's
-    own client from the hotkey bind, and `-c` draws on exactly that terminal where `-t`
-    draws on whichever attached most recently.
+    The row has neither problem. It is a pane charter already paints, so writing to it
+    costs no client freeze; it is read by that frame's own panel out of that frame's own
+    state directory, so it cannot be drawn on a frame it is not about; and every client
+    attached to that frame sees it, which is strictly more than the one client `-c` could
+    name and removes the "which of several clients pressed the key" question entirely.
 
-    `-d 4000`: long enough to read a sentence, short enough that it is gone before the
-    operator wants the screen back. tmux's own default comes from `display-time`, which is
-    an operator's setting for THEIR messages and typically 750ms — too short for a refusal
-    that names a workspace and says what to do about it.
+    Because the row is a surface with an owner, this takes the FRAME the notice belongs
+    to — which is not always the frame the outcome was computed for. A successful chat
+    switch moves the operator to a sibling frame (`choose.py`: "the frame IS the chat"),
+    so its caller passes the chat being switched TO; every other outcome leaves the
+    operator where they are.
+
+    *ok* picks the dwell and nothing else — `state.NOTICE_SECONDS` for an outcome that
+    happened, `state.REFUSAL_SECONDS` for one that did not, and see those constants for
+    why a refusal earns longer. There is deliberately no second visual treatment keyed off
+    it: every refusal `switch.py` produces already reads as one ("cannot switch: …",
+    "no workspace 'x' — have: …"), and the row is one line where a marker only spends
+    columns the message itself needs.
+
+    The `bump` is what makes the notice APPEAR promptly rather than at whatever the panel
+    next happened to repaint for: a panel polls `state.version`, so writing the notice
+    without moving the version would leave it invisible until something unrelated bumped
+    the frame — the exact shape of #727, reached from the writing side instead of the
+    expiring side. `state.say` writes before this returns, so the version a panel then
+    reads always has the notice already behind it.
     """
-    socket = state.frame_server(fid) or SOCKET
-    argv = tmuxctl.server_argv(socket, "display-message", "-d", "4000")
-    if client:
-        argv += ["-c", client]
-    else:
-        # **The frame's own PANE, and never its id** (#695). A chat id is
-        # `{workspace}.{ordinal}` and tmux parses a `-t` on the dot, so
-        # `-t harness-wrapper.2` is not the window of that name: measured on 3.7c it
-        # resolves to session
-        # `harness-wrapper`, its CURRENT window, and `2` as a pane index — and
-        # `-t harness-wrapper.9` answers rc 0 with pane index 0 rather than failing. The
-        # session half happens to be the right screen, which is why nothing has ever been
-        # seen to go wrong here; the target has never once meant what it was spelled to
-        # mean, and the day a workspace is called `api.2` beside one called `api` it means
-        # a different operator's frame. There is no spelling that fixes a window: tmux
-        # takes `session:window` and this side has no session in hand — so the answer is
-        # the record charter already keeps of where this frame's harness runs, which is a
-        # `%N` and cannot be parsed as anything else.
-        pane = state.harness_pane(fid) or ""
-        if not _PANE_ID_RE.fullmatch(pane):
-            # No usable record and no client: there is nothing this can be aimed at that is
-            # certainly this frame. Silence rather than `-t <fid>`, which is how a refusal
-            # came to be drawn across somebody else's frame — the same direction the empty
-            # id above is refused for, and one an operator loses only a sentence to.
-            return
-        argv += ["-t", pane]
-    # One prefix for every outcome. Every refusal `switch.py` produces already reads as
-    # one ("cannot switch: …", "no workspace 'x' — have: …"), and a second word saying so
-    # only ate columns off a status line tmux truncates without saying it did — measured
-    # against a 100-column client: `charter: refused — cannot switch: …` ran off the end.
-    tmuxctl.run("reporting on the frame's own screen",
-                argv + [tmuxctl.inert_format("charter: " + message)])
+    # One prefix for every outcome, as it always was. A second word saying "refused" only
+    # ate columns off a row that truncates — measured against a 100-column client:
+    # `charter: refused — cannot switch: …` ran off the end.
+    state.say(fid, "charter: " + message,
+              seconds=state.NOTICE_SECONDS if ok else state.REFUSAL_SECONDS)
+    state.bump(fid)
 
 
 def cmd_respawn(args) -> int:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -5320,8 +5320,10 @@ def cmd_chat(args) -> int:
         # No `contain.one_line` on *target*: `chats.check` has already held it to
         # `chats.ID_RE`, whose alphabet holds nothing `one_line` touches, so the call
         # would be one whose result is provably its argument — the sweep found it as a
-        # survivor for that reason. `_say_on_screen`'s own `inert_format` is what makes
-        # this a tmux format's business rather than this line's.
+        # survivor for that reason. Since #729 there is no tmux format on this path at
+        # all: `_say_on_screen` writes the line into this frame's own state and its
+        # attention panel draws it, so the containment this line does not need is
+        # `contain.one_line`'s, applied once in `state.say`.
         _say_on_screen(fid, f"cannot switch: chat '{target}' has no window any more")
         return 0
     if _session_window(socket, here_place[0]) != there_place[1]:

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -49,6 +49,15 @@ the directory absent, or present and empty — that is one syscall per tick, alo
 one `state.version` already pays, and the panel paints nothing. It is self-limiting by
 construction rather than by a budget: the ticking stops when the records do.
 
+**And it stops by PAINTING, which is the part that was missing** (#727). Both clock-driven
+fields on that row — the spinner, and a switch outcome's dwell (`state.say`) — are true
+for a while and then false, and the loop below had no reason to repaint on the instant
+they went false: the version has not moved, nothing resized, no event arrived. So the pane
+kept whatever it last drew, which is a spinner frozen mid-animation over a count of work
+that had already finished — indistinguishable from a hung frame, and measured holding for
+over fifteen minutes across a detach/reattach. `_watch` carries the previous answer in
+`was_ticking` and spends exactly one more paint on the falling edge.
+
 **A panel can now READ its pane, and only when a component asked it to** (#607). The loop
 below is otherwise unchanged: `_wait` replaces the tick's `time.sleep` with a `select` of
 the same length when — and only when — the placed component declared an event kind charter
@@ -599,8 +608,39 @@ def _wait(evs, timeout: float = TICK) -> bool:
     return evs.poll(timeout)
 
 
+def _notice_pending(fid: str) -> bool:
+    """Is a switch outcome still inside its dwell — i.e. will this row draw it?
+
+    The second clock-driven reason to repaint, beside :func:`_running`. `state.say`
+    bumps the version when it writes, so the notice APPEARING is already an ordinary
+    version repaint; what needs this is the notice going AWAY, which no version bump,
+    resize or event announces. `_watch`'s falling edge turns "was pending, is not now"
+    into exactly one repaint, and the row loses the line the same tick it expires.
+
+    One small read per tick, and only on a slot in `slots.ANIMATED` — `_watch`'s `and`
+    short-circuits before this is called for any other, so a `top`, `left` or `right`
+    panel pays nothing at all.
+
+    **It costs about what `state.version` costs, and that is the number worth stating
+    rather than an absolute one.** Both are a containment resolve plus a small read of one
+    file in the frame's own directory, so they measure alike and they move together with
+    the machine: 136µs against 130µs here, five times a second, on ONE of the four panels
+    — where the version read is paid by every panel on every tick already. Deliberately
+    NOT cached behind `_running`'s stamp trick. The cheap version is available — a notice
+    can only appear on a version bump, because `state.say`'s caller bumps — but it buys
+    ~136µs of a 200,000µs tick in exchange for a rule that a future writer of a notice
+    must also bump the version or their notice silently never appears. A read that is
+    correct whoever writes it is worth more than 0.07% of one core.
+
+    Never raises: `state.notice_expiry` answers `0.0` for every degenerate case, and a
+    panel that threw out of its run loop would lose the pane (`run`'s `_hold` catches it,
+    but a panel that stopped repainting has already lost).
+    """
+    return time.time() < state.notice_expiry(fid)
+
+
 def _tick(resized: dict, seen: str, slot: str, fid: str, *,
-          animating: bool = False, paint=None, events=None,
+          ticking: bool = False, paint=None, events=None,
           handled: bool = False) -> str:
     """One loop iteration's decision AND its effect — split out of `run` so the
     DECISION (paint now, or wait) can be exercised without also exercising `run`'s
@@ -632,13 +672,15 @@ def _tick(resized: dict, seen: str, slot: str, fid: str, *,
     is still visible to the next comparison — pinned directly by
     `Tick.test_a_bump_landing_during_the_paint_is_not_marked_seen`.
 
-    *animating* is the third reason to repaint, and it is the same shape as *resized*: the
+    *ticking* is the third reason to repaint, and it is the same shape as *resized*: the
     frame's version has not moved and the pane's size has not changed, but what the panel
-    would draw NOW differs from what is on screen, because the spinner is on a different
-    frame (`slots.spinner_frame` reads the clock). Defaulted to `False` so the two callers
-    that mean "repaint only on news" — every test in this module that exercises the
-    decision directly — keep saying exactly that. `_watch` is what decides it, from
-    :func:`_running`.
+    would draw NOW differs from what is on screen, because the CLOCK moved. Two things on
+    this row are functions of the clock rather than of the frame's version — the spinner
+    (`slots.spinner_frame`) and a notice's expiry (`state.notice`) — and *ticking* is
+    both, which is why it is no longer spelled `animating`. Defaulted to `False` so the
+    callers that mean "repaint only on news" — every test in this module that exercises
+    the decision directly — keep saying exactly that. `_watch` is what decides it, from
+    :func:`_running` and :func:`_notice_pending`.
 
     *paint* is WHAT to draw, defaulting to :func:`_paint` — charter's own renderer for
     this slot. A panel hosting a provider's component passes :func:`_component_painter`'s
@@ -662,7 +704,7 @@ def _tick(resized: dict, seen: str, slot: str, fid: str, *,
     and the rectangle is what the event is about.
     """
     now = state.version(fid)
-    if resized["flag"] or now != seen or animating or handled:
+    if resized["flag"] or now != seen or ticking or handled:
         if events is not None:
             events.note_resize()
         resized["flag"] = False
@@ -672,14 +714,24 @@ def _tick(resized: dict, seen: str, slot: str, fid: str, *,
 
 
 def _watch(slot: str, fid: str, *, once: bool, paint=None, evs=None) -> int:
-    """The live loop: paint on every version bump, resize, or spinner frame, until killed.
+    """The live loop: paint on every version bump, resize, spinner frame, notice or
+    expiry, until killed.
 
     The third reason is the only one that repeats on its own, and it is bounded twice over
     rather than by a timer this module owns: by the WORK, since `_running` answers 0 the
-    moment the last in-flight record clears; and by the SLOT, since only a renderer in
-    `slots.ANIMATED` draws anything that moves. A `top`, `left` or `right` panel therefore
-    behaves exactly as it did before this feature existed — including paying no `stat`,
-    because the `and` below short-circuits before `_running` is ever called.
+    moment the last in-flight record clears and `_notice_pending` answers False the moment
+    a notice's dwell is up; and by the SLOT, since only a renderer in `slots.ANIMATED`
+    draws anything that moves. A `top`, `left` or `right` panel therefore behaves exactly
+    as it did before this feature existed — including paying no `stat` and no notice read,
+    because the `and` below short-circuits before either is ever called.
+
+    **And it paints once MORE when that reason stops being true.** The loop used to have
+    a rising edge and no falling one: it repainted for every tick a spinner was live and
+    then, on the tick after the last record cleared, had no reason left to paint — so the
+    pane kept the last thing drawn into it, a spinner frame and a count of work that had
+    finished (#727). `was_ticking` is the whole of the fix, and it is one variable rather
+    than one per field because "what I last drew was clock-driven and now is not" is the
+    same question for the spinner and for a notice's expiry.
 
     Split out of `run` so the SIGWINCH handler it arms is restored by its own `finally`
     before `run`'s failure path can hold the pane open — a handler left installed for
@@ -713,11 +765,23 @@ def _watch(slot: str, fid: str, *, once: bool, paint=None, evs=None) -> int:
         # that write, so a failed `open` is still fully unwound here.
         if evs is not None:
             evs.open()
-        seen, handled = "", False
+        seen, handled, was_ticking = "", False, False
         while True:
+            # `animates and ...` still short-circuits, so a `top`, `left` or `right`
+            # panel pays neither the `stat` nor the notice read — see `animates` above.
+            ticking = animates and (bool(_running(inflight_cache))
+                                    or _notice_pending(fid))
+            # `or was_ticking` is the FALLING EDGE (#727), and it is one term rather
+            # than two because both clock-driven fields need exactly the same thing.
+            # Without it, the tick after the last in-flight record cleared had no reason
+            # to repaint at all — not resized, version unmoved, nothing handled — so the
+            # screen kept the last frame drawn, which is the one with the spinner on it.
+            # Measured before this line existed: `⠏ 1 running` held for 12s with an empty
+            # tracker directory, and once for over fifteen minutes across a
+            # detach/reattach. A notice expiring is the identical edge.
             seen = _tick(resized, seen, slot, fid, paint=paint, events=evs,
-                         animating=animates and bool(_running(inflight_cache)),
-                         handled=handled)
+                         ticking=ticking or was_ticking, handled=handled)
+            was_ticking = ticking
             if once:
                 return 0
             handled = _wait(evs)

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2024,8 +2024,25 @@ def _bottom(fid: str) -> str:
     that fixes it, and slicing into that command mid-word reads as "no problem here" — the
     exact false-clean failure this plan's Global Constraints call out by name.
 
-    Priority order, highest first: the one alert (`_alerts()`'s own top pick — an
-    actionable control-plane problem, carrying its own fix); the in-flight spinner
+    **This row is also where a switch says what it did** (#729), and that is the highest
+    priority on it while it lasts. It is the surface the outcome of an F2 choice moved
+    ONTO, off `display-message`, because a tmux client does not repaint its panes while a
+    message is up — measured at four seconds of a frozen screen on tmux 3.7c and at the
+    3.2 floor alike, spent hiding the very repaint the message announced. This row is the
+    right destination rather than merely an available one: `instance.FRAME_DENSITY` puts
+    `bottom` in every level charter ships (`minimal`, `normal`, `full`), so it is the one
+    surface besides `top` that is always there to be written on — and `docs/frame.md`'s
+    promise that this row is never dropped is exactly the promise an outcome line needs.
+    It is also per-FRAME, read by that frame's own panel off that frame's own state, which
+    is the second half of what `display-message` could not do: `-t <pane>` selects the
+    format target and not the client, so an outcome about one frame was being drawn on
+    whichever client attached most recently (measured on both versions — see
+    `state.say`).
+
+    Priority order, highest first: the switch outcome (`state.notice` — a few seconds
+    long, the direct answer to the last thing the operator CHOSE, and the only field here
+    that is about an instant rather than a state); the one alert (`_alerts()`'s own top
+    pick — an actionable control-plane problem, carrying its own fix); the in-flight spinner
     (:func:`_inflight_field` — work happening RIGHT NOW, and the only thing on this row
     that will be different in a second); the selected repo's detail
     (:func:`_selected_detail` — the direct answer to the last thing the operator DID, which
@@ -2097,22 +2114,29 @@ def _bottom(fid: str) -> str:
 
     inflight_text = _inflight_field()
     repo_text = _selected_detail(fid)
+    # The outcome of the last thing the operator CHOSE, for the few seconds it is worth
+    # saying (#729). Empty the rest of the time, and `_fit_fields` drops an empty field
+    # whole — so a frame nobody has just switched draws the row it always drew.
+    notice_text = state.notice(fid)
 
     # Decide who survives, highest priority first (see this function's own docstring
     # above for why); `_fit_fields` does the actual budgeting so it can be tested in
     # isolation.
     keep = _fit_fields(
-        [("alert", alert_text), ("inflight", inflight_text), ("repo", repo_text),
-         ("news", news_text), ("todo", todo_text), ("hotkey", hotkey_text)], w,
+        [("notice", notice_text), ("alert", alert_text), ("inflight", inflight_text),
+         ("repo", repo_text), ("news", news_text), ("todo", todo_text),
+         ("hotkey", hotkey_text)], w,
         limit=1 if verbosity(fid) == "terse" else None)
 
     # Re-assembled in the original reading order, not priority order — priority decided
     # only who was cut. `repo` is LAST, which is the "right side" the selected row's
     # detail was asked for: this row is composed left to right and joined with ` · `, so
     # last is as far right as a field gets without a second layout rule for one field.
-    fields = {"alert": alert_text, "inflight": inflight_text, "news": news_text,
-              "todo": todo_text, "hotkey": hotkey_text, "repo": repo_text}
-    parts = [fields[n] for n in ("todo", "alert", "inflight", "news", "hotkey", "repo")
+    fields = {"notice": notice_text, "alert": alert_text, "inflight": inflight_text,
+              "news": news_text, "todo": todo_text, "hotkey": hotkey_text,
+              "repo": repo_text}
+    parts = [fields[n]
+             for n in ("notice", "todo", "alert", "inflight", "news", "hotkey", "repo")
              if n in keep]
     return tui.truncate(" · ".join(parts), w)
 

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -379,6 +379,143 @@ def version(fid: str) -> str:
         return "0"
 
 
+#: How long a SUCCESSFUL outcome stays on the attention row. The same four seconds
+#: `_say_on_screen` used to ask `display-message -d 4000` for, and for the same stated
+#: reason ("long enough to read a sentence") — but now it is four seconds of a row, not
+#: four seconds of a frozen client, so the number costs what it was always assumed to
+#: cost. A success is also the case that needs the row least: the frame ITSELF is the
+#: confirmation, and the top row already reads `⬢ gamma` by the time this is drawn.
+NOTICE_SECONDS = 4.0
+
+#: How long a REFUSAL stays there. Longer, because a refusal is the one outcome with no
+#: other surface — nothing moved, so no panel repaints into the answer — and because it
+#: carries the fix in its own text (`no workspace 'x' — have: a, b, c`), which is more to
+#: read than `workspace → gamma`. Bounded rather than sticky: the row's next-highest
+#: field is an `_alerts()` entry, an actionable problem the operator also needs, and a
+#: refusal that never expired would sit on top of one indefinitely.
+REFUSAL_SECONDS = 10.0
+
+
+def say(fid: str, message: str, *, seconds: float = NOTICE_SECONDS) -> None:
+    """Put one line on this frame's attention row for *seconds*, then let it expire.
+
+    **The frame's own surface, not the tmux client's message line** (#729). What this
+    replaces was `display-message -d 4000`, and it was replaced for two measured reasons
+    rather than one:
+
+    * A tmux client does not redraw its PANES while a message is up. Measured on tmux
+      3.7c and at the 3.2 floor alike, with an outer terminal mirroring an inner session:
+      the pane's own content changed at 0.02s and the operator's screen did not catch up
+      until 4.03s. The freeze is exactly the `-d` value — `-d 200` freezes for 0.20s,
+      `-d 750` for 0.74s — so the cost was the duration, spent entirely on hiding the
+      repaint the message was announcing.
+    * `display-message -t <pane>` does not choose the SCREEN. `-t` is the target for
+      FORMAT evaluation; the client is `-c`, and with no `-c` tmux picks its own current
+      client. Measured on both versions, two sessions on one server with a terminal on
+      each: a message aimed at a pane of session `sa` was drawn on the terminal attached
+      to `sb` and not on `sa`'s at all. On a socket with eleven frames on it — an
+      ordinary control plane — a refusal about one frame was being drawn across another
+      operator's, which is why this is per-frame state read by that frame's own panel and
+      not a message aimed at a server.
+
+    Best effort, never raises: the callers are switch outcomes, and one that cannot write
+    its notice must still return the exit status it owes tmux. Same atomic
+    `write_for`-then-`os.replace` shape as :func:`bump`, so a reader never sees half a
+    line, and a failed write leaves the previous notice exactly as it was.
+
+    The expiry is stored, not the duration, so a reader needs only the clock and never
+    has to know when the write happened. `time.time()` rather than `time.monotonic()`:
+    the writer and the reader are different processes, and a monotonic clock is only
+    comparable within one.
+
+    *message* goes through `contain.one_line` for the same reason every other caller of
+    it does, and for one more that is specific to this file: the notice is stored as an
+    expiry line followed by the text, so a newline in *message* would write a value that
+    reads back truncated at it. Callers in `switch.py` and `frame/actions.py` already
+    contain their own interpolated names; this contains the assembled line, which is a
+    different claim — the file format's, not the message's.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    # Stripped BEFORE the emptiness check, not after. `contain.one_line` turns a
+    # character with no glyph into a visible escape, so a message that is only
+    # whitespace stays truthy and would write a notice that draws nothing — and then
+    # hold the row's top priority over an `_alerts()` entry, and keep `panel._watch`
+    # repainting for the whole dwell, to say it. `notice()` strips on the way out too;
+    # this is what stops the file being written in the first place.
+    text = contain.one_line(message).strip()
+    if not text:
+        return
+    tmp = d / "notice.tmp"
+    try:
+        config.write_for(tmp, f"{time.time() + float(seconds)}\n{text}\n")
+        os.replace(tmp, d / "notice")
+    except (OSError, ValueError, OverflowError):
+        return
+
+
+def notice(fid: str) -> str:
+    """This frame's unexpired notice, or ``""``. A pure read, several times a second.
+
+    Answers ``""`` for every degenerate case — no frame, no file, an unparseable expiry,
+    bytes that are not UTF-8, an expiry already passed — because the caller is
+    `slots._bottom`, drawing the one row `docs/frame.md` promises is never dropped. A row
+    that raised would take that promise down with it.
+
+    **The file is not deleted on expiry, and that is deliberate.** This is a read, and
+    this module's own contract is that reads do not mutate: a panel polling five times a
+    second must not be the thing that unlinks state, or two panels would race over it and
+    a reap would fight a poll. An expired notice is a few dozen stale bytes in the
+    frame's own directory, which `reap()` removes with everything else.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return ""
+    try:
+        raw = (d / "notice").read_text()
+    except (OSError, ValueError):
+        return ""
+    expiry, _, text = raw.partition("\n")
+    try:
+        # Spelled as "the clock is still BEFORE the expiry" rather than as its negation,
+        # because the two are not the same for one value a file can hold. `float("nan")`
+        # parses, and every comparison against a NaN is False — so `now >= expiry` reads
+        # False and the notice becomes PERMANENT, which is the one outcome this whole
+        # cluster is about (#727). Asking for the live case makes NaN answer "not live",
+        # which is the direction every other degenerate case here already falls.
+        live = time.time() < float(expiry)
+    except ValueError:
+        return ""
+    return text.strip() if live else ""
+
+
+def notice_expiry(fid: str) -> float:
+    """When this frame's notice stops being drawn, as a `time.time()` value — ``0.0``
+    when there is nothing pending.
+
+    Split from :func:`notice` for `panel._watch`, which needs the DEADLINE rather than
+    the text: the panel has to repaint once when a notice expires, and the only thing
+    that changes at that instant is the clock. Nothing bumps the version, nothing
+    resizes, and no event arrives — the identical falling edge #727 records for the
+    in-flight spinner, which is why one loop change answers both.
+
+    Answers ``0.0``, not ``None``, so a caller can compare it against `time.time()`
+    without a branch: an absent notice is one whose deadline has already passed.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return 0.0
+    try:
+        raw = (d / "notice").read_text()
+    except (OSError, ValueError):
+        return 0.0
+    try:
+        return float(raw.partition("\n")[0])
+    except ValueError:
+        return 0.0
+
+
 def record_exit(fid: str, code: int) -> None:
     """Record the harness's exit code. Same atomic-write shape as :func:`bump`."""
     d = frame_dir(fid, create=True)

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -451,7 +451,15 @@ def say(fid: str, message: str, *, seconds: float = NOTICE_SECONDS) -> None:
     try:
         config.write_for(tmp, f"{time.time() + float(seconds)}\n{text}\n")
         os.replace(tmp, d / "notice")
-    except (OSError, ValueError, OverflowError):
+    except OSError:
+        # `OSError` alone, exactly as `bump` and `record_exit` above — one shape for the
+        # three writers in this module rather than a wider net here. `ValueError` and
+        # `OverflowError` were in this tuple first, for a `float(seconds)` that cannot
+        # happen: every caller passes one of the two module constants below. The sweep
+        # found the wider catch as a survivor and it was right to — a clause no input
+        # reaches is not a guard, it is a claim that some caller might one day pass
+        # nonsense, and the honest place for that is the caller raising rather than this
+        # swallowing it into a silent no-notice.
         return
 
 

--- a/charter/frame/switch.py
+++ b/charter/frame/switch.py
@@ -46,12 +46,16 @@ typed.
 
 Every name that reaches a message goes through `contain.one_line` first — a workspace or
 persona name is a committed value, and a message is a line of charter's own output that a
-newline in a name could forge a second line of (`contain.py`, #453). The tmux side of the
-same rule lives in `frame/tmuxctl.inert_format`, which makes a line inert before it reaches
-tmux's own format parser.
+newline in a name could forge a second line of (`contain.py`, #453).
+
+There is no longer a tmux side to that rule. Until #729 the outcome went out as a
+`display-message`, whose argument tmux parses as a FORMAT, and `frame/tmuxctl.inert_format`
+was what made the line inert before it got there. The outcome is now written to the frame's
+own state and drawn by its attention panel into a pane charter owns, so nothing on this
+path reaches a tmux parser and `contain.one_line` is the whole of the containment.
 
 No tmux call is made from here at all. That keeps this module testable without a server —
-`commands_frame` owns the one `display-message` that puts a refusal on screen.
+`commands_frame` owns the one call that puts a refusal on screen.
 """
 
 from __future__ import annotations

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -333,11 +333,29 @@ def inert_format(text: str) -> str:
        the style-reset sequence tmux appends after it, rendering as literal
        `trailing#[default]` garbage. A trailing space breaks the adjacency.
 
-    Lives here, in the module that owns every tmux argv charter builds, rather than beside
-    one of the two callers: `commands_frame._say_on_screen` puts a switch outcome on a
-    status line and `frame/palette.py` puts an action's refusal on the same one, and a
-    second copy of this would be a second answer to "what may reach tmux's parser" — which
-    is #547's shape, and which this repo has already paid for once.
+    **Nothing in charter calls this today, and that is a statement of fact rather than a
+    reservation** (#729). It had one caller, `commands_frame._say_on_screen`, which put a
+    switch outcome on the client's status line; that outcome now goes into the frame's own
+    state and is drawn by its attention panel into a pane charter owns, where no tmux
+    parser is in the path. (This docstring also named `frame/palette.py` as a second
+    caller. That was never true on this branch — `palette.py` does not import `tmuxctl` at
+    all — and it is corrected here rather than left to be believed.)
+
+    Every remaining place charter puts a derived value into a tmux grammar is closed by a
+    narrower, construction-specific guard instead, which is stronger than doubling `#`: a
+    pane id by `PANE_ID_RE`, a frame or chat id by `commands_frame._FRAME_ID_RE`, a session
+    name by `state.workspace_prefix`'s alphabet, a hotkey by `instance._HOTKEY_RE`, a
+    chrome or background value by a lookup table that answers `()` for anything it does not
+    know. charter sets no `status-left`, `status-right`, `pane-border-format` or
+    `window-status-format`, and has no `display-menu` or `display-popup` at all, so there
+    is no format today whose text is not a module constant.
+
+    It is kept rather than deleted because the measurements above are the reason those
+    guards are shaped the way they are, and because the next surface that hands tmux a
+    string built from a name will need exactly this. **A caller that appears must use it
+    rather than re-spell it** — a second copy would be a second answer to "what may reach
+    tmux's parser", which is #547's shape and which this repo has already paid for once.
+    If no such surface arrives, this and its tests are a clean deletion.
     """
     text = text.replace("#", "##")
     if text.startswith("-"):

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -208,13 +208,23 @@ running"*. Every reader now says which kinds it means, and the default is dispat
 the next kind of work charter learns to record cannot leak into a sentence by being
 forgotten at one call site.
 
-The moment the last of it finishes, the frame goes completely still again and the panel
-goes back to waiting for a version bump. Nothing is polled to find this out: charter
-records work when it *starts* (that is also what makes overlapping agents visible at all),
-so the panel asks one question per tick — a single `stat` of that tracker's own directory
-— and reads the records themselves only when that answer moves. Measured on macOS/APFS:
-about 5µs per tick added to the ~26µs a panel already spends checking the version file,
-five times a second, or roughly 0.003% of one core while idle.
+The moment the last of it finishes, the frame paints once more and then goes completely
+still, and the panel goes back to waiting for a version bump. Nothing is polled to find
+this out: charter records work when it *starts* (that is also what makes overlapping
+agents visible at all), so the panel asks one question per tick — a single `stat` of that
+tracker's own directory — and reads the records themselves only when that answer moves.
+Measured on macOS/APFS: about 5µs per tick added to the ~26µs a panel already spends
+checking the version file, five times a second, or roughly 0.003% of one core while idle.
+
+**That one last paint is the whole of it, and until #727 it was missing.** The panel had
+a reason to repaint for every tick work was running and no reason at all on the tick after
+the last record cleared — nothing resized, the version had not moved, no event arrived —
+so the pane kept the last thing drawn into it: a spinner stopped mid-turn over a count of
+work that had already finished, which is exactly what a hung frame looks like. Measured
+against a real client with the tracker directory empty, it held for 15 s and kept holding;
+one sighting survived a detach and reattach and was still claiming `⠸ 1 running` fifteen
+minutes later. It now clears **0.21 s** after the last record goes, on tmux 3.7c and at
+the 3.2 floor alike.
 
 Work charter has stopped believing in — no result after thirty minutes, so the process was
 probably killed — is still reported, and deliberately *not* animated: `⋯ 1 stalled`.
@@ -292,6 +302,30 @@ is restarted, and the chat you left goes on running exactly as it was.
 A switch is refused, with the reason on your own screen, for a chat this workspace does not
 have, one whose window has gone, one charter has no pane record for, and the chat you are
 already in.
+
+### Where a switch says what it did
+
+**On the attention row — the frame's own last row, not tmux's message line.** Whatever you
+choose off `F2`, the outcome appears there for a few seconds and then gives the row back:
+`charter: workspace → gamma`, or `charter: no workspace 'gamm' — have: alpha, beta,
+gamma`. A refusal stays up longer than a success, because a refusal is the only one of the
+two with nothing else confirming it — when a switch takes, the identity row above has
+already changed to say so.
+
+**It used to be a `display-message`, and that cost four seconds of frozen screen** (#729).
+A tmux client does not redraw its *panes* while a message is up, and the freeze is exactly
+as long as the message asks for. So every workspace, persona and chat switch put a sentence
+on screen announcing a repaint that the same sentence was hiding: measured with a real
+client, the panes were correct at 0.5 s and the operator went on looking at the previous
+workspace until 4.3 s — on tmux 3.7c and at the 3.2 floor alike, within 0.1 s of each
+other. The same switch now reaches your eyes in **0.33 s**, with no stale window at all.
+
+The row is also the only surface that can be aimed at *your* frame. `display-message -t`
+selects the target for format evaluation, not the client — measured on both versions, a
+message aimed at a pane of one session was drawn on a terminal attached to a *different*
+one — so on a machine running several frames a refusal about one could be drawn across
+another. A panel reads its own frame's state, and every client attached to that frame sees
+it.
 
 ### The two bars, and why they are off unless you ask
 

--- a/docs/news/unreleased-the-frame-stops-freezing-to-tell-you-it-moved.md
+++ b/docs/news/unreleased-the-frame-stops-freezing-to-tell-you-it-moved.md
@@ -1,0 +1,85 @@
+---
+version: unreleased
+headline: The frame stops freezing for four seconds to tell you it moved, and stops spinning after the work ends
+---
+
+Two defects, one mechanism. Every `F2` switch froze the whole frame for four seconds
+saying what it had just done (#729), and the attention row kept a spinner turning over
+work that had already finished (#727). Both are the frame having entirely correct state
+and failing to put it on screen at the moment it changed.
+
+## A switch no longer costs four seconds of a screen you cannot see
+
+Choosing a workspace, a persona or a chat put its outcome up as a tmux
+`display-message -d 4000`. **A tmux client does not redraw its panes while a message is
+up**, so the sentence announcing the switch was also what hid it. Measured with an outer
+terminal mirroring a real panel, `capture-pane` on both at once:
+
+```
+                                    origin/main      this branch
+the pane had repainted at              0.52 s           0.33 s
+the operator's screen showed it at     4.28 s           0.33 s
+-> stale screen for                    3.76 s           0.00 s
+```
+
+and at the tmux **3.2 floor**, the same rig, the same shape: 3.85 s of stale screen before,
+none after. The freeze tracks `-d` exactly — `-d 200` froze for 0.20 s, `-d 750` for
+0.74 s, `-d 4000` for 4.03 s — so the four seconds bought nothing at all. `docs/frame.md`
+measures a chat switch at about a third of a second; that is what it now takes to see.
+
+**The outcome goes on the attention row instead**, charter's own last row, for a few
+seconds, and then the row goes back to what it was saying. `instance.FRAME_DENSITY` puts
+`bottom` in every level charter ships, so it is the one surface besides the identity row
+that is always there to be written on — and it is the row `docs/frame.md` already promises
+is never dropped, which is exactly the promise an outcome line needs. A refusal gets ten
+seconds where a success gets four: when a switch takes, the identity row above has already
+changed to say so, and a refusal has nothing else confirming it.
+
+## And it can be aimed at your frame, which the message never could
+
+`display-message -t <pane>` does not choose the screen. `-t` is the target for **format
+evaluation**; the client is `-c`, and with no `-c` tmux picks its own current client.
+Measured on tmux 3.7c and at the 3.2 floor, two sessions on one server with a terminal
+attached to each: a message aimed at a pane of session `sa` was drawn on the terminal
+attached to `sb`, and not on `sa`'s at all.
+
+charter had already been bitten by this by hand and read it as a property of an *empty*
+target — `cmd_chat` carries a guard and a comment saying so. It is not: a well-formed `%N`
+naming the right frame's own harness pane leaks identically, because the pane was never
+what selected the screen. On a control plane with several frames on one socket, a refusal
+about one frame was being drawn across another operator's.
+
+A panel reads its own frame's state, so there is no direction for that to leak in — and
+every client attached to the frame sees the row, which is strictly more than the one client
+`-c` could name. The hotkey bind stops carrying `#{client_name}` altogether: it was
+threaded through a tmux bind, a CLI positional and a subprocess relaunch for that one
+consumer. `charter frame-palette` still *accepts* the positional, because a bind installed
+by an older charter is still sitting in a running server's key table across the upgrade.
+
+## The spinner stops when the work does
+
+The attention row kept claiming work was running after the last record cleared, holding
+whichever spinner frame it had last drawn — which is precisely what a hung frame looks
+like. `panel._watch` repainted while something was in flight and had no reason to repaint
+on the tick after the last record went: nothing resized, the version had not moved, no
+event arrived. So the pane kept the last frame drawn into it, and only something unrelated
+bumping the frame ever cleared it.
+
+Reproduced on a real client with the tracker directory empty:
+
+```
+                                 origin/main      this branch
+row stopped claiming it runs     never (15 s+)      0.21 s
+```
+
+on both tmux versions. One sighting during the audit survived a detach and reattach and was
+still reading `⠸ 1 running` fifteen minutes later. The loop now carries the previous
+answer and spends exactly one more paint on the falling edge — and one more only, so
+`docs/frame.md`'s promise that the frame goes completely still is still true.
+
+**The two fixes are one line each because they are the same missing edge.** A notice
+expiring and a spinner stopping are both "what this row would draw now differs from what is
+on it, because the clock moved, and nothing will say so" — which is why the loop's third
+repaint reason is now called `ticking` rather than `animating`, and why the switch outcome
+could move onto that row at all: without the falling edge it would have become a sentence
+that never went away.

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -23,6 +23,7 @@ directory and that `cmd_density` touches no `charter.toml` at all.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import subprocess
@@ -715,14 +716,14 @@ class TheLoopPaintsForTheSpinner(PersonaIso, unittest.TestCase):
     """`panel._tick` gains a third reason to repaint, and it must not gain a fourth by
     accident: an idle panel repainting every tick is the cost this whole design avoids."""
 
-    def test_animating_paints_even_with_no_version_change_and_no_resize(self):
+    def test_ticking_paints_even_with_no_version_change_and_no_resize(self):
         fid = f"an-{_a_dead_pid()}"
         seen = state.version(fid)
         with mock.patch("charter.frame.panel._paint") as paint:
-            panel._tick({"flag": False}, seen, "bottom", fid, animating=True)
+            panel._tick({"flag": False}, seen, "bottom", fid, ticking=True)
         paint.assert_called_once_with("bottom", fid)
 
-    def test_not_animating_is_the_default_and_paints_nothing(self):
+    def test_not_ticking_is_the_default_and_paints_nothing(self):
         fid = f"an-{_a_dead_pid()}"
         seen = state.version(fid)
         with mock.patch("charter.frame.panel._paint") as paint:
@@ -734,7 +735,7 @@ class TheLoopAsksBeforeItAnimates(PersonaIso, unittest.TestCase):
     """`_watch` is what connects `_running` to `_tick`, and nothing else does.
 
     Pinned separately from both because the wiring is its own failure: a loop that never
-    passes `animating` leaves a perfectly correct `_running` and a perfectly correct
+    passes `ticking` leaves a perfectly correct `_running` and a perfectly correct
     `_tick` with a spinner that never turns, and every test of either half stays green.
     """
 
@@ -747,17 +748,200 @@ class TheLoopAsksBeforeItAnimates(PersonaIso, unittest.TestCase):
             panel._watch("bottom", self.fid, once=True)
         return tick.call_args
 
-    def test_a_record_in_flight_reaches_the_tick_as_animating(self):
+    def test_a_record_in_flight_reaches_the_tick_as_ticking(self):
         d = config.STATE_DIR / "dispatch-inflight"
         d.mkdir(parents=True, exist_ok=True)
         (d / "w.1.json").write_text(json.dumps({"agent": "w", "ts": time.time()}))
-        self.assertIs(self._watch_once().kwargs["animating"], True)
+        self.assertIs(self._watch_once().kwargs["ticking"], True)
 
     def test_an_idle_loop_does_not_animate(self):
         """The half that stops the test above from passing against a loop hardcoded to
         animate — which would repaint every panel five times a second, forever, which is
         the one thing this feature may not do."""
-        self.assertIs(self._watch_once().kwargs["animating"], False)
+        self.assertIs(self._watch_once().kwargs["ticking"], False)
+
+
+class TheOutcomeGoesOnTheFramesOwnRow(PersonaIso, unittest.TestCase):
+    """`commands_frame._say_on_screen` — #729.
+
+    It was `display-message -d 4000`. Two independent measurements moved it, either
+    enough on its own:
+
+    * A tmux client suspends its PANE redraw for the whole of a message's duration. With
+      an outer terminal mirroring an inner session, the pane's content changed at 0.02s
+      and the operator's screen did not catch up until **4.03s** on tmux 3.7c and
+      **3.99s** at the 3.2 floor. The freeze tracks `-d` linearly (`-d 200` → 0.20s,
+      `-d 750` → 0.74s), so every switch bought four seconds of frozen screen to announce
+      a repaint it was itself hiding.
+    * `display-message -t <pane>` does not choose the SCREEN — `-t` is the target for
+      FORMAT evaluation and the client is `-c`. Measured on both versions with two
+      sessions on one server and a terminal on each: a message aimed at a pane of session
+      `sa` was drawn on `sb`'s terminal and not on `sa`'s at all.
+
+    So the assertions here are about a file and a version bump, and about tmux being left
+    entirely alone.
+    """
+
+    FID = "say-1"
+
+    def _say(self, message="workspace \u2192 gamma", **kw):
+        calls = []
+        with mock.patch.object(commands_frame.tmuxctl, "run",
+                               side_effect=lambda *a, **k: calls.append(a)):
+            commands_frame._say_on_screen(self.FID, message, **kw)
+        return calls
+
+    def test_the_outcome_lands_on_the_frames_attention_row(self):
+        self._say()
+        self.assertEqual(state.notice(self.FID), "charter: workspace \u2192 gamma")
+
+    def test_no_tmux_command_is_issued_at_all(self):
+        """The whole of the freeze fix. A version that kept the `display-message` beside
+        the notice would satisfy every other assertion here and still cost the operator
+        four seconds of a screen that cannot repaint."""
+        self.assertEqual(self._say(), [],
+                         "a switch outcome still reaches tmux's own message line")
+
+    def test_the_version_moves_so_the_row_repaints_promptly(self):
+        """A panel repaints on a version bump; writing the notice without moving the
+        version would leave it invisible until something unrelated bumped the frame —
+        #727's defect reached from the writing side instead of the expiring side."""
+        before = state.version(self.FID)
+        self._say()
+        self.assertNotEqual(state.version(self.FID), before)
+
+    def test_every_outcome_keeps_the_one_charter_prefix(self):
+        self._say("cannot switch: nope")
+        self.assertTrue(state.notice(self.FID).startswith("charter: "))
+
+    def test_a_refusal_is_given_longer_on_screen_than_a_success(self):
+        """`ok` decides the dwell and nothing else. A refusal is the outcome with no other
+        surface — nothing moved, so no panel repaints into the answer — where a success
+        has the frame itself confirming it a row higher up."""
+        self._say(ok=True)
+        quick = state.notice_expiry(self.FID)
+        self._say(ok=False)
+        self.assertGreater(state.notice_expiry(self.FID), quick)
+
+    def test_a_frame_this_is_not_about_never_sees_it(self):
+        """The targeting half. `-t <a well-formed pane of the right frame>` leaked to
+        whichever client attached most recently just as an empty target did; a row reads
+        its own frame's state, so there is no direction for it to leak in."""
+        self._say()
+        self.assertEqual(state.notice("some-other-frame"), "")
+
+
+class _StopWatching(Exception):
+    """Ends `_watch`'s `while True` from inside `_wait`, so a test can drive an exact
+    number of iterations. `once=True` cannot: it returns after the FIRST tick, and every
+    property below is about what the SECOND one does."""
+
+
+class TheLoopPaintsOnTheFallingEdge(PersonaIso, unittest.TestCase):
+    """#727 — the tick after the last reason to animate goes away.
+
+    Found by driving a real frame, not by a test: with a record in flight the attention
+    row drew `\u280f 1 running`; the record was removed, and the row held the SAME spinner
+    frame for 12s over an empty tracker directory, and once for over fifteen minutes
+    across a detach/reattach. It is what a hung frame looks like.
+
+    The loop had a rising edge and no falling one. While a record existed it repainted
+    every tick; on the tick after the last one cleared, `_running` answered 0, the
+    version had not moved, nothing was resized and no event was handled — so no paint
+    happened at all and the pane kept the last thing drawn into it, which is the frame
+    with the spinner on it. `docs/frame.md` promises "the moment the last of it finishes,
+    the frame goes completely still again", and it did: still showing a spinner and a
+    count of work that had already ended.
+
+    Driven through `_watch` rather than `_tick`, deliberately. `_tick` is a pure decision
+    and would happily be given `ticking=True` by a test on a falling edge no production
+    loop ever produces; the defect was that `_watch` never produced one. So these patch
+    what `_watch` READS (`_running`, `_notice_pending`) and assert on what it PASSES.
+    """
+
+    FID = "fe-1"
+
+    def _ticks(self, answers: list[bool], *, notice=None) -> list[bool]:
+        """Run `_watch` for `len(answers)` iterations, `_running` answering each in
+        turn, and report the `ticking` it passed to `_tick` on each."""
+        seen = []
+        running = iter([1 if a else 0 for a in answers])
+
+        def _tick(resized, s, slot, fid, **kw):
+            seen.append(kw["ticking"])
+            return s
+
+        def _wait(evs, timeout=panel.TICK):
+            if len(seen) >= len(answers):
+                raise _StopWatching
+            return False
+
+        with mock.patch.object(panel, "_tick", side_effect=_tick), \
+             mock.patch.object(panel, "_wait", side_effect=_wait), \
+             mock.patch.object(panel, "_running", side_effect=lambda _c: next(running)), \
+             mock.patch.object(panel, "_notice_pending",
+                               side_effect=notice or (lambda _f: False)):
+            with contextlib.suppress(_StopWatching):
+                panel._watch("bottom", self.FID, once=False)
+        return seen
+
+    def test_the_tick_after_the_last_record_clears_still_paints(self):
+        """The whole of #727. Without the falling edge this is `[True, False]` and the
+        spinner stays on screen with nothing left to take it off."""
+        self.assertEqual(self._ticks([True, False]), [True, True])
+
+    def test_it_paints_exactly_once_more_and_then_goes_still(self):
+        """The other half, and the one that stops the fix from being "repaint forever".
+        `docs/frame.md`'s promise is stillness, so a third tick with nothing running must
+        pass `ticking` False — a loop that latched on the first spinner it ever saw would
+        repaint `bottom` five times a second for the rest of the frame's life."""
+        self.assertEqual(self._ticks([True, False, False]), [True, True, False])
+
+    def test_a_loop_that_never_animated_never_paints_for_the_clock(self):
+        """An idle panel is the cost this whole design avoids, and the falling edge must
+        not become a reason to paint on the first tick of every panel ever started."""
+        self.assertEqual(self._ticks([False, False]), [False, False])
+
+    def test_a_notice_expiring_is_the_same_edge(self):
+        """Why one variable and not two: a switch outcome's dwell ends exactly the way a
+        spinner's does — the clock crosses it, and nothing bumps the version, resizes a
+        pane or delivers an event to say so. A row that kept a stale `charter: workspace
+        \u2192 gamma` would be #727 again through the surface #729 moved onto."""
+        pending = iter([True, False, False])
+        self.assertEqual(self._ticks([False, False, False],
+                                     notice=lambda _f: next(pending)),
+                         [True, True, False])
+
+    def test_a_slot_that_does_not_animate_asks_neither_question(self):
+        """`animates and (...)` short-circuits, and that is the promise a `top`, `left` or
+        `right` panel is owed: no `stat` of the tracker AND no read of the notice file,
+        because it draws neither. Asserted by making both answers explode."""
+        def _boom(*_a, **_k):
+            raise AssertionError("a non-animated slot asked a clock question")
+
+        def _tick(resized, s, slot, fid, **kw):
+            raise _StopWatching
+
+        with mock.patch.object(panel, "_tick", side_effect=_tick), \
+             mock.patch.object(panel, "_running", side_effect=_boom), \
+             mock.patch.object(panel, "_notice_pending", side_effect=_boom):
+            with contextlib.suppress(_StopWatching):
+                panel._watch("top", self.FID, once=False)
+
+
+class TheNoticeIsPendingUntilItExpires(PersonaIso, unittest.TestCase):
+    """`panel._notice_pending` — the second clock-driven reason to repaint."""
+
+    def test_a_live_notice_is_pending(self):
+        state.say("np-1", "charter: hello", seconds=30)
+        self.assertIs(panel._notice_pending("np-1"), True)
+
+    def test_an_expired_notice_is_not(self):
+        state.say("np-1", "charter: hello", seconds=-1)
+        self.assertIs(panel._notice_pending("np-1"), False)
+
+    def test_a_frame_that_never_said_anything_is_not(self):
+        self.assertIs(panel._notice_pending("np-never"), False)
 
 
 class PanesAreRememberedForTheFrame(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -817,11 +817,18 @@ class TheOutcomeGoesOnTheFramesOwnRow(PersonaIso, unittest.TestCase):
     def test_a_refusal_is_given_longer_on_screen_than_a_success(self):
         """`ok` decides the dwell and nothing else. A refusal is the outcome with no other
         surface — nothing moved, so no panel repaints into the answer — where a success
-        has the frame itself confirming it a row higher up."""
-        self._say(ok=True)
-        quick = state.notice_expiry(self.FID)
-        self._say(ok=False)
-        self.assertGreater(state.notice_expiry(self.FID), quick)
+        has the frame itself confirming it a row higher up.
+
+        **Asserted as two DURATIONS, not as one expiry being later than the other.** The
+        obvious spelling — say a success, read the expiry, say a refusal, assert the
+        second is greater — is satisfied by the clock advancing between the two calls, so
+        it passes against a version that hands both the same dwell. The sweep found it
+        exactly that way, as a `collapse-ifexp` survivor on both branches at once."""
+        for ok, want in ((True, state.NOTICE_SECONDS), (False, state.REFUSAL_SECONDS)):
+            with self.subTest(ok=ok):
+                self._say(ok=ok)
+                left = state.notice_expiry(self.FID) - time.time()
+                self.assertAlmostEqual(left, want, delta=1.0)
 
     def test_a_frame_this_is_not_about_never_sees_it(self):
         """The targeting half. `-t <a well-formed pane of the right frame>` leaked to
@@ -942,6 +949,20 @@ class TheNoticeIsPendingUntilItExpires(PersonaIso, unittest.TestCase):
 
     def test_a_frame_that_never_said_anything_is_not(self):
         self.assertIs(panel._notice_pending("np-never"), False)
+
+    def test_it_stops_being_pending_AT_the_expiry_and_not_a_moment_after(self):
+        """The boundary rather than the direction, and it matters here for a reason it
+        does not in `state.notice`: this is what decides the tick on which `_watch` spends
+        its falling-edge repaint. A `<=` would put that repaint one tick later than the
+        row stopped drawing the notice, so for one tick the pane would hold a line
+        `slots._bottom` had already dropped — the stale frame this whole cluster is
+        about, one tick wide."""
+        state.say("np-1", "charter: on the edge", seconds=30)
+        at = state.notice_expiry("np-1")
+        with mock.patch("time.time", return_value=at - 0.001):
+            self.assertIs(panel._notice_pending("np-1"), True)
+        with mock.patch("time.time", return_value=at):
+            self.assertIs(panel._notice_pending("np-1"), False)
 
 
 class PanesAreRememberedForTheFrame(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -333,9 +333,19 @@ class Conf(unittest.TestCase):
         text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
                                         session="x")
         self.assertIn('bind -n F2 run-shell \'"$CHARTER_PY" -m charter '
-                      'frame-palette "#{client_name}" --chat "#{@charter_chat}"\'',
+                      'frame-palette --chat "#{@charter_chat}"\'',
                       text)
         self.assertNotIn("frame palette", text)
+
+    def test_the_hotkey_bind_no_longer_carries_a_client_name(self):
+        """#729. `#{client_name}` was in this bind for exactly one consumer,
+        `display-message -c`, and an outcome is now drawn on the frame's own attention row
+        by a panel every attached client can see. A format still expanded into the bind
+        would be a value threaded through a tmux bind, a CLI positional and a subprocess
+        relaunch to be ignored at the end of it."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                        session="x")
+        self.assertNotIn("client_name", text)
 
     def test_the_menu_is_gone_rather_than_left_beside_the_palette(self):
         """§4h, and the plan's own exit criterion: two answers to "how do I do a thing" is
@@ -4653,9 +4663,11 @@ class MainDeliversFrameRest(unittest.TestCase):
 class PaletteCommands(PersonaIso, unittest.TestCase):
     """`cmd_palette` — the handler `charter frame-palette` dispatches to, in both halves.
 
-    Its `args.client` is `#{client_name}`, expanded by tmux INSIDE the bind's own text
-    before this process ever starts (see `conf_text`'s docstring) — never queried here, so
-    these tests supply it directly. `fid` is resolved purely from `$CHARTER_SESSION_ID`;
+    Its `args.client` is accepted and ignored (#729) — a pre-#729 bind still in a running
+    server's key table fires this command with a `#{client_name}` in it, so the parser must
+    keep taking one; nothing reads it. These tests still supply it, which is what pins that
+    such a bind is parsed rather than refused. `fid` is resolved purely from
+    `$CHARTER_SESSION_ID`;
     neither half ever takes a frame id as an argument, because one bind is shared by every
     frame on `SOCKET`.
     """
@@ -4697,11 +4709,15 @@ class PaletteCommands(PersonaIso, unittest.TestCase):
         self.assertEqual(verbs, ["split-window", "set-option", "select-pane",
                                  "resize-pane"], calls)
 
-    def test_the_pane_runs_charters_own_palette_and_is_told_which_client_pressed(self):
+    def test_the_pane_runs_charters_own_palette_and_carries_no_client(self):
+        """The client name stopped being threaded to the palette's pane with #729: its one
+        consumer was `display-message -c`, and the outcome moved to the frame's own row.
+        `/dev/ttys7` is what this opener was handed, so asserting its ABSENCE is what pins
+        that the value is dropped here rather than merely unused two hops later."""
         self._frame()
         split = self._open()[0]
         self.assertIn("--pane", split)
-        self.assertIn("/dev/ttys7", split)
+        self.assertNotIn("/dev/ttys7", split)
         self.assertIn("frame-palette", split)
         self.assertEqual(split[split.index("--") + 1], sys.executable,
                          "the pane must run charter through this interpreter, never a "

--- a/tests/test_frame_palette.py
+++ b/tests/test_frame_palette.py
@@ -637,12 +637,17 @@ class ThePaletteCommand(PersonaIso, unittest.TestCase):
     def test_a_refusal_at_the_moment_of_the_keypress_is_said_on_the_operators_screen(self):
         """`invoke` re-asks availability, so a row drawn while a plane was one way and
         pressed while it is another is refused — and that sentence has nowhere else to go,
-        because the pane it would have been drawn in is the one about to be killed."""
+        because the pane it would have been drawn in is the one about to be killed.
+
+        It is said on the frame, not at a client: since #729 the outcome is a line in this
+        frame's own state that its attention panel draws, so there is no third argument
+        naming a terminal and no way for the sentence to land on a frame it is not about.
+        The refusal itself is unchanged, which is what this asserts."""
         state.record_harness_pane(self.FID, "not-a-pane-id")
         self.assertEqual(self._draw(overlay.Row(id="density.full", title="d")), 0)
         self.said.assert_called_once()
         self.assertIn("no record of this frame's harness pane", self.said.call_args[0][1])
-        self.assertEqual(self.said.call_args[0][2], "/dev/ttys7")
+        self.assertEqual(self.said.call_args[0][0], self.FID)
 
     def test_the_pane_is_not_killed_before_the_action_has_started(self):
         """§4g says `run` starts work and returns; `kill-pane` hands SIGHUP to this pane's
@@ -681,8 +686,22 @@ class ThePaletteCommand(PersonaIso, unittest.TestCase):
 
 
 class WhatReachesTheOperatorsScreen(PersonaIso, unittest.TestCase):
-    """`_say_on_screen` — the one line charter puts on a status area, and the parser it
-    has to survive on the way."""
+    """`_say_on_screen` — the one line charter puts on the operator's screen.
+
+    **It no longer goes through tmux at all** (#729), and every property below changed
+    with it. What it was: `display-message -d 4000`, whose argument is a tmux FORMAT and
+    whose `-c`/`-t` decided which terminal saw it. What it is: a line in the frame's own
+    state, drawn by that frame's attention panel into a pane charter owns.
+
+    So the escaping question is answered by removal rather than by `tmuxctl.inert_format`
+    — there is no tmux parser left in the path — and the "which client" question is
+    answered by the surface, since every client attached to a frame sees its panes.
+
+    The dwell and the row itself are pinned in
+    `tests/test_frame_density.py::TheOutcomeGoesOnTheFramesOwnRow` and
+    `tests/test_frame_slots.py::BottomRenderer`; this class keeps the two properties that
+    are about what does NOT happen any more.
+    """
 
     FID = "f-say"
 
@@ -690,58 +709,40 @@ class WhatReachesTheOperatorsScreen(PersonaIso, unittest.TestCase):
         super().setUp()
         state.frame_dir(self.FID, create=True)
         state.record_server(self.FID, "charter")
-        # A frame HAS one, and since #695 it is what a message without a client is aimed
-        # at — the record charter already keeps of where this frame's harness runs, whose
-        # `%N` tmux cannot read as anything but a pane.
         state.record_harness_pane(self.FID, "%4")
 
-    def test_what_is_put_on_screen_is_inert_before_tmux_ever_parses_it(self):
-        """`display-message`'s argument is a tmux FORMAT (its own docs say so), and what
-        goes into it here is a workspace name or a provider's own refusal. The escaping is
-        `tmuxctl.inert_format`'s and is asked for rather than re-spelled — a second copy is
-        a second answer to "what may reach tmux's parser"."""
+    def test_a_hostile_message_reaches_no_tmux_parser_because_it_reaches_no_tmux(self):
+        """`#(...)` in an unexpanded tmux format EXECUTES the moment tmux draws it — found
+        for real through charter's production path with a git branch named
+        `#(id>/tmp/...)`, where the job ran and the branch never appeared on screen. The
+        old fix was to double every `#`. The fix now is that nothing charter says on a
+        switch is handed to tmux at all, which is the stronger of the two: a doubling can
+        be forgotten at a new call site, and an argv that is never built cannot be.
+        """
         with mock.patch.object(commands_frame.tmuxctl, "run") as run:
             commands_frame._say_on_screen(self.FID, "x #(touch /tmp/pwned) y")
-        argv = run.call_args[0][1]
-        self.assertNotIn("x #(touch /tmp/pwned) y", argv)
-        self.assertIn("charter: x ##(touch /tmp/pwned) y", argv)
+        self.assertEqual(run.call_count, 0, run.call_args)
 
-    def test_a_named_client_is_told_and_an_unnamed_one_is_the_frames_own_pane(self):
-        """Measured against tmux 3.7c with two real ptys on one session: `-t <session>`
-        drew on the most recently attached client regardless of who pressed, and `-c` drew
-        on exactly the named one. The palette carries the presser's own client from the
-        hotkey bind, so a refusal reaches the terminal that asked for it.
+    def test_the_hash_is_kept_literal_rather_than_doubled(self):
+        """The other half, and the reason the old escaping cannot simply be left in place
+        "for safety": the row is charter's own pane, so a `##` would now be two visible
+        characters where the operator typed one. Escaping for a parser that is no longer
+        in the path is not free — it is a wrong answer drawn on screen."""
+        commands_frame._say_on_screen(self.FID, "branch #(x) here")
+        self.assertEqual(state.notice(self.FID), "charter: branch #(x) here")
 
-        With no client the target is the frame's own PANE and never its id (#695). A chat
-        id is `{workspace}.{ordinal}` and tmux splits a `-t` on the dot, so
-        `-t harness-wrapper.2` is not the window of that name: measured on 3.7c it resolves
-        to session `harness-wrapper`, its CURRENT window, and `2` as a pane index. The
-        session half happened to be the right screen, which is why nothing was ever seen to
-        go wrong — the target has never once meant what it was spelled to mean."""
-        with mock.patch.object(commands_frame.tmuxctl, "run") as run:
-            commands_frame._say_on_screen(self.FID, "hello", "/dev/ttys7")
-        self.assertIn("-c", run.call_args[0][1])
-        self.assertIn("/dev/ttys7", run.call_args[0][1])
-        with mock.patch.object(commands_frame.tmuxctl, "run") as run:
-            commands_frame._say_on_screen(self.FID, "hello")
-        argv = run.call_args[0][1]
-        self.assertNotIn("-c", argv)
-        self.assertEqual(argv[argv.index("-t") + 1], "%4")
-        self.assertNotIn(self.FID, argv,
-                         "a frame id reached tmux as a target, where the dot in it is a "
-                         "separator and not a character")
-
-    def test_a_frame_with_no_usable_pane_record_is_told_nothing_at_all(self):
-        """The direction the refusal falls, and it is the same one an empty id already
-        falls: there is nothing here that can be aimed at that is CERTAINLY this frame, and
-        `-t <fid>` is how a refusal came to be drawn across somebody else's. An operator
-        loses a sentence; the alternative is another operator gaining one."""
+    def test_a_frame_with_no_pane_record_is_still_told(self):
+        """**This is the case that got better, not merely different.** The old path had
+        nothing it could safely aim a `display-message` at without a harness pane on
+        record, so it stayed silent and the operator lost the sentence — and it stayed
+        silent because `-t <fid>` was how a refusal came to be drawn across somebody
+        else's frame. A row needs no pane id: it is read by whichever panel is drawing
+        that frame, so there is no target to get wrong and no reason to withhold."""
         for record in ("", "not-a-pane", "%1;kill-server"):
             with self.subTest(record=record):
                 state.record_harness_pane(self.FID, record)
-                with mock.patch.object(commands_frame.tmuxctl, "run") as run:
-                    commands_frame._say_on_screen(self.FID, "hello")
-                self.assertEqual(run.call_count, 0, run.call_args)
+                commands_frame._say_on_screen(self.FID, "hello")
+                self.assertEqual(state.notice(self.FID), "charter: hello")
 
 
 if __name__ == "__main__":                          # pragma: no cover

--- a/tests/test_frame_palette_integration.py
+++ b/tests/test_frame_palette_integration.py
@@ -430,11 +430,16 @@ class ATmuxFormatInAMessageIsInert(_ThePalette, unittest.TestCase):
     """The CRITICAL finding, carried onto the surface that still has it.
 
     `display-menu`'s item names were formats, and so is a `display-message` argument —
-    tmux's own docs say so — and that is where `commands_frame._say_on_screen` still puts a
-    workspace name, a persona name and an action's refusal. `tests/test_frame_menu.py::
-    LabelSafety` proved the ESCAPING at argv level and moved whole to
-    `test_frame_tmuxctl.py::InertFormat`; this proves the escaping is still NECESSARY,
-    which is the half a unit test cannot show.
+    tmux's own docs say so. charter no longer puts a switch outcome through either
+    (#729: it goes to the frame's own attention row, where no tmux parser is in the path),
+    so what this class proves is no longer "the escaping charter applies is necessary" but
+    the fact underneath it: **an unescaped `#` in a tmux message argument really is read by
+    tmux's parser rather than drawn.** That is what makes `inert_format` the right thing
+    for the next surface that hands tmux a string built from a name, and what makes the
+    narrower per-value guards charter uses elsewhere load-bearing rather than decorative.
+    `tests/test_frame_menu.py::LabelSafety` proved the ESCAPING at argv level and moved
+    whole to `test_frame_tmuxctl.py::InertFormat`; this is the half a unit test cannot
+    show, and it is asserted against tmux rather than against charter.
 
     **`#{...}`, not `#(...)`, and that is a measurement rather than a preference.** On tmux
     3.7c a `#(shell command)` in a `display-message` substitutes to EMPTY and the job was

--- a/tests/test_frame_palette_names.py
+++ b/tests/test_frame_palette_names.py
@@ -569,5 +569,60 @@ class AHostileNameFoundByTypingIsOneRowAndRunsNothing(_Frame, unittest.TestCase)
         self.assertNotIn("\n", "".join(surface.render(*self.SIZE)))
 
 
+class TheOutcomeIsWrittenToTheFrameTheOperatorEndsUpOn(_Frame, unittest.TestCase):
+    """#729's one asymmetry. The outcome is drawn by a panel out of a FRAME's own state,
+    so it has to be written to the frame the operator will be looking at a moment from
+    now — which is not always the frame the switch was computed for.
+
+    A workspace or persona switch moves the frame in place, so that is this one. A chat
+    switch does not move anything: it moves the tmux CLIENT to a sibling frame
+    (`choose.py` — "the frame IS the chat"), and a chat's name IS its frame id. Written to
+    the wrong one, a chat switch's outcome would be filed on the frame the operator just
+    left and never read by anybody, which is exactly the class of silent refusal #517 and
+    #684 exist to prevent — reached, this time, through the fix for #729.
+
+    `display-message` had no equivalent of this bug and no equivalent of the property
+    either: it drew on a CLIENT, which follows the operator by construction, and could not
+    be aimed at a frame at all (see `state.say` for the measurement).
+    """
+
+    def _picked(self, noun, name, *, ok=True, message="did the thing"):
+        """Drive `cmd_palette` to the outcome for *noun*/*name* without needing a real
+        roster of that noun on disk: what is under test is which FID the outcome is filed
+        against, and the row that produced it is `tests/test_frame_pickers`' subject."""
+        row = SimpleNamespace(id=f"row-{noun}", note="", title=name)
+        self.enterContext(mock.patch.object(
+            palette, "own_the_tty", lambda surface, **kw: row))
+        self.enterContext(mock.patch.object(
+            commands_frame, "_chosen_name", return_value=(noun, name)))
+        self.enterContext(mock.patch.object(
+            choose, "switch_to", return_value=switch.Outcome(ok, message)))
+        self.enterContext(mock.patch.object(commands_frame, "_start_chat_switch"))
+        self.assertEqual(
+            commands_frame.cmd_palette(SimpleNamespace(client="", pane=True)), 0)
+        return self.said.call_args
+
+    def test_a_workspace_switch_is_filed_on_this_frame(self):
+        self.assertEqual(self._picked(choose.WORKSPACE, "gamma")[0][0], self.FID)
+
+    def test_a_chat_switch_that_took_is_filed_on_the_chat_being_switched_TO(self):
+        """The client ends up in front of `api.2`'s panels, so `api.2`'s row is the one
+        that has to carry the sentence."""
+        self.assertEqual(self._picked(choose.CHAT, "api.2")[0][0], "api.2")
+
+    def test_a_chat_switch_that_was_REFUSED_stays_on_this_frame(self):
+        """Nothing moved, so the operator is still looking at this frame — and the target
+        chat may be precisely the thing that does not exist."""
+        self.assertEqual(
+            self._picked(choose.CHAT, "api.9", ok=False,
+                         message="cannot switch: no such chat")[0][0], self.FID)
+
+    def test_the_outcome_carries_whether_it_happened(self):
+        """`ok` is what picks the dwell, and a caller that dropped it would give every
+        refusal a success's shorter one — silently, since both still say something."""
+        self.assertIs(self._picked(choose.WORKSPACE, "gamma", ok=True)[1]["ok"], True)
+        self.assertIs(self._picked(choose.WORKSPACE, "zzz", ok=False)[1]["ok"], False)
+
+
 if __name__ == "__main__":                          # pragma: no cover
     unittest.main()

--- a/tests/test_frame_pickers.py
+++ b/tests/test_frame_pickers.py
@@ -318,7 +318,12 @@ class ThePaletteOpensThePickerAndActsOnWhatComesBack(_Frame, unittest.TestCase):
         self.assertNotEqual(state.version(self.FID), was)
         self.said.assert_called_once()
         self.assertIn("workspace → beta", self.said.call_args[0][1])
-        self.assertEqual(self.said.call_args[0][2], "/dev/ttys7")
+        # On THIS frame, and said as an outcome that happened. Since #729 the sentence is
+        # a line in the frame's own state that its attention panel draws, so the argument
+        # after the message names the frame rather than a client's terminal — a workspace
+        # switch moves this frame in place, so the frame it is filed against is this one.
+        self.assertEqual(self.said.call_args[0][0], self.FID)
+        self.assertIs(self.said.call_args[1]["ok"], True)
 
     def test_a_persona_name_takes_the_same_route(self):
         self.assertEqual(self._draw(self._doorway(choose.PERSONA),

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -775,6 +775,61 @@ class BottomRenderer(PersonaIso, unittest.TestCase):
             out = tui.strip_ansi(slots.render("bottom", "f-1"))
         self.assertEqual(out, "5 todos · F2 palette")
 
+    def test_a_switch_outcome_is_drawn_on_this_row(self):
+        """#729. The outcome of an F2 choice was a `display-message`, which suspends the
+        client's pane redraw for its whole duration — measured at 4.03s of frozen screen
+        on tmux 3.7c and 3.99s at the 3.2 floor, spent hiding the repaint it announced.
+        It is a field of this row instead."""
+        state.say("f-1", "charter: workspace \u2192 gamma")
+        self.assertIn("charter: workspace \u2192 gamma",
+                      tui.strip_ansi(slots.render("bottom", "f-1")))
+
+    def test_an_expired_outcome_leaves_the_row_as_it_was(self):
+        """The dwell is the whole reason this may sit at the top of the priority order:
+        it gives the row back. Without an expiry it would sit on top of an `_alerts()`
+        entry — an actionable problem carrying its own fix — for the rest of the frame's
+        life, which is #727's defect wearing #729's clothes."""
+        with mock.patch("charter.statusline._alerts", return_value=[]), \
+             mock.patch("charter.statusline._session_news", return_value=[]), \
+             mock.patch("charter.statusline._todo_count", return_value=5), \
+             mock.patch.dict(config.FRAME, {"hotkey": "F2"}):
+            state.say("f-1", "charter: long gone", seconds=-1)
+            out = tui.strip_ansi(slots.render("bottom", "f-1"))
+        self.assertEqual(out, "5 todos \u00b7 F2 palette")
+
+    def test_the_outcome_outranks_every_other_field_on_a_starved_pane(self):
+        """It is the direct answer to the last thing the operator DID, and it is the only
+        field here that is about an instant rather than a state — a row too narrow to say
+        both should say the one that will not be true in a moment. `terse` asks the same
+        question through `limit=1` and gets the same answer."""
+        state.say("f-1", "charter: NOTICED")
+        with mock.patch("charter.statusline._alerts", return_value=["AAAAA"]), \
+             mock.patch("charter.statusline._session_news", return_value=["NNNNN"]), \
+             mock.patch("charter.statusline._todo_count", return_value=3), \
+             mock.patch("os.get_terminal_size", return_value=os.terminal_size((20, 3))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = tui.strip_ansi(slots.render("bottom", "f-1"))
+        self.assertIn("NOTICED", out, "the outcome lost its columns to a lower field")
+        self.assertNotIn("AAAAA", out)
+
+    def test_a_frame_with_nothing_to_say_draws_the_row_it_always_drew(self):
+        """An empty field is dropped whole, so the notice must cost nothing at all on the
+        overwhelming majority of repaints, when no switch has just happened."""
+        with mock.patch("charter.statusline._alerts", return_value=[]), \
+             mock.patch("charter.statusline._session_news", return_value=[]), \
+             mock.patch("charter.statusline._todo_count", return_value=5), \
+             mock.patch.dict(config.FRAME, {"hotkey": "F2"}):
+            out = tui.strip_ansi(slots.render("bottom", "f-1"))
+        self.assertEqual(out, "5 todos \u00b7 F2 palette")
+
+    def test_the_outcome_belongs_to_ITS_frame_and_no_other(self):
+        """The half `display-message` could not do at all. `-t <pane>` picks the FORMAT
+        target, not the client: measured on tmux 3.7c and 3.2 alike, a message aimed at a
+        pane of session `sa` was drawn on the terminal attached to `sb`. A row reads its
+        own frame's state, so a second frame cannot see the first one's outcome."""
+        state.say("f-1", "charter: FOR-F1-ONLY")
+        self.assertNotIn("FOR-F1-ONLY", tui.strip_ansi(slots.render("bottom", "f-2")))
+
     def test_the_todo_count_still_shows_at_zero_unlike_the_new_news_field(self):
         """`todo` predates Task 4 and keeps its own, different presence rule: `_bottom`
         showed `0 todo` even at zero before this task touched the function, unlike

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -1298,6 +1298,36 @@ class ANotice(PersonaIso, unittest.TestCase):
         self.assertEqual(state.notice_expiry("f-1"), 0.0)
         self.assertFalse((state.frame_dir("f-1") / "notice").exists())
 
+    def test_what_is_written_is_already_trimmed(self):
+        """Asserted on the FILE, and it has to be: `notice()` strips on the way out too,
+        so a writer that only `lstrip`ped would be invisible through the reader — which is
+        exactly how the sweep found this line unpinned. The property is that what charter
+        stores is already clean, because the row joins fields with ` · ` and a trailing
+        space would draw as `charter: gamma  · 5 todos`."""
+        state.say("f-1", "charter: gamma   ")
+        raw = (state.frame_dir("f-1") / "notice").read_text()
+        self.assertEqual(raw.split("\n")[1], "charter: gamma")
+
+    def test_a_notice_is_gone_AT_its_expiry_and_not_a_moment_after(self):
+        """The boundary, not just the direction. `<=` here would keep a notice for one
+        more instant than it was given, which no operator could see — but the sweep is
+        right that an unpinned boundary is an unpinned line, and the dwell is a half-open
+        interval on purpose: `say(seconds=n)` means n seconds of it, not n plus a tick."""
+        state.say("f-1", "charter: on the edge", seconds=30)
+        at = state.notice_expiry("f-1")
+        with mock.patch("time.time", return_value=at - 0.001):
+            self.assertEqual(state.notice("f-1"), "charter: on the edge")
+        with mock.patch("time.time", return_value=at):
+            self.assertEqual(state.notice("f-1"), "")
+
+    def test_a_hostile_fid_has_no_expiry_either(self):
+        """`notice`'s containment guard has a twin in `notice_expiry`, and it is a
+        separate line that needs a separate reason to exist: `frame_dir` answers `None`
+        for a name `contain.child` refuses, and `None / "notice"` is a `TypeError` that
+        the `(OSError, ValueError)` below would not catch — out of `panel._watch`'s run
+        loop, which is the one place in this module that must never raise."""
+        self.assertEqual(state.notice_expiry("../escape"), 0.0)
+
     def test_a_notice_whose_expiry_is_nan_is_not_live_forever(self):
         """`float("nan")` parses, and every comparison against a NaN is False — so a
         `now >= expiry` test reads False and the notice never expires. That is exactly the

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import time
 import unittest
 from unittest import mock
 
@@ -1204,6 +1205,117 @@ class ThePinOutranksTheFramesOwnRungs(PersonaIso, unittest.TestCase):
         self._pin("   ")
         state.record_workspace("f-1", "recorded-at-launch")
         self.assertEqual(state.workspace_for("f-1"), "recorded-at-launch")
+
+
+class ANotice(PersonaIso, unittest.TestCase):
+    """`state.say` / `state.notice` / `state.notice_expiry` — the surface a switch
+    outcome moved onto with #729.
+
+    What it replaced was `display-message -d 4000`, and the two measurements that moved
+    it are recorded on `state.say` itself: a tmux client suspends its PANE redraw for the
+    whole of a message's duration (4.03s of frozen screen on tmux 3.7c and at the 3.2
+    floor alike), and `display-message -t <pane>` selects the format target rather than
+    the client, so an outcome about one frame was drawn on whichever client attached most
+    recently. Neither is reachable from a file a frame's own panel reads.
+    """
+
+    def test_a_notice_is_read_back(self):
+        state.say("f-1", "charter: workspace \u2192 gamma")
+        self.assertEqual(state.notice("f-1"), "charter: workspace \u2192 gamma")
+
+    def test_a_frame_with_no_notice_has_nothing_to_say(self):
+        self.assertEqual(state.notice("f-1"), "")
+
+    def test_reading_a_notice_creates_nothing_on_disk(self):
+        """`version`'s rule, for the same reason and the same caller: a panel polls this
+        five times a second, and a read that created a directory would fight `reap`."""
+        self.assertEqual(state.notice("never-noticed"), "")
+        self.assertFalse(state.frame_dir("never-noticed").exists())
+
+    def test_a_notice_stops_being_read_back_once_it_expires(self):
+        """The property the whole dwell rests on. Written with a duration already spent,
+        so this pins the EXPIRY rather than sleeping through one."""
+        state.say("f-1", "charter: gone by now", seconds=-1)
+        self.assertEqual(state.notice("f-1"), "")
+
+    def test_the_expiry_is_when_it_stops_being_drawn(self):
+        """`panel._watch` needs the deadline and not the text: the falling edge it has to
+        repaint on is a clock crossing this number, and nothing else announces it."""
+        before = time.time()
+        state.say("f-1", "charter: still here", seconds=30)
+        self.assertGreaterEqual(state.notice_expiry("f-1"), before + 30)
+
+    def test_an_absent_notices_expiry_is_already_past(self):
+        """`0.0` rather than `None`, so `time.time() < expiry` is the whole of the
+        caller's question and there is no branch for "no notice" to get wrong."""
+        self.assertEqual(state.notice_expiry("f-1"), 0.0)
+
+    def test_a_newline_cannot_write_a_second_line_of_the_file(self):
+        """The notice is stored as an expiry line and then the text, so a newline in the
+        message is a value crossing into a format with structure — `contain.one_line`'s
+        own case. Without it the text after the newline is silently dropped on read, and
+        with a leading newline the message would vanish entirely."""
+        state.say("f-1", "charter: first\nsecond")
+        said = state.notice("f-1")
+        self.assertNotIn("\n", said)
+        self.assertIn("second", said)
+
+    def test_a_corrupt_expiry_degrades_to_silence_rather_than_raising(self):
+        """`slots._bottom` draws the one row `docs/frame.md` promises is never dropped,
+        so a notice file it cannot parse must cost the line and never the row."""
+        d = state.frame_dir("f-1", create=True)
+        (d / "notice").write_text("not-a-number\ncharter: hello\n")
+        self.assertEqual(state.notice("f-1"), "")
+        self.assertEqual(state.notice_expiry("f-1"), 0.0)
+
+    def test_a_non_utf8_notice_degrades_to_silence(self):
+        d = state.frame_dir("f-1", create=True)
+        (d / "notice").write_bytes(b"\xff\xfe\x80")
+        self.assertEqual(state.notice("f-1"), "")
+        self.assertEqual(state.notice_expiry("f-1"), 0.0)
+
+    def test_a_hostile_fid_writes_nothing_and_says_nothing(self):
+        """`frame_dir`'s containment, reached through the new writer. `say` takes an id
+        that came off `$CHARTER_SESSION_ID` exactly as `bump` does."""
+        state.say("../escape", "charter: nope")
+        self.assertEqual(state.notice("../escape"), "")
+
+    def test_a_refusal_is_given_longer_than_an_outcome_that_happened(self):
+        """The one thing `ok` decides. A refusal is the outcome with no other surface —
+        nothing moved, so no panel repaints into the answer — and it carries the fix in
+        its own text."""
+        self.assertGreater(state.REFUSAL_SECONDS, state.NOTICE_SECONDS)
+
+    def test_an_empty_message_writes_no_notice(self):
+        """Otherwise a blank line would take the row's top priority away from an alert
+        for the whole dwell, saying nothing while it did — and keep `panel._watch`
+        repainting five times a second to keep saying it.
+
+        Asserted on the FILE, not on `notice()`: the reader strips too, so a version that
+        wrote the blank notice and hid it on the way out would satisfy a `notice() == ""`
+        check while still holding the dwell open for `notice_expiry`."""
+        state.say("f-1", "   ")
+        self.assertEqual(state.notice_expiry("f-1"), 0.0)
+        self.assertFalse((state.frame_dir("f-1") / "notice").exists())
+
+    def test_a_notice_whose_expiry_is_nan_is_not_live_forever(self):
+        """`float("nan")` parses, and every comparison against a NaN is False — so a
+        `now >= expiry` test reads False and the notice never expires. That is exactly the
+        stuck row #727 is about, reachable through a corrupt file rather than a loop, so
+        the comparison asks for the LIVE case and NaN falls out with every other
+        degenerate value."""
+        d = state.frame_dir("f-1", create=True)
+        (d / "notice").write_text("nan\ncharter: forever\n")
+        self.assertEqual(state.notice("f-1"), "")
+
+    def test_a_notice_whose_expiry_is_infinite_is_still_bounded_by_nothing_but_reap(self):
+        """The companion value: `inf` also parses, and unlike NaN it compares the way it
+        reads. Pinned so the NaN guard above is understood as being about NaN rather than
+        about "unusual floats" — an `inf` here is a notice that genuinely never expires,
+        which nothing in charter writes and `reap` still removes."""
+        d = state.frame_dir("f-1", create=True)
+        (d / "notice").write_text("inf\ncharter: forever\n")
+        self.assertEqual(state.notice("f-1"), "charter: forever")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #729. Closes #727.

Two defects, one missing repaint edge. Both are the frame having entirely correct state and
failing to put it on screen at the moment it changed, so they share a fix rather than
merely a theme.

## #729 — a switch no longer costs four seconds of a screen you cannot see

Every workspace, persona and chat switch put its outcome up as `display-message -d 4000`.
**A tmux client does not redraw its panes while a message is up**, so the sentence
announcing the switch was also what hid it.

Measured with an outer terminal mirroring a real panel, `capture-pane` on both at the same
instant — the auditor's own method:

|                                   | origin/main | this branch |
|-----------------------------------|-------------|-------------|
| the pane had repainted at         | 0.52 s      | 0.33 s      |
| the operator's screen showed it at| 4.28 s      | 0.33 s      |
| **stale screen for**              | **3.76 s**  | **0.00 s**  |

At the tmux **3.2 floor**, same rig: **3.85 s** before, **0.00 s** after. The freeze tracks
`-d` linearly — `-d 200` froze for 0.20 s, `-d 750` for 0.74 s, `-d 4000` for 4.03 s — so
the four seconds bought nothing at all.

**Where the confirmation goes instead: the attention row.** `instance.FRAME_DENSITY` puts
`bottom` in every level charter ships (`minimal`, `normal`, `full`), so it is the one
surface besides the identity row that is always there — and it is the row `docs/frame.md`
already promises is never dropped, which is exactly the promise an outcome line needs. It
is a new highest-priority field on that row with a dwell: 4 s for a success (the frame
itself is the confirmation — the identity row already reads the new workspace), 10 s for a
refusal (nothing moved, so no panel repaints into the answer, and the text carries the
fix). "Just delete the message" was not the answer; #517 and #684 are still right that a
silent refusal is worse than a slow one.

### A second, independent reason, which the issue does not name

**`display-message -t <pane>` does not choose the screen.** `-t` is the target for FORMAT
evaluation; the client is `-c`, and with no `-c` tmux picks its own current client.
Measured on tmux 3.7c and at the 3.2 floor, two sessions on one server with a terminal
attached to each: a message aimed at a pane of session `sa` was drawn on the terminal
attached to `sb`, and not on `sa`'s at all.

charter had already been bitten by this by hand and read it as a property of an *empty*
target — `cmd_chat` carries a guard and a comment saying so. It is not. A well-formed `%N`
naming the right frame's own harness pane leaks identically, because the pane was never
what selected the screen. On a control plane with eleven frames on one socket, that is a
refusal about one frame drawn across another operator's.

A panel reads its own frame's state, so there is no direction for that to leak in — and
every client attached to the frame sees the row, which is strictly more than the one client
`-c` could name. Consequently the hotkey bind stops carrying `#{client_name}`: it was
threaded through a tmux bind, a CLI positional and a subprocess relaunch for that one
consumer. `charter frame-palette` still *accepts* the positional, because a bind installed
by an older charter is still sitting in a running server's key table across the upgrade.

## #727 — the spinner stops when the work does

`panel._watch` repainted while work was in flight and had no reason to repaint on the tick
after the last record cleared: nothing resized, the version had not moved, no event
arrived. So the pane kept the last thing drawn into it — a spinner frozen mid-turn over a
count of work that had finished, which is what a hung frame looks like.

Reproduced on a real client with the tracker directory empty:

|                              | origin/main      | this branch |
|------------------------------|------------------|-------------|
| row stopped claiming it runs | never (15 s+)    | **0.21 s**  |

on both tmux versions. `was_ticking` spends exactly one more paint on the falling edge —
and one more only, so `docs/frame.md`'s promise that the frame goes completely still stays
true.

## Why one PR

A notice expiring and a spinner stopping are the same question: *what this row would draw
now differs from what is on it, because the clock moved, and nothing will say so.* That is
why `_tick`'s third repaint reason is now `ticking` rather than `animating`, and why the
switch outcome could move onto that row at all — without the falling edge it would have
become a sentence that never went away, i.e. #727 again through #729's surface.

**#728 is deliberately not here.** Its 1.8 s blank happens before any client is attached,
so during it the frame has no state to show and no surface to show it on — a different
defect from these two. Measurements and two refutations of its proposed remedies are posted
on the issue.

## Also fixed, found while writing the tests

- A whitespace-only message wrote a live notice that drew nothing and still held the row's
  top priority (and `_watch` repainting) for its whole dwell.
- `float("nan")` parses, and every comparison against NaN is False — so a `now >= expiry`
  test read False and the notice became permanent. The comparison asks for the live case
  instead, which is the direction every other degenerate value here already falls.

## Verification

Full suite green. Every new guard mutation-checked by hand (`python3 -B`): reverting the
falling edge reddens 3 tests, the destination rule 1, and each of the two guards above 1.
Real-tmux numbers above measured on tmux 3.7c and on the 3.2 floor at
`~/.local/share/charter-testing/tmux-3.2`, each on its own socket, servers reaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
