### PR TITLE
Charter says which key it refused, and a frame-* command that did nothing stops reporting success (#738) (#734) (#747) (#744)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -668,6 +668,37 @@ def _add_frame_parsers(sub) -> None:
     cases this docstring just said get different responses.
     """
     def _wire(parser, name):
+        # **How to drive the thing this command opens, on the command that opens it**
+        # (#747). `charter claude --help` and `charter frame --help` described four flags
+        # and never mentioned that the window they are about to hand the operator has a
+        # palette, an escape hatch, and somebody else's scrollback. The only place any of
+        # it was written outside the frame is `charter docs show frame`, and nothing
+        # pointed there; the only place inside it is the attention strip's two-word `F2
+        # palette` field, which `density = minimal` drops.
+        #
+        # Set here rather than at each `add_parser` for the reason this whole function is
+        # generated from `harness.all()`: one launcher per registered harness plus the
+        # escape hatch, and a per-parser epilog is one more thing to remember for a
+        # harness registered next year. It is also what makes `charter claude --help` and
+        # `charter frame --help` identical BY CONSTRUCTION, which is the property #747
+        # observed and wanted kept — they should say the same thing, and what was wrong
+        # was that the thing they both said was silent on the frame.
+        #
+        # Three facts and no more. They are the three an operator hits in the first
+        # minute: the palette is how you reach everything, the hatch is how you get the
+        # keyboard back from a pane that stopped answering, and scrollback is tmux's
+        # copy-mode now — which `docs/frame.md` itself calls "the difference people notice
+        # first", and the one an operator has no reason to connect to charter at all.
+        # `RawDescriptionHelpFormatter` because argparse reflows an epilog otherwise and
+        # a wrapped key name reads as prose. Called rather than read off a module constant:
+        # the sentence names this plane's own palette key, and a value frozen at import is
+        # a second answer to a question `config.FRAME` already answers — the masked-default
+        # shape the sweep is written to catch.
+        parser.formatter_class = argparse.RawDescriptionHelpFormatter
+        _keys = "\n".join(f"  {k}" for k in commands_frame.driving_keys())
+        parser.epilog = (f"Inside the frame:\n{_keys}\n"
+                         f"  charter docs show frame  —  all of it, and what `[frame]` "
+                         f"configures.")
         parser.add_argument("rest", nargs=argparse.REMAINDER,
                             help="Passed to the harness verbatim.")
         parser.add_argument("--no-frame", action="store_true",

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -373,6 +373,46 @@ def no_renderer_message(missing: list[str]) -> str:
             f"nothing there, so the harness pane keeps that space")
 
 
+def driving_keys() -> list[str]:
+    """The three facts a first launch needs, one per entry. Read by `cli._wire`'s epilog —
+    every `charter <harness> --help` and `charter frame --help` — and by
+    :func:`frame_ready`, so the launcher and the probe cannot come to disagree.
+
+    **Nothing charter printed outside the frame said any of this** (#747). `charter claude
+    --help` listed four flags; `charter frame --help` was the same text; `frame-probe`
+    named every standing limit and no key. Inside the frame it is one two-word field on
+    the attention strip — `F2 palette` — which `density = minimal` drops, and
+    `charter docs show frame` had the whole answer with nothing pointing at it.
+
+    **The keys are resolved, not spelled.** `[frame] hotkey` moves the palette off `F2`,
+    and a help line that says `F2` on a plane that moved it is worse than one that says
+    nothing: it is a fact an operator will act on. `config.FRAME` has already resolved the
+    committed value (or the shipped default, for a key charter refused) by the time any
+    parser is built, and `frame/overlay.py`'s `HATCH_KEY` is charter's own constant for
+    the hatch — the same object `conf_text` binds in both cases.
+
+    Scrollback is the third and it is not a key at all. `docs/frame.md` calls it "the
+    difference people notice first", and it is the one an operator has no reason to
+    connect to charter: their terminal's own scrollbar stops moving, and the frame is
+    simply what was on screen when it happened.
+
+    **A list rather than a sentence, and the two readers join it differently on purpose.**
+    A `--help` epilog is not reflowed (`RawDescriptionHelpFormatter`, which is what keeps
+    a key name off the end of a line) and wants one fact per row; `frame_ready` prints a
+    paragraph per limit and wants a sentence. What must not be duplicated is the FACTS,
+    and they are here once — a joiner at each surface is presentation, not a second
+    answer.
+    """
+    return [
+        f"{config.FRAME['hotkey']} opens the palette — every action the frame has is in "
+        f"there",
+        f"{overlay.HATCH_KEY} takes the keyboard back from a pane that has stopped "
+        f"answering",
+        "scrollback is tmux's copy-mode now, not your terminal's own",
+    ]
+
+
+
 def frame_ready() -> tuple[int, str, str]:
     """Can a frame run on this machine right now, and what will it not be able to do?
     ``(exit code, util.* level, text)`` — read-only: `tmuxctl.version()` and
@@ -385,7 +425,8 @@ def frame_ready() -> tuple[int, str, str]:
     launcher goes on to draw regardless — a probe that lies about `cmd_launch`'s own
     behaviour is worse than one that runs nothing at all.
 
-    **The three STANDING conditions are reported here and nowhere else.** All three used
+    **The four STANDING conditions are reported here and nowhere else.** The first three
+    used
     to be `util.warn` calls inside `cmd_launch` (or, for the resize hook, inside
     `_draw_panels`), and all three were measured to be unreadable there: `util.warn` for
     an unimplemented slot lands 86 bytes before tmux's own `\\x1b[?1049h`, so the
@@ -405,6 +446,17 @@ def frame_ready() -> tuple[int, str, str]:
     recovery at all — the gap being closed here. It does NOT change this function's exit
     code, for the same reason the other two do not: `cmd_launch` draws the frame
     regardless, and a probe stricter than the launcher lies about the launcher.
+
+    **A refused `[[frame.component]]` arrangement is the fourth (#738), and it is the one
+    that is about the plane rather than the machine.** It joins the list rather than
+    getting a surface of its own because it is the same KIND of fact as the unimplemented
+    slot beside it — a standing property of the committed file, true on every launch until
+    somebody edits it — and because it fails in the same way: the frame comes up, at rc 0,
+    looking exactly like the frame the operator would have had if they had never written
+    the tables. It does not change the exit code either. `doctor.check_control_plane_config`
+    is its second reader, where `[plane] worktrees` and `[harness] default` are already
+    named for being silently ignored; this is the surface an operator asks BEFORE they
+    launch, and the one `docs/frame.md` sends them to.
 
     Two callers share this, both read-only for the same reason `charter/news.py`
     requires of a `check:` (reads, never acts; and this module's own tmux calls all go
@@ -426,9 +478,29 @@ def frame_ready() -> tuple[int, str, str]:
     missing = frame_slots.unimplemented(config.FRAME["slots"])
     if missing:
         ceilings.append(no_renderer_message(missing))
+    # The fourth, and the only one that is about this PLANE rather than this machine —
+    # which is `no_renderer_message`'s position too, and the reason it belongs on the same
+    # list rather than in a report of its own. A `[[frame.component]]` arrangement charter
+    # will not draw is refused whole and falls back to `slots`, and the frame that comes
+    # up is indistinguishable from the one the operator would have got without the tables
+    # (#738). Read off `config.FRAME`, which resolved it once at import, so this stays what
+    # this function promises to be: `tmuxctl.version()` and `config.FRAME`, nothing
+    # started, nothing written.
+    refused = config.FRAME.get("components_refused")
+    if refused:
+        ceilings.append(instance.refused_arrangement_message(refused))
+    # **Said on every probe, ceiling or none** (#747). This is not a limit and it is not
+    # news; it is the answer to the question an operator is actually asking when they run
+    # the closest thing charter has to "tell me about the frame", and it was the one thing
+    # this command could not tell them. It rides BELOW the ceilings rather than joining
+    # them, for `_statusline_suppressed_note`'s reason one surface over: a ceiling is a
+    # capability this machine does not have, and a key that works is the opposite of one.
+    drive = "\n".join([f"  \u00b7 {k}" for k in driving_keys()]
+                      + ["  · charter docs show frame — all of it, and what `[frame]` "
+                         "configures."])
     if not ceilings:
-        return 0, "ok", head
-    return 0, "warn", "\n".join([head, *(f"  ↳ {c}" for c in ceilings)])
+        return 0, "ok", "\n".join([head, drive])
+    return 0, "warn", "\n".join([head, *(f"  ↳ {c}" for c in ceilings), drive])
 
 
 def _report_probe(code: int, level: str, line: str) -> int:
@@ -5188,7 +5260,14 @@ def cmd_resize(args) -> int:
     """
     fid = getattr(args, "frame", None) or os.environ.get("CHARTER_SESSION_ID", "")
     if not fid:
-        return 0
+        # **This command stopped being hook-only the day the 3.2 limit named it** (#744).
+        # Below `tmuxctl.RESIZE_HOOK_FLOOR` there is no `window-resized` hook to fire it,
+        # and typing it by hand is the operator's ONLY way to get the panels back — so
+        # `frame-probe` and `docs/frame.md` now tell them to, and a hand-typed recovery
+        # that answers rc 0 and nothing else is the worst possible reply to "did that
+        # work?". The hook path cannot reach here: `_resize_hook_argv` writes
+        # `--frame <fid>` into the action or arms no hook at all.
+        return outside_a_frame("charter frame-resize")
     harness_pane = state.harness_pane(fid) or ""
     if not _PANE_ID_RE.fullmatch(harness_pane):
         return 0
@@ -5309,8 +5388,14 @@ def cmd_density(args) -> int:
     settled would repaint into the old shape.
     """
     fid = os.environ.get("CHARTER_SESSION_ID", "")
+    if not fid:
+        return outside_a_frame("charter frame-density")
+    # Split off the empty *fid* above rather than sharing its `or`, and left a quiet
+    # no-op: a level outside the closed set is a DIFFERENT silence from #734's, on the
+    # `run-shell` side of the line `outside_a_frame`'s docstring draws, and it is not this
+    # change's to make. See that docstring, and the note in `cmd_toggle`.
     level = instance.density_level(getattr(args, "level", None))
-    if not fid or level is None:
+    if level is None:
         return 0
     where = _relayout_target(fid)
     if where is None:
@@ -5333,6 +5418,52 @@ def cmd_density(args) -> int:
     state.record_hidden(fid, [n for n in arrangement if n not in want])
     _apply_arrangement(fid, where=where, want=[n for n in arrangement if n in want])
     return 0
+
+
+def outside_a_frame(command: str) -> int:
+    """Say that *command* acts on a frame and this shell is not in one, and refuse. Never 0.
+
+    **The one sentence every `frame-*` command an operator can type says when it has no
+    frame to act on (#734), and having exactly one is the point.** `charter frame-chat`,
+    `frame-density`, `frame-toggle`, `frame-chrome`, `frame-switch` and `frame-resize` each
+    used to open with `if not fid: return 0` — four bytes of silence and a success status
+    for a command that did nothing. There was no way to tell "it worked" from "you are not
+    in a frame", and `docs/frame.md` makes two of them the ONLY route to their action:
+    inside a tmux you already have, charter binds no key at all, so typing the command in
+    the frame's own window is the documented escape hatch — and typing it in the window you
+    started from, one keystroke away, was indistinguishable from success.
+
+    **stderr, and never `_say_on_screen`.** There is no frame here by construction, so
+    there is no frame's screen to draw on: `_say_on_screen` with an empty id resolves `-t
+    ""` to whichever session on the SHARED server attached most recently, which is how
+    charter's refusal came to be drawn across somebody else's frame (see `cmd_chat`'s own
+    note). The operator's own stderr is the one surface that is certainly theirs.
+
+    **Non-zero, and the `run-shell` objection does not reach this branch.** Every one of
+    these commands is *also* fired by tmux — a `bind -n`, a window hook, a palette row —
+    and a non-zero status there makes tmux print `'<the whole command>' returned 1` INTO
+    THE HARNESS PANE, the one rectangle ADR 0018 says charter never draws in (measured on
+    3.7c; `conf_text`'s own docstring records the 127 case). That is why these commands
+    return 0 for every other refusal and always will. It does not apply here: a bind
+    carries `--chat` expanded from the presser's own window, the resize hook carries
+    `--frame`, a palette row's child is handed `CHARTER_SESSION_ID` explicitly
+    (`frame/builtin_actions._spawn`) — so on every path tmux drives, *fid* is set and this
+    function is unreachable. What is left is a human at a prompt, for whom rc 0 was the
+    lie. Measured on tmux 3.7c beside it: `run-shell` shows a child's **stdout** and
+    discards its **stderr** entirely, so even on a stale bind from an older charter the
+    sentence below costs the harness pane nothing; only the status would show.
+
+    The text names the window rather than only the failure, because "not in a frame" tells
+    an operator who typed this in the wrong pane nothing they did not know, and `charter
+    docs show frame` is where the rest of it lives — the one place F2, F12 and copy-mode
+    scrollback are written down (#747).
+    """
+    util.err(f"charter: {command} acts on the frame it is run inside, and this shell is "
+             f"not in one — nothing was changed.\n"
+             f"  Run it in the window `charter <harness>` opened. Inside a tmux you "
+             f"already have, charter binds no key, so typing it there is the route.\n"
+             f"  charter docs show frame")
+    return 1
 
 
 def _relayout_target(fid: str):
@@ -5538,8 +5669,13 @@ def cmd_chrome(args) -> int:
     (`_split_panels` reads `_current_chrome`).
     """
     fid = os.environ.get("CHARTER_SESSION_ID", "")
+    if not fid:
+        return outside_a_frame("charter frame-chrome")
+    # `cmd_density`'s split, for its reason: the empty *fid* is #734's silence and is
+    # answered on the operator's own stderr; a word outside the closed set is not, and
+    # stays the quiet no-op it was.
     level = instance.chrome_level(getattr(args, "level", None))
-    if not fid or level is None:
+    if level is None:
         return 0
     panes = state.panes(fid)
     if not panes:
@@ -5659,10 +5795,29 @@ def cmd_toggle(args) -> int:
     property that survives it, and names the line that carries it.
     """
     fid = _pressers_chat(args)
+    # **The `if not fid` this function deleted, back — and back because it now carries a
+    # consequence a test can pin** (#734). It was removed as a guard nothing could turn
+    # red: with an empty id this command emitted nothing either way, so no mutation of it
+    # was observable. It says something now, on a surface that is certainly the asker's,
+    # and `test_a_frame_command_outside_a_frame_says_so.py` fails without it. It comes
+    # FIRST, before the arrangement is even read: `charter frame-toggle repos` typed in an
+    # ordinary shell names a component that IS in this plane's arrangement, so it used to
+    # fall past the check below and die in `_relayout_target`, where "you are not in a
+    # frame" and "this frame has no recorded harness pane" are one silence.
+    if not fid:
+        return outside_a_frame("charter frame-toggle")
     name = getattr(args, "component", None)
     frame = config.FRAME
     arrangement = instance.frame_arrangement(frame)
     if name not in arrangement:
+        # **Still a silent 0, and that is a scope line rather than an oversight.** A name
+        # this arrangement does not hold is the same "did nothing, said nothing" shape
+        # #734 is about, and it is worth its own issue — but every route to it is a
+        # `bind -n` charter wrote from the arrangement itself, and this is the ONE guard
+        # standing between an argv word and a `split-window`/hook action text
+        # (`test_component_toggle_keys.py`'s hostile-name class). Widening it into a
+        # `display-message` is a change to a security-shaped guard and belongs with a
+        # review of its own, not folded into a fix about being outside a frame.
         return 0
     where = _relayout_target(fid)
     if where is None:
@@ -5841,15 +5996,17 @@ def cmd_chat(args) -> int:
     """
     fid = _pressers_chat(args)
     if not fid:
-        # **Not fired from inside a frame at all, and unlike `cmd_toggle` this refusal is
-        # not free.** That command emits nothing by construction with an empty id, which
-        # is why the deletion sweep found its own `if not fid` equivalent and it was
-        # deleted. This one reaches :func:`_say_on_screen`, whose `-t <fid>` with an empty
+        # **Not fired from inside a frame at all.** This guard has always been here — what
+        # it may not do is reach :func:`_say_on_screen`, whose `-t <fid>` with an empty
         # target resolves to whichever session on the SHARED server was attached most
-        # recently — so `charter frame-chat api.2` typed in an ordinary shell drew
-        # charter's refusal across somebody else's frame. Measured by hand against the
-        # real server, which is how it was found. `cmd_switch`'s guard, for its reason.
-        return 0
+        # recently, which is how `charter frame-chat api.2` typed in an ordinary shell drew
+        # charter's refusal across somebody else's frame. Measured by hand against the real
+        # server, which is how it was found. What it does now is say so on the asker's own
+        # stderr instead of returning 0 into their silence (#734), which is the one surface
+        # that is certainly theirs — see :func:`outside_a_frame`. `docs/frame.md` makes
+        # this command the documented fallback when the palette's doorway is refused, so it
+        # is the last one that can afford to answer a typo with a success status.
+        return outside_a_frame("charter frame-chat")
     target = (getattr(args, "chat_id", None) or "").strip()
     # Asked again rather than trusted from the palette that spawned this: the same
     # command is typeable by hand on a name nobody drew, and `chats.check` is the one
@@ -6369,7 +6526,7 @@ def cmd_switch(args) -> int:
     """
     fid = os.environ.get("CHARTER_SESSION_ID", "")
     if not fid:
-        return 0
+        return outside_a_frame("charter frame-switch")
     ws = getattr(args, "workspace", None)
     persona_name = getattr(args, "persona", None)
     if ws:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -5390,12 +5390,17 @@ def cmd_density(args) -> int:
     fid = os.environ.get("CHARTER_SESSION_ID", "")
     if not fid:
         return outside_a_frame("charter frame-density")
-    # Split off the empty *fid* above rather than sharing its `or`, and left a quiet
-    # no-op: a level outside the closed set is a DIFFERENT silence from #734's, on the
-    # `run-shell` side of the line `outside_a_frame`'s docstring draws, and it is not this
-    # change's to make. See that docstring, and the note in `cmd_toggle`.
+    # Split off the empty *fid* above rather than sharing its `or`, because the two are
+    # different silences with different surfaces. That one has no frame and goes to the
+    # asker's stderr; this one HAS a frame, and #729 gave the frame a row to answer on.
+    # A level outside the closed set can only be hand-typed — a palette row carries one of
+    # the three constants — so nothing reaches here but a person who typed a fourth word
+    # and, until now, got a success status and no output.
     level = instance.density_level(getattr(args, "level", None))
     if level is None:
+        _say_on_screen(fid, f"no density level "
+                            f"{contain.readable(getattr(args, 'level', None))} — have: "
+                            f"{', '.join(instance.FRAME_DENSITY)}")
         return 0
     where = _relayout_target(fid)
     if where is None:
@@ -5683,10 +5688,13 @@ def cmd_chrome(args) -> int:
     if not fid:
         return outside_a_frame("charter frame-chrome")
     # `cmd_density`'s split, for its reason: the empty *fid* is #734's silence and is
-    # answered on the operator's own stderr; a word outside the closed set is not, and
-    # stays the quiet no-op it was.
+    # answered on the asker's own stderr, because there is no frame; a word outside the
+    # closed set has a frame, so it is answered on that frame's own attention row.
     level = instance.chrome_level(getattr(args, "level", None))
     if level is None:
+        _say_on_screen(fid, f"no chrome level "
+                            f"{contain.readable(getattr(args, 'level', None))} — have: "
+                            f"{', '.join(instance.FRAME_CHROME)}")
         return 0
     panes = state.panes(fid)
     if not panes:
@@ -5821,14 +5829,23 @@ def cmd_toggle(args) -> int:
     frame = config.FRAME
     arrangement = instance.frame_arrangement(frame)
     if name not in arrangement:
-        # **Still a silent 0, and that is a scope line rather than an oversight.** A name
-        # this arrangement does not hold is the same "did nothing, said nothing" shape
-        # #734 is about, and it is worth its own issue — but every route to it is a
-        # `bind -n` charter wrote from the arrangement itself, and this is the ONE guard
-        # standing between an argv word and a `split-window`/hook action text
-        # (`test_component_toggle_keys.py`'s hostile-name class). Widening it into a
-        # `display-message` is a change to a security-shaped guard and belongs with a
-        # review of its own, not folded into a fix about being outside a frame.
+        # **The refusal stays exactly as strict; only its silence goes.** This is the ONE
+        # guard between an argv word and a `split-window` target and a hook's action text
+        # (`test_component_toggle_keys.py`'s hostile-name class), and *name* still travels
+        # no further than this line — what is added is a sentence about it, on the frame's
+        # own row.
+        #
+        # Saying it was not affordable until #729. The surface was `display-message`, so a
+        # committed or typed name reached a tmux FORMAT evaluator, and the message landed
+        # on whichever client tmux picked. The row is charter's own pane, written through
+        # `state.say`'s `contain.one_line` and read by this frame's own panel, so neither
+        # is true of it any more.
+        #
+        # It also answers a live frame's dead key: a component's `bind -n` outlives an
+        # edit to `charter.toml` that drops the component, so this is the one thing that
+        # tells an operator why a key they configured has stopped doing anything.
+        _say_on_screen(fid, f"no component {contain.readable(name)} in this plane's "
+                            f"arrangement — have: {', '.join(arrangement)}")
         return 0
     where = _relayout_target(fid)
     if where is None:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -5434,10 +5434,21 @@ def outside_a_frame(command: str) -> int:
     started from, one keystroke away, was indistinguishable from success.
 
     **stderr, and never `_say_on_screen`.** There is no frame here by construction, so
-    there is no frame's screen to draw on: `_say_on_screen` with an empty id resolves `-t
-    ""` to whichever session on the SHARED server attached most recently, which is how
-    charter's refusal came to be drawn across somebody else's frame (see `cmd_chat`'s own
-    note). The operator's own stderr is the one surface that is certainly theirs.
+    there is no frame's screen to draw on — and `display-message` would not find one
+    anyway. Measured by hand on tmux 3.7c and at the 3.2 floor, one server, sessions `sa`
+    and `sb`, the only client attached to `sb`::
+
+        $ tmux -L t display-message -t %0 MSG        # %0 is a pane of session sa
+        # the message appears on sb's terminal, and nowhere on sa's
+
+    **`-t` is the target for FORMAT EVALUATION, not the choice of screen.** The screen is
+    `-c`, and with no `-c` tmux draws on its own current client. Charter had this recorded
+    as a property of an EMPTY target (`cmd_chat`'s own note, and `_say_on_screen`'s); it is
+    not — an empty target is merely the loudest case of something true of every target.
+    So on a socket carrying eleven frames, a refusal put on screen without the presser's
+    own `#{client_name}` is a refusal that can land on somebody else's terminal, and this
+    command has no client to pass: nobody pressed a key, somebody typed into a shell. That
+    shell's stderr is the one surface that is certainly theirs.
 
     **Non-zero, and the `run-shell` objection does not reach this branch.** Every one of
     these commands is *also* fired by tmux — a `bind -n`, a window hook, a palette row —
@@ -5996,16 +6007,17 @@ def cmd_chat(args) -> int:
     """
     fid = _pressers_chat(args)
     if not fid:
-        # **Not fired from inside a frame at all.** This guard has always been here — what
-        # it may not do is reach :func:`_say_on_screen`, whose `-t <fid>` with an empty
-        # target resolves to whichever session on the SHARED server was attached most
-        # recently, which is how `charter frame-chat api.2` typed in an ordinary shell drew
-        # charter's refusal across somebody else's frame. Measured by hand against the real
-        # server, which is how it was found. What it does now is say so on the asker's own
-        # stderr instead of returning 0 into their silence (#734), which is the one surface
-        # that is certainly theirs — see :func:`outside_a_frame`. `docs/frame.md` makes
-        # this command the documented fallback when the palette's doorway is refused, so it
-        # is the last one that can afford to answer a typo with a success status.
+        # **Not fired from inside a frame at all.** This guard has always been here —
+        # what it may not do is reach :func:`_say_on_screen`, which is how `charter
+        # frame-chat api.2` typed in an ordinary shell drew charter's refusal across
+        # somebody else's frame. That was recorded as a property of the EMPTY `-t` target;
+        # re-measured for #734 on 3.7c and at the 3.2 floor it is not — `-t` never chooses
+        # the screen at all, `-c` does, and with neither, tmux draws on its own current
+        # client. See :func:`outside_a_frame` for the measurement. What this branch does
+        # now is say so on the asker's own stderr instead of returning 0 into their
+        # silence (#734). `docs/frame.md` makes this command the documented fallback when
+        # the palette's doorway is refused, so it is the last one that can afford to
+        # answer a typo with a success status.
         return outside_a_frame("charter frame-chat")
     target = (getattr(args, "chat_id", None) or "").strip()
     # Asked again rather than trusted from the palette that spawned this: the same

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -316,6 +316,30 @@ def check_control_plane_config() -> Result:
                  f"plane that declares no default gets, so the key currently reads as "
                  f"absent. `charter <harness>` is unaffected.",
         )
+    # A committed `[[frame.component]]` arrangement charter cannot draw is refused WHOLE
+    # (`instance.component_arrangement`, #535) and degrades to the frame `[frame] slots`
+    # describes — which is byte-identical to the frame a plane that wrote no arrangement
+    # gets. So the third silently-ignored setting in a row, and here for the two above's
+    # reason: `docs/frame.md` told the operator they would "see your whole arrangement not
+    # take effect", and there was nothing to see (#738). The launch itself deliberately
+    # prints nothing — `commands_frame.frame_ready`'s docstring measures why a warning 86
+    # bytes before tmux's alternate screen is worse than silence — so this row and
+    # `charter frame-probe` are the whole surface.
+    #
+    # Read from `instance.frame_of` on the file parsed above, not from `config.FRAME`,
+    # which is the `[harness] default` branch's rule for its reason: this row is about the
+    # FILE. Reached only on a plane that actually wrote the key — the resolver answers
+    # `None` for every other one, which is every plane charter ships with — so no correct
+    # configuration can put this row in the yellow (#371's rule: a guard that fires on
+    # working setups gets switched off and then protects nothing).
+    _no_arrangement = _instance.frame_of(_cfg).get("components_refused")
+    if _no_arrangement:
+        return Result(
+            "charter.toml",
+            WARN,
+            detail="[[frame.component]] is refused; the frame is drawing `[frame] slots`",
+            hint=_instance.refused_arrangement_message(_no_arrangement),
+        )
     if not _config.HAS_CONTROL_PLANE:
         # NOT ok. Every check below reports green against a plane that does not exist —
         # `personas: none defined`, `vaults: none configured` — so a session with no

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -466,12 +466,43 @@ def below_resize_hook_message(v: tuple[int, int]) -> str:
     reading surfaces (`commands_frame.frame_ready`, `doctor.check_frame`), for the reason
     that message's own history records: two copies of one standing fact drift into two
     different facts.
+
+    **Two things this used to say were measured false (#744), and both were the kind of
+    wrong that stops an operator looking.**
+
+    *"…until the frame is relaunched."* It is until they ask. `charter frame-resize` typed
+    in the frame's own window does exactly what the missing hook would have done — it is
+    the same `cmd_resize`, and nothing in it is version-dependent; only the HOOK that
+    fires it is. Measured on ``~/.local/share/charter-testing/tmux-3.2``, a frame launched
+    at 120x40, dragged to 80x24 and back::
+
+        %1 5x120   %0 22x97   %4 22x22   %3 5x120   %2 5x120     <- stretched, and staying
+        $ charter frame-resize
+        %1 1x120   %0 34x97   %4 34x22   %3 1x120   %2 1x120     <- launch geometry, exactly
+
+    Naming the remedy on the ceiling it answers is `doctor.check_harness`'s rule for its
+    deficit lines, and it matters more here than there: below this floor that command is
+    the operator's ONLY recovery, and a limit stated with no remedy reads as "nothing can
+    be done".
+
+    *"Everything else in the frame works."* At 80x24 on the same build, the sidebar is
+    squeezed to **two columns** (`%4 18x2`, one truncated glyph per row) and the repo pane
+    holds `⋯ too narrow for the repo table — 95 columns needed` — a line
+    `frame/slots.py` writes to be transient, and which on 3.2 never settles because
+    nothing re-measures. "The panels stretch" reads as cosmetic; a sidebar of stubs and a
+    permanently apologising repo pane is not, and an operator told the first will not
+    connect the second to their tmux version.
     """
     return (f"tmux {v[0]}.{v[1]} predates the `window-resized` hook "
             f"(tmux {RESIZE_HOOK_FLOOR[0]}.{RESIZE_HOOK_FLOOR[1]}+), which is what "
-            f"restores each panel's fixed size after the terminal is resized. Everything "
-            f"else in the frame works; resize this terminal and the panels stretch, and "
-            f"stay stretched until the frame is relaunched.")
+            f"restores each panel's fixed size after the terminal is resized. Resize this "
+            f"terminal and the panels do not come back on their own: the sidebar can be "
+            f"left a couple of columns wide and the repo pane can hold `⋯ too narrow for "
+            f"the repo table` for good, because nothing re-measures. Run `charter "
+            f"frame-resize` in the frame's own window and every panel is restored to its "
+            f"launch geometry at once — that is the same command the hook would have "
+            f"called, and it is the recovery on this tmux. Everything else works "
+            f"unchanged.")
 
 
 def report_failure(action: str, cmd: list[str], proc: subprocess.CompletedProcess) -> None:

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -1352,6 +1352,21 @@ def frame_of(cfg: dict) -> dict:
     # `[frame]` table is spelled `components`, and the generic type check below would read
     # `[[frame.component]]`'s raw tables straight into it without resolving one.
     out["components"] = []
+    # Set here for `components`' own reason, and carried for :func:`harness_of`'s: a
+    # `[[frame.component]]` arrangement charter refuses degrades to the frame `slots`
+    # describes, which is byte-identical to the frame a plane that wrote no arrangement at
+    # all gets — so the operator who committed one sees charter behaving exactly as though
+    # their tables were not there. Every OTHER key in this function degrades to a shipped
+    # default and the frame still draws with the rest of the file in force; this one takes
+    # the whole arrangement out of play (#535), which is the difference that earns it a
+    # reader. `None` is "nothing to say" and covers both the ordinary plane (no tables
+    # written) and the good one (tables written and honoured); a string is the one key that
+    # did it, ready for a sentence. Read by `doctor.check_control_plane_config`, where
+    # `config.worktrees_root_for`'s and `[harness] default`'s own silently-ignored keys are
+    # named for the same reason, and by `commands_frame.frame_ready` (`--probe`,
+    # `charter frame-probe`), which is the surface an operator asks "what will this frame
+    # not be able to do".
+    out["components_refused"] = None
     section = cfg.get("frame")
     if not isinstance(section, dict):
         return out
@@ -1402,7 +1417,8 @@ def frame_of(cfg: dict) -> dict:
     # refused when it would steal the frame's palette key, and the value it is compared
     # against has to be the one `conf_text` will actually bind — the operator's, if they
     # wrote a usable one, and the shipped ``F2`` if they did not.
-    placed = component_tables(section, hotkey=out["hotkey"])
+    placed, refused = component_arrangement(section, hotkey=out["hotkey"])
+    out["components_refused"] = refused
     if placed is not None:
         out["slots"] = [p["slot"] for p in placed if p["visible"]]
     # The arrangement itself, and not only the names it comes down to. `slots` carries
@@ -1598,10 +1614,104 @@ def _built_in_size(c, value):
 def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None:
     """The ``[[frame.component]]`` arrangement *section* declares, or ``None``.
 
-    ``None`` means "nothing usable was declared here" — no tables at all, or an
+    **The projection of :func:`component_arrangement` that drops the reason**, and a
+    separate function rather than a second resolver: every rule about what an arrangement
+    may say lives once, next door, and this is the shape the twenty-odd callers that only
+    want the placements already read. `frame_of` — the one caller that has somewhere to
+    put a refusal — asks the other one.
+    """
+    placed, _why = component_arrangement(section, hotkey=hotkey)
+    return placed
+
+
+def _component_value(value) -> str:
+    """A committed ``[[frame.component]]`` value, spelled the way its own file spells it.
+
+    Every refusal below quotes the operator's line back at them, and a line they cannot
+    find by searching for it is worth rather less: ``bg = "midnight"`` is what is in the
+    file, and :func:`contain.readable` alone answers ``midnight``, which matches nothing.
+    So a string gets its quotes and everything else — an int, a bool, a list, the table a
+    single-bracket `[frame.component]` produces — gets `readable`'s rendering unchanged.
+
+    The containment is `readable`'s either way and is not weakened by the two quote
+    characters: it runs on the value FIRST, so what they wrap is already ASCII with every
+    newline, control code and invisible codepoint escaped. A ``bg`` holding a `"` of its
+    own comes out as one visible character inside charter's pair, which reads oddly and
+    forges nothing — the property this is for.
+    """
+    return (f'"{contain.readable(value)}"' if isinstance(value, str)
+            else contain.readable(value))
+
+
+def _component_at(cid, n: int) -> str:
+    """Which ``[[frame.component]]`` table a refusal is about.
+
+    The ``use`` wherever one has already been established as a string, because that is the
+    name an operator reads their own file by; the ordinal for a table whose ``use`` is
+    itself the broken key, counting from 1 because that is how the file reads rather than
+    how the list indexes.
+
+    Contained even here: *cid* is a committed string on its way into a sentence `doctor`
+    prints, and a table whose ``use`` is a newline would otherwise forge a row of charter's
+    own report — :func:`harness_of`'s rule for :data:`contain.readable`, said about the
+    other committed identifier that reaches the same surface.
+    """
+    return (f"on `{contain.readable(cid)}`" if isinstance(cid, str)
+            else f"in `[[frame.component]]` table {n}")
+
+
+def refused_arrangement_message(why: str) -> str:
+    """The one sentence for a ``[[frame.component]]`` arrangement charter would not draw.
+
+    Shared by `doctor.check_control_plane_config` and `commands_frame.frame_ready`
+    (`--probe`, `charter frame-probe`) rather than written twice, for
+    `commands_frame.no_renderer_message`'s reason: this is a standing property of the
+    committed file, and two copies of a standing fact drift into two different facts.
+
+    *why* is :func:`component_arrangement`'s second answer — the ONE key that did it,
+    already contained. This adds what an operator cannot see for themselves: that the
+    refusal is whole-arrangement rather than one table, and that the frame they are
+    looking at is the `slots` one. Without that half, "``bg`` is not a colour word" reads
+    as one pane's worth of missing paint rather than as the entire arrangement dropped.
+    """
+    return (f"`[[frame.component]]` is not in force — {why}. An arrangement charter "
+            f"cannot draw is refused whole rather than one table at a time, so the frame "
+            f"you get is the one `[frame] slots` describes and every other table's "
+            f"`edge`, `size`, `bg`, `pad` and `key` goes with it. Fix that one key and "
+            f"the arrangement comes back.")
+
+
+def component_arrangement(section, *,
+                          hotkey: str | None = None) -> tuple[list[dict] | None, str | None]:
+    """The ``[[frame.component]]`` arrangement *section* declares, and why it was refused:
+    ``(placements or None, reason or None)``.
+
+    ``None`` placements means "nothing usable was declared here" — no tables at all, or an
     arrangement charter cannot draw — and the caller falls back to ``slots``, which falls
     back to ``density``, which falls back to the shipped default. Every layer of that is
     a frame charter is certain it can build.
+
+    **The two ``None`` placements are different facts and the reason is what tells them
+    apart (#738).** A plane that wrote no arrangement is every plane charter ships with,
+    and there is nothing to say about it; a plane that wrote one charter threw away is a
+    committed file whose declared layout is not the layout it has. Both used to come back
+    as one bare ``None``, so the only surfaces that could have said so — `doctor` and
+    `charter frame-probe` — had nothing to distinguish and said nothing. The reason is
+    ``None`` for the first and a sentence for the second, and the sentence names the ONE
+    key that did it, because "your arrangement was refused" without the key is a file to
+    re-read line by line.
+
+    **What counts as declared is the KEY's presence, not a usable value.** ``component =
+    "identity"`` and ``component = []`` are both a key an operator wrote that decides
+    nothing, which is the same class as the value refusals below; ``component`` absent is
+    a plane spelled with `slots` and gets silence. That line is where the whole reporting
+    risk sits: a warning that fires on correct configurations gets switched off and then
+    protects nothing (#371, and `_BRANCH_MOVERS`' deletion), and *every* plane charter
+    ships with — this repository's own included — takes the absent branch.
+
+    Everything below this paragraph is unchanged from when this function was
+    :func:`component_tables`, and each ``return`` now carries the sentence for its own
+    refusal rather than sharing one bare ``None`` with fourteen others.
 
     **An arrangement is refused whole, and #535 is the reason it is not refused one table
     at a time.** The obvious design — drop the table charter cannot make sense of, keep
@@ -1692,9 +1802,29 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
     outside a `[frame]` section has; the hatch and the two mouse keys are reserved
     regardless, because charter binds all three for every frame on its own server.
     """
+    # **The absent key is the one branch that must never produce a reason**, and it is
+    # asked before the value is looked at rather than inferred from the value being
+    # missing: `component = false` is a key an operator wrote and `section.get` answers
+    # `None` for a key nobody wrote, so a truthiness test here would put every plane on
+    # earth one `get` away from a warning about a table it never had.
+    declared = isinstance(section, dict) and FRAME_COMPONENT_KEY in section
     tables = section.get(FRAME_COMPONENT_KEY) if isinstance(section, dict) else None
-    if not isinstance(tables, list) or not tables:
-        return None
+    if not isinstance(tables, list):
+        if not declared:
+            return None, None
+        # `[frame.component]` — ONE pair of brackets — is the typo this branch is really
+        # about: TOML reads it as a table rather than an array of tables, so an operator
+        # who wrote every key correctly and one bracket wrong got the default frame and no
+        # word about it anywhere.
+        return None, (f"`component = {_component_value(tables)}` is not an array of "
+                      f"tables — an arrangement is spelled `[[frame.component]]`, with "
+                      f"two brackets, once per component")
+    if not tables:
+        # No `declared` test, and its absence is deliberate: the only value that reaches
+        # here is a list, and a key nobody wrote answers `None`, which is not one. A second
+        # `if not declared` would be a guard no mutation could turn red — the shape the
+        # deletion sweep calls a survivor.
+        return None, "`component = []` places no components at all"
     from .frame import builtins as _builtins
     from .frame import overlay as _overlay
     from .frame import tmuxctl as _tmuxctl
@@ -1723,18 +1853,33 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
     # re-checking, so this filter is load-bearing; see the comment there for what a
     # ``None`` in here would cost.
     bound: set[str] = {k for k in (hotkey, _overlay.HATCH_KEY, *_tmuxctl.MOUSE_KEYS) if k}
-    for table in tables:
+    for n, table in enumerate(tables, 1):
         if not isinstance(table, dict):
-            return None
-        if any(k not in FRAME_COMPONENT_FIELDS for k in table):
-            return None
+            return None, (f"the entry {_component_at(None, n)} is "
+                          f"{_component_value(table)} rather than a table of keys")
+        stray = sorted(str(k) for k in table if k not in FRAME_COMPONENT_FIELDS)
+        if stray:
+            # Named one at a time and not "has unknown keys": a misspelt key is the
+            # commonest way into this whole function, and the operator's next move is to
+            # find that word in their file.
+            form = ", ".join("`" + f + "`" for f in FRAME_COMPONENT_FIELDS)
+            return None, (f"`{contain.readable(stray[0])}` "
+                          f"{_component_at(table.get('use'), n)} is not a "
+                          f"`[[frame.component]]` key — the whole form is {form}")
         cid = table.get("use")
-        if not isinstance(cid, str) or cid in seen:
-            return None
+        if not isinstance(cid, str):
+            return None, (f"no `use` names a component {_component_at(None, n)} — every "
+                          f"table needs one, and it is a component id rather than a "
+                          f"`[frame] slots` word")
+        if cid in seen:
+            return None, (f"`use = \"{contain.readable(cid)}\"` is placed twice — a "
+                          f"component sits in one rectangle, so charter has no answer for "
+                          f"the second")
         seen.add(cid)
         visible = table.get("visible", True)
         if not isinstance(visible, bool):
-            return None
+            return None, (f"`visible = {_component_value(visible)}` "
+                          f"{_component_at(cid, n)} is not `true` or `false`")
         # The two refusals a toggle key gets, each its own line because each is a
         # different thing going wrong and the sweep has to be able to tell them apart.
         key = table.get("key")
@@ -1742,7 +1887,8 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
         # hotkey`'s own injection, arriving through a second committed key — see
         # :func:`toggle_key`, which is the SAME pattern and not a second one.
         if key is not None and toggle_key(key) is None:
-            return None
+            return None, (f"`key = {_component_value(key)}` {_component_at(cid, n)} is "
+                          f"not a key charter will write into a `bind` line")
         # Two: something has already bound it. tmux key tables have no notion of a
         # conflict — the later `bind -n` simply replaces the earlier — so unrefused this
         # is one dead key and nothing anywhere saying which. `bound` starts holding the
@@ -1780,7 +1926,11 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
         # the shape the deletion sweep calls a survivor: a line nothing can fail without.
         # One invariant, stated once, where it is established.
         if key in bound:
-            return None
+            return None, (f"`key = {_component_value(key)}` {_component_at(cid, n)} "
+                          f"is already bound — the frame's own palette, its escape hatch, "
+                          f"its two mouse keys and each other component's `key` have it "
+                          f"first, and tmux's later `bind` would silently replace the "
+                          f"earlier one rather than report a conflict")
         if key is not None:
             bound.add(key)
         # The pane's own surface. Refused by NAME rather than passed through, which is
@@ -1792,7 +1942,10 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
         # subclass with a hostile `__str__` cannot travel onward either.
         bg = table.get("bg")
         if bg is not None and pane_bg(bg) is None:
-            return None
+            return None, (f"`bg = {_component_value(bg)}` {_component_at(cid, n)} is not "
+                          f"one of charter's {len(FRAME_PANE_BG)} pane background words "
+                          f"(`default`, the {len(FRAME_PANE_COLOURS)} ANSI colour names, "
+                          f"and each of those with a `bright` prefix)")
         # And the inset. Called ONCE, with the answer kept: `pad = table.get("pad", 0)`
         # followed by `if pane_pad(pad) is None` reads as two steps and is one — `pane_pad`
         # answers its own argument unchanged, so the second call could not have produced a
@@ -1806,7 +1959,9 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
         # spelling-not-property shape this project has paid for six times.
         pad = pane_pad(table.get("pad", 0))
         if pad is None:
-            return None
+            return None, (f"`pad = {_component_value(table.get('pad'))}` "
+                          f"{_component_at(cid, n)} is not a whole number of cells from 0 "
+                          f"to {FRAME_PANE_PAD_MAX}")
         # **`places`, not `cid in SLOT_OF`, and the difference is Phase 5's two bars.**
         # That table is the shorthand between a committed `[frame] slots` word and a
         # component id; this asks the question this branch is actually about — is *cid*
@@ -1819,7 +1974,10 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
         if _builtins.places(cid, reg):
             c = reg.get(cid)
             if "edge" in table and table["edge"] != c.edge:
-                return None
+                return None, (f"`edge = {_component_value(table['edge'])}` "
+                              f"{_component_at(cid, n)} is not the edge that built-in sits "
+                              f"on — charter derives its geometry at import, so `{c.edge}` "
+                              f"is the only value it can honour there")
             # The one key on a built-in that a plane may do more with than echo, and
             # :func:`_built_in_size` is where that asymmetry is argued: `identity`,
             # `attention` and `sidebar` are read out of a table `layout` derives at
@@ -1840,7 +1998,9 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
             if "size" in table:
                 size = _built_in_size(c, table["size"])
                 if size is None:
-                    return None
+                    return None, (f"`size = {_component_value(table['size'])}` "
+                                  f"{_component_at(cid, n)} is not a size charter reads "
+                                  f"for that built-in — see `charter docs show frame`")
             out.append(_built_in_placement(reg, cid, size=size, visible=visible, key=key,
                                            bg=bg, pad=pad))
             continue
@@ -1848,13 +2008,32 @@ def component_tables(section, *, hotkey: str | None = None) -> list[dict] | None
         # installed distribution declares it. Asked of entry point METADATA — nothing is
         # imported here, and a machine without the distribution refuses the arrangement
         # rather than drawing a frame with a hole where the panel was.
+        #
+        # **Three sequential tests where there was one `or` chain, and the split is the
+        # reporting, not a change of behaviour.** The order is the chain's order and the
+        # short-circuit is the same one — a `size < 1` still never runs against a value
+        # `isinstance(size, int)` has not already admitted. What it buys is that the three
+        # facts stop sharing a sentence: "no distribution on this machine supplies
+        # `chats`" sends an operator to `pip install`, "`edge` must be one of four words"
+        # sends them to their own file, and one message covering both said neither.
         edge, size = table.get("edge"), table.get("size")
-        if (not reg.providers.supplies(cid) or edge not in EDGES
-                or not isinstance(size, int) or isinstance(size, bool) or size < 1):
-            return None
+        if not reg.providers.supplies(cid):
+            return None, (f"`use = \"{contain.readable(cid)}\"` is not one of charter's "
+                          f"own components and no installed distribution supplies it on "
+                          f"this machine")
+        if edge not in EDGES:
+            return None, (f"`edge = {_component_value(edge)}` {_component_at(cid, n)} is "
+                          f"not one of {', '.join('`' + e + '`' for e in EDGES)} — a "
+                          f"component charter did not write must say which side it "
+                          f"attaches to, and how many cells it takes")
+        if not isinstance(size, int) or isinstance(size, bool) or size < 1:
+            return None, (f"`size = {_component_value(size)}` {_component_at(cid, n)} is "
+                          f"not a whole number of cells of 1 or more — a component "
+                          f"charter did not write must say how big it is, because asking "
+                          f"the provider would mean importing it on every charter command")
         out.append(_placement(cid, edge=edge, size=Fixed(size), visible=visible, key=key,
                               bg=bg, pad=pad))
-    return out
+    return out, None
 
 
 def frame_components(cfg: dict) -> list[dict]:

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -1857,7 +1857,14 @@ def component_arrangement(section, *,
         if not isinstance(table, dict):
             return None, (f"the entry {_component_at(None, n)} is "
                           f"{_component_value(table)} rather than a table of keys")
-        stray = sorted(str(k) for k in table if k not in FRAME_COMPONENT_FIELDS)
+        # **File order, not sorted, and the sweep is what settled it.** Alphabetical was
+        # the first spelling and `[swap-synonym] sorted -> list` survived it: no test could
+        # tell the two apart, which is the sweep's definition of a line that earns nothing.
+        # Asked again from the operator's side, file order is also the better answer — a
+        # `dict` from `tomllib` preserves the order the keys were written in, so the key
+        # this names is the first misspelt one going down their own file rather than the
+        # one that happens to sort first.
+        stray = [str(k) for k in table if k not in FRAME_COMPONENT_FIELDS]
         if stray:
             # Named one at a time and not "has unknown keys": a misspelt key is the
             # commonest way into this whole function, and the operator's next move is to
@@ -1867,6 +1874,15 @@ def component_arrangement(section, *,
                           f"{_component_at(table.get('use'), n)} is not a "
                           f"`[[frame.component]]` key — the whole form is {form}")
         cid = table.get("use")
+        # **This one is not only a message, and the sweep is why that is written down.**
+        # `[drop-if]` survived here, because a non-str `use` that IS hashable falls through
+        # to the provider branch and is refused there anyway — so the guard looked like it
+        # only chose which sentence came back. An UNHASHABLE one does not: `component = [{
+        # use = ["identity"] }]` is four keystrokes of TOML, and without this line
+        # `cid in seen` raises `TypeError: unhashable type` out of a function
+        # `config.derive` resolves OUTSIDE its try/except — taking down `import
+        # charter.config`, and with it `charter --version` and every other command on that
+        # clone. Exactly the cost this function's docstring already records for `Fixed`.
         if not isinstance(cid, str):
             return None, (f"no `use` names a component {_component_at(None, n)} — every "
                           f"table needs one, and it is a component id rather than a "

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -1888,9 +1888,27 @@ def component_arrangement(section, *,
                           f"table needs one, and it is a component id rather than a "
                           f"`[frame] slots` word")
         if cid in seen:
-            return None, (f"`use = \"{contain.readable(cid)}\"` is placed twice — a "
-                          f"component sits in one rectangle, so charter has no answer for "
-                          f"the second")
+            # **The one message here that interpolates a committed value RAW, and the
+            # sweep is what forced the argument out into the open.** `[uncontain]` on a
+            # `contain.readable` here survived: nothing could reach this line with a value
+            # that needed containing, which makes the call dead code rather than defence —
+            # and this project's rule is that an equivalent mutant and a dead line are the
+            # same finding.
+            #
+            # Why it cannot be reached: `seen` only ever holds an id that completed a whole
+            # pass of this loop, which means it got past `places()` or
+            # `providers.supplies()`. The first is charter's own four-plus-two constants;
+            # the second is an entry point NAME out of a `.dist-info`, which is INI and
+            # cannot hold a newline. So a `use` needing containment is refused on its FIRST
+            # occurrence and never becomes a duplicate — pinned by
+            # `test_a_hostile_use_never_reaches_the_duplicate_message`.
+            #
+            # What would make it necessary again is a REORDER: move this test above the
+            # two membership branches and the value stops being one that passed them. That
+            # is exactly the "guard whose consequence depends on where another line sits"
+            # shape #553 names, so it is written here rather than left to be rediscovered.
+            return None, (f"`use = \"{cid}\"` is placed twice — a component sits in one "
+                          f"rectangle, so charter has no answer for the second")
         seen.add(cid)
         visible = table.get("visible", True)
         if not isinstance(visible, bool):

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -40,9 +40,9 @@ that carry the harness's exit code back out. Below 3.2 `charter <harness>` still
 nothing is switched off: the escape hatch stays bound but may do nothing, and if the
 exit-code hooks
 fail to install charter says so and declines to attach rather than risk a session nothing
-can end. The resize-recovery hook needs a further 3.3; below that a resize still works, the panels
-just do not come back on their own — `charter frame-resize`, typed in the frame's own
-window, restores them.
+can end. The resize-recovery hook needs a further 3.3; below that a resize still works, the
+panels just do not come back on their own — `charter frame-resize`, typed in the frame's
+own window, restores them.
 
 `charter <harness> --probe` (or the standalone `charter frame-probe`) answers "can a frame
 run here, and what will it not be able to do" without starting anything: exit 0 if a frame
@@ -81,8 +81,10 @@ $ charter frame-resize
 %1 1x120   %0 34x97   %4 34x22   %3 1x120   %2 1x120     <- the launch geometry, exactly
 ```
 
-So the standing limit below 3.3 is not "until you relaunch", it is "until you ask". `F2 →`
-the palette reaches it too, and on this tmux that is the one recovery worth knowing.
+So the standing limit below 3.3 is not "until you relaunch", it is "until you ask" — and
+on this tmux that command is the one recovery worth knowing. There is no palette row and
+no key for it: the frame binds keys through the config it sources onto its own server, and
+this is a command you type.
 
 Those limits are deliberately **not** printed when a frame launches. A warning written to
 your terminal microseconds before tmux switches to the alternate screen is not readable —

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -40,22 +40,49 @@ that carry the harness's exit code back out. Below 3.2 `charter <harness>` still
 nothing is switched off: the escape hatch stays bound but may do nothing, and if the
 exit-code hooks
 fail to install charter says so and declines to attach rather than risk a session nothing
-can end. The resize-recovery hook needs a further 3.3; below that a resize still works,
-panels can just drift out of shape until the frame is relaunched.
+can end. The resize-recovery hook needs a further 3.3; below that a resize still works, the panels
+just do not come back on their own — `charter frame-resize`, typed in the frame's own
+window, restores them.
 
 `charter <harness> --probe` (or the standalone `charter frame-probe`) answers "can a frame
 run here, and what will it not be able to do" without starting anything: exit 0 if a frame
 can run, non-zero if tmux is missing entirely, plus a line for each standing limit — a
-tmux below 3.2, a tmux below 3.3 (no resize-recovery hook), and any `[frame] slots` entry
-charter sizes but has no renderer for. `charter doctor` carries the same facts as its own
-`frame` row.
+tmux below 3.2, a tmux below 3.3 (no resize-recovery hook), any `[frame] slots` entry
+charter sizes but has no renderer for, and a `[[frame.component]]` arrangement charter
+refused. It closes with the three keys below, because it is also the closest thing charter
+has to "tell me about the frame". `charter doctor` carries the same facts — the machine's
+in its `frame` row, the file's in its `charter.toml` row, beside the other settings a plane
+declares and charter is not honouring.
 
 The 3.3 line is worth calling out because the two floors are easy to conflate: 3.3 sits
 *above* the 3.2 floor, so a tmux 3.2 passes the floor cleanly and still has no
 `window-resized` hook. Charter used to say so only in the milliseconds before the frame
-came up, which is nowhere. Now both surfaces name it, and what it costs is exactly one
-thing: resize your terminal and the panels stretch, and stay stretched until the frame is
-relaunched.
+came up, which is nowhere. Now both surfaces name it, and they name the remedy with it.
+
+What it costs is this. Resize your terminal on a tmux below 3.3 and nothing re-measures the
+panels, so they keep the shape the drag left them in. Measured on 3.2, a frame launched at
+120x40 and dragged to 80x24 and back:
+
+```
+%1 5x120   %0 22x97   %4 22x22   %3 5x120   %2 5x120     <- and staying that way
+```
+
+While you are at the small size it is more than cosmetic: the sidebar is squeezed to **two
+columns** of truncated glyphs (and still costs three, with its border), and the repo pane
+holds `⋯ too narrow for the repo table — 95 columns needed` — a line written to be
+transient, which here never settles because nothing measures again.
+
+**`charter frame-resize`, typed in the frame's own window, fixes it completely and at
+once.** It is the same command the missing hook would have called, and nothing in it
+depends on your tmux version — only the hook that fires it does. On the same frame:
+
+```
+$ charter frame-resize
+%1 1x120   %0 34x97   %4 34x22   %3 1x120   %2 1x120     <- the launch geometry, exactly
+```
+
+So the standing limit below 3.3 is not "until you relaunch", it is "until you ask". `F2 →`
+the palette reaches it too, and on this tmux that is the one recovery worth knowing.
 
 Those limits are deliberately **not** printed when a frame launches. A warning written to
 your terminal microseconds before tmux switches to the alternate screen is not readable —
@@ -794,6 +821,23 @@ component's `key`: the binds live in the config charter sources onto its own ser
 it never does inside your tmux, so `charter frame-toggle <name>` typed in the frame's own
 window is the route there.
 
+**"The frame's own window" is load-bearing, and charter says so if you miss it.** Every
+`charter frame-*` command acts on the frame it is run *inside*; typed in the window you
+started from, or in any ordinary shell, there is no frame to act on. Each one now says that
+on stderr and exits non-zero, rather than doing nothing and reporting success:
+
+```
+$ charter frame-toggle repos
+charter: charter frame-toggle acts on the frame it is run inside, and this shell is not in
+one — nothing was changed.
+  Run it in the window `charter <harness>` opened. …
+```
+
+That covers `frame-chat`, `frame-density`, `frame-toggle`, `frame-chrome`, `frame-switch`
+and `frame-resize` — the six you can type. The commands tmux fires for itself
+(`frame-palette`, `frame-respawn`, `frame-gather`) stay quiet at 0, because a non-zero exit
+inside a `run-shell` is what makes tmux print into your harness pane.
+
 `hotkey` is checked against the shape of a tmux key name — optional `C-`/`M-`/`S-`
 modifiers and then a key (`F2`, `Up`, `PPage`, `a`, `/`). Anything else falls back to
 `F2`, the same way every other key in `[frame]` falls back to its default when charter
@@ -1369,7 +1413,10 @@ one of the four, a provider placed without an `edge` and a `size`, or a `visible
 not `true`/`false` all mean the same thing: the arrangement is ignored and you get the
 frame your `slots` (or `density`, or the default) describes. You see your whole arrangement
 not take effect, which is something you can act on, rather than one pane's worth of quiet
-fiction. A `key` charter will not bind, a key two components both claim, and a key equal to
+fiction — and **`charter frame-probe` and `charter doctor` name the one key that did it**,
+so you are not re-reading the file line by line. The launch itself stays silent, for the
+reason every other standing limit does: a warning printed microseconds before tmux switches
+to the alternate screen is not readable. A `key` charter will not bind, a key two components both claim, and a key equal to
 your frame's own `hotkey` are on that list too — and so are a `bg` that is not one of the
 seventeen words, a `pad` outside `0` to `5`, and a `size` charter cannot give the component
 (any number but its own on the three whose height is fixed, and anything that is not a

--- a/docs/news/unreleased-charter-stops-refusing-things-in-silence.md
+++ b/docs/news/unreleased-charter-stops-refusing-things-in-silence.md
@@ -1,0 +1,87 @@
+---
+version: unreleased
+headline: A frame charter would not build, and a command that did nothing, both say so now
+---
+
+*"I put `bg = "midnight"` in one table, launched, and got the default frame. `frame-probe`
+said `✓`. `doctor`'s frame row said `✓`. Nothing anywhere mentioned my arrangement."*
+
+Four things charter already knew and did not tell you.
+
+**A `[[frame.component]]` arrangement charter cannot draw is refused whole — and now it
+says which key did it.** The whole-arrangement rule stays and is right: dropping just the
+table charter could not make sense of hands you a frame with a panel silently missing from
+it, and a missing repo table is a plane that looks like it has no clones. What was wrong is
+that the refusal left no trace anywhere. The frame that came up was the `slots` one, byte
+for byte identical to the frame you would have had if you had never written the tables, and
+every surface whose job is to report configuration health reported health.
+
+```
+$ charter frame-probe
+! charter frame: tmux 3.7 — a frame can run on this machine
+  ↳ `[[frame.component]]` is not in force — `bg = "midnight"` on `repos` is not one of
+    charter's 17 pane background words… the frame you get is the one `[frame] slots`
+    describes and every other table's `edge`, `size`, `bg`, `pad` and `key` goes with it.
+
+$ charter doctor
+  !  charter.toml   [[frame.component]] is refused; the frame is drawing `[frame] slots`
+```
+
+`charter.toml` and not the `frame` row, because it is the same fact as the two ignored
+settings already there — a committed key that is not in force and reads exactly like one
+nobody wrote. Every refusal on the documented list gets a sentence naming the table, the key
+and the value: an unknown `use`, a misspelt key, a duplicate, a `visible` that is not a
+bool, a `pad` outside 0–5, a `size` charter cannot give that component, an `edge` it cannot
+move a built-in to, a `key` it will not bind or that something already has, a provider with
+no `edge`/`size`, a provider this machine has no distribution for — and the single-bracket
+`[frame.component]` typo, which TOML reads as a table rather than an array of them.
+
+**A plane that wrote no arrangement still says nothing**, and that line is the whole reason
+this is worth having. A warning that fires on working configurations gets switched off and
+then protects nothing; the reason is `None` for every plane that did not write the key,
+which is every plane charter ships.
+
+**Six `frame-*` commands stopped reporting success for doing nothing.** `charter
+frame-chat`, `frame-density`, `frame-toggle`, `frame-chrome`, `frame-switch` and
+`frame-resize` each opened with four bytes of silence and a zero exit when there was no
+frame to act on. Inside a tmux you already have, two of them are the *only* route to their
+action — charter binds no key there — so typing one in the window you started from, rather
+than the one charter opened, was indistinguishable from it working.
+
+```
+$ charter frame-toggle repos ; echo $?
+charter: charter frame-toggle acts on the frame it is run inside, and this shell is not in
+one — nothing was changed.
+  Run it in the window `charter <harness>` opened. …
+  charter docs show frame
+1
+```
+
+The commands tmux fires for itself — `frame-palette`, `frame-respawn`, `frame-gather` — are
+untouched and still exit 0 in silence, because a non-zero status inside a `run-shell` is
+what makes tmux print into your harness pane. `frame-switch` was not on the original list
+and turned out to be the same defect: it is the one of the six with a `--help` line, so it
+is the one `charter --help` shows you.
+
+**`charter claude --help` now says what the window it opens is.** Three facts, on every
+launcher and on `frame-probe`: your palette key opens everything, `F12` takes the keyboard
+back from a pane that has stopped answering, and scrollback is tmux's copy-mode rather than
+your terminal's — which `docs/frame.md` calls the difference people notice first, and which
+you had no reason to connect to charter at all. The palette key is read from your plane, so
+a `[frame] hotkey` you moved is the key the page names.
+
+**And the tmux 3.2 resize limit stops promising a relaunch.** Both surfaces said a
+stretched frame stayed stretched until you started a new one. It stays stretched until you
+ask. Measured at the floor, a frame launched at 120x40 and dragged to 80x24 and back:
+
+```
+%1 5x120   %0 22x97   %4 22x22   %3 5x120   %2 5x120     <- stretched, and staying
+$ charter frame-resize
+%1 1x120   %0 34x97   %4 34x22   %3 1x120   %2 1x120     <- the launch geometry, exactly
+```
+
+That is the same command the missing hook would have called; only the hook is
+version-dependent. The same message also stopped saying "everything else in the frame
+works" — at 80x24 on 3.2 the sidebar is squeezed to two columns of truncated glyphs and the
+repo pane holds `⋯ too narrow for the repo table`, a line written to be transient that here
+never settles, because nothing measures again.

--- a/docs/news/unreleased-charter-stops-refusing-things-in-silence.md
+++ b/docs/news/unreleased-charter-stops-refusing-things-in-silence.md
@@ -63,6 +63,15 @@ what makes tmux print into your harness pane. `frame-switch` was not on the orig
 and turned out to be the same defect: it is the one of the six with a `--help` line, so it
 is the one `charter --help` shows you.
 
+**Inside a frame, an argument charter does not know now answers on the attention row.**
+`charter frame-density enormous`, `charter frame-chrome solarized` and `charter frame-toggle
+reposs` were the same silence one branch over — right command, right window, a word charter
+has no meaning for, and nothing back. They each name the closed set they were measured
+against. The exit status stays 0, which is what a `run-shell` child owes tmux; the row is
+where the sentence goes. That last one also answers a live frame's dead key: a component's
+`bind -n` outlives an edit to `charter.toml` that drops the component, and this is the only
+thing that says why a key you configured has stopped doing anything.
+
 **`charter claude --help` now says what the window it opens is.** Three facts, on every
 launcher and on `frame-probe`: your palette key opens everything, `F12` takes the keyboard
 back from a pane that has stopped answering, and scrollback is tmux's copy-mode rather than

--- a/tests/test_charter_says_what_it_would_not_do.py
+++ b/tests/test_charter_says_what_it_would_not_do.py
@@ -40,8 +40,9 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import cli, commands_frame, doctor, instance
-from charter.frame import overlay, tmuxctl
+from charter.frame import component, overlay, tmuxctl
 from tests import _envguard
+from tests.test_component_providers import CID, ENTRY, MODULE, _SitePackages, _source
 
 
 def _frame(section: dict) -> dict:
@@ -172,6 +173,47 @@ class ARefusedArrangementNamesTheKeyThatDidIt(unittest.TestCase):
                 self.assertEqual(out["components"], [])
                 self.assertTrue(out["components_refused"])
 
+    def test_a_stray_key_is_contained_too_because_toml_keys_can_be_quoted(self):
+        """A bare TOML key cannot hold a newline; a QUOTED one can — `"bg\\nx" = 1` is a
+        legal table key — and this one is interpolated into `doctor`'s hint the same way a
+        value is. The sweep found it uncontained: the `bg` case covered the values and
+        nothing covered the keys."""
+        why = _frame({"component": [{"use": "repos", "bg\n  ✓  frame": 1}]})
+        self.assertTrue(why["components_refused"])
+        self.assertNotIn("\n", why["components_refused"])
+        self.assertNotIn("✓", why["components_refused"])
+
+    def test_a_value_that_is_not_a_string_is_cut_to_a_length_a_row_can_hold(self):
+        """`_component_value`'s other branch. A `pad` holding a four-thousand-element
+        inline array is ordinary TOML and its `str()` is twenty kilobytes; unclipped it
+        goes into a `doctor` hint and a `frame-probe` line whole. `contain.readable`'s
+        limit is what stands between a committed file and a report nobody can read, and
+        the sweep found nothing asserting it on this branch."""
+        why = _frame({"component": [{"use": "repos", "pad": list(range(4000))}]})
+        self.assertTrue(why["components_refused"])
+        self.assertLess(len(why["components_refused"]), 500)
+
+    def test_a_table_with_no_usable_use_is_named_by_its_position(self):
+        """`_component_at`'s other branch. When the broken key IS the `use`, there is no
+        name to quote back and the ordinal is all the operator has to find the table by —
+        counting from 1, because that is how the file reads. The sweep collapsed the
+        conditional and nothing noticed: every other case in this module has a usable
+        `use` for it to fall back on."""
+        why = _frame({"component": [{"use": "identity"}, {"edge": "top"}]})
+        self.assertIn("table 2", why["components_refused"])
+
+    def test_a_hostile_use_never_reaches_the_duplicate_message(self):
+        """The argument that lets the duplicate message interpolate its `use` raw, written
+        as a test rather than left in a comment. `seen` only ever holds an id that
+        completed a whole pass of the loop, so a `use` that needs containing is refused on
+        its FIRST occurrence — by the branch that says no distribution supplies it, not by
+        the one that says it is placed twice. Reorder those and this goes red."""
+        forged = "repos\n  ✓  frame             tmux 3.7"
+        why = _frame({"component": [{"use": forged}, {"use": forged}]})["components_refused"]
+        self.assertIn("no installed distribution supplies it", why)
+        self.assertNotIn("placed twice", why)
+        self.assertNotIn("\n", why)
+
     def test_the_stray_key_named_is_the_first_one_down_the_file(self):
         """`tomllib` hands back keys in the order they were written, and the operator is
         about to go looking for one. Alphabetical was the first spelling and the sweep
@@ -180,6 +222,33 @@ class ARefusedArrangementNamesTheKeyThatDidIt(unittest.TestCase):
         why = _frame({"component": [{"use": "repos", "zzz": 1, "aaa": 2}]})
         self.assertIn("`zzz`", why["components_refused"])
         self.assertNotIn("`aaa`", why["components_refused"])
+
+
+class OneCellIsASizeAndZeroIsNot(unittest.TestCase):
+    """The provider branch's `size < 1`, from both sides.
+
+    Splitting one `or` chain into three sentences made the boundary its own line, and the
+    sweep immediately shifted it: `size <= 1` passed the whole suite, because every case
+    that reached this branch was refused for a different reason first — no installed
+    distribution supplied the id. A boundary only one side of which is exercised is not a
+    boundary that has been tested, so this class installs a real distribution and asks for
+    the smallest size charter will honour as well as the largest it will not.
+    """
+
+    def setUp(self) -> None:
+        _envguard.unset_all()
+        site = _SitePackages(self)
+        site.install("acme-charter", "1.0", {CID: ENTRY}, {MODULE: _source()})
+
+    def test_one_cell_is_placed(self):
+        out = _frame({"component": [{"use": CID, "edge": "right", "size": 1}]})
+        self.assertIsNone(out["components_refused"])
+        self.assertEqual([p["size"] for p in out["components"]], [component.Fixed(1)])
+
+    def test_zero_cells_is_refused_and_says_so(self):
+        why = _frame({"component": [{"use": CID, "edge": "right", "size": 0}]})
+        self.assertEqual(why["components"], [])
+        self.assertIn("`size = 0`", why["components_refused"])
 
 
 class RefusedIsNotTheSameAsUndeclared(unittest.TestCase):

--- a/tests/test_charter_says_what_it_would_not_do.py
+++ b/tests/test_charter_says_what_it_would_not_do.py
@@ -121,6 +121,66 @@ class ARefusedArrangementNamesTheKeyThatDidIt(unittest.TestCase):
         self.assertNotIn("\n", why["components_refused"])
         self.assertIn("\\u000a", why["components_refused"])
 
+    def test_a_hostile_use_is_contained_on_both_paths_that_print_it(self):
+        """The `use` reaches the report twice and the two are different lines of code:
+        `_component_at` names the table a refusal is about, and the provider branch names
+        an id no distribution supplies. The deletion sweep found BOTH uncontained — a
+        `bg` with a newline was pinned and a `use` with one was not, so the guard rested on
+        the value the test happened to pick.
+
+        A `use` is the likelier of the two, at that: it is the key an operator writing an
+        arrangement types first, and `frame/component.py`'s own `_ID_RE` docstring records
+        what a committed name that reaches tmux already cost once."""
+        forged = "repos\n  ✓  frame             tmux 3.7"
+        # `_component_at`: the id is good enough to be named, and a LATER key is refused.
+        by_at = _frame({"component": [{"use": forged, "bg": "midnight"}]})
+        # The provider branch: the id itself is what nothing supplies.
+        by_provider = _frame({"component": [{"use": forged, "edge": "top", "size": 1}]})
+        for name, out in (("_component_at", by_at), ("provider branch", by_provider)):
+            with self.subTest(name):
+                why = out["components_refused"]
+                self.assertTrue(why)
+                self.assertNotIn("\n", why)
+                self.assertNotIn("✓", why)
+
+    def test_a_value_is_quoted_the_way_its_own_file_spells_it(self):
+        """`bg = "midnight"` is what is in the file; `bg = midnight` matches nothing an
+        operator can search for. The quotes are a string's and only a string's — a `pad =
+        99` that came back `pad = "99"` would send them looking for a line they did not
+        write. The sweep found the branch unpinned: nothing failed when
+        `contain.readable(value)` became the answer for both."""
+        quoted = _frame({"component": [{"use": "repos", "bg": "midnight"}]})
+        bare = _frame({"component": [{"use": "repos", "pad": 99}]})
+        self.assertIn('`bg = "midnight"`', quoted["components_refused"])
+        self.assertIn("`pad = 99`", bare["components_refused"])
+
+    def test_a_use_charter_cannot_hash_is_refused_rather_than_raised(self):
+        """**The one refusal here whose consequence is not a sentence.** `use = ["repos"]`
+        and `use = {a = 1}` are both ordinary TOML, and both are unhashable — so without
+        the `isinstance(cid, str)` line, `cid in seen` raises `TypeError` out of a function
+        `config.derive` resolves OUTSIDE its try/except. That does not degrade to the
+        default frame: it takes down `import charter.config`, and with it `charter
+        --version` and every other command on that clone. The same cost this function's
+        docstring already records for `Fixed`.
+
+        Written because the sweep dropped that guard and stayed green: a hashable non-str
+        `use` falls through to the provider branch and is refused there anyway, so the
+        line looked like it merely chose which sentence came back."""
+        for value in (["repos"], {"a": 1}, {1, 2}):
+            with self.subTest(repr(value)):
+                out = _frame({"component": [{"use": value}]})
+                self.assertEqual(out["components"], [])
+                self.assertTrue(out["components_refused"])
+
+    def test_the_stray_key_named_is_the_first_one_down_the_file(self):
+        """`tomllib` hands back keys in the order they were written, and the operator is
+        about to go looking for one. Alphabetical was the first spelling and the sweep
+        found `sorted` and `list` indistinguishable — asked again from the operator's side,
+        file order is also the better answer."""
+        why = _frame({"component": [{"use": "repos", "zzz": 1, "aaa": 2}]})
+        self.assertIn("`zzz`", why["components_refused"])
+        self.assertNotIn("`aaa`", why["components_refused"])
+
 
 class RefusedIsNotTheSameAsUndeclared(unittest.TestCase):
     """The half of #738 that keeps it from becoming #371.

--- a/tests/test_charter_says_what_it_would_not_do.py
+++ b/tests/test_charter_says_what_it_would_not_do.py
@@ -492,6 +492,36 @@ class InsideAFrameTheRefusalGoesOnTheFrame(PersonaIso, unittest.TestCase):
         self.assertIn("reposs", state.notice(self.fid))
         self.assertEqual(calls, [])
 
+    def test_a_level_that_renders_as_nothing_is_still_named(self):
+        """`state.say` already runs `contain.one_line`, so the newline half is covered
+        before these ever call it — which is exactly why the sweep found the extra
+        `contain.readable` unpinned and why the difference had to be MEASURED rather than
+        reasoned about.
+
+        The two differ on **invisible codepoints**, and `contain.readable`'s own docstring
+        says why: `one_line` decides on `_INVISIBLE`, a list of five categories, and
+        U+3164 HANGUL FILLER and U+2800 BRAILLE PATTERN BLANK are on none of them, are not
+        `isspace`, and survive `strip`. Measured through this exact path, `charter
+        frame-density <three U+3164>`:
+
+            with    `contain.readable`: charter: no density level \\u3164\\u3164\\u3164 — have: …
+            without it:                 charter: no density level ㅤㅤㅤ — have: …
+
+        The second draws as `no density level    — have: …` — a refusal naming NO level,
+        which is #498's defect one surface over and the precise opposite of what this
+        message exists to do. Both commands, because they are two lines, and the sweep
+        reported them as two survivors."""
+        for name, fn, field in (
+                ("frame-density", commands_frame.cmd_density, "density level"),
+                ("frame-chrome", commands_frame.cmd_chrome, "chrome level")):
+            with self.subTest(name):
+                state.say(self.fid, "", seconds=0.0)
+                fn(SimpleNamespace(level="\u3164\u3164\u3164"))
+                said = state.notice(self.fid)
+                self.assertIn(field, said)
+                self.assertIn("\\u3164", said,
+                              "an invisible level reached the row as nothing at all")
+
     def test_a_hostile_component_name_is_contained_and_still_travels_no_further(self):
         """The guard is unchanged and only its silence went. The name reaches a sentence
         and nothing else — no `split-window`, no hook action text — and the sentence is one

--- a/tests/test_charter_says_what_it_would_not_do.py
+++ b/tests/test_charter_says_what_it_would_not_do.py
@@ -34,14 +34,16 @@ already owns the other kind.
 from __future__ import annotations
 
 import io
+import os
 import unittest
 from contextlib import redirect_stderr
 from types import SimpleNamespace
 from unittest import mock
 
 from charter import cli, commands_frame, doctor, instance
-from charter.frame import component, overlay, tmuxctl
+from charter.frame import component, overlay, state, tmuxctl
 from tests import _envguard
+from tests._isolation import PersonaIso
 from tests.test_component_providers import CID, ENTRY, MODULE, _SitePackages, _source
 
 
@@ -422,6 +424,87 @@ class AFrameCommandOutsideAFrameSaysSo(unittest.TestCase):
                     rc = fn(args)
                 self.assertEqual(rc, 0)
                 self.assertEqual(err.getvalue(), "")
+
+
+class InsideAFrameTheRefusalGoesOnTheFrame(PersonaIso, unittest.TestCase):
+    """The other half of #734's class, and the half that had no affordable surface until
+    #729 built one.
+
+    `outside_a_frame` answers the operator who is not in a frame. These three are the
+    operator who IS, and typed an argument charter does not know: `charter frame-density
+    enormous`, `charter frame-chrome solarized`, `charter frame-toggle reposs`. Each did
+    the same nothing at rc 0 — the same defect, one branch over, and it was left alone in
+    the first pass of this work for two reasons that #729 has since removed.
+
+    The surface was `display-message`, so saying anything meant putting a typed argument
+    through a tmux FORMAT evaluator, and `cmd_toggle`'s guard is the one thing standing
+    between an argv word and a `split-window` target (`test_component_toggle_keys.py`'s
+    hostile-name class). It also meant the message landed on whichever client tmux picked,
+    which on an eleven-frame socket is somebody else's terminal. The attention row is
+    charter's own pane, written through `state.say`'s `contain.one_line` and read by this
+    frame's own panel, so neither objection survives — and the exit status stays 0, which
+    is what a `run-shell` child owes tmux.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.fid = "knows-1"
+        self.enterContext(mock.patch.dict(os.environ,
+                                          {"CHARTER_SESSION_ID": self.fid}))
+        self.enterContext(mock.patch("charter.frame.tmuxctl.version",
+                                     return_value=(3, 7)))
+        state.record_harness_pane(self.fid, "%0")
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+
+    def _tmux_calls(self):
+        """Every `tmuxctl.run` the command made. The row is state plus a version bump, so
+        a refusal that reached tmux at all would be one that moved a pane."""
+        calls = []
+        return calls, mock.patch("charter.frame.tmuxctl.run",
+                                 side_effect=lambda *a, **k: calls.append(a))
+
+    def test_a_density_level_charter_does_not_know_says_which_three_it_does(self):
+        calls, patched = self._tmux_calls()
+        with patched:
+            rc = commands_frame.cmd_density(SimpleNamespace(level="enormous"))
+        self.assertEqual(rc, 0, "a run-shell child still owes tmux a zero")
+        self.assertIn("enormous", state.notice(self.fid))
+        for level in instance.FRAME_DENSITY:
+            self.assertIn(level, state.notice(self.fid))
+        self.assertEqual(calls, [], "a refused level moved something")
+
+    def test_a_chrome_level_charter_does_not_know_says_which_it_does(self):
+        calls, patched = self._tmux_calls()
+        with patched:
+            rc = commands_frame.cmd_chrome(SimpleNamespace(level="solarized"))
+        self.assertEqual(rc, 0)
+        self.assertIn("solarized", state.notice(self.fid))
+        self.assertEqual(calls, [])
+
+    def test_a_component_this_arrangement_does_not_hold_says_which_it_does(self):
+        """It also answers a live frame's dead key. A component's `bind -n` outlives an
+        edit to `charter.toml` that drops the component, so this is the only thing that
+        tells an operator why a key they configured has stopped doing anything."""
+        calls, patched = self._tmux_calls()
+        with patched:
+            rc = commands_frame.cmd_toggle(SimpleNamespace(component="reposs", chat=""))
+        self.assertEqual(rc, 0)
+        self.assertIn("reposs", state.notice(self.fid))
+        self.assertEqual(calls, [])
+
+    def test_a_hostile_component_name_is_contained_and_still_travels_no_further(self):
+        """The guard is unchanged and only its silence went. The name reaches a sentence
+        and nothing else — no `split-window`, no hook action text — and the sentence is one
+        line, because `state.say` runs `contain.one_line` over the assembled row."""
+        calls, patched = self._tmux_calls()
+        with patched:
+            commands_frame.cmd_toggle(
+                SimpleNamespace(component="repos\nkill-server", chat=""))
+        said = state.notice(self.fid)
+        self.assertTrue(said)
+        self.assertNotIn("\n", said)
+        self.assertNotIn("kill-server", said.replace("\\u000akill-server", ""))
+        self.assertEqual(calls, [])
 
 
 class TheHelpSaysHowToDriveIt(unittest.TestCase):

--- a/tests/test_charter_says_what_it_would_not_do.py
+++ b/tests/test_charter_says_what_it_would_not_do.py
@@ -277,9 +277,11 @@ class AFrameCommandOutsideAFrameSaysSo(unittest.TestCase):
     def test_the_commands_tmux_fires_for_itself_stay_quiet_at_zero(self):
         """The exit code is not free. `run-shell` prints `'<the whole command>' returned 1`
         into the harness pane — the one rectangle ADR 0018 says charter never draws in —
-        so a command tmux drives must not start doing that. These three are never typed:
-        `frame-palette` is a bind, `frame-respawn` a `pane-died` hook, `frame-gather` a
-        detached child of the launcher."""
+        so a command tmux drives must not start doing that. Neither of these is ever typed:
+        `frame-respawn` is a `pane-died` hook and `frame-gather` a detached child of the
+        launcher. (`frame-palette` is the third of that set and is not driven here — it has
+        no early return to assert against; it opens a palette whatever it finds, which is
+        the one of the nine that was never in this class.)"""
         for name, fn, args in (
                 ("frame-respawn", commands_frame.cmd_respawn,
                  SimpleNamespace(slot="repos", pane="%9", frame=None)),

--- a/tests/test_charter_says_what_it_would_not_do.py
+++ b/tests/test_charter_says_what_it_would_not_do.py
@@ -1,0 +1,399 @@
+"""Charter knowing a thing and not saying it, on the four surfaces that measured it.
+
+Every case here is the same defect wearing a different hat: **charter established a fact,
+acted on it, and reported success.** The four are filed separately because they fail on
+four different surfaces, and one fix does not reach the others.
+
+* **A refused `[[frame.component]]` arrangement** (#738). `instance.component_arrangement`
+  throws the operator's whole arrangement away for one unusable value — which is #535's
+  rule and stays — and until now the only trace was a `None` indistinguishable from "no
+  arrangement was written". `charter frame-probe` printed a tick, `doctor`'s rows were
+  green, and the frame that came up was the `slots` one, byte for byte identical to the
+  frame the operator would have had if they had never written the tables.
+* **`RefusedIsNotTheSameAsUndeclared`** is the half that keeps the fix honest. A warning
+  that fires on correct configurations gets switched off and then protects nothing (#371,
+  and `_BRANCH_MOVERS`' deletion), and *every* plane charter ships with — this repository's
+  own included — declares no arrangement at all.
+* **A `frame-*` command outside a frame** (#734). Six commands an operator can type opened
+  with `if not fid: return 0`: no output, a success status, nothing done. Two of them are
+  the *only* route to their action inside a tmux the operator already has, where charter
+  binds no key.
+* **What the frame is to drive** (#747). Nothing charter printed outside the frame named
+  `F2`, `F12`, or that scrollback had become tmux's copy-mode.
+* **The 3.2 resize limit** (#744). Both surfaces said a stretched frame stayed stretched
+  "until the frame is relaunched". It stays stretched until you ask: `charter frame-resize`
+  restores it in place, measured at the floor — see
+  `tmuxctl.below_resize_hook_message`'s own docstring for the pane geometry.
+
+Nothing here starts a tmux server. Every property is answerable from a resolved config, a
+message constant, or a command's refusal branch, which is what makes them cheap enough to
+assert one by one rather than through a launched frame — and `tests/test_frame_tmux_*`
+already owns the other kind.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import cli, commands_frame, doctor, instance
+from charter.frame import overlay, tmuxctl
+from tests import _envguard
+
+
+def _frame(section: dict) -> dict:
+    """`instance.frame_of` for a `[frame]` section written out as a dict.
+
+    Through `frame_of` rather than `component_arrangement` directly, because the key this
+    module is about is one `frame_of` sets and the readers below read: a test that called
+    the resolver would assert the plumbing exists without asserting anything is plumbed
+    into it.
+    """
+    return instance.frame_of({"frame": section})
+
+
+class ARefusedArrangementNamesTheKeyThatDidIt(unittest.TestCase):
+    """#738. One unusable value takes the whole arrangement out of play; the reason says
+    which value, so the operator is not re-reading a committed file line by line."""
+
+    def test_the_issues_own_bg_typo_is_named(self):
+        """The reproduction as filed: four tables, one `bg = "midnight"`."""
+        why = _frame({"component": [{"use": "identity"}, {"use": "attention"},
+                                    {"use": "repos", "bg": "midnight"},
+                                    {"use": "sidebar"}]})["components_refused"]
+        self.assertIsNotNone(why)
+        # The KEY, the VALUE and the COMPONENT — all three, because any two of them leave
+        # a four-table file with more than one candidate line.
+        self.assertIn("bg", why)
+        self.assertIn("midnight", why)
+        self.assertIn("repos", why)
+
+    def test_the_arrangement_really_is_the_one_thrown_away(self):
+        """The reason is only worth printing if it describes what happened. #535's rule is
+        that the refusal is WHOLE, so the resolved frame must be the `slots` one — the same
+        answer a plane that wrote nothing gets."""
+        section = {"slots": ["top", "bottom"],
+                   "component": [{"use": "identity"}, {"use": "repos", "bg": "midnight"}]}
+        self.assertEqual(_frame(section)["slots"], ["top", "bottom"])
+        self.assertEqual(_frame(section)["components"], [])
+
+    def test_every_refusal_on_the_documented_list_has_a_reason(self):
+        """`docs/frame.md` lists what is refused; a reason for some of them and a bare
+        `None` for the rest would leave the operator guessing which kind they hit — and
+        `frame_ready`/`doctor` would go silent on exactly the ones nobody thought of.
+
+        Each row is a section that MUST refuse. The assertion is that no refusal comes back
+        reasonless, which is the property, rather than the specific wording, which is not.
+        """
+        refusals = {
+            "unknown use": [{"use": "nosuchthing"}],
+            "misspelt key": [{"use": "repos", "bgg": "blue"}],
+            "duplicate": [{"use": "repos"}, {"use": "repos"}],
+            "no use at all": [{"edge": "top"}],
+            "use is not a string": [{"use": 7}],
+            "table is not a table": ["identity"],
+            "visible is not a bool": [{"use": "repos", "visible": "yes"}],
+            "bg outside the words": [{"use": "repos", "bg": "midnight"}],
+            "pad above the max": [{"use": "repos", "pad": 99}],
+            "pad below zero": [{"use": "repos", "pad": -1}],
+            "edge on a built-in": [{"use": "repos", "edge": "left"}],
+            "size charter cannot give": [{"use": "identity", "size": 4}],
+            "key charter will not bind": [{"use": "repos", "key": "F2\nkill-server"}],
+            "key already bound": [{"use": "repos", "key": "F2"}],
+            "provider with no edge": [{"use": "weather", "size": 1}],
+            "provider with no size": [{"use": "weather", "edge": "top"}],
+        }
+        for name, tables in refusals.items():
+            with self.subTest(name):
+                out = _frame({"component": tables})
+                self.assertEqual(out["components"], [], f"{name} was not refused")
+                self.assertTrue(out["components_refused"], f"{name} refused in silence")
+
+    def test_a_committed_value_cannot_forge_a_line_of_the_report(self):
+        """The reason is interpolated into `doctor`'s hint and `frame-probe`'s output, and
+        every value in it arrives from a committed file that came off someone else's
+        machine — `_HOTKEY_RE`'s own hazard, one key over. `contain.readable` is what
+        stands between a `bg` holding a newline and a second row of charter's own report."""
+        why = _frame({"component": [{"use": "repos", "bg": "blue\n  ✓  frame  all good"}]})
+        self.assertNotIn("\n", why["components_refused"])
+        self.assertIn("\\u000a", why["components_refused"])
+
+
+class RefusedIsNotTheSameAsUndeclared(unittest.TestCase):
+    """The half of #738 that keeps it from becoming #371.
+
+    `_BRANCH_MOVERS` is this repository's record of a guard that fired too often being
+    deleted outright, and a warning an operator learns to ignore protects nothing. The
+    reason must be `None` for every plane that is *working*, and the population of those is
+    "every plane that did not write the key" — which is every plane charter ships.
+    """
+
+    def test_a_plane_that_declared_no_arrangement_says_nothing(self):
+        for name, cfg in {"no [frame] section": {},
+                          "[frame] with other keys": {"frame": {"slots": ["top"]}},
+                          "a density preset": {"frame": {"density": "minimal"}}}.items():
+            with self.subTest(name):
+                self.assertIsNone(instance.frame_of(cfg)["components_refused"])
+
+    def test_an_arrangement_charter_accepts_says_nothing(self):
+        out = _frame({"component": [{"use": "identity"}, {"use": "repos", "bg": "blue"},
+                                    {"use": "sidebar", "key": "F9", "pad": 1}]})
+        self.assertIsNone(out["components_refused"])
+        self.assertEqual(len(out["components"]), 3)
+
+    def test_this_repositorys_own_plane_says_nothing(self):
+        """The sharpest form of the same test, and the one that would have caught a fix
+        that warned on a working file: charter's own `charter.toml` is a real, committed,
+        hand-maintained plane config, and it must not put `doctor` in the yellow."""
+        import tomllib
+        from pathlib import Path
+        here = Path(__file__).resolve().parent.parent / "charter.toml"
+        cfg = tomllib.loads(here.read_text())
+        self.assertIsNone(instance.frame_of(cfg)["components_refused"])
+
+    def test_the_key_is_present_on_every_path_frame_of_returns_by(self):
+        """`frame_of`'s own rule for `components`: a key on one path and absent on another
+        is two shapes for one answer, and the reader would be catching a `KeyError` on
+        exactly the planes that declare no `[frame]` section."""
+        for cfg in ({}, {"frame": "not a table"}, {"frame": {}},
+                    {"frame": {"component": [{"use": "identity"}]}},
+                    {"frame": {"component": [{"use": "repos", "bg": "midnight"}]}}):
+            with self.subTest(repr(cfg)):
+                self.assertIn("components_refused", instance.frame_of(cfg))
+
+
+class BothSurfacesSayIt(unittest.TestCase):
+    """#738's actual complaint: three surfaces whose job is to report configuration health,
+    all reporting health. The launch stays silent on purpose (`frame_ready`'s docstring
+    measures why), so these two are the whole surface."""
+
+    def setUp(self) -> None:
+        _envguard.unset_all()
+        self.refused = _frame({"component": [{"use": "repos", "bg": "midnight"}]})
+
+    def test_frame_probe_names_it_as_a_standing_limit(self):
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch.dict(commands_frame.config.FRAME, self.refused, clear=False):
+            code, level, line = commands_frame.frame_ready()
+        self.assertEqual(level, "warn")
+        self.assertIn("[[frame.component]]", line)
+        self.assertIn("midnight", line)
+        # Not an error, for the reason none of the other ceilings are: `cmd_launch` draws
+        # the frame regardless, and a probe stricter than the launcher lies about it.
+        self.assertEqual(code, 0)
+
+    def test_a_clean_plane_leaves_the_probe_a_tick(self):
+        """The #371 half at this surface. It held before the fix and has to go on holding
+        after it: a probe that warned about a working arrangement would be the ceiling list
+        learning to cry wolf, and the whole list gets ignored together."""
+        clean = _frame({"component": [{"use": "identity"}]})
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch.dict(commands_frame.config.FRAME, clean, clear=False):
+            code, level, line = commands_frame.frame_ready()
+        self.assertEqual((code, level), (0, "ok"))
+        self.assertNotIn("[[frame.component]]", line)
+
+    def test_doctor_puts_it_where_the_other_ignored_keys_are(self):
+        """`charter.toml`, not `frame` — beside `[plane] worktrees` and `[harness] default`
+        (#715), because it is the same fact as those two: a committed setting that is not
+        in force and reads exactly like one that was never written. `check_frame` answers
+        "can a frame run on this MACHINE"."""
+        with mock.patch("charter.instance.frame_of", return_value=self.refused):
+            r = doctor.check_control_plane_config()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("[[frame.component]]", r.detail)
+        self.assertIn("midnight", r.hint)
+
+    def test_both_surfaces_say_it_in_the_same_words(self):
+        """One sentence, shared. Two copies of a standing fact drift into two different
+        facts — `no_renderer_message`'s own reason for existing, and `below_floor_message`'s
+        history before it."""
+        why = self.refused["components_refused"]
+        sentence = instance.refused_arrangement_message(why)
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch.dict(commands_frame.config.FRAME, self.refused, clear=False):
+            _code, _level, line = commands_frame.frame_ready()
+        with mock.patch("charter.instance.frame_of", return_value=self.refused):
+            r = doctor.check_control_plane_config()
+        self.assertIn(sentence, line)
+        self.assertIn(sentence, r.hint)
+
+
+class AFrameCommandOutsideAFrameSaysSo(unittest.TestCase):
+    """#734, and the class turned out wider than the four commands it names.
+
+    `frame-switch` is the fifth — the ONLY one of them with a `help=` string, so it is the
+    one `charter --help` lists and the most likely to be typed by somebody who has never
+    been in a frame. `frame-resize` is the sixth, and #744 is what made it one: below tmux
+    3.3 it is the operator's only resize recovery, and both surfaces now tell them to type
+    it.
+    """
+
+    #: Every `frame-*` command an operator can type, with an argv that is otherwise valid.
+    #: The point of "otherwise valid" is that nothing else in the command can be blamed for
+    #: the silence — `repos` IS in this plane's arrangement, `minimal` IS a density level.
+    TYPEABLE = {
+        "charter frame-chat": (commands_frame.cmd_chat,
+                               SimpleNamespace(chat_id="alpha.1", chat="")),
+        "charter frame-density": (commands_frame.cmd_density,
+                                  SimpleNamespace(level="minimal")),
+        "charter frame-toggle": (commands_frame.cmd_toggle,
+                                 SimpleNamespace(component="repos", chat="")),
+        "charter frame-chrome": (commands_frame.cmd_chrome, SimpleNamespace(level="dark")),
+        "charter frame-switch": (commands_frame.cmd_switch,
+                                 SimpleNamespace(workspace="beta", persona=None)),
+        "charter frame-resize": (commands_frame.cmd_resize, SimpleNamespace(frame=None)),
+    }
+
+    def setUp(self) -> None:
+        # The whole condition under test is "no `$CHARTER_SESSION_ID`", and the shell the
+        # suite was launched from may well be inside a live frame — which is exactly how
+        # this issue's own reproduction was first run against the wrong branch.
+        _envguard.unset_all()
+
+    def test_each_one_says_which_command_did_nothing(self):
+        for name, (fn, args) in self.TYPEABLE.items():
+            with self.subTest(name):
+                err = io.StringIO()
+                with redirect_stderr(err):
+                    rc = fn(args)
+                self.assertNotEqual(rc, 0, f"{name} reported success having done nothing")
+                self.assertIn(name, err.getvalue())
+
+    def test_the_sentence_says_where_to_run_it_instead(self):
+        """"Not in a frame" tells an operator who typed this in the wrong pane nothing they
+        did not already know. The window is the actionable half, and `charter docs show
+        frame` is where the rest of it lives (#747)."""
+        err = io.StringIO()
+        with redirect_stderr(err):
+            commands_frame.cmd_toggle(SimpleNamespace(component="repos", chat=""))
+        said = err.getvalue()
+        self.assertIn("charter <harness>", said)
+        self.assertIn("charter docs show frame", said)
+
+    def test_the_commands_tmux_fires_for_itself_stay_quiet_at_zero(self):
+        """The exit code is not free. `run-shell` prints `'<the whole command>' returned 1`
+        into the harness pane — the one rectangle ADR 0018 says charter never draws in —
+        so a command tmux drives must not start doing that. These three are never typed:
+        `frame-palette` is a bind, `frame-respawn` a `pane-died` hook, `frame-gather` a
+        detached child of the launcher."""
+        for name, fn, args in (
+                ("frame-respawn", commands_frame.cmd_respawn,
+                 SimpleNamespace(slot="repos", pane="%9", frame=None)),
+                ("frame-gather", commands_frame.cmd_gather,
+                 SimpleNamespace(session="", workspace="beta"))):
+            with self.subTest(name):
+                err = io.StringIO()
+                with redirect_stderr(err):
+                    rc = fn(args)
+                self.assertEqual(rc, 0)
+                self.assertEqual(err.getvalue(), "")
+
+
+class TheHelpSaysHowToDriveIt(unittest.TestCase):
+    """#747. `charter claude --help` and `charter frame --help` described four flags and
+    never said what the frame they open is, or how to work it."""
+
+    def setUp(self) -> None:
+        _envguard.unset_all()
+
+    def _epilog(self, command: str) -> str:
+        parser = cli.build_parser()
+        return parser._subparsers._group_actions[0].choices[command].epilog or ""
+
+    def test_every_launcher_names_the_palette_the_hatch_and_scrollback(self):
+        """Both, and by construction: `cli._wire` sets one epilog for every registered
+        harness plus the escape hatch, so a harness registered next year gets it too."""
+        for command in ("claude", "frame"):
+            with self.subTest(command):
+                epilog = self._epilog(command)
+                self.assertIn(commands_frame.config.FRAME["hotkey"], epilog)
+                self.assertIn(overlay.HATCH_KEY, epilog)
+                self.assertIn("copy-mode", epilog)
+                self.assertIn("charter docs show frame", epilog)
+
+    def test_the_two_launchers_still_say_the_same_thing(self):
+        """#747 observed that the two help pages are identical and did not ask for that to
+        change — what was wrong is that the identical thing they said was silent on the
+        frame. `assertTrue` first, because equality alone was satisfied on the day both
+        epilogs were `None`: an assertion that holds over the defect it is guarding is one
+        this project has paid for repeatedly."""
+        self.assertTrue(self._epilog("claude"))
+        self.assertEqual(self._epilog("claude"), self._epilog("frame"))
+
+    def test_the_palette_key_is_this_planes_own_and_not_the_constant(self):
+        """A help line saying `F2` on a plane that moved `[frame] hotkey` is worse than one
+        that says nothing: it is a fact the operator will act on, once, and then stop
+        trusting the page."""
+        with mock.patch.dict(commands_frame.config.FRAME, {"hotkey": "C-b"}, clear=False):
+            keys = " ".join(commands_frame.driving_keys())
+        self.assertIn("C-b", keys)
+        self.assertNotIn("F2 opens", keys)
+
+    def test_the_probe_says_it_too_ceiling_or_no_ceiling(self):
+        """`frame-probe` is the closest thing charter has to "tell me about the frame", and
+        it named every standing limit and no key at all. It rides below the ceilings rather
+        than joining them: a ceiling is a capability this machine does not have, and a key
+        that works is the opposite of one."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)):
+            _code, level, line = commands_frame.frame_ready()
+        self.assertEqual(level, "ok")
+        self.assertIn(overlay.HATCH_KEY, line)
+        self.assertIn("copy-mode", line)
+
+
+class TheThirtyTwoResizeLimitNamesItsRemedy(unittest.TestCase):
+    """#744, measured on `~/.local/share/charter-testing/tmux-3.2`: a frame launched at
+    120x40, dragged to 80x24 and back, reports `%1 5x120 %0 22x97 %4 22x22 %3 5x120
+    %2 5x120` and keeps them; `charter frame-resize` puts back `%1 1x120 %0 34x97 %4 34x22
+    %3 1x120 %2 1x120`, which is the launch geometry exactly.
+
+    So the standing limit is not "until the frame is relaunched" — it is "until you ask",
+    and asking is one command that already exists.
+    """
+
+    def setUp(self) -> None:
+        # `doctor.check_frame` asks `_statusline_suppressed_note` whether THIS session's
+        # footer is being blanked, which reads `$CHARTER_SESSION_ID`. Outside a frame is
+        # the state these assertions are about, and it is stated rather than inherited.
+        _envguard.unset_all()
+
+    def test_the_message_stops_promising_a_relaunch(self):
+        said = tmuxctl.below_resize_hook_message((3, 2))
+        self.assertNotIn("until the frame is relaunched", said)
+        self.assertIn("charter frame-resize", said)
+
+    def test_it_stops_saying_everything_else_works(self):
+        """"Panels stretch" reads as cosmetic. At 80x24 on 3.2 the sidebar is two columns
+        of glyph stubs and the repo pane holds a permanent `⋯ too narrow for the repo
+        table` — a line written to be transient, which never settles because nothing
+        re-measures."""
+        said = tmuxctl.below_resize_hook_message((3, 2))
+        self.assertIn("too narrow for the repo table", said)
+        self.assertIn("sidebar", said)
+
+    def test_both_reading_surfaces_carry_the_remedy(self):
+        """`frame_ready` and `doctor.check_frame` share the one sentence rather than
+        writing it twice — the reason `below_floor_message` was extracted in the first
+        place."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 2)):
+            _code, level, line = commands_frame.frame_ready()
+            row = doctor.check_frame()
+        self.assertEqual(level, "warn")
+        self.assertIn("charter frame-resize", line)
+        self.assertEqual(row.status, doctor.WARN)
+        self.assertIn("charter frame-resize", row.hint)
+
+    def test_a_tmux_above_the_floor_is_told_none_of_it(self):
+        """The limit is real on 3.2 and absent on 3.3+; a remedy offered to somebody who
+        does not need it is the noise that gets a whole surface ignored."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)):
+            _code, _level, line = commands_frame.frame_ready()
+        self.assertNotIn("charter frame-resize", line)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_component_toggle_keys.py
+++ b/tests/test_component_toggle_keys.py
@@ -38,6 +38,8 @@ alphabet, and a name that is not in this frame's arrangement toggles nothing.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 import subprocess
 import sys
@@ -254,27 +256,36 @@ class ARefusedToggleChangesNothingAtAll(PersonaIso, unittest.TestCase):
         self.assertEqual(fake.killed(), {"%5"}, fake.calls)
         self.assertEqual(state.hidden(self.fid), ("repos",))
 
-    def test_outside_a_frame_it_does_nothing(self):
+    def test_outside_a_frame_it_says_so_and_moves_nothing(self):
         """No `$CHARTER_SESSION_ID` — typed in an ordinary shell rather than fired by a
-        bind. Nothing runs and nothing is written.
+        bind. Nothing runs, nothing is written, and — since #734 — charter says so.
 
-        **`cmd_toggle` has no refusal of its own for this, and that is a finding rather
-        than an omission.** The deletion sweep proved an `if not fid: return 0` at the top
-        of that function exactly equivalent: with it gone the full suite stayed green and
-        every observable was identical — same return code, no tmux command, no file
-        created, nothing readable back. The line that actually carries the property is
-        `_relayout_target`'s `_PANE_ID_RE` check, because `contain.child` refuses `""` as a
-        path segment, so `state.frame_dir` and `state.harness_pane` both answer `None` and
-        the pane id is the empty string. That line IS pinned
-        (`test_a_harness_pane_that_is_not_tmuxs_own_shape_moves_nothing`), so the guarantee
-        rests on something a mutation can reach — which is the whole test the sweep applies.
+        **`cmd_toggle` used to have no refusal of its own for this, and that WAS defensible
+        until it was measured from the operator's side.** The deletion sweep had proved an
+        `if not fid: return 0` at the top of the function exactly equivalent: with it gone
+        the suite stayed green and every observable was identical — same return code, no
+        tmux command, nothing readable back. A guard nothing can pin is a comment with a
+        runtime cost, so it went, and the property was left resting on `_relayout_target`'s
+        `_PANE_ID_RE` check (which is pinned, by
+        `test_a_harness_pane_that_is_not_tmuxs_own_shape_moves_nothing`).
 
-        The chain is asserted here, not inferred: if `frame_dir` ever started answering for
-        an empty id, this test says so at the step where it changed."""
+        What that argument missed is that "every observable was identical" was itself the
+        bug. Inside a tmux you already have, charter binds no key at all, so
+        `charter frame-toggle <name>` typed in the frame's own window is the *only* route
+        to a toggle — and typed one window over it printed nothing and exited 0. The guard
+        is back with a consequence a mutation can reach: delete it now and this test goes
+        red on the stderr line and on the exit code.
+
+        The chain below it is still asserted rather than inferred: if `frame_dir` ever
+        started answering for an empty id, this test says so at the step where it changed.
+        """
         self.assertIsNone(state.frame_dir(""))
         self.assertIsNone(state.harness_pane(""))
-        rc, fake = self._toggle("repos")
-        self.assertEqual(rc, 0)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            rc, fake = self._toggle("repos")
+        self.assertNotEqual(rc, 0)
+        self.assertIn("charter frame-toggle", err.getvalue())
         self.assertEqual(fake.calls, [])
         self.assertIsNone(state.hidden(self.fid))
 

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -19,6 +19,8 @@ claim about.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 import unittest
 from unittest import mock
@@ -827,18 +829,25 @@ class TheSwitchIsFourStepsInOneOrder(PersonaIso, unittest.TestCase):
         `-L charter` server was attached most recently — so `charter frame-chat api.2`
         typed in an ordinary shell drew charter's refusal across another operator's frame.
 
-        Unlike `cmd_toggle`'s deleted `if not fid`, this refusal is not free: that command
-        emits nothing with an empty id and its guard was an equivalent mutant, and this
-        one issues a real tmux command aimed at a session it has no business naming.
+        This refusal issues a real tmux command aimed at a session it has no business
+        naming, which is what makes the guard worth having at all.
+
+        **The refusal is now said on the asker's own stderr and the status is non-zero**
+        (#734): rc 0 and zero bytes was indistinguishable from the switch working, and
+        `docs/frame.md` makes this command the documented fallback when the palette's
+        doorway is refused. What must not change, and is what this test is for, is that
+        nothing goes near tmux — stderr is the one surface that is certainly the asker's.
         """
         said = []
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": ""}, clear=False), \
              mock.patch.object(commands_frame, "_say_on_screen",
-                               lambda fid, msg, *a, **k: said.append(msg)):
-            self.assertEqual(
+                               lambda fid, msg, *a, **k: said.append(msg)), \
+             contextlib.redirect_stderr(io.StringIO()) as stderr:
+            self.assertNotEqual(
                 commands_frame.cmd_chat(mock.Mock(chat_id="api.2", chat="")), 0)
         self.assertEqual(self.fake.calls, [])
         self.assertEqual(said, [], "a refusal was aimed at a frame this is not in")
+        self.assertIn("charter frame-chat", stderr.getvalue())
 
     def test_an_absent_or_padded_chat_id_is_refused_rather_than_raising(self):
         """`(… or "").strip()`, both halves. `None` reaches `str.strip` as an

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -24,6 +24,7 @@ directory and that `cmd_density` touches no `charter.toml` at all.
 from __future__ import annotations
 
 import contextlib
+import io
 import json
 import os
 import subprocess
@@ -1527,16 +1528,30 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         armed = [c for c in fake.calls if "pane-died" in c and "-u" not in c]
         self.assertEqual(len(armed), 1, fake.calls)
 
-    def test_no_session_id_is_a_quiet_no_op(self):
-        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": ""}):
+    def test_no_session_id_is_not_a_quiet_no_op_any_more(self):
+        """It used to be, and that was the defect (#734). `charter frame-density minimal`
+        typed in the window you started from rather than the one charter opened printed
+        nothing and exited 0 — and inside a tmux you already have, where charter binds no
+        key, typing it IS the documented route to a density change. The frame is still
+        untouched, which is the half worth keeping."""
+        err = io.StringIO()
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": ""}), \
+             contextlib.redirect_stderr(err):
             rc, fake = self._run("full")
-        self.assertEqual(rc, 0)
+        self.assertNotEqual(rc, 0)
+        self.assertIn("charter frame-density", err.getvalue())
         self.assertEqual(fake.calls, [])
         self.assertIsNone(state.density(self.fid))
 
     def test_an_unknown_level_is_refused_before_anything_moves(self):
         """The level reaches a slot list and a palette row; the closed set is the guard,
-        and it must be asked BEFORE the frame is touched, not after."""
+        and it must be asked BEFORE the frame is touched, not after.
+
+        Still a silent 0, and deliberately so: #734 separated the two refusals this
+        function used to share an `or` with, and only the empty `$CHARTER_SESSION_ID` half
+        crossed the line into "an operator typed this and got nothing back". A level
+        outside the closed set is answered inside a frame, on the `run-shell` side of that
+        line — see `commands_frame.outside_a_frame`'s own docstring."""
         rc, fake = self._run("enormous")
         self.assertEqual(rc, 0)
         self.assertEqual(fake.calls, [])

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1142,6 +1142,22 @@ class MissingTmux(unittest.TestCase):
         run.assert_not_called()
 
 
+def _ceilings(line: str) -> list[str]:
+    """The capability ceilings `frame_ready` named, and nothing else it printed.
+
+    "No ceiling" used to be spelled `assertNotIn("\\n", line)` — true only for as long as a
+    clean probe was exactly one line. It is not any more: since #747 every probe closes
+    with the three keys the frame is driven by, because `frame-probe` is the closest thing
+    charter has to "tell me about the frame" and it named every limit and no key at all.
+
+    So the assertion asks the question it always meant: `frame_ready` marks a ceiling with
+    `↳` and nothing else in its output carries that character, which makes the count of
+    them the property rather than the shape of the whole message. A probe that started
+    warning about a working machine still fails these, which is what they are for.
+    """
+    return [ln for ln in line.split("\n") if "↳" in ln]
+
+
 class Probe(unittest.TestCase):
     """`--probe` (on `cmd_launch`) and `charter frame-probe` (`cmd_probe`) share one
     read-only gate, `commands_frame.frame_ready` — mirroring `cmd_launch`'s OWN behaviour
@@ -1255,7 +1271,7 @@ class Probe(unittest.TestCase):
              mock.patch.dict(config.FRAME, {"slots": ["top", "bottom"]}):
             code, level, line = commands_frame.frame_ready()
         self.assertEqual((code, level), (0, "ok"))
-        self.assertNotIn("\n", line)
+        self.assertEqual(_ceilings(line), [])
 
     def test_an_ordinary_machine_gets_no_ceilings_at_all(self):
         """The other direction, and what stops the two tests above from passing against
@@ -1265,7 +1281,7 @@ class Probe(unittest.TestCase):
              mock.patch.dict(config.FRAME, {"slots": ["top", "bottom"]}):
             code, level, line = commands_frame.frame_ready()
         self.assertEqual((code, level), (0, "ok"))
-        self.assertNotIn("\n", line)
+        self.assertEqual(_ceilings(line), [])
 
     def test_cmd_launch_short_circuits_on_probe_before_touching_anything(self):
         """`args.probe` is checked before `harness.all()`, `workspace.resolve()`, or any

--- a/tests/test_frame_surface_live.py
+++ b/tests/test_frame_surface_live.py
@@ -34,6 +34,8 @@ a refusal with no measurement behind it, on the one path where a refusal is invi
 
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 import pathlib
 import subprocess
@@ -337,10 +339,21 @@ class TheChromeCommandChangesOneRunningFrame(PersonaIso, unittest.TestCase):
         self.assertEqual(state.chrome(self.FID), "off")
         self.assertTrue(all("-u" in a for a in self.ran), self.ran)
 
-    def test_no_session_id_records_nothing_and_runs_nothing(self):
+    def test_no_session_id_says_so_and_still_runs_nothing(self):
+        """Records nothing, runs nothing — and, since #734, says so and exits non-zero.
+
+        `charter frame-chrome dark` typed in an ordinary shell used to print zero bytes and
+        report success. Separated from the level check below because they are two different
+        refusals: this one is an operator who is not where they think they are, and the
+        surface that is certainly theirs is their own stderr; that one is a word outside a
+        closed set, answered inside a frame where a `run-shell` child's non-zero status
+        would print into the harness pane."""
         self._with_panes()
-        with mock.patch.dict(os.environ, {}, clear=True):
-            self.assertEqual(commands_frame.cmd_chrome(self._args("dark")), 0)
+        err = io.StringIO()
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             contextlib.redirect_stderr(err):
+            self.assertNotEqual(commands_frame.cmd_chrome(self._args("dark")), 0)
+        self.assertIn("charter frame-chrome", err.getvalue())
         self.assertIsNone(state.chrome(self.FID))
         self.assertEqual(self.ran, [])
 


### PR DESCRIPTION
Five issues filed tonight by a UX auditor driving a real frame, four of them fixed here.
They are one defect wearing four hats: **charter established a fact, acted on it, and
reported health.**

Closes #738, closes #734, closes #747, closes #744.

---

## #738 — a refused `[[frame.component]]` arrangement was silent on every surface

Reproduced as filed. Four tables, one `bg = "midnight"`:

```
$ charter frame-probe
✓ charter frame: tmux 3.7 — a frame can run on this machine     rc=0
$ charter doctor | grep -E 'frame|charter.toml'
  ✓  charter.toml   parsed cleanly (…)
  ✓  frame          tmux 3.7
```

The arrangement is refused whole — #535's rule, and it stays, for its own good reason —
so the frame that comes up is the `slots` one, byte for byte identical to the frame the
operator would have had if they had never written the tables. `docs/frame.md` promised
they would "see your whole arrangement not take effect". There was nothing to see.

`instance.component_arrangement` now answers `(placements, reason)` and each of the
fifteen refusals carries a sentence naming the table, the key and the value.
`component_tables` stays as the projection that drops the reason, so its twenty-odd
callers are untouched. `frame_of` records the reason as `components_refused`, which is
`harness_of`'s `refused` under a name that says which of `[frame]`'s keys it is about.

```
$ charter frame-probe
! charter frame: tmux 3.7 — a frame can run on this machine
  ↳ `[[frame.component]]` is not in force — `bg = "midnight"` on `repos` is not one of
    charter's 17 pane background words (`default`, the 8 ANSI colour names, and each of
    those with a `bright` prefix). An arrangement charter cannot draw is refused whole
    rather than one table at a time, so the frame you get is the one `[frame] slots`
    describes and every other table's `edge`, `size`, `bg`, `pad` and `key` goes with it.
    Fix that one key and the arrangement comes back.

$ charter doctor
  !  charter.toml   [[frame.component]] is refused; the frame is drawing `[frame] slots`
```

**`charter.toml` and not the `frame` row**, per the brief's steering and on its merits: it
is the same fact as the two silently-ignored settings already in that row —
`config.worktrees_root_for`'s `[plane] worktrees` and #715's `[harness] default`. A
committed key that is not in force and reads exactly like one nobody wrote. `check_frame`
answers "can a frame run on this MACHINE"; this is about the file.

### What is genuinely refused

Every path that already threw the arrangement away, and nothing else. Enumerated in
`ARefusedArrangementNamesTheKeyThatDidIt.test_every_refusal_on_the_documented_list_has_a_reason`:
an unknown `use`, a `use` that is not a string, a duplicate, a table that is not a table, a
misspelt key, a non-bool `visible`, a `pad` outside 0–5, a `size` charter cannot give that
component, an `edge` it cannot move a built-in to, a `key` it will not bind, a `key`
something already has, a provider with no `edge`, a provider with no `size`, a provider
this machine has no distribution for — plus one the issue did not list and TOML makes easy:
**single-bracket `[frame.component]`**, which parses as a table rather than an array of
them and produced the default frame in silence.

### And what is deliberately not

`_BRANCH_MOVERS` and #371 are this repo's record of a guard that fired too often being
deleted outright, so the reporting branch is gated on the KEY's presence and not on the
value being falsy: `component` absent → `None`, always. That covers every plane charter
ships. `RefusedIsNotTheSameAsUndeclared` pins it, including
`test_this_repositorys_own_plane_says_nothing`, which parses this repository's real
`charter.toml` — the test that would have caught a fix that warned on a working file.

## #734 — six commands, not four

Reproduced, and **the class is wider than the issue names**:

| command | typeable by hand? | before |
|---|---|---|
| `frame-chat` | yes — the documented palette fallback | rc 0, 0 bytes |
| `frame-density` | yes — the only route inside your own tmux | rc 0, 0 bytes |
| `frame-toggle` | yes — the only route inside your own tmux | rc 0, 0 bytes |
| `frame-chrome` | yes | rc 0, 0 bytes |
| **`frame-switch`** | **yes — and the only one of the six with a `help=`, so the only one `charter --help` shows you** | rc 0, 0 bytes |
| **`frame-resize`** | **yes, and #744 is what makes it so** | rc 0, 0 bytes |
| `frame-palette` / `frame-respawn` / `frame-gather` | no — a bind, a `pane-died` hook, a detached child | rc 0, 0 bytes — **unchanged** |

`commands_frame.outside_a_frame` gives the six one sentence on stderr and a non-zero
status. The three tmux drives are left exactly as they were.

**The exit code was measured before it was changed.** On tmux 3.7c, `run-shell` shows a
child's **stdout** and discards its **stderr** entirely, and prints `'<the whole command>'
returned 1` for any non-zero status — into the harness pane, the one rectangle ADR 0018
says charter never draws in. That is why the other refusals in these functions still
return 0 and always will. It does not reach this branch: a bind carries `--chat` expanded
from the presser's own window, the resize hook carries `--frame`, and a palette row's child
is handed `CHARTER_SESSION_ID` explicitly by `builtin_actions._spawn`. On every path tmux
drives, `fid` is set.

`cmd_toggle` is the interesting one. Its `if not fid` was **deleted** on purpose, by the
deletion sweep, as a guard nothing could pin — with it gone every observable was identical.
That argument was right about the mechanism and wrong about the operator: "every observable
was identical" was the bug. The guard is back with a consequence a mutation can reach, and
`test_outside_a_frame_it_says_so_and_moves_nothing` now goes red without it.

## #747 — nothing outside the frame said how to drive it

One epilog, set in `cli._wire`, so every registered harness plus the escape hatch gets it
and the two pages stay identical **by construction**:

```
Inside the frame:
  F2 opens the palette — every action the frame has is in there
  F12 takes the keyboard back from a pane that has stopped answering
  scrollback is tmux's copy-mode now, not your terminal's own
  charter docs show frame  —  all of it, and what `[frame]` configures.
```

The same three close every `charter frame-probe`, ceiling or no ceiling — it is the closest
thing charter has to "tell me about the frame", and it named every limit and no key at all.
The palette key is read from `config.FRAME`, so a plane that moved `[frame] hotkey` gets its
own key rather than a page telling it `F2`. That also answers the auditor's related note:
`charter docs show frame` now has something pointing at it, from both surfaces.

## #744 — measured at the floor, and the issue is right

`~/.local/share/charter-testing/tmux-3.2`, a real frame under a real pty, launched at
120x40, dragged to 80x24 and back:

```
%1 5x120   %0 22x97   %4 22x22   %3 5x120   %2 5x120     <- stretched, and staying
$ charter frame-resize
%1 1x120   %0 34x97   %4 34x22   %3 1x120   %2 1x120     <- the launch geometry, exactly
```

Identical to the issue's numbers. `cmd_resize` is not version-dependent; only the hook that
fires it is. So `tmuxctl.below_resize_hook_message` stops saying "until the frame is
relaunched" and names the command, and `docs/frame.md` does the same in both places.

The second half is right too. At 80x24 on 3.2 the sidebar is `%4 18x2` — **two columns**,
one truncated glyph per row — and the repo pane holds `⋯ too narrow for the repo table — 95
columns needed`, a line `frame/slots.py` writes to be transient and which here never settles
because nothing measures again. "Everything else in the frame works" is gone.

## #752 — not in this PR

Verified and reproduced exactly as filed: `mv workspaces/alpha` under a running frame
leaves the frame drawing `⬢ alpha`, `no clones in alpha · charter clone <repo> -w alpha`,
`no personas` and `0 todos` while `charter workspace list` lists only `beta` — three ways of
saying "empty" for a thing that is absent, on the only surface still claiming it exists.

The fix belongs in `charter/frame/slots.py`, which another agent holds for the windowed tab
strip. Left out rather than collided with; see the scope note below.

---

## Scope

`charter/commands_frame.py` and `charter/instance.py` are held by other clusters. The
changes here are confined to functions those clusters do not name — `frame_ready`,
`cmd_probe`, and the six commands' first guard in `commands_frame.py`;
`component_tables`/`frame_of` in `instance.py`. `doctor.py`, `cli.py`, `frame/tmuxctl.py`
and `docs/` were free.

## Verification

- **Full suite green locally**: `Ran 9344 tests … OK (skipped=1)`. CI green on 3.11, 3.12,
  3.13 and 3.14.
- **Deletion sweep on `d2ff872`: 45 mutations, 44 pinned, 0 survivors, 1 unresolved.**
  Shard 1 `no survivors` (23/23 pinned); shard 2 0 survived, 21 pinned, 1 unresolved. The
  unresolved one is `instance.py:1420 [retune-string] "hotkey"` — selected against 269
  modules and timed out rather than failing, which is #773's signature and is not a
  survivor. Measured locally instead: it is a `KeyError` inside `config.derive`, so it
  takes down `import charter.config` and every test that imports charter. Pinned many
  times over. An earlier run reported 2 survivors; both were real (not equivalent), and
  the comment thread below carries the measurement and the test that kills them.
- Every test in `tests/test_charter_says_what_it_would_not_do.py` fails without its fix,
  except the handful that are explicitly noise-guards and say so in their own docstrings.
- Real tmux 3.7c and the 3.2 floor, each on its own socket directory via `$TMUX_TMPDIR`.
  The operator's live `charter` socket was never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy

