### PR TITLE
The sweep charges you for your own lines, says when it measured nothing, and stops reporting its own runaway mutants as a dead runner (#776, #782, #773)

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -18,11 +18,12 @@ name: deletion sweep
 # repository rather than read out of the documentation:
 #
 #   * **The two events sweep different trees.** On `pull_request`, `github.sha` is the merge
-#     commit and `--base` is the pull request's base sha — the tree that will land. A `push`
-#     run has neither: `BASE_SHA` is empty, so `sweep.py` takes its own default of the
-#     merge-base with `origin/main` and charges the branch TIP. Both answers are defensible.
-#     They are not the same answer, and under `push:` they would arrive on the same pull
-#     request under the same check names.
+#     commit — the tree that will land — and the sweep charges it against its merge-base
+#     with `origin/main`, which for a merge commit is the base branch tip it was merged
+#     into. A `push` run has no merge commit: the same default charges the branch TIP
+#     against where it was cut from. Both answers are defensible. They are not the same
+#     answer, and under `push:` they would arrive on the same pull request under the same
+#     check names.
 #   * **That is what makes it worse rather than better.** The remedy #646 settles on is to
 #     require this workflow's `collect` job, so that a missing row BLOCKS instead of passing
 #     silently. The moment `push:` can also produce that check, its presence stops proving
@@ -102,6 +103,11 @@ jobs:
       mutations: ${{ steps.size.outputs.mutations }}
       shards: ${{ steps.size.outputs.shards }}
       matrix: ${{ steps.size.outputs.matrix }}
+      # The sha the mutations were actually read against, resolved by the tool from the
+      # tree it swept. The merge step runs at `fetch-depth: 1` on its own machine, where
+      # neither `HEAD^` nor `origin/main` is an object it has, so it cannot work this out
+      # and must be told — and the value it used to be told was the one #776 is about.
+      base: ${{ steps.size.outputs.base }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -129,25 +135,39 @@ jobs:
         with:
           path: ${{ runner.temp }}/sweep/cache
           key: sweep-map-${{ hashFiles('charter/**/*.py', 'tests/**/*.py') }}
+      # **No `--base`, and `github.event.pull_request.base.sha` is refused by name (#776).**
+      #
+      # That field is the payload's idea of where the branch started, and it is not the
+      # tree `actions/checkout` just put on disk. Measured, from run 33331151759's own log
+      # rather than from documentation:
+      #
+      #     HEAD is now at 58411a9 Merge 04bf8e6 into c29f3a8
+      #     diff against d40d998e06bd: 3 file(s), 458 added line(s)
+      #
+      # The checkout merged the branch into `c29f3a8`; the payload said the base was
+      # `d40d998`, three commits and three hours earlier. So the sweep charged that branch
+      # for `d40d998..c29f3a8` — main's own commits, one of them a nine-file `charter
+      # save` — and reported **3 files** for a branch that touches exactly one Python file.
+      # A survivor in a file the author has never opened destroys the one premise this
+      # gate runs on, which is that a survivor is YOUR untested line.
+      #
+      # The tool's own default is already the right answer and always was: the merge-base
+      # of the checked-out merge commit with `origin/main` **is** that merge's first
+      # parent, because nothing later than the first parent is reachable from the merge.
+      # `fetch-depth: 0` above fetches `+refs/heads/*`, so `origin/main` is there to ask.
+      # On a manual dispatch there is no merge commit and no base sha either, and the same
+      # default gives the branch tip's merge-base — which is what that run wants.
+      #
+      # The over-charge also multiplies #773: a longer plan is more shards, and more
+      # shards spread the runaway mutations across more of them. Three of six shards died
+      # on the over-charged plan where the same branch on a correct one lost one of five.
       - name: How many mutations, and how many jobs they need
         id: size
-        env:
-          # Through the environment and not interpolated into the script. A `${{ }}` inside
-          # `run:` is textual substitution before bash ever sees it, which is how a value
-          # somebody else controls becomes a command; the same rule `release.yml` follows.
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
-          # No --base on a manual dispatch: with no pull request there is no base sha, and
-          # the tool's own default (the merge-base with origin/main) is the right answer.
-          if [ -n "${BASE_SHA:-}" ]; then
-            set -- --base "$BASE_SHA"
-          else
-            set --
-          fi
           python3 tools/sweep.py --plan --warm-map --jobs 4 \
             --workdir "$RUNNER_TEMP/sweep" \
-            --github-output "$GITHUB_OUTPUT" "$@"
+            --github-output "$GITHUB_OUTPUT"
 
   # ------------------------------------------------------------------------------------
   # 2. The sweep itself, on as many machines as the plan asked for.
@@ -183,22 +203,23 @@ jobs:
       # answer and must never write a page that looks like the answer: five partial
       # tables on one pull request is the same defect #617 is about, arriving five times.
       # The merge step below is the only thing that tells this branch anything.
+      # No `--base` here either, and for a stronger reason than in `plan`: a shard's
+      # slice is `shard_of` over the whole plan, so a shard that charged a different base
+      # would deal a different plan and sweep a slice nobody asked for — while the merge
+      # step added the pieces up and reported a complete sweep. The two jobs agree because
+      # they ask the same question of the same tree: `github.sha` is fixed for the run, so
+      # both check out the same merge commit, and its merge-base with a fast-forward-only
+      # `main` cannot move while the run is going.
       - name: Sweep the guards this branch adds
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           SHARD: ${{ matrix.shard }}
           SHARDS: ${{ needs.plan.outputs.shards }}
         run: |
           set -euo pipefail
-          if [ -n "${BASE_SHA:-}" ]; then
-            set -- --base "$BASE_SHA"
-          else
-            set --
-          fi
           python3 tools/sweep.py --gate --jobs 4 \
             --shard "$SHARD/$SHARDS" \
             --workdir "$RUNNER_TEMP/sweep" \
-            --json "sweep-results-$SHARD.json" "$@"
+            --json "sweep-results-$SHARD.json"
       - name: Keep the result set, whatever the sweep said
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -302,7 +323,12 @@ jobs:
           # is the tree they actually swept. Naming the branch head on a page about the
           # merge result would be one sha out on every run with a moving base.
           SWEPT_SHA: ${{ github.sha }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          # From the job that resolved it, and never from the pull request payload (#776).
+          # This step is a page header away from the sweep itself, and a header naming a
+          # base the mutations were not read against is the quietest way for the two to
+          # drift apart again. Empty when `plan` did not finish, which `--base` renders as
+          # "merge-base" rather than as a sha nobody charged.
+          BASE_SHA: ${{ needs.plan.outputs.base }}
         run: |
           set -euo pipefail
           # `--enforce` is the one flag that makes any of this block a merge, and it is

--- a/docs/news/unreleased-the-sweep-stops-reporting-things-that-are-not-true.md
+++ b/docs/news/unreleased-the-sweep-stops-reporting-things-that-are-not-true.md
@@ -1,0 +1,115 @@
+---
+version: unreleased
+headline: The deletion sweep charges you for your own lines, says when it measured nothing, and stops reporting its own runaway mutants as a dead runner
+---
+
+Three things the sweep said that were not true. They are one change because they interact:
+the first makes the third worse, and the second is the one that reads best while saying
+least.
+
+## It charged your branch for `main`'s lines (#776)
+
+The workflow told the tool where the branch started by passing
+`github.event.pull_request.base.sha`. That field is the payload's record of where the
+branch started; it is **not** the tree `actions/checkout` puts on disk. Measured, from one
+run's own log rather than from documentation:
+
+```
+HEAD is now at 58411a9 Merge 04bf8e6 into c29f3a8
+diff against d40d998e06bd: 3 file(s), 458 added line(s)
+```
+
+The checkout merged the branch into `c29f3a8`. The payload said `d40d998` — three commits
+and three hours earlier — so the sweep charged that branch for `d40d998..c29f3a8`, which is
+`main`'s own work, one commit of it a nine-file `charter save`. A branch touching exactly
+one Python file was swept for three, and on another run of the same branch the plan grew
+from 118 mutations to 149 and reported a survivor in `charter/frame/state.py`, a file that
+branch never opened.
+
+**A survivor in somebody else's file is not a smaller finding, it is a different branch's
+finding**, and it destroys the premise the whole gate runs on — that a survivor is *your*
+untested line.
+
+The fix is a deletion. The tool's own default was already exact and always had been: the
+merge-base of a merge commit with `origin/main` **is** that merge's first parent, because
+nothing later than the first parent is reachable from the merge. The workflow now passes no
+base at all and lets the tool resolve it, the sizing job publishes the sha it charged so
+the summary page names the same one, and `tests/test_sweep.py` refuses
+`pull_request.base.sha` by name in any `env:` of the file — so the one-line convenience
+meets an assertion rather than a reviewer.
+
+**Every shard is re-dealt by this.** `shard_of` deals the plan round-robin, so a shorter
+plan puts different mutations on different machines. Nothing is dropped and nothing is
+added; the membership simply moves, which is why this lands on its own.
+
+## It said `no survivors` for a branch it never measured (#782)
+
+`no survivors: pass`, published beside `mutations applied: 0`. The branch's one added
+statement offered no operator anything to mutate, so the plan was empty and the gate passed
+having measured nothing — in the exact words of a gate that measured everything and found
+nothing wrong.
+
+That is the last of the four ways this gate could let silence read as success. A green tick
+that was not "no survivors" was the first; a check name that carries the verdict, because
+GitHub's conclusions cannot, was the second; a run that never happened and so had no row at
+all was the third. **This one is the most misleading of the four**, because nothing looks
+wrong: the row is there, the job succeeded, and the sentence is affirmative.
+
+There is now a fourth verdict beside the other three:
+
+```
+no survivors                     N mutations, none survived
+nothing to sweep                 0 mutations planned          <- new
+no verdict: 2 of 5 shards …      the run could not answer
+```
+
+**It does not fail.** A docs commit, a config key, a news entry and a one-line reordering
+all land here, they are all legitimate, and failing them would teach people to route around
+the gate — which is worse than a gate that says too little. It says what happened instead,
+in the check's name, in the run summary and in the terminal report, and the summary says in
+as many words that the page is not evidence the branch is tested.
+
+`nothing to sweep` can never be worn by a run that lost a shard: a missing shard is asked
+about first and still answers `no verdict`.
+
+## A mutant could eat the runner, and the report blamed the pool (#773)
+
+The sweep bounds what a mutation may spend in **time**, and a timeout cannot save a runner
+that has already been consumed — the timer and the process die together. Enumerating every
+mutation one branch offered, 118 of them, under a wall clock: **four never terminate, and
+three of those allocate on every pass.** The fastest grows at **4,274 MB/min**, which
+exhausts a 16 GB runner in under four minutes against a 900 s cap. The shard then reports
+
+```
+##[error]The runner has received a shutdown signal…
+##[error]Process completed with exit code 143.
+```
+
+which is byte-for-byte a spot reclaim. On the run that was measured, the one shard holding a
+memory-eater was the one shard that died — and the shard that drew the mutation which spins
+*without* allocating survived on the timeout, which is the control that makes it more than
+a coincidence. Nobody reading `no verdict: 1 of 5 shards did not report` would suspect the
+branch's own mutants; the natural reading is "flaky pool, re-run it", which reproduces the
+same failure on the same slice. It cost three runs before the shape was suspected.
+
+Every run now gets an address-space cap — one share of the machine per sandbox and one left
+over, floored at the 2 GiB the suite was measured to need. A mutant that crosses it raises
+`MemoryError` in the child: a red, on tests that were green unmutated, which the tool reads
+as a **pin**. That is the correct verdict for a mutation that destroys the apparatus, and it
+replaces a verdict that was not about the branch at all.
+
+The baseline runs under the same cap as the mutants, deliberately: a cap the mutants have
+and the baseline does not could only ever manufacture a red the baseline never had.
+
+**Two things that were tried and rejected, both measured rather than reasoned about.**
+Setting the limit with `resource.setrlimit` in a `preexec_fn` — the obvious form — *raises*
+on macOS, and a `preexec_fn` that raises surfaces as an error in the parent, so it would
+have made every mutation on a macOS machine fail to run at all. And a static "does this
+mutant contain a runaway loop" check fails in the fail-open direction: the fastest of the
+four leaves every loop inside its own function terminating and corrupts a cursor returned
+*across* a function boundary, so the caller is what spins. Any scanner, tokenizer or parser
+is mostly made of functions like that.
+
+macOS enforces no address-space limit at all, so the sweep measures once whether the
+platform takes one and says which it got, in the log, rather than wrapping every run in a
+shell that does nothing.

--- a/docs/superpowers/specs/2026-08-27-deletion-sweep-harness.md
+++ b/docs/superpowers/specs/2026-08-27-deletion-sweep-harness.md
@@ -126,11 +126,12 @@ asserts too little. The harness should surface *what the test asserted* alongsid
 the reviewer's first question is "did my test look closely enough" rather than "can I suppress
 this".
 
-## Five ways a sweep lies, all measured here
+## Six ways a sweep lies, all measured here
 
 The first four make a mutation score **pinned** when it is not — the worst failure this tool can
 have and the hardest to notice, because the report comes back green. The fifth lies in the
-**other** direction, which is why it took longest to find.
+**other** direction, which is why it took longest to find. The sixth does not produce a wrong
+answer at all: it destroys the apparatus, and the wreckage is charged to somebody else.
 
 1. **Exit-code scoring.** Deleting `release.yml`'s `-z "$claimed"` refusal (#558) left the run
    still exiting 1 — the mismatch check below it caught the empty string instead. Same code,
@@ -163,7 +164,30 @@ have and the hardest to notice, because the report comes back green. The fifth l
    **Every mutation must assert that it actually applied.** A verdict from an edit that did not
    happen is not a verdict.
 
-None of the five is visible from outside. Together they are the argument for why this harness
+6. **A mutation that consumes the machine.** #4's answer is a timeout, and a timeout cannot save
+   a runner that has already been eaten: the timer and the process die together. Measured on
+   #710 — of its 118 mutations, **four never terminate and three of those allocate on every
+   pass**, the fastest at **4,274 MB/min**, which exhausts a 16 GB runner in under four minutes
+   against a 900 s cap. The shard reports `exit 143` and *"The runner has received a shutdown
+   signal"*, byte-for-byte a spot reclaim, so the gate charges it to infrastructure and the
+   mutations in that slice are silently never measured. On run 33331151759 the one shard holding
+   a memory-eater is the one shard that died; the shard that drew the mutation which spins
+   **without** allocating survived on the timeout, which is the control.
+
+   This is the only one of the six whose distinguishing property is that the mutant takes the
+   *measuring apparatus* with it rather than producing a wrong answer — and the only one that
+   compounds, because the natural reading of `exit 143` is "flaky pool, re-run it", which
+   reproduces the same failure on the same slice.
+
+   **Bound it, do not predict it.** A static "does this mutant contain a runaway loop" check
+   fails in the fail-open direction and that was measured too: the fastest of the four leaves
+   every loop inside its own function terminating, and corrupts a **cursor returned across a
+   function boundary** so that the *caller* spins. Any scanner, tokenizer or parser is mostly
+   made of functions like that. Every child gets an address-space cap instead, and a mutant that
+   crosses it raises `MemoryError` — a red, on tests that were green unmutated, which is a
+   **pin**, the correct verdict for a mutant that destroys the process.
+
+None of the six is visible from outside. Together they are the argument for why this harness
 needs its own tests and its own sweep rather than being trusted because it is short: a gate that
 silently passes everything is worse than no gate, because it is *believed*.
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -17,6 +17,7 @@ import io
 import json
 import os
 import re
+import resource
 import subprocess
 import sys
 import tempfile
@@ -566,14 +567,26 @@ class TheStringShape(unittest.TestCase):
     def test_a_withheld_verdict_gets_its_own_bucket_and_fails_nothing(self):
         """Its own bucket and not `unresolved`: the two say opposite things about what
         the tool knows, and a deliberate subtraction that rendered as a timeout is how a
-        branch comes to sit behind a `no verdict` no re-run can clear (#693)."""
+        branch comes to sit behind a `no verdict` no re-run can clear (#693).
+
+        **Beside the verdict and never instead of it** (#698) — so the case needs a
+        measured mutation to sit beside, and it used to have none. A gate holding one
+        withheld mutation and nothing else measured *nothing*, and #782 gives that its own
+        sentence: the aside is the same either way, and the verdict in front of it is the
+        honest one in both.
+        """
         m = sweep.Mutation(path="p.py", line=1, end_line=1, operator="retune-string",
                            question="q", before="a", after="b", symbol="f",
                            withheld="not a pattern")
-        gate = sweep.classify([sweep.Result(m, "withheld", None, None, [], None)])
+        held = sweep.Result(m, "withheld", None, None, [], None)
+        gate = sweep.classify([held, _result("pinned")])
         self.assertEqual(len(gate.withheld), 1)
         self.assertEqual((gate.unresolved, gate.unapplied, gate.actionable), ([], [], []))
         self.assertEqual(sweep.headline(gate), "no survivors, 1 withheld")
+        # And on its own it is not a clean sweep of anything — nothing was measured.
+        alone = sweep.classify([held])
+        self.assertEqual(sweep.gate_conclusion(alone), sweep.NOTHING)
+        self.assertEqual(sweep.headline(alone), "nothing to sweep, 1 withheld")
 
     def test_a_string_with_nothing_to_move_offers_no_mutation(self):
         muts = _mutations("""
@@ -1639,6 +1652,209 @@ class AHangIsNotAPass(unittest.TestCase):
         sweep._kill_group(proc)
 
 
+class AMutantThatEatsTheMachineIsARedAndNotAnOutage(unittest.TestCase):
+    """#773, the sixth way a sweep lies and the one the timeouts cannot reach.
+
+    `SUBSET_TIMEOUT` and `FULL_TIMEOUT` answer "a mutation that hangs". They do not answer
+    this, and the reason is exact: **the timer dies with the process it is timing.** A
+    mutant that allocates without bound exhausts the runner in two to four minutes against
+    a 900 s cap, the host kills the machine, and the shard reports
+
+        ##[error]The runner has received a shutdown signal…
+        ##[error]Process completed with exit code 143.
+
+    which is byte-for-byte a spot reclaim. Measured on #710: four of its 118 mutations
+    never terminate, the fastest growing at 4,274 MB/min, and on run 33331151759 the one
+    shard holding a memory-eater is the one shard that died — while the shard holding the
+    mutation that spins WITHOUT allocating survived on the timeout, which is the control.
+
+    Capped, that becomes a `MemoryError` in the child: a red, on tests that were green
+    unmutated, which `decide` reads as a **pin**. That is the right verdict for a mutant
+    that destroys the apparatus.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="charter-sweep-cap-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        (self.tmp / "tests").mkdir()
+        (self.tmp / "tests" / "__init__.py").write_text("")
+        (self.tmp / "tests" / "test_limit.py").write_text(textwrap.dedent("""
+            import os, resource, unittest
+            class T(unittest.TestCase):
+                def test_reports_the_limit_it_was_given(self):
+                    soft, _ = resource.getrlimit(resource.RLIMIT_AS)
+                    self.assertEqual(soft, int(os.environ["WANT_SOFT_LIMIT"]))
+        """))
+        (self.tmp / "tests" / "test_runaway.py").write_text(textwrap.dedent("""
+            import unittest
+            class T(unittest.TestCase):
+                def test_allocates_without_end(self):
+                    held = []
+                    while True:                     # the shape of every #710 runaway
+                        held.append(bytearray(4 * 1024 * 1024))
+        """))
+        self.box = object.__new__(sweep.Sandbox)
+        self.box.path = self.tmp
+        self.box._pristine = {}
+        self.box.memory_cap = 0
+
+    # -- the arithmetic ---------------------------------------------------------------
+
+    def test_one_share_per_sandbox_and_one_left_over_for_everything_else(self):
+        """The sweep is not the only thing on the box: the parent, the trace cache, the
+        runner's own agent and the operating system live in the share nobody is given. A
+        cap of `total // jobs` would let four concurrent runaways add up to the whole
+        machine, which is the failure this exists for."""
+        self.assertEqual(sweep.address_space_cap(4, total=16 * 1024 ** 3),
+                         16 * 1024 ** 3 // 5)
+        self.assertEqual(sweep.address_space_cap(1, total=16 * 1024 ** 3),
+                         8 * 1024 ** 3)
+        self.assertLess(sweep.address_space_cap(4, total=16 * 1024 ** 3) * 4,
+                        16 * 1024 ** 3)
+
+    def test_the_floor_is_what_the_suite_measured_and_it_wins_on_a_small_machine(self):
+        """The two failures are not symmetrical. Too loose is the status quo — the runner
+        dies. Too tight reddens the **unmutated baseline**, and this tool refuses to sweep
+        a red tree, so the gate stops answering for everybody. Erring loose costs one
+        branch a re-run; erring tight costs every branch the gate."""
+        self.assertEqual(sweep.address_space_cap(4, total=2 * 1024 ** 3),
+                         sweep.SUITE_ADDRESS_SPACE)
+        # And a machine that will not say how big it is gets the measured figure, not none.
+        self.assertEqual(sweep.address_space_cap(4, total=0), sweep.SUITE_ADDRESS_SPACE)
+        # 1,580 MB is the whole process tree's peak on a ten-core Linux box, so the floor
+        # has to be above it — asserted, because a floor below what the suite needs is a
+        # floor that reddens every baseline.
+        self.assertGreater(sweep.SUITE_ADDRESS_SPACE, 1580 * 1024 ** 2)
+
+    # -- the wrapper ------------------------------------------------------------------
+
+    def test_no_cap_means_no_wrapper_at_all(self):
+        """On a platform that will not enforce it there is nothing to gain from a shell in
+        the way, and something to lose: the pid the sweep holds is what `_kill_group` and
+        both timeouts work through."""
+        self.assertEqual(sweep.under_cap(["python", "-m", "unittest"], 0),
+                         ["python", "-m", "unittest"])
+
+    def test_the_wrapper_execs_so_the_pid_the_sweep_holds_is_the_interpreters(self):
+        """A shell that *called* python would leave the sweep holding the shell's pid, and
+        `_kill_group`, the process group and the timeout all reach for that pid."""
+        argv = sweep.under_cap(["python", "-m", "unittest", "tests.test_x"], 3 * 1024 ** 3)
+        self.assertEqual(argv[0], "/bin/sh")
+        self.assertIn("exec", argv[2])
+        self.assertIn("ulimit -v", argv[2])
+        self.assertEqual(argv[-4:], ["python", "-m", "unittest", "tests.test_x"])
+        # `ulimit -v` counts KiB, and getting that wrong by 1024 is a cap that either
+        # never fires or reddens the baseline.
+        self.assertEqual(argv[4], str(3 * 1024 ** 2))
+
+    def test_the_probe_agrees_with_what_the_platform_actually_does(self):
+        """`cap_holds` is the one thing that decides whether anything is wrapped at all, so
+        a probe that disagreed with reality would either leave every run uncapped in
+        silence or fail every mutation on a platform that was fine. Asserted as an
+        equivalence, so it holds on whichever platform runs it — Linux says yes, macOS says
+        no, and both are measured here rather than assumed."""
+        cap = 512 * 1024 ** 2
+        done = subprocess.run(sweep.under_cap([sys.executable, "-c", "pass"], cap),
+                              capture_output=True, timeout=120)
+        self.assertEqual(done.returncode == 0, sweep.cap_holds(cap), done.stderr)
+
+    def test_a_preexec_fn_that_cannot_set_the_limit_takes_the_parent_down_with_it(self):
+        """Why this is a shell rather than `resource.setrlimit` in a `preexec_fn`, which is
+        the form the issue proposed. On macOS that call RAISES — and a `preexec_fn` that
+        raises surfaces as `SubprocessError` **in the parent**, so the proposal as written
+        makes every mutation on the operator's own machine fail to run at all. #572 is the
+        issue about this tool being unusable on macOS.
+
+        (The second reason has no case of its own because it is a hazard rather than a
+        behaviour: `preexec_fn` calls back into Python between `fork` and `exec`, which the
+        standard library says is unsafe in the presence of threads, and this sweep runs its
+        sandboxes from a thread pool.)
+        """
+        def refuses():
+            raise ValueError("[Errno 22] Invalid argument")
+
+        with self.assertRaises(subprocess.SubprocessError):
+            subprocess.run([sys.executable, "-c", "pass"], preexec_fn=refuses,
+                           capture_output=True, timeout=120)
+
+    # -- the cap, measured through the code path a mutation uses ----------------------
+
+    def test_the_cap_the_sandbox_was_given_is_the_cap_the_child_is_run_under(self):
+        """End to end through `Sandbox.run`, and the child is the witness: it reads its own
+        `RLIMIT_AS` back and fails if it is not the number the sweep asked for. A wiring
+        test that only read the argv would agree with itself."""
+        cap = 512 * 1024 ** 2
+        if not sweep.cap_holds(cap):
+            self.skipTest(f"{sys.platform} does not enforce an address-space limit, so "
+                          "there is no cap here to measure — see #773")
+        self.box.memory_cap = cap
+        os.environ["WANT_SOFT_LIMIT"] = str(cap)
+        self.addCleanup(os.environ.pop, "WANT_SOFT_LIMIT", None)
+        outcome = self.box.run(["tests.test_limit"], timeout=120)
+        self.assertTrue(outcome.green, outcome.detail)
+        self.assertEqual(outcome.ran, 1)
+
+    def test_with_no_cap_the_child_is_left_exactly_as_it_was(self):
+        """The other half, and it runs everywhere: an uncapped sandbox must not quietly
+        acquire a limit from somewhere, because a limit nobody chose is a red nobody can
+        explain."""
+        os.environ["WANT_SOFT_LIMIT"] = str(resource.getrlimit(resource.RLIMIT_AS)[0])
+        self.addCleanup(os.environ.pop, "WANT_SOFT_LIMIT", None)
+        outcome = self.box.run(["tests.test_limit"], timeout=120)
+        self.assertTrue(outcome.green, outcome.detail)
+
+    def test_a_mutation_that_allocates_without_end_comes_back_red_and_named(self):
+        """The whole point. Uncapped, this is the run that takes the machine with it and
+        reports `exit 143`; capped, it is a red on a named test — which `decide` compares
+        against the same module-set unmutated and turns into a **pin**."""
+        cap = 512 * 1024 ** 2
+        if not sweep.cap_holds(cap):
+            self.skipTest(f"{sys.platform} does not enforce an address-space limit, so a "
+                          "runaway mutation can still take the machine — see #773")
+        self.box.memory_cap = cap
+        outcome = self.box.run(["tests.test_runaway"], timeout=300)
+        self.assertFalse(outcome.green)
+        # A red, and not a timeout: `conclusive` is what separates "the guard is tested"
+        # from "the machine was busy", and a mutant killed by the cap is the first of those.
+        self.assertTrue(outcome.conclusive, outcome.detail)
+        self.assertEqual(outcome.ran, 1)
+        self.assertEqual(outcome.failing,
+                         frozenset({"tests.test_runaway.T.test_allocates_without_end"}))
+
+    def test_every_sandbox_a_sweep_builds_is_given_the_cap(self):
+        """One uncapped sandbox in a pool of four is a pool that can still lose the
+        machine, and the mutation that did it would be reported as infrastructure."""
+        boxes = []
+        real = sweep.Sandbox
+        # Inside the fixture's own directory, and that is load-bearing: `sweep()` ends by
+        # `shutil.rmtree`-ing every box's `path`. A stub that pointed one at `Path(".")`
+        # deleted the working tree it was being written in — measured, once, the hard way.
+        where = self.tmp / "boxes"
+
+        class _Counted(real):
+            def __init__(self, *a, **k):
+                boxes.append(self)
+                self.path = where / f"w{len(boxes)}"
+                self.path.mkdir(parents=True)
+                self._pristine, self._clean_failures = {}, {}
+
+        sweep.Sandbox = _Counted
+        self.addCleanup(setattr, sweep, "Sandbox", real)
+        plan = [sweep.Mutation("charter/m.py", n, n, "drop-if", "q?", "if x: pass",
+                               "", "f") for n in range(3)]
+        for name, stub in (("plan_for", lambda *a: (plan, {})),
+                           ("decide", lambda box, m, mods:
+                            ("pinned", sweep.Outcome(False, 1, "x"), None))):
+            was = getattr(sweep, name)
+            setattr(sweep, name, stub)
+            self.addCleanup(setattr, sweep, name, was)
+        with contextlib.redirect_stdout(io.StringIO()):
+            sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {}, self.tmp, 2, {},
+                        0, print, 60.0, None, cap=7 * 1024 ** 2)
+        self.assertEqual(len(boxes), 2)
+        self.assertEqual([b.memory_cap for b in boxes], [7 * 1024 ** 2] * 2)
+
+
 class TheVerdictIsTheSetOfNewlyFailingTests(unittest.TestCase):
     """An exit code cannot say WHY a run died, and this project has measured the confusion
     in both directions.
@@ -2522,8 +2738,13 @@ class TheReportNamesTheMaskingRisk(unittest.TestCase):
         self.assertNotIn("mask each other", text)
 
     def test_a_clean_sweep_says_so_and_lists_nothing(self):
-        text = sweep.report([], Path("."), "abc", "def", None, 1.0)
+        """A sweep that MEASURED something and found nothing wrong. It used to be written
+        with an empty result set, which is a sweep that measured nothing — the same
+        sentence for the two facts #782 exists to tell apart, in the terminal report this
+        time rather than in the check's name."""
+        text = sweep.report([_result("pinned")], Path("."), "abc", "def", None, 1.0)
         self.assertIn("Every mutation this diff offered goes red", text)
+        self.assertNotIn("NOTHING TO SWEEP", text)
 
     def test_the_survivor_line_carries_file_line_operator_and_both_spellings(self):
         text = sweep.report([self._result(291, "_placed_here")],
@@ -3062,6 +3283,79 @@ class TheGateSaysWhichOfThreeThingsItFound(unittest.TestCase):
         self.assertEqual(sweep.verdict_exit_code(gate, missing=1, enforce=True), 1)
 
 
+class NothingToSweepIsNotNoSurvivors(unittest.TestCase):
+    """#782, which is #617 and #630 one level further in.
+
+    Each earlier fix removed one way for silence to read as success: a green tick that was
+    not "no survivors" (#617), a check whose NAME had to carry the verdict because
+    GitHub's conclusions cannot (#630), a run that never happened and therefore had no row
+    at all (#646/#561). This is the last one, and the most misleading of them, because
+    nothing looks wrong: the row is present, the job succeeded, and the sentence is
+    affirmative. Measured on #779 — `no survivors: pass` beside `mutations applied: 0`.
+
+    It is a fourth ANSWER and not a fourth failure. The branches that land here are docs,
+    config, a news entry, a one-line reordering — all legitimate — and failing them would
+    teach people to route around the gate, which is worse than a gate that says too little.
+    """
+
+    def test_a_sweep_that_applied_no_mutation_does_not_say_it_found_none(self):
+        gate = sweep.classify([])
+        self.assertEqual(gate.measured, 0)
+        self.assertEqual(sweep.gate_conclusion(gate), sweep.NOTHING)
+        self.assertEqual(sweep.headline(gate), "nothing to sweep")
+        self.assertNotIn("no survivors", sweep.headline(gate))
+
+    def test_one_mutation_that_went_red_is_a_sweep_that_checked(self):
+        """The other side of the same line, and the one that keeps `no survivors` meaning
+        what it means: a single pinned mutation IS a measurement, and calling that
+        "nothing to sweep" would spend the sentence on the branches that earned the
+        other one."""
+        gate = sweep.classify([_result("pinned")])
+        self.assertEqual(gate.measured, 1)
+        self.assertEqual(sweep.gate_conclusion(gate), sweep.CLEAN)
+        self.assertEqual(sweep.headline(gate), "no survivors")
+
+    def test_every_bucket_that_reached_a_sandbox_counts_as_measured(self):
+        """`unresolved` and `unapplied` are not "nothing to sweep" — they are mutations
+        that exist and came back without an answer, which is `no verdict` and stays there.
+        A run that folded them into the empty case would turn the loudest state this gate
+        has into the quietest."""
+        for verdict in ("pinned", "survived", "unresolved", "unapplied"):
+            gate = sweep.classify([_result(verdict)])
+            self.assertEqual(gate.measured, 1, verdict)
+            self.assertNotEqual(sweep.gate_conclusion(gate), sweep.NOTHING, verdict)
+
+    def test_a_shard_that_vanished_can_never_wear_the_empty_sentence(self):
+        """The dangerous confusion, and the reason `missing` is asked first. A sweep whose
+        every shard was cancelled merges to zero results too, and "nothing to sweep" said
+        over that would be the #617 defect returning under a new name."""
+        gate = sweep.classify([])
+        self.assertEqual(sweep.gate_conclusion(gate, missing=1), sweep.NO_VERDICT)
+        self.assertEqual(sweep.headline(gate, missing=1, shards=2),
+                         "no verdict: 1 of 2 shards did not report")
+
+    def test_it_is_a_verdict_and_not_a_failure_even_once_the_gate_enforces(self):
+        """A docs-only branch is legitimate and common. Failing it would train people to
+        bypass the gate, which is the one outcome worse than a gate that says too little.
+        Asserted under `--enforce`, because that is the flag every other bucket changes
+        behaviour on and this one must not."""
+        gate = sweep.classify([])
+        self.assertEqual(sweep.gate_exit_code(gate, enforce=True), 0)
+        self.assertEqual(sweep.verdict_exit_code(gate, missing=0, enforce=True), 0)
+
+    def test_the_page_says_what_did_not_happen_instead_of_congratulating_the_branch(self):
+        page = sweep.gate_summary(sweep.classify([]), "a" * 40, "b" * 40, 12.0, False)
+        self.assertIn("## Deletion sweep — nothing to sweep", page)
+        self.assertIn("Not one mutation was applied on this branch", page)
+        self.assertNotIn("Nothing added here is a line the suite would not miss", page)
+
+    def test_a_page_that_did_measure_something_keeps_the_clean_sentence(self):
+        page = sweep.gate_summary(sweep.classify([_result("pinned")]),
+                                  "a" * 40, "b" * 40, 12.0, False)
+        self.assertIn("Nothing added here is a line the suite would not miss", page)
+        self.assertNotIn("Not one mutation was applied on this branch", page)
+
+
 class TheSweepIsSplitAcrossMachinesAndNothingIsDropped(unittest.TestCase):
     """#617's other half: five runs cancelled at `timeout-minutes: 60` across two branches.
 
@@ -3507,7 +3801,14 @@ class TheAnswerSurvivesTheTripThroughAFile(unittest.TestCase):
 
     def test_an_empty_sweep_that_ran_is_not_a_sweep_that_did_not(self):
         """A shard with nothing to do writes `[]`, and `[]` is an answer. The directory
-        being empty is the other thing entirely."""
+        being empty is the other thing entirely.
+
+        And `[]` is `NOTHING`, not `CLEAN` (#782). This case asserted `CLEAN` and the
+        assertion was the defect written down: a shard that measured no mutation at all
+        reached the pull request as `no survivors`, which is the sentence for having
+        measured everything. The distinction this case exists for — an answer against no
+        answer — is untouched, and there are now three of them rather than two.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             (Path(tmp) / "sweep-results-1.json").write_text(sweep.as_json([]))
             ran, ran_missing = sweep.merge(Path(tmp), 1)
@@ -3516,7 +3817,7 @@ class TheAnswerSurvivesTheTripThroughAFile(unittest.TestCase):
         self.assertEqual((ran, ran_missing), ([], 0))
         self.assertEqual(gone_missing, 1)
         self.assertEqual(sweep.gate_conclusion(sweep.classify(ran), ran_missing),
-                         sweep.CLEAN)
+                         sweep.NOTHING)
         self.assertEqual(sweep.gate_conclusion(sweep.classify(gone), gone_missing),
                          sweep.NO_VERDICT)
 
@@ -3604,6 +3905,19 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
         self.assertEqual(int(out["mutations"]), 2)      # the two refusals added above
         self.assertEqual(out["shards"], "1")
         self.assertEqual(out["matrix"], "[1]")
+        # And the sha those two mutations were read against, for the merge step's page
+        # header — the one machine that cannot work it out for itself (#776).
+        self.assertEqual(out["base"], self.base)
+
+    def test_the_plan_publishes_the_base_it_resolved_and_not_the_one_it_was_given(self):
+        """No `--base` at all is the shape CI runs, and the output has to carry a real sha
+        even then — an empty `base` reaches the merge step's header as the literal string
+        it falls back to, and the page would stop naming what was charged."""
+        code, said = self._cli("--plan", "--workdir", str(self.workdir),
+                               "--github-output", str(self.outputs))
+        self.assertEqual(code, 0, said)
+        self.assertEqual(self._read_outputs()["base"], self.base)
+        self.assertIn(f"diff against {self.base[:12]}", said)
 
     def test_a_diff_past_the_fan_out_ceiling_warns_on_the_pull_request(self):
         """A log line is not loud. `over_budget` reaching the plan's stdout as a workflow
@@ -3709,14 +4023,73 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
 
     def test_a_branch_with_nothing_to_sweep_writes_an_empty_answer_and_not_no_answer(self):
         """A shard that writes nothing is indistinguishable from a shard that was
-        cancelled, which is the whole of #617 arriving one level down."""
+        cancelled, which is the whole of #617 arriving one level down.
+
+        And it says so in the sentence the check is named with (#782). This path used to
+        publish a private paragraph of its own — "there was nothing to sweep" — into the
+        step summary while the check on the pull request said `no survivors`. Two readers,
+        two answers, and the affirmative one is the one people read.
+        """
         code, said = self._cli("--gate", "--base", "HEAD", "--path", "charter",
                                "--workdir", str(self.workdir),
+                               "--summary", str(self.summary),
+                               "--github-output", str(self.outputs),
                                "--json", str(self.tmp / "r.json"))
         self.assertEqual(code, 0, said)
         self.assertEqual((self.tmp / "r.json").read_text(), "[]")
         merged, missing = sweep.merge(self.tmp, 1)
         self.assertEqual((merged, missing), ([], 0))
+        self.assertEqual(self._read_outputs(),
+                         {"conclusion": "nothing", "headline": "nothing to sweep"})
+        self.assertIn("## Deletion sweep — nothing to sweep", self.summary.read_text())
+
+    def test_a_diff_that_offers_no_mutation_is_not_a_branch_that_was_checked(self):
+        """#779's own shape, run end to end, and the half `--base HEAD` cannot reach.
+
+        Here a file DID change and lines WERE added — the scope is not empty — and still
+        not one mutation exists, because no operator has anything to say about
+        `rows.append(1)`. That is the normal result for exactly the changes a reviewer is
+        least able to check by eye, and it published `no survivors: pass` beside
+        `mutations applied: 0`.
+        """
+        was = sweep.git("rev-parse", "HEAD", cwd=self.tmp).strip()
+        source = (self.tmp / "charter" / "m.py").read_text()
+        (self.tmp / "charter" / "m.py").write_text(
+            source + "\n\ndef record(rows):\n    rows.append(1)\n")
+        subprocess.run(("git", "-c", "core.hooksPath=", "commit", "-qam", "one statement"),
+                       cwd=self.tmp, check=True, timeout=60,
+                       env=dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull,
+                                GIT_CONFIG_SYSTEM=os.devnull, GIT_CONFIG_NOSYSTEM="1"),
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        # The fixture repository has no `tests/`, so the trace would refuse to sweep
+        # blind. The plan is what this case is about and `plan_for` is untouched.
+        real = sweep.load_map
+        sweep.load_map = lambda *a, **k: {}
+        self.addCleanup(lambda: setattr(sweep, "load_map", real))
+        code, said = self._cli("--gate", "--base", was, "--no-baseline", "--jobs", "1",
+                               "--workdir", str(self.workdir),
+                               "--summary", str(self.summary),
+                               "--github-output", str(self.outputs))
+        self.assertEqual(code, 0, said)
+        # The diff is real. The plan is not.
+        self.assertIn("1 file(s), 4 added line(s)", said)
+        self.assertIn("0 mutations across 1 file(s)", said)
+        self.assertIn("NOTHING TO SWEEP", said)
+        self.assertNotIn("Every mutation this diff offered goes red", said)
+        self.assertEqual(self._read_outputs(),
+                         {"conclusion": "nothing", "headline": "nothing to sweep"})
+        self.assertIn("Not one mutation was applied on this branch",
+                      self.summary.read_text())
+
+    def test_a_merged_sweep_that_measured_nothing_says_so_on_the_pull_request(self):
+        """The same answer through the file every shard writes and the step that adds them
+        up — which is where the pull request actually reads it."""
+        code, said = self._cli("--verdict", str(self._shards([])), "--shards", "1",
+                               "--summary", str(self.summary),
+                               "--github-output", str(self.outputs))
+        self.assertEqual(code, 0, said)
+        self.assertEqual(self._read_outputs(),
+                         {"conclusion": "nothing", "headline": "nothing to sweep"})
 
     def _shards(self, *payloads):
         where = self.tmp / "shards"
@@ -3978,6 +4351,44 @@ class TheWorkflowSaysTheAnswerWhereItCanBeSeen(unittest.TestCase):
         self.assertIn('--github-output "$GITHUB_OUTPUT"', run)
         self.assertEqual(self.jobs["sweep"]["strategy"]["matrix"]["shard"],
                          "${{ fromJSON(needs.plan.outputs.matrix) }}")
+
+    def test_no_step_charges_a_branch_against_the_payloads_idea_of_the_base(self):
+        """#776, and it is refused by NAME because the one-line convenience is exactly
+        what was there. `github.event.pull_request.base.sha` reads like the right thing —
+        it is even called the base — and it is the payload's record of where the branch
+        started, which lags the merge commit `actions/checkout` puts on disk. Measured on
+        run 33331151759: the checkout merged into `c29f3a8`, the payload said `d40d998`,
+        and a branch touching one Python file was swept for three.
+
+        Every value of every `env:` in the file, so a future reader cannot reintroduce it
+        under a different variable name or in a different job.
+        """
+        values = [str(v) for job in self.jobs.values() for step in job["steps"]
+                  for v in (step.get("env") or {}).values()]
+        self.assertTrue(values)     # the reader found the env blocks at all
+        self.assertEqual([v for v in values if "pull_request.base.sha" in v], [])
+
+    def test_the_two_jobs_that_sweep_ask_the_tool_where_the_branch_starts(self):
+        """`base_for` resolves the merge-base of the checked-out merge commit with
+        `origin/main`, which for a merge IS the parent it was merged into. `fetch-depth: 0`
+        on both jobs is what makes `origin/main` an object they have — which is why the
+        depth is asserted here beside the flag it exists for."""
+        for job, step in (("plan", "How many mutations, and how many jobs they need"),
+                          ("sweep", "Sweep the guards this branch adds")):
+            self.assertNotIn("--base", self._run(job, step), job)
+            depths = [s["with"]["fetch-depth"] for s in self.jobs[job]["steps"]
+                      if "checkout@" in s.get("uses", "")]
+            self.assertEqual(depths, ["0"], job)
+
+    def test_the_page_names_the_base_the_sweep_actually_charged(self):
+        """The merge step runs on its own machine at `fetch-depth: 1`, where neither
+        `HEAD^` nor `origin/main` is an object it has — so it cannot work the base out and
+        has to be told. Told by the job that resolved it, and not by the payload, or the
+        header drifts back to naming a sha nobody charged."""
+        self.assertEqual(self.jobs["plan"]["outputs"]["base"],
+                         "${{ steps.size.outputs.base }}")
+        self.assertEqual(self._collect_step("say")["env"]["BASE_SHA"],
+                         "${{ needs.plan.outputs.base }}")
 
     def test_the_shards_restore_the_map_the_plan_measured(self):
         """Otherwise a second machine costs a whole trace, which is the largest fixed cost
@@ -4838,6 +5249,129 @@ class TheBranchIsChargedAgainstItsUpstream(unittest.TestCase):
         side = sweep.git("rev-parse", "HEAD", cwd=tmp).strip()
         self.assertNotEqual(first, second)
         self.assertEqual(sweep.base_for(tmp, side, None), first)
+
+
+class ABranchIsNotChargedForWhatMainGainedWhileItWasOpen(unittest.TestCase):
+    """#776, built as the tree CI actually checks out rather than as a diff of two tips.
+
+    `actions/checkout` puts `refs/pull/N/merge` on disk: a merge commit whose FIRST parent
+    is the base branch tip it was merged into and whose second is the branch head. The
+    workflow used to charge that tree against `github.event.pull_request.base.sha`, which
+    is the payload's idea of where the branch started and lags the merge GitHub computed.
+    Measured on run 33331151759's own log:
+
+        HEAD is now at 58411a9 Merge 04bf8e6 into c29f3a8
+        diff against d40d998e06bd: 3 file(s), 458 added line(s)
+
+    `d40d998` is three main commits and three hours behind `c29f3a8`, so a branch touching
+    exactly one Python file was charged for three. A survivor in a file its author has
+    never opened destroys the one premise the gate runs on — that a survivor is YOUR
+    untested line — and it compounds: the plan grows, so the shard count grows, so #773's
+    runaway mutations are spread across more shards.
+
+    The tool's own default was already right and is what the workflow now uses. The
+    property below is why: **nothing later than a merge's first parent is reachable from
+    the merge**, so the merge-base of the merge with `origin/main` IS that first parent,
+    exactly, however far `main` has moved since.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="sweep-merge-ref-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull,
+                   GIT_CONFIG_SYSTEM=os.devnull, GIT_CONFIG_NOSYSTEM="1",
+                   GIT_TERMINAL_PROMPT="0")
+
+        def run(*a):
+            subprocess.run(("git", "-c", "core.hooksPath=", "-c", "commit.gpgsign=false")
+                           + a, cwd=self.tmp, check=True, env=env, timeout=60,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        def sha(ref="HEAD"):
+            return sweep.git("rev-parse", ref, cwd=self.tmp).strip()
+
+        run("init", "-q", "-b", "main")
+        run("config", "user.email", "sweep@example.invalid")
+        run("config", "user.name", "sweep")
+        (self.tmp / "charter").mkdir()
+        (self.tmp / "charter" / "shared.py").write_text("a = 1\n")
+        run("add", "-A")
+        run("commit", "-qm", "where the branch was cut from")
+        #: What the pull request payload says the base is, recorded when the branch opened.
+        self.payload_base = sha()
+
+        run("checkout", "-q", "-b", "side")
+        (self.tmp / "charter" / "mine.py").write_text(
+            "def close(arm, pane):\n"
+            "    if arm is None:\n"
+            "        return []\n"
+            "    return [arm, pane]\n")
+        run("add", "-A")
+        run("commit", "-qm", "the branch's own file")
+        head = sha()
+
+        # `main` moves on twice while the pull request sits open. Nothing forces a rebase:
+        # `required_status_checks.strict` is false on this repository, so a branch may
+        # merge while behind, which is the mechanism by which the staleness accumulates.
+        run("checkout", "-q", "main")
+        (self.tmp / "charter" / "theirs.py").write_text(
+            "def other(y):\n"
+            "    if y < 3:\n"
+            "        return y - 1\n"
+            "    return y\n")
+        run("add", "-A")
+        run("commit", "-qm", "main gains a file")
+        (self.tmp / "charter" / "theirs_too.py").write_text(
+            "def more(z):\n"
+            "    while z > 0:\n"
+            "        z -= 1\n"
+            "    return z\n")
+        run("add", "-A")
+        run("commit", "-qm", "main gains another")
+        self.main_tip = sha()
+
+        # And GitHub recomputes `refs/pull/N/merge` against the tip it has now.
+        run("checkout", "-q", "--detach", self.main_tip)
+        run("merge", "-q", "--no-ff", "-m", f"Merge {head} into {self.main_tip}", head)
+        self.merge = sha()
+        run("update-ref", "refs/remotes/origin/main", self.main_tip)
+
+    def _charged(self, base):
+        return sweep.added_lines(self.tmp, base, self.merge, ("charter",))
+
+    def test_the_merge_base_of_a_merge_commit_is_the_parent_it_was_merged_into(self):
+        """The property the whole fix rests on, asserted rather than assumed. If this ever
+        stops holding, the default silently starts charging a branch for main again — and
+        it would not fail, it would report."""
+        self.assertEqual(sweep.base_for(self.tmp, self.merge, None), self.main_tip)
+        self.assertEqual(sweep.git("rev-parse", f"{self.merge}^1",
+                                   cwd=self.tmp).strip(), self.main_tip)
+        self.assertNotEqual(self.main_tip, self.payload_base)
+
+    def test_the_default_charges_the_branch_for_its_own_file_and_no_other(self):
+        charged = self._charged(sweep.base_for(self.tmp, self.merge, None))
+        self.assertEqual(sorted(charged), ["charter/mine.py"])
+
+    def test_the_payloads_base_charges_the_branch_for_mains_files_too(self):
+        """The defect, kept as a measurement rather than described in a comment. These are
+        real files, added by real commits on `main`, and every mutation in them would have
+        arrived on this branch's check as this branch's finding."""
+        charged = self._charged(self.payload_base)
+        self.assertEqual(sorted(charged),
+                         ["charter/mine.py", "charter/theirs.py", "charter/theirs_too.py"])
+
+    def test_the_over_charge_is_a_longer_plan_and_therefore_more_shards(self):
+        """Not merely noise. A longer plan is more shards, and more shards spread #773's
+        runaway mutations over more of them — three of six shards died on the over-charged
+        plan where the same branch on a correct one lost one of five."""
+        def plan(base):
+            return sweep.plan_for(self.tmp, self.merge, self._charged(base), {})[0]
+
+        honest = plan(sweep.base_for(self.tmp, self.merge, None))
+        inflated = plan(self.payload_base)
+        self.assertGreater(len(inflated), len(honest))
+        self.assertEqual({m.path for m in honest}, {"charter/mine.py"})
+        self.assertIn("charter/theirs.py", {m.path for m in inflated})
 
 
 if __name__ == "__main__":      # pragma: no cover

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1712,6 +1712,37 @@ class AMutantThatEatsTheMachineIsARedAndNotAnOutage(unittest.TestCase):
         self.assertLess(sweep.address_space_cap(4, total=16 * 1024 ** 3) * 4,
                         16 * 1024 ** 3)
 
+    def test_a_machine_that_will_not_say_how_big_it_is_gets_the_floor(self):
+        """Found unpinned by this branch's own sweep, at `tools/sweep.py:1803`.
+
+        `os.sysconf` is not on every platform and does not answer on every platform, and
+        the one thing this must not do is propagate: an unbounded mutant is the failure
+        being fixed, and a sweep that refuses to start because it could not size a cap is a
+        worse one. So the catch is real, and the sweep was right that nothing held it.
+        """
+        real = os.sysconf
+
+        def refuses(_name):
+            raise ValueError("unrecognised configuration name")
+
+        os.sysconf = refuses
+        self.addCleanup(setattr, os, "sysconf", real)
+        self.assertEqual(sweep.total_memory(), 0)
+        self.assertEqual(sweep.address_space_cap(4), sweep.SUITE_ADDRESS_SPACE)
+
+    def test_a_job_count_nobody_validated_does_not_divide_by_zero(self):
+        """Found unpinned by this branch's own sweep, at `tools/sweep.py:1820`.
+
+        `--jobs` is an integer the operator types and nothing checks its sign, and
+        `jobs + 1` is a **divisor** — so `--jobs -1` is a `ZeroDivisionError` raised while
+        sizing a memory cap, which is a sweep that will not start at all, over a typo. The
+        floor is not decoration and it is not dead: it is the only thing between a
+        mistyped flag and a stack trace.
+        """
+        for jobs in (-5, -1, 0):
+            self.assertEqual(sweep.address_space_cap(jobs, total=64 * 1024 ** 3),
+                             64 * 1024 ** 3, f"--jobs {jobs}")
+
     def test_the_floor_is_what_the_suite_measured_and_it_wins_on_a_small_machine(self):
         """The two failures are not symmetrical. Too loose is the status quo — the runner
         dies. Too tight reddens the **unmutated baseline**, and this tool refuses to sweep

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -1745,6 +1745,128 @@ def _kill_group(proc: subprocess.Popen) -> None:
         proc.kill()
 
 
+# --------------------------------------------------------------------------------------
+# 4a. The sixth way a sweep lies: a mutant that eats the machine (#773)
+# --------------------------------------------------------------------------------------
+#
+# `SUBSET_TIMEOUT` and `FULL_TIMEOUT` bound what a mutation may spend in **time**, and
+# they are the answer to "a mutation that hangs" — the fourth way the spec lists. They do
+# not cover this one, and the reason is exact: **a timeout cannot save a runner that has
+# already been consumed.** The timer and the process it is timing die together.
+#
+# Measured on #710. Enumerating all 118 mutations that branch offers and running each
+# under a wall clock found four that never terminate, three of which append on every
+# iteration. The fastest — `charter/hooks.py`'s `drop-if`, whose deleted guard makes
+# `_heredoc_header` hand its caller a cursor pointing *backwards* — grows at **4,274
+# MB/min**, which exhausts a 16 GB runner in under four minutes against a 900 s subset
+# timeout. Run 33331151759, shard 2 of 5: ten mutations reported, then
+#
+#     ##[error]The runner has received a shutdown signal…
+#     ##[error]Process completed with exit code 143.
+#
+# which is byte-for-byte what a spot reclaim looks like. Shard 2 was the only shard
+# holding a memory-eater and the only shard that died; shard 3 drew the one that spins
+# WITHOUT allocating and survived on the timeout, which is the control that makes it more
+# than a coincidence.
+#
+# **Detection is not the fix, and that was measured too.** The obvious guard — read the
+# mutant and see whether it contains an unbounded loop — fails in the fail-open direction:
+# the fastest of the four leaves every loop in its own function terminating, because what
+# it corrupts is a cursor returned ACROSS a function boundary and the caller is the one
+# that spins. Any scanner, tokenizer or parser is mostly made of functions like that. So
+# the bound is imposed rather than predicted.
+
+#: The floor under :func:`address_space_cap`, in bytes, and it is measured rather than
+#: chosen. The whole suite — 9,581 tests, the real tmux servers it starts and every child
+#: it spawns — peaks at **1,580 MB of address space summed across the process tree** and
+#: 253 MB resident, on a ten-core Linux box where glibc's per-thread arenas are at their
+#: most generous. `RLIMIT_AS` applies to each process on its own, so two GiB is that whole
+#: tree's figure with room over, charged to every process in it.
+#:
+#: The floor exists because the two failures are not symmetrical. A cap too LOOSE is the
+#: status quo: the runner dies and the shard reports nothing. A cap too TIGHT reddens the
+#: **unmutated baseline**, and this tool refuses to sweep a red tree at all — so an
+#: over-tight cap does not mislead anybody, it stops the gate answering for everybody.
+#: Erring loose costs one branch a re-run; erring tight costs every branch the gate.
+SUITE_ADDRESS_SPACE = 2 * 1024 ** 3
+
+
+def total_memory() -> int:
+    """What this machine has, in bytes, or ``0`` when it will not say.
+
+    ``0`` is not an error and is not treated as one — :func:`address_space_cap` has a
+    floor for exactly this, and a machine that will not report its own size is a reason to
+    use the measured figure rather than a reason to leave a mutant unbounded.
+    """
+    try:
+        return os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+    except (ValueError, OSError, AttributeError):    # pragma: no cover - platform
+        return 0
+
+
+def address_space_cap(jobs: int, total: int | None = None) -> int:
+    """How much address space ONE mutant may claim, in bytes.
+
+    One share per sandbox and **one left over**, because the sweep is not the only thing
+    on the box: the parent, the trace cache, the runner's own agent and the operating
+    system all live in the share nobody is given. On a 16 GB runner at `--jobs 4` that is
+    3.2 GiB each, which a 4,274 MB/min runaway reaches in about forty-five seconds —
+    twenty times inside the subset timeout, and with the machine still standing.
+
+    The floor can beat the share on a small machine, and it is allowed to: see
+    :data:`SUITE_ADDRESS_SPACE` for why the loose direction is the safe one.
+    """
+    have = total_memory() if total is None else total
+    return max(SUITE_ADDRESS_SPACE, have // max(1, jobs + 1))
+
+
+def under_cap(argv: list[str], cap: int) -> list[str]:
+    """*argv*, wrapped so the kernel refuses it more than *cap* bytes of address space.
+
+    **A shell and not `preexec_fn`**, and both halves of that were measured rather than
+    reasoned about:
+
+    * On macOS `resource.setrlimit(RLIMIT_AS, …)` raises, and a `preexec_fn` that raises
+      surfaces as `SubprocessError` **in the parent** — so the obvious form of this fix,
+      written as proposed, makes every mutation on the operator's own machine fail to run
+      at all. #572 is the issue about this tool being unusable on macOS; this is that
+      again, from the other end.
+    * `preexec_fn` calls back into Python between `fork` and `exec`, and this sweep runs
+      its sandboxes from a thread pool. The standard library says in as many words that it
+      is not safe in the presence of threads.
+
+    `exec` and not a plain invocation, so the shell is **replaced**: the pid the sweep
+    holds is the interpreter's own, which is what :func:`_kill_group`, the process group
+    and both timeouts depend on.
+    """
+    if cap <= 0:
+        return list(argv)
+    # `|| exit 89` and not `2>/dev/null`. This wrapper is only ever reached once
+    # `cap_holds` has measured that the platform takes the limit, so a refusal here is a
+    # surprise, and a surprise gets a distinctive exit code rather than a run that
+    # silently proceeds uncapped. `ulimit -v` counts KiB.
+    return ["/bin/sh", "-c", 'ulimit -v "$1" || exit 89; shift; exec "$@"',
+            "sweep", str(cap // 1024), *argv]
+
+
+def cap_holds(cap: int) -> bool:
+    """Whether this platform really enforces *cap* on a child. Measured, never assumed.
+
+    macOS accepts neither `ulimit -v` nor `setrlimit(RLIMIT_AS)` — it answers *Invalid
+    argument* — so on the machine this tool is developed on there is no cap to have, and
+    the honest thing is to say so once rather than to wrap every run in a shell that does
+    nothing. One process, at startup, and the answer decides whether anything is wrapped.
+    """
+    if cap <= 0:
+        return False
+    try:
+        done = subprocess.run(under_cap(["/bin/echo", "held"], cap), timeout=60,
+                              stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    except (OSError, subprocess.SubprocessError):    # pragma: no cover - no /bin/sh
+        return False
+    return done.returncode == 0 and done.stdout.strip() == b"held"
+
+
 #: `FAIL: test_x (tests.test_mod.Class.test_x)` / `ERROR: ...`, and for an import failure
 #: `ERROR: tests.test_mod (unittest.loader._FailedTest.tests.test_mod)`. The parenthesised
 #: id is the stable name; a subtest's trailing `[value]` sits outside it.
@@ -1902,7 +2024,15 @@ class Sandbox:
         # it. `subprocess.run(timeout=…)` kills only the direct child, and this suite
         # starts real tmux servers — a wedged run that left one behind would be inherited
         # by the next mutation and reported as ITS failure.
-        proc = subprocess.Popen([sys.executable, "-m", "unittest", *argv],
+        # And an address-space cap around the whole thing, which is the bound the two
+        # timeouts cannot supply: a mutant that allocates without bound kills the machine
+        # BEFORE either timer fires, because the timer dies with it (#773). Capped, it
+        # raises `MemoryError` inside the child instead — a red, on tests that were green
+        # unmutated, which `decide` reads as a pin. That is the right verdict for a
+        # mutation that destroys the apparatus, and the wrong one is what it replaces:
+        # `exit 143`, indistinguishable from the runner pool taking the machine back.
+        proc = subprocess.Popen(under_cap([sys.executable, "-m", "unittest", *argv],
+                                          self.memory_cap),
                                 cwd=str(self.path), text=True, env=env,
                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                 start_new_session=True)
@@ -1925,6 +2055,13 @@ class Sandbox:
     #: measured, at a load average of 100, a five-minute suite ran past 2400 s and two
     #: known-unpinned guards came back "pinned" on the strength of a stopwatch.
     full_timeout: float = FULL_TIMEOUT
+
+    #: Bytes of address space one run may claim, or ``0`` for no cap — the same shape as
+    #: `full_timeout`: a default here so a sandbox built for something other than a sweep
+    #: still works, and the real figure set per box by whoever knows how many of them
+    #: there are. Zero on any platform that will not enforce it (:func:`cap_holds`), which
+    #: is honest rather than decorative: an uncapped run is exactly the run #773 measured.
+    memory_cap: int = 0
 
     def subset(self, modules: list[str]) -> Outcome:
         return self.run(list(modules), SUBSET_TIMEOUT)
@@ -2158,7 +2295,7 @@ def plan_for(root: Path, ref: str, scope: dict[str, set[int]], dirty: dict[str, 
 def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str, list[str]],
           workdir: Path, jobs: int, dirty: dict[str, bytes], second_order: int = 0,
           log=print, full_timeout: float = FULL_TIMEOUT,
-          shard: tuple[int, int] | None = None
+          shard: tuple[int, int] | None = None, cap: int = 0
           ) -> tuple[list[Result], list["Pair"]]:
     """Every mutation, run; every survivor, re-run against the whole suite."""
     plan, sources = plan_for(root, ref, scope, dirty)
@@ -2176,6 +2313,7 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
     boxes = [Sandbox(root, run_dir(workdir) / f"w{i}", ref, dirty) for i in range(jobs)]
     for box in boxes:
         box.full_timeout = full_timeout
+        box.memory_cap = cap
     free: list[Sandbox] = list(boxes)
     import threading
     lock = threading.Lock()
@@ -2378,7 +2516,16 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
         w("")
 
     if not survivors:
-        if unresolved or unapplied:
+        if not results:
+            # The same distinction the check's NAME now carries (#782), in the terminal
+            # report, because the two must not disagree: "every mutation went red" said
+            # over a plan of no mutations is the words for having checked, and the count
+            # two lines above it is zero.
+            w("NOTHING TO SWEEP — not one mutation was applied, so this is a record of a")
+            w("question nobody asked rather than of an answer. Either no file under the")
+            w("swept paths changed, or the lines that did offer no operator anything to")
+            w("mutate. That is legitimate and it is not evidence that this diff is tested.")
+        elif unresolved or unapplied:
             w("No survivor — but see above: not every mutation was measured, so this is")
             w("not the same claim as a clean sweep.")
         else:
@@ -2544,6 +2691,21 @@ class Gate:
     def actionable(self) -> list[Result]:
         """Survivors a person should act on. Platform-deferred ones are not among them."""
         return self.unpinned + self.masked
+
+    @property
+    def measured(self) -> int:
+        """How many mutations were actually put to the suite (#782).
+
+        Zero here is the difference between "I checked and found nothing wrong" and "there
+        was nothing to check", which are the same sentence today and must not be. Every
+        bucket except `withheld` counts, including `unresolved` and `unapplied`: those two
+        reached a sandbox and came back without an answer, which is a fact about a
+        mutation that exists. `withheld` is the one the tool declined to ask, so it never
+        reached anything — and a plan of nothing but withheld mutations measured nothing,
+        which is exactly what this property is for.
+        """
+        return (self.pinned + len(self.unpinned) + len(self.masked) + len(self.platform)
+                + len(self.unresolved) + len(self.unapplied))
 
 
 def classify(results: list[Result]) -> Gate:
@@ -2769,10 +2931,22 @@ SURVIVORS = "survivors"
 #: that never reached the tree — three spellings of the same thing, which is that the
 #: numbers on this page are not an answer about this branch.
 NO_VERDICT = "no-verdict"
+#: Completed, and there was nothing to complete: the plan was empty, so not one mutation
+#: was ever put to the suite. **This is not `CLEAN` and the difference is #782.** A branch
+#: that changed no swept file, or whose added lines offer no operator anything to mutate,
+#: measured nothing — and `no survivors` is the sentence for having measured everything
+#: and found nothing wrong. Measured on #779: `no survivors: pass` beside `mutations
+#: applied: 0`, on a branch whose one added statement no operator touches.
+#:
+#: It is a fourth ANSWER and not a fourth failure. A documentation commit, a config
+#: change, a news entry and a one-line reordering are all legitimate and all land here,
+#: and failing them would teach people to route around the gate — which is the one
+#: outcome worse than a gate that says too little.
+NOTHING = "nothing"
 
 
 def gate_conclusion(gate: Gate, missing: int = 0) -> str:
-    """Which of the three a run found. *missing* is shards that never reported.
+    """Which of the four a run found. *missing* is shards that never reported.
 
     The precedence is :func:`gate_exit_code`'s, deliberately — 4 outranks 1 outranks 3 —
     because the two answers are the same answer in two vocabularies and a branch that
@@ -2783,12 +2957,19 @@ def gate_conclusion(gate: Gate, missing: int = 0) -> str:
     not a severity ranking, it is what each one licenses a reader to believe: "8
     survivors, 2 not measured" is still a true statement about 8 real findings, whereas
     "8 survivors" from two thirds of a plan is a number nobody should quote.
+
+    :data:`NOTHING` is last and it is reached only from the bottom — every count zero AND
+    every shard in. Anything unmeasured has already answered above it, so "nothing to
+    sweep" can never be worn by a run that lost a shard, and `missing` is what keeps
+    `classify([])` from a cancelled sweep saying it.
     """
     if missing or gate.unapplied:
         return NO_VERDICT
     if gate.actionable:
         return SURVIVORS
-    return NO_VERDICT if gate.unresolved else CLEAN
+    if gate.unresolved:
+        return NO_VERDICT
+    return CLEAN if gate.measured else NOTHING
 
 
 def _plural(n: int, one: str, many: str) -> str:
@@ -2815,6 +2996,13 @@ def headline(gate: Gate, missing: int = 0, shards: int = 1) -> str:
     # into `no verdict` over that would spend the one signal a reviewer must stop on, and
     # #693 is what it costs when `no verdict` stops meaning "look at this".
     aside = f", {len(gate.withheld)} withheld" if gate.withheld else ""
+    # Its own sentence, beside the other three rather than inside `no survivors` (#782).
+    # The two say opposite things about what was done: one is "the guards you added are
+    # tested", the other is "you added nothing this tool knows how to test" — and on a
+    # branch whose whole content is a one-line ordering fix, the second is the more
+    # important of the two, because it is the one that tells a reviewer not to lean here.
+    if conclusion == NOTHING:
+        return f"nothing to sweep{aside}"
     if conclusion == CLEAN:
         return f"no survivors{aside}"
     found = _plural(len(gate.actionable), "survivor", "survivors")
@@ -3071,6 +3259,19 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float | None,
         for r in gate.unresolved:
             w(f"- `{r.mutation.tag}` in `{r.mutation.symbol}`")
         w("")
+    if gate_conclusion(gate, missing) == NOTHING:
+        w("### Nothing to sweep — and that is not the same as nothing wrong")
+        w("")
+        w("**Not one mutation was applied on this branch**, so this page is a record of a "
+          "question nobody asked rather than of an answer. Either no file under the swept "
+          "paths changed, or the lines that changed offer no operator anything to mutate "
+          "— a docs commit, a news entry, a config key, a one-line reordering. All of "
+          "those are legitimate, none of them fails here, and none of them is evidence "
+          "that what this branch added is tested.")
+        w("")
+        w("If the branch does add a guard, the guard is somewhere this sweep does not "
+          "charge, or in a shape no operator in the table reaches. Say what would break "
+          "if the line were deleted, and show it — by hand is fine. This gate cannot.")
     if gate_conclusion(gate, missing) == CLEAN:
         w("Every mutation this branch offered goes red. Nothing added here is a line the "
           "suite would not miss.")
@@ -3191,6 +3392,19 @@ def base_for(root: Path, ref: str, override: str | None) -> str:
     `origin/main` when the remote is there, `main` when it is not — a fresh clone, a
     worktree, and CI all differ on that. The merge-base and not the tip, because a branch
     is answerable for what IT added and not for what main gained while it was open.
+
+    **This default is also the right answer on a merge commit, and #776 is what it costs
+    to override it.** `refs/pull/N/merge` has the base branch tip as its FIRST parent, and
+    nothing later than that parent is reachable from the merge — so the merge-base of the
+    merge with `origin/main` *is* that parent, exactly. `sweep.yml` used to pass the pull
+    request payload's `base.sha` instead, which is the payload's idea of where the branch
+    started and lags the tree `actions/checkout` produces: measured on run 33331151759,
+    `HEAD is now at 58411a9 Merge 04bf8e6 into c29f3a8` against a payload base of
+    `d40d998`, three main commits earlier, so a branch touching one Python file was
+    charged for three. **A stale explicit base is not a smaller default, it is a different
+    branch's lines**, and the survivors it produces land on an author who cannot judge
+    them. The override stays — it is how a person asks about some other range — and the
+    workflow no longer uses it.
     """
     if override:
         return git("rev-parse", override, cwd=root).strip()
@@ -3381,24 +3595,46 @@ def main(argv: list[str] | None = None) -> int:
         log(f"  diff against {base[:12]}: {len(scope)} file(s), "
             f"{sum(len(v) for v in scope.values())} added line(s)")
     if args.plan or args.warm_map:
-        return _plan_step(args, root, ref, scope, dirty, workdir, cache_dir, log)
+        return _plan_step(args, root, ref, base, scope, dirty, workdir, cache_dir,
+                          log)
     if not scope:
         log("  nothing under the swept paths changed. Nothing to do.")
+        # The same page and the same sentence the merge step publishes, and not a private
+        # paragraph of its own (#782). This branch used to write "there was nothing to
+        # sweep" here while the check on the pull request said `no survivors` — two
+        # readers, two answers, and the affirmative one is the one people read.
+        empty = classify([])
         if args.summary:
-            _append(args.summary, "## Deletion sweep\n\nNothing under the swept paths "
-                                  "changed on this branch, so there was nothing to sweep.\n")
+            _append(args.summary, gate_summary(empty, ref, base, time.time() - started,
+                                               args.enforce))
         # An empty result set and not a missing file. Downstream — the merge step, and
         # anyone reading the artifact — "the sweep ran and found nothing to do" and "the
         # sweep never reported" are the two answers #617 is about, and a shard that
         # writes nothing here is indistinguishable from a shard that was cancelled.
         if args.json:
             Path(args.json).write_text(as_json([]))
+        if args.gate:
+            _say(args, empty, log)
         return 0
+
+    # Decided once, before a sandbox exists, and said out loud either way (#773). The
+    # baseline is capped along with the mutants and not without them: a cap the mutants
+    # run under and the baseline does not can only ever manufacture a red the baseline
+    # never had, which is the one direction this tool must never fail in.
+    cap = address_space_cap(args.jobs)
+    if not cap_holds(cap):
+        cap = 0
+        log("  memory: this platform does not enforce an address-space limit, so a "
+            "mutation that allocates without bound can still take the machine (#773)")
+    else:
+        log(f"  memory: {cap / 1024 ** 3:.1f} GiB of address space per run — a mutant "
+            f"that allocates without bound is a red here, not a dead machine")
 
     # The map is measured on a clean checkout of the ref, so that a mutation is the only
     # thing that ever differs from what was traced.
     log("  preparing the reference sandbox…")
     ref_box = Sandbox(root, run_dir(workdir) / "ref", ref, dirty)
+    ref_box.memory_cap = cap
     selection = load_map(ref_box.path, paths, cache_dir, args.jobs, args.refresh_map, log)
 
     baseline = None
@@ -3431,7 +3667,7 @@ def main(argv: list[str] | None = None) -> int:
 
     results, pairs = sweep(root, ref, scope, selection, workdir, args.jobs, dirty,
                            args.second_order, log, full_timeout,
-                           parse_shard(args.shard) if args.shard else None)
+                           parse_shard(args.shard) if args.shard else None, cap=cap)
     elapsed = time.time() - started
     text = report(results, root, ref, base, baseline, elapsed, pairs)
     log("")
@@ -3494,7 +3730,7 @@ def _write_output(path: str | None, **values: str) -> None:
     _append(path, "\n".join(lines))
 
 
-def _plan_step(args, root: Path, ref: str, scope: dict[str, set[int]],
+def _plan_step(args, root: Path, ref: str, base: str, scope: dict[str, set[int]],
                dirty: dict[str, bytes], workdir: Path, cache_dir: Path,
                log) -> int:
     """Size the sweep, and optionally leave the selection map where the shards will find it.
@@ -3508,6 +3744,14 @@ def _plan_step(args, root: Path, ref: str, scope: dict[str, set[int]],
     plan, _ = plan_for(root, ref, scope, dirty)
     shards = shards_for(len(plan))
     log(f"  {len(plan)} mutations → {shards} shard(s) of at most {per_shard()} each")
+    # Named, so a foreign path is visible on the one job that runs before anything is
+    # spent (#776). A branch charged for another branch's file used to be invisible until
+    # a survivor arrived in it, and by then the reader is being asked to judge a line
+    # they have never seen. Capped, because `--all` puts the whole tree through here.
+    for rel in sorted(scope)[:20]:
+        log(f"    charged: {rel}")
+    if len(scope) > 20:
+        log(f"    charged: … and {len(scope) - 20} more file(s)")
     loud = over_budget(len(plan))
     if loud:
         # An annotation and not a log line. A cap nobody can see is the failure the spec
@@ -3515,8 +3759,14 @@ def _plan_step(args, root: Path, ref: str, scope: dict[str, set[int]],
         # nobody can see.
         log(f"::warning title={_property('The deletion sweep is over its budget')}::"
             + _escape(loud))
+    # `base` travels with the rest (#776). The merge step runs on its own machine, at
+    # `fetch-depth: 1`, where neither `HEAD^` nor `origin/main` is an object it has — so
+    # it cannot work out what was charged, and the value the workflow used to hand it was
+    # the pull request payload's `base.sha`, which is the very thing that issue is about.
+    # One job resolves the base, once, and every page that names it names the same sha the
+    # mutations were read against.
     _write_output(args.github_output, mutations=str(len(plan)), shards=str(shards),
-                  matrix=json.dumps(list(range(1, shards + 1))))
+                  matrix=json.dumps(list(range(1, shards + 1))), base=base)
     if args.warm_map:
         # From a sandbox, for the reason `main` builds it from one: the map is measured on
         # a clean checkout of the ref so that a mutation is the only thing that ever


### PR DESCRIPTION
Three things the deletion sweep said that were not true. One pull request, because they
interact: #776 lengthens the plan, a longer plan is more shards, and more shards spread
#773's runaway mutations across more of them.

Closes #776, closes #782, closes #773.

---

## #776 — it charged your branch for `main`'s lines

**The mechanism is not what the issue says, and the difference decides the fix.**

The issue reads as if the tool's scoping were wrong — "the correct charge is
`merge-base..HEAD`". The tool's scoping was already exactly that. `base_for`'s default is
the merge-base of the swept ref with `origin/main`, and for a merge commit **that is the
merge's own first parent**, because nothing later than the first parent is reachable from
the merge. It has always been right.

What was wrong is that `sweep.yml` overrode it with
`github.event.pull_request.base.sha`. That field is the payload's record of where the
branch started; it is **not** the tree `actions/checkout` puts on disk, and it lags. From
run 33331151759's own log, both lines from the same job:

```
HEAD is now at 58411a9 Merge 04bf8e6 into c29f3a8
diff against d40d998e06bd: 3 file(s), 458 added line(s)
```

`d40d998` is three `main` commits and three hours behind `c29f3a8`. So that branch — which
touches exactly one Python file — was swept for **three**, the extra two arriving from
`main`'s own commits, one of them a nine-file `charter save`.

**The fix is a deletion.** `plan` and `sweep` pass no `--base` at all and let the tool
resolve it; `plan` publishes the sha it charged as an output; `collect` takes its page
header from that output instead of from the payload. `tests/test_sweep.py` refuses
`pull_request.base.sha` by name in *any* `env:` of the file, so the one-line convenience
meets an assertion rather than a reviewer.

Reproduced as a real repository shaped like the tree CI checks out —
`ABranchIsNotChargedForWhatMainGainedWhileItWasOpen` — where the payload's base charges
three files and the tool's default charges one.

**This re-deals every shard**, and that is the reason it is worth saying out loud. `shard_of`
deals the plan round-robin, so a shorter plan puts different mutations on different
machines. Nothing is dropped and nothing is added — #754's property (order and membership
are settled before any shard runs, and identical across the plan and shard jobs) still
holds; membership simply moves once, here.

**A hazard that was checked and is not one.** Plan and shards resolve the base
independently, so they could in principle disagree. They cannot: `actions/checkout` fetches
`+<github.sha>:refs/remotes/pull/N/merge`, so every job in the run checks out the *same*
fixed merge commit, and the merge-base of a fixed merge commit with a fast-forward-only
`main` is invariant however far `main` moves mid-run.

---

## #782 — it said `no survivors` for a branch it never measured

`no survivors: pass` published beside `mutations applied: 0`. There is now a fourth verdict
beside the other three, in the same place they live — the check's name:

```
no survivors                 N mutations, none survived
nothing to sweep             0 mutations planned            <- new
no verdict: 2 of 5 shards …  the run could not answer
```

It **does not fail**, deliberately: docs, config, a news entry and a one-line reordering all
land here and failing them would train people around the gate. The run summary gains a
section saying in as many words that the page is not evidence the branch is tested, and the
terminal report says the same thing rather than "Every mutation this diff offered goes red"
over a plan of none.

`nothing to sweep` can never be worn by a run that lost a shard: `missing` is asked first
and still answers `no verdict`.

**The issue's suggested source for the count was not used, and using it would have been a
new lie of the same kind.** It proposed taking the plan length from the sizing job. That
output is the *empty string* when `plan` is cancelled, and an empty string read as zero
publishes `nothing to sweep` for a sweep that was superseded — exactly the shape #782 is
about. The merged result set answers the question exactly and cannot be empty for any other
reason: `Gate.measured == 0` with `missing == 0` is true if and only if no mutation reached
a sandbox.

Reproduced end to end at `test_a_diff_that_offers_no_mutation_is_not_a_branch_that_was_checked`
— #779's shape, a branch that adds `rows.append(1)`: a file changes, lines are added, the
scope is not empty, and no operator has anything to say about it.

---

## #773 — a mutant could eat the runner, and the report blamed the pool

Every run now gets an address-space cap: one share of the machine per sandbox and one left
over (`total // (jobs + 1)`), floored at the 2 GiB the suite was measured to need. A mutant
that crosses it raises `MemoryError` in the child — a red, on tests that were green
unmutated, which `decide` turns into a **pin**. The baseline runs under the same cap as the
mutants, because a cap the mutants have and the baseline does not could only ever
manufacture a red the baseline never had.

**The proposed delivery does not survive contact, and it fails toward "the tool does not
run".** `resource.setrlimit(RLIMIT_AS, …)` *raises* on macOS, and a `preexec_fn` that raises
surfaces as `SubprocessError` **in the parent** — so `RLIMIT_AS` via `preexec_fn`, written
as the issue proposes it, makes every mutation on the operator's own machine fail to run at
all. #572 is the issue about this tool being unusable on macOS. Second, `preexec_fn` calls
back into Python between `fork` and `exec`, which the standard library says is unsafe in the
presence of threads, and this sweep runs its sandboxes from a `ThreadPoolExecutor`.

Shipped instead as `/bin/sh -c 'ulimit -v "$1" || exit 89; shift; exec "$@"'` — thread-safe,
and `exec` keeps the pid the sweep holds, which `_kill_group`, the process group and both
timeouts all work through. `cap_holds()` measures once, in one process, whether the platform
takes a limit at all, and the sweep says which answer it got. macOS takes none, and says so.

**Measured, not assumed** (a Debian container, since the mechanism is Linux-only):

| what | result |
|---|---|
| whole suite, uncapped | 9,581 tests, peak tree RSS **253 MB**, peak tree VSZ **1,580 MB** |
| whole suite under a runner-sized cap (`ulimit -v 3355443`, = 3.2 GiB) | same failures, same skips — the cap changes nothing legitimate |
| a mutant allocating without bound, capped at 512 MiB | red, `conclusive`, one named failing test — a **pin** |
| the same mutant, cap removed | the child is killed with no verdict at all — #773's own signature |

The last two are `AMutantThatEatsTheMachineIsARedAndNotAnOutage`, which runs for real on
Linux (all four CI Pythons) and skips loudly on macOS.

**A static detector was not built, and the issue is right that it would fail open** — the
fastest of #710's four runaways leaves every loop inside its own function terminating and
corrupts a cursor returned *across* a function boundary, so the caller is what spins.

`docs/superpowers/specs/2026-08-27-deletion-sweep-harness.md` now lists six ways a sweep
lies rather than five, with this one's distinguishing property written down: it takes the
measuring apparatus with it rather than producing a wrong answer.

---

## Checks

* Every new case was run with its guard removed and confirmed red — including the two
  Linux-only ones, checked in a container.
* `tools/sweep.py --gate --path tools` on this branch: the sweep's own verdict on its own
  new code, reported in the pull request thread.
