### PR TITLE
The pull-request link charter prints names the forge it resolved, not a hostname found anywhere in the URL (code scanning #4)

### DIFF
--- a/charter/planegit.py
+++ b/charter/planegit.py
@@ -168,12 +168,16 @@ def _compare_url(https: str, branch: str, root) -> str | None:
     forge = registry.resolve_host(base, root)
     if forge is None:
         return None
+    if forge.kind not in ("github", "gitlab"):
+        # A kind registered after this was written. Stated rather than left to fall
+        # through the bottom of the function: falling through is the same `None`, but it
+        # is `None` by accident, and the accident sits one edit away from being the GitLab
+        # form handed to a forge that has no such page.
+        return None
     if forge.kind == "github":
         return f"{base}/compare/{branch}?expand=1"
-    if forge.kind == "gitlab":
-        # GitLab, and self-hosted GitLab, use the same new-MR form.
-        return (f"{base}/-/merge_requests/new?merge_request%5Bsource_branch%5D={branch}")
-    return None  # a kind registered later: no link beats a link to a form it does not have
+    # GitLab, and self-hosted GitLab, use the same new-MR form.
+    return (f"{base}/-/merge_requests/new?merge_request%5Bsource_branch%5D={branch}")
 
 
 #: What a push of the plane root's HEAD did, in one word. Recorded as well as printed —

--- a/charter/planegit.py
+++ b/charter/planegit.py
@@ -138,20 +138,42 @@ def _is_protected_rejection(stderr: str) -> bool:
     return any(s.lower() in blob for s in _PROTECTED_SIGNATURES)
 
 
-def _compare_url(https: str, branch: str) -> str | None:
+def _compare_url(https: str, branch: str, root) -> str | None:
     """A one-click "open a pull request for this branch" URL.
 
     A plain HTTPS link, deliberately: charter has no PR-creation capability in any forge
     adapter, and this closes the PR-gated workflow **without** adding one — no API call, no
     extra token scope, no new adapter surface.
+
+    Which form to build is decided by RESOLVING the forge (`registry.resolve_host`, the
+    same call `_origin_https` made one step earlier), never by looking for a hostname
+    inside the URL string. The check here used to be ``"github.com" in base``, which is
+    FINDING 1's bug in the one place FINDING 1 did not reach: a substring of the whole
+    URL matches in the *path* as readily as in the host. A self-hosted GitLab with a
+    ``mirrors/github.com/…`` namespace — an ordinary name for a mirror group — was handed
+    ``https://git.internal/mirrors/github.com/acme/plane/compare/…``, a form GitLab does
+    not serve, which is exactly the case the else-branch exists for. And because the line
+    charter prints is a link an operator clicks, a host that merely *contains* the literal
+    got a charter-blessed GitHub URL pointing at it.
+
+    Resolving also fixes the sibling the substring check could never get right: a declared
+    **GitHub Enterprise** host says nothing about github.com, so it used to be given
+    GitLab's new-MR form. A forge this plane does not recognise gets no link rather than a
+    guessed one — the same refusal `_origin_https` makes about the same URL.
     """
     base = (https or "").removesuffix(".git")
     if not base.startswith("https://"):
         return None
-    if "github.com" in base:
+    from .forge import registry
+    forge = registry.resolve_host(base, root)
+    if forge is None:
+        return None
+    if forge.kind == "github":
         return f"{base}/compare/{branch}?expand=1"
-    # GitLab, and self-hosted GitLab, use the same new-MR form.
-    return (f"{base}/-/merge_requests/new?merge_request%5Bsource_branch%5D={branch}")
+    if forge.kind == "gitlab":
+        # GitLab, and self-hosted GitLab, use the same new-MR form.
+        return (f"{base}/-/merge_requests/new?merge_request%5Bsource_branch%5D={branch}")
+    return None  # a kind registered later: no link beats a link to a form it does not have
 
 
 #: What a push of the plane root's HEAD did, in one word. Recorded as well as printed —
@@ -393,7 +415,7 @@ def _land_via_branch(root, https: str, cred: list, default_branch: str,
             for ln in tail.splitlines():
                 util.err("  " + ln)
         return PushResult(STRANDED, default_branch, detail=tail)
-    url = _compare_url(https, branch)
+    url = _compare_url(https, branch, root)
     if announce:
         util.ok(f"'{default_branch}' requires a pull request — pushed {branch} instead.")
         if url:

--- a/docs/news/unreleased-the-pull-request-link-names-the-forge-it-resolved.md
+++ b/docs/news/unreleased-the-pull-request-link-names-the-forge-it-resolved.md
@@ -1,0 +1,70 @@
+---
+version: unreleased
+headline: The pull-request link `charter save` prints is built from the forge charter resolved, not from a hostname it found somewhere in the URL
+security: true
+---
+
+**Affected: every release that has shipped `charter save`'s pull-request path. Fixed
+here.** Read the last section first if you run a self-hosted forge; if your plane's origin
+is github.com or gitlab.com, nothing you can see changes.
+
+When a plane's default branch is protected, `charter save` pushes the commit to
+`charter/<sha>` and prints one line you are meant to click:
+
+```
+• open it: https://…/compare/charter/abc?expand=1
+```
+
+Which form to build was decided by asking whether the string `github.com` appeared
+**anywhere in the remote URL**. That is the substring check `registry._host_of` was
+written to replace after it misresolved a remote whose *path* began `gitlab.com-` — the
+same bug, in the one place the earlier fix did not reach. GitHub's compare form and
+GitLab's new-MR form are different URLs, and the choice between them was being made by a
+string that a repository path can contain as easily as a hostname can.
+
+## What it actually did
+
+A self-hosted GitLab with a mirror namespace called `github.com` — an ordinary thing to
+call a group that mirrors GitHub — got GitHub's compare URL pointed at a GitLab host:
+
+```
+https://git.internal/mirrors/github.com/acme/plane/compare/charter/abc?expand=1
+```
+
+GitLab does not serve that. The operator, on a protected branch, following the one link
+charter gave them, landed on a 404 — which is precisely the case the other branch exists
+for. The commit was pushed and safe throughout; what was lost was the route to opening the
+pull request, in the workflow that has no other route.
+
+The reason this is filed as security rather than as a broken link is the direction the
+mistake runs in. The line is a **link charter blesses and an operator clicks**, and its
+host was being chosen by a string that appears in a part of the URL the host does not
+control. Charter now refuses to print a link for a remote it cannot resolve to a forge at
+all, rather than assembling a plausible one — the same refusal `_origin_https` already
+makes about the same URL, one call earlier.
+
+Two things bound how far that went, and they are worth stating rather than leaving you to
+work out: charter only reaches this line for a remote whose **host component** already
+resolved to a forge that is either a registered default or one your own `charter.toml`
+declares, and it declines entirely for anything that is not an `https://` remote. A host
+you have not declared never got a link and still does not.
+
+## What it does now
+
+The forge is **resolved** — `registry.resolve_host`, the call `_origin_https` makes on the
+same URL one step earlier — and the link is built from `forge.kind`. There is no hostname
+literal left in that function for a path to impersonate.
+
+Resolving instead of string-matching also fixes the sibling the old check could never have
+got right: a declared **GitHub Enterprise** host says nothing about `github.com`, so a GHE
+plane was handed GitLab's new-MR form. It gets its compare form now, for the first time.
+
+Unchanged, deliberately: self-hosted GitLab keeps the new-MR form it always had, and
+github.com and gitlab.com behave exactly as before.
+
+## If you run a self-hosted forge
+
+Nothing to adopt beyond upgrading. If `charter save` on a protected branch has been
+handing you a link that 404s, this is why, and it will now be the right one. If you run
+GitHub Enterprise, the link changes shape from a GitLab form to a GitHub one — that is the
+fix, not a regression.

--- a/tests/test_a_secret_guard_names_the_kind_not_the_value.py
+++ b/tests/test_a_secret_guard_names_the_kind_not_the_value.py
@@ -1,0 +1,253 @@
+"""The secret guards report the KIND, never the value — pinned at the source.
+
+Three code-scanning alerts (CodeQL `py/clear-text-logging-sensitive-data`, alerts #2 and
+#3) traced five flows from `hooks._secret_kind` to two printers: `hooks._emit`
+(`print(json.dumps(obj))`, which the harness reads and a transcript can keep) and
+`util.err` (`print(…, file=sys.stderr)`). Every one of them is a false positive, and they
+are all false for the SAME reason: `_secret_kind` answers with a label out of the
+`_SECRET_CHECKS` tuple — "AWS access key", "JWT" — and never with anything taken from the
+text it scanned. CodeQL cannot see that, because its heuristic classifies a value by the
+NAME of the function that produced it, and this one is called `_secret_kind`.
+
+The dismissal on those alerts points here, so the claim it rests on has to be checkable
+and has to stay true. What makes a guard like this dangerous is exactly the change that
+looks like an improvement — putting the offending line in the message so the author can
+find it — so the property is pinned where it would break, at the source, and again at
+each of the three real call sites that print the answer:
+
+  * `hooks._posttooluse_secret_scan`  → `_emit`, to the harness (alert #2)
+  * `planegit.commit_push`            → `util.err`, `charter save` (alert #3, flow 3)
+  * `commands_persona.cmd_persona_memory_sync` → `util.err` (alert #3, flows 0-2)
+
+The one place charter DOES print a secret value is `cmd_secret_reveal`, which is a
+different thing entirely: gated behind `--force`, traced before the write, and preceded by
+a warning. Nothing here is about that path.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+from charter import commands_persona, config, hooks, persona, planegit
+from charter.hooks import _SECRET_CHECKS, _secret_kind
+from tests._isolation import PersonaIso
+
+#: Two DIFFERENT live specimens per rule in `_SECRET_CHECKS`. Two, because one specimen
+#: only proves the answer is a label *this time*; a pair of them proves the answer does
+#: not vary with the input at all — which is the actual property, and the one a
+#: `f"{label}: {m.group(0)}"` "helpful" rewrite breaks.
+_SPECIMENS: tuple[tuple[str, str, str], ...] = (
+    ("AgentMail key",
+     "am_us_9f2ac41b8e0d4c7a",
+     "am_us_TTTTvvvv1111wwww"),
+    ("JWT",
+     "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9",
+     "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJib2IifQ"),
+    ("private key (PEM)",
+     "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA9x2\n",
+     "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEA\n"),
+    ("AWS access key",
+     "AKIAQ7VZ3RJHT2LMNPQR",
+     "AKIA5555XXXX8888YYYY"),
+    ("credential assignment",
+     'api_key = "sk-live-8Hq2Wm4Tz9Rb"',
+     "password: hunter2-not-a-real-one"),
+)
+
+_LABELS = tuple(label for label, _rx in _SECRET_CHECKS)
+
+
+class TestEverySpecimenIsActuallyDetected(unittest.TestCase):
+    """The fixture's own load-bearing assumption. A specimen that quietly stops matching
+    turns every assertion below into a statement about `None`, which is the failure mode
+    this repository keeps finding: a test that passes because it can no longer see the
+    thing it measures."""
+
+    def test_each_rule_has_two_specimens_that_hit_it(self):
+        self.assertEqual(len(_SPECIMENS), len(_SECRET_CHECKS),
+                         "a rule was added to _SECRET_CHECKS with no specimen here")
+        for expected, a, b in _SPECIMENS:
+            with self.subTest(expected):
+                self.assertEqual(_secret_kind(a), expected)
+                self.assertEqual(_secret_kind(b), expected)
+        self.assertIsNone(_secret_kind("an ordinary memo about routing coverage"))
+
+
+class TestTheKindIsALabelNotTheMatch(unittest.TestCase):
+    """The source property, and the whole basis of the dismissal on alerts #2 and #3."""
+
+    def test_the_answer_is_one_of_the_declared_labels(self):
+        for expected, a, b in _SPECIMENS:
+            for text in (a, b):
+                with self.subTest(expected, text=text[:12]):
+                    self.assertIn(_secret_kind(text), _LABELS)
+
+    def test_two_different_secrets_of_one_kind_give_the_identical_answer(self):
+        """The answer is a function of the RULE that matched, not of the text. This is
+        what fails the moment anyone splices the offending value into the label."""
+        for expected, a, b in _SPECIMENS:
+            with self.subTest(expected):
+                self.assertNotEqual(a, b)
+                self.assertEqual(_secret_kind(a), _secret_kind(b))
+
+    def test_no_part_of_the_secret_survives_into_the_answer(self):
+        for expected, a, b in _SPECIMENS:
+            for text in (a, b):
+                kind = _secret_kind(text)
+                for chunk in text.split():
+                    if len(chunk) < 6:
+                        continue
+                    with self.subTest(expected, chunk=chunk[:16]):
+                        self.assertNotIn(chunk, kind)
+
+    def test_surrounding_text_does_not_reach_the_answer(self):
+        """The scanned text is a whole memory file in the field, not a bare token."""
+        kind = _secret_kind(
+            "# Deploy notes\n\nThe prod runner uses AKIAQ7VZ3RJHT2LMNPQR for S3.\n")
+        self.assertEqual(kind, "AWS access key")
+        self.assertNotIn("AKIA", kind)
+        self.assertNotIn("prod runner", kind)
+
+
+class TestTheHookWarningCarriesNoValue(PersonaIso):
+    """Alert #2: `_emit` prints JSON the harness reads, so anything in that object can
+    land in a transcript."""
+
+    def _scan(self, body: str, name: str = "leak.md") -> str:
+        d = Path(config.ROOT) / "personas" / "qa" / "memory"
+        d.mkdir(parents=True, exist_ok=True)
+        fp = d / name
+        fp.write_text(body)
+        out = io.StringIO()
+        with redirect_stdout(out):
+            hooks._posttooluse_secret_scan({"content": body}, str(fp), "sess-1")
+        return out.getvalue()
+
+    def test_it_warns_at_all(self):
+        emitted = self._scan("aws key AKIAQ7VZ3RJHT2LMNPQR here\n")
+        self.assertIn("SECURITY", emitted)
+        self.assertIn("AWS access key", emitted)
+        self.assertIn("leak.md", emitted)
+
+    def test_the_emitted_object_holds_no_specimen(self):
+        for expected, a, b in _SPECIMENS:
+            for text in (a, b):
+                with self.subTest(expected, text=text[:12]):
+                    emitted = self._scan(f"a memo\n\n{text}\n")
+                    self.assertIn(expected, emitted)
+                    for chunk in text.split():
+                        if len(chunk) >= 6:
+                            self.assertNotIn(chunk, emitted)
+
+    def test_what_it_emits_is_one_json_object_naming_the_kind(self):
+        emitted = self._scan('token = "gh-p-Zq81LmVw03Rk"\n')
+        obj = json.loads(emitted)
+        blob = json.dumps(obj)
+        self.assertIn("credential assignment", blob)
+        self.assertNotIn("gh-p-Zq81LmVw03Rk", blob)
+
+    def test_a_clean_memory_file_emits_nothing(self):
+        self.assertEqual(self._scan("a durable fact about routing coverage\n"), "")
+
+
+def _git(root, *a):
+    return subprocess.run(["git", "-C", str(root), *a], stdout=subprocess.PIPE,
+                          stderr=subprocess.DEVNULL, text=True)
+
+
+class TestTheSaveRefusalCarriesNoValue(PersonaIso):
+    """Alert #3, flow 3: `charter save`'s own guard, which prints through `util.err`."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        self.root = Path(config.ROOT)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.root)],
+                       check=True, capture_output=True)
+        _git(self.root, "config", "user.email", "t@e")
+        _git(self.root, "config", "user.name", "t")
+        (self.root / "seed").write_text("x\n")
+        _git(self.root, "add", "-A")
+        _git(self.root, "-c", "commit.gpgsign=false", "commit", "-qm", "seed")
+        _git(self.root, "remote", "add", "origin", "https://github.com/acme/plane.git")
+
+    def _save_with(self, body: str) -> tuple[int, str]:
+        d = self.root / "personas" / "qa" / "memory"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "leak.md").write_text(body)
+        err = io.StringIO()
+        with redirect_stderr(err), redirect_stdout(io.StringIO()):
+            rc = planegit.commit_push(self.root, ["add", "personas"], "m", no_push=True)
+        return rc, err.getvalue()
+
+    def test_it_refuses_and_names_the_kind_and_the_file(self):
+        rc, err = self._save_with("aws key AKIAQ7VZ3RJHT2LMNPQR here\n")
+        self.assertEqual(rc, 1)
+        self.assertIn("AWS access key", err)
+        self.assertIn("personas/qa/memory/leak.md", err)
+
+    def test_the_refusal_holds_no_specimen(self):
+        for expected, a, b in _SPECIMENS:
+            for text in (a, b):
+                with self.subTest(expected, text=text[:12]):
+                    rc, err = self._save_with(f"a memo\n\n{text}\n")
+                    self.assertEqual(rc, 1)
+                    self.assertIn(expected, err)
+                    for chunk in text.split():
+                        if len(chunk) >= 6:
+                            self.assertNotIn(chunk, err)
+
+
+class TestTheMemorySyncRefusalCarriesNoValue(PersonaIso):
+    """Alert #3, flows 0-2: the same refusal on `charter persona memory-sync`, which is
+    the path the SessionStart hook actually tells an agent to use.
+
+    `PersonaIso` rather than a hand-rolled `config.use` + restore. This module sorts near
+    the front of discovery, so a restore that re-derives instead of putting back exactly
+    what it took would hand the rest of the run a config nobody wrote — the failure the
+    base class's own docstring is mostly about."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        root = Path(config.ROOT)
+        _git(root, "init", "-q")
+        _git(root, "config", "user.email", "t@t")
+        _git(root, "config", "user.name", "t")
+        _git(root, "config", "commit.gpgsign", "false")
+        d = config.PERSONAS_DIR / "qa"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "persona.md").write_text("---\nname: qa\nrole: QA\nvault: qa\n---\n\n# QA\n")
+        persona.scaffold_memory("qa")
+        _git(root, "add", "personas")
+        _git(root, "commit", "-q", "-m", "init")
+
+    class _Args:
+        no_push = True
+
+    def _sync_with(self, body: str) -> tuple[int, str]:
+        persona.remember("qa", body, title="leak")
+        err = io.StringIO()
+        with redirect_stderr(err), redirect_stdout(io.StringIO()):
+            rc = commands_persona.cmd_persona_memory_sync(self._Args())
+        return rc, err.getvalue()
+
+    def test_it_refuses_and_names_the_kind(self):
+        rc, err = self._sync_with("aws key AKIAQ7VZ3RJHT2LMNPQR here")
+        self.assertEqual(rc, 1)
+        self.assertIn("AWS access key", err)
+
+    def test_the_refusal_holds_no_specimen(self):
+        rc, err = self._sync_with('the api_key = "sk-live-8Hq2Wm4Tz9Rb" lives here')
+        self.assertEqual(rc, 1)
+        self.assertIn("credential assignment", err)
+        self.assertNotIn("sk-live-8Hq2Wm4Tz9Rb", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_save_pr_gated.py
+++ b/tests/test_save_pr_gated.py
@@ -18,7 +18,9 @@ only a different *remote* ref for a commit that already exists locally.
 from __future__ import annotations
 
 import io
+import shutil
 import subprocess
+import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -163,18 +165,73 @@ class TestItOnlyFiresOnARecognisedRefusal(SaveCase):
 
 
 class TestCompareUrls(unittest.TestCase):
+    """FINDING 1's last unfixed site (CodeQL `py/incomplete-url-substring-sanitization`,
+    alert #4). `_compare_url` chose between the GitHub compare form and the GitLab
+    new-MR form with ``"github.com" in base`` — a substring of the WHOLE url, the exact
+    check `registry._host_of` was written to replace after it misresolved
+    ``git@git.internal:gitlab.com-mirror/api.git``. The link is printed for the operator
+    to click, so a self-hosted GitLab whose path merely contains ``github.com`` (a
+    ``mirrors/github.com/…`` namespace is an ordinary thing to call a mirror group) was
+    handed a GitHub URL against a GitLab host: a 404 where the whole point of the
+    else-branch is that self-hosted GitLab keeps working.
+
+    The forge is now RESOLVED, not string-matched — same primitive `_origin_https`
+    already used one call earlier — so there is no hostname literal left for a path to
+    impersonate, and a declared GitHub Enterprise host gets its compare form for the
+    first time."""
+
+    def _root(self, toml: str = "schema = 1\n") -> Path:
+        d = Path(tempfile.mkdtemp(prefix="charter-cmpurl-"))
+        self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
+        (d / "charter.toml").write_text(toml)
+        return d
+
     def test_github(self):
         self.assertEqual(
-            planegit._compare_url("https://github.com/acme/plane.git", "charter/abc"),
+            planegit._compare_url("https://github.com/acme/plane.git", "charter/abc",
+                                  self._root()),
             "https://github.com/acme/plane/compare/charter/abc?expand=1")
 
     def test_gitlab(self):
-        url = planegit._compare_url("https://gitlab.com/acme/plane.git", "charter/abc")
+        url = planegit._compare_url("https://gitlab.com/acme/plane.git", "charter/abc",
+                                    self._root())
         self.assertIn("/-/merge_requests/new", url)
         self.assertIn("charter/abc", url)
 
     def test_an_unknown_scheme_yields_nothing_rather_than_a_guess(self):
-        self.assertIsNone(planegit._compare_url("git@github.com:acme/plane.git", "b"))
+        self.assertIsNone(
+            planegit._compare_url("git@github.com:acme/plane.git", "b", self._root()))
+
+    def test_a_self_hosted_gitlab_keeps_the_mr_form_when_its_path_says_github_com(self):
+        """The live reproduction: a mirror namespace called `github.com` on a declared
+        self-hosted GitLab. Substring-matching sent the operator to `<gitlab>/compare/…`,
+        which GitLab does not serve."""
+        root = self._root('schema = 1\n[[forge]]\nkind = "gitlab"\n'
+                          'host = "git.internal"\ngroup = "acme"\n')
+        url = planegit._compare_url(
+            "https://git.internal/mirrors/github.com/acme/plane.git", "charter/abc", root)
+        self.assertIn("/-/merge_requests/new", url)
+        self.assertNotIn("/compare/", url)
+
+    def test_a_host_that_only_ends_with_github_com_is_not_github(self):
+        """`https://github.com.evil.example/…` and `https://evil.example/github.com/…`
+        both matched the substring. Neither is a forge this plane declares, so the honest
+        answer is no link at all — never a charter-blessed one pointing off-host."""
+        for url in ("https://github.com.evil.example/x/y.git",
+                    "https://evil.example/github.com/y.git",
+                    "https://notgithub.com/x/y.git"):
+            with self.subTest(url=url):
+                self.assertIsNone(planegit._compare_url(url, "b", self._root()))
+
+    def test_a_declared_github_enterprise_host_gets_the_compare_form(self):
+        """The other half of resolving instead of string-matching: GHE is a `github`
+        forge whose host says nothing about github.com, and it used to be handed
+        GitLab's new-MR form."""
+        root = self._root('schema = 1\n[[forge]]\nkind = "github"\n'
+                          'host = "ghe.internal"\nowner = "acme"\n')
+        self.assertEqual(
+            planegit._compare_url("https://ghe.internal/acme/plane.git", "charter/abc", root),
+            "https://ghe.internal/acme/plane/compare/charter/abc?expand=1")
 
 
 if __name__ == "__main__":

--- a/tests/test_save_pr_gated.py
+++ b/tests/test_save_pr_gated.py
@@ -24,8 +24,10 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest import mock
 
 from charter import config, planegit
+from charter.forge import registry as planegit_registry
 from tests._isolation import PersonaIso
 
 
@@ -222,6 +224,18 @@ class TestCompareUrls(unittest.TestCase):
                     "https://notgithub.com/x/y.git"):
             with self.subTest(url=url):
                 self.assertIsNone(planegit._compare_url(url, "b", self._root()))
+
+    def test_a_forge_kind_this_function_predates_gets_no_link(self):
+        """Only two kinds are registered today, so the third-kind branch is unreachable
+        from a config file and would otherwise be an untested line that reads as covered.
+        A third kind must not inherit GitLab's URL by being last in the if-chain: that is
+        a link to a page the forge does not have, printed as though charter knew."""
+        class _Later:
+            kind, host = "bitbucket", "bitbucket.example"
+        with mock.patch.object(planegit_registry, "resolve_host", return_value=_Later()):
+            self.assertIsNone(
+                planegit._compare_url("https://bitbucket.example/a/b.git", "x",
+                                      self._root()))
 
     def test_a_declared_github_enterprise_host_gets_the_compare_form(self):
         """The other half of resolving instead of string-matching: GHE is a `github`


### PR DESCRIPTION
GitHub code scanning opened four High-severity alerts on `main`. This lands one code fix
and the evidence for three dismissals. Every alert ends in exactly one state — **fixed
with a test that fails without it**, or **dismissed with a written reason** — and nothing
here is silenced by renaming a variable or by a suppression comment.

| Alert | Rule | Disposition |
|---|---|---|
| [#4](https://github.com/diazoxide/charter/security/code-scanning/4) | `py/incomplete-url-substring-sanitization` | **Fixed** — `planegit._compare_url` |
| [#3](https://github.com/diazoxide/charter/security/code-scanning/3) | `py/clear-text-logging-sensitive-data` | **Dismissed** — false positive, pinned by a new test |
| [#2](https://github.com/diazoxide/charter/security/code-scanning/2) | `py/clear-text-logging-sensitive-data` | **Dismissed** — false positive, same test |
| [#1](https://github.com/diazoxide/charter/security/code-scanning/1) | `py/clear-text-storage-sensitive-data` | **Dismissed** — false positive, a `Path` named `secret` |

## Alert #4 — fixed

`_compare_url` chose between GitHub's compare form and GitLab's new-MR form with
`"github.com" in base` — a substring of the **whole** URL. That is FINDING 1's bug in the
one place FINDING 1 did not reach: `registry._host_of` exists precisely because a known
host string matches in the *path* as readily as in the host, after
`git@git.internal:gitlab.com-mirror/api.git` misresolved.

Reproduced against the shipped function before anything was changed:

```
_compare_url("https://git.corp.example/mirrors/github.com/acme/plane.git", "b")
  -> 'https://git.corp.example/mirrors/github.com/acme/plane/compare/b?expand=1'
```

A self-hosted GitLab with a `mirrors/github.com/…` namespace — an ordinary name for a
mirror group — got a GitHub URL against a GitLab host, i.e. a 404 in exactly the case the
else-branch exists to serve. And the line is a **link charter prints for the operator to
click**, so its host was being chosen by a string that lives in a part of the URL the host
does not control.

**The forge is now resolved, not string-matched** — `registry.resolve_host`, the same call
`_origin_https` makes on the same URL one step earlier — and the branch is on `forge.kind`.
No hostname literal is left in that function for a path to impersonate. A remote that
resolves to no forge gets no link rather than a guessed one, matching `_origin_https`'s own
refusal.

Resolving also fixes the sibling the substring check could never have got right: a declared
**GitHub Enterprise** host says nothing about github.com, so GHE was being handed GitLab's
new-MR form. It gets its compare form now.

Seven cases in `TestCompareUrls`. Reverting the whole branch back to `"github.com" in base`
fails **6 of the 7**, including two that already existed; restoring the fix returns all seven
to green.

The second commit is about the shape rather than the behaviour: the first cut ended the
function with a bare `return None`, which deletes to an identical function — an equivalent
mutant, and `tools/sweep.py`'s own rule is that "equivalent mutant" and "dead code" are one
finding. Hoisted to `if forge.kind not in ("github", "gitlab")` ahead of both branches,
which makes the deletion observable (a third kind would otherwise inherit GitLab's URL by
being last in the chain) and testable by patching `resolve_host` to hand back a
`kind = "bitbucket"` forge.

Every line this branch adds to `charter/planegit.py` was then mutated by hand, `python3 -B`
with `__pycache__` cleared: the `forge is None` guard (3 errors), the unknown-kind guard
(1 failure), the github branch (3), the gitlab return (2), `"github"` → `"gitlab"` (5).
All killed.

### One correction to the scouting this started from

The reachable defect is the **path** substring, not a hostile host. `https://github.com.evil.com/x`
cannot reach `_compare_url`: `_origin_https` only returns a URL whose **host component**
already resolved through `registry.resolve_host`, which matches `host in declared` /
`.get(host)` — an exact host-component match, not a substring — so an undeclared host
returns `None` and the whole PR path is skipped. Reaching `_compare_url` with an
attacker-chosen host requires that host to be declared as a `[[forge]]` in the plane's own
`charter.toml`, at which point charter is already pushing credentials to it, which is a
larger and separately-gated problem. The bug that bites a real plane today is the mirror
namespace above.

## Alerts #2 and #3 — dismissed, and pinned so the dismissal stays true

Five flows between them, and the SARIF shows all five start at the same place:
`hooks._secret_kind`, reached from `hooks._posttooluse_secret_scan` (to `_emit`),
`commands_persona.cmd_persona_memory_sync` and `planegit.commit_push` (both to `util.err`).

`_secret_kind` returns a **label out of the `_SECRET_CHECKS` tuple** — "AWS access key",
"JWT", "credential assignment" — and never any part of the text it scanned. The section
header above it in `hooks.py` already says so: *"secret detection (shared): report the
KIND, never the value"*. CodeQL flags it because its sensitive-data heuristic classifies a
value by the **name of the function that produced it**, and this one is called
`_secret_kind`.

A dismissal that rests on a code-reading is only as good as the next edit, and the edit
that breaks this is the one that looks like an improvement — putting the offending line in
the message so the author can find it. So the property is pinned, at the source and at all
three sinks: `tests/test_a_secret_guard_names_the_kind_not_the_value.py`.

Verified by hand mutation rather than assumed, `python3 -B` with `__pycache__` cleared:

* `_secret_kind` returning `f"{label}: {m.group(0)}"` → **60 failures**.
* Leaving `_secret_kind` clean and splicing the value into the two sink messages instead
  (`_posttooluse_secret_scan`'s `additionalContext`, and `commit_push`'s per-file
  `util.err` line) → **21 failures**.

The fixture also asserts its own premise — that each specimen still matches the rule it is
there for — because a specimen that quietly stops matching turns every other assertion in
the file into a statement about `None`.

### Also checked, and refuted

The starting hypothesis for #3 was `commands_secrets.py`'s `util.err(str(e))` on a
`base.VaultError`, on the theory that a provider might put the secret **value** into an
exception message. That is not where CodeQL points — `commands_secrets.py` appears in none
of the five flows — and it does not happen: every `VaultError` construction in `charter/`
was read, and none interpolates a stored value. The two that handle text which *could*
contain one withhold it explicitly, with a comment saying why —
`onepassword._fail` ("charter withholds op's output because it can contain the secret",
and `_diagnose` returns a fixed string per signature, never interpolating stderr) and
`reference.py`'s resolver timeout ("Resolver output withheld — it can contain the
secret").

`cmd_secret_reveal`, which writes plaintext to stdout on purpose behind `--force` and after
`_trace_secret_use`, was **not** flagged by any of the four alerts and is untouched.

## Alert #1 — dismissed

`tests/test_state_migration.py`. The source CodeQL names is line 45,
`secret = legacy / "vaults" / "devops.json"` — a `Path`, sensitive to the query only
because the variable is called `secret`. The flagged sink at line 50 writes
`str(secret)` — the **filesystem path** — into a vault-registry fixture inside a
`TemporaryDirectory` the case removes. The only value written anywhere here is the literal
`{"k":"v"}` on line 46, and the fixture exists to prove that migration keeps a vault file
at mode 0600 and repoints the registry that names it.

Not renamed. Renaming the variable would make the alert disappear without answering it,
which is the worse outcome.

## Verification

* Full suite, `python3 -m unittest discover -s tests`, run in a **pristine clone of this
  branch** rather than in a worktree. That is not fussiness: a linked worktree resolves its
  plane back to the tree it was cut from (`root._plane_of`), so the suite reads the
  operator's *uncommitted* `charter.toml`, and
  `test_frame_border_surface.test_this_planes_own_committed_frame_answers_the_report` — a
  case whose whole subject is that file — fails on a locally-edited `bg`. It passes on a
  clean clone of `main` too, so it is the harness and not this branch.
* `TestCompareUrls`: 5 cases fail when the branch condition is reverted to
  `"github.com" in base`; every added line in `_compare_url` dies to hand mutation.
* `test_a_secret_guard_names_the_kind_not_the_value`: 60 and 21 failures under the two
  hand mutations above; green with both reverted.
* News entry: `docs/news/unreleased-the-pull-request-link-names-the-forge-it-resolved.md`,
  `security: true`.
* Deletion sweep: **`no survivors`** — and the count is stated rather than trusted, because a
  sweep that planned zero mutations says the same thing (#782). It planned **6**, all in
  `charter/planegit.py`, and all 6 came back `pinned`: the `forge is None` refusal, the
  unknown-kind refusal, the github branch, and retunes of the `"github"` and `"gitlab"`
  literals. `gate: 0 unpinned, 0 unresolved, 0 withheld, 6 pinned`, over a baseline of
  `Ran 9504 tests — OK`.

Alerts #1, #2 and #3 are dismissed on the alert itself with the reasoning above; #4 closes
when this merges.
