### PR TITLE
The frame reads on the terminal it is on: paired foregrounds, an uncoloured highlight, a live-pane cue, and the accent palette is the plane's (#737, #736, #750)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2236,15 +2236,48 @@ _CHROME_STYLE = f"{_CHROME_FG},dim"
 #: **Both styles, and that is the whole first half of the fix**: setting one leaves the
 #: other at tmux's default, which is how the two came to disagree in the first place.
 #:
-#: The other three are the same defect wearing different options, and they bite on the
-#: OPERATOR'S server where their own `.tmux.conf` is what charter would otherwise
-#: inherit (measured, with a hostile config on a real 3.7c): `pane-border-indicators
-#: arrows` puts `↑`/`←` glyphs on the active pane's borders and no others, so one rule
-#: carries a glyph its neighbour does not; `pane-border-lines double`/`heavy`/`number`
-#: redraws every rule in a different weight (`number` writes pane NUMBERS into them);
-#: and `pane-border-status top` is the worst of the three — it turns every border into a
-#: title bar carrying `#{pane_title}` (the machine's hostname, by default) AND adds a
-#: border row above the topmost pane, a row `layout._BORDER_ROWS` never budgeted for.
+#: The other two on this list are the same defect wearing different options, and they bite
+#: on the OPERATOR'S server where their own `.tmux.conf` is what charter would otherwise
+#: inherit (measured, with a hostile config on a real 3.7c): `pane-border-lines
+#: double`/`heavy`/`number` redraws every rule in a different weight (`number` writes pane
+#: NUMBERS into them); and `pane-border-status top` is the worst of them — it turns every
+#: border into a title bar carrying `#{pane_title}` (the machine's hostname, by default)
+#: AND adds a border row above the topmost pane, a row `layout._BORDER_ROWS` never
+#: budgeted for.
+#:
+#: **`pane-border-indicators` is pinned to `arrows`, and it used to be pinned to `off`.**
+#: That is #750, and the correction is a measurement rather than a change of taste. With
+#: the shipped `chrome = "off"` there is no surface, so `window-active-style` has no shade
+#: to be one step from and the two rule styles are pinned to one value on purpose — which
+#: left the frame with **nothing at all** saying which pane the keyboard is in. That
+#: matters more than it sounds, because `F12` exists for "you are in a pane that is not
+#: answering" and the frame gave no way to notice you were in one.
+#:
+#: The reason it was `off` was that `arrows` "puts a glyph on the active pane's borders
+#: and no others, so one rule carries a glyph its neighbour does not". That is true, and
+#: read off an attached client's wire through a nested tmux on 3.7c it is not #514's
+#: defect — it is the cue. #514 was a rule whose COLOUR changed mid-line; the arrow is a
+#: glyph substituted into a rule that keeps one style along its whole length. Measured,
+#: charter's own shape (a harness beside a sidebar, a footer under both), the bottom rule
+#: in full::
+#:
+#:     harness active   ESC[2m ─↑─────────────────────────────────┴──────────────
+#:     sidebar active   ESC[2m ───────────────────────────────────┴─↑────────────
+#:     footer active    ESC[2m ─↓─────────────────────────────────┴─↓────────────
+#:
+#: One `ESC[2m` at the start of the row and none anywhere else in it: the rule is the same
+#: dim default-foreground rule charter has drawn since #514, and the only thing that moved
+#: is which cell holds an arrow. The vertical divider carries `←`/`→` the same way.
+#:
+#: **And it costs nothing on the frame that already has an answer.** Over a surface with
+#: the shipped `rules = "hidden"` the rule is `fg=<surface>,bg=<surface>` — the glyph IS
+#: the background — so the arrow disappears exactly where `window-active-style`'s one-shade
+#: step is already saying which pane is live. The cue appears where there is no other, and
+#: nowhere else, without a word being read to decide it.
+#:
+#: What is lost below `tmuxctl.BORDER_INDICATORS_FLOOR` is the cue and not the frame: tmux
+#: 3.2 has no such option, charter does not issue it there, and that plane gets the frame
+#: it has today. Which is the third field's whole job.
 #:
 #: `pane-border-format` is deliberately NOT here: it is inert while `pane-border-status`
 #: is `off`, and pinning a format nothing renders would be pinning a spelling rather than
@@ -2277,7 +2310,7 @@ _CHROME_STYLE = f"{_CHROME_FG},dim"
 _CHROME: tuple[tuple[str, str, tuple[int, int]], ...] = (
     ("pane-border-style", _CHROME_STYLE, tmuxctl.FLOOR),
     ("pane-active-border-style", _CHROME_STYLE, tmuxctl.FLOOR),
-    ("pane-border-indicators", "off", tmuxctl.BORDER_INDICATORS_FLOOR),
+    ("pane-border-indicators", "arrows", tmuxctl.BORDER_INDICATORS_FLOOR),
     ("pane-border-lines", "single", tmuxctl.FLOOR),
     ("pane-border-status", "off", tmuxctl.FLOOR),
 )

--- a/charter/frame/chrome.py
+++ b/charter/frame/chrome.py
@@ -310,6 +310,87 @@ def undim(row: str) -> str:
         row)
 
 
+#: Every SGR parameter that names a COLOUR, read as numbers.
+#:
+#: ``30``–``49`` is the whole of the ordinary pair — 30-37 foreground, 38 the extended
+#: foreground introducer, 39 the default foreground, and 40-49 the same four things said
+#: about the background — and ``90``–``97``/``100``–``107`` are the aixterm bright halves
+#: of the first two. ``58``/``59`` are the underline colour and its default, which are a
+#: colour by the same reading and have to be walked anyway: 58 introduces a colour space
+#: exactly as 38 and 48 do (:data:`_EXTENDED_COLOUR`).
+#:
+#: **A range and not a list of the codes charter happens to write.** :func:`reverse` runs
+#: over a row a renderer finished, and the property is "this parameter names a colour", not
+#: "this is one of the six spellings `statusline` uses". That is
+#: :func:`resets_everything`'s own distinction said about a wider question — and it is what
+#: made ``[frame] ok``/``warn``/``bad`` widen charter's palette without widening this.
+#:
+#: 38, 48 and 58 are inside the range and :func:`_without_colour` never reaches them
+#: through it, because :data:`_EXTENDED_COLOUR` claims them one branch earlier. They stay
+#: because the range is the STATEMENT — every parameter from 30 to 49 names a colour — and
+#: carving three holes in it to record which branch happens to catch them would make the
+#: constant a description of the loop rather than of SGR.
+_COLOUR_PARAMS = frozenset({*range(30, 50), 58, 59, *range(90, 98), *range(100, 108)})
+
+
+def _without_colour(params: str) -> str | None:
+    """The SGR parameter list *params* with every colour removed — ``None`` when the whole
+    escape should go.
+
+    :func:`_without_dim`'s walk asked about a different set, and every one of that
+    function's measured hazards is live here for the same reasons: a parameter's numeric
+    value and not its spelling (``\\x1b[032m`` is magenta), a parameter anywhere in the
+    list and not only at its head (``\\x1b[1;32m`` is bold AND green, and only the green
+    goes), and — the one that would hand a terminal a colour nobody asked for —
+    :data:`_EXTENDED_COLOUR`'s space parameter, so ``38;2;255;0;0`` is consumed as one run
+    of five rather than filtered a digit at a time. Measured against the spellings that
+    reach a pane::
+
+        params         string-match ("3x")   numeric, position-aware
+        '32'           True                  dropped
+        '032'          False  <- MISSED      dropped
+        '1;32'         False  <- MISSED      '1'
+        '0;7'          False                 '0;7'      <- an attribute list, kept whole
+        '38;5;236'     False                 dropped    <- the colour SPACE, consumed
+        '2'            False                 '2'
+
+    **It DROPS the introducer where :func:`_without_dim` keeps it, and the two are right to
+    differ.** That function removes one attribute from a list it otherwise leaves alone, so
+    it extends the whole colour run through untouched; this one removes the colour, so the
+    introducer goes with it. Where the two visibly disagree is on a colour space neither
+    recognises — ECMA-48 leaves that undefined and there is no run length to consume — so
+    ``58;7;1`` comes out of `_without_dim` intact and out of this as ``7;1``, reverse and
+    bold. Whatever a terminal made of the original, what is left here is what it would have
+    made of the tail: an unknown space cannot be walked past, and charter does not invent a
+    length for it. `test_a_colour_space_charter_does_not_know_is_taken_as_one_parameter_too`
+    pins the whole answer rather than an absence.
+
+    ``None`` rather than ``""`` for a list that emptied, and it is the same correctness
+    :func:`_without_dim` spells out rather than a copied idiom: ``\\x1b[m`` is an SGR whose
+    omitted parameter takes SGR's default of **zero**, so emitting it for a ``\\x1b[35m``
+    that had nothing else in it would replace "draw this magenta" with "turn EVERYTHING
+    off" — cancelling the reverse video this pass exists to protect, one escape after
+    :func:`reverse` re-asserted it. A list that still holds a parameter comes back as a
+    string even when that string is empty, because ``\\x1b[;35m`` really did carry a reset
+    and the reset survives.
+    """
+    kept: list[str] = []
+    pieces = params.split(";")
+    i = 0
+    while i < len(pieces):
+        # Every piece is digits or empty — `_SGR` admits nothing else — so `int` cannot
+        # raise, and an empty piece is spelled as the zero it means.
+        value = int(pieces[i] or "0")
+        if value in _EXTENDED_COLOUR:
+            space = int(pieces[i + 1] or "0") if i + 1 < len(pieces) else -1
+            i += {5: 3, 2: 5}.get(space, 1)
+            continue
+        if value not in _COLOUR_PARAMS:
+            kept.append(pieces[i])
+        i += 1
+    return ";".join(kept) if kept else None
+
+
 def _role_values() -> dict[str, str]:
     """The roles of §5 a RENDERER can write, and the SGR each one is. **The vocabulary.**
 
@@ -329,8 +410,23 @@ def _role_values() -> dict[str, str]:
     24-bit triple.** That is `instance.FRAME_CHROME`'s rule reaching the one place a
     stranger's code would otherwise have to guess it, and it is why these need no
     `[frame] chrome` gate: bold and reverse are statements relative to whatever the
-    operator's terminal already is, and ``green``/``yellow``/``red`` are slots in their
-    own palette rather than colours charter picked out of the 256.
+    operator's terminal already is, and the three accents are slots in the operator's own
+    palette rather than colours charter picked out of the 256.
+
+    **The three accents are the PLANE's words now** (`instance.FRAME_ACCENTS`,
+    `statusline.accent`), and that is the half of the argument above that did not hold. "A
+    slot in the operator's own palette" says the colour is theirs; it does not say it is
+    legible on the ground charter is drawing it on, and those are different claims. Green,
+    yellow and red are chosen against a dark terminal exactly as `muted`'s dim was — on the
+    machine `[frame] text` was written for, **yellow on tan** is the pair nobody's palette
+    was designed for, and no amount of it being their own yellow makes it readable. Charter
+    still cannot compute which of the sixteen would be (`instance.FRAME_PANE_FG` carries
+    the measurements), so it is told, in the vocabulary the plane already answers ``bg``
+    and ``text`` in.
+
+    So the gate is a role's own word rather than a switch — one asked of `statusline`, the
+    same function charter's own renderers ask, so a provider composing with
+    ``ctx.chrome["warn"]`` and the frame's own attention strip cannot come out two colours.
 
     **That argument used to name three attributes and it was wrong about one of them.**
     Dim is relative in exactly one direction — toward the background — and the direction is
@@ -349,7 +445,7 @@ def _role_values() -> dict[str, str]:
     """
     from .. import statusline as sl
     return {"heading": sl._BOLD, "muted": sl._DIM, "selected": _REVERSE,
-            "ok": sl._GREEN, "warn": sl._YELLOW, "bad": sl._RED, "reset": sl._R}
+            **sl.accents(), "reset": sl._R}
 
 
 def recipes() -> MappingProxyType:
@@ -425,6 +521,16 @@ def recipes() -> MappingProxyType:
     return MappingProxyType(out)
 
 
+def _params_of(*values: str) -> frozenset[int]:
+    """Every SGR parameter in *values*, as numbers — :func:`served_params`' inner walk, said
+    once so the constant below and the live half cannot read a role two ways."""
+    out: set[int] = set()
+    for value in values:
+        for m in _SGR.finditer(value):
+            out.update(int(p or "0") for p in m.group(1).split(";"))
+    return frozenset(out)
+
+
 def served_params() -> frozenset[int]:
     """Every SGR parameter charter's own recipes are made of, read as NUMBERS.
 
@@ -433,12 +539,57 @@ def served_params() -> frozenset[int]:
     handed a colour that is escaped on the way out, which is #707 — or *admitted and not
     served*, which is a vocabulary charter enforces and nobody documents. One source, and
     a role added above widens this on the same commit.
+
+    **And the SHIPPED accents stay admitted whatever the plane said**, which is the half a
+    plain derivation gets wrong now that three of the roles are configurable. `_role_values`
+    answers the plane's colours; a provider's component is ordinary Python that hard-coded
+    ``\x1b[32m`` long before this plane existed, and a green ESCAPED into a pane as the
+    six visible characters of its own SGR is #707 arriving through the new key. So the two
+    are UNIONED: what the plane chose is served and admitted, and what charter has always
+    drawn stays admitted. This is `[frame] dim`'s own decision said about a colour —
+    #768 kept SGR 2 admitted on a plane that turned dim off for exactly this reason, so a
+    provider's dim is deleted by :func:`undim` on the way out rather than escaped into
+    their pane as text.
+
+    The union only ever GROWS the vocabulary, and every parameter in it is one of the
+    sixteen ANSI names or an attribute — `instance.FRAME_PANE_COLOURS`' rule, unchanged.
+    A plane cannot narrow what a provider may write, which is the direction that would
+    have broken somebody else's component.
+
+    **This is asked once per LINE of every foreign pane**, which is :func:`is_recipe`'s own
+    "the vocabulary is on the repaint path" said one function up, and the accents made it
+    cost more. Measured on this machine, per call::
+
+        a `look_of` per role, ten escapes walked   6.69 us
+        one `look_of`, seven escapes walked        5.09 us   <- this
+        before the accents existed                 3.30 us
+
+    The first line's extra came from two places, and both are fixed rather than accepted.
+    `_role_values` asked `statusline.accent` three times and each resolved `config.FRAME`
+    for itself — three readings of one plane inside one expression, which is `no_colour`'s
+    "one question asked in one place" costing time as well as correctness;
+    `statusline.accents` resolves the `Look` once and answers all three (1.77 us -> 0.75).
+    And the union walked three more escapes with a regex, which is the paragraph below.
+
+    What is LEFT is 1.8 us a call and it is not free: a 24-row foreign pane carrying a dozen
+    escapes a row pays 122 us where it paid 79, against `render`'s own measured 4 816 us —
+    2.5% of what that pane already costs, and paid only by a pane charter did not write. It
+    buys the plane's own three words reaching a provider's component, which is the whole
+    point of serving recipes at all, and the alternative is a cached vocabulary that a frame
+    relaunch would have to invalidate.
+
+    **The shipped half arrives as a SET and is never walked here**, which is the other half
+    of the cost. `statusline._SHIPPED_ACCENT_PARAMS` is `frozenset({31, 32, 33})`, computed
+    once at that module's import from its own constants — so this walks the seven roles it
+    always walked rather than ten, and the numbers cannot drift from the escapes they came
+    from. That constant lives there rather than here because `chrome` cannot reach
+    `statusline` at ITS import time: `frame/registry.py` imports this module while
+    `charter.frame` is still initialising, and the reach closes a cycle through `config` ->
+    `instance.frame_of` -> `frame/builtins.build` (measured, as an `AttributeError` on a
+    partially initialised module).
     """
-    out: set[int] = set()
-    for value in _role_values().values():
-        for m in _SGR.finditer(value):
-            out.update(int(p or "0") for p in m.group(1).split(";"))
-    return frozenset(out)
+    from .. import statusline as sl
+    return _params_of(*_role_values().values()) | sl._SHIPPED_ACCENT_PARAMS
 
 
 def is_recipe(params: str, served: frozenset[int]) -> bool:
@@ -712,9 +863,53 @@ def reverse(row: str, width: int) -> str:
     unconditionally keeps the row highlighted just as well and says so three times as
     often — bytes written into a pane on every repaint that change nothing on the screen.
 
+    **And every colour inside the run is DELETED, which is #736 and a correction to the
+    argument above rather than an addition to it.** "Reverse video is your own foreground
+    and background exchanged, so it is right on every colour scheme" holds only for a
+    reversed run that sets no colour of its own — and both surfaces that use this one set
+    an absolute ANSI foreground inside it. Read off the operator's own live frame with
+    ``capture-pane -e``, the sidebar's active row and the repo table's selected row::
+
+        ESC[7m ESC[35m ▸ ESC[1m steward ESC[0;7m        ESC[32m ✎47 ESC[0m
+        ESC[7m   ESC[2m ├─ ESC[0;7m ESC[36m billing       ESC[33m main* ESC[39m
+
+    SGR 7, and then magenta, cyan and **yellow** — colours a renderer chose to sit on the
+    terminal's BACKGROUND, painted onto a cell whose background is now the terminal's
+    FOREGROUND. On a dark theme the selected repo row draws yellow on light grey, which is
+    the worst pair the sixteen can make, on the one row charter uses to say "this is the
+    one you picked". On a light theme it inverts and reads fine, which is why it survived
+    being written.
+
+    **A DELETION and never a substitution**, which is :func:`undim`'s own honesty and the
+    only form this could take: charter cannot know what the operator's magenta looks like
+    on the operator's foreground (:data:`instance.FRAME_PANE_FG` records why), so it cannot
+    choose a replacement — but it can decline to paint a pair it has no way to check. What
+    is lost is nothing the row was saying: `NoStatusIsCarriedByColourAlone` already asserts
+    every status in this frame survives having its escapes stripped, so the glyph column
+    says it and the reverse video says the row is picked. Attributes are untouched — bold
+    is bold and dim is dim on any ground — so `_table_row`'s emphasis and the tree's dim
+    still read.
+
+    **Here rather than at the two call sites**, and the reason is what a renderer can know
+    rather than a third caller: `slots.py`'s sidebar and repo table are the only two rows
+    that reverse today, and neither renderer knows it is about to be highlighted — the
+    highlight goes on after the row is finished, which is this module's whole ordering rule.
+    A colour deleted at the call site would be deleted by the code that has no idea whether
+    the row is the chosen one.
+
+    **This does NOT reach a provider's pane, and that is stated rather than implied.** A
+    component draws its own rectangle; charter never highlights a row a provider wrote, so
+    nothing here runs over one. `contain_row` — the pass that DOES run over a provider's row
+    — admits SGR 33 and passes it through untouched, which is #707's channel working as
+    designed: charter cannot know what somebody else's yellow means, so it neither recolours
+    it nor escapes it into their pane as text. A component that inverts its own row and
+    wants this is served the same three words charter uses (:func:`recipes`) and can delete
+    its own colours; charter deleting them for it would be deciding what its row means.
+
     Applied to the row a renderer has already finished, at the width that renderer
-    measured. It needs no `[frame] chrome` gate: reverse names no colour, so there is no
-    theme it can be wrong on.
+    measured. It needs no `[frame] chrome` gate: what leaves here names no colour at all,
+    so there is no theme it can be wrong on — which is the claim `docs/frame.md` was
+    already making and this is what makes it true.
 
     **The no-columns refusal is live here and it is not in `fill`.** Without it a pane of
     zero width still gets `_OFF` written into it — a bare `\\x1b[0m` where the caller
@@ -724,7 +919,43 @@ def reverse(row: str, width: int) -> str:
     """
     if width <= 0:
         return ""
-    body = _SGR.sub(
-        lambda m: m.group(0) + (_REVERSE if cancels_reverse(m.group(1)) else ""),
-        tui.truncate(row, width))
+    body = _SGR.sub(_restated, tui.truncate(row, width))
     return fill(_REVERSE + body, width) + _OFF
+
+
+def _restated(m: re.Match) -> str:
+    """One SGR inside a reversed run, rewritten: its colours gone and reverse put back if
+    it turned reverse off.
+
+    **"Did this cancel reverse" is asked of what SURVIVED, and that ordering is the whole
+    correctness of the pair.** A colour's ARGUMENTS are not SGR parameters — they are the
+    channels of one — and :func:`cancels_reverse` cannot tell the difference on its own,
+    because by the time it sees a list they are all just numbers. Measured on the spellings
+    that make it matter::
+
+        params           any parameter == 0?   what the escape really says
+        '38;2;255;0;0'   yes  <- GREEN, BLUE   a 24-bit red foreground
+        '38;2;0;0;27'    yes  <- and 27 again  a 24-bit green foreground
+        '0'              yes                   turn everything off
+
+    Read whole, the first two say "reverse was cancelled" and charter writes a ``\\x1b[7m``
+    that changes nothing on the screen — bytes into a pane on every repaint, which is the
+    one thing :func:`reverse`'s "only where it was cancelled" rule exists to prevent.
+    Deleting the colour FIRST is what turns a parameter list into its parameters: the run is
+    consumed whole (:data:`_EXTENDED_COLOUR`), so the channels are gone and what is left is
+    the SGR the escape actually carried. An escape that emptied cancelled nothing at all.
+
+    ``\\x1b[38;m`` is the case that shows these are not one question asked twice: the
+    introducer is consumed, the omitted parameter after it survives, and an omitted
+    parameter is SGR's default of **zero** — so the escape becomes ``\\x1b[m`` and the
+    re-assertion is owed after it. Both answers come from the same surviving list, which is
+    what keeps them from disagreeing.
+
+    The colour goes first and the re-assertion is appended after whatever survived, because
+    an escape that emptied is deleted whole: ``\\x1b[35m\\x1b[7m`` for a row that only ever
+    said magenta would be two escapes where the row needs none.
+    """
+    kept = _without_colour(m.group(1))
+    if kept is None:
+        return ""
+    return f"\x1b[{kept}m" + (_REVERSE if cancels_reverse(kept) else "")

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -881,7 +881,7 @@ def _table_row(lead: str, name_markup: str, r: dict, width: int,
 
     change = r.get("change")
     sigil = r.get("sigil") or "!"
-    mr = f"{sl._GREEN}{sigil}{change}{sl._R}" if change else ""
+    mr = f"{sl.accent('ok')}{sigil}{change}{sl._R}" if change else ""
 
     row = tui.Row(tui.Cell(f"{lead}{name_markup}", 2 + 3 + sl._NAME_W),
                   tui.Cell(branch_cell, sl._BRANCH_W),
@@ -1061,7 +1061,15 @@ def _table_lines(data: dict, width: int, budget: int, *, offset: int = 0,
         # — `chrome.reverse`'s whole reason, measured on this exact shape of row: every
         # coloured span here ends in `sl._R`, and a `\x1b[7m` wrapped naively around the
         # outside dies at the first one. Applied to the finished row rather than composed
-        # into it so that the branch, CI and change cells keep their own colours inside it.
+        # into it, so this function composes one row and one function decides what a chosen
+        # row looks like.
+        #
+        # **What it does NOT do is keep the cells' colours, and that line used to say it
+        # did** (#736). The branch cell is `sl._YELLOW` when the repo is dirty and the CI
+        # cell is `sl._GREEN`/`sl._RED`, and inside a reversed run those sit on the
+        # terminal's own FOREGROUND — yellow on light grey, on a dark theme, on the one row
+        # that says which repo you picked. `chrome.reverse` deletes them; the glyphs and
+        # `NoStatusIsCarriedByColourAlone` are what still say what the cells mean.
         lines.append(_Line(r["name"],
                            chrome.reverse(row, width) if r["name"] == selected else row))
 
@@ -2281,7 +2289,7 @@ def _inflight_field() -> str:
     stalled = len(records) - running
     parts = []
     if running:
-        parts.append(f"{sl._YELLOW}{spinner_frame()} {running} running{sl._R}")
+        parts.append(f"{sl.accent('warn')}{spinner_frame()} {running} running{sl._R}")
     if stalled:
         parts.append(f"{sl._DIM}⋯ {stalled} stalled{sl._R}")
     return " ".join(parts)

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -629,6 +629,66 @@ def chrome_options(level) -> tuple[tuple[str, str], ...]:
     return FRAME_CHROME[lv] if lv else ()
 
 
+#: The foreground that goes with each :data:`FRAME_CHROME` surface — the other half of a
+#: recipe that shipped with only one.
+#:
+#: **A background with no paired foreground is the defect** (#737). ``window-style
+#: bg=white`` leaves every cell no renderer coloured drawing in the TERMINAL's own default
+#: foreground, which the operator's theme picked to sit on the terminal's own background —
+#: and that is no longer the background it is sitting on. So ``chrome = "light"`` on a dark
+#: terminal is light-on-white and ``chrome = "dark"`` on a light terminal is dark-on-black.
+#: Measured from the attention strip's own bytes on a dark-theme terminal::
+#:
+#:     ESC[0m ESC[47m 7 todos · F2 palette · ESC[2m…
+#:            ^^^^^^^ the pane's `bg=white`, and no `SGR 3x` anywhere after it
+#:
+#: Not "a background that clashes" — panels whose text is not there. An operator toggling
+#: `chrome` from the palette to see which of the two words they like finds one of them
+#: blank and reasonably concludes the frame is broken.
+#:
+#: **This is a table of TWO words and it is deliberately not seventeen**, which is the
+#: whole of what makes it a measurement rather than the guess :data:`FRAME_PANE_FG` refuses
+#: to make. Charter cannot compute contrast — the sixteen ANSI names have no fixed RGB, OSC
+#: 11 through tmux answers nothing, and ``$COLORTERM`` inside a pane describes the terminal
+#: that started the SERVER — so it cannot say what goes on ``bg=blue``. It can say what goes
+#: on ``bg=black`` and ``bg=white``, because those two are not colours charter is guessing
+#: about: they are the POLES of the sixteen. A theme is free to render its blue as anything
+#: it likes, and a theme that renders its ``white`` darker than its ``black`` has stopped
+#: being a theme. `dark` and `light` are charter's OWN recipes rather than words an operator
+#: wrote, so completing them is charter finishing a sentence it started.
+#:
+#: **Which is exactly why a component's own ``bg`` is NOT in here.** ``bg = "blue"`` is the
+#: operator's word out of their own palette, and pairing a foreground with it would be
+#: charter deciding a contrast it has already established it cannot see. What that pane has
+#: instead is :data:`FRAME_PANE_FG` — ``[frame] text``, the plane saying it in the same
+#: vocabulary it said the background in. :func:`surface_options` holds that line by
+#: construction: this table is read only where `chrome_options` supplied the background.
+#:
+#: ``off`` is here with an empty clause for :data:`FRAME_PANE_FG`'s ``default`` reason — a
+#: frame with no background needs no foreground to go with it, and the empty string is what
+#: makes a plane that said nothing emit byte-identical options to the frame it had before
+#: this key existed. Keyed on every word of :data:`FRAME_CHROME` so a third surface added
+#: there cannot be the one that ships without its foreground; `TheChromeTableAndItsFore
+#: groundsAreOneVocabulary` asserts the two key sets are equal.
+FRAME_CHROME_FG: dict[str, str] = {"off": "", "dark": "fg=white", "light": "fg=black"}
+
+
+def chrome_fg(level) -> str:
+    """The ``fg=`` clause that goes with the :data:`FRAME_CHROME` surface *level* — ``""``
+    for ``off``, and ``""`` for every word charter does not know.
+
+    :func:`text_fg`'s contract for the frame-wide half, and the same function for the same
+    reason: what comes back is charter's own constant and never the caller's argument, so a
+    committed word charter does not recognise indexes nothing and leaves through neither
+    half of the style.
+
+    Empty is the ANSWER for ``off`` and only incidentally the failure mode, which is
+    :func:`text_fg`'s own note said about the other table.
+    """
+    lv = chrome_level(level)
+    return FRAME_CHROME_FG[lv] if lv else ""
+
+
 #: The eight ANSI colour names, each of which also has a ``bright`` form. The whole
 #: vocabulary a ``[[frame.component]] bg`` may say, doubled to sixteen and given a
 #: seventeenth word by :data:`FRAME_PANE_BG` below.
@@ -990,9 +1050,16 @@ class Look(NamedTuple):
     It carries what the PLANE said and nothing derived from a pane: which pane wears which
     background is `component_style`'s question and stays there.
 
-    ``dim`` is a ``bool`` and the other two are words out of :data:`FRAME_RULES` and
-    :data:`FRAME_PANE_FG`. Nothing here is trusted as a tmux VALUE — `rules` selects a
-    branch, `text` is a key into a table, and `dim` decides whether a constant is appended.
+    ``dim`` is a ``bool`` and every other field is a word out of :data:`FRAME_RULES` or
+    :data:`FRAME_PANE_FG`. Nothing here is trusted as a tmux VALUE or as an SGR — `rules`
+    selects a branch, the four colour words are keys into tables, and `dim` decides whether
+    a constant is appended.
+
+    **The three accents have DEFAULTS on the field and the other three do not**, which is
+    not tidiness: `Look` is built positionally at a hundred call sites and in a dozen tests
+    written before the accents existed, and every one of them means "the shipped green,
+    yellow and red". A field with no default would have made those a syntax error rather
+    than a decision, and the decision they were making has not changed.
     """
 
     #: ``hidden`` or ``visible`` — :data:`FRAME_RULES`.
@@ -1001,6 +1068,14 @@ class Look(NamedTuple):
     text: str
     #: Whether charter may reduce the contrast of its own chrome — ``[frame] dim``.
     dim: bool
+    #: ``[frame] ok`` — what "this is fine" is drawn in. A key into :data:`FRAME_PANE_FG`'s
+    #: seventeen words, resolved to an SGR by `statusline.accent`.
+    ok: str = "green"
+    #: ``[frame] warn`` — what "look at this" is drawn in. **Yellow on a tan surface is the
+    #: pair this key exists for.**
+    warn: str = "yellow"
+    #: ``[frame] bad`` — what "this is broken" is drawn in.
+    bad: str = "red"
 
 
 def look_of(frame: dict) -> Look:
@@ -1020,7 +1095,8 @@ def look_of(frame: dict) -> Look:
     """
     return Look(rules=frame.get("rules", FRAME_DEFAULTS["rules"]),
                 text=frame.get("text", FRAME_DEFAULTS["text"]),
-                dim=frame.get("dim", FRAME_DEFAULTS["dim"]))
+                dim=frame.get("dim", FRAME_DEFAULTS["dim"]),
+                **{r: frame.get(r, FRAME_DEFAULTS[r]) for r in FRAME_ACCENTS})
 
 
 def rule_style(surface: str | None, style: str, look: Look) -> str:
@@ -1046,6 +1122,25 @@ def rule_style(surface: str | None, style: str, look: Look) -> str:
       (:func:`text_fg`) and the caller's *style* where it did not, so a frame that gave its
       panes a foreground draws its rules in it rather than in a colour nothing else on the
       screen is wearing.
+
+      **It does NOT reach for :data:`FRAME_CHROME_FG`, and that is a scope this function
+      does not have rather than an omission it made.** #737 paired a foreground with
+      charter's own two surfaces for the pane's INTERIOR, so a plane on
+      ``rules = "visible"`` with ``chrome = "light"`` gets ``fg=default,dim,bg=white`` on
+      its rules while its panes get ``fg=black,bg=white`` — the rule drawn in the
+      terminal's own foreground over charter's white. Three things bound how much that
+      costs: the shipped ``rules`` is ``hidden``, which returns before this line and gives
+      the glyph the surface's own colour; ``text`` overrides it in one line; and a rule is
+      one dim glyph rather than a pane of text.
+
+      Fixing it properly is not a line here. The surface this is handed is a bare ``bg=``
+      clause and ``bg=black`` is *both* ``chrome = "dark"``'s and a component's own
+      ``bg = "black"`` — so pairing off the surface would give a component's word the
+      foreground :data:`FRAME_CHROME_FG` deliberately refuses it, and pairing off the
+      ``chrome`` word means threading it through :func:`rule_options`,
+      :func:`pane_border_options` and `commands_frame._chrome_argvs`, whose surfaces come
+      from :func:`border_bg` and may be a component's rather than charter's. That is a
+      decision about the per-component half of the pairing, not a bug in this assembly.
     * ``dim`` is appended unless the plane turned it off, and never under ``hidden`` — see
       above.
 
@@ -1158,9 +1253,27 @@ def surface_options(name, chrome, look: Look) -> tuple[tuple[str, str], ...]:
     :data:`FRAME_PANE_BG`/:data:`FRAME_CHROME` as it always did, and the foreground out of
     :data:`FRAME_PANE_FG` through :func:`text_fg`, so a committed word that charter does not
     know indexes nothing and leaves through neither.
+
+    **A pane that took the frame-wide surface takes the foreground that goes with it**
+    (#737, :data:`FRAME_CHROME_FG`). ``chrome = "light"`` is charter's own ``bg=white``, and
+    shipping it without ``fg=black`` left every uncoloured cell drawing in the terminal's
+    default foreground — which on a dark theme is white, on white. The pairing is read off
+    the same ``or`` the background came from, so it reaches a pane exactly when
+    `chrome_options` did: a component that named its own ``bg`` supplied its own background
+    and gets no foreground it did not ask for, which is the line :data:`FRAME_CHROME_FG`
+    draws between charter's two recipes and the operator's seventeen words.
+
+    **``text`` wins, and it wins by being the only ``fg`` in the value rather than by
+    coming last in it.** A plane that named a foreground has said what its frame's text is
+    and charter's default for the surface is not a second opinion — so the two are resolved
+    to ONE clause here, not appended in an order that leaves tmux's last-wins parse to
+    decide. `TheStyleCarriesExactlyOneForeground` pins that over every pairing of the two
+    tables, because a value carrying two ``fg=`` clauses is a frame whose colour depends on
+    a tmux parsing rule nobody wrote down.
     """
-    pairs = pane_bg_options(name) or chrome_options(chrome)
-    fg = text_fg(look.text)
+    own = pane_bg_options(name)
+    pairs = own or chrome_options(chrome)
+    fg = text_fg(look.text) or ("" if own else chrome_fg(chrome))
     if not fg:
         return pairs
     if not pairs:
@@ -1377,6 +1490,20 @@ def verbosity_for(level) -> str:
     lv = density_level(level)
     return FRAME_DENSITY[lv]["verbosity"] if lv else DEFAULT_VERBOSITY
 
+#: The three roles `[frame]` lets a plane recolour, in the order they are documented.
+#:
+#: **A tuple and not three spellings**, for `chrome.served_params`' reason one module over:
+#: :class:`Look`, :func:`look_of`, :func:`frame_of`'s validation and `statusline.accent` all
+#: need the same list, and a fourth role added here reaches every one of them on the same
+#: commit or none of them. `TheAccentRolesAreOneList` asserts this against
+#: :data:`FRAME_FIELDS` and against `frame/chrome.py`'s served vocabulary, so a role that is
+#: configurable and not served — or served and not configurable — is red.
+#:
+#: Declared ABOVE :data:`FRAME_FIELDS` rather than beside it because a ``#:`` block attaches
+#: to the assignment that FOLLOWS it: appended to the end of that table's own comment, this
+#: one silently took the documentation off `FRAME_FIELDS` and wore it.
+FRAME_ACCENTS: tuple[str, ...] = ("ok", "warn", "bad")
+
 #: Every ``[frame]`` setting, keyed by the name :func:`frame_of` returns it under
 #: (underscore — reads better at the call site, e.g. ``frame["history_limit"]``) and
 #: paired with ``(default, toml_key)``: the shipped default, and the name charter.toml
@@ -1553,6 +1680,37 @@ FRAME_FIELDS = {
     #: whose hierarchy is flat. Turning it off is right for a plane whose surface makes it
     #: unreadable and wrong as an answer for every plane, so the plane says it.
     "dim": (True, "dim"),
+    #: The three ACCENT roles — what charter's own "this is fine", "look at this" and
+    #: "this is broken" are drawn in, and what `frame/chrome.py` serves a provider under
+    #: the same three names.
+    #:
+    #: **The gap `[frame] text` named and could not close.** `text` fixes a pane whose
+    #: background is INVERTED relative to the terminal's; on a terminal that is already
+    #: light it has nothing to do, and what is hard to read there is these three. They are
+    #: slots in the operator's own palette, which is why they shipped un-configurable — and
+    #: that argument holds exactly while the palette's green, yellow and red are readable
+    #: on the ground they are drawn on. On the machine `text` was written for they are not:
+    #: **yellow on tan is the combination no palette was designed for.**
+    #:
+    #: **Charter still cannot compute this and still does not try** (:data:`FRAME_PANE_FG`
+    #: carries the measurements). It cannot know which of the sixteen the operator's theme
+    #: renders legibly on their own background, so it asks — in the same seventeen-word
+    #: vocabulary the plane already answers ``bg`` and ``text`` in, checked at this same
+    #: boundary and resolved to an SGR by `statusline.accent`.
+    #:
+    #: ``default`` is a real answer here rather than a hole, and it is the one worth
+    #: reaching for first: it is the pane's OWN foreground (SGR 39), which is `[frame]
+    #: text` where the plane set one and the terminal's own where it did not. So
+    #: ``warn = "default"`` is "stop colouring the warnings", and the frame still says
+    #: everything it said — `NoStatusIsCarriedByColourAlone` asserts every status here
+    #: survives having its escapes stripped, so the glyph carries it.
+    #:
+    #: The shipped values are the three colours charter has always drawn, so a plane that
+    #: says nothing gets a byte-identical frame — `TheShippedAccentsAreTheOnesCharterAlways
+    #: Drew` asserts that against `statusline`'s own constants rather than against a copy.
+    "ok": ("green", "ok"),
+    "warn": ("yellow", "warn"),
+    "bad": ("red", "bad"),
     "hotkey": ("F2", "hotkey"),
     "history_limit": (50000, "history-limit"),
     "min_cols": (100, "min-cols"),
@@ -1769,6 +1927,16 @@ def frame_of(cfg: dict) -> dict:
             # checked against `FRAME_PANE_BG` at the component boundary: what an accepted
             # word buys is an index into charter's own table, and what a refused one costs
             # is the shipped `default`.
+            if pane_text(value):
+                out[key] = value
+            continue
+        if key in FRAME_ACCENTS:
+            # `text`'s check for the three accent roles, and the same table: what an
+            # accepted word buys is an index into charter's own constants and what a
+            # refused one costs is the colour charter has always drawn. These reach an SGR
+            # rather than a tmux style, so no format expansion is at stake — but the
+            # containment is the same one for the same reason, and a second shape for
+            # "is this one of the seventeen" is how the two come to disagree.
             if pane_text(value):
                 out[key] = value
             continue

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -53,12 +53,131 @@ import time
 from pathlib import Path
 from typing import NamedTuple
 
-from . import config, tui
+from . import config, instance, tui
 
 # ANSI — status lines render escape codes.
 _R, _DIM, _BOLD, _UNDER = "\033[0m", "\033[2m", "\033[1m", "\033[4m"
 _CYAN, _YELLOW, _MAGENTA, _GREEN = "\033[36m", "\033[33m", "\033[35m", "\033[32m"
 _BLUE, _RED = "\033[34m", "\033[31m"
+
+#: Every word `[frame] ok`/`warn`/`bad` may say, and the SGR each one is.
+#:
+#: **Derived from `instance.FRAME_PANE_COLOURS` rather than spelled**, and the derivation
+#: is the containment: the eight names are in ECMA-48's own order, so the foreground code
+#: is ``30 + index`` and the aixterm bright form is ``90 + index`` (§8.3.118 and the
+#: aixterm extension every terminal charter runs on implements). A hand-written table of
+#: seventeen escapes beside a hand-written table of seventeen tmux clauses is two
+#: vocabularies that come to disagree about which word charter knows, which is
+#: `chrome.served_params`' own argument said about the other side of the boundary.
+#:
+#: ``default`` is **SGR 39**, the pane's own foreground — which is `[frame] text` where the
+#: plane set one and the terminal's own where it did not. That is what makes it a real
+#: answer rather than a hole: a plane that says ``warn = "default"`` has asked for its
+#: warnings uncoloured, and gets text in the colour the rest of its frame is already in.
+#:
+#: **No cube index and no triple**, which is `instance.FRAME_PANE_COLOURS`' rule reaching
+#: the SGR side of the frame: `test_frame_appearance.py`'s
+#: `TheFrameNamesColoursAndNeverIndexes` renders every slot and asserts charter emits
+#: neither, and this table is inside that assertion rather than an exception to it.
+_ACCENT_SGR: dict[str, str] = {
+    "default": "\033[39m",
+    **{name: f"\033[{30 + i}m" for i, name in enumerate(instance.FRAME_PANE_COLOURS)},
+    **{f"bright{name}": f"\033[{90 + i}m"
+       for i, name in enumerate(instance.FRAME_PANE_COLOURS)},
+}
+
+
+#: What charter has ALWAYS drawn each accent in — the three escapes above, named by role.
+#:
+#: **Live on the degradation path rather than kept for symmetry**: :func:`accent` falls
+#: back to it for a role whose word is not one of the seventeen, which `instance.frame_of`
+#: cannot produce and a `frame.state` written by a charter that predates these keys can.
+#:
+#: It is deliberately a SECOND spelling of what :data:`_ACCENT_SGR` says about
+#: `instance.FRAME_DEFAULTS`, and `TheShippedAccentsAreTheOnesCharterAlwaysDrew` asserts
+#: the two agree. That is the shape `FRAME_FIELDS`' own `slots`/`density` pair already
+#: uses: the derivation is what makes the table right, and an assertion is what stops the
+#: default drifting away from the colour this module has drawn since before it had a key.
+_SHIPPED_ACCENT: dict[str, str] = {"ok": _GREEN, "warn": _YELLOW, "bad": _RED}
+
+#: The SGR PARAMETERS of the three above — ``frozenset({31, 32, 33})``.
+#:
+#: **Computed here rather than by `frame/chrome.py`, and that siting is a measured
+#: constraint rather than a preference.** `chrome.served_params` needs these on the repaint
+#: path — once per line of every foreign pane — and walking three more escapes with a regex
+#: there cost 1.3 us a call. It cannot hoist them into a constant of its own: `chrome` is
+#: imported by `frame/registry.py` while `charter.frame` is still initialising, and reaching
+#: `statusline` at that moment closes a cycle through `config` -> `instance.frame_of` ->
+#: `frame/builtins.build` (measured, as an `AttributeError` on a partially initialised
+#: module). This module has no such problem about its own constants, so it answers the
+#: question here and `chrome` reads a set.
+#:
+#: Every value in :data:`_ACCENT_SGR` is one parameter between ``ESC[`` and ``m`` by
+#: construction, so the slice is a property of that table rather than a shape hoped for.
+_SHIPPED_ACCENT_PARAMS: frozenset[int] = frozenset(
+    int(sgr.removeprefix("\033[").removesuffix("m")) for sgr in _SHIPPED_ACCENT.values())
+
+
+def accent(role: str) -> str:
+    """The SGR the plane wants *role* — one of `instance.FRAME_ACCENTS` — drawn in.
+
+    **One question asked in one place**, which is `frame/chrome.py`'s `no_colour` and
+    `dim_ok` discipline said about the third appearance key. Charter's own renderers ask
+    this and `chrome.recipes` asks it for a provider composing with ``ctx.chrome["warn"]``,
+    and two readings of one key is how a frame comes to draw its own warnings in one colour
+    and a component's in another.
+
+    **Read through `config.FRAME` at call time rather than cached**, exactly as
+    `chrome.dim_ok` and `slots.pad_of` read the keys they need: a panel is a long-lived
+    process and `charter.toml` is re-read when the frame relaunches. Measured at 1.4us a
+    call against `render`'s own 4816us, and the frame's densest panel asks it fourteen
+    times a repaint — under half a percent, on the one path that could have justified a
+    module-level constant and the drift that comes with it.
+
+    **What comes back is charter's own constant.** `instance.frame_of` has already refused
+    a word charter does not know, and :data:`_SHIPPED_ACCENT` catches the second door.
+
+    **What actually reaches that door is `instance.look_of` answering a PARTIAL mapping**,
+    stated precisely rather than gestured at: `look_of` reads every key with `.get` and a
+    shipped default exactly so a mapping written before a key existed still yields a whole
+    `Look`, and a `Look` built by hand — which `commands_frame` and this suite both do —
+    carries whatever its caller passed.
+
+    **``isinstance`` before the lookup**, which is `instance.pane_text`'s and
+    `instance.chrome_level`'s guard for their own reason and not defensiveness: ``value in
+    _ACCENT_SGR`` raises ``TypeError`` for an unhashable value, and ``tomllib`` can hand a
+    `[frame]` key a list or a table. `statusline` is what draws every status line charter
+    has, so a raise here is a plane with no status line at all.
+    """
+    return _resolve(instance.look_of(config.FRAME), role)
+
+
+def _resolve(look, role: str) -> str:
+    """*role*'s SGR out of an ALREADY-RESOLVED :class:`instance.Look`.
+
+    The half of :func:`accent` that does not read the plane, so :func:`accents` can ask one
+    `look_of` three questions instead of asking three `look_of`s one each.
+    """
+    word = getattr(look, role)
+    return (_ACCENT_SGR.get(word, "") if isinstance(word, str) else "") \
+        or _SHIPPED_ACCENT[role]
+
+
+def accents() -> dict[str, str]:
+    """``{role: SGR}`` for all three, resolved from ONE reading of the plane.
+
+    **`frame/chrome.py`'s `served_params` is asked once per line of every foreign pane**,
+    and it builds `_role_values()`, and three separate :func:`accent` calls there meant
+    three `instance.look_of(config.FRAME)` per line — measured at 3.1 us of the 7.4 us that
+    function then cost. One plane read, three answers.
+
+    A fresh `dict` and not a cached one: `charter.toml` is re-read when the frame relaunches
+    and a panel is a long-lived process, which is :func:`accent`'s own reason for reading at
+    call time. Keyed by `instance.FRAME_ACCENTS` so a fourth role reaches every caller on
+    the commit that adds it.
+    """
+    look = instance.look_of(config.FRAME)
+    return {role: _resolve(look, role) for role in instance.FRAME_ACCENTS}
 
 # Box-drawing, for an unbroken tree. These are East-Asian *Ambiguous* — a terminal may
 # draw them one cell or two — and unlike the frame and the divider, the count here is NOT
@@ -152,17 +271,25 @@ _BRAND_GAP = 3  # min blank columns between content and the right-aligned brand
 # never be half-rendered, so it alone pays this margin.
 _BRAND_MARGIN = 2
 
-#: GitLab pipeline status → (colour, glyph, label). Glyphs are single-width so
+#: GitLab pipeline status → (role, glyph, label). Glyphs are single-width so
 #: columns stay aligned.
+#:
+#: **A ROLE and not an escape, which is what `[frame] ok`/`warn`/`bad` needed of it.**
+#: This is the one accent site in charter that is a module-level table rather than an
+#: expression, so it is the one that would have resolved its colours at IMPORT — before
+#: any plane is read — and gone on drawing green after the plane said otherwise. The three
+#: words here are `instance.FRAME_ACCENTS`' own; `_DIM` and `_CYAN` stay escapes because
+#: neither is an accent (`manual`/`canceled`/`skipped` are muted rather than good or bad,
+#: and `running` is a state rather than a verdict).
 _CI_MARK = {
-    "success": (_GREEN, "✓", "passed"),
-    "failed": (_RED, "✗", "failed"),
+    "success": ("ok", "✓", "passed"),
+    "failed": ("bad", "✗", "failed"),
     "running": (_CYAN, "●", "running"),
-    "pending": (_YELLOW, "○", "pending"),
-    "created": (_YELLOW, "○", "pending"),
-    "preparing": (_YELLOW, "○", "pending"),
-    "waiting_for_resource": (_YELLOW, "○", "queued"),
-    "scheduled": (_YELLOW, "○", "scheduled"),
+    "pending": ("warn", "○", "pending"),
+    "created": ("warn", "○", "pending"),
+    "preparing": ("warn", "○", "pending"),
+    "waiting_for_resource": ("warn", "○", "queued"),
+    "scheduled": ("warn", "○", "scheduled"),
     "manual": (_DIM, "‖", "manual"),
     "canceled": (_DIM, "⊘", "canceled"),
     "skipped": (_DIM, "»", "skipped"),
@@ -174,7 +301,10 @@ def _ci_part(status: str | None) -> str:
     if not status:
         return ""
     color, glyph, label = _CI_MARK.get(status, (_DIM, "?", status))
-    return f"{color}{glyph} {label}{_R}"
+    # An accent role is resolved here and an escape is already one. Told apart by whether
+    # the table's first field names a role rather than by its shape: a `startswith("\033")`
+    # test would be a check on a spelling in the one module that spells escapes by hand.
+    return f"{accent(color) if color in instance.FRAME_ACCENTS else color}{glyph} {label}{_R}"
 
 #: Distinct colours cycled per repo (magenta, blue, cyan, green, yellow, then
 #: bright variants). Assigned by position so adjacent repos always differ; a
@@ -397,7 +527,7 @@ def _cache_hint(streak: int) -> str | None:
     """One short, actionable line — only once the cache has been cold for several turns."""
     if streak < _COLD_STREAK:
         return None
-    return (f"{_RED}⚠ cache cold {streak} turns{_R}{_DIM} — model/effort switch or MCP toggle "
+    return (f"{accent('bad')}⚠ cache cold {streak} turns{_R}{_DIM} — model/effort switch or MCP toggle "
             f"churns the prefix; prefer {_R}{_BOLD}/rewind{_R}{_DIM} over /compact{_R}")
 
 
@@ -424,7 +554,7 @@ def _ctx_part(pct: int | None) -> str:
     """
     if pct is None:
         return ""
-    col = _GREEN if pct < 50 else (_YELLOW if pct < 80 else _RED)
+    col = accent('ok') if pct < 50 else (accent('warn') if pct < 80 else accent('bad'))
     return f"{_DIM}ctx{_R} {col}{int(pct)}%{_R}"
 
 
@@ -437,7 +567,7 @@ def _cache_part(hit: int | None) -> str:
     """
     if hit is None:
         return ""
-    col = _GREEN if hit >= 80 else (_YELLOW if hit >= 50 else _RED)
+    col = accent('ok') if hit >= 80 else (accent('warn') if hit >= 50 else accent('bad'))
     return f"{_DIM}cache{_R} {col}{hit}%{_R}"
 
 
@@ -524,7 +654,7 @@ def _context_gauge(payload: dict) -> list[str]:
             # cumulatively so the price of a mid-task switch stays on screen.
             n, cost = _rebuilds(_history(sid))
             if n:
-                col = _RED if cost >= _REBUILD_LOUD else _YELLOW
+                col = accent('bad') if cost >= _REBUILD_LOUD else accent('warn')
                 out.append(f"{col}↻{n} {_fmt_tok(cost)}{_R}")
             if cost >= _REBUILD_LOUD:
                 out.append(f"{_DIM}rebuilt prefix — model/effort switch, MCP toggle or a resumed "
@@ -579,7 +709,7 @@ def recorded_context_gauge(sid: str) -> list[str]:
             out.append(_cache_part(hits[-1]))
         n, cost = _rebuilds(_pairs(rows))
         if n:
-            col = _RED if cost >= _REBUILD_LOUD else _YELLOW
+            col = accent('bad') if cost >= _REBUILD_LOUD else accent('warn')
             out.append(f"{col}↻{n} {_fmt_tok(cost)}{_R}")
         return out
     except Exception:
@@ -750,7 +880,7 @@ def _markers(state: dict) -> tuple[str, str, bool]:
     ahead, behind = int(state.get("ahead") or 0), int(state.get("behind") or 0)
     plain = coloured = ""
     if dirty:
-        plain += "*"; coloured += f"{_YELLOW}*{_R}"
+        plain += "*"; coloured += f"{accent('warn')}*{_R}"
     if ahead:
         plain += f"↑{ahead}"; coloured += f"{_CYAN}↑{ahead}{_R}"
     if behind:
@@ -873,7 +1003,7 @@ def _branch_cell_for(branch_text: str, presence: str, marks_plain: str = "",
     # the shape this repo keeps shipping — the second one passes because the first one
     # caught it, and no mutation can turn it red.
     br = tui.truncate(branch_text, room)
-    out = f"{_YELLOW if is_dirty else _DIM}{br}{_R}{marks_col}"
+    out = f"{accent('warn') if is_dirty else _DIM}{br}{_R}{marks_col}"
     if not presence:
         return out
     used = tui.width(br) + tui.width(marks_plain)
@@ -1046,7 +1176,7 @@ def _tree_cells(lead: str, label: str, d, states, branches, gl, branch=None,
     if plan.mr:
         change = info.get("change")
         sigil = info.get("sigil") or "!"   # old caches (pre-forge-protocol) carry no sigil
-        cells.append(tui.Cell(f"{_GREEN}{sigil}{change}{_R}" if change else "", plan.mr))
+        cells.append(tui.Cell(f"{accent('ok')}{sigil}{change}{_R}" if change else "", plan.mr))
 
     return tui.Row(*cells, gap=_GAP)
 
@@ -1194,9 +1324,9 @@ def _piece_summary(ws: str) -> str | None:
 
     parts = [f"{_DIM}pieces{_R} {total}"]
     if done:
-        parts.append(f"{_GREEN}{done} done{_R}")
+        parts.append(f"{accent('ok')}{done} done{_R}")
     if gave_up:
-        parts.append(f"{_YELLOW}{gave_up} abandoned{_R}")
+        parts.append(f"{accent('warn')}{gave_up} abandoned{_R}")
     if quiet:
         parts.append(f"{_DIM}{len(quiet)} silent {max(quiet, key=_silence_rank)}{_R}")
     return " ".join(parts)
@@ -1542,7 +1672,7 @@ def _vault_dot(vault: str | None) -> str:
             return f" {_DIM}◦{_R}"
         ok, detail = _vault_health(vault)
         if not ok:
-            return f" {_YELLOW}!{_R}"
+            return f" {accent('warn')}!{_R}"
         # `plain-file.health()` returns ok=True with "not created yet (<path>)" for a
         # registered vault holding nothing. Reading only `ok` once painted a green ✓ on
         # a vault that did not exist; it now reads as unusable, which it is.
@@ -1578,9 +1708,9 @@ def _health_mark(name: str, known: set[str] | None = None) -> str:
     try:
         from . import persona
         if persona.is_draft(name):
-            return f" {_YELLOW}⚑{_R}"
+            return f" {accent('warn')}⚑{_R}"
         if persona.structural_errors(name, known=known):
-            return f" {_RED}✗{_R}"
+            return f" {accent('bad')}✗{_R}"
         return ""
     except Exception:
         return ""
@@ -1625,9 +1755,9 @@ def _mem_badge(persistent: int, ephemeral: int = 0) -> str:
     ephemeral (yellow, session scratch). '' when both are zero."""
     parts = []
     if persistent:
-        parts.append(f"{_GREEN}✎{persistent}{_R}")
+        parts.append(f"{accent('ok')}✎{persistent}{_R}")
     if ephemeral:
-        parts.append(f"{_YELLOW}◌{ephemeral}{_R}")
+        parts.append(f"{accent('warn')}◌{ephemeral}{_R}")
     return (" " + " ".join(parts)) if parts else ""
 
 
@@ -1692,7 +1822,7 @@ def _inflight_badge(entry: tuple[int, float, bool] | None) -> str:
         age = pieces._presence_age(datetime.fromtimestamp(started, timezone.utc),
                                    datetime.now(timezone.utc))
         mark = "?" if presumed_dead else ""
-        return f" {_YELLOW}⚡{n if n > 1 else ''}{_R} {_DIM}{age}{mark}{_R}"
+        return f" {accent('warn')}⚡{n if n > 1 else ''}{_R} {_DIM}{age}{mark}{_R}"
     except Exception:
         return ""
 
@@ -1866,7 +1996,7 @@ def _session_news(sid: str | None, *, inflight: bool = True) -> list[str]:
             # `_MAX_PERSONA_LINES` and disappears entirely below `_LEFT_W + _RIGHT_MIN_W`,
             # so this is what survives a narrow pane — the same contract `_repo_rows`
             # keeps with its own "(+N more)" row.
-            out.append(f"{_YELLOW}⚡ {len(live)}{_R}")
+            out.append(f"{accent('warn')}⚡ {len(live)}{_R}")
     except Exception:
         pass
 
@@ -1879,9 +2009,9 @@ def _session_news(sid: str | None, *, inflight: bool = True) -> list[str]:
             if k:
                 kinds[k] = kinds.get(k, 0) + 1
         if kinds.get("deny"):
-            out.append(f"{_RED}⛊ {kinds['deny']} denied{_R}")
+            out.append(f"{accent('bad')}⛊ {kinds['deny']} denied{_R}")
         if kinds.get("memory"):
-            out.append(f"{_GREEN}✎ {kinds['memory']}{_R}{_DIM} recorded{_R}")
+            out.append(f"{accent('ok')}✎ {kinds['memory']}{_R}{_DIM} recorded{_R}")
         if kinds.get("dispatch"):
             out.append(f"{_DIM}⇢ {kinds['dispatch']} dispatched{_R}")
     except Exception:
@@ -1919,7 +2049,7 @@ def _alerts(active: str) -> list[str]:
         from . import __version__, config, instance as _instance, workspace as _ws
         locked = _instance.locked_version(_instance.load(config.ROOT))
         if locked and locked != __version__:
-            out.append(f"{_YELLOW}⚠{_R} {_DIM}charter{_R} {__version__} {_DIM}→ pinned{_R} "
+            out.append(f"{accent('warn')}⚠{_R} {_DIM}charter{_R} {__version__} {_DIM}→ pinned{_R} "
                        f"{locked}{_DIM} · charter version sync{_R}")
         # A declared front door that names nothing resolves to no persona at all, and
         # every surface that would have shown one shows nothing instead — including this
@@ -1927,11 +2057,11 @@ def _alerts(active: str) -> list[str]:
         # unreadable; the row is what makes it a message. `doctor` has room to explain.
         declared = _instance.default_persona_of(_instance.load(config.ROOT))
         if declared and not _persona_exists(declared):
-            out.append(f"{_YELLOW}⚠{_R} {_DIM}front door{_R} {declared} {_DIM}— no such "
+            out.append(f"{accent('warn')}⚠{_R} {_DIM}front door{_R} {declared} {_DIM}— no such "
                        f"persona · charter persona default <name>{_R}")
         stale = [w for w in _ws.list_workspaces() if w != active and _ws.needs_reinit(w)]
         if stale:
-            out.append(f"{_YELLOW}⚠{_R} {_DIM}reinit{_R} {len(stale)} {_DIM}ws · "
+            out.append(f"{accent('warn')}⚠{_R} {_DIM}reinit{_R} {len(stale)} {_DIM}ws · "
                        f"charter ws reinit --all{_R}")
         # Fires only when the resolution was OVERRIDDEN into a nested plane — `find_root`
         # now hops outward through `workspaces/`, so reaching here at all means
@@ -1951,7 +2081,7 @@ def _alerts(active: str) -> list[str]:
         outer = _nested_under() if getattr(config, "NESTED_ORIGIN", None) == config.ROOT else None
         if outer is not None:
             from .util import short_path
-            out.append(f"{_RED}⚠{_R} {_DIM}nested plane{_R} — {_DIM}memory and vault go to"
+            out.append(f"{accent('bad')}⚠{_R} {_DIM}nested plane{_R} — {_DIM}memory and vault go to"
                        f"{_R} {short_path(config.ROOT)}{_DIM}, not{_R} {short_path(outer)}"
                        f"{_DIM} · unset CHARTER_ROOT{_R}")
         root_line = _plane_root_alert()
@@ -2094,8 +2224,8 @@ def _unlanded_memory(root: Path) -> str | None:
     if not rec:
         return None
     if rec.get("outcome") == planegit.BRANCHED and rec.get("landed"):
-        return f"{_YELLOW}memory awaiting a pull request{_R}"
-    return f"{_RED}memory commit not pushed{_R}"
+        return f"{accent('warn')}memory awaiting a pull request{_R}"
+    return f"{accent('bad')}memory commit not pushed{_R}"
 
 
 def _plane_root_alert() -> str | None:
@@ -2173,7 +2303,7 @@ def _plane_root_alert() -> str | None:
         if state.get("tracked_dirty"):
             # The word, not the repo table's `*`. A marker reads as a marker beside a
             # column of them; this line has no siblings to be read against.
-            bits.append(f"{_YELLOW}dirty{_R}")
+            bits.append(f"{accent('warn')}dirty{_R}")
         if _head_detached(gitdir):
             # Reported on its own terms and WITHOUT a default to compare against, unlike
             # the branch case below. Detachment is a fact about HEAD alone, it is the
@@ -2182,7 +2312,7 @@ def _plane_root_alert() -> str | None:
             # about it on a plane whose default cannot be discovered would be the wrong
             # way round. `doctor`'s `check_plane_root` reports it the same way and on the
             # same terms; the words match so the two cannot be read as different findings.
-            bits.append(f"{_YELLOW}detached HEAD{_R}")
+            bits.append(f"{accent('warn')}detached HEAD{_R}")
         # `?` is `_branch`'s "HEAD unreadable" — nothing to compare, so nothing to claim.
         # A detached HEAD never reaches here: it is already said above, and saying it
         # again as "on 1a2b3c4, not main" would dress the worst state up as an ordinary
@@ -2200,7 +2330,7 @@ def _plane_root_alert() -> str | None:
         # Nothing but ASCII and `⚠` — the same glyph the alerts above already use, so
         # this adds no character whose width some font gets to disagree about.
         sep = f"{_DIM} · {_R}"
-        return (f"{_YELLOW}⚠{_R} {_DIM}plane root{_R} {root.name}{sep}"
+        return (f"{accent('warn')}⚠{_R} {_DIM}plane root{_R} {root.name}{sep}"
                 + sep.join(bits)
                 + f"{_DIM} · work belongs in a workspace clone{_R}")
     except Exception:
@@ -2321,7 +2451,7 @@ def _brand() -> str:
     except Exception:
         newer = None
     if newer:
-        out += f" {_YELLOW}↑{newer}{_R}"
+        out += f" {accent('warn')}↑{newer}{_R}"
     return out
 
 
@@ -2465,12 +2595,12 @@ def render(payload: dict | None = None) -> str:
         gl = glstate.read_for(scan, branches)
         glstate.maybe_spawn(scan, active)
 
-        pin = f"{_YELLOW}*{_R}" if src == "$CHARTER_WORKSPACE" else ""
+        pin = f"{accent('warn')}*{_R}" if src == "$CHARTER_WORKSPACE" else ""
         # Reinit tip sits right after the name so it survives truncation on narrow panes.
         # Nothing informational goes in front of it: it is the one item on this row that
         # reports something BROKEN, and it carries the command that fixes it. A pane with
         # room for one item and not two must spend that room on the problem.
-        reinit = f"{_YELLOW}⚠ reinit: {_BOLD}charter ws reinit{_R}" if _stale_structure(active) else None
+        reinit = f"{accent('warn')}⚠ reinit: {_BOLD}charter ws reinit{_R}" if _stale_structure(active) else None
         # Zone 1 — WHERE I am. Identity and navigation only: which workspace is active,
         # what it still means to do, and how many others exist to switch to. Everything
         # that used to ride along here (repo count, vault count, ctx/cache) described

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -943,8 +943,8 @@ row. Here is all of them.
 | `▫` | start of a row | a persona you are not. Dispatchable, adoptable, otherwise idle |
 | `◦` | after the name | this persona **declares a vault charter cannot use here** — either this machine has no vault by that name, or it has one whose file does not exist yet. `charter persona create` writes the declaration; nothing writes the vault, so this is the ordinary state of a persona nobody has given credentials to, and it is not an error |
 | `!` | after the name | the vault is registered and **unhealthy** — unreadable, or its provider is misconfigured |
-| `✎N` | badge column | `N` **committed** memories. Green |
-| `◌N` | badge column | `N` **session-scratch** memories, not committed. Yellow |
+| `✎N` | badge column | `N` **committed** memories. Drawn in `ok` |
+| `◌N` | badge column | `N` **session-scratch** memories, not committed. Drawn in `warn` |
 | `⚑` | badge column | the persona's **charter is a draft**, so charter generates no sub-agent for it and it cannot be dispatched. `charter persona show <name>` says what it still needs |
 | `✗` | badge column | the persona's **config is broken** — a dangling `extends:`/`uses:`, or an inheritance cycle |
 | `⚡N age` | badge column | `N` dispatches **in flight**, and how long the oldest has been running. A `?` after the age means that record is past the point charter presumes it dead |
@@ -952,6 +952,10 @@ row. Here is all of them.
 Nothing after the name and nothing in the badge column is the healthy, quiet case, and
 silence is deliberate: a column that said *ok* on every row would spend the sidebar's
 width on the rows with nothing to report.
+
+`ok` and `warn` above are the [accent words](#the-three-accents) — green and yellow unless
+your plane says otherwise. Named rather than spelled here so this table stays true on a
+plane that changed them.
 
 **You do not have to come here to read it.** Click the badge column on any persona row —
 the right-hand column the `⚑`s line up in — and the frame puts the legend on the attention
@@ -1006,6 +1010,15 @@ are on whatever you write in `charter.toml`:
   whole pane, to its last column — not a marker at the start of it. Reverse video is your
   own foreground and background exchanged, so it is right on every colour scheme,
   including the ones where every grey charter could have picked is somebody's background.
+  **The inverted row carries no colour of charter's own**, and that is what makes the
+  sentence above true rather than nearly true: it used to keep the cells' greens and
+  yellows, which put a colour chosen for your background on top of your *foreground* — a
+  selected repo row drawn yellow-on-light-grey on any dark theme, on the one row charter
+  uses to say "this is the one you picked". They are dropped inside the inversion and
+  nowhere else, so the glyphs and the highlight say it and nothing is drawn on a pair
+  charter cannot check. Bold and dim survive: neither can be wrong on a ground charter
+  cannot see. A pane a *component* draws is its own — charter never inverts somebody else's
+  row, and does not reach into one to delete a colour whose meaning it does not know.
 - **A status you can read without colour.** Every status in the frame carries a glyph or a
   word that says the same thing as its colour: `⚠` on an alert, `⚑`/`✗` on a persona whose
   charter is a draft or broken, a count next to a badge. Colour is the second channel,
@@ -1036,7 +1049,40 @@ chrome = "dark"     # or "light", or "off" — the default
 
 `chrome` gives charter's own panes a background, so the frame reads as chrome around your
 session rather than as more text beside it. The focused panel is one shade off the others,
-which is also how you can see which pane is live.
+which is one of the two ways you can see which pane is live — the other is on the border,
+below, and it is the one that works when you have set no surface at all.
+
+**Each word carries the text that goes on it.** `dark` is `bg=black` *and* `fg=white`;
+`light` is `bg=white` *and* `fg=black`. It did not used to: `chrome` set a background and
+left every cell no renderer coloured drawing in the foreground your terminal picked to sit
+on *its own* background — so `light` on a dark terminal was white text on white, and `dark`
+on a light terminal was black on black. Not "a background that clashes": panels whose text
+is not there, on whichever of the two words was the wrong one for you.
+
+Those two are the only pairing charter makes, and the line is where a measurement stops
+being one. `black` and `white` are the **poles** of the sixteen — a theme is not free to
+render its white darker than its black — so charter can say what goes on them. It cannot say
+what goes on `bg = "blue"`, which is why a pane that names its own background gets no
+foreground it did not ask for; `text`, below, is how that pane is told. And if you set
+`text`, it wins: charter's pairing is the default for its own recipe, not a second opinion.
+
+Two caveats, named rather than papered over.
+
+`dark`'s focused shade is `brightblack`, and `brightblack` is the one word in charter's own
+recipes whose shade a theme really moves — a dark grey on most, a light tan on at least one.
+On such a theme `chrome = "dark"` draws a focused pane that is lighter than the rest and
+still carries `fg=white`. That is the background *pair* straddling the ledger rather than
+the foreground being wrong, it predates this pairing, there is no second dark shade in the
+sixteen to move it to, and `text` overrides it in one line.
+
+And the pairing reaches the panes and not the **rules** between them. With
+`rules = "visible"` and `chrome = "light"` the rules come out `fg=default,dim,bg=white` —
+your terminal's own foreground, dimmed, over charter's white. The shipped `rules = "hidden"`
+gives the glyph the surface's own colour and never reaches that line, and `text` overrides
+it; the reason it is not fixed here is that `bg=black` is both `chrome = "dark"`'s
+background *and* a component's own `bg = "black"`, so pairing a foreground off the surface
+would hand a word you wrote the foreground the paragraph above says charter will not choose
+for you. That is a decision about the per-component half, not a line in the rule assembler.
 
 tmux paints it, not charter: the value sets `window-style` and `window-active-style` on
 charter's panel panes. That is why it costs nothing on a repaint, cannot wrap a line, fills
@@ -1152,13 +1198,14 @@ on tmux 3.7c and at the 3.2 floor.
 **Which case this actually fixes**, stated plainly so you can tell whether it is yours. It
 fixes a pane whose background is *inverted* relative to your terminal's — a dark terminal
 with `bg = "white"`, or a light terminal with `bg = "black"` — where the foreground your
-terminal picked for its own background is now sitting on the opposite one. If your terminal
-is already light and your panes are light, your default foreground was already dark and this
-key has nothing to do; what is hard to read there is the **accent** colours, and `text` does
-not reach those. That gap is real and named rather than papered over: `ok`, `warn` and `bad`
-are still your palette's green, yellow and red, and yellow on a tan surface is exactly the
-combination nobody's palette was designed for. Making those three configurable is the
-obvious next key and is not in this release.
+terminal picked for its own background is now sitting on the opposite one. **If you have
+written `bg = "black"` on a light terminal, this key is the one you want**, and it is easy
+to miss that you are in that case: your panes are dark, your text is your terminal's own
+dark foreground, and nothing but `text = "white"` moves it.
+
+If your terminal is already light and your panes are light, your default foreground was
+already dark and this key has nothing to do. What is hard to read there is the **accent**
+colours, and `text` does not reach those — they are the three keys below.
 
 `dim = false` stops charter reducing the contrast of its own chrome — the `ESC[2m` on muted
 text, and the `dim` on the frame's rules. It is a key of its own rather than one more colour
@@ -1172,24 +1219,61 @@ thing separating muted text from ordinary text in the frame — a tree glyph fro
 a count from a heading — so a frame with it off everywhere is a frame with a flat hierarchy.
 Turn it off when your surface makes it unreadable.
 
-**Why there is no `accent` yet, and no key per colour.** charter draws through eight named
-roles — `heading`, `muted`, `selected`, `ok`, `warn`, `bad`, `reset`, `inset`. Four of them
-are theme-safe by construction: bold, reverse, a reset and two spaces. Three of them —
-`ok`, `warn`, `bad` — are green, yellow and red **as your palette defines them**, so
-renaming them would swap your own green for your own blue, which is a preference and not a
-legibility fix. What is left is the two that are not slots in your palette at all: the
-default foreground, which your terminal chose to sit on *its* background rather than on the
-one charter painted, and dim. Those are the two keys here.
+### The three accents
 
-The argument for stopping there is weaker than it looks, and the honest version is this: it
-holds while the three accents are readable on your surface, and an operator has reported
-that they are not on a light one. Restating them would be three more words in this table —
-`ok`, `warn`, `bad` — and the reason it is not in this release is mechanical rather than
-principled: charter's own panels write those colours directly, so serving new ones means
-routing about forty call sites through the same recipe table a component already reads, and
-that is a change worth making on its own rather than at the end of this one.
+```toml
+[frame]
+ok   = "green"      # any of `bg`'s seventeen words — these three are the defaults
+warn = "yellow"
+bad  = "red"
+```
 
-`NO_COLOR` still wins over both, and over everything else here.
+charter draws through eight named roles — `heading`, `muted`, `selected`, `ok`, `warn`,
+`bad`, `reset`, `inset`. Four are theme-safe by construction: bold, reverse, a reset and two
+spaces. `dim` and the default foreground are the two keys above. These three are the rest.
+
+They shipped un-configurable on the argument that they are slots in **your** palette — your
+green, not a green charter picked out of the 256 — so renaming them is a preference rather
+than a legibility fix. That argument holds exactly while your palette's green, yellow and
+red are readable on the ground they are drawn on, and on a light terminal they are not:
+**yellow on tan is the pair no palette was designed for**, and no amount of it being your
+own yellow makes it legible on your own tan.
+
+Charter still cannot work out which of the sixteen would be — the same three measurements
+as above — so it asks, in the vocabulary you already answer `bg` and `text` in.
+
+`default` is a real answer here and often the best one: it is the pane's **own** foreground,
+which is your `text` where you set one and your terminal's where you did not. `warn =
+"default"` means "stop colouring the warnings", and the frame still says everything it said
+— every status in it carries a glyph or a word, and charter's own suite fails if one stops
+being distinguishable with the escapes stripped.
+
+The three reach charter's own panels *and* the status line, because both are drawn on the
+same terminal, and they reach a component you wrote through `ctx.chrome["warn"]` — one
+answer, so the frame's own attention strip and a provider's pane cannot come out two
+colours. A component that hard-coded its own green is left exactly alone and still shows it:
+charter cannot know what somebody else's green means, so it neither recolours it nor escapes
+it.
+
+**What these three name is charter's own green, yellow and red** — every place the frame
+draws one of those to mean "fine", "look at this" or "broken". They are not a general
+recolouring: a repo's identity colour is its own (charter cycles eight of the sixteen to
+keep neighbouring rows apart, and two of those eight happen to be green and yellow), and the
+marks charter draws in cyan, blue or magenta stay where they are. So a pipeline that is
+`running` keeps its cyan `●` while `⚡3 running` in the attention strip moves with `warn` —
+they are the same word drawn two ways because they were always two colours, and these keys
+rename colours rather than concepts.
+
+If you want a badge uncoloured rather than recoloured, `default` is the word: the glyph
+carries it either way, which charter's own suite asserts by stripping every escape from each
+panel and failing if a status stops being distinguishable.
+
+`charter doctor` is **not** covered, and that is deliberate rather than an oversight: it is a
+one-shot report printed into your shell, not a surface the frame paints, and its `✓`/`!`/`✗`
+are the same three colours by coincidence of meaning rather than by sharing this table. A
+`[frame]` key reaching a command that runs with no frame would be the wrong scope.
+
+`NO_COLOR` still wins over all of these, and over everything else here.
 
 ### Why the frame ships with no surface at all
 
@@ -1297,8 +1381,36 @@ the frame-wide colour, so the rules are too.
 A pane's two edge colours are always identical, and that is deliberate: tmux draws the
 border of the active pane from a second option, and letting the two differ is exactly the
 defect that put charter in charge of these options in the first place — a rule that changes
-colour halfway along, where it passes the active pane's corner. Which pane is live is shown
-on the pane itself (its background is one shade off the others), never on the border.
+colour halfway along, where it passes the active pane's corner. So which pane is live is
+never said with a border **colour**.
+
+**It is said with a glyph.** tmux puts a small arrow on the borders of the active pane —
+`pane-border-indicators arrows` — pointing into it, and charter pins that on. Read off a
+real client, charter's own shape, the same rule with the focus in three places:
+
+```
+harness active   ESC[2m ─↑─────────────────────────────────┴──────────────
+sidebar active   ESC[2m ───────────────────────────────────┴─↑────────────
+footer active    ESC[2m ─↓─────────────────────────────────┴─↓────────────
+```
+
+One escape, at the start of the row, and none anywhere else in it: the rule is the same
+one-colour rule charter has always drawn and the only thing that moved is which cell holds
+an arrow. That is why this is not the two-coloured-rule defect wearing a new hat — a cue
+made of a second *style* does put a seam mid-line, which is measured and is the arrangement
+charter did not take.
+
+It exists because without it there was **no answer at all**. With the shipped `chrome =
+"off"` and no `bg`, every pane has your terminal's background, both rule styles are one
+value, and nothing on screen said where the keyboard was — which matters more than it
+sounds, because `F12` exists for "you are in a pane that has stopped answering".
+
+Over a surface with the shipped `rules = "hidden"` the arrow is drawn in the colour of the
+cell behind it, like the rest of that rule, so it disappears exactly where the pane's own
+one-shade-off background is already telling you. The cue shows up where there is no other
+one, and nowhere else. Below tmux **3.3** the option does not exist, charter does not send
+it, and that plane gets the frame it had.
+
 `chrome = "off"` with no `bg` anywhere puts the rules back to your terminal's own, and
 `NO_COLOR` takes the background off them while leaving the frame's rules drawn.
 

--- a/docs/news/unreleased-the-frame-reads-on-the-terminal-it-is-on.md
+++ b/docs/news/unreleased-the-frame-reads-on-the-terminal-it-is-on.md
@@ -1,0 +1,122 @@
+---
+version: unreleased
+headline: The frame reads on the terminal it is on — paired foregrounds, an uncoloured highlight, a live-pane cue, and the accent palette is yours
+---
+
+*"we need to care about text colors too, maybe also make them configurable, because on
+bright background bright text is not readable"*
+
+Four things, one cause. Every colour decision in the frame was taken on a dark terminal, and
+each of these is what that costs on a light one — or the mirror of it, which is the half a
+developer on a dark terminal never sees fail.
+
+## A `chrome` word carries the text that goes on it
+
+`chrome = "light"` set `bg=white` and nothing else, so every cell no renderer coloured drew
+in the foreground *your terminal* picked to sit on *its own* background. On a dark theme
+that is white. The attention strip's own bytes, measured:
+
+```
+ESC[0m ESC[47m 7 todos · F2 palette · ESC[2m…
+       ^^^^^^^ the pane's `bg=white`, and no `SGR 3x` anywhere after it
+```
+
+Not a background that clashes — a panel whose text is not there. `dark` is the same failure
+mirrored on a light theme. Both are charter's own recipes, so both now carry their own
+foreground: `bg=black,fg=white` and `bg=white,fg=black`.
+
+**Two words and not seventeen, and the line is where the measurement stops.** `black` and
+`white` are the poles of the sixteen — a theme is not free to render its white darker than
+its black — so charter can say what goes on them. It cannot say what goes on `bg = "blue"`,
+so a pane that named its own background still gets no foreground it did not ask for;
+`[frame] text` is how that pane is told, and if you set it, it wins.
+
+## The row you are on stops painting yellow on your foreground
+
+`docs/frame.md` argued the selected row is right on every colour scheme *precisely because
+reverse video names no colour*. Both surfaces that use it named one. Read off a live frame:
+
+```
+ESC[7m ESC[35m ▸ ESC[1m steward ESC[0;7m        ESC[32m ✎47 ESC[0m
+ESC[7m   ESC[2m ├─ ESC[0;7m ESC[36m billing       ESC[33m main* ESC[39m
+```
+
+`SGR 7`, and then magenta, cyan and **yellow** — colours chosen for your background, painted
+on a cell whose background is now your foreground. On a dark theme the selected repo row
+drew yellow on light grey, which is the worst pair the sixteen can make, on the one row
+charter uses to say "this is the one you picked".
+
+Every colour inside the inversion is **deleted** — a deletion and never a substitution,
+because charter cannot know what your magenta looks like on your own foreground but it can
+decline to paint a pair it has no way to check. Nothing the row was saying is lost: the
+glyphs still say it, and charter's suite already fails if a status stops being
+distinguishable with its escapes stripped. Bold and dim survive; neither can be wrong on a
+ground charter cannot see. It is done in `chrome.reverse` rather than at the two call sites,
+so a component composing with `ctx.chrome["selected"]` gets the same answer.
+
+## Something finally says which pane is live
+
+With the shipped `chrome = "off"` and no `bg`, every pane had your terminal's background,
+both rule styles were pinned to one value on purpose, and the answer to "where is the
+keyboard" was: nowhere. That matters more than it sounds, because `F12` exists for "you are
+in a pane that has stopped answering" and the frame gave no way to notice you were in one.
+
+tmux marks the active pane's borders with a small arrow, and charter pins that on now. Read
+off an attached client, charter's own shape, the same rule with the focus in three places:
+
+```
+harness active   ESC[2m ─↑─────────────────────────────────┴──────────────
+sidebar active   ESC[2m ───────────────────────────────────┴─↑────────────
+footer active    ESC[2m ─↓─────────────────────────────────┴─↓────────────
+```
+
+**One escape, at the start of the row, and none anywhere else in it.** That is what makes
+this not the two-coloured-rule defect arriving through a new door: the rule is the same
+one-colour rule charter has drawn since #514 and the only thing that moved is which cell
+holds an arrow. A cue made of a second *style* — the "weight rather than a colour" the issue
+proposed — does put a seam mid-line, measured, and is the arrangement charter did not take.
+
+Over a surface with the shipped `rules = "hidden"` the arrow is the colour of the cell behind
+it, like the rest of that rule, so it disappears exactly where the pane's own one-shade-off
+background is already telling you. Below tmux 3.3 the option does not exist and that plane
+gets the frame it had.
+
+## `ok`, `warn` and `bad` are words your plane chooses
+
+```toml
+[frame]
+ok   = "green"      # any of `bg`'s seventeen words — these three are the defaults
+warn = "yellow"
+bad  = "red"
+```
+
+This is the gap `[frame] text` named and could not close. `text` fixes a pane whose
+background is *inverted* relative to your terminal's; on a terminal that is already light it
+has nothing to do, and what is hard to read there is these three. They shipped
+un-configurable on the argument that they are slots in **your** palette rather than colours
+charter picked — which says the colour is yours, and does not say it is legible on the
+ground it is drawn on. Those are different claims. **Yellow on tan is the pair no palette
+was designed for.**
+
+Charter still cannot compute which of the sixteen would be legible — the sixteen names have
+no fixed RGB, a colour query through tmux gets no reply, and `$COLORTERM` inside a pane
+describes the terminal that started the *server*. So it asks, in the vocabulary you already
+answer `bg` and `text` in.
+
+`default` is a real answer and often the best one: it is the pane's **own** foreground, which
+is your `text` where you set one and your terminal's where you did not. `warn = "default"` is
+"stop colouring the warnings".
+
+One reading, so charter's own panels, the status line and a component composing with
+`ctx.chrome["warn"]` cannot come out three colours. A component that hard-coded its own green
+is left alone and still shows it — charter neither recolours somebody else's green nor
+escapes it into their pane as text. And nothing that is not a verdict moves: a repo's
+identity colour, `running` on a pipeline, and the muted `manual`/`canceled`/`skipped` marks
+stay exactly where they were.
+
+## Unchanged
+
+A plane that says nothing gets a byte-identical frame. `chrome = "off"` with no `bg` and no
+`text` emits no pane option at all, the shipped accents are the three colours charter has
+always drawn, and `chrome.served_params()` is the same seven numbers it was — a plane cannot
+narrow what a component may write, only widen it. `NO_COLOR` still wins over all of it.

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -179,6 +179,31 @@ def no_background_refresh(case) -> None:
         case.addCleanup(patcher.stop)
 
 
+def shipped_frame(case) -> None:
+    """Pin this case's ``config.FRAME`` to the frame charter SHIPS.
+
+    **For a case whose subject is a default, and it exists because a default stopped being
+    a constant.** `[frame] ok`/`warn`/`bad` made three of `frame/chrome.py`'s recipes read
+    the plane, so "``ok`` is green" and "the served vocabulary is these seven numbers" are
+    now claims about the plane the suite is running INSIDE — which on a developer's machine
+    is charter's own control plane, and on the machine those keys were written for is a
+    plane actively being tuned. Without this, an operator who writes ``warn = "blue"`` in
+    their own `charter.toml` turns somebody else's test red, and the failure is about their
+    config rather than about charter.
+
+    That is #402/#492's rule — the suite reads the repo, never the machine — arriving
+    through the newest door, and it is the door this whole file was built for.
+
+    **Only for cases about the shipped answer.** A case that is about the keys DOING
+    something patches `config.FRAME` with the words it means and asserts on those; this is
+    for the ones that assert what a plane which said nothing gets. `clear=True`, so a key
+    the ambient plane set and `FRAME_DEFAULTS` does not name cannot survive into the case.
+    """
+    patcher = mock.patch.dict(config.FRAME, instance.FRAME_DEFAULTS, clear=True)
+    patcher.start()
+    case.addCleanup(patcher.stop)
+
+
 def child_plane_env(case, **extra: str) -> tuple[Path, dict]:
     """A throwaway plane, and the environment that points a CHILD charter at it.
 

--- a/tests/test_a_plane_chooses_how_its_frame_reads.py
+++ b/tests/test_a_plane_chooses_how_its_frame_reads.py
@@ -369,13 +369,43 @@ class TheForegroundIsPaintedByTmuxAndNotByARenderer(unittest.TestCase):
     `tests/test_a_planes_frame_really_reads_that_way.py`.
     """
 
-    def test_a_plane_that_named_no_foreground_emits_exactly_what_it_did_before(self):
-        for bg in (None, "brightblack", "nonsense"):
+    def test_a_plane_that_named_no_foreground_still_emits_only_a_background(self):
+        """**Where the background is the OPERATOR'S word, and that qualifier is #737.**
+
+        This used to be asked of every pairing, and the answer for two of them was the
+        defect: `chrome = "dark"` and `chrome = "light"` are charter's OWN recipes, and
+        shipping a `bg` with no `fg` left every uncoloured cell drawing in the terminal's
+        default foreground — light-on-white on a dark theme, and the mirror of that on a
+        light one. `instance.FRAME_CHROME_FG` pairs those two and nothing else, so a pane
+        whose background came from a word the operator wrote is unmoved: charter cannot see
+        what their `brightblack` looks like and does not decide what goes on it.
+        """
+        for bg in ("brightblack", "blue", "default"):
             for level in instance.FRAME_CHROME:
                 with self.subTest(bg=bg, chrome=level):
-                    self.assertEqual(
-                        instance.surface_options(bg, level, _SHIPPED),
-                        instance.pane_bg_options(bg) or instance.chrome_options(level))
+                    self.assertEqual(instance.surface_options(bg, level, _SHIPPED),
+                                     instance.pane_bg_options(bg))
+
+    def test_a_frame_with_no_surface_at_all_is_still_byte_identical(self):
+        """The half that must never move: `chrome = "off"`, no `bg`, no `text` is the
+        frame charter ships, and `_surface_argvs` issues no command at all for it."""
+        for bg in (None, "nonsense"):
+            with self.subTest(bg=bg):
+                self.assertEqual(instance.surface_options(bg, "off", _SHIPPED), ())
+
+    def test_charters_own_two_surfaces_carry_the_foreground_that_goes_with_them(self):
+        """#737, stated as the change rather than as the absence of one. The pairing is
+        charter completing its own recipe: `black` and `white` are the POLES of the sixteen
+        and a theme is not free to render them the same way round, which is exactly what
+        makes this a measurement where a foreground for `bg=blue` would be a guess."""
+        for level, want in (("dark", "fg=white"), ("light", "fg=black")):
+            for bg in (None, "nonsense"):
+                with self.subTest(chrome=level, bg=bg):
+                    got = instance.surface_options(bg, level, _SHIPPED)
+                    self.assertEqual(len(got), len(instance.chrome_options(level)))
+                    for name, value in got:
+                        self.assertTrue(value.startswith(f"{want},"),
+                                        f"{name} = {value!r}")
 
     def test_the_foreground_joins_the_background_on_both_options(self):
         """Both, always — a pane whose two differed would show one colour focused and

--- a/tests/test_a_planes_frame_really_reads_that_way.py
+++ b/tests/test_a_planes_frame_really_reads_that_way.py
@@ -371,6 +371,198 @@ class NoAttributeInAPaneStyleReachesTheWire(_NestedClient, unittest.TestCase):
                                  f"{params}")
 
 
+#: What `pane-border-indicators arrows` marks the ACTIVE pane's borders with — the same
+#: four `test_frame_tmux_integration.py` names, spelled here for that file's own reason:
+#: they are outside the Box Drawing block, so nothing that looks for a rule can see them.
+_ARROWS = frozenset("←→↑↓")
+
+
+class TheLivePaneIsMarkedOnASurfacelessFrame(_NestedClient, unittest.TestCase):
+    """#750 — with the shipped `chrome = "off"` nothing said which pane the keyboard is in.
+
+    **The whole question is whether a cue can exist without a colour**, and it is the same
+    question `NoAttributeInAPaneStyleReachesTheWire` closed one door on. That measurement
+    stands: a pane's INTERIOR cannot carry an attribute, so there is no theme-independent
+    surface and `chrome` stays `off`. What is left is the BORDER, which tmux draws itself
+    and which does honour an attribute — charter's own rule has carried `dim` since #514.
+
+    `pane-border-indicators arrows` is the answer charter takes, and these are the two
+    properties that make it one rather than #514 arriving through a new door: the glyph
+    MOVES with the focus, and the rule it sits in keeps ONE style along its whole length.
+    A cue made of a second style has the second property false, which is measured here as
+    the control — it is the arrangement #750's own text proposed, and it is the one this
+    rejects.
+
+    Three panes, because two cannot show the defect: a rule has to span two panes for a
+    style that changes at the active pane's corner to change halfway along it.
+    """
+
+    def _frame(self, *, indicators, active, border, active_border):
+        """A harness beside a sidebar with a footer under both — charter's own shape — and
+        the outer client's capture of it."""
+        self._session_seq = getattr(self, "_session_seq", 0) + 1
+        session = f"s{self._session_seq}"
+        r = self._tmux(self._inner, "new-session", "-d", "-s", session, "-x", "70",
+                       "-y", "16", "--", "sh", "-c", 'printf "HARNESS\\r\\n"; cat')
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness = self._tmux(self._inner, "list-panes", "-t", session,
+                             "-F", "#{pane_id}").stdout.strip()
+        self._tmux(self._inner, "set", "-t", session, "status", "off")
+        for name, value in (("pane-border-lines", "single"),
+                            ("pane-border-status", "off"),
+                            ("pane-border-style", border),
+                            ("pane-active-border-style", active_border)):
+            self.assertEqual(self._tmux(self._inner, "set", "-w", "-t", harness,
+                                        name, value).returncode, 0, name)
+        got = self._tmux(self._inner, "set", "-w", "-t", harness,
+                         "pane-border-indicators", indicators)
+        if got.returncode != 0:
+            self.skipTest(f"this tmux has no `pane-border-indicators`: {got.stderr.strip()}")
+        side = self._tmux(self._inner, "split-window", "-t", harness, "-h", "-P", "-F",
+                          "#{pane_id}", "-l", "18", "--",
+                          "sh", "-c", 'printf "SIDEBAR\\r\\n"; cat').stdout.strip()
+        foot = self._tmux(self._inner, "split-window", "-t", session, "-v", "-f", "-P",
+                          "-F", "#{pane_id}", "-l", "4", "--",
+                          "sh", "-c", 'printf "FOOTER\\r\\n"; cat').stdout.strip()
+        self._tmux(self._inner, "select-pane",
+                   "-t", {"harness": harness, "sidebar": side, "footer": foot}[active])
+        host = f"h{session}"
+        self.assertEqual(
+            self._tmux(self._outer, "new-session", "-d", "-s", host, "-x", "70", "-y", "16",
+                       "--", self.BIN, "-L", self._inner, "attach", "-t", session
+                       ).returncode, 0)
+        self._tmux(self._outer, "set", "-t", host, "status", "off")
+        shot = ""
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            got = self._tmux(self._outer, "capture-pane", "-p", "-e", "-N", "-t", host)
+            if got.returncode == 0:
+                shot = got.stdout
+            if "FOOTER" in shot and _RULE_GLYPH in shot:
+                break
+            time.sleep(0.1)
+        self._tmux(self._outer, "kill-session", "-t", host)
+        self._tmux(self._inner, "kill-session", "-t", session)
+        if _RULE_GLYPH not in shot:
+            self.skipTest("this machine rendered no pane border through a nested client, "
+                          "so there is nothing here to measure")
+        return shot
+
+    def _shipped(self, active):
+        """Charter's own pins, READ OUT of `_CHROME` rather than spelled here.
+
+        The whole point of these tests is that charter's shipped frame marks its live
+        pane, and a harness that named `arrows` itself would have gone on passing with the
+        pin back at `off` — measuring tmux instead of charter. `_chrome_values` is the one
+        reading of that table, so a value changed there is what these run against.
+        """
+        pins = commands_frame._chrome_values()
+        return self._frame(indicators=pins["pane-border-indicators"], active=active,
+                           border=pins["pane-border-style"],
+                           active_border=pins["pane-active-border-style"])
+
+    def _rule_row(self, shot: str) -> str:
+        """The horizontal rule that spans the whole window — the row a cue would show a
+        seam in. The longest run of rule glyphs on the screen is that row."""
+        rows = [ln for ln in shot.split("\n") if ln.count(_RULE_GLYPH) > 5]
+        self.assertTrue(rows, f"no spanning rule on this screen: {shot!r}")
+        return max(rows, key=lambda ln: ln.count(_RULE_GLYPH))
+
+    def test_the_shipped_frame_marks_a_pane_at_all(self):
+        """#750's headline. Before this the answer to "which pane is live" on a plane that
+        wrote nothing was: nowhere."""
+        shot = self._shipped("harness")
+        self.assertTrue(set(shot) & _ARROWS,
+                        f"nothing on the shipped frame says which pane is live: {shot!r}")
+
+    def test_the_mark_moves_when_the_focus_does(self):
+        """The control that it is a FOCUS cue and not decoration: a mark that read the same
+        whichever pane was live would satisfy the assertion above.
+
+        **Read as (column, glyph) and not as a column**, which is a correction this test
+        needed rather than a precaution. tmux points the arrow INTO the active pane, so a
+        rule with the pane above it live and the same rule with the pane below it live
+        carry their marks in the SAME cell and differ only in direction — measured on CI,
+        where `harness` and `footer` both marked column 5, one `↑` and one `↓`. A
+        column-only reading called that "the mark did not move" about a cue that is doing
+        exactly its job, and it is the reading a dark-terminal fixture would never have
+        caught either.
+        """
+        rows = {who: self._rule_row(self._shipped(who))
+                for who in ("harness", "sidebar", "footer")}
+        marks = {who: tuple((i, ch) for i, ch in enumerate(row) if ch in _ARROWS)
+                 for who, row in rows.items()}
+        for who, at in marks.items():
+            self.assertTrue(at, f"the rule carries no mark with {who} live: {rows[who]!r}")
+        self.assertEqual(len(set(marks.values())), len(marks),
+                         f"the mark did not move with the focus: {marks}")
+
+    def test_the_rule_the_mark_sits_in_is_one_style_along_its_whole_length(self):
+        """**#514 is not reopened, and this is the line that says so.** That defect was a
+        rule whose COLOUR changed where it passed the active pane's corner — measured then
+        as `ESC[32m` for 77 cells and `ESC[39m` for the next 22, in one horizontal rule.
+        The arrow is a glyph substituted into a rule charter still draws one way, so the
+        whole row carries exactly one SGR run: the one that starts it."""
+        for who in ("harness", "sidebar", "footer"):
+            with self.subTest(active=who):
+                row = self._rule_row(self._shipped(who))
+                inside = [m.group(1) for m in _SGR.finditer(row)
+                          if m.start() > row.index(_RULE_GLYPH)]
+                self.assertEqual(inside, [],
+                                 f"the rule changes style partway along it: {row!r}")
+
+    def test_a_cue_made_of_a_second_style_really_would_reopen_it(self):
+        """The control, and it is the arrangement #750's own text proposed — "the active
+        pane's border getting a weight rather than a colour", said there to re-open
+        nothing. It does: with the active rule at full strength and the rest dim, the one
+        spanning rule carries both, and the seam lands mid-line.
+
+        **The two arrangements are compared rather than each asked in turn**, which is a
+        correction to how this was first written: a `skipTest` in front of an `assertTrue`
+        on the same value cannot fail — the skip has already consumed the only case that
+        would — so it passed whatever tmux did and whatever charter did. Asked as a
+        difference, the assertion is about the two styles rather than about this machine,
+        and a machine that renders both identically genuinely has nothing to say.
+        """
+        def seams(border, active_border):
+            row = self._rule_row(self._frame(indicators="off", active="harness",
+                                             border=border, active_border=active_border))
+            return [m.group(1) for m in _SGR.finditer(row)
+                    if m.start() > row.index(_RULE_GLYPH)]
+
+        pinned = seams(commands_frame._CHROME_STYLE, commands_frame._CHROME_STYLE)
+        weight = seams(commands_frame._CHROME_STYLE, commands_frame._CHROME_FG)
+        self.assertEqual(pinned, [],
+                         f"charter's own pinned pair put a seam in the rule: {pinned}")
+        if not weight:
+            self.skipTest("this tmux renders the two weights identically, so there is no "
+                          "difference here to attribute to the styles")
+        self.assertNotEqual(weight, pinned,
+                            "the weight cue put no seam in the rule after all, so charter "
+                            "could have used one")
+
+
+@unittest.skipUnless(_FLOOR_BIN.exists(),
+                     f"no {_FLOOR_BIN.name} built on this machine — `docs/frame.md` says "
+                     "how, and CI installs no tmux at all")
+class TheFloorHasNoSuchCueAndSaysSo(TheLivePaneIsMarkedOnASurfacelessFrame):
+    """`pane-border-indicators` arrived in tmux 3.3 and charter's floor is 3.2, so every
+    test above SKIPS here rather than passing or failing.
+
+    **The skip is the measurement and it is not an assertion about the floor**, which is
+    worth saying because the first version of this docstring claimed it was. What runs here
+    is `tmux set -w pane-border-indicators` against a real 3.2 binary, and what it proves is
+    that the option is absent from that tmux — a fact about tmux, which is the fact
+    `tmuxctl.BORDER_INDICATORS_FLOOR` exists to encode and the one #716 shipped a release
+    without. That charter HONOURS the floor is `AnOptionThisTmuxDoesNotHaveIsNeverIssued`'s
+    job in `test_frame_border_surface.py`, and that the number is 3.3 is pinned in
+    `test_the_frame_reads_on_the_terminal_it_is_on.py`. Three facts, three places, none of
+    them asserting itself.
+    """
+
+    BIN = str(_FLOOR_BIN)
+
+
 @unittest.skipUnless(_FLOOR_BIN.exists(),
                      f"no {_FLOOR_BIN.name} built on this machine — `docs/frame.md` says "
                      "how, and CI installs no tmux at all")

--- a/tests/test_frame_appearance.py
+++ b/tests/test_frame_appearance.py
@@ -591,8 +591,11 @@ class TheSurfaceIsSetOnPanelPanesAndNoOther(unittest.TestCase):
             commands_frame._surface_argvs(socket="s", pane_id="%3", chrome=hostile), [])
         argvs = commands_frame._surface_argvs(socket="s", pane_id="%3", chrome="dark")
         values = [a[-1] for a in argvs]
+        # Against the ASSEMBLER: #737 pairs a foreground with charter's own two surfaces,
+        # and `surface_options` is the one place the background and that foreground meet.
         self.assertEqual(set(values),
-                         {v for _n, v in instance.FRAME_CHROME["dark"]})
+                         {v for _n, v in instance.surface_options(
+                             None, "dark", instance.SHIPPED_LOOK)})
         for v in values:
             self.assertNotIn("#", v)
 
@@ -631,8 +634,11 @@ class TheHarnessPaneIsNeverStyled(_TmuxServerFixture, PersonaIso):
     def test_a_surfaced_panel_leaves_the_harness_pane_bare(self):
         harness, panel = self._panes()
         self._apply(panel, "dark")
-        self.assertEqual(self._style(panel), "bg=black")
-        self.assertEqual(self._style(panel, "window-active-style"), "bg=brightblack")
+        self.assertEqual(self._style(panel), dict(instance.surface_options(
+            None, "dark", instance.SHIPPED_LOOK))["window-style"])
+        self.assertEqual(self._style(panel, "window-active-style"),
+                         dict(instance.surface_options(
+                             None, "dark", instance.SHIPPED_LOOK))["window-active-style"])
         self.assertEqual(self._style(harness), "",
                          "charter styled the pane the operator's harness runs in")
         self.assertEqual(self._style(harness, "window-active-style"), "")
@@ -655,8 +661,12 @@ class TheHarnessPaneIsNeverStyled(_TmuxServerFixture, PersonaIso):
         for level in ("dark", "light"):
             with self.subTest(level=level):
                 self._apply(panel, level)
-                self.assertEqual(dict(instance.FRAME_CHROME[level])["window-style"],
-                                 self._style(panel))
+                # `fg=white,bg=black` and `fg=black,bg=white` — this test is the one that
+                # says a real tmux parses what charter sends, so it has to read the whole
+                # style rather than the background half of it (#737).
+                self.assertEqual(dict(instance.surface_options(
+                    None, level, instance.SHIPPED_LOOK))["window-style"],
+                    self._style(panel))
 
     def test_the_surface_belongs_to_the_pane_and_not_to_the_process_in_it(self):
         """`commands_frame`'s `pane-died` hook respawns a dead panel INTO THE SAME PANE,
@@ -668,7 +678,8 @@ class TheHarnessPaneIsNeverStyled(_TmuxServerFixture, PersonaIso):
         self._apply(panel, "dark")
         r = self._srv("respawn-pane", "-k", "-t", panel, "--", "sleep", "600")
         self.assertEqual(r.returncode, 0, r.stderr)
-        self.assertEqual(self._style(panel), "bg=black")
+        self.assertEqual(self._style(panel), dict(instance.surface_options(
+            None, "dark", instance.SHIPPED_LOOK))["window-style"])
         self.assertEqual(self._style(harness), "")
 
     def test_the_surface_survives_the_window_being_resized(self):
@@ -679,7 +690,8 @@ class TheHarnessPaneIsNeverStyled(_TmuxServerFixture, PersonaIso):
         self._apply(panel, "dark")
         r = self._srv("resize-window", "-t", "h", "-x", "120", "-y", "40")
         self.assertEqual(r.returncode, 0, r.stderr)
-        self.assertEqual(self._style(panel), "bg=black")
+        self.assertEqual(self._style(panel), dict(instance.surface_options(
+            None, "dark", instance.SHIPPED_LOOK))["window-style"])
 
     def test_a_format_string_would_have_been_stored_verbatim(self):
         """The measurement behind the enum, run here rather than quoted: tmux keeps a

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -508,8 +508,8 @@ class Chrome(unittest.TestCase):
     def test_the_three_inherited_border_settings_are_pinned_too(self):
         """Colour is not the only thing an operator's own `.tmux.conf` hands charter's
         window. Measured on a real 3.7c with a hostile config: `pane-border-indicators
-        arrows` marks the ACTIVE pane's borders and no others (one rule with a glyph, its
-        neighbour without); `pane-border-lines double` redraws every rule in a different
+        arrows` marks the ACTIVE pane's borders and no others; `pane-border-lines double`
+        redraws every rule in a different
         weight, and `number` writes pane numbers into them; and `pane-border-status top`
         turns every border into a title bar carrying the machine's hostname AND adds a
         border row above the topmost pane — a row `layout._BORDER_ROWS` never budgeted.
@@ -518,7 +518,11 @@ class Chrome(unittest.TestCase):
         `tests/test_frame_tmux_integration.py`, so a border option tmux grows later is
         caught by the second even though this one names today's."""
         pinned = {cmd[-2]: cmd[-1] for cmd in self._argvs()}
-        self.assertEqual(pinned.get("pane-border-indicators"), "off")
+        # `arrows` rather than `off` since #750: with the shipped `chrome = "off"` there
+        # is no surface, so nothing else in the frame said which pane the keyboard was in.
+        # The point of the row is unchanged — the operator's own `.tmux.conf` does not
+        # decide it — and `commands_frame._CHROME` carries the measurement.
+        self.assertEqual(pinned.get("pane-border-indicators"), "arrows")
         self.assertEqual(pinned.get("pane-border-lines"), "single")
         self.assertEqual(pinned.get("pane-border-status"), "off")
 

--- a/tests/test_frame_pane_style.py
+++ b/tests/test_frame_pane_style.py
@@ -445,8 +445,13 @@ class ThePaneWearsItsOwnColourAndTheFrameWearsTheRest(unittest.TestCase):
         every plane written before this key existed."""
         argvs = commands_frame._surface_argvs(socket="s", pane_id="%3", chrome="dark",
                                               bg=None)
+        # Against the ASSEMBLER and not against `FRAME_CHROME`'s bare values: #737 pairs a
+        # foreground with charter's own two surfaces, and `instance.surface_options` is the
+        # one place the two halves meet. A test spelling the background table here would be
+        # asserting half of what the pane wears.
         self.assertEqual([a[-1] for a in argvs],
-                         [v for _n, v in instance.FRAME_CHROME["dark"]])
+                         [v for _n, v in instance.surface_options(
+                             None, "dark", instance.SHIPPED_LOOK)])
 
     def test_the_default_parameter_is_no_background(self):
         """Called without `bg` at all — which every existing call site and every test
@@ -471,7 +476,8 @@ class ThePaneWearsItsOwnColourAndTheFrameWearsTheRest(unittest.TestCase):
         argvs = commands_frame._surface_argvs(socket="s", pane_id="%3", chrome="dark",
                                               bg="bg=#{?1,colour196,colour46}")
         self.assertEqual([a[-1] for a in argvs],
-                         [v for _n, v in instance.FRAME_CHROME["dark"]])
+                         [v for _n, v in instance.surface_options(
+                             None, "dark", instance.SHIPPED_LOOK)])
         for a in argvs:
             self.assertNotIn("#", a[-1])
 
@@ -481,6 +487,12 @@ class ThePaneWearsItsOwnColourAndTheFrameWearsTheRest(unittest.TestCase):
         — but "nothing charter did not write can appear here"."""
         ours = {v for pairs in instance.FRAME_PANE_BG.values() for _n, v in pairs}
         ours |= {v for pairs in instance.FRAME_CHROME.values() for _n, v in pairs}
+        # The paired foregrounds (#737) are charter's own constants too, and the property
+        # is "nothing charter did not write can appear here" — so the vocabulary widens
+        # with the table rather than the assertion being loosened. Derived from both
+        # tables, so a surface word added to either is inside this line on the same commit.
+        ours |= {f"{fg},{v}" for fg in instance.FRAME_CHROME_FG.values() if fg
+                 for pairs in instance.FRAME_CHROME.values() for _n, v in pairs}
         for word in (*instance.FRAME_PANE_BG, "chartreuse", "colour236",
                      "bg=#{?1,colour196,colour46}", None, 7, ["black"]):
             with self.subTest(bg=word):
@@ -569,8 +581,9 @@ class TheLauncherActuallyAsksForEachPanesColour(PersonaIso, unittest.TestCase):
         """The other half of the `or`, driven through the funnel rather than the helper."""
         frame = dict(_arrangement(repos={"bg": "blue"}), chrome="dark")
         styles = self._styles(self._issued(frame, ["repos", "right"]))
-        self.assertEqual(list(styles.values()),
-                         [["bg=blue", "bg=brightblue"], ["bg=black", "bg=brightblack"]])
+        dark = [v for _n, v in instance.surface_options(None, "dark",
+                                                        instance.SHIPPED_LOOK)]
+        self.assertEqual(list(styles.values()), [["bg=blue", "bg=brightblue"], dark])
 
     def test_the_harness_pane_is_never_a_target(self):
         """ADR 0018, asked of the funnel: `-p` never names the harness. Its window options
@@ -593,8 +606,10 @@ class TheLauncherActuallyAsksForEachPanesColour(PersonaIso, unittest.TestCase):
         # is not one.
         self.assertEqual(len(styles), 2,
                          f"both panes must have been styled, not {sorted(styles)}")
+        dark = [v for _n, v in instance.surface_options(None, "dark",
+                                                        instance.SHIPPED_LOOK)]
         for values in styles.values():
-            self.assertEqual(values, ["bg=black", "bg=brightblack"])
+            self.assertEqual(values, dark)
 
 
 class ThePadComesOutOfTheBudget(PersonaIso, unittest.TestCase):
@@ -1077,7 +1092,11 @@ class RealTmuxAcceptsEveryWordAndPaintsPerPane(_TmuxServerFixture, PersonaIso):
         _harness, a, b = self._panes()
         self._apply(a, chrome="dark")
         self._apply(b, chrome="dark", bg="default")
-        self.assertEqual(self._style(a), "bg=black")
+        # `fg=white,bg=black` — the frame-wide surface with the foreground #737 pairs with
+        # it. `b` opted out and therefore gets neither half, which is the line
+        # `FRAME_CHROME_FG` draws: the pairing belongs to the background it came with.
+        self.assertEqual(self._style(a), dict(instance.surface_options(
+            None, "dark", instance.SHIPPED_LOOK))["window-style"])
         self.assertEqual(self._style(b), "bg=default")
 
     def test_the_colour_belongs_to_the_pane_and_not_to_the_process_in_it(self):

--- a/tests/test_frame_provider_recipes.py
+++ b/tests/test_frame_provider_recipes.py
@@ -37,7 +37,7 @@ from unittest import mock
 
 from charter import contain, statusline, tui
 from charter.frame import chrome, component, ctx, registry, slots
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, shipped_frame
 from tests.test_component_providers import CID, ENTRY, MODULE, _SitePackages, _source
 
 #: One SGR escape with its parameter list captured — the shape `chrome._SGR` matches.
@@ -119,9 +119,15 @@ class TheRecipesAreDataAndNothingElse(unittest.TestCase):
 
 class TheRecipesNameNoColourCharterChose(unittest.TestCase):
     """The rule `instance.FRAME_CHROME` keeps, reaching the one place a stranger's code
-    would otherwise have to guess it."""
+    would otherwise have to guess it.
+
+    Pinned against the frame charter SHIPS (`shipped_frame`), because three of these roles
+    are `[frame]` keys now: without it, "``ok`` is green" is a claim about whatever plane
+    the suite is running inside.
+    """
 
     def setUp(self):
+        shipped_frame(self)
         self.env = mock.patch.dict(os.environ, {}, clear=True)
         self.env.start()
         self.addCleanup(self.env.stop)
@@ -567,9 +573,15 @@ class TheContainmentAdmitsCharterSVocabularyAndNothingElse(unittest.TestCase):
 
 class TheVocabularyIsTheRolesAndNotASecondListOfThem(unittest.TestCase):
     """`chrome.served_params` is derived from `chrome._role_values`, and #707 is what a
-    second list costs: a role served at one end and unknown at the other."""
+    second list costs: a role served at one end and unknown at the other.
+
+    Against the SHIPPED frame (`shipped_frame`): the vocabulary is a union of charter's own
+    three accents and the plane's, so on a plane that named a fourth colour these numbers
+    are correctly different — and this class is about the ones charter ships.
+    """
 
     def setUp(self):
+        shipped_frame(self)
         self.env = mock.patch.dict(os.environ, {}, clear=True)
         self.env.start()
         self.addCleanup(self.env.stop)

--- a/tests/test_frame_surface_live.py
+++ b/tests/test_frame_surface_live.py
@@ -257,7 +257,8 @@ class TurningTheSurfaceOffIsARemovalAndNotAStyle(unittest.TestCase):
     def test_dark_sets_both_options_and_unsets_nothing(self):
         tails = self._tails("dark")
         self.assertEqual(tails, [["set-option", "-p", "-t", "%3", name, value]
-                                 for name, value in instance.FRAME_CHROME["dark"]])
+                                 for name, value in instance.surface_options(
+                                     None, "dark", instance.SHIPPED_LOOK)])
 
     def test_a_word_charter_does_not_know_is_off_here_too(self):
         """The refusal is named: the argv is the UNSET list, which is `off`'s answer —
@@ -538,8 +539,10 @@ class TheLiveChangeReachesRealTmux(_TmuxServerFixture, PersonaIso):
         state.record_server(self.FID, self.SOCKET_NAME)
 
         self._run("dark")
-        self.assertEqual(self._style(panel), "bg=black")
-        self.assertEqual(self._style(panel, "window-active-style"), "bg=brightblack")
+        dark = dict(instance.surface_options(None, "dark", instance.SHIPPED_LOOK))
+        self.assertEqual(self._style(panel), dark["window-style"])
+        self.assertEqual(self._style(panel, "window-active-style"),
+                         dark["window-active-style"])
         self.assertEqual(self._style(harness), "",
                          "charter styled the pane the operator's harness runs in")
 
@@ -557,8 +560,10 @@ class TheLiveChangeReachesRealTmux(_TmuxServerFixture, PersonaIso):
         state.record_server(self.FID, self.SOCKET_NAME)
         self._run("dark")
         self._run("light")
-        self.assertEqual(self._style(panel), "bg=white")
-        self.assertEqual(self._style(panel, "window-active-style"), "bg=brightwhite")
+        light = dict(instance.surface_options(None, "light", instance.SHIPPED_LOOK))
+        self.assertEqual(self._style(panel), light["window-style"])
+        self.assertEqual(self._style(panel, "window-active-style"),
+                         light["window-active-style"])
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -4796,6 +4796,7 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         writes this machine's hostname into every rule and takes a row the frame's own
         arithmetic never budgeted for."""
         self._control(hostile=True)
+        own = None
         shot = self._screenshot(arm=True, hostile=True)
         states = _rule_states(shot)
         self.assertTrue(states, "the armed frame rendered no rules at all")
@@ -4811,14 +4812,34 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
         # charter's — an assertion nobody can read the strength of. Skipping it there is
         # naming what cannot be measured; the tmux that HAS the option still measures it.
         if self._has_option("pane-border-indicators"):
-            self.assertEqual(set(shot) & _INDICATOR_GLYPHS, set(),
-                             "`pane-border-indicators` is still theirs, so charter's "
-                             "frame marks its active pane's borders and not its others")
+            # **The property is that the answer is CHARTER'S, and it stopped being "no
+            # glyph" at #750.** With the shipped `chrome = "off"` there is no surface, so
+            # `window-active-style` had no shade to be one step from and nothing on screen
+            # said which pane the keyboard was in; the pin moved from `off` to `arrows`,
+            # and `commands_frame._CHROME` carries the measurement that a glyph in a rule
+            # is not #514's two-coloured rule. So this asks what it always meant to ask —
+            # that the operator's own `.tmux.conf` did not decide it — by comparing the two
+            # servers rather than by naming the value, which is what keeps the line true on
+            # the day charter picks a different one.
+            own = self._screenshot(arm=True)
+            self.assertEqual(set(shot) & _INDICATOR_GLYPHS,
+                             set(own) & _INDICATOR_GLYPHS,
+                             "`pane-border-indicators` is still theirs: charter's frame "
+                             "marks its panes differently inside their tmux than on its "
+                             "own server")
+            self.assertTrue(set(own) & _INDICATOR_GLYPHS,
+                            "charter's own frame marks no pane as the live one, which is "
+                            "#750 — on the shipped surfaceless frame this glyph is the "
+                            "only thing that does")
         # The whole property in one line: the frame drawn inside their tmux is the same
         # frame, cell for cell of chrome, as the one drawn on charter's own server.
         # Colour alone would not catch a `pane-border-lines double` — every rule would
         # still be one colour, and the frame would still not be charter's.
-        own = self._screenshot(arm=True)
+        # Reused where the indicator check above already took it, taken here where that
+        # check was skipped — one nested-tmux session rather than two, which is a fifteen
+        # second deadline this test does not need to spend twice.
+        if own is None:
+            own = self._screenshot(arm=True)
         self.assertEqual((_rule_glyphs(shot), states),
                          (_rule_glyphs(own), _rule_states(own)),
                          "charter's frame is drawn differently on the operator's server "

--- a/tests/test_statusline_gauge.py
+++ b/tests/test_statusline_gauge.py
@@ -18,7 +18,7 @@ from unittest import mock
 from charter import config, statusline
 from tests import _envguard
 from tests._isolation import (PersonaIso, isolate_state_dir, no_background_refresh,
-                              pin_update_channel)
+                              pin_update_channel, shipped_frame)
 
 
 def _plain(parts):
@@ -447,6 +447,11 @@ class ThePanelsGaugeReadsTheSameAsTheFooters(unittest.TestCase):
 
     def setUp(self):
         isolate_state_dir(self)
+        # The colours below are `[frame] ok`/`warn`/`bad` now, so "green at 49%" is a
+        # claim about the plane this suite is running inside unless the plane is pinned
+        # to the one charter ships. `shipped_frame` is that pin, and this class is about
+        # the shipped thresholds rather than about what a plane renamed them to.
+        shipped_frame(self)
         import shutil
         import tempfile
         d = tempfile.mkdtemp()

--- a/tests/test_the_frame_reads_on_the_terminal_it_is_on.py
+++ b/tests/test_the_frame_reads_on_the_terminal_it_is_on.py
@@ -1,0 +1,775 @@
+"""What a frame looks like on a ground charter did not choose — the three defects that
+only appear once you run it on the other kind of terminal.
+
+**Every one of these was written on a dark terminal and is wrong on a light one, or the
+mirror of that.** That is the whole reason the cluster exists, so the assertions here are
+written as PAIRS wherever a pair is possible: what the row says about the operator's
+foreground and what it says about their background, asked separately, so a fix verified on
+one ground cannot pass as a fix.
+
+* **#737** — ``chrome`` set a background and no foreground, so one of its two words made
+  every panel's text the colour of the surface it was drawn on.
+* **#736** — a reverse-video row set an absolute foreground INSIDE the inverted run, which
+  is the one place a sixteen-colour name stops meaning what the operator's theme says.
+* **#750** — with the shipped ``chrome = "off"`` nothing said which pane the keyboard was
+  in, and `docs/frame.md` described a cue that only exists once a surface is set.
+
+The real-tmux half of #750 lives in `test_a_planes_frame_really_reads_that_way.py`, beside
+the other measurements taken off an attached client's wire; what is here is charter's own
+answer, which is what a machine with no tmux can still check.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+from unittest import mock
+
+from charter import commands_frame, config, instance, statusline as sl, tui
+from charter.frame import chrome, slots
+from tests._isolation import PersonaIso
+
+#: One SGR escape, parameters captured — this file's own reading, so a change to
+#: `chrome._SGR` cannot quietly change what these tests measure.
+_SGR = re.compile(r"\x1b\[([0-9;]*)m")
+
+#: Every SGR parameter that names one of the sixteen as a FOREGROUND, and every one that
+#: names a background. Spelled here as the ECMA-48/aixterm ranges rather than imported from
+#: `chrome`, because the implementation's own set is the thing under test.
+_FG = frozenset({*range(30, 40), *range(90, 98)})
+_BG = frozenset({*range(40, 50), *range(100, 108)})
+
+
+def _params(row: str) -> list[int]:
+    """Every SGR parameter in *row*, as numbers — an empty parameter is the zero it means."""
+    return [int(p or "0") for m in _SGR.finditer(row) for p in m.group(1).split(";")]
+
+
+class TheChromeTableAndItsForegroundsAreOneVocabulary(unittest.TestCase):
+    """#737 — a surface word without a paired foreground is half a recipe.
+
+    The two tables are keyed identically and asserted so, for `chrome.served_params`' own
+    reason one module over: a second list of the words is exactly how a third surface comes
+    to ship with a background and no foreground, which is the defect rather than a risk of
+    it.
+    """
+
+    def test_every_chrome_word_says_what_goes_on_it(self):
+        self.assertEqual(set(instance.FRAME_CHROME), set(instance.FRAME_CHROME_FG),
+                         "a surface word and its foreground must arrive together")
+
+    def test_the_two_surfaces_charter_ships_carry_opposite_poles(self):
+        """`bg=black` wants `fg=white` and `bg=white` wants `fg=black`, and this is the only
+        pairing in charter that is a measurement rather than a guess: the two are the POLES
+        of the sixteen, so a theme is not free to render them the same way round."""
+        self.assertEqual(instance.FRAME_CHROME_FG["dark"], "fg=white")
+        self.assertEqual(instance.FRAME_CHROME_FG["light"], "fg=black")
+
+    def test_off_pairs_with_nothing_at_all(self):
+        """`off` is the absence of a surface, so there is no background for a foreground to
+        go with — and the empty clause is what keeps a plane that said nothing emitting the
+        options it emitted before this table existed."""
+        self.assertEqual(instance.FRAME_CHROME_FG["off"], "")
+
+    def test_a_word_charter_does_not_know_leaves_through_neither_half(self):
+        """`chrome_fg`'s containment is `text_fg`'s: what comes back is charter's own
+        constant, so a committed word indexes nothing."""
+        for word in ("solarized", "", None, 7, ["light"], {"a": 1}):
+            with self.subTest(word=word):
+                self.assertEqual(instance.chrome_fg(word), "")
+
+    def test_the_paired_foreground_is_a_palette_name_and_never_an_index(self):
+        """§3.2 said about the new table — `TheFrameNamesColoursAndNeverIndexes` names
+        `FRAME_CHROME` and `FRAME_PANE_BG`, and this one has to be inside the same rule
+        rather than an exception to it."""
+        known = {*instance.FRAME_PANE_COLOURS,
+                 *(f"bright{n}" for n in instance.FRAME_PANE_COLOURS), "default"}
+        for word, clause in instance.FRAME_CHROME_FG.items():
+            with self.subTest(word=word):
+                if clause:
+                    self.assertTrue(clause.startswith("fg="), clause)
+                    self.assertIn(clause.removeprefix("fg="), known, clause)
+
+
+class ASurfaceCarriesTheTextThatGoesOnIt(unittest.TestCase):
+    """#737 — the pairing where it reaches tmux, which is the only place it counts."""
+
+    #: A plane that has said nothing about its text.
+    QUIET = instance.SHIPPED_LOOK
+
+    def test_the_light_surface_stops_drawing_light_text_on_itself(self):
+        """The defect, stated as the operator meets it: `chrome = "light"` on a dark
+        terminal painted `bg=white` and left every uncoloured cell in the terminal's own
+        foreground, which on that theme is white."""
+        for name, value in instance.surface_options(None, "light", self.QUIET):
+            with self.subTest(option=name):
+                self.assertIn("fg=black", value, f"{name} = {value!r}")
+                self.assertIn("bg=", value, f"{name} = {value!r}")
+
+    def test_the_dark_surface_stops_drawing_dark_text_on_itself(self):
+        """The mirror, which is the half a developer on a dark terminal never sees fail."""
+        for name, value in instance.surface_options(None, "dark", self.QUIET):
+            with self.subTest(option=name):
+                self.assertIn("fg=white", value, f"{name} = {value!r}")
+
+    def test_both_style_options_carry_the_same_foreground(self):
+        """A foreground that moved with focus would say which pane is live twice, and
+        `FRAME_PANE_FG`'s own docstring argues why it must not: text that changed colour
+        from pane to pane stops reading as one document. The background pair is what says
+        it."""
+        for chrome_word in ("dark", "light"):
+            with self.subTest(chrome=chrome_word):
+                got = {v.split(",")[0]
+                       for _n, v in instance.surface_options(None, chrome_word, self.QUIET)}
+                self.assertEqual(len(got), 1, got)
+
+    def test_the_planes_own_text_word_still_wins(self):
+        """The pairing is charter's default for its own recipe, not a second opinion over a
+        plane that said what its frame's text is."""
+        look = instance.Look("hidden", "blue", True)
+        for name, value in instance.surface_options(None, "light", look):
+            with self.subTest(option=name):
+                self.assertIn("fg=blue", value, f"{name} = {value!r}")
+                self.assertNotIn("fg=black", value, f"{name} = {value!r}")
+
+    def test_the_style_carries_exactly_one_foreground(self):
+        """**`TheStyleCarriesExactlyOneForeground`.** A value with two `fg=` clauses is a
+        frame whose colour depends on a tmux parsing rule nobody wrote down — so the two
+        are resolved to one clause rather than appended in an order that leaves last-wins
+        to decide. Over every pairing of the two vocabularies."""
+        words = [*instance.FRAME_PANE_FG]
+        for chrome_word in instance.FRAME_CHROME:
+            for text in words:
+                look = instance.Look("hidden", text, True)
+                for bg in (None, "blue", "default"):
+                    for name, value in instance.surface_options(bg, chrome_word, look):
+                        with self.subTest(chrome=chrome_word, text=text, bg=bg):
+                            self.assertLessEqual(value.count("fg="), 1,
+                                                 f"{name} = {value!r}")
+
+    def test_a_component_that_named_its_own_background_gets_no_foreground_it_did_not_ask_for(self):
+        """The line the pairing draws, and the reason it is not seventeen words wide.
+        `bg = "blue"` is the operator's word out of their own palette; charter cannot see
+        what their blue looks like, so it does not decide what goes on it. `[frame] text`
+        is how that pane is told."""
+        for name, value in instance.surface_options("blue", "light", self.QUIET):
+            with self.subTest(option=name):
+                self.assertNotIn("fg=", value, f"{name} = {value!r}")
+
+    def test_a_frame_with_no_surface_at_all_is_byte_identical(self):
+        """`chrome = "off"` and no `bg`: the shipped frame, which must not have moved.
+        `_surface_argvs` issues no command at all for an empty answer, so this is the
+        assertion that the default did not gain a pane option."""
+        self.assertEqual(instance.surface_options(None, "off", self.QUIET), ())
+
+    def test_no_operator_string_reaches_the_foreground_half(self):
+        """The containment, asked the way `pane_bg_options`' own is: a `chrome` value from
+        a committed `charter.toml` is a KEY, and what leaves is charter's constant."""
+        for hostile in ("light,bg=#{?#{==:1,1},colour196,colour46}", "#(touch /tmp/x)",
+                        "light;bg=red"):
+            with self.subTest(hostile=hostile):
+                for _n, value in instance.surface_options(None, hostile, self.QUIET):
+                    self.assertNotIn("#", value)
+                self.assertEqual(instance.chrome_fg(hostile), "")
+
+
+class TheRuleStillReadsABareBackgroundClause(unittest.TestCase):
+    """#737's blast radius, pinned rather than hoped for.
+
+    `instance.rule_style`'s `hidden` arm does `surface.removeprefix("bg=")` and
+    `TheSurfaceIsAlwaysABareBackgroundClause` pins that over both tables. The paired
+    foreground is therefore a SEPARATE table rather than an `fg=` appended to
+    `FRAME_CHROME`'s values: an `fg` inside a `window-style` entry would reach that
+    `removeprefix` and compose a rule with two foregrounds in it.
+    """
+
+    def test_every_chrome_surface_is_still_exactly_a_background_clause(self):
+        for word, pairs in instance.FRAME_CHROME.items():
+            for name, value in pairs:
+                with self.subTest(word=word, option=name):
+                    self.assertTrue(value.startswith("bg="), value)
+                    self.assertNotIn("fg=", value)
+
+    def test_the_rule_over_a_paired_surface_still_carries_one_foreground(self):
+        got = instance.pane_border_options(None, "light", commands_frame._CHROME_FG,
+                                           instance.SHIPPED_LOOK)
+        self.assertTrue(got)
+        for name, value in got:
+            with self.subTest(option=name):
+                self.assertEqual(value.count("fg="), 1, f"{name} = {value!r}")
+
+
+class TheRowYouAreOnNamesNoColourAtAll(unittest.TestCase):
+    """#736 — reverse video is only theme-independent while the run sets no colour.
+
+    `docs/frame.md` argued the highlight is right on every scheme *precisely because it
+    names nothing*, and both surfaces that used it named something. These are the two rows
+    read off the operator's own live frame with `capture-pane -e`.
+    """
+
+    #: The sidebar's active persona row, as `statusline._persona_chip_cells` composes it.
+    SIDEBAR = "\x1b[35m▸ \x1b[1msteward\x1b[0m   \x1b[32m✎47\x1b[0m"
+
+    #: The repo table's selected row — cyan for the name, **yellow** for a dirty branch.
+    REPOS = ("  \x1b[2m├─ \x1b[0m\x1b[36mbilling\x1b[39m       "
+             "\x1b[33mmain*\x1b[39m  \x1b[32m✓ passed\x1b[39m")
+
+    def test_the_sidebars_chosen_row_carries_no_foreground(self):
+        got = chrome.reverse(self.SIDEBAR, 40)
+        self.assertFalse([p for p in _params(got) if p in _FG],
+                         f"a foreground survived the inversion: {got!r}")
+
+    def test_the_repo_tables_chosen_row_carries_no_foreground(self):
+        """The one #736 is titled for: `SGR 33` on the terminal's own foreground is the
+        worst pair the sixteen can make, on the row that says which repo you picked."""
+        got = chrome.reverse(self.REPOS, 60)
+        self.assertFalse([p for p in _params(got) if p in _FG],
+                         f"a foreground survived the inversion: {got!r}")
+
+    def test_it_carries_no_background_either(self):
+        """Under reverse a background parameter paints the TEXT, so both halves of the pair
+        are the same defect — asked separately because a fix that deleted one and not the
+        other would pass every assertion above."""
+        got = chrome.reverse("\x1b[41m\x1b[7mred bg\x1b[0m", 20)
+        self.assertFalse([p for p in _params(got) if p in _BG],
+                         f"a background survived the inversion: {got!r}")
+
+    def test_an_extended_colour_is_taken_whole_and_not_a_digit_at_a_time(self):
+        """The hazard `_without_dim` names and this one inherits: a pass that filtered the
+        parameter list would turn `38;2;255;0;0` into `255;0;0` and hand the terminal an
+        SGR nobody wrote. A provider's component is ordinary Python and writes what its
+        author's terminal supports."""
+        for spelling in ("\x1b[38;2;255;0;0m", "\x1b[48;5;236m", "\x1b[1;38;5;236mx",
+                         "\x1b[58;2;1;2;3m"):
+            with self.subTest(spelling=spelling):
+                got = chrome.reverse(f"a{spelling}b", 12)
+                self.assertNotIn("38", got, repr(got))
+                self.assertNotIn("48", got, repr(got))
+                self.assertNotIn("255", got, repr(got))
+                self.assertNotIn("236", got, repr(got))
+
+    def test_a_truncated_colour_introducer_is_taken_as_one_parameter(self):
+        """**`ESC[38m` with nothing after it**, which is where the walk runs off the end.
+
+        The three survivors `chrome.undim` was pinned for, asked again of the pass beside
+        it: an introducer at the END of the list has no space parameter to read, and a walk
+        that reached for one would raise `IndexError` inside a repaint — a panel that dies
+        rather than a colour that survives. `tui.sanitize` passes any
+        `ESC[<digits and semicolons>m` through, so a provider's row really can carry this.
+
+        `38` is dropped like any other colour and what followed it, if anything, is read as
+        the ordinary parameters they are.
+        """
+        for row, want in (("\x1b[38m", ""),
+                          ("\x1b[48m", ""),
+                          ("\x1b[58m", ""),
+                          ("\x1b[1;38m", "\x1b[1m"),
+                          ("\x1b[38;m", "\x1b[m")):
+            with self.subTest(row=row):
+                got = chrome.reverse(f"a{row}b", 12)
+                self.assertIn(f"a{want}", got, repr(got))
+                self.assertFalse([p for p in _params(got) if p in _FG or p in _BG],
+                                 repr(got))
+
+    def test_a_colour_space_charter_does_not_know_is_taken_as_one_parameter_too(self):
+        """The other half of the same walk. `ESC[38;99m` names a colour space that does not
+        exist, so there is no run length to consume — the introducer goes and the `99` is
+        whatever a terminal makes of it, which is not charter's to rewrite. A pass with no
+        fallback would raise or would swallow parameters it has no reason to.
+        """
+        for row, want in (("\x1b[38;99m", "\x1b[99m"),
+                          ("\x1b[38;4;9m", "\x1b[4;9m"),
+                          ("\x1b[58;7;1m", "\x1b[7;1m"),
+                          ("\x1b[48;0m", "\x1b[0m")):
+            with self.subTest(row=row):
+                got = chrome.reverse(f"a{row}b", 12)
+                self.assertIn(f"a{want}", got, repr(got))
+
+    def test_the_run_lengths_the_two_real_colour_spaces_have_are_the_ones_consumed(self):
+        """`5;<n>` is three parameters and `2;<r>;<g>;<b>` is five, and off-by-one either
+        way leaves a stray digit in the row that a terminal reads as an SGR of its own.
+        Asserted as the whole answer rather than as an absence."""
+        for row, want in (("\x1b[38;5;236m", ""),
+                          ("\x1b[38;5;236;1m", "\x1b[1m"),
+                          ("\x1b[38;2;255;0;0m", ""),
+                          ("\x1b[38;2;255;0;0;4m", "\x1b[4m"),
+                          ("\x1b[1;48;5;236;2m", "\x1b[1;2m")):
+            with self.subTest(row=row):
+                got = chrome.reverse(f"a{row}b", 12)
+                self.assertIn(f"a{want}b", got, repr(got))
+
+    def test_a_colour_spelled_with_a_leading_zero_goes_too(self):
+        """The numeric reading, which this file's six predecessors (#547, #558, #537, #498,
+        #577, #594) are the reason for: `ESC[032m` is green and a string match for `32`
+        finds it, but `ESC[1;032m` is bold AND green and only one of the two goes."""
+        got = chrome.reverse("a\x1b[1;032mb", 12)
+        self.assertFalse([p for p in _params(got) if p in _FG], repr(got))
+        self.assertIn(1, _params(got), f"the bold went with it: {got!r}")
+
+    def test_the_attributes_inside_the_run_are_untouched(self):
+        """A deletion of colour and not of everything: bold adds weight and dim reduces it
+        relative to whatever ground the cell already has, so neither can be wrong on a
+        theme charter cannot see. `_table_row`'s emphasis and the tree's dim are drawn with
+        exactly these."""
+        got = chrome.reverse("\x1b[1m\x1b[4mA\x1b[2mB", 12)
+        for attr in (1, 4, 2):
+            with self.subTest(attr=attr):
+                self.assertIn(attr, _params(got), repr(got))
+
+    def test_an_escape_that_emptied_is_deleted_and_never_left_as_a_bare_reset(self):
+        """The correctness of the whole pass, and the reason `_without_colour` answers
+        `None` rather than `""`: `ESC[m` is an omitted parameter, an omitted parameter is
+        SGR's default of ZERO, and a `ESC[35m` rewritten to `ESC[m` would turn everything
+        off — cancelling the reverse one escape after it was asserted."""
+        got = chrome.reverse("a\x1b[35mb", 12)
+        self.assertNotIn("\x1b[m", got, repr(got))
+
+    def test_a_colour_channel_that_happens_to_be_zero_is_not_read_as_a_reset(self):
+        """**A colour's arguments are not SGR parameters**, and by the time
+        `chrome.cancels_reverse` sees a list they are all just numbers. `ESC[38;2;255;0;0m`
+        is a 24-bit red foreground whose green and blue channels are zero — read whole it
+        says "reverse was cancelled", and charter answers a `ESC[7m` that changes nothing
+        on the screen, on every repaint, forever.
+
+        Deleting the colour first is what turns the list into its parameters, so the
+        question is asked of what survived. This asserts the byte that is NOT there."""
+        for row in ("\x1b[38;2;255;0;0m", "\x1b[38;2;0;0;27m", "\x1b[48;5;0m",
+                    "\x1b[38;5;27m"):
+            with self.subTest(row=row):
+                got = chrome.reverse(f"a{row}b", 12)
+                self.assertEqual(got.count("\x1b[7m"), 1,
+                                 f"reverse was re-asserted for a colour channel: {got!r}")
+
+    def test_an_escape_that_really_did_reset_still_gets_its_re_assertion(self):
+        """The control for the line above, and the reason it is not a licence to stop
+        re-asserting: a `0` that is a PARAMETER survives the deletion and is answered."""
+        for row in ("\x1b[0m", "\x1b[38;2;255;0;0;0m", "\x1b[38;m", "\x1b[27m"):
+            with self.subTest(row=row):
+                got = chrome.reverse(f"a{row}b", 12)
+                self.assertEqual(got.count("\x1b[7m"), 2,
+                                 f"the highlight was not put back: {got!r}")
+
+    def test_a_reset_inside_the_run_still_survives_with_its_re_assertion(self):
+        """`0` is not a colour, so the pass leaves it — and `cancels_reverse` is asked of
+        the ORIGINAL list, so the re-assertion still lands behind it."""
+        got = chrome.reverse("a\x1b[0mb", 12)
+        self.assertIn("\x1b[0m\x1b[7m", got, repr(got))
+
+    def test_the_row_is_still_highlighted_to_the_last_column(self):
+        """The property the deletion must not cost. Walked as a terminal would."""
+        for row, width in ((self.SIDEBAR, 40), (self.REPOS, 60)):
+            with self.subTest(width=width):
+                got = chrome.reverse(row, width)
+                self.assertEqual(tui.width(got), width)
+                on = True
+                for i, ch in enumerate(got):
+                    m = _SGR.match(got, i)
+                    if m and m.start() == i:
+                        for p in m.group(1).split(";"):
+                            v = int(p or "0")
+                            on = True if v == 7 else False if v in (0, 27) else on
+                self.assertFalse(on, "the row left reverse video open")
+
+    def test_the_row_says_exactly_what_it_said_before(self):
+        """A deletion of colour changes no cell's text and no cell's width — every SGR
+        costs zero columns. `chrome.plain` is the frame's own reading of "what a terminal
+        with no colour would show", and it is unmoved."""
+        for row, width in ((self.SIDEBAR, 40), (self.REPOS, 60)):
+            with self.subTest(width=width):
+                self.assertEqual(chrome.plain(chrome.reverse(row, width)),
+                                 chrome.plain(tui.truncate(row, width)))
+
+    def test_a_provider_composing_with_the_selected_recipe_gets_the_same_answer(self):
+        """The third caller, which is why the pass is in `reverse` and not at the two call
+        sites in `slots.py`. A component's row reaching this is ordinary Python that may
+        have written any colour at all."""
+        got = chrome.reverse("\x1b[33mprovider\x1b[0m", 20)
+        self.assertFalse([p for p in _params(got) if p in _FG], repr(got))
+
+
+class TheRealRowCharterDrawsCarriesNoColourInside(PersonaIso, unittest.TestCase):
+    """#736 measured through the renderer rather than through a fixture.
+
+    A fixture is a row somebody typed, and this whole cluster exists because a row somebody
+    typed matched what was drawn on the machine it was typed on. This renders the repo
+    table — the surface #736 is titled for — from `gather`-cache-shaped rows and walks the
+    line that came back.
+
+    The rows are built here rather than read from the plane this suite is running on
+    (#785): a table read live carries whatever the operator's clones happen to be doing,
+    and "the dirty branch is yellow" is the case that has to be in the fixture rather than
+    hoped for.
+    """
+
+    #: Wide enough that no column is dropped — `statusline._LEFT_W` is the floor.
+    WIDE = 200
+
+    def _rows(self, name, **kw):
+        row = {"name": name, "branch": "main", "dirty": True, "tracked_dirty": False,
+               "ahead": 0, "behind": 3, "ci": "success", "change": 4, "sigil": "✎",
+               "current": False, "worktree_count": 0}
+        row.update(kw)
+        return row
+
+    def _table(self, selected):
+        data = {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+                "repos": [self._rows("alpha"), self._rows("beta", ci="failed")],
+                "worktrees": []}
+        return slots._table_lines(data, self.WIDE, 6, selected=selected)
+
+    def test_the_unselected_rows_still_carry_their_colours(self):
+        """The control, and it is not decoration: "no colour inside the inversion" is
+        equally satisfied by a renderer that drew no colour at all, and this fixture is
+        exactly the dirty-branch, CI-failing shape #736 measured."""
+        rows = [ln.text for ln in self._table(selected="alpha")]
+        self.assertTrue([p for p in _params(rows[1]) if p in _FG],
+                        f"the fixture drew no colour to delete: {rows[1]!r}")
+
+    def test_the_selected_row_carries_none(self):
+        rows = [ln.text for ln in self._table(selected="alpha")]
+        self.assertIn("\x1b[7m", rows[0], "the fixture did not highlight anything")
+        self.assertFalse([p for p in _params(rows[0]) if p in _FG or p in _BG],
+                         f"a colour survived the inversion: {rows[0]!r}")
+
+    def test_the_yellow_branch_is_the_one_that_goes(self):
+        """#736's own headline. A dirty branch is `statusline._YELLOW`; inside the reversed
+        run that is yellow on the terminal's own foreground."""
+        selected = self._table(selected="alpha")[0].text
+        self.assertNotIn(33, _params(selected), repr(selected))
+        unselected = self._table(selected="beta")[0].text
+        self.assertIn(33, _params(unselected),
+                      f"the control lost its yellow too: {unselected!r}")
+
+    def test_the_row_still_says_what_it_said(self):
+        """Selection is paint and never content — `TheSelectedRowIsDrawnAsSelected`'s own
+        rule, re-asked now that the paint is a deletion."""
+        self.assertEqual(chrome.plain(self._table(selected="alpha")[0].text),
+                         chrome.plain(self._table(selected="beta")[0].text))
+
+
+class TheFrameSaysWhichPaneIsLive(unittest.TestCase):
+    """#750 — with the shipped `chrome = "off"` there was no answer at all.
+
+    Charter's half of it: the option is pinned, and it is pinned to the value that draws a
+    cue. What tmux actually puts on the wire for it is measured in
+    `test_a_planes_frame_really_reads_that_way.py`, because a pane border belongs to no
+    pane and `capture-pane` cannot see one.
+    """
+
+    def test_the_active_pane_is_marked(self):
+        """`arrows` and not `off`. The frame charter ships has no surface, so
+        `window-active-style` has no shade to be one step from and both rule styles are
+        pinned to one value on purpose — which left nothing on screen saying which pane the
+        keyboard was in."""
+        self.assertEqual(commands_frame._chrome_values()["pane-border-indicators"],
+                         "arrows")
+
+    def test_the_two_rule_styles_are_still_one_value(self):
+        """#514 is not reopened by it, and this is the assertion that says so. The cue is a
+        GLYPH substituted into a rule that keeps one style along its whole length; a cue
+        made of a second style would be a rule that changes appearance halfway, which is
+        the defect that put charter in charge of these options."""
+        values = commands_frame._chrome_values()
+        self.assertEqual(values["pane-border-style"], values["pane-active-border-style"])
+
+    def test_it_is_still_floored_where_the_option_arrived(self):
+        """The option does not exist at `tmuxctl.FLOOR` — pinning a name tmux does not have
+        is refused rather than degraded, which is #716, and the value moving does not move
+        the floor."""
+        floors = {name: floor for name, _v, floor in commands_frame._CHROME}
+        # The NUMBER, not the constant compared to itself: `_CHROME` is written with the
+        # constant in it, so naming it here would pass whatever either one said. 3.3 is
+        # where tmux's own CHANGES file put the option, and it is the fact this row is
+        # floored on.
+        self.assertEqual(floors["pane-border-indicators"], (3, 3))
+        self.assertEqual(commands_frame.tmuxctl.BORDER_INDICATORS_FLOOR, (3, 3))
+        self.assertGreater(floors["pane-border-indicators"],
+                           commands_frame.tmuxctl.FLOOR,
+                           "an option floored at charter's own floor needs no floor")
+
+    def test_it_is_still_pinned_rather_than_inherited(self):
+        """Whatever the value, the point of the row is that the operator's own `.tmux.conf`
+        does not decide it."""
+        self.assertIn("pane-border-indicators", commands_frame._chrome_values())
+
+
+class TheAccentRolesAreOneList(unittest.TestCase):
+    """`[frame] ok`/`warn`/`bad` — the gap `[frame] text` named and could not close.
+
+    `text` fixes a pane whose background is inverted relative to the terminal's. On a
+    terminal that is already light it has nothing to do, and what is hard to read there is
+    these three: **yellow on tan** is the pair no palette was designed for, and no amount of
+    it being the operator's own yellow makes it legible on the operator's own tan.
+
+    `instance.FRAME_ACCENTS` is the one list, and these are the joins that have to hold
+    across it — a role configurable and not served, or served and not configurable, is a
+    vocabulary charter enforces and nobody can use.
+    """
+
+    def test_every_accent_role_is_a_frame_key(self):
+        for role in instance.FRAME_ACCENTS:
+            with self.subTest(role=role):
+                self.assertIn(role, instance.FRAME_FIELDS)
+                self.assertIn(role, instance.FRAME_DEFAULTS)
+
+    def test_every_accent_role_is_a_field_on_the_look(self):
+        for role in instance.FRAME_ACCENTS:
+            with self.subTest(role=role):
+                self.assertIn(role, instance.Look._fields)
+
+    def test_every_accent_role_reaches_a_provider_as_the_plane_s_own_colour(self):
+        """`chrome.recipes` is what a component composes with, and a role charter lets a
+        plane recolour without serving it would be two frames in one pane.
+
+        Asked of the VALUE and not of the key: the keys are built by a comprehension over
+        `FRAME_ACCENTS`, so "is this role served" cannot fail by construction. What can
+        fail is a role served the colour charter always drew on a plane that asked for a
+        different one — the wiring being present and inert."""
+        with mock.patch.dict(config.FRAME, {"ok": "blue", "warn": "cyan", "bad": "magenta"}), \
+                mock.patch.object(chrome, "colour_ok", lambda: True):
+            got = chrome.recipes()
+        for role, want in (("ok", "\x1b[34m"), ("warn", "\x1b[36m"),
+                           ("bad", "\x1b[35m")):
+            with self.subTest(role=role):
+                self.assertEqual(got[role], want)
+
+    def test_the_toml_key_is_the_role_name(self):
+        """One word, so `docs/frame.md`'s hyphen rule does not arise — and the key an
+        operator types is the word this table is indexed by."""
+        for role in instance.FRAME_ACCENTS:
+            with self.subTest(role=role):
+                self.assertEqual(instance.FRAME_FIELDS[role][1], role)
+
+
+class TheShippedAccentsAreTheOnesCharterAlwaysDrew(unittest.TestCase):
+    """A plane that says nothing gets a byte-identical frame.
+
+    **Against `FRAME_DEFAULTS` and never against the ambient plane**, which is this
+    suite's own recurring defect said about the newest key: `statusline.accent` reads
+    `config.FRAME`, and `config.FRAME` on a developer's machine is the plane the suite is
+    running inside. Every assertion here is about the plane that said NOTHING, so the
+    plane has to actually say nothing — otherwise the first operator to write
+    `warn = "blue"` in the `charter.toml` this feature was written for turns three of
+    these red, and the failure is about their config rather than about charter.
+
+    The mechanism is new; the colours are not. This is the pair of sources agreeing —
+    `statusline._SHIPPED_ACCENT` is what this module has drawn since before it had a key,
+    and `_ACCENT_SGR` indexed by `FRAME_DEFAULTS` is what the new table derives.
+    """
+
+    def setUp(self):
+        super().setUp()
+        patch = mock.patch.dict(config.FRAME, instance.FRAME_DEFAULTS, clear=True)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def test_the_two_spellings_of_the_shipped_colour_agree(self):
+        for role in instance.FRAME_ACCENTS:
+            with self.subTest(role=role):
+                self.assertEqual(sl._SHIPPED_ACCENT[role],
+                                 sl._ACCENT_SGR[instance.FRAME_DEFAULTS[role]])
+
+    def test_a_quiet_plane_draws_green_yellow_and_red(self):
+        self.assertEqual(
+            [sl.accent(r) for r in instance.FRAME_ACCENTS],
+            [sl._GREEN, sl._YELLOW, sl._RED])
+
+    def test_the_recipes_a_quiet_plane_serves_are_the_ones_it_always_served(self):
+        got = chrome._role_values()
+        self.assertEqual([got[r] for r in instance.FRAME_ACCENTS],
+                         [sl._GREEN, sl._YELLOW, sl._RED])
+
+    def test_a_frame_written_before_these_keys_existed_still_has_them(self):
+        """**`look_of`'s `.get` with a default, and the case it is there for.** A frame
+        relaunched by a charter that predates these keys has a `frame.state` with `rules`,
+        `text` and `dim` in it and no accents at all — a subscript would raise inside the
+        launcher, which is a plane with no frame rather than a plane with a green `✓`.
+
+        Asked of a dict that really is missing them, because `config.FRAME` has been
+        through `frame_of` and always carries all three: a test that went through the
+        config boundary would exercise the key and never the fallback."""
+        got = instance.look_of({"rules": "visible", "text": "black", "dim": False})
+        for role in instance.FRAME_ACCENTS:
+            with self.subTest(role=role):
+                self.assertEqual(getattr(got, role), instance.FRAME_DEFAULTS[role])
+
+    def test_each_accent_falls_back_on_its_own_and_not_on_a_neighbours(self):
+        """The other half of the same line: a comprehension keyed on the wrong role would
+        give all three the same colour and the assertion above would not see it, because
+        the three shipped defaults are read from the same table it reads."""
+        got = instance.look_of({"ok": "blue", "bad": "cyan"})
+        self.assertEqual((got.ok, got.warn, got.bad), ("blue", "yellow", "cyan"))
+
+    def test_the_shipped_vocabulary_is_exactly_what_it_was(self):
+        """`chrome.served_params` is the containment #707 opened, and a key that widened it
+        for a plane that said nothing would be a hole rather than a feature."""
+        self.assertEqual(sorted(chrome.served_params()), [0, 1, 2, 7, 31, 32, 33])
+
+
+class ThePlanesOwnPaletteReachesTheAccent(unittest.TestCase):
+    """The keys doing something — asked of every word, because #687's warning bites in the
+    direction of acceptance and a vocabulary that is documented and half-usable is worse
+    than a smaller one."""
+
+    def _with(self, **frame):
+        return mock.patch.dict(config.FRAME, frame)
+
+    def test_every_word_in_the_vocabulary_is_accepted(self):
+        for word in instance.FRAME_PANE_FG:
+            with self.subTest(word=word), self._with(warn=word):
+                self.assertEqual(sl.accent("warn"), sl._ACCENT_SGR[word])
+
+    def test_default_is_the_panes_own_foreground_and_not_a_hole(self):
+        """SGR 39 — which is `[frame] text` where the plane set one and the terminal's own
+        where it did not. So `warn = "default"` is "stop colouring the warnings", and the
+        glyph still says what the row means."""
+        with self._with(warn="default"):
+            self.assertEqual(sl.accent("warn"), "\x1b[39m")
+
+    def test_the_three_roles_are_independent(self):
+        with self._with(ok="blue", warn="magenta", bad="cyan"):
+            self.assertEqual([sl.accent(r) for r in instance.FRAME_ACCENTS],
+                             ["\x1b[34m", "\x1b[35m", "\x1b[36m"])
+
+    def test_a_word_charter_does_not_know_draws_what_it_always_drew(self):
+        """`[frame]`'s degrade-rather-than-refuse contract (#535's right half): a typo costs
+        the shipped colour in a frame that is otherwise entirely intact."""
+        for hostile in ("chartreuse", "colour236", "", None, 7, ["blue"], {"a": 1}):
+            with self.subTest(hostile=hostile):
+                with self._with(warn=hostile):
+                    self.assertEqual(sl.accent("warn"), sl._YELLOW)
+
+    def test_the_word_is_refused_at_the_config_boundary(self):
+        """Where `text` is refused, and by the same function — a second shape for "is this
+        one of the seventeen" is how the two come to disagree about a word."""
+        for hostile in ("chartreuse", "colour236", 7, ["blue"]):
+            with self.subTest(hostile=hostile):
+                self.assertEqual(instance.frame_of({"frame": {"warn": hostile}})["warn"],
+                                 "yellow")
+        self.assertEqual(instance.frame_of({"frame": {"warn": "blue"}})["warn"], "blue")
+
+    def test_no_accent_can_name_a_cube_index_or_a_triple(self):
+        """§3.2 said about the SGR side — `TheFrameNamesColoursAndNeverIndexes` renders
+        every slot and asserts this, and the new table is inside that rule rather than an
+        exception to it."""
+        for word, sgr in sl._ACCENT_SGR.items():
+            with self.subTest(word=word):
+                self.assertRegex(sgr, r"^\x1b\[(3[0-9]|9[0-7])m$", f"{word} = {sgr!r}")
+
+
+class ThePlanesAccentReachesARealRow(PersonaIso, unittest.TestCase):
+    """The keys reaching a pane, which is the only place any of this counts.
+
+    A plane setting a word and a `recipes()` dict agreeing about it proves the wiring and
+    not the frame: charter's own renderers wrote those escapes directly, and routing them
+    is the half #768 named as remaining work.
+    """
+
+    WIDE = 200
+
+    def _branch(self, **frame):
+        data = {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+                "repos": [{"name": "alpha", "branch": "main", "dirty": True,
+                           "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": "success",
+                           "change": None, "sigil": "", "current": False,
+                           "worktree_count": 0}],
+                "worktrees": []}
+        with mock.patch.dict(config.FRAME, frame):
+            return slots._table_lines(data, self.WIDE, 6)[0].text
+
+    def test_a_dirty_branch_is_yellow_on_a_plane_that_said_nothing(self):
+        """The control. `warn` is a dirty branch here, and yellow on tan is the pair the
+        key exists for — so the fixture has to actually draw one."""
+        self.assertIn(33, _params(self._branch()))
+
+    def test_a_plane_that_asked_for_blue_gets_blue(self):
+        got = self._branch(warn="blue")
+        self.assertIn(34, _params(got), repr(got))
+        self.assertNotIn(33, _params(got), repr(got))
+
+    def test_a_plane_that_asked_for_no_colour_at_all_still_says_it_is_dirty(self):
+        """`NoStatusIsCarriedByColourAlone` is what makes `default` a usable answer rather
+        than a loss: the row says the same thing with its escapes stripped."""
+        self.assertEqual(chrome.plain(self._branch(warn="default")),
+                         chrome.plain(self._branch()))
+
+    def test_the_ci_table_resolves_its_role_rather_than_an_escape_from_import_time(self):
+        """`statusline._CI_MARK` is the one accent site that is a module-level TABLE, so it
+        is the one that would have frozen its colours before any plane was read."""
+        with mock.patch.dict(config.FRAME, {"ok": "magenta"}):
+            self.assertIn("\x1b[35m", sl._ci_part("success"))
+        self.assertIn(sl._GREEN, sl._ci_part("success"))
+
+    def test_every_pipeline_status_gitlab_reports_has_its_own_row(self):
+        """**The KEYS of `_CI_MARK`, pinned, and they are pinned here because this change
+        rewrote every value in that table.** They are GitLab's own status names off the
+        wire, so a typo in one is not a colour that comes out wrong — it is a pipeline that
+        falls through to the `?` fallback and reads as a status charter does not recognise.
+        Nothing asserted them before, which the deletion sweep found by retuning
+        `"pending"`, `"created"` and `"preparing"` and watching all 9 647 tests pass.
+
+        The glyph and the label are pinned with the name, because what an operator reads is
+        those two and the three names above are three different ways of saying `○ pending`.
+        """
+        for status, glyph, label in (
+                ("success", "✓", "passed"), ("failed", "✗", "failed"),
+                ("running", "●", "running"), ("pending", "○", "pending"),
+                ("created", "○", "pending"), ("preparing", "○", "pending"),
+                ("waiting_for_resource", "○", "queued"),
+                ("scheduled", "○", "scheduled"), ("manual", "‖", "manual"),
+                ("canceled", "⊘", "canceled"), ("skipped", "»", "skipped")):
+            with self.subTest(status=status):
+                self.assertEqual(chrome.plain(sl._ci_part(status)), f"{glyph} {label}")
+
+    def test_a_status_charter_does_not_know_says_so_rather_than_guessing(self):
+        """The control for the row above, and the behaviour a mistyped key degrades to: the
+        name comes back verbatim behind a `?`, which is the honest answer to a status
+        GitLab grew after this table was written."""
+        self.assertEqual(chrome.plain(sl._ci_part("blocked")), "? blocked")
+        self.assertEqual(sl._ci_part(""), "")
+        self.assertEqual(sl._ci_part(None), "")
+
+    def test_a_role_that_is_not_an_accent_keeps_its_own_colour(self):
+        """`running` is a state rather than a verdict and `manual`/`skipped` are muted, so
+        none of them moves with `ok`. A pass that recoloured the whole table would be
+        charter deciding that every mark in it means the same three things."""
+        with mock.patch.dict(config.FRAME, {"ok": "magenta", "warn": "blue",
+                                            "bad": "cyan"}):
+            self.assertIn(sl._CYAN, sl._ci_part("running"))
+            self.assertIn(sl._DIM, sl._ci_part("skipped"))
+
+    def test_a_repos_identity_colour_does_not_move_with_an_accent(self):
+        """`statusline._PALETTE` cycles green and yellow as REPO identity, which is why the
+        routing is at the call sites and not a substitution over the finished row: a pass
+        over the pane would have recoloured a repo's name as though it were a status."""
+        self.assertIn("\x1b[33m", sl._PALETTE)
+        with mock.patch.dict(config.FRAME, {"warn": "blue"}):
+            self.assertIn("\x1b[33m", sl._PALETTE)
+
+
+class NoColourStillWinsOverThePlanesPalette(unittest.TestCase):
+    """`NO_COLOR` is a superset of every key here and meets them in one ordering rather
+    than fighting — `chrome.recipes`' own argument, re-asked now that three of the roles
+    can be words."""
+
+    def test_every_accent_role_is_empty_under_no_color(self):
+        with mock.patch.dict(os.environ, {"NO_COLOR": ""}), \
+                mock.patch.dict(config.FRAME, {"warn": "blue"}):
+            got = chrome.recipes()
+            for role in instance.FRAME_ACCENTS:
+                with self.subTest(role=role):
+                    self.assertEqual(got[role], "")
+
+    def test_the_vocabulary_the_plane_widened_is_still_admitted(self):
+        """`served_params` is deliberately NOT emptied by `NO_COLOR` — `contain_row` asks
+        `colour_ok` for itself one call earlier, and a vocabulary that shrank would be a
+        second answer to a question already answered."""
+        with mock.patch.dict(config.FRAME, {"warn": "blue"}):
+            self.assertIn(34, chrome.served_params())
+            self.assertIn(33, chrome.served_params(),
+                          "a plane cannot narrow what a provider may write")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_the_statusline_counts_only_what_it_has.py
+++ b/tests/test_the_statusline_counts_only_what_it_has.py
@@ -1,0 +1,373 @@
+"""Every count and threshold in `statusline.py` that renames its own colour, pinned.
+
+**These are the eighteen the deletion sweep charged this branch for**, and the charge is
+right even though the defect is older than the branch: routing `ok`/`warn`/`bad` through
+`statusline.accent` rewrote one token on each of these ten lines, and a rewritten line is a
+line whose guards you now own. What the sweep actually mutated is the logic AROUND the
+token — `if done:`, `if persistent:`, `cost >= _REBUILD_LOUD`, `src ==
+"$CHARTER_WORKSPACE"` — and nothing in 9 678 tests could tell the difference when it was
+deleted.
+
+**The property they all share is `Presence IS the signal`.** `_session_news`' own docstring
+says it: *"a counter that renders every turn becomes furniture within a day, and then a real
+guard denial appearing in it gets no more attention than a zero would."* `_mem_badge`,
+`_piece_summary` and `_alerts` each make the same promise in their own words. Every
+`drop-if` mutation below breaks exactly that promise — it renders `✎0`, `0 done`, `⛊ 0
+denied` on every line forever — and every one of them passed.
+
+So each case here asserts the SILENCE and its own control: the row that must not appear
+when the count is zero, and the row that must appear when it is not. A test for only the
+second half is what let these through.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import statusline as sl
+from tests._isolation import (PersonaIso, no_background_refresh, shipped_frame)
+
+
+def _plain(text) -> str:
+    """*text* as a terminal with no colour would show it — a string or a list of pieces."""
+    from charter import tui
+    if not isinstance(text, str):
+        text = " ".join(text)
+    return tui.strip_ansi(text)
+
+
+class AMemoryBadgeCountsNothingItDoesNotHave(unittest.TestCase):
+    """`statusline._mem_badge` — `✎N` committed, `◌N` scratch, and **nothing at zero**.
+
+    Its own docstring says "'' when both are zero", and nothing asserted the halves: with
+    `if persistent:` deleted every persona in the sidebar grows a permanent `✎0`, on the one
+    column whose whole design is that an empty cell means "nothing to report".
+    """
+
+    def setUp(self):
+        super().setUp()
+        shipped_frame(self)
+
+    def test_neither_count_draws_nothing_at_all(self):
+        self.assertEqual(sl._mem_badge(0, 0), "")
+
+    def test_a_zero_persistent_count_draws_no_committed_badge(self):
+        """`drop-if` on `if persistent:` — the badge that would render on every row."""
+        self.assertNotIn("✎", sl._mem_badge(0, 3))
+        self.assertIn("◌3", _plain(sl._mem_badge(0, 3)))
+
+    def test_a_zero_ephemeral_count_draws_no_scratch_badge(self):
+        """`drop-if` on `if ephemeral:`, and the mirror of the case above."""
+        self.assertNotIn("◌", sl._mem_badge(4, 0))
+        self.assertIn("✎4", _plain(sl._mem_badge(4, 0)))
+
+    def test_both_counts_draw_both_badges_in_their_own_accents(self):
+        """The control. Every assertion above is an absence, so this is what proves the
+        function draws anything at all — and it pins which accent each half wears, which is
+        the token this branch rewrote."""
+        got = sl._mem_badge(4, 3)
+        self.assertEqual(_plain(got), " ✎4 ◌3")
+        self.assertIn(f"{sl.accent('ok')}✎4", got)
+        self.assertIn(f"{sl.accent('warn')}◌3", got)
+
+
+class ABranchCellIsColouredByWhetherItIsDirty(unittest.TestCase):
+    """`statusline._branch_cell_for` — `warn` when the clone is dirty, `dim` when it is not.
+
+    Both `collapse-ifexp` arms survived, so nothing said the cell changes at all: a repo
+    table where every branch was drawn dirty, or none was, passed the whole suite. This is
+    the same cell #736 measured inside a reversed row, which is why it is worth two lines.
+    """
+
+    def setUp(self):
+        super().setUp()
+        shipped_frame(self)
+
+    def test_a_dirty_clone_draws_its_branch_in_warn(self):
+        got = sl._branch_cell_for("main", "", is_dirty=True)
+        self.assertIn(sl.accent("warn"), got)
+        self.assertNotIn(sl._DIM, got)
+
+    def test_a_clean_clone_draws_its_branch_dim(self):
+        got = sl._branch_cell_for("main", "", is_dirty=False)
+        self.assertIn(sl._DIM, got)
+        self.assertNotIn(sl.accent("warn"), got)
+
+    def test_the_two_really_are_different(self):
+        """The control, and it is not decoration: both assertions above are satisfied by a
+        function that returns one constant, if that constant happened to contain both."""
+        self.assertNotEqual(sl._branch_cell_for("main", "", is_dirty=True),
+                            sl._branch_cell_for("main", "", is_dirty=False))
+
+    def test_the_branch_name_survives_either_way(self):
+        for dirty in (True, False):
+            with self.subTest(dirty=dirty):
+                self.assertIn("main", _plain(sl._branch_cell_for("main", "",
+                                                                 is_dirty=dirty)))
+
+
+class APieceSummaryCountsOnlyTheOutcomesItHas(unittest.TestCase):
+    """`statusline._piece_summary` — `N done` and `N abandoned` appear only when non-zero.
+
+    Both `drop-if`s survived. With them deleted, a workspace whose pieces are all still
+    running renders `pieces 3 0 done 0 abandoned` on every turn — three numbers where the
+    row's whole design is that a number present means something happened.
+    """
+
+    def setUp(self):
+        super().setUp()
+        shipped_frame(self)
+
+    def _summary(self, decls):
+        """*decls* is one declaration per worktree, `None` for "still running"."""
+        from charter import pieces as _p, worktree as _wt
+        names = [f"wt{i}" for i in range(len(decls))]
+        # `.name` is assigned AFTER construction on every mock here, and that is not a
+        # style choice: `MagicMock(name="repo")` names the MOCK and leaves `.name` a child
+        # mock, so a fixture built the obvious way silently hands `_piece_summary` a
+        # directory whose name is a `MagicMock` — it counted one worktree instead of three
+        # and every assertion below passed for the wrong reason.
+        repo = mock.MagicMock()
+        repo.name = "repo"
+        repo.is_dir.return_value = True
+        root = mock.MagicMock()
+        root.iterdir.return_value = [repo]
+        dirs = []
+        for n in names:
+            d = mock.MagicMock()
+            d.name = n
+            dirs.append(d)
+        by_name = dict(zip(names, decls))
+        with mock.patch.object(_wt, "root", lambda ws: root), \
+                mock.patch.object(_wt, "dirs_for", lambda ws, repo: dirs), \
+                mock.patch.object(_p, "declaration_for",
+                                  lambda ws, repo, wt: by_name[wt]):
+            return sl._piece_summary("w")
+
+    def test_pieces_that_are_all_still_running_report_no_outcome_at_all(self):
+        """`drop-if` on both. Three pieces, none finished: the row says how many there are
+        and nothing else."""
+        got = _plain(self._summary([None, None, None]))
+        self.assertEqual(got, "pieces 3",
+                         "a piece with no outcome yet was counted as one that had")
+
+    def test_a_finished_piece_is_counted_and_an_abandoned_one_is_not(self):
+        got = _plain(self._summary([{"event": "done"}, None]))
+        self.assertIn("1 done", got)
+        self.assertNotIn("abandoned", got)
+
+    def test_an_abandoned_piece_is_counted_and_a_finished_one_is_not(self):
+        got = _plain(self._summary([{"event": "gave-up"}, None]))
+        self.assertIn("1 abandoned", got)
+        # `"1 done"` and not `"done"`: **`abandoned` ends in the same five letters**, so the
+        # obvious spelling of this assertion is false about a row that is entirely correct.
+        # It failed here, which is the only reason it is not still in the file.
+        self.assertNotIn("1 done", got)
+
+    def test_each_outcome_wears_its_own_accent(self):
+        """The control for both, and the token this branch rewrote: `done` is `ok` and
+        `abandoned` is `warn`."""
+        got = self._summary([{"event": "done"}, {"event": "gave-up"}])
+        self.assertIn(f"{sl.accent('ok')}1 done", got)
+        self.assertIn(f"{sl.accent('warn')}1 abandoned", got)
+
+
+class SessionNewsCountsOnlyWhatHappened(unittest.TestCase):
+    """`statusline._session_news` — *"Deliberately silent when nothing is happening.
+    Presence IS the signal."*
+
+    Both `drop-if`s survived, so nothing held that sentence to its word. With them gone,
+    every session renders `⛊ 0 denied ✎ 0 recorded` from its first turn — and a real guard
+    denial then arrives in a counter the reader has been ignoring for a day.
+    """
+
+    def setUp(self):
+        super().setUp()
+        shipped_frame(self)
+
+    def _news(self, events):
+        from charter import trace
+        with mock.patch.object(trace, "read", lambda sid: [{"event": e} for e in events]):
+            return sl._session_news("s1", inflight=False)
+
+    def test_a_session_with_no_denials_says_nothing_about_denials(self):
+        got = _plain(self._news(["memory"]))
+        self.assertNotIn("denied", got)
+        self.assertIn("✎ 1", got)
+
+    def test_a_session_with_no_memories_says_nothing_about_memories(self):
+        got = _plain(self._news(["deny"]))
+        self.assertNotIn("recorded", got)
+        self.assertIn("⛊ 1", got)
+
+    def test_a_session_where_nothing_happened_says_nothing(self):
+        self.assertEqual(self._news([]), [])
+
+    def test_a_counter_with_nothing_to_say_does_not_silence_the_ones_after_it(self):
+        """**The refusal is what keeps the row from ending early**, and that is the half a
+        `drop-if` here breaks in a way no absence can see.
+
+        `_session_news` has ONE `except Exception: pass` around the whole trace block, so a
+        counter that stops asking `kinds.get(...)` and reaches for `kinds[...]` does not
+        render a zero — it raises, the handler swallows it, and every counter BELOW it is
+        silently dropped. `dispatch` is drawn after `memory`, so a session that dispatched
+        without recording anything is exactly the shape that loses a row.
+
+        Asserting only "no `recorded` row" cannot catch it: the mutant does not draw one
+        either. What it costs is the row that never got its turn."""
+        got = _plain(self._news(["dispatch", "dispatch"]))
+        self.assertNotIn("recorded", got)
+        self.assertIn("⇢ 2 dispatched", got,
+                      "a counter above it swallowed the rest of the row")
+
+    def test_each_counter_wears_its_own_accent(self):
+        """The control, and the tokens this branch rewrote: a denial is `bad`, a recorded
+        memory is `ok`, and a dispatch is neither — it is `dim`, and must stay `dim` when a
+        plane recolours the other two."""
+        got = " ".join(self._news(["deny", "memory", "dispatch"]))
+        self.assertIn(f"{sl.accent('bad')}⛊ 1 denied", got)
+        self.assertIn(f"{sl.accent('ok')}✎ 1", got)
+        self.assertIn(f"{sl._DIM}⇢ 1 dispatched", got)
+
+
+class AReinitAlertFiresOnlyWhenAWorkspaceNeedsOne(PersonaIso, unittest.TestCase):
+    """`statusline._alerts` — *"They render only when real, so they cost no rows on a
+    healthy control plane."*
+
+    The `drop-if` on `if stale:` survived: with it deleted, every healthy plane grows a
+    full-width `⚠ reinit 0 ws` alert on every turn — a row that carries a command to fix a
+    problem that does not exist.
+    """
+
+    def setUp(self):
+        super().setUp()
+        shipped_frame(self)
+
+    def _alerts(self, stale):
+        # `PersonaIso` rather than a plain case: `_alerts` ends at `_plane_root_alert`,
+        # which asks `_repo_states` for the plane root and that opens a cache directory
+        # under `.charter`. `tests._planeguard` refuses the write into the developer's real
+        # plane, which is the guard doing its job and the reason this class has a plane of
+        # its own.
+        from charter import workspace as _ws
+        with mock.patch.object(_ws, "list_workspaces", lambda: ["a", "b"]), \
+                mock.patch.object(_ws, "needs_reinit", lambda w: w in stale):
+            return _plain(sl._alerts("active"))
+
+    def test_a_plane_whose_workspaces_are_current_gets_no_reinit_row(self):
+        self.assertNotIn("reinit", self._alerts([]))
+
+    def test_a_plane_with_a_stale_workspace_gets_one_and_it_counts_them(self):
+        """The control. `active` is excluded by the comprehension, so `b` alone is stale."""
+        got = self._alerts(["b"])
+        self.assertIn("reinit", got)
+        self.assertIn("1 ws", got)
+
+    def test_the_row_carries_the_command_that_fixes_it(self):
+        self.assertIn("charter ws reinit --all", self._alerts(["a", "b"]))
+
+
+class ThePinnedWorkspaceMarkerSaysWhereThePinCameFrom(PersonaIso, unittest.TestCase):
+    """`statusline.render` — the `*` beside the workspace name means `$CHARTER_WORKSPACE`
+    pinned it, and nothing else does.
+
+    All three mutations survived: both arms of the conditional and the environment
+    variable's own SPELLING. With the literal retuned the marker never renders, and an
+    operator whose shell pins a workspace has no way to see that it is pinned — which is
+    the whole of what the glyph is for.
+    """
+
+    def setUp(self):
+        super().setUp()
+        no_background_refresh(self)
+        shipped_frame(self)
+
+    def _row(self, src):
+        with mock.patch.object(sl, "_active", lambda *a, **k: ("alpha", src)):
+            return sl.render({})
+
+    def test_a_workspace_pinned_by_the_environment_is_marked(self):
+        self.assertIn("alpha*", _plain(self._row("$CHARTER_WORKSPACE")))
+
+    def test_a_workspace_chosen_any_other_way_is_not(self):
+        for src in ("cwd", "pointer", "default", ""):
+            with self.subTest(src=src):
+                got = _plain(self._row(src))
+                self.assertIn("alpha", got)
+                self.assertNotIn("alpha*", got)
+
+    def test_the_marker_is_drawn_in_warn(self):
+        """The token this branch rewrote. It is `warn` rather than `dim` because a pin is
+        something to notice — it overrides every other way a workspace is chosen."""
+        self.assertIn(f"{sl.accent('warn')}*", self._row("$CHARTER_WORKSPACE"))
+
+
+class ALoudRebuildIsTheOneThatCrossedTheLine(unittest.TestCase):
+    """The `↻N` rebuild counter's threshold — `bad` at or above `_REBUILD_LOUD`, `warn`
+    below it, on **both** surfaces that draw it.
+
+    Six mutations survived here: the two arms and the boundary, at each of the two call
+    sites. Nothing said the counter changes colour at all, and nothing said the two
+    surfaces agree about where — which is `ThePanelsGaugeReadsTheSameAsTheFooters`' own
+    correctness condition said about the third number on that strip.
+
+    **At the boundary and not in the middle of a band**, which is that class's rule: a test
+    at 100 000 and 300 000 passes with the comparison shifted by one either way.
+    """
+
+    def setUp(self):
+        super().setUp()
+        shipped_frame(self)
+
+    def _live(self, cost):
+        """`_context_gauge` — the footer's, off a live payload."""
+        payload = {"context_window": {"used_percentage": 50,
+                                      "current_usage": {"cache_read_input_tokens": 100,
+                                                        "cache_creation_input_tokens": 50}},
+                   "session_id": "s1"}
+        with mock.patch.object(sl, "_rebuilds", lambda rows: (2, cost)), \
+                mock.patch.object(sl, "record_usage", lambda p: []), \
+                mock.patch.object(sl, "_history", lambda sid: []):
+            return " ".join(sl._context_gauge(payload))
+
+    def _panel(self, cost):
+        """`recorded_context_gauge` — the frame panel's, off the recorded history."""
+        with mock.patch.object(sl, "_rebuilds", lambda rows: (2, cost)), \
+                mock.patch.object(sl, "_usage_rows", lambda sid: []):
+            return " ".join(sl.recorded_context_gauge("s1"))
+
+    def test_a_rebuild_cost_at_the_line_is_loud_on_both_surfaces(self):
+        """`>=`, so exactly `_REBUILD_LOUD` is already loud. A `>` here is the shift the
+        sweep asked about and nothing answered."""
+        for name, got in (("footer", self._live(sl._REBUILD_LOUD)),
+                          ("panel", self._panel(sl._REBUILD_LOUD))):
+            with self.subTest(surface=name):
+                self.assertIn(f"{sl.accent('bad')}↻2", got)
+
+    def test_one_token_below_the_line_is_not(self):
+        """The other side of the same boundary, and the half a `>` mutation moves."""
+        for name, got in (("footer", self._live(sl._REBUILD_LOUD - 1)),
+                          ("panel", self._panel(sl._REBUILD_LOUD - 1))):
+            with self.subTest(surface=name):
+                self.assertIn(f"{sl.accent('warn')}↻2", got)
+                self.assertNotIn(sl.accent("bad"), got)
+
+    def test_the_two_surfaces_agree_about_where_the_line_is(self):
+        """#413's own correctness condition, asked of the third number: a loud rebuild in
+        the footer beside a quiet one in the panel would be undebuggable from the screen."""
+        for cost in (0, sl._REBUILD_LOUD - 1, sl._REBUILD_LOUD, sl._REBUILD_LOUD * 2):
+            with self.subTest(cost=cost):
+                loud = sl.accent("bad") in self._live(cost)
+                self.assertEqual(loud, sl.accent("bad") in self._panel(cost))
+
+    def test_a_session_with_no_rebuilds_draws_no_counter(self):
+        """The control that the counter is conditional at all, and the reason the two
+        assertions above are about colour rather than presence."""
+        with mock.patch.object(sl, "_rebuilds", lambda rows: (0, 0)), \
+                mock.patch.object(sl, "_usage_rows", lambda sid: []):
+            self.assertNotIn("↻", " ".join(sl.recorded_context_gauge("s1")))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Closes #737. Closes #736. Closes #750. And the accent gap #768 named as its own remaining work.

> *"we need to care about text colors too, maybe also make them configurable, because on bright background bright text is not readable"*

Four colour decisions taken on a dark terminal, and what each one costs on a light one — or the mirror of it, which is the half a dark-terminal developer never sees fail.

## #737 — a `chrome` word carries the text that goes on it

`chrome = "light"` set `bg=white` and nothing else, so every cell no renderer coloured drew in the foreground the *terminal* picked to sit on *its own* background. Measured on a dark theme:

```
ESC[0m ESC[47m 7 todos · F2 palette · ESC[2m…
       ^^^^^^^ the pane's `bg=white`, and no `SGR 3x` anywhere after it
```

Not a background that clashes — a panel whose text is not there. `dark` is the same failure mirrored.

`instance.FRAME_CHROME_FG` pairs `dark` with `fg=white` and `light` with `fg=black`; `surface_options` folds it in, and `[frame] text` still wins by being the **only** `fg=` in the value rather than by coming last in it (`test_the_style_carries_exactly_one_foreground`, over every pairing of the two vocabularies — a frame whose colour depends on a tmux parsing rule nobody wrote down is not a frame charter chose).

**Two words and not seventeen**, and that line is where the measurement stops being one. `black` and `white` are the poles of the sixteen — a theme is not free to render its white darker than its black — so charter can say what goes on them. It cannot say what goes on somebody's `blue`, so a component that named its own `bg` gets no foreground it did not ask for.

**It is a separate table and not an `fg=` appended to `FRAME_CHROME`'s values**, deliberately: `rule_style`'s `hidden` arm does `surface.removeprefix("bg=")` and `TheSurfaceIsAlwaysABareBackgroundClause` pins it. An `fg` inside a `window-style` entry would have reached that and composed a rule with two foregrounds in it. `TheRuleStillReadsABareBackgroundClause` pins the invariant from this side too.

## #736 — the row you are on stops painting yellow on your foreground

`docs/frame.md` argued the highlight is right on every scheme *precisely because reverse video names no colour*. Both surfaces that use it named one. Off a live frame:

```
ESC[7m ESC[35m ▸ ESC[1m steward ESC[0;7m        ESC[32m ✎47 ESC[0m
ESC[7m   ESC[2m ├─ ESC[0;7m ESC[36m billing       ESC[33m main* ESC[39m
```

`SGR 7`, then magenta, cyan and **yellow** — on a cell whose background is now the terminal's foreground.

`chrome.reverse` deletes every colour parameter inside the inverted run. **A deletion and never a substitution** (`undim`'s own honesty): charter cannot know what somebody's magenta looks like on their own foreground, but it can decline to paint a pair it has no way to check. `_without_colour` carries `_without_dim`'s measured hazards — the numeric reading (`ESC[032m`), a parameter anywhere in the list (`1;32` keeps the bold), and `_EXTENDED_COLOUR`'s space parameter consumed as a run so `38;2;255;0;0` is never filtered into a colour nobody asked for. An emptied list answers `None` and the escape goes whole, because `ESC[m` is a full reset and would cancel the reverse one escape after it was asserted.

**In `chrome.reverse` and not at the two call sites**, so a component composing with `ctx.chrome["selected"]` gets the same answer, and so does a renderer that has no idea it is about to be highlighted — which is every renderer.

## #750 — something finally says which pane is live

`pane-border-indicators` moves from `off` to `arrows`. Read off an attached client through a nested tmux, charter's own shape, the same bottom rule with the focus in three places:

```
harness active   ESC[2m ─↑─────────────────────────────────┴──────────────
sidebar active   ESC[2m ───────────────────────────────────┴─↑────────────
footer active    ESC[2m ─↓─────────────────────────────────┴─↓────────────
```

**One escape, at the start of the row, and none anywhere else in it.** #514 is not reopened: that was a rule whose *colour* changed at the active pane's corner; this is a glyph substituted into a rule charter still draws one way. `test_the_rule_the_mark_sits_in_is_one_style_along_its_whole_length` asserts exactly that, and `test_a_cue_made_of_a_second_style_really_would_reopen_it` is the control — the "weight rather than a colour" #750's own text proposed **does** put a seam mid-line, measured:

```
harness active, active rule undimmed   ────────────────┴ESC[2m──────────────
```

so that is the arrangement charter did not take. Over a surface with the shipped `rules = "hidden"` the arrow is the colour of the cell behind it and disappears exactly where `window-active-style`'s one-shade step already answers — the cue shows up where there is no other one, without a word being read to decide it. Floored at `BORDER_INDICATORS_FLOOR`; tmux 3.2 gets the frame it had, and the floor test **skips** there rather than passing, which is what proves the floor.

## The accent gap — `[frame] ok`, `warn`, `bad`

```toml
[frame]
ok   = "green"      # any of `bg`'s seventeen words — these three are the defaults
warn = "yellow"
bad  = "red"
```

#768 shipped `text` and named this: `text` fixes a pane whose background is *inverted*; on a terminal that is already light it has nothing to do, and what is hard to read there is these three. They shipped un-configurable on the argument that they are slots in the operator's own palette — which says the colour is theirs, and does not say it is legible on the ground it is drawn on. **Yellow on tan is the pair no palette was designed for.**

Charter still cannot compute it and does not try. Words out of the same seventeen, checked by the same `pane_text` at the same boundary, resolved to an SGR by `statusline.accent` — one reading, so charter's panels, the status line and `ctx.chrome["warn"]` cannot come out three colours. `default` is a real answer (SGR 39 — the pane's own foreground, which is `text` where the plane set one), and `NoStatusIsCarriedByColourAlone` is what makes it usable rather than a loss.

`served_params()` **unions** the shipped triple with the plane's: a plane that sets `warn = "blue"` admits `34` **and still admits `33`**, so a component that hard-coded its own yellow is not escaped into its pane as six visible characters. That is #768's own decision about SGR 2 said about a colour, and a plane can only ever widen what a component may write.

## What I found wrong in the brief, and in the issues

1. **The ~40 accent call sites are in `charter/statusline.py`, not `frame/slots.py`.** #768's author and my brief both named `slots.py`; it has exactly two. That matters, because `statusline.py` also draws the Claude Code status line — so a `[frame]` key here reaches two surfaces. Taken deliberately and documented: both sit on the same terminal, and splitting them would give one glyph two colours.
2. **A blanket substitution over a finished panel row would have been wrong for a reason nobody named.** `statusline._PALETTE` cycles green and yellow as *repo identity*. A pass over the pane would have recoloured a repo's name as though it were a status — pinned by `test_a_repos_identity_colour_does_not_move_with_an_accent`. Hence call sites.
3. **#750's claim that a weight cue "does not re-open the two-colour-rule defect" is false**, measured above.
4. **Brief fact 4 — "`text` earns almost nothing on an already-light ground" — is refuted by the operator's own live plane.** They have changed `charter.toml` from `bg = "brightblack"` to `bg = "black"` on every component. Dark panes, light terminal, no `text` — so every uncoloured cell in their frame is their terminal's *dark* foreground on black **right now**. `text = "white"` is the one-line fix and nothing in this PR reaches it, by design (their background is their word, not charter's). Called out in `docs/frame.md`.
5. **`ok`/`warn`/`bad` already existed as served words** in `chrome._role_values()`. What was missing was that they were configurable and that charter's own renderers went through them.

## Found after this PR was opened, and fixed

Three rounds of review found things the first pass did not. Each is listed because each is a
class of defect rather than a typo.

**CI caught a test that was wrong about tmux.** `test_the_mark_moves_when_the_focus_does`
compared the arrow's COLUMN. tmux points the arrow *into* the active pane, so a rule with the
pane above it live and the same rule with the pane below it live mark the same cell and differ
only in direction — `↑` and `↓` at column 5, measured on CI. A column-only reading called that
"the mark did not move" about a cue doing exactly its job. It reads `(column, glyph)` now.

**The deletion sweep found three survivors in `_without_colour`**, all on the extended-colour
walk: the `i + 1 < len(pieces)` boundary, its `else -1`, and the `{5: 3, 2: 5}.get(space, 1)`
fallback. `ESC[38m` with nothing after it raised `IndexError` under two of those mutants —
inside a repaint, so a dead panel rather than a wrong colour. `chrome.undim` was pinned for
exactly these three by an earlier sweep and this walk had not been. Three tests, and each
mutant re-run by hand to confirm the kill.

**Those tests then found a real defect in `cancels_reverse`.** A colour's ARGUMENTS are not SGR
parameters, and by the time that function sees a list they are all just numbers:
`ESC[38;2;255;0;0m` is a 24-bit red whose green and blue channels are zero, so it read as "reverse
was cancelled" and charter wrote a `ESC[7m` that changed nothing on screen, on every repaint.
`_restated` asks the question of what SURVIVED the deletion — the run is consumed whole, so the
channels are gone and what is left is the SGR the escape actually carried.

**An adversarial review found the accent keys made the suite non-hermetic.** Five test classes
asserted "`ok` is green" while reading the ambient `config.FRAME` — which on a developer's
machine is charter's own control plane, and on the machine these keys were written for is a
plane actively being tuned. An operator writing `warn = "blue"` in their own `charter.toml`
turned somebody else's test red. `tests/_isolation.shipped_frame` is the one spelling of the
pin, and the whole suite is now run under a plane that sets all three and diffed against the
same plane without them: **zero difference.** That is #402/#492's rule arriving through the
newest door.

It also found, and this PR fixes: a `#:` block that silently took `FRAME_FIELDS`' documentation
and wore it; `served_params()` costing 2× on the per-line containment path (three `look_of`
calls where one would do, plus three more escapes walked — `statusline.accents()` and
`_SHIPPED_ACCENT_PARAMS`, 6.69µs → 5.09µs against 3.30 before the accents); four tautological
tests including a `skipTest` in front of an `assertTrue` on the same value, which could not
fail whatever tmux or charter did; a duplicated nested-tmux screenshot; and three docstring
claims that were false — a "third caller" of `chrome.reverse` that does not exist, a `docs/frame.md`
sentence that implied a provider's inverted row gets the deletion (it does not, and should not),
and `rule_style`'s claim to draw rules in the plane's foreground.

The sweep also charged three `_CI_MARK` KEYS (`"pending"`, `"created"`, `"preparing"`) whose
spelling nothing asserted — retuning any of them made a real GitLab status fall through to the
`?` fallback and all 9 647 tests still passed. Pinned now, with glyph and label.

## The sweep's 18 survivors — every one classified, every one pinned

CI's deletion sweep reported **18 survivors, 7 not measured**. All 18 are in
`charter/statusline.py`, on the ten lines where routing the accents rewrote one token
(`_YELLOW` -> `accent('warn')`). The mutations are of the logic *around* that token, and the
charge is right: a rewritten line is a line whose guards you now own.

**All 18 are now pinned**, by `tests/test_the_statusline_counts_only_what_it_has.py` — 27
tests, with each of the 18 mutations applied by hand afterwards to confirm the kill:
**18 killed, 0 survived.**

| line | mutation | what it broke, unpinned |
|---|---|---|
| 1006 x2 | `collapse-ifexp` | a repo table where *every* branch reads dirty, or none does |
| 1326, 1328 | `drop-if` | `pieces 3 0 done 0 abandoned` on a workspace where nothing finished |
| 1757, 1759 | `drop-if` | a permanent `✎0` on every persona row in the sidebar |
| 2011, 2013 | `drop-if` | `⛊ 0 denied ✎ 0 recorded` from a session's first turn |
| 2063 | `drop-if` | a full-width `⚠ reinit 0 ws` alert on every healthy plane |
| 2598 x3 | `collapse-ifexp` x2, `retune-string` | the `*` that says `$CHARTER_WORKSPACE` pinned this workspace — never drawn, or always |
| 657, 712 (x3 each) | `collapse-ifexp` x2, `shift-boundary` | the `↻N` rebuild counter never changing colour, and the two surfaces disagreeing about where the line is |

Two are worth calling out, because they say something about how these hid.

**`if kinds.get("memory")` could not be killed by an absence.** `_session_news` has one
`except Exception: pass` around the whole trace block, so the mutant does not render a zero —
it raises on `kinds['memory']`, the handler swallows it, and every counter *below* it is
silently dropped. Asserting "no `recorded` row" passes against the mutant too. What kills it is
a session that dispatched without recording: the `⇢ 2 dispatched` row that never got its turn.

**The `_REBUILD_LOUD` boundary had to be asserted at the boundary**, per
`ThePanelsGaugeReadsTheSameAsTheFooters`' own rule — a test at 100 000 and 300 000 passes with
the comparison shifted either way. Pinned at exactly `_REBUILD_LOUD` and one token below, on
both surfaces, plus that the two surfaces agree about where the line is.

**How many were inherited?** All ten lines pre-date this branch, and one was measured rather
than assumed: applying `f"{_YELLOW if is_dirty else _DIM}"` -> `f"{_DIM}"` to a clean
`origin/main` worktree and running the **full 9 603-test suite** left it green (bar the known
#785 artefact). The gaps are older than the change — but they are charged correctly, and
arguing about the charge is worth less than closing them, so they are closed.

### The 7 not measured

All seven are **wall-clock timeouts**, not dead runners — shards 3 and 4 ran 40.1 and 43.1
minutes, and the sweep says so itself: *"it timed out rather than failing... nothing here has
been shown to be tested."* No `MemoryError` pin fired, so this run is not evidence either way
about that half of #790.

They are `instance.py:1098` x2 and `:1099` (`look_of`'s `.get` fallbacks, 46 modules),
`instance.py:1711`–`1713` (the three `FRAME_FIELDS` accent keys, 301 modules), and
`statusline.py:118` (`_SHIPPED_ACCENT_PARAMS`' `removesuffix("m")`, 94 modules). **All seven
were applied by hand and confirmed killed** — the `look_of` fallbacks by
`test_a_plane_chooses_how_its_frame_reads` and `test_the_frame_reads_on_the_terminal_it_is_on`,
the `FRAME_FIELDS` keys by `test_every_accent_role_is_a_frame_key` and
`test_the_toml_key_is_the_role_name` (a `KeyError` on two of them), and the `removesuffix` by a
`ValueError` at import.

## Deliberately not fixed

- **A per-component `bg` gets no paired foreground.** `bg = "blue"` is the operator's word and
  charter cannot see their blue. `[frame] text` is the mechanism and it exists.
- **The RULES between panes do not take the chrome pairing.** With `rules = "visible"` and
  `chrome = "light"` a rule is `fg=default,dim,bg=white`. The shipped `rules = "hidden"` returns
  before that line and `text` overrides it — and fixing it properly means deciding whether a
  component's own `bg = "black"` should be paired too, since `bg=black` is *both* that and
  `chrome = "dark"`'s. That is the per-component decision this PR answered "no" for the interior
  and must not answer differently for the border. Named in `docs/frame.md` and in `rule_style`.
- **`chrome = "dark"`'s focused shade is `brightblack`**, the one word in charter's own recipes
  whose shade a theme really moves. On a theme that renders it light, that pane carries `fg=white`
  on a light ground. That is the background *pair* straddling the ledger, it predates this
  pairing, there is no second dark shade in the sixteen to move it to, and `text` overrides it.
- **`charter doctor`'s `✓`/`!`/`✗` are not routed.** A one-shot report printed into a shell is not
  a surface the frame paints, and a `[frame]` key reaching a command that runs with no frame
  would be the wrong scope. Named in `docs/frame.md` rather than left as an unstated exception.
- **`magenta`, `blue` and `cyan` stay fixed**, and `statusline._PALETTE` is untouched — a repo's
  identity colour must not move when a status colour does.
- **Figure/ground.** The auditor's *"it reads as text above and below a session"* needs a
  background, and charter still cannot pick one. #750 asked "which pane is live"; that is what is
  answered.

## Verification

- **Full suite green**, 9 649 tests, `OK (skipped=6)` — `env -u PYTHONSAFEPATH python3 -m unittest
  discover -s tests`. The 6 skips are the #750 wire tests on the 3.2 floor, skipping because the
  option does not exist there, which is the floor asserting itself.
- **Hermetic**: the whole suite run under a plane setting `ok`/`warn`/`bad`, diffed against the
  same plane without them — no difference.
- **In the linked worktree one test is red**: `test_frame_border_surface`'s
  `test_this_planes_own_committed_frame_answers_the_report`. That is #785 and not this branch — a
  suite run from a linked worktree reads the operator's live plane, whose uncommitted
  `charter.toml` says `bg = "black"` where the committed one says `brightblack`. Green on a clean
  clone of this commit.
- **Real tmux, 3.7c and the `tmuxctl.FLOOR` 3.2 build**, own sockets, controls rendered first.
- **Every new test run against the unfixed source and confirmed red** — 20 failures and 53 errors
  across the new file; the two #750 wire tests go red when the pin alone is reverted, because
  `_shipped` reads `_chrome_values()` rather than naming `arrows`.
- **Deletion sweep**: reported in a comment on this PR.
- The operator's live frame on socket `charter` was **read only** (`capture-pane -p -e`,
  `list-panes`, `list-sessions`). No option was set on it; its 11 sessions are intact. My own
  probe servers were on `charter-colourprobe-*`/`charter-hidearrow-*` sockets and are reaped.
- `dependencies = []` untouched; nothing in `charter/__init__.py`, `pyproject.toml`,
  `.claude-plugin/plugin.json` or `hooks/hooks.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAsFiqpWRsNFshVyaPTG2X
