### PR TITLE
The overflow line says which side the hidden rows are on, and the tab strip stops collapsing to one tab (#741, #767)

### DIFF
--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -954,6 +954,27 @@ def _table_lines(data: dict, width: int, budget: int, *, offset: int = 0,
                   + pieces[:start] + pieces[start + len(kids):])
         quiet = not any(_needs_attention(r) for r in hidden)
         note = ", all clean" if quiet else ""
+        # **Which SIDE they are on, which `+N more` never said** (#741). The count was
+        # always right — `hidden` is the complement of what was drawn, true at every
+        # offset — but `more` asserts a direction the window has not earned. Driven at
+        # offsets 0, 4 and 8 over twelve repos in five rows, the old line read
+        # `…(+8 more, all clean)` all three times: eight below, four-and-four, and eight
+        # ABOVE are three different places to be standing and the row said one thing.
+        # Scrolled to the bottom it pointed under itself at nothing.
+        #
+        # The window is one window over one list — repo rows then piece rows, the order
+        # the budget above is spent in — so *offset* IS how many rows are above it and
+        # what is left of `hidden` is below. Taken from the numbers the rows were sliced
+        # with rather than re-derived: a second arithmetic for "where is the window" is a
+        # second answer, which is `_Line`'s own reason one column over.
+        above = offset
+        below = len(hidden) - above
+        # **Each count is drawn only for a side that HAS something on it** — `_bar`'s rule
+        # one axis over, where a leading `+3` beside a page starting mid-list is what stops
+        # a lone trailing count claiming the row holds the first names. `0 above` would be
+        # a field that is always false and always drawn.
+        where = ", ".join(f"{n} {side}" for n, side in
+                          ((above, "above"), (below, "below")) if n)
         # **About no repo, so a click here selects nothing.** It stands for the rows that
         # are NOT on screen, and picking one of them because the operator clicked the line
         # that says they exist would be charter answering a question nobody asked.
@@ -963,7 +984,7 @@ def _table_lines(data: dict, width: int, budget: int, *, offset: int = 0,
         # exclusive — they no longer are, and a "there is more below" line with three more
         # rows below it is the note pointing at the wrong place.
         lines.append(_Line(None, tui.truncate(
-            f"  {sl._DIM}…(+{len(hidden)} more{note}){sl._R}", width)))
+            f"  {sl._DIM}…({where}{note}){sl._R}", width)))
     return lines[:budget]
 
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2745,7 +2745,23 @@ def _page(fields: list[str], at: int, room: int) -> tuple[int, int]:
     # while that condition alone stops the loop 757 times. Dropping both leaves every one
     # of those 1,194,017 pages identical. An equivalent mutant and dead code are the same
     # finding, and this repository deletes rather than suppresses.
-    while len(cuts) >= 3 and cuts[-1] - cuts[-2] < 2:
+    #
+    # **A `len(cuts) >= 3` conjunct went the same way, and it is the more interesting of
+    # the three.** It was not unreachable: with a SINGLE field the cuts are `[0, 1]` and
+    # it is what stops the loop, 665 times in the sweep below. What it is not is
+    # OBSERVABLE. A one-name list reaches this rung only when that name did not fit the
+    # row, and the body composed from it is that same name — so `_bar`'s own measurement
+    # refuses the rung whatever this returns. That is the identical masking already
+    # recorded one function down for `if len(names) > 1`, which the sweep found for the
+    # same reason. Measured over 1,963,800 rows, keeping the conjunct and dropping it draw
+    # byte-identical output, with no runaway loop.
+    #
+    # The property it was informally protecting — that a page never starts left of zero,
+    # so no negative column can reach :data:`TABS` — is not left to a masked guard. It is
+    # asserted directly by `tests/test_frame_bars.AClickResolvesAgainstWhatWasDrawn
+    # .test_no_row_at_any_width_ever_draws_or_maps_a_column_left_of_zero`, which stays
+    # true if the measurement above ever stops masking it.
+    while cuts[-1] - cuts[-2] < 2:
         moved = cuts[-2] - 1
         if reach(moved) < cuts[-1]:
             break

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -34,6 +34,7 @@ rather than a plausible number.
 
 from __future__ import annotations
 
+import bisect
 import os
 import time
 from typing import NamedTuple
@@ -2674,16 +2675,57 @@ def _page(fields: list[str], at: int, room: int) -> tuple[int, int]:
     # The widest count either end can carry: every name but one left out. Measured with
     # `tui.width` for this module's own reason, even though charter mints the digits.
     tail = _BAR_GAP + tui.width(f"+{len(fields) - 1}")
-    start = 0
-    while True:
-        budget = room - tail - (_BAR_GAP + tui.width(f"+{start}") if start else 0)
+
+    def room_for(start: int) -> int:
+        """What a page beginning at *start* may spend on names and the gaps between."""
+        return room - tail - (_BAR_GAP + tui.width(f"+{start}") if start else 0)
+
+    def reach(start: int) -> int:
+        """Where a page beginning at *start* ends when it is filled to the brim."""
         used, stop = tui.width(fields[start]), start + 1
+        budget = room_for(start)
         while stop < len(fields) and used + _BAR_GAP + tui.width(fields[stop]) <= budget:
             used += _BAR_GAP + tui.width(fields[stop])
             stop += 1
-        if at < stop:
-            return start, stop
-        start = stop
+        return stop
+
+    cuts = [0]
+    while cuts[-1] < len(fields):
+        cuts.append(reach(cuts[-1]))
+    # **The last page is not allowed to be a lone tab while the boundary can move**, and
+    # that is #767. Every page but the last is filled to the brim, so the last one holds
+    # the REMAINDER — and a remainder shrinks as the pages grow. With the marked name
+    # sorting last that made a WIDER bar draw fewer names, and at 228 columns on a
+    # fifteen-workspace plane it collapsed to a single tab: the one the operator was
+    # already on, which `_Tabs.switch_to` correctly refuses. #758 returning at a width
+    # wider than the one that fixed it.
+    #
+    # Moving the final cut one name left is decided on the NAMES and the WIDTH alone, so
+    # it cannot move a page out from under a click — the property `_Tabs` depends on and
+    # the reason this is not a window centred on the mark. Measured across 82 lists at
+    # every room from 5 to 300: no page moves when the frame switches to a tab drawn on it.
+    #
+    # **Balancing every page instead was measured and is WORSE**, which is why only the
+    # last one is rescued. Equal-sized pages ignore what names actually cost: on this
+    # project's own fifteen workspaces it drew 4/4/5/7/7 tabs at 100/120/160/200/240
+    # columns where filling each page draws 4/6/8/10/13, and across those 82 lists it left
+    # MORE pages holding a single tab (6,969 against 4,775), not fewer. Packing the last
+    # page from the right instead removes the drops and puts them on a middle name: the
+    # same fifteen workspaces then draw 8 tabs at 160 and 6 at 200.
+    while len(cuts) >= 3 and cuts[-1] - cuts[-2] < 2:
+        moved = cuts[-2] - 1
+        if moved <= cuts[-3] or reach(cuts[-3]) < moved or reach(moved) < cuts[-1]:
+            break
+        cuts[-2] = moved
+    # **What this does NOT restore is a monotone COUNT, and that is a stated limit rather
+    # than an oversight.** The remainder still shrinks as the pages grow, so a name that
+    # sorts late can still lose one tab as the pane widens — 10 such widths between 60 and
+    # 280 on a fifteen-name list, down from 12, each of exactly one name. What it does
+    # guarantee is that the row is never reduced to the tab you are standing on while
+    # there was room for another, which is the harm: at every width from 150 columns up,
+    # the marked page holds at least two names where it used to hold one.
+    i = bisect.bisect_right(cuts, at) - 1
+    return cuts[i], cuts[i + 1]
 
 
 def _bar(head: str, names: list[str], here: str, width: int, *,

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2733,15 +2733,31 @@ def _page(fields: list[str], at: int, room: int) -> tuple[int, int]:
     # MORE pages holding a single tab (6,969 against 4,775), not fewer. Packing the last
     # page from the right instead removes the drops and puts them on a middle name: the
     # same fifteen workspaces then draw 8 tabs at 160 and 6 at 200.
+    #
+    # **One condition, and the two that used to sit beside it were deleted rather than
+    # documented.** They were written as guards against an empty page before the last one
+    # and against a page before it that could not span the gap, and the deletion sweep
+    # reported both as survivors — `<=` to `<` and `<` to `<=` changed nothing. Measured
+    # rather than read, over 1,194,017 pages: `reach(cuts[-3]) < moved` is **never true**,
+    # because `cuts[-3]` never moves and `reach` of it IS the greedy `cuts[-2]` this loop
+    # only ever walks down from; and `moved <= cuts[-3]` is never the only reason to stop
+    # — it is true 11,804 times and the condition below is true at every one of them,
+    # while that condition alone stops the loop 757 times. Dropping both leaves every one
+    # of those 1,194,017 pages identical. An equivalent mutant and dead code are the same
+    # finding, and this repository deletes rather than suppresses.
     while len(cuts) >= 3 and cuts[-1] - cuts[-2] < 2:
         moved = cuts[-2] - 1
-        if moved <= cuts[-3] or reach(cuts[-3]) < moved or reach(moved) < cuts[-1]:
+        if reach(moved) < cuts[-1]:
             break
         cuts[-2] = moved
     # **What this does NOT restore is a monotone COUNT, and that is a stated limit rather
     # than an oversight.** The remainder still shrinks as the pages grow, so a name that
     # sorts late can still lose one tab as the pane widens — 10 such widths between 60 and
-    # 280 on a fifteen-name list, down from 12, each of exactly one name. What it does
+    # 280 on a fifteen-name list, down from 12, each of exactly one name. Those two numbers
+    # are asserted by `tests/test_frame_bars.TheLadderGivesUpWholeThings
+    # .test_the_limit_this_cut_does_not_fix_is_ten_widths_of_exactly_one_name`, so a change
+    # to the cut has to come back and restate its cost rather than leaving this paragraph
+    # to rot into folklore. What it does
     # guarantee is that the row is never reduced to the tab you are standing on while
     # there was room for another, which is the harm: at every width from 150 columns up,
     # the marked page holds at least two names where it used to hold one.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -136,7 +136,11 @@ Three things follow that are worth saying plainly rather than leaving you to fin
 - **The wheel does nothing when the table already fits**, which is most of the time — the
   pane is sized to its own content. There is nothing below to scroll to, so nothing moves
   and nothing repaints. It starts moving on any plane with more table ROWS than the pane
-  has, which is the same plane that shows `…(+7 more)`.
+  has, which is the same plane that shows `…(7 below)`.
+- **The last line says which side the rows you cannot see are on** — `…(4 above, 4 below,
+  all clean)`, and just `…(8 above, all clean)` once you have scrolled to the end. It is one
+  window over one list, so the first number is how far down you are. A side with nothing on
+  it is not drawn, and the line is about no repo: clicking it selects nothing.
 - **Rows, not clones.** A worktree gets a row of its own on a plane with a single clone, and
   those rows scroll like any other: a monorepo plane with twenty worktrees is a
   twenty-one-row table however few repos are in it. Scrolling past the clone's own row

--- a/docs/news/unreleased-the-overflow-line-says-which-side.md
+++ b/docs/news/unreleased-the-overflow-line-says-which-side.md
@@ -1,0 +1,56 @@
+---
+version: unreleased
+headline: The repo table says whether the rows you cannot see are above you or below you
+---
+
+Scroll the repo table to the bottom and the last line said:
+
+```
+  …(+8 more, all clean)
+```
+
+There is nothing below it. All eight are above. The count was right — charter works it out
+as "every row that is not on screen", which is true wherever the window sits — but `more`
+asserts a direction, and at the bottom of the table it was pointing at empty screen.
+
+Worse than wrong in one place: it was *the same sentence everywhere*. Twelve repos in a
+five-row pane, at three scroll positions:
+
+```
+offset 0   …(+8 more, all clean)      <- 8 below
+offset 4   …(+8 more, all clean)      <- 4 above, 4 below
+offset 8   …(+8 more, all clean)      <- 8 above
+```
+
+Three different places to be standing, one string. Scrolling moved a number that never
+changed.
+
+**It now says which side.**
+
+```
+  …(8 below, all clean)
+  …(4 above, 4 below, all clean)
+  …(8 above, all clean)
+```
+
+The table is one window over one list — repo rows, then the worktree rows beneath them — so
+the first number is simply how far down you have scrolled. A side with nothing on it is not
+drawn, because `0 above` is a field that is always false and always there.
+
+**Why it is not an arrow, and not a second row.** An arrow was the obvious thing and it is a
+trap on this surface: `●`, `◆` and the pointing triangles are East-Asian *Ambiguous* width,
+and they have broken this layout twice — the mark on the tab bars is an ASCII `*` for exactly
+that reason. A marker row along the top was the other obvious thing, and it costs a **repo
+row**: this table's budget is measured in rows, and it would spend one at precisely the
+budgets short enough to need scrolling in the first place. The line at the bottom was already
+reserved out of that budget, so putting both numbers on it costs nothing at all.
+
+Clicking it still does nothing, which is the point of it: it stands for rows that are not on
+screen, and picking one of them because you clicked the line saying they exist is a question
+nobody asked.
+
+This is the same defect the tab bars were fixed for one release earlier — an overflow marker
+that describes a window but is computed as though the window always starts at the top. The
+bars would have produced a wrong *number* and ship two counts to avoid it; the table's number
+was right and its *sentence* was false. They share no code, so this is the same rule applied
+twice rather than one fix in two places.

--- a/tests/test_a_real_click_reaches_the_real_repo_table.py
+++ b/tests/test_a_real_click_reaches_the_real_repo_table.py
@@ -77,7 +77,7 @@ _TERM_CANDIDATES = tuple(dict.fromkeys(
 COLS = 120
 
 #: Rows the `repos` pane is split with: one heading and four rows of table. Four rows is
-#: the STARVED shape for both plane shapes below — three rows of content and `…(+N more)` —
+#: the STARVED shape for both plane shapes below — three rows of content and `…(N below)` —
 #: which is the shape both reports were about. A pane sized to its content would have
 #: nothing to scroll, which is the case the unit half pins and this one cannot reach
 #: without a second frame.
@@ -344,7 +344,7 @@ class _ARealFrame(PersonaIso):
 class ARealPointerOnTheRealRepoTable(_ARealFrame):
     """**Many clones, no pieces** — the shape #658 was built and measured on.
 
-    Six repos into four rows of table: three repo rows and `…(+3 more)`, so there is
+    Six repos into four rows of table: three repo rows and `…(3 below)`, so there is
     somewhere below to scroll TO. A pane sized to its content would have nothing to
     scroll, which is the case the unit half pins and this one cannot reach.
     """
@@ -401,7 +401,7 @@ class ARealPointerOnTheRealRepoTable(_ARealFrame):
         self.assertIsNone(state.selection(self.fid))
 
     def test_the_wheel_moves_the_window_over_the_repos(self):
-        """The literal report. Six repos into four rows: three rows and `…(+3 more)`, so
+        """The literal report. Six repos into four rows: three rows and `…(3 below)`, so
         there is somewhere below to go, and one notch must change WHICH repos are drawn."""
         before = self._table()
         self.assertIn("(+3 more", "\n".join(before), before)
@@ -574,12 +574,17 @@ class ARealWheelOverAPaneThatFitsItsPieces(_ARealFrame):
                               for i in range(PIECES_THAT_FIT)]}
 
     def test_every_row_of_the_plane_is_on_screen_and_nothing_admits_otherwise(self):
-        """Four rows of content in four rows of table: no `…(+N more)` and no `⑂N`, because
-        there is nothing this pane is not showing. The badge is the half that would go
-        wrong in the other direction — counted from the pieces DRAWN, it must vanish here."""
+        """Four rows of content in four rows of table: no overflow line and no `⑂N`,
+        because there is nothing this pane is not showing. The badge is the half that would
+        go wrong in the other direction — counted from the pieces DRAWN, it must vanish
+        here.
+
+        Asserted on `…(`, the marker every shape of that line starts with, rather than on
+        one wording of it: this case used to look for `more)` and #741 deleted that word,
+        which would have left it passing against a line it had stopped being able to see."""
         rows = self._table()
         self.assertEqual(len(rows), 1 + PIECES_THAT_FIT, rows)
-        self.assertNotIn("more)", "\n".join(rows))
+        self.assertNotIn("…(", "\n".join(rows))
         self.assertNotIn("⑂", "\n".join(rows))
 
     def test_the_wheel_moves_nothing_on_a_pane_that_fits(self):

--- a/tests/test_a_real_click_reaches_the_real_repo_table.py
+++ b/tests/test_a_real_click_reaches_the_real_repo_table.py
@@ -404,7 +404,7 @@ class ARealPointerOnTheRealRepoTable(_ARealFrame):
         """The literal report. Six repos into four rows: three rows and `…(3 below)`, so
         there is somewhere below to go, and one notch must change WHICH repos are drawn."""
         before = self._table()
-        self.assertIn("(+3 more", "\n".join(before), before)
+        self.assertIn("(3 below", "\n".join(before), before)
         self._wheel(self.repos_pane, down=True)
         self.assertTrue(_await(lambda: self._table() != before),
                         f"a wheel notch changed nothing: {before!r}")
@@ -526,7 +526,7 @@ class ARealWheelOverAPlaneWithOneCloneAndManyPieces(_ARealFrame):
         simply dropped". A table that shows three of ten rows and says nothing is the
         false-clean reading this module refuses everywhere else, so the count on the
         overflow line has to be a count of ROWS and include the pieces."""
-        self.assertIn("(+7 more", "\n".join(self._table()), self._table())
+        self.assertIn("(7 below", "\n".join(self._table()), self._table())
 
     def test_a_click_on_a_worktree_row_selects_its_clone(self):
         """**No drawn row answers nobody.** Asserted with the table SCROLLED, so the only

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -571,6 +571,35 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         for col in self._cells(row, slots.ADD_CHAT):
             self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
 
+    def test_no_row_at_any_width_ever_draws_or_maps_a_column_left_of_zero(self):
+        """**The property a deleted guard used to protect by accident** (#767).
+
+        `_page` walks the last boundary LEFT to keep the final page from being a lone tab.
+        A `len(cuts) >= 3` conjunct kept that walk away from a single-field list, where the
+        boundary would step to `-1` — and the deletion sweep found it, because on such a
+        list `_bar` refuses the rung on width whatever `_page` answers, so the guard could
+        not change a row. It was deleted rather than suppressed. What was NOT deleted is
+        the property: a `+-1` field is unreadable and a negative column in the strip is the
+        wrong-answer-hiding index `_Tabs` refuses on purpose.
+
+        So this asserts the property where it can be seen, on the drawn row and the
+        published map, rather than trusting a guard whose effect nothing could observe.
+        Singletons and a name far wider than the pane are the shapes that reach the walk.
+        """
+        lists = (["only"], ["a"], ["x" * 60], ["a", "b"], ["x" * 40, "y"],
+                 [f"workspace-{i:02d}" for i in range(15)])
+        for names in lists:
+            for here in names:
+                for width in range(0, 120):
+                    rows = slots._bar("chats", list(names), here, width)
+                    row = rows[0] if rows else ""
+                    self.assertNotIn("+-", row,
+                                     f"{names} at {width}: a count went negative: {row!r}")
+                    for col in range(-4, 0):
+                        self.assertIsNone(
+                            slots.TABS.switch_to(col),
+                            f"{names} at {width}: column {col} is a tab: {row!r}")
+
     def test_a_column_nothing_drew_answers_nothing_however_far_out(self):
         """A mapping has no answer to give for a column outside it — which is where
         `_Viewport.repo_at`'s bounds check went. `-1` is the one that matters: a tuple

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -133,6 +133,42 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
                              "the row does not fill the width it is first drawn at, so "
                              "this measures no boundary")
 
+    def test_the_last_page_is_never_the_tab_you_are_on_alone(self):
+        """**#767, and it is #758 coming back at a WIDER width.**
+
+        Every page but the last is filled to the brim, so the last holds the remainder —
+        and a remainder shrinks as the pages grow. With the marked name sorting last, a
+        fifteen-name plane drew `+14  *workspace-14` at 228 columns: one tab, the one the
+        frame is already on, which `_Tabs.switch_to` correctly refuses. The bar was
+        clickable and reached nothing, at a width wider than the one that fixed it.
+
+        The last page now takes a name back from the page before it rather than standing
+        alone. Asked from 150 columns up, where the room is never the reason.
+        """
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        here = names[-1]
+        for width in range(150, 281):
+            row = self._row(width, names=names, here=here)
+            drawn = [n for n in names if n in row]
+            self.assertIn(here, drawn, f"{width}: the marked name is not on the row")
+            self.assertGreaterEqual(
+                len(drawn), 2,
+                f"{width} columns drew only the tab the frame is on: {row!r}")
+
+    def test_rescuing_the_last_page_costs_the_pages_before_it_nothing_here(self):
+        """The floor is on the LAST page, so it moves one boundary and no other. On this
+        project's own fifteen workspaces — where `harness-wrapper` sorts mid-list and the
+        last page is never the marked one — every width draws exactly what filling each
+        page to the brim drew, which is what makes this free rather than a trade."""
+        ws = ThisPlaneIsWhyTheRungIsWindowed.NAMES
+        drawn = []
+        for width in (100, 120, 160, 200, 240):
+            rows = slots._bar("workspaces", list(ws), "harness-wrapper", width)
+            row = rows[0] if rows else ""
+            drawn.append(len([n for n in ws if n in row]))
+        self.assertEqual(drawn, [4, 6, 8, 10, 13],
+                         "the rescue took a tab off a plane it was not for")
+
     def test_the_page_is_the_same_page_for_every_name_on_it(self):
         """**Why it is a page and not a window centred on the marked name.** The cut is a
         function of the names and the width alone, so switching to a tab that is ON the row

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -155,6 +155,36 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
                 len(drawn), 2,
                 f"{width} columns drew only the tab the frame is on: {row!r}")
 
+    def test_the_limit_this_cut_does_not_fix_is_ten_widths_of_exactly_one_name(self):
+        """**The stated cost, asserted instead of merely described** (#767).
+
+        `_page`'s docstring says the count is still not monotone — "10 such widths between
+        60 and 280 on a fifteen-name list, down from 12, each of exactly one name" — and a
+        number that lives only in a docstring is a claim nothing can falsify. It was
+        written from a measurement and there was nothing to keep it true.
+
+        Two claims, and the second is the one that matters: **no drop is ever more than a
+        single name.** A cut that started losing three at a time would still be "not
+        monotone" and would be a different, worse thing. The count of ten is pinned beside
+        it so that a change to the cut has to come back here and restate what it costs —
+        which is how the docstring stays honest rather than becoming folklore.
+        """
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        here = names[-1]
+        drops = []
+        previous = None
+        for width in range(60, 281):
+            row = self._row(width, names=names, here=here)
+            count = len([n for n in names if n in row])
+            if previous is not None and count < previous:
+                drops.append((width, previous - count))
+            previous = count
+        self.assertEqual([step for _w, step in drops], [1] * len(drops),
+                         f"a drop cost more than one name: {drops}")
+        self.assertEqual(len(drops), 10,
+                         f"the ladder's docstring says ten widths and this found "
+                         f"{len(drops)}: {drops}")
+
     def test_rescuing_the_last_page_costs_the_pages_before_it_nothing_here(self):
         """The floor is on the LAST page, so it moves one boundary and no other. On this
         project's own fifteen workspaces — where `harness-wrapper` sorts mid-list and the

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -417,7 +417,18 @@ class TerseSaysLess(PersonaIso, unittest.TestCase):
         terse = self._render("repos", "minimal")
         self.assertEqual(len(normal.split("\n")), 1 + 9)
         self.assertEqual(len(terse.split("\n")), 1 + slots._TERSE_ROWS)
-        self.assertIn("more", terse, "a panel showing less must say how much less")
+        # `6 below` and not `more`: #741 deleted that word, and a test looking for it
+        # would have gone on passing against a line it had stopped being able to read —
+        # the same way `test_every_row_of_the_plane_is_on_screen_and_nothing_admits_
+        # otherwise` searched for `more)` to assert the line's ABSENCE. Asserted as the
+        # real count of what this level hid, so "says how much less" is measured rather
+        # than the presence of any word at all.
+        # `- 1` because the overflow line is reserved OUT of the budget rather than
+        # appended on top of it (`_table_lines`), so a four-row terse table is three repo
+        # rows and the line that admits the other six.
+        hidden = 9 - (slots._TERSE_ROWS - 1)
+        self.assertIn(f"{hidden} below", terse,
+                      "a panel showing less must say how much less")
 
     def test_the_terse_table_still_keeps_the_repo_that_needs_attention(self):
         """The rows that survive are `_pick_rows`' ranked subset, not the first four —

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -1191,7 +1191,7 @@ class ReposTable(PersonaIso, unittest.TestCase):
         rows += [_row(f"clean-{i}") for i in range(5)]
         _seed("f-1", repos=rows)
         out = tui.strip_ansi(self._render(rows=4))
-        self.assertIn("more)", out)
+        self.assertIn("below)", out)
         self.assertNotIn("all clean", out)
 
     def test_a_one_row_budget_spends_it_on_saying_how_much_is_hidden(self):
@@ -1209,7 +1209,7 @@ class ReposTable(PersonaIso, unittest.TestCase):
         # would fold every row onto one line and make a line-count assertion meaningless.
         lines = [tui.strip_ansi(ln) for ln in self._render(rows=2).split("\n")]
         self.assertEqual(len(lines), 2, lines)
-        self.assertIn("+10 more", lines[1])
+        self.assertIn("10 below", lines[1])
         self.assertNotIn("all clean", lines[1],
                          "it is hiding a dirty repo and must not claim otherwise")
 

--- a/tests/test_the_repo_table_scrolls_and_selects.py
+++ b/tests/test_the_repo_table_scrolls_and_selects.py
@@ -1150,9 +1150,6 @@ class TheRankingStillAnswersEveryOtherCaller(unittest.TestCase):
         self.assertEqual(statusline._pick_rows(dirs, 3, None, st, {}, offset=9), [])
 
 
-if __name__ == "__main__":
-    unittest.main()
-
 
 class TheOverflowLineSaysWhichSideTheHiddenRowsAreOn(unittest.TestCase):
     """`…(4 above, 4 below, all clean)` — #741, and it is a sentence bug, not a sum bug.
@@ -1238,3 +1235,7 @@ class TheOverflowLineSaysWhichSideTheHiddenRowsAreOn(unittest.TestCase):
             lines = slots._table_lines(data, 100, budget, offset=offset)
             if lines and "…(" in tui.strip_ansi(lines[-1].text):
                 self.assertIsNone(lines[-1].repo)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_the_repo_table_scrolls_and_selects.py
+++ b/tests/test_the_repo_table_scrolls_and_selects.py
@@ -235,6 +235,23 @@ class TheViewportRemembersOneThingAndClampsIt(unittest.TestCase):
         self.assertEqual(self.v.repo_at(0), "a")
 
 
+def _sides(note: str) -> tuple[int, int]:
+    """The `(above, below)` the drawn overflow line states, read off the line itself.
+
+    Off the ROW rather than off `_table_lines`' own arithmetic, for the reason
+    `tests/test_frame_bars.AClickResolvesAgainstWhatWasDrawn` gives one surface over:
+    asking the renderer what it computed and then asserting it computed that agrees with
+    itself whatever the row says. This is the sentence the operator reads.
+    """
+    body = note.strip().removeprefix("…(").rstrip(")")
+    sides = {"above": 0, "below": 0}
+    for field in body.split(", "):
+        count, _, side = field.partition(" ")
+        if side in sides:
+            sides[side] = int(count)
+    return sides["above"], sides["below"]
+
+
 class TheWindowMovesAlongTheRanking(PersonaIso, unittest.TestCase):
     """What the table actually draws at each offset.
 
@@ -282,11 +299,21 @@ class TheWindowMovesAlongTheRanking(PersonaIso, unittest.TestCase):
     def test_the_overflow_note_still_counts_every_hidden_repo(self):
         """It needs no arithmetic of its own at any offset: what is hidden is "every key
         not in *show*", which is true wherever the window is. Twenty repos, thirteen shown,
-        seven hidden — at the top and at the bottom alike."""
+        seven hidden — at the top and at the bottom alike.
+
+        **The SIDES are what change**, and this case used to assert they did not: it read
+        `(+7 more` at every offset and passed, which is #741 exactly — a right number in a
+        sentence that claimed a direction the window had not earned."""
         data = _data([_row(f"r{i}") for i in range(20)])
+        seen = []
         for offset in (0, 3, 7):
             note = tui.strip_ansi(self._lines(data, 14, offset=offset)[-1].text)
-            self.assertIn("(+7 more", note)
+            above, below = _sides(note)
+            self.assertEqual(above + below, 7, f"offset {offset}: {note!r}")
+            self.assertEqual(above, offset, f"offset {offset}: {note!r}")
+            seen.append(note)
+        self.assertEqual(len(set(seen)), len(seen),
+                         f"the note said the same thing at three offsets: {seen}")
 
     def test_the_overflow_line_is_about_no_repo(self):
         """It stands for the rows that are NOT on screen. Selecting one of them because
@@ -369,11 +396,17 @@ class TheWindowMovesOverPieceRowsToo(PersonaIso, unittest.TestCase):
 
     def test_the_note_counts_the_pieces_it_is_not_showing(self):
         """Ten rows, three drawn, seven hidden — at the top and at the bottom alike. A
-        count over repos alone would say `(+0 more)` and there would be no note at all,
-        which is the half of #663 that reads as "the worktrees are simply dropped"."""
+        count over repos alone would say nothing was hidden and there would be no note at
+        all, which is the half of #663 that reads as "the worktrees are simply dropped".
+
+        The pieces are counted on the side they are actually on, which is the same rule
+        the repo rows above get: the window is ONE window over repo rows then piece rows,
+        so *offset* is how many of that one list are above it whichever kind they are."""
         for offset in (0, 1, 7):
             note = tui.strip_ansi(self._lines(offset=offset)[-1].text)
-            self.assertIn("(+7 more", note)
+            above, below = _sides(note)
+            self.assertEqual(above + below, 7, f"offset {offset}: {note!r}")
+            self.assertEqual(above, offset, f"offset {offset}: {note!r}")
 
     def test_a_dirty_worktree_off_screen_stops_the_note_saying_all_clean(self):
         """`_needs_attention` is asked of the hidden PIECES too. A table admitting seven
@@ -384,7 +417,7 @@ class TheWindowMovesOverPieceRowsToo(PersonaIso, unittest.TestCase):
                      worktrees=[_row(f"w{i}", repo="solo", dirty=(i == 8))
                                 for i in range(9)])
         note = tui.strip_ansi(slots._table_lines(data, WIDE, 4)[-1].text)
-        self.assertIn("(+7 more)", note)
+        self.assertIn("7 below)", note)
         self.assertNotIn("all clean", note)
 
     def test_a_pane_that_fits_every_piece_draws_no_note_and_ends_its_tree(self):
@@ -413,7 +446,7 @@ class TheWindowMovesOverPieceRowsToo(PersonaIso, unittest.TestCase):
         the middle of the table with three drawn rows under it, which could not happen
         while a capped table had no piece rows and now can."""
         drawn = self._lines()
-        self.assertIn("…(+7 more", tui.strip_ansi(drawn[-1].text))
+        self.assertIn("…(7 below", tui.strip_ansi(drawn[-1].text))
         self.assertIsNone(drawn[-1].repo)
 
     def test_every_drawn_piece_row_still_answers_its_clone(self):
@@ -1119,3 +1152,89 @@ class TheRankingStillAnswersEveryOtherCaller(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TheOverflowLineSaysWhichSideTheHiddenRowsAreOn(unittest.TestCase):
+    """`…(4 above, 4 below, all clean)` — #741, and it is a sentence bug, not a sum bug.
+
+    `_table_lines` computes `hidden` as the complement of what it drew, which its own
+    comment argues is "true wherever the window is" — and that is correct. What was wrong
+    was the word. `more` asserts *below*, and the row sits at the bottom of the table, so a
+    table scrolled to the end pointed underneath itself at nothing. Measured on twelve
+    repos in five rows before the fix, the line read `…(+8 more, all clean)` at offset 0,
+    at offset 4 and at offset 8 alike: eight below, four-and-four, and eight ABOVE are
+    three different places to be standing and the row said one thing at all three.
+
+    **Swept over shapes rather than asserted on the ones that came to mind.** #754's author
+    re-introduced the collision they were fixing because their fixture "was too short — I
+    wrote it from the shapes rather than from the tree", and `test_frame_bars`' own
+    346,084-row check is the shape this borrows: every repo count against every budget
+    against every legal offset, asking the drawn line rather than the arithmetic behind it.
+    """
+
+    def _shapes(self):
+        """Every (repos, pieces, budget, offset) this table can legally be asked for."""
+        for repos in range(1, 13):
+            for pieces in (0, 3, 9):
+                worktrees = [_row(f"w{i}", repo="r0") for i in range(pieces)]
+                data = _data([_row(f"r{i}") for i in range(repos)], worktrees=worktrees)
+                rows = slots._content_rows(data)
+                for budget in range(1, 16):
+                    limit = slots._scroll_limit(rows, budget)
+                    for offset in range(0, limit + 1):
+                        yield data, budget, offset
+
+    def test_every_shape_states_the_side_and_the_sides_add_up(self):
+        """Three claims at once, on the row itself. The counts add to what is hidden; the
+        leading one is exactly how far the window has been scrolled, because the window is
+        one window over one list; and a side with nothing on it is not drawn, which is
+        `_bar`'s `+0` rule one axis over."""
+        checked = capped = 0
+        for data, budget, offset in self._shapes():
+            lines = slots._table_lines(data, 100, budget, offset=offset)
+            checked += 1
+            note = tui.strip_ansi(lines[-1].text) if lines else ""
+            if "…(" not in note:
+                continue
+            capped += 1
+            above, below = _sides(note)
+            drawn = sum(1 for ln in lines if ln.repo is not None)
+            total = slots._content_rows(data)
+            self.assertEqual(above, offset,
+                             f"budget {budget} offset {offset}: {note!r}")
+            self.assertEqual(above + below, total - drawn,
+                             f"budget {budget} offset {offset}: {note!r}")
+            self.assertEqual("above" in note, above > 0,
+                             f"budget {budget} offset {offset}: {note!r}")
+            self.assertEqual("below" in note, below > 0,
+                             f"budget {budget} offset {offset}: {note!r}")
+        self.assertGreater(capped, 500,
+                           f"only {capped} of {checked} shapes overflowed, so this sweep "
+                           f"is measuring almost nothing")
+
+    def test_the_word_more_is_gone_because_it_was_the_false_half(self):
+        """It is the only word in the line that claimed a direction, and it claimed the
+        wrong one at every offset but the first."""
+        for data, budget, offset in self._shapes():
+            lines = slots._table_lines(data, 100, budget, offset=offset)
+            if lines:
+                self.assertNotIn("more", tui.strip_ansi(lines[-1].text))
+
+    def test_scrolled_to_the_bottom_the_line_says_above_and_never_below(self):
+        """The report's own case. At the scroll limit there is nothing under the row, so a
+        count that reads as "below" is pointing at empty screen."""
+        data = _data([_row(f"r{i}") for i in range(12)])
+        limit = slots._scroll_limit(slots._content_rows(data), 5)
+        note = tui.strip_ansi(slots._table_lines(data, 100, 5, offset=limit)[-1].text)
+        self.assertIn("above", note)
+        self.assertNotIn("below", note)
+        self.assertEqual(_sides(note), (limit, 0), note)
+
+    def test_the_line_is_still_about_no_repo_so_a_click_on_it_selects_nothing(self):
+        """Two counts rather than one changes what the row SAYS and not what it answers:
+        it stands for rows that are not on screen, and picking one of them because the
+        operator clicked the line saying they exist is the question nobody asked."""
+        for data, budget, offset in self._shapes():
+            lines = slots._table_lines(data, 100, budget, offset=offset)
+            if lines and "…(" in tui.strip_ansi(lines[-1].text):
+                self.assertIsNone(lines[-1].repo)

--- a/tests/test_the_repo_table_scrolls_and_selects.py
+++ b/tests/test_the_repo_table_scrolls_and_selects.py
@@ -138,11 +138,11 @@ class TheOffsetIsBoundedByTheDataAndThePane(unittest.TestCase):
         self.assertEqual(slots._scroll_limit(14, 15), 0)
 
     def test_the_limit_leaves_the_overflow_line_its_row(self):
-        """`_table_lines` reserves `…(+N more)` OUT of the budget rather than trimming it
-        off the end, so a 14-row pane draws 13 repo rows — and the last repo is reachable
-        only if this subtracts the same row. Twenty repos, thirteen rows of them, so the
-        window's last position is 7; at 7 it shows ranks 7..19 and nothing is out of
-        reach."""
+        """`_table_lines` reserves the `…(N above, N below)` line OUT of the budget rather
+        than trimming it off the end, so a 14-row pane draws 13 repo rows — and the last
+        repo is reachable only if this subtracts the same row. Twenty repos, thirteen of
+        them drawn, so the window's last position is 7; at 7 it shows ranks 7..19 and
+        nothing is out of reach."""
         self.assertEqual(slots._scroll_limit(20, 14), 7)
         self.assertEqual(slots._scroll_limit(7, 6), 2)
 
@@ -156,7 +156,7 @@ class TheOffsetIsBoundedByTheDataAndThePane(unittest.TestCase):
         self.assertEqual(slots._scroll_limit(15, 3), 13)
 
     def test_a_one_row_pane_is_all_overflow_line_and_does_not_scroll(self):
-        """A budget of exactly one is spent on `…(+N more)` — "there is more here than
+        """A budget of exactly one is spent on `…(N below)` — "there is more here than
         fits" outranks "here is an arbitrary one of them" — so every offset over such a
         table draws the identical line. A limit taken from the repo count alone would let
         the wheel repaint that one line forty times, each repaint byte-identical."""
@@ -435,7 +435,7 @@ class TheWindowMovesOverPieceRowsToo(PersonaIso, unittest.TestCase):
 
     def test_a_capped_table_never_closes_its_tree_above_the_note(self):
         """`╰─` means *this is where the tree ends*, and on a capped table it does not:
-        `…(+N more)` is the next line. The glyph and the line under it would be saying
+        `…(N below)` is the next line. The glyph and the line under it would be saying
         opposite things, which is the one thing `_TREE_WT` exists to prevent."""
         drawn = self._lines()
         self.assertNotIn(statusline._TREE_WT.strip(),
@@ -843,7 +843,7 @@ class TheAttentionRowSaysWhatWasPicked(PersonaIso, unittest.TestCase):
     def test_a_quiet_repo_says_clean_rather_than_saying_nothing(self):
         """An absence standing in for a claim is the defect this repository keeps finding:
         a reader cannot tell "nothing is wrong" from "this field was cut". The word comes
-        from `_needs_attention`, the same predicate the `…(+N more), all clean` note asks,
+        from `_needs_attention`, the same predicate the `…(N below, all clean)` note asks,
         so the two cannot come to disagree about what clean means."""
         self.assertEqual(tui.strip_ansi(slots._detail_text(_row("charter"))),
                          "▪ charter · main · clean")


### PR DESCRIPTION
Closes #741 and #767. Two surfaces, one rule: **an overflow marker that describes a window
has to say where the window is.**

## #741 — the repo table's count was right and its sentence was false

`hidden` is the complement of what was drawn, "true wherever the window is". The arithmetic
was never the bug. `more` is: it asserts *below*, the line sits at the bottom of the table,
and scrolled to the end it pointed underneath itself at nothing.

And it was the same sentence everywhere. Twelve repos in a five-row pane:

| offset | before | after |
|---|---|---|
| 0 | `…(+8 more, all clean)` | `…(8 below, all clean)` |
| 4 | `…(+8 more, all clean)` | `…(4 above, 4 below, all clean)` |
| 8 (bottom) | `…(+8 more, all clean)` | `…(8 above, all clean)` |

Three places to be standing, one string. Scrolling moved a number that never moved.

The table is one window over one list — repo rows then piece rows, the order its budget is
already spent in — so `offset` **is** what is above, and what is left of `hidden` is below.
Taken from the numbers the rows were sliced with, not re-derived.

**Not a marker row, not an arrow.** A row along the top costs a *repo row* out of a budget
counted in rows, at exactly the budgets short enough to scroll; the bottom line was already
reserved out of that budget, so two numbers on it cost nothing. `●`, `◆` and the pointing
triangles are East-Asian Ambiguous and have broken this layout twice (`_BAR_MARK`'s record).

## #767 — a wider tab bar could draw fewer tabs, and collapse to one

Found by the coordinator reviewing #759. Every page but the last is filled to the brim, so
the last holds the **remainder** — and a remainder shrinks as the pages grow. With the
marked name sorting last, 14 widths between 60 and 280 drew *fewer* names as the bar got
wider, and **228 columns collapsed to `+14  *workspace-14`**: one tab, the one the frame is
already on. #758 returning at a width wider than the one that fixed it. This plane escapes
it only because `harness-wrapper` sorts mid-list; `zzz-scratch` would not.

**Not covered by the monotonicity #759 pinned** — that asks whether the row is drawn *at
all*, and with the marked name last it always is. Measured: that case stays green while the
count drops at 12 widths. Different property, and it was unpinned.

Four cuts measured over 82 name lists at every room from 5 to 300. "Avoidable inert" counts
pages holding a single tab while some page held two or more:

| cut | avoidable inert | this plane 100/120/160/200/240 | drops | min tabs ≥150 cols |
|---|---|---|---|---|
| greedy (shipped) | 4775 | 4, 6, 8, 10, 13 | 12 | **1 — inert** |
| equal-sized pages | 6969 | 4, 4, 5, 7, 7 | 0 | 1 |
| last page from the right | 4911 | 4, 6, 8, **6**, 12 | 0 | 2 |
| **floor of 2 on the last page** | **4175** | **4, 6, 8, 10, 13** | 10 | **2** |

Balancing every page is **worse**, not better — equal-sized pages ignore what names cost, so
short-name runs go under-packed. Packing the last page from the right removes the drops by
moving them onto a middle name. A floor of two costs this plane nothing and removes the
inert row.

**The count is still not monotone — 10 drops, each of one name — and that is stated in the
ladder's docstring rather than left to be found.** Every cut that removes the rest was
measured worse on the harm that matters.

The coordinator's central question was whether a last-page merge breaks the column stability
that ruled out a centred window. **It does not**, and that is measured, not reasoned: any
`here`-independent repartition keeps it, at **0 of 1,131,087** press/switch/press triples
where a second press at the same column switched again.

## Verification

- Full suite green; real tmux on **3.7c and the 3.2 floor**, both surfaces.
- #741 swept over **1,414 (repos, pieces, budget, offset) shapes, 1,084 of them overflowing**
  — sides add to what is hidden, the leading count equals the offset, a side with nothing on
  it is never drawn. Three of four new cases go red on the old line.
- Two existing cases **pinned the defect** ("at the top and at the bottom alike", asserting
  the identical string at three offsets) and now assert the total holds while the sides move.
- `test_every_row_of_the_plane_is_on_screen_and_nothing_admits_otherwise` looked for `more)`,
  a word this change deletes — it would have passed against a line it had stopped being able
  to see. It asks for `…(` now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy