### PR TITLE
The paint mark's `arm=False` gives a reason that is still true, and #719's news carries the rates it was finally measured at

### DIFF
--- a/docs/news/unreleased-the-frames-screenshot-waits-for-the-whole-frame.md
+++ b/docs/news/unreleased-the-frames-screenshot-waits-for-the-whole-frame.md
@@ -71,22 +71,20 @@ is a fact about the machine's load and not about the frame — halve the cadence
 starts being wrong.
 
 **Measured end to end, both worktrees run at once under one load**, three legs each,
-135 runs per worktree per binary, 14-core darwin, `python3.14`.
+14-core darwin, `python3.14`.
 
-| binary | leg | runs | failed |
+| binary | runs each | `main` failed | this branch |
 |---|---|---|---|
-| tmux 3.7c | `main` | 135 | **6** |
-| tmux 3.7c | this branch | 135 | **0** |
-| tmux 3.2 | `main` | 135 | **18** |
-| tmux 3.2 | this branch | 135 | **0** |
+| tmux 3.7c | 135 | **6** | **0** |
+| tmux 3.2 | 135 | **18** | **0** |
+| tmux 3.2, re-run against `main` once #716/#717/#718 had landed | 45 | **9** | **0** |
 
-Every one of `main`'s 24 failures is one of #719's own two:
-`test_no_shipped_design_leaves_a_seam_between_two_panes_of_one_colour` (19) and
-`test_an_unsurfaced_rule_really_does_leave_a_seam_between_painted_panes` (5) — the two
-messages the issue was filed with, and neither of them about colour. The tmux 3.2 leg
-needed #716's four deterministic floor failures patched out of the way first, or the
-surfaced screenshots never run at all; that patch is measurement scaffolding and is not in
-this branch.
+Every one of `main`'s 33 failures is one of #719's own two:
+`test_no_shipped_design_leaves_a_seam_between_two_panes_of_one_colour` (24) and
+`test_an_unsurfaced_rule_really_does_leave_a_seam_between_painted_panes` (9) — the two
+messages the issue was filed with, and neither of them about colour. The first tmux 3.2
+campaign needed #716's floor failures patched out of the way so the surfaced screenshots
+could run at all; the third needed nothing, because by then #716 had shipped.
 
 Per screenshot rather than per run, which is the more sensitive instrument: `main` stopped
 at a screen that was not the one the frame settled to on **5 of 716** shots on 3.7c and
@@ -99,8 +97,5 @@ on this tmux rather than argued from tmux's source: six rounds repaint a pane an
 mark behind the repaint, and the screen carrying each mark carries exactly one background
 and a new one — a screen caught between two paints carries both, which is the frame this
 was photographing.
-
-The module's deterministic tmux 3.2 failures are unchanged, four in this class and all of
-them #716's.
 
 Nothing to adopt — no production behaviour changed.

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -5017,12 +5017,12 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         frame — which this asks for first, and skips on if this machine cannot render one.
 
         **`arm=False`, and that is not laziness** — the same argument
-        `test_neither_server_this_class_uses_is_ever_rebuilt_mid_test` makes. This is
-        about the mark and the harness's own background, and neither is charter's; arming
-        would put charter's chrome argvs on the path, which at `tmuxctl.FLOOR` fail over
-        an option tmux 3.2 does not have (#716) and would make this report somebody else's
-        failure. The panels are still painted either way — `_screenshot` paints a
-        *surface* whether or not the rules are armed — so the reading is the same one.
+        `test_neither_server_this_class_uses_is_ever_rebuilt_mid_test` makes. Neither the
+        mark nor the harness's own background is charter's chrome, so arming would put
+        every one of charter's chrome argvs on the path of a test that says nothing about
+        them, and a red here would be reporting their failure rather than this one's. The
+        panels are painted either way — `_screenshot` paints a *surface* whether or not
+        the rules are armed — so the reading is the same one.
         """
         self.assertEqual(
             set(_PAINT_MARK) & (_RULE_GLYPHS | _INDICATOR_GLYPHS), set(),


### PR DESCRIPTION
Follow-up to #756 (#719), which merged while its last two measurements were still
running. **Neither change is code** — the gate, the mark and both new tests are exactly
what merged; this is one docstring paragraph and one news entry.

## The `arm=False` reason had a shelf life

`test_the_paint_mark_arrives_and_reads_as_the_harnesss_own_background` explained its
`arm=False` by saying arming would put charter's chrome argvs on the path, "which at
`tmuxctl.FLOOR` fail over an option tmux 3.2 does not have (#716)". #716 landed in #760
about an hour later: `_CHROME` carries a floor per option now and the floor is issued
nothing it lacks. So the sentence points the next reader at a failure that no longer
exists, and it was never the argument that mattered anyway.

What it says now is the durable half: neither the mark nor the harness's own background
is charter's chrome, so arming would put every one of charter's chrome argvs on the path
of a test that says nothing about them, and a red here would be reporting their failure
rather than this one's. Same choice, a reason that stays true.

## The rates were superseded

The tmux 3.2 campaign the news entry quoted needed #716's four deterministic floor
failures patched out of the way, or the surfaced screenshots never ran at all. That leg
was re-run against `main` once #716, #717 and #718 had all landed — no scaffolding of any
kind:

| binary | runs each | `main` failed | this branch |
|---|---|---|---|
| tmux 3.7c | 135 | **6** | **0** |
| tmux 3.2 (with #716 patched out to let the shots run) | 135 | **18** | **0** |
| tmux 3.2, re-run once #716/#717/#718 had landed | 45 | **9** | **0** |

All 33 of `main`'s failures are #719's own two:
`test_no_shipped_design_leaves_a_seam_between_two_panes_of_one_colour` (24) and
`test_an_unsurfaced_rule_really_does_leave_a_seam_between_painted_panes` (9).

## Verification

* `ChromeIsOneColour` green on tmux 3.7c and at `~/.local/share/charter-testing/tmux-3.2`;
  the whole `test_frame_tmux_integration` module is green at the floor too (102 tests,
  9 skips), which it now is for the first time.
* The news lints pass (`test_news`, `test_news_gate`,
  `test_a_news_entry_cannot_forge_a_report_line`).
* Tests and one news entry only — `git diff --quiet -- charter tools hooks skills personas
  charter.toml pyproject.toml` exits 0. A tests-only diff plans 0 mutations under
  `--path charter`, so the sweep's `no survivors` says nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy