### PR TITLE
The palette keeps one pane, answers the name you typed, and stops hiding the only key the frame has (#739, #732, #749, #746, #743, #745)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -148,8 +148,9 @@ import sys
 import time
 
 from . import config, contain, harness, instance, tui, util, workspace
-from .frame import (builtin_actions, chats, choose, component, gather, layout, overlay,
-                    pane, palette, picker, state, switch, tmuxctl)
+from .frame import (actions as frame_actions, builtin_actions, chats, choose, component,
+                    gather, layout, overlay, pane, palette, picker, state, switch,
+                    tmuxctl)
 # Aliased: `cmd_launch` already has a local variable named `slots` (the VISIBLE slot
 # list `layout.visible_slots` returns) — importing the renderer registry under its own
 # name would be shadowed by that local the moment it's assigned, and a `slots.SLOTS`
@@ -6266,16 +6267,20 @@ def cmd_palette(args) -> int:
     0018 says it never draws — so every refusal here is a quiet no-op, exactly like
     `cmd_density`'s.
 
-    **Pressing the hotkey while the palette is already open opens a second one.** A
+    **Pressing the hotkey while the palette is already open REOPENS it** (#739). A
     `bind -n` is the ROOT key table, so tmux matches `F2` before any byte reaches the
     palette's pane — which is measured only for a key tmux's own table claims, and is the
-    same property that makes the escape hatch work against a wedged overlay. The second
-    palette is the modal one and Escape closes it; the first is left as an ordinary
-    pane, closable by selecting it and pressing Escape, or by the hatch. Not guarded
-    here on purpose: every cheap test for "is one
-    already open" is a stale-state problem of its own (the hatch deliberately leaves the
-    window option naming a pane that is gone), and a guard that refuses the palette after
-    an escape-hatch press would be worse than the state it is preventing.
+    same property that makes the escape hatch work against a wedged overlay. So the second
+    press runs this function again, and :func:`_close_open_overlays` is what stops it
+    leaving the first palette standing as an invisible pane holding a live process.
+
+    This used to be left unguarded on purpose, and the reason was right about the guard it
+    was imagining: "every cheap test for 'is one already open' is a stale-state problem of
+    its own", and a guard that REFUSED after an escape-hatch press would be worse than the
+    state it prevented. Neither objection reaches the sweep. The mark is a tmux **pane**
+    option, so it is tmux's state and dies with the pane — there is nothing charter can
+    believe that is out of date — and nothing is ever refused: every press answers with a
+    palette.
 
     **``--pane`` is this process being handed a rectangle, so it is where the pane is
     claimed** (`frame/pane.py`, #606/#611) — and the claim is HERE rather than inside
@@ -6334,6 +6339,7 @@ def _open_palette(args) -> int:
     v = tmuxctl.version()
     if v is None:
         return 0
+    _close_open_overlays(socket, harness=harness)
     argv = overlay.open_argv(
         socket, harness=harness,
         command=util.self_relaunch_argv("frame-palette",
@@ -6346,6 +6352,57 @@ def _open_palette(args) -> int:
                                    overlay_pane=opened.stdout.strip()):
         tmuxctl.run("making the palette the surface", cmd)
     return 0
+
+
+def _close_open_overlays(socket: str, *, harness: str) -> None:
+    """Close any palette already open on this frame's window, before opening another.
+
+    **`F2` while a palette is up means REOPEN**, and #739 is what it meant before. A
+    `bind -n` is the root key table, so tmux matches the key before any byte reaches the
+    overlay's pane — that is not a defect to be fixed at the bind, it is the same property
+    that makes the escape hatch work against a wedged surface. So the second press really
+    does run this command, and what it must not do is leave the first palette standing:
+    Escape closes the one holding the keyboard, and the other stayed as a blank five-row
+    pane holding a live Python process, six rows off the harness, for the life of the
+    frame — invisible, since a blank gap above the repo table's rule reads as empty
+    terminal. `F12` is `select-pane` and does not clear it; a resize does not; no palette
+    row does. Only tmux's own prefix + `x` did, which `charter frame` neither binds nor
+    documents.
+
+    **Reopen rather than no-op or toggle, and the reason is the double press itself.**
+    Both of those require charter to BELIEVE a palette is open, and being wrong makes the
+    key do nothing — the worst possible answer for a key whose response takes a visible
+    moment to appear (#728 measures ~1.8 s of blank terminal on a launch; #729 measures a
+    four-second freeze on the switch path). An operator who presses `F2` twice is
+    precisely an operator who thinks the first press did not register; answering them with
+    no palette at all is the complaint they already had, made permanent. This answers
+    every press with a palette. It is also the *fresher* one: the catalogue resolves the
+    density, the surface, the workspace and the persona at the moment it opens, so a
+    reopen re-reads a plane that may have moved under the first.
+
+    **Nothing here is charter's own record of what is open**, which is what the old
+    refusal to guard was right about: `cmd_palette`'s docstring argued that "every cheap
+    test for 'is one already open' is a stale-state problem of its own", and a value
+    charter writes down can outlive the pane it describes — the hatch option deliberately
+    does. `overlay.OVERLAY_OPTION` is a **pane** option, so the answer is tmux's and dies
+    with the pane. There is no state to be stale, and this never refuses anything: a
+    listing that comes back empty, unparseable, or naming panes that have since gone costs
+    one no-op and the palette opens regardless.
+
+    **Every overlay on the window, not only the last one.** The reachable route is a
+    double `F2`, but it is not the only one — any second open against a live palette does
+    it, including a `charter frame-palette` typed in the harness and a second client
+    attached to the same session pressing the key — and a frame that has been running
+    since before this fix can already be carrying orphans. Sweeping what tmux says is
+    there heals those too, rather than making one route safe and calling the class closed.
+    """
+    listing = overlay.live_argv(socket, harness=harness)
+    if listing is None:
+        return
+    found = overlay.live_panes(tmuxctl.run("finding an open palette", listing).stdout)
+    argv = overlay.sweep_argv(socket, found)
+    if argv is not None:
+        tmuxctl.run("closing the palette already open", argv)
 
 
 def _draw_palette(args) -> int:
@@ -6401,8 +6458,18 @@ def _draw_palette(args) -> int:
                        + palette.rows(reg.offers(fid=fid, snapshot=snapshot))),
             query_only=lambda: _name_rows(fid, opened),
             mouse=True)
-        chosen = palette.own_the_tty(
-            surface, then=lambda row: _picker(row, fid, opened))
+        def _then(row):
+            # Two ways a chosen row does NOT end the palette, asked in the order they
+            # cost: a doorway replaces the surface, and a repeatable action runs and
+            # leaves this one standing. Explicit rather than `_picker(...) or _again(...)`
+            # — both answer a `Surface`, and a surface's truthiness is not a thing this
+            # file gets to assume on `own_the_tty`'s behalf.
+            nxt = _picker(row, fid, opened)
+            if nxt is not None:
+                return nxt
+            return _again(row, surface, reg, fid=fid, snapshot=snapshot)
+
+        chosen = palette.own_the_tty(surface, then=_then)
         if chosen is None:
             return 0
         picked = _chosen_name(chosen, opened)
@@ -6489,6 +6556,52 @@ def _picker(row, fid: str, opened: list) -> "palette.Palette | None":
         return None
     return palette.Palette(catalogue=_roster(noun, fid, opened).rows,
                            label=noun, mouse=True)
+
+
+def _again(row, surface, reg, *, fid: str, snapshot) -> "palette.Palette | None":
+    """Run *row* and hand *surface* back to be drawn again — or ``None`` for every row
+    that is not repeatable, which ends the palette exactly as before. **#746.**
+
+    **One palette opening, not one per row.** `repo: select the next row` and its
+    `previous` twin are the only actions charter offers whose natural use is *repeated*,
+    and with `[frame] mouse = false` shipped as the default they are the repo table's only
+    interaction model. Measured by the report: moving the selection three rows down a
+    fourteen-row table cost fourteen keystrokes and three ~3-second cycles, because each
+    Enter closed the pane, killed the process and re-split, re-imported and re-drew the
+    whole surface for the next one. Everything about that cost is the palette OPENING; the
+    action itself is `state.record_selection` plus `state.bump`, two file writes, done in
+    this process (`builtin_actions._select` says why it does not spawn).
+
+    **The query and the cursor are deliberately left alone.** `Palette._refilter` resets
+    the selection to the top on every edit, and calling it here would move the cursor off
+    the row the operator is holding Enter on — turning a repeat into "type the filter
+    again". So this writes `heading` directly and touches nothing else on the surface:
+    what comes back is the same list, the same filter, the same row under the cursor.
+
+    **The heading is where the outcome goes, and that is forced rather than chosen.** The
+    overlay pane is `resize-pane -Z`'d over the whole window (`overlay.modal_argvs`, whose
+    own measurement is that a zoomed pane's siblings are not drawn) — so the repo table
+    the selection is moving through is NOT on screen behind the palette. A repeat whose
+    only feedback was the table would be moving a highlight nobody can see. `Invocation`
+    already carries the sentence the action answered with (`selected auth`), so the
+    surface the operator IS looking at says what just happened, and the next Enter says
+    the next one.
+
+    A refusal lands in the same place for the same reason, and the palette stays up: the
+    row is still listed, still says why in its note, and an operator who pressed it has
+    been told without losing the pane. That is `_say_on_screen`'s job for a palette that
+    is CLOSING and this one's for a palette that is not.
+    """
+    try:
+        act = reg.get(row.id)
+    except frame_actions.ActionError:
+        return None           # a picker row, or an id no provider on this machine has
+    if not act.repeat:
+        return None
+    inv = reg.invoke(row.id, fid=fid, snapshot=snapshot)
+    inv.join(timeout=_ACTION_START_GRACE)
+    surface.report(inv.reason if not inv.started else (inv.note or inv.error))
+    return surface
 
 
 def _name_rows(fid: str, opened: list) -> "tuple[overlay.Row, ...]":

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -6597,6 +6597,15 @@ def _again(row, surface, reg, *, fid: str, snapshot) -> "palette.Palette | None"
     surface the operator IS looking at says what just happened, and the next Enter says
     the next one.
 
+    **And that is why this does not use `state.say`**, which is the frame's own surface
+    for exactly this kind of sentence (#729) and is the right one everywhere else in this
+    function. It is drawn by a panel, on the attention row, in a pane the zoom is covering
+    — so a repeat that wrote a notice would be writing to a surface the operator cannot
+    see, and would then have to wait for a palette that is deliberately not closing before
+    they could. A notice per press would also outlive its own occasion: the dwell is
+    seconds and the presses are faster than that, so the row would settle on whichever
+    move happened to be last. The header is redrawn by the same keystroke that caused it.
+
     A refusal lands in the same place for the same reason, and the palette stays up: the
     row is still listed, still says why in its note, and an operator who pressed it has
     been told without losing the pane. That is `_say_on_screen`'s job for a palette that

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -6371,12 +6371,16 @@ def _close_open_overlays(socket: str, *, harness: str) -> None:
 
     **Reopen rather than no-op or toggle, and the reason is the double press itself.**
     Both of those require charter to BELIEVE a palette is open, and being wrong makes the
-    key do nothing — the worst possible answer for a key whose response takes a visible
-    moment to appear (#728 measures ~1.8 s of blank terminal on a launch; #729 measures a
-    four-second freeze on the switch path). An operator who presses `F2` twice is
-    precisely an operator who thinks the first press did not register; answering them with
-    no palette at all is the complaint they already had, made permanent. This answers
-    every press with a palette. It is also the *fresher* one: the catalogue resolves the
+    key do nothing — the worst possible answer for a key whose response is not instant.
+    Opening the palette splits a pane, starts a Python process, imports every installed
+    provider and paints; #728 measures the neighbouring launch path at ~1.8 s of blank
+    terminal, and the palette's own open was reported at about three seconds. **The
+    argument does not rest on any particular number, and deliberately not on #729's
+    four-second freeze, which #763 has since removed.** It rests on the shape: an operator
+    who presses `F2` twice is precisely an operator who thinks the first press did not
+    register, and answering them with no palette at all is the complaint they already had,
+    made permanent. A faster palette makes that press rarer; it does not make refusing it
+    the right answer. This answers every press with a palette. It is also the *fresher* one: the catalogue resolves the
     density, the surface, the workspace and the persona at the moment it opens, so a
     reopen re-reads a plane that may have moved under the first.
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -6389,6 +6389,16 @@ def _close_open_overlays(socket: str, *, harness: str) -> None:
     listing that comes back empty, unparseable, or naming panes that have since gone costs
     one no-op and the palette opens regardless.
 
+    **The palette this kills does not fight back**, and that is measured rather than
+    assumed. `_draw_palette` hands the pane back from a ``finally``, so the obvious worry
+    is a swept process running `_close_palette` on its way out: that would `select-pane`
+    the harness — pulling focus off the palette being opened — and re-arm the hatch with
+    NO overlay, leaving `F12` unable to close the new one. It cannot happen. `kill-pane`
+    terminates the pane's program without Python cleanup; measured directly, on a pane
+    running a process whose ``finally`` writes a file, the file is never written. The
+    ``finally`` runs when the palette CHOOSES to close, which is the only time anything
+    needs it to.
+
     **Every overlay on the window, not only the last one.** The reachable route is a
     double `F2`, but it is not the only one — any second open against a live palette does
     it, including a `charter frame-palette` typed in the harness and a second client

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -22,12 +22,48 @@ from .commands import (_cred_flag, _git, _origin_https, cmd_clone, commit_memory
 
 
 def cmd_workspace_list(args) -> int:
+    """Every workspace this plane offers, with the active one marked — #745.
+
+    **The always-present workspace is folded in whether or not its directory exists**,
+    which is `frame/switch.workspaces`' rule asked at the other surface rather than a
+    second one invented here. `workspace.list_workspaces` reads DIRECTORIES, and
+    `config.DEFAULT_WORKSPACE` is the rung `workspace.resolve` terminates on — so a plane
+    where nobody has selected anything resolves to a name this listing did not contain,
+    and the table printed a "you are here" inset with the mark on no row at all:
+
+        Active workspace: default  (via default (nothing selected))
+
+          WORKSPACE  MODE   CLONES  REPOS
+          alpha      local  0       —
+          beta       local  0       —
+
+    That is #745 read from the CLI side. The report came from the frame — the `F2`
+    workspace picker offers `default`, switching to it succeeds, and `charter workspace
+    list` then does not list where the frame is standing — but the picker is not what is
+    wrong: `charter workspace use default` accepts the same name on a plane that has never
+    made one, and says so in as many words, because `workspace.ensure` creates it on
+    demand. The disagreement was between the LISTING and everything else.
+
+    **Not created here, and not by `charter init` either**, which is the other half of the
+    report and the half this declines. `[workspace] default` names it, so `init` would be
+    baking a directory for a value the operator may change in the charter.toml `init`
+    itself just wrote — and every route that puts something IN the workspace (`clone`,
+    `workspace use`, `workspace create`) already calls `ensure`. A row costs nothing and
+    cannot go stale; a directory named after last week's config can.
+
+    A row for it is honest about what it is: `local`, no clones, `—` for repos, which is
+    exactly what it holds.
+    """
     active = workspace.resolve()
     names = workspace.list_workspaces()
-    if not names:
-        util.info(f"No workspaces yet. Active resolves to '{active}'. "
+    fresh = not names
+    if config.DEFAULT_WORKSPACE not in names:
+        names = sorted(names + [config.DEFAULT_WORKSPACE])
+    if fresh:
+        # Still said, because "there is one row and it is the fallback" and "somebody has
+        # made a workspace" are different states and the table cannot tell them apart.
+        util.info(f"No workspaces yet — '{active}' is the one every plane starts on. "
                   "Create one: charter workspace create <name>")
-        return 0
     print(f"Active workspace: {active}  (via {workspace.source()})\n")
     live = workspace.live_workspaces()
     # `{:<22}` was a guess about a name the operator minted, and `{:<7}` twice over about

--- a/charter/frame/action.py
+++ b/charter/frame/action.py
@@ -128,6 +128,34 @@ class Action:
     #: What this action reaches, drawn from :data:`TOUCHES`. The ctx is built from it, so
     #: an action gets what it declared and not one field more.
     touches: tuple[str, ...] = ()
+    #: Whether this row is the state the frame is already IN — `density: full` on a frame
+    #: at `full`, `chrome: off` on a frame with no surface. Drawn as
+    #: `frame/overlay.ROW_MARK` in a column every row reserves.
+    #:
+    #: **A flag and not two characters in the title**, which is #749: `_register_density`
+    #: and `_register_chrome` used to compose `"* "` into the title themselves, and every
+    #: other action — every doorway, every provider's — composed nothing, so the palette
+    #: had two left edges. A bool cannot be spelled a third way by the next row source.
+    #:
+    #: Static rather than a callable, unlike :attr:`available`: the mark is resolved when
+    #: the registry is BUILT (`builtin_actions.build` is handed the density and chrome in
+    #: effect), because it describes the moment the palette opened rather than a plane
+    #: other processes are moving underneath it.
+    mark: bool = False
+    #: Whether running this leaves the palette OPEN, with the query and the cursor where
+    #: the operator left them, so the next Enter runs it again — #746.
+    #:
+    #: **For an action whose natural use is repeated, and for nothing else.** `repo:
+    #: select the next row` moves a selection by one; with `[frame] mouse = false`
+    #: shipped as the default it is the only route the repo table has, and it cost a full
+    #: palette open, filter and close per row — three rows measured at three ~3-second
+    #: pane cycles. Everything else the palette runs is a thing you do once.
+    #:
+    #: **What it does NOT relax is fire-and-report.** A repeatable action still starts its
+    #: work and returns; what changes is only whether the surface that ran it is torn
+    #: down. `commands_frame._draw_palette` still joins on the same grace and still says a
+    #: refusal on the operator's own screen.
+    repeat: bool = False
 
     def __post_init__(self) -> None:
         # The id first: every message below names the action it is about, and an action

--- a/charter/frame/actions.py
+++ b/charter/frame/actions.py
@@ -106,6 +106,12 @@ class Offer:
     #: Empty exactly when :attr:`available`. Never empty when it is not — charter writes
     #: a sentence when the action would not.
     reason: str
+    #: `Action.mark`, carried so the surface drawing this row does not have to hold the
+    #: registry to find out whether it is the state the frame is in.
+    mark: bool = False
+    #: `Action.repeat`, carried for the same reason — and it is what
+    #: `commands_frame._draw_palette` reads to decide whether the palette closes.
+    repeat: bool = False
 
 
 class Invocation:
@@ -339,7 +345,8 @@ class ActionRegistry:
         out = []
         for a in self.all():
             available, reason, _ = self._check(a, fid=fid, snapshot=snapshot)
-            out.append(Offer(id=a.id, title=a.title, available=available, reason=reason))
+            out.append(Offer(id=a.id, title=a.title, available=available, reason=reason,
+                             mark=a.mark, repeat=a.repeat))
         return tuple(out)
 
     def invoke(self, aid: str, *, fid: str, snapshot: Mapping) -> Invocation:

--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -50,6 +50,12 @@ from . import action, actions, choose, state, tmuxctl
 #: `frame/choose.py`'s, which marks the workspace and the persona a frame is on for the
 #: identical reason, and a second copy here would be a second answer to what "the one you
 #: are on" looks like. See that module for why it is ASCII.
+#:
+#: Nothing in this module composes it into a title any more — `action.Action.mark` says
+#: which row is the one in effect and `frame/overlay.py` draws it, which is #749. The
+#: name is kept because it is what a reader looking for "how is the current one marked"
+#: comes here for, and because it is still the width `frame/slots.py` measures its own
+#: rows against.
 MARK = choose.MARK
 
 
@@ -210,7 +216,7 @@ def _register_selection(reg: actions.ActionRegistry) -> None:
     for word, step, start in _SELECT_STEPS:
         reg.register(action.Action(
             id=f"repo.{word}", title=f"repo: select the {word} row",
-            touches=("repos",),
+            touches=("repos",), repeat=True,
             run=(lambda ctx, st=step, sr=start: _select(ctx, st, sr)),
             available=lambda ctx: bool(ctx.repos),
             reason_unavailable=lambda ctx: NO_REPOS))
@@ -258,9 +264,8 @@ def _register_density(reg: actions.ActionRegistry, *, current: str) -> None:
     """
     from .. import instance
     for level in instance.FRAME_DENSITY:
-        on = MARK[0] if level == current else MARK[1]
         reg.register(action.Action(
-            id=f"density.{level}", title=f"{on}density: {level}",
+            id=f"density.{level}", title=f"density: {level}", mark=(level == current),
             run=(lambda ctx, lv=level: _run_density(ctx.fid, lv)),
             available=lambda ctx: _laid_out(ctx.fid),
             reason_unavailable=lambda ctx: NO_LAYOUT))
@@ -295,9 +300,8 @@ def _register_chrome(reg: actions.ActionRegistry, *, current: str) -> None:
     """
     from .. import instance
     for level in instance.FRAME_CHROME:
-        on = MARK[0] if level == current else MARK[1]
         reg.register(action.Action(
-            id=f"chrome.{level}", title=f"{on}chrome: {level}",
+            id=f"chrome.{level}", title=f"chrome: {level}", mark=(level == current),
             run=(lambda ctx, lv=level: _run_chrome(ctx.fid, lv)),
             available=lambda ctx: bool(state.panes(ctx.fid)),
             reason_unavailable=lambda ctx: NO_PANES))

--- a/charter/frame/choose.py
+++ b/charter/frame/choose.py
@@ -120,13 +120,21 @@ PIN = {WORKSPACE: "CHARTER_WORKSPACE", PERSONA: "CHARTER_PERSONA"}
 NO_CHANGES = ("no cross-repo change in this workspace — create one with "
               "`charter change create <slug> --why \"…\"`")
 
-#: What marks the name the frame is on right now.
+#: What marks the name the frame is on right now — **`overlay.ROW_MARK`, not a second
+#: pair**, and that is #749's fix seen from this side.
 #:
-#: **ASCII, deliberately** — `overlay._MARK`'s own rule and `statusline._persona_chips`'
-#: measurement behind it: `●`, `◆` and the pointing triangles are East-Asian *Ambiguous*
-#: and have broken this layout twice. Both entries are the same width by construction, so
-#: the mark moving does not move the names beside it.
-MARK = ("* ", "  ")
+#: A row used to arrive here already carrying two characters of mark, which made the width
+#: of the mark column a thing each row source spelled for itself: this module spelled it,
+#: `frame/builtin_actions.py` spelled it through this name, and the doorways and every
+#: other action spelled nothing at all — so the palette drew two left edges. The mark is
+#: now :attr:`overlay.Row.mark`, a flag, and the column is reserved for every row by
+#: `overlay.Surface.render`.
+#:
+#: The name stays because it is charter's "you are here" marker beyond this surface:
+#: `frame/slots.py`'s changes section draws its own rows with it and must not invent a
+#: second spelling of the same idea. Bound to the overlay's pair rather than copied, so
+#: there is one answer to what the mark IS as well as to how wide it is.
+MARK = overlay.ROW_MARK
 
 #: The id of the palette row that OPENS a picker, and of one name row inside one. See the
 #: module docstring for why both carry a `:` — it is what keeps them out of the action
@@ -139,9 +147,15 @@ class Roster(NamedTuple):
     """One picker's rows, and the names they stand for.
 
     The two are carried together and matched by ROW ID rather than by title, because the
-    title carries :data:`MARK` and a committed name that `overlay.Surface.render`
-    contains before drawing — so the string on screen is not the string to switch to, and
-    a surface that matched on what it drew would switch to a repaired name or to nothing.
+    title is a committed name that `overlay.Surface.render` contains before drawing — so
+    the string on screen is not the string to switch to, and a surface that matched on
+    what it drew would switch to a repaired name or to nothing.
+
+    **The title is the bare name now** (#749, where the mark moved to
+    :attr:`overlay.Row.mark`), and that does not soften the rule above by one word:
+    containment is what the two strings differ by, and it is exactly the difference that
+    matters — a name holding a `\\u2028` is one row and one name, and only one of those
+    two is the thing `switch.to_workspace` may be handed.
     """
 
     #: :data:`WORKSPACE` or :data:`PERSONA`. Carried so a caller that opened a picker does
@@ -247,9 +261,9 @@ def pin_reason(noun: str, fid: str) -> str:
 def roster(noun: str, fid: str) -> Roster:
     """Every name *noun* has, as rows, with the one *fid* is on marked.
 
-    No cap and no reordering: `frame/palette.py`'s `narrow` filters this list as the
-    operator types and never reorders it, so the row under the cursor stays under the
-    cursor between keystrokes.
+    No cap, and the order is `switch.py`'s: `frame/palette.py`'s `narrow` filters this
+    list as the operator types and moves only a row whose whole name has been typed
+    (#732), so a picker of forty names reads down its listing order every other time.
 
     The note column is left empty for three of the four nouns. The one refusal a picker
     could carry per row is the launch pin, and that is reported by the row that OPENS the
@@ -265,8 +279,7 @@ def roster(noun: str, fid: str) -> Roster:
     """
     names = tuple(names_of(noun, fid))
     now = current(noun, fid)
-    rows = tuple(overlay.Row(id=NAME_ID.format(noun, i),
-                             title=f"{MARK[0] if n == now else MARK[1]}{n}",
+    rows = tuple(overlay.Row(id=NAME_ID.format(noun, i), title=n, mark=(n == now),
                              note=_note(noun, n))
                  for i, n in enumerate(names))
     return Roster(noun=noun, rows=rows, names=names)
@@ -314,11 +327,19 @@ def labelled(roster: Roster, reason: str = "") -> tuple[overlay.Row, ...]:
     (#512). The reason names `$CHARTER_WORKSPACE` or `$CHARTER_PERSONA`, so the kind is
     still on the row; it is a sentence instead of a word.
 
-    ``_replace`` rather than a fresh `overlay.Row`, so the id is carried over untouched:
-    it is what :meth:`Roster.name_of` matches on, and a labelled row that minted its own
-    would be a row that stands for no name.
+    **A *reason* also makes the row REFUSED**, and that is a second field rather than a
+    re-reading of the first because the note means two different things here. With no
+    reason the note is the kind — `workspace`, `persona` — and the row runs perfectly
+    well; with one, the note is why it cannot. `frame/palette.narrow` has to tell those
+    apart to decide which row the cursor starts on (#732), and "the note is non-empty"
+    would call every labelled row in the palette unavailable.
+
+    ``_replace`` rather than a fresh `overlay.Row`, so the id and the mark are carried
+    over untouched: the id is what :meth:`Roster.name_of` matches on, and a labelled row
+    that minted its own would be a row that stands for no name.
     """
-    return tuple(r._replace(note=reason or roster.noun) for r in roster.rows)
+    return tuple(r._replace(note=reason or roster.noun, refused=bool(reason))
+                 for r in roster.rows)
 
 
 def open_rows(fid: str) -> tuple[overlay.Row, ...]:
@@ -335,14 +356,23 @@ def open_rows(fid: str) -> tuple[overlay.Row, ...]:
     on" without opening anything, and so typing `alpha` still finds the row when `alpha`
     is where the frame is. The note is the pin reason, which is what makes a pinned frame
     say so **before** a keypress — Task 4's rule, unchanged, one row instead of forty.
+
+    **A reason here is a refusal, and the row says so in a field** (#732). A doorway with
+    a reason is one `commands_frame._picker` will not open: it says the note on the
+    operator's screen and nothing else happens. That is the right behaviour for a
+    keypress and the wrong place for a cursor to be resting when the query also matched a
+    name that switches — which is the whole of #732, where `chat: alpha.1 — pick another`
+    outranked the `alpha` workspace row because a substring of a title beat an exact
+    match on a name.
     """
     out = []
     for noun in NOUNS:
         now = current(noun, fid)
+        reason = pin_reason(noun, fid)
         out.append(overlay.Row(
             id=OPEN_ID.format(noun),
             title=(f"{noun}: {now} — pick another" if now else f"{noun} — pick one"),
-            note=pin_reason(noun, fid)))
+            note=reason, refused=bool(reason)))
     return tuple(out)
 
 

--- a/charter/frame/overlay.py
+++ b/charter/frame/overlay.py
@@ -945,12 +945,19 @@ def live_panes(listing: str) -> tuple[str, ...]:
     is build a `kill-pane` around it: this is a value read back off tmux, and #442's rule
     is that a value's shape is checked where it re-enters charter rather than trusted
     because of where it came from.
+
+    **`split()` and not a partition**, which is a smaller claim rather than a tidier one.
+    A partition has an end to pick and a strip has an amount to take, and neither choice
+    is observable on this format — the deletion sweep says so, offering `rpartition` and
+    `lstrip` as passing substitutes. `split()` on whitespace has no such knob: it is "the
+    fields of this line", which is what the format is. `>= 2` rather than `== 2` so a mark
+    somebody set by hand to a value with a space in it still counts as a mark.
     """
     out = []
     for line in listing.splitlines():
-        pid, _, flag = line.strip().partition(" ")
-        if flag.strip() and tmuxctl.PANE_ID_RE.fullmatch(pid):
-            out.append(pid)
+        fields = line.split()
+        if len(fields) >= 2 and tmuxctl.PANE_ID_RE.fullmatch(fields[0]):
+            out.append(fields[0])
     return tuple(out)
 
 
@@ -963,13 +970,16 @@ def sweep_argv(server: str, panes) -> list[str] | None:
     charter has no reason to pay, and the operator's window relayouts once instead of
     once per orphan.
 
-    ``None`` and not an empty chain when there is nothing to kill: an empty target list
+    ``None`` and never an empty chain when there is nothing to kill: an empty target list
     reaching `kill-pane` is the measured failure `close_argvs` records — a `kill-pane`
-    with no `-t` kills the *current* pane, which here is the operator's harness.
+    with no `-t` kills the *current* pane, which here is the operator's harness. That
+    answer is `tmuxctl.chain`'s own (`if not argvs: return None`) and is deliberately not
+    restated here: an `if kills else None` in front of it reads as a second guard and is
+    the same guard, which the deletion sweep correctly reported as a line nothing could
+    go red without.
     """
-    kills = [tmuxctl.server_argv(server, "kill-pane", "-t", p)
-             for p in panes if tmuxctl.PANE_ID_RE.fullmatch(p)]
-    return tmuxctl.chain(kills) if kills else None
+    return tmuxctl.chain([tmuxctl.server_argv(server, "kill-pane", "-t", p)
+                          for p in panes if tmuxctl.PANE_ID_RE.fullmatch(p)])
 
 
 def modal_argvs(server: str, *, harness: str,

--- a/charter/frame/overlay.py
+++ b/charter/frame/overlay.py
@@ -126,6 +126,36 @@ HATCH_KEY = "F12"
 #: because the operator's own tmux may be the server charter is a guest on.
 HATCH_OPTION = "@charter_hatch"
 
+#: The **pane** option that says "this pane is an overlay" — how charter finds a palette
+#: that is already open, and #739's whole fix.
+#:
+#: **A second `F2` used to leave the first palette running, invisible, forever.** A
+#: `bind -n` is the ROOT key table, so tmux matches the key before any byte reaches the
+#: overlay's pane — the same property that makes the escape hatch work against a wedged
+#: surface, and it is not negotiable. The second press therefore split a second overlay off
+#: the harness; Escape closed the one holding the keyboard and left the other as a blank
+#: five-row pane holding a live Python process, taking six rows off the harness for the
+#: life of the frame. `F12` is `select-pane` and does not clear it, `cmd_resize` has no
+#: opinion about a pane charter does not know, and no palette row closes it. The only cure
+#: was tmux's own prefix + `x`, which is outside what `charter frame` binds or documents.
+#:
+#: **Why a PANE option and not a record charter keeps.** `cmd_palette`'s own docstring
+#: declined to guard this, and its reason was right about the guard it was imagining:
+#: "every cheap test for 'is one already open' is a stale-state problem of its own". A
+#: value charter writes down can outlive the thing it describes — the hatch option
+#: deliberately does, naming a pane that is gone. A pane option cannot: it is tmux's
+#: state, stored on the pane, and it is destroyed with the pane. Measured on 3.7c and on
+#: the 3.2 floor: set with `set-option -p`, read back through `#{@charter_overlay}` in a
+#: `list-panes` format, and absent from every pane after a `kill-pane`.
+#:
+#: **And it is set in the SAME invocation as the split**, so there is no instant in which
+#: an overlay pane exists unmarked. Measured on both versions: `split-window … ;
+#: set-option -p @charter_overlay 1` sent as one command list marks the NEW pane, because
+#: the split makes it current for the rest of the list — see :func:`open_argv`.
+#:
+#: `@`-prefixed and charter-prefixed for :data:`HATCH_OPTION`'s reasons exactly.
+OVERLAY_OPTION = "@charter_overlay"
+
 #: What the overlay writes to its own tty to ask for SGR mouse reporting: 1006 (SGR
 #: encoding, so coordinates past column 223 survive) then 1000 (press/release only —
 #: deliberately NOT 1002/1003, which add motion, because §4f closed the event kinds
@@ -218,6 +248,27 @@ _R, _DIM, _BOLD, _REV = "\033[0m", "\033[2m", "\033[1m", "\033[7m"
 #: ._persona_chips` measured breaking this exact layout twice. Both entries are the same
 #: width by construction, so a selection moving does not move the text beside it.
 _MARK = ("> ", "  ")
+
+#: What marks the row the frame is ON — the workspace it is in, the density it is at, the
+#: chat it is. Held here rather than at each row source, and **reserved on every row this
+#: surface draws**, which is the whole of #749.
+#:
+#: **One inset is a rule of the frame** (`docs/frame.md`: "Every row's text starts in the
+#: same column"), and a mark composed into the TITLE by whoever built the row cannot keep
+#: it: a row source that has a mark to carry writes two columns and one that has none
+#: writes nothing, so the palette drew its thirteen rows down two left edges — text at
+#: column 3 for the doorways and the actions, column 5 for the density and chrome rows the
+#: `*` could land on. The cursor `>` sits at column 1 either way, so the same list put two
+#: columns between cursor and text on one half and four on the other.
+#:
+#: A column reserved HERE cannot be got wrong by a row source, including a provider's:
+#: :attr:`Row.mark` is a flag, and how many cells a flag costs is this module's arithmetic
+#: — the same reason :data:`_MARK` is not something a caller prefixes either.
+#:
+#: ASCII and both entries the same width, for :data:`_MARK`'s reason exactly: `●`, `◆` and
+#: the pointing triangles are East-Asian *Ambiguous*, and `statusline._persona_chips`
+#: measured them breaking this layout twice.
+ROW_MARK = ("* ", "  ")
 
 #: One SGR mouse report: `ESC [ < button ; col ; row (M|m)`, `M` a press and `m` a
 #: release. Anchored at the start because :func:`decode` matches it against the head of
@@ -346,11 +397,17 @@ def _title_width(shown: list[tuple[str, str]], width: int) -> int:
     Half rather than a fixed number of columns because both sides have to scale: a wide
     pane should spend its extra width on whichever column needs it, and only a
     proportional cap does that without a second rule for wide panes. `tui.width` on the
-    marker rather than `len`, because :data:`_MARK`'s two entries are only the same width
-    by construction and the day one of them stops being ASCII this must still be right.
+    markers rather than `len`, because :data:`_MARK`'s and :data:`ROW_MARK`'s entries are
+    only the same width by construction and the day one of them stops being ASCII this
+    must still be right.
+
+    **Both markers, because both are drawn on every row** (#749). Counting only the
+    cursor's would size the title column two cells wider than the row has, which is a
+    note truncated by two columns on the exact panes where the note is the whole reason
+    the row is listed.
     """
     longest = max([tui.width(t) for t, _ in shown] or [0])
-    room = width - tui.width(_MARK[0]) - _GAP
+    room = width - tui.width(_MARK[0]) - tui.width(ROW_MARK[0]) - _GAP
     return min(longest, max(_MIN_TITLE, room // 2))
 
 
@@ -366,6 +423,19 @@ class Row(NamedTuple):
     id: str
     title: str
     note: str = ""
+    #: Whether this row is the one the frame is ON — drawn with :data:`ROW_MARK`. A flag
+    #: and not two characters a caller prefixes, because the column it costs is this
+    #: module's arithmetic and #749 is what happens when it is not: see :data:`ROW_MARK`.
+    mark: bool = False
+    #: Whether this row CANNOT run right now. Not "has a note": a note is any right-hand
+    #: sentence, and `frame/choose.labelled` puts the row's KIND there (`workspace`,
+    #: `persona`) on rows that run perfectly well. The two were one field until #732,
+    #: where the difference decides which row Enter lands on — see `frame/palette.narrow`.
+    #:
+    #: A refused row is still listed, with its reason, which is #512's rule and is not
+    #: what this changes. What it changes is that the cursor does not START on one while a
+    #: row that can run matches the same query just as exactly.
+    refused: bool = False
 
 
 class Event(NamedTuple):
@@ -625,19 +695,25 @@ class Surface:
         it (#472): a committed value is what a picker's rows are made of, and a name
         carrying a newline that reached width arithmetic first would size the column from
         a string that is about to become two rows.
+
+        **Two markers, in a fixed order, on every row**: the cursor, then
+        :data:`ROW_MARK`. Every row pays for both whether or not it carries either, which
+        is what makes "every row's text starts in the same column" a property of this
+        function rather than a convention each row source is trusted to keep (#749).
         """
         top, n = self._window(height)
-        shown = [(contain.one_line(r.title), contain.one_line(r.note))
+        shown = [(contain.one_line(r.title), contain.one_line(r.note), r.mark)
                  for r in self.rows[top:top + n]]
-        title_w = _title_width(shown, width)
+        title_w = _title_width([(t, note) for t, note, _ in shown], width)
         out = [tui.truncate(f"{_BOLD}{contain.one_line(self.heading)}{_R}"
                             f"{_DIM} · {len(self.rows)} to choose from{_R}", width)]
         if not self.rows:
             out.append(tui.truncate(f"  {_DIM}{EMPTY}{_R}", width))
-        for i, (title, note) in enumerate(shown, start=top):
+        for i, (title, note, marked) in enumerate(shown, start=top):
             on = i == self._sel
             mark = _MARK[0] if on else _MARK[1]
-            body = (f"{mark}{tui.pad(title, title_w)}{' ' * _GAP}"
+            here = ROW_MARK[0] if marked else ROW_MARK[1]
+            body = (f"{mark}{here}{tui.pad(title, title_w)}{' ' * _GAP}"
                     f"{_DIM}{note}{_R}")
             out.append(tui.truncate(f"{_REV}{body}{_R}" if on else body, width))
         while len(out) < height - _FOOTER_ROWS:
@@ -817,10 +893,83 @@ def open_argv(server: str, *, harness: str, command: list[str],
     """
     if not tmuxctl.PANE_ID_RE.fullmatch(harness):
         return None
-    return tmuxctl.server_argv(server, "split-window", "-t", harness,
-                               "-v", "-l", str(_SPLIT_ROWS),
-                               *layout._env_argv(env),
-                               "-P", "-F", "#{pane_id}", "--", *command)
+    split = tmuxctl.server_argv(server, "split-window", "-t", harness,
+                                "-v", "-l", str(_SPLIT_ROWS),
+                                *layout._env_argv(env),
+                                "-P", "-F", "#{pane_id}", "--", *command)
+    return tmuxctl.chain([split, mark_argv(server)])
+
+
+def mark_argv(server: str) -> list[str]:
+    """`set-option -p`: stamp :data:`OVERLAY_OPTION` on **the current pane**.
+
+    **No `-t`, and that is the whole of why this can be chained onto the split** (#739).
+    A pane id is not knowable until `split-window` has answered with one, so a targeted
+    mark would have to be a second invocation — leaving an instant in which an overlay
+    pane exists and is not findable, which is exactly the instant a second `F2` arrives
+    in. tmux runs a command list server-side and the split makes the new pane current for
+    the rest of it, so the untargeted form lands on the pane just created. Measured on
+    3.7c and on the 3.2 floor, both: the mark is on the new pane and not on the harness.
+
+    Split out of :func:`open_argv` rather than inlined so the chain can be read as the two
+    things it is, and so a test can assert the mark without parsing an argv for it.
+    """
+    return tmuxctl.server_argv(server, "set-option", "-p", OVERLAY_OPTION, "1")
+
+
+def live_argv(server: str, *, harness: str) -> list[str] | None:
+    """`list-panes`: every pane in the harness's own window, with its overlay mark.
+
+    **Scoped to that window and never `-a`**, which is a property rather than a saving: a
+    chat is a window and every chat on this server shares the socket, so an `-a` sweep
+    would find another chat's open palette and :func:`sweep_argv` would kill it. Measured
+    on 3.7c and 3.2: `list-panes -t <a pane id>` resolves to that pane's window and lists
+    only its panes.
+
+    ``None`` for a harness that is not tmux's own word for a pane, following every other
+    builder here: charter would rather ask nothing than ask about a target it cannot
+    predict the parse of.
+    """
+    if not tmuxctl.PANE_ID_RE.fullmatch(harness):
+        return None
+    return tmuxctl.server_argv(server, "list-panes", "-t", harness, "-F",
+                               f"#{{pane_id}} #{{{OVERLAY_OPTION}}}")
+
+
+def live_panes(listing: str) -> tuple[str, ...]:
+    """The overlay pane ids in :func:`live_argv`'s output.
+
+    A pane with no mark formats as its id, a space, and nothing — so "marked" is "there is
+    a second field", and the harness never qualifies. Every id is held to
+    `tmuxctl.PANE_ID_RE` before it is answered with, because what the caller does with one
+    is build a `kill-pane` around it: this is a value read back off tmux, and #442's rule
+    is that a value's shape is checked where it re-enters charter rather than trusted
+    because of where it came from.
+    """
+    out = []
+    for line in listing.splitlines():
+        pid, _, flag = line.strip().partition(" ")
+        if flag.strip() and tmuxctl.PANE_ID_RE.fullmatch(pid):
+            out.append(pid)
+    return tuple(out)
+
+
+def sweep_argv(server: str, panes) -> list[str] | None:
+    """One invocation that kills every overlay pane named, or ``None`` for none.
+
+    ONE, for `tmuxctl.chain`'s reason at half strength: this caller is not in the pane
+    being killed, so it would survive sending them separately — but a sweep that killed
+    the first of two and then had its own pane resized under it is a second round trip
+    charter has no reason to pay, and the operator's window relayouts once instead of
+    once per orphan.
+
+    ``None`` and not an empty chain when there is nothing to kill: an empty target list
+    reaching `kill-pane` is the measured failure `close_argvs` records — a `kill-pane`
+    with no `-t` kills the *current* pane, which here is the operator's harness.
+    """
+    kills = [tmuxctl.server_argv(server, "kill-pane", "-t", p)
+             for p in panes if tmuxctl.PANE_ID_RE.fullmatch(p)]
+    return tmuxctl.chain(kills) if kills else None
 
 
 def modal_argvs(server: str, *, harness: str,

--- a/charter/frame/palette.py
+++ b/charter/frame/palette.py
@@ -132,14 +132,37 @@ def matches(query: str, row: overlay.Row) -> bool:
     the question `frame/action.py` already asks of an action id, asked here rather than
     re-spelled, so "can be an action id" and "is matched as one" cannot drift apart.
 
-    `casefold` on both sides rather than `lower`, and applied to the query once per row
-    rather than hoisted, because this is the whole of the case rule and a hoisted copy is
-    a second place for it to be wrong.
+    `casefold` rather than `lower` — see :func:`typed`, which is where the whole of the
+    case rule now lives, because :func:`exact` asks the identical question of the
+    identical string and two spellings of it is two places for it to be wrong.
     """
-    q = contain.one_line(query).casefold()
+    q = typed(query)
     if q in row.title.casefold():
         return True
     return component.usable_id(row.id) and q in row.id.casefold()
+
+
+def typed(query: str) -> str:
+    """What the operator typed, contained and case-folded — the one normalisation.
+
+    **One function because two callers ask the identical question.** :func:`matches`
+    decides which rows survive and :func:`exact` decides which of the survivors goes
+    first, and a palette that filtered case-insensitively and then ranked
+    case-sensitively would find the row and put the cursor somewhere else, which an
+    operator cannot tell from not finding it. Spelled twice, that is two lines to keep in
+    step; spelled once, it is one line with both callers' tests behind it — which is also
+    what the deletion sweep said about the copy, reporting the second `casefold` as a line
+    nothing could go red without.
+
+    `casefold` and not `lower`: `lower` gets Turkish dotless-i and German sharp-s wrong.
+
+    Contained for the reason every display string here is (#472) — the guard belongs at
+    the join rather than at whichever writer happens to exist today. The query cannot hold
+    a newline by the route it is built (`Palette.handle` takes printable single
+    characters), and this function is also reachable from a caller that did not build it
+    that way.
+    """
+    return contain.one_line(query).casefold()
 
 
 def exact(query: str, row: overlay.Row) -> bool:
@@ -162,7 +185,7 @@ def exact(query: str, row: overlay.Row) -> bool:
     nothing typed and would sort to the top of the unfiltered palette — which is the one
     thing the two-bucket sort promises cannot happen.
     """
-    q = contain.one_line(query).casefold()
+    q = typed(query)
     if not q:
         return False
     if q == row.title.casefold():

--- a/charter/frame/palette.py
+++ b/charter/frame/palette.py
@@ -27,7 +27,7 @@ process — but the doorway it left cost the operator a keypress on the thing th
 browsing does not, gathered the first time something is typed and never while the query is
 empty. Still rows, still no `Action`, and still nothing spawned until Enter.
 
-**Three rules the plan states and a first implementation loses.**
+**Four rules the plan states and a first implementation loses.**
 
 *An unavailable action is listed WITH ITS REASON.* `frame/actions.py` already refuses to
 produce a reasonless unavailable offer; this module refuses to drop the row. The session
@@ -42,6 +42,10 @@ tmux 3.1c drew 20 rows fine). The overlay scrolls, so a cap would only hide rows
 sides are `casefold`ed rather than `lower`ed, because `lower` gets Turkish dotless-i and
 German sharp-s wrong and a palette that cannot find a row is indistinguishable from one
 that does not have it.
+
+*The name you typed in FULL is the row Enter runs* (#732). Everything else keeps the
+position the catalogue gave it — see :func:`narrow`, which states the whole ordering rule
+and why the two things it does not do (score, cap) are still not done.
 
 **The query never reaches a parser.** It is built one keypress at a time out of
 `overlay.decode`'s printable single-character events, so no newline and no escape
@@ -96,10 +100,18 @@ def rows(offers: Iterable) -> tuple[overlay.Row, ...]:
     unavailable, so "listed with its reason" and "listed at all" are the same decision
     here rather than two.
 
+    **`available` and not `reason` is what becomes `Row.refused`**, even though
+    `frame/actions.py` guarantees the two agree. The offer holds both because they are two
+    facts, and a row that re-derived one from the other would be the surface where they
+    could come apart: an offer available with a reason on it, or refused with an empty
+    one, would draw as its opposite here rather than as the defect it is one module down.
+
     A `tuple`, so what a `Palette` was built with cannot be edited underneath it by
     whoever passed it in.
     """
-    return tuple(overlay.Row(id=o.id, title=o.title, note=o.reason) for o in offers)
+    return tuple(overlay.Row(id=o.id, title=o.title, note=o.reason,
+                             mark=o.mark, refused=not o.available)
+                 for o in offers)
 
 
 def matches(query: str, row: overlay.Row) -> bool:
@@ -130,15 +142,75 @@ def matches(query: str, row: overlay.Row) -> bool:
     return component.usable_id(row.id) and q in row.id.casefold()
 
 
-def narrow(catalogue: Iterable[overlay.Row], query: str) -> tuple[overlay.Row, ...]:
-    """*catalogue*, keeping the rows :func:`matches` keeps. Order is never disturbed.
+def exact(query: str, row: overlay.Row) -> bool:
+    """Whether *query* IS this row's name, rather than a piece of it.
 
-    No ranking, no fuzzy scoring, no cap. A palette that reordered itself as the operator
-    typed would move the row under the cursor out from under it between keystrokes, which
-    is the same "rows that move around depending on state" the old menu deliberately
-    refused for its density entries.
+    The same two strings :func:`matches` looks at and the same `casefold` on both sides,
+    so a row can never be exact without also being a match — the ordering below is a
+    refinement of the filter and not a second, disagreeing opinion about what the operator
+    typed.
+
+    **The title is the name now**, which is what makes this askable at all. Until #749 a
+    picker's row arrived here as `"* alpha"` — two characters of mark composed into the
+    title by whoever built the row — so "is this the name they typed" would have been a
+    prefix-strip against a constant, in a function that would then have to know which row
+    sources mark and which do not. The mark is `overlay.Row.mark` and the title is `alpha`.
+
+    **An empty query is not a name**, and the guard is here rather than in :func:`narrow`
+    because that is where it is true: nobody has typed anything, so nothing can be what
+    they typed. Without it a row with an empty title would be "exact" for `F2` with
+    nothing typed and would sort to the top of the unfiltered palette — which is the one
+    thing the two-bucket sort promises cannot happen.
     """
-    return tuple(r for r in catalogue if matches(query, r))
+    q = contain.one_line(query).casefold()
+    if not q:
+        return False
+    if q == row.title.casefold():
+        return True
+    return component.usable_id(row.id) and q == row.id.casefold()
+
+
+def narrow(catalogue: Iterable[overlay.Row], query: str) -> tuple[overlay.Row, ...]:
+    """*catalogue*, keeping the rows :func:`matches` keeps, **exact names first**.
+
+    No fuzzy scoring and no cap, and the order is disturbed in exactly one way, stated as
+    a rule:
+
+        **An exact match comes first, an actionable one ahead of a refused one, and
+        everything else keeps the position it already had.**
+
+    Two buckets, and a stable sort, so *within* each the catalogue's own order is
+    untouched: the doorways in `choose.NOUNS` order, then every action in registration
+    order, then the names (`Palette._reachable` decides that much). A plane with forty
+    workspaces still cannot bury `detach` under the ones whose names contain a `d`,
+    because none of those forty is `detach`.
+
+    **What this fixes is #732, and it was a real two-keystroke route failing on the most
+    obvious input there is.** `docs/frame.md` sells `F2` + the name + Enter as the way to
+    switch when you know where you are going. A chat id is `<workspace>.<n>`, so on a
+    plane with a workspace `alpha` the row `chat: alpha.1 — pick another` holds `alpha` as
+    a substring of its TITLE, and it sorted above the `alpha` workspace row because a
+    doorway is in the catalogue and a name is not. Worse, that doorway was refused — one
+    chat, nothing to pick — so Enter opened nothing, switched nothing, and put a sentence
+    about chats on the screen of an operator who had typed a workspace's name.
+
+    **A refused row is still listed, and it is still listed with its reason.** That is
+    #512's rule and this does not touch it: an operator cannot ask about an option they
+    cannot see, and hiding the pinned workspace or the doorway that cannot open would be
+    the defect that rule exists to prevent. What moves is only which row Enter lands on
+    first, and only among rows the operator has typed the *whole* name of.
+
+    **The "no ranking" this replaces defended itself with a property this class does not
+    have.** It argued that reordering "would move the row under the cursor out from under
+    it between keystrokes" — but `Palette._refilter` sets the selection back to the top on
+    every single edit, deliberately and with its own docstring saying so. There was no row
+    under the cursor to move. The real cost of reordering is that the LIST reads
+    differently, which is why the sort is two buckets rather than a score: with nothing
+    typed, no row is an exact match for `""`, so `F2` draws exactly the list it drew
+    before this function learned to sort.
+    """
+    kept = [r for r in catalogue if matches(query, r)]
+    return tuple(sorted(kept, key=lambda r: (0, r.refused) if exact(query, r) else (1, 0)))
 
 
 @dataclass
@@ -182,6 +254,13 @@ class Palette(overlay.Surface):
     #: what makes that distinguishable from a plane that genuinely has no names.
     _found: tuple[overlay.Row, ...] | None = field(default=None, init=False)
 
+    #: What the last repeated row ANSWERED, appended to the heading until the next
+    #: keystroke — see :meth:`report`. Held apart from :attr:`heading` because the heading
+    #: is derived and is rebuilt from scratch on every edit; a sentence written straight
+    #: into it would either be lost at the next keystroke or, worse, kept and appended to
+    #: again, growing by one clause per Enter.
+    said: str = ""
+
     def __post_init__(self) -> None:
         self._refilter()
 
@@ -201,10 +280,12 @@ class Palette(overlay.Surface):
         has — `commands_frame._roster` hands both paths the one roster — and a palette
         lives for as long as somebody is looking at it.
 
-        **After the catalogue, never before.** `narrow` does not reorder, so this is the
-        only place the order of the two groups is decided: every action and both doorways
+        **After the catalogue, never before.** `narrow` reorders only exact matches, so this
+        is where the order of the two GROUPS is decided: every action and both doorways
         keep the position they had before names existed, and a plane with forty workspaces
-        cannot bury `detach` under the ones whose names happen to contain a `d`.
+        cannot bury `detach` under the ones whose names happen to contain a `d`. A name
+        the operator has typed in full goes first wherever it was gathered — that is
+        #732, and it is a decision about one row rather than about these two blocks.
         """
         if not self.query or self.query_only is None:
             return self.catalogue
@@ -224,7 +305,40 @@ class Palette(overlay.Surface):
         self.rows = narrow(self._reachable(), self.query)
         self._sel = 0
         self._top = 0
-        self.heading = self.label + (PROMPT + self.query if self.query else "")
+        self.said = ""
+        self._headline()
+
+    def _headline(self) -> None:
+        """Compose :attr:`heading` from the three things that make it up.
+
+        One place, called by :meth:`_refilter` and by :meth:`report`, so that "what the
+        header says" cannot be assembled two ways — a second spelling is how a repeated
+        action's sentence would come to be appended to a heading that already had one.
+        """
+        self.heading = (self.label + (PROMPT + self.query if self.query else "")
+                        + (f" · {contain.one_line(self.said)}" if self.said else ""))
+
+    def report(self, said: str) -> None:
+        """Say *said* in the header, leaving the query and the cursor exactly as they are.
+
+        **What a repeatable row answers with, and the only surface it can answer on**
+        (#746). `frame/overlay.modal_argvs` zooms this pane over the whole window, and its
+        own measurement is that a zoomed pane's siblings are not drawn — so an action that
+        moves the repo table's selection while the palette is up moves a highlight that is
+        not on screen. The header is what the operator is looking at.
+
+        **Not `_refilter`**, which is the whole reason this is a method rather than a
+        caller writing `heading`. That function resets the selection to the top by design,
+        and a repeat that reset it would move the cursor off the row the operator is
+        pressing Enter on — one repeat, and then a re-filter and a re-aim for the next.
+        Nothing here touches :attr:`rows`, :attr:`_sel`, :attr:`_top` or :attr:`query`.
+
+        An empty *said* clears rather than keeps: an action that answered nothing has
+        nothing to report, and leaving the previous sentence up would attribute it to the
+        keypress that just happened.
+        """
+        self.said = said
+        self._headline()
 
     def handle(self, ev: overlay.Event, height: int) -> str | None:
         """One event: text edits the query, everything else is the overlay's.

--- a/charter/frame/palette.py
+++ b/charter/frame/palette.py
@@ -137,7 +137,8 @@ def matches(query: str, row: overlay.Row) -> bool:
     identical string and two spellings of it is two places for it to be wrong.
 
     **The id is not folded, and the guard in front of it is why.** `component.usable_id`
-    holds an id to `^[a-z][a-z0-9_]{0,31}(\.[a-z][a-z0-9_]{0,31})?$` — measured: every
+    holds an id to `component._ID_RE`, which admits lower-case letters, digits and
+    underscores with at most one dot between two such runs — measured: every
     spelling with a capital in it answers False — so an id that reached the comparison
     cannot carry case, and `casefold` on it is a claim that it can. The deletion sweep
     reported that call as a line nothing could go red without, and it was right. What the

--- a/charter/frame/palette.py
+++ b/charter/frame/palette.py
@@ -135,11 +135,20 @@ def matches(query: str, row: overlay.Row) -> bool:
     `casefold` rather than `lower` — see :func:`typed`, which is where the whole of the
     case rule now lives, because :func:`exact` asks the identical question of the
     identical string and two spellings of it is two places for it to be wrong.
+
+    **The id is not folded, and the guard in front of it is why.** `component.usable_id`
+    holds an id to `^[a-z][a-z0-9_]{0,31}(\.[a-z][a-z0-9_]{0,31})?$` — measured: every
+    spelling with a capital in it answers False — so an id that reached the comparison
+    cannot carry case, and `casefold` on it is a claim that it can. The deletion sweep
+    reported that call as a line nothing could go red without, and it was right. What the
+    removal depends on is the guard being asked FIRST, which
+    `tests/test_frame_palette.py` pins as a property of the pair rather than of the order
+    they happen to be written in today.
     """
     q = typed(query)
     if q in row.title.casefold():
         return True
-    return component.usable_id(row.id) and q in row.id.casefold()
+    return component.usable_id(row.id) and q in row.id
 
 
 def typed(query: str) -> str:
@@ -190,7 +199,7 @@ def exact(query: str, row: overlay.Row) -> bool:
         return False
     if q == row.title.casefold():
         return True
-    return component.usable_id(row.id) and q == row.id.casefold()
+    return component.usable_id(row.id) and q == row.id
 
 
 def narrow(catalogue: Iterable[overlay.Row], query: str) -> tuple[overlay.Row, ...]:

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -2287,8 +2287,22 @@ def _inflight_field() -> str:
     return " ".join(parts)
 
 
+#: The attention row's fields a density may not trim — see :func:`_fit_fields`' *exempt*.
+#:
+#: **One name, and the set is the point rather than the name.** `hotkey` is the only field
+#: on that row that is chrome rather than news, and #743 is what ranking it against news
+#: did: `density = minimal` — the arrangement with no repo table, no sidebar and no
+#: version, where `F2` is the only route to the repo table, the todos, the workspace, the
+#: persona and getting back to `full` — was the one arrangement that stopped saying `F2`
+#: exists. A frozenset rather than a `name == "hotkey"` in the loop so that the question
+#: "which fields are chrome" is one a test can ask directly, and so the next field of this
+#: kind joins a list rather than an `or`.
+_ALWAYS = frozenset({"hotkey"})
+
+
 def _fit_fields(priority: list[tuple[str, str]], width: int,
-                limit: int | None = None) -> set[str]:
+                limit: int | None = None,
+                exempt: frozenset[str] = frozenset()) -> set[str]:
     """Which names among *priority* — an ordered list of ``(name, text)`` pairs, highest
     priority first — fit *width* once joined with `` · ``, decided one at a time in that
     order: each field's FULL text counted against what is left, included whole or
@@ -2308,19 +2322,39 @@ def _fit_fields(priority: list[tuple[str, str]], width: int,
     is one question, and answering it twice is how the two answers come to disagree about
     whether an alert outranks a todo count. ``None`` (the default) is "as many as fit",
     which is exactly what every caller wanted before densities existed.
+
+    *exempt* names fields *limit* does not count and does not stop — **and it is a
+    different KIND of field, not a favoured one** (#743). Every other field on this row is
+    news about the plane: an alert, a spinner, a selection, a todo count. Ranking them
+    against each other is exactly right, and at `terse` keeping only the loudest is the
+    density doing its job. The hotkey hint is not news; it is the one thing on screen that
+    says how to drive the frame — and `minimal` is the arrangement where the palette is
+    the only route to anything, including back to `full`. Ranking it against news is what
+    dropped it from the only frame that needed it, leaving a two-strip frame advertising
+    nothing at all to an operator who closed and reopened their terminal.
+
+    **Width still applies to an exempt field**, which is what keeps this an exemption from
+    the density and not from the arithmetic: a starved pane drops the hint like anything
+    else, because a hint sliced in half is the false-clean failure this whole function
+    refuses. And the loop `continue`s past a capped field rather than breaking out of it,
+    so an exempt field LAST in the priority order is still reached — which the hotkey is,
+    being the one field that is always rediscoverable another way.
     """
     sep_w = tui.width(" · ")
     budget = width
     keep: set[str] = set()
+    capped = 0
     for name, text in priority:
         if not text:
             continue
-        if limit is not None and len(keep) >= limit:
-            break
+        if limit is not None and name not in exempt and capped >= limit:
+            continue          # over the density's budget — but a later exempt field is not
         need = tui.width(text) + (sep_w if keep else 0)
         if need > budget and keep:
             continue          # doesn't fit and something already does — drop it whole
         keep.add(name)
+        if name not in exempt:
+            capped += 1
         budget -= need
     return keep
 
@@ -2507,11 +2541,20 @@ def _bottom(fid: str) -> str:
     could not explain. The status line keeps `⚡ 2` unchanged: it repaints once per turn,
     where a spinner is a still picture of an arbitrary frame.
 
-    **At `terse` exactly one field survives** — the highest-priority one that has anything
-    to say. On a quiet plane that is the todo count, so the row is never blank; the moment
-    something is wrong or something is running, the row is that instead. `_fit_fields`
-    does it through the same priority order it already uses for width, so "less" and
-    "too narrow" cannot disagree about what matters.
+    **At `terse` exactly one field of NEWS survives** — the highest-priority one that has
+    anything to say. On a quiet plane that is the todo count, so the row is never blank;
+    the moment something is wrong or something is running, the row is that instead.
+    `_fit_fields` does it through the same priority order it already uses for width, so
+    "less" and "too narrow" cannot disagree about what matters.
+
+    **The hotkey hint is not news and the density does not trim it** (#743, :data:`_ALWAYS`).
+    It used to be, and the result was that `minimal` — a frame of two one-row strips, with
+    the repo table, the sidebar, the todos, the workspace switch, the persona switch and
+    the way back to `full` all behind `F2` — was the single arrangement that stopped
+    saying `F2` anywhere on screen. An operator who chose it and reopened their terminal
+    had a frame advertising nothing. So `terse` keeps one field of news **and** the hint:
+    `7 todos · F2 palette` rather than `7 todos`. A narrow pane still drops it, because
+    that is width and not density.
 
     The hotkey is READ, not spelled out: `[frame] hotkey` is configurable, and this row
     used to hardcode `F2 palette` — so a plane on `hotkey = "F1"` had its own panel telling
@@ -2561,7 +2604,7 @@ def _bottom(fid: str) -> str:
         [("notice", notice_text), ("alert", alert_text), ("inflight", inflight_text),
          ("repo", repo_text), ("news", news_text), ("todo", todo_text),
          ("hotkey", hotkey_text)], w,
-        limit=1 if verbosity(fid) == "terse" else None)
+        limit=1 if verbosity(fid) == "terse" else None, exempt=_ALWAYS)
 
     # Re-assembled in the original reading order, not priority order — priority decided
     # only who was cut. `repo` is LAST, which is the "right side" the selected row's

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -182,6 +182,13 @@ Three things follow that are worth saying plainly rather than leaving you to fin
   only route on a plane with `mouse = false`, which is the default, and charter will not
   bind a bare arrow key to change it: a `bind -n Up` is server-wide and would take the arrow
   before your harness sees it.
+- **Those two rows repeat, and that is what makes them usable.** Enter on either one moves
+  the selection and **leaves the palette open**, with what you typed and the row you are on
+  exactly where you left them — so three rows down the table is `F2`, `next`, Enter, Enter,
+  Enter, and one palette rather than three. The header says what each press did
+  (`charter /next · selected auth`), because the palette is drawn over the whole window and
+  the table is not on screen behind it. Escape leaves; every other row still closes the
+  palette when it runs.
 
 **The tab bars are the exception to "a click only selects", and they say why.** Click a name
 on the `chats` or `workspaces` bar and the frame *switches* to it — there is no in-between
@@ -818,7 +825,7 @@ There are three levels:
 
 | level | edges | each panel says |
 |---|---|---|
-| `minimal` | `top` and `bottom` | the two one-row strips and nothing else — no repo table, no sidebar, so every row and column the frame is not using is your session's; `top` drops the charter version and `bottom` keeps one field |
+| `minimal` | `top` and `bottom` | the two one-row strips and nothing else — no repo table, no sidebar, so every row and column the frame is not using is your session's; `top` drops the charter version and `bottom` keeps one attention field, plus the hotkey hint |
 | `normal` | `top`, `bottom` and `repos` | both strips saying everything they have, and the repo table between them, as tall as the window can spare |
 | `full` | every edge | the sidebar as well |
 
@@ -840,6 +847,14 @@ remaining panel terser: `top` drops the charter version (the workspace and the p
 what it exists to tell you), and `bottom` keeps only its highest-priority attention field
 — an alert if there is one, the spinner if work is running, otherwise the todo count, so
 the row is never blank.
+
+**The hotkey hint survives `minimal`, and it is the one field that does.** The other three
+are news about your plane and ranking them against each other is what the level is for; the
+hint is not news, it is the one thing on screen that says how to drive the frame — and
+`minimal` is the arrangement where the palette is the only route to the repo table, the
+todos, the workspace, the persona and the way back to `full`. So `bottom` reads
+`7 todos · F2 palette` rather than `7 todos`. A pane too narrow for both still drops it,
+because that is width and not density.
 
 If you want the table but at `minimal`'s verbosity, write the `slots` list by hand and
 declare the level beside it: an explicit `slots` wins over a preset, and the table then
@@ -1668,7 +1683,7 @@ chats was last in front of you.
 
 ```
 charter · 11 to choose from
-> workspace: alpha — pick another
+>   workspace: alpha — pick another
     persona: steward — pick another
     detach — leave the harness running
     repo: select the next row
@@ -1685,7 +1700,14 @@ charter · 11 to choose from
 
 **Everything is listed, including what cannot run right now — with the reason beside it.**
 An option you cannot see is one you cannot ask about, so a row that is refused stays and
-says what would make it available. The reason is the right-hand column.
+says what would make it available. The reason is the right-hand column. A refused row is
+listed lower than a row you typed the whole name of, and never dropped.
+
+**Every row reserves the `*` column, whether or not it has a mark to put in it** — the
+frame's one-inset rule, applied here. Four cells stand in front of every row's text: two
+for the cursor and two for the "you are on this one" mark, in that order, whether or not
+the row has either. So `detach` and `density: full` start in the same column, and the
+distance from the cursor to the text is the same on every row of the list.
 
 **Two of those rows are doorways.** `workspace:` and `persona:` say which one this frame is
 on, and Enter opens the list of the others **in the same pane** — a picker, which is this
@@ -1708,12 +1730,25 @@ with which it is, so `F2` `b` `e` `t` `a` Enter switches without opening anythin
 
 ```
 charter /zeb · 3 to choose from
-> zeb-api                     workspace
+>   zeb                       persona
+    zeb-api                   workspace
     zebra-ui                  workspace
-    zeb                       persona
 
   up/down move   enter choose   esc cancel   F12 back to the harness
 ```
+
+**The name you typed in full is the row Enter runs.** That is the whole of the ordering
+rule and it has two clauses: a row whose name is exactly what you typed comes first, and
+between two of those the one that can actually run comes before the one that cannot.
+Everything else keeps the position the list already gave it — the doorways in their order,
+then the actions in theirs, then the names — so nothing shuffles under you as you type, and
+with nothing typed the list is the one pictured above, unmoved.
+
+It matters because names overlap. `zeb` above is a persona and a prefix of two workspaces.
+A chat id is `<workspace>.<n>`, so on a plane with a workspace `alpha` the `chat:` doorway
+holds `alpha` in its own title — and it used to win, which meant `F2` `a` `l` `p` `h` `a`
+Enter reached a doorway about chats instead of the workspace whose name you had just typed
+in full.
 
 The doorways are for browsing — when you do not know the name — and typing is for
 switching, when you do. Both reach the same rows, and the one you are on keeps its `*`
@@ -1776,11 +1811,19 @@ the lock and names what it overrode: `workspace → beta  (lock moved from 'alph
 would be the wrong answer: an agent inside the frame took that lock, and its next command
 acts on a workspace it was never told had moved.
 
-**Pressing `F2` again while the palette is open opens a second one.** `bind -n` is tmux's
-root key table, so tmux matches the key before any byte reaches the palette's pane — the
-same property that makes `F12` work against a pane that has stopped answering. The second
-palette is the one taking your keys; Escape closes it, and the first is an ordinary pane
-you can select and close the same way.
+**Pressing `F2` again while the palette is open REOPENS it.** `bind -n` is tmux's root key
+table, so tmux matches the key before any byte reaches the palette's pane — the same
+property that makes `F12` work against a pane that has stopped answering — so the second
+press really does run charter again. What it does is close the palette that is open and
+draw a fresh one, which is also the more correct of the two: the list is resolved against
+your plane at the moment it opens, so a reopen re-reads a workspace, persona, density or
+surface that has moved since.
+
+There is never more than one palette pane on a frame's window. charter finds an open one by
+asking tmux — the overlay's pane carries a tmux pane option, so the answer is tmux's and
+disappears with the pane, and there is nothing charter can believe that is out of date.
+A second press therefore never refuses and never does nothing, which matters most on the
+press you make because the first one seemed not to register.
 
 ### What a component can be told about
 

--- a/docs/news/unreleased-the-palette-answers-the-name-you-typed.md
+++ b/docs/news/unreleased-the-palette-answers-the-name-you-typed.md
@@ -1,0 +1,120 @@
+---
+version: unreleased
+headline: The palette answers the name you typed, keeps one pane, and stops hiding the only key the frame has
+---
+
+*"I typed the workspace's name and pressed Enter, and nothing happened."*
+
+A UX audit drove a real frame through a real outer tmux with real keystrokes and filed five
+things about the `F2` palette. Four of them are here, and the worst one was not the one that
+looked worst.
+
+**Pressing `F2` twice used to leak a pane, permanently.** `bind -n` is tmux's root key
+table, so the second press is matched before any byte reaches the palette — that is the same
+property that makes `F12` work against a pane that has stopped answering, and it is not
+negotiable. What charter did with it was split a second overlay off the harness. Escape then
+closed the one holding the keyboard and left the other: a blank five-row pane holding a live
+Python process, six rows off a 24-row harness, for the life of the frame. It was invisible —
+a blank gap above the repo table's rule reads as empty terminal — and nothing charter binds
+or documents could clear it. `F12` is `select-pane`. A resize is not about panes charter did
+not make. No palette row closes it. Only tmux's own prefix + `x`, which an operator who has
+never used tmux has no route to.
+
+**A second `F2` now reopens the palette**, and there is never more than one palette pane on a
+frame's window. The choice between "no-op", "toggle shut" and "reopen" comes down to what the
+double press *is*: it is the press you make because the first one seemed not to register. A
+no-op and a toggle both require charter to believe a palette is open, and being wrong makes
+the key do nothing — which is the complaint that produced the second press, made permanent.
+Reopening answers every press with a palette, and with the *fresher* one: the list resolves
+your density, surface, workspace and persona at the moment it opens.
+
+**And charter asks tmux, rather than remembering.** The overlay's pane carries a tmux pane
+option, set in the same command list as the split — so no instant exists in which an overlay
+pane is open and not findable, and the answer to "is one open" dies with the pane. That was
+the objection to guarding this at all, and it was a good one: the escape hatch deliberately
+leaves an option naming a pane that is gone, and a stale belief here would mean an `F2` that
+refuses. Nothing is refused. A listing that comes back empty, unparseable, or naming panes
+that have since gone costs one no-op and the palette opens regardless. The sweep also clears
+orphans a frame is already carrying from before this fix, and it is scoped to the frame's own
+window, so it cannot reach another chat's open palette.
+
+---
+
+**Typing a name in full now lands on that name.** `docs/frame.md` sells `F2`, the name, Enter
+as the route for an operator who knows where they are going, and it failed on the most
+obvious input there is. A chat id is `<workspace>.<n>`, so on a plane with a workspace
+`alpha` the row `chat: alpha.1 — pick another` holds `alpha` inside its own title — and the
+doorways are in the catalogue while the names are gathered after it, so the doorway sorted
+first:
+
+```
+charter /alpha · 3 to choose from
+> chat: alpha.1 — pick another   this workspace has one chat — open another with `charter <harness>` …
+    alpha                        workspace
+  * alpha.1                      this workspace has one chat — open another with `charter <harness>` …
+```
+
+That first row is a doorway charter was refusing to open. Enter opened nothing, switched
+nothing, and put a sentence about chats on the screen of somebody who had typed a workspace's
+name. The row they wanted was one Down away.
+
+**The ordering rule, in full: an exact match comes first, an actionable one ahead of a
+refused one, and everything else keeps the position it already had.** Two buckets and a
+stable sort — so the doorways stay in their order, the actions in theirs, and the names after
+them, and nothing shuffles under you as you type. With nothing typed no row is an exact match
+for anything, so `F2` draws exactly the list it always drew.
+
+It reaches the documented example too. `zeb` a persona beside `zeb-api` and `zebra-ui` used
+to answer `zeb-api` first, because workspaces come before personas — so typing a persona's
+whole name and pressing Enter switched to a workspace nobody had named.
+
+**A refused row is still listed, and still with its reason.** That rule is why the palette is
+worth reading and this does not touch it: an option you cannot see is one you cannot ask
+about. What moved is which row Enter lands on, and only among rows whose whole name you
+typed.
+
+---
+
+**The palette had two left edges.** Rows that could carry a `*` composed it into their own
+title and rows that could not composed nothing, so text started at column 3 for the doorways
+and the actions and at column 5 for the density and chrome rows — the cursor two cells from
+the text on one half of the list and four on the other, against the frame's own stated
+one-inset rule. The mark is a field now and the column is reserved by the surface that draws
+it, for every row including a provider's, so it cannot be got wrong one row source at a time.
+That is also what made "is this row's name what you typed" a comparison rather than a
+prefix-strip against a constant, which is what the ordering above needed.
+
+---
+
+**`repo: select the next row` repeats.** It is the only action charter offers whose natural
+use is repeated, and with `mouse = false` shipped as the default it is the repo table's only
+interaction model — and it cost a whole palette per row: open, filter, Enter, the pane closes,
+again. Three rows down a fourteen-row table was fourteen keystrokes and three ~3-second
+cycles. Enter on either repo row now moves the selection and leaves the palette open, with
+what you typed and the row you are on exactly where you left them.
+
+The header says what each press did (`charter /next · selected auth`), and that is forced
+rather than decorative: the overlay pane is zoomed over the whole window, measured on 3.7c
+and on the 3.2 floor, so **the repo table is not on screen behind the palette**. A repeat
+whose only feedback was the table would be moving a highlight nobody can see. Every other row
+still closes the palette when it runs.
+
+---
+
+**`density = minimal` still says `F2 palette`.** At `minimal` there is no repo table, no
+sidebar and no version — two one-row strips, with the repo table, the todo list, the workspace
+switch, the persona switch and the way back to `full` all behind the hotkey. It was the one
+arrangement that stopped saying the hotkey exists, because the hint was ranked against the
+attention row's other fields and `minimal` keeps one.
+
+The hint is a different kind of thing from the other three. An alert, a spinner and a todo
+count are news about your plane, and keeping only the loudest is what the density is for; the
+hint is the one piece of chrome that says how to drive the frame. So it is exempt from the
+density's trim and nothing else is: `7 todos · F2 palette` rather than `7 todos`, with the
+news still cut to one field. A pane too narrow for both still drops it, because that is width
+and not density. It still reads `[frame] hotkey`, so a plane on `F1` is told `F1`.
+
+Verified end to end on real tmux — 3.7c and the 3.2 floor — with a real client on a real pty
+and real keys through tmux's own root key table: the pane count after two presses and after
+three, the harness getting all its rows back on Escape, and the zoom measurement the repeat's
+design rests on.

--- a/docs/news/unreleased-the-palette-answers-the-name-you-typed.md
+++ b/docs/news/unreleased-the-palette-answers-the-name-you-typed.md
@@ -25,6 +25,8 @@ frame's window. The choice between "no-op", "toggle shut" and "reopen" comes dow
 double press *is*: it is the press you make because the first one seemed not to register. A
 no-op and a toggle both require charter to believe a palette is open, and being wrong makes
 the key do nothing — which is the complaint that produced the second press, made permanent.
+Opening a palette is a pane split, a Python start and a paint, so it is never instant; a
+faster one makes the double press rarer without making a refusal the right answer to it.
 Reopening answers every press with a palette, and with the *fresher* one: the list resolves
 your density, surface, workspace and persona at the moment it opens.
 

--- a/docs/news/unreleased-the-workspace-you-are-standing-in-is-listed.md
+++ b/docs/news/unreleased-the-workspace-you-are-standing-in-is-listed.md
@@ -1,0 +1,44 @@
+---
+version: unreleased
+headline: charter workspace list stops hiding the workspace you are standing in
+---
+
+*"The `F2` picker offered me `default`, I chose it, and now `charter workspace list` does not
+show where I am."*
+
+Reported against the frame's workspace picker, as a picker offering something that is not a
+workspace. It is a workspace. The listing was the surface that was wrong.
+
+**What was on screen.** A plane with four workspaces, nobody having selected one:
+
+```
+Active workspace: default  (via default (nothing selected))
+
+  WORKSPACE  MODE   CLONES  REPOS
+  alpha      local  8       api, auth, billing, gateway, ledger, notify, search, web
+  beta       local  2       api, ledger
+  delta      local  0       —
+  gamma      local  1       search
+```
+
+A header naming a workspace, a column reserved for marking which row you are on, and no row
+for it.
+
+**`default` is where every plane starts.** It is the rung the resolution ladder terminates
+on, so a plane that has never selected anything is standing in it; `charter workspace use
+default` accepts it on a plane that has never made one and says so; `charter clone <repo> -w
+default` creates it, which is what the frame's own repo panel tells you to run. The `F2`
+picker and the launch prompt both offer it for exactly that reason. Everything agreed about
+it except `charter workspace list`, which reads directories — and `charter init` does not
+make `workspaces/default/`, unlike `personas/steward`.
+
+**So it is listed, whether or not the directory is there yet**, with `—` for its repos,
+because that is what it holds. The listing and the picker now answer the same question the
+same way, and the mark always has a row to land on. The name is `[workspace] default` if
+your `charter.toml` names one — the row follows your config rather than a literal.
+
+**Nothing is created to make this true**, here or in `charter init`. `[workspace] default`
+names this workspace, so `init` would be baking a directory for a value you may change in the
+`charter.toml` it just wrote; and every route that puts something *in* a workspace already
+creates it on demand. A row costs nothing and cannot go stale. A plane with no workspaces at
+all still gets the nudge that says how to make one, beside the row.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -13,6 +13,15 @@ made while working on them, and a written account of what the task is for.
 
 `default` always exists. `charter workspace create <name> --use` starts another.
 
+**"Always exists" is about the name, not about the directory.** `default` is the rung the
+resolution below terminates on, so a plane that has never selected anything is standing in
+it; `charter init` does not create `workspaces/default/`, and the first command that puts
+something in it does (`charter clone -w default`, `charter workspace use default`,
+`charter workspace create default`). `charter workspace list` lists it either way, with
+`—` for its repos, because a table that draws a "you are here" mark has to have a row for
+where you are — and because the `F2` picker inside a frame offers exactly the same names.
+The name is `[workspace] default` if your `charter.toml` sets one.
+
 ## Which workspace am I in
 
 Resolved fresh on every command, in this order. The first rung that answers, wins:

--- a/tests/test_change_surface.py
+++ b/tests/test_change_surface.py
@@ -630,8 +630,8 @@ class TestTwoKeystrokes(SurfaceCase):
         switch.to_change(FID, "b-2")
         roster = choose.roster(choose.CHANGE, FID)
         self.assertEqual(list(roster.names), ["a-1", "b-2"])
-        self.assertTrue(roster.rows[1].title.startswith(choose.MARK[0]))
-        self.assertTrue(roster.rows[0].title.startswith(choose.MARK[1]))
+        self.assertEqual([(r.title, r.mark) for r in roster.rows],
+                         [("a-1", False), ("b-2", True)])
 
     def test_choosing_one_records_it_and_bumps_the_frame(self):
         self.make_change("a-1")

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -383,14 +383,12 @@ class TheChatDoorwaySaysWhyBeforeTheKeypress(PersonaIso, unittest.TestCase):
         _plant("api.1", workspace="api")
         _plant("api.2", workspace="api")
         rows = choose.roster(choose.CHAT, "api.2").rows
-        marked = [r.title for r in rows if r.title.startswith(choose.MARK[0])]
-        self.assertEqual(marked, [f"{choose.MARK[0]}api.2"])
+        self.assertEqual([r.title for r in rows if r.mark], ["api.2"])
 
     def test_a_chats_row_carries_its_harness_and_the_other_nouns_carry_nothing(self):
         _plant("api.1", workspace="api", harness="Claude Code")
         _plant("api.2", workspace="api", harness="Codex")
-        notes = {r.title[len(choose.MARK[0]):]: r.note
-                 for r in choose.roster(choose.CHAT, "api.1").rows}
+        notes = {r.title: r.note for r in choose.roster(choose.CHAT, "api.1").rows}
         self.assertEqual(notes, {"api.1": "Claude Code", "api.2": "Codex"})
         self.assertEqual(choose._note(choose.WORKSPACE, "api"), "")
 

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -381,16 +381,32 @@ class TerseSaysLess(PersonaIso, unittest.TestCase):
         self.assertIn("dev", normal)
         self.assertNotIn("dev", terse)
 
-    def test_bottom_keeps_exactly_one_field(self):
+    def test_bottom_keeps_exactly_one_field_of_news_and_the_hotkey_hint(self):
+        """The trim is about NEWS, and #743 is where the difference was learned.
+
+        An alert, a spinner, a selection and a todo count are things that happened on the
+        plane, and keeping only the loudest is what `minimal` is for. The hotkey hint is
+        not one of those — it is the one piece of chrome that says how to drive the frame,
+        and `minimal` is the arrangement where the palette is the only route to anything,
+        including back to `full`. Ranking it against news dropped it from the only frame
+        that needed it, and an operator who chose `minimal` and reopened their terminal
+        had a frame advertising nothing at all.
+        """
         with mock.patch("charter.statusline._todo_count", return_value=3), \
              mock.patch("charter.statusline._alerts",
-                        return_value=["⚠ reinit: charter ws reinit needed"]):
+                        return_value=["⚠ reinit: charter ws reinit needed"]), \
+             mock.patch("charter.statusline._session_news",
+                        return_value=["⛊ 1 denied"]), \
+             mock.patch.dict(config.FRAME, {"hotkey": "F2"}):
             normal = self._render("bottom", "normal")
             terse = self._render("bottom", "minimal")
         self.assertIn("·", normal, "a healthy `normal` row carries several fields")
-        self.assertNotIn("·", terse)
         self.assertIn("reinit", terse,
                       "the field that survives must be the highest-priority one")
+        self.assertIn("F2 palette", terse, "minimal stopped saying how to drive the frame")
+        self.assertNotIn("todo", terse, "a second field of news survived the trim")
+        self.assertNotIn("denied", terse, "a second field of news survived the trim")
+        self.assertEqual(terse.count("·"), 1, terse)
 
     def test_bottom_is_never_blank_on_a_quiet_plane(self):
         """The one-field cap must not produce an empty row when nothing is wrong: the
@@ -1328,11 +1344,9 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         reg = builtin_actions.build(
             self.fid, current_density=commands_frame._current_density(self.fid),
             current_chrome=commands_frame._current_chrome(self.fid))
-        titles = [a.title for a in reg.all() if a.id.startswith("density.")]
-        on = builtin_actions.MARK[0]
-        self.assertIn(f"{on}density: full", titles)
-        self.assertEqual([t for t in titles if t.startswith(on)],
-                         [f"{on}density: full"], titles)
+        density = [a for a in reg.all() if a.id.startswith("density.")]
+        self.assertEqual([a.title for a in density if a.mark], ["density: full"],
+                         [(a.title, a.mark) for a in density])
 
     def test_a_terminal_too_small_for_the_level_still_drops_the_side_panel(self):
         """A density change goes through the SAME size floors a launch does — asking for

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -2888,10 +2888,10 @@ class Launch(PersonaIso, unittest.TestCase):
                     self.assertEqual(started,
                                      [util.self_relaunch_argv("frame-density", level)])
                     self.assertIn(f"density: {level}", a.title)
-        titles = [a.title for a in reg.all() if a.id.startswith("density.")]
-        marked = [t for t in titles if t.startswith(builtin_actions.MARK[0])]
-        self.assertEqual(marked, [f"{builtin_actions.MARK[0]}density: "
-                                  f"{config.FRAME['density']}"], titles)
+        density = [a for a in reg.all() if a.id.startswith("density.")]
+        self.assertEqual([a.title for a in density if a.mark],
+                         [f"density: {config.FRAME['density']}"],
+                         [(a.title, a.mark) for a in density])
 
     def test_the_write_hook_is_installed_before_the_teardown_hook(self):
         """Load-bearing, not incidental — see `_pane_died_teardown_hook_argv`'s own
@@ -4784,8 +4784,25 @@ class PaletteCommands(PersonaIso, unittest.TestCase):
         self._frame()
         calls = self._open()
         verbs = [c[3] for c in calls]
-        self.assertEqual(verbs, ["split-window", "set-option", "select-pane",
-                                 "resize-pane"], calls)
+        # `list-panes` first is #739's sweep: charter asks tmux which panes on this
+        # window carry the overlay mark and closes them before splitting another, so a
+        # second `F2` reopens the palette rather than stacking an invisible one behind
+        # it. The mark itself is not a verb here — it rides on the `split-window`
+        # invocation as one chained command list, so that no instant exists in which an
+        # overlay pane is open and not findable.
+        self.assertEqual(verbs, ["list-panes", "split-window", "set-option",
+                                 "select-pane", "resize-pane"], calls)
+        self.assertIn(overlay.OVERLAY_OPTION, self._split(calls),
+                      "the split does not mark the pane it just made")
+
+    def _split(self, calls) -> list[str]:
+        """The `split-window` invocation, found by its verb and not by its position.
+
+        The list gained a `list-panes` in front of it (#739's sweep) and could gain more;
+        a test that indexed would then be asserting about whichever command happened to be
+        first, which is how an assertion comes to sit on a path it was never about.
+        """
+        return next(c for c in calls if "split-window" in c)
 
     def test_the_pane_runs_charters_own_palette_and_carries_no_client(self):
         """The client name stopped being threaded to the palette's pane with #729: its one
@@ -4793,7 +4810,7 @@ class PaletteCommands(PersonaIso, unittest.TestCase):
         `/dev/ttys7` is what this opener was handed, so asserting its ABSENCE is what pins
         that the value is dropped here rather than merely unused two hops later."""
         self._frame()
-        split = self._open()[0]
+        split = self._split(self._open())
         self.assertIn("--pane", split)
         self.assertNotIn("/dev/ttys7", split)
         self.assertIn("frame-palette", split)
@@ -4807,7 +4824,7 @@ class PaletteCommands(PersonaIso, unittest.TestCase):
         `$CHARTER_WORKSPACE` may be another frame's. A palette built from those would offer
         to switch to another plane's workspaces."""
         self._frame()
-        split = self._open()[0]
+        split = self._split(self._open())
         self.assertIn(f"CHARTER_SESSION_ID={self.FID}", split)
 
     def test_a_frame_with_no_recorded_harness_pane_opens_nothing_at_all(self):

--- a/tests/test_frame_overlay.py
+++ b/tests/test_frame_overlay.py
@@ -27,7 +27,7 @@ import re
 import unittest
 
 from charter import commands_frame, config, tui
-from charter.frame import layout, overlay
+from charter.frame import layout, overlay, tmuxctl
 
 #: The two DEC private modes the overlay turns on and has to turn back off, spelled out
 #: here rather than reached for through `overlay.ENTER`/`overlay.LEAVE`. A constant
@@ -947,7 +947,27 @@ class TheOverlayPaneIsCharterOwn(unittest.TestCase):
         self.assertIn("split-window", argv)
         self.assertEqual(argv[argv.index("-t") + 1], "%0")
         self.assertEqual(argv[argv.index("-F") + 1], "#{pane_id}")
-        self.assertEqual(argv[argv.index("--") + 1:], ["python3", "-m", "x"])
+        # Up to the command SEPARATOR, not to the end: the mark rides on this same
+        # invocation as a second command (below), and everything after `--` and before it
+        # is the pane's program.
+        cmd = argv[argv.index("--") + 1:]
+        self.assertEqual(cmd[:cmd.index(tmuxctl.SEPARATOR)], ["python3", "-m", "x"])
+
+    def test_the_pane_is_marked_in_the_SAME_invocation_that_makes_it(self):
+        """#739. A pane id is not knowable until `split-window` has answered with one, so
+        a targeted mark is necessarily a second round trip — and the gap between the two
+        is exactly the instant a second `F2` arrives in, finding an overlay pane that is
+        open and not yet findable. One command list closes it: tmux runs the whole list
+        server-side and the split makes the new pane current for the rest of it, so an
+        untargeted `set-option -p` lands on the pane just made (measured on 3.7c and on
+        the 3.2 floor).
+        """
+        argv = overlay.open_argv("charter", harness="%0", command=["true"])
+        after = argv[argv.index(tmuxctl.SEPARATOR) + 1:]
+        self.assertEqual(after, overlay.mark_argv("charter")[3:])
+        self.assertNotIn("-t", after,
+                         "a targeted mark cannot be chained onto the split that makes "
+                         "the pane it would target")
 
     def test_a_target_that_is_not_a_pane_id_opens_nothing(self):
         self.assertIsNone(overlay.open_argv("charter", harness="0", command=["true"]))

--- a/tests/test_frame_overlay.py
+++ b/tests/test_frame_overlay.py
@@ -969,6 +969,29 @@ class TheOverlayPaneIsCharterOwn(unittest.TestCase):
                          "a targeted mark cannot be chained onto the split that makes "
                          "the pane it would target")
 
+    def test_only_a_marked_pane_whose_id_is_tmuxs_own_is_swept(self):
+        """`live_panes` reads a listing back off tmux, and what the caller builds out of
+        one is a `kill-pane`. Three rows, three reasons to drop or keep (#739/#442):
+
+        * the harness formats as its id and nothing else — no mark, not swept;
+        * an overlay formats as its id and the mark — swept;
+        * a first field that is not tmux's own word for a pane never becomes a kill
+          target, however marked it looks. That is not hypothetical tidiness: the value
+          arrives off another process's stdout, and `close_argvs`' own docstring records
+          what an unpredictable `-t` costs.
+        """
+        listing = "%0 \n%1 1\n%2 1\nnot-a-pane 1\n"
+        self.assertEqual(overlay.live_panes(listing), ("%1", "%2"))
+
+    def test_a_sweep_of_nothing_issues_nothing_at_all(self):
+        """An empty target list reaching `kill-pane` is a `kill-pane` with no `-t`, which
+        kills the CURRENT pane — the operator's harness. `None` is the whole answer, and
+        it is `tmuxctl.chain`'s rather than a second guard in front of it."""
+        self.assertIsNone(overlay.sweep_argv("charter", ()))
+        self.assertIsNone(overlay.sweep_argv("charter", ("not-a-pane",)))
+        self.assertEqual(overlay.sweep_argv("charter", ("%4",))[3:],
+                         ["kill-pane", "-t", "%4"])
+
     def test_a_target_that_is_not_a_pane_id_opens_nothing(self):
         self.assertIsNone(overlay.open_argv("charter", harness="0", command=["true"]))
 

--- a/tests/test_frame_overlay.py
+++ b/tests/test_frame_overlay.py
@@ -969,6 +969,30 @@ class TheOverlayPaneIsCharterOwn(unittest.TestCase):
                          "a targeted mark cannot be chained onto the split that makes "
                          "the pane it would target")
 
+    def test_the_overlay_mark_is_in_tmuxs_user_namespace_and_is_charters_own(self):
+        """What the option's SPELLING has to satisfy, which is not the word itself.
+
+        Two properties, and neither is a change-detector. `@` is tmux's own namespace for
+        a user option, so anything without it is a real tmux option charter would be
+        overwriting. `charter` on the front is because the operator's own tmux may be the
+        server charter is a guest on (`is_operator_socket`), where an unprefixed name is a
+        collision with whatever else that operator has set. And it must not be the hatch's
+        option: one names a pane to kill and the other holds a command line tmux re-parses,
+        so a single name would arm the hatch with a `1` and mark every overlay with a
+        command.
+
+        The deletion sweep asked "would any spelling do?" and no test could say no. This
+        says which spellings do.
+        """
+        self.assertTrue(overlay.OVERLAY_OPTION.startswith("@charter"),
+                        overlay.OVERLAY_OPTION)
+        self.assertNotEqual(overlay.OVERLAY_OPTION, overlay.HATCH_OPTION)
+        self.assertIn(overlay.OVERLAY_OPTION, overlay.mark_argv("charter"))
+        listing = overlay.live_argv("charter", harness="%0")
+        self.assertIn(f"#{{{overlay.OVERLAY_OPTION}}}",
+                      listing[listing.index("-F") + 1],
+                      "the listing does not read the option the mark writes")
+
     def test_only_a_marked_pane_whose_id_is_tmuxs_own_is_swept(self):
         """`live_panes` reads a listing back off tmux, and what the caller builds out of
         one is a `kill-pane`. Three rows, three reasons to drop or keep (#739/#442):

--- a/tests/test_frame_palette.py
+++ b/tests/test_frame_palette.py
@@ -27,7 +27,8 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, contain, tui
-from charter.frame import action, actions, builtin_actions, overlay, palette, state
+from charter.frame import (action, actions, builtin_actions, component, overlay, palette,
+                           state)
 
 from tests._isolation import PersonaIso
 
@@ -275,6 +276,33 @@ class FilteringIsPinnedInBothDirections(unittest.TestCase):
         p._refilter()
         self.assertEqual([r.title for r in p.rows],
                          ["zzz match", "aaa match", "mmm match"])
+
+    def test_an_id_that_could_carry_case_is_not_an_id_the_filter_matches(self):
+        """What `matches` and `exact` depend on for not folding an id.
+
+        Both ask `component.usable_id` before comparing against `Row.id`, and neither
+        folds it — a call the deletion sweep correctly reported as one nothing could go
+        red without, because `_ID_RE` admits no capital. This pins that as a property of
+        the PAIR rather than of the regex alone: an id with a capital in it is not matched
+        by either function whatever case the operator types, so the missing `casefold`
+        cannot become a missed row. If the alphabet is ever widened, this reddens.
+        """
+        for rid in ("Acme.Deploy", "ACME", "A_b1"):
+            with self.subTest(id=rid):
+                self.assertFalse(component.usable_id(rid))
+                row = overlay.Row(id=rid, title="nothing like the id")
+                for q in (rid, rid.casefold(), rid.upper()):
+                    self.assertFalse(palette.matches(q, row), (rid, q))
+                    self.assertFalse(palette.exact(q, row), (rid, q))
+
+    def test_an_id_that_is_usable_is_matched_and_ranked_by_the_case_it_has(self):
+        """The counter-control, so the case above cannot pass by nothing ever matching an
+        id at all. A provider's documented id is what somebody types on purpose."""
+        row = overlay.Row(id="acme.deploy", title="Deploy to production")
+        self.assertTrue(palette.matches("acme.dep", row))
+        self.assertTrue(palette.exact("acme.deploy", row))
+        self.assertTrue(palette.exact("ACME.DEPLOY", row),
+                        "the QUERY's case is folded even though the id's cannot differ")
 
     def test_the_row_whose_whole_title_was_typed_goes_first(self):
         """The other side of the same bound, here rather than only in the file about

--- a/tests/test_frame_palette.py
+++ b/tests/test_frame_palette.py
@@ -261,18 +261,36 @@ class FilteringIsPinnedInBothDirections(unittest.TestCase):
         p = self._p("one", "two", "three")
         self.assertEqual(len(p.rows), 3)
 
-    def test_the_order_is_never_disturbed_by_filtering(self):
-        """No ranking: a palette that reordered itself as the operator typed would move the
-        row under the cursor out from under it between keystrokes."""
+    def test_a_partial_match_never_disturbs_the_order(self):
+        """The bound on #732's ordering: only a name typed in FULL moves.
+
+        This used to be "no ranking at all", argued from a property the class does not
+        have — that reordering "would move the row under the cursor out from under it
+        between keystrokes", when `_refilter` puts the selection back at the top on every
+        edit and always has. What reordering really costs is that the LIST reads
+        differently, so the sort is two buckets rather than a score: none of these three
+        is `match`, so all three keep the catalogue's order and the screen is unchanged.
+        """
         p = self._p("zzz match", "aaa match", "mmm match", query="match")
         p._refilter()
         self.assertEqual([r.title for r in p.rows],
                          ["zzz match", "aaa match", "mmm match"])
 
+    def test_the_row_whose_whole_title_was_typed_goes_first(self):
+        """The other side of the same bound, here rather than only in the file about
+        #732, so the two cases sit together and neither can be deleted as the odd one."""
+        p = self._p("zzz match", "match", "mmm match", query="match")
+        p._refilter()
+        self.assertEqual([r.title for r in p.rows],
+                         ["match", "zzz match", "mmm match"])
+
     def test_a_hundred_rows_are_a_hundred_rows(self):
         """The cap mutation, from the top: `rows` may not clip, and neither may `narrow`."""
-        offers = [SimpleNamespace(id=f"a.a{i:03d}", title=f"row {i:03d}",
-                                  available=True, reason="") for i in range(100)]
+        # A real `Offer` and not a stand-in: `rows` reads every field of one, and a
+        # namespace holding the four this test happened to think of would go green over a
+        # field added to the contract and never carried across.
+        offers = [actions.Offer(id=f"a.a{i:03d}", title=f"row {i:03d}",
+                                available=True, reason="") for i in range(100)]
         self.assertEqual(len(palette.rows(offers)), 100)
         self.assertEqual(len(palette.narrow(palette.rows(offers), "row")), 100)
 

--- a/tests/test_frame_palette_integration.py
+++ b/tests/test_frame_palette_integration.py
@@ -80,6 +80,10 @@ _F2 = b"\x1bOQ"
 #: source file is a byte the next reader cannot see.
 _ESCAPE = b"\x1b"
 
+#: What `overlay.HATCH_KEY` is on the wire. F12 in the same xterm form :data:`_F2` uses —
+#: `\x1b[24~` — spelled beside it so a reader can see the two are the same kind of thing.
+_HATCH = b"\x1b[24~"
+
 _TERM_CANDIDATES = tuple(dict.fromkeys(
     ([os.environ["TERM"]] if os.environ.get("TERM", "dumb") != "dumb" else [])
     + ["xterm-256color", "screen", "vt100"]))
@@ -526,6 +530,27 @@ class ThereIsNeverMoreThanOnePalettePane(_ThePalette, unittest.TestCase):
             os.write(fd, _F2)
             pane = self._await_drawn(replacing=pane)
         self.assertEqual(self._overlays(), [pane])
+
+    def test_the_escape_hatch_still_closes_the_palette_a_reopen_drew(self):
+        """The hatch is armed per palette, and a reopen must leave the LIVE one armed.
+
+        The worry is a swept process running `_close_palette` from its `finally` on the
+        way out: that re-arms the hatch with no overlay, and `F12` would then select the
+        harness and leave the new palette standing — the very leak this is fixing, one
+        keypress later. It cannot happen, because `kill-pane` terminates a Python process
+        without running its `finally` (measured directly, against a process whose
+        `finally` writes a file: the file is never written). This is that fact asserted
+        through the surface rather than restated as a comment.
+        """
+        fd, first = self._open()
+        os.write(fd, _F2)
+        self._await_drawn(replacing=first)
+        os.write(fd, _HATCH)
+        self.assertTrue(_await(lambda: self._overlays() == []),
+                        f"the hatch left the reopened palette standing: {self._panes()}")
+        self.assertTrue(
+            _await(lambda: self._panes().get(self.harness) == "1"),
+            f"the hatch did not put the operator back in the harness: {self._panes()}")
 
     def test_the_sweep_cannot_reach_another_chats_palette(self):
         """Scoped to the frame's own window, and this is the case that says so.

--- a/tests/test_frame_palette_integration.py
+++ b/tests/test_frame_palette_integration.py
@@ -356,6 +356,32 @@ class ThePaletteOpensAndRuns(_ThePalette, unittest.TestCase):
         self.assertTrue(_await(lambda: state.version(self.fid) != was),
                         "the frame was never bumped, so no panel repaints")
 
+    def test_a_name_that_the_doorway_also_matches_still_wins_the_cursor(self):
+        """**#732, end to end, on the collision that produced it.** The frame is in
+        `alpha`, so the workspace doorway reads `workspace: alpha — pick another` and holds
+        the typed name inside its own title. The doorway is in the catalogue and the names
+        are gathered after it, so it used to be the row Enter ran — and on the reported
+        plane the colliding row was the `chat:` doorway, which was also *refused*, so Enter
+        opened nothing and switched nothing.
+
+        Asserted on what Enter DOES rather than on the drawn order, because the drawn order
+        is a rendering and this is about the keypress: pressing it must hand the pane back
+        (the row was a name) and must not replace the surface with a picker (the row was a
+        doorway). `zebra` is the tell — it is the other workspace, so it is on the picker
+        and on nothing else.
+        """
+        fd, pane = self._open()
+        self._await_screen(pane, "workspace: alpha")
+        os.write(fd, b"alpha")
+        # Both rows are on screen: the doorway is not hidden, it is outranked.
+        self._await_screen(pane, "detach", present=False)
+        self._await_screen(pane, "workspace: alpha — pick another")
+        os.write(fd, b"\r")
+        self.assertTrue(_await(lambda: self._palette_pane() is None),
+                        f"Enter did not hand the pane back — the doorway took the "
+                        f"keypress and opened a picker:\n{self._screen(pane)}")
+        self.assertEqual(state.frame_workspace(self.fid), "alpha")
+
     def test_nothing_typed_lists_no_names_at_all(self):
         """The other half, and the one a display test cannot fake: the palette that just
         opened is the doorways and the actions, with `zebra` nowhere on it. A palette that

--- a/tests/test_frame_palette_integration.py
+++ b/tests/test_frame_palette_integration.py
@@ -76,6 +76,10 @@ _DEADLINE = 25.0
 #: cannot drift into a test pressing a key charter does not bind.
 _F2 = b"\x1bOQ"
 
+#: What Escape is on the wire, spelled the way :data:`_F2` is. A lone `\x1b` in a
+#: source file is a byte the next reader cannot see.
+_ESCAPE = b"\x1b"
+
 _TERM_CANDIDATES = tuple(dict.fromkeys(
     ([os.environ["TERM"]] if os.environ.get("TERM", "dumb") != "dumb" else [])
     + ["xterm-256color", "screen", "vt100"]))
@@ -395,6 +399,182 @@ class ThePaletteOpensAndRuns(_ThePalette, unittest.TestCase):
                   overlay.HATCH_OPTION).stdout.strip(),
             overlay.hatch_command(harness=self.harness),
             "the hatch still names the pane the palette was drawn in")
+
+
+class ThereIsNeverMoreThanOnePalettePane(_ThePalette, unittest.TestCase):
+    """#739, and the invariant is stated as a COUNT rather than per route.
+
+    The report is a double `F2`: the second press split a second overlay off the harness,
+    Escape closed the one holding the keyboard, and the other stayed — a blank five-row
+    pane holding a live Python process, six rows off the harness, for the life of the
+    frame. `F12` is `select-pane` and did not clear it; a resize did not; no palette row
+    did. Only tmux's own prefix + `x`, which `charter frame` neither binds nor documents.
+
+    **Counted, not route-checked.** Making the double press safe and calling the class
+    closed is how this repository has three times ended up with an assertion sitting on
+    the path that already satisfied it (#682, #683, #689) — and the double press is not
+    the only route: any second open against a live palette does it. The cases below press
+    the key, run the command by hand, and press the key three times in a row, and each one
+    asks the same question of tmux: how many panes on this window carry the overlay mark.
+    """
+
+    def _overlays(self) -> list[str]:
+        """Every pane on the frame's window that charter marked as an overlay.
+
+        Read back through `overlay.live_argv`'s own format, so this asks the question the
+        production sweep asks. A test that counted "panes that are not the harness" would
+        also count a panel, and would go green over a sweep that killed the mark and left
+        the pane.
+        """
+        argv = overlay.live_argv(SOCKET, harness=self.harness)
+        self.assertIsNotNone(argv)
+        return list(overlay.live_panes(
+            subprocess.run(argv, capture_output=True, text=True, timeout=20).stdout))
+
+    def _await_drawn(self, *, replacing: str = "") -> str:
+        """Wait for exactly one overlay pane — a NEW one when *replacing* names the old —
+        drawn, and answer its id.
+
+        Three halves, and each one cost a red run to learn.
+
+        **Exactly one** is the invariant every case here is about.
+
+        **Not the one before it.** `F2` fires a `run-shell`, so the press returns long
+        before charter has swept, split and drawn; for a measured moment the answer to
+        "which panes are overlays" is still the FIRST palette, alone and correct-looking.
+        A wait that only counted was satisfied by that moment, and the Escape that followed
+        went to a palette charter was in the middle of replacing — which read as a leak and
+        was a race in this test. Measured, with the panes dumped at each step: after the
+        second press the listing still said `%1`, and `%2` did not appear until after the
+        Escape had already been sent.
+
+        **Drawn.** The palette puts its own tty in raw mode on the way in
+        (`palette.own_the_tty`), and until it has, a byte written to the client sits in
+        canonical mode waiting for a newline — so an Escape sent to a pane that exists but
+        has not drawn looks exactly like a palette that ignored Escape.
+        """
+        def replaced() -> bool:
+            found = self._overlays()
+            return len(found) == 1 and found[0] != replacing
+
+        self.assertTrue(_await(replaced),
+                        f"{self._overlays()} — not exactly one palette"
+                        + (f" other than {replacing}" if replacing else ""))
+        pane = self._overlays()[0]
+        self.assertTrue(
+            _await(lambda: "detach" in self._screen(pane)),
+            f"the palette's pane never drew its rows:\n{self._screen(pane)}")
+        return pane
+
+    def test_one_press_marks_exactly_one_pane(self):
+        """The control, and it is load-bearing: every count below is zero for a palette
+        that is never marked at all, so a sweep that found nothing would pass them."""
+        _, pane = self._open()
+        self.assertEqual(self._overlays(), [pane])
+
+    def test_a_second_press_replaces_the_palette_instead_of_stacking_one(self):
+        fd, first = self._open()
+        os.write(fd, _F2)
+        second = self._await_drawn(replacing=first)
+        self.assertNotEqual(second, first, "the first palette is the one still open")
+
+    def test_the_harness_gets_its_rows_back_after_ONE_open_and_close(self):
+        """The control for the case below, and the one that says whose defect a row leak
+        is. If a single open/close already loses rows, the reopen is not what lost them."""
+        def rows() -> int:
+            return int(_tmux("display-message", "-p", "-t", self.harness,
+                             "#{pane_height}").stdout.strip() or 0)
+
+        fd = self._attach()
+        self.assertTrue(_await(lambda: rows() > 0))
+        before = rows()
+        os.write(fd, _F2)
+        self._await_drawn()
+        os.write(fd, _ESCAPE)
+        self.assertTrue(_await(lambda: self._overlays() == []))
+        self.assertTrue(_await(lambda: rows() == before),
+                        f"the harness kept {rows()} rows of the {before} it had")
+
+    def test_the_harness_gets_its_rows_back_when_the_reopened_palette_closes(self):
+        """The half an operator actually sees. The leak was invisible — a blank gap above
+        the repo table's rule reads as empty terminal — so what it cost was rows: the
+        harness went from 24 to 18 and stayed there. Escape must give all of them back.
+        """
+        def rows() -> int:
+            return int(_tmux("display-message", "-p", "-t", self.harness,
+                             "#{pane_height}").stdout.strip() or 0)
+
+        fd = self._attach()
+        self.assertTrue(_await(lambda: rows() > 0))
+        before = rows()
+        os.write(fd, _F2)
+        first = self._await_drawn()
+        os.write(fd, _F2)
+        self._await_drawn(replacing=first)
+        os.write(fd, _ESCAPE)
+        self.assertTrue(_await(lambda: self._overlays() == []),
+                        f"a palette survived Escape: {self._panes()}")
+        self.assertTrue(_await(lambda: rows() == before),
+                        f"the harness kept {rows()} rows of the {before} it had")
+
+    def test_three_presses_still_leave_one(self):
+        """The count is an invariant and not a special case for two. Each press closes
+        what is open and draws a fresh one, so the answer is the same however many times
+        an operator leans on a key that seems not to have registered."""
+        fd, pane = self._open()
+        for _ in range(2):
+            os.write(fd, _F2)
+            pane = self._await_drawn(replacing=pane)
+        self.assertEqual(self._overlays(), [pane])
+
+    def test_the_sweep_cannot_reach_another_chats_palette(self):
+        """Scoped to the frame's own window, and this is the case that says so.
+
+        Every chat on charter's socket is a window on one server, and each has its own
+        harness and its own palette. A sweep that asked `list-panes -a` would find a
+        palette another chat has open — a different operator's screen, in the ordinary
+        two-agent case — and kill it. Measured on 3.7c and on the 3.2 floor,
+        `list-panes -t <a pane id>` resolves to that pane's window and lists only its
+        panes; this is that property asserted through the production call rather than
+        through the format string it is spelled with.
+
+        The pane in the other window is marked BY HAND, because what is under test is the
+        reach of the sweep and not how a real palette gets there. A second real frame
+        would put a second `charter frame-palette` between the test and the one question
+        it is asking.
+        """
+        other = _tmux("new-window", "-t", self.fid, "-d", "-P", "-F", "#{pane_id}",
+                      "cat", env=self.env)
+        self.assertEqual(other.returncode, 0, other.stderr)
+        elsewhere = other.stdout.strip()
+        self.addCleanup(lambda: _tmux("kill-pane", "-t", elsewhere))
+        marked = _tmux("set-option", "-p", "-t", elsewhere,
+                       overlay.OVERLAY_OPTION, "1")
+        self.assertEqual(marked.returncode, 0, marked.stderr)
+
+        fd, first = self._open()
+        os.write(fd, _F2)
+        self._await_drawn(replacing=first)
+        alive = _tmux("list-panes", "-a", "-F", "#{pane_id}").stdout.split()
+        self.assertIn(elsewhere, alive,
+                      "the sweep killed a palette open on another chat's window")
+
+    def test_the_route_is_the_open_and_not_the_key(self):
+        """`F2` is the reachable route and it is not the only one: `charter frame-palette`
+        typed in the harness, and a second client attached to the same session pressing
+        the key, open a palette by the same call. Asserted against that call, so the
+        invariant belongs to opening rather than to one key.
+        """
+        _, first = self._open()
+        r = subprocess.run(
+            [sys.executable, "-m", "charter", "frame-palette"],
+            capture_output=True, text=True, timeout=60,
+            env=dict(self.env, CHARTER_SESSION_ID=self.fid,
+                     **{tmuxctl.CHARTER_PY_ENV: sys.executable}))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        second = self._await_drawn(replacing=first)
+        self.assertNotEqual(second, first,
+                            "a hand-run palette stacked on the key's")
 
 
 class AnUnavailableActionIsDrawnWithItsReason(_ThePalette, unittest.TestCase):

--- a/tests/test_frame_palette_names.py
+++ b/tests/test_frame_palette_names.py
@@ -160,8 +160,16 @@ class TypingAtTheTopLevelFindsANameDirectly(_Frame, unittest.TestCase):
     """The headline, and the worked example from the decision itself."""
 
     def test_a_query_matches_workspace_and_persona_names(self):
+        """All three, and the one the operator typed IN FULL first (#732).
+
+        `zeb` is a persona here and a prefix of two workspaces, which is the shape the
+        decision's own worked example has. It used to answer `zeb-api` first — the
+        catalogue's order, workspaces before personas — so `F2` `z` `e` `b` Enter switched
+        to a workspace nobody had named. `frame/palette.narrow` states the rule; the two
+        partial matches keep the order they had behind it.
+        """
         self.assertEqual(self._titles(self._typed("zeb")),
-                         ["  zeb-api", "  zebra-ui", "  zeb"])
+                         ["zeb", "zeb-api", "zebra-ui"])
 
     def test_each_name_says_which_KIND_it_is_so_two_nouns_are_told_apart(self):
         """`zeb` the persona and `zeb-api` the workspace are one keystroke apart and would
@@ -169,9 +177,9 @@ class TypingAtTheTopLevelFindsANameDirectly(_Frame, unittest.TestCase):
         column — which is where `frame/palette.py` already puts what charter has to say
         about a row rather than what the operator typed."""
         rows = self._typed("zeb").rows
-        self.assertEqual([(r.title.strip(), r.note) for r in rows],
-                         [("zeb-api", "workspace"), ("zebra-ui", "workspace"),
-                          ("zeb", "persona")])
+        self.assertEqual([(r.title, r.note) for r in rows],
+                         [("zeb", "persona"), ("zeb-api", "workspace"),
+                          ("zebra-ui", "workspace")])
 
     def test_the_name_in_use_keeps_its_mark_here_too(self):
         """A name row is the picker's own row re-noted, so the `*` that answers "which one
@@ -181,9 +189,15 @@ class TypingAtTheTopLevelFindsANameDirectly(_Frame, unittest.TestCase):
         The doorway matches `alpha` too — it says `workspace: alpha — pick another`, which
         is Task 6's own reason for putting the name in that title — so this asks the name
         rows rather than the first row.
+
+        **The mark is a FIELD and the title is the bare name** (#749). It used to be two
+        characters on the front of the title, which is what gave the palette two left
+        edges — and what made "did the operator type this row's name" a prefix-strip
+        rather than a comparison. Both properties are asserted here, because dropping
+        either one is what the field exists to stop.
         """
         rows = self._names(self._typed("alpha"))
-        self.assertEqual([r.title for r in rows], [f"{choose.MARK[0]}alpha"])
+        self.assertEqual([(r.title, r.mark) for r in rows], [("alpha", True)])
 
     def test_an_empty_query_is_the_doorways_and_the_actions_and_nothing_else(self):
         """The other half of "the doorways stay": with nothing typed the list is exactly

--- a/tests/test_frame_pickers.py
+++ b/tests/test_frame_pickers.py
@@ -91,9 +91,12 @@ class AWorkspacePickerListsWorkspaces(_Frame, unittest.TestCase):
     """Step 1, whole: the list, and what choosing off it does to the frame."""
 
     def test_the_picker_lists_every_workspace_with_the_one_in_use_marked(self):
+        """The names, and the mark as a FIELD rather than as two characters on the front
+        of one (#749). The title is what the operator typed to get here, so it has to be
+        the name and nothing else — `frame/palette.exact` compares against it."""
         roster = choose.roster(choose.WORKSPACE, self.FID)
-        self.assertEqual([r.title for r in roster.rows],
-                         ["* alpha", "  beta", "  default"])
+        self.assertEqual([(r.title, r.mark) for r in roster.rows],
+                         [("alpha", True), ("beta", False), ("default", False)])
 
     def test_choosing_a_row_switches_the_frame_and_bumps_it_so_panels_repaint(self):
         roster = choose.roster(choose.WORKSPACE, self.FID)
@@ -106,7 +109,8 @@ class AWorkspacePickerListsWorkspaces(_Frame, unittest.TestCase):
 
     def test_a_persona_picker_is_the_same_thing_one_noun_over(self):
         roster = choose.roster(choose.PERSONA, self.FID)
-        self.assertEqual([r.title for r in roster.rows], ["  forge", "  scribe"])
+        self.assertEqual([(r.title, r.mark) for r in roster.rows],
+                         [("forge", False), ("scribe", False)])
         was = state.version(self.FID)
         out = choose.switch_to(choose.PERSONA, self.FID, "scribe")
         self.assertTrue(out.ok, out.message)
@@ -114,14 +118,22 @@ class AWorkspacePickerListsWorkspaces(_Frame, unittest.TestCase):
         self.assertNotEqual(state.version(self.FID), was)
 
     def test_the_name_a_row_stands_for_is_matched_by_ID_and_never_by_TITLE(self):
-        """The title carries `choose.MARK` and a name `overlay.Surface.render` contains
-        before drawing, so the string on screen is not the string to switch to. A surface
-        that matched on what it drew would switch to a repaired name or to nothing."""
+        """A row resolves through its id, and a row that merely LOOKS the same does not.
+
+        The title is the bare name since #749, so "the string on screen differs from the
+        string to switch to" is no longer the thing that would catch a title match — the
+        difference is containment, and it only shows on a hostile name
+        (`test_a_hostile_name_is_one_row_and_switches_to_the_raw_name`). What still has to
+        hold, and what a title match would lose, is that a row this roster did not build
+        stands for no name however it is spelled: `overlay.Surface.render` draws what it
+        is given, and a foreign row carrying `alpha` must not switch this frame anywhere.
+        """
         roster = choose.roster(choose.WORKSPACE, self.FID)
         for row, name in zip(roster.rows, roster.names):
             self.assertEqual(roster.name_of(row), name)
-            self.assertNotEqual(row.title, name)
         self.assertIsNone(roster.name_of(overlay.Row(id="not:mine", title="alpha")))
+        self.assertIsNone(roster.name_of(
+            overlay.Row(id="workspace:n99", title="alpha", mark=True)))
 
 
 class APickerRowIsNotAnAction(_Frame, unittest.TestCase):

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -901,6 +901,24 @@ class MinimalStillSaysHowToDriveTheFrame(PersonaIso, unittest.TestCase):
             out = tui.strip_ansi(slots.render("bottom", "f-min2"))
         self.assertEqual(out, "⚠ reinit needed · F2 palette")
 
+    def test_a_notice_takes_the_one_news_slot_and_the_hint_still_shows(self):
+        """The composition with #763, which landed on this same call while this was open.
+
+        A notice is the outcome of the last thing the operator CHOSE, and it is now the
+        top-priority field — so at `minimal` it is the one piece of news that survives,
+        outranking even an alert for the few seconds it dwells. The hint is not news and
+        does not compete with it: both are on the row. Asserted because two changes met at
+        one line, and "each is right alone" is not the same claim as "the pair is right".
+        """
+        state.record_density("f-min-n", "minimal")
+        state.say("f-min-n", "charter: workspace → gamma")
+        with mock.patch("charter.statusline._alerts", return_value=["⚠ reinit needed"]), \
+             mock.patch("charter.statusline._session_news", return_value=[]), \
+             mock.patch("charter.statusline._todo_count", return_value=7), \
+             mock.patch.dict(config.FRAME, {"hotkey": "F2"}):
+            out = tui.strip_ansi(slots.render("bottom", "f-min-n"))
+        self.assertEqual(out, "charter: workspace → gamma · F2 palette")
+
     def test_the_hint_follows_the_configured_key(self):
         """It is READ, never spelled: a plane on `hotkey = "F1"` must not be told about a
         key that does nothing. The exemption must not become a hardcoded string."""

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -863,6 +863,78 @@ class BottomRenderer(PersonaIso, unittest.TestCase):
         self.assertLessEqual(tui.width(out), 3)
 
 
+class MinimalStillSaysHowToDriveTheFrame(PersonaIso, unittest.TestCase):
+    """#743. `density = minimal` is the arrangement with no repo table, no sidebar and no
+    charter version — two one-row strips, with the repo table, the todo list, the
+    workspace switch, the persona switch and the way back to `full` ALL behind `F2`. It
+    was also the one arrangement that stopped saying `F2` anywhere on screen.
+
+    The cause is that the hint was ranked against the other fields, and `terse` keeps one.
+    The hint is a different kind of thing from the other three: an alert, a spinner and a
+    todo count are news about the plane, and the hint is the one piece of chrome that says
+    how to drive the frame. Ranking it against news is what dropped it from the only frame
+    that needed it.
+    """
+
+    def _row(self, fid: str) -> str:
+        with mock.patch("charter.statusline._alerts", return_value=[]), \
+             mock.patch("charter.statusline._session_news", return_value=[]), \
+             mock.patch("charter.statusline._todo_count", return_value=7), \
+             mock.patch.dict(config.FRAME, {"hotkey": "F2"}):
+            return tui.strip_ansi(slots.render("bottom", fid))
+
+    def test_a_minimal_frame_still_advertises_the_palette(self):
+        """The report, exactly: `7 todos · F2 palette` before, `7 todos` after."""
+        state.record_density("f-min", "minimal")
+        self.assertEqual(slots.verbosity("f-min"), "terse")
+        self.assertEqual(self._row("f-min"), "7 todos · F2 palette")
+
+    def test_the_density_still_trims_everything_that_is_news(self):
+        """The exemption is one field, not the end of the trim. With something running and
+        something wrong, a terse row still says exactly one of them — the highest-priority
+        — and still says how to open the palette."""
+        state.record_density("f-min2", "minimal")
+        with mock.patch("charter.statusline._alerts", return_value=["⚠ reinit needed"]), \
+             mock.patch("charter.statusline._session_news", return_value=["⛊ 1 denied"]), \
+             mock.patch("charter.statusline._todo_count", return_value=7), \
+             mock.patch.dict(config.FRAME, {"hotkey": "F2"}):
+            out = tui.strip_ansi(slots.render("bottom", "f-min2"))
+        self.assertEqual(out, "⚠ reinit needed · F2 palette")
+
+    def test_the_hint_follows_the_configured_key(self):
+        """It is READ, never spelled: a plane on `hotkey = "F1"` must not be told about a
+        key that does nothing. The exemption must not become a hardcoded string."""
+        state.record_density("f-min3", "minimal")
+        with mock.patch("charter.statusline._alerts", return_value=[]), \
+             mock.patch("charter.statusline._session_news", return_value=[]), \
+             mock.patch("charter.statusline._todo_count", return_value=7), \
+             mock.patch.dict(config.FRAME, {"hotkey": "F1"}):
+            out = tui.strip_ansi(slots.render("bottom", "f-min3"))
+        self.assertEqual(out, "7 todos · F1 palette")
+
+    def test_a_starved_pane_still_drops_it(self):
+        """An exemption from the DENSITY, never from the arithmetic. A hint sliced in half
+        is the false-clean failure `_fit_fields` exists to refuse, so a pane with room for
+        one field gets one field — which is width doing its job, not `minimal` doing it.
+        """
+        state.record_density("f-min4", "minimal")
+        with mock.patch("charter.statusline._alerts", return_value=[]), \
+             mock.patch("charter.statusline._session_news", return_value=[]), \
+             mock.patch("charter.statusline._todo_count", return_value=7), \
+             mock.patch.dict(config.FRAME, {"hotkey": "F2"}), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((9, 3))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = tui.strip_ansi(slots.render("bottom", "f-min4"))
+        self.assertEqual(out, "7 todos")
+
+    def test_a_normal_density_is_unchanged(self):
+        """The control. Nothing about this is a new field or a new order — `normal` drew
+        both already, and an exemption that changed what a full frame says would be a
+        second defect wearing the first one's fix."""
+        self.assertEqual(self._row("f-normal"), "7 todos · F2 palette")
+
+
 class FitFields(unittest.TestCase):
     """`slots._fit_fields` in isolation, free of `_bottom`'s other, always-present
     fields (todo, hotkey) — so a test can construct the exact width pressure it wants
@@ -874,6 +946,44 @@ class FitFields(unittest.TestCase):
     def test_a_later_field_is_dropped_whole_once_the_budget_runs_out(self):
         self.assertEqual(
             slots._fit_fields([("a", "AAA"), ("b", "BBBBBBBBBB")], 6), {"a"})
+
+    def test_an_exempt_field_is_not_counted_by_the_limit_and_not_stopped_by_it(self):
+        """#743's mechanism, in isolation. `limit=1` is what a `terse` density asks for;
+        an exempt name neither consumes that one slot nor is cut off by it — and it is
+        reached even though it is LAST in the priority order, which is where the hotkey
+        hint sits and why the loop `continue`s past a capped field instead of breaking."""
+        fields = [("alert", "AAA"), ("todo", "TTT"), ("hotkey", "HHH")]
+        self.assertEqual(slots._fit_fields(fields, 80, limit=1), {"alert"})
+        self.assertEqual(
+            slots._fit_fields(fields, 80, limit=1, exempt=frozenset({"hotkey"})),
+            {"alert", "hotkey"})
+
+    def test_an_exempt_field_does_not_spend_the_densitys_one_slot(self):
+        """Asked with the exempt field FIRST, which `_bottom` does not do today and which
+        is exactly why it is worth asking here. `hotkey` is last in that caller's priority
+        order, so an implementation that counted an exempt field against the cap would
+        behave identically on the only list charter passes it — and would silently eat the
+        one slot the news fields get the day a second piece of chrome is added above them.
+        A general function's contract does not get to depend on its one current caller.
+        """
+        fields = [("hotkey", "HHH"), ("alert", "AAA"), ("todo", "TTT")]
+        self.assertEqual(
+            slots._fit_fields(fields, 80, limit=1, exempt=frozenset({"hotkey"})),
+            {"hotkey", "alert"})
+
+    def test_an_exempt_field_still_answers_to_the_width(self):
+        """The half that keeps this an exemption from the density rather than from the
+        arithmetic: no budget, no field, exempt or not."""
+        fields = [("todo", "TTTTTTTT"), ("hotkey", "HHHHHHHH")]
+        self.assertEqual(
+            slots._fit_fields(fields, 10, limit=1, exempt=frozenset({"hotkey"})),
+            {"todo"})
+
+    def test_the_row_names_the_hotkey_hint_and_nothing_else(self):
+        """`_ALWAYS` is a set so that "which fields are chrome rather than news" is a
+        question with an answer somebody can read, and so the next field of that kind
+        joins a list rather than an `or` buried in a loop. One entry today."""
+        self.assertEqual(slots._ALWAYS, frozenset({"hotkey"}))
 
     def test_measures_in_display_cells_not_characters(self):
         """`"測"` is one character but TWO display cells. Sized so a `len()`-based

--- a/tests/test_frame_surface_live.py
+++ b/tests/test_frame_surface_live.py
@@ -447,8 +447,8 @@ class ThePaletteCarriesTheThreeSurfaces(PersonaIso, unittest.TestCase):
 
     def test_the_row_in_effect_is_marked_and_the_others_are_not(self):
         rows = self._rows(current="dark")
-        self.assertTrue(rows["chrome.dark"].title.startswith(builtin_actions.MARK[0]))
-        self.assertTrue(rows["chrome.off"].title.startswith(builtin_actions.MARK[1]))
+        self.assertTrue(rows["chrome.dark"].mark)
+        self.assertFalse(rows["chrome.off"].mark)
 
     def test_the_mark_moves_with_the_frame(self):
         """Marked, never filtered: a list whose rows move around depending on state is a
@@ -457,8 +457,7 @@ class ThePaletteCarriesTheThreeSurfaces(PersonaIso, unittest.TestCase):
             with self.subTest(level=level):
                 rows = self._rows(current=level)
                 marked = [r for r, o in rows.items()
-                          if r.startswith("chrome.")
-                          and o.title.startswith(builtin_actions.MARK[0])]
+                          if r.startswith("chrome.") and o.mark]
                 self.assertEqual(marked, [f"chrome.{level}"])
 
     def test_a_frame_with_no_panes_lists_the_rows_with_a_reason(self):

--- a/tests/test_frame_switch.py
+++ b/tests/test_frame_switch.py
@@ -26,7 +26,8 @@ import unittest
 from unittest import mock
 
 from charter import cli, commands_frame, config, persona, tui, workspace
-from charter.frame import builtin_actions, choose, palette, picker, state, switch
+from charter.frame import (builtin_actions, choose, overlay, palette, picker,
+                           state, switch)
 
 from tests._isolation import PersonaIso
 
@@ -243,17 +244,37 @@ def _rows(fid: str, *, density: str = "normal"):
 def _titles(fid: str, kind: str, *, density: str = "normal") -> list[str]:
     """Every row title whose ID belongs to *kind* (today: `density`).
 
-    Selected by ID and never by what the title says, because the mark charter puts in
-    front of the current one is part of the title — a prefix match on the title would
-    silently drop exactly the row every one of these tests is about.
+    Selected by ID and never by what the title says: the title is what a caller is here to
+    assert about, and a prefix match on it would decide membership from the same string
+    the case is measuring. That was doubly true when the mark was part of the title, and
+    it is still true now that it is `overlay.Row.mark` (#749).
     """
     return [r.title for r in _rows(fid, density=density)
             if r.id.startswith(kind + ".")]
 
 
+def _marked(fid: str, kind: str, *, density: str = "normal") -> list[str]:
+    """The titles of *kind*'s rows carrying the "you are on this one" mark.
+
+    The mark is a FIELD since #749, so "which row is marked" is a question asked of the
+    row rather than of its first two characters. Selected by ID for :func:`_titles`'
+    reason exactly.
+    """
+    return [r.title for r in _rows(fid, density=density)
+            if r.id.startswith(kind + ".") and r.mark]
+
+
 def _names(fid: str, noun: str) -> list[str]:
-    """Every row title inside *noun*'s picker — the list one keypress past the palette."""
-    return [r.title for r in choose.roster(noun, fid).rows]
+    """Every row inside *noun*'s picker, marked — the list one keypress past the palette.
+
+    Rendered here rather than read off `Row.title`, because since #749 the title is the
+    bare name and the mark is `Row.mark`. The two are spelled back together for these
+    cases because what they are about is *which* row is marked, and a pair per row reads
+    worse than the line the operator sees. `overlay.ROW_MARK` and not two characters, so
+    a marker that changes width does not silently change what these cases assert.
+    """
+    return [f"{overlay.ROW_MARK[0] if r.mark else overlay.ROW_MARK[1]}{r.title}"
+            for r in choose.roster(noun, fid).rows]
 
 
 class ThePaletteOffersAPickerForEach(PersonaIso, unittest.TestCase):
@@ -414,9 +435,10 @@ class ThePaletteCannotGoStale(PersonaIso, unittest.TestCase):
         derived when the palette opens, from `_current_density`."""
         state.record_density(self.FID, "full")
         self._switch(workspace="beta")
-        titles = _titles(self.FID, "density",
-                         density=commands_frame._current_density(self.FID))
-        self.assertIn("* density: full", titles)
+        self.assertEqual(
+            _marked(self.FID, "density",
+                    density=commands_frame._current_density(self.FID)),
+            ["density: full"])
 
 
 class ThePickerDecidesNothingOnItsOwn(unittest.TestCase):

--- a/tests/test_the_always_present_workspace_is_listed.py
+++ b/tests/test_the_always_present_workspace_is_listed.py
@@ -1,0 +1,148 @@
+"""`charter workspace list` lists the workspace the plane is standing in — #745.
+
+**The report came from the frame and the defect is in the CLI.** A UX audit found that the
+`F2` workspace picker offers `default` on a plane whose `workspaces/` holds four other
+names, that choosing it succeeds, and that `charter workspace list` then does not list
+where the frame is. It read as "the picker offers something that is not a workspace".
+
+**It is a workspace.** Measured on a plane built by `charter init`, before anything else:
+
+* `workspace.resolve()` answers `default` and `workspace.source()` says
+  `default (nothing selected)` — it is the rung the resolution ladder terminates on, so
+  every plane starts there and there is no other answer for it to give.
+* `charter workspace use default` accepts it on a plane that has never made one, says so
+  in a comment older than this issue, and `workspace.ensure` creates the directory then.
+* `charter clone <repo> -w default` creates it too, which is what the frame's own repo
+  panel tells the operator to run.
+* `frame/switch.workspaces` folds it in for exactly that reason, and the docs' own picker
+  example draws `default` as an ordinary row beside `alpha`, `beta` and `zebra`.
+
+So `default` is a real workspace that is a real DIRECTORY on some planes and not others —
+`charter init` does not make it, unlike `personas/steward`. Everything in charter agreed
+about that except the listing, which reads directories.
+
+**What that cost, in one screen.** The table draws a two-cell "you are here" inset, and on
+a plane with workspaces where nobody has selected one the mark landed on no row at all::
+
+    Active workspace: default  (via default (nothing selected))
+
+      WORKSPACE  MODE   CLONES  REPOS
+      alpha      local  0       —
+      beta       local  0       —
+
+A header naming a workspace, a column reserved for marking it, and no row for it.
+
+**Nothing is created to fix it, here or in `charter init`.** `[workspace] default` names
+this workspace, so `init` would be baking a directory for a value the operator may change
+in the charter.toml `init` itself just wrote — and every route that puts something IN a
+workspace calls `workspace.ensure` already. A row costs nothing and cannot go stale.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_workspace, config, workspace
+from charter.frame import switch
+
+from tests._isolation import PersonaIso
+
+
+class TheListingAndThePickerAnswerTheSameQuestion(PersonaIso, unittest.TestCase):
+    """One plane, two surfaces, one set of names."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        config.WORKSPACES_DIR.mkdir(parents=True, exist_ok=True)
+
+    def make(self, *names: str) -> None:
+        for n in names:
+            workspace.workspace_dir(n).mkdir(parents=True, exist_ok=True)
+
+    def listing(self) -> list[str]:
+        out = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(io.StringIO()):
+            commands_workspace.cmd_workspace_list(SimpleNamespace())
+        return out.getvalue().splitlines()
+
+    def names_in(self, lines: list[str]) -> list[str]:
+        """The WORKSPACE cell of every body row, in order.
+
+        Read off the drawn table rather than off `list_workspaces`, because what is being
+        asserted is what the operator sees — a fix that changed the model and not the
+        renderer would pass a test that asked the model.
+        """
+        body = [ln for ln in lines if ln and not ln.lstrip().startswith("WORKSPACE")
+                and not ln.startswith("Active workspace:")]
+        return [ln[2:].split()[0] for ln in body if ln[2:].strip()]
+
+    def test_the_active_workspace_has_a_row_and_it_is_the_marked_one(self):
+        """The reported screen. `default` is where the plane resolves and where the frame
+        stands after the picker, and it was the one name the table could not show."""
+        self.make("alpha", "beta")
+        lines = self.listing()
+        self.assertEqual(self.names_in(lines), ["alpha", "beta", "default"])
+        marked = [ln for ln in lines if ln.startswith("* ")]
+        self.assertEqual(len(marked), 1, lines)
+        self.assertIn("default", marked[0])
+
+    def test_the_listing_names_exactly_what_the_picker_offers(self):
+        """The property the two surfaces disagreeing about is what produced the report.
+        `frame/switch.workspaces` is what the `F2` picker and the launch prompt both draw,
+        so a name in one and not the other is a route to a workspace one of them denies
+        exists."""
+        self.make("alpha", "beta", "gamma")
+        self.assertEqual(self.names_in(self.listing()), switch.workspaces())
+
+    def test_the_mark_always_has_a_row_to_land_on(self):
+        """The general statement of the defect: the table reserves two cells for "you are
+        here", so a listing that can resolve to a name it does not draw has a column that
+        is sometimes about nothing. Asked across the three shapes a plane comes in."""
+        for made in ((), ("alpha",), ("alpha", "default")):
+            with self.subTest(made=made):
+                self.make(*made)
+                lines = self.listing()
+                self.assertIn(workspace.resolve(), self.names_in(lines))
+
+    def test_a_plane_that_declares_another_default_gets_no_extra_row(self):
+        """`[workspace] default` names this workspace, and folding in a literal `default`
+        rather than the configured one would put a row on the table for a name nothing on
+        the plane resolves to — the defect this fixes, inverted."""
+        self.make("alpha", "beta")
+        with mock.patch.object(config, "DEFAULT_WORKSPACE", "alpha"):
+            names = self.names_in(self.listing())
+        self.assertEqual(names, ["alpha", "beta"])
+
+    def test_listing_creates_nothing(self):
+        """A read stays a read. The row is the answer, not a directory made to justify one
+        — `charter init` deliberately does not make it either, and a listing that did
+        would be creating a workspace as a side effect of being asked what exists.
+        """
+        self.make("alpha")
+        self.listing()
+        self.assertFalse(workspace.workspace_dir(config.DEFAULT_WORKSPACE).exists())
+        self.assertEqual(workspace.list_workspaces(), ["alpha"])
+
+    def test_a_plane_with_no_workspaces_still_says_how_to_make_one(self):
+        """"There is one row and it is the fallback" and "somebody has made a workspace"
+        are different states, and a one-row table cannot tell them apart. The nudge that
+        was the whole of the old empty-plane answer stays, beside the row."""
+        err = io.StringIO()
+        out = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            commands_workspace.cmd_workspace_list(SimpleNamespace())
+        self.assertEqual(self.names_in(out.getvalue().splitlines()),
+                         [config.DEFAULT_WORKSPACE])
+        self.assertIn("charter workspace create", err.getvalue())
+
+    def test_a_plane_that_has_made_it_gets_one_row_and_not_two(self):
+        """The fold-in is conditional, and the condition is the one `switch.workspaces`
+        already uses. A second `default` row would be the same name twice with the mark on
+        one of them."""
+        self.make("alpha", config.DEFAULT_WORKSPACE)
+        self.assertEqual(self.names_in(self.listing()),
+                         ["alpha", config.DEFAULT_WORKSPACE])

--- a/tests/test_the_palette_lands_on_the_name_you_typed.py
+++ b/tests/test_the_palette_lands_on_the_name_you_typed.py
@@ -52,6 +52,13 @@ from tests._isolation import PersonaIso
 from tests.test_frame_pickers import _plane_personas, _plane_workspaces
 
 
+#: A line separator `str.splitlines` honours, which is the bound #472 settled on: the
+#: property is "renders as one line", not "holds no `\\n`". Spelled with an escape rather
+#: than the character itself, because a U+2028 in this file's own source is a line the
+#: next reader cannot see.
+_SEPARATOR = "\u2028"
+
+
 def _row(rid: str, title: str, note: str = "", *, mark: bool = False,
          refused: bool = False) -> overlay.Row:
     return overlay.Row(id=rid, title=title, note=note, mark=mark, refused=refused)
@@ -180,10 +187,34 @@ class TypingAWholeNameLandsOnIt(unittest.TestCase):
     def test_the_case_rule_reaches_the_ordering_too(self):
         """`casefold` on both sides, the same as `matches`. A palette that filtered
         case-insensitively and then ranked case-sensitively would find the row and still
-        put the cursor somewhere else, which is indistinguishable from not finding it."""
+        put the cursor somewhere else, which is indistinguishable from not finding it.
+
+        **Both sides, in both directions**, because one case each way is what an operator
+        actually produces: a workspace named `Beta` reached by typing `beta`, and one
+        named `beta` reached by a shift key nobody meant to hold. Asserted as two cases in
+        one so that neither half can be dropped as the redundant one — the sweep reported
+        exactly that about the query's own `casefold`, which only the second case reaches.
+        """
         rows = (_row("a.b", "beta — do the thing"), _row("workspace:n0", "Beta"))
         self.assertEqual([r.id for r in palette.narrow(rows, "beta")],
                          ["workspace:n0", "a.b"])
+        rows = (_row("a.b", "beta — do the thing"), _row("workspace:n0", "beta"))
+        self.assertEqual([r.id for r in palette.narrow(rows, "BETA")],
+                         ["workspace:n0", "a.b"])
+
+    def test_the_query_is_contained_and_folded_in_one_place(self):
+        """`typed` is the whole of the case rule and #472's rule, asked once for both the
+        filter and the ordering.
+
+        Two assertions, one per transform, because either alone leaves the other
+        deletable — which is what the sweep reported when `exact` carried its own copy of
+        this line. The palette builds its own query out of printable single characters, so
+        a separator cannot be typed into it; `narrow` and `matches` are functions anything
+        may call, and the guard belongs at the join rather than at whichever writer
+        happens to exist today.
+        """
+        self.assertEqual(palette.typed("ALPHA"), "alpha")
+        self.assertNotIn(_SEPARATOR, palette.typed("al" + _SEPARATOR + "pha"))
 
     def test_an_action_id_typed_in_full_is_exact_too(self):
         """`matches` accepts a provider's documented id (`acme.deploy`) as well as the
@@ -393,11 +424,24 @@ class ARepeatableRowKeepsThePaletteOpen(PersonaIso, unittest.TestCase):
 
     def test_the_next_keystroke_clears_it(self):
         """It is a report about the last keypress, not a second label. Typing is a new
-        question and the answer to the old one must not stand over it."""
+        question and the answer to the old one must not stand over it.
+
+        Asserted as the WHOLE heading rather than as the sentence being absent: an empty
+        report that still emitted its separator would leave `charter /n · ` on screen —
+        a header with a dangling `·` and nothing after it, which "the sentence is gone"
+        cannot tell from the header being right. The sweep reported exactly that gap.
+        """
         p = self._palette()
         p.report("selected auth")
         p.handle(overlay.Event(kind=overlay.KEY, name="n"), 24)
-        self.assertNotIn("selected auth", p.heading)
+        self.assertEqual(p.heading, palette.HEADING + palette.PROMPT + "n")
+
+    def test_an_empty_report_leaves_the_header_exactly_as_it_was(self):
+        """The same property one step earlier: an action that answered nothing has nothing
+        to say, and the header must not gain a separator for it."""
+        p = self._palette()
+        p.report("")
+        self.assertEqual(p.heading, palette.HEADING)
 
     def test_the_query_still_shows_beside_the_report(self):
         """Both, because both are live: what is being filtered, and what the last Enter

--- a/tests/test_the_palette_lands_on_the_name_you_typed.py
+++ b/tests/test_the_palette_lands_on_the_name_you_typed.py
@@ -382,6 +382,34 @@ class ARepeatableRowKeepsThePaletteOpen(PersonaIso, unittest.TestCase):
         self.assertIsNone(commands_frame._again(detach, p, reg, fid="f-1", snapshot={}))
         self.assertEqual(self.ran, [])
 
+    def test_a_repeatable_row_that_REFUSES_keeps_the_palette_and_says_why(self):
+        """The other branch of what a repeat reports, and the one a docstring claimed
+        without anything asserting it.
+
+        `repo: select the next row` refuses on a workspace with no clones, and that is an
+        ordinary state rather than an edge: a plane whose gather has not run yet, or one
+        that genuinely has nothing cloned. The palette must not close — nothing was
+        started, and closing would cost the operator the pane for a keypress that did
+        nothing — and the reason must land where a repeat's outcome always lands, because
+        the attention row it would otherwise use is under the zoom.
+
+        The deletion sweep found this: `inv.reason if not inv.started else (inv.note or
+        inv.error)` collapsed to its second branch and no test noticed, because every case
+        here ran an action that starts.
+        """
+        from charter import commands_frame
+        from charter.frame import action
+        reg = actions.ActionRegistry()
+        reg.register(action.Action(
+            id="repo.next", title="repo: select the next row", repeat=True,
+            run=lambda ctx: self.fail("a refused action must not be run"),
+            available=lambda ctx: False,
+            reason_unavailable=lambda ctx: "this workspace has no clones"))
+        p = self._palette()
+        got = commands_frame._again(p.rows[0], p, reg, fid="f-1", snapshot={})
+        self.assertIs(got, p, "a refusal closed the palette")
+        self.assertIn("this workspace has no clones", p.heading)
+
     def test_a_row_that_is_not_an_action_at_all_ends_the_palette(self):
         """A picker row reaches this function too — `_draw_palette` asks `_picker` first,
         and a doorway that opened nothing falls through to here. `ActionRegistry.get`

--- a/tests/test_the_palette_lands_on_the_name_you_typed.py
+++ b/tests/test_the_palette_lands_on_the_name_you_typed.py
@@ -1,0 +1,489 @@
+"""Three properties of the `F2` palette, reported together and fixed together.
+
+A UX audit drove a real frame through a real outer tmux with real keystrokes and filed
+five things; three of them are this surface, and two of the three turned out to be one
+change seen from two sides.
+
+**#732 — typing a workspace's exact name did not switch to it.** `docs/frame.md` sells
+`F2`, the name, Enter as *the* route for an operator who knows where they are going. A
+chat id is `<workspace>.<n>`, so on a plane with a workspace `alpha` the doorway row
+`chat: alpha.1 — pick another` holds `alpha` as a substring of its title — and the
+doorways are in the catalogue while the names are gathered after it, so the doorway sorted
+first. On the reported plane that doorway was also *refused* (one chat, nothing to pick),
+so Enter opened nothing, switched nothing, and answered a question about chats. The
+`alpha` row was one Down away the whole time.
+
+**#749 — the palette had two left insets.** Rows that could carry a `*` composed it into
+their own title; rows that could not composed nothing. Text started at column 3 for the
+doorways and the actions and at column 5 for the density and chrome rows, so the cursor
+sat two columns from the text on one half of the list and four on the other — against
+`docs/frame.md`'s own stated rule that every row's text starts in the same column.
+
+**#746 — a repo selection cost a whole palette per row.** `repo: select the next row` is
+the only action charter offers whose natural use is repeated, and with `[frame] mouse =
+false` shipped as the default it is the repo table's only interaction model. Every Enter
+closed the pane and killed the process, so three rows down a fourteen-row table was
+fourteen keystrokes and three ~3-second cycles.
+
+**The three are one change and this file is why.** #749 moved the mark off the title and
+into `overlay.Row.mark`; that is what makes "is this row's name what the operator typed"
+a comparison rather than a prefix-strip against a constant, which is what #732's ordering
+needed. #746 is separate machinery but the same surface, and its feedback lands in the
+header for a reason the other two share: the palette pane is zoomed over the whole window
+(`overlay.modal_argvs`), so nothing behind it is on screen to look at.
+
+**What is deliberately NOT here: refused rows being hidden.** #512's rule is that an
+operator cannot ask about an option they cannot see, and the audit confirmed the rule
+works. A refused row is still listed and still carries its reason; what changed is only
+which row the cursor starts on.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, tui
+from charter.frame import actions, overlay, palette, state
+
+from tests._isolation import PersonaIso
+from tests.test_frame_pickers import _plane_personas, _plane_workspaces
+
+
+def _row(rid: str, title: str, note: str = "", *, mark: bool = False,
+         refused: bool = False) -> overlay.Row:
+    return overlay.Row(id=rid, title=title, note=note, mark=mark, refused=refused)
+
+
+#: The reported plane, as rows, in the order `_draw_palette` composes them: the four
+#: doorways, then the actions, then — once something has been typed — the names.
+#:
+#: Spelled here rather than driven through `commands_frame._draw_palette` because the
+#: defect is an ORDERING and the ordering is `palette.narrow`'s; a plane fixture would put
+#: a frame directory, four listers and a tmux socket between the test and the two lines it
+#: is about. `tests/test_frame_palette_names.py` drives the real surface over a real plane
+#: and asserts the same rule from that end.
+_DOORWAYS = (
+    _row("pick:workspace", "workspace: default — pick another"),
+    _row("pick:persona", "persona: steward — pick another"),
+    _row("pick:change", "change — pick one",
+         "no cross-repo change in this workspace", refused=True),
+    _row("pick:chat", "chat: alpha.1 — pick another",
+         "this workspace has one chat — open another with `charter <harness>`",
+         refused=True),
+)
+_ACTIONS = (
+    _row("frame.detach", "detach — leave the harness running"),
+    _row("repo.next", "repo: select the next row"),
+    _row("density.full", "density: full", mark=True),
+)
+_NAMES = (
+    _row("workspace:n0", "alpha", "workspace"),
+    _row("persona:n0", "steward", "persona", mark=True),
+    _row("chat:n0", "alpha.1", "this workspace has one chat", mark=True, refused=True),
+)
+
+
+class TypingAWholeNameLandsOnIt(unittest.TestCase):
+    """#732. The rule, stated once: an exact match first, an actionable one ahead of a
+    refused one, everything else in the position the catalogue gave it."""
+
+    def _typed(self, query: str) -> list[overlay.Row]:
+        return list(palette.narrow(_DOORWAYS + _ACTIONS + _NAMES, query))
+
+    def test_the_reported_case_puts_the_workspace_under_the_cursor(self):
+        """The audit's own transcript, end to end. `alpha` matched three rows; the first
+        was a doorway that could not run, so Enter closed the palette having done nothing
+        the operator asked for.
+
+        Asserted as the FIRST row rather than as "somewhere in the list", because where it
+        is in the list is the whole defect — every one of these rows was already listed.
+        """
+        got = self._typed("alpha")
+        self.assertEqual([r.id for r in got],
+                         ["workspace:n0", "pick:chat", "chat:n0"])
+
+    def test_the_row_the_cursor_starts_on_is_one_that_can_run(self):
+        """The second half of the report, said about the palette rather than about
+        `narrow`: a `Palette` puts its cursor at 0, so "first" and "under the cursor" are
+        the same row and the surface is where that is worth pinning."""
+        p = palette.Palette(catalogue=_DOORWAYS + _ACTIONS,
+                            query_only=lambda: _NAMES)
+        for ch in "alpha":
+            p.handle(overlay.Event(kind=overlay.KEY, name=ch), 24)
+        self.assertEqual(p.rows[p._sel].id, "workspace:n0")
+        self.assertFalse(p.rows[p._sel].refused)
+
+    def test_an_exact_match_beats_a_partial_one_even_when_both_can_run(self):
+        """`docs/frame.md`'s own worked example, which used to answer the wrong row: `zeb`
+        is a persona and a prefix of two workspaces, and the catalogue lists workspaces
+        first. Typing a name in full and getting a different name is the defect whether or
+        not the row that won could run."""
+        rows = (_row("workspace:n0", "zeb-api", "workspace"),
+                _row("workspace:n1", "zebra-ui", "workspace"),
+                _row("persona:n0", "zeb", "persona"))
+        self.assertEqual([r.title for r in palette.narrow(rows, "zeb")],
+                         ["zeb", "zeb-api", "zebra-ui"])
+
+    def test_between_two_exact_matches_the_one_that_can_run_comes_first(self):
+        """A pinned frame is the case: `$CHARTER_WORKSPACE` refuses the workspace `alpha`
+        while a persona of the same name switches fine. Both are exactly what was typed,
+        and only one of them does anything."""
+        rows = (_row("workspace:n0", "alpha", "cannot switch: $CHARTER_WORKSPACE pins "
+                                              "this frame to 'beta'", refused=True),
+                _row("persona:n0", "alpha", "persona"))
+        self.assertEqual([r.id for r in palette.narrow(rows, "alpha")],
+                         ["persona:n0", "workspace:n0"])
+
+    def test_a_refused_row_is_still_listed_with_its_reason(self):
+        """#512's rule, which this ordering must not quietly become a way around. The
+        chat doorway that started the report is refused, and it is still on the list with
+        the sentence that says why — one row further down, not gone."""
+        got = self._typed("alpha")
+        refused = [r for r in got if r.refused]
+        self.assertEqual([r.id for r in refused], ["pick:chat", "chat:n0"])
+        for r in refused:
+            self.assertTrue(r.note, f"{r.id} is refused and says nothing")
+
+    def test_nothing_typed_is_the_list_it_always_was(self):
+        """The cost of ranking, and the bound on it. With an empty query no row is an
+        exact match for anything, so `F2` draws the catalogue in the catalogue's order —
+        the eleven-row screen `docs/frame.md` pictures, unmoved."""
+        catalogue = _DOORWAYS + _ACTIONS
+        self.assertEqual([r.id for r in palette.narrow(catalogue, "")],
+                         [r.id for r in catalogue])
+
+    def test_a_row_with_no_title_is_not_what_an_empty_query_typed(self):
+        """The guard `exact` opens with, and the case that makes it more than a spelling.
+
+        `Action` holds its title to being a string and nothing more, so `title=""` is a
+        row a provider can register — and `""` is what `casefold` gives an untyped query.
+        Without the guard that row is an exact match for having typed nothing, and `F2`
+        on a plane with such a provider installed opens with the cursor on it, above every
+        row charter put in the catalogue on purpose.
+        """
+        rows = (_row("frame.detach", "detach"), _row("acme.nameless", ""))
+        self.assertEqual([r.id for r in palette.narrow(rows, "")],
+                         ["frame.detach", "acme.nameless"])
+
+    def test_a_partial_query_leaves_every_match_where_it_was(self):
+        """The other bound. `re` matches an action and a doorway and neither is a name
+        typed in full, so the pair keeps the catalogue's order — a palette whose rows
+        shuffled on every keystroke is what the old menu refused and this does too."""
+        got = palette.narrow(_DOORWAYS + _ACTIONS, "e")
+        self.assertEqual([r.id for r in got],
+                         [r.id for r in _DOORWAYS + _ACTIONS
+                          if "e" in r.title.casefold()])
+
+    def test_the_case_rule_reaches_the_ordering_too(self):
+        """`casefold` on both sides, the same as `matches`. A palette that filtered
+        case-insensitively and then ranked case-sensitively would find the row and still
+        put the cursor somewhere else, which is indistinguishable from not finding it."""
+        rows = (_row("a.b", "beta — do the thing"), _row("workspace:n0", "Beta"))
+        self.assertEqual([r.id for r in palette.narrow(rows, "beta")],
+                         ["workspace:n0", "a.b"])
+
+    def test_an_action_id_typed_in_full_is_exact_too(self):
+        """`matches` accepts a provider's documented id (`acme.deploy`) as well as the
+        title, so the ordering has to accept the same one — a filter and a ranking that
+        disagree about what counts as typing the name is the defect one layer up."""
+        rows = (_row("x.y", "something acme.deploy adjacent"),
+                _row("acme.deploy", "Deploy to production"))
+        self.assertEqual([r.id for r in palette.narrow(rows, "acme.deploy")],
+                         ["acme.deploy", "x.y"])
+
+    def test_a_picker_id_is_not_a_name_the_operator_can_type(self):
+        """`frame/choose.py`'s ids are charter's own counter and are never drawn, so
+        `matches` does not match them — and `exact` must not either, or `workspace:n0`
+        would be a query that ranks a row nobody can see the id of."""
+        row = _row("workspace:n0", "alpha", "workspace")
+        self.assertFalse(palette.exact("workspace:n0", row))
+        self.assertFalse(palette.matches("workspace:n0", row))
+
+
+class EveryRowStartsInTheSameColumn(unittest.TestCase):
+    """#749. One inset, measured on the drawn line rather than on the model."""
+
+    #: Where a row's text begins: two cells of cursor, two of mark. Derived from the
+    #: constants rather than written as `4`, so a marker that changes width moves this
+    #: with it instead of turning every case below red at once.
+    INSET = tui.width(overlay._MARK[0]) + tui.width(overlay.ROW_MARK[0])
+
+    #: Wide enough that `_title_width`'s half-the-row cap truncates nothing here. A
+    #: truncated title cannot be found on the line, and "the title is missing" is not the
+    #: failure any of these cases is about — the narrow-pane arithmetic has its own case
+    #: at the bottom of this class.
+    WIDE = 120
+
+    def _drawn(self, rows) -> list[str]:
+        body = overlay.Surface(rows=tuple(rows)).render(self.WIDE, len(rows) + 4)
+        return [tui.strip_ansi(ln) for ln in body[1:1 + len(rows)]]
+
+    def _text_starts(self, rows) -> set[int]:
+        """Which CELL each row's title begins in, as a set.
+
+        Measured against the title rather than with `lstrip`, because the two things in
+        front of it are not both spaces: the selected row opens with `> ` and a marked row
+        carries `* `, so "how many leading spaces" answers 0 and 2 for rows whose text is
+        in the same column. That reading is the defect said backwards.
+        """
+        return {tui.width(ln[:ln.index(r.title)])
+                for ln, r in zip(self._drawn(rows), rows)}
+
+    def test_a_markable_row_and_a_plain_one_line_up(self):
+        """The reported screen in miniature: a `density` row that carries the `*` beside a
+        `detach` row that has no mark to carry. They used to start two columns apart."""
+        starts = self._text_starts([_row("frame.detach", "detach"),
+                                    _row("density.full", "density: full", mark=True)])
+        self.assertEqual(starts, {self.INSET})
+
+    def test_every_row_of_the_reported_palette_starts_at_one_column(self):
+        """All of them, as reported. Asserted as a SET of one so a failure names how many
+        left edges the list has rather than which row happens to be checked first."""
+        self.assertEqual(self._text_starts(_DOORWAYS + _ACTIONS + _NAMES),
+                         {self.INSET})
+
+    def test_the_mark_says_which_row_the_frame_is_on(self):
+        """Reserving the column is only half of it — the column still has to hold the
+        mark. A palette that lined up by drawing two spaces on every row would pass the
+        case above and lose the one thing the column is for."""
+        lines = self._drawn([_row("a.b", "beta"), _row("a.c", "alpha", mark=True)])
+        self.assertNotIn(overlay.ROW_MARK[0], lines[0])
+        self.assertIn(overlay.ROW_MARK[0] + "alpha", lines[1])
+
+    def test_the_cursor_and_the_mark_are_two_columns_not_one(self):
+        """They answer different questions — where you are pointing, and where the frame
+        is — and the row the frame is on is very often not the row under the cursor. A
+        surface that reused one column would make the second unaskable."""
+        rows = (_row("a.b", "beta"), _row("a.c", "alpha", mark=True))
+        surface = overlay.Surface(rows=rows)
+        surface.move(1)
+        line = tui.strip_ansi(surface.render(self.WIDE, 6)[2])
+        self.assertTrue(line.startswith(overlay._MARK[0] + overlay.ROW_MARK[0]), line)
+
+    def test_the_note_column_is_sized_against_both_markers(self):
+        """The arithmetic half, and it is the NOTE that pays for getting it wrong.
+
+        `_title_width` splits what is left of the pane after the markers and the gap.
+        Counting only the cursor's two cells makes the title column two wider than the row
+        can hold, and the trailing `tui.truncate` then takes those two cells off the right
+        — out of the note. Task 4's rule is that an unavailable action is listed *with its
+        reason*, and a reason cut by two characters still LOOKS like an answer, which is
+        the false-clean failure #512 is about one surface over.
+
+        Measured against a pane sized so the note fits exactly: at :data:`WIDE`-minus-what
+        the row needs, the whole reason is on the line, and two stolen cells take the end
+        of it off. Both halves are asserted — that it fits, and that nothing overflows —
+        because a version that never truncated at all would pass one of them.
+        """
+        title, note = "t" * 40, "n" * 17
+        rows = (_row("a.b", title, note),)
+        width = 40
+        line = tui.strip_ansi(overlay.Surface(rows=rows).render(width, 6)[1])
+        self.assertIn(note, line, line)
+        self.assertLessEqual(tui.width(line), width, line)
+
+
+class ARepeatableRowKeepsThePaletteOpen(PersonaIso, unittest.TestCase):
+    """#746. The palette is the pane; a repeat is what stops paying for it per row.
+
+    `PersonaIso` because `ActionRegistry.invoke` writes an `inflight` record before it
+    starts the work — the frame's spinner cannot miss a fast action — and that is a write
+    into the plane's state directory. `tests/_planeguard.py` refuses it against the real
+    one, correctly.
+    """
+
+    def _palette(self) -> palette.Palette:
+        offers = (actions.Offer(id="repo.next", title="repo: select the next row",
+                                available=True, reason="", repeat=True),
+                  actions.Offer(id="frame.detach", title="detach", available=True,
+                                reason=""))
+        return palette.Palette(catalogue=palette.rows(offers))
+
+    def test_the_repeat_flag_reaches_the_row_source_from_the_action(self):
+        """`Action` → `Offer` → the caller that decides whether to close. Three hops, and
+        the one that matters is that charter's own repo rows declare it — a flag nothing
+        sets is a feature that ships off."""
+        from charter.frame import builtin_actions
+        reg = actions.ActionRegistry()
+        builtin_actions._register_selection(reg)
+        self.assertEqual(sorted(a.id for a in reg.all() if a.repeat),
+                         ["repo.next", "repo.previous"])
+
+    def _reg(self):
+        """A registry with one repeatable action and one that is not, both able to run.
+
+        `frame/action.py`'s own contract objects rather than a stand-in, so the flag under
+        test travels the route it travels in production: `Action` → `ActionRegistry.get` →
+        the branch in `commands_frame._again`.
+        """
+        from charter.frame import action
+        reg = actions.ActionRegistry()
+        self.ran = []
+        reg.register(action.Action(
+            id="repo.next", title="repo: select the next row", repeat=True,
+            run=lambda ctx: self.ran.append("next") or "selected auth"))
+        reg.register(action.Action(
+            id="frame.detach", title="detach",
+            run=lambda ctx: self.ran.append("detach") or "detaching"))
+        return reg
+
+    def test_a_repeatable_row_hands_the_same_surface_back_and_runs_the_action(self):
+        """The whole of #746 at the seam `own_the_tty` reads: a `Surface` back means the
+        pane is not torn down, and it is the SAME object, so the query, the rows and the
+        cursor are the ones the operator left."""
+        from charter import commands_frame
+        reg, p = self._reg(), self._palette()
+        got = commands_frame._again(p.rows[0], p, reg, fid="f-1", snapshot={})
+        self.assertIs(got, p)
+        self.assertEqual(self.ran, ["next"])
+        self.assertIn("selected auth", p.heading)
+
+    def test_an_ordinary_row_still_ends_the_palette(self):
+        """The bound on it. `None` is what `own_the_tty` reads as "this row is the
+        answer", and every row that is not declared repeatable must still give it — a
+        palette that stayed open on `detach` would be a pane over a detaching client."""
+        from charter import commands_frame
+        reg, p = self._reg(), self._palette()
+        detach = next(r for r in p.rows if r.id == "frame.detach")
+        self.assertIsNone(commands_frame._again(detach, p, reg, fid="f-1", snapshot={}))
+        self.assertEqual(self.ran, [])
+
+    def test_a_row_that_is_not_an_action_at_all_ends_the_palette(self):
+        """A picker row reaches this function too — `_draw_palette` asks `_picker` first,
+        and a doorway that opened nothing falls through to here. `ActionRegistry.get`
+        raises for an id it does not hold, and that is an ordinary answer here rather than
+        a traceback into a pane that is about to stop existing."""
+        from charter import commands_frame
+        reg, p = self._reg(), self._palette()
+        row = _row("workspace:n0", "alpha", "workspace")
+        self.assertIsNone(commands_frame._again(row, p, reg, fid="f-1", snapshot={}))
+
+    def test_reporting_leaves_the_query_and_the_cursor_exactly_where_they_were(self):
+        """The property that makes a repeat a repeat. `Palette._refilter` puts the cursor
+        back at the top by design, so a repeat that re-filtered would move it off the row
+        the operator is holding Enter on — one move per typed filter, which is the cost
+        the report is about, reintroduced."""
+        p = self._palette()
+        for ch in "next":
+            p.handle(overlay.Event(kind=overlay.KEY, name=ch), 24)
+        before = (p.query, p._sel, [r.id for r in p.rows])
+        p.report("selected auth")
+        self.assertEqual((p.query, p._sel, [r.id for r in p.rows]), before)
+
+    def test_the_header_says_what_the_repeat_just_did(self):
+        """The overlay pane is zoomed over the window (`overlay.modal_argvs`), so the repo
+        table the selection is moving through is not drawn. The header is the only surface
+        the operator can be told on."""
+        p = self._palette()
+        p.report("selected auth")
+        self.assertIn("selected auth", p.heading)
+
+    def test_a_second_repeat_replaces_the_first_sentence_and_does_not_append(self):
+        """Held in a field and recomposed, never appended: a heading that grew by one
+        clause per Enter would be a header that scrolls the list off the top of the pane
+        after a dozen moves."""
+        p = self._palette()
+        p.report("selected auth")
+        p.report("selected billing")
+        self.assertIn("selected billing", p.heading)
+        self.assertNotIn("selected auth", p.heading)
+
+    def test_the_next_keystroke_clears_it(self):
+        """It is a report about the last keypress, not a second label. Typing is a new
+        question and the answer to the old one must not stand over it."""
+        p = self._palette()
+        p.report("selected auth")
+        p.handle(overlay.Event(kind=overlay.KEY, name="n"), 24)
+        self.assertNotIn("selected auth", p.heading)
+
+    def test_the_query_still_shows_beside_the_report(self):
+        """Both, because both are live: what is being filtered, and what the last Enter
+        did. A report that replaced the query would leave the operator unable to see why
+        the list is three rows long."""
+        p = self._palette()
+        for ch in "next":
+            p.handle(overlay.Event(kind=overlay.KEY, name=ch), 24)
+        p.report("selected auth")
+        self.assertIn("next", p.heading)
+        self.assertIn("selected auth", p.heading)
+
+    def test_a_report_is_contained_before_it_reaches_the_header(self):
+        """#472's rule at one more join. An action's answer is a string charter's own code
+        wrote today and a provider's code writes tomorrow, and the header is measured and
+        drawn — a newline in it is two rows where the surface counted one."""
+        p = self._palette()
+        p.report("selected\nauth now")
+        self.assertEqual(len(p.heading.splitlines()), 1, repr(p.heading))
+
+
+class TheRepeatIsWiredAndNotMerelyDeclared(PersonaIso, unittest.TestCase):
+    """The palette `_draw_palette` actually builds, asked whether its `then` repeats.
+
+    **The mutation this exists for is `then=lambda row: _picker(...)`** — the shape the
+    function had before #746 — which leaves `Action.repeat`, `Offer.repeat` and
+    `commands_frame._again` all present, all tested, and reached by nothing. A flag
+    nothing consults is a feature that ships off, and this repository has shipped one
+    before (#168: the plane-root guard, inert on any plane not running the plugin, with
+    `doctor` showing a green tick over it).
+
+    **The repo rows are deliberately left UNAVAILABLE here**, and that is the case rather
+    than a gap in the fixture: this frame has no clones, so `repo: select the next row`
+    refuses. A repeatable row that refuses still keeps the palette open and still says why
+    in the header — which is the behaviour a palette that is not closing owes the
+    operator, and it means this case pins the wiring without a gather, a clone or a repo
+    table standing between the test and the one line it is about.
+    """
+
+    FID = "f-repeat"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(
+            os.environ, {"CHARTER_SESSION_ID": self.FID}, clear=True))
+        _plane_workspaces("alpha")
+        _plane_personas("steward")
+        state.frame_dir(self.FID, create=True)
+        state.record_server(self.FID, "charter")
+        state.record_harness_pane(self.FID, "%3")
+        state.record_identity(self.FID, {"CHARTER_SESSION_ID": self.FID})
+        state.record_workspace(self.FID, "alpha")
+        self.enterContext(mock.patch.object(commands_frame, "_say_on_screen"))
+        self.enterContext(mock.patch.object(commands_frame, "_close_palette"))
+
+    def _then(self):
+        """The surface and the `then` `_draw_palette` handed `own_the_tty`, taken off it.
+
+        Both, because the test has to press a row of the real catalogue on the real
+        surface — rebuilding either here would be a second answer to what the palette is,
+        and the mutation that unwires the real one would leave this green.
+        """
+        seen: list = []
+        with mock.patch.object(palette, "own_the_tty",
+                               lambda surface, *, then=None, **kw: seen.append(
+                                   (surface, then))):
+            commands_frame.cmd_palette(SimpleNamespace(client="", pane=True))
+        return seen[0]
+
+    def test_pressing_a_repo_row_hands_the_palette_back_instead_of_closing_it(self):
+        surface, then = self._then()
+        row = next(r for r in surface.rows if r.id == "repo.next")
+        self.assertIs(then(row), surface)
+
+    def test_pressing_an_ordinary_row_still_ends_the_palette(self):
+        surface, then = self._then()
+        row = next(r for r in surface.rows if r.id == "frame.detach")
+        self.assertIsNone(then(row))
+
+    def test_a_doorway_still_opens_its_picker_first(self):
+        """`_picker` is asked before the repeat, and a doorway is neither an action nor
+        repeatable — so a wiring that put the repeat first would answer a doorway with the
+        palette it was already looking at."""
+        surface, then = self._then()
+        row = next(r for r in surface.rows if r.id == "pick:workspace")
+        nxt = then(row)
+        self.assertIsInstance(nxt, palette.Palette)
+        self.assertIsNot(nxt, surface)
+        self.assertEqual(nxt.label, "workspace")

--- a/tests/test_the_strips_and_the_roster_answer_a_click.py
+++ b/tests/test_the_strips_and_the_roster_answer_a_click.py
@@ -266,13 +266,41 @@ class TheMapDescribesWhatWasDrawn(_Strip):
     so* — nothing later can.
     """
 
-    def test_terse_keeps_one_field_on_the_attention_strip_and_it_is_not_the_hint(self):
-        """`_fit_fields(limit=1)` keeps the highest-priority field with anything to say,
-        which on a quiet plane is the todo count. So the row has no door at all — and that
-        has to be *published*, not left over from the paint before it."""
+    def test_terse_keeps_the_hint_and_republishes_it_where_it_actually_landed(self):
+        """`_fit_fields(limit=1)` keeps one field of NEWS, and the hint is not news (#743):
+        `minimal` is the arrangement where the palette is the only route to anything, so
+        the one thing that says how to open it is exempt from the density's trim.
+
+        That makes this a case about the map rather than about the field going away. The
+        terse row is shorter — the alert takes the single news slot and the todo count is
+        gone — so the hint lands in a different column than the wide paint put it in, and
+        a map left over from the paint before would open the palette from a cell holding
+        the middle of the alert. Which is this class's whole finding, with the door moving
+        instead of disappearing.
+
+        This case used to assert the opposite, because before #743 `terse` was the
+        cheapest way to make a field stop being drawn. The two rungs that still draw no
+        door — a starved pane and the operator's own tmux — have their own cases below and
+        keep that half covered.
+        """
         self.bottom_row()
-        self.assertTrue(self.doors(), "the wide paint should have published a door")
-        row = self.bottom_row(terse=True)
+        wide = self.doors()
+        self.assertTrue(wide, "the wide paint should have published a door")
+        row = self.bottom_row(terse=True, alerts=["reinit needed"])
+        self.assertEqual(row, "reinit needed · F2 palette")
+        at = row.index("F2 palette")
+        self.assertEqual(self.doors(), set(range(at, at + len("F2 palette"))),
+                         self.under(row, self.doors()))
+        self.assertNotEqual(self.doors(), wide,
+                            "the map did not move when the paint did")
+
+    def test_a_terse_row_too_narrow_for_both_drops_the_hint_and_says_so(self):
+        """The exemption is from the DENSITY and never from the arithmetic, so the rung
+        that draws no door is still reachable at `terse` — and it still has to publish the
+        absence rather than leave the wide paint's door standing."""
+        self.bottom_row()
+        self.assertTrue(self.doors())
+        row = self.bottom_row(terse=True, width=9)
         self.assertEqual(row, "7 todos")
         self.assertEqual(self.doors(), set(), self.under(row, self.doors()))
 


### PR DESCRIPTION
Six issues from one UX audit, all on the `F2` palette and the surfaces it reaches. They are
one PR because two of them turned out to be one change seen from two sides, and a third
could not be tested honestly without the first.

Closes #739, #732, #749, #746, #743, #745.

## #739 — a second `F2` leaked a pane, permanently

`bind -n` is tmux's root key table, so the second press is matched before any byte reaches
the overlay — the same property that makes `F12` work against a wedged pane, and not
negotiable. charter split a second overlay off the harness; Escape closed the one holding
the keyboard and left the other as a blank five-row pane holding a live Python process, six
rows off a 24-row harness, for the life of the frame. `F12` is `select-pane`, a resize is
about panes charter made, no palette row closes it. Only tmux's own prefix + `x`, which
`charter frame` neither binds nor documents.

**A second `F2` now reopens.** The three candidates were no-op, toggle-shut and reopen. Both
of the first two require charter to *believe* a palette is open, and being wrong makes the
key do nothing — the worst answer for a key whose response takes a visible moment (#728
measures ~1.8 s; #729 measures a four-second freeze), because that delay is exactly what
produces the second press. Reopening answers every press with a palette, and with the fresher
one: the catalogue resolves density, surface, workspace and persona at open time.

**The state is tmux's, not charter's.** The overlay pane carries `@charter_overlay`, a tmux
**pane** option, set in the *same command list* as the split — measured on 3.7c and the 3.2
floor: `split-window … ; set-option -p @charter_overlay 1` marks the new pane, because the
split makes it current for the rest of the list. So no instant exists in which an overlay
pane is open and not findable, and the mark dies with the pane. That answers the objection
`cmd_palette` recorded for declining to guard this at all ("every cheap test for 'is one
already open' is a stale-state problem of its own"): there is no charter-side belief to go
stale, and nothing is ever refused.

**Scoped to the frame's own window**, so a sweep cannot reach another chat's open palette —
`list-panes -t <a pane id>` resolves to that pane's window, measured on both versions.

The invariant is asserted as a **count** — `len(overlays) == 1` after one press, two, three,
and after a hand-run `charter frame-palette` — rather than route by route.

## #732 — typing a name in full did not switch to it

A chat id is `<workspace>.<n>`, so on a plane with a workspace `alpha` the row
`chat: alpha.1 — pick another` holds `alpha` inside its title, and the doorways are in the
catalogue while names are gathered after it. That doorway also happened to be *refused*, so
Enter opened nothing and switched nothing.

**The ordering rule: an exact match comes first, an actionable one ahead of a refused one,
and everything else keeps the position it already had.** Two buckets and a stable sort — so
the doorways keep their order, the actions theirs, the names after them; with nothing typed
no row is exact, so `F2` draws the list it always drew. Refused rows are still listed, still
with their reason (#512 untouched).

## #749 — the palette had two left edges

Rows that could carry a `*` composed it into their own title; rows that could not composed
nothing. The mark is `overlay.Row.mark` now and the column is reserved by the surface that
draws every row, so it cannot be got wrong one row source at a time — including a provider's.
That is also what makes "is this row's name what was typed" a comparison rather than a
prefix-strip, which #732's ordering needed.

## #746 — a repo selection cost a whole palette per row

`repo: select the next row` is the only action whose natural use is repeated, and on the
shipped `mouse = false` it is the repo table's only route. `Action.repeat` keeps the palette
open with the query and the cursor exactly where they were.

**The issue's first proposal is not available**: it suggests leaving the palette open because
"the selection is drawn in the pane behind it", and there is no pane behind it — the overlay
is `resize-pane -Z`'d over the whole window (charter's own `modal_argvs` says so; re-measured
here on 3.7c and 3.2: the overlay takes all 24 rows of a 24-row window). Its second proposal,
holding Down/Up, collides with the palette's own cursor keys. So the feedback goes in the
header: `charter /next · selected auth`.

## #743 — `density = minimal` dropped the `F2 palette` hint

The hint is not news about the plane; it is the one piece of chrome that says how to drive
the frame, and `minimal` is the arrangement where the palette is the only route to anything
including back to `full`. It is exempt from the density's trim and nothing else is —
`7 todos · F2 palette`, with news still cut to one field. Width still drops it.

## #745 — `default` is a real workspace; the listing was wrong

The report is that the picker offers something that is not a workspace. It is a workspace:
it is the rung `workspace.resolve` terminates on, `charter workspace use default` accepts and
creates it on a plane that has never made one, `charter clone -w default` creates it, and the
docs' own picker example draws it beside `alpha`/`beta`/`zebra`. It is a real *directory* on
some planes and not others — `charter init` does not make it, unlike `personas/steward`.

Everything agreed about it except `charter workspace list`, which reads directories: on a
plane with workspaces where nobody has selected one, it printed `Active workspace: default`
above a table with a "you are here" inset and no row carrying the mark. So the listing folds
in `config.DEFAULT_WORKSPACE` exactly as `frame/switch.workspaces` does.

**The issue's other half is declined with a reason**: `charter init` should not create
`workspaces/default/`, because `[workspace] default` names this workspace and `init` would be
baking a directory for a value the operator may change in the `charter.toml` it just wrote.

## Verification

- Full suite green.
- Hand mutation, `python3 -B` with `PYTHONDONTWRITEBYTECODE=1`: every mutant of the new
  behaviour killed, including the pre-fix shape of each of the six.
- Real tmux, 3.7c and the 3.2 floor, own sockets, reaped: the zoom measurement #746 rests on,
  the pane-option mechanism #739 rests on, and the palette integration suite with real keys
  through tmux's own root key table.

---

## After review: what the deletion sweep found in this branch

The sweep named twelve survivors on the first run. Five were `frame/state.py` and
`commands_frame.py` lines belonging to #757/#763, charged to this branch because it was
behind `main` — the effect #776 describes. Rebasing dropped the plan from 48 mutations to
44 on exactly this branch's nine files.

Of the rest, three were **dead code and are deleted**: `sweep_argv`'s `if kills else None`
restated `tmuxctl.chain`'s own answer for an empty list; `live_panes` picked an end to
partition on and an amount to strip, neither observable on a two-field format (it splits on
whitespace now); and `exact` carried its own copy of the query normalisation, which is the
one line that must not differ between the filter and the ordering — it is `palette.typed`
now, asked by both. A fourth followed from a measurement rather than the sweep:
`component.usable_id` admits no capital, so `casefold` on a `Row.id` is a claim an id can
carry case, and it is gone from `matches` and `exact` with the guard's precedence pinned.

The others were **tests asking too little** and are pinned: `live_panes`' pane-id and
two-field checks, `sweep_argv` answering nothing for nothing, the case rule in both
directions (only an UPPERCASE query reaches the query's own `casefold`), and `report("")`
asserted as the whole heading rather than as the sentence being absent — an empty report
that still emitted its separator leaves a dangling `·` the weaker assertion cannot see.

All re-checked by hand under `python3 -B` with `__pycache__` cleared: every mutant killed.

## Where this met other work

#763 landed on the same `slots._bottom` call while this was open, adding a top-priority
`notice`. The pair is asserted rather than each half alone: at `minimal` the notice is the
one piece of news that survives and the hotkey hint is beside it —
`charter: workspace → gamma · F2 palette`. A repeated palette row still reports in the
palette's own header rather than through `state.say`, because the overlay pane is zoomed
over the window and a notice would be written to a surface the operator cannot see until a
palette that is deliberately not closing has closed.

## Second sweep, and the two it found

`2 survivors, 10 not measured` on the rebased branch. Nine of the ten unmeasured are
`charter/instance.py` lines this branch does not touch — #776's charge again, from `main`
moving between the push and the sweep's merge. Both survivors were this branch's own and
both were real gaps, now pinned:

* **A repeatable row that REFUSES.** `_again` reports `inv.reason if not inv.started else
  (inv.note or inv.error)`, and every case ran an action that starts, so the refusal branch
  collapsed unnoticed. `repo: select the next row` refuses on a workspace with no clones,
  which is ordinary: the palette must stay open (nothing was started) and the reason must
  reach the header (the attention row is under the zoom). Pinning it also resolved the
  `if not act.repeat` mutation the sweep had timed out on.
* **What `@charter_overlay`'s spelling must satisfy** — `@` is tmux's user-option
  namespace, `charter` is because the operator's own tmux may be the host, and it must not
  be `HATCH_OPTION`, which holds a command line tmux re-parses. The test pins those three
  rather than the literal.

## Where this met #751

#751's click-map case used `terse` as the cheapest way to make the `F2 palette` hint stop
being drawn, so it could check the map loses that door in the same paint. #743 is that
disappearance being the defect. The case keeps the finding and changes its example: at
`terse` with an alert the hint lands in a *different column*, so a stale map would open the
palette from a cell holding the middle of the alert — the door moves instead of vanishing.
The rung that draws no door is still reachable at `terse` (a nine-column row) and has its
own case now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
