### PR TITLE
The `F2 palette` hint is a button, a persona row is a row you pick, and its badges say what they mean (#742, #751, #753)

### DIFF
--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -422,6 +422,180 @@ def _bar_events(fid: str, command: tuple[str, ...]):
     return on_event
 
 
+#: What a click on the `personas` column starts — the same front door
+#: :data:`_WORKSPACE_SWITCH` opens for the other noun, one option over
+#: (`commands_frame.cmd_switch` takes both). Not `choose.switch_to` called in process, for
+#: :data:`_CHAT_SWITCH`'s two reasons: every refusal `switch.to_persona` can raise reaches
+#: the operator through `_say_on_screen`, which is a `display-message` on the frame's own
+#: client and a surface no panel process has; and a switch re-gathers the plane, which is
+#: not a paint loop's work to sit through.
+_PERSONA_SWITCH = ("frame-switch", "--persona")
+
+#: What a click on a door opens: `F2`'s own action, spelled the way `commands_frame
+#: .conf_text` binds it minus the client name.
+#:
+#: **The client is not passed, and that is a real difference from the bind.** `conf_text`
+#: expands `#{client_name}` because tmux knows which client pressed the key; a panel
+#: process is not a `run-shell` child of a keypress and has no presser to name. What the
+#: client buys is which screen `cmd_palette`'s refusals are drawn on, and without it
+#: `_say_on_screen` falls back to `-t <session>` — the most recently attached client,
+#: measured in that function. On the one-client frame this is drawn for they are the same
+#: screen; on a two-client one a refusal can land on the other operator's status line,
+#: which is the honest cost of a doorway that is a rectangle rather than a keystroke.
+#:
+#: **And no `--chat` either, for `_bar_events`' reason**: `builtin_actions._spawn` sets
+#: `$CHARTER_SESSION_ID` to this panel's own *fid*, which is the chat this pane was
+#: launched for, and `commands_frame._pressers_chat` falls back to exactly that. The
+#: option exists because one `bind` text is shared by every frame on the socket; a panel
+#: was TOLD which frame it draws and has no such ambiguity to resolve.
+_PALETTE = ("frame-palette",)
+
+
+def _strip_events(fid: str):
+    """The identity and attention strips' handler: a click on a door opens the palette.
+
+    **The complaint this answers is that `F2 palette` is the only affordance charter
+    advertises on screen and the one thing on the row that could not be operated the way
+    it is drawn** (#751). A key name beside a noun is a button everywhere else an operator
+    has seen one. It is a button here now, and so are the workspace chip and the persona
+    head beside it — the other two nouns on those rows that the palette already opens by
+    name.
+
+    **All three go to the same place, and that is the design rather than a shortcut.**
+    §4i's rule is that the irreversible half of an interaction never rides on a pointer
+    event, because one can arrive unpaired. `_bar_events` gets out from under it by acting
+    on the PRESS and switching to a tab that is still one click away — a gesture that
+    completes on the pointer. A strip has no such gesture available: `⬢ alpha` names the
+    workspace you are ON and `◆ steward` the persona you ARE, so a click on either can
+    only mean *let me pick another one*, and picking needs a chooser. `key` is in
+    `component.EVENT_KINDS` and deliberately NOT in `events.DELIVERED` — the harness owns
+    the keyboard — so charter cannot grow a second, pointer-driven chooser inside a one-row
+    pane. The palette IS the chooser, it is the surface both nouns are reachable through
+    already, and opening it is a complete gesture: the overlay makes itself the active
+    pane (`overlay.modal_argvs`), so the keyboard reaches the list it just drew.
+
+    **The PRESS is acted on and the release is dropped**, kept word for word from
+    :func:`_repos_events` and :func:`_bar_events`: a drag begun on a pane border delivers
+    exactly one release (`frame/overlay.py` measured it), and a drag that began elsewhere
+    and happens to end over this row never pointed here.
+
+    **It answers falsy even when it opened the palette**, which is :func:`_bar_events`'
+    reading and not the table's: nothing this process draws has changed, and the pane the
+    palette carves comes off the harness rather than out of this rectangle. Truthy would
+    buy one repaint of a byte-identical row.
+
+    **No `ev.kind` test and no `scroll`**, for :func:`_bar_events`' reasons — these two
+    components declare `click` and nothing else, `events.Dispatcher._deliver` drops
+    anything they did not declare before it reaches here, and a one-row strip has nothing
+    a wheel could move.
+
+    *fid* is closed over rather than read back out of `$CHARTER_SESSION_ID`: one tmux
+    server is shared by every frame on the machine, and this process was told which frame
+    it draws.
+    """
+    def on_event(ev):
+        from .. import util
+        from . import slots as _slots
+        from .builtin_actions import _spawn
+        if not ev.pressed or ev.name != _ACT_BUTTON:
+            return False
+        if not _slots.DOORS.opens_palette(ev.col):
+            return False
+        _spawn(util.self_relaunch_argv(*_PALETTE), fid=fid)
+        return False
+
+    return on_event
+
+
+def _persona_events(fid: str):
+    """The sidebar's handler: a persona's NAME switches to it, its BADGES say what they mean.
+
+    **Two meanings on one row, resolved by which CELL the pointer landed in** — which is
+    not a second gesture bolted on, but the layout `slots._persona_rows` already draws
+    being read back. A row is a name cell and a badge cell, and they are asking different
+    questions: the name is *be this persona*, the badges are *what is that glyph*.
+    `slots._Chips.hit` owns the resolution and this branches on what it answers.
+
+    **The complaint is that the sidebar draws the roster as an inverted-row list with a
+    cursor-looking marker on the active one — the visual vocabulary of something you pick
+    from — and handles no events at all** (#742). It picks from now on.
+
+    **A click SWITCHES, exactly as it does on the two tab bars, and the three reasons
+    :func:`_bar_events` states hold here unchanged**: this acts on the PRESS, so the one
+    event that can arrive unpaired (a release from a drag begun elsewhere) switches
+    nothing; a persona switch is reversible by the identical gesture, because the row you
+    left is still in the column one click away and nothing is created, destroyed or
+    started; and there is no chooser a select-then-confirm column could be confirmed with,
+    since `key` is in `component.EVENT_KINDS` and deliberately not in `events.DELIVERED`.
+    A column that merely *selected* would draw a second mark beside `▸` that nothing on
+    the machine could ever act on.
+
+    That is where this deliberately departs from #742's own suggestion, which asked for
+    "selecting, not switching — the same 'a click only ever selects' rule the repo table
+    follows". The table's rule is not "a click never switches", it is `frame/overlay.py`'s
+    "the irreversible half is never driven by an event that can arrive unpaired", and what
+    makes selection the right answer THERE is that the table has a real intermediate state
+    (a highlighted row, a detail on the attention strip) and `Enter` in the palette to
+    choose from it. A persona column has neither: the row in reverse video IS the
+    selection, and a second one would be dead code wearing a feature's name.
+
+    **The rows that answer nothing are `slots._Chips`' to refuse, not this handler's** —
+    the `▪ personas 6` heading, the `…(+N more)` row, the `no personas` sentence, the
+    blank rows between the sidebar's sections, every todo and change row below them, and
+    the persona you are already being. See that class; the last of those is
+    `_Tabs.switch_to`'s rule and is also what stops a double-click switching twice.
+
+    **The badge half deliberately does NOT refuse the persona you are being.** *"What does
+    the flag on my own row mean"* is the commonest form of the question #753 is about, and
+    answering it is not the no-op that re-adopting yourself would be. That asymmetry is
+    `_Chips.hit`'s and is argued there.
+
+    **Falsy even when it started a switch**, for :func:`_bar_events`' reason:
+    `switch.to_persona` ends in a `state.bump` of its own, which is the version this
+    panel's poll is already watching, so truthy would buy one repaint of a row that has
+    not changed yet.
+
+    **It is declared on the `sidebar` COMPOSITE and nowhere else, because
+    `frame/registry.py` refuses a part that declares events** — a part is never placed
+    (`on_edge`), and `panel._dispatcher` asks `wanted()` of the component that WAS placed,
+    so a declaration on `personas` would pass every check, build a handler and receive
+    nothing, ever. That refusal says the composite "is also the only thing that knows
+    which of its parts a pointer would have been over"; here it does not have to work that
+    out, because `slots.persona_section` is the one pass that composes those rows and they
+    are the first thing the pane draws, so `slots.CHIPS` needs no base and no offset.
+
+    The cost is stated at the `personas` registration: a plane that places that component
+    on its own gets the column drawn and inert.
+    """
+    def on_event(ev):
+        from .. import util
+        from . import slots as _slots
+        from . import state
+        from .builtin_actions import _spawn
+        if not ev.pressed or ev.name != _ACT_BUTTON:
+            return False
+        hit = _slots.CHIPS.hit(ev.row, ev.col)
+        if hit is None:
+            return False
+        if hit.explain:
+            # **#729's dwell, used rather than a second surface of its own** — which is
+            # the whole reason this half of #753 is three lines. `state.say` writes the
+            # frame's own notice file and bumps the version, so the ATTENTION pane — a
+            # different process — draws the legend on its next poll and drops it when the
+            # dwell expires. Nothing here draws, and nothing here waits.
+            #
+            # `REFUSAL_SECONDS` and not the default four: that constant is the longer
+            # dwell for the outcome that has to be READ rather than glanced at, and a
+            # legend is exactly that — seven glyphs and what each one stands for, against
+            # a `workspace → gamma` the frame has already confirmed by repainting.
+            state.say(fid, _slots.BADGE_LEGEND, seconds=state.REFUSAL_SECONDS)
+            return False
+        _spawn(util.self_relaunch_argv(*_PERSONA_SWITCH, hit.name), fid=fid)
+        return False
+
+    return on_event
+
+
 def _chats(ctx) -> list[str]:
     """The chat bar — `slots.chats_bar` at this pane's OWN width.
 
@@ -490,19 +664,28 @@ def build(fid: str = "") -> Registry:
     from . import slots
 
     reg = Registry()
+    # **The two one-row strips declare `click` and nothing else** (#751). `scroll` is not
+    # declared for the reason `chats` and `workspaces` do not declare it: a one-row pane
+    # has nothing a wheel could move, so its handler could only ever answer False, and
+    # `events.Dispatcher.open` charges the same `overlay.MOUSE_ON` for one pointer kind as
+    # for two — declaring it would cost nothing and mean nothing, which is exactly what
+    # makes it wrong to declare.
     reg.register(Component(
         id="identity", title="identity", edge="top", size=Fixed(1),
-        needs=(), render=_panel("top")))
+        needs=(), render=_panel("top"),
+        events=("click",), on_event=_strip_events(fid)))
     reg.register(Component(
         id="attention", title="attention", edge="bottom", size=Fixed(1),
-        needs=(), render=_panel("bottom")))
+        needs=(), render=_panel("bottom"),
+        events=("click",), on_event=_strip_events(fid)))
     # `Content()` with no cap, and `layout.repos_rows` is the cap: the table's height is
     # what the plane's repos need, bounded by what the harness may not be charged
     # (`layout.HARNESS_MIN_ROWS`), which is a fact about the WINDOW rather than about the
     # component. A cap here would be a second, weaker copy of that arithmetic.
     #
-    # **The one component that declares events, and it is the first thing in charter that
-    # ever has** (#607 built the path; nothing consumed it). `scroll` and `click` are the
+    # **The first component in charter that ever declared events** (#607 built the path;
+    # nothing consumed it), and still the only one that declares `scroll` — the other five
+    # are one-row strips and a column with nothing under it. `scroll` and `click` are the
     # two `frame/events.py` can carry to a pane the pointer is over without moving the
     # keyboard, and they are declared TOGETHER because `events.Dispatcher.open` asks the
     # terminal for one request that serves both — a component declaring only one of them
@@ -525,6 +708,18 @@ def build(fid: str = "") -> Registry:
     # (`slots._MAX_TODO_LINES`) — `slots._right`'s docstring argues that ordering, and
     # this is the same decision said in the registry's vocabulary rather than a second
     # one.
+    # **`personas` declares no events, and it is not an oversight — `registry.Registry`
+    # refuses one that does.** It is a PART of the `sidebar` composite below, a part is
+    # never placed on the frame (`on_edge`), and `panel._dispatcher` asks `wanted()` of the
+    # component that was placed — so a declaration here would pass every check, build a
+    # handler and receive nothing, ever. That refusal is #607's own defect one level down
+    # and it is deliberate; the composite is what declares, and `slots.CHIPS` is what
+    # tells it which of its parts a click was over.
+    #
+    # The honest cost: a plane that places `personas` on its own through
+    # `[[frame.component]]`, instead of the `sidebar` that ships, gets the column drawn
+    # and inert. Lifting that means letting a composite delegate a kind to one part, which
+    # is a change to the registry's contract and not this one's.
     reg.register(Component(
         id="personas", title="personas", edge="right", size=Fill(),
         needs=(), render=_personas))
@@ -568,7 +763,8 @@ def build(fid: str = "") -> Registry:
     reg.register(Component(
         id="sidebar", title="sidebar", edge="right", size=Fixed(22),
         needs=("gather", "changes"), render=_panel("right"),
-        children=("personas", "todos", "changes")))
+        children=("personas", "todos", "changes"),
+        events=("click",), on_event=_persona_events(fid)))
     # **Phase 5's two bars, and they are REGISTERED but not PLACED** — the same shape
     # `changes` takes above, and for a stronger version of its argument.
     #

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -259,6 +259,119 @@ def _height() -> int:
     return _DEFAULT_ROWS if measured is None else measured.lines
 
 
+class _Doors:
+    """Which COLUMNS of a one-row strip are a doorway to the palette.
+
+    The third of the three maps in this module, and the same finding each time: a pointer
+    event arrives as a NUMBER (`frame/events.py`), and the only thing that knows what is
+    at that number is the pass that composed the row. :class:`_Viewport` answers it for
+    the repo table's rows, :class:`_Tabs` for a bar's columns, and this for the two
+    one-row strips — :func:`_top` and :func:`_bottom`.
+
+    **A SET of columns rather than a column→name mapping, and the difference is the whole
+    design of #751.** The two strips have exactly three fields a click can act on — the
+    workspace chip, the persona head, and the `F2 palette` hint — and all three lead to
+    the same place, because the palette is the only chooser charter has and *a click
+    cannot choose*. `key` is in `component.EVENT_KINDS` and deliberately not in
+    `events.DELIVERED` (the harness owns the keyboard), so the select-then-confirm shape
+    `_repos_events` uses on the table is not available on a strip: whatever a click on one
+    of these does, it has to finish on the pointer alone. Opening the chooser is the one
+    thing that does, and it is what the row already advertises.
+
+    So the destination does not vary, and a mapping whose values nothing branches on would
+    be data no input could make observable — the survivor the deletion sweep reports and
+    `_Tabs`' own docstring argues away one axis over. What the field was CALLED is the
+    renderer's business and a test's; what reaches the handler is "is this cell a door".
+
+    **The bounds check is structural for :class:`_Tabs`' reason.** A column nothing
+    published is absent whether it is ``-1``, ``4096``, one of the two cells of a ` · `
+    separator, or the empty space past the last field — `in` has no wrong answer to give
+    the way a tuple indexed with a negative number has.
+
+    **Everything else on both strips answers nothing, and each has a case**: the charter
+    version and the context gauge on `top`, and the todo count, the alert, the in-flight
+    spinner, the news and the selected repo's detail on `bottom`, are READOUTS. They are
+    the frame reporting, not offering; the repo detail is the sharpest of them, because it
+    is the readout of a selection made on another pane and a click on it could only mean
+    "select what is already selected", which is the one gesture `_Tabs.switch_to` and
+    `builtins._repos_events` both already refuse.
+
+    One object at module scope for :class:`_Tabs`' reason: `panel.run` resolves one
+    component and draws it for the life of the process, so "which strip is this" has
+    exactly one answer here.
+    """
+
+    __slots__ = ("_cols",)
+
+    def __init__(self) -> None:
+        self._cols: frozenset[int] = frozenset()
+
+    def forget(self) -> None:
+        """Back to a strip nobody has drawn — for a test, and only a test.
+
+        `_Viewport.forget`'s reason exactly: production never calls it, because a panel
+        process is born here and the object dies with the process.
+        """
+        self.publish(())
+
+    def publish(self, columns) -> None:
+        """Record which columns of the row that was just painted are doors.
+
+        Columns of the component's OWN canvas — the rectangle `ctx.width` describes, which
+        is what `events.Dispatcher._on_canvas` delivers a click in, with `[frame] pad`
+        already subtracted.
+
+        **Every rung of both ladders publishes, including the rungs that draw no door at
+        all.** That is `_Viewport.blank`'s finding and `_bar.row`'s discipline: `_top` has
+        a terse rung and a too-narrow rung, `_bottom` drops whole fields as the row gets
+        starved and keeps exactly one at `terse`, and a strip that kept a stale map
+        through a resize would open the palette from a cell whose field the operator can
+        see is gone.
+        """
+        self._cols = frozenset(columns)
+
+    def opens_palette(self, col: int) -> bool:
+        """Whether a click at canvas column *col* should open this frame's palette."""
+        return col in self._cols
+
+
+#: The one strip this process draws into. See :class:`_Doors` for why there is exactly
+#: one; `frame/builtins._strip_events` is the other half and holds no state of its own,
+#: so the handler and the renderer cannot come to disagree about where the doors are.
+DOORS = _Doors()
+
+
+def _door_columns(limit: int, *fields) -> set[int]:
+    """The columns *fields* occupies, given as ``(start, text)`` pairs, clipped to *limit*.
+
+    Measured with `tui.width` and never `len`, for the reason every other measurement in
+    this module is: the glyphs on these two rows (`⬢`, `◆`, `⚡`) are exactly the ones
+    `statusline._persona_chip_cells`' comment says have broken a column twice, and the
+    strings arrive carrying SGR that `len` would count as cells.
+
+    A field whose text is empty contributes nothing — which is how a `top` with no gauge
+    and a `bottom` whose `hotkey` field was dropped by `_fit_fields` publish the absence
+    rather than a zero-width door at somebody else's column.
+
+    ***limit* is the width the finished row was `tui.truncate`d to, and clipping to it is
+    not tidiness.** Both strips end in a truncate, and a field that ran past the pane is
+    drawn as a `…` or not drawn at all — so a door published at the columns the field
+    WOULD have had is a door on a cell the operator can see is empty. This is
+    `_Viewport.blank`'s rule at the finest grain the row offers: what is published
+    describes what was drawn, never what was composed.
+
+    There is deliberately no lower clamp beside the upper one. Every *start* here is
+    composed out of widths — a `tui.width` sum starting at column 0 — so a negative one is
+    not a case this can be given, and a `max(0, start)` guarding against it would be a line
+    no input could turn red: the survivor the deletion sweep reports and this repository
+    deletes.
+    """
+    cols: set[int] = set()
+    for start, text in fields:
+        cols.update(range(start, min(limit, start + tui.width(text))))
+    return cols
+
+
 def _top(fid: str) -> str:
     """Identity: where you are, pinned or not, and who you are being.
 
@@ -398,10 +511,32 @@ def _top(fid: str) -> str:
         state.harness_session(fid) or ""))
     left = f" ⬢ {ws}{pin}"
     identity = f"{left}  {gauge}  {persona}" if gauge else f"{left}  {persona}"
-    if verbosity(fid) == "terse":
-        return tui.truncate(identity, content_width("top"))
-    build = f"charter {__version__}{statusline._dev_chip()} "
+    # **The two doors on this row, and both are measured from the pieces that were
+    # composed rather than found in the finished string** (#751). `left` is the workspace
+    # chip and starts at column 0; the persona field is `PersonaLine.head` — *identity*,
+    # the `◆ steward` half — which begins after `left`, the two spaces, and the gauge with
+    # its own two spaces when there is one. The ROSTER half that may follow it is left
+    # inert deliberately: `_top` draws it only when the sidebar is not (#530), so a door
+    # there would exist on some frames and not others for a reason no operator can see.
+    #
+    # Composed rather than searched for the reason this function already gives about the
+    # chips: a fact recovered from a rendered row by looking for `◆` in it is a second
+    # reading of what was drawn, free to drift from the first.
+    #
+    # **One publish, above the ladder rather than on each of its three rungs.** All three
+    # draw *identity* from column 0 and differ only in what they put to the RIGHT of it —
+    # nothing, the version, or a `…` — so the doors are at the same columns on every rung
+    # and clipping to *w* is what the difference costs them. `_bar.row` reaches the same
+    # place from the other direction, with a closure, because its rungs draw different
+    # names; here there is nothing for a second call to say differently, and two calls
+    # would be two places for that to stop being true.
     w = content_width("top")
+    head_at = tui.width(left) + 2 + (tui.width(gauge) + 2 if gauge else 0)
+    DOORS.publish(_door_columns(w, (0, left),
+                                (head_at, "" if line is None else line.head)))
+    if verbosity(fid) == "terse":
+        return tui.truncate(identity, w)
+    build = f"charter {__version__}{statusline._dev_chip()} "
     # `+ 1` is the one column that must separate them; without it a full-width identity
     # would butt straight up against the version and read as one word.
     if tui.width(identity) + tui.width(build) + 1 > w:
@@ -1527,6 +1662,44 @@ def _cap_personas(cells: list, keep: int) -> list:
                            hidden)]
 
 
+def _badge_width(cells: list, width: int) -> int:
+    """How many columns the badge column takes on a *width*-wide persona table.
+
+    The widest badge ON SCREEN, measured with `tui.width` and never `len` — `✎ ◌ ⚑ ✗ ⚡`
+    and the vault dot are exactly the glyphs `statusline._persona_chip_cells`' own comment
+    says have broken this layout twice — bounded by :data:`_NAME_MIN_W` so a persona with
+    three dispatches in flight cannot take a 22-column sidebar's names away from it.
+
+    **Extracted because two passes need the same number and must not compute it twice.**
+    :func:`_persona_rows` lays the cell out and :func:`persona_section` publishes the
+    column it starts at, so a click can tell a badge from a name; a second copy of this
+    arithmetic is a second answer to "where does the badge column begin", and the two
+    disagree the first time either is edited. It is the same reason `_Chips` is published
+    by the pass that composed the rows rather than re-derived when a click arrives.
+
+    **The floor is on the OUTSIDE of the `min`, and that position is the deletion sweep's
+    finding rather than a preference.** Written `min(widest, max(0, width - _NAME_MIN_W))`
+    — which is where this arithmetic sat for as long as only `_persona_rows` used it — the
+    clamp is an exact equivalent: measured over 3,280 cell configurations at every width
+    from 0 to 40, dropping it changed not one drawn row and not one resolved click,
+    because a negative width fell into `_persona_rows`' own ``badge_w <= 0`` branch and
+    was treated as zero there. A guard whose effect another branch already provides is a
+    line no input can turn red.
+
+    Outside the `min` it is this function's own contract instead — *a column is never a
+    negative number of cells* — which is one assertion on one call
+    (`_badge_width(cells, 8) == 0`) rather than a property of whatever the caller does
+    next. It also makes :func:`persona_section`'s ``width - badge_w`` honest: a negative
+    badge width published a badge column starting PAST the pane, which no click could
+    reach and which was therefore wrong in the way that only shows up later.
+
+    The two forms are equal wherever the old one was defined — the widest badge is never
+    negative, so `min(widest, 0)` and `max(0, min(widest, negative))` are both zero.
+    """
+    return max(0, min(max((tui.width(c.badges) for c in cells), default=0),
+                      width - _NAME_MIN_W))
+
+
 def _persona_rows(cells: list, width: int) -> list[str]:
     """The persona chips drawn as a TABLE: names down the left, badges in a right-hand
     column of their own (#516).
@@ -1548,8 +1721,7 @@ def _persona_rows(cells: list, width: int) -> list[str]:
     put on themselves, so the cells are joined with no gap and `head + badges` is still
     byte-for-byte what `statusline._persona_chips` renders.
     """
-    badge_w = min(max((tui.width(c.badges) for c in cells), default=0),
-                  max(0, width - _NAME_MIN_W))
+    badge_w = _badge_width(cells, width)
     rows: list[str] = []
     for c in cells:
         if badge_w <= 0 or c.name is None:
@@ -1640,6 +1812,200 @@ def _todo_rows(data: dict, width: int, budget: int) -> list[str]:
     return rows
 
 
+class _Hit(NamedTuple):
+    """What `_Chips.hit` resolved a click to — which of the two things, and about whom.
+
+    A pair rather than two methods, because *which cell did the pointer land in* is one
+    question with one answer and asking it twice is how a renderer and a handler come to
+    disagree. `builtins._persona_events` branches on :attr:`explain` and never re-derives
+    it.
+
+    **A bool rather than a pair of named string kinds, and the deletion sweep is why.**
+    This was ``kind: str`` against two module constants (``SWITCH = "switch"``,
+    ``EXPLAIN = "explain"``), and the sweep reported both spellings as survivors — rightly
+    so: every producer and every consumer went through the constant, so the VALUE was
+    unobservable and any string would have done. That is a literal nothing can turn red.
+    A bool has no spelling to get wrong, and flipping it is caught by the first case that
+    clicks a badge.
+
+    The column matters more than the vocabulary here: there are exactly two things on a
+    persona row, they are decided by which cell the pointer landed in, and a third would
+    be a different question (which cell?) rather than a third value of this one.
+    """
+
+    #: True when the pointer was in the BADGE cell — say what the glyphs mean. False when
+    #: it was in the name cell — adopt this persona.
+    explain: bool
+    name: str
+
+
+#: What a click on the badge column puts on the attention row — #753, answered in the
+#: frame rather than in `charter docs show frame`.
+#:
+#: **One legend for every row, not a readout of the row that was clicked**, and that is a
+#: deliberate limit rather than the first draft of a better version. `PersonaChip.badges`
+#: is a RENDERED string by the time this module sees it; saying what *this* persona's
+#: badges mean would take either decoding those glyphs back out — the drift
+#: `statusline.PersonaChip`'s own docstring exists to prevent — or a handler reading the
+#: plane, which §4f forbids it (`on_event` is handed no ctx, precisely so a handler cannot
+#: grow a second reading of a plane the repaint is about to read anyway). A legend needs
+#: neither, and the question an operator actually has — *what is that glyph* — is the one
+#: it answers.
+#:
+#: Kept to the width of an ordinary frame's attention row on purpose: `state.say` hands
+#: this to `_bottom`, where it is the top-priority field and is still `tui.truncate`d to
+#: the pane. The full table, with the sentence each of these compresses, is
+#: `docs/frame.md`'s — this is the reminder, not the reference.
+BADGE_LEGEND = ("◦ no usable vault · ! vault unhealthy · ⚑ draft charter · "
+                "✗ broken config · ✎ memories · ◌ session notes · ⚡ in flight")
+
+
+class _Chips:
+    """Which persona each ROW of the sidebar's persona column is about, and who you are.
+
+    Also where the BADGE column starts, so a click can tell *be this persona* from *what
+    is that glyph* (#753) — see :meth:`hit`.
+
+    `_Tabs` on the other axis, and the argument for existing is the one that class makes
+    for a bar and `_Viewport` makes for the table: a pointer event arrives as a NUMBER,
+    and the only thing that knows what is at that number is the pass that composed the
+    rows. :func:`persona_section` is that pass.
+
+    **The column needs a published map for `_Tabs`' reason — the ladder is not
+    invertible.** :func:`_cap_personas` drops the tail of an ORDER (the active persona
+    first, then anything carrying a health mark) and replaces it with one `…(+N more)`
+    row, and `terse` caps the list again at :data:`_TERSE_ROWS`; so "which persona is on
+    row 4" cannot be worked back from the roster and the pane's height, and re-deriving it
+    when a click arrives would be a second answer to what is on screen, disagreeing with
+    the first the moment a repaint lands in between.
+
+    **The map and the mark are written by ONE call**, which is `_Tabs.publish`'s rule and
+    `_Viewport.blank`'s finding: a column that published its rows and left a stale *here*
+    would answer "you are already there" for a persona the operator can see is not in
+    reverse video.
+
+    **Rows that name no persona hold ``None``, and rows below the section are out of
+    bounds**: the `▪ personas N` heading and the `…(+N more)` line are the first kind (it
+    stands for personas that are *not* drawn — `_Tabs` refuses its `+14` for the identical
+    reason); the `no personas` sentence, the blank separator rows the sidebar puts between
+    its sections, and every todo and change row below them are the second. Both answer
+    ``None`` out of :meth:`switch_to`, which is where the whole refusal lives.
+
+    **It is `_Viewport`'s sequence rather than `_Tabs`' mapping, and the sweep is what
+    settled that.** The first version filtered the empty rows out of a dict, and the
+    deletion sweep reported the filter as an exact equivalent — an absent key and a
+    ``None`` value were indistinguishable to everything downstream, so the guard was a
+    line no input could turn red. A bar's columns really are sparse (a `_BAR_GAP` belongs
+    to nothing); a column of rows is not. See :meth:`publish`.
+
+    One object at module scope for `_Tabs`' reason. Note that the `sidebar` composite and
+    the standalone `personas` component both reach it through the same
+    :func:`persona_section` call, and the persona rows are the FIRST thing either pane
+    draws — so one base of row 0 is right for both, and neither caller offsets anything.
+    """
+
+    __slots__ = ("_rows", "_here", "_badge_at")
+
+    def __init__(self) -> None:
+        self._rows: tuple[str | None, ...] = ()
+        self._here = ""
+        self._badge_at = 0
+
+    def forget(self) -> None:
+        """Back to a column nobody has drawn — for a test, and only a test."""
+        self.publish((), "", 0)
+
+    def publish(self, rows, here: str, badge_at: int) -> None:
+        """Record which persona the paint that just happened put on each row.
+
+        *rows* is indexed by a row of the component's own canvas — `[frame] pad` insets
+        columns only (`inset_rows`), so a pane row and a composed line are the same number
+        here — and holds the RAW persona name, never the drawn one. `_persona_rows` runs
+        every name through `tui.Cell`, which contains and may truncate it (#472); what
+        goes into `charter frame-switch --persona` has to be the name on disk.
+        `_Tabs.publish` is this decision one axis over.
+
+        **A SEQUENCE with ``None`` in it, which is `_Viewport.publish`'s shape and
+        deliberately not `_Tabs`'.** A bar's columns are sparse — a `_BAR_GAP` is two
+        cells belonging to nothing — so a mapping is right there and absence is the
+        answer. A column of rows is dense: every row of this section was drawn, and the
+        ones that name no persona (the `▪ personas N` heading, the `…(+N more)` line) are
+        rows with nothing on them rather than rows that are not there. `_Viewport.publish`
+        spells exactly this with its leading ``None`` for the table's own heading.
+
+        It also stops "no persona here" having two spellings. A dict with the empty rows
+        filtered out has both an absent key and — if a filter is ever dropped — a ``None``
+        value meaning the same thing, and the deletion sweep found that filter to be
+        precisely equivalent: nothing downstream could tell the two apart, so the guard
+        was a line no input could turn red.
+
+        *here* is the persona this frame is ON, taken from `PersonaChip.active` in the
+        same paint that drew the reverse-video row — data the chips carry, never a search
+        for `▸` or magenta in a rendered head, which is `persona_section`'s own rule for
+        the highlight itself. The map and the mark are written by ONE call for
+        `_Tabs.publish`'s reason.
+
+        *badge_at* is the first column of the badge cell `_persona_rows` laid out, or
+        ``0`` when the pane was too narrow to give the badges a column of their own — the
+        rung where `_badge_width` answers zero and every row is drawn full width. It is
+        the third thing this one call writes, for the same reason the mark is: a paint
+        that moved the badge column and left a stale offset behind would explain a glyph
+        for a cell the operator clicked a NAME in.
+        """
+        self._rows = tuple(rows)
+        self._here = here
+        self._badge_at = badge_at
+
+    def hit(self, row: int, col: int):
+        """What a click at canvas *row*, *col* on this column means, or ``None``.
+
+        **Two answers, because the persona column has two things on it** (#753). A row is
+        a NAME with a BADGE COLUMN to the right of it, and the two are asking different
+        questions: the name is *be this persona*, the badges are *what is that glyph*.
+        `_persona_rows` already draws them as two cells, so resolving a click against
+        which cell it landed in is reading the layout that is on screen rather than
+        inventing a second one.
+
+        A hit with :attr:`_Hit.explain` false is the front door `builtins._persona_events`
+        starts; a true one puts :data:`BADGE_LEGEND` on the attention row through
+        `state.say`, which is the dwell #729 built and the reason this needs no surface of
+        its own.
+
+        **Explaining works on the persona you already are, and switching does not.** *"What does
+        the flag on my own row mean"* is the commonest form of the question this answers,
+        and nothing about it is a no-op — where re-adopting the persona you are being is
+        exactly the nothing `_Tabs.switch_to` refuses, and is also what keeps a
+        double-click from switching twice.
+
+        **The bounds check is spelled out, and `_Viewport.repo_at` is why**: a tuple
+        indexed with a negative number answers the LAST row — a wrong answer that hides a
+        wrong reading — so a row outside what was painted is refused here rather than
+        wrapped around. `_Tabs` gets this structurally from a mapping; a sequence does
+        not, and this is the price of the shape :meth:`publish` argues for.
+
+        **A row that names no persona answers ``None`` for BOTH kinds**, badge column or
+        not: the `▪ personas N` heading and the `…(+N more)` line hold ``None``, and
+        `_persona_rows` draws the second of those full width with no badge cell at all —
+        so a click past where the badges would have been is a click on a sentence about
+        the list, which explains nothing and switches nothing.
+
+        ``_badge_at`` of ``0`` is the rung where the pane was too narrow to give the
+        badges a column (`_badge_width` answered zero); the ``> 0`` test is what keeps
+        every column on such a row a name rather than making column 0 a badge.
+        """
+        name = self._rows[row] if 0 <= row < len(self._rows) else None
+        if name is None:
+            return None
+        if self._badge_at > 0 and col >= self._badge_at:
+            return _Hit(True, name)
+        return None if name == self._here else _Hit(False, name)
+
+
+#: The one persona column this process draws. See :class:`_Chips`;
+#: `frame/builtins._persona_events` is the other half and holds no state of its own.
+CHIPS = _Chips()
+
+
 def persona_section(width: int, height: int, *, terse: bool) -> list[str]:
     """The sidebar's persona rows: the heading, and every chip a *height*-row pane fits.
 
@@ -1680,12 +2046,34 @@ def persona_section(width: int, height: int, *, terse: bool) -> list[str]:
     from .. import statusline as sl
     cells = sl._persona_chip_cells()
     if not cells:
+        # **The rung that draws no persona publishes too**, which is `_Viewport.blank`'s
+        # whole finding and `_bar.row`'s discipline: a pane that said `no personas` while
+        # a map from the paint before it was still standing would switch this frame to a
+        # persona nobody can see on the row that was clicked.
+        CHIPS.publish((), "", 0)
         return [tui.truncate(f"{sl._DIM}no personas{sl._R}", width)]
     keep = height - 1                       # the heading takes a row off the list
     if terse:
         keep = min(keep, _TERSE_ROWS)
     cells = _cap_personas(cells, keep)
     rows = _persona_rows(cells, width)
+    # The leading `None` is the `▪ personas N` heading, which belongs to no persona —
+    # `_Viewport.publish`'s own `(None, *…)` for the table's heading, one section over.
+    # The `…(+N more)` row already carries `name is None` from `_cap_personas`, so it
+    # lands as a row with nothing on it without a filter here: it stands for the personas
+    # that are NOT on screen, which is why `_Tabs` refuses its `+14` too.
+    # `_badge_width` rather than a second copy of its arithmetic: `_persona_rows` lays the
+    # cell out at exactly this column and a click has to resolve against what was DRAWN.
+    #
+    # **Zero when there is no badge column, spelled out rather than left to fall out of
+    # the subtraction.** `width - 0` is `width`, which is a column no click can reach and
+    # would therefore have degraded correctly by accident — the kind of accident that
+    # stops being one the first time either side of it is edited. `_Chips.hit` reads this
+    # as "was a badge cell drawn at all", so it has to be a number that says so.
+    badge_w = _badge_width(cells, width)
+    CHIPS.publish((None, *(c.name for c in cells)),
+                  next((c.name for c in cells if c.active), ""),
+                  width - badge_w if badge_w else 0)
     return [_sidebar_head("personas", _persona_total(cells), width),
             *(chrome.reverse(row, width) if c.active else row
               for c, row in zip(cells, rows))]
@@ -2148,9 +2536,48 @@ def _bottom(fid: str) -> str:
     fields = {"notice": notice_text, "alert": alert_text, "inflight": inflight_text,
               "news": news_text, "todo": todo_text, "hotkey": hotkey_text,
               "repo": repo_text}
-    parts = [fields[n]
-             for n in ("notice", "todo", "alert", "inflight", "news", "hotkey", "repo")
-             if n in keep]
+    order = ("notice", "todo", "alert", "inflight", "news", "hotkey", "repo")
+    parts = [fields[n] for n in order if n in keep]
+    # **The one door on this row is the `F2 palette` hint, and it is the sharpest case in
+    # #751**: it is the only affordance charter advertises on screen, drawn as a key name
+    # beside a noun, which is a button everywhere else an operator has seen one. Clicking
+    # it now does what pressing the key does.
+    #
+    # **Its column is walked out of `parts` rather than searched for in the joined row**,
+    # for `_top`'s reason: the text is `config.FRAME['hotkey']` and an operator on
+    # `hotkey = "F1"` would have a row this function could not find its own field in by
+    # looking — and the alert on an ordinary plane puts several ` · ` on the row, so
+    # "the field after the second separator" is not a thing to search for either.
+    #
+    # **Every rung publishes**, including the ones that draw no door: `_fit_fields` drops
+    # `hotkey` first when the row is starved (it is last in the priority list), `terse`
+    # keeps exactly one field and it is never this one, and a frame inside the operator's
+    # own tmux has no hotkey to advertise at all (`hotkey_text` is empty there, so
+    # `_door_columns` contributes nothing). A strip that kept a stale map through any of
+    # those would open the palette from a cell the operator can see is empty.
+    #
+    # **#729's `notice` is a seventh field and the walk needs no case for it**, which is
+    # the property this shape was chosen for: the loop reads `order`, so a field added at
+    # the head of the row moves the hint's columns by exactly its own width plus a
+    # separator, and the door follows without anything here being told about it. It is
+    # also correctly INERT — a notice is the outcome of something the operator already
+    # chose, dwelling for a few seconds, which is a readout in the same sense the todo
+    # count and the selected repo's detail are.
+    sep_w = tui.width(" · ")
+    at, doors = -sep_w, []
+    for name in order:
+        if name not in keep:
+            continue
+        # Paid at the TOP of the iteration and started one separator behind, which is
+        # `_tab_columns`' own trick for the identical off-by-one: the first field is not
+        # preceded by a separator, and a `if at:` in here would be a branch that could
+        # only ever be observed by a first field of zero width — which `_fit_fields`
+        # already refuses to keep.
+        at += sep_w
+        if name == "hotkey":
+            doors.append((at, fields[name]))
+        at += tui.width(fields[name])
+    DOORS.publish(_door_columns(w, *doors))
     return tui.truncate(" · ".join(parts), w)
 
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -120,10 +120,12 @@ One consequence of that first column worth knowing, because it is new: a panel w
 component declares `click` or `scroll` asks *its own* terminal to report, so if you select
 that panel's pane (with your tmux prefix, say), your terminal starts reporting and native
 selection goes for as long as it is the active pane. Selecting the harness back — or `F12`
-— ends it. Panels that declare neither ask for nothing and change nothing, which is three
-of the four panels charter ships — and the two bars, if you place one, are not among them.
+— ends it. **All four panels charter ships declare `click` now, and the two bars do too**,
+so that consequence applies to any pane of the frame you make active — where before this
+release it was the repo table alone. A component that declares neither kind still asks for
+nothing and changes nothing; charter simply no longer ships one.
 
-**The repo table is the fourth: it scrolls and it selects.** Roll the wheel over it and the
+**The repo table scrolls and it selects.** Roll the wheel over it and the
 window moves down the list; click a row and that repo is selected, its row drawn in reverse
 video and its state read back in words on the right of the attention row — `▪ charter ·
 fix/x · dirty · 2 ahead · CI failed`. A click only ever *selects*; nothing charter does from
@@ -171,6 +173,46 @@ redraws the same row with the `*` moved and every other tab still where you pres
 is what makes a double-click harmless: the second press lands on the tab you just arrived at,
 and that one does nothing. It also means the names a click can reach are the ones on your
 page; `F2` is what reaches the other pages.
+
+**A persona row's badges explain themselves.** Clicking the badge column puts the glyph
+legend on the attention row (see *Every glyph on a persona row* above). It works on the
+row you are already on, which is where the question usually comes from.
+
+**A persona row's name switches to it**, for the tab bar's three reasons, unchanged:
+charter acts on the press, the row you came from is still in the column one click away, and
+nothing on the machine could finish a two-step gesture, because your typing goes to the
+harness. Click the name `docs` and the frame adopts `docs` — the same thing `charter frame-switch
+--persona docs` does, started the same way, with the same refusals reaching you on the same
+status line. Clicking the *name* of the persona you already are does nothing, which is also
+what stops a double-click switching twice — though clicking its badges still explains them.
+Neither the `▪ personas 6` heading, the `…(+N more)` row (it stands for the personas that
+are *not* drawn), the `no personas` line, nor anything below the column does anything at
+all — the todos and the changes are readouts. On a sidebar too narrow to give the badges a
+column of their own, every cell of a persona row is its name.
+
+**The `F2 palette` hint is a button now, and so are the two nouns on the identity row.**
+Click `F2 palette` on the attention strip and the palette opens; click `⬢ <workspace>` or
+`◆ <persona>` on the identity strip and the same palette opens. All three go to the same
+place on purpose: `⬢ alpha` names the workspace you are *on* and `◆ steward` the persona
+you *are*, so a click on either can only mean *let me pick another*, and picking needs a
+list to pick from. The palette is that list, and opening it finishes on the pointer alone —
+it makes itself the active pane, so your keyboard reaches the rows it just drew.
+
+Everything else on those two rows is inert, and each one is a readout rather than an
+offer: the charter version and the context gauge on the identity row; the todo count, the
+alert, the in-flight spinner, this session's news, and the selected repo's `▪ ledger · main
+· clean` on the attention row. That last one is the sharpest of them — it is the readout of
+a row you selected on *another* pane, so a click on it could only mean "select what is
+already selected", which is the one gesture the repo table and the tab bars both already
+refuse. On a row starved narrow enough to drop the hotkey field, or at `terse` density
+where only one field survives, there is nothing clickable on the attention strip at all —
+and inside your own tmux there is no hint drawn, because charter binds no key there.
+
+**None of this needs a mouse, and none of it is a route that did not already exist.** Every
+one of these clicks is a shortcut to something `F2` reaches: the palette itself, and the
+`workspace:` and `persona:` rows in it. That is the rule charter holds itself to — a
+pointer affordance always has a key or a palette row beside it — and it is why adding these
+added no new obligation.
 
 **Focus events are on inside a frame charter launched, and off inside your own tmux.** tmux
 ships `focus-events` off, and it is a server-wide setting; charter turns it on for its own
@@ -820,6 +862,43 @@ them. The todo list is what `charter ws todo` shows, oldest first, cut to what t
 room for with a `…(+N more)` line saying how many it hid; a workspace with nothing open
 gets no todo section at all rather than a heading over an empty space. The sidebar drops
 itself on a terminal too small for it.
+
+#### Every glyph on a persona row
+
+A glyph only says something to someone who has been told what it says, and the sidebar's
+persona column is the densest thing charter draws — five glyph classes on one 22-column
+row. Here is all of them.
+
+| | where | means |
+|---|---|---|
+| `▪` | heading | a section heading, and the count beside it is the whole section — `▪ personas 6` |
+| `▸` | start of a row | the persona you *are*. Its row is also drawn in reverse video |
+| `▫` | start of a row | a persona you are not. Dispatchable, adoptable, otherwise idle |
+| `◦` | after the name | this persona **declares a vault charter cannot use here** — either this machine has no vault by that name, or it has one whose file does not exist yet. `charter persona create` writes the declaration; nothing writes the vault, so this is the ordinary state of a persona nobody has given credentials to, and it is not an error |
+| `!` | after the name | the vault is registered and **unhealthy** — unreadable, or its provider is misconfigured |
+| `✎N` | badge column | `N` **committed** memories. Green |
+| `◌N` | badge column | `N` **session-scratch** memories, not committed. Yellow |
+| `⚑` | badge column | the persona's **charter is a draft**, so charter generates no sub-agent for it and it cannot be dispatched. `charter persona show <name>` says what it still needs |
+| `✗` | badge column | the persona's **config is broken** — a dangling `extends:`/`uses:`, or an inheritance cycle |
+| `⚡N age` | badge column | `N` dispatches **in flight**, and how long the oldest has been running. A `?` after the age means that record is past the point charter presumes it dead |
+
+Nothing after the name and nothing in the badge column is the healthy, quiet case, and
+silence is deliberate: a column that said *ok* on every row would spend the sidebar's
+width on the rows with nothing to report.
+
+**You do not have to come here to read it.** Click the badge column on any persona row —
+the right-hand column the `⚑`s line up in — and the frame puts the legend on the attention
+row for ten seconds. That is the same dwell a workspace switch uses to say what it did, so
+it costs no extra row and nothing stays on screen. Clicking a persona's *name* still
+switches to it; the badges and the name are two cells of one row and mean two different
+things. It is one legend for every row rather than a reading of the row you clicked —
+short enough for the attention row, with this table as the long version.
+
+**`◦` and `⚑` together on most rows is normal, and it was worth writing down.** A plane
+whose personas came from `charter persona create` and were never given a vault shows `◦`
+on every one of them; a plane whose charters are still drafts shows `⚑` beside it. Six
+personas, five flags, nothing wrong — which is exactly the reading that sent one operator
+into `frame/slots.py` to find out what charter was warning them about.
 
 **The attention strip is last, and the table floats above it.** The table's height is its
 content's, so whichever of the two sits lower moves up and down the screen as repos are

--- a/docs/news/unreleased-the-frame-answers-what-it-advertises.md
+++ b/docs/news/unreleased-the-frame-answers-what-it-advertises.md
@@ -1,0 +1,125 @@
+---
+version: unreleased
+headline: The `F2 palette` hint is a button, the persona column is a list you pick from, and every glyph on it has a name
+---
+
+*"I clicked the one affordance the frame advertises and nothing happened. Then I read
+`frame/slots.py` to find out what `◦` meant."*
+
+Three reports from one evening of driving a real frame, and they were one defect wearing
+three hats: charter drew nouns, drew a roster with a cursor-looking marker on it, drew the
+words `F2 palette`, and handled no pointer event on any of them. Of the four panels charter
+ships, `repos` was the only one that had ever declared an event at all.
+
+## `F2 palette` does what it says
+
+```
+7 todos · F2 palette · ▪ ledger · main · clean
+          ^^^^^^^^^^  click it, and the palette opens
+```
+
+It was the only affordance charter advertised on screen and the one thing on the row that
+could not be operated the way it is drawn — a key name beside a noun, which is a button
+everywhere else you have ever seen one. It is a button now. So are the two nouns on the
+identity row above it:
+
+```
+ ⬢ alpha    ◆ steward                                        charter 0.55.0
+ ^^^^^^^    ^^^^^^^^^  both open the same palette
+```
+
+**All three go to the same place on purpose.** `⬢ alpha` names the workspace you are *on*
+and `◆ steward` the persona you *are*, so a click on either can only mean *let me pick
+another one* — and picking needs a list. The palette is that list, it is where both nouns
+were already reachable, and opening it finishes on the pointer alone: it makes itself the
+active pane, so your keyboard reaches the rows it just drew. Charter cannot grow a second,
+pointer-driven chooser inside a one-row pane, because a keypress does not reach a panel at
+all — tmux gives your typing to the active pane, and that pane is your harness.
+
+**Everything else on those two rows still answers nothing, and each one is a readout rather
+than an offer**: the charter version, the context gauge, the todo count, the alert, the
+in-flight spinner, this session's news, and `▪ ledger · main · clean`. That last is the
+sharpest — it is the readout of a row you selected on *another* pane, so a click on it could
+only mean "select what is already selected", which is the one gesture the repo table and the
+tab bars both already refuse. So does the ` · ` between two fields, and so does the space
+past the last one.
+
+## A persona row is a row you can pick
+
+```
+▪ personas 6
+▸ steward
+▫ docs ◦             ⚑     <- click it, and the frame is being `docs`
+▫ forge ◦            ⚑
+```
+
+The column was already drawn as an inverted-row list with a marker on the active one, which
+is the visual vocabulary of something you pick from. Clicking one runs exactly what `charter
+frame-switch --persona docs` runs — the same command, the same refusals, the same sentence on
+your own screen when one fires.
+
+**A click *switches* here, for the same three reasons it switches on the tab bars**: charter
+acts on the press, which is never the half a drag delivers unpaired; the row you left is
+still in the column one click away; and nothing on the machine could finish a
+select-then-confirm gesture, so a column that merely selected would draw a second mark
+nothing could ever act on.
+
+Clicking the persona you already *are* does nothing, which is also what stops a double-click
+switching twice. Neither does the `▪ personas 6` heading, the `…(+N more)` row — it stands
+for the personas that are *not* drawn — the `no personas` line, or anything below the column.
+
+## Every glyph on a persona row now has a name — and says it in the frame
+
+**Click the badge column on any persona row and the legend lands on the attention row for
+ten seconds:**
+
+```
+▫ forge ◦            ⚑     <- click the ⚑
+                             ↓
+◦ no usable vault · ! vault unhealthy · ⚑ draft charter · ✗ broken config · ✎ memories …
+```
+
+That is the dwell a workspace switch already uses to say what it did, so the answer costs
+no extra row and clears itself. It works on the row you are already on, which is where the
+question usually comes from — and the *name* half of the row still switches, so a persona
+row is two cells that mean two things.
+
+`docs/frame.md` names all ten glyphs in a table, so `charter docs show frame` is the long
+version. The two that sent an operator into the source:
+
+- **`◦`** — this persona **declares a vault charter cannot use here**: either this machine
+  has no vault by that name, or it has one whose file does not exist yet. `charter persona
+  create` writes the declaration and nothing writes the vault, so this is the ordinary state
+  of a persona nobody has given credentials to. **It is not a warning.**
+- **`⚑`** — the persona's **charter is a draft**, so charter generates no sub-agent for it
+  and it cannot be dispatched. `charter persona show <name>` says what it still needs.
+
+A plane whose six personas came from `charter persona create` and were never given a vault
+shows `◦` on every row and `⚑` beside most of them. Six personas, five flags, nothing wrong —
+which was exactly the reading that made this worth writing down.
+
+## What has not changed
+
+**You still need `[frame] mouse = true`**, and this entry does not change that: with mouse
+off, tmux asks your terminal to report from the *active* pane's own request alone, so a click
+on a panel is not an event charter drops — it is an event that never happens. `F2` reaches
+every one of these routes at any width and with no mouse at all, which is the rule charter
+holds itself to: a pointer affordance always has a key or a palette row beside it.
+
+**Your keyboard stays on the harness.** A persona switch acts where you pointed and leaves
+you typing where you were. The palette is the deliberate exception, exactly as it is from the
+key: a modal surface you cannot type into is not one.
+
+**One thing on the sidebar is still unreachable, and it is worth saying rather than
+implying.** The todo list's `…(+N more)` line still cannot be opened from the frame — the
+hidden todos are `charter ws todo`'s. Every cheap way to reach them was worse than the honest
+count: a wheel with no keyboard twin, or a scroll offset shared across processes that would
+bump the whole frame on every notch. It wants a read-only list surface, which is its own
+change.
+
+Verified end to end on a real tmux — 3.7c and the 3.2 floor — with a real client on a real
+pty, real `charter panel` processes holding the strip's and the sidebar's panes, and a real
+detached `charter frame-palette` / `charter frame-switch --persona` started by those panels
+out of their own handlers: the palette pane appears and takes the keyboard, `▸` moves to the
+persona that was clicked, the keyboard never leaves the harness for the switch, and a click on
+a readout, a separator, a heading, or the row you are already on does nothing at all.

--- a/tests/test_a_real_click_opens_the_real_palette.py
+++ b/tests/test_a_real_click_opens_the_real_palette.py
@@ -1,0 +1,551 @@
+"""A real click on `F2 palette`, and on a real persona row, in a REAL tmux — #742, #751.
+
+The reports these answer are *"I clicked the one thing the frame advertises and nothing
+happened"* and *"I clicked a persona and the active persona did not change"*, and nothing
+about either could have been settled by a unit test:
+`tests/test_the_strips_and_the_roster_answer_a_click.py` says which column is a door and
+which row is which persona; only this can say that a report injected into a real client's
+terminal becomes a palette pane and a moved `▸` at all.
+
+Everything here is real: a real tmux server, a real attached client on a real pty, real
+`charter panel` processes each holding their own pane, the frame's own private config
+sourced from `commands_frame.conf_text`, and — for the palette case — a real detached
+`charter frame-palette` that carves a real pane off the harness. What that buys over the
+unit half, link by link:
+
+* that `charter panel bottom` and `charter panel right` build a dispatcher at all, which
+  they did not before this change: the two strips and the sidebar declared no events, so
+  `panel._run` opened no input path, wrote no `overlay.MOUSE_ON`, and left the tty alone;
+* that the pane really asks its terminal to report (a process nobody in this test can
+  monkey-patch writing to fd 1);
+* that tmux routes the report to the pane under the pointer, **in that pane's own cells**,
+  and leaves the keyboard on the harness — the pane a click on a DOOR then moves it to is
+  the palette's, which is what `F2` does and is the whole of what the hint promises;
+* that the persona switch reaches the OTHER pane: the sidebar is one process and the
+  switch is another, and `▸` moving is the only proof the two are talking through
+  `persona.set_active` and `state.bump` rather than through an object one interpreter has.
+
+**`mouse = true`, because that is the regime this feature is for.** With charter's flag
+off, tmux asks the terminal to report from the ACTIVE pane's own request alone, and the
+active pane here is a `cat` — so nothing would be sent, nothing would arrive, and a green
+test would be measuring an empty room. `docs/frame.md` states that half to the operator.
+
+**A socket per TEST**, which is
+`tests/test_a_real_click_on_a_real_tab_bar_switches.py`'s measurement and matters more
+here: a click starts a DETACHED charter that goes on making tmux calls after the case has
+finished asserting, and on a shared socket the next case's panes inherit ids the previous
+case's child is still aiming at.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import itertools
+import os
+import shutil
+import struct
+import subprocess
+import termios
+import time
+import unittest
+from pathlib import Path
+
+from charter import commands_frame, config
+from charter.frame import layout, state, tmuxctl
+
+from tests import _tmuxreap
+from tests._isolation import PersonaIso, make_plane
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_SERVERS = itertools.count()
+
+_DEADLINE = 30.0
+
+_TERM_CANDIDATES = tuple(dict.fromkeys(
+    ([os.environ["TERM"]] if os.environ.get("TERM", "dumb") != "dumb" else [])
+    + ["xterm-256color", "screen", "vt100"]))
+
+#: Wide enough for the attention row to keep every field it has, so the `hotkey` field —
+#: the LAST one `slots._fit_fields` keeps, and therefore the first a narrow row drops — is
+#: actually drawn. A case run below that width would be measuring the absence.
+COLS = 120
+
+#: Rows the sidebar pane is split with: the heading and three persona rows, with room to
+#: spare so `_cap_personas` draws no `…(+N more)` — that row is the unit half's case.
+SIDEBAR_ROWS = 8
+
+
+def _await(predicate, timeout: float = _DEADLINE) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
+
+
+def _fork_pty(rows: int, cols: int) -> tuple[int, int]:
+    """`pty.fork` with the window size set BEFORE the exec — #648's fix, borrowed.
+
+    A client born at the kernel's 80x24 default attaching to a wider session makes tmux
+    resize the window, which is a SIGWINCH in every pane — a repaint no case here asked
+    for, which is exactly the noise these cases have to be free of.
+    """
+    master, slave = os.openpty()
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+    pid = os.fork()
+    if pid == 0:
+        os.close(master)
+        os.login_tty(slave)
+        return 0, -1
+    os.close(slave)
+    return pid, master
+
+
+class _ARealFrameWithStrips(PersonaIso):
+    """One real frame with charter's OWN `attention` and `sidebar` panels and a pointer.
+
+    **`make_plane` and not merely `PersonaIso`'s root**: both gestures under test start a
+    CHILD charter that resolves its own plane, and `PersonaIso` writes no `charter.toml`,
+    so such a child would go looking for a plane of its own and find the operator's live
+    one (#527).
+    """
+
+    #: The persona the frame starts on and the one it is clicked onto. Literals, so a case
+    #: cannot be satisfied by whatever the plane happens to contain.
+    HERE = "steward"
+    THERE = "docs"
+
+    def setUp(self) -> None:
+        super().setUp()
+        v = tmuxctl.version()
+        if v is None or v < tmuxctl.FLOOR:
+            self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}."
+                          f"{tmuxctl.FLOOR[1]}; this machine has {v}")
+        self.socket = _tmuxreap.name(f"doors{next(_SERVERS)}")
+        self.socket_path = os.path.join(os.environ.get("TMUX_TMPDIR") or "/tmp",
+                                        f"tmux-{os.getuid()}", self.socket)
+        self.addCleanup(self._teardown_socket)
+        self.plane = make_plane(self, "schema = 1\n")
+        for name in (self.HERE, self.THERE):
+            self.make_persona(name)
+        # **One persona with a real badge on it, because #753's half of this file needs a
+        # glyph to click.** `draft: true` is what `charter persona create` stamps and what
+        # `persona.is_draft` reads, so `⚑` here is the badge an ordinary un-finished
+        # persona carries rather than a string this fixture painted — which is the whole
+        # point: `make_persona` alone produces a HEALTHY persona and no badge column at
+        # all, so a version of this file without this line was measuring a pane that had
+        # nothing to explain.
+        self.make_persona("forge", draft="true")
+        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
+
+        self.fid = state.frame_id("doors", os.getpid())
+        state.frame_dir(self.fid, create=True)
+
+        existing = os.environ.get("PYTHONPATH", "")
+        parts = [str(_REPO_ROOT)] + ([existing] if existing else [])
+        # **`$CHARTER_SESSION_ID` is in the environment the SERVER is started with**, which
+        # is how every pane tmux later spawns inherits it — the same rung
+        # `commands_frame._session_id_env_argv` writes with `set-environment`, and the one
+        # `persona.resolve_active` reads to answer "who is this frame being" (ADR 0019).
+        # Without it the sidebar child resolves a persona for no session and draws every
+        # row idle, so the marker this file measures would never be anywhere to move from.
+        self.env = dict(os.environ, CHARTER_ROOT=str(self.plane),
+                        CHARTER_SESSION_ID=self.fid,
+                        PYTHONPATH=os.pathsep.join(parts))
+        self.env.pop("CHARTER_HOME", None)
+        # **`$CHARTER_PERSONA` is deliberately absent.** It is a PIN: `switch.to_persona`
+        # refuses outright when the launch carried one, and that value would sit in every
+        # panel pane's environment — so a fixture that set it would make the persona case
+        # below measure the refusal instead of the switch.
+        self.env.pop("CHARTER_PERSONA", None)
+        self.env.pop("CHARTER_WORKSPACE", None)
+
+        self.harness = self._start_session(self.fid)
+        self._tmux("set-environment", "-t", self.fid, "CHARTER_SESSION_ID", self.fid)
+        state.record_server(self.fid, self.socket)
+        state.record_harness_pane(self.fid, self.harness)
+        self._source_conf(self.fid)
+
+    # -- the frame ---------------------------------------------------------- #
+
+    def _tmux(self, *args: str, env=None) -> subprocess.CompletedProcess:
+        return subprocess.run(["tmux", "-L", self.socket, *args], capture_output=True,
+                              text=True, timeout=20, env=env)
+
+    def _start_session(self, fid: str) -> str:
+        started = self._tmux("-f", "/dev/null", "new-session", "-d", "-s", fid,
+                             "-x", str(COLS), "-y", "24", "-P", "-F", "#{pane_id}", "cat",
+                             env=self.env)
+        self.assertEqual(started.returncode, 0, started.stderr)
+        return started.stdout.strip()
+
+    def _source_conf(self, fid: str) -> None:
+        """charter's OWN frame config, `mouse = true`.
+
+        Asking `conf_text` for the text rather than writing `set mouse on` by hand is what
+        keeps the `MouseDown1Pane` rebind (#634) under test — a hand-written config would
+        leave tmux's default binding in place and "the keyboard stays on the harness"
+        would be measuring a config this file invented.
+        """
+        conf = str(self.tmp / f"{fid}.conf")
+        with open(conf, "w") as fh:
+            fh.write(commands_frame.conf_text(hotkey=config.FRAME["hotkey"], mouse=True,
+                                              history_limit=100, session=fid))
+        sourced = self._tmux("source-file", conf)
+        self.assertEqual(sourced.returncode, 0, sourced.stderr)
+
+    def _split_panel(self, slot: str, *, flag: str, size: int) -> str:
+        """One real `charter panel <slot>` pane, marked the way its launcher marks it.
+
+        `layout.panel_command` and `commands_frame._panel_mark_argv` are called rather
+        than re-spelled: that argv is what the launcher really sends, and that mark is what
+        the `MouseDown1Pane` bind asks about before it decides whether a click may move the
+        keyboard.
+        """
+        argv = layout.panel_command(slot=slot, session=self.fid)
+        r = self._tmux("split-window", "-t", self.harness, flag, "-l", str(size),
+                       "-P", "-F", "#{pane_id}", "--", *argv, env=self.env)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pane = r.stdout.strip()
+        marked = subprocess.run(
+            commands_frame._panel_mark_argv(socket=self.socket, pane_id=pane),
+            capture_output=True, text=True, timeout=20)
+        self.assertEqual(marked.returncode, 0, marked.stderr)
+        return pane
+
+    def _bring_up(self, *panels) -> None:
+        """Split the named panels, put the harness back in front, and attach a client.
+
+        **The harness is put back in front, and that is the regime rather than tidiness.**
+        `split-window` selects the pane it made, and a frame whose strip was the ACTIVE
+        pane would be reporting the mouse because THAT pane asked — the `mouse = false`
+        route, which would make every case below pass with charter's flag off.
+        `commands_frame._split_panels` ends the same way for the same reason.
+        """
+        for slot, flag, size in panels:
+            setattr(self, slot, self._split_panel(slot, flag=flag, size=size))
+        selected = self._tmux("select-pane", "-t", self.harness)
+        self.assertEqual(selected.returncode, 0, selected.stderr)
+        size = self._window_size()
+        self.assertNotEqual(size, (-1, -1), "tmux would not say how big its window is")
+        self.fd = self._attach(size)
+        self.assertEqual(self._active(), self.harness,
+                         "the harness is not the active pane, so a report reaching a "
+                         "panel would prove nothing about `[frame] mouse`")
+
+    def _attach(self, size) -> int:
+        cols, rows = size
+        refusals = []
+        for term in _TERM_CANDIDATES:
+            pid, fd = _fork_pty(rows=rows, cols=cols)
+            if pid == 0:
+                try:
+                    os.environ["TERM"] = term
+                    os.environ["CHARTER_ROOT"] = str(self.plane)
+                    os.execvp("tmux",
+                              ["tmux", "-L", self.socket, "attach", "-t", self.fid])
+                finally:
+                    os._exit(127)
+            if _await(lambda: bool(self._tmux("list-clients", "-t", self.fid,
+                                              "-F", "#{client_name}").stdout.strip()),
+                      timeout=10.0):
+                self.addCleanup(self._reap, pid, fd)
+                self.assertTrue(
+                    _await(lambda: self._window_size() == size),
+                    "attaching the client resized the window, so every panel took a "
+                    "SIGWINCH the cases below would read as an event")
+                return fd
+            refusals.append(term)
+            self._reap(pid, fd)
+        self.skipTest("no tmux client will attach on this machine, and a pointer needs "
+                      "one — tried TERM=" + ", ".join(refusals))
+
+    @staticmethod
+    def _reap(pid: int, fd: int) -> None:
+        for call in (lambda: os.kill(pid, 9), lambda: os.waitpid(pid, 0),
+                     lambda: os.close(fd)):
+            try:
+                call()
+            except OSError:
+                pass
+
+    def _teardown_socket(self) -> None:
+        said = self._tmux("display-message", "-p", "#{socket_path}")
+        was_running = said.returncode == 0
+        path = said.stdout.strip()
+        self._tmux("kill-server")
+        for candidate in {self.socket_path,
+                          path if path.startswith("/") else self.socket_path}:
+            try:
+                os.unlink(candidate)
+            except OSError:
+                pass
+        if not was_running:
+            return
+        self.assertTrue(path.startswith("/"), "tmux would not say where its socket is")
+        self.assertFalse(os.path.exists(path), f"{path} survived this test's teardown")
+
+    # -- reading the frame back --------------------------------------------- #
+
+    def _shown(self, pane: str) -> str:
+        return self._tmux("capture-pane", "-p", "-t", pane).stdout
+
+    def _row(self, pane: str, n: int = 0) -> str:
+        rows = self._shown(pane).split("\n")
+        return rows[n].rstrip() if n < len(rows) else ""
+
+    def _window_size(self) -> tuple[int, int]:
+        r = self._tmux("display-message", "-p", "-t", self.fid,
+                       "#{window_width} #{window_height}")
+        said = r.stdout.split()
+        if r.returncode != 0 or len(said) != 2:
+            return (-1, -1)
+        return int(said[0]), int(said[1])
+
+    def _rect(self, pane: str) -> tuple[int, int]:
+        r = self._tmux("display-message", "-p", "-t", pane, "#{pane_left} #{pane_top}")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        left, top = (int(n) for n in r.stdout.split())
+        return left, top
+
+    def _active(self) -> str:
+        return self._tmux("display-message", "-p", "#{pane_id}").stdout.strip()
+
+    def _panes(self) -> list[str]:
+        return self._tmux("list-panes", "-t", self.fid,
+                          "-F", "#{pane_id}").stdout.split()
+
+    def _click(self, pane: str, *, col: int, row: int = 0, button: int = 0) -> None:
+        """One left press and its release, at the pane's own cell, through the client.
+
+        Both halves are sent because that is what a terminal sends. Only the press is
+        acted on — every one of charter's handlers reads §4i the same way — and sending
+        only the press would leave this measuring a gesture no mouse makes.
+        """
+        left, top = self._rect(pane)
+        os.write(self.fd, b"\x1b[<%d;%d;%dM" % (button, left + col + 1, top + row + 1))
+        os.write(self.fd, b"\x1b[<%d;%d;%dm" % (button, left + col + 1, top + row + 1))
+
+    def _column_of(self, pane: str, field: str, row: int = 0) -> int:
+        """Which column of *pane* the drawn *field* starts in — read off the PANE.
+
+        Off the pane and never off `slots.DOORS`: that object lives in the panel's own
+        process and not in this one, and asking charter where it put something and then
+        clicking there would be a test that agrees with itself. This is the column the
+        operator's eye lands on.
+        """
+        drawn = self._row(pane, row)
+        at = drawn.index(field)
+        self.assertNotIn(field, drawn[at + 1:], f"{field!r} is not unique in {drawn!r}")
+        return at
+
+    def _row_of(self, pane: str, name: str) -> int:
+        """Which row of *pane* draws persona *name* — again read off the pane."""
+        rows = self._shown(pane).split("\n")
+        hits = [i for i, r in enumerate(rows) if f" {name}" in r]
+        self.assertEqual(len(hits), 1, f"{name!r} is not on exactly one row of {rows!r}")
+        return hits[0]
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealClickOnTheHotkeyHintOpensTheRealPalette(_ARealFrameWithStrips,
+                                                   unittest.TestCase):
+    """`F2 palette` is the only affordance charter advertises, and it is a button now.
+
+    **Three processes and none of them is this one.** The row is painted by a `charter
+    panel bottom` child, the click is decoded there, and the palette is carved by a
+    detached `charter frame-palette` that child started. What this asserts is what the
+    operator sees: a pane appears, it is the one their keyboard is now in, and it is the
+    palette.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._bring_up(("bottom", "-v", 1))
+        self.assertTrue(
+            _await(lambda: "palette" in self._row(self.bottom)),
+            f"the attention row never drew the hint: {self._row(self.bottom)!r}")
+
+    def test_clicking_the_hint_opens_a_palette_pane_and_the_keyboard_follows_it(self):
+        """What pressing `F2` does, reached with the pointer instead.
+
+        The keyboard moving is not the pointer moving it — `overlay.modal_argvs` makes the
+        palette's pane the active one deliberately, because a modal surface you cannot
+        type into is not one. `docs/frame.md`'s promise that a click on a PANEL leaves the
+        keyboard on the harness is kept and is asserted separately below: what moved the
+        keyboard here is the palette opening, exactly as it does from the key.
+        """
+        before = self._panes()
+        self.assertEqual(self._active(), self.harness)
+        self._click(self.bottom, col=self._column_of(self.bottom, "palette"))
+        self.assertTrue(
+            _await(lambda: len(self._panes()) > len(before)),
+            "no pane was carved off the harness, so the palette never opened")
+        opened = [p for p in self._panes() if p not in before]
+        self.assertEqual(len(opened), 1, f"expected one new pane, got {opened}")
+        self.assertTrue(_await(lambda: self._active() == opened[0]),
+                        "the palette opened and the keyboard did not follow it")
+        self.assertTrue(
+            _await(lambda: "workspace" in self._shown(opened[0])
+                   or "persona" in self._shown(opened[0])),
+            f"the new pane is not the palette: {self._shown(opened[0])!r}")
+
+    def test_clicking_the_todo_count_beside_it_opens_nothing(self):
+        """The control for the case above, and the half a feature like this gets wrong: a
+        row that answers EVERY click is as wrong as one that answers none. The todo count
+        is a readout — the frame reporting, not offering.
+        """
+        before = self._panes()
+        self._click(self.bottom, col=self._column_of(self.bottom, "todo"))
+        time.sleep(1.5)
+        self.assertEqual(self._panes(), before,
+                         "a click on the todo count opened something")
+        self.assertEqual(self._active(), self.harness,
+                         "and it moved the keyboard off the harness")
+
+    def test_a_click_on_the_separator_before_the_hint_opens_nothing(self):
+        """The ` · ` belongs to neither field, and charter will not pick the nearer one —
+        `slots._Tabs` refuses its own `_BAR_GAP` for the identical reason.
+
+        The column is the one immediately left of the hint rather than the first ` · ` on
+        the row: this plane draws an alert, so the row has several, and a case that clicked
+        whichever came first would be clicking a different cell on a plane that has none.
+        """
+        before = self._panes()
+        at = self._column_of(self.bottom, "F2 palette")
+        self.assertEqual(self._row(self.bottom)[at - 3:at], " · ")
+        self._click(self.bottom, col=at - 2)
+        time.sleep(1.5)
+        self.assertEqual(self._panes(), before)
+
+    def test_a_release_with_no_press_opens_nothing(self):
+        """§4i, measured end to end: `frame/overlay.py` recorded a drag begun on a pane
+        border delivering exactly one release, and every charter handler acts on the press
+        for that reason. This sends only the unpaired half a real drag delivers.
+        """
+        before = self._panes()
+        left, top = self._rect(self.bottom)
+        col = self._column_of(self.bottom, "palette")
+        os.write(self.fd, b"\x1b[<0;%d;%dm" % (left + col + 1, top + 1))
+        time.sleep(1.5)
+        self.assertEqual(self._panes(), before,
+                         "a release with no press opened the palette")
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealClickOnARealPersonaRowSwitchesTheFrame(_ARealFrameWithStrips,
+                                                  unittest.TestCase):
+    """The sidebar's roster: click a persona, the frame is being that persona.
+
+    The proof is `▸` moving on the pane, which is a fact about THREE processes — the
+    sidebar that drew it, the detached `charter frame-switch --persona` the click started,
+    and `persona.set_active` writing where both can see it. An in-process assertion would
+    prove none of that.
+    """
+
+    #: Split alongside the sidebar so the legend has somewhere to land. `bottom` is a
+    #: THIRD process: the click is decoded in the sidebar's, `state.say` writes the frame's
+    #: notice file and bumps the version, and this pane draws it on its own next poll —
+    #: which is the only thing that can show the two are talking through the frame's state
+    #: rather than through an object one interpreter has.
+    PANELS = (("right", "-h", 22), ("bottom", "-v", 1))
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._bring_up(*self.PANELS)
+        self.assertTrue(
+            _await(lambda: "▪ personas" in self._shown(self.right)),
+            f"the sidebar never painted: {self._shown(self.right)!r}")
+        # **The frame is put on `HERE` as a FIXTURE, in this process, not by running the
+        # thing under test.** `persona.set_active` keyed on the frame's own id is exactly
+        # what `switch.to_persona` calls, and `state.bump` is what it ends with — so the
+        # sidebar child sees it through the same two writes the click will use, and the
+        # case below is still measuring the click rather than a second run of itself.
+        #
+        # Stated rather than assumed, because `_persona_chip_cells` orders the ACTIVE
+        # persona first: a frame that started on some other name would put every row this
+        # case clicks somewhere else.
+        from charter import persona as p_mod
+        p_mod.set_active(self.HERE, session_id=self.fid, terminal_id="")
+        state.bump(self.fid)
+        self.assertTrue(
+            _await(lambda: f"▸ {self.HERE}" in self._shown(self.right)),
+            f"the frame did not start on {self.HERE}: {self._shown(self.right)!r}")
+
+    def test_clicking_an_idle_persona_moves_the_marker_to_it(self):
+        at = self._row_of(self.right, self.THERE)
+        self._click(self.right, col=3, row=at)
+        self.assertTrue(
+            _await(lambda: f"▸ {self.THERE}" in self._shown(self.right)),
+            f"the frame never adopted {self.THERE}: {self._shown(self.right)!r}")
+        self.assertNotIn(f"▸ {self.HERE}", self._shown(self.right),
+                         "two personas are marked active")
+
+    def test_the_keyboard_stays_on_the_harness(self):
+        """`docs/frame.md`'s promise, and the one #634 had to rebind `MouseDown1Pane` to
+        keep once `mouse = true`: a click on a PANEL acts where you pointed and leaves your
+        typing where it was. A persona switch is not a surface, so nothing about it should
+        move the keyboard the way opening the palette deliberately does.
+        """
+        at = self._row_of(self.right, self.THERE)
+        self._click(self.right, col=3, row=at)
+        self.assertTrue(_await(lambda: f"▸ {self.THERE}" in self._shown(self.right)))
+        self.assertEqual(self._active(), self.harness)
+
+    def test_clicking_the_badge_column_puts_the_legend_on_the_attention_row(self):
+        """#753, end to end and across two panes: click the `⚑` on a persona row and the
+        frame itself says what the glyph means.
+
+        The column is found by looking for the glyph ON THE PANE rather than by asking
+        `slots.CHIPS` where it put the badges — that object lives in the sidebar's process
+        and not in this one, and a test that asked charter where it drew something and then
+        clicked there would be a test that agrees with itself.
+        """
+        rows = self._shown(self.right).split("\n")
+        hits = [(i, r.rindex("⚑")) for i, r in enumerate(rows) if "⚑" in r]
+        self.assertTrue(hits, f"no persona carries a badge to click: {rows!r}")
+        row, col = hits[0]
+        self.assertNotIn("no usable vault", self._shown(self.bottom))
+        self._click(self.right, col=col, row=row)
+        self.assertTrue(
+            _await(lambda: "no usable vault" in self._shown(self.bottom)),
+            f"the legend never reached the attention row: "
+            f"{self._shown(self.bottom)!r}")
+        self.assertEqual(self._active(), self.harness,
+                         "explaining a glyph moved the keyboard")
+
+    def test_clicking_the_badge_column_switches_no_persona(self):
+        """The other half of the two-cell rule, on a real pane: the row that was clicked
+        must still be the row it was, and the marker must not have moved."""
+        rows = self._shown(self.right).split("\n")
+        hits = [(i, r.rindex("⚑")) for i, r in enumerate(rows) if "⚑" in r]
+        self.assertTrue(hits)
+        row, col = hits[0]
+        self._click(self.right, col=col, row=row)
+        self.assertTrue(_await(lambda: "no usable vault" in self._shown(self.bottom)))
+        self.assertIn(f"▸ {self.HERE}", self._shown(self.right),
+                      "a click on the badges adopted a persona")
+
+    def test_clicking_the_heading_switches_nothing(self):
+        """`▪ personas 3` names no persona, so it is absent from the map rather than
+        guarded against — `slots._Chips`' structural bounds check."""
+        self._click(self.right, col=3, row=0)
+        time.sleep(1.5)
+        self.assertIn(f"▸ {self.HERE}", self._shown(self.right),
+                      "a click on the heading moved the marker")
+
+    def test_clicking_the_persona_you_already_are_switches_nothing(self):
+        """`slots._Chips.switch_to`'s rule, end to end: re-adopting is not news, and this
+        is also what stops a double-click switching twice."""
+        at = self._row_of(self.right, self.HERE)
+        self._click(self.right, col=3, row=at)
+        time.sleep(1.5)
+        self.assertIn(f"▸ {self.HERE}", self._shown(self.right))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -780,6 +780,13 @@ class NoCharterEscapesThroughTheExecFamily(unittest.TestCase):
             "starts a real detached charter, and a mouse report still has to be put on a "
             "real client's terminal for tmux to route it anywhere. `os._exit`s in its "
             "`finally`.",
+        "tests/test_a_real_click_opens_the_real_palette.py:execvp":
+            "The same `tmux attach` inside a `pty.fork` child, for the sibling reason a "
+            "third time: that file exercises the pointer against the two one-row STRIPS "
+            "and the sidebar's persona column, whose clicks start a real detached "
+            "`charter frame-palette` and `charter frame-switch --persona`, and a mouse "
+            "report still has to be put on a real client's terminal for tmux to route it "
+            "anywhere. `os._exit`s in its `finally`.",
     }
 
     _WATCHED = ("execl", "execle", "execlp", "execlpe", "execv", "execve", "execvp",

--- a/tests/test_the_repo_table_scrolls_and_selects.py
+++ b/tests/test_the_repo_table_scrolls_and_selects.py
@@ -978,10 +978,23 @@ class ThePanelDeliversToCharterSOwnComponent(PersonaIso, unittest.TestCase):
     built-in was the one kind of component that could declare `events` and never receive
     any."""
 
-    def test_only_the_repo_table_gets_an_event_path(self):
+    def test_a_component_that_declared_nothing_pays_for_no_input_path(self):
+        """**This case used to read "only the repo table gets an event path", and #742 and
+        #751 turned that sentence over deliberately** — the four PLACED panels all declare
+        `click` now, and the table is merely the only one that also declares `scroll`.
+
+        What it was actually pinning survives and is the half worth keeping: a component
+        that declared nothing opens no input path at all. `events.Dispatcher.open` leaves
+        such a pane's tty mode alone, writes no `overlay.MOUSE_ON` and takes none of the
+        operator's own drag-select — `slots.ANIMATED`'s rule that a feature costing every
+        panel is a feature every panel pays for. The three that qualify are the sidebar's
+        own parts, and `registry.Registry` refuses a part that declares a kind.
+        """
         reg = builtins.build(FID)
-        self.assertIsNotNone(panel._dispatcher(reg, "repos"))
-        for cid in ("identity", "attention", "sidebar"):
+        for cid in ("repos", "identity", "attention", "sidebar"):
+            self.assertIsNotNone(panel._dispatcher(reg, cid),
+                                 f"{cid} declares an event and gets no path for it")
+        for cid in ("personas", "todos", "changes"):
             self.assertIsNone(panel._dispatcher(reg, cid),
                               f"{cid} pays for an input path it declared nothing for")
 

--- a/tests/test_the_strips_and_the_roster_answer_a_click.py
+++ b/tests/test_the_strips_and_the_roster_answer_a_click.py
@@ -1,0 +1,752 @@
+"""The three panels that advertised something and answered nothing — #742, #751, #753.
+
+Before this change `repos`, `chats` and `workspaces` were the only components on the
+machine that declared any event at all. The identity strip, the attention strip and the
+sidebar drew nouns the palette already opens by name, drew a roster with a cursor-looking
+marker on the active row, and drew the words `F2 palette` — *the only affordance charter
+advertises on screen* — and handled nothing.
+
+**What is asserted here is a COLUMN and a ROW wherever a column or a row is what the code
+computes.** `_Doors` and `_Chips` are maps from a number to a meaning, and a test that
+asked "is anything published" would go green over a map off by two — which is precisely the
+defect a published map exists to prevent, since the alternative was re-deriving the number
+when the click arrived. So the door on `' ⬢ alpha    ◆ steward'` is asserted to be columns
+0–7 and 10–20 and not to be "non-empty", and the persona on row 3 is asserted to be `forge`.
+
+**Every rung of both ladders is asserted, INCLUDING the rungs that draw nothing.** That is
+`slots._Viewport.blank`'s finding and `slots._bar.row`'s discipline, and it is the half a
+test suite skips: a strip that kept a stale map through a resize opens the palette from a
+cell the operator can see is empty, and a persona column that kept one through a `terse`
+switch adopts a persona whose row is no longer drawn. `TheMapDescribesWhatWasDrawn` is
+those cases and nothing else.
+
+**The refusals are tested as hard as the answers.** A component that answers every click is
+as wrong as one that answers none: the heading, the `…(+N more)` row, the gap between two
+fields, the space past the last one, the release half of a drag, the button that is not
+left, and the row you are already on all have to answer nothing, and an accident that
+happened to cancel would be indistinguishable from a design that refuses.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import statusline as sl
+from charter import tui
+from charter.frame import builtins, events, overlay, slots, state, tmuxctl
+
+from tests._isolation import PersonaIso
+
+FID = "f-doors"
+
+#: A pane wide enough for both strips to draw every field they have, so nothing here is
+#: accidentally measuring the starved rung the ladder cases below are for.
+WIDE = 120
+
+
+def _chip(name, *, active=False, badges="") -> sl.PersonaChip:
+    """One persona row shaped the way `statusline._persona_chip_cells` shapes it.
+
+    The head carries the marker, the name and the vault dot exactly as that function
+    composes them (`▸` for the active persona, `▫` otherwise), because `slots._persona_rows`
+    measures what it is handed and a head built some other way would be a different column.
+    """
+    head = (f"{sl._MAGENTA}{sl._MARK_ACTIVE} {sl._BOLD}{name}{sl._R}" if active
+            else f"{sl._DIM}{sl._MARK_IDLE} {name}{sl._R}")
+    return sl.PersonaChip(name, head, badges, 0, active=active)
+
+
+def _roster(*chips):
+    """`statusline._persona_chip_cells` answering *chips* — the one read `persona_section`
+    makes of the plane."""
+    return mock.patch.object(sl, "_persona_chip_cells", lambda: list(chips))
+
+
+def _click(row=0, col=0, *, pressed=True, name="left"):
+    return overlay.Event(overlay.CLICK, name, row=row, col=col, pressed=pressed)
+
+
+class _Strip(PersonaIso):
+    """A base that draws either strip at a width and hands back the flat row.
+
+    Both strips are composed out of pieces and then truncated, and every case below wants
+    the same two things: what the row SAYS with the escapes gone, and which columns the
+    paint published. Doing it here keeps a case to its own assertion.
+
+    **`PersonaIso` rather than a bare `TestCase`, and `tests/_envguard.py` is why**: both
+    `_top` and `_bottom` read `$CHARTER_WORKSPACE` and `$CHARTER_SESSION_ID`, which are
+    exactly the names an operator's own frame exports — sixteen tests failed on that and
+    one went falsely green (#519, #521, #528). The base declares the whole charter
+    environment unset, which is the answer CI gives.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        slots.DOORS.forget()
+        self.addCleanup(slots.DOORS.forget)
+
+    def top_row(self, *, width=WIDE, terse=False, gauge=(), line=None, sidebar=False):
+        """`slots._top` drawn at *width*, with the escapes stripped."""
+        parts = sl.PersonaLine(f"  {sl._MAGENTA}◆{sl._R} {sl._BOLD}steward{sl._R}",
+                               f"  {sl._DIM}◇ personas 6{sl._R}", "")
+        with mock.patch.object(slots, "content_width", lambda n: width), \
+             mock.patch.object(slots, "verbosity",
+                               lambda f: "terse" if terse else "full"), \
+             mock.patch.object(slots, "_frame_workspace", lambda f: "alpha"), \
+             mock.patch.object(slots, "_sidebar_live", lambda f: sidebar), \
+             mock.patch.object(sl, "recorded_context_gauge", lambda s: list(gauge)), \
+             mock.patch.object(sl, "_persona_line_parts",
+                               lambda: parts if line is None else line()):
+            return tui.strip_ansi(slots._top(FID))
+
+    def bottom_row(self, *, width=WIDE, terse=False, repo="", todos=7, alerts=(),
+                   news=(), inflight="", operator_socket=False, notice=""):
+        """`slots._bottom` drawn at *width*, with the escapes stripped."""
+        with mock.patch.object(state, "notice", lambda f: notice), \
+             mock.patch.object(slots, "content_width", lambda n: width), \
+             mock.patch.object(slots, "verbosity",
+                               lambda f: "terse" if terse else "full"), \
+             mock.patch.object(slots, "_frame_workspace", lambda f: "alpha"), \
+             mock.patch.object(slots, "_selected_detail", lambda f: repo), \
+             mock.patch.object(slots, "_inflight_field", lambda: inflight), \
+             mock.patch.object(sl, "_todo_count", lambda ws: todos), \
+             mock.patch.object(sl, "_alerts", lambda ws: list(alerts)), \
+             mock.patch.object(sl, "_session_news", lambda s, inflight: list(news)), \
+             mock.patch.object(tmuxctl, "is_operator_socket",
+                               lambda s: operator_socket):
+            return tui.strip_ansi(slots._bottom(FID))
+
+    def doors(self) -> set[int]:
+        """Every column the last paint published, as a set of ints."""
+        return {c for c in range(-2, 400) if slots.DOORS.opens_palette(c)}
+
+    def under(self, text: str, cols) -> str:
+        """*text* with a `^` under each of *cols* — what a failure prints."""
+        return "\n" + text + "\n" + "".join(
+            "^" if i in cols else " " for i in range(len(text)))
+
+
+class TheIdentityStripPublishesItsTwoDoors(_Strip):
+    """`slots._top` — `⬢ <workspace>` and `◆ <persona>`, and nothing else on the row.
+
+    #751: "both are doorways the palette opens by name". The columns are worked out from
+    the pieces `_top` composed rather than by finding `⬢` or `◆` in the finished row, for
+    the reason that function already gives about the chips — a fact recovered from a
+    rendered row is a second reading of what was drawn, free to drift from the first. So
+    these cases assert the arithmetic, at the exact columns.
+    """
+
+    def test_the_workspace_chip_is_columns_0_to_7_and_the_persona_head_10_to_20(self):
+        """The two doors of ` ⬢ alpha    ◆ steward`, at the columns they are drawn in.
+
+        Asserted as the exact sets, not as "the row has some doors": the whole reason this
+        map is published rather than recomputed is that a click arrives as a NUMBER, and a
+        map that is right about *how many* doors there are and wrong about *where* is the
+        version that opens the palette from a blank cell.
+        """
+        row = self.top_row()
+        self.assertEqual(row[:21], " ⬢ alpha    ◆ steward")
+        self.assertEqual(self.doors(), set(range(0, 8)) | set(range(10, 21)),
+                         self.under(row[:24], self.doors()))
+
+    def test_a_gauge_between_them_moves_the_persona_door_and_is_not_one(self):
+        """`ctx 42%` is a readout — the frame reporting, not offering — so the columns it
+        occupies answer nothing, and the persona door starts after it."""
+        row = self.top_row(gauge=["ctx 42%"])
+        self.assertEqual(row[:30], " ⬢ alpha  ctx 42%    ◆ steward")
+        self.assertEqual(self.doors(), set(range(0, 8)) | set(range(19, 30)),
+                         self.under(row[:33], self.doors()))
+        for col in range(8, 19):
+            self.assertFalse(slots.DOORS.opens_palette(col),
+                             f"column {col} is the gauge and must answer nothing")
+
+    def test_the_roster_half_is_not_a_door(self):
+        """`◇ personas 6` trails the head on a frame with no sidebar (#530), so it is drawn
+        on some frames and not others — a door there would exist for a reason no operator
+        can see. Only `PersonaLine.head` is published."""
+        row = self.top_row(sidebar=False)
+        self.assertIn("◇ personas 6", row)
+        self.assertEqual(max(self.doors()), 20,
+                         self.under(row[:36], self.doors()))
+
+    def test_the_charter_version_is_not_a_door(self):
+        """It is right-aligned on the same row and is a build number, not a noun the
+        palette has an action for."""
+        row = self.top_row()
+        at = row.index("charter 0.")
+        for col in range(at, len(row)):
+            self.assertFalse(slots.DOORS.opens_palette(col),
+                             f"column {col} is the charter version")
+
+    def test_a_plane_with_no_personas_still_publishes_the_workspace_door(self):
+        """`_persona_line_parts` answers `None` on a plane that defines none, so the head
+        is empty and contributes no columns — and the workspace chip is unaffected. The
+        half-published map is the failure this asserts against: a `None` that took the
+        whole publish with it would leave the paint before it standing."""
+        self.top_row()
+        self.assertIn(20, self.doors(), "the ordinary paint has a persona door")
+        drawn = self.top_row(line=lambda: None)
+        self.assertEqual(self.doors(), set(range(0, 8)),
+                         self.under(drawn[:24], self.doors()))
+
+
+class TheAttentionStripPublishesTheHotkeyHint(_Strip):
+    """`slots._bottom` — `F2 palette`, and nothing else on the row.
+
+    #751's sharpest case: it is the only affordance charter advertises on screen and it was
+    the one thing on the row that could not be operated the way it is drawn.
+    """
+
+    def test_the_hint_is_the_door_and_the_todo_count_beside_it_is_not(self):
+        """`7 todos · F2 palette` — columns 10 to 19 and no others. The todo count is a
+        readout; the hint is a key name beside a noun, which is a button everywhere else an
+        operator has seen one."""
+        row = self.bottom_row()
+        self.assertEqual(row, "7 todos · F2 palette")
+        self.assertEqual(self.doors(), set(range(10, 20)), self.under(row, self.doors()))
+
+    def test_a_field_added_in_front_of_the_hint_moves_its_door_with_it(self):
+        """#729's `notice` dwells at the HEAD of this row for a few seconds after a
+        switch, and the door has to move by exactly its width plus a separator.
+
+        **This is the case that pins the walk against the next field somebody adds.** The
+        columns are walked out of `_fit_fields`' surviving set rather than searched for in
+        the joined row, so a seventh field needs no case of its own here — and a version
+        that hard-coded the hint's offset would put the palette on a cell holding the tail
+        of somebody's notice. The notice itself answers nothing: it is the outcome of
+        something the operator already chose, which is a readout in the same sense the
+        todo count is.
+        """
+        plain = self.bottom_row()
+        self.assertEqual(min(self.doors()), 10, self.under(plain, self.doors()))
+        row = self.bottom_row(notice="persona → docs")
+        self.assertTrue(row.startswith("persona → docs · "), row)
+        at = row.index("F2 palette")
+        self.assertEqual(self.doors(), set(range(at, at + 10)),
+                         self.under(row, self.doors()))
+        for col in range(0, len("persona → docs")):
+            self.assertFalse(slots.DOORS.opens_palette(col),
+                             f"column {col} is the notice and must answer nothing")
+
+    def test_the_separator_between_two_fields_answers_nothing(self):
+        """The three cells of ` · ` belong to neither field, and charter will not pick the
+        nearer one — `slots._Tabs` refuses its own `_BAR_GAP` for the same reason."""
+        self.bottom_row()
+        for col in (7, 8, 9):
+            self.assertFalse(slots.DOORS.opens_palette(col),
+                             f"column {col} is the ` · ` before the hint")
+
+    def test_the_selected_repos_detail_answers_nothing(self):
+        """It is the readout of a row selected on ANOTHER pane, so a click on it could only
+        mean "select what is already selected" — the one gesture `slots._Tabs.switch_to`
+        and `builtins._repos_events` both already refuse."""
+        row = self.bottom_row(repo=f"{sl._DIM}▪{sl._R} ledger")
+        at = row.index("▪ ledger")
+        self.assertEqual(self.doors(), set(range(10, 20)), self.under(row, self.doors()))
+        for col in range(at, len(row)):
+            self.assertFalse(slots.DOORS.opens_palette(col),
+                             f"column {col} is the repo detail")
+
+    def test_the_space_past_the_last_field_answers_nothing(self):
+        """A 120-column pane drawing a 20-column row has a hundred cells nothing was drawn
+        into. `_door_columns` clips to the width, so they are absent rather than guarded."""
+        self.bottom_row()
+        for col in (20, 21, 60, 119, 400):
+            self.assertFalse(slots.DOORS.opens_palette(col))
+
+
+class TheMapDescribesWhatWasDrawn(_Strip):
+    """Every rung of both ladders publishes, including the rungs that draw no door.
+
+    `slots._Viewport.blank`'s whole finding, one surface over: three of `_repos`' four
+    exits cleared the click map and none of them cleared the scroll bound. A strip that
+    kept a stale map through a resize would open the palette from a cell the operator can
+    see is empty, and *the paint that stops drawing a field is the paint that has to say
+    so* — nothing later can.
+    """
+
+    def test_terse_keeps_one_field_on_the_attention_strip_and_it_is_not_the_hint(self):
+        """`_fit_fields(limit=1)` keeps the highest-priority field with anything to say,
+        which on a quiet plane is the todo count. So the row has no door at all — and that
+        has to be *published*, not left over from the paint before it."""
+        self.bottom_row()
+        self.assertTrue(self.doors(), "the wide paint should have published a door")
+        row = self.bottom_row(terse=True)
+        self.assertEqual(row, "7 todos")
+        self.assertEqual(self.doors(), set(), self.under(row, self.doors()))
+
+    def test_a_starved_row_drops_the_hint_first_and_publishes_the_absence(self):
+        """`hotkey` is last in `_fit_fields`' priority list, so it is the first field a
+        narrow pane loses. The map has to lose it in the same paint."""
+        self.bottom_row()
+        row = self.bottom_row(width=12)
+        self.assertNotIn("palette", row)
+        self.assertEqual(self.doors(), set(), self.under(row, self.doors()))
+
+    def test_a_frame_in_the_operators_own_tmux_advertises_no_hotkey_and_opens_no_door(self):
+        """Charter binds no key inside a tmux it did not start, so `hotkey_text` is empty
+        there — and an empty field contributes no columns rather than a zero-width door at
+        somebody else's column."""
+        row = self.bottom_row(operator_socket=True)
+        self.assertNotIn("palette", row)
+        self.assertEqual(self.doors(), set(), self.under(row, self.doors()))
+
+    def test_a_narrow_identity_strip_clips_its_doors_to_what_survived_the_truncate(self):
+        """At 14 columns ` ⬢ alpha    ◆ steward` is drawn as ` ⬢ alpha    ◆…`. A door
+        published at the columns the persona head WOULD have had is a door on a cell that
+        is not on the screen."""
+        row = self.top_row(width=14)
+        self.assertEqual(len(row), 14)
+        self.assertEqual(max(self.doors()), 13, self.under(row, self.doors()))
+
+    def test_a_zero_width_strip_publishes_no_door_at_all(self):
+        """`tui.truncate(s, 0)` is `""`, and a map over a row nothing was drawn on is the
+        empty one."""
+        self.top_row()
+        self.assertTrue(self.doors())
+        self.assertEqual(self.top_row(width=0), "")
+        self.assertEqual(self.doors(), set())
+
+
+class TheSidebarPublishesWhichPersonaIsOnWhichRow(unittest.TestCase):
+    """`slots.persona_section` and `slots._Chips` — #742's persona half.
+
+    The column is drawn as an inverted-row list with a cursor-looking marker on the active
+    one, which is the visual vocabulary of something you pick from. What is asserted is the
+    ROW each persona landed on, because the ladder is not invertible: `_cap_personas` drops
+    the tail of an order and `terse` caps the list again, so "which persona is on row 4"
+    cannot be worked back from the roster and the pane's height.
+    """
+
+    def setUp(self) -> None:
+        slots.CHIPS.forget()
+        self.addCleanup(slots.CHIPS.forget)
+
+    def switched(self, row: int):
+        """The persona a click on *row*'s NAME cell switches to, or ``None``.
+
+        Column 0 is inside the name cell on every rung these cases draw — the badge column
+        is right-aligned — so this asks the question every case here was written to ask
+        before the badges became clickable too. `TheBadgeColumnExplainsInstead` is the
+        other cell.
+        """
+        hit = slots.CHIPS.hit(row, 0)
+        return None if hit is None or hit.explain else hit.name
+
+    def test_row_0_is_the_heading_and_the_personas_start_at_row_1(self):
+        with _roster(_chip("steward", active=True), _chip("docs"), _chip("forge")):
+            lines = slots.persona_section(22, 10, terse=False)
+        self.assertEqual(tui.strip_ansi(lines[0]), "▪ personas 3")
+        self.assertIsNone(self.switched(0), "the heading names no persona")
+        self.assertEqual(self.switched(2), "docs")
+        self.assertEqual(self.switched(3), "forge")
+
+    def test_the_persona_you_are_already_being_answers_nothing(self):
+        """`_Tabs.switch_to`'s rule, kept in the map object rather than in the handler so
+        it is a property of one class with one test. It is also what stops a double-click
+        switching twice."""
+        with _roster(_chip("steward", active=True), _chip("docs")):
+            slots.persona_section(22, 10, terse=False)
+        self.assertIsNone(self.switched(1))
+        self.assertEqual(self.switched(2), "docs")
+
+    def test_the_overflow_row_answers_nothing_because_it_stands_for_rows_not_drawn(self):
+        """A three-row budget draws the heading, one persona and `…(+2 more)`. That last
+        row is a sentence about the list — `_Tabs` refuses its own `+14` for the identical
+        reason — so the persona a click there would have to guess at is not published."""
+        with _roster(_chip("steward", active=True), _chip("docs"), _chip("forge")):
+            lines = slots.persona_section(22, 3, terse=False)
+        self.assertEqual(tui.strip_ansi(lines[2]).strip(), "…(+2 more)")
+        self.assertIsNone(self.switched(2))
+
+    def test_a_row_below_the_column_answers_nothing(self):
+        """The sidebar puts a blank row and then the todos under the personas. Neither is
+        published, and a row past the end of a dict is absent rather than the LAST one —
+        which is what a tuple indexed with a big number would not have been."""
+        with _roster(_chip("steward", active=True), _chip("docs")):
+            slots.persona_section(22, 10, terse=False)
+        for row in (3, 4, 9, 400, -1):
+            self.assertIsNone(self.switched(row), f"row {row}")
+
+    def test_a_plane_with_no_personas_publishes_an_empty_map(self):
+        """The rung that draws `no personas` publishes too — `_Viewport.blank`'s finding.
+        A map left standing from the paint before it would switch this frame to a persona
+        nobody can see on the row that was clicked."""
+        with _roster(_chip("steward", active=True), _chip("docs")):
+            slots.persona_section(22, 10, terse=False)
+        self.assertEqual(self.switched(2), "docs")
+        with _roster():
+            lines = slots.persona_section(22, 10, terse=False)
+        self.assertEqual(tui.strip_ansi(lines[0]), "no personas")
+        for row in range(0, 6):
+            self.assertIsNone(self.switched(row), f"row {row}")
+
+    def test_terse_republishes_the_shorter_column(self):
+        """`_TERSE_ROWS` caps the list again, so a density change moves what is on row 4.
+        The paint that stops drawing a row is the paint that has to say so."""
+        chips = [_chip("steward", active=True)] + [_chip(f"p{i}") for i in range(6)]
+        with _roster(*chips):
+            slots.persona_section(22, 20, terse=False)
+        self.assertEqual(self.switched(4), "p2")
+        with _roster(*chips):
+            lines = slots.persona_section(22, 20, terse=True)
+        self.assertEqual(len(lines), 1 + slots._TERSE_ROWS)
+        self.assertIsNone(self.switched(5),
+                          "terse drew four rows; row 5 is not one of them")
+
+    def test_row_zero_resolves_like_any_other_row(self):
+        """`slots._Chips` is indexed by row and knows nothing about headings.
+
+        **Pinned against the object rather than through the renderer, and the deletion
+        sweep is why.** `persona_section` always draws `▪ personas N` first, so row 0
+        always holds `None` — which makes `0 <= row` and `0 < row` behave identically
+        through every paint, and the sweep reported the boundary as an exact equivalent.
+        It is not one: that row 0 is a heading is the *composition's* choice, not this
+        class's contract, and the day a column is drawn without one the two spellings stop
+        agreeing. `_Viewport.repo_at` carries the same lower bound for the same reason and
+        argues it — a negative index into a tuple answers the LAST row, which is the one
+        wrong answer available here.
+        """
+        slots.CHIPS.publish(("docs", "forge"), "forge", 0)
+        self.assertEqual(self.switched(0), "docs")
+        self.assertIsNone(self.switched(1), "row 1 is the one you are on")
+        self.assertIsNone(self.switched(-1),
+                          "a negative row must not answer the last one")
+
+    def test_a_frame_being_no_persona_makes_every_row_clickable(self):
+        """`_persona_chip_cells` marks nobody active on a frame that has adopted no
+        persona — the state a frame is in before its first `charter persona use`, and the
+        one a plane with three personas and no default sits in indefinitely.
+
+        The mark this column compares against is then the empty string, which is a name no
+        chip carries, so every row switches. Asserted because the alternative is worse than
+        it looks: a default that happened to equal the first persona's name would make
+        exactly one row of a fresh frame silently dead.
+        """
+        with _roster(_chip("docs"), _chip("forge")):
+            slots.persona_section(22, 10, terse=False)
+        self.assertEqual(self.switched(1), "docs")
+        self.assertEqual(self.switched(2), "forge")
+
+    def test_the_name_published_is_the_raw_one_and_not_the_drawn_one(self):
+        """`_persona_rows` runs every name through `tui.Cell`, which truncates it into a
+        22-column pane (#472). What goes into `charter frame-switch --persona` has to be
+        the name on disk — `_Tabs.publish`'s rule one axis over."""
+        long = "a-persona-with-a-very-long-name"
+        with _roster(_chip("steward", active=True), _chip(long)):
+            lines = slots.persona_section(22, 10, terse=False)
+        self.assertNotIn(long, tui.strip_ansi(lines[2]), "the drawn name should be cut")
+        self.assertEqual(self.switched(2), long)
+
+
+class TheBadgeColumnExplainsInstead(unittest.TestCase):
+    """`slots._Chips.hit` on the BADGE cell — #753's in-frame half.
+
+    The auditor read `frame/slots.py` to learn that `◦` is the ordinary state of a persona
+    with no vault. The docs table added by this change answers that outside the frame;
+    this is the answer *inside* it, and it lands on the dwell #729 built rather than on a
+    surface of its own.
+
+    **What is asserted is the CELL boundary**, because that is the whole mechanism: a
+    column one to the left of the badge cell must still switch, and one column into it
+    must explain. A test that only asked "does a badge click explain" would go green over
+    a boundary off by the width of a name.
+    """
+
+    def setUp(self) -> None:
+        slots.CHIPS.forget()
+        self.addCleanup(slots.CHIPS.forget)
+
+    def _drawn(self, *chips, width=22, height=10):
+        with _roster(*chips):
+            return slots.persona_section(width, height, terse=False)
+
+    def test_a_pane_too_narrow_for_a_name_gets_no_badge_column_rather_than_a_negative_one(self):
+        """`slots._badge_width`'s own contract — *a column is never a negative number of
+        cells* — asserted on the function rather than on what a caller does next.
+
+        **This case exists because the deletion sweep found the old spelling to be an
+        exact equivalent.** The floor used to sit inside the `min`
+        (`min(widest, max(0, width - _NAME_MIN_W))`), where dropping it changed nothing an
+        input could observe: a negative width fell straight into `_persona_rows`'
+        ``badge_w <= 0`` branch and was treated as zero there. Measured over 3,280 cell
+        configurations at every width from 0 to 40, the unclamped version drew byte-identical
+        rows and resolved every click identically.
+
+        Moved outside the `min` it is this function's answer instead of a caller's
+        accident, and one call pins it. `_NAME_MIN_W` is 12, and `_PAD_MIN_CONTENT` is the
+        same constant — so `pad_for` already guarantees a padded pane keeps 12 columns and
+        the only way here is a pane narrower than that, which a plane can ask for with a
+        `[[frame.component]]` of its own.
+        """
+        cells = [_chip("a", badges=" ⚑"), _chip("b", badges=" ✎47 ⚡3")]
+        widest = max(tui.width(c.badges) for c in cells)
+        self.assertEqual(slots._NAME_MIN_W, 12, "this case is written against that floor")
+        for width in (0, 1, 8, 11, 12):
+            self.assertEqual(slots._badge_width(cells, width), 0,
+                             f"width {width} leaves nothing for a name, so no badge column")
+        self.assertEqual(slots._badge_width(cells, 13), 1,
+                         "one column past the floor buys exactly one badge cell")
+        self.assertEqual(slots._badge_width(cells, 100), widest,
+                         "a wide pane gives the badges the widest one on screen")
+
+    def test_the_column_the_badges_were_drawn_in_is_where_explaining_starts(self):
+        """`▫ docs ◦             ⚑` on a 22-column pane: the `⚑` cell is one column wide
+        at the right edge, so column 21 explains and column 20 — the last cell of the name
+        — still switches."""
+        self._drawn(_chip("steward", active=True), _chip("docs", badges="⚑"))
+        at = slots.CHIPS._badge_at
+        self.assertEqual(at, 21, "the badge cell should be the pane's last column")
+        self.assertEqual(slots.CHIPS.hit(2, at), slots._Hit(True, "docs"))
+        self.assertEqual(slots.CHIPS.hit(2, at - 1), slots._Hit(False, "docs"))
+
+    def test_the_badges_on_the_persona_you_are_explain_where_the_name_refuses(self):
+        """The asymmetry, stated: re-adopting yourself is the nothing `_Tabs.switch_to`
+        refuses, but *"what does the flag on my own row mean"* is the commonest form of
+        the question this answers."""
+        self._drawn(_chip("steward", active=True, badges="⚑"), _chip("docs"))
+        at = slots.CHIPS._badge_at
+        self.assertIsNone(slots.CHIPS.hit(1, 0), "the name you are on switches nothing")
+        self.assertEqual(slots.CHIPS.hit(1, at), slots._Hit(True, "steward"))
+
+    def test_a_row_naming_no_persona_explains_nothing_even_in_the_badge_column(self):
+        """`_persona_rows` draws the `…(+N more)` row FULL WIDTH with no badge cell, so a
+        click where the badges would have been is a click on a sentence about the list."""
+        lines = self._drawn(_chip("steward", active=True, badges="⚑"),
+                            _chip("docs"), _chip("forge"), height=3)
+        self.assertEqual(tui.strip_ansi(lines[2]).strip(), "…(+2 more)")
+        for col in (0, 3, 21, 40):
+            self.assertIsNone(slots.CHIPS.hit(2, col), f"column {col}")
+        self.assertIsNone(slots.CHIPS.hit(0, 21), "the heading explains nothing")
+
+    def test_a_column_with_no_badges_at_all_is_all_name(self):
+        """`_badge_width` answers zero when no chip carries a badge, so no badge cell is
+        drawn and `badge_at` is published as 0 — which `hit` reads as "there is no badge
+        column" rather than as "column 0 is one"."""
+        self._drawn(_chip("steward", active=True), _chip("docs"))
+        self.assertEqual(slots.CHIPS._badge_at, 0)
+        for col in (0, 10, 21):
+            self.assertEqual(slots.CHIPS.hit(2, col), slots._Hit(False, "docs"),
+                             f"column {col} should still be the name")
+
+    def test_the_legend_names_every_glyph_the_docs_table_does(self):
+        """One legend for every row, because `PersonaChip.badges` is a RENDERED string by
+        the time this module sees it and a handler is handed no ctx (§4f) — so saying what
+        *this* persona's badges mean would need either decoding glyphs back out or a
+        second reading of the plane. It has to be worth reading on its own, which means
+        naming every glyph `docs/frame.md`'s own table does."""
+        for glyph in ("◦", "!", "⚑", "✗", "✎", "◌", "⚡"):
+            self.assertIn(glyph, slots.BADGE_LEGEND, f"{glyph} is unexplained")
+
+    def test_the_legend_fits_an_ordinary_attention_row(self):
+        """`state.say` hands it to `_bottom`, where it is top priority and still
+        `tui.truncate`d to the pane. 120 columns is the width `docs/frame.md` uses for
+        every frame it draws, and a legend cut on an ordinary terminal would be a reminder
+        that needs the reference to make sense of it."""
+        self.assertLessEqual(tui.width(slots.BADGE_LEGEND), 120)
+
+    def test_the_legend_is_one_line(self):
+        """`state.say` stores an expiry line and then the text, so a newline in the value
+        reads back truncated at it — that function contains its argument for exactly this,
+        and a constant that needed containing would be relying on the repair."""
+        self.assertNotIn("\n", slots.BADGE_LEGEND)
+
+
+class TheHandlersActOnThePressAndNothingElse(unittest.TestCase):
+    """`builtins._strip_events` and `builtins._persona_events`.
+
+    The half of §4i both handlers inherit word for word from `_repos_events`: a `click`
+    release can arrive with no matching press — `frame/overlay.py` measured a drag begun on
+    a pane border delivering exactly one release — so charter acts on the press, which is
+    where the operator actually pointed.
+    """
+
+    def setUp(self) -> None:
+        slots.DOORS.forget()
+        slots.CHIPS.forget()
+        self.addCleanup(slots.DOORS.forget)
+        self.addCleanup(slots.CHIPS.forget)
+        self.spawned: list[tuple] = []
+        patch = mock.patch("charter.frame.builtin_actions._spawn",
+                           lambda argv, *, fid: self.spawned.append((tuple(argv), fid)))
+        patch.start()
+        self.addCleanup(patch.stop)
+        #: Every `state.say` the handler made, as `(fid, message, seconds)`. Captured
+        #: rather than written, because what is under test is that the handler reaches for
+        #: the frame's own dwell at all — `state.say`'s file format is its own module's.
+        self.said: list[tuple] = []
+        say = mock.patch.object(
+            state, "say",
+            lambda f, msg, *, seconds=None: self.said.append((f, msg, seconds)))
+        say.start()
+        self.addCleanup(say.stop)
+
+    # -- the strips ---------------------------------------------------------- #
+
+    def test_a_press_on_a_door_starts_the_palette_for_this_frame(self):
+        slots.DOORS.publish(range(10, 20))
+        on_event = builtins._strip_events(FID)
+        self.assertFalse(on_event(_click(col=12)), "nothing this pane draws has changed")
+        self.assertEqual(len(self.spawned), 1)
+        argv, fid = self.spawned[0]
+        self.assertEqual(argv[-1], "frame-palette")
+        self.assertEqual(fid, FID, "the frame is closed over, never read back out of "
+                                   "an environment one tmux server shares")
+
+    def test_a_release_over_a_door_opens_nothing(self):
+        slots.DOORS.publish(range(10, 20))
+        self.assertFalse(builtins._strip_events(FID)(_click(col=12, pressed=False)))
+        self.assertEqual(self.spawned, [], "a drag begun elsewhere never pointed here")
+
+    def test_a_middle_or_right_press_on_a_door_opens_nothing(self):
+        """Middle-click is paste on every terminal an operator has used and right-click
+        opens their emulator's own menu — `builtins._ACT_BUTTON`'s whole argument."""
+        slots.DOORS.publish(range(10, 20))
+        for button in ("middle", "right"):
+            self.assertFalse(builtins._strip_events(FID)(_click(col=12, name=button)))
+        self.assertEqual(self.spawned, [])
+
+    def test_a_press_on_a_cell_no_field_was_drawn_into_opens_nothing(self):
+        slots.DOORS.publish(range(10, 20))
+        for col in (0, 9, 20, 4096, -1):
+            self.assertFalse(builtins._strip_events(FID)(_click(col=col)), f"col {col}")
+        self.assertEqual(self.spawned, [])
+
+    def test_the_palette_argv_is_the_one_the_hotkey_bind_runs(self):
+        """`commands_frame.conf_text` binds `frame-palette "#{client_name}"`; this is the
+        same subcommand with the client left off, because a panel is not a `run-shell`
+        child of a keypress and has no presser to name."""
+        slots.DOORS.publish({3})
+        builtins._strip_events(FID)(_click(col=3))
+        argv, _ = self.spawned[0]
+        self.assertEqual(argv[-1:], ("frame-palette",))
+
+    # -- the sidebar --------------------------------------------------------- #
+
+    def test_a_press_on_a_persona_row_starts_that_frames_persona_switch(self):
+        slots.CHIPS.publish((None, "steward", "docs"), "steward", 0)
+        on_event = builtins._persona_events(FID)
+        self.assertFalse(on_event(_click(row=2)),
+                         "the switch bumps the frame from its own process")
+        self.assertEqual(len(self.spawned), 1)
+        argv, fid = self.spawned[0]
+        self.assertEqual(argv[-3:], ("frame-switch", "--persona", "docs"))
+        self.assertEqual(fid, FID)
+
+    def test_a_press_on_the_persona_you_are_starts_nothing(self):
+        slots.CHIPS.publish((None, "steward"), "steward", 0)
+        self.assertFalse(builtins._persona_events(FID)(_click(row=1)))
+        self.assertEqual(self.spawned, [])
+
+    def test_a_release_on_a_persona_row_starts_nothing(self):
+        slots.CHIPS.publish((None, "steward", "docs"), "steward", 0)
+        self.assertFalse(builtins._persona_events(FID)(_click(row=2, pressed=False)))
+        self.assertEqual(self.spawned, [])
+
+    def test_a_press_on_a_row_naming_no_persona_starts_nothing(self):
+        slots.CHIPS.publish((None, "steward", "docs"), "steward", 0)
+        for row in (0, 3, 400, -1):
+            self.assertFalse(builtins._persona_events(FID)(_click(row=row)), f"row {row}")
+        self.assertEqual(self.spawned, [])
+
+    def test_a_press_on_the_badge_column_says_the_legend_and_starts_nothing(self):
+        """#753 in the frame: the answer goes on the attention row through #729's dwell,
+        which is a different pane and a different process — `state.say` bumps the version
+        and that pane's own poll draws it. Nothing is spawned, because nothing is being
+        started."""
+        slots.CHIPS.publish((None, "steward", "docs"), "steward", 20)
+        self.assertFalse(builtins._persona_events(FID)(_click(row=2, col=21)))
+        self.assertEqual(self.spawned, [], "explaining a glyph starts no process")
+        self.assertEqual(len(self.said), 1)
+        fid, message, seconds = self.said[0]
+        self.assertEqual(fid, FID)
+        self.assertEqual(message, slots.BADGE_LEGEND)
+        self.assertEqual(seconds, state.REFUSAL_SECONDS,
+                         "a legend is read rather than glanced at, so it takes the "
+                         "longer of the two dwells")
+
+    def test_a_press_on_the_name_beside_it_still_switches(self):
+        """The control for the case above: the two cells of one row mean two things, and a
+        handler that had collapsed them would pass one of these and fail the other."""
+        slots.CHIPS.publish((None, "steward", "docs"), "steward", 20)
+        self.assertFalse(builtins._persona_events(FID)(_click(row=2, col=3)))
+        self.assertEqual(self.said, [], "switching says nothing on the attention row")
+        self.assertEqual(self.spawned[0][0][-3:],
+                         ("frame-switch", "--persona", "docs"))
+
+    def test_a_release_on_the_badge_column_says_nothing(self):
+        """§4i does not stop applying because the outcome is a sentence: a drag begun on a
+        pane border delivers exactly one release, and it never pointed here."""
+        slots.CHIPS.publish((None, "steward", "docs"), "steward", 20)
+        self.assertFalse(
+            builtins._persona_events(FID)(_click(row=2, col=21, pressed=False)))
+        self.assertEqual(self.said, [])
+        self.assertEqual(self.spawned, [])
+
+    def test_a_press_on_the_badge_column_of_the_persona_you_are_still_explains(self):
+        slots.CHIPS.publish((None, "steward"), "steward", 20)
+        self.assertFalse(builtins._persona_events(FID)(_click(row=1, col=21)))
+        self.assertEqual(len(self.said), 1)
+        self.assertEqual(self.spawned, [])
+
+    def test_the_switch_argv_is_the_one_the_workspace_bar_uses_one_option_over(self):
+        """`commands_frame.cmd_switch` takes both nouns, and going through it is what keeps
+        `switch.to_persona`'s refusals reaching the operator on the frame's own status
+        line — a surface no panel process has."""
+        self.assertEqual(builtins._PERSONA_SWITCH[0], builtins._WORKSPACE_SWITCH[0])
+        self.assertEqual(builtins._PERSONA_SWITCH[1], "--persona")
+
+
+class TheComponentsDeclareWhatTheyHandle(unittest.TestCase):
+    """The registry half — a declaration is what makes `panel._run` build a dispatcher.
+
+    #742 and #751 were both, mechanically, the same defect `chats` and `workspaces` had
+    before #725: a component with no `events` is a caption that happens to draw nouns.
+    `events.Dispatcher._deliver` drops a kind the component never declared before it
+    reaches any handler, so the declaration is the feature.
+    """
+
+    def setUp(self) -> None:
+        self.reg = builtins.build(FID)
+        self.by_id = {c.id: c for c in self.reg.all()}
+
+    def test_the_two_strips_and_the_sidebar_declare_click(self):
+        for cid in ("identity", "attention", "sidebar"):
+            self.assertEqual(self.by_id[cid].events, ("click",), cid)
+            self.assertEqual(events.wanted(self.by_id[cid]), ("click",), cid)
+
+    def test_no_charter_component_is_left_handling_nothing_but_the_sidebars_parts(self):
+        """The four PLACED panels all declare a kind now. The three that do not are the
+        sidebar's own parts, and `registry.Registry` refuses a part that declares one."""
+        silent = sorted(c.id for c in self.reg.all() if not c.events)
+        self.assertEqual(silent, ["changes", "personas", "todos"])
+
+    def test_a_part_declaring_events_is_still_refused(self):
+        """The rule this change had to work with rather than around: a part is never
+        placed, so charter would dispatch to the parent and a child's declaration would
+        build a handler that received nothing, ever."""
+        from charter.frame.component import Component, Fill
+        from charter.frame.registry import ComponentError, Registry
+
+        reg = Registry()
+        reg.register(Component(id="part", title="part", edge="right", size=Fill(),
+                               needs=(), render=lambda ctx: [],
+                               events=("click",), on_event=lambda ev: False))
+        with self.assertRaises(ComponentError) as caught:
+            reg.register(Component(id="whole", title="whole", edge="right", size=Fill(),
+                                   needs=(), render=lambda ctx: [],
+                                   children=("part",)))
+        self.assertIn("declares events", str(caught.exception))
+
+    def test_neither_strip_declares_scroll(self):
+        """A one-row pane has nothing a wheel could move, so a handler for it could only
+        ever answer False. `events.Dispatcher.open` charges the same `overlay.MOUSE_ON` for
+        one pointer kind as for two, so declaring it would cost nothing and mean nothing —
+        which is exactly what makes it wrong to declare."""
+        for cid in ("identity", "attention"):
+            self.assertNotIn("scroll", self.by_id[cid].events, cid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
*"I clicked the one affordance the frame advertises and nothing happened. Then I read `frame/slots.py` to find out what `◦` meant."*

Three reports from one evening of driving a real frame with real SGR bytes through a real outer tmux, and they were one defect wearing three hats. Charter drew nouns the palette opens by name, drew a roster with a cursor-looking marker on the active row, drew the words `F2 palette` — **the only affordance it advertises on screen** — and handled no pointer event on any of them. Of the four panels charter ships, `repos` was the only one that had ever declared an event at all.

Closes #751, closes #753. **#742 is deliberately NOT auto-closed** — its persona half is
fixed here and its todo-overflow half is not; see *Known limits* below. Leave it open.

## What answers now

`identity` and `attention` declare `click` and publish a set of door **columns**; `sidebar` declares `click` and publishes a **row→persona** map with the active name beside it. Both new objects are `slots._Tabs` on another axis and keep its rules word for word: published by the pass that composed the row rather than re-derived when the click arrives; published on **every rung, including the rungs that draw nothing**; and the "you are already there" refusal living in the map object rather than in the handler, so it is a property of one class with one test.

| gesture | what happens |
|---|---|
| click `F2 palette` on the attention strip | opens this frame's palette — `charter frame-palette`, the same thing the hotkey bind runs |
| click `⬢ <workspace>` on the identity strip | the same palette |
| click `◆ <persona>` on the identity strip | the same palette |
| click a persona's **name** in the sidebar | `charter frame-switch --persona <name>` — the front door the `workspaces` bar already uses, one option over |
| click a persona's **badge column** | the glyph legend lands on the attention row for ten seconds, through #729's dwell |

## All three doors go to the same place, and that is the design

§4i's rule is that the irreversible half never rides on a pointer event. `_bar_events` got out from under it by acting on the **press** and switching to a tab that is still one click away — a gesture that completes on the pointer. **A strip has no such gesture available.** `⬢ alpha` names the workspace you are *on* and `◆ steward` the persona you *are*, so a click on either can only mean *let me pick another one*, and picking needs a chooser.

`key` is in `component.EVENT_KINDS` and deliberately **not** in `events.DELIVERED` — the harness owns the keyboard — so charter cannot grow a second, pointer-driven chooser inside a one-row pane. The palette *is* the chooser, both nouns are already reachable through it, and opening it completes on the pointer alone: `overlay.modal_argvs` makes it the active pane, so the keyboard reaches the rows it just drew.

Because the destination does not vary, `_Doors` holds a **set of columns** rather than a column→name mapping. A mapping whose values nothing branches on is data no input could make observable — the survivor the sweep reports.

The persona column is the other side: a click **switches**, for `_bar_events`' three reasons unchanged (press not release; the row you left is one click away; nothing could finish a two-step gesture). That is where this departs from #742's own suggestion of "selecting, not switching" — the table's rule is not *a click never switches*, it is *the irreversible half is never driven by an event that can arrive unpaired*, and what makes selection right on the table is that it has a real intermediate state and `Enter` to choose from it. A persona column has neither; the row in reverse video **is** the selection.

## What deliberately answers nothing, each with a case

- **The charter version and the context gauge** on `top`; **the todo count, the alert, the in-flight spinner and the news** on `bottom` — readouts. The frame reporting, not offering.
- **The selected repo's `▪ ledger · main · clean`** — the sharpest of them: it is the readout of a row selected on *another pane*, so a click could only mean "select what is already selected", which `_Tabs.switch_to` and `_repos_events` both already refuse.
- **The roster half of the identity row** (`◇ personas 6`) — drawn only when the sidebar is not (#530), so a door there would exist on some frames and not others for a reason no operator can see.
- **The ` · ` between two fields, and the space past the last one.** Charter will not pick the nearest field.
- **The `▪ personas N` heading, the `…(+N more)` row** (it stands for personas *not* drawn — `_Tabs` refuses its `+14` identically), **the `no personas` line, the blank rows between sections, every todo and change row**, and **the persona you already are** (also what stops a double-click switching twice).

## #753: every glyph has a name

**#753 asked for a legend reachable *from the frame*, and it gets one — because #763 built the surface three days after that issue was filed.** Clicking the badge column puts `slots.BADGE_LEGEND` on the attention row through `state.say`: the same dwell a workspace switch uses to say what it did, so the answer costs no extra row, clears itself after ten seconds, and needed no second surface. It works on the row you are already on, which is where the question usually comes from — the *name* refuses that click (re-adopting yourself is a no-op) and the badges do not, and that asymmetry is argued at `_Chips.hit`.

It is **one legend for every row rather than a reading of the row clicked**, and that is a stated limit: `PersonaChip.badges` is a rendered string by the time `slots.py` sees it, and a handler is handed no `ctx` (§4f) — so a per-row answer would need either decoding glyphs back out of display text or a second reading of the plane, and the question an operator actually has is *what is that glyph*.

`docs/frame.md` also names all ten glyphs in a table, so `charter docs show frame` is the long version. The two that sent the auditor into the source:

- **`◦`** — a declared vault charter **cannot use here** (no such vault on this machine, or its file does not exist yet). `charter persona create` writes the declaration and nothing writes the vault, so this is the ordinary state of a persona nobody has given credentials to. **Not a warning.**
- **`⚑`** — the charter is a **draft**, so no sub-agent is generated and it cannot be dispatched.

Six personas, five flags, nothing wrong — written down, because that reading is what cost an operator a trip through `slots.py`.

## The hover measurement, which the brief asked for either way

The operator asked for hover ("on hover somehow highlight text… tooltip on the footer"). **Measured before designing anything**, on real tmux 3.7c **and** the 3.2 floor, real client on a real pty, two panes, SGR reports injected as a reporting terminal sends them:

```
mouse=off:  outer terminal told 1000h 1006h   (the ACTIVE pane's request only)
            panel asking 1003 -> tmux does NOT propagate it. no motion is ever sent.

mouse=on:   outer terminal told ... 1003h     (BECAUSE the non-active panel asked)
            motion over the PANEL   -> panel READ \x1b[<35;11;5M  (pane-relative, 1-based)
            motion over the HARNESS -> nobody
```

Byte-identical on both versions. Three findings:

1. **Hover IS deliverable** to a non-active `charter panel` process, conditional on `[frame] mouse = true`. With mouse off the panel's 1003 request is never propagated — only the active pane's is — so no motion is ever sent.
2. **It cannot poison the harness.** tmux filters per-pane by what each pane asked for: with 1003 on for the whole terminal, motion over the harness (which asks 1000/1002) reaches **nobody**.
3. **The brief's stated cost is wrong in one respect and right in another.** It is *not* "a wake-up for every panel process" — only the pane under the pointer that asked for 1003 wakes. What is genuinely expensive is the operator's own preferred *shape*: a tooltip on the **footer** means the sidebar telling the attention pane what the pointer is over, and the only cross-pane channel is a state write plus `state.bump` — a file write and a repaint of every other panel **per motion event**, ~40 for one sweep of a 40-column pane.

The measurement, and what building it would take, are filed as **#766** so they outlive this PR.

**#766 now carries the full cost measurement too** — every cell is a wire event on both versions (40 in, 40 resolved), but the pty coalesces those into 18 `read()`s, and a panel that did not declare hover sees **zero**. The expensive shape is the footer tooltip, not 1003: a cross-pane answer is a `state.bump` per motion, which is ~160 panel repaints for one sweep, against 6 local repaints for an in-pane highlight. My judgement, on the issue: not yet, and not first — this PR's badge click removes the reason hover was urgent.

**So hover is not built here, and that is a scope decision rather than a refusal.** It needs a new kind in `component.EVENT_KINDS` (a closed vocabulary, §4f), a place in `events.DELIVERED`, a motion branch in `overlay.decode`, a `MOUSE_ON` variant, per-component opt-in and a debounce on the resolved target rather than on the event. That is its own change. The affordable shape, when it is written, is **highlight in the same pane** (repaint only when the resolved row changes), not a footer tooltip.

## Known limits, stated rather than implied

- **The sidebar's todo overflow is still unreachable** — #742's second half. Every cheap route was worse than the honest `…(+N more)`: a wheel with no keyboard twin; a palette noun that is not switchable; a state-backed offset that bumps the whole frame on every notch (which `_Viewport.move` refuses in as many words). It wants a read-only list surface, which is its own change. **#742 should stay open on that point.**
- **`personas` placed on its own is drawn and inert.** `registry.Registry` refuses a composite *part* that declares events (a part is never placed, so the declaration would build a handler that received nothing, ever) — so the `sidebar` composite declares, and a plane that places the bare component through `[[frame.component]]` gets no click. Lifting that means letting a composite delegate a kind to one part, which is a change to the registry's contract.
- **No client name on the palette argv.** `conf_text` expands `#{client_name}` because tmux knows who pressed; a panel has no presser, so `_say_on_screen` falls back to the most recently attached client. Same screen on a one-client frame; on a two-client one a refusal can land on the other operator's status line.

## Verification

- `python3 -m unittest discover -s tests` green.
- **Real tmux, 3.7c and the 3.2 floor, run twice each**: `tests/test_a_real_click_opens_the_real_palette.py` — a real client on a real pty, `mouse = true` sourced from `conf_text` (so #634's `MouseDown1Pane` rebind is under test), real `charter panel bottom` / `charter panel right` processes, and a real detached `charter frame-palette` / `charter frame-switch --persona` started by those panels out of their own handlers. The palette pane appears and takes the keyboard; `▸` moves to the persona that was clicked; the keyboard never leaves the harness for the switch; and a click on a readout, a separator, a heading, the row you are already on, or an unpaired release does nothing at all.
- Red-first: with `slots.py` and `builtins.py` reverted, the unit module fails 33 of its 36.
- `tools/sweep.py` — verdict below.

## Rebased onto `c183fe0`

One conflict, in `slots._bottom`, and it was #763's: that change added a top-priority `notice` field at the head of the attention row. Resolved by keeping #763's field and its reading order and running the door walk over the merged `order` tuple — the walk reads `order`, so a field added at the head moves the hint's columns by its own width plus a separator and the door follows with no case for it. `test_a_field_added_in_front_of_the_hint_moves_its_door_with_it` is that merge, pinned. #729's notice is itself correctly inert: it is the outcome of something the operator already chose.

`#774`'s `_sidebar_live` change is inside a function `_top` calls and did not touch my hunks. `switch.py`, `chats.py` and `commands_frame.py` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
