### PR TITLE
The frame's rules and its text palette are the plane's to choose

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2137,7 +2137,21 @@ def _remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
 #: the 256 and imposed on a theme it cannot see. A terminal too old to honour SGR 2
 #: renders both borders in the plain default instead, which is still ONE colour — the
 #: property here is sameness, and it survives the attribute being dropped.
-_CHROME_STYLE = "fg=default,dim"
+#: The foreground half of it, alone — what a rule is drawn IN before the plane has said
+#: anything. Split out because the ``dim`` beside it is a decision now (`[frame] dim`) and
+#: the surface behind it always was: `instance.rule_style` composes all three, and handing
+#: it the assembled string instead would make it take an attribute back out of one.
+_CHROME_FG = "fg=default"
+
+#: The style every rule in the frame is drawn in when the plane has said nothing — and the
+#: MARKER in :data:`_CHROME` for "this entry is a style", which is how `_chrome_argvs` knows
+#: which of the five options carry a colour without a second list saying so.
+#:
+#: `instance.rule_style(None, _CHROME_FG, instance.look_of({}))` is this string, and
+#: `TheShippedRuleIsStillTheOneCharterAlwaysDrew` asserts it rather than leaving a reader to
+#: check by eye — so the day the shipped `Look` changes, the table stops agreeing with the
+#: assembler loudly instead of quietly.
+_CHROME_STYLE = f"{_CHROME_FG},dim"
 
 #: Every window option tmux consults to draw a pane border, pinned to charter's own
 #: answer. #514: the frame's rules came out in two colours, and neither of them was
@@ -2207,7 +2221,8 @@ def _chrome_values() -> dict[str, str]:
 
 
 def _chrome_argvs(*, socket: str, harness_pane: str, v: tuple[int, int] | None,
-                  surface: str | None = None) -> list[list[str]]:
+                  surface: str | None = None,
+                  look: instance.Look = instance.SHIPPED_LOOK) -> list[list[str]]:
     """`set-option -w`: charter's own answer for every option tmux draws a border from.
 
     **Charter owns the frame's chrome, and tmux draws all of it.** #514 named two
@@ -2280,6 +2295,26 @@ def _chrome_argvs(*, socket: str, harness_pane: str, v: tuple[int, int] | None,
     exactly what it is about. Asked through `chrome.no_colour` so there is one reading of
     the variable (#547), the same way `_surface_argvs` asks.
 
+    **It refuses the plane's own `text` colour by the same line**, and that falls out of
+    the surface being refused rather than needing a second answer: with no surface,
+    `instance.rule_style` has nothing to hide a rule in, and the foreground it composes is
+    the only thing `NO_COLOR` would still have to argue about. It does not — a `text` word
+    IS a colour charter was asked to paint, so it goes with the background. What survives
+    is `_CHROME_FG` and the `dim`, which are the operator's own foreground and an
+    attribute over it, exactly as before.
+
+    ***look* is the plane's own `[frame] rules`, `text` and `dim`** — the frame-wide
+    appearance, resolved once by `instance.look_of` and passed whole rather than as three
+    keywords, so this and the three functions below cannot be handed different halves of
+    one frame's answer. `instance.rule_style` is where all three are spent; nothing here
+    reads a word out of it.
+
+    **It is a different question from *v* and the two do not meet.** A floor says which
+    tmuxes are told about an option at all; a `look` says what the two style rows carry
+    when they are. `pane-border-indicators` is dropped below its floor whatever the plane
+    asked for, and a `hidden` rule is composed identically on every tmux that gets one —
+    which is why the `>= floor` filter below is applied to the row and never to the value.
+
     ***v* is this tmux's version, and every row of `_CHROME` is filtered through its own
     floor by it (#716).** REQUIRED rather than defaulted, because a default is the shape
     the defect had: `pane-border-indicators` does not exist below
@@ -2296,8 +2331,8 @@ def _chrome_argvs(*, socket: str, harness_pane: str, v: tuple[int, int] | None,
     supported baseline: pin everything every tmux charter supports has, and leave the one
     option that arrived after it to a tmux that says so.
     """
-    rule = (f"{_CHROME_STYLE},{surface}"
-            if surface and not chrome_mod.no_colour() else _CHROME_STYLE)
+    rule = instance.rule_style(
+        None if chrome_mod.no_colour() else surface, _CHROME_FG, look)
     known = v if v is not None else tmuxctl.FLOOR
     return [tmuxctl.server_argv(socket, "set-option", "-w", "-t", harness_pane, name,
                                 rule if value == _CHROME_STYLE else value)
@@ -2322,7 +2357,9 @@ def _pane_borders_wanted(v: tuple[int, int] | None) -> bool:
     return v is not None and v >= tmuxctl.PANE_BORDER_FLOOR
 
 
-def _pane_border_pairs(*, chrome, bg, pane_borders: bool) -> tuple[tuple[str, str], ...]:
+def _pane_border_pairs(*, chrome, bg, pane_borders: bool,
+                       look: instance.Look = instance.SHIPPED_LOOK
+                       ) -> tuple[tuple[str, str], ...]:
     """This PANEL pane's own edges, in this panel's own surface — or nothing at all.
 
     **A panel's edges are its own colour, which is the half of #631 that stands.** A
@@ -2357,12 +2394,13 @@ def _pane_border_pairs(*, chrome, bg, pane_borders: bool) -> tuple[tuple[str, st
     `_CHROME_STYLE`, so no operator string reaches a style here any more than it does one
     function up.
     """
-    return (instance.pane_border_options(bg, chrome, _CHROME_STYLE)
+    return (instance.pane_border_options(bg, chrome, _CHROME_FG, look)
             if pane_borders else ())
 
 
 def _harness_rule_argvs(*, socket: str, harness_pane: str, surface: str | None,
-                        pane_borders: bool) -> list[list[str]]:
+                        pane_borders: bool,
+                        look: instance.Look = instance.SHIPPED_LOOK) -> list[list[str]]:
     """`set-option -p`: the rules AROUND the harness pane, in the frame's own surface —
     and never, at any value, anything that reaches INSIDE it.
 
@@ -2449,7 +2487,7 @@ def _harness_rule_argvs(*, socket: str, harness_pane: str, surface: str | None,
     if not pane_borders:
         return []
     pairs = instance.rule_options(None if chrome_mod.no_colour() else surface,
-                                  _CHROME_STYLE)
+                                  _CHROME_FG, look)
     if not pairs:
         return [tmuxctl.server_argv(socket, "set-option", "-p", "-u", "-t", harness_pane,
                                     name) for name in instance.PANE_BORDER_OPTIONS]
@@ -2458,7 +2496,8 @@ def _harness_rule_argvs(*, socket: str, harness_pane: str, surface: str | None,
 
 
 def _surface_argvs(*, socket: str, pane_id: str, chrome, bg=None,
-                   pane_borders: bool = False) -> list[list[str]]:
+                   pane_borders: bool = False,
+                   look: instance.Look = instance.SHIPPED_LOOK) -> list[list[str]]:
     """`set-option -p`: the pane surface `[frame] chrome` asked for, on ONE panel pane.
 
     **tmux paints the background; charter sets an option.** `window-style` and
@@ -2534,9 +2573,8 @@ def _surface_argvs(*, socket: str, pane_id: str, chrome, bg=None,
     # takes the frame's own answer". One expression, so there is no state in which a pane
     # gets one option from here and the other from there.
     return [tmuxctl.server_argv(socket, "set-option", "-p", "-t", pane_id, name, value)
-            for name, value in (*(instance.pane_bg_options(bg)
-                                  or instance.chrome_options(chrome)),
-                                *_pane_border_pairs(chrome=chrome, bg=bg,
+            for name, value in (*instance.surface_options(bg, chrome, look),
+                                *_pane_border_pairs(chrome=chrome, bg=bg, look=look,
                                                     pane_borders=pane_borders))]
 
 
@@ -2611,7 +2649,8 @@ def _panel_slot_argv(*, socket: str, pane_id: str, slot: str) -> list[str] | Non
 
 
 def _resurface_argvs(*, socket: str, pane_id: str, chrome, bg=None,
-                     pane_borders: bool = False) -> list[list[str]]:
+                     pane_borders: bool = False,
+                     look: instance.Look = instance.SHIPPED_LOOK) -> list[list[str]]:
     """:func:`_surface_argvs` for a pane that is ALREADY DRAWN — with the unsets.
 
     **The difference is `off`, and it is not a detail.** On a launch, `off` is free:
@@ -2663,9 +2702,8 @@ def _resurface_argvs(*, socket: str, pane_id: str, chrome, bg=None,
     `chrome.no_colour` so there is one reading of the variable (#547).
     """
     want = dict(() if chrome_mod.no_colour()
-                else (*(instance.pane_bg_options(bg)
-                        or instance.chrome_options(chrome)),
-                      *_pane_border_pairs(chrome=chrome, bg=bg,
+                else (*instance.surface_options(bg, chrome, look),
+                      *_pane_border_pairs(chrome=chrome, bg=bg, look=look,
                                           pane_borders=pane_borders)))
     # The removal reaches the pane's own EDGES too, and only where charter ever wrote
     # them: below `tmuxctl.PANE_BORDER_FLOOR` a `set -p -u` on these two names removes the
@@ -3431,12 +3469,19 @@ def _dress_window(socket: str, *, fid: str, harness_pane: str, env: dict | None,
     # reads on the live path — the agreement #610 is about, made by construction rather
     # than by two call sites matching.
     pane_borders = _pane_borders_wanted(v)
+    # The plane's own answers about how its chrome READS — its rules, its foreground and
+    # whether charter may dim. Resolved ONCE for the whole dressing and handed to both
+    # calls below, for the reason `instance.Look` is a record at all: the window's rules
+    # and the harness's three edges are two writes of one decision, and a frame whose two
+    # disagreed is #514 with a new cause.
+    look = instance.look_of(config.FRAME)
     # The same *v*, handed on rather than re-read: `_chrome_argvs` drops the rows of
     # `_CHROME` this tmux has no such option for (#716), and a second `tmux -V` here would
     # be a second subprocess for one unchanging fact — and one more place for the two
-    # readings to disagree.
+    # readings to disagree. It answers a different question from *look*: one says which
+    # rows are issued, the other says what the two style rows carry.
     for argv in _chrome_argvs(
-            socket=socket, harness_pane=harness_pane, v=v,
+            socket=socket, harness_pane=harness_pane, v=v, look=look,
             surface=None if pane_borders else instance.border_bg(config.FRAME, chrome)):
         tmuxctl.run("styling the frame's own rules", argv, env=env)
     # And the three rules AROUND the harness, which above the floor are the harness's own
@@ -3448,7 +3493,7 @@ def _dress_window(socket: str, *, fid: str, harness_pane: str, env: dict | None,
     # `ESC[49m` beside 22 cells of `ESC[100m`.
     for argv in _harness_rule_argvs(
             socket=socket, harness_pane=harness_pane, pane_borders=pane_borders,
-            surface=instance.agreed_border_bg(config.FRAME, chrome)):
+            look=look, surface=instance.agreed_border_bg(config.FRAME, chrome)):
         tmuxctl.run("styling the rules around the pane charter does not paint", argv,
                     env=env)
 
@@ -3504,6 +3549,11 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     # `off`. `_dress_window` resolves the same word for the WINDOW's options; both ask
     # `_current_chrome`, so the pane scope and the window scope cannot answer differently.
     chrome = _current_chrome(fid)
+    # The frame-wide appearance, resolved once for the whole batch rather than per pane —
+    # `chrome` above is resolved once here for the same reason, and the two travel together
+    # into `_surface_argvs`. A per-pane read would let two panes split in one loop be
+    # painted from two readings of one file.
+    look = instance.look_of(config.FRAME)
     pane_borders = _pane_borders_wanted(v)
     panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=socket,
                                     harness_pane=harness_pane, env=pane_env,
@@ -3558,7 +3608,7 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
             # word about this pane.
             bg = instance.component_style(config.FRAME, slot)["bg"]
             for surface in _surface_argvs(socket=socket, pane_id=pane_id, chrome=chrome,
-                                          bg=bg, pane_borders=pane_borders):
+                                          bg=bg, pane_borders=pane_borders, look=look):
                 tmuxctl.run("painting a panel's surface", surface, env=env)
     return panes
 
@@ -5560,6 +5610,10 @@ def cmd_chrome(args) -> int:
     # fact on a path that is a keypress, and two answers that could disagree.
     v = tmuxctl.version()
     pane_borders = _pane_borders_wanted(v)
+    # `_dress_window`'s own read, on the live path — one resolution for the whole keypress,
+    # so a panel repainted at the top of this function and the rules repainted at the
+    # bottom are two halves of one frame rather than two readings of one file.
+    look = instance.look_of(config.FRAME)
     for slot, pane_id in panes.items():
         # `_PANE_ID_RE` is #475's rule applied to a value that arrived off DISK and is
         # about to be a tmux argv — the same check `_relayout_target` makes of the harness
@@ -5575,7 +5629,7 @@ def cmd_chrome(args) -> int:
         # back until relaunch.
         bg = instance.component_style(config.FRAME, slot)["bg"]
         for argv in _resurface_argvs(socket=socket, pane_id=pane_id, chrome=level,
-                                     bg=bg, pane_borders=pane_borders):
+                                     bg=bg, pane_borders=pane_borders, look=look):
             tmuxctl.run("painting a panel's surface", argv)
     # And the frame's RULES, which are the surface's other half and are not any pane's
     # (`instance.border_bg`): a level change that repainted the panes and left the borders
@@ -5593,7 +5647,7 @@ def cmd_chrome(args) -> int:
     harness = state.harness_pane(fid) or ""
     if _PANE_ID_RE.fullmatch(harness):
         for argv in _chrome_argvs(
-                socket=socket, harness_pane=harness, v=v,
+                socket=socket, harness_pane=harness, v=v, look=look,
                 surface=None if pane_borders
                 else instance.border_bg(config.FRAME, level)):
             tmuxctl.run("styling the frame's own rules", argv)
@@ -5607,7 +5661,7 @@ def cmd_chrome(args) -> int:
         # prevent.
         for argv in _harness_rule_argvs(
                 socket=socket, harness_pane=harness, pane_borders=pane_borders,
-                surface=instance.agreed_border_bg(config.FRAME, level)):
+                look=look, surface=instance.agreed_border_bg(config.FRAME, level)):
             tmuxctl.run("styling the rules around the pane charter does not paint", argv)
     return 0
 

--- a/charter/frame/chrome.py
+++ b/charter/frame/chrome.py
@@ -166,6 +166,138 @@ def colour_ok() -> bool:
     return pane.is_tty()
 
 
+def dim_ok() -> bool:
+    """Whether the frame may reduce the contrast of its own text — ``[frame] dim``.
+
+    **One question asked in one place**, which is :func:`no_colour`'s discipline said about
+    a different setting and for the same measured reason: :func:`recipes` answers it for a
+    provider that composes with ``ctx.chrome["muted"]`` and `panel._write` answers it for
+    every row charter's own renderers finished, and two readings of one key is how those
+    two come to disagree about a frame nobody can see twice.
+
+    **Why the key exists at all is a correction to this module**, and it is written down
+    here rather than quietly fixed. :func:`_role_values` argues that its three attributes
+    need no gate because "bold, dim and reverse are statements relative to whatever the
+    operator's terminal already is". Bold and reverse survive that argument — bold adds
+    weight and reverse is defined as the operator's own two colours exchanged, so neither
+    can be wrong on a theme charter cannot see. Dim does not: it is relative in ONE
+    direction, toward the background, and the direction is the whole problem. Charter's
+    eight recipes were chosen against a dark terminal, where a dim grey has the whole
+    distance to the background to spend. A plane that paints its panes light spends that
+    distance the other way, and the operator reported the muted rows unreadable on
+    ``bg = "brightblack"`` — a word their theme renders as a light tan.
+
+    Read through `config.FRAME` at call time rather than cached, exactly as
+    `slots.verbosity` and `slots.pad_of` read the keys they need: a panel is a long-lived
+    process and `charter.toml` is re-read when the frame relaunches. The import is
+    function-level for `_role_values`' own reason — this module is on a panel's repaint
+    path and `config` resolves a plane at import.
+    """
+    from .. import config, instance
+    return instance.look_of(config.FRAME).dim
+
+
+#: The SGR parameters that INTRODUCE an extended colour, and therefore the ones whose
+#: following parameters are not attributes at all.
+#:
+#: 38 (foreground), 48 (background) and 58 (underline colour) are each followed by a colour
+#: SPACE and then that space's arguments: ``5;<n>`` for one of the 256, ``2;<r>;<g>;<b>``
+#: for a 24-bit triple. The truecolor spelling is the hazard :func:`undim` exists to not
+#: create — its space parameter is the digit **2**, and a pass that deleted every 2 from a
+#: parameter list would turn ``38;2;255;0;0`` into ``38;255;0;0`` and hand a terminal a
+#: foreground it never asked for.
+#:
+#: **Charter writes none of these** — `instance.FRAME_PANE_COLOURS` argues at length why
+#: charter names the sixteen and never indexes the cube — and that is exactly why the case
+#: is real rather than theoretical: :func:`undim` runs on a row a PROVIDER's component
+#: finished, which is ordinary Python that may write whatever its author's terminal
+#: supports, and `tui.sanitize` passes any ``ESC[<digits and semicolons>m`` through
+#: untouched.
+_EXTENDED_COLOUR = frozenset({38, 48, 58})
+
+#: The SGR parameter that turns dim on. Named for `resets_everything`'s reason: the
+#: property is the NUMBER, and ``ESC[02m`` and ``ESC[1;2m`` are both dim.
+_DIM_PARAM = 2
+
+
+def _without_dim(params: str) -> str | None:
+    """The SGR parameter list *params* with every dim removed — ``None`` when the whole
+    escape should go.
+
+    **The numeric reading again** (:func:`resets_everything`), because this is the same
+    mistake with a different number: "an SGR that turns dim on" is not the string
+    ``\\x1b[2m``. It is a parameter list containing a parameter whose numeric value is two,
+    and leading zeros are legal digits, and a parameter may sit anywhere in the list.
+    Measured against the spellings that reach a pane::
+
+        params        string-match ("2")   numeric, position-aware
+        '2'           True                 dropped
+        '02'          False  <- MISSED     dropped
+        '1;2'         False  <- MISSED     '1'
+        '2;32'        False  <- MISSED     '32'
+        '38;2;255;0;0' False               '38;2;255;0;0'  <- the colour SPACE, kept
+
+    The last row is why this walks the list rather than filtering it
+    (:data:`_EXTENDED_COLOUR`).
+
+    ``None`` rather than ``""`` for a list that emptied, and the difference is the whole
+    correctness of the pass: ``\\x1b[m`` is an SGR with an omitted parameter, and an
+    omitted parameter takes SGR's default of **zero** — so emitting it for a ``\\x1b[2m``
+    that had nothing else in it would replace "turn dim on" with "turn EVERYTHING off",
+    cancelling the colour of whatever span the row was in the middle of. A list that still
+    holds a parameter comes back as a string even when that string is empty, because
+    ``\\x1b[2;m`` really did carry a reset and the reset survives.
+    """
+    kept: list[str] = []
+    pieces = params.split(";")
+    i = 0
+    while i < len(pieces):
+        # Every piece is digits or empty — `_SGR` admits nothing else — so `int` cannot
+        # raise, and an empty piece is spelled as the zero it means.
+        value = int(pieces[i] or "0")
+        if value in _EXTENDED_COLOUR:
+            space = int(pieces[i + 1] or "0") if i + 1 < len(pieces) else -1
+            run = {5: 3, 2: 5}.get(space, 1)
+            kept.extend(pieces[i:i + run])
+            i += run
+            continue
+        if value != _DIM_PARAM:
+            kept.append(pieces[i])
+        i += 1
+    return ";".join(kept) if kept else None
+
+
+def undim(row: str) -> str:
+    """*row* with every dim taken out of it and nothing else touched.
+
+    **A DELETION and never a substitution**, which is what makes it honest to run over a
+    row charter did not write. `plain` already deletes every SGR from a provider's finished
+    row when the operator asked for no colour, and this is the same class of answer about a
+    smaller question: it removes an instruction to reduce contrast and leaves every colour
+    the component chose exactly where it put it. A pass that remapped a provider's green to
+    some other colour would be charter deciding what somebody else's component means, which
+    is not a thing `[frame] dim` was asked for.
+
+    **On the FINISHED row, in `panel._write`, which is the one place anything reaches a
+    pane's screen.** That siting is the whole of why one key reaches the whole frame:
+    charter's own renderers spell `statusline._DIM` at some forty call sites in
+    `frame/slots.py` and a provider's component spells whatever it likes, and neither has
+    to be told. It is the same argument `_write`'s own docstring already makes about
+    `NO_COLOR`.
+
+    Takes a finished row and hands back a string that must not go back through `tui` — the
+    module docstring's ordering rule, unchanged. It changes no cell's width: every SGR
+    costs zero columns, and this only ever makes one shorter or removes it.
+    """
+    # The membership test before the regex, `tui.strip_ansi`'s own shortcut: a row with no
+    # escape in it cannot carry a dim, and most rows in a repaint are that row.
+    if "\x1b" not in row:
+        return row
+    return _SGR.sub(
+        lambda m: "" if (kept := _without_dim(m.group(1))) is None else f"\x1b[{kept}m",
+        row)
+
+
 def _role_values() -> dict[str, str]:
     """The roles of §5 a RENDERER can write, and the SGR each one is. **The vocabulary.**
 
@@ -184,9 +316,18 @@ def _role_values() -> dict[str, str]:
     **Every value is an attribute or one of the sixteen ANSI names — no cube index, no
     24-bit triple.** That is `instance.FRAME_CHROME`'s rule reaching the one place a
     stranger's code would otherwise have to guess it, and it is why these need no
-    `[frame] chrome` gate: bold, dim and reverse are statements relative to whatever the
+    `[frame] chrome` gate: bold and reverse are statements relative to whatever the
     operator's terminal already is, and ``green``/``yellow``/``red`` are slots in their
     own palette rather than colours charter picked out of the 256.
+
+    **That argument used to name three attributes and it was wrong about one of them.**
+    Dim is relative in exactly one direction — toward the background — and the direction is
+    the defect: these values were chosen against a dark terminal, where a dim grey has the
+    whole distance to the background to spend, and a plane that paints its panes light
+    spends it the other way. The operator reported ``muted`` unreadable on
+    ``bg = "brightblack"``, a word their own theme renders as a light tan. So dim has a
+    gate now and the other two still do not — :func:`dim_ok`, honoured here and in
+    `panel._write`, which is where the rest of that correction is written down.
 
     Composed from `statusline.py`'s OWN constants rather than spelled here, for
     `slots._sidebar_head`'s reason: a second copy of ``\033[1m`` in this module is how a
@@ -242,10 +383,32 @@ def recipes() -> MappingProxyType:
     spec was written about. Empty rather than absent: a provider that wrote
     ``ctx.chrome["ok"] + text`` would otherwise raise inside its own draw and lose its
     pane to honour a request about colour.
+
+    **``[frame] dim = false`` takes the dim out of every role that carries one**
+    (:func:`dim_ok`), which today is ``muted`` alone and is asked as the property rather
+    than by that name: :func:`undim` is run over the values, so a role added to
+    :func:`_role_values` with a dim in it is covered on the day it is added instead of
+    being the one that still reduces contrast on a plane that asked charter not to. It is
+    also the same transform `panel._write` applies to the finished row, so the two cannot
+    come to disagree about what "no dim" means.
+
+    The interaction with the paragraph above is worth stating because it is an ordering:
+    ``NO_COLOR`` empties every SGR role including this one, so a plane that turned dim off
+    and an operator who turned colour off do not fight — the second is a superset of the
+    first and wins by arriving at the same answer, not by being asked first.
+
+    Emptied here rather than only stripped downstream by `panel._write`, even though the
+    strip alone would produce the same pane. A provider handed a live ``\\x1b[2m`` for a
+    role the frame is about to delete would be composing against a promise charter is not
+    keeping — the same "convincing empty" this module refuses everywhere else — and a
+    component that reads the role to decide something other than what to emit would decide
+    it wrongly. It is also the cheaper half: nothing composed is nothing to strip.
     """
     from . import slots
     live = colour_ok()
-    out = {role: (sgr if live else "") for role, sgr in _role_values().items()}
+    dim = dim_ok()
+    out = {role: (sgr if dim else undim(sgr)) if live else ""
+           for role, sgr in _role_values().items()}
     out["inset"] = slots._inset()
     return MappingProxyType(out)
 

--- a/charter/frame/chrome.py
+++ b/charter/frame/chrome.py
@@ -288,11 +288,23 @@ def undim(row: str) -> str:
     Takes a finished row and hands back a string that must not go back through `tui` — the
     module docstring's ordering rule, unchanged. It changes no cell's width: every SGR
     costs zero columns, and this only ever makes one shorter or removes it.
+
+    **There is no `if "\\x1b" not in row` shortcut in front of this, and the deletion is a
+    measurement rather than a preference.** One was written first, copying
+    `tui.strip_ansi`'s own, and the mutation sweep found it surviving. Timed on this
+    machine over 200 000 calls each, the two rows a repaint actually carries::
+
+        row with no escape   guard 0.032us   no guard 0.111us   saves 0.079us
+        painted row          guard 1.933us   no guard 1.977us   saves 0.044us
+
+    3.5x on the first row reads like a reason until it is spent: at 0.079us a line, a
+    50-line repaint saves **4us against `render`'s own measured 4816us** — under a tenth of
+    a percent, on a path that only runs at all for a plane that turned `dim` off. And most
+    rows in this frame are not that row: the sidebar and the repo table colour nearly every
+    line they compose. `re.sub` on a string it does not match returns that string, so the
+    guard could not change an outcome either — which makes it the shape #568's sweep
+    deletes, and "equivalent mutant" and "dead code" one finding rather than two.
     """
-    # The membership test before the regex, `tui.strip_ansi`'s own shortcut: a row with no
-    # escape in it cannot carry a dim, and most rows in a repaint are that row.
-    if "\x1b" not in row:
-        return row
     return _SGR.sub(
         lambda m: "" if (kept := _without_dim(m.group(1))) is None else f"\x1b[{kept}m",
         row)

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -203,6 +203,19 @@ def _write(text: str) -> None:
     strip is `tui.strip_ansi` per LINE and never over the whole write: `sanitize` drops
     every CSI that is not SGR, so stripping the assembled string would delete the
     clear-screen that makes a repaint a repaint.
+
+    **And it is where `[frame] dim` is honoured** (`chrome.dim_ok`, `chrome.undim`), for
+    exactly that reason said about a smaller question. Charter's own renderers spell
+    `statusline._DIM` at some forty call sites in `frame/slots.py` and a provider's
+    component spells whatever it likes; one deletion here reaches both, where forty edits
+    would reach one of them and drift. The setting is read ONCE per write rather than per
+    line — it cannot change in the middle of a paint, and a panel repaints on a clock.
+
+    **The two are not two branches of one question**, and the order says so: `NO_COLOR`
+    already strips every SGR, dim included, so the dim pass is unreachable under it rather
+    than skipped by it. A frame that asked for no colour and a plane that asked for no dim
+    agree about dim; they differ about everything else, and the stronger answer is the one
+    that runs.
     """
     lines = text.split("\n")[:_rows()]
     if not chrome.colour_ok():
@@ -210,7 +223,9 @@ def _write(text: str) -> None:
         # painted, and "no colour on the operator's screen caused by charter" is the
         # promise rather than "no colour except charter's own housekeeping".
         return _out("\x1b[H\x1b[2J" + "\n".join(chrome.plain(ln) for ln in lines))
-    _out("\x1b[m\x1b[H\x1b[2J" + "\n".join(lines))
+    dim = chrome.dim_ok()
+    _out("\x1b[m\x1b[H\x1b[2J"
+         + "\n".join(ln if dim else chrome.undim(ln) for ln in lines))
 
 
 def _out(payload: str) -> None:

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import re
 import tomllib
 from pathlib import Path
+from typing import NamedTuple
 
 from . import contain
 from .root import MARKER
@@ -741,6 +742,87 @@ def pane_bg_options(name) -> tuple[tuple[str, str], ...]:
     return FRAME_PANE_BG[n] if n else ()
 
 
+#: The word a plane's ``[frame] text`` may say, and the ``fg`` clause each one means.
+#:
+#: **The FOREGROUND half of :data:`FRAME_PANE_BG`, and it exists because the eight recipes
+#: `frame/chrome.py` hands out were chosen against a dark terminal and nothing could say
+#: so.** ``bg`` is configurable across seventeen words; the text drawn on it was not
+#: configurable at all. An operator who writes ``bg = "brightblack"`` gets a surface their
+#: own theme decides the shade of — dark grey on most, a light tan on the machine this key
+#: was written for — and every uncoloured cell in the pane still comes out in the
+#: foreground their terminal picked to sit on its OWN background, which is no longer the
+#: background it is sitting on.
+#:
+#: **Charter cannot compute this and does not try.** The sixteen ANSI names have no fixed
+#: RGB, and this plane's own `charter.toml` already records why charter cannot find out
+#: what they look like: OSC 11 through tmux answers nothing, and ``$COLORTERM`` inside a
+#: pane describes the terminal that started the SERVER rather than the one looking at the
+#: pane. A charter that picked a "legible" foreground from the background word would be
+#: claiming a measurement it does not have — so the plane is asked instead, in the same
+#: vocabulary it already answers ``bg`` in.
+#:
+#: **Painted by tmux, not by a renderer**, which is what makes one key reach every cell.
+#: `window-style` carries an ``fg`` exactly as it carries a ``bg``, and tmux resolves the
+#: pane's DEFAULT foreground from it — so charter's own ``\\033[0m`` returns to the plane's
+#: colour rather than the terminal's, and no renderer has to be told. Measured through a
+#: nested client, one panel at ``fg=black,bg=brightblack``, on 3.7c and at
+#: `tmuxctl.FLOOR` alike::
+#:
+#:     bg only    '\\x1b[0m\\x1b[100mPLAIN one'          <- reset returns to the TERMINAL's fg
+#:     fg and bg  '\\x1b[0m\\x1b[30m\\x1b[100mPLAIN one'  <- reset returns to the PLANE's
+#:     …and a green span's own close came back '\\x1b[30m' rather than '\\x1b[39m'
+#:
+#: **One word for the frame and not one per pane.** ``bg`` is per component because a frame
+#: reads as an application when its regions are told apart; a foreground has the opposite
+#: property — text that changed colour from pane to pane would stop reading as one
+#: document — and a per-pane foreground would only add a second way to make one pane
+#: unreadable. `FRAME_PANE_BG`'s focus partner has no counterpart here for the same reason:
+#: which pane is live is said by the background pair, and a foreground that moved with focus
+#: would say it twice.
+#:
+#: ``default`` is the seventeenth word and its clause is **empty**, which is not a hole. A
+#: pane whose style names no ``fg`` already draws in the terminal's own foreground, so
+#: "leave the text alone" and "say ``fg=default``" are the same pane — and the empty clause
+#: is what makes a plane that says nothing emit byte-identical options to the frame it had
+#: before this key existed. The word is in the table anyway so the vocabulary is exactly
+#: `FRAME_PANE_BG`'s seventeen and a plane can say the default out loud.
+FRAME_PANE_FG: dict[str, str] = {
+    "default": "",
+    **{name: f"fg={name}" for name in FRAME_PANE_COLOURS},
+    **{f"bright{name}": f"fg=bright{name}" for name in FRAME_PANE_COLOURS},
+}
+
+
+def pane_text(name) -> str | None:
+    """*name* if it names a :data:`FRAME_PANE_FG` foreground, else ``None``.
+
+    :func:`pane_bg`'s job for the foreground key, and the same function for the same
+    reasons: ``isinstance`` first because ``value in FRAME_PANE_FG`` raises ``TypeError``
+    for an unhashable value, and the matched NAME rather than ``True`` so a caller can
+    store a value it has already checked.
+
+    The containment is :func:`text_fg`'s, not this one's — what reaches tmux is a value out
+    of the table, indexed by a word that was only ever a key.
+    """
+    return name if isinstance(name, str) and name in FRAME_PANE_FG else None
+
+
+def text_fg(name) -> str:
+    """The ``fg=`` clause *name* means — ``""`` for ``default``, and ``""`` for every word
+    charter does not know.
+
+    :func:`pane_bg_options`' contract said about one clause instead of two pairs: what
+    comes back is charter's own constant and never the caller's argument, so a word this
+    function did not recognise cannot leave through it.
+
+    Empty is the ANSWER for ``default`` and only incidentally the failure mode — see
+    :data:`FRAME_PANE_FG`. Both callers append it to a style, and appending nothing is
+    exactly what a plane that named no foreground asked for.
+    """
+    n = pane_text(name)
+    return FRAME_PANE_FG[n] if n else ""
+
+
 #: The most cells a component may inset its content by, per side.
 #:
 #: **A cap and not a clamp**: a ``pad`` above this is REFUSED by
@@ -854,7 +936,159 @@ def chrome_option_names() -> tuple[str, ...]:
 PANE_BORDER_OPTIONS: tuple[str, ...] = ("pane-border-style", "pane-active-border-style")
 
 
-def rule_options(surface: str | None, style: str) -> tuple[tuple[str, str], ...]:
+#: What a plane's ``[frame] rules`` may say about the seam between two panes.
+#:
+#: **tmux always paints a glyph on a border cell, so this is a CONTRAST question and never
+#: a character one.** `pane-border-lines` has no ``none``: its five values are ``single``,
+#: ``double``, ``heavy``, ``simple`` and ``number``, and every one of them draws something.
+#: A frame whose panels are painted therefore cannot stop tmux drawing the rule; it can
+#: only decide what the glyph is drawn IN.
+#:
+#: ``visible`` is what charter has always drawn — `commands_frame._CHROME_STYLE` over the
+#: surface, an ``fg=default`` and a ``dim``. On a plane whose panels carry no colour that is
+#: a quiet line in the operator's own foreground and it is the whole of the frame's
+#: structure. On a plane whose panels ARE painted it is a dim default-foreground glyph
+#: sitting in the middle of a surface, which is the seam this operator has now reported four
+#: times (#627, #631, #657, and again against the frame that fixed #657).
+#:
+#: ``hidden`` gives the glyph the surface's own colour, so tmux draws it and nobody sees it
+#: and two adjacent panels read as one surface. Measured through a nested client on 3.7c,
+#: three panes at ``bg = "brightblack"``, read off the wire::
+#:
+#:     visible  '\\x1b[2m\\x1b[100m───…'   <- ESC[2m: a dim default fg ON the surface
+#:     hidden   '\\x1b[90m\\x1b[100m───…'  <- ESC[90m on ESC[100m: the glyph is the surface
+#:
+#: **A WORD, never a style string**, which is :data:`FRAME_CHROME`'s rule and not a fresh
+#: one: a tmux style value is FORMAT-EXPANDED at draw time (measured on this very option —
+#: ``set -w pane-border-style 'bg=#{?#{==:1,1},colour196,colour46}'`` is rc 0 and reaches
+#: the wire as ``ESC[48;5;196m``), and `charter.toml` arrives from someone else's machine.
+#: So the operator's word selects a BRANCH here and the colour it resolves to comes out of
+#: charter's own tables, exactly as ``bg`` and ``chrome`` do.
+FRAME_RULES: tuple[str, ...] = ("hidden", "visible")
+
+
+def rules_level(name) -> str | None:
+    """*name* if it names a :data:`FRAME_RULES` treatment, else ``None``.
+
+    :func:`chrome_level`'s job for the rules key — the one place a value arriving from a
+    hand-edited, committed `charter.toml` is admitted, with ``isinstance`` first for
+    :func:`density_level`'s reason.
+    """
+    return name if isinstance(name, str) and name in FRAME_RULES else None
+
+
+class Look(NamedTuple):
+    """The three frame-wide answers about how charter's own chrome READS, resolved once.
+
+    **One record rather than three parameters threaded through five functions**, and the
+    reason is #547's rather than tidiness: `_chrome_argvs`, `_harness_rule_argvs`,
+    `_surface_argvs` and `_resurface_argvs` all need the same answers, two of them run on
+    the launch path and two on the live `charter frame-chrome` path, and three loose
+    keywords is three chances for one of those four to be handed a different frame's
+    appearance. Passed whole, they cannot come apart.
+
+    It carries what the PLANE said and nothing derived from a pane: which pane wears which
+    background is `component_style`'s question and stays there.
+
+    ``dim`` is a ``bool`` and the other two are words out of :data:`FRAME_RULES` and
+    :data:`FRAME_PANE_FG`. Nothing here is trusted as a tmux VALUE — `rules` selects a
+    branch, `text` is a key into a table, and `dim` decides whether a constant is appended.
+    """
+
+    #: ``hidden`` or ``visible`` — :data:`FRAME_RULES`.
+    rules: str
+    #: The ``[frame] text`` word — a key into :data:`FRAME_PANE_FG`.
+    text: str
+    #: Whether charter may reduce the contrast of its own chrome — ``[frame] dim``.
+    dim: bool
+
+
+def look_of(frame: dict) -> Look:
+    """*frame*'s :class:`Look` — the appearance keys, read once for a whole launch.
+
+    ``.get`` with the shipped default rather than a subscript, for `component_style`'s own
+    reason: a frame relaunched by a charter that predates these keys has a `frame.state`
+    record without them, and a caller must get the shipped answer there rather than a
+    ``KeyError`` raised on the repaint path.
+
+    **No re-validation.** :func:`frame_of` is the boundary and it already refuses a word
+    charter does not know; asking again here would be the second, weaker answer #568's
+    sweep deletes. What guards a value that never went through `frame_of` — a dict a test
+    built by hand — is the same thing that guards every other one: :func:`text_fg` indexes
+    a table and :func:`rule_style` compares against a constant, so an unknown word reaches
+    no tmux value through either.
+    """
+    return Look(rules=frame.get("rules", FRAME_DEFAULTS["rules"]),
+                text=frame.get("text", FRAME_DEFAULTS["text"]),
+                dim=frame.get("dim", FRAME_DEFAULTS["dim"]))
+
+
+def rule_style(surface: str | None, style: str, look: Look) -> str:
+    """The ONE style value every rule in a frame is drawn with — the whole assembly, in one
+    place.
+
+    **Three decisions and no more**, taken in the order that makes each one answerable:
+
+    * ``rules = "hidden"`` over a surface that names a COLOUR wins outright, because it is
+      the only answer where the foreground is not a choice at all: the glyph is asked for in
+      the same colour as the cell behind it, which is the most a frame can do about a glyph
+      tmux insists on drawing. **Asked for, and not promised invisible** — the two clauses
+      name one word out of the operator's own palette, so what a terminal actually paints
+      for ``fg=brightblack`` and ``bg=brightblack`` is theirs rather than charter's, and a
+      theme that renders its bright foreground and bright background as different shades
+      leaves a faint glyph rather than none. Charter cannot see which theme that is
+      (:data:`FRAME_PANE_FG`), so the honest claim is the one about the values it emits.
+      No ``dim`` beside them: an attribute over a glyph asked to disappear is an
+      instruction to make it visibly something. The live style the operator hand-applied
+      and confirmed on their own frame is exactly this — ``fg=brightblack,bg=brightblack``
+      — and this is that value made permanent.
+    * otherwise the foreground is the plane's own ``text`` word where it named one
+      (:func:`text_fg`) and the caller's *style* where it did not, so a frame that gave its
+      panes a foreground draws its rules in it rather than in a colour nothing else on the
+      screen is wearing.
+    * ``dim`` is appended unless the plane turned it off, and never under ``hidden`` — see
+      above.
+
+    **``bg=default`` is a surface that ``hidden`` cannot be honoured over, and it is a real
+    input rather than a defensive one**: ``default`` is the seventeenth `FRAME_PANE_BG`
+    word and a component may name it to opt one pane out of a frame-wide `chrome`. It means
+    "the terminal's own background", and there is no ``fg=`` spelling for that — ``fg=
+    default`` is the terminal's own FOREGROUND, which is the one colour guaranteed to be
+    visible against it. So a ``hidden`` honoured there would emit ``fg=default,bg=default``
+    and draw the rule at FULL strength: brighter than the ``dim`` it replaced, which is the
+    opposite of what the word asked for. It falls through to *visible* instead, which is
+    the frame such a pane already had.
+
+    *style* is the caller's base rule foreground — `commands_frame._CHROME_FG`,
+    ``fg=default`` — passed in rather than imported so the one place that decides what a
+    charter rule looks like stays the one place. It is the FOREGROUND alone and not the
+    whole of `_CHROME_STYLE`, because the ``dim`` half is now a decision rather than a
+    constant: a caller that handed the composed style in would be asking this function to
+    take an attribute back out of a string, which is the parsing-charter's-own-constants
+    shape one function over deliberately avoids.
+
+    **``look.rules`` is compared against a constant and never validated here.** It selects
+    a branch; it is not a value that reaches tmux. :func:`frame_of` is the boundary that
+    refuses a word charter does not know, and a word that got past nothing still cannot be
+    ``"hidden"``, so it draws the frame charter shipped.
+    """
+    hidden = bool(surface) and look.rules == "hidden"
+    if hidden:
+        # `removeprefix` and not a split: every value this can be handed comes out of
+        # `FRAME_PANE_BG` or `FRAME_CHROME`, whose `window-style` entries are all exactly
+        # `bg=<name>`. `TheSurfaceIsAlwaysABareBackgroundClause` pins that over every word
+        # in both tables, so the prefix is a property of charter's own constants rather
+        # than a shape hoped for at a call site.
+        colour = surface.removeprefix("bg=")
+        if colour != "default":
+            return f"fg={colour},{surface}"
+        hidden = False
+    return ((text_fg(look.text) or style)
+            + ("" if hidden or not look.dim else ",dim")
+            + (f",{surface}" if surface else ""))
+
+
+def rule_options(surface: str | None, style: str, look: Look) -> tuple[tuple[str, str], ...]:
     """The ``(option, value)`` pairs that draw ONE pane's own edges over *surface* — empty
     where there is no surface to draw them over.
 
@@ -875,9 +1109,10 @@ def rule_options(surface: str | None, style: str) -> tuple[tuple[str, str], ...]
     with the pair identical every rule cell held its colour, and the frame did not move when
     focus did.
 
-    *style* is the caller's rule style — `commands_frame._CHROME_STYLE`, `fg=default,dim` —
-    passed in rather than imported so the one place that decides what a charter rule looks
-    like stays the one place.
+    *style* and *look* are :func:`rule_style`'s, which is where the value itself is now
+    assembled: this function is the PAIR — which options carry it, and that they carry the
+    identical thing — and that split is what lets `_chrome_argvs` draw the same rule
+    window-wide below `tmuxctl.PANE_BORDER_FLOOR` without a second assembler.
 
     Empty rather than a bare *style* for a pane with no surface: the window option is
     already exactly that, so a pane that adds nothing must SET nothing. What a caller does
@@ -885,11 +1120,55 @@ def rule_options(surface: str | None, style: str) -> tuple[tuple[str, str], ...]
     a pane that may be carrying yesterday's value issues the unset
     (`commands_frame._harness_rule_argvs`) — and that is the caller's question, not this
     one's.
+
+    **The emptiness is still asked of the SURFACE and not of the assembled style**, which
+    matters now that a style can differ from the caller's without a surface: a plane that
+    named a ``text`` colour changes what `_chrome_argvs` puts on the window, and must still
+    put nothing on a pane that has no surface to draw a rule over. Those are two questions
+    and this one answers the second.
     """
-    return tuple((n, f"{style},{surface}") for n in PANE_BORDER_OPTIONS) if surface else ()
+    if not surface:
+        return ()
+    value = rule_style(surface, style, look)
+    return tuple((n, value) for n in PANE_BORDER_OPTIONS)
 
 
-def pane_border_options(name, chrome, style: str) -> tuple[tuple[str, str], ...]:
+def surface_options(name, chrome, look: Look) -> tuple[tuple[str, str], ...]:
+    """The ``(option, value)`` pairs ONE pane's whole rectangle is painted from — the
+    background it wears and the foreground its text comes out in.
+
+    **`pane_bg_options(name) or chrome_options(chrome)` with the plane's own ``text``
+    folded in, and it is one expression rather than two call sites merging.** The ``or`` is
+    `commands_frame._surface_argvs`' own and unchanged — a component that named no ``bg``,
+    and one whose word charter does not know, both take the frame-wide surface — and the
+    foreground is appended to whatever that answered, so a pane is one word's background or
+    the other's and never a blend, while every pane in the frame carries the same
+    foreground.
+
+    **A ``text`` with no surface at all is a real arrangement and gets the options anyway.**
+    `chrome = "off"`, no ``bg`` anywhere, ``text = "black"``: there is no background to
+    paint, and the plane has still said what colour its frame's text is. So the pairs are
+    built from :func:`chrome_option_names` — the two style options, derived from the table
+    the way everything else in this module derives them — carrying the foreground alone.
+
+    Empty only when the plane said neither, which is the frame charter shipped: no
+    background, no foreground, and `_surface_argvs` issues no command at all.
+
+    What reaches tmux is charter's own constant on both halves. The background comes out of
+    :data:`FRAME_PANE_BG`/:data:`FRAME_CHROME` as it always did, and the foreground out of
+    :data:`FRAME_PANE_FG` through :func:`text_fg`, so a committed word that charter does not
+    know indexes nothing and leaves through neither.
+    """
+    pairs = pane_bg_options(name) or chrome_options(chrome)
+    fg = text_fg(look.text)
+    if not fg:
+        return pairs
+    if not pairs:
+        return tuple((n, fg) for n in chrome_option_names())
+    return tuple((n, f"{fg},{value}") for n, value in pairs)
+
+
+def pane_border_options(name, chrome, style: str, look: Look) -> tuple[tuple[str, str], ...]:
     """The ``(option, value)`` pairs that draw ONE panel pane's own edges in its own
     surface — empty for a pane that has no surface to draw them in.
 
@@ -906,13 +1185,22 @@ def pane_border_options(name, chrome, style: str) -> tuple[tuple[str, str], ...]
     (:func:`agreed_border_bg`) and its INTERIOR is not a question at all — `window-style`
     is not in :data:`PANE_BORDER_OPTIONS`, so nothing assembled here can reach one.
 
-    *style* and the pair-building are :func:`rule_options`'. The surface is
+    *style*, *look* and the pair-building are :func:`rule_options`'. The surface is
     ``pane_bg_options(name) or chrome_options(chrome)``'s ``window-style`` value, which is
     the SAME expression the pane's interior is painted from: a pane and its own edges cannot
     come out two colours, because they are read off one answer.
+
+    **The BACKGROUND expression and not :func:`surface_options`**, and the difference is
+    load-bearing rather than an oversight. A plane that named a ``text`` colour has an
+    ``fg`` in the value its pane's rectangle is painted with, and a rule resolved off that
+    string would carry two foregrounds — the plane's, and then whatever
+    :func:`rule_style` appends. The rule's own foreground is `rule_style`'s decision, taken
+    from the same ``look``, and what this reads off the pane is only which colour it is
+    sitting in. `TheRuleReadsTheBackgroundAndNotTheWholeSurface` pins it.
     """
     return rule_options(
-        dict(pane_bg_options(name) or chrome_options(chrome)).get("window-style"), style)
+        dict(pane_bg_options(name) or chrome_options(chrome)).get("window-style"),
+        style, look)
 
 
 def _component_surfaces(frame: dict, chrome) -> set:
@@ -1215,6 +1503,56 @@ FRAME_FIELDS = {
     #: One word, so `docs/frame.md`'s hyphen rule (`history-limit`, not `history_limit`)
     #: does not arise.
     "chrome": ("off", "chrome"),
+    #: How the seam between two panes is drawn — see :data:`FRAME_RULES` for why this is a
+    #: contrast question rather than a character one, and what the two words mean.
+    #:
+    #: **``hidden`` is the shipped default, and unlike `chrome` it cannot make an existing
+    #: frame worse.** The two are not symmetric: `chrome`'s default is `off` because
+    #: `dark` would repaint a stranger's terminal, and a stranger's terminal is exactly
+    #: what charter cannot see. ``hidden`` repaints nothing. It has an effect only where
+    #: there is already a surface to hide the rule INTO, which is a plane that has written
+    #: a `chrome` or a `bg` by hand — and such a plane has already said it wants panels
+    #: rather than boxes, which is the whole of what this word means.
+    #:
+    #: **A plane with no surface gets byte-identical options to the frame it had**, and
+    #: that is stated rather than left implicit: there is no colour for the glyph to take,
+    #: so `rule_style` falls through to the ``visible`` assembly and emits `_CHROME_STYLE`
+    #: exactly as it always did. `hidden` there is not a silent failure — it is the same
+    #: rendering the word would produce if it could be honoured, because a rule over the
+    #: terminal's own background IS the terminal's own background either way.
+    #:
+    #: The asymmetry that makes `hidden` right as the default is the report: an operator
+    #: who wanted the seam and gets none can say ``rules = "visible"`` in one line, and the
+    #: operator who did not want it has now reported it four times.
+    "rules": ("hidden", "rules"),
+    #: The foreground every pane charter paints draws its text in — see
+    #: :data:`FRAME_PANE_FG` for the seventeen words, why charter cannot compute this one,
+    #: and why it is frame-wide where ``bg`` is per component.
+    #:
+    #: ``default`` is the shipped value and it emits nothing at all, so a plane that says
+    #: nothing gets the frame it had. One word, so `docs/frame.md`'s hyphen rule does not
+    #: arise.
+    "text": ("default", "text"),
+    #: Whether charter may reduce the contrast of its own chrome — the ``dim`` in the rule
+    #: style, and the ``\\033[2m`` `frame/chrome.py` calls ``muted``.
+    #:
+    #: **The one thing in the frame that is wrong by construction on a surface it was not
+    #: chosen for**, which is why it is a key of its own rather than one more colour.
+    #: `frame/chrome.py`'s `_role_values` argues that bold, dim and reverse need no gate
+    #: because they are "statements relative to whatever the operator's terminal already
+    #: is". That is true of bold and reverse and it is the wrong half of true for dim: dim
+    #: is relative, and it is relative in the direction of LESS contrast. On the terminal
+    #: charter's recipes were chosen against — light text on a dark ground — a dim grey is
+    #: readable. On a pane the plane painted light it moves the text toward the background
+    #: it is already too close to, and the operator reported it unreadable.
+    #:
+    #: **``true`` is the shipped value and the default does not move**, for a reason that
+    #: is about information rather than caution. `dim` is not decoration in this frame: it
+    #: is the ONLY thing separating muted text from ordinary text — a tree glyph from a
+    #: repo name, a count from a heading — and a frame with it off everywhere is a frame
+    #: whose hierarchy is flat. Turning it off is right for a plane whose surface makes it
+    #: unreadable and wrong as an answer for every plane, so the plane says it.
+    "dim": (True, "dim"),
     "hotkey": ("F2", "hotkey"),
     "history_limit": (50000, "history-limit"),
     "min_cols": (100, "min-cols"),
@@ -1224,6 +1562,16 @@ FRAME_FIELDS = {
 #: The plain ``{key: default}`` view of :data:`FRAME_FIELDS`, for callers (and the
 #: ``config.FRAME`` docstring) that only want the shipped defaults, not the TOML mapping.
 FRAME_DEFAULTS = {key: default for key, (default, _toml_key) in FRAME_FIELDS.items()}
+
+#: The :class:`Look` of a plane that has said nothing — derived from :data:`FRAME_DEFAULTS`
+#: rather than spelled, so it cannot drift from the table above.
+#:
+#: It is the DEFAULT for every parameter that takes a `Look` in `commands_frame`, and that
+#: choice is deliberate: a call site that forgets to pass one draws the frame charter
+#: ships, never the frame charter used to ship. The failure mode of the other default —
+#: `Look("visible", "default", True)`, today's rendering — is a new call site quietly
+#: keeping the old behaviour, which is the one bug this whole change is about.
+SHIPPED_LOOK: Look = look_of({})
 
 #: The shape of a tmux key name, and the ONE thing standing between ``[frame] hotkey``
 #: and arbitrary code execution at launch.
@@ -1317,13 +1665,25 @@ def frame_of(cfg: dict) -> dict:
     module is imported by every command, including ``charter --version``, so a
     hand-edited charter.toml must degrade to the defaults rather than raise.
 
-    Four keys need more than a type check, and all four get it here rather than
+    Six keys need more than a type check, and all six get it here rather than
     downstream: ``slots`` is filtered against :data:`FRAME_SLOTS`, ``density`` against
-    :data:`FRAME_DENSITY`, ``chrome`` against :data:`FRAME_CHROME`, and ``hotkey``
-    against :data:`_HOTKEY_RE` — see those two constants for the injection a bare
-    ``isinstance(value, str)`` lets through in each case. All four degrade to
+    :data:`FRAME_DENSITY`, ``chrome`` against :data:`FRAME_CHROME`, ``rules`` against
+    :data:`FRAME_RULES`, ``text`` against :data:`FRAME_PANE_FG`, and ``hotkey``
+    against :data:`_HOTKEY_RE` — see those constants for the injection a bare
+    ``isinstance(value, str)`` lets through in each case. All six degrade to
     the shipped default, which is the contract every other key in this function already
     keeps: a charter.toml charter cannot make sense of never stops charter from running.
+
+    **Degrading rather than refusing is the right half of #535 for a `[frame]` key**, and
+    the boundary is worth stating because the neighbouring rule goes the other way. An
+    ARRANGEMENT is refused whole (:func:`component_tables`) because a component silently
+    missing reads as a plane with no clones — a frame short a pane looks like a machine
+    short a repo, and nobody suspects a typo. A `rules` or `text` word charter cannot read
+    costs a rule drawn the shipped way in a frame that is otherwise entirely intact, which
+    is what `chrome`, `density` and `hotkey` have always done. #687 is the standing warning
+    against over-refusing, and it bites here in the direction of ACCEPTANCE: every word in
+    both new vocabularies is usable, so the tests assert the whole of each rather than a
+    sample.
 
     **`density` is expanded here, and only when it was actually declared.** A declared
     level replaces ``slots`` with the list it expands to, so everything downstream —
@@ -1377,6 +1737,24 @@ def frame_of(cfg: dict) -> dict:
             # bare `isinstance(value, str)` here would carry a committed string from
             # someone else's machine into a tmux evaluator. See :data:`FRAME_CHROME`.
             if chrome_level(value):
+                out[key] = value
+            continue
+        if key == "rules":
+            # The closed enum again, and for `chrome`'s sharper reason rather than by
+            # symmetry: `rules` decides a `pane-border-style`, which tmux FORMAT-EXPANDS at
+            # draw time exactly as it does a `window-style` (measured — see
+            # :data:`FRAME_RULES`). A bare `isinstance(value, str)` here would be the one
+            # door in this section that a committed string could walk a tmux format
+            # through.
+            if rules_level(value):
+                out[key] = value
+            continue
+        if key == "text":
+            # Checked against :data:`FRAME_PANE_FG` here for the same reason `bg` is
+            # checked against `FRAME_PANE_BG` at the component boundary: what an accepted
+            # word buys is an index into charter's own table, and what a refused one costs
+            # is the shipped `default`.
+            if pane_text(value):
                 out[key] = value
             continue
         if key == "hotkey":

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -937,6 +937,146 @@ on: `window-style` is pane-scoped, it honours a colour and silently ignores `rev
 byte-identical to 3.7c, and the two that were not turned out to be the measuring harness.
 So there is no version gate on any of it.
 
+### The seam between two panels
+
+```toml
+[frame]
+rules = "hidden"    # or "visible" — `hidden` is the default
+```
+
+Once your panels have a background, the one-cell gap between two of them is the only part
+of the frame that does not. tmux draws that cell from `pane-border-style`, and charter has
+pinned it to a dim glyph in your own foreground since it started drawing its own chrome —
+so four grey panels came out as four grey rectangles with a dark line between each pair.
+Reported four times, off a screenshot each time.
+
+**You cannot ask for fewer characters.** tmux always paints something on a border cell:
+`pane-border-lines` takes `single`, `double`, `heavy`, `simple` or `number`, and there is no
+`none`. So this is a contrast question. `hidden` asks for the glyph in the same colour as the
+cell behind it, and the two panels read as one surface. Both halves of that name one word out
+of your own palette, so how close to invisible it lands is your theme's answer and not
+charter's — the same reason `chrome` has no `auto`:
+
+```
+visible  ESC[2m ESC[100m ─────   a dim foreground glyph, on the surface
+hidden   ESC[90m ESC[100m ─────  the glyph IS the surface
+```
+
+**A plane with no surface is unchanged, byte for byte.** There is no colour for the glyph
+to take, so `hidden` composes exactly the style charter always drew and your frame looks
+the same as it did. That is why this default is safe where `chrome`'s is `off`: it only
+does anything on a plane that has already written a `chrome` or a `bg` by hand, which is a
+plane that has already said it wants panels rather than boxes.
+
+One pane can opt out of a frame-wide `chrome` with `bg = "default"`, and a rule over *that*
+stays visible: `default` means your terminal's own background, and there is no way to spell
+"your terminal's background" as a foreground. `hidden` there would draw the rule at full
+strength, which is the opposite of what you asked for, so it draws the dim one instead.
+
+Say `rules = "visible"` if you want the seams back.
+
+### The colour of the text on it
+
+```toml
+[frame]
+text = "black"      # any of `bg`'s seventeen words — `default` is the default
+dim  = false        # `true` is the default
+```
+
+`bg` has been configurable across seventeen words for a while. The text drawn *on* it was
+not configurable at all — charter's greens, blues, dims and bolds were chosen against a
+dark terminal, and a plane that paints its panes light is drawing them on a background none
+of them was picked for. `brightblack` is a dark grey on most themes and a light **tan** on
+at least one real operator's, which is how this was found.
+
+**Charter cannot work this out for you and does not pretend to.** The sixteen names have no
+fixed RGB — that is the whole point of naming them rather than indexing the cube — so
+"is this readable" is a question about a terminal charter cannot see. It cannot see it for
+the same reason `chrome` has no `auto`: a colour query through tmux gets no reply, and
+`$COLORTERM` inside a pane describes the terminal that started the *server*. A charter that
+computed a "legible" foreground from your background word would be guessing and calling it
+a measurement.
+
+`text` sets your panes' **default foreground**, and tmux resolves it the way it resolves the
+background — from the same two options, on the same rectangle, at draw time. So it reaches
+every cell no renderer coloured, charter's own `ESC[0m` returns to *your* colour rather than
+the terminal's, and nothing in charter or in a component you wrote has to be told. Measured
+on tmux 3.7c and at the 3.2 floor.
+
+**Which case this actually fixes**, stated plainly so you can tell whether it is yours. It
+fixes a pane whose background is *inverted* relative to your terminal's — a dark terminal
+with `bg = "white"`, or a light terminal with `bg = "black"` — where the foreground your
+terminal picked for its own background is now sitting on the opposite one. If your terminal
+is already light and your panes are light, your default foreground was already dark and this
+key has nothing to do; what is hard to read there is the **accent** colours, and `text` does
+not reach those. That gap is real and named rather than papered over: `ok`, `warn` and `bad`
+are still your palette's green, yellow and red, and yellow on a tan surface is exactly the
+combination nobody's palette was designed for. Making those three configurable is the
+obvious next key and is not in this release.
+
+`dim = false` stops charter reducing the contrast of its own chrome — the `ESC[2m` on muted
+text, and the `dim` on the frame's rules. It is a key of its own rather than one more colour
+because it is the one thing in the frame that is **wrong by construction** on a surface it
+was not chosen for: bold adds weight and reverse swaps your own two colours, so neither can
+be wrong on a theme charter cannot see, but dim moves text toward the background, and that
+is only safe when there is contrast to spare.
+
+It stays *on* by default, and the reason is information rather than caution: dim is the only
+thing separating muted text from ordinary text in the frame — a tree glyph from a repo name,
+a count from a heading — so a frame with it off everywhere is a frame with a flat hierarchy.
+Turn it off when your surface makes it unreadable.
+
+**Why there is no `accent` yet, and no key per colour.** charter draws through eight named
+roles — `heading`, `muted`, `selected`, `ok`, `warn`, `bad`, `reset`, `inset`. Four of them
+are theme-safe by construction: bold, reverse, a reset and two spaces. Three of them —
+`ok`, `warn`, `bad` — are green, yellow and red **as your palette defines them**, so
+renaming them would swap your own green for your own blue, which is a preference and not a
+legibility fix. What is left is the two that are not slots in your palette at all: the
+default foreground, which your terminal chose to sit on *its* background rather than on the
+one charter painted, and dim. Those are the two keys here.
+
+The argument for stopping there is weaker than it looks, and the honest version is this: it
+holds while the three accents are readable on your surface, and an operator has reported
+that they are not on a light one. Restating them would be three more words in this table —
+`ok`, `warn`, `bad` — and the reason it is not in this release is mechanical rather than
+principled: charter's own panels write those colours directly, so serving new ones means
+routing about forty call sites through the same recipe table a component already reads, and
+that is a change worth making on its own rather than at the end of this one.
+
+`NO_COLOR` still wins over both, and over everything else here.
+
+### Why the frame ships with no surface at all
+
+`chrome = "off"` is the default and stays there, and the reason is the one above: charter
+cannot see your theme, so any colour it shipped would be wrong for whoever's theme differs.
+That is not a hedge — it is what produced the tan.
+
+The obvious way out is an attribute rather than a colour. **`reverse` is theme-independent**
+by definition: it swaps whatever your own foreground and background are, so a reversed panel
+is distinct from your work area on every theme without charter knowing which, and tmux's own
+status line has used it forever. It was measured for exactly this, on tmux 3.7c and at the
+3.2 floor, and it does not work. tmux **accepts** `window-style reverse`, stores it, and
+reads it back verbatim — and puts nothing at all on an attached client's wire for it. The
+same is true of `bold` and `dim`. A pane style honours colour and silently ignores every
+attribute.
+
+A panel could reverse its own rows instead, and that is worse rather than merely harder: a
+pane style fills the whole rectangle — the cells no renderer wrote, on resize, on reattach —
+while a fill a panel painted itself lasts until the pane changes shape. You would get three
+reversed rows in a fifteen-row pane and twelve of your terminal's own until the next tick.
+
+So there is no theme-independent surface to ship, and what you get instead is three lines:
+
+```toml
+[frame]
+chrome = "dark"     # or "light" — whichever side your terminal is on
+text   = "white"    # or "black" — the other side
+dim    = false      # if your surface is light
+```
+
+`rules = "hidden"` is already the default, so the seams are gone without you writing
+anything. Add a `bg` per component if you want your regions told apart (below).
+
 ### A colour and an inset for one pane
 
 `chrome` gives every panel the same background, which is the right default and the wrong

--- a/docs/news/unreleased-the-frames-rules-and-its-text-are-yours-to-choose.md
+++ b/docs/news/unreleased-the-frames-rules-and-its-text-are-yours-to-choose.md
@@ -1,0 +1,120 @@
+---
+version: unreleased
+headline: The frame's rules and the colour of its text are the plane's to choose
+---
+
+Two things an operator hit on their own frame within ten minutes of each other, and one
+measurement that closes a door behind them.
+
+## The seam, for the fourth time
+
+A plane that paints its panels — `chrome` plus a `bg` on each component — got a one-cell
+line between every pair of them. It has been reported four times now, and each earlier fix
+made it smaller rather than gone: first the rule had no background at all, then it had one
+everywhere except around the harness pane, then it had one there too and the **glyph** was
+still visible sitting in the middle of it.
+
+That last one cannot be fixed by asking for fewer characters. **tmux always paints
+something on a border cell** — `pane-border-lines` takes `single`, `double`, `heavy`,
+`simple` or `number`, and there is no `none`. So it was never a character question. It is a
+contrast question:
+
+```toml
+[frame]
+rules = "hidden"    # the default now; say "visible" to keep your seams
+```
+
+`hidden` asks for the glyph in the same colour as the cell behind it, so tmux still draws it
+and two adjacent panels read as one surface. Both clauses name one word out of *your*
+palette, so how close to invisible it lands is your theme's answer rather than charter's —
+a theme whose bright foreground and bright background are different shades leaves a faint
+glyph rather than none. Read off an attached client's wire through a nested tmux, three
+panes each `bg = "brightblack"`:
+
+```
+visible  ESC[2m  ESC[100m ─────    a dim foreground glyph, on the surface
+hidden   ESC[90m ESC[100m ─────    the glyph IS the surface
+```
+
+**It is the default, and it cannot make an existing frame worse.** A plane with no surface
+has no colour for the glyph to take, so it composes exactly the style charter has always
+drawn and your frame is byte-identical to the one you had. It only does anything on a plane
+that has already written a `chrome` or a `bg` by hand — which is a plane that has already
+said it wants panels rather than boxes. One pane that opted out with `bg = "default"` keeps
+its visible rule, because "your terminal's own background" has no spelling as a foreground
+and hiding into it would draw the rule *brighter* than before.
+
+## The text on it
+
+`bg` has been configurable across seventeen words for a while. The text drawn on it was not
+configurable at all — charter's greens, blues, dims and bolds were all chosen against a dark
+terminal. `brightblack` is a dark grey on most themes and a light **tan** on at least one
+real operator's, and that is how this was found.
+
+```toml
+[frame]
+text = "black"      # any of `bg`'s seventeen words — `default` is the default
+dim  = false        # `true` is the default
+```
+
+`text` sets your panes' default foreground, through the same tmux option that already
+paints their background. So it reaches every cell no renderer coloured, charter's own
+`ESC[0m` returns to *your* colour rather than the terminal's, and nothing in charter or in a
+component you wrote has to be told. `dim = false` stops charter reducing the contrast of its
+own chrome — the muted text and the `dim` on the frame's rules. Dim is the one thing in the
+frame that is wrong by construction on a surface it was not chosen for: bold adds weight and
+reverse swaps your own two colours, so neither can be wrong on a theme charter cannot see,
+but dim always moves text *toward* the background.
+
+**Charter does not compute any of this for you, and that is deliberate.** The sixteen colour
+names have no fixed RGB — that is the whole point of naming them rather than indexing the
+256-colour cube — so "is this readable" is a question about a terminal charter cannot see.
+It cannot see it for the same reason `chrome` has no `auto`: a colour query through tmux
+gets no reply, and `$COLORTERM` inside a pane describes the terminal that started the
+*server*, not the one looking at the pane. A charter that picked a "legible" foreground from
+your background word would be guessing and calling it a measurement.
+
+`NO_COLOR` still wins over all of it.
+
+## Why the frame still ships with no surface at all
+
+`chrome = "off"` stays the default, and this release is where the alternative was actually
+measured rather than assumed.
+
+The problem with shipping a coloured default is the one above — charter cannot see your
+theme. The obvious way out is an **attribute** instead of a colour. `reverse` is
+theme-independent by definition: it swaps whatever your own foreground and background are,
+so a reversed panel is distinct from your work area on every theme without charter knowing
+which one you use, and tmux's own status line has worked that way forever.
+
+It does not work, and it fails silently. tmux **accepts** `window-style reverse`, stores it,
+and reads it back verbatim — and puts **no escape at all** on an attached client's wire for
+it. The same is true of `bold` and `dim`. A pane style honours colour and ignores every
+attribute. Measured on tmux 3.7c and at the 3.2 floor, with a control proving tmux really
+does accept the value, so a future charter that sets it and checks the return code cannot
+report success while painting nothing.
+
+Painting the reverse from a panel instead is worse rather than merely harder: a pane style
+fills the whole rectangle including the cells no renderer wrote and survives a resize, while
+a fill a panel painted itself lasts until the pane changes shape — three reversed rows in a
+fifteen-row pane and twelve of your terminal's own until the next tick.
+
+So there is no theme-independent surface to ship, and what you get instead is three lines:
+
+```toml
+[frame]
+chrome = "dark"     # or "light" — whichever side your terminal is on
+text   = "white"    # or "black" — the other side
+dim    = false      # if your surface is light
+```
+
+`rules = "hidden"` is already the default, so the seams are gone without you writing
+anything.
+
+## What this does not fix
+
+If your terminal is already light and your panes are light, your default foreground was
+already dark and `text` has nothing to do for you. What is hard to read there is the
+**accent** colours — `ok`, `warn` and `bad` are still your palette's green, yellow and red,
+and yellow on a tan surface is the combination nobody's palette was designed for. Making
+those three configurable is the next key and it is not in this release.

--- a/tests/test_a_plane_chooses_how_its_frame_reads.py
+++ b/tests/test_a_plane_chooses_how_its_frame_reads.py
@@ -485,6 +485,42 @@ class DimIsDeletedFromTheFinishedRow(unittest.TestCase):
             with self.subTest(row=row):
                 self.assertEqual(chrome.undim(row), row)
 
+    def test_an_extended_colour_that_never_says_which_space_is_left_alone(self):
+        """**A truncated introducer, which is a row a provider can really write.** SGR 38,
+        48 and 58 announce a colour space in the parameter that follows them — and there
+        may not BE one. `ESC[38m` is a foreground introducer at the end of its own list;
+        the walk has to notice that `pieces[i + 1]` is off the end rather than reach for
+        it.
+
+        Three of this file's mutation-sweep survivors lived here, and all three were real
+        gaps rather than equivalent mutants: dropping the `i + 1 < len(pieces)` guard, or
+        widening it to `<=`, turns this row into an `IndexError` — raised inside
+        `panel._write`, on the repaint path, in a pane that then shows nothing."""
+        for row in ("\x1b[38m", "\x1b[48mx", "\x1b[58m", "\x1b[1;38m", "\x1b[38;m"):
+            with self.subTest(row=row):
+                self.assertEqual(chrome.undim(row), row)
+
+    def test_an_extended_colour_space_charter_does_not_know_is_left_alone(self):
+        """The other half of the same walk, and the third survivor. `ESC[38;99m` names a
+        colour space that is neither 5 nor 2 — malformed, or from a terminal extension
+        charter has never heard of — and the run length has to fall back to one parameter
+        rather than index a table that has two keys in it.
+
+        `{5: 3, 2: 5}[space]` is a `KeyError` on exactly this row. Charter writes no such
+        escape (`instance.FRAME_PANE_COLOURS` argues why it names the sixteen), which is
+        precisely what makes the case real: this runs over a row a PROVIDER's component
+        finished, and `tui.sanitize` passes any `ESC[<digits and semicolons>m` through
+        untouched."""
+        for row in ("\x1b[38;99mx", "\x1b[48;0m", "\x1b[58;7;1m", "\x1b[38;4;9mx"):
+            with self.subTest(row=row):
+                self.assertEqual(chrome.undim(row), row)
+
+    def test_a_dim_beyond_an_unknown_space_is_still_found(self):
+        """The walk must resume at the right place after a run it could not size, or the
+        parameter after an unknown space is skipped and a dim survives the pass."""
+        self.assertEqual(chrome.undim("\x1b[38;99;2mx"), "\x1b[38;99mx")
+        self.assertEqual(chrome.undim("\x1b[38;2mx"), "\x1b[38;2mx")
+
     def test_a_dim_after_a_true_colour_is_still_deleted(self):
         """The walk has to resume at the right place, or the sub-parameters swallow the
         attribute that follows them."""
@@ -516,9 +552,15 @@ class DimIsDeletedFromTheFinishedRow(unittest.TestCase):
         self.assertNotIn("\x1b[2m", got)
 
     def test_a_row_with_no_escape_at_all_comes_back_unchanged(self):
-        for row in ("", "plain text", "  ⋯ gathering"):
+        """Equality and not identity, which is the second thing the sweep corrected here.
+        This asserted `assertIs` while `undim` still had a `"\\x1b" not in row` shortcut in
+        front of it — and it went on passing when that shortcut was deleted, because
+        `re.sub` hands back the string it was given when nothing matched. So the identity
+        was CPython's answer rather than charter's, and asserting it pinned an
+        implementation detail while leaving the property untested."""
+        for row in ("", "plain text", "  ⋯ gathering", "\t\ttabs", "── ── ──"):
             with self.subTest(row=row):
-                self.assertIs(chrome.undim(row), row)
+                self.assertEqual(chrome.undim(row), row)
 
     def test_it_changes_no_cell_of_width(self):
         """Every SGR costs zero columns, so this only ever makes one shorter or removes

--- a/tests/test_a_plane_chooses_how_its_frame_reads.py
+++ b/tests/test_a_plane_chooses_how_its_frame_reads.py
@@ -1,0 +1,654 @@
+"""`[frame] rules`, `[frame] text` and `[frame] dim` — the three words a plane says about
+how charter's own chrome reads, and the boundary each of them stops at.
+
+**The report, and the measurement under it.** An operator whose plane paints every panel
+`bg = "brightblack"` reported two things within ten minutes of each other, on a terminal
+whose theme renders that word as a light **tan**:
+
+* a one-cell seam between every pair of panels — a dim default-foreground glyph sitting in
+  the middle of a surface. tmux ALWAYS paints a border cell (`pane-border-lines` has no
+  `none`: its five values are `single`, `double`, `heavy`, `simple` and `number`), so this
+  was never a character question. It is a contrast question, and giving the glyph the
+  surface's own colour is the whole answer. Reported four times now — #627, #631, #657, and
+  again against the frame that fixed #657.
+* the text on that surface. Captured off their live frame with `capture-pane -e`, charter
+  paints `ESC[32m`, `ESC[34m`, `ESC[35m`, `ESC[2m`, `ESC[1m` and `ESC[7m` through eight
+  recipes — and every one of those was chosen against a **dark** terminal. `bg` has been
+  configurable across seventeen words since #631; the foreground drawn on it was not
+  configurable at all.
+
+**Charter cannot compute its way out of the second one, and that is established rather than
+assumed.** The sixteen ANSI names have no fixed RGB — `brightblack` is a dark grey on most
+themes and tan on this operator's — so "is this readable" is a question about a terminal
+charter cannot see. This plane's own `charter.toml` already records why it cannot see it:
+OSC 11 through tmux answers nothing, and `$COLORTERM` inside a pane describes the terminal
+that started the SERVER rather than the one looking at the pane. A guard that claimed to
+measure contrast would be exactly the overclaim this project refuses. So the plane is
+asked, in the vocabulary it already answers `bg` in.
+
+**Three keys and not eight, and the count is argued.** Of `chrome.recipes()`' eight roles,
+`heading` (bold), `selected` (reverse), `reset` and `inset` are theme-safe by construction
+and `frame/chrome.py` already argues why; `ok`/`warn`/`bad` are slots in the operator's own
+palette, which is `instance.FRAME_PANE_COLOURS`' own argument for refusing `colour24`.
+Renaming those slots per recipe would let a plane swap its own green for its own blue,
+which is a choice and not a legibility fix. What is left is the two things that are NOT
+slots: the default foreground, which the terminal chose to sit on its own background rather
+than on the one charter painted, and `dim`, which is an attribute that always moves toward
+the background. Those are `text` and `dim`. `rules` is the third because a rule is chrome
+rather than text and has its own question — whether it is there at all.
+
+The live half of all three — what tmux really does with the values these produce, on 3.7c
+and at `tmuxctl.FLOOR` — is `tests/test_a_planes_frame_really_reads_that_way.py`.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
+
+from charter import commands_frame, config, instance
+from charter.frame import chrome, pane, panel
+from tests._isolation import PersonaIso
+
+#: The frame a plane that has written nothing gets.
+_SHIPPED = instance.SHIPPED_LOOK
+
+#: A `window-style`/`pane-border-style` value is `bg=` and one word, always. Pinned below,
+#: because `instance.rule_style` takes the colour out of one with `removeprefix`.
+_BARE_BG = re.compile(r"^bg=[a-z]+$")
+
+
+def _frame(**keys) -> dict:
+    """A `[frame]` mapping `instance.frame_of` really produced, from the TOML spellings.
+
+    Resolved rather than assembled, so what these tests read is what a committed
+    `charter.toml` would have produced — refusals included.
+    """
+    return instance.frame_of({"frame": keys})
+
+
+class TheThreeWordsAreCheckedWhereTheyEnter(unittest.TestCase):
+    """`instance.frame_of` — the boundary, and what a value charter cannot read costs.
+
+    **These are `[frame]` keys, so a word charter does not know degrades to the shipped
+    default and does not refuse the frame.** That is deliberate and it is the OTHER side of
+    #535's rule rather than a departure from it. #535 refuses an ARRANGEMENT whole because
+    a component silently missing reads as a plane with no clones — a frame that is missing
+    a pane looks like a machine that is missing repos, and no operator would suspect a
+    typo. A `rules` word charter cannot read costs the operator a rule drawn the shipped
+    way in a frame that is otherwise entirely intact, which is what every other key in this
+    section already does (`chrome`, `density`, `hotkey`) and what `frame_of`'s own contract
+    promises: a charter.toml charter cannot make sense of never stops charter from running.
+
+    #687 is the standing warning against the other direction — a refusal is wrong when the
+    value was in fact usable — and it applies here twice: `text = "brightblack"` and
+    `rules = "hidden"` are usable words, so what has to be got right is that they are
+    ACCEPTED, which is what the first tests below are about.
+    """
+
+    def test_the_shipped_frame_hides_its_rules_keeps_its_foreground_and_may_dim(self):
+        self.assertEqual(_SHIPPED, instance.Look(rules="hidden", text="default", dim=True))
+        self.assertEqual(instance.look_of(_frame()), _SHIPPED)
+
+    def test_every_word_the_vocabularies_name_is_accepted(self):
+        """#687's direction: the cost of refusing a word an operator meant is theirs, so
+        each vocabulary is asserted whole rather than by sampling one member."""
+        for word in instance.FRAME_RULES:
+            with self.subTest(rules=word):
+                self.assertEqual(instance.look_of(_frame(rules=word)).rules, word)
+        for word in instance.FRAME_PANE_FG:
+            with self.subTest(text=word):
+                self.assertEqual(instance.look_of(_frame(text=word)).text, word)
+        for flag in (True, False):
+            with self.subTest(dim=flag):
+                self.assertEqual(instance.look_of(_frame(dim=flag)).dim, flag)
+
+    def test_the_two_vocabularies_are_the_ones_the_operator_already_knows(self):
+        """`text` says the seventeen words `bg` says, and `rules` says two. A plane that
+        learned one table has learned the other, which is the whole reason `text` is not
+        spelled with numbers or hex."""
+        self.assertEqual(set(instance.FRAME_PANE_FG), set(instance.FRAME_PANE_BG))
+        self.assertEqual(instance.FRAME_RULES, ("hidden", "visible"))
+
+    def test_a_word_charter_does_not_know_leaves_the_frame_whole_and_shipped(self):
+        """Degrades, and only for the key that said it: the arrangement is not refused and
+        the two keys beside it are untouched."""
+        got = _frame(rules="invisible", text="tan", dim=True)
+        self.assertEqual(instance.look_of(got), _SHIPPED)
+        self.assertEqual(got["slots"], instance.FRAME_DEFAULTS["slots"],
+                         "an unreadable appearance word took the frame's shape with it")
+
+    def test_a_style_string_never_becomes_a_rule_or_a_foreground(self):
+        """The sharp reason these are closed enums rather than `isinstance(value, str)`.
+        A tmux style value is FORMAT-EXPANDED at draw time — measured on this very option,
+        `set -w pane-border-style 'bg=#{?#{==:1,1},colour196,colour46}'` is rc 0 and reaches
+        the wire as `ESC[48;5;196m` — and `charter.toml` arrives from someone else's
+        machine."""
+        hostile = "bg=#{?#{==:1,1},colour196,colour46}"
+        look = instance.look_of(_frame(rules=hostile, text=hostile))
+        self.assertEqual(look, _SHIPPED)
+        for surface in (None, "bg=brightblack"):
+            value = instance.rule_style(surface, commands_frame._CHROME_FG, look)
+            self.assertNotIn("#", value)
+        for _name, value in instance.surface_options("brightblack", "dark", look):
+            self.assertNotIn("#", value)
+
+    def test_a_value_of_the_wrong_type_is_refused_without_raising(self):
+        """`instance` is imported by every command including `charter --version`, so a
+        hand-edited file has to degrade rather than raise — and `tomllib` can hand this
+        key a list or a table, which is why the membership test is guarded by
+        `isinstance`."""
+        for value in (7, ["hidden"], {"a": 1}, True, None):
+            with self.subTest(value=value):
+                self.assertEqual(instance.look_of(_frame(rules=value, text=value)),
+                                 _SHIPPED)
+
+    def test_dim_refuses_an_int_the_way_every_bool_key_in_this_section_does(self):
+        """`isinstance(True, int)` is True in Python, so the type check is written both
+        ways round — `dim = 1` is not a `false` spelled oddly, it is a value charter
+        cannot read."""
+        for value in (1, 0, "false", "no"):
+            with self.subTest(value=value):
+                self.assertIs(instance.look_of(_frame(dim=value)).dim, True)
+
+    def test_the_toml_spellings_are_the_words_docs_frame_md_documents(self):
+        """One word each, so `docs/frame.md`'s hyphen rule (`history-limit`, never
+        `history_limit`) does not arise — and the underscore form is not a second,
+        undocumented alias, which is `FRAME_FIELDS`' own contract."""
+        for key in ("rules", "text", "dim"):
+            with self.subTest(key=key):
+                self.assertEqual(instance.FRAME_FIELDS[key][1], key)
+
+    def test_a_frame_relaunched_by_an_older_charter_still_answers(self):
+        """`look_of` reads with `.get` and the shipped default, for `component_style`'s own
+        reason: a frame whose record predates these keys is a real dict on a real disk, and
+        a panel repaint must not raise a `KeyError` into a pane."""
+        self.assertEqual(instance.look_of({}), _SHIPPED)
+        self.assertEqual(instance.look_of({"slots": ["top"], "chrome": "dark"}), _SHIPPED)
+
+
+class TheShippedRuleIsStillTheOneCharterAlwaysDrew(unittest.TestCase):
+    """The default's safety, asserted rather than argued: `hidden` changes nothing at all
+    for a plane that has no surface to hide a rule into.
+
+    That is what makes it a defensible default where `chrome`'s is `off`. The two are not
+    symmetric — `chrome = "dark"` would repaint a stranger's terminal, and a stranger's
+    terminal is the one thing charter cannot see — while `hidden` has an effect ONLY where
+    the plane has already written a `chrome` or a `bg` by hand, which is a plane that has
+    already said it wants panels rather than boxes.
+    """
+
+    def test_the_table_and_the_assembler_still_agree_about_the_shipped_style(self):
+        """`_CHROME_STYLE` is both the value a surfaceless frame carries and the MARKER
+        `_chrome_argvs` uses to find which of the five options are styles, so the day the
+        shipped `Look` changes this fails loudly instead of the marker quietly matching
+        nothing."""
+        self.assertEqual(
+            instance.rule_style(None, commands_frame._CHROME_FG, _SHIPPED),
+            commands_frame._CHROME_STYLE)
+
+    def test_a_surfaceless_frame_is_byte_identical_under_either_word(self):
+        for word in instance.FRAME_RULES:
+            with self.subTest(rules=word):
+                self.assertEqual(
+                    instance.rule_style(None, commands_frame._CHROME_FG,
+                                        instance.Look(word, "default", True)),
+                    commands_frame._CHROME_STYLE)
+
+    def test_a_text_colour_with_no_surface_still_reaches_the_rule(self):
+        """The arm no other case gets to: `chrome = "off"`, no `bg` anywhere, and a `text`
+        word. There is no background to hide a rule in, so `hidden` cannot apply and the
+        *visible* assembly runs — but the plane HAS said what colour its frame's text is,
+        and the rule is chrome drawn on the same panes. So it takes the foreground and the
+        `dim`, and no background clause at all.
+
+        Byte-identical to `_CHROME_STYLE` only when the plane named no foreground either,
+        which is what the case above pins. The two together are the whole of what a
+        surfaceless frame can carry."""
+        self.assertEqual(
+            instance.rule_style(None, commands_frame._CHROME_FG,
+                                instance.Look("hidden", "black", True)),
+            "fg=black,dim")
+        self.assertEqual(
+            instance.rule_style(None, commands_frame._CHROME_FG,
+                                instance.Look("hidden", "black", False)),
+            "fg=black")
+
+    def test_the_five_pinned_options_are_untouched_by_any_of_the_three_words(self):
+        """`hidden` decides a colour, `text` decides a colour and `dim` decides an
+        attribute. None of them is a line weight, an indicator or a border status — and
+        `pane-border-lines` has no `none` for one of them to reach for even if it wanted
+        to."""
+        # Read through `_chrome_values`, which is #716's own unpacking of a row that is
+        # three fields wide now — the floor decides which tmuxes are TOLD about an option
+        # and is a different question from what the option carries, so a version high
+        # enough to be told about all five is what these are asked at.
+        not_styles = [(n, v) for n, v in commands_frame._chrome_values().items()
+                      if v != commands_frame._CHROME_STYLE]
+        self.assertTrue(not_styles)
+        every_option = max(f for _n, _v, f in commands_frame._CHROME)
+        for look in (_SHIPPED, instance.Look("visible", "red", False)):
+            got = {a[-2]: a[-1] for a in commands_frame._chrome_argvs(
+                socket="s", harness_pane="%1", surface="bg=blue", look=look,
+                v=every_option)}
+            for name, value in not_styles:
+                with self.subTest(look=look, option=name):
+                    self.assertEqual(got[name], value)
+
+
+class TheSurfaceIsAlwaysABareBackgroundClause(unittest.TestCase):
+    """The property `instance.rule_style`'s `removeprefix("bg=")` rests on.
+
+    A hidden rule's foreground is the only value in the frame that is DERIVED from another
+    charter constant rather than looked up in a table, so the shape it derives from is
+    pinned here over both tables at once. A `window-style` entry that grew an `fg` or an
+    attribute would otherwise make `hidden` emit `fg=fg=black,bg=black`, which tmux refuses
+    — reported as one panel's rules failing to paint, in a call `tmuxctl.run` treats as
+    non-fatal.
+    """
+
+    def test_every_surface_charter_can_name_is_bg_and_one_word(self):
+        seen = 0
+        for table in (instance.FRAME_PANE_BG, instance.FRAME_CHROME):
+            for word, pairs in table.items():
+                for name, value in pairs:
+                    with self.subTest(word=word, option=name):
+                        self.assertRegex(value, _BARE_BG)
+                        seen += 1
+        self.assertGreater(seen, 30, "almost nothing was checked")
+
+    def test_the_foreground_table_is_the_mirror_of_it(self):
+        """`fg=` and one word, or nothing at all for `default` — which is not a hole: a
+        pane whose style names no `fg` already draws in the terminal's own foreground, so
+        the empty clause is what keeps a plane that says nothing byte-identical."""
+        self.assertEqual(instance.FRAME_PANE_FG["default"], "")
+        self.assertEqual(instance.text_fg("default"), "")
+        for word, clause in instance.FRAME_PANE_FG.items():
+            if word != "default":
+                with self.subTest(word=word):
+                    self.assertEqual(clause, f"fg={word}")
+
+
+class AHiddenRuleTakesTheSurfaceAndNeverAnAttribute(unittest.TestCase):
+    """`instance.rule_style` — the three decisions, one input each.
+
+    The value the operator hand-applied to their own live frame and confirmed is
+    `fg=brightblack,bg=brightblack`: the surface on both halves, and **no `dim`**. Every
+    arm below is reached by an input that reaches only it.
+    """
+
+    FG = commands_frame._CHROME_FG
+
+    def test_a_hidden_rule_over_a_colour_is_that_colour_twice(self):
+        for word in instance.FRAME_PANE_BG:
+            surface = dict(instance.FRAME_PANE_BG[word])["window-style"]
+            if surface == "bg=default":
+                continue
+            with self.subTest(bg=word):
+                self.assertEqual(
+                    instance.rule_style(surface, self.FG, _SHIPPED),
+                    f"fg={surface.removeprefix('bg=')},{surface}")
+
+    def test_hidden_never_appends_dim_even_where_the_plane_left_it_on(self):
+        """The attribute is dropped by the ARM and not by the `dim` key: an invisible glyph
+        made visibly something is not what the word asked for, and the style the operator
+        confirmed carries no attribute."""
+        self.assertNotIn(
+            "dim", instance.rule_style("bg=blue", self.FG,
+                                       instance.Look("hidden", "default", True)))
+
+    def test_a_hidden_rule_over_the_terminals_own_background_stays_visible(self):
+        """**`bg=default` is a real committed arrangement**, not a defensive case: it is
+        the seventeenth `FRAME_PANE_BG` word and a component names it to opt one pane out
+        of a frame-wide `chrome`. It means "the terminal's own background", and there is no
+        `fg=` spelling for that — `fg=default` is the terminal's own FOREGROUND, the one
+        colour guaranteed to be visible against it. Honouring `hidden` there would draw the
+        rule at FULL strength, brighter than the `dim` it replaced, which is the opposite of
+        the word. So it falls through, and the input that reaches this arm reaches no
+        other."""
+        self.assertEqual(instance.rule_style("bg=default", self.FG, _SHIPPED),
+                         f"{self.FG},dim,bg=default")
+
+    def test_a_visible_rule_is_the_frames_foreground_dimmed_over_the_surface(self):
+        self.assertEqual(
+            instance.rule_style("bg=brightblack", self.FG,
+                                instance.Look("visible", "default", True)),
+            f"{self.FG},dim,bg=brightblack")
+
+    def test_a_visible_rule_takes_the_planes_own_text_colour_where_it_named_one(self):
+        """A frame whose panes carry a foreground draws its rules in it rather than in a
+        colour nothing else on the screen is wearing — `border_bg`'s argument about the
+        background, said one clause over. The input reaches only this arm: `text` changes
+        nothing under `hidden`, where the foreground is the surface's."""
+        self.assertEqual(
+            instance.rule_style("bg=brightblack", self.FG,
+                                instance.Look("visible", "black", True)),
+            "fg=black,dim,bg=brightblack")
+        self.assertEqual(
+            instance.rule_style("bg=brightblack", self.FG,
+                                instance.Look("hidden", "black", True)),
+            "fg=brightblack,bg=brightblack",
+            "a `text` colour leaked into a rule that is supposed to be invisible")
+
+    def test_dim_off_drops_the_attribute_and_touches_nothing_else(self):
+        """The one input that reaches this arm and no other, on both sides of the surface
+        question — and the reason `[frame] dim` is a frame-wide word rather than a text
+        one: `fg=default` at full strength is the operator's own foreground, so it is the
+        only way to make the frame's own separation louder that cannot be wrong on a theme
+        charter cannot see."""
+        loud = instance.Look("visible", "default", False)
+        self.assertEqual(instance.rule_style(None, self.FG, loud), self.FG)
+        self.assertEqual(instance.rule_style("bg=blue", self.FG, loud),
+                         f"{self.FG},bg=blue")
+
+    def test_a_word_that_is_not_hidden_draws_the_visible_rule(self):
+        """`rule_style` compares against a constant rather than validating, because the
+        word selects a BRANCH and is not a value that reaches tmux. `frame_of` is the
+        boundary; a word that got past nothing still cannot be `"hidden"`."""
+        for word in ("Hidden", "hide", "", None, 7):
+            with self.subTest(rules=word):
+                self.assertEqual(
+                    instance.rule_style("bg=blue", self.FG,
+                                        instance.Look(word, "default", True)),
+                    f"{self.FG},dim,bg=blue")
+
+
+class TheForegroundIsPaintedByTmuxAndNotByARenderer(unittest.TestCase):
+    """`instance.surface_options` — one key, every cell, and no renderer told anything.
+
+    `window-style` carries an `fg` exactly as it carries a `bg`, and tmux resolves a pane's
+    DEFAULT foreground from it — so charter's own `ESC[0m` returns to the plane's colour
+    rather than the terminal's, and the forty `statusline._DIM` call sites in
+    `frame/slots.py` and a provider's component alike are covered without being asked. The
+    rendering that makes that true is measured in
+    `tests/test_a_planes_frame_really_reads_that_way.py`.
+    """
+
+    def test_a_plane_that_named_no_foreground_emits_exactly_what_it_did_before(self):
+        for bg in (None, "brightblack", "nonsense"):
+            for level in instance.FRAME_CHROME:
+                with self.subTest(bg=bg, chrome=level):
+                    self.assertEqual(
+                        instance.surface_options(bg, level, _SHIPPED),
+                        instance.pane_bg_options(bg) or instance.chrome_options(level))
+
+    def test_the_foreground_joins_the_background_on_both_options(self):
+        """Both, always — a pane whose two differed would show one colour focused and
+        another unfocused, which is `pane_bg_options`' own rule about the background."""
+        got = dict(instance.surface_options("brightblack", "off",
+                                            instance.Look("hidden", "black", True)))
+        self.assertEqual(got, {"window-style": "fg=black,bg=brightblack",
+                               "window-active-style": "fg=black,bg=black"})
+
+    def test_a_foreground_with_no_surface_at_all_is_still_written(self):
+        """`chrome = "off"`, no `bg` anywhere, `text = "black"`: a real arrangement. There
+        is no background to paint and the plane has still said what colour its frame's text
+        is, so the two style options carry the foreground alone."""
+        self.assertEqual(
+            dict(instance.surface_options(None, "off",
+                                          instance.Look("hidden", "black", True))),
+            {name: "fg=black" for name in instance.chrome_option_names()})
+
+    def test_a_plane_that_said_neither_writes_nothing(self):
+        self.assertEqual(instance.surface_options(None, "off", _SHIPPED), ())
+
+    def test_no_operator_string_reaches_a_pane_style(self):
+        """The containment on both halves: the background comes out of `FRAME_PANE_BG` or
+        `FRAME_CHROME` as it always did, and the foreground out of `FRAME_PANE_FG`, each
+        indexed by a word that was only ever a key."""
+        allowed = {v for pairs in instance.FRAME_PANE_BG.values() for _n, v in pairs}
+        allowed |= {v for pairs in instance.FRAME_CHROME.values() for _n, v in pairs}
+        allowed |= set(instance.FRAME_PANE_FG.values())
+        for word in (*instance.FRAME_PANE_FG, "colour236", "chartreuse", None, 7,
+                     "fg=#{?#{==:1,1},colour196,colour46}", ["blue"], True):
+            with self.subTest(text=word):
+                pairs = instance.surface_options("brightblack", "dark",
+                                                 instance.Look("hidden", word, True))
+                self.assertTrue(pairs)
+                for _name, value in pairs:
+                    self.assertNotIn("#", value)
+                    for clause in value.split(","):
+                        self.assertIn(clause, allowed)
+
+    def test_the_rule_reads_the_background_and_not_the_whole_surface(self):
+        """`pane_border_options` resolves its colour off `pane_bg_options(bg) or
+        chrome_options(chrome)` and never off `surface_options`, and the difference is
+        load-bearing rather than an oversight: a rule resolved off a pane style that
+        already carries the plane's `text` would come out with two foregrounds in it."""
+        look = instance.Look("visible", "red", True)
+        for _name, value in instance.pane_border_options("brightblack", "dark",
+                                                         commands_frame._CHROME_FG, look):
+            with self.subTest(value=value):
+                self.assertEqual(value.count("fg="), 1)
+                self.assertEqual(value, "fg=red,dim,bg=brightblack")
+
+    def test_no_colour_refuses_the_foreground_with_the_background(self):
+        """A `text` word IS a colour charter was asked to paint, so it goes with the
+        surface rather than surviving beside it — and on the live path that means the
+        unsets rather than silence, because a frame surfaced before `NO_COLOR` was exported
+        has values to remove."""
+        look = instance.Look("hidden", "black", True)
+        with mock.patch.dict(os.environ, {"NO_COLOR": ""}, clear=True):
+            self.assertEqual(
+                commands_frame._surface_argvs(socket="s", pane_id="%3", chrome="off",
+                                              bg=None, look=look), [])
+            tails = [a[a.index("set-option"):] for a in commands_frame._resurface_argvs(
+                socket="s", pane_id="%3", chrome="off", bg=None, look=look)]
+            for name in instance.chrome_option_names():
+                self.assertIn(["set-option", "-p", "-u", "-t", "%3", name], tails)
+
+    def test_the_live_path_sets_the_foreground_where_the_launch_path_does(self):
+        """`_surface_argvs` and `_resurface_argvs` resolve the pane through the same
+        expression, which is why `look` is a parameter of both rather than something either
+        looks up: a pane painted one way at launch and another way on a palette keypress is
+        #547's shape on a surface the operator can see."""
+        look = instance.Look("hidden", "black", True)
+        kw = dict(socket="s", pane_id="%3", chrome="dark", bg="brightblack", look=look)
+        with mock.patch.dict(os.environ, {}, clear=True):
+            launch = {a[-2]: a[-1] for a in commands_frame._surface_argvs(**kw)}
+            live = {a[-2]: a[-1] for a in commands_frame._resurface_argvs(**kw)
+                    if "-u" not in a}
+        self.assertEqual(launch, live)
+        self.assertEqual(launch["window-style"], "fg=black,bg=brightblack")
+
+
+class DimIsDeletedFromTheFinishedRow(unittest.TestCase):
+    """`chrome.undim` — the property is the NUMBER and the position, not the spelling.
+
+    `chrome.resets_everything`'s lesson, applied to a different parameter. The extra hazard
+    here is that **2 is also a colour SPACE**: `ESC[38;2;255;0;0m` is a 24-bit foreground,
+    and a pass that filtered every 2 out of a parameter list would turn it into
+    `ESC[38;255;0;0m` and hand a terminal a colour nobody asked for. Charter writes no such
+    escape — `FRAME_PANE_COLOURS` argues at length why it names the sixteen — which is
+    exactly what makes the case real: this runs on a row a PROVIDER's component finished,
+    and `tui.sanitize` passes any `ESC[<digits and semicolons>m` through untouched.
+    """
+
+    def test_every_spelling_of_dim_goes_and_nothing_beside_it_does(self):
+        for row, want in (("\x1b[2mDIM\x1b[0m", "DIM\x1b[0m"),
+                          ("\x1b[02mx", "x"),
+                          ("\x1b[1;2mx", "\x1b[1mx"),
+                          ("\x1b[2;32mx", "\x1b[32mx"),
+                          ("\x1b[22;2;35mx", "\x1b[22;35mx"),
+                          ("\x1b[7m\x1b[2m\x1b[0m", "\x1b[7m\x1b[0m")):
+            with self.subTest(row=row):
+                self.assertEqual(chrome.undim(row), want)
+
+    def test_a_colour_space_of_two_is_a_colour_and_not_an_attribute(self):
+        for row in ("\x1b[38;2;255;0;0mRED\x1b[0m", "\x1b[48;2;0;0;0mBG",
+                    "\x1b[58;2;1;2;3mUL", "\x1b[38;5;196mx", "\x1b[38;5;2mx"):
+            with self.subTest(row=row):
+                self.assertEqual(chrome.undim(row), row)
+
+    def test_a_dim_after_a_true_colour_is_still_deleted(self):
+        """The walk has to resume at the right place, or the sub-parameters swallow the
+        attribute that follows them."""
+        self.assertEqual(chrome.undim("\x1b[48;2;0;0;0;2mBG"), "\x1b[48;2;0;0;0mBG")
+
+    def test_an_escape_that_emptied_is_removed_rather_than_reset(self):
+        """`ESC[m` is an SGR with an omitted parameter, and an omitted parameter takes
+        SGR's default of ZERO — so emitting it for a `ESC[2m` that had nothing else in it
+        would replace "turn dim on" with "turn everything off", cancelling the colour of
+        whatever span the row was in the middle of."""
+        self.assertEqual(chrome.undim("\x1b[32ma\x1b[2mb\x1b[0m"),
+                         "\x1b[32mab\x1b[0m")
+        self.assertNotIn("\x1b[m", chrome.undim("\x1b[2mb"))
+
+    def test_a_reset_inside_the_list_survives_the_deletion(self):
+        """`ESC[2;m` really did carry a reset, and the reset is not dim's to take with
+        it."""
+        self.assertEqual(chrome.undim("\x1b[2;mx"), "\x1b[mx")
+
+    def test_it_deletes_and_never_substitutes(self):
+        """Honest to run over a row charter did not write: it removes an instruction to
+        reduce contrast and leaves every colour the component chose exactly where it put
+        it. A pass that remapped a provider's green would be charter deciding what somebody
+        else's component means."""
+        row = "\x1b[35m▸ \x1b[1mname\x1b[0m \x1b[2m47\x1b[0m \x1b[32mok\x1b[0m"
+        got = chrome.undim(row)
+        for span in ("\x1b[35m", "\x1b[1m", "\x1b[32m", "\x1b[0m"):
+            self.assertIn(span, got)
+        self.assertNotIn("\x1b[2m", got)
+
+    def test_a_row_with_no_escape_at_all_comes_back_unchanged(self):
+        for row in ("", "plain text", "  ⋯ gathering"):
+            with self.subTest(row=row):
+                self.assertIs(chrome.undim(row), row)
+
+    def test_it_changes_no_cell_of_width(self):
+        """Every SGR costs zero columns, so this only ever makes one shorter or removes
+        it — which is what lets it run AFTER `chrome.fill` clamped the row to the pane."""
+        from charter import tui
+        for row in ("\x1b[2mDIM\x1b[0m two", "\x1b[1;2mboth\x1b[0m",
+                    "\x1b[38;2;9;9;9mtrue\x1b[0m"):
+            with self.subTest(row=row):
+                self.assertEqual(tui.width(chrome.undim(row)), tui.width(row))
+
+
+class TheDimKeyReachesEveryRowAndNoColourStillWins(PersonaIso, unittest.TestCase):
+    """`chrome.dim_ok`, `chrome.recipes` and `panel._write` — one reading, three sites.
+
+    **`NO_COLOR` keeps winning and nothing here adds a second reading of it.**
+    `chrome.no_colour` is still the one place that variable is read; `dim_ok` is a
+    different question about a different input, and the two meet in exactly one ordering:
+    no colour empties every SGR role including this one, so a plane that turned dim off and
+    an operator who turned colour off do not fight — the second is a superset of the first.
+    """
+
+    def _look(self, **keys) -> dict:
+        return {**config.FRAME, **_frame(**keys)}
+
+    def test_recipes_empties_the_muted_role_and_leaves_the_others_alone(self):
+        with mock.patch.object(chrome, "colour_ok", return_value=True):
+            with mock.patch.dict(config.FRAME, self._look(dim=False)):
+                off = dict(chrome.recipes())
+            with mock.patch.dict(config.FRAME, self._look(dim=True)):
+                on = dict(chrome.recipes())
+        self.assertEqual(on["muted"], "\033[2m")
+        self.assertEqual(off["muted"], "")
+        self.assertEqual({k: v for k, v in off.items() if k != "muted"},
+                         {k: v for k, v in on.items() if k != "muted"})
+
+    def test_it_is_asked_as_the_property_and_not_by_the_roles_name(self):
+        """`undim` is run over the values, so a role added with a dim in it is covered on
+        the day it is added rather than being the one that still reduces contrast on a
+        plane that asked charter not to."""
+        with mock.patch.object(chrome, "colour_ok", return_value=True), \
+                mock.patch.object(chrome, "_role_values",
+                                  return_value={"muted": "\033[2m",
+                                                "footnote": "\033[2;35m"}), \
+                mock.patch.dict(config.FRAME, self._look(dim=False)):
+            got = dict(chrome.recipes())
+        self.assertEqual(got["footnote"], "\033[35m")
+
+    def test_no_colour_empties_every_role_whichever_way_dim_is_set(self):
+        for flag in (True, False):
+            with self.subTest(dim=flag):
+                with mock.patch.dict(os.environ, {"NO_COLOR": ""}, clear=True), \
+                        mock.patch.dict(config.FRAME, self._look(dim=flag)):
+                    got = dict(chrome.recipes())
+                self.assertEqual({k: v for k, v in got.items() if k != "inset"},
+                                 {k: "" for k in chrome._role_values()})
+
+    def test_the_inset_survives_both_because_two_spaces_are_not_colour(self):
+        """A frame that lost its inset under either key would be answering a question about
+        colour with a change to LAYOUT — `recipes`' own rule, restated for the second
+        key."""
+        for env in ({}, {"NO_COLOR": ""}):
+            for flag in (True, False):
+                with self.subTest(no_color=bool(env), dim=flag):
+                    with mock.patch.dict(os.environ, env, clear=True), \
+                            mock.patch.dict(config.FRAME, self._look(dim=flag)):
+                        self.assertTrue(chrome.recipes()["inset"].strip() == "")
+                        self.assertTrue(chrome.recipes()["inset"])
+
+    def test_turning_dim_off_does_not_make_a_providers_dim_print_as_text(self):
+        """**The seam between this key and #722, and it is the one that could bite.**
+
+        `chrome.served_params` decides which escapes in a FOREIGN pane's row survive
+        `contain_row` and which are escaped into visible text — #707 was a provider's
+        colour arriving in its pane as `^[[32m`. It is derived from `_role_values`, which
+        this key does not touch, so SGR 2 stays admitted whatever the plane said and a
+        provider's dim is deleted on the way out rather than printed on the way in.
+
+        Derived from `recipes()` instead — which is the obvious other wiring, and the one
+        that reads as tidier — `dim = false` would have re-opened #707 for exactly one
+        parameter: a component's own `ESC[2m` escaped into its pane as four characters of
+        garbage, on the planes that had asked for less visual noise. The two questions are
+        different and the layering is what keeps them apart: admission is about charter's
+        VOCABULARY, and `[frame] dim` is about whether the frame spends it."""
+        for flag in (True, False):
+            with self.subTest(dim=flag):
+                with mock.patch.dict(config.FRAME, self._look(dim=flag)):
+                    self.assertIn(2, chrome.served_params())
+                    self.assertTrue(chrome.is_recipe("2", chrome.served_params()))
+
+    def _painted(self, text: str, *, frame: dict, env: dict) -> str:
+        out = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(io.StringIO()):
+            # The pane's own descriptor answers the colour question (`frame/pane.py`,
+            # #606), never `sys.stdout` — which under `redirect_stdout` is a `StringIO`
+            # with no terminal behind it. Patched at that seam rather than at
+            # `chrome.colour_ok`, so the `NO_COLOR` branch below is the real one.
+            with mock.patch.object(pane, "is_tty", return_value=True), \
+                    mock.patch.object(sys.stdout, "fileno", return_value=1,
+                                      create=True), \
+                    mock.patch("os.get_terminal_size",
+                               return_value=os.terminal_size((40, 6))), \
+                    mock.patch.dict(os.environ, env, clear=True), \
+                    mock.patch.dict(config.FRAME, frame):
+                panel._write(text)
+        return out.getvalue()
+
+    def test_the_panel_strips_dim_from_every_row_it_paints(self):
+        """The siting is the whole of why one key reaches the whole frame: `_write` is the
+        one place anything reaches a pane's screen, so charter's own renderers and a
+        provider's component are covered by the same answer and neither has to ask."""
+        rows = "\x1b[2mmuted\x1b[0m\n\x1b[32mok\x1b[0m \x1b[1;2mboth\x1b[0m"
+        got = self._painted(rows, frame=self._look(dim=False), env={})
+        self.assertNotIn("\x1b[2m", got)
+        self.assertNotIn("\x1b[1;2m", got)
+        self.assertIn("\x1b[1m", got)
+        self.assertIn("\x1b[32m", got)
+        self.assertIn("muted", got)
+
+    def test_a_plane_that_left_dim_on_is_painted_byte_for_byte_as_before(self):
+        rows = "\x1b[2mmuted\x1b[0m"
+        self.assertIn("\x1b[2mmuted", self._painted(rows, frame=self._look(dim=True),
+                                                    env={}))
+
+    def test_no_colour_still_takes_everything_including_the_dim(self):
+        """The ordering, asserted: the strip is unreachable under `NO_COLOR` rather than
+        skipped by it, and what an operator gets is the same pane either way."""
+        rows = "\x1b[2mmuted\x1b[0m \x1b[32mok\x1b[0m"
+        for flag in (True, False):
+            with self.subTest(dim=flag):
+                got = self._painted(rows, frame=self._look(dim=flag),
+                                    env={"NO_COLOR": ""})
+                self.assertNotIn("\x1b[", got.split("\x1b[2J", 1)[1])
+                self.assertIn("muted ok", got)

--- a/tests/test_a_planes_frame_really_reads_that_way.py
+++ b/tests/test_a_planes_frame_really_reads_that_way.py
@@ -1,0 +1,401 @@
+"""What tmux really does with the values `[frame] rules`, `[frame] text` and `[frame] dim`
+produce — read off an attached client's wire, on this machine, at this moment.
+
+**A pane border belongs to no pane, so `capture-pane` cannot see one**, and a pane's
+DEFAULT foreground is not in the pane's content either — both are composed by tmux for the
+client, at draw time. So the frame is rendered inside a second tmux: an OUTER server holds
+one pane whose program is a client attached to the INNER server, which makes that pane's
+content the frame's whole screen, borders and default cells included. `capture-pane -e -N`
+on the outer pane then hands it back with the escapes still attached. That is
+`test_frame_tmux_integration.py`'s `ChromeIsOneColour` harness, kept small here because
+these tests need one panel rather than charter's whole shape.
+
+**Every test renders the control first.** "The rule is invisible" is equally satisfied by a
+machine that rendered no rule at all, and "the text is black" by a machine that rendered no
+text — so each measurement is taken twice, once with the word and once without, and a
+machine whose two readings agree SKIPS rather than passing quietly.
+
+**And this file is where the third question is answered.** Charter cannot ship a coloured
+frame as its default, because it cannot see the terminal (`[frame] chrome`'s own recorded
+reasoning: OSC 11 through tmux answers nothing and `$COLORTERM` inside a pane describes the
+terminal that started the SERVER). The obvious way out is an attribute rather than a
+colour — `reverse` swaps whatever the operator's own two colours are, so it is right on
+every theme, and tmux's own status line is reverse by default. `NoAttributeInAPaneStyle
+ReachesTheWire` is the measurement that closes that door: tmux ACCEPTS every attribute in a
+`window-style`, stores it, reads it back verbatim, and puts **nothing at all** on the wire
+for it. Measured here on both 3.7c and at `tmuxctl.FLOOR`, which is the same answer
+`frame/chrome.py`'s `recipes` recorded for a different phase and is now asserted rather
+than remembered.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import time
+import unittest
+from pathlib import Path
+
+from charter import commands_frame, instance
+from charter.frame import tmuxctl
+from tests import _tmuxreap
+from tests._isolation import PersonaIso
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: The tmux this repo builds to measure its own floor against — `docs/frame.md` and
+#: `test_frame_surface_live.py`'s module docstring both name it. Absent on CI, which
+#: installs no tmux at all, so every floor test here skips there and says so.
+_FLOOR_BIN = Path.home() / ".local/share/charter-testing" / f"tmux-{tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]}"
+
+#: One SGR escape as it comes back out of `capture-pane -e`.
+_SGR = re.compile(r"\x1b\[([0-9;]*)m")
+
+#: A row of the box-drawing glyph tmux draws a horizontal rule with under
+#: `pane-border-lines single` — the one charter pins.
+_RULE_GLYPH = "─"
+
+
+#: The SGR parameters that SET a foreground and a background to one of the sixteen — the
+#: two ranges each, and the codes are ten apart by construction (ECMA-48 §8.3.117/118: 30-37
+#: and 40-47, and the aixterm bright pair 90-97 and 100-107). That ten is what lets a test
+#: say "the glyph is the colour it is sitting in" without naming a colour.
+_FG_CODES = frozenset({*range(30, 38), *range(90, 98)})
+_BG_CODES = frozenset({*range(40, 48), *range(100, 108)})
+
+#: How far a background code sits above its own foreground code.
+_FG_TO_BG = 10
+
+
+def _colour_pair(params: list[str]) -> tuple[int | None, int | None]:
+    """The foreground and background codes *params* leaves in effect, or ``None`` each.
+
+    **Asked as a pair of codes rather than as a string, because the string is the machine's
+    and the property is charter's.** Nesting one tmux inside another downsamples: at
+    `tmuxctl.FLOOR` the outer client's own `default-terminal` renders this harness's
+    `brightblack` as ``ESC[30m``/``ESC[40m`` rather than ``ESC[90m``/``ESC[100m``. Both
+    readings say the same thing about charter — the glyph is the colour of the cell it sits
+    in — and only one of them survives being spelled out, which is exactly the
+    spelling-not-property mistake `frame/chrome.py` is written about.
+    """
+    fg = bg = None
+    for group in params:
+        for piece in group.split(";"):
+            value = int(piece or "0")
+            if value in _FG_CODES:
+                fg = value
+            elif value in _BG_CODES:
+                bg = value
+            elif value == 0:
+                fg = bg = None
+    return fg, bg
+
+
+def _sgr_before(shot: str, needle: str) -> list[str]:
+    """The SGR parameter lists in effect on the shot line that holds *needle*.
+
+    Line-scoped, because `capture-pane -e` restates a line's attributes at its start: the
+    escapes that matter for a cell are the ones on its own line, and reading across lines
+    would attribute a neighbour's paint to it.
+    """
+    for line in shot.split("\n"):
+        if needle in line:
+            return [m.group(1) for m in _SGR.finditer(line.split(needle, 1)[0])]
+    return []
+
+
+class _NestedClient(PersonaIso):
+    """An inner tmux showing a harness pane and one panel, seen through an outer one."""
+
+    #: Overridden by the floor class.
+    BIN = "tmux"
+
+    def setUp(self) -> None:
+        super().setUp()
+        if not _HAS_TMUX:
+            self.skipTest("no tmux on this machine, so there is no frame to look at")
+        # **The binary is part of the socket name, and that is a defect this harness had
+        # rather than belt-and-braces.** `TheFloorAnswersIdentically` subclasses the 3.7c
+        # class and changes only `BIN`, so with a name built from the pid alone both would
+        # reach for the same `/tmp/tmux-<uid>/<name>` — and a tmux 3.2 client cannot talk
+        # to a 3.7c server that is still winding down from the previous test. Observed as
+        # eight of fifteen failing on one run and none on the next, which is the signature
+        # `#713` and `#719` both chased in the neighbouring harness. One socket per
+        # binary per process, so the two versions never meet.
+        tag = Path(self.BIN).name
+        self._inner = _tmuxreap.name(f"frame-reads-in-{tag}")
+        self._outer = _tmuxreap.name(f"frame-reads-out-{tag}")
+        self.addCleanup(self._teardown)
+
+    def _teardown(self) -> None:
+        for socket in (self._outer, self._inner):
+            self._tmux(socket, "kill-server")
+            (Path("/tmp") / f"tmux-{os.getuid()}" / socket).unlink(missing_ok=True)
+
+    def _tmux(self, socket: str, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run([self.BIN, "-L", socket, *args],
+                              capture_output=True, text=True, timeout=20)
+
+    def _shot(self, *, window_style: str | None, border_style: str | None,
+              text: str = "PLAIN one") -> str:
+        """Render one harness pane above one panel and return the outer pane's capture.
+
+        *window_style* is set pane-scoped on the PANEL alone, exactly as `_surface_argvs`
+        sets it — the harness pane is never an argument, which is ADR 0018's boundary held
+        by construction here as it is in production.
+        """
+        # Counted, never hashed: `hash()` is salted per process and taking it modulo
+        # anything can hand two different styles the same session name on one server.
+        self._session_seq = getattr(self, "_session_seq", 0) + 1
+        session = f"s{self._session_seq}"
+        r = self._tmux(self._inner, "new-session", "-d", "-s", session,
+                       "-x", "60", "-y", "12", "--", "cat")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness = self._tmux(self._inner, "list-panes", "-t", session,
+                             "-F", "#{pane_id}").stdout.strip()
+        self._tmux(self._inner, "set", "-t", session, "status", "off")
+        # `pane-border-lines single` is charter's own pin and the reason the glyph below is
+        # the one this file looks for. `pane-border-indicators` does not exist at the
+        # floor, so it is set where it exists and skipped where it does not — production
+        # issues it either way and `tmuxctl.run` reports the failure without refusing.
+        for name, value in (("pane-border-lines", "single"),
+                            ("pane-border-status", "off")):
+            self._tmux(self._inner, "set", "-w", "-t", harness, name, value)
+        if border_style is not None:
+            for name in instance.PANE_BORDER_OPTIONS:
+                self.assertEqual(
+                    self._tmux(self._inner, "set", "-w", "-t", harness, name,
+                               border_style).returncode, 0, border_style)
+        panel = self._tmux(self._inner, "split-window", "-t", harness, "-v",
+                           "-P", "-F", "#{pane_id}", "-l", "4", "--",
+                           "sh", "-c", f'printf "{text}\\r\\n"; cat').stdout.strip()
+        if window_style is not None:
+            for name in instance.chrome_option_names():
+                self.assertEqual(
+                    self._tmux(self._inner, "set", "-p", "-t", panel, name,
+                               window_style).returncode, 0, window_style)
+        self._tmux(self._inner, "select-pane", "-t", harness)
+        host = f"h{session}"
+        self.assertEqual(
+            self._tmux(self._outer, "new-session", "-d", "-s", host, "-x", "60", "-y", "12",
+                       "--", self.BIN, "-L", self._inner, "attach", "-t", session
+                       ).returncode, 0)
+        self._tmux(self._outer, "set", "-t", host, "status", "off")
+        shot = ""
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            # `-N` keeps the trailing spaces, and without it a painted pane is invisible to
+            # this harness: the panel writes one line and tmux fills the rest with spaces,
+            # which `capture-pane` trims — taking the paint's own SGR with them.
+            got = self._tmux(self._outer, "capture-pane", "-p", "-e", "-N", "-t", host)
+            if got.returncode == 0:
+                shot = got.stdout
+            if text in shot and _RULE_GLYPH in shot:
+                break
+            time.sleep(0.1)
+        self._tmux(self._outer, "kill-session", "-t", host)
+        self._tmux(self._inner, "kill-session", "-t", session)
+        if _RULE_GLYPH not in shot:
+            self.skipTest("this machine rendered no pane border through a nested client, "
+                          "so there is nothing here to measure the colour of")
+        return shot
+
+
+class TheHiddenRuleIsDrawnAndCannotBeSeen(_NestedClient, unittest.TestCase):
+    """`[frame] rules = "hidden"` — the shipped default, rendered.
+
+    tmux always paints a glyph on a border cell, so the seam the operator reported four
+    times cannot be removed by asking for fewer characters. It is removed by giving the
+    glyph the colour it is sitting in — which is exactly the style they hand-applied to
+    their own live frame and confirmed, `fg=brightblack,bg=brightblack`, and which
+    `instance.rule_style` now composes from the word.
+    """
+
+    #: The surface the operator's own plane wears on every panel.
+    SURFACE = "bg=brightblack"
+
+    def _rule_sgr(self, border_style: str) -> list[str]:
+        shot = self._shot(window_style=self.SURFACE, border_style=border_style)
+        return _sgr_before(shot, _RULE_GLYPH)
+
+    def test_the_seam_the_operator_reported_really_does_render(self):
+        """The control, and the reason it is not decoration: without it "the fixed rule is
+        the surface's colour" is satisfied by a machine that rendered no colour at all."""
+        params = self._rule_sgr(instance.rule_style(
+            self.SURFACE, commands_frame._CHROME_FG,
+            instance.Look("visible", "default", True)))
+        self.assertIn("2", params,
+                      f"the dim that IS the seam never reached the wire: {params}")
+
+    def test_the_shipped_rule_puts_the_surface_on_the_glyph_as_well(self):
+        """`ESC[90m` on `ESC[100m`: `brightblack` foreground on `brightblack` background,
+        so tmux draws the glyph and there is nothing to see. Asserted as the two SGR
+        parameters rather than as a string, because what an operator looks at is the
+        colour pair and not charter's spelling of it."""
+        params = self._rule_sgr(instance.rule_style(
+            self.SURFACE, commands_frame._CHROME_FG, instance.SHIPPED_LOOK))
+        fg, bg = _colour_pair(params)
+        self.assertIsNotNone(fg, f"the glyph did not take a colour at all: {params}")
+        self.assertIsNotNone(bg, f"the rule lost its background: {params}")
+        self.assertEqual(bg, fg + _FG_TO_BG,
+                         f"the glyph is not the colour it is sitting in: {params}")
+        self.assertNotIn("2", params, f"an attribute survived `hidden`: {params}")
+
+    def test_the_two_renderings_really_are_different(self):
+        """The control and the fix, side by side — a machine whose readings agree has
+        measured nothing, and says so rather than passing."""
+        visible = self._rule_sgr(instance.rule_style(
+            self.SURFACE, commands_frame._CHROME_FG,
+            instance.Look("visible", "default", True)))
+        hidden = self._rule_sgr(instance.rule_style(
+            self.SURFACE, commands_frame._CHROME_FG, instance.SHIPPED_LOOK))
+        if visible == hidden:
+            self.skipTest(f"this tmux renders both rules identically ({visible}), so "
+                          "there is no difference here to attribute to the word")
+        self.assertNotEqual(visible, hidden)
+
+
+class TheFrameSTextIsThePanesOwnDefault(_NestedClient, unittest.TestCase):
+    """`[frame] text` — one key, every cell, and no renderer told anything.
+
+    The whole design rests on one property of tmux: a `window-style` carries an `fg` as
+    well as a `bg`, and tmux resolves the pane's DEFAULT foreground from it. If that were
+    false, `text` would have to be a substitution over forty `statusline._DIM` call sites
+    in `frame/slots.py` plus whatever a provider's component writes. It is true, on 3.7c
+    and at the floor, which is what these read off the wire.
+    """
+
+    def test_a_pane_with_only_a_background_leaves_the_foreground_the_terminals(self):
+        """The control: with no `fg` in the style, nothing on the panel's line names a
+        foreground colour, so the operator's own is what draws it."""
+        fg, bg = _colour_pair(_sgr_before(self._shot(window_style="bg=brightblack",
+                                                     border_style=None), "PLAIN one"))
+        self.assertIsNotNone(bg, "the pane was not painted at all")
+        self.assertIsNone(fg, f"a foreground appeared from nowhere: {fg}")
+
+    def test_a_pane_that_names_a_foreground_draws_its_text_in_it(self):
+        """`ESC[30m` beside the `ESC[100m`: the plane's word, on text no renderer coloured.
+        This is what makes one frame-wide key reach every uncoloured cell in the frame."""
+        style = dict(instance.surface_options(
+            "brightblack", "off", instance.Look("hidden", "black", True)))["window-style"]
+        fg, bg = _colour_pair(_sgr_before(self._shot(window_style=style,
+                                                     border_style=None), "PLAIN one"))
+        self.assertIsNotNone(fg, "the plane's foreground never reached a cell")
+        self.assertIsNotNone(bg, "the background went with it")
+        self.assertNotEqual(bg, fg + _FG_TO_BG,
+                            "the text came out the colour of its own background")
+
+    def test_charters_own_reset_returns_to_the_planes_colour_and_not_the_terminals(self):
+        """The half that makes it work without touching a renderer. Charter writes
+        `statusline._R` — a full `ESC[0m` — after every coloured span, and if that returned
+        to the TERMINAL's foreground the plane's word would apply only to the cells nobody
+        wrote. It does not: tmux re-states the pane's own default after the reset."""
+        style = dict(instance.surface_options(
+            "brightblack", "off", instance.Look("hidden", "black", True)))["window-style"]
+        shot = self._shot(window_style=style, border_style=None,
+                          text="\\033[32mGREEN\\033[0m AFTER")
+        params = _sgr_before(shot, "AFTER")
+        self.assertIsNotNone(
+            _colour_pair(params)[0],
+            f"a reset inside the pane went back to the terminal's own foreground, so the "
+            f"plane's word would cover only the cells no renderer wrote: {params}")
+
+
+class NoAttributeInAPaneStyleReachesTheWire(_NestedClient, unittest.TestCase):
+    """**The third question, answered by measurement: `reverse` cannot be the default.**
+
+    A default surface has to be theme-independent, because charter cannot see the theme.
+    `reverse` is the one candidate that is — it swaps whatever the operator's own two
+    colours are, so a reversed panel is distinct from the work area on every theme, and
+    tmux's own status line has used it forever. It does not work, and the failure is not
+    subtle: tmux accepts the value, stores it, reads it back verbatim, and emits **nothing
+    at all**.
+
+    So the questions that would have followed it do not arise. It cannot leave twelve rows
+    of a fifteen-row pane unreversed, because it reverses none of them. It cannot compose
+    badly with `chrome.recipes()`' green, because there is nothing for the green to compose
+    with. It cannot conflict with the `rules` work, because there is no rendering to
+    conflict.
+
+    **And a renderer-side reverse is not the way round it.** `_surface_argvs`' own docstring
+    measures why: tmux fills a pane's whole rectangle from `window-style` — the cells no
+    renderer wrote included, on resize, on reattach — and a fill a panel painted itself is a
+    property of the PROCESS rather than of the rectangle. A panel that reversed its own rows
+    would leave every row it did not write, and every row a resize added, in the terminal's
+    own colours until the next tick.
+
+    The consequence is stated in `docs/frame.md` rather than worked around: there is no
+    theme-independent surface, `chrome` stays `off`, and a plane that wants one writes three
+    lines.
+    """
+
+    def test_tmux_stores_an_attribute_in_a_pane_style_and_reads_it_back(self):
+        """The control for the measurement below: an attribute is not REFUSED, which is
+        what makes the silence worth a test. A charter that set `window-style reverse` and
+        checked the return code would report success on every tmux and paint nothing."""
+        r = self._tmux(self._inner, "new-session", "-d", "-s", "probe", "--", "cat")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pane = self._tmux(self._inner, "list-panes", "-t", "probe",
+                          "-F", "#{pane_id}").stdout.strip()
+        for value in ("reverse", "bold", "dim", "fg=default,bg=default,reverse"):
+            with self.subTest(style=value):
+                self.assertEqual(
+                    self._tmux(self._inner, "set", "-p", "-t", pane,
+                               "window-style", value).returncode, 0)
+                self.assertEqual(
+                    self._tmux(self._inner, "show", "-pv", "-t", pane,
+                               "window-style").stdout.strip(), value)
+        self._tmux(self._inner, "kill-session", "-t", "probe")
+
+    def test_a_colour_in_the_same_option_really_does_reach_the_wire(self):
+        """The other control, and the one that makes the silence attributable to the
+        ATTRIBUTE rather than to this harness: the same option, the same pane, a colour."""
+        params = _sgr_before(self._shot(window_style="bg=brightblack",
+                                        border_style=None), "PLAIN one")
+        self.assertIsNotNone(_colour_pair(params)[1],
+                             f"this harness cannot see a pane style at all: {params}")
+
+    def test_no_attribute_puts_a_single_escape_on_an_attached_clients_wire(self):
+        """`reverse` (SGR 7), `bold` (1) and `dim` (2), each set on both style options of a
+        real pane and read off a real client. None of them appears."""
+        for value, sgr in (("reverse", "7"), ("bold", "1"), ("dim", "2")):
+            with self.subTest(style=value):
+                params = _sgr_before(self._shot(window_style=value, border_style=None),
+                                     "PLAIN one")
+                self.assertNotIn(sgr, params,
+                                 f"`window-style {value}` reached the wire after all — "
+                                 f"the recorded measurement is wrong and a "
+                                 f"theme-independent default surface may be possible: "
+                                 f"{params}")
+
+
+@unittest.skipUnless(_FLOOR_BIN.exists(),
+                     f"no {_FLOOR_BIN.name} built on this machine — `docs/frame.md` says "
+                     "how, and CI installs no tmux at all")
+class TheFloorAnswersIdentically(TheHiddenRuleIsDrawnAndCannotBeSeen):
+    """Every rendering above, re-run against `tmuxctl.FLOOR`.
+
+    The floor is the version that decides whether any of this needs a gate. It did not for
+    `window-style` (`test_frame_surface_live.py`'s Phase 3.5), and it does not here: a
+    `pane-border-style` carrying `fg=` and `bg=` is one value on one option, which 3.2 has
+    had since long before charter existed. Measured rather than inherited — the class it
+    subclasses is the measurement, and only the binary changes.
+
+    **Subclassed deliberately, which is the one place this suite's own "a mixin, never a
+    base TestCase" rule does not apply**: re-running these three renderings on a second
+    tmux is exactly what this class is for, so inheriting them is the feature rather than
+    the surprise `_TmuxServerFixture`'s docstring warns about.
+    """
+
+    BIN = str(_FLOOR_BIN)
+
+
+@unittest.skipUnless(_FLOOR_BIN.exists(), "no floor tmux built on this machine")
+class TheFloorIsSilentAboutAttributesToo(NoAttributeInAPaneStyleReachesTheWire):
+    """The `reverse` finding at the floor. If the two versions disagreed, a default could
+    in principle be gated at the version that works — the way `display-popup` is gated at
+    3.3. They do not disagree, so there is nothing to gate."""
+
+    BIN = str(_FLOOR_BIN)

--- a/tests/test_frame_border_surface.py
+++ b/tests/test_frame_border_surface.py
@@ -64,6 +64,19 @@ def _pinned_at(v) -> dict[str, str]:
     return {name: value for name, value, floor in commands_frame._CHROME if known >= floor}
 
 
+#: The frame a plane that has written nothing gets — `[frame] rules = "hidden"`, no
+#: `text`, `dim` on. Named rather than spelled at each call site so a test that means "the
+#: shipped frame" cannot come to mean "the frame charter used to ship".
+_SHIPPED = instance.SHIPPED_LOOK
+
+#: The rules a plane asked to keep. Every test below that is about the MECHANISM of a rule
+#: — which options carry it, that both carry the same thing, that no operator string
+#: reaches one — pins this one deliberately: under `hidden` the foreground is derived from
+#: the background, so the two halves of a value are the same word and a test that mixed
+#: them up would still pass. `visible` keeps them distinguishable.
+_VISIBLE = instance.Look(rules="visible", text="default", dim=True)
+
+
 def _frame(*bgs, **rest) -> dict:
     """A `[frame]` mapping whose arrangement names one component per *bgs* entry — `None`
     for a component that names no background of its own.
@@ -213,13 +226,46 @@ class TheRuleIsDrawnInIt(unittest.TestCase):
     """`commands_frame._chrome_argvs` — the five `set-option -w`s, with the surface in
     the two that are styles."""
 
-    def _tails(self, surface=None, v=_EVERY_CHROME_OPTION):
+    #: `_VISIBLE` and not the shipped look, everywhere below except the two cases that
+    #: are about the shipped look. This class is about WHICH of the five options carry a
+    #: surface and which do not, and `hidden` builds a value whose foreground and
+    #: background are the same word — so a case that mixed the two up would still pass.
+    LOOK = _VISIBLE
+
+    def _tails(self, surface=None, look=None, v=_EVERY_CHROME_OPTION):
         return [a[a.index("set-option"):]
                 for a in commands_frame._chrome_argvs(socket="s", harness_pane="%1",
-                                                      v=v, surface=surface)]
+                                                      v=v, surface=surface,
+                                                      look=look or self.LOOK)]
 
-    def _values(self, surface=None, v=_EVERY_CHROME_OPTION):
-        return {a[-2]: a[-1] for a in self._tails(surface, v=v)}
+    def _values(self, surface=None, look=None, v=_EVERY_CHROME_OPTION):
+        return {a[-2]: a[-1] for a in self._tails(surface, look, v=v)}
+
+    def test_the_shipped_frame_hides_the_window_wide_rule_in_the_surface(self):
+        """The default, below `tmuxctl.PANE_BORDER_FLOOR` where this function carries the
+        whole answer: a frame that painted its panes gets its rules painted OUT, which is
+        what `[frame] rules = "hidden"` means and what the operator confirmed on their own
+        frame before it was a key.
+
+        The three options that are not styles are untouched by it — `hidden` decides a
+        colour, not a line weight, and `pane-border-lines` has no `none` to decide."""
+        got = self._values("bg=brightblack", _SHIPPED)
+        for name in _STYLES:
+            with self.subTest(option=name):
+                self.assertEqual(got[name], "fg=brightblack,bg=brightblack")
+        for name, value in _pinned_at(_EVERY_CHROME_OPTION).items():
+            if name not in _STYLES:
+                with self.subTest(option=name):
+                    self.assertEqual(got[name], value)
+
+    def test_the_shipped_frame_leaves_a_surfaceless_window_byte_identical(self):
+        """`hidden` on a plane with no surface is not a silent failure and not a change: a
+        rule has no colour to hide into, so `rule_style` composes the same value it
+        composes for `visible`, which is the string charter has drawn since #514. Stated
+        because it is the half of the default that has to be safe for every plane that
+        never asked for any of this."""
+        self.assertEqual(self._values(None, _SHIPPED), _pinned_at(_EVERY_CHROME_OPTION))
+        self.assertEqual(self._values(None, _SHIPPED), self._values(None, _VISIBLE))
 
     def test_no_surface_is_byte_identical_to_the_frame_charter_shipped(self):
         """The `off` invariant, and the reason the border needs no `-u` where the pane
@@ -288,6 +334,26 @@ class TheRuleIsDrawnInIt(unittest.TestCase):
             self.assertNotEqual(self._values("bg=brightblack"),
                                 commands_frame._chrome_values())
 
+    def test_a_plane_that_turned_dim_off_gets_its_rules_at_full_strength(self):
+        """`[frame] dim` reaches the rules and not only the text, which is one word
+        meaning one thing in both places it is honoured. It is also the only
+        theme-independent way to make the frame's own separation louder: `fg=default` is
+        the operator's own foreground, so there is no terminal it can be wrong on."""
+        loud = instance.Look(rules="visible", text="default", dim=False)
+        self.assertEqual(self._values(None, loud)["pane-border-style"],
+                         commands_frame._CHROME_FG)
+        self.assertEqual(self._values("bg=blue", loud)["pane-border-style"],
+                         f"{commands_frame._CHROME_FG},bg=blue")
+
+    def test_a_planes_own_text_colour_draws_its_rules_too(self):
+        """A frame whose panes carry a foreground draws its rules in it rather than in a
+        colour nothing else on the screen is wearing — the same argument `border_bg` makes
+        about the background, one clause over."""
+        self.assertEqual(
+            self._values("bg=brightblack",
+                         instance.Look("visible", "black", True))["pane-border-style"],
+            "fg=black,dim,bg=brightblack")
+
     def test_no_operator_string_reaches_a_style_value(self):
         """The boundary asserted end to end rather than at the table: whatever a committed
         `bg` says, the value that reaches a `set-option` is `_CHROME_STYLE` plus a clause
@@ -298,6 +364,7 @@ class TheRuleIsDrawnInIt(unittest.TestCase):
         for level in ("dark", hostile):
             argvs = commands_frame._chrome_argvs(
                 socket="s", harness_pane="%1", v=_EVERY_CHROME_OPTION,
+                look=self.LOOK,
                 surface=instance.border_bg(_frame(hostile, hostile), level))
             for argv in argvs:
                 for word in argv:
@@ -391,27 +458,46 @@ class APanelDrawsItsOwnEdgesAndTheHarnessKeepsItsOwn(unittest.TestCase):
         with the rules      harness top ESC[100m  right ESC[100m  panel|panel ESC[100m
     """
 
-    STYLE = "fg=default,dim"
+    #: The base rule FOREGROUND, which is what `pane_border_options` takes now: the `dim`
+    #: beside it and the surface behind it are both `instance.rule_style`'s to decide.
+    STYLE = commands_frame._CHROME_FG
+    LOOK = _VISIBLE
 
     def test_a_pane_with_a_colour_gets_both_of_its_edges_in_that_colour(self):
         self.assertEqual(
-            instance.pane_border_options("brightblack", "dark", self.STYLE),
+            instance.pane_border_options("brightblack", "dark", self.STYLE, self.LOOK),
             (("pane-border-style", "fg=default,dim,bg=brightblack"),
              ("pane-active-border-style", "fg=default,dim,bg=brightblack")))
+
+    def test_the_shipped_frame_hides_that_panes_edges_in_its_own_colour(self):
+        """The same pane, with the word the plane did not have to write. `hidden` is the
+        shipped `[frame] rules`, and on a pane that HAS a surface it gives the glyph that
+        surface's own colour — which is the style the operator hand-applied to their own
+        frame and confirmed, made permanent."""
+        self.assertEqual(
+            instance.pane_border_options("brightblack", "dark", self.STYLE, _SHIPPED),
+            (("pane-border-style", "fg=brightblack,bg=brightblack"),
+             ("pane-active-border-style", "fg=brightblack,bg=brightblack")))
 
     def test_a_pane_with_no_colour_of_its_own_takes_the_frame_wide_one(self):
         """The same `pane_bg_options(bg) or chrome_options(chrome)` its INTERIOR is
         painted from, so a pane and its edges cannot come out two colours."""
         self.assertEqual(
-            [v for _n, v in instance.pane_border_options(None, "dark", self.STYLE)],
-            [f"{self.STYLE},{dict(instance.FRAME_CHROME['dark'])['window-style']}"] * 2)
+            [v for _n, v in instance.pane_border_options(None, "dark", self.STYLE,
+                                                         self.LOOK)],
+            [f"{self.STYLE},dim,"
+             f"{dict(instance.FRAME_CHROME['dark'])['window-style']}"] * 2)
 
     def test_a_pane_with_no_surface_at_all_sets_nothing(self):
         """Not a bare style — the window option already IS that. A pane-scoped copy of the
         window's own value would be a value `off`'s removal has to find and remove, for a
         pane that never needed one."""
-        self.assertEqual(instance.pane_border_options(None, "off", self.STYLE), ())
-        self.assertEqual(instance.pane_border_options("nonsense", "off", self.STYLE), ())
+        for look in (self.LOOK, _SHIPPED):
+            with self.subTest(rules=look.rules):
+                self.assertEqual(
+                    instance.pane_border_options(None, "off", self.STYLE, look), ())
+                self.assertEqual(
+                    instance.pane_border_options("nonsense", "off", self.STYLE, look), ())
 
     def test_both_edges_always_carry_the_identical_value(self):
         """#514 surviving the move to pane scope. tmux picks between the two per border
@@ -419,16 +505,18 @@ class APanelDrawsItsOwnEdgesAndTheHarnessKeepsItsOwn(unittest.TestCase):
         differed would have edges that changed colour at the active pane's corner."""
         for word in (None, *instance.FRAME_PANE_BG):
             for level in instance.FRAME_CHROME:
-                with self.subTest(bg=word, chrome=level):
-                    values = {v for _n, v
-                              in instance.pane_border_options(word, level, self.STYLE)}
-                    self.assertLessEqual(len(values), 1, values)
+                for look in (self.LOOK, _SHIPPED):
+                    with self.subTest(bg=word, chrome=level, rules=look.rules):
+                        values = {v for _n, v in instance.pane_border_options(
+                            word, level, self.STYLE, look)}
+                        self.assertLessEqual(len(values), 1, values)
 
     def test_the_two_option_names_are_the_ones_the_removal_reads(self):
         """One list, read by the setter and by `_resurface_argvs`' unset — so an option
         added to the pair cannot be set by one half and left behind by the other."""
         self.assertEqual(
-            tuple(n for n, _v in instance.pane_border_options("blue", "dark", self.STYLE)),
+            tuple(n for n, _v in instance.pane_border_options("blue", "dark", self.STYLE,
+                                                              self.LOOK)),
             instance.PANE_BORDER_OPTIONS)
 
     def test_no_operator_string_reaches_a_pane_edge(self):
@@ -437,12 +525,21 @@ class APanelDrawsItsOwnEdgesAndTheHarnessKeepsItsOwn(unittest.TestCase):
         ever a key."""
         ours = {v for pairs in instance.FRAME_PANE_BG.values() for _n, v in pairs}
         ours |= {v for pairs in instance.FRAME_CHROME.values() for _n, v in pairs}
+        # Under `hidden` the foreground is DERIVED from the background rather than taken
+        # from *style*, so the containment has to be asserted clause by clause rather than
+        # by stripping a known prefix — which is the point: the derivation is the one place
+        # a rule's foreground is built out of something other than a constant, and it is
+        # built out of another constant.
+        allowed = ours | {self.STYLE, "dim"} | {f"fg={n}" for n in instance.FRAME_PANE_BG}
         for word in (*instance.FRAME_PANE_BG, "colour236", "chartreuse", None, 7,
                      "bg=#{?#{==:1,1},colour196,colour46}", ["blue"], True):
-            with self.subTest(bg=word):
-                for _n, value in instance.pane_border_options(word, "dark", self.STYLE):
-                    self.assertNotIn("#", value)
-                    self.assertIn(value.removeprefix(f"{self.STYLE},"), ours)
+            for look in (self.LOOK, _SHIPPED):
+                with self.subTest(bg=word, rules=look.rules):
+                    for _n, value in instance.pane_border_options(word, "dark",
+                                                                  self.STYLE, look):
+                        self.assertNotIn("#", value)
+                        for clause in value.split(","):
+                            self.assertIn(clause, allowed)
 
 
 class TheRulesAroundTheHarnessAreTheFramesToo(unittest.TestCase):
@@ -472,7 +569,11 @@ class TheRulesAroundTheHarnessAreTheFramesToo(unittest.TestCase):
     is the whole of what naming the harness here costs.
     """
 
-    STYLE = commands_frame._CHROME_STYLE
+    #: `APanelDrawsItsOwnEdgesAndTheHarnessKeepsItsOwn`'s own two, for its own reasons:
+    #: the base rule foreground, and the `visible` rules that keep a value's two halves
+    #: distinguishable while the MECHANISM is what is under test.
+    STYLE = commands_frame._CHROME_FG
+    LOOK = _VISIBLE
 
     def _surface_of(self, word, level):
         """What a PANEL with this component `bg` at this level actually wears — the
@@ -558,18 +659,25 @@ class TheRulesAroundTheHarnessAreTheFramesToo(unittest.TestCase):
             with self.subTest(bg=word):
                 self.assertEqual(
                     instance.rule_options(
-                        instance.agreed_border_bg(_frame(*[word] * 4), "dark"), self.STYLE),
-                    instance.pane_border_options(word, "dark", self.STYLE))
+                        instance.agreed_border_bg(_frame(*[word] * 4), "dark"),
+                        self.STYLE, self.LOOK),
+                    instance.pane_border_options(word, "dark", self.STYLE, self.LOOK))
 
     def test_both_of_the_harness_options_carry_the_identical_value(self):
         """#514, on the pane where it is most visible: a rule whose two options differed
         would change colour where it passed the active pane's corner."""
-        pairs = instance.rule_options("bg=blue", self.STYLE)
+        pairs = instance.rule_options("bg=blue", self.STYLE, self.LOOK)
         self.assertEqual(tuple(n for n, _v in pairs), instance.PANE_BORDER_OPTIONS)
-        self.assertEqual({v for _n, v in pairs}, {f"{self.STYLE},bg=blue"})
+        self.assertEqual({v for _n, v in pairs}, {f"{self.STYLE},dim,bg=blue"})
 
     def test_no_surface_builds_no_pair_at_all(self):
-        self.assertEqual(instance.rule_options(None, self.STYLE), ())
+        """Asked of the SURFACE and not of the assembled style, which is a distinction a
+        `text` colour makes real: `rule_style` answers a value for a frame with no surface
+        (it is what `_chrome_argvs` puts on the window), and a pane with nothing to draw a
+        rule over must still get no command."""
+        for look in (self.LOOK, _SHIPPED, instance.Look("hidden", "black", False)):
+            with self.subTest(look=look):
+                self.assertEqual(instance.rule_options(None, self.STYLE, look), ())
 
     def test_no_operator_string_reaches_the_rules_around_the_harness(self):
         """The containment, on the new path: what comes back is charter's style constant
@@ -581,15 +689,32 @@ class TheRulesAroundTheHarnessAreTheFramesToo(unittest.TestCase):
                      "bg=#{?#{==:1,1},colour196,colour46}", ["blue"], True):
             with self.subTest(bg=word):
                 surface = instance.agreed_border_bg(_frame(word, word), "dark")
-                pairs = instance.rule_options(surface, self.STYLE)
-                self.assertTrue(pairs, "no value was built at all, so nothing was "
-                                       "contained here")
-                for _n, value in pairs:
-                    self.assertNotIn("#", value)
-                    self.assertIn(value.removeprefix(f"{self.STYLE},"), ours)
+                # Both looks, because they build the foreground two different ways and
+                # only one of them takes it from a constant the caller passed in.
+                allowed = (ours | {self.STYLE, "dim"}
+                           | {f"fg={n}" for n in instance.FRAME_PANE_BG})
+                for look in (self.LOOK, _SHIPPED):
+                    pairs = instance.rule_options(surface, self.STYLE, look)
+                    self.assertTrue(pairs, "no value was built at all, so nothing was "
+                                           "contained here")
+                    for _n, value in pairs:
+                        self.assertNotIn("#", value)
+                        for clause in value.split(","):
+                            self.assertIn(clause, allowed)
 
     def _argvs(self, **kw):
+        kw.setdefault("look", self.LOOK)
         return commands_frame._harness_rule_argvs(socket="s", harness_pane="%1", **kw)
+
+    def test_the_shipped_frame_hides_the_harnesss_edges_in_the_agreed_colour(self):
+        """The default, on the pane the report is about. The harness's three edges take
+        the colour its neighbours agree on — and now they take it on the GLYPH as well, so
+        the rule under the identity bar stops being a line and becomes the surface running
+        through. This is the value the operator hand-applied to their own frame."""
+        self.assertEqual(
+            [a[-1] for a in self._argvs(surface="bg=brightblack", pane_borders=True,
+                                        look=_SHIPPED)],
+            ["fg=brightblack,bg=brightblack"] * 2)
 
     def test_above_the_floor_both_options_are_set_on_the_harness_pane_itself(self):
         """`-p`, and `-t <the harness>` — the one place charter targets that pane with a
@@ -597,7 +722,7 @@ class TheRulesAroundTheHarnessAreTheFramesToo(unittest.TestCase):
         self.assertEqual(
             [a[a.index("set-option"):] for a in
              self._argvs(surface="bg=brightblack", pane_borders=True)],
-            [["set-option", "-p", "-t", "%1", n, f"{self.STYLE},bg=brightblack"]
+            [["set-option", "-p", "-t", "%1", n, f"{self.STYLE},dim,bg=brightblack"]
              for n in instance.PANE_BORDER_OPTIONS])
 
     def test_no_surface_is_the_unset_and_never_silence(self):
@@ -716,7 +841,9 @@ class TheFloorCannotHavePerPaneEdgesAndIsNotGivenThem(unittest.TestCase):
         argvs = commands_frame._resurface_argvs(socket="s", pane_id="%3", chrome="off",
                                                 bg="brightblack", pane_borders=True)
         self.assertEqual([a for a in argvs if "-u" in a], [])
-        self.assertIn("fg=default,dim,bg=brightblack", [a[-1] for a in argvs])
+        # The SHIPPED rule, which is `_resurface_argvs`' own default look: the pane keeps
+        # its colour and its edges are hidden in it.
+        self.assertIn("fg=brightblack,bg=brightblack", [a[-1] for a in argvs])
 
     def test_no_colour_takes_the_edges_off_too(self):
         """The fill is tmux's paint either way, so a `NO_COLOR` that stripped the pane and
@@ -790,7 +917,7 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         frame = _resolved(*["brightblack"] * 4, chrome="dark")
         rules = self._rules(self._issued(frame, ["top", "bottom", "repos", "right"]))
         self.assertEqual(rules["pane-border-style"],
-                         f"{commands_frame._CHROME_STYLE},bg=brightblack")
+                         "fg=brightblack,bg=brightblack")
         self.assertEqual(rules["pane-active-border-style"], rules["pane-border-style"])
 
     def _per_pane(self, issued, names) -> dict[str, list[str]]:
@@ -808,7 +935,7 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         self.assertEqual(self._rules(issued), commands_frame._chrome_values(),
                          "the window carries a surface above the floor, so a rule is "
                          "being coloured in two places")
-        want = f"{commands_frame._CHROME_STYLE},bg=brightblack"
+        want = "fg=brightblack,bg=brightblack"
         per_pane = self._per_pane(issued, instance.PANE_BORDER_OPTIONS)
         self.assertEqual(len(per_pane), 5,
                          f"not every panel and the harness got edges: {per_pane}")
@@ -827,7 +954,7 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         rectangle ADR 0018 is about.
         """
         frame = _resolved(*["brightblack"] * 4, chrome="dark")
-        want = f"{commands_frame._CHROME_STYLE},bg=brightblack"
+        want = "fg=brightblack,bg=brightblack"
         for v in (None, (3, 2), (3, 7)):
             with self.subTest(v=v):
                 issued = self._issued(frame, ["top", "right"], v=v)
@@ -860,7 +987,7 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         self.assertEqual(one, whole)
         self.assertEqual(one, whole)
         self.assertEqual(one["pane-border-style"],
-                         f"{commands_frame._CHROME_STYLE},bg=blue")
+                         "fg=blue,bg=blue")
 
     def test_the_live_word_and_not_the_committed_one_decides_the_rules(self):
         """`_split_panels` resolves the level through `_current_chrome`, so a pane split
@@ -871,8 +998,9 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         state.record_chrome("f-live", "dark")
         rules = self._rules(self._issued(frame, ["top"], fid="f-live"))
         self.assertEqual(rules["pane-border-style"],
-                         f"{commands_frame._CHROME_STYLE},"
-                         f"{dict(instance.FRAME_CHROME['dark'])['window-style']}")
+                         "fg=black,bg=black",
+                         "the live word decides the colour, and the shipped `rules` "
+                         "decides that the glyph is drawn in it")
 
 
 class TheVersionReachesTheFunnelFromTheFunctionThatKnowsIt(PersonaIso, unittest.TestCase):
@@ -924,7 +1052,7 @@ class TheVersionReachesTheFunnelFromTheFunctionThatKnowsIt(PersonaIso, unittest.
                          "the version never reached `_split_panels`, so a real frame "
                          f"above the floor took the floor's design: {edges}")
         self.assertEqual(set(edges.values()),
-                         {f"{commands_frame._CHROME_STYLE},bg=brightblack"})
+                         {"fg=brightblack,bg=brightblack"})
         self.assertEqual(self._window_rule(calls), commands_frame._CHROME_STYLE,
                          "the window kept a surface above the floor, so a rule is being "
                          "coloured in two places")
@@ -935,7 +1063,7 @@ class TheVersionReachesTheFunnelFromTheFunctionThatKnowsIt(PersonaIso, unittest.
                          "a frame below the floor wrote a pane-scoped border option, "
                          "which on that tmux lands on the window")
         self.assertEqual(self._window_rule(calls),
-                         f"{commands_frame._CHROME_STYLE},bg=brightblack")
+                         "fg=brightblack,bg=brightblack")
 
     def test_the_harness_is_among_the_panes_given_edges_only_above_the_floor(self):
         """The version has to reach the harness's own rules too, and the direction it can
@@ -944,7 +1072,7 @@ class TheVersionReachesTheFunnelFromTheFunctionThatKnowsIt(PersonaIso, unittest.
         #514 pin with it."""
         self.assertNotIn("%1", self._edges(self._calls((3, 6))))
         self.assertEqual(self._edges(self._calls((3, 7))).get("%1"),
-                         f"{commands_frame._CHROME_STYLE},bg=brightblack",
+                         "fg=brightblack,bg=brightblack",
                          "the rules round the harness are bare while the panels' are "
                          "surfaced, so one rule is two colours")
 
@@ -1091,7 +1219,7 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
         self.assertEqual(
             self._harness_rules(self._live_calls(_resolved(*["blue"] * 4),
                                                  "dark", (3, 7)))[0][-1],
-            f"{commands_frame._CHROME_STYLE},bg=blue",
+            "fg=blue,bg=blue",
             "an agreeing arrangement got no surface either, so the removal above is not "
             "the disagreement's doing")
 
@@ -1100,7 +1228,7 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
         component wrote. The rules stay the panels' colour, because the panels do — on the
         window below the floor, on the pane itself above it."""
         frame = _resolved(*["brightblack"] * 4)
-        want = f"{commands_frame._CHROME_STYLE},bg=brightblack"
+        want = "fg=brightblack,bg=brightblack"
         self.assertEqual(self._live_value(frame, "off", (3, 2))[("-w", "pane-border-style")],
                          want)
         self.assertEqual(self._live_value(frame, "off", (3, 7))[("-p", "pane-border-style")],
@@ -1120,7 +1248,7 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
         the per-pane edges exist to unbox; a pane written below it would land on the
         window anyway and the last panel would decide the frame."""
         frame = _resolved(*["brightblack"] * 4)
-        want = f"{commands_frame._CHROME_STYLE},bg=brightblack"
+        want = "fg=brightblack,bg=brightblack"
         floor = self._live_value(frame, "dark", (3, 2))
         self.assertEqual(floor[("-w", "pane-border-style")], want)
         self.assertNotIn(("-p", "pane-border-style"), floor)
@@ -1227,7 +1355,7 @@ class ARelayoutThatAddsNoPaneStillAssertsTheWindowsOwnOptions(PersonaIso,
         horizontal rule in two colours."""
         panels = {"top": "%3", "bottom": "%4"}
         calls = self._calls(panels=panels, want=list(panels))
-        want = f"{commands_frame._CHROME_STYLE},bg=brightblack"
+        want = "fg=brightblack,bg=brightblack"
         harness = [a for a in calls if "set-option" in a and "-p" in a
                    and a[a.index("-t") + 1] == "%1"]
         self.assertEqual([a[-1] for a in harness], [want, want],

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -5382,7 +5382,10 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         for option in instance.PANE_BORDER_OPTIONS:
             with self.subTest(option=option):
                 got = self._srv("show", "-p", "-t", harness, "-v", option).stdout.strip()
-                self.assertEqual(got, f"{commands_frame._CHROME_STYLE},bg=brightblack",
+                # The SHIPPED rule, which is what these argvs build with no `look=`
+                # passed: `[frame] rules = "hidden"` gives the glyph the surface's own
+                # colour, so the rule and the panes beside it are one surface.
+                self.assertEqual(got, "fg=brightblack,bg=brightblack",
                                  "tmux did not read charter's rule back off the harness")
                 self.assertEqual(
                     got,


### PR DESCRIPTION
Two keys the operator hit on their own frame within ten minutes of each other, and one measurement that closes a door behind them. Both are "the frame's appearance is the plane's to choose".

## Part 1 — `[frame] rules`, defaulting to `hidden`

tmux **always** paints a glyph on a border cell: `pane-border-lines` takes `single`/`double`/`heavy`/`simple`/`number` and has no `none`. So the seam reported in #627, #631, #657 — and again against the frame that fixed #657 — was never a character question. It is a contrast question.

`rules = "hidden"` asks for the glyph in the same colour as the cell behind it. Read off an attached client's wire through a nested tmux, three panes each `bg = "brightblack"`:

```
visible  ESC[2m  ESC[100m ─────    a dim foreground glyph, on the surface
hidden   ESC[90m ESC[100m ─────    the glyph IS the surface
```

That is byte-for-byte the style the operator hand-applied to their own live frame and confirmed (`fg=brightblack,bg=brightblack`, no `dim`). This makes it permanent.

**It ships as the default and cannot make an existing frame worse.** A plane with no surface has no colour for the glyph to take, so `rule_style` composes exactly the string charter has drawn since #514 — asserted, not argued (`test_a_surfaceless_frame_is_byte_identical_under_either_word`). It only does anything on a plane that already wrote a `chrome` or a `bg` by hand.

**One arm is reached by an input that reaches only it:** a component with `bg = "default"` keeps its *visible* rule. `default` means the terminal's own background and there is no `fg=` spelling for that — `fg=default` is the terminal's own *foreground* — so honouring `hidden` there would draw the rule at full strength, brighter than the `dim` it replaced.

Follows `FRAME_PANE_BG`'s shape throughout: a **word**, never a style string. Measured again on this option — `set -w pane-border-style 'bg=#{?#{==:1,1},colour196,colour46}'` is rc 0 and reaches the wire as `ESC[48;5;196m`.

## Part 2 — `[frame] text` and `[frame] dim`

### Charter must be told, not compute

Established rather than assumed. The sixteen ANSI names have no fixed RGB; `brightblack` is a dark grey on most themes and a light tan on this operator's. Charter cannot find out which: OSC 11 through tmux answers nothing, and `$COLORTERM` inside a pane describes the terminal that started the **server**. **If charter cannot know what a colour looks like, it cannot compute contrast** — so the plane is asked, in the vocabulary it already answers `bg` in.

### Three keys, not eight — the axis argued

Of `chrome.recipes()`' eight roles, four are theme-safe by construction (`heading` bold, `selected` reverse, `reset`, `inset`) and `chrome.py` already argues why. `ok`/`warn`/`bad` are slots in the operator's *own* palette, which is `FRAME_PANE_COLOURS`' own argument for refusing `colour24`. What is left is the two that are **not** slots:

- **`text`** — the pane's default foreground, set through `window-style fg=`. tmux resolves a pane's default cell from it, so charter's own `ESC[0m` returns to the plane's colour rather than the terminal's, and neither the ~40 `statusline._DIM` sites in `slots.py` nor a provider's component has to be told. Measured on 3.7c and at the 3.2 floor.
- **`dim`** — its own key because it is the one thing in the frame **wrong by construction** on a surface it was not chosen for. `_role_values` claimed bold, dim and reverse "are statements relative to whatever the operator's terminal already is"; that is the wrong half of true for dim, which is relative in one direction — toward the background. This PR corrects that docstring. Measured on the operator's live frame, `ESC[2m` is the most frequent SGR charter paints (12, 8, 6 and 3 occurrences across their four panels).

Default stays `dim = true`: dim is the only thing separating muted text from ordinary text, so off-everywhere is a flat hierarchy.

## The refutation — `reverse` cannot be a default surface

Measured on 3.7c and at `tmuxctl.FLOOR`, through a nested client: tmux **accepts** `window-style reverse`, stores it, reads it back verbatim — and puts **no SGR at all** on the wire. Same for `bold` and `dim`. A pane style honours colour and silently ignores every attribute. A renderer-side reverse is worse rather than harder: `_surface_argvs`' own docstring measures that tmux fills the whole rectangle including cells no renderer wrote and across resize, which a panel's own fill cannot.

So there is no theme-independent surface to ship, `chrome` stays `off`, and the consequence is documented rather than worked around. Pinned by `NoAttributeInAPaneStyleReachesTheWire` **with a control proving tmux accepts the value**, so a future charter that sets it and checks the return code cannot report success while painting nothing.

## `NO_COLOR`

`chrome.no_colour()` remains the one reading; nothing here adds a second. `recipes()` already returned `""` for every role when colour is off, so no-colour is a **superset** of dim-off and they meet in one ordering rather than fighting — asserted both ways. In `panel._write` the dim pass is unreachable under `NO_COLOR` rather than skipped by it.

`chrome.served_params` deliberately still reads `_role_values`, so SGR 2 stays *admitted* whatever the plane said and a provider's own dim is deleted on the way out rather than escaped into its pane as text. Deriving it from `recipes()` — the tidier-looking wiring — would have re-opened #707 for exactly one parameter. Pinned.

## Boundary: refuse or degrade

These are `[frame]` keys, so an unreadable word degrades to the shipped default and leaves the frame whole — `chrome`, `density` and `hotkey`'s existing contract. #535's refuse-the-arrangement-whole rule is about a **component** silently missing, which reads as a plane with no clones; a `rules` typo costs a rule drawn the shipped way in an otherwise intact frame. #687's warning applies in the other direction, so every word in both vocabularies is asserted **accepted** rather than sampled.

## What this does not fix — named, not papered over

`text` fixes a pane whose background is *inverted* relative to the terminal's. On a terminal that is already light it has nothing to do, and what is hard to read there is the **accent** triple — `ok`/`warn`/`bad`, still the operator's own green, yellow and red, and yellow on tan is the combination no palette was designed for. That is a real remaining gap, stated in `docs/frame.md` and the news entry. It is not in this PR because the only mechanism reaching charter's own renderers is routing ~40 `slots.py` call sites through the recipe table — a change worth making on its own.

## Verification

- Full suite green (8930+ tests), `unittest`, `env -u PYTHONSAFEPATH`.
- **59 new tests** across two files. `tests/test_a_planes_frame_really_reads_that_way.py` drives real tmux on **3.7c and the 3.2 floor**, renders the control first every time, and skips rather than passing quietly on a machine whose two readings agree.
- Rebased onto current `main` (through #759). Verified against #760's per-option floor: a floor says which tmuxes are *told* about an option, a `look` says what the two style rows *carry* — orthogonal, and pinned.
- Live assertions are property-based (`bg - fg == 10`), because nesting tmux downsamples `brightblack` at the floor and the spelling is the machine's while the property is charter's.
- `dependencies = []` untouched; nothing in `charter/__init__.py`, `pyproject.toml`, `.claude-plugin/plugin.json`, `hooks/hooks.json`, or any `0.54.0-*` note.
- The operator's frame was read only (`capture-pane -p -e`, `show -pv`); no option was set on socket `charter` and its 11 sessions are intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy