### PR TITLE
A chat cannot be drawing one workspace and be missing from that workspace's roster (#733)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -5686,9 +5686,10 @@ def _pane_place(socket: str, pane: str | None) -> tuple[str, str] | None:
     """Which tmux SESSION and WINDOW *pane* is in, as ids — or ``None`` (#684).
 
     **The question `chats.py` cannot ask and `select-window`'s return code does not
-    answer.** `chats.of_workspace` decides membership from a FILE — `state.frame_workspace`,
-    which `charter workspace use` rewrites and `switch.to_workspace` rewrites again — so
-    two chats can share a roster while their windows are in two different tmux sessions.
+    answer.** `chats.of_workspace` decides membership from RECORDS — `state.own_workspace`,
+    which reads the pin the launcher wrote down, then the per-session pointer `charter
+    workspace use` writes, then the workspace `switch.to_workspace` records — so two chats
+    can share a roster while their windows are in two different tmux sessions.
     The session is where a chat actually lives (`cmd_launch` makes the workspace the
     session), it is not written down anywhere charter can read, and it moves at runtime.
     So it is asked of tmux, at the moment it matters.
@@ -5780,9 +5781,10 @@ def cmd_chat(args) -> int:
     0. **Where both chats are, asked of tmux, before anything is aimed anywhere** (#684,
        :func:`_pane_place`). Not one of the four, and it is here because every one of them
        assumes something no record on disk can promise: that the target's window is a
-       window this client can be moved to. `chats.of_workspace` matches a workspace FILE,
-       which `charter workspace use` and `switch.to_workspace` both rewrite, so two chats
-       can share a roster with their windows in two different tmux sessions — and
+       window this client can be moved to. `chats.of_workspace` matches RECORDS
+       (`state.own_workspace`), which `charter workspace use` and `switch.to_workspace`
+       both write to, so two chats can share a roster with their windows in two different
+       tmux sessions — and
        `select-window` at another session's pane returns **0**, moves that session, and
        leaves this client exactly where it was. Steps 1 and 2 then reported a switch that
        had not happened and tore down the panels of the chat still on screen.
@@ -5878,10 +5880,11 @@ def cmd_chat(args) -> int:
     # anything** (#684). `chats.check` has established that both are chats of one
     # workspace and — since this issue — that both are on one tmux SERVER, and neither of
     # those is "in one tmux session". `cmd_launch` makes the workspace the session, but
-    # the record membership is read from is a FILE that moves: `charter workspace use
-    # beta` typed inside chat `api.1` repoints it, `switch.to_workspace` repoints it
-    # again, and after one of those `of_workspace("beta")` returns `api.1` — a window of
-    # session `api` — beside `beta.1`, in one roster.
+    # what membership is read from is RECORDS that move (`state.own_workspace`): `charter
+    # workspace use beta` typed inside chat `api.1` writes its pointer rung,
+    # `switch.to_workspace` writes that one and the launch record both, and after either
+    # of those `of_workspace("beta")` returns `api.1` — a window of session `api` —
+    # beside `beta.1`, in one roster.
     here_place = _pane_place(socket, chats.pane_of(fid))
     there_place = _pane_place(socket, pane)
     if there_place is None:

--- a/charter/frame/chats.py
+++ b/charter/frame/chats.py
@@ -103,7 +103,26 @@ def is_chat(fid: str) -> bool:
 
 
 def of_workspace(workspace: str) -> list[str]:
-    """Every chat id whose record names *workspace*, in ordinal order.
+    """Every chat that says it is in *workspace*, in ordinal order.
+
+    **Membership is `state.own_workspace`, which is `state.workspace_for`'s middle** — and
+    the difference between those two functions is the whole of #733. `workspace_for` is
+    what a frame DRAWS, and its outer rungs answer for the process ASKING:
+    ``$CHARTER_WORKSPACE`` above and a local `workspace.resolve()` below. Asked here they
+    would be catastrophic rather than merely wrong: rung 0 returns the same value for every
+    id on the plane, so one pinned palette process would sweep every chat on the machine
+    into its own pin and out of its own workspace; rung 3 would hand every record-less chat
+    to whatever the asker had chosen. **So membership cannot come from `workspace_for`, and
+    the fix for a chat missing from a roster is never to call it here.**
+
+    What was wrong was the DEPTH, not the direction. This read `state.frame_workspace`
+    alone — the launch record, rung 2 — while `roster` keyed on all four, and
+    `charter workspace use <name>` typed at the agent writes rung 1 and never rung 2. So a
+    chat repaired that way was DRAWING `alpha` and excluded from `alpha`'s roster at the
+    same time, and the chats it had left could never see it again however it was repaired.
+    `state.own_workspace` is those chat-owned rungs — the recorded pin, the pointer, the
+    record — in the ladder's own order, so this and `roster` now ask one question at one
+    depth.
 
     **Ordinal order, and it is not `created`'s.** Spec §3.5 asks for a `created` stamp
     per chat "so tab order and the ordinal allocator do not depend on directory mtime".
@@ -122,17 +141,36 @@ def of_workspace(workspace: str) -> list[str]:
     out of the picker while its window is on screen.
 
     The scan is `os.scandir` over ~30 entries and it is asked when a palette opens and
-    when a bar repaints, not on a tick. `state.reap` is what bounds it.
+    when a bar repaints, not on a tick — `frame/panel.py` polls `state.version`, which is
+    one `stat`, and only renders when it moved. `state.reap` is what bounds the entries.
+
+    **What the ladder costs, measured rather than assumed**: one entry now reads three
+    small files where it read one — the identity record, the per-session pointer, the
+    workspace record — so 30 chats is 90 reads per call instead of 30. That is paid on a
+    repaint and never on a tick, and it is the price of the two halves of one question
+    being asked at one depth. Deliberately NOT cached: a cache here is a second source of
+    truth for a fact `.charter/frame/` already holds and free to disagree with it, which
+    is the #411 shape this module's own opening paragraph refuses.
     """
     try:
-        # **No `is_dir()` filter, and the deletion sweep is what settled that too.** It
-        # reads as the obvious first question and it cannot change the answer: a frame's
-        # workspace is a FILE inside its directory, so `frame_workspace` answers ``None``
-        # for a loose file whatever its name is, and the filter below already refuses it.
-        # A guard that passes only because a different guard caught it is the shape this
-        # repository deletes. What it cost was one `stat` per entry, which the read below
-        # pays anyway.
-        names = [e.name for e in os.scandir(state._root())]
+        # **`is_dir()`, and it came BACK with #733 — measured, not restored on taste.** A
+        # deletion sweep had removed it on the grounds that it could not change the answer:
+        # a frame's workspace was a FILE inside its directory, so `frame_workspace` already
+        # answered ``None`` for a loose file whatever its name was, and a guard that passes
+        # only because a different guard caught it is the shape this repository deletes.
+        #
+        # That stopped being true the moment membership grew a rung that does NOT live in
+        # the frame's directory. `state.own_workspace`'s pointer rung is
+        # `workspace.for_session`, whose file is `SESSIONS_DIR/<id>.workspace` — so an
+        # interrupted `os.replace` leaving a loose FILE called `api.2` under the frame
+        # root, beside a per-session pointer some earlier `api.2` wrote, is a name this
+        # would put on a bar and in a picker: measured, it joins the roster and then
+        # refuses when pressed, because it has no harness pane to aim at.
+        #
+        # `os.DirEntry.is_dir` is answered from `readdir`'s own `d_type` on Linux and macOS,
+        # so on the ~30 entries this scans it is ordinarily not a `stat` at all — and where
+        # it is one, it is the one the pointer read no longer pays on its behalf.
+        names = [e.name for e in os.scandir(state._root()) if e.is_dir()]
     except OSError:
         # No frame root at all is the ordinary answer on a plane that has never launched
         # one, and an unreadable one is the same answer for the caller: no chats to
@@ -140,7 +178,7 @@ def of_workspace(workspace: str) -> list[str]:
         # sentence one layer up.
         return []
     return sorted((n for n in names
-                   if is_chat(n) and state.frame_workspace(n) == workspace),
+                   if is_chat(n) and state.own_workspace(n) == workspace),
                   key=_order)
 
 
@@ -222,6 +260,15 @@ def roster(fid: str) -> list[Chat]:
     **Keyed on the FRAME's workspace, not this process's** (#512) — `state.workspace_for`
     is the one rule every frame surface asks, and resolving locally would list another
     plane's chats on this frame's screen.
+
+    **Two questions, one ladder** (#733). This one is "which workspace is *fid* DRAWING",
+    which is `workspace_for` and includes the rungs that answer for *fid*'s own process —
+    the pin it was launched under, and, for a frame with no records at all, a local
+    resolve. :func:`of_workspace` then asks "which chats say they are in that one", which
+    is `state.own_workspace` and can only be the records. Those are genuinely different
+    questions and they are asked at the same depth: `own_workspace` IS the middle of
+    `workspace_for`, so a chat's own answer moving moves both. It used to be a rung
+    shallower, and a chat could be drawing `alpha` while `alpha`'s roster did not have it.
 
     *fid* itself is folded in whether or not the scan found it, and that is the honest
     answer rather than a convenience: a frame whose `workspace` file could not be read is

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -931,10 +931,71 @@ def frame_workspace(fid: str) -> str | None:
     return val if ws_mod.valid_name(val) else None
 
 
+def own_workspace(fid: str) -> str | None:
+    """The workspace *fid* itself says it is in, or ``None`` when *fid* says nothing.
+
+    **The MEMBERSHIP question, and the reason it is not :func:`workspace_for`** (#733).
+    Every rung here is a record written under *fid*'s own id, so this may be asked about a
+    chat that is not the asking process — which is exactly what a roster does.
+    :func:`workspace_for` is this with the two rungs that answer for the ASKING PROCESS on
+    either end, and that is the whole difference between them:
+
+    * **rung 0** of that ladder is ``$CHARTER_WORKSPACE`` **in this process**. It answers
+      the same value for every *fid* on the plane, so a membership test that reached it
+      would put every chat into whichever workspace the palette happened to be pinned to
+      and take them all out of their own.
+    * **rung 3** is a local `workspace.resolve()`, which walks this process's cwd, session
+      pointer and terminal pointer. A chat that recorded nothing of its own would join
+      whatever the ASKER had chosen and appear on a bar it has never been in.
+
+    That is why `chats.of_workspace` read `frame_workspace` and nothing else before this
+    existed, and why swapping it for `workspace_for(n)` is the wrong fix rather than the
+    obvious one. What was wrong was the DEPTH, not the direction: the roster asked four
+    rungs and membership asked one, so a chat could be drawing `alpha` and be excluded
+    from `alpha`'s roster at the same time — `charter workspace use alpha` writes rung 1
+    and membership could only see rung 2.
+
+    The three rungs, in :func:`workspace_for`'s own order because they ARE its middle:
+
+    1. **The pin the launcher recorded.** `state.identity` holds what the launch put on
+       tmux's ``-e`` (`commands_frame._frame_identity_env`), which is `os.environ` inside
+       every one of that frame's own panes and is therefore the chat-owned reading of
+       rung 0. Read from the record and never from `os.environ`, for `switch._pin`'s
+       reason — this runs as a child of a tmux server shared between every frame on the
+       machine, so this process's own variable may be another chat's. It is FIRST because
+       a pinned frame cannot be moved off its pin by anything below: `switch.to_workspace`
+       refuses outright, `commands_workspace` warns that `ws use` will not stick, and a
+       pointer written under a pinned chat is one nothing draws. Take this rung away and a
+       pinned chat that ran `charter workspace use other` is stranded in exactly the shape
+       #733 describes, on a plane where it is coherent today.
+    2. **What was chosen inside the chat** — `workspace.for_session(fid)`, which takes the
+       id explicitly and reads one file under it. Never `workspace.chosen(session_id=fid)`,
+       which looks like the same thing and is not: its rungs fall through to a cwd read and
+       a terminal pointer that are the ASKER's.
+    3. **What the launcher resolved** — :func:`frame_workspace`, #512's seed.
+
+    ``None`` where every rung is empty, and that is a real answer rather than a failure:
+    "this chat says nothing" belongs in nobody's roster, while :func:`workspace_for` still
+    has to hand a panel a name to draw and falls through to its own last rung for it.
+
+    Name-checked on the pin like every other rung that hands a value to `workspace_dir()`'s
+    join (#442); rungs 2 and 3 are checked by the functions that own them. `valid_name`
+    alone with no truthiness test in front of it — `valid_name("")` is already False, and
+    `_frame_identity_env` emits an empty value for every name a launch did not have, so an
+    unpinned launch falls through here on the name check's own terms.
+    """
+    from .. import workspace as ws_mod
+    pin = identity(fid).get("CHARTER_WORKSPACE", "").strip()
+    if ws_mod.valid_name(pin):
+        return pin
+    return ws_mod.for_session(fid) or frame_workspace(fid)
+
+
 def workspace_for(fid: str) -> str:
     """The workspace this frame is DRAWING — what every surface of the frame asks.
 
-    Four rungs, and the order is the whole of it:
+    Three rungs, the middle of which is a ladder of its own, and the order is the whole of
+    it:
 
     0. **The pin.** ``$CHARTER_WORKSPACE`` outranks everything, because that is what it
        means everywhere else in charter: `workspace.resolve` puts it above every pointer,
@@ -944,27 +1005,42 @@ def workspace_for(fid: str) -> str:
        framed session that also typed `charter workspace use other` draws `other` while
        every command it runs acts on the pinned name — a panel naming a workspace nothing
        in the session touches, wearing `slots`' `*` that says the environment chose it.
-    1. **What was chosen inside this frame.** `charter workspace use <name>` typed at the
-       agent writes the per-session pointer under the FRAME's id, because inside a frame
-       the frame is the charter session (`docs/frame.md`, ADR 0019) — and "it moves the
-       panels too" is a documented promise, not an accident. An explicit choice made while
-       the frame runs outranks anything the launch decided.
-    2. **What the launcher resolved**, :func:`record_workspace`. The seed: the launch's own
-       answer to a question nothing inside the frame can ask (#512).
-    3. **Whatever this process resolves for itself**, for a frame launched by a charter
+    1. **What the frame itself says** — :func:`own_workspace`, which is the recorded pin,
+       then `charter workspace use <name>` typed at the agent (the per-session pointer
+       under the FRAME's id, because inside a frame the frame is the charter session —
+       `docs/frame.md`, ADR 0019 — and "it moves the panels too" is a documented promise),
+       then what the launcher resolved (:func:`record_workspace`, #512's seed: the launch's
+       own answer to a question nothing inside the frame can ask).
+    2. **Whatever this process resolves for itself**, for a frame launched by a charter
        that predates the record and still running across the upgrade — today's behaviour,
        so this is never worse than what it replaces.
 
-    Rungs 1 and 2 are the only two below the pin that can ever disagree, and it is worth
-    saying why the others cannot. `$CHARTER_WORKSPACE` reaches a panel exactly when the
-    launcher had it (`commands_frame._frame_identity_env` carries it, empty when absent),
-    and the launcher resolves it first — so the record holds the same value; rung 0 is
-    therefore invisible on an ordinary pinned launch and only shows itself when something
-    inside the frame tried to move off the pin. The cwd rung is the same story: a panel's
-    cwd is the launcher's, and the launcher asked `from_path` about it before anything
-    else. The per-terminal pointer and the declared default are the two rungs a panel
-    reaches that answer for the PANEL rather than for the frame, and those are exactly the
-    two the record is here to outrank.
+    **The middle is not spelled out here, and that is the point** (#733). It is
+    :func:`own_workspace`, which `chats.of_workspace` asks to decide membership — so the
+    roster and the panels walk ONE ladder rather than two that agree today, which is the
+    shape `workspace.chosen` already warns about in as many words. What #733 cost was
+    exactly that: this function read the per-session pointer, membership read only the
+    record, and `charter workspace use` writes the first and not the second — so a chat
+    could be drawing `alpha` and be excluded from `alpha`'s roster at the same time. A rung
+    added below is now a rung both readers ask.
+
+    Rung 0 and the pin inside :func:`own_workspace` hold the same value on an ordinary
+    launch — `_frame_identity_env` puts the launcher's `$CHARTER_WORKSPACE` on the pane's
+    `-e` and records it — so the recorded one shows itself only where this process's
+    environment is not the frame's, which on a tmux server shared between every frame on
+    the machine is a real case and the one `switch._pin` already reads the record for.
+
+    The pointer and the record inside :func:`own_workspace` are the only two rungs below
+    the pin that can ever disagree, and it is worth saying why the others cannot.
+    `$CHARTER_WORKSPACE` reaches a panel exactly when the launcher had it
+    (`commands_frame._frame_identity_env` carries it, empty when absent), and the launcher
+    resolves it first — so the record holds the same value; rung 0 is therefore invisible
+    on an ordinary pinned launch and only shows itself when something inside the frame
+    tried to move off the pin. The cwd rung is the same story: a panel's cwd is the
+    launcher's, and the launcher asked `from_path` about it before anything else. The
+    per-terminal pointer and the declared default are the two rungs a panel reaches that
+    answer for the PANEL rather than for the frame, and those are exactly the two the
+    record is here to outrank.
 
     **Name-checked, and `valid_name` alone with no `env and` in front of it** — the same
     rule and the same reasoning as :func:`frame_workspace`, since this value ends up in
@@ -973,16 +1049,17 @@ def workspace_for(fid: str) -> str:
     workspace does not get drawn: it falls through, and `slots` withholds the `*` because
     the name on screen is then not the one the environment named.
 
-    Asked through `workspace.for_session` rather than by reading `workspace.source()`'s
-    label: that function returns a sentence written for a status line, and matching the
-    string ``"session"`` would be this repo's own recurring defect — a spelling standing in
-    for a property. Rung 0 reads the variable itself for the same reason.
+    Rung 0 reads the variable itself rather than matching `workspace.source()`'s label,
+    the same reason :func:`own_workspace` asks `workspace.for_session` directly: that
+    function returns a sentence written for a status line, and matching the string
+    ``"session"`` would be this repo's own recurring defect — a spelling standing in for a
+    property.
     """
     from .. import workspace as ws_mod
     env = os.environ.get("CHARTER_WORKSPACE", "").strip()
     if ws_mod.valid_name(env):
         return env
-    return ws_mod.for_session(fid) or frame_workspace(fid) or ws_mod.resolve()
+    return own_workspace(fid) or ws_mod.resolve()
 
 
 def record_density(fid: str, level: str) -> None:

--- a/docs/news/unreleased-a-chat-cannot-be-drawing-a-workspace-and-missing-from-it.md
+++ b/docs/news/unreleased-a-chat-cannot-be-drawing-a-workspace-and-missing-from-it.md
@@ -1,0 +1,130 @@
+---
+version: unreleased
+headline: A chat cannot be drawing one workspace and missing from that workspace's own tab bar
+---
+
+*"I pressed `F2` → workspace in one chat, and the chat next to it stopped existing. I got
+mine back with `charter workspace use`, and it still could not see me."*
+
+Both halves were real, and the second one is the defect. **The two halves of "which chats
+does this workspace have" were being asked at two different depths.**
+
+`chats.roster` — what the tab bar draws and what the chat picker offers — keyed on
+`state.workspace_for`, the four-rung ladder every surface of a frame asks: the
+`$CHARTER_WORKSPACE` pin, then `charter workspace use`'s per-session pointer, then what
+the launcher recorded, then a local resolve. `chats.of_workspace` — what decides whether a
+given chat is a *member* — read the launch record and nothing else. And the two writers
+disagree about which rungs they move: `F2 → workspace` writes the pointer **and** the
+record, while `charter workspace use` writes only the pointer.
+
+So a rung existed that the roster read and membership could not see, and one command
+landed squarely on it:
+
+```
+alpha.1, alpha.2 both in `alpha`         alpha.1 sees: alpha.1  alpha.2
+                                         alpha.2 sees: alpha.1  alpha.2
+
+F2 → workspace → gamma, inside alpha.1   alpha.1 sees: alpha.1
+                                         alpha.2 sees: alpha.2          <- the strand
+
+`charter workspace use alpha`,           alpha.1 sees: alpha.1  alpha.2 <- repaired
+typed inside alpha.1                     alpha.2 sees: alpha.2          <- still cannot
+```
+
+**The last line is the bug.** `alpha.1` was drawing `alpha` — its panels, its status line
+and every command it ran all said `alpha` — and `alpha`'s own roster did not have it in.
+The repair moved the rung the roster reads and left the rung membership reads pointing
+somewhere else, so the fix was one-way: the moved chat could find its way home, and the
+chats it left could never see it again, however either side tried.
+
+**Membership is now `state.own_workspace`, which is `state.workspace_for`'s middle.**
+Three rungs, all of them records written under the chat's own id: the pin the launcher
+wrote down, the per-session pointer, the recorded workspace — in the ladder's own order.
+`workspace_for` is that same function with the asking process's two rungs bracketing it,
+so the roster and the panels now walk one ladder rather than two that agreed until
+somebody wrote to the rung only one of them read.
+
+## Why membership cannot simply ask what the frame is drawing
+
+This is worth stating, because it is the one-line fix this defect invites and it is wrong
+in a way that is much worse than the defect.
+
+`state.workspace_for(n)` looks like the answer and is not: **its outer two rungs answer
+for the process ASKING, not for chat `n`.** Rung 0 is `$CHARTER_WORKSPACE` in this
+process's own environment — so it returns the same value for every id on the plane.
+Measured: with one pinned palette process asking, `workspace_for` answers the pin for
+`alpha.1`, `alpha.2` and a chat that has no records at all alike, which as a membership
+test would sweep every chat on the machine into that pin and out of its own workspace.
+Rung 3 is a local `workspace.resolve()`, which walks this process's cwd, session pointer
+and terminal pointer — measured, it hands every record-less chat to whatever the *asker*
+had chosen.
+
+That is why `of_workspace` read one record and nothing else in the first place. What was
+wrong with it was the depth, not the direction, and `own_workspace` is the fix that keeps
+the direction.
+
+## The recorded pin is a rung, and leaving it out would have made a new strand
+
+The narrow two-rung version — the pointer, then the record — is the obvious shape and it
+regresses a case that is coherent today. `$CHARTER_WORKSPACE` set at launch lives in every
+one of that frame's panes for as long as they live, so `charter workspace use other` typed
+inside a pinned chat writes a pointer that nothing draws: `commands_workspace` warns as
+much, and `F2 → workspace` refuses the same move outright rather than reporting one it
+cannot make. Measured on a pinned chat: the two-rung version moves its membership to
+`other` while its panels keep drawing the pin — which is #733 again, arrived at by the
+fix for #733. So the pin is the first rung, read from the launcher's own record
+(`state.identity`) and never from `os.environ`, because this code runs as a child of a
+tmux server shared between every frame on the machine.
+
+## One filter came back, because the reason it was deleted stopped being true
+
+`of_workspace` had had its `is_dir()` filter removed by a deletion sweep, correctly at the
+time: membership was a file *inside* the frame's directory, so a loose file under the
+frame root was refused by the read whatever the filter did, and a guard that only passes
+because another guard caught it is a line no test can turn red.
+
+Membership now also asks `workspace.for_session`, whose file lives under `SESSIONS_DIR`
+and knows nothing about what the frame root holds. Measured: a stray file called `api.2`
+under the frame root — the shape an interrupted `os.replace` leaves — beside a per-session
+pointer some earlier `api.2` wrote, joins the roster and then refuses when pressed,
+because it has no harness pane to aim at. The filter is back, and the case it exists for
+is pinned *with* that pointer planted; without it the test passes against the defect it is
+there to catch.
+
+## What this does not decide
+
+**Whether `F2 → workspace` moves the chat or the frame is still open** (#733's other
+half), and nothing here answers it. This change does not stop the strand forming — press
+`F2 → workspace` in one chat of two and it still leaves the other. What it stops is
+charter holding both answers at once: a chat is now in the roster of the workspace it is
+drawing, whichever way that question is eventually settled.
+
+Two things the issue reported that the measurements refute, recorded because the next
+person will start from the issue:
+
+- **There is a route back.** `charter workspace use <original>`, typed inside the moved
+  chat, has always restored that chat's own view. What did not exist was any way to become
+  visible again from the other side, which is the asymmetry this entry is about.
+- **`charter workspace use` never rewrote the launch record.** Two docstrings said it did
+  — `commands_frame._pane_place` and the test class for #684 — and that is precisely the
+  misapprehension the defect is made of. Both are corrected here.
+
+## Verification
+
+Reproduced without tmux and pinned as tests: two chat directories, `switch.to_workspace`,
+then `chats.roster` from each side. Eleven new cases, and every rung of the new ladder was
+hand-mutated to confirm it is load-bearing — dropping the `is_dir()` filter, dropping the
+pin rung, swapping the pointer and the record, checking the pin for truth instead of for a
+name, and reducing membership to the record alone (which is the old behaviour) each turn
+the suite red, on the case that names them.
+
+The deletion sweep found one guard the hand pass had missed and it was worth having:
+`.strip()` on the recorded pin passed every case as `.lstrip()`. Left-padding is what a
+whitespace-only record has and both answers agree on it; right-padding is what
+`CHARTER_WORKSPACE="alpha "` leaves, and there `lstrip` hands the name to `valid_name`,
+which refuses it, and membership falls to the pointer — while the switcher strips the same
+value, sees a pin and refuses to move the frame. A chat pinned to `alpha`, unmovable, and
+in another workspace's roster: this defect rebuilt out of one missing character. Pinned
+now, and the sweep is clean.
+
+Nothing to adopt.

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -23,8 +23,8 @@ import os
 import unittest
 from unittest import mock
 
-from charter import commands_frame, config, contain, instance
-from charter.frame import chats, choose, slots, state, tmuxctl
+from charter import commands_frame, config, contain, instance, workspace
+from charter.frame import chats, choose, slots, state, switch, tmuxctl
 from tests._isolation import PersonaIso
 from tests._tmuxsocket import OPERATOR_SOCKET
 # The one list of hostile display strings this suite has, imported rather than retyped:
@@ -207,9 +207,22 @@ class TheRosterIsTheDirectory(PersonaIso, unittest.TestCase):
     def test_a_loose_file_under_the_frame_root_is_not_a_chat(self):
         """The directory is the list, and a file in it is not a directory. `exit`, a
         temp file a write was interrupted mid-`os.replace`, anything — none of them has a
-        frame directory's shape and none may become a row."""
+        frame directory's shape and none may become a row.
+
+        **The per-session pointer is planted deliberately, and without it this test cannot
+        see its own guard** (#733). Membership used to be a file INSIDE the frame's
+        directory, so a loose file was refused by the read whatever the filter did; it now
+        also asks `workspace.for_session`, whose file lives under `SESSIONS_DIR` and knows
+        nothing about whether the frame root holds a directory or a stray byte of a
+        half-written temp file. Measured: without the `is_dir()` filter this case goes red
+        on the second name and green on the first, which is the same test passing against
+        the defect it exists to catch.
+        """
         _plant("api.1", workspace="api")
         (state._root() / "api.2").write_text("not a chat\n")
+        workspace.set_active("api", session_id="api.2", force=True, terminal_id="")
+        self.assertEqual(workspace.for_session("api.2"), "api",
+                         "the pointer this case turns on was not written")
         self.assertEqual(chats.of_workspace("api"), ["api.1"])
 
     def test_a_chat_with_no_recorded_workspace_belongs_to_none(self):
@@ -257,6 +270,208 @@ class TheRosterIsTheDirectory(PersonaIso, unittest.TestCase):
                              clear=False):
             self.assertEqual(chats.harness_of("api.1"), "Codex")
         self.assertEqual(chats.harness_of("api.404"), "")
+
+
+class MembershipIsTheChatsOwnAnswerAndNotTheAskersAnswer(PersonaIso,
+                                                         unittest.TestCase):
+    """#733: a chat could be DRAWING `alpha` and be excluded from `alpha`'s roster.
+
+    `roster` keys on `state.workspace_for` — the pin, the per-session pointer, the launch
+    record, a local resolve. `of_workspace` decided membership with the launch record
+    ALONE. `switch.to_workspace` writes the pointer AND the record; `charter workspace
+    use` writes only the pointer. So the pointer was a rung the roster read and
+    membership could not see, and the two halves of one question were asked at two
+    depths.
+
+    The visible cost is an asymmetry rather than a dead end. `F2 → workspace → gamma`
+    inside `alpha.1` takes it out of `alpha.2`'s list; `charter workspace use alpha`
+    typed back inside `alpha.1` repaired `alpha.1`'s own view and **nothing else** —
+    `alpha.2` could never see `alpha.1` again, so the route back existed only from the
+    side that is hardest to reach.
+
+    The fix is `state.own_workspace`: the same ladder with the two rungs that answer for
+    the ASKING PROCESS taken off either end, asked by `of_workspace` and by
+    `workspace_for` alike. One ladder asked twice — the shape `workspace.chosen` already
+    names — rather than two that agree today.
+
+    **None of this decides what `F2 → workspace` MEANS** (#733's other half: whether that
+    keypress moves the chat or the frame). It stops charter holding both answers at once.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Both ladders read `$CHARTER_WORKSPACE` and `$CHARTER_SESSION_ID`, so a
+        # developer running this inside a live frame would be supplying half of every
+        # fixture (#519/#521/#528). The cases that need a rung state it themselves.
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        for n in ("alpha", "gamma"):
+            (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
+        _plant("alpha.1", workspace="alpha", pane="%1")
+        _plant("alpha.2", workspace="alpha", pane="%2")
+
+    def test_a_chat_that_is_drawing_a_workspace_is_in_that_workspaces_roster(self):
+        """The incoherence, stated as the invariant it broke.
+
+        After `F2 → workspace → gamma` in `alpha.1` and `charter workspace use alpha`
+        typed back inside it, `alpha.1` draws `alpha` — its panels, its status line and
+        every command it runs say `alpha` — while `of_workspace` still read the record
+        `to_workspace` had left pointing at `gamma`.
+        """
+        self.assertTrue(switch.to_workspace("alpha.1", "gamma").ok)
+        workspace.set_active("alpha", session_id="alpha.1", force=True, terminal_id="")
+        self.assertEqual(state.workspace_for("alpha.1"), "alpha")
+        self.assertIn("alpha.1", chats.of_workspace("alpha"))
+        self.assertNotIn("alpha.1", chats.of_workspace("gamma"))
+
+    def test_the_repair_is_visible_from_the_chat_that_was_left_behind(self):
+        """The asymmetry, which is the defect #733 actually has.
+
+        The issue says the moved chat "has no route back". It has one, and it is one
+        command: `charter workspace use alpha`, typed inside it. What it did not have was
+        any way to become visible AGAIN to the chats it left — the repair writes the
+        pointer, and membership read only the record.
+        """
+        self.assertTrue(switch.to_workspace("alpha.1", "gamma").ok)
+        self.assertEqual(chats.others("alpha.2"), [],
+                         "the strand this test is about did not form")
+        workspace.set_active("alpha", session_id="alpha.1", force=True, terminal_id="")
+        self.assertEqual(chats.others("alpha.2"), ["alpha.1"])
+        self.assertTrue(chats.check("alpha.2", "alpha.1").ok,
+                        chats.check("alpha.2", "alpha.1").message)
+
+    def test_membership_is_not_the_asking_processes_pin(self):
+        """Why membership cannot simply ask `state.workspace_for(n)`, which is the
+        one-liner this defect invites and the reason `of_workspace` read the record and
+        nothing else in the first place.
+
+        Rung 0 of that ladder is `$CHARTER_WORKSPACE` in the process ASKING. It answers
+        the same value for every `n`, so `workspace_for(n)` used as a membership test
+        would put every chat on the plane into whichever workspace the palette process
+        happened to be pinned to, and take them all out of their own.
+        """
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "gamma"}, clear=False):
+            self.assertEqual(state.workspace_for("alpha.1"), "gamma",
+                             "the rung this test is about has moved")
+            self.assertEqual(state.workspace_for("alpha.2"), "gamma")
+            self.assertEqual(chats.of_workspace("gamma"), [])
+            self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.2"])
+
+    def test_membership_is_not_the_asking_processes_own_resolve(self):
+        """The other end of the same ladder, and the rung the narrow version of that
+        one-liner still reaches.
+
+        Rung 3 is `workspace.resolve()`, which answers for the asking process's session,
+        terminal and cwd. A chat that recorded nothing of its own — the migration case —
+        would join whatever workspace the ASKER had chosen, and appear on a bar it has
+        never been in.
+        """
+        state.frame_dir("alpha.9", create=True)     # no record, no pointer, no pin
+        workspace.set_active("gamma", session_id="an-asker", force=True, terminal_id="")
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "an-asker"},
+                             clear=False):
+            self.assertEqual(state.workspace_for("alpha.9"), "gamma",
+                             "the rung this test is about has moved")
+            self.assertNotIn("alpha.9", chats.of_workspace("gamma"))
+
+    def test_a_chat_with_nothing_recorded_owns_no_answer_and_still_falls_through(self):
+        """`own_workspace` answers ``None`` where `workspace_for` answers a name, and
+        that difference is the whole point of the split: "this chat says nothing" is a
+        real answer for membership, and "charter still has to draw SOMETHING" is a
+        different question with a different last rung."""
+        state.frame_dir("alpha.9", create=True)
+        self.assertIsNone(state.own_workspace("alpha.9"))
+        self.assertEqual(state.workspace_for("alpha.9"), workspace.resolve())
+
+    def test_a_pinned_chat_belongs_to_its_pin_and_not_to_what_was_typed_inside_it(self):
+        """The rung a two-rung membership test would have got WRONG, measured.
+
+        `$CHARTER_WORKSPACE` at launch is in every panel pane's process environment for
+        as long as the pane lives, so `charter workspace use gamma` inside a pinned chat
+        writes a pointer nothing draws — `commands_workspace` warns exactly that, and
+        `switch.to_workspace` refuses the same move outright rather than reporting a move
+        that cannot happen. Membership follows the pin because the screen does; a
+        `for_session or frame_workspace` pair would strand a pinned chat in precisely the
+        way #733 describes, on a plane where it is coherent today.
+
+        Read from `state.identity` — the launcher's own record — and never from
+        `os.environ`, for `switch._pin`'s reason: this runs as a child of a tmux server
+        shared between every frame on the machine.
+        """
+        state.record_identity("alpha.1", {"CHARTER_HARNESS": "Claude Code",
+                                          "CHARTER_WORKSPACE": "alpha"})
+        workspace.set_active("gamma", session_id="alpha.1", force=True, terminal_id="")
+        self.assertFalse(switch.to_workspace("alpha.1", "gamma").ok,
+                         "a pinned frame cannot be moved, so it cannot have moved")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "alpha"}, clear=False):
+            self.assertEqual(state.workspace_for("alpha.1"), "alpha")
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.2"])
+        self.assertEqual(chats.of_workspace("gamma"), [])
+
+    def test_an_empty_recorded_pin_is_not_a_pin_here_either(self):
+        """`commands_frame._frame_identity_env` emits every name, present or not, so an
+        unpinned launch records `CHARTER_WORKSPACE=""`. Testing for presence rather than
+        for truth would take every ordinary chat out of every roster — the same
+        measurement `switch.to_workspace`'s own pin check already carries."""
+        state.record_identity("alpha.1", {"CHARTER_WORKSPACE": ""})
+        self.assertEqual(state.own_workspace("alpha.1"), "alpha")
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.2"])
+
+    def test_a_recorded_pin_with_a_TRAILING_space_is_still_that_pin(self):
+        """`.strip()`, and both halves of it — the deletion sweep found `lstrip` passing
+        every other case here, exactly as it once did for `chats.harness_of`.
+
+        Padding on the left is what a whitespace-only record has, and for that both
+        answers agree on `""`. Padding on the RIGHT is what an operator who exported
+        `CHARTER_WORKSPACE="alpha "` leaves, and there the two diverge: `lstrip` keeps the
+        trailing space, `workspace.valid_name` refuses the name, and membership falls
+        through to the pointer — while `switch._pin` strips the same value, sees a pin, and
+        refuses to move the frame at all. That is a chat pinned to `alpha`, unmovable, and
+        in `gamma`'s roster: #733 rebuilt out of one missing character. Stripped here on
+        the same terms as `workspace_for`'s rung 0 and `switch._pin`, because all three are
+        reading one variable.
+        """
+        state.record_identity("alpha.1", {"CHARTER_WORKSPACE": "alpha "})
+        workspace.set_active("gamma", session_id="alpha.1", force=True, terminal_id="")
+        self.assertFalse(switch.to_workspace("alpha.1", "gamma").ok,
+                         "the pin is a pin to the switcher, so it must be one here")
+        self.assertEqual(state.own_workspace("alpha.1"), "alpha")
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.2"])
+        self.assertEqual(chats.of_workspace("gamma"), [])
+
+    def test_a_recorded_pin_that_cannot_name_a_workspace_is_not_a_pin(self):
+        """The record is charter's own file, but the value lands in `workspace_dir()`'s
+        join and in `of_workspace`'s comparison, and #442 is what an unchecked `../../`
+        in that position already cost once. A pin that cannot name a workspace falls
+        through to the rung below rather than becoming a workspace nothing can be a
+        member of."""
+        state.record_identity("alpha.1", {"CHARTER_WORKSPACE": "../../escape"})
+        self.assertEqual(state.own_workspace("alpha.1"), "alpha")
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.2"])
+
+    def test_the_pointer_outranks_the_record_here_exactly_as_it_does_there(self):
+        """The rung ORDER is the fix, not merely the rung set. `charter workspace use`
+        outranks what the launcher resolved in `workspace_for`, so it has to outrank it
+        in membership too — reversed, a repaired chat would stay in the workspace the
+        switch left it in while its own panels drew the other one."""
+        workspace.set_active("gamma", session_id="alpha.1", force=True, terminal_id="")
+        self.assertEqual(state.frame_workspace("alpha.1"), "alpha")
+        self.assertEqual(state.own_workspace("alpha.1"), "gamma")
+        self.assertEqual(chats.of_workspace("gamma"), ["alpha.1"])
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.2"])
+
+    def test_the_two_questions_walk_one_ladder(self):
+        """`workspace_for` is `own_workspace` with the asking process's rungs on either
+        end, rather than a second copy of the middle — the shape `workspace.chosen`
+        already names in as many words ("one ladder, asked twice, not two ladders that
+        agree today"). A rung added to one is a rung the other asks."""
+        for fid in ("alpha.1", "alpha.2"):
+            self.assertEqual(state.workspace_for(fid), state.own_workspace(fid))
+        self.assertTrue(switch.to_workspace("alpha.1", "gamma").ok)
+        self.assertEqual(state.workspace_for("alpha.1"),
+                         state.own_workspace("alpha.1"))
+        workspace.set_active("alpha", session_id="alpha.1", force=True, terminal_id="")
+        self.assertEqual(state.workspace_for("alpha.1"),
+                         state.own_workspace("alpha.1"))
 
 
 class TheCheckSaysWhichRefusalFired(PersonaIso, unittest.TestCase):
@@ -1006,10 +1221,10 @@ class TheSwitchEstablishesTheWindowItIsMovingTo(PersonaIso, unittest.TestCase):
     `_apply_arrangement(fid, want=[])`: charter tearing down the panels of the chat still
     on screen, having reported a switch that did not happen.
 
-    Reachable because membership is a FILE. `chats.of_workspace` matches
-    `state.frame_workspace`, which `charter workspace use <other>` typed at the agent
-    rewrites ("it moves the panels too" is a documented promise) and which
-    `switch.to_workspace` rewrites again — so after one `F2 → workspace → beta` inside
+    Reachable because membership is a RECORD. `chats.of_workspace` matches
+    `state.own_workspace`, whose rungs `charter workspace use <other>` typed at the agent
+    writes ("it moves the panels too" is a documented promise) and which
+    `switch.to_workspace` writes again — so after one `F2 → workspace → beta` inside
     chat `api.1`, `of_workspace("beta")` returns `api.1` (a window of tmux session `api`)
     beside `beta.1`, in one roster, and `chats.check` says ok.
 


### PR DESCRIPTION
Fixes the half of #733 that is a defect under **either** answer to its product question.
It deliberately does **not** settle whether `F2 → workspace` moves the chat or the frame —
that decision is untouched, the strand still forms, and nothing here builds toward either
answer.

## The bug

`chats.roster` — what the tab bar draws and what the picker offers — keys on
`state.workspace_for`, a **four-rung** ladder. `chats.of_workspace` — what decides
*membership* — decided it with `state.frame_workspace`, **rung 2 alone**. And the two
writers move different rungs: `switch.to_workspace` writes rungs 1 and 2, `charter
workspace use` writes only rung 1.

So a rung existed that the roster read and membership could not see, and one ordinary
command landed on it. Reproduced without tmux — two chat directories, `switch.to_workspace`,
then `chats.roster` from each side:

```
before                         alpha.1 roster: ['alpha.1', 'alpha.2']
                               alpha.2 roster: ['alpha.1', 'alpha.2']

after F2 → workspace → gamma   alpha.1 roster: ['alpha.1']
inside alpha.1                 alpha.2 roster: ['alpha.2']

after `workspace use alpha`    alpha.1 roster: ['alpha.1', 'alpha.2']   <- repaired
typed inside alpha.1           alpha.2 roster: ['alpha.2']              <- still cannot
                               workspace_for(alpha.1) = 'alpha'
                               of_workspace('alpha')  = ['alpha.2']     <- the defect
```

The last two lines are it: **`alpha.1` is DRAWING `alpha` and is excluded from `alpha`'s
roster at the same time.** That is incoherent under any answer to the `F2` question, which
is why it is safe to fix now.

## The fix

`state.own_workspace(fid)` — the workspace *fid* itself says it is in, every rung a record
written under *fid*'s own id: the recorded pin, then the per-session pointer, then the
launch record, in `workspace_for`'s own order. `chats.of_workspace` filters on it, and
`workspace_for` becomes that same function with the asking process's two rungs bracketing
it:

```python
def workspace_for(fid: str) -> str:
    env = os.environ.get("CHARTER_WORKSPACE", "").strip()
    if ws_mod.valid_name(env):
        return env
    return own_workspace(fid) or ws_mod.resolve()
```

One ladder asked twice — the shape `workspace.chosen` already names in as many words —
rather than two that agreed until somebody wrote to the rung only one of them read.

## Why membership cannot come from `workspace_for`

Stated in `own_workspace`'s docstring and in `of_workspace`'s, because the next person
will reach for it exactly as the investigating agent did. **Its outer two rungs answer for
the process ASKING, not for chat `n`.** Measured on an isolated plane:

```
$CHARTER_WORKSPACE=beta in the ASKING process:
  workspace_for(alpha.1)='beta'   frame_workspace='alpha'  for_session=None
  workspace_for(alpha.2)='beta'   frame_workspace='alpha'  for_session=None
  workspace_for(web.9)  ='beta'   frame_workspace=None     for_session=None

the ASKER's own session pointer says gamma, for a chat with no record at all:
  workspace_for(web.9)='gamma'    for_session(web.9)=None  frame_workspace(web.9)=None
```

Rung 0 returns the same value for **every id on the plane**, so one pinned palette process
would sweep every chat on the machine into its own pin and out of its own workspace. Rung
3 hands every record-less chat to whatever the asker had chosen. That is why
`of_workspace` read the record and nothing else in the first place — what was wrong with
it was the **depth**, not the direction.

## Two things found by measuring rather than by reading

**The recorded pin has to be a rung, and the narrow two-rung version regresses a case that
is coherent today.** `$CHARTER_WORKSPACE` set at launch is in every one of that frame's
panes for as long as they live, so `charter workspace use other` typed inside a pinned chat
writes a pointer nothing draws — `commands_workspace` warns as much and `switch.to_workspace`
refuses the same move outright. Measured: `for_session or frame_workspace` moves that
chat's membership to `other` while its panels keep drawing the pin — #733 again, arrived at
by the fix for #733. So the pin is first, read from `state.identity` (the launcher's own
record) and never from `os.environ`, for `switch._pin`'s reason.

**`of_workspace`'s `is_dir()` filter had to come back, and the existing test for it could
not see why.** A deletion sweep had removed it, correctly at the time: membership was a
file *inside* the frame's directory, so a loose file was refused by the read whatever the
filter did. Membership now also asks `workspace.for_session`, whose file lives under
`SESSIONS_DIR` and knows nothing about the frame root. Measured — a stray file called
`alpha.2` under the frame root beside a per-session pointer some earlier `alpha.2` wrote:

```
no pointer:      ['alpha.1']
stale pointer:   ['alpha.1', 'alpha.2']     <- a row that refuses when pressed
```

`test_a_loose_file_under_the_frame_root_is_not_a_chat` now plants that pointer. Without it
the case is green either way, which is the same test passing against the defect it exists
to catch.

## Refutations, and what they cost the prose

- **There IS a route back.** #733 says the moved chat "has no route back and the chats it
  left behind cannot see it". The first half does not hold: `charter workspace use
  <original>` typed inside the moved chat has always restored that chat's own view. The
  second half held permanently, and **that asymmetry is the real defect** — the escape
  existed only from the side that is hardest to reach.
- **`charter workspace use` never rewrote the launch record.** `state.record_workspace`
  has exactly three writers: the two launchers in `commands_frame`, and
  `switch.to_workspace`. **Four** places said otherwise —
  `commands_frame._pane_place`, `cmd_chat`'s step-0 docstring, the `#684` comment inside
  `cmd_chat`, and this repo's own test class for #684 — and that is precisely the
  misapprehension the defect is made of. All four are corrected here.
- **One of those comments described a hazard that was not reachable the way it said, and
  now is.** `cmd_chat`'s #684 comment claims that after `charter workspace use beta`
  inside chat `api.1`, `of_workspace("beta")` returns `api.1` beside `beta.1` — a roster
  spanning two tmux sessions. On `main` it did not: that is the very rung membership
  could not see. On this branch it does, which makes the comment true and puts the case
  through #684's own guard — `_pane_place` refuses it with "another tmux session", and
  `TheSwitchEstablishesTheWindowItIsMovingTo` already pins that refusal.

## What it costs

Measured, not assumed: one entry of `of_workspace` now reads three small files where it
read one, so **30 chats is 90 reads per call instead of 30**. Paid when a palette opens or
a bar repaints, never on a tick — `frame/panel.py` polls `state.version` (one `stat`) and
renders only when it moved, and `IdleCostsOneStat`'s syscall budget is untouched.
Deliberately not cached: a cache here is a second source of truth for a fact
`.charter/frame/` already holds, which is the #411 shape `chats.py`'s own opening
paragraph refuses.

## Verification

- **11 new cases**, all reproducing without tmux.
- **Hand mutation, `python3 -B` with `__pycache__` cleared.** Every rung is load-bearing —
  each of these turns the suite red on the case that names it:
  | mutation | result |
  |---|---|
  | drop the `is_dir()` filter | 1 failure |
  | `own_workspace` = `frame_workspace` alone (this is `main`) | 3 failures |
  | drop the pin rung | 1 failure |
  | swap the pointer and the record | 3 failures |
  | check the pin for truth instead of for a name | 1 failure |
  | `.strip()` → `.lstrip()` on the pin | 1 failure |
- **Deletion sweep — clean, and it earned its keep.** `python3 tools/sweep.py`, 6
  mutations against merge-base `d9df038` (3 files, 172 added lines — the branch is not
  behind `main`, so #776's mis-charge does not apply).

  The **first** run was `baseline: Ran 9324 tests — OK / pinned 5 / SURVIVED 1 /
  UNRESOLVED 0` — `state.py:988`, `.strip()` on the recorded pin passing as `.lstrip()`.
  That survivor was real and is the last row of the table above: left-padding is what a
  whitespace-only record has and both answers agree on it, but right-padding is what
  `CHARTER_WORKSPACE="alpha "` leaves, and there `lstrip` hands the name to `valid_name`,
  which refuses it, and membership falls to the pointer — while `switch._pin` strips the
  same value, sees a pin and refuses to move the frame. A chat pinned to `alpha`,
  unmovable, and in `gamma`'s roster: #733 rebuilt out of one missing character. Now
  pinned by `test_a_recorded_pin_with_a_TRAILING_space_is_still_that_pin`.

  The **final** run, on `b384a5b`:

  ```
  baseline          : Ran 9325 tests — OK
  mutations applied : 6
  pinned            : 6
  SURVIVED          : 0
  UNRESOLVED        : 0
  ```

  CI agrees, by check name: **`no survivors`: pass** (with `Size the sweep`,
  `Sweep shard 1 of 1` and `Add up what the shards found` all pass).

  One intermediate run is discarded rather than reported: its baseline came back
  `Ran 0 tests — no tests ran in 470s` on a box that was also running the suite, which is
  **unresolved**, not a verdict — the sweep's own rule that machine load must not become
  evidence.
- **Full suite: `Ran 9325 tests — OK`**, from the sweep's own baseline in its private
  workdir. Run directly from the worktree it is 9325/1 skip plus one pre-existing
  environmental failure, below.
- **CI green on every check**: `test (3.11)`, `(3.12)`, `(3.13)`, `(3.14)`,
  `Analyze (python)`, `Analyze (actions)`, `CodeQL`, and the four sweep checks.
- **No rendered text changed**, so no `assertIn`/`assertNotIn` grep was needed; the diff
  outside the two code lines is docstrings, comments, tests and news.

### One local failure, pre-existing and environmental

`test_frame_border_surface.TheRuleTakesTheSurfaceTheComponentsAgreeOn.test_this_planes_own_committed_frame_answers_the_report`
fails locally with `'bg=black' != 'bg=brightblack'`. It is **not from this branch** —
it fails identically on a clean `origin/main` checkout, and CI is green on `d9df038`.

Cause: that case is the one in the suite that reads the plane's *real* `config.FRAME`,
and `root.find_root` deliberately redirects a linked worktree to the tree it was cut from
(`_plane_of`). So an agent working in a worktree of this clone reads the **operator's live
plane**, whose `charter.toml` a running frame has rewritten in place (`bg` brightblack →
black, uncommitted). Confirmed: with `CHARTER_ROOT` pointed at the worktree's own
committed `charter.toml`, the module is 76/76 green. This is #726's blast radius one hop
wider than "it gets swept into a commit" — it also reddens a test for every agent working
in a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJucitN89LunSiQKeLHMYy
