### PR TITLE
The top bar stops keeping a roster it drew before the frame's shape was on disk (#748)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -3368,6 +3368,23 @@ def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     # meant as which slot. Slots only: `state.record_harness_pane` already owns the
     # harness pane, and one fact recorded twice is one fact free to disagree with itself.
     state.record_panes(fid, panels=panes)
+    # And SAID so — #748. The panels above are processes, and the ids in that record are
+    # what their own `split-window` calls returned, so the record cannot be written until
+    # after the last of them exists and every one of them may already have painted. A
+    # panel repaints on a version bump and on nothing else (`panel._watch`; `top` is not
+    # in `slots.ANIMATED`), and this launch's own bump happened before the first split, so
+    # a shape written with nothing behind it is a shape the panels that lost the race
+    # never read: `slots._sidebar_live` answered `False` off an empty `state.panes`, `top`
+    # drew the roster the sidebar was already drawing, and it stood for the life of the
+    # frame. Measured on 90 real launches at 200x50 before this line: 16 of them.
+    #
+    # AFTER the write and never before it, which is `notify.plane_changed`'s order and its
+    # reason — a poller that saw the new version must never then read the old record —
+    # and the order `_apply_arrangement` already keeps around the OTHER call to
+    # `record_panes`, for this same question one keypress later. Charging the launch one
+    # `os.replace` and at most one
+    # repaint per panel, both spent before any client is attached or any window selected.
+    state.bump(fid)
     return panes
 
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -164,14 +164,26 @@ def _sidebar_live(fid: str) -> bool:
     rather than the cost. A panel is a `charter panel` PROCESS in a pane of its own: it
     would be asking the server about a sibling that may not have been split yet. `right` is
     split last on the shipped frame, so `top`'s first paint can precede that pane
-    EXISTING — no reading of tmux, however authoritative, turns that into `True`. #748 is
-    that race, measured at roughly one launch in six, and its fix is an ordering one: get
-    the shape recorded (or the first paint deferred) before anything can bump the frame.
-    Reading tmux here would move which file the race is against and close nothing.
+    EXISTING — no reading of tmux, however authoritative, turns that into `True`. #748 was
+    that race, and reading tmux here would have moved which file it was against and closed
+    nothing.
+
+    **#748 is closed on the WRITING side, and this function is unchanged by it.**
+    Measured on real launches: 16 of 90 on an idle machine and 16 of 25 on a loaded one
+    drew the roster here and kept it, because the launch recorded the frame's shape
+    without moving the frame's version and `top` — not in :data:`ANIMATED` — had no reason
+    to ask a second time. The pane's own history is the proof rather than the rate: on
+    every one of those launches `top` painted exactly ONCE. Neither of the
+    two remedies #748 proposed shipped: deferring the first paint would have made every
+    panel wait on a file, and making the gather's bump wait on the record would have put
+    the correction behind a detached child that `_spawn_gather` is allowed to fail to
+    spawn. `commands_frame._draw_panels` bumps the frame immediately after
+    `state.record_panes` instead, so a paint that lost the race is followed by one that
+    reads the shape. A `False` here is now always either transient or true.
 
     **The cost is one small JSON read on a slot that is not animated.** `top` is not in
-    :data:`ANIMATED`, so it repaints on a version bump, never on `panel.TICK` — and a
-    density change bumps the version precisely so that surviving panels re-read, which is
+    :data:`ANIMATED`, so it repaints on a version bump, never on `panel.TICK` — and both
+    writers of this record bump the version precisely so that the panels re-read, which is
     exactly when this answer can have changed. It reads the same directory `_top` already
     opens four times over (`_frame_workspace`, `verbosity`, `state.harness_session`, the
     recorded gauge), and nothing on the idle path (`panel._running`, whose one `stat` per

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -1417,6 +1417,18 @@ def record_panes(fid: str, *, panels: dict[str, str]) -> None:
     one fact, written at different moments, free to disagree; `commands_frame.cmd_density`
     reads :func:`harness_pane` for it instead.
 
+    **Both callers :func:`bump` immediately afterwards, and #748 is what that costs when
+    one of them does not.** This record is also read on the repaint path —
+    `slots._sidebar_live` asks it whether the sidebar is drawing the persona roster — and a
+    panel repaints on a version bump and on nothing else. So a shape written in silence is
+    a shape every panel that had already painted goes on contradicting: `top` painted exactly
+    once per launch, so 16 launches in 90 idle — and 16 in 25 loaded — kept a roster the
+    sidebar was drawing too, before `commands_frame._draw_panels` bumped. The bump stays at the call
+    sites rather than moving in here, which is this module's rule throughout (a writer
+    writes; the caller decides the change is worth waking the frame for) — and both of them
+    now say so where they call it: `_draw_panels` for the launch, `_apply_arrangement` for
+    the density keypress.
+
     JSON, read back through :func:`panes` — same atomic write as everything else here, and
     the same silence on failure: a frame whose pane map could not be written simply cannot
     be re-laid-out, which is a palette row doing nothing rather than a launch failing.

--- a/docs/news/unreleased-the-top-bar-stops-keeping-a-roster-it-drew-by-losing-a-race.md
+++ b/docs/news/unreleased-the-top-bar-stops-keeping-a-roster-it-drew-by-losing-a-race.md
@@ -1,0 +1,91 @@
+---
+version: unreleased
+headline: The top bar stops keeping a roster it drew before the frame's shape was on disk
+---
+
+Launches came up with the persona roster drawn twice — once across the identity row and
+again down the sidebar — and stayed that way for the life of that frame. Roughly one in
+six on an idle machine, and **about two in three on a busy one**, which is what a control
+plane running several frames is. #530 had removed that duplication a release ago; this is why it kept coming back.
+
+## What was happening
+
+`_top` asks `slots._sidebar_live` on every repaint whether the sidebar is on screen, and
+that reads `state.panes` — the record of which tmux pane charter meant as which slot. The
+record is written by the launcher, and it can only be written **after** every
+`split-window`, because the pane ids in it are what those splits returned.
+
+A panel is a `charter panel` process in a pane of its own, and `top` is the first pane
+split. So `top` can be up and painting while the launcher is still carving `bottom`,
+`repos` and `right`. When it is, `state.panes` answers `{}`, `_sidebar_live` answers
+`False` — its documented-safe direction, because a wrong `True` would take the plane's
+only roster off a screen that has no sidebar — and the roster goes on the top bar.
+
+That would have been a flicker if anything had told the panel to look again. Nothing did.
+`top` is not an animated slot: it repaints on a version bump and on nothing else. The
+launch's own bump happens before the first split, so the only bump that could still land
+after the record was the detached repo gather's — and the gather is deliberately racing
+the frame's construction, so it just as often landed first. Once it had, the frame was
+still until the session's first tool call.
+
+## The fix is one line, on the writing side
+
+`commands_frame._draw_panels` now bumps the frame immediately after `state.record_panes`.
+Writing the shape down is an event rather than a silent file, so a panel that painted
+before the record has a reason to paint again, and its second paint reads the shape.
+
+That is the ordering fix #748 asked for, but neither of the two it proposed. Deferring
+every panel's first paint until the record exists would put a wait on the launch path,
+which is already the slowest thing charter does. Making the gather's bump wait on the
+record would put the correction behind a detached child that `_spawn_gather` is explicitly
+allowed to fail to spawn. Bumping where the shape is written needs neither: it is the
+order `_apply_arrangement` already keeps around the other call to `record_panes`, for this
+same question one keypress later, and the order `notify.plane_changed` states outright — a poller that saw the new
+version must never then read the old record.
+
+## Measured
+
+Real launches on the private-server path — a real pty, a real `tmux attach`, the same
+plane and the same command every time — with `main` and this branch **alternated**, run
+for run, because the race moves with machine load and two batches taken back to back are
+not a comparison. A frame counts as duplicated only if the roster was still on the top bar
+once the frame had gone still.
+
+```
+                                        origin/main      this branch
+launches that kept the roster            16 / 25            0 / 25
+                                          (64%)
+times the top bar painted at all          1 every time   2 on 22 of 25
+median time to first content              0.385 s          0.390 s
+```
+
+The middle row is the defect and the fix in one number. On `main` the top bar paints
+**once per launch and never again** — so whatever it drew before the shape reached disk is
+what that frame keeps. On this branch it paints a second time, and the second paint reads
+the shape.
+
+Forcing the race — the launcher's own `record_panes` write delayed so the panels lose
+every time — shows the same two lines with nothing left to chance. The pane's own history,
+verbatim:
+
+```
+origin/main                        this branch
+⬢ alpha*  ◆ steward · ◇ perso…     ⬢ alpha*  ◆ steward · ◇ perso…
+                                   ⬢ alpha*  ◆ steward
+(one paint, 5 of 5 launches)       (two paints, 5 of 5 launches)
+```
+
+On an otherwise idle machine the rate is lower and the defect is the same: 16 of 90
+launches on `main` at 200x50 kept the roster, against 0 of 90 on this branch. Across every
+rig run for this change — idle, loaded, and forced — `main` produced 61 standing
+duplications and this branch produced **none in 163 launches**.
+
+The roster still goes up on the launches that lose the race; that paint is honest, because
+charter genuinely cannot tell yet, and it is the one `_sidebar_live` has always called the
+safe direction. What has changed is that it is now followed by a paint that can tell. On 2
+of 5 forced launches the correction landed before the client had even attached, so the
+duplicated row never reached the terminal at all.
+
+The launch pays one `os.replace` of a version file and at most one extra repaint per
+panel, both spent before any client is attached and before the frame's window is selected.
+It does not show up in the time to first content.

--- a/tests/test_a_frame_repaints_once_its_shape_is_recorded.py
+++ b/tests/test_a_frame_repaints_once_its_shape_is_recorded.py
@@ -1,0 +1,247 @@
+"""#748: a launch writes the frame's shape down, so it moves the frame's version too.
+
+**The defect this closes was permanent and it was the operator's oldest live
+complaint.** #530 stopped the top bar repeating the persona roster the sidebar already
+draws, by asking `slots._sidebar_live` — `"right" in state.panes(fid)` — live on every
+repaint. That record is written by `commands_frame._draw_panels`, and it is written
+*after* every `split-window`, because the ids in it are what those splits returned. A
+panel is a `charter panel` PROCESS in a pane, and `top` is split FIRST: it can therefore
+be up and painting before the launcher has finished carving the other three panes and
+written the file. When it is, `state.panes` answers `{}`, `_sidebar_live` answers its
+documented-safe `False`, and the roster is drawn on a screen whose sidebar is drawing it
+too.
+
+That would be a flicker if anything told the panel to look again. Nothing did. `top` is
+not in `slots.ANIMATED`, so it repaints on a version bump and on nothing else, and the
+launch's own bump happens *before* the splits (`cmd_launch`), so the only bump left that
+could land after the record is the detached gather's — which is deliberately racing the
+frame's own construction and just as often lands first. **Measured on this branch's
+parent over 90 real launches at 200x50 on tmux 3.7c: 16 of them (17.8%) kept the
+duplicated roster for the life of the frame.**
+
+**The fix is the ordering one #748 and #774 both ask for, made local.** `_draw_panels`
+bumps the frame immediately after `state.record_panes`, so writing the shape down is an
+EVENT rather than a silent file. A panel that painted before the record now has a reason
+to paint again, and its second paint reads the shape. `cmd_density` has recorded and then
+bumped since #387 for exactly this reason — the launch path is the one that recorded
+without saying so.
+
+Two classes, because there are two properties and either alone is satisfied by a wrong
+change. :class:`RecordingTheShapeMovesTheVersion` pins the ordering in the launcher, where
+a bump placed before the record would look identical to a reader and close nothing.
+:class:`APanelThatLostTheRaceIsToldToLookAgain` pins what the operator sees, through the
+real `panel._tick` decision and the real `slots.render` — so the roster is asserted on
+bytes charter would have put in the pane, not on a stubbed predicate.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+from charter import commands_frame, persona, tui
+from charter.frame import panel, slots, state
+from tests._isolation import PersonaIso
+
+#: The roster the sidebar already draws — what must not also be on the identity row.
+ROSTER = "◇ personas"
+#: The half of the row that is IDENTITY rather than a list, and must survive either way.
+ACTIVE = "◆ steward"
+
+
+def _a_dead_pid() -> int:
+    """A real pid that has exited and been reaped — the suite's own idiom, repeated
+    rather than imported because a test module reaching into another test module's
+    private helper couples two files that are otherwise independent. A hand-written `-1`
+    would read as `launchd`, which never exits."""
+    p = subprocess.Popen([sys.executable, "-c", "pass"])
+    p.wait()
+    return p.pid
+
+
+class _Tmux:
+    """A stand-in for `tmuxctl.run` big enough for one `_draw_panels` and no bigger.
+
+    `list-panes` answers empty — a window that holds the harness pane and nothing else,
+    which is what both launch paths hand `_reconcile_panels` — and each `split-window`
+    answers the next pane id. Everything else succeeds silently, which is all
+    `_dress_window` and `_install_resize_hook` need to be asked for here.
+    """
+
+    def __init__(self, new_panes=("%11", "%12", "%13", "%14")):
+        self.new_panes = list(new_panes)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, action, argv, *, env=None, timeout=None, report=True):
+        self.calls.append(list(argv))
+        out = ""
+        if "display-message" in argv:
+            out = "200:50"
+        elif "split-window" in argv:
+            out = self.new_panes.pop(0) if self.new_panes else ""
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+
+class _LaunchFixture(PersonaIso):
+    """A plane with a roster to duplicate, and the one launcher call that records a
+    shape. The personas are real files rather than a patched `_persona_line_parts`,
+    because what #530 conditions is the row `statusline` really builds."""
+
+    #: Names carried purely so a hit in an assertion is a roster charter drew, never the
+    #: fixture's own vocabulary.
+    OTHERS = ("forge", "release")
+    SLOTS = ["top", "bottom", "right"]
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"race-{_a_dead_pid()}"
+        self.make_persona("steward")
+        for n in self.OTHERS:
+            self.make_persona(n)
+        persona.set_active("steward")
+
+    def draw_panels(self, fake=None):
+        """One real `commands_frame._draw_panels` — the launcher's own funnel, both
+        launch paths' only way to record a shape."""
+        fake = fake or _Tmux()
+        with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            return commands_frame._draw_panels(
+                "charter", slots=self.SLOTS, fid=self.fid, harness_pane="%0",
+                env=None, v=(3, 7))
+
+
+class RecordingTheShapeMovesTheVersion(_LaunchFixture, unittest.TestCase):
+    """The launcher half: writing the shape down is an event, and it is one at the right
+    moment."""
+
+    def test_a_launch_bumps_the_frame_after_it_has_recorded_the_panes(self):
+        """Without this the record is a file nothing is watching. `top` repaints on a
+        version bump and on nothing else, so a shape written with no bump behind it is a
+        shape every panel that painted first will never read."""
+        state.bump(self.fid)          # the launch's own bump, before any split
+        before = state.version(self.fid)
+        self.draw_panels()
+        self.assertEqual({"top": "%11", "bottom": "%12", "right": "%13"},
+                         state.panes(self.fid))
+        self.assertNotEqual(before, state.version(self.fid),
+                            "the launch recorded the frame's shape and left the version "
+                            "where it was, so nothing that had already painted has any "
+                            "reason to read it")
+
+    def test_the_bump_lands_after_the_write_and_not_before_it(self):
+        """The order is the whole property, and a bump on the wrong side of the write
+        reads identically in a diff. What a panel woken by the bump then reads is the
+        file as it stood when the bump was made — so at that moment the shape must
+        already be on disk, whole.
+
+        `notify.plane_changed` keeps this same order for this same reason ("a poller
+        that saw the new version must never then read the old cache"), and
+        `cmd_density` records before it bumps. This is the launch path saying so too.
+        """
+        seen_at_bump: list[dict] = []
+        real_bump = state.bump
+
+        def _watch_bump(fid):
+            seen_at_bump.append(state.panes(fid))
+            real_bump(fid)
+
+        with mock.patch.object(state, "bump", _watch_bump):
+            self.draw_panels()
+        self.assertTrue(seen_at_bump,
+                        "`_draw_panels` never bumped the frame at all")
+        self.assertEqual({"top": "%11", "bottom": "%12", "right": "%13"},
+                         seen_at_bump[-1],
+                         "the frame was bumped before its shape was on disk, so a panel "
+                         "woken by that bump reads the same empty record it already had")
+
+
+class APanelThatLostTheRaceIsToldToLookAgain(_LaunchFixture, unittest.TestCase):
+    """The operator half, driven through the real repaint decision and the real renderer.
+
+    `panel._tick` is `panel._watch`'s one iteration — the function that decides "paint
+    now, or wait" — so a test that calls it twice around a launch is asking exactly what
+    a live `top` panel asks, without a `while True` or a real clock.
+    """
+
+    def _render(self, slot, fid, *, cols=200) -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, 3))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return tui.strip_ansi(slots.render(slot, fid))
+
+    def test_the_top_bar_drops_the_roster_it_drew_before_the_shape_was_recorded(self):
+        """The whole of #748, in the order it happens.
+
+        `top` is the FIRST pane split, so its process can be painting while the launcher
+        is still carving `bottom` and `right`; `state.panes` is empty until every split
+        has answered. The roster on that first paint is correct — charter genuinely
+        cannot tell yet, and `_sidebar_live`'s False is the safe direction for a frame
+        with no sidebar. What was wrong was that it stood: nothing moved the version
+        afterwards, and `top` is not in `slots.ANIMATED`.
+        """
+        state.bump(self.fid)
+        painted: list[str] = []
+        resized = {"flag": True}      # `_watch`'s own first pass: paint, resized or not
+
+        def _paint(slot, fid):
+            painted.append(self._render(slot, fid))
+
+        seen = panel._tick(resized, "", "top", self.fid, paint=_paint)
+        self.assertEqual({}, state.panes(self.fid))
+        self.assertIn(ROSTER, painted[0],
+                      "the fixture never reproduced the losing paint at all")
+
+        # The launcher finishes carving the frame and writes the shape down.
+        self.draw_panels()
+
+        panel._tick(resized, seen, "top", self.fid, paint=_paint)
+        self.assertEqual(2, len(painted),
+                         "the panel was never told to look again, so the duplicated "
+                         "roster stands for the life of the frame — #748")
+        self.assertNotIn(ROSTER, painted[1], painted[1])
+        for n in self.OTHERS:
+            self.assertNotIn(n, painted[1],
+                             f"`{n}` is on the top bar and in the sidebar: {painted[1]!r}")
+
+    def test_the_active_persona_survives_the_repaint_that_drops_the_roster(self):
+        """The half that must never go with it. The roster is a LIST the sidebar holds
+        better; `◆ <active>` is identity, and this row is where "who am I being" is read.
+        Without this, a fix that simply blanked the persona half of the row would pass
+        the test above."""
+        state.bump(self.fid)
+        painted: list[str] = []
+        resized = {"flag": True}
+
+        def _paint(slot, fid):
+            painted.append(self._render(slot, fid))
+
+        seen = panel._tick(resized, "", "top", self.fid, paint=_paint)
+        self.draw_panels()
+        panel._tick(resized, seen, "top", self.fid, paint=_paint)
+        self.assertEqual(2, len(painted), "there was no repaint to inspect")
+        self.assertIn(ACTIVE, painted[-1], painted[-1])
+
+    def test_a_frame_whose_launch_recorded_no_sidebar_keeps_its_roster(self):
+        """The other direction, which the bump must not quietly take away. A terminal too
+        narrow for `right` (`layout.visible_slots` drops it first on any shortage) makes
+        the top bar the plane's only roster — so the repaint the fix adds has to arrive at
+        the same answer the frame already had, not at a blank half-row."""
+        self.SLOTS = ["top", "bottom"]
+        state.bump(self.fid)
+        painted: list[str] = []
+        resized = {"flag": True}
+
+        def _paint(slot, fid):
+            painted.append(self._render(slot, fid, cols=60))
+
+        seen = panel._tick(resized, "", "top", self.fid, paint=_paint)
+        self.draw_panels()
+        panel._tick(resized, seen, "top", self.fid, paint=_paint)
+        self.assertEqual({"top": "%11", "bottom": "%12"}, state.panes(self.fid))
+        self.assertEqual(2, len(painted), "there was no repaint to inspect")
+        self.assertIn(ROSTER, painted[-1], painted[-1])
+        for n in self.OTHERS:
+            self.assertIn(n, painted[-1], painted[-1])


### PR DESCRIPTION
Closes #748.

#530 stopped the top bar repeating the persona roster the sidebar already draws, by asking
`slots._sidebar_live` — `"right" in state.panes(fid)` — live on every repaint. The
duplication kept coming back on roughly one launch in six. This is why.

## The race

`commands_frame._draw_panels` writes that record, and it can only write it **after** every
`split-window`, because the pane ids in it are what those splits returned. A panel is a
`charter panel` **process** in a pane of its own, and `top` is the first pane split — so it
can be up and painting while the launcher is still carving `bottom`, `repos` and `right`.
When it is, `state.panes` answers `{}`, `_sidebar_live` answers its documented-safe
`False`, and the roster goes on the identity row.

That would be a flicker if anything told the panel to look again. Nothing did. `top` is not
in `slots.ANIMATED`: it repaints on a version bump and on nothing else, and the launch's own
`state.bump` happens *before* the first split.

**The pane's own paint history is the proof, and it is what makes this checkable.** Across
25 alternated launches on the real private-server path, with a real pty and a real
`tmux attach`, `top` on `main` painted **exactly once, every single time**:

```
                                        origin/main      this branch
launches that kept the roster            16 / 25            0 / 25
times the top bar painted at all          1 every time   2 on 22 of 25
median time to first content              0.385 s          0.390 s
```

So this is not "the race is likely" — it is "the state the race lands in is terminal".

## The fix

`_draw_panels` bumps the frame immediately after `state.record_panes`. Writing the shape
down becomes an event rather than a silent file, so a panel that painted before the record
has a reason to paint again, and its second paint reads the shape.

That is the ordering fix #748 asked for, but **neither of the two it proposed**:

- *defer the panels' first paint until the record exists* — puts a wait on the launch path,
  which #728 already measures as the slowest thing charter does;
- *make the gather's bump wait on the record* — puts the correction behind a detached child
  `_spawn_gather` is explicitly allowed to fail to spawn.

Bumping where the shape is written needs neither. It is the order `_apply_arrangement`
already keeps around the other call to `record_panes`, and the one `notify.plane_changed`
states outright: write, then bump, so a poller woken by the bump never reads the old record.

`_sidebar_live` itself is unchanged. #774 is right that reading tmux here would only move
which file the race is against.

## Measured

Forcing the race — the launcher's own `record_panes` write delayed so the panels lose every
time — with the pane's history read back verbatim:

```
origin/main                        this branch
⬢ alpha*  ◆ steward · ◇ perso…     ⬢ alpha*  ◆ steward · ◇ perso…
                                   ⬢ alpha*  ◆ steward
(one paint, 5 of 5)                (two paints, 5 of 5)
```

| rig | main | this branch |
|---|---|---|
| idle machine, operator's tmux, 90 launches | 16 (17.8%) | **0** |
| idle machine, private server, 15 launches | 2 | **0** |
| loaded, alternated, private server, 25 launches | 16 (64%) | **0** |
| forced race, operator's tmux, 20 launches | 20 | **0** |
| forced race, private server, 5 launches | 5 | **0** |

**61 standing duplications on `main`; 0 in 163 launches on this branch.**

Two findings worth recording:

- **The rate is load-dependent, and the filed 1-in-6 is the idle case.** Under load it is
  about two launches in three — which is what a control plane running several frames is.
  Alternating the two trees run-for-run is the only way the comparison holds; two batches
  taken back to back are not one.
- **The panel loses the race just as often on this branch** (19 of 25 launches drew the
  roster at some point, against 16 on `main`). That paint is honest — charter genuinely
  cannot tell yet. What changed is that it is now followed by a paint that can. On 2 of 5
  forced launches the correction landed before the client had even attached, so the
  duplicated row never reached the terminal at all.

## Cost

One `os.replace` of a version file and at most one extra repaint per panel, both spent
before any client is attached and before the frame's window is selected. It does not show
up in the time to first content (0.385 s → 0.390 s, within run-to-run noise).

## Tests

`tests/test_a_frame_repaints_once_its_shape_is_recorded.py`, five tests in two classes —
all five red on `main`:

- the launcher half: `_draw_panels` moves the version, and the bump lands **after** the
  write (a bump on the wrong side reads identically in a diff and closes nothing);
- the operator half, driven through the real `panel._tick` decision and the real
  `slots.render`: a `top` that painted before the record repaints, and the repaint has no
  roster — plus both directions, so `◆ steward` survives it and a frame whose launch
  recorded no sidebar still keeps its roster.

Full suite green: 9251 tests, 1 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
