### PR TITLE
Switching workspace moves your terminal and stops nothing (#733, #789)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -6457,6 +6457,21 @@ def _switch_client(fid: str, ws: str, *, said: str) -> None:
     deletes.
     """
     socket = state.frame_server(fid) or SOCKET
+    if tmuxctl.is_operator_socket(socket):
+        # **A workspace is a tmux session only on charter's OWN server** (§2.1), and this
+        # frame is not on it. Inside an operator's tmux every chat charter opens is a
+        # `new-window` in the session that operator was already in (`layout.window_argv`,
+        # `_launch_in_operator_tmux`) — whatever workspace it names — so there is no
+        # session for another workspace to be, and the two things `switch-client` could
+        # do there are both wrong: refuse "already in that workspace" for a workspace this
+        # frame is not in, or move the operator's client between two tmux sessions of
+        # their own that charter has no business having an opinion about. Refused by name
+        # instead, with the route that does work — which is `chats.check`'s own
+        # "not on this frame's tmux server" one noun out (#684).
+        _say_on_screen(fid, "cannot switch: this chat is a window in your own tmux, "
+                            "where a workspace is not a session — open the other "
+                            f"workspace with `charter <harness> --workspace {ws}`")
+        return
     here = _pane_place(socket, state.harness_pane(fid))
     if here is None:
         # `cmd_chat`'s own sentence, for its own reason: with no reading of where this

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -6381,13 +6381,22 @@ def _clients_on(socket: str, session: str) -> list[str]:
     `_workspace_to_focus`'s own reading of tmux's output — a client name holds no
     whitespace, and a server answering a bare newline has told us about no clients rather
     than about one with a blank name.
+
+    **No branch on the return code, and its absence is a deletion rather than an
+    omission.** This had `if out.returncode != 0: return []` and the deletion sweep
+    reported it as a survivor — correctly: a `list-clients` that failed has an empty
+    stdout, so `"".split()` is already `[]` and the branch could not change an answer.
+    `_window_seats` and `_plane_session` say the same sentence about the same shape, and
+    this repository deletes an equivalent mutant rather than documenting it. What the
+    branch might have caught — output on stdout beside a non-zero status — is safe in the
+    one direction that matters: a name that is not a client makes `switch-client -c`
+    fail, and the reading afterwards then finds nothing of ours on the target and refuses
+    without tearing anything down.
     """
     out = tmuxctl.run("asking who is looking at this workspace",
                       tmuxctl.server_argv(socket, "list-clients", "-t", session,
                                           "-F", "#{client_name}"),
                       timeout=5, report=False)
-    if out.returncode != 0:
-        return []
     return out.stdout.split()
 
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1124,9 +1124,12 @@ def _plane_option_argv(*, socket: str, harness_pane: str) -> list[str] | None:
 
     * **No `-w`.** That is the whole of what makes this session-scoped rather than
       window-scoped; the target is still the harness pane, for `_chat_option_argv`'s
-      reason — a pane id resolves to its window and to its session on both versions, where
-      a session NAME is parsed as ``window.pane`` and a workspace with a dot in it would
-      hand this to somebody else's window.
+      reason — a pane id resolves to its window and to its session on both versions, and a
+      workspace NAME is unusable as a target twice over: tmux parses `api.1` as
+      ``window.pane``, and a bare name is matched against WINDOW NAMES before it settles
+      for a session's current window (measured for §4b; `layout.chat_window_argv` carries
+      the reading). Charter's chat windows are named `<workspace>.<n>`, so `-t
+      <workspace>` on charter's own server names one of that workspace's chats.
     * **Written once, by the launch that CREATES the session, and never afterwards.** A
       launch that finds `session in live_sessions` is joining a session it did not
       necessarily make: that test is on the NAME, which is exactly the collision this

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -214,6 +214,42 @@ _EXIT_PATH_ENV = "CHARTER_FRAME_EXIT"
 #: per window.
 _CHAT_OPTION = "@charter_chat"
 
+#: The SESSION option that says which plane a workspace session belongs to — §4b's plane
+#: marker, and the answer to a question `#{session_name}` cannot be asked.
+#:
+#: **One tmux server serves every plane on this machine (`SOCKET`) and a session's name is
+#: a bare workspace name.** Measured on the operator's own socket while this was written:
+#: eleven sessions from three different projects, and `default` — `DEFAULT_WORKSPACE`, a
+#: name every plane has whether anybody chose it or not — is one of them. So a
+#: `switch-client -t default` decided on a name can put an operator in another project's
+#: frame, across every isolation boundary charter has: a different `CHARTER_ROOT`, a
+#: different persona set, different vaults, different memory. That is the correctness
+#: problem §4b's switch is built around, and it is why `_plane_session` never resolves a
+#: name.
+#:
+#: **The value is `config.STATE_DIR` and not `config.ROOT`, which is a narrower claim and
+#: the true one.** What makes two charters one plane, for every read on this path, is
+#: sharing the `.charter/frame/` directory the chat records live in — two roots pointed at
+#: one `$CHARTER_HOME` are one plane by every other question charter asks, and marking
+#: them as two would refuse a switch that is perfectly safe.
+#:
+#: **Session-scoped, and the scope is load-bearing.** A chat is a window and a workspace is
+#: a session (§2.1), so this is the one thing on the server whose lifetime is the
+#: workspace's. Measured on tmux 3.7c and at the 3.2 floor: `set-option -t <a pane id>`
+#: with neither `-w` nor `-p` sets it on that pane's SESSION, another session on the same
+#: server reads it as unset, and `show-options -g` does not have it — so no session can
+#: answer for a plane that is not its own.
+#:
+#: **It is read through a FORMAT and never through `show-options`, and that is measured
+#: rather than preferred.** `#{@charter_plane}` in a `list-panes -a` format resolves the
+#: option hierarchically — pane, then window, then session — so one call answers "which
+#: session, which pane, whose plane" on both versions. `show-options -t <session> -v
+#: @charter_plane` for an option nobody set answers **rc 1 with `invalid option:` on 3.7c
+#: and rc 0 with an empty line on 3.2**: a reader built on it would have to branch on the
+#: tmux version to tell "unmarked" from "would not answer", and the format has no such
+#: split.
+_PLANE_OPTION = "@charter_plane"
+
 #: The second value carried the same out-of-band way, for the same reason: the
 #: interpreter the hotkey bind runs charter with. Owned by `tmuxctl` so every module
 #: that spells the name reaches one definition; see `_charter_py_env_argv` and
@@ -1069,6 +1105,51 @@ def _chat_option_argv(*, socket: str, harness_pane: str, chat: str) -> list[str]
                                _CHAT_OPTION, chat)
 
 
+def _this_plane() -> str:
+    """Which plane this process is acting for, as :data:`_PLANE_OPTION` spells it.
+
+    Asked rather than cached, because `config.use` re-points every charter path at
+    runtime — that seam is how `tests/_isolation.py` gives a test its own plane and how
+    the two-plane tests put two of them in one process. A module-level constant would be
+    the first plane that happened to import this.
+    """
+    return str(config.STATE_DIR)
+
+
+def _plane_option_argv(*, socket: str, harness_pane: str) -> list[str] | None:
+    """`set-option`: write which PLANE this session belongs to. ``None`` to refuse.
+
+    :func:`_chat_option_argv` one scope out, and the differences between them are all
+    that is worth saying:
+
+    * **No `-w`.** That is the whole of what makes this session-scoped rather than
+      window-scoped; the target is still the harness pane, for `_chat_option_argv`'s
+      reason — a pane id resolves to its window and to its session on both versions, where
+      a session NAME is parsed as ``window.pane`` and a workspace with a dot in it would
+      hand this to somebody else's window.
+    * **Written once, by the launch that CREATES the session, and never afterwards.** A
+      launch that finds `session in live_sessions` is joining a session it did not
+      necessarily make: that test is on the NAME, which is exactly the collision this
+      option exists to record, so re-writing the marker there could relabel another
+      plane's session as this one's — turning the guard into the defect. A session an
+      older charter created carries no marker and keeps none; :func:`_plane_session` reads
+      that as "unmarked", which is where the pane records it already relies on still
+      decide.
+    * **The refusal is about the ROUND TRIP, not about an alphabet.** A chat id has one
+      (`_FRAME_ID_RE`); a state directory is a filesystem path and charter does not get to
+      narrow it. What this reader needs is a value that survives
+      `list-panes -F 'a\\tb\\t#{@charter_plane}'`, so the check is exactly that: a tab
+      would add a field and a newline would add a row, and either would be read as a
+      server answering some other format. A plane whose path holds one is left unmarked
+      rather than marked wrongly, which costs it §4b's veto and nothing else.
+    """
+    value = _this_plane()
+    if not value or any(c in value for c in "\t\r\n"):
+        return None
+    return tmuxctl.server_argv(socket, "set-option", "-t", harness_pane,
+                               _PLANE_OPTION, value)
+
+
 def _pane_died_write_hook_argv(*, socket: str, harness_pane: str) -> list[str]:
     """`pane-died[0]`: writes the harness's real exit status, out of band.
 
@@ -1638,36 +1719,70 @@ def _chat_being_left(socket: str, *, beside: str) -> str:
     option, and it is about to be a state directory's name and the key `state.harness_pane`
     is read under.
     """
-    out = tmuxctl.run("finding the chat this launch is leaving",
-                      tmuxctl.server_argv(socket, "list-windows", "-a", "-F",
-                                          _WINDOW_SEAT_FORMAT),
-                      timeout=5, report=False)
-    # No branch on the return code: a listing that failed has an empty stdout, so it
-    # falls out below as "no seats and therefore no answer" — the same sentence, said
-    # once. Exactly three fields per row, because `#{@charter_chat}` is an option and an
-    # option's value is whatever somebody set: one holding a tab of its own would
-    # otherwise have its first half read as a chat id.
-    seats = [line.split("\t") for line in out.stdout.splitlines()]
-    seats = [s for s in seats if len(s) == 3]
+    seats = _window_seats(socket, "finding the chat this launch is leaving")
     # `None` when *beside*'s own window is not in the listing, and it needs no branch of
     # its own: no session id is ever `None`, so the second lookup below matches nothing
     # and answers "". A sentinel that cannot collide is one guard rather than two.
     session = next((s[0] for s in seats if s[2] == beside), None)
+    # *beside* itself is this function's own case and not :func:`_chat_showing`'s: the
+    # launch that CREATED the session is already on its only window, and there is nothing
+    # for it to leave.
+    chat = _chat_showing(seats, session)
+    return chat if chat != beside else ""
+
+
+def _window_seats(socket: str, why: str) -> list[list[str]]:
+    """Every window on *socket* as a :data:`_WINDOW_SEAT_FORMAT` row, rows charter cannot
+    read dropped.
+
+    One `list-windows -a` for both readers of it — :func:`_chat_being_left`, before a
+    launch takes the client somewhere else, and :func:`_chat_showing`, after a workspace
+    switch has taken it. They ask the same question of the same listing keyed two
+    different ways (by a chat, by a session), and a second call would be a second reading
+    of a server that moves between them.
+
+    **No branch on the return code**, which is the shape both callers had: a listing that
+    failed has an empty stdout and falls out as "no seats and therefore no answer" — the
+    same sentence, said once. **Exactly three fields**, because `#{@charter_chat}` is an
+    option and an option's value is whatever somebody set: one holding a tab of its own
+    would otherwise have its first half read as a chat id.
+    """
+    out = tmuxctl.run(why, tmuxctl.server_argv(socket, "list-windows", "-a", "-F",
+                                               _WINDOW_SEAT_FORMAT),
+                      timeout=5, report=False)
+    return [s for s in (line.split("\t") for line in out.stdout.splitlines())
+            if len(s) == 3]
+
+
+def _chat_showing(seats: list[list[str]], session: str | None) -> str:
+    """Which chat *session*'s current window is drawing, out of *seats* — or ``""``.
+
+    ``""`` for every way this can fail to answer, because both callers do one thing with
+    all of them: leave that window alone. A *session* nothing in the listing is in (a
+    `None` sentinel from `_chat_being_left`, or a session id that went away between two
+    calls), and a session whose current window carries no chat at all — the operator's own
+    shell, on their own server, or a workspace session an older charter left unnamed.
+
+    Held to `_FRAME_ID_RE` on the way out, at #475's boundary: this value came off a tmux
+    option, and it is about to be a state directory's name and the key
+    `state.harness_pane` is read under.
+
+    **Not stripped, and that is the guard rather than a missing one.** `splitlines` has
+    already taken the line terminator and the fields are cut on tabs, so there is no
+    whitespace here tmux put in — only whitespace somebody put in the OPTION, and
+    `_FRAME_ID_RE`'s alphabet holds none. Stripping would turn ` demo.1 ` into a chat
+    charter then re-dresses, which is normalising a value the one rule here is there to
+    refuse. It is also the `strip`/`lstrip` shape `_live_chats`' own docstring names:
+    truthy for exactly the same strings, so no test can tell the two apart — a question
+    with one answer, not asked.
+    """
     chat = next((s[2] for s in seats if s[0] == session and s[1] == "1"), "")
-    # **Not stripped, and that is the guard rather than a missing one.** `splitlines`
-    # has already taken the line terminator and the fields are cut on tabs, so there is
-    # no whitespace here tmux put in — only whitespace somebody put in the OPTION, and
-    # `_FRAME_ID_RE`'s alphabet holds none. Stripping would turn ` demo.1 ` into a chat
-    # charter then tears the panels off, which is normalising a value the one rule below
-    # is there to refuse. It is also the `strip`/`lstrip` shape `_live_chats`' own
-    # docstring names: truthy for exactly the same strings, so no test can tell the two
-    # apart — a question with one answer, not asked.
-    return chat if chat != beside and _FRAME_ID_RE.fullmatch(chat) else ""
+    return chat if _FRAME_ID_RE.fullmatch(chat) else ""
 
 
-#: What :func:`_workspace_to_focus` asks of every pane on a server, in one call.
+#: What :func:`_plane_session` asks of every pane on a server, in one call.
 #:
-#: Two fields, both of them tmux's OWN ids and neither of them a name —
+#: The first two fields are tmux's OWN ids and neither of them is a name —
 #: :data:`_WINDOW_SEAT_FORMAT`'s rule one noun over, and here it is the whole correctness
 #: argument rather than a target-grammar convenience. One tmux server serves every plane
 #: on this machine (:data:`SOCKET`), session names are bare workspace names, and `default`
@@ -1675,9 +1790,83 @@ def _chat_being_left(socket: str, *, beside: str) -> str:
 #: `#{pane_id}` can: a pane id is minted by the server, and the only plane holding one is
 #: the plane whose launcher wrote it down (`state.record_harness_pane`).
 #:
-#: `\t` because neither can contain one: `#{session_id}` is `$<digits>` and `#{pane_id}`
-#: is `%<digits>`, both tmux's own and neither settable by anyone.
-_PANE_SEAT_FORMAT = "#{session_id}\t#{pane_id}"
+#: **The third field is the marker that closes what a pane id alone cannot** — see
+#: :data:`_PLANE_OPTION`, and :func:`_plane_session` for which of the two decides what.
+#: It is read here rather than through a second `show-options` call because a session
+#: option resolves in a PANE's format on both versions (measured on 3.7c and at the 3.2
+#: floor), so this stays one round trip, and because `show-options -v` for an unset user
+#: option answers differently on the two versions where a format does not.
+#:
+#: `\t` between them because none of the three can contain one: `#{session_id}` is
+#: `$<digits>` and `#{pane_id}` is `%<digits>`, both tmux's own and neither settable by
+#: anyone, and `_plane_option_argv` refuses to write a marker holding one.
+_PANE_SEAT_FORMAT = f"#{{session_id}}\t#{{pane_id}}\t#{{{_PLANE_OPTION}}}"
+
+
+def _plane_session(socket: str, *, ws: str) -> tuple[str, str] | None:
+    """``(tmux session id, chat id)`` for THIS PLANE's live *ws* — or ``None``.
+
+    **The one question two surfaces ask**: §4k's open-or-focus
+    (:func:`_workspace_to_focus`) and §4b's workspace switch (:func:`_switch_client`).
+    Both need "which session on this shared server is MY plane's `ws`", both are wrong in
+    the same way if they answer it from a name, and a second implementation would be a
+    second chance to answer it differently.
+
+    **Matched on this plane's own chat directories, never on a live session name, and that
+    inversion is §3.3's.** `cmd_launch` asks `if session in live_sessions:` and that
+    question is unanswerable across planes: `_live_sessions` returns every session on the
+    machine, `default` is `DEFAULT_WORKSPACE_FALLBACK` and therefore a name every plane
+    has, and `config.STATE_DIR` is the only thing that is per-plane. Reading the answer off
+    a name would make an existing collision into ADVERTISED behaviour — `charter -w
+    default` in one plane attaching to another plane's frame, and a workspace tab in one
+    plane switching an operator into another project's harnesses. So the question starts on
+    disk: `chats.of_workspace` is `.charter/frame/` under THIS plane's state directory, and
+    `state.harness_pane` is a `%N` this plane's own launcher wrote down.
+
+    **The marker is a veto and the pane record is the finder, and each covers what the
+    other cannot.** A pane id is unique on a running server but restarts at `%0` when that
+    server does, so a `%3` recorded for a chat that is over can later name a different live
+    pane — on the launch path `cmd_launch`'s reap narrows that to almost nothing, and on
+    the switch path there is no reap in front of it at all. :data:`_PLANE_OPTION` closes it
+    from the other side: a candidate session whose marker names a plane that is not this
+    one is refused however well its pane id matched. What the marker cannot do is find
+    anything, because a session an older charter created carries none — every session on
+    the operator's own socket the day this was written — so an ABSENT marker is read as
+    "unmarked" and decides nothing, and the pane record still answers. The residual is
+    therefore one recycled pane id belonging to a session created by a charter that
+    predates this option, and it ages out with those sessions.
+
+    ``None`` for every way this can fail to answer, because both callers do the same thing
+    with each: a workspace this plane has never opened has no chat directory, reaches no
+    tmux call at all, and can never be confused with anybody's.
+
+    Measured on tmux 3.7c and at the 3.2 floor, identically on both: `list-panes -a` lists
+    every pane on the server with its own session id, and a session-scoped user option
+    resolves in that pane format.
+    """
+    mine: dict[str, str] = {}
+    for chat in chats.of_workspace(ws):
+        pane = state.harness_pane(chat)
+        if pane is not None:
+            mine[pane] = chat
+    if not mine:
+        return None
+    out = tmuxctl.run("finding this plane's live chats in this workspace",
+                      tmuxctl.server_argv(socket, "list-panes", "-a", "-F",
+                                          _PANE_SEAT_FORMAT),
+                      timeout=5, report=False)
+    # No branch on the return code, for `_window_seats`' reason: a listing that failed has
+    # an empty stdout and falls out below as "no seats and therefore no answer". Exactly
+    # three fields per row, so a server answering some other format cannot have half a row
+    # read as a pane id — and `_plane_option_argv` is what guarantees charter's own marker
+    # never adds a fourth.
+    seats = [line.split("\t") for line in out.stdout.splitlines()]
+    ours = _this_plane()
+    seat = next((s for s in seats
+                 if len(s) == 3 and s[1] in mine and s[2] in ("", ours)), None)
+    if seat is None:
+        return None
+    return seat[0], mine[seat[1]]
 
 
 def _workspace_to_focus(socket: str, *, ws: str) -> tuple[str, str] | None:
@@ -1696,31 +1885,10 @@ def _workspace_to_focus(socket: str, *, ws: str) -> tuple[str, str] | None:
     already in is FOCUSED — one more client on the session they are on, looking at the
     window they are on — and a workspace nobody is in opens a chat exactly as before.
 
-    **Matched on this plane's own chat directories, never on a live session name, and
-    that inversion is §3.3's.** `cmd_launch` already asks `if session in live_sessions:`
-    and that question is unanswerable across planes: `_live_sessions` returns every
-    session on the machine, `default` is `DEFAULT_WORKSPACE_FALLBACK` and therefore a name
-    every plane has, and `config.STATE_DIR` is the only thing that is per-plane. Reading
-    the answer off a name would make an existing collision into the ADVERTISED behaviour —
-    `charter -w default` in one plane attaching to another plane's frame. So the question
-    starts on disk: `chats.of_workspace` is `.charter/frame/` under THIS plane's state
-    directory, and `state.harness_pane` is a `%N` this plane's own launcher wrote down.
-
-    **The residual, stated rather than hidden, and it is narrower than it first looks.**
-    A pane id is unique on a running server but restarts at `%0` when that server does, so
-    a `%3` recorded for a chat that is over can later name a different live pane. Within
-    ONE plane that is already closed by the caller: `cmd_launch` reaps immediately above
-    this, and a chat directory whose id tmux no longer reports live is removed — so the
-    only directories reaching here are ones the server still lists. Across two planes it
-    is not, because that liveness list is by CHAT ID and chat ids collide exactly as
-    session names do: `new_chat_id` counts from 1 on each plane's own disk, so `shared.1`
-    is the id both planes mint first. What it costs is one focus of a frame that is not
-    yours, on a machine running two planes, across a tmux server restart, for a workspace
-    both planes have, on a pane id that came back round. Closing it needs a plane marker
-    on the window — a second option written at launch and a schema both halves agree on —
-    which is a stage, not a line. What is closed today is the case §3.3 names: a plane
-    that has never opened `ws` has no directory for it, reaches no tmux call at all, and
-    can never focus anybody.
+    **Which session is this plane's is :func:`_plane_session`'s question and not this
+    one's** — a workspace tab asks it too now (§4b), and one answer is what stops a focus
+    and a switch disagreeing about whose `default` is whose. What is left here is the
+    second half, and it is the half §4k is actually about: **is anybody looking at it.**
 
     **Three answers, and the two tmux calls are asked in the order that makes most
     launches pay for neither.** No chat directory for *ws* on this plane — the ordinary
@@ -1729,40 +1897,16 @@ def _workspace_to_focus(socket: str, *, ws: str) -> tuple[str, str] | None:
     session nobody is attached to returns ``None`` as well, deliberately: with no client
     on it there is nobody to drag, so a launch there SHOULD add its chat and select it,
     which is the behaviour that shipped and the one an operator reopening a detached
-    workspace wants.
+    workspace wants. **§4b's switch takes the opposite view of that same reading and is
+    right to**: it is moving a client rather than avoiding a drag, so a detached workspace
+    is a perfectly good place to move one to and it never asks this question at all.
 
-    Measured on tmux 3.7c and at the 3.2 floor, identically on both: `list-panes -a` lists
-    every pane on the server with its own session id; `list-clients -t $N` takes a session
-    ID as its target, prints one line per attached client, and exits 0 with nothing on
-    stdout when none is attached (rc 1 only for a session id the server does not have).
-
-    **Nothing off tmux is re-checked on the way out and that is deliberate**, unlike
-    `_chat_being_left`, which holds its answer to `_FRAME_ID_RE` because `@charter_chat`
-    is a user OPTION and its value is whatever somebody set. Both fields here are tmux's
-    own built-in ids; a shape check over them would be a guard no input can reach, which
-    is the shape this repository's deletion sweep exists to delete rather than document.
-    The chat id returned is this plane's own directory name and never came from tmux at
-    all. The recorded pane ids are not held to `tmuxctl.PANE_ID_RE` for the mirror-image
-    reason: they are only ever COMPARED against what tmux just said, never sent to it, so
-    a value that is not a pane id matches nothing and is refused by the comparison itself.
+    Measured on tmux 3.7c and at the 3.2 floor, identically on both: `list-clients -t $N`
+    takes a session ID as its target, prints one line per attached client, and exits 0 with
+    nothing on stdout when none is attached (rc 1 only for a session id the server does not
+    have).
     """
-    mine: dict[str, str] = {}
-    for chat in chats.of_workspace(ws):
-        pane = state.harness_pane(chat)
-        if pane is not None:
-            mine[pane] = chat
-    if not mine:
-        return None
-    out = tmuxctl.run("finding this plane's live chats in this workspace",
-                      tmuxctl.server_argv(socket, "list-panes", "-a", "-F",
-                                          _PANE_SEAT_FORMAT),
-                      timeout=5, report=False)
-    # No branch on the return code, for `_chat_being_left`'s reason: a listing that failed
-    # has an empty stdout and falls out below as "no seats and therefore no answer", which
-    # is the same sentence said once. Exactly two fields per row, so a server that answers
-    # something other than this format cannot have half a row read as a pane id.
-    seats = [line.split("\t") for line in out.stdout.splitlines()]
-    seat = next((s for s in seats if len(s) == 2 and s[1] in mine), None)
+    seat = _plane_session(socket, ws=ws)
     if seat is None:
         return None
     clients = tmuxctl.run("asking whether anybody is looking at that workspace",
@@ -1784,7 +1928,7 @@ def _workspace_to_focus(socket: str, *, ws: str) -> tuple[str, str] | None:
     # reads as one client with a blank name.
     if clients.returncode != 0 or not clients.stdout.split():
         return None
-    return seat[0], mine[seat[1]]
+    return seat
 
 
 def _frame_is_live(socket: str, fid: str) -> bool:
@@ -4149,12 +4293,14 @@ def _pin_workspace(ws: str, fid: str, picked: bool) -> None:
     here rather than in the picker, because it describes what the LAUNCH did with the
     answer, not what the answer was.
 
-    **That sentence used to lead with `F2 → workspace` and no longer can** (§4j). The
-    escape it named was `switch.to_workspace` overriding the lock, and that switch is now
-    a refusal — a chat belongs to its workspace for life. The argument above is unchanged
-    because the OTHER escape was always the one that does the work: `unlock` releases the
-    lock without moving the chat, which is exactly what a lock the operator wants gone
-    needs and all it needs.
+    **That sentence used to lead with `F2 → workspace` and no longer can** (§4j/§4b). The
+    escape it named was `switch.to_workspace` overriding the lock — and that switch no
+    longer touches the lock at all, because what it moves is the tmux client rather than
+    the chat: after it the operator is looking at another workspace and this session is
+    still locked to the one its commands act on. The argument above is unchanged because
+    the OTHER escape was always the one that does the work: `unlock` releases the lock
+    without moving the chat, which is exactly what a lock the operator wants gone needs
+    and all it needs.
 
     **This write is a lock, not a membership move, which is why §4j leaves it standing.**
     The pointer lands under a chat whose workspace is *ws* already — this launch is what
@@ -4495,7 +4641,8 @@ def cmd_launch(args) -> int:
     # frame still live across the upgrade, and it stops being reachable at all once the
     # last pre-chat frame on the machine has ended. Telling the two apart would mean
     # asking tmux a second question on every launch to buy a case that expires on its own.
-    if session in live_sessions:
+    joining = session in live_sessions
+    if joining:
         start_cmd = layout.chat_window_argv(
             socket=SOCKET, session=session, chat=fid, cwd=os.getcwd(),
             harness_argv=argv, env=_frame_identity_env(env))
@@ -4532,6 +4679,23 @@ def cmd_launch(args) -> int:
             util.warn("charter frame: continuing without it — this chat's state may be "
                       "reaped while it is still running, and its exit code may not be "
                       "recorded")
+    # And which PLANE the session belongs to — §4b's marker, written by the launch that
+    # CREATED the session and by no other. `joining` is the same NAME test three dozen
+    # lines up, which is exactly the cross-plane collision this marker records: a launch
+    # that joined a session it did not make may be standing in another plane's session,
+    # and re-marking it there would relabel that plane's frame as this one's. A warning
+    # rather than a failure, because what is lost is a veto and not the switch: an
+    # unmarked session is still found by the pane records `_plane_session` starts from.
+    if not joining:
+        marked = _plane_option_argv(socket=SOCKET, harness_pane=harness_pane)
+        if marked is None:
+            util.warn("charter frame: this plane's state directory is not a shape tmux "
+                      "can carry as an option — a workspace switch cannot tell this "
+                      "session from another plane's of the same name")
+        elif tmuxctl.run("marking the workspace session with its plane", marked,
+                         env=env).returncode != 0:
+            util.warn("charter frame: continuing without it — a workspace switch cannot "
+                      "tell this session from another plane's of the same name")
 
     frame = config.FRAME
     config.write_for(conf_path,
@@ -6201,6 +6365,164 @@ def cmd_chat(args) -> int:
     return 0
 
 
+def _clients_on(socket: str, session: str) -> list[str]:
+    """Every client attached to *session*, by `#{client_name}`.
+
+    *session* is `#{session_id}` — held to `_SESSION_ID_RE` by the two things that produce
+    one on this path (`_pane_place`, `_plane_session`) — for `_session_window`'s reason: a
+    session NAME is renameable and `-t api.1` is parsed by tmux as ``window.pane``.
+
+    ``[]`` for a server that would not answer and for a session nobody is on, because the
+    caller does the same thing with both: there is no client to move, so nothing is moved
+    and nothing is torn down. `.split()` rather than `.splitlines()` is
+    `_workspace_to_focus`'s own reading of tmux's output — a client name holds no
+    whitespace, and a server answering a bare newline has told us about no clients rather
+    than about one with a blank name.
+    """
+    out = tmuxctl.run("asking who is looking at this workspace",
+                      tmuxctl.server_argv(socket, "list-clients", "-t", session,
+                                          "-F", "#{client_name}"),
+                      timeout=5, report=False)
+    if out.returncode != 0:
+        return []
+    return out.stdout.split()
+
+
+def _switch_client(fid: str, ws: str, *, said: str) -> None:
+    """Move the client(s) reading chat *fid* to this plane's workspace *ws* — §4b.
+
+    **The operator's own requirement, and the whole of it**: *"switching workspace means
+    keep the opened chat open in the background, so a user can simultaneously run many
+    harnesses in one charter environment. Changing workspace does not mean stopping the old
+    chat session."* So this kills nothing and starts nothing. Measured on tmux 3.7c and at
+    the 3.2 floor, with a real pty client on a two-window session: after `switch-client -c
+    <client> -t $N` every pane on the server is still there with the same pid and
+    `pane_dead=0`, and the `attach` process itself is still alive. It is `cmd_chat`'s four
+    steps one scope out, and each of them changes in exactly one way:
+
+    0. **Where both ends are, asked of tmux before anything is aimed anywhere** (#684).
+       Here is `_pane_place` on this chat's harness pane; there is :func:`_plane_session`,
+       which answers for THIS PLANE and refuses to resolve a session name — see it for why
+       a name cannot be used, and :data:`_PLANE_OPTION` for what it costs when it is.
+    1. **`switch-client -c <client>`, once per client on this session, and never without
+       `-c`.** tmux picks its own "current client" for a `switch-client` that names none,
+       and on a socket serving eleven sessions from three projects that client is very
+       likely somebody else's — #734 measured exactly that leak for `display-message` and
+       the cost here is higher than a misdrawn line: it would move another operator's
+       terminal off what they were reading. Charter has no presser to name (`cli.py`'s
+       palette `client` positional is accepted and ignored since #729, and a panel process
+       is not a `run-shell` child of a keypress at all), so the clients it moves are the
+       ones it can prove are looking at THIS chat: every client attached to this chat's
+       session. They already share one current window (§2.10), so they were already looking
+       at the same thing, and moving them together keeps them so.
+    2. **`_apply_arrangement(want=[])` on the chat being left**, which is #686's rule
+       unchanged: a background window keeps STALE geometry (§7.4, measured identically on
+       both versions), so panels left running in one are not idle, they are rendering at a
+       width that is no longer their window's. Only this chat has panels to lose — every
+       other chat of the workspace is a background window and lost its own the same way.
+    3. **`_apply_arrangement` on the chat tmux LANDED on**, unconditionally, which is §4b's
+       "#686's treatment one scope out". Which chat that is, charter does not choose:
+       `switch-client` restores the target session's own last active window, so the landing
+       chat is read back off the server (:func:`_chat_showing`) rather than guessed from
+       the seat :func:`_plane_session` happened to match. Re-dressing is not optional and
+       not conditional on the geometry having changed — the panels there were torn down
+       when that workspace went to the background, so they have to be split into a window
+       that tmux has just resized, and that is the same thing `cmd_chat` step 3 does.
+
+    **The teardown is gated on the client having MOVED, not on a command having exited 0**
+    — #684's rule, re-asked here because the failure it names exists here too:
+    `switch-client` against a client that is not attached, or a session that went away
+    between two calls, returns 1, and a partial success across several clients returns 0.
+    So the reading afterwards is `list-clients` on the TARGET, and `display-message -p -c
+    <client>` is deliberately not used for it: measured at the 3.2 floor, that answers an
+    empty string for a client that has demonstrably moved, so a check built on it would
+    refuse every switch on the older tmux and pass on the newer.
+
+    **Nothing on this path writes a record**, which is §4j surviving contact with a switch
+    that now does something: no `record_workspace`, no `workspace.set_active`, no pointer
+    of any kind. The chat left behind is still its workspace's, and the chat arrived at was
+    always its own.
+
+    *said* is `switch.to_workspace`'s own success sentence, carried in rather than spelled
+    again: one switch says one thing, and the sentence belongs beside the refusals it is
+    the alternative to. It is said HERE rather than by the caller because only this
+    function knows which chat the operator ended up on, and a notice is drawn by a panel
+    out of the frame's own state.
+
+    **Called only after `switch.to_workspace` has said yes**, which is what lets every
+    message below interpolate *ws* raw: that check holds it to `workspace.valid_name`,
+    whose alphabet (`instance.WORKSPACE_NAME_RE`) has no whitespace and no control
+    character in it, so a `contain.one_line` here would be a call provably equal to its
+    argument — the shape this repository's deletion sweep reports and this repository
+    deletes.
+    """
+    socket = state.frame_server(fid) or SOCKET
+    here = _pane_place(socket, state.harness_pane(fid))
+    if here is None:
+        # `cmd_chat`'s own sentence, for its own reason: with no reading of where this
+        # client is standing there is no way to tell afterwards whether it moved, and a
+        # switch that cannot establish that must not tear anything down.
+        _say_on_screen(fid, "cannot switch: charter cannot find this chat's own window, "
+                            "so it cannot tell whether a switch would move this client")
+        return
+    there = _plane_session(socket, ws=ws)
+    if there is None:
+        # **What a workspace with no session yet is answered with**, and it is a refusal
+        # rather than a launch. Opening one is `cmd_launch` — a directory, an ordinal, a
+        # harness process and an `attach` — and this runs detached with its streams on
+        # `/dev/null` (`builtin_actions._spawn`), with no terminal to attach anything to.
+        # `switch.py`'s rule is the same one: nothing there creates anything either, and
+        # #518 is why. So the refusal names the command that does.
+        _say_on_screen(fid, f"workspace '{ws}' is not open on this plane — open it with "
+                            f"`charter <harness> --workspace {ws}`")
+        return
+    if there[0] == here[0]:
+        # Records can disagree with tmux: `switch.to_workspace` refused this by NAME a
+        # moment ago, off `state.workspace_for`, and this is the same question asked of
+        # the server. Switching a client to the session it is already on is a no-op that
+        # would then tear this chat's panels down and re-dress them for nothing.
+        _say_on_screen(fid, f"already in workspace '{ws}'")
+        return
+    moving = _clients_on(socket, here[0])
+    if not moving:
+        # Nobody is attached — the operator detached, or this frame is being driven by an
+        # agent with no terminal on it. There is no client to move, and reporting a switch
+        # that moved nothing is #411's shape arriving through a success.
+        _say_on_screen(fid, "cannot switch: no terminal is attached to this workspace, "
+                            "so there is no client to move")
+        return
+    for client in moving:
+        tmuxctl.run("switching this terminal to another workspace",
+                    tmuxctl.server_argv(socket, "switch-client", "-c", client,
+                                        "-t", there[0]),
+                    report=False)
+    if not set(moving) & set(_clients_on(socket, there[0])):
+        _say_on_screen(fid, "cannot switch: tmux did not move this terminal to "
+                            f"'{ws}', so this chat keeps its panels")
+        return
+    landed = _chat_showing(_window_seats(socket, "finding the chat this switch landed on"),
+                           there[0])
+    left = _relayout_target(fid)
+    if left is not None:
+        _apply_arrangement(fid, where=left, want=[])
+    # Both re-layouts are attempted independently and a failure of the first does not
+    # cancel the second — `cmd_chat`'s rule, for its reason: the frame the operator is now
+    # looking at is the one that matters, and abandoning it because the workspace they just
+    # left could not be tidied would leave them on a bare harness pane.
+    arrived = _relayout_target(landed) if landed else None
+    if arrived is not None:
+        _apply_arrangement(landed, where=arrived,
+                           want=_visible_now(landed, config.FRAME))
+    # On the chat the operator is now looking at, for `_draw_palette`'s reason: the notice
+    # is drawn by a panel out of a frame's own state, so it has to be written to the frame
+    # they will be reading a moment from now. A workspace whose landing chat charter could
+    # not name is left unsaid rather than announced on a frame nobody is looking at — the
+    # client visibly moved, which is the report, and `state.say` on the chat being left
+    # would write into panels that are being torn down two lines above.
+    if landed:
+        _say_on_screen(landed, said, ok=True)
+
+
 def _pressers_chat(args) -> str:
     """Which chat the keypress that started this process was fired in.
 
@@ -6481,6 +6803,17 @@ def _draw_palette(args) -> int:
             out = choose.switch_to(noun, fid, name)
             if out.ok and noun == choose.CHAT:
                 _start_chat_switch(fid, name)
+            if out.ok and noun == choose.WORKSPACE:
+                # §4b, and the one row whose outcome this function may not say. A
+                # workspace switch ends on a chat of ANOTHER session — whichever window
+                # tmux restores — and nothing here knows which that is until the switch
+                # has happened. So the sentence goes with the work: `_switch_client` says
+                # it on the chat the operator landed on, out of `switch.to_workspace`'s
+                # own message, and this returns having started it. That is the same
+                # promise a started ACTION makes a few lines below — what it started
+                # surfaces through `inflight`, not through a second clock here.
+                _start_workspace_switch(fid, name)
+                return 0
             # **Which frame's row, and it is not always this one.** The notice is drawn by
             # a panel out of a frame's own state, so it has to be written to the frame the
             # operator will be LOOKING at a moment from now. A chat switch that took moves
@@ -6532,6 +6865,33 @@ def _start_chat_switch(fid: str, chat: str) -> None:
     split `frame-toggle`'s `--chat` already makes.
     """
     builtin_actions._spawn(util.self_relaunch_argv("frame-chat", chat), fid=fid)
+
+
+def _start_workspace_switch(fid: str, ws: str) -> None:
+    """Start :func:`cmd_switch` for workspace *ws*, detached, and return having started it.
+
+    :func:`_start_chat_switch` one noun out, and every word of its argument applies
+    unchanged: the palette closes the instant it has invoked, `kill-pane` hands SIGHUP to
+    that pane's process group, and a switch that ran in this process would be racing its
+    own teardown for the tmux calls that matter. The frame is stated on `_spawn`'s own
+    `$CHARTER_SESSION_ID` rather than inherited, because this is a `run-shell` child of a
+    server shared between every frame on the machine.
+
+    **`frame-switch --workspace`, which is the same front door the `workspaces` bar
+    clicks** (`frame/builtins._WORKSPACE_SWITCH`) and the same one an operator types. One
+    argv rather than a second in-process path is what keeps a click, a palette row and a
+    typed command from drifting into three switches.
+
+    Safe to detach for the measurement `_start_chat_switch` records: `_close_palette` aims
+    `select-pane` at the chat being LEFT, and on 3.7c and at the 3.2 floor `select-pane`
+    on a pane in another window does not move a client — so it cannot pull the operator
+    back off the workspace this is switching them to. What it CAN do is race the teardown
+    of this chat's panels, and that is harmless in the one direction: `_close_palette`
+    kills the overlay pane, `_apply_arrangement(want=[])` kills the panel panes, and
+    neither is the other's.
+    """
+    builtin_actions._spawn(
+        util.self_relaunch_argv("frame-switch", "--workspace", ws), fid=fid)
 
 
 def _picker(row, fid: str, opened: list) -> "palette.Palette | None":
@@ -6722,8 +7082,9 @@ def cmd_switch(args) -> int:
     shared by every frame on `SOCKET`, so the frame a command acts on is resolved at the
     moment it runs, never baked into anything.
 
-    The switch itself is `frame/switch.py`'s — this function is the tmux half and nothing
-    else: which frame, and where the answer is shown.
+    The decision is `frame/switch.py`'s and the tmux half is this function's: which frame,
+    where the answer is shown, and — for a workspace since §4b — the client that actually
+    moves (:func:`_switch_client`).
 
     **Every outcome is put on the operator's screen, and that is the point of the command
     existing at all.** #517: "a menu that silently fails against a lock is worse than no
@@ -6755,7 +7116,16 @@ def cmd_switch(args) -> int:
     ws = getattr(args, "workspace", None)
     persona_name = getattr(args, "persona", None)
     if ws:
+        # **The one noun this command performs itself** (§4b). A persona switch IS
+        # `switch.to_persona` — a file and a bump — so its outcome is complete the moment
+        # that call returns. A workspace switch is a client moved between tmux sessions
+        # and three re-layouts around it (:func:`_switch_client`), which is the same split
+        # `cmd_chat` makes one noun down: the check says which names may be switched to,
+        # and the command owns every reading only a live server can give.
         out = switch.to_workspace(fid, ws)
+        if out.ok:
+            _switch_client(fid, ws, said=out.message)
+            return 0
     elif persona_name:
         out = switch.to_persona(fid, persona_name)
     else:

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -317,16 +317,19 @@ def _repos_events(fid: str):
 #: **The existing front door for each noun, and neither is a shortcut past it.** A chat
 #: switch is `commands_frame.cmd_chat` — `chats.check`'s five refusals, `_pane_place`'s
 #: cross-session reading (#684), `select-window`, and the two re-layouts — and a workspace
-#: switch is `cmd_switch` over `switch.to_workspace`'s one (§4j). Every one of those
-#: refusals
-#: reaches the operator through `_say_on_screen`, which is a `display-message` on the
-#: frame's own client; a panel process has no such surface, and a click that silently did
-#: nothing is exactly the report this feature answers.
+#: switch is `cmd_switch` over `switch.to_workspace`'s three plus `_switch_client`'s own
+#: (§4b): which plane's session that name has, whether anybody is attached to move, and
+#: whether the client really moved. Every one of those refusals reaches the operator
+#: through `_say_on_screen`, which writes to the frame's own attention row; a panel process
+#: has no surface of its own, and a click that silently did nothing is exactly the report
+#: this feature answers.
 #:
 #: Spelled as the argv rather than called in-process for a second reason: what these start
 #: is slow and is not this loop's to wait on. A chat switch is 41 tmux invocations and
-#: ~360 ms measured; a workspace switch re-gathers the plane. `panel._watch` is a paint
-#: loop, and a handler that blocked it would freeze the pane it was clicked on.
+#: ~360 ms measured; a workspace switch is a `switch-client` plus a re-layout at each end,
+#: which is the same order of cost. `panel._watch` is a paint loop, and a handler that
+#: blocked it would freeze the pane it was clicked on — and this pane is one of the panels
+#: the switch it starts is about to tear down.
 _CHAT_SWITCH = ("frame-chat",)
 _WORKSPACE_SWITCH = ("frame-switch", "--workspace")
 
@@ -348,9 +351,10 @@ def _bar_events(fid: str, command: tuple[str, ...]):
       they never pointed here.
     * **A switch is reversible by the same gesture that made it.** The tab you left is
       still on the bar, one click away; nothing is created, nothing is destroyed, and no
-      work is started. A workspace tab is stronger than reversible since §4j — it moves
-      nothing at all, and puts the reason on the frame's own screen. That is the property
-      §4i is actually about, and it holds.
+      work is started. That holds for a workspace tab exactly as it does for a chat tab
+      (§4b): the switch moves a tmux client, the workspace it left keeps every harness it
+      had, and clicking the tab you came from puts you back. That is the property §4i is
+      actually about, and it holds.
     * **There is no chooser for a select-then-confirm bar to be confirmed with.** On the
       table, selecting is a real intermediate state (a highlighted row, a detail on the
       attention strip) and `Enter` in the palette is the chooser. A bar has no such

--- a/charter/frame/choose.py
+++ b/charter/frame/choose.py
@@ -84,20 +84,20 @@ WORKSPACE, PERSONA, CHANGE, CHAT = "workspace", "persona", "change", "chat"
 #: frame is looking at, a persona is who is looking, and a change is what they are in the
 #: middle of — which is the narrowest of those three and so goes third.
 #:
-#: **Workspace keeps its place in that order and no longer moves anything** (§4j). Its
-#: doorway is refused on every frame (:func:`pin_reason`), and it is still listed for the
-#: reason `_name_rows` lists a pinned noun's names: it is where the operator looks to see
-#: which workspace this chat is in, and a row that says why is worth more than a row that
-#: is missing.
+#: **Workspace keeps its place in that order and moves the CLIENT rather than the chat**
+#: (§4b). Its doorway opened again with #789's refusal removed, and what it opens onto is
+#: `switch-client`: the chat this frame is is left running in the background, and §4j is
+#: untouched because nothing about it is re-pointed.
 #:
 #: **`chat` is last, and not because it is narrower still — it is a different KIND of
 #: thing, which is why it does not slot into that ordering at all.** The middle two move
 #: what THIS frame is looking at, by writing a file the frame's own panels then read
 #: (`frame/switch.py`). A chat is a sibling frame: choosing one moves the tmux client to
 #: another window and leaves this frame exactly as it was, still running, still burning
-#: whatever it was burning. Putting it at the end keeps the ones that share a mechanism
-#: together and puts the one that does not beside them rather than among them;
-#: :func:`switch_to` says the same thing in code.
+#: whatever it was burning — and a workspace is that same kind of thing one scope out, a
+#: client moved to another SESSION. Putting `chat` at the end keeps the two that write a
+#: file together and puts the one that has no name-shaped sibling beside them rather than
+#: among them; :func:`switch_to` says the same thing in code.
 NOUNS = (WORKSPACE, PERSONA, CHANGE, CHAT)
 
 #: Which launch pin outranks a switch of each noun — the rung nothing charter writes can
@@ -118,12 +118,13 @@ NOUNS = (WORKSPACE, PERSONA, CHANGE, CHAT)
 #: has ever been. A launch pin is a thing that stops a frame MOVING; a chat's id is what
 #: the frame is, and moving to another chat does not move it.
 #:
-#: **`workspace` is absent because a stronger refusal fires in front of it.**
+#: **`workspace` is absent because the pin is about a different noun than the switch.**
 #: `$CHARTER_WORKSPACE` is still a pin and still outranks everything
-#: (`state.own_workspace`'s first rung) — but §4j refuses that doorway on every frame,
-#: pinned or not, so an entry here could only ever produce a second sentence for a case
-#: the first one already covers, and a narrower one: it would say the pin is what forbids
-#: the move, when an unpinned chat is forbidden identically. See :func:`pin_reason`.
+#: (`state.own_workspace`'s first rung) — over which workspace THIS CHAT is in. A
+#: workspace switch moves the tmux client to another session and re-points nothing
+#: (§4b), so the pin is neither contradicted nor relevant, and an entry here would refuse
+#: a look at another workspace on the grounds that this chat cannot leave the one it is
+#: in. See :func:`pin_reason`.
 PIN = {PERSONA: "CHARTER_PERSONA"}
 
 #: What a doorway says when this workspace has no changes at all. Its own sentence rather
@@ -239,13 +240,19 @@ def current(noun: str, fid: str) -> str:
 def pin_reason(noun: str, fid: str) -> str:
     """Why *fid* will not offer a picker for *noun*, or `""` when it will.
 
-    **For a workspace it is unconditional, and it is §4j** (`switch.FOR_LIFE`): a chat
-    belongs to its workspace for life, so there is no frame on which that picker could
-    honour a keypress. This is the shape a pinned frame already had, arriving through the
-    same field for every frame instead of for some — which is why it is one more answer
-    here rather than a new mechanism beside this one. The sentence is
-    `switch.to_workspace`'s own, read from one constant, so the row and the keypress cannot
-    describe one frame two ways.
+    **For a workspace it is `""` on every frame, and that is §4b undoing #789's doorway.**
+    #789 refused this picker unconditionally, because the only thing behind it was a move
+    §4j forbids for life. What is behind it now is `switch-client` — the client moves and
+    the chat stays exactly where it is (`switch.to_workspace`) — so there is no frame on
+    which the picker is dishonest, and a `$CHARTER_WORKSPACE` pin does not make one: it
+    pins which workspace this CHAT is in, and nothing here proposes to change that.
+
+    **The one refusal a workspace row can still earn is not asked here, deliberately.**
+    "That workspace is not open" is a question about live tmux sessions, and `pin_reason`
+    runs when the palette OPENS — so an answer taken here would be a reading of the server
+    from before the operator had chosen anything, drawn as though it were about the name
+    they went on to press. `commands_frame._switch_client` asks it at the instant it
+    matters, which is `cmd_chat`'s own split one noun out.
 
     For a persona it is the launch pin: the same sentence `switch.to_persona` refuses
     with, built from the same read (`switch._pin`), for the same reason.
@@ -264,7 +271,7 @@ def pin_reason(noun: str, fid: str) -> str:
     one the picker would make a keystroke later.
     """
     if noun == WORKSPACE:
-        return switch.FOR_LIFE
+        return ""
     if noun == CHANGE:
         return "" if names_of(CHANGE, fid) else NO_CHANGES
     if noun == CHAT:
@@ -414,18 +421,21 @@ def noun_of(row: overlay.Row) -> str | None:
 def switch_to(noun: str, fid: str, name: str) -> switch.Outcome:
     """Move frame *fid* to *name*, and answer with what happened and what to say.
 
-    One call into `frame/switch.py` and nothing else for the first three, which is what
-    makes "the switch moves the frame's own identity and bumps it" (#411/#412) a property
-    of one function rather than of every surface that switches. The pointer under the
-    frame's id, the recorded change and the bump are all that function's, in that order,
-    and a picker that wrote any of them itself would be the second answer #411 is about.
+    One call into `frame/switch.py` and nothing else for the two that write a file, which
+    is what makes "the switch moves the frame's own identity and bumps it" (#411/#412) a
+    property of one function rather than of every surface that switches. The pointer under
+    the frame's id, the recorded change and the bump are all that function's, in that
+    order, and a picker that wrote any of them itself would be the second answer #411 is
+    about.
 
-    **`workspace` performs nothing and is still dispatched here**, which is the point of
-    it keeping a branch too: `switch.to_workspace` is §4j's refusal, and routing it through
-    the same call is what makes the palette's row, `charter frame-switch --workspace` and a
-    typed name give one sentence rather than three surfaces each deciding to refuse.
+    **`workspace` is a CHECK here and is performed by the caller** (§4b), which is `chat`'s
+    split one scope out and is dispatched here for the same reason: `switch.to_workspace`
+    is the one rule the palette's row, `charter frame-switch --workspace` and a typed name
+    all get, so the three surfaces cannot each decide to refuse a different set of names.
+    What it cannot decide is whether that workspace is open, which is a live tmux reading
+    and belongs where the switch happens (`commands_frame._switch_client`).
 
-    **`chat` is the one noun this function does not perform, and saying so is the point
+    **`chat` is the other noun this function does not perform, and saying so is the point
     of it having a branch here at all.** A chat switch is not a file write: it is
     `select-window` plus a re-layout of the panels into the window tmux has just resized
     (spec §3.7), and no tmux call may be made from this module or from `frame/switch.py`

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -974,11 +974,23 @@ def chat_window_argv(*, socket: str, session: str, chat: str, cwd: str,
     attached to this session must not be dragged to a half-built window. The launcher
     `select-window`s once the frame has actually been drawn.
 
-    **`-a`, and it is not decoration.** `-t <session>` resolves to that session's CURRENT
-    window, and `new-window` reads a resolved window target as the INDEX to create at — so
-    without it tmux answers `create window failed: index 0 in use` for the second chat of
-    a workspace and no chat is ever added. Measured against tmux 3.7c and tmux 3.2, which
-    is also how :func:`window_argv` came to carry it.
+    **`-a`, and it is not decoration.** `-t <session>` resolves to a WINDOW, and
+    `new-window` reads a resolved window target as the INDEX to create at — so without it
+    tmux answers `create window failed: index 0 in use` for the second chat of a workspace
+    and no chat is ever added. Measured against tmux 3.7c and tmux 3.2, which is also how
+    :func:`window_argv` came to carry it.
+
+    **Which window it resolves to is not "the session's current one", and that correction
+    was measured for §4b.** tmux matches a bare target against WINDOW NAMES too, and a
+    name match wins: a session `ws` whose current window is index 0 (`zzz`) resolves `-t
+    ws` to index **1** when index 1 is named `ws.9`, on both versions. Charter names every
+    chat window `<workspace>.<n>` — so on charter's own server a bare `-t <workspace>`
+    names *a chat's window*, chosen by name matching rather than by what is on screen, and
+    which chat that is moves as chats are opened and closed. Nothing in charter relies on
+    it: this call passes `-a`, and every other window-scoped target charter builds is a
+    `%<pane>` id (`_chat_option_argv`, `_plane_option_argv`, `overlay.arm_hatch_argv`,
+    `cmd_chat`'s `select-window`). The claim is corrected here rather than deleted because
+    the next person to write `-t <session>` will reach for the reason this paragraph gives.
 
     ``-P -F '#{pane_id}'`` and NOT the window id, deliberately: `session_argv` reports the
     pane alone, every caller downstream scopes itself to the pane (`split-window`,

--- a/charter/frame/switch.py
+++ b/charter/frame/switch.py
@@ -6,22 +6,32 @@ names, contain them, perform the switch, repaint the panels.** The palette
 (`frame/builtin_actions._register_names` → `cmd_switch`) and the launch picker
 (`frame/picker.py` → `cmd_launch`) are two front doors onto the same rooms.
 
-**A WORKSPACE is not one of the things a switch may move, and that is the correction
-this file carries.** Spec §4j settled it on 2026-08-26 — *"a chat belongs to its
-workspace for life; `{workspace}-{hash}` is identity, not a property"* — and Phase 5's
-§3.6 and §8 both reaffirm it. This module was written on 2026-08-25, one day earlier,
+**A WORKSPACE is still not one of the things a switch may MOVE, and that is the
+correction this file carries.** Spec §4j settled it on 2026-08-26 — *"a chat belongs to
+its workspace for life; `{workspace}-{hash}` is identity, not a property"* — and Phase
+5's §3.6 and §8 both reaffirm it. This module was written on 2026-08-25, one day earlier,
 when a frame **was** a workspace one-to-one and moving it was coherent. Phase 5 then made
 a frame a **chat**, nobody re-read the sentence, and "moves the frame" quietly became
-"moves the chat". :func:`to_workspace` therefore refuses, with :data:`FOR_LIFE`, and #733
-and #788 are the two directions of the strand it used to open.
+"moves the chat"; #733 and #788 are the two directions of the strand that opened, and
+#789 closed it by refusing.
+
+**§4b then names the operation that refusal was standing in for, and it is a different
+one.** *"Switching workspace means keep the opened chat open in the background, so a user
+can run many harnesses in one charter environment"* — the operator's own words. That is
+`switch-client`: **the client moves and nothing else does.** The chat left behind keeps
+its harness, its pid, its window and its workspace; so does every chat in the workspace
+arrived at. :func:`to_workspace` is therefore a CHECK — the refusals that need no server
+— and `commands_frame._switch_client` is the tmux half, exactly as `chats.check` and
+`commands_frame.cmd_chat` already split one noun down.
 
 **A switch is a write to the frame's OWN identity, never a pointer somebody might read.**
 #411 is the whole reason this file is not four lines: panels followed `charter ws use`
 only through the `$CHARTER_SESSION_ID` collision, and #412 made that identity explicit on
-tmux's `-e`. What is left that a switch may move is a persona — who is reading — and a
-change — what one panel is looking at. Neither is a plane the harness's own cwd, files and
-history are about, which is the whole of §4j's argument and the whole of why the workspace
-is the one noun that leaves.
+tmux's `-e`. What a switch may write is a persona — who is reading — and a change — what
+one panel is looking at. Neither is a plane the harness's own cwd, files and history are
+about, which is the whole of §4j's argument and the whole of why the workspace is the one
+noun this file writes nothing for: a workspace switch has no file to write, because what
+it moves is a tmux client.
 
 **A pin is a refusal and not a best effort**, which is now the persona's rule alone. A
 panel pane was started with `-e CHARTER_PERSONA=<pin>` (`commands_frame._frame_identity_env`);
@@ -138,69 +148,56 @@ def _pin(fid: str, name: str) -> str | None:
     return val or None
 
 
-#: What a workspace keypress inside a chat is answered with — spec §4j, and the whole
-#: operator-facing surface of restoring it.
-#:
-#: **`{workspace}-{hash}` is identity, not a property.** A chat IS its harness session:
-#: the cwd it was started in, the files it has open and the history it is holding are one
-#: workspace's. Re-pointing the record made all three about a different plane while the
-#: tmux window stayed exactly where it was — charter calls `move-window` nowhere — and
-#: #733 and #788 are the two directions that produced. Backward: the moved chat's siblings
-#: could never see it again, so a live window of the session on screen was unreachable
-#: from inside it. Forward: its new neighbours were drawn on its bar, approved by
-#: `chats.check`, and refused by `cmd_chat` every time, because their windows are in
-#: another tmux session.
-#:
-#: **It names the route that exists, because there is no other one to name.** Attaching a
-#: client to another workspace's chat is `switch-client` (spec §4b, delivery stage 9) and
-#: charter makes that call nowhere yet, so until it does there is nothing a workspace
-#: keypress CAN do beyond stopping the frame claiming a workspace it is not in. What works
-#: today is opening a chat there, which is §4j's own answer: *"a conversation wanted
-#: elsewhere is a new chat."*
-#:
-#: **`--workspace` and not `-w`**: the harness launcher's flag has no short form
-#: (`cli.py`'s `_add_frame_parsers`), and a refusal that names a flag the command would
-#: reject is worse than one that names none. `<harness>` rather than `claude` is
-#: `chats.ONLY_CHAT`'s spelling for the same affordance one noun over — a frame may be
-#: running codex or opencode, and this sentence is drawn on both.
-#:
-#: One sentence in one place, read by this refusal and by the palette row that carries it
-#: (`choose.pin_reason`), so the row and the keypress cannot describe one frame two ways.
-#: No name is interpolated into it, which is what lets those two share it: the doorway is
-#: refused before any name has been chosen, and the row it sits on already says which
-#: workspace the frame is in.
-FOR_LIFE = ("cannot switch: a chat belongs to its workspace for life — open a chat in "
-            "another workspace with `charter <harness> --workspace <name>`")
-
-
 def to_workspace(fid: str, name: str) -> Outcome:
-    """Refuse to move chat *fid* to workspace *name*, and name the route that exists.
+    """May chat *fid*'s client be moved to workspace *name*? — the whole of the decision
+    that does not need a tmux server, and none of the decision that does.
 
-    **One refusal and no queue of them, which is a decision rather than a shortcut.**
-    This used to check four things in order — the name's alphabet, whether the workspace
-    exists, a `$CHARTER_WORKSPACE` pin, then the lock — and every one of those is now a
-    narrower and less true reason than the one that always applies. Answering "no
-    workspace 'gamam'" first would teach an operator that a typo is what stands between
-    them and a move that cannot happen at any spelling; answering "pinned" first would
-    say the pin is what forbids it, when an unpinned chat is forbidden identically. So
-    *name* is not looked at: :data:`FOR_LIFE` is the answer for every value of it,
-    including the empty string and a name off a picker charter built itself.
+    **This is a CHECK, in `chats.check`'s sense, and that is what §4b changed about it.**
+    Until #789 the same call was "re-point this chat at that workspace", which §4j forbids
+    for life; #789 made it an unconditional refusal, which was right about the chat and
+    left the operator's `workspaces` bar a listing where every tab refused. §4b names the
+    operation that was missing: **switching moves the CLIENT, not the chat.**
+    `switch-client -c <client> -t <the other workspace's session>` puts this terminal on
+    another workspace of this plane; the chat it left keeps its harness, its window, its
+    pid and its workspace, and so does every chat in the workspace it arrived in. Nothing
+    is re-pointed, so §4j is untouched — measured by
+    `tests/test_a_chat_belongs_to_its_workspace_for_life.py`, which now asserts the
+    invariant across a switch that SUCCEEDS.
 
-    **Nothing is read and nothing is written**, and both halves are asserted. A read
-    would be a directory listing for an answer that does not depend on it. A write would
-    be #411's shape arriving through the refusal — a switch reported as refused and half
-    performed — and there were two of them to lose: the per-session pointer under the
-    chat's id (`workspace.set_active(..., session_id=fid)`, `state.own_workspace`'s middle
-    rung) and the launch record (`state.record_workspace`, its last). There is no
-    `state.bump` either: a panel repaints because the version moved, so bumping would make
-    every panel of this chat re-render an identical plane and would be charter agreeing on
-    screen that something happened.
+    **Three refusals, and each is a thing the operator can act on**: a name that cannot
+    name a workspace (`workspace.valid_name`, the one rule), a name this plane does not
+    have — a question, never an implicit create (#518: "a picker that creates on a typo
+    leaves litter") — and the workspace this frame is already in, which is not an error
+    and is still not a switch. They are asked in that order for :func:`to_persona`'s
+    reason: the narrower answer is the one the operator can do something with.
 
-    *fid* is unused and kept, because `choose.switch_to` dispatches all four nouns through
-    one signature and a refusal that took a different shape from the thing it replaces
-    would move the difference into every caller.
+    **The fourth refusal is deliberately not here, because it is tmux's.** "That workspace
+    is not open" is a question about live sessions on a shared server, and answering it
+    here would answer it at the instant a palette opened rather than at the instant the
+    switch runs — `chats.check`'s own split, one noun out. `commands_frame._switch_client`
+    owns it, together with every other reading only a server can give.
+
+    **`$CHARTER_WORKSPACE` is no longer a pin on this noun, and its absence is a
+    decision.** The variable pins which workspace THIS CHAT is in
+    (`state.own_workspace`'s first rung) and it still does; a switch that moves a client
+    to another session does not touch it, does not contradict it, and leaves the pinned
+    chat pinned and running. Refusing on it would be refusing to look at another workspace
+    because this chat cannot leave the one it is in, which is two different nouns wearing
+    one name — the confusion #789's own refusal was made of.
+
+    Nothing is written and nothing is bumped: a switch's only effect is on the tmux
+    client, and the panels that repaint are re-laid-out by the caller that moved it.
     """
-    return Outcome(False, FOR_LIFE)
+    from .. import workspace as ws_mod
+    shown = contain.one_line(name)
+    if not ws_mod.valid_name(name):
+        return Outcome(False, f"'{shown}' cannot name a workspace")
+    known = workspaces()
+    if name not in known:
+        return Outcome(False, f"no workspace '{shown}' — have: {_some(known)}")
+    if name == current_workspace(fid):
+        return Outcome(False, f"already in workspace '{shown}'")
+    return Outcome(True, f"workspace → {shown}")
 
 
 def to_persona(fid: str, name: str) -> Outcome:

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -388,6 +388,40 @@ might have opened. Charter matches on the pane id its own launcher wrote down fo
 `.charter/frame/`, which the server minted and only one plane holds. A workspace this plane
 has never opened is never focused, whatever another plane happens to be calling its own.
 
+### Switching workspaces — several open, one on screen
+
+**Your terminal moves; nothing stops.** `F2` → `workspace`, a click on the `workspaces`
+bar, or `charter frame-switch --workspace <name>` puts your client on another workspace's
+tmux session. The chat you were in keeps its harness, its pid, its window and its
+workspace, and so does every chat in the workspace you arrive at — so you can have several
+harnesses working at once and look at one of them. Come back and they are where you left
+them.
+
+Measured on tmux 3.7c and at the 3.2 floor with a real client: `switch-client` moves the
+client, every pane on the server is still there afterwards with the same pid, and the
+`attach` process itself is untouched. The switch itself is about **5 ms** of tmux; what it
+costs beyond that is one re-layout at each end — the panels of the chat you left are torn
+down and the chat you arrive at gets fresh ones, for the same reason a chat switch does it
+(a background window keeps stale geometry). You land on whichever chat that workspace was
+last showing, which is tmux's own answer and not a record charter keeps.
+
+**Switching is restricted to workspaces of this plane, and anything else is refused by
+name.** One tmux server serves every plane on the machine: the operator's own socket had
+eleven sessions from three different projects on it the day this was written, and `default`
+is a name every plane has. Crossing to another plane's session would cross every isolation
+boundary charter has — a different `CHARTER_ROOT`, different personas, different vaults,
+different memory — so charter will not do it by accident and will not do it on purpose.
+
+Which session is yours is decided by two things, and neither is a session name. Charter
+matches the `%<pane>` id **its own launcher wrote down** for a chat in `.charter/frame/`,
+and it refuses any session whose `@charter_plane` marker names another plane. The marker is
+set once, by the launch that creates a workspace's session, and holds that plane's
+`.charter` path. Sessions started by a charter older than this carry no marker; those are
+still found by the pane record, which is what they were always found by.
+
+A workspace with no session yet is **not open**, and the switch says so rather than opening
+one — see *Switching a workspace moves your terminal* below for why.
+
 ### Switching between them
 
 `F2` → `chat` lists this workspace's chats with the one you are typing in marked and the
@@ -450,12 +484,13 @@ usually drawing a page. At 120 columns it draws six of them, at 160 eight, at 20
 
 **They are tabs: with `mouse = true`, clicking a name switches to it.** A chat tab does
 exactly what `F2` → `chat` does — the same command, the same five refusals, the same
-sentence on your screen when one fires. A **workspace** tab does what `charter frame-switch
---workspace <name>` does, which since §4j is to put one sentence on your screen and move
-nothing: a chat belongs to its workspace for life, and the tab names the workspace this
-chat is in rather than one it could become. *Mouse is off by default* above has the rules a click follows and
-why a tab switches where a repo row only selects; the short of it is that clicking the tab
-you are on, the `+N`, or anything that is not a drawn name does nothing at all.
+sentence on your screen when one fires. A **workspace** tab does exactly what `charter
+frame-switch --workspace <name>` does: your terminal moves to that workspace, and the chat
+you were in keeps running behind you. *Mouse is off by default* above has the rules a click
+follows and why a tab switches where a repo row only selects; the short of it is that
+clicking the tab you are on, the `+N`, or anything that is not a drawn name does nothing at
+all. The mark stays on the workspace **this chat** is in, because that is what it names —
+switching does not move the chat.
 
 **Neither is drawn unless a plane places it**, and that is deliberate rather than
 unfinished: on the ordinary plane there is one chat, and a row saying so permanently costs
@@ -1894,21 +1929,21 @@ neither does the `display-menu` they opened. `F2` was always trying to be a pale
 keeping both would have left two answers to "how do I do a thing", which is how the single
 menu became weird in the first place.
 
-**A chat cannot be switched to another workspace, and the row says so before you press
-it.** A chat belongs to the workspace it was opened in for life: its id is
-`<workspace>.<n>`, and the harness inside it has that workspace's directory as its cwd,
-that workspace's files open and that workspace's work in its history. Moving the label
-would leave all three behind — the tmux window does not move, so the chat would be listed
-in a workspace whose other chats it cannot reach and unreachable from the one it is
-actually in. So the `workspace` row carries `cannot switch: a chat belongs to its
-workspace for life — open a chat in another workspace with `charter <harness> --workspace
-<name>`` and opens no picker. **Opening a chat there is the way to work in another
-workspace**, and it is the honest one: a new conversation, in the right plane, with its own
-cwd and its own history.
+**Switching a workspace moves your terminal, not your chat.** `F2` → `workspace` lists
+the workspaces of this plane with the one this chat is in marked; choose another and your
+terminal moves to that workspace's session. **A chat belongs to the workspace it was
+opened in for life** — its id is `<workspace>.<n>`, and the harness inside it has that
+workspace's directory as its cwd, that workspace's files open and that workspace's work in
+its history — so nothing about the chat you left changes. It keeps running, keeps burning
+whatever it was burning, and is still there when you switch back. That is the point:
+several workspaces open at once, one on screen.
 
-The workspace names are still listed and the row still marks the one you are in, because
-that is where you look to answer "which workspace is this chat in" — you just cannot press
-one into a move.
+A switch is refused, with the reason on your own screen, for a name that cannot name a
+workspace, a workspace this plane does not have, the workspace you are already in, and a
+workspace that **is not open** — nothing on this plane has a session for it yet. Charter
+does not open one for you: opening a workspace starts a harness and attaches a terminal,
+and the switch runs detached with no terminal to attach. The refusal names the command that
+does it: `charter <harness> --workspace <name>`.
 
 **Switching a persona from the picker moves the frame, and says so.** Choosing one writes
 the choice under the frame's own id and bumps the frame so every panel repaints, and a
@@ -2061,7 +2096,8 @@ closed stdin end the launch having started nothing; the exit code is 130.
 meant — `charter workspace use` locks the session to what it selected — and the launch
 says so on the line after your answer, naming the way out in the same sentence: `charter
 workspace unlock`, in the frame's own shell. (It used to name `F2 → workspace` first; that
-route is gone, because a chat belongs to its workspace for life.)
+route no longer releases a lock — a workspace switch moves your terminal to another session
+and leaves this one locked to the workspace its commands act on.)
 
 **It never asks twice, and it never asks a script.** Your choice is written as the
 terminal's own pointer, so the next launch from that terminal has an answer and goes

--- a/docs/news/unreleased-switching-workspace-moves-your-terminal-and-stops-nothing.md
+++ b/docs/news/unreleased-switching-workspace-moves-your-terminal-and-stops-nothing.md
@@ -1,0 +1,97 @@
+---
+version: unreleased
+headline: Switching workspace moves your terminal and stops nothing, so several harnesses can run at once with one on screen
+---
+
+*"switching workspace — it means keep opened chat opened in background, so user can
+simultaneously run many harnesses in one charter environment. Changing workspace or changing
+sessions does not mean stopping old chat session."*
+
+That is the feature, and until now charter had the opposite of it. The workspace tab and the
+`F2 → workspace` row both refused: a chat belongs to its workspace for life, so the switch
+that used to re-point one was removed and nothing replaced it. On a plane with fifteen
+workspaces that left a bar of fifteen tabs where every click put a sentence on screen and
+moved nothing.
+
+**The sentence was right about the chat and wrong about the operator.** Moving a *chat*
+between workspaces is still forbidden and still impossible — its id is `<workspace>.<n>`, and
+the harness inside it has that workspace's directory as its cwd, that workspace's files open
+and that workspace's work in its history. What was missing is a different operation on a
+different noun: **moving the client.** A workspace is a tmux session, your terminal is a tmux
+client, and `switch-client` puts one on the other.
+
+So a workspace tab, an `F2 → workspace` row and `charter frame-switch --workspace <name>` now
+all move your terminal to that workspace. Everything you left keeps running: the same harness,
+the same pid, the same window, the same workspace. Come back and it is where you left it, and
+the workspace you arrive in is whichever chat it was last showing.
+
+Measured with a real client on tmux 3.7c and at the 3.2 floor, identically on both: after the
+switch every pane on the server is still there with the same pid and none of them dead, and
+the `attach` process itself is untouched. `switch-client` costs about **5 ms**. What it costs
+beyond that is one re-layout at each end — the panels of the chat you left are torn down, and
+the chat you arrive at gets fresh ones, because a tmux window that is not the current one
+keeps the size it had when it was, so panels left running in one are drawing at a width that
+is no longer their window's.
+
+## Switching is restricted to the workspaces of this plane
+
+One tmux server serves **every plane on this machine**. The socket charter uses had eleven
+sessions on it from three different projects the day this was written, and `default` — a name
+every plane has whether anybody chose it or not — was one of them. A switch decided on a
+session *name* would therefore have been able to put you inside another project's harnesses,
+across every isolation boundary charter has: a different `CHARTER_ROOT`, a different persona
+set, different vaults, different memory.
+
+Charter will not do that, and a workspace of another plane is refused by name rather than
+silently landed in. Which session is yours is decided by two facts and neither of them is a
+name:
+
+* the `%<pane>` id **this plane's own launcher** wrote down for a chat in `.charter/frame/` —
+  minted by the server, held by one plane;
+* a new `@charter_plane` marker on the session, holding that plane's `.charter` path, which
+  refuses any session that says it belongs to somebody else.
+
+Each closes what the other cannot. Pane ids restart at `%0` when a tmux server does, so a
+pane id recorded for a chat that is over can later name another plane's live pane — the
+marker refuses that. And a session started by a charter older than this carries no marker at
+all, including every session running on this machine today — those are still found by the
+pane record, exactly as they were before. The marker is written once, by the launch that
+*creates* a workspace's session, and never by a launch that joins one: joining is decided on
+the session name, which is the collision itself, so re-marking there could relabel another
+plane's session as yours.
+
+## A workspace with no session yet is not open, and charter says so
+
+The bar lists every workspace the plane has, and most of them are not running. Clicking one
+answers `workspace 'foo' is not open on this plane — open it with `charter <harness>
+--workspace foo``. Charter does not open it for you: opening a workspace starts a harness and
+attaches a terminal, and a switch runs detached with no terminal to attach — a picker that
+creates on a typo leaves litter, which is the same rule every other switch in the palette
+follows.
+
+The other refusals are a name that cannot name a workspace, a name this plane does not have
+(with the names it does have beside it), the workspace you are already in, and a terminal
+that has moved nowhere — the teardown of your panels is gated on charter having *read* your
+client on the other session, not on `switch-client` having exited 0.
+
+## Verification
+
+Two planes on one machine, one tmux server, and one workspace name they share — the only
+arrangement the cross-plane flaw exists in, and a single-plane test is structurally blind to
+it. The plane that opened the workspace resolves it; the plane that did not resolves nothing,
+though its workspace name, its chat id and the live session's name all match. Then the same
+fixture with the recycled pane id — plane B recording the pane id the server actually
+minted, which is what a `kill-server` produces — is resolved for plane B **without** the
+marker and refused **with** it, so the marker is measured against the hazard it exists for
+rather than against a hypothetical.
+
+Six hand-written mutations of the switch were run and every one goes red: dropping the plane
+veto, dropping `-c <client>` from `switch-client`, never verifying the client moved, dressing
+the seat charter matched instead of the window tmux landed on, leaving the old chat's panels
+up, and writing the plane marker on a launch that joined a session rather than made one.
+
+Run against real tmux on **3.7c and on tmux 3.2**, the floor charter promises. CI installs no
+tmux, so the real-server half runs only by hand.
+
+Nothing to adopt — the `workspaces` bar is still off by default (`[frame] slots`), and a
+switch is the same command it always was.

--- a/tests/test_a_chat_belongs_to_its_workspace_for_life.py
+++ b/tests/test_a_chat_belongs_to_its_workspace_for_life.py
@@ -12,6 +12,14 @@ written when a frame WAS a workspace, one to one, and `docs/frame.md` honestly s
 "switching from the picker moves the frame". Phase 5 then made a frame a **chat**, and
 "moves the frame" quietly became "moves the chat" — which §4j had already forbidden.
 
+**§4b then made the switch DO something again, and every assertion here is now made
+across a switch that says yes** — which is the stronger statement and the reason this
+module was not simply left alone. What a workspace switch moves is the tmux CLIENT
+(`commands_frame._switch_client`); the chat it leaves keeps its harness, its window, its
+pid and its workspace. A `to_workspace` that answered "yes" and re-pointed one rung on the
+way would put #733 and #788 straight back, and nothing about the refusal it used to be
+would have caught it.
+
 **The two directions of the one strand that produced, both closed here.**
 
 * **#733, backward.** `F2 → workspace → gamma` inside `alpha.1` re-pointed that chat and
@@ -80,9 +88,12 @@ class TheSwitchNoLongerMovesTheChat(PersonaIso, unittest.TestCase):
     def test_the_chat_is_still_in_the_workspace_it_was_launched_for(self):
         """The invariant itself, asked of the one rule every frame surface asks
         (`state.workspace_for`) rather than of the files the switch used to write — which
-        is this repository's rule about asserting a layer below the code that prints."""
+        is this repository's rule about asserting a layer below the code that prints.
+
+        The switch SAYS YES here, and that is what makes this the strong form: the chat
+        stays in `alpha` while the client is cleared to go to `gamma`."""
         out = switch.to_workspace("alpha.1", "gamma")
-        self.assertFalse(out.ok, out.message)
+        self.assertTrue(out.ok, out.message)
         self.assertEqual(state.workspace_for("alpha.1"), "alpha")
         self.assertEqual(state.own_workspace("alpha.1"), "alpha")
 
@@ -90,45 +101,48 @@ class TheSwitchNoLongerMovesTheChat(PersonaIso, unittest.TestCase):
         """Both halves, because they were two writes and either one alone re-creates the
         defect: the per-session pointer under the chat's id (`workspace.for_session`,
         `own_workspace`'s middle rung) and the launch record (`state.frame_workspace`,
-        its last). A refusal that wrote one of them would be #411's shape — a switch
-        reported as refused and half performed."""
+        its last). A switch that wrote one of them would be #411's shape — an outcome
+        reported for one noun and performed on another."""
         switch.to_workspace("alpha.1", "gamma")
         self.assertIsNone(workspace.for_session("alpha.1"))
         self.assertEqual(state.frame_workspace("alpha.1"), "alpha")
 
-    def test_nothing_repaints_for_a_move_that_did_not_happen(self):
-        """A panel repaints because the version moved (`frame/panel.py`'s contract), so
-        bumping here would make every panel of this chat re-render an identical plane —
-        and would be charter agreeing on screen that something happened."""
+    def test_nothing_repaints_because_the_check_alone_moved_nothing(self):
+        """A panel repaints because the version moved (`frame/panel.py`'s contract), and
+        this function is a decision rather than an effect: the bumps a workspace switch
+        earns are `_apply_arrangement`'s, after the client has actually moved and the
+        panels have been re-laid-out. Bumping here would repaint every panel of this chat
+        into an identical plane before anything had happened."""
         before = state.version("alpha.1")
         switch.to_workspace("alpha.1", "gamma")
         self.assertEqual(state.version("alpha.1"), before)
 
-    def test_the_refusal_names_the_route_that_exists(self):
-        """#517's rule — "a menu that silently fails is worse than no menu" — and the
-        whole operator-facing surface of this change. Until §4b's `switch-client` lands
-        there is nothing a workspace keypress CAN do, so the sentence has to carry the
-        thing that works today, spelled the way the launcher's own flag is spelled
-        (`--workspace`, `cli.py`; the harness launcher has no `-w`)."""
+    def test_the_sentence_is_about_the_workspace_and_not_about_the_chat(self):
+        """#517's rule — "a menu that silently fails is worse than no menu". What the
+        operator is told is which workspace they are going to, because that is what
+        happened; a switch that announced the CHAT moving would be describing the defect
+        §4j names."""
         out = switch.to_workspace("alpha.1", "gamma")
-        self.assertIn("--workspace", out.message)
-        self.assertIn("charter", out.message)
+        self.assertIn("gamma", out.message)
+        self.assertNotIn("alpha.1", out.message)
 
-    def test_a_name_that_is_not_a_workspace_gets_the_same_answer(self):
-        """One refusal, not a queue of them. A chat cannot move to a workspace that
-        exists, so "no such workspace" is a narrower and less true reason than the one
-        that applies — and answering the narrower one first would teach an operator that
-        creating the workspace is what is missing."""
-        for name in ("nope", "../escape", ""):
-            out = switch.to_workspace("alpha.1", name)
-            self.assertFalse(out.ok)
-            self.assertEqual(out.message, switch.FOR_LIFE)
+    def test_a_name_that_is_not_a_workspace_is_refused_by_its_own_reason(self):
+        """Each refusal is a thing the operator can act on, which is what #789's single
+        unconditional sentence could not be: a typo now says it is a typo, and a name
+        outside the alphabet says that instead."""
+        self.assertIn("no workspace 'nope'",
+                      switch.to_workspace("alpha.1", "nope").message)
+        self.assertIn("cannot name a workspace",
+                      switch.to_workspace("alpha.1", "../escape").message)
+        self.assertIn("cannot name a workspace",
+                      switch.to_workspace("alpha.1", "").message)
 
-    def test_nothing_is_created_by_the_refusal(self):
+    def test_nothing_is_created_by_a_switch_or_by_a_refusal(self):
         """`switch.py`'s standing rule (#518: "a picker that creates on a typo leaves
         litter"), which a refusal must keep rather than inherit by accident."""
         before = sorted(p.name for p in config.WORKSPACES_DIR.iterdir())
         switch.to_workspace("alpha.1", "nope")
+        switch.to_workspace("alpha.1", "gamma")
         self.assertEqual(sorted(p.name for p in config.WORKSPACES_DIR.iterdir()), before)
 
     def test_a_persona_switch_is_untouched(self):
@@ -180,12 +194,12 @@ class TheChatsItLeftBehindCanStillSeeIt(PersonaIso, unittest.TestCase):
         self.assertEqual(chats.of_workspace("gamma"), ["gamma.1"])
 
 
-class TheDoorwaySaysSoBeforeTheKeypress(PersonaIso, unittest.TestCase):
-    """Task 4's rule, inherited whole: a refusal the palette can see BEFORE the keypress
-    is drawn on the row, so the operator is not offered a list of moves that would not
-    happen. `choose.pin_reason` is where that lives and this is one more reason arriving
-    through it — the same shape a pinned frame and a workspace with no changes already
-    have, rather than a new mechanism beside them."""
+class TheDoorwayOpensAgainAndStillMovesNoChat(PersonaIso, unittest.TestCase):
+    """Task 4's rule, and the direction §4b turns it: a refusal the palette can see BEFORE
+    the keypress is drawn on the row, so the operator is not offered a list of moves that
+    would not happen — and a workspace picker is no longer such a list. #789 closed this
+    doorway on every frame, which was the visible half of the bar's fifteen dead rows.
+    What is asserted here is that it opens and that opening it re-points nothing."""
 
     FID = "alpha.1"
 
@@ -196,19 +210,29 @@ class TheDoorwaySaysSoBeforeTheKeypress(PersonaIso, unittest.TestCase):
             (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
         _plant(self.FID, ws="alpha")
 
-    def test_the_workspace_doorway_carries_the_reason_the_keypress_would_give(self):
-        """One sentence, read once — `switch.to_workspace` and the row cannot describe
-        one frame two ways, which is the rule the pin reason was built to keep."""
-        self.assertEqual(choose.pin_reason(choose.WORKSPACE, self.FID),
-                         switch.to_workspace(self.FID, "gamma").message)
+    def test_the_workspace_doorway_carries_no_reason_at_all(self):
+        """`""` is what `pin_reason` answers when the picker is worth opening, and a
+        workspace picker now always is: the names behind it are names a client can be
+        moved to. The one refusal a row can still earn is a live tmux reading and is
+        deliberately not taken here — see `choose.pin_reason`."""
+        self.assertEqual(choose.pin_reason(choose.WORKSPACE, self.FID), "")
 
-    def test_the_row_is_marked_refused_so_it_opens_no_picker(self):
+    def test_the_row_opens_a_picker_rather_than_a_sentence(self):
         """#732: a doorway with a reason is one `commands_frame._picker` will not open,
-        and `refused` is the field that says so rather than the note being parsed."""
+        and `refused` is the field that says so rather than the note being parsed. Both
+        halves are asserted, because either alone can be right by accident."""
         row = next(r for r in choose.open_rows(self.FID)
                    if choose.noun_of(r) == choose.WORKSPACE)
-        self.assertTrue(row.refused)
-        self.assertEqual(row.note, switch.FOR_LIFE)
+        self.assertFalse(row.refused)
+        self.assertEqual(row.note, "")
+
+    def test_pressing_a_name_still_leaves_this_chat_in_its_own_workspace(self):
+        """The doorway opening is only safe because what is behind it moves a client, so
+        the invariant is re-asserted at the surface that reopened — the palette's own
+        dispatch (`choose.switch_to`), not `switch.to_workspace` directly."""
+        out = choose.switch_to(choose.WORKSPACE, self.FID, "gamma")
+        self.assertTrue(out.ok, out.message)
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
 
     def test_the_other_three_doorways_are_untouched(self):
         """One noun, not four. A chat switch moves the client and leaves every chat where
@@ -218,13 +242,16 @@ class TheDoorwaySaysSoBeforeTheKeypress(PersonaIso, unittest.TestCase):
         self.assertEqual(choose.pin_reason(choose.PERSONA, self.FID), "")
         self.assertEqual(choose.pin_reason(choose.CHAT, self.FID), "")
 
-    def test_the_names_are_still_listed_with_the_reason_beside_them(self):
-        """`_name_rows`' own rule, and it is not softened here: a name the operator has
-        already typed is a question they asked, so the workspaces are still rows — they
-        carry the reason and refuse when pressed, rather than vanishing from the palette
-        and leaving the query answered with an empty pane (#512)."""
+    def test_the_names_are_listed_and_pressable(self):
+        """`_name_rows`' own rule: a name the operator has already typed is a question
+        they asked, so the workspaces are rows. Under #789 every one of them carried a
+        refusal; under §4b none of them does, and a row that still did would be the bar's
+        dead listing arriving through the palette instead. With no reason the note is the
+        KIND rather than empty — `choose.labelled`'s own rule, and the field that says
+        "unavailable" is `refused`."""
         self.assertIn("gamma", choose.names_of(choose.WORKSPACE, self.FID))
         rows = choose.labelled(choose.roster(choose.WORKSPACE, self.FID),
                                choose.pin_reason(choose.WORKSPACE, self.FID))
         self.assertTrue(rows)
-        self.assertTrue(all(r.refused and r.note == switch.FOR_LIFE for r in rows))
+        self.assertTrue(all(not r.refused and r.note == choose.WORKSPACE
+                            for r in rows))

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -50,12 +50,25 @@ import unittest
 from pathlib import Path
 
 from charter import commands_frame, config
-from charter.frame import layout, state, switch, tmuxctl
+from charter.frame import layout, state, tmuxctl
 
 from tests import _tmuxreap
 from tests._isolation import PersonaIso, make_plane
 
 _HAS_TMUX = shutil.which("tmux") is not None
+
+
+def _NOT_OPEN(ws: str) -> str:
+    """What `commands_frame._switch_client` says for a workspace with no session on this
+    server — the answer every click in this module gets, because a test fixture builds one
+    workspace session and clicks the tab of another.
+
+    Spelled here rather than imported, deliberately: it is the operator-visible sentence
+    and this module's whole subject is that a click PRODUCES one. A constant read out of
+    the module under test would follow a reworded sentence silently, and the wording is
+    the thing. It carries the name, so a click that landed on the wrong tab fails here.
+    """
+    return f"workspace '{ws}' is not open on this plane"
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -144,11 +157,14 @@ class _ARealFrameWithBars(PersonaIso):
         self.env = dict(os.environ, CHARTER_ROOT=str(self.plane),
                         PYTHONPATH=os.pathsep.join(parts))
         self.env.pop("CHARTER_HOME", None)
-        # **`$CHARTER_WORKSPACE` is deliberately absent from the pane environment.** It is
-        # a PIN: `switch.to_workspace` refuses outright when the launch carried one,
-        # because that value sits in every panel pane's process environment and no file
-        # charter writes can take it out. A fixture that set it would make every case here
-        # measure the refusal.
+        # **`$CHARTER_WORKSPACE` is deliberately absent from the pane environment.** It
+        # is a PIN on which workspace this CHAT is in (`state.own_workspace`'s first rung),
+        # and a fixture that set it would be answering half of every case here for
+        # charter: `switch.current_workspace` would come back from the environment rather
+        # than from the record the launcher wrote, so the "already in this workspace"
+        # refusal would fire on a name the test never chose. It no longer refuses a switch
+        # (§4b — a client moves and the chat does not), which is why this comment is about
+        # the fixture rather than about a refusal.
         self.env.pop("CHARTER_WORKSPACE", None)
 
     def _tmux(self, *args: str, env=None) -> subprocess.CompletedProcess:
@@ -365,31 +381,38 @@ class ARealClickOnTheWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
                          "the harness is not the active pane, so a report reaching the "
                          "bar would prove nothing about `[frame] mouse`")
 
-    def test_clicking_a_tab_reaches_the_switch_and_the_refusal_comes_back(self):
-        """The report, answered end to end — and since §4j the answer is a sentence rather
-        than a move: a chat belongs to its workspace for life.
+    def test_clicking_a_tab_reaches_the_switch_and_the_answer_comes_back(self):
+        """The report, answered end to end.
 
-        **The observable had to change and the chain did not.** This used to await
-        `state.frame_workspace(fid) == THERE`, which is the write §4j removed, so keeping
-        it would have measured nothing this file exists for. `state.notice` is the other
-        end of the same three processes — the panel decodes the click, spawns `charter
-        frame-switch --workspace <name>`, and that child writes the outcome to the frame's
-        attention row — so a sentence arriving there proves the click reached the switch
-        exactly as a moved record used to.
+        **The observable has changed twice and the chain has not.** It was
+        `state.frame_workspace(fid) == THERE` until §4j removed that write, then
+        `switch.FOR_LIFE` while #789 refused every tab. Under §4b the answer names the
+        workspace that was clicked: `THERE` exists on this plane and has no tmux session
+        on this test's server, so the switch has nowhere to move the client and says so.
+        That is a strictly stronger reading than the constant it replaces — it proves the
+        NAME reached the child, which `FOR_LIFE` interpolated nothing to prove.
+
+        `state.notice` is the other end of the same three processes — the panel decodes
+        the click, spawns `charter frame-switch --workspace <name>`, and that child writes
+        the outcome to the frame's attention row.
+
+        A switch that actually lands a client in another workspace needs a second live
+        workspace session and is measured in
+        `tests/test_a_workspace_switch_moves_the_client.py`.
         """
         self._click(self.bar, col=self._column_of(self.bar, f" {self.THERE}"))
         self.assertTrue(
-            _await(lambda: switch.FOR_LIFE in state.notice(self.fid)),
+            _await(lambda: _NOT_OPEN(self.THERE) in state.notice(self.fid)),
             f"the click never reached the switch: notice is "
             f"{state.notice(self.fid)!r}")
         self.assertEqual(state.frame_workspace(self.fid), self.HERE,
-                         "the refusal moved the chat anyway")
+                         "the switch moved the chat anyway")
 
     def test_the_bar_repaints_and_the_mark_stays_where_the_chat_is(self):
         """The switch ends in a `state.bump` — the version this panel's poll was already
         watching — so the bar redraws without a repaint of this test's own. What it
-        redraws is the same mark: the frame did not move, and a bar that showed it moving
-        would be the lie §4j is about.
+        redraws is the same mark: the bar marks the workspace this CHAT is in
+        (`switch.current_workspace`), and no switch moves that.
 
         Was `test_the_bar_repaints_with_the_mark_on_the_workspace_it_moved_to`.
         """
@@ -407,7 +430,7 @@ class ARealClickOnTheWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
         your prompt is not a tab an operator will click twice."""
         self._click(self.bar, col=self._column_of(self.bar, f" {self.THERE}"))
         self.assertTrue(_await(
-            lambda: switch.FOR_LIFE in state.notice(self.fid)))
+            lambda: _NOT_OPEN(self.THERE) in state.notice(self.fid)))
         self.assertEqual(self._active(), self.harness,
                          "clicking the workspace bar moved the keyboard off the harness")
 
@@ -631,15 +654,16 @@ class ARealClickOnAWINDOWEDWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
         row was `workspaces  *harness-wrapper  +14` and this click had nothing to land
         on.
 
-        What comes back is §4j's sentence rather than a move — see
-        `ARealClickOnTheWorkspaceBarMovesTheFrame` for why the observable moved from the
-        frame's record to its attention row. The column arithmetic this class exists for
-        is untouched: a click that landed on the wrong cell, or on none, produces no
-        notice at all.
+        What comes back names the workspace that was clicked — see
+        `ARealClickOnTheWorkspaceBarMovesTheFrame` for why the observable is the attention
+        row rather than the frame's record. The column arithmetic this class exists for is
+        untouched: a click that landed on the wrong cell, or on none, produces no notice at
+        all — and one that landed on the wrong TAB now names the wrong workspace, which
+        this assertion would catch and the old constant could not.
         """
         self._click(self.bar, col=self._column_of(self.bar, f" {self.THERE}"))
         self.assertTrue(
-            _await(lambda: switch.FOR_LIFE in state.notice(self.fid)),
+            _await(lambda: _NOT_OPEN(self.THERE) in state.notice(self.fid)),
             f"the click never reached the switch: {state.notice(self.fid)!r} — "
             f"row {self._bar_row(self.bar)!r}")
 
@@ -650,16 +674,16 @@ class ARealClickOnAWINDOWEDWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
         tab it did the first time.
 
         A window centred on the marked name would have slid one step here, putting a third
-        workspace under that cell. §4j makes that harder to observe, not less true: the
-        mark no longer moves, so what is asserted is that the page is identical and that
-        the second press produces the same answer as the first rather than acting on a
-        name that arrived under the pointer.
+        workspace under that cell. The mark does not move — it marks the workspace this
+        chat is in — so what is asserted is that the page is identical and that the second
+        press produces the same answer as the first rather than acting on a name that
+        arrived under the pointer.
         """
         before = self._bar_row(self.bar)
         col = self._column_of(self.bar, f" {self.THERE}")
         self._click(self.bar, col=col)
         self.assertTrue(
-            _await(lambda: switch.FOR_LIFE in state.notice(self.fid)),
+            _await(lambda: _NOT_OPEN(self.THERE) in state.notice(self.fid)),
             "the first click never reached the switch, so there is nothing to measure")
         after = self._bar_row(self.bar)
         self.assertEqual([n for n in self.NAMES if n in after],

--- a/tests/test_a_second_launch_focuses_instead_of_dragging.py
+++ b/tests/test_a_second_launch_focuses_instead_of_dragging.py
@@ -86,6 +86,23 @@ def _completed(argv, rc=0, out="", err=""):
     return subprocess.CompletedProcess(argv, rc, stdout=out, stderr=err)
 
 
+#: "the plane this test is standing in", resolved when the row is built rather than when
+#: the module is imported — `config.STATE_DIR` is re-pointed per test by `PersonaIso` and
+#: per plane by `_plane`, which is the whole point of both.
+_MINE = object()
+
+
+def _seat(session: str, pane: str, plane=_MINE) -> str:
+    """One `commands_frame._PANE_SEAT_FORMAT` row, in tmux's own spelling.
+
+    *plane* is `_MINE` for a session this plane's launcher marked (what every launch
+    writes since §4b), ``None`` for one an older charter created and left unmarked, and a
+    string for another plane's.
+    """
+    marker = str(config.STATE_DIR) if plane is _MINE else (plane or "")
+    return f"{session}\t{pane}\t{marker}"
+
+
 class _FakeServer:
     """The three answers a focus decision reads, and a record of everything it asked.
 
@@ -159,7 +176,7 @@ class TheFocusDecision(PersonaIso, unittest.TestCase):
         """The ordinary first launch, and the property that keeps this free: with no chat
         directory there is nothing to compare against, so the decision is made on disk and
         the server is never asked anything."""
-        fake = _FakeServer(panes=["$0\t%0"], clients=["/dev/ttys001"])
+        fake = _FakeServer(panes=[_seat("$0", "%0")], clients=["/dev/ttys001"])
         self.assertIsNone(self._decide(fake))
         self.assertEqual(fake.calls, [])
 
@@ -168,7 +185,7 @@ class TheFocusDecision(PersonaIso, unittest.TestCase):
         that could identify it on the server — a chat id would, and a chat id is exactly
         what two planes can both hold (§3.3)."""
         _a_chat("shared.1", ws=SHARED, pane=None)
-        fake = _FakeServer(panes=["$0\t%0"], clients=["/dev/ttys001"])
+        fake = _FakeServer(panes=[_seat("$0", "%0")], clients=["/dev/ttys001"])
         self.assertIsNone(self._decide(fake))
         self.assertEqual(fake.calls, [])
 
@@ -176,7 +193,8 @@ class TheFocusDecision(PersonaIso, unittest.TestCase):
         """Every chat of this workspace is cold. There is nothing to focus, and the
         second question is not worth a subprocess."""
         _a_chat("shared.1", ws=SHARED, pane="%4")
-        fake = _FakeServer(panes=["$0\t%0", "$1\t%2"], clients=["/dev/ttys001"])
+        fake = _FakeServer(panes=[_seat("$0", "%0"), _seat("$1", "%2")],
+                           clients=["/dev/ttys001"])
         self.assertIsNone(self._decide(fake))
         self.assertEqual(fake.asked("list-panes"), 1)
         self.assertEqual(fake.asked("list-clients"), 0)
@@ -186,20 +204,20 @@ class TheFocusDecision(PersonaIso, unittest.TestCase):
         makes: with no client on the session there is nobody to drag, so the chat is
         added and selected exactly as it shipped."""
         _a_chat("shared.1", ws=SHARED, pane="%0")
-        fake = _FakeServer(panes=["$0\t%0"], clients=[])
+        fake = _FakeServer(panes=[_seat("$0", "%0")], clients=[])
         self.assertIsNone(self._decide(fake))
         self.assertEqual(fake.asked("list-clients"), 1)
 
     def test_a_live_workspace_somebody_is_looking_at_is_focused(self):
         _a_chat("shared.1", ws=SHARED, pane="%0")
-        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"])
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients=["/dev/ttys001"])
         self.assertEqual(self._decide(fake), ("$3", "shared.1"))
 
     def test_the_session_is_targeted_by_its_id_and_never_by_its_name(self):
         """#693's rule, and here it is the correctness argument rather than a convenience:
         a session NAME is a name every plane on the machine may have."""
         _a_chat("shared.1", ws=SHARED, pane="%0")
-        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"])
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients=["/dev/ttys001"])
         self._decide(fake)
         self.assertEqual(fake.clients_target, "$3")
 
@@ -207,7 +225,7 @@ class TheFocusDecision(PersonaIso, unittest.TestCase):
         """`chats.of_workspace` reads each directory's own `workspace` file, so a live
         chat of a DIFFERENT workspace on this same plane focuses nothing."""
         _a_chat("elsewhere.1", ws="elsewhere", pane="%0")
-        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"])
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients=["/dev/ttys001"])
         self.assertIsNone(self._decide(fake))
         self.assertEqual(fake.calls, [])
 
@@ -222,7 +240,7 @@ class TheFocusDecision(PersonaIso, unittest.TestCase):
         open a chat and select it. Pins `.split()`, which is what asks "is there a client"
         in a form a test can go red on (see the comment at the line)."""
         _a_chat("shared.1", ws=SHARED, pane="%0")
-        fake = _FakeServer(panes=["$3\t%0"], clients=["", "   "])
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients=["", "   "])
         self.assertIsNone(self._decide(fake))
 
     def test_a_server_that_will_not_list_that_sessions_clients_focuses_nothing(self):
@@ -230,7 +248,8 @@ class TheFocusDecision(PersonaIso, unittest.TestCase):
         launch that cannot tell whether anybody is there opens its own chat, which is the
         behaviour that shipped."""
         _a_chat("shared.1", ws=SHARED, pane="%0")
-        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"], clients_rc=1)
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients=["/dev/ttys001"],
+                           clients_rc=1)
         self.assertIsNone(self._decide(fake))
 
     def test_a_row_with_too_few_fields_is_not_read_as_a_pane(self):
@@ -245,7 +264,7 @@ class TheFocusDecision(PersonaIso, unittest.TestCase):
         different servers: a row that is short raises where a row that is long merely
         lies, and only the second can be mistaken for a match."""
         _a_chat("shared.1", ws=SHARED, pane="%0")
-        fake = _FakeServer(panes=["$3\t%0\textra"], clients=["/dev/ttys001"])
+        fake = _FakeServer(panes=[_seat("$3", "%0") + "\textra"], clients=["/dev/ttys001"])
         self.assertIsNone(self._decide(fake))
 
     def test_a_server_that_cannot_be_listed_is_not_reported_on_every_launch(self):
@@ -262,7 +281,7 @@ class TheFocusDecision(PersonaIso, unittest.TestCase):
 
     def test_a_session_whose_clients_cannot_be_listed_is_not_reported_either(self):
         _a_chat("shared.1", ws=SHARED, pane="%0")
-        fake = _FakeServer(panes=["$3\t%0"], clients_rc=1)
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients_rc=1)
         said = io.StringIO()
         with redirect_stderr(said):
             self.assertIsNone(self._decide(fake))
@@ -273,7 +292,7 @@ class TheFocusDecision(PersonaIso, unittest.TestCase):
         a state file holding something that is not a pane id is refused by the comparison
         itself rather than by a shape check that could never fire."""
         _a_chat("shared.1", ws=SHARED, pane="; kill-server")
-        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"])
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients=["/dev/ttys001"])
         self.assertIsNone(self._decide(fake))
 
 
@@ -330,7 +349,7 @@ class TheLaunchTakesTheDecision(PersonaIso, unittest.TestCase):
 
     def test_a_focused_launch_attaches_by_session_id_and_returns_zero(self):
         _a_chat("shared.1", ws=SHARED, pane="%0")
-        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"],
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients=["/dev/ttys001"],
                            sessions=[SHARED], chats=["shared.1"])
         self.assertEqual(self._launch(fake), 0)
         attaches = [c for c in fake.calls if "attach" in c]
@@ -343,7 +362,7 @@ class TheLaunchTakesTheDecision(PersonaIso, unittest.TestCase):
         the operator detaches a second later."""
         _a_chat("shared.1", ws=SHARED, pane="%0")
         before = sorted(p.name for p in (config.STATE_DIR / "frame").iterdir())
-        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"],
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients=["/dev/ttys001"],
                            sessions=[SHARED], chats=["shared.1"])
         self._launch(fake)
         after = sorted(p.name for p in (config.STATE_DIR / "frame").iterdir())
@@ -353,7 +372,7 @@ class TheLaunchTakesTheDecision(PersonaIso, unittest.TestCase):
         """`new-window` plus `select-window` IS the drag (§2.3). A focus must issue
         neither — that is the whole of what makes it not one."""
         _a_chat("shared.1", ws=SHARED, pane="%0")
-        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"],
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients=["/dev/ttys001"],
                            sessions=[SHARED], chats=["shared.1"])
         self._launch(fake)
         for verb in ("new-window", "new-session", "select-window", "split-window"):
@@ -363,7 +382,7 @@ class TheLaunchTakesTheDecision(PersonaIso, unittest.TestCase):
         """The negative control, and it must be a launch that could have focused: same
         plane, same workspace, same live session — only nobody attached."""
         _a_chat("shared.1", ws=SHARED, pane="%0")
-        fake = _FakeServer(panes=["$3\t%0"], clients=[],
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients=[],
                            sessions=[SHARED], chats=["shared.1"])
         with mock.patch("charter.commands_frame._spawn_gather"):
             self._launch(fake)
@@ -375,7 +394,7 @@ class TheLaunchTakesTheDecision(PersonaIso, unittest.TestCase):
         the operator typed. Same workspace, same live session, same attached client — the
         only difference is that this launch named something to RUN."""
         _a_chat("shared.1", ws=SHARED, pane="%0")
-        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"],
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients=["/dev/ttys001"],
                            sessions=[SHARED], chats=["shared.1"])
         with mock.patch("charter.commands_frame._spawn_gather"):
             self._launch(fake, harness=None, rest=["--", "htop"])
@@ -386,7 +405,7 @@ class TheLaunchTakesTheDecision(PersonaIso, unittest.TestCase):
         """`charter claude --resume <id>` is the same fact one harness over: `rest` is the
         operator's own flags, `launch_argv` carries them, and a focus would drop them."""
         _a_chat("shared.1", ws=SHARED, pane="%0")
-        fake = _FakeServer(panes=["$3\t%0"], clients=["/dev/ttys001"],
+        fake = _FakeServer(panes=[_seat("$3", "%0")], clients=["/dev/ttys001"],
                            sessions=[SHARED], chats=["shared.1"])
         with mock.patch("charter.commands_frame._spawn_gather"):
             self._launch(fake, rest=["--resume", "abc123"])
@@ -403,7 +422,7 @@ class TheLaunchTakesTheDecision(PersonaIso, unittest.TestCase):
                     return _completed(cmd, 3)
                 return super().__call__(cmd, **kwargs)
 
-        fake = _RefusesToAttach(panes=["$3\t%0"], clients=["/dev/ttys001"],
+        fake = _RefusesToAttach(panes=[_seat("$3", "%0")], clients=["/dev/ttys001"],
                                sessions=[SHARED], chats=["shared.1"])
         self.assertEqual(self._launch(fake), 3)
 

--- a/tests/test_a_workspace_switch_moves_the_client.py
+++ b/tests/test_a_workspace_switch_moves_the_client.py
@@ -46,7 +46,7 @@ from unittest import mock
 
 from charter import commands_frame, config, workspace
 from charter.frame import chats, state, switch
-from tests import _tmuxreap
+from tests import _tmuxreap, _tmuxsocket
 from tests._isolation import PersonaIso
 
 _HAS_TMUX = shutil.which("tmux") is not None
@@ -332,7 +332,11 @@ class TheSwitchItself(PersonaIso, unittest.TestCase):
         were already in, whatever workspace it names, so there is no session for another
         workspace to be — and both things `switch-client` could do there are wrong. This
         is asked FIRST, before any reading, because it is about what this frame IS."""
-        state.record_server(self.FID, "/tmp/tmux-1000/default")
+        # `_tmuxsocket.OPERATOR_SOCKET` and never a spelled path (#601): a socket path
+        # with a literal uid in it is one developer's machine written into the suite. What
+        # `is_operator_socket` reads is the leading slash, and this is the real thing tmux
+        # would hand this machine.
+        state.record_server(self.FID, _tmuxsocket.OPERATOR_SOCKET)
         s = self._switch(self._ordinary())
         self.assertEqual(s.calls, [], "a guest frame asked the server anything at all")
         self.laid_out.assert_not_called()

--- a/tests/test_a_workspace_switch_moves_the_client.py
+++ b/tests/test_a_workspace_switch_moves_the_client.py
@@ -326,6 +326,20 @@ class TheSwitchItself(PersonaIso, unittest.TestCase):
         self.laid_out.assert_not_called()
         self.assertIn("no terminal is attached", self.said.call_args[0][1])
 
+    def test_a_frame_inside_the_operators_own_tmux_is_refused_by_name(self):
+        """**A workspace is a tmux session only on charter's own server** (§2.1). Inside
+        an operator's tmux every chat charter opens is a `new-window` in the session they
+        were already in, whatever workspace it names, so there is no session for another
+        workspace to be — and both things `switch-client` could do there are wrong. This
+        is asked FIRST, before any reading, because it is about what this frame IS."""
+        state.record_server(self.FID, "/tmp/tmux-1000/default")
+        s = self._switch(self._ordinary())
+        self.assertEqual(s.calls, [], "a guest frame asked the server anything at all")
+        self.laid_out.assert_not_called()
+        said = self.said.call_args[0][1]
+        self.assertIn("a window in your own tmux", said)
+        self.assertIn("charter <harness> --workspace beta", said)
+
     def test_a_chat_whose_own_window_cannot_be_found_refuses_before_anything_moves(self):
         """`cmd_chat`'s own sentence for its own reason: with no reading of where this
         client is standing there is no way to tell afterwards whether it moved, and a

--- a/tests/test_a_workspace_switch_moves_the_client.py
+++ b/tests/test_a_workspace_switch_moves_the_client.py
@@ -1,0 +1,737 @@
+"""§4b: switching workspace moves the CLIENT, kills nothing, and never leaves this plane.
+
+The operator's own requirement, which is the whole specification:
+
+> switching workspace — it means keep opened chat opened in background, so user can
+> simultaneously run many harnesses in one charter environment. Changing workspace or
+> changing sessions does not mean stopping old chat session. User can manually close or
+> stop session.
+
+**Three things had to be true and each has its own class here.**
+
+* **The switch happens at all.** #789 made `switch.to_workspace` an unconditional refusal
+  — correct about §4j, and it left the `workspaces` bar a fifteen-row listing where every
+  tab refused. :class:`TheSwitchDecision` and :class:`TheSwitchItself` are the two halves
+  of what replaces it.
+* **It cannot cross planes.** `commands_frame.SOCKET` is one tmux server per MACHINE, not
+  per plane: measured on the operator's own socket while this was written, eleven sessions
+  from three different projects, and `default` — a name every plane has whether anybody
+  chose it or not — among them. A `switch-client -t default` decided on a name can put an
+  operator in another project's frame, across every isolation boundary charter has.
+  :class:`TwoPlanesOnOneMachine` is that arrangement on a real server, and it is the only
+  class here that two planes are needed for — a single-plane test is structurally blind to
+  it.
+* **It kills nothing.** :class:`ARealSwitchOnARealServer` moves a real client between two
+  real workspace sessions and reads back every pane's pid.
+
+**The plane marker and the pane record are two mechanisms and each covers the other's
+gap**, which is why both are measured: a session an older charter created carries no
+`@charter_plane`, so an absent marker decides nothing and the pane records still answer;
+a pane id recorded for a chat that is over can name another plane's live pane after a
+`kill-server`, and the marker refuses that.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import pty
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import commands_frame, config, workspace
+from charter.frame import chats, state, switch
+from tests import _tmuxreap
+from tests._isolation import PersonaIso
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: This module's own server, unique per test PROCESS — `tests/_tmuxreap.py`'s namespace,
+#: so a run the deletion sweep kills mid-flight is recognised and collected by the next
+#: one rather than left running for days.
+SOCKET = _tmuxreap.name("ws-switch")
+
+#: The FALLBACK path for :data:`SOCKET`'s file. tmux is the authority on its own socket
+#: path and the teardown asks it; this copy of tmux's rule is spent only on the teardown
+#: that has no server left to ask, and nothing is ever asserted about it.
+SOCKET_PATH = os.path.join(os.environ.get("TMUX_TMPDIR") or "/tmp",
+                           f"tmux-{os.getuid()}", SOCKET)
+
+#: The workspace name BOTH planes have. Any shared name reproduces the collision;
+#: `shared` is spelled out rather than `default` so a reader is not left wondering whether
+#: the fallback name is doing something special. It is not — every name is shared.
+SHARED = "shared"
+
+_DEADLINE = 20.0
+
+_TERM_CANDIDATES = tuple(dict.fromkeys(
+    ([os.environ["TERM"]] if os.environ.get("TERM", "dumb") != "dumb" else [])
+    + ["xterm-256color", "screen", "vt100"]))
+
+
+def _completed(argv, rc=0, out="", err=""):
+    return subprocess.CompletedProcess(argv, rc, stdout=out, stderr=err)
+
+
+#: "the plane this test is standing in", resolved when the row is built rather than when
+#: the module is imported — `config.STATE_DIR` is re-pointed per test by `PersonaIso` and
+#: per plane by `_plane`, which is the whole point of both.
+_MINE = object()
+
+
+def _seat(session: str, pane: str, plane=_MINE) -> str:
+    """One `commands_frame._PANE_SEAT_FORMAT` row, in tmux's own spelling.
+
+    *plane* is `_MINE` for a session this plane's launcher marked, ``None`` for one an
+    older charter created and left unmarked, and a string for another plane's.
+    """
+    marker = str(config.STATE_DIR) if plane is _MINE else (plane or "")
+    return f"{session}\t{pane}\t{marker}"
+
+
+def _a_chat(fid: str, *, ws: str, pane: str | None,
+            server: str = commands_frame.SOCKET) -> None:
+    """A chat directory on THIS plane, in the shape a launcher leaves one."""
+    state.frame_dir(fid, create=True)
+    state.record_workspace(fid, ws)
+    state.record_server(fid, server)
+    if pane is not None:
+        state.record_harness_pane(fid, pane)
+
+
+class TheSwitchDecision(PersonaIso, unittest.TestCase):
+    """`switch.to_workspace` — which names a client may be aimed at, decided with no
+    server in the room.
+
+    `frame/switch.py` makes no tmux call at all, which is what lets the palette ask it on
+    its own open and a panel ask it on a repaint. What it therefore cannot answer is
+    whether that workspace is *open*, and :class:`TheSwitchItself` is where that lives.
+    """
+
+    FID = "alpha.1"
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        for n in ("alpha", "beta"):
+            (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
+        _a_chat(self.FID, ws="alpha", pane="%1")
+
+    def test_another_workspace_of_this_plane_is_a_yes(self):
+        self.assertTrue(switch.to_workspace(self.FID, "beta").ok)
+
+    def test_the_sentence_names_the_workspace_the_operator_is_going_to(self):
+        """It is said on the chat the switch LANDS on, by `_switch_client`, so it has to
+        make sense read there — beside a harness in a workspace the operator has just
+        arrived in, not beside the one they left."""
+        self.assertEqual(switch.to_workspace(self.FID, "beta").message,
+                         "workspace → beta")
+
+    def test_nothing_at_all_is_written(self):
+        """The whole function is a decision. A write here would be #411's shape — an
+        outcome computed for one noun and performed on another — and there are two rungs
+        to lose: the per-session pointer under the chat's id and the launch record."""
+        was = state.version(self.FID)
+        switch.to_workspace(self.FID, "beta")
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+        self.assertIsNone(workspace.for_session(self.FID))
+        self.assertEqual(state.version(self.FID), was)
+
+
+class TheSwitchItself(PersonaIso, unittest.TestCase):
+    """`commands_frame._switch_client` — the tmux half, against a fake server.
+
+    Deliberately not a real tmux: what a fake can show and a server cannot is **which
+    questions were asked, in which order, and which were not asked at all** — and the
+    refusals here are all about a reading charter took before it moved anything.
+    :class:`ARealSwitchOnARealServer` is the other half of the pair.
+    """
+
+    FID = "alpha.1"
+    HERE = "$1"
+    THERE = "$2"
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        for n in ("alpha", "beta"):
+            (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
+        _a_chat(self.FID, ws="alpha", pane="%1")
+        _a_chat("beta.1", ws="beta", pane="%2")
+        self.said = self.enterContext(
+            mock.patch.object(commands_frame, "_say_on_screen"))
+        self.laid_out = self.enterContext(
+            mock.patch.object(commands_frame, "_apply_arrangement"))
+        self.enterContext(mock.patch.object(
+            commands_frame, "_relayout_target",
+            side_effect=lambda fid: (commands_frame.SOCKET, "%9", (3, 7))))
+
+    class _Server:
+        """The four answers a switch reads, and a record of everything it asked."""
+
+        def __init__(self, *, place="$1\t@1", panes=(), here=(), there=(),
+                     landing=(), switch_rc=0):
+            self.place = place
+            self.panes = list(panes)
+            #: `list-clients -t` answers, keyed by the session id asked about.
+            self.clients = {"$1": list(here), "$2": list(there)}
+            self.landing = list(landing)
+            self.switch_rc = switch_rc
+            self.calls: list[list[str]] = []
+            self.switched: list[tuple[str, str]] = []
+
+        @staticmethod
+        def _lines(rows) -> str:
+            return "".join(f"{r}\n" for r in rows)
+
+        def __call__(self, cmd, **kwargs):
+            self.calls.append(list(cmd))
+            if "display-message" in cmd:
+                return _completed(cmd, 0, self.place)
+            if "list-panes" in cmd:
+                return _completed(cmd, 0, self._lines(self.panes))
+            if "list-clients" in cmd:
+                target = cmd[cmd.index("-t") + 1]
+                # After the switch, the clients that moved are on the target — modelled
+                # by answering the target's list from what the switches recorded, which
+                # is what makes the "did it move" reading a real reading here.
+                rows = list(self.clients.get(target, []))
+                rows += [c for c, t in self.switched if t == target]
+                return _completed(cmd, 0, self._lines(rows))
+            if "list-windows" in cmd:
+                return _completed(cmd, 0, self._lines(self.landing))
+            if "switch-client" in cmd:
+                # Recorded only when tmux took it, which is what makes `switch_rc=1` a
+                # server that refused rather than a fake that lies about itself: the
+                # client list below is built from these, so a refused switch leaves the
+                # target's list exactly as it was.
+                if self.switch_rc == 0:
+                    self.switched.append((cmd[cmd.index("-c") + 1],
+                                          cmd[cmd.index("-t") + 1]))
+                return _completed(cmd, self.switch_rc)
+            return _completed(cmd, 0)
+
+        def asked(self, verb: str) -> int:
+            return sum(1 for c in self.calls if verb in c)
+
+    def _switch(self, server, ws="beta", said="workspace → beta"):
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=server):
+            commands_frame._switch_client(self.FID, ws, said=said)
+        return server
+
+    def _ordinary(self, **kw):
+        """A server where everything is in place: this chat's pane in `$1` with one
+        client on it, `beta.1`'s pane in `$2`, and `$2`'s current window drawing
+        `beta.1`."""
+        opts = dict(place="$1\t@1", panes=[_seat("$1", "%1"), _seat("$2", "%2")],
+                    here=["/dev/ttys001"], landing=["$2\t1\tbeta.1"])
+        opts.update(kw)
+        return self._Server(**opts)
+
+    # -- the switch ---------------------------------------------------------------------
+
+    def test_every_client_on_this_session_is_moved_by_name_to_the_target_session(self):
+        """`-c <client>` and `-t <session id>`, and both halves matter. Without `-c` tmux
+        picks its own current client, which on a socket serving eleven sessions from three
+        projects is very likely somebody else's terminal; a session NAME as the target is
+        the cross-plane collision this whole feature is built around."""
+        s = self._switch(self._ordinary(here=["/dev/ttys001", "/dev/ttys002"]))
+        self.assertEqual(s.switched, [("/dev/ttys001", "$2"), ("/dev/ttys002", "$2")])
+
+    def test_the_chat_left_behind_loses_its_panels_and_keeps_everything_else(self):
+        """#686's rule, one scope out: a background window keeps stale geometry, so panels
+        left running in one are rendering at a width that is no longer their window's.
+        Nothing else about the chat is touched — the harness keeps running, which is the
+        operator's requirement in one sentence."""
+        self._switch(self._ordinary())
+        left = [c for c in self.laid_out.call_args_list if c[0][0] == self.FID]
+        self.assertEqual(len(left), 1)
+        self.assertEqual(left[0][1]["want"], [])
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+
+    def test_the_chat_landed_on_is_re_dressed_unconditionally(self):
+        """§4b: *"a workspace switched back into must be re-dressed unconditionally,
+        exactly as #686 now does for chats."* The panels there were torn down when that
+        workspace went to the background, so they have to be split into the window tmux
+        has just resized — there is no "has the geometry changed" question to ask."""
+        self._switch(self._ordinary())
+        arrived = [c for c in self.laid_out.call_args_list if c[0][0] == "beta.1"]
+        self.assertEqual(len(arrived), 1)
+        self.assertTrue(arrived[0][1]["want"])
+
+    def test_which_chat_it_landed_on_is_read_off_the_server_and_never_guessed(self):
+        """`switch-client` restores the target session's own last active window, which is
+        not the seat `_plane_session` happened to match. Two chats in `beta`, the SECOND
+        of them current: dressing the first would leave the operator looking at bare
+        panes and re-laying-out a window nobody is in."""
+        _a_chat("beta.2", ws="beta", pane="%3")
+        self._switch(self._ordinary(landing=["$2\t0\tbeta.1", "$2\t1\tbeta.2"]))
+        self.assertEqual([c[0][0] for c in self.laid_out.call_args_list],
+                         [self.FID, "beta.2"])
+
+    def test_the_outcome_is_said_on_the_chat_the_operator_landed_on(self):
+        """A notice is drawn by a panel out of a frame's own state, so it has to be
+        written to the frame the operator will be reading. Said on `alpha.1` it would go
+        into panels this switch has just torn down."""
+        self._switch(self._ordinary())
+        self.said.assert_called_once_with("beta.1", "workspace → beta", ok=True)
+
+    # -- the refusals, and what each one leaves standing ---------------------------------
+
+    def test_a_workspace_with_no_session_is_refused_and_nothing_is_launched(self):
+        """**What a workspace nobody has opened is answered with.** Opening one is
+        `cmd_launch` — a directory, an ordinal, a harness and an `attach` — and this runs
+        detached with its streams on `/dev/null`, with no terminal to attach anything to.
+        `switch.py`'s standing rule is the same one (#518), so the refusal names the
+        command that does."""
+        s = self._switch(self._ordinary(panes=[_seat("$1", "%1")]))
+        self.assertEqual(s.switched, [])
+        self.laid_out.assert_not_called()
+        said = self.said.call_args[0][1]
+        self.assertIn("workspace 'beta' is not open on this plane", said)
+        self.assertIn("charter <harness> --workspace beta", said)
+
+    def test_a_workspace_this_plane_has_never_opened_reaches_no_tmux_call_for_it(self):
+        """The ordinary case of the same refusal, and the property that keeps it cheap:
+        with no chat directory there is nothing to compare against, so the answer is on
+        disk. `_pane_place` is still asked, because charter has to know where it is
+        standing before it can say it is not going anywhere."""
+        for chat in chats.of_workspace("beta"):
+            state.record_harness_pane(chat, "")
+        s = self._switch(self._ordinary())
+        self.assertEqual(s.asked("list-panes"), 0)
+        self.assertEqual(s.switched, [])
+
+    def test_a_client_that_did_not_move_keeps_this_chats_panels(self):
+        """#684's rule, re-asked one scope out: a command that exits 0 having acted on the
+        wrong thing is indistinguishable from one that acted on the right thing, so the
+        teardown is gated on a READING — the clients are on the target session — and not
+        on a return code. A refusal here leaves both workspaces exactly as they were."""
+        s = self._switch(self._ordinary(switch_rc=1))
+        self.laid_out.assert_not_called()
+        self.assertIn("did not move this terminal", self.said.call_args[0][1])
+        self.assertTrue(s.asked("switch-client"))
+
+    def test_a_session_with_nobody_attached_moves_nothing_and_says_so(self):
+        """There is no client to move — the operator detached, or an agent is driving this
+        frame with no terminal on it. Reporting a switch that moved nothing is #411's
+        shape arriving through a success."""
+        s = self._switch(self._ordinary(here=[]))
+        self.assertEqual(s.switched, [])
+        self.laid_out.assert_not_called()
+        self.assertIn("no terminal is attached", self.said.call_args[0][1])
+
+    def test_a_chat_whose_own_window_cannot_be_found_refuses_before_anything_moves(self):
+        """`cmd_chat`'s own sentence for its own reason: with no reading of where this
+        client is standing there is no way to tell afterwards whether it moved, and a
+        switch that cannot establish that must not tear anything down."""
+        s = self._switch(self._ordinary(place=""))
+        self.assertEqual(s.switched, [])
+        self.laid_out.assert_not_called()
+        self.assertIn("cannot find this chat's own window", self.said.call_args[0][1])
+
+    def test_a_target_that_resolves_to_this_very_session_is_refused(self):
+        """`switch.to_workspace` refused this by NAME off `state.workspace_for`, and
+        records can disagree with tmux. Switching a client to the session it is already on
+        is a no-op that would then tear this chat's panels down and re-dress them for
+        nothing."""
+        s = self._switch(self._ordinary(panes=[_seat("$1", "%1"), _seat("$1", "%2")]))
+        self.assertEqual(s.switched, [])
+        self.laid_out.assert_not_called()
+        self.assertIn("already in workspace 'beta'", self.said.call_args[0][1])
+
+    def test_a_landing_chat_charter_cannot_name_is_left_undressed_and_unsaid(self):
+        """A workspace session an older charter created carries no `@charter_chat` on its
+        windows. The client still moved — that is the report — and charter says nothing
+        rather than announcing a switch on a frame nobody is looking at. This chat's own
+        panels still go, because the operator is no longer in front of them."""
+        s = self._switch(self._ordinary(landing=["$2\t1\t"]))
+        self.assertEqual(s.switched, [("/dev/ttys001", "$2")])
+        self.assertEqual([c[0][0] for c in self.laid_out.call_args_list], [self.FID])
+        self.said.assert_not_called()
+
+    # -- §4j, across a switch that happens -----------------------------------------------
+
+    def test_no_record_of_either_chat_is_re_pointed(self):
+        """The invariant #733 and #788 are about, asserted across a SUCCESSFUL switch —
+        which is the only form of it that could catch a `record_workspace` added on this
+        path, and the form #789's refusal could never assert at all."""
+        self._switch(self._ordinary())
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+        self.assertEqual(state.frame_workspace(self.FID), "alpha")
+        self.assertIsNone(workspace.for_session(self.FID))
+        self.assertEqual(chats.of_workspace("alpha"), [self.FID])
+        self.assertEqual(chats.of_workspace("beta"), ["beta.1"])
+
+    def test_nothing_is_killed_and_no_window_is_selected(self):
+        """The operator's requirement as a list of verbs charter must not issue. A
+        `kill-session` would end the harnesses they asked to keep running; a
+        `select-window` would drag the OTHER workspace's client off what it was reading
+        (§2.3, measured), which is the defect open-or-focus exists to avoid."""
+        s = self._switch(self._ordinary())
+        for verb in ("kill-session", "kill-window", "kill-pane", "select-window",
+                     "new-session", "new-window", "detach-client"):
+            self.assertEqual(s.asked(verb), 0, verb)
+
+
+class ThePlaneIsWhatDecidesWhichSessionIsOurs(PersonaIso, unittest.TestCase):
+    """`commands_frame._plane_session` — the resolver both §4k's focus and §4b's switch
+    ask, and the two mechanisms it answers with.
+
+    The pane record FINDS the session and the `@charter_plane` marker VETOES it. Each
+    covers what the other cannot: a session an older charter created carries no marker, and
+    a pane id recorded for a chat that is over can name another plane's live pane after a
+    `kill-server`.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        (config.WORKSPACES_DIR / SHARED).mkdir(parents=True, exist_ok=True)
+        _a_chat("shared.1", ws=SHARED, pane="%0")
+
+    def _resolve(self, rows):
+        done = _completed(["tmux"], 0, "".join(f"{r}\n" for r in rows))
+        with mock.patch.object(commands_frame.tmuxctl, "run", return_value=done):
+            return commands_frame._plane_session(commands_frame.SOCKET, ws=SHARED)
+
+    def test_a_session_this_plane_marked_is_ours(self):
+        self.assertEqual(self._resolve([_seat("$3", "%0")]), ("$3", "shared.1"))
+
+    def test_a_session_nobody_marked_is_still_ours_if_we_recorded_its_pane(self):
+        """**Every session on the operator's own socket the day this shipped.** A marker
+        that had to be present would refuse a switch into a workspace the operator is
+        looking at right now, which is a migration charged to the person who upgrades."""
+        self.assertEqual(self._resolve([_seat("$3", "%0", plane=None)]),
+                         ("$3", "shared.1"))
+
+    def test_a_session_another_plane_marked_is_refused_though_the_pane_id_matches(self):
+        """**The residual the pane record cannot close, closed.** Pane ids restart at `%0`
+        when a tmux server does, so a `%0` recorded for a chat that is over can name
+        another plane's live pane — and on the switch path there is no reap in front of
+        it. The marker is the only thing on this machine that says whose session it is."""
+        self.assertIsNone(self._resolve([_seat("$3", "%0", plane="/somewhere/.charter")]))
+
+    def test_a_marked_session_further_down_the_list_is_still_found(self):
+        """The veto skips a row rather than ending the search: two planes can hold the
+        same recorded pane id across a server restart, and the one that is really ours may
+        be listed second."""
+        self.assertEqual(
+            self._resolve([_seat("$9", "%0", plane="/somewhere/.charter"),
+                           _seat("$3", "%0")]),
+            ("$3", "shared.1"))
+
+    def test_a_row_that_is_not_three_fields_is_not_read_as_a_pane(self):
+        """`_window_seats`' rule: exactly the field count the format asks for, so a server
+        answering something else cannot have half a row read as a pane id.
+        `_plane_option_argv` is what guarantees charter's own marker never adds a
+        fourth."""
+        self.assertIsNone(self._resolve(["$3\t%0"]))
+        self.assertIsNone(self._resolve(["$3\t%0\t/a\textra"]))
+
+
+def _tmux(*args: str, socket: str = SOCKET) -> subprocess.CompletedProcess:
+    return subprocess.run(["tmux", "-L", socket, *args], capture_output=True, text=True,
+                          timeout=15)
+
+
+def _await(predicate, timeout: float = _DEADLINE) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
+
+
+@contextlib.contextmanager
+def _plane(root: Path):
+    """Resolve every charter path against *root* for the duration — one plane of the two.
+
+    `config.use`/`config.restore` is the same seam `PersonaIso` uses; entering it twice
+    with two roots inside one test process is what "two planes on one machine" means when
+    the machine is a test runner.
+    """
+    previous = config.use(root)
+    try:
+        yield
+    finally:
+        config.restore(previous)
+
+
+class _RealServer(unittest.TestCase):
+    """One tmux server of this module's own, and the pty plumbing the classes below share.
+
+    Nothing here touches `commands_frame.SOCKET`: the operator's own frame lives on that
+    socket with eleven sessions on it, and this suite starts, moves and kills clients.
+    """
+
+    def setUp(self) -> None:
+        self.addCleanup(self._teardown_socket)
+        self.kids: list[tuple[int, int]] = []
+
+    def _teardown_socket(self) -> None:
+        """End the server and unlink its socket, in that order and in one cleanup —
+        `tests/test_frame_tmux_integration.py::_TmuxServerFixture`'s rule, which measures
+        why the reverse order leaves the real server running."""
+        for pid, fd in self.kids:
+            self._reap_pty(pid, fd)
+        said = _tmux("display-message", "-p", "#{socket_path}")
+        path = said.stdout.strip()
+        _tmux("kill-server")
+        for candidate in {SOCKET_PATH, path if path.startswith("/") else SOCKET_PATH}:
+            try:
+                os.unlink(candidate)
+            except OSError:
+                pass
+
+    def _attach(self, session: str) -> str:
+        """A real client on *session*, or a skip naming what tmux refused."""
+        refusals = []
+        for term in _TERM_CANDIDATES:
+            pid, fd = pty.fork()
+            if pid == 0:
+                try:
+                    os.environ["TERM"] = term
+                    os.execvp("tmux", ["tmux", "-L", SOCKET, "attach", "-t", session])
+                finally:
+                    os._exit(127)
+            if _await(lambda: self._clients(session) != []):
+                self.kids.append((pid, fd))
+                return self._clients(session)[-1]
+            refusals.append(f"TERM={term}")
+            self._reap_pty(pid, fd)
+        self.skipTest("no tmux client can attach on this machine, and a workspace "
+                      "switch is a decision about an ATTACHED client — tried "
+                      + ", ".join(refusals))
+
+    def _reap_pty(self, pid: int, fd: int) -> None:
+        try:
+            os.kill(pid, 9)
+            os.waitpid(pid, 0)
+        except OSError:
+            pass
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+    def _clients(self, session: str) -> list[str]:
+        return [c for c in _tmux("list-clients", "-t", session,
+                                 "-F", "#{client_name}").stdout.split() if c]
+
+    def _panes(self) -> list[str]:
+        return sorted(_tmux("list-panes", "-a", "-F",
+                            "#{session_name}:#{window_name} dead=#{pane_dead} "
+                            "pid=#{pane_pid}").stdout.splitlines())
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealSwitchOnARealServer(_RealServer):
+    """The tmux facts §4b rests on, measured rather than assumed.
+
+    Two workspace sessions, one real client on a real pty, and a `switch-client` between
+    them. What a fake cannot supply is tmux's own behaviour: whether the client really
+    moves, whether anything dies, and which window it lands on.
+
+    Verified on tmux 3.7c and at the 3.2 floor (`~/.local/share/charter-testing/tmux-3.2`
+    first on `$PATH`), identically on both — so nothing here carries a version gate.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertEqual(_tmux("new-session", "-d", "-s", "alpha", "-n", "alpha.1",
+                               "sleep 300").returncode, 0)
+        _tmux("new-session", "-d", "-s", "beta", "-n", "beta.1", "sleep 300")
+        # **`-a`, and the fixture is wrong without it** — `layout.chat_window_argv`'s own
+        # measurement, met here: `-t <session>` resolves to that session's CURRENT window
+        # and `new-window` reads a resolved window target as the INDEX to create at, so
+        # without `-a` this answers `create window failed: index 0 in use` and the second
+        # window never exists. A fixture that swallowed that would leave this class
+        # asserting that a one-window session lands on its one window.
+        second = _tmux("new-window", "-d", "-a", "-t", "beta", "-n", "beta.2",
+                       "-P", "-F", "#{window_id}", "sleep 300")
+        self.assertEqual(second.returncode, 0, second.stderr)
+        # By `@<id>`, never `-t beta:beta.2`: tmux parses a target's dot as
+        # `window.pane`, so the name a chat window actually carries cannot select it —
+        # the same rule `_WINDOW_SEAT_FORMAT` records for a workspace name with a dot.
+        self.assertEqual(_tmux("select-window", "-t",
+                               second.stdout.strip()).returncode, 0)
+        self.beta = _tmux("display-message", "-p", "-t", "beta",
+                          "#{session_id}").stdout.strip()
+
+    def test_the_client_moves_and_nothing_at_all_is_killed(self):
+        """The operator's requirement, measured: *"changing workspace does not mean
+        stopping the old chat session."* Every pane on the server is still there with the
+        same pid and `pane_dead=0`, and the `attach` process itself is still alive."""
+        client = self._attach("alpha")
+        before = self._panes()
+        alive = os.waitpid(self.kids[0][0], os.WNOHANG) == (0, 0)
+        self.assertEqual(_tmux("switch-client", "-c", client, "-t",
+                               self.beta).returncode, 0)
+        self.assertTrue(_await(lambda: self._clients("beta") == [client]),
+                        "the client never arrived on the other workspace")
+        self.assertEqual(self._clients("alpha"), [])
+        self.assertEqual(self._panes(), before, "a switch killed or replaced a pane")
+        self.assertTrue(alive)
+        self.assertEqual(os.waitpid(self.kids[0][0], os.WNOHANG), (0, 0),
+                         "the attach process died with the switch")
+
+    def test_it_lands_on_the_window_that_session_was_last_on(self):
+        """Which chat the operator arrives at is tmux's answer and not charter's, which is
+        why `_switch_client` reads it back rather than dressing the seat it matched."""
+        client = self._attach("alpha")
+        _tmux("switch-client", "-c", client, "-t", self.beta)
+        self.assertTrue(_await(lambda: self._clients("beta") == [client]))
+        self.assertEqual(_tmux("display-message", "-p", "-t", "beta",
+                               "#{window_name}").stdout.strip(), "beta.2")
+
+    def test_the_move_is_readable_from_list_clients_on_both_versions(self):
+        """**The reading `_switch_client` verifies with, and the one it must not use.**
+        `display-message -p -c <client> '#{session_name}'` answers an EMPTY string at the
+        3.2 floor for a client that has demonstrably moved — measured — so a check built
+        on it would refuse every switch on the older tmux and pass on the newer.
+        `list-clients -t <session>` answers on both."""
+        client = self._attach("alpha")
+        _tmux("switch-client", "-c", client, "-t", self.beta)
+        self.assertTrue(_await(lambda: self._clients("beta") == [client]),
+                        "list-clients could not see the move this tmux performed")
+
+    def test_a_session_option_is_readable_in_a_pane_format_and_is_not_global(self):
+        """What makes `_PANE_SEAT_FORMAT` one round trip instead of two: a session-scoped
+        user option resolves in a PANE's format. And it is per session — `beta` reads
+        empty — which is the whole of what makes it able to say whose plane a session is.
+
+        `show-options -v` is deliberately not how this is read: for an option nobody set it
+        answers rc 1 with `invalid option:` on 3.7c and rc 0 with an empty line on 3.2, so
+        a reader built on it would have to branch on the tmux version.
+        """
+        pane = _tmux("list-panes", "-t", "alpha", "-F", "#{pane_id}").stdout.strip()
+        self.assertEqual(_tmux("set-option", "-t", pane,
+                               commands_frame._PLANE_OPTION, "/p/.charter").returncode, 0)
+        rows = _tmux("list-panes", "-a", "-F",
+                     commands_frame._PANE_SEAT_FORMAT).stdout.splitlines()
+        fields = [r.split("\t") for r in rows]
+        marks = {f[0]: f[2] for f in fields if len(f) == 3}
+        self.assertEqual(marks[_tmux("display-message", "-p", "-t", "alpha",
+                                     "#{session_id}").stdout.strip()], "/p/.charter")
+        self.assertEqual(marks[self.beta], "")
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class TwoPlanesOnOneMachine(_RealServer):
+    """**The hazard at the centre of §4b, reproduced before it is fixed.**
+
+    One tmux server, two plane roots, one workspace name they share. Session names are
+    unique per server, so there is exactly ONE session called `shared` and it belongs to
+    whichever plane created it — which is precisely the trap: plane B's `workspaces` bar
+    lists `shared`, a live session called `shared` exists, and a switch decided on that
+    name would put plane B's operator inside plane A's harnesses.
+
+    A single-plane test cannot fail for this reason, which is why this class exists at all.
+    Everything asserted here is read back off a real server: the pane ids it minted, the
+    session ids it minted, and the option charter set on it.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.plane_a = Path(tempfile.mkdtemp(prefix="4b-plane-a-"))
+        self.plane_b = Path(tempfile.mkdtemp(prefix="4b-plane-b-"))
+        for p in (self.plane_a, self.plane_b):
+            self.addCleanup(shutil.rmtree, p, True)
+        self.assertEqual(_tmux("new-session", "-d", "-s", SHARED, "-n", "c1",
+                               "sleep 300").returncode, 0)
+        seats = _tmux("list-panes", "-a", "-F", "#{session_id}\t#{pane_id}").stdout
+        self.session_id, self.pane = seats.split()[0], seats.split()[1]
+        # The window carries the chat id a launcher would have written on it — which is
+        # the SECOND name both planes have. `new_chat_id` counts from 1 on each plane's
+        # own disk, so `shared.1` is not plane A's id, it is the id both planes mint
+        # first. Without this the fixture would let an implementation that matched on
+        # `@charter_chat` pass for the wrong reason.
+        self.assertEqual(_tmux("set-option", "-w", "-t", self.pane,
+                               commands_frame._CHAT_OPTION, "shared.1").returncode, 0)
+        with _plane(self.plane_a):
+            (config.WORKSPACES_DIR / SHARED).mkdir(parents=True, exist_ok=True)
+            _a_chat("shared.1", ws=SHARED, pane=self.pane, server=SOCKET)
+            self.a_state = str(config.STATE_DIR)
+        # Plane B has a chat directory for the SAME workspace under the SAME chat id, but
+        # its own chat is over and the pane it recorded is not on this server.
+        with _plane(self.plane_b):
+            (config.WORKSPACES_DIR / SHARED).mkdir(parents=True, exist_ok=True)
+            _a_chat("shared.1", ws=SHARED, pane="%9000", server=SOCKET)
+
+    def _mark(self, state_dir: str) -> None:
+        """What plane *state_dir*'s launcher would have written when it made the session."""
+        with mock.patch.object(commands_frame, "_this_plane", return_value=state_dir):
+            argv = commands_frame._plane_option_argv(socket=SOCKET, harness_pane=self.pane)
+        self.assertIsNotNone(argv)
+        self.assertEqual(subprocess.run(argv, capture_output=True,
+                                        text=True, timeout=15).returncode, 0)
+
+    def test_the_plane_that_opened_it_resolves_it(self):
+        with _plane(self.plane_a):
+            self.assertEqual(commands_frame._plane_session(SOCKET, ws=SHARED),
+                             (self.session_id, "shared.1"))
+
+    def test_the_other_plane_resolves_nothing_though_every_NAME_matches(self):
+        """Plane B has a workspace called `shared`, a chat directory called `shared.1`,
+        and a live tmux session called `shared`. Every NAME lines up. The one thing that
+        does not is the pane its own launcher wrote down — which is the only fact on this
+        machine that belongs to one plane and not the other."""
+        with _plane(self.plane_b):
+            self.assertIsNone(commands_frame._plane_session(SOCKET, ws=SHARED))
+
+    def test_the_marker_refuses_a_pane_id_that_came_back_round(self):
+        """**The residual a pane record cannot close.** Plane B is made to record the pane
+        id this server actually minted — which is what a `kill-server` plus a recycled
+        `%0` produces — so its pane record now matches plane A's live session and every
+        name matches too. The marker plane A's launcher wrote is the only thing left that
+        can tell them apart, and it does."""
+        self._mark(self.a_state)
+        with _plane(self.plane_b):
+            _a_chat("shared.1", ws=SHARED, pane=self.pane, server=SOCKET)
+            self.assertIsNone(commands_frame._plane_session(SOCKET, ws=SHARED))
+        with _plane(self.plane_a):
+            self.assertEqual(commands_frame._plane_session(SOCKET, ws=SHARED),
+                             (self.session_id, "shared.1"))
+
+    def test_without_the_marker_the_recycled_pane_id_is_the_hazard_itself(self):
+        """The negative control, and the reason the marker is not decoration: the same
+        arrangement with no marker on the session resolves plane A's live frame FOR PLANE
+        B. This is the failure being prevented, run to prove it is reachable."""
+        with _plane(self.plane_b):
+            _a_chat("shared.1", ws=SHARED, pane=self.pane, server=SOCKET)
+            self.assertEqual(commands_frame._plane_session(SOCKET, ws=SHARED),
+                             (self.session_id, "shared.1"))
+
+    def test_a_switch_from_the_other_plane_refuses_by_name_and_moves_no_client(self):
+        """**End to end, and it is the operator's decision made observable**: switching is
+        restricted to workspaces of THIS plane, and anything else is refused by name.
+        Plane B clicks `shared`; there is a live session called `shared` with plane B's
+        own operator's terminal nowhere near it; the switch says the workspace is not open
+        *on this plane* and the client that is attached to plane A's session stays there.
+        """
+        self._mark(self.a_state)
+        client = self._attach(SHARED)
+        with _plane(self.plane_b):
+            _a_chat("shared.2", ws=SHARED, pane="%9001", server=SOCKET)
+            state.record_harness_pane("shared.2", "%9001")
+            said = []
+            with mock.patch.object(commands_frame, "_pane_place",
+                                   return_value=("$9000", "@9000")), \
+                 mock.patch.object(commands_frame, "_say_on_screen",
+                                   side_effect=lambda fid, msg, **kw: said.append(msg)):
+                commands_frame._switch_client("shared.2", SHARED,
+                                              said="workspace → shared")
+        self.assertTrue(any("is not open on this plane" in m for m in said), said)
+        self.assertEqual(self._clients(SHARED), [client],
+                         "another plane's switch moved this plane's client")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1509,7 +1509,7 @@ class _FakeTmux:
                 kill_rc=0, arm_rc=0, hatch_rc=0, mark_rc=0, chrome_rc=0,
                 resize_hook_rc=0,
                 capture_rc=0,
-                respawn_hook_rc=0, chat_option_rc=0,
+                respawn_hook_rc=0, chat_option_rc=0, plane_option_rc=0,
                 resize_hook_stderr="bad resize hook target"):
         self.pane_id = pane_id
         self.exit_code = exit_code
@@ -1565,6 +1565,12 @@ class _FakeTmux:
         self.capture_rc = capture_rc
         self.respawn_hook_rc = respawn_hook_rc
         self.chat_option_rc = chat_option_rc
+        self.plane_option_rc = plane_option_rc
+        #: Every value the launcher wrote to `@charter_plane`, in order — a list rather
+        #: than a flag because "written once, by the launch that made the session" is a
+        #: COUNT, and the case that would have caught a second write is a launch that
+        #: joins a session it did not create.
+        self.plane_marks: list[str] = []
         # Distinct from every other stderr string in this fake — a test needs to
         # control it independently to exercise the "invalid option" degrade (fix
         # round 3, item 2) separately from an ordinary resize-hook failure.
@@ -1604,6 +1610,16 @@ class _FakeTmux:
             self.fid = cmd[-1]
             return subprocess.CompletedProcess(cmd, self.chat_option_rc, stdout="",
                                                stderr="" if self.chat_option_rc == 0
+                                               else "cannot set")
+        if commands_frame._PLANE_OPTION in cmd:
+            # Which PLANE this session belongs to (§4b) — recorded rather than merely
+            # allowed, because two cases below assert that it is written exactly once and
+            # only by the launch that CREATED the session. Matched on the production
+            # constant and ahead of the generic `set-option` branch, for `_CHAT_OPTION`'s
+            # reason: the value is a plain path another branch could answer for.
+            self.plane_marks.append(cmd[-1])
+            return subprocess.CompletedProcess(cmd, self.plane_option_rc, stdout="",
+                                               stderr="" if self.plane_option_rc == 0
                                                else "cannot set")
         if "source-file" in cmd:
             conf_path = cmd[cmd.index("source-file") + 1]
@@ -2138,6 +2154,104 @@ class AWorkspaceIsASessionAndAChatIsAWindow(PersonaIso, unittest.TestCase):
              mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
             _launch(_FakeTmux(exit_code=0, still_live=True))
         self.assertTrue(any("reaped while it is still running" in m for m in buf), buf)
+
+
+class TheSessionIsMarkedWithItsPlane(PersonaIso, unittest.TestCase):
+    """§4b's marker on the launch path — `@charter_plane`, and the two facts about WHEN.
+
+    One tmux server serves every plane on this machine and a session's name is a bare
+    workspace name, so `#{session_name}` cannot say whose session it is. The marker is what
+    can, and `commands_frame._plane_session` reads it as a veto: a candidate session whose
+    marker names another plane is refused however well its pane id matched.
+
+    `PersonaIso` and `_launch`'s own `_refuse_the_real_plane` are what make this safe to
+    run at all: these cases drive the real `cmd_launch`, `state.reap` included, so the plane
+    they mark has to be the test's temporary one and never the operator's.
+    """
+
+    def test_the_launch_that_creates_the_session_marks_it_with_this_planes_state_dir(self):
+        """`config.STATE_DIR` and not `config.ROOT`: what makes two charters one plane, for
+        every read on this path, is sharing the `.charter/frame/` directory the chat
+        records live in."""
+        fake = _FakeTmux(exit_code=0, still_live=True)
+        _launch(fake)
+        self.assertEqual(fake.plane_marks, [str(config.STATE_DIR)])
+
+    def test_it_is_set_on_the_session_and_not_on_the_window_or_a_global(self):
+        """The scope is the whole of what makes this answerable. `-w` would put it on one
+        chat's window, and `-g` would hand every session on this shared server one plane's
+        answer — which is the collision the marker exists to end, made worse."""
+        fake = _FakeTmux(exit_code=0, still_live=True)
+        _launch(fake)
+        cmd = next(c for c in fake.calls if commands_frame._PLANE_OPTION in c)
+        self.assertEqual(cmd[3:6], ["set-option", "-t", fake.pane_id], cmd)
+        self.assertNotIn("-w", cmd)
+        self.assertNotIn("-g", cmd)
+        self.assertNotIn("-p", cmd)
+
+    def test_a_launch_that_JOINS_a_session_marks_nothing(self):
+        """**The case the whole guard rests on, and the one that would make it the defect
+        it prevents.** `session in live_sessions` is a test on the NAME — exactly the
+        cross-plane collision this marker records — so a launch that joined may be standing
+        in another plane's session, and re-marking it there would relabel that plane's
+        frame as this one's."""
+        state.record_server("demo.1", commands_frame.SOCKET)
+        fake = _FakeTmux(exit_code=0, still_live=True,
+                         pre_existing_sessions=("demo",),
+                         pre_existing_chats=("demo.1",))
+        _launch(fake)
+        self.assertEqual(fake.plane_marks, [])
+
+    def test_a_marker_tmux_refused_is_reported_with_what_it_costs(self):
+        """Continuing is right — the harness is already running and the pane records still
+        find this session — but silently is not: without the marker a switch cannot tell
+        this session from another plane's of the same name."""
+        buf = []
+        with mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
+            rc = _launch(_FakeTmux(exit_code=0, still_live=True, plane_option_rc=1))
+        self.assertEqual(rc, 0, "a refused session option must not fail the launch")
+        self.assertTrue(any("another plane's of the same name" in m for m in buf), buf)
+
+    def test_a_plane_tmux_could_not_carry_is_reported_rather_than_silently_dropped(self):
+        """`_plane_option_argv` refuses a value that would not survive the round trip, and
+        the launch says what that costs rather than carrying on as though the session had
+        been marked."""
+        buf = []
+        with mock.patch.object(commands_frame, "_plane_option_argv", return_value=None), \
+             mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
+            _launch(_FakeTmux(exit_code=0, still_live=True))
+        self.assertTrue(any("another plane's of the same name" in m for m in buf), buf)
+
+
+class ThePlaneOptionIsCheckedWhereItEntersTmux(unittest.TestCase):
+    """`_plane_option_argv`. Unlike a chat id there is no alphabet to hold a filesystem
+    path to, so what is checked is the ROUND TRIP: the value is read back out of
+    `list-panes -F 'a\tb\t#{@charter_plane}'`, and a tab would add a field where a
+    newline would add a row. Either would be read as a server answering some other
+    format."""
+
+    def _argv(self, state_dir: str):
+        with mock.patch.object(commands_frame, "_this_plane", return_value=state_dir):
+            return commands_frame._plane_option_argv(socket="charter", harness_pane="%9")
+
+    def test_an_ordinary_path_is_written_as_a_session_option(self):
+        self.assertEqual(self._argv("/home/a/proj/.charter"),
+                         ["tmux", "-L", "charter", "set-option", "-t", "%9",
+                          "@charter_plane", "/home/a/proj/.charter"])
+
+    def test_a_path_with_a_space_in_it_is_perfectly_fine(self):
+        """A space is not a separator in this format and never reaches a shell — the argv
+        goes to `subprocess.run` as a list. Refusing one would leave every plane under a
+        macOS `~/My Documents` unmarked for no reason."""
+        self.assertIn("/home/a/my plane/.charter", self._argv("/home/a/my plane/.charter"))
+
+    def test_a_path_that_would_not_survive_the_format_is_refused(self):
+        """`None`, never a sanitised spelling — `_chat_option_argv`'s rule: rewriting a
+        value into a safe-looking one invents a second identity for it, and here the two
+        spellings would be two planes."""
+        for hostile in ("/a\tb/.charter", "/a\nb/.charter", "/a\rb/.charter", ""):
+            with self.subTest(hostile=hostile):
+                self.assertIsNone(self._argv(hostile))
 
 
 class TheChatOptionIsCheckedWhereItEntersTmux(unittest.TestCase):

--- a/tests/test_frame_palette_integration.py
+++ b/tests/test_frame_palette_integration.py
@@ -644,35 +644,41 @@ class ThereIsNeverMoreThanOnePalettePane(_ThePalette, unittest.TestCase):
 class AnUnavailableActionIsDrawnWithItsReason(_ThePalette, unittest.TestCase):
     """Step 4, on the plan's own example, against a real frame.
 
-    The example was a `$CHARTER_WORKSPACE` pin and is now §4j: a chat belongs to its
-    workspace for life, so that doorway carries a reason on every frame rather than on
-    some. The mechanism under test is unchanged and is the whole point of the class — the
-    row stays, it carries the sentence `switch.to_workspace` refuses with, and Enter on it
-    opens nothing and moves nothing.
+    **The noun this is staged on has moved twice and the mechanism has not.** The plan's
+    example was a `$CHARTER_WORKSPACE` pin; #789 made the workspace doorway carry §4j's
+    refusal on every frame and this class moved onto that; §4b removed the refusal, because
+    a workspace switch moves a client and re-points nothing, so the workspace doorway is
+    available again and a `change` is the doorway this plane genuinely cannot open.
 
-    Not staged on a pin any more because it no longer decides anything here: with the pin
-    set, `choose.pin_reason` answers §4j's sentence first, so a pinned fixture would have
-    proved only that the frame draws the same row it draws unpinned. The pin's own end of
-    the rule is measured on the persona, in `tests/test_frame_pickers.py`.
+    That is the closest thing to the original example available without a fixture that
+    pins the frame: nothing can pin a change (`choose.PIN` says why), and what stands
+    between the doorway and a picker is having no names at all — `choose.NO_CHANGES`, and
+    a pane of no names is the offer charter knows it cannot honour, exactly as a pinned
+    frame's list of unswitchable ones was. The mechanism under test is the one this class
+    has always been about: the row stays, it carries the sentence, and Enter on it opens
+    nothing and moves nothing.
+
+    The pin's own end of the rule is measured on the persona, in
+    `tests/test_frame_pickers.py`.
     """
 
     def test_the_row_is_listed_and_says_why_it_cannot_run(self):
         _, pane = self._open()
-        self._await_screen(pane, "workspace: alpha")
-        self._await_screen(pane, "cannot switch: a chat belongs to its")
+        self._await_screen(pane, "change — pick one")
+        self._await_screen(pane, "no cross-repo change in this workspa")
 
     def test_choosing_it_opens_no_picker_changes_nothing_and_the_frame_says_so(self):
-        """A pinned frame does not get a list of names it cannot switch to. The row is
+        """A doorway with a reason does not get a list of names behind it. The row is
         still there, still says why, and Enter on it closes the palette having moved
         nothing — the reason goes to the operator's own screen on the way out."""
         fd, pane = self._open()
-        self._await_screen(pane, "workspace: alpha")
-        os.write(fd, b"workspace\r")
+        self._await_screen(pane, "change — pick one")
+        os.write(fd, b"change\r")
         self.assertTrue(_await(lambda: self._palette_pane() is None),
                         "the palette never closed")
         time.sleep(0.5)
-        self.assertEqual(state.frame_workspace(self.fid), "alpha",
-                         "a refused switch must not move the frame")
+        self.assertIsNone(state.frame_change(self.fid),
+                          "a refused doorway must not point the frame at anything")
 
 
 class ATmuxFormatInAMessageIsInert(_ThePalette, unittest.TestCase):

--- a/tests/test_frame_palette_names.py
+++ b/tests/test_frame_palette_names.py
@@ -178,22 +178,18 @@ class TypingAtTheTopLevelFindsANameDirectly(_Frame, unittest.TestCase):
         about a row rather than what the operator typed."""
         rows = self._typed("zeb").rows
         self.assertEqual([(r.title, r.note) for r in rows],
-                         [("zeb", "persona"), ("zeb-api", switch.FOR_LIFE),
-                          ("zebra-ui", switch.FOR_LIFE)])
+                         [("zeb", "persona"), ("zeb-api", "workspace"),
+                          ("zebra-ui", "workspace")])
 
-    def test_a_workspace_names_note_is_its_refusal_rather_than_its_kind(self):
-        """**The cost of §4j on this surface, asserted rather than discovered.** The note
-        column holds one thing, and `choose.labelled` gives a refused row its reason
-        instead of its kind — which used to happen only on a pinned frame and now happens
-        on every frame for this one noun. So a workspace name says why it cannot be
-        pressed where it used to say what it is.
-
-        It is still tellable from a persona: exactly one of the two sentences is a kind
-        label, and the rows carry `refused` as a field either way (#732). Restoring the
-        kind label would mean a row that says "workspace" and refuses when pressed, which
-        is the defect that field exists to prevent."""
+    def test_no_name_on_an_unpinned_frame_is_marked_refused(self):
+        """**What #789 cost on this surface and §4b gave back, asserted rather than
+        discovered.** The note column holds one thing, and `choose.labelled` gives a
+        refused row its reason instead of its kind — so under #789 every workspace name
+        said why it could not be pressed where it should say what it is. Both fields are
+        asserted, here and in the case above, because either alone can be right by
+        accident: the note is the KIND, and `refused` is false."""
         rows = self._typed("zeb").rows
-        self.assertEqual([r.refused for r in rows], [False, True, True])
+        self.assertEqual([r.refused for r in rows], [False, False, False])
 
     def test_the_name_in_use_keeps_its_mark_here_too(self):
         """A name row is the picker's own row re-noted, so the `*` that answers "which one
@@ -257,23 +253,24 @@ class TypingAtTheTopLevelFindsANameDirectly(_Frame, unittest.TestCase):
         self.assertIn("persona → forge", self.said.call_args[0][1])
 
     def test_a_workspace_typed_at_the_top_level_takes_the_same_route_and_is_refused(self):
-        """The other end of the same route, and the reason this file is where the typed
-        workspace name is measured at all: `_name_rows` is the only surface a workspace
-        name still reaches, now that its doorway opens no picker.
+        """The other end of the same route: the row resolves to a name,
+        `choose.switch_to` is asked, and — since §4b — the switch is STARTED rather than
+        answered here. A palette that silently dropped the name would leave the operator
+        pressing a row that does nothing, which is the property this has always asserted;
+        what changed is where the answer comes from.
 
-        What must hold is that the refusal arrives *through the palette* — the row
-        resolves to a name, `choose.switch_to` is asked, and the sentence lands on the
-        frame's own screen. A palette that silently dropped the name would leave the
-        operator pressing a row that does nothing."""
+        `_start_workspace_switch` is what carries the name to `charter frame-switch
+        --workspace`, and nothing is said from this process, because the sentence belongs
+        on the chat the operator lands on and only the switch knows which that is."""
         was = state.version(self.FID)
-        with mock.patch.object(palette, "own_the_tty", _pick("zebra")):
+        with mock.patch.object(palette, "own_the_tty", _pick("zebra")), \
+             mock.patch.object(commands_frame, "_start_workspace_switch") as started:
             self.assertEqual(commands_frame.cmd_palette(
                 SimpleNamespace(client="/dev/ttys7", pane=True)), 0)
+        started.assert_called_once_with(self.FID, "zebra-ui")
         self.assertEqual(state.workspace_for(self.FID), "alpha")
         self.assertEqual(state.version(self.FID), was)
-        self.said.assert_called_once()
-        self.assertEqual(self.said.call_args[0][1], switch.FOR_LIFE)
-        self.assertIs(self.said.call_args[1]["ok"], False)
+        self.said.assert_not_called()
 
     def test_the_doorway_still_opens_a_picker_and_switching_from_it_still_works(self):
         """**The constraint that is not negotiable, asserted after the change**: browsing
@@ -285,9 +282,10 @@ class TypingAtTheTopLevelFindsANameDirectly(_Frame, unittest.TestCase):
         The frame is on no persona to begin with, so landing on one is a real switch
         rather than a no-op a broken doorway would also produce.
 
-        Row 1 and not row 0 since §4j — row 0 is the workspace doorway, which now opens no
-        picker at all (`choose.pin_reason`), so pressing it would measure the refusal
-        rather than the route. The route itself is unchanged, which is what this asserts.
+        Row 1 and not row 0 — row 0 is the workspace doorway, whose route ends in a tmux
+        client rather than in a file, and `tests/test_a_workspace_switch_moves_the_client
+        .py` is where that is measured. The persona is the noun whose whole route is
+        in-process, which is what makes it the one to assert the route with.
         """
         was = state.version(self.FID)
         self.assertIsNone(switch.current_persona(self.FID))
@@ -474,11 +472,12 @@ class APinnedNounListsItsNamesWithTheReason(_Frame, unittest.TestCase):
     already been typed is a question the operator asked, and an empty pane is the wrong
     answer to it. So the row is listed and it carries the sentence.
 
-    **The pinned noun here is the PERSONA, and it was the workspace until §4j.** That one
-    now carries `switch.FOR_LIFE` on every frame, pinned or not, so a pin-shaped assertion
-    on it would stay green with the pin removed and measure nothing. Both halves are still
-    asserted — the pin's, on the noun a pin still decides, and §4j's, on the noun it
-    decides — because what this class is really about is the mechanism they share.
+    **The pinned noun here is the PERSONA, and it was the workspace until §4j.** A
+    workspace name carried #789's blanket refusal on every frame, pinned or not, so a
+    pin-shaped assertion on it would have stayed green with the pin removed and measured
+    nothing. §4b removed that refusal and did not put the pin back (`choose.PIN` says
+    why), so the persona is the only noun a launch pin still decides and the workspace is
+    the negative control for it.
     """
 
     PIN = {"CHARTER_WORKSPACE": "", "CHARTER_PERSONA": "forge"}
@@ -494,13 +493,13 @@ class APinnedNounListsItsNamesWithTheReason(_Frame, unittest.TestCase):
         """One pin, one noun. Reading a pin as "this frame cannot switch anything" would
         take another noun's names away for a reason that is not about it.
 
-        Asserted as "the other rows carry a DIFFERENT sentence" rather than "no sentence":
-        a workspace name carries §4j's, always, and the leak this guards against would
-        show as the persona's variable named on a row that is not about personas."""
+        Both halves, because either alone can be right by accident: a workspace name on a
+        persona-pinned frame is not refused at all, and in particular does not name the
+        persona's own variable on a row that is not about personas."""
         rows = [r for r in self._typed("zeb").rows if r.id.startswith("workspace:")]
         self.assertTrue(rows)
         for row in rows:
-            self.assertEqual(row.note, switch.FOR_LIFE)
+            self.assertFalse(row.refused)
             self.assertNotIn("CHARTER_PERSONA", row.note)
 
     def test_pressing_one_says_the_same_sentence_and_moves_nothing(self):
@@ -514,16 +513,18 @@ class APinnedNounListsItsNamesWithTheReason(_Frame, unittest.TestCase):
         self.said.assert_called_once()
         self.assertIn("$CHARTER_PERSONA pins this frame", self.said.call_args[0][1])
 
-    def test_pressing_a_workspace_name_says_its_own_sentence_and_moves_nothing(self):
-        """The §4j half of the same property: the note the row carried is the sentence the
-        keypress produces, read from one constant so the two cannot drift apart."""
+    def test_pressing_a_workspace_name_on_a_pinned_frame_still_starts_a_switch(self):
+        """The negative control's other end: a `$CHARTER_PERSONA` pin must not reach the
+        workspace names either. Pressing one starts the switch and re-points nothing,
+        exactly as it does on an unpinned frame."""
         row = [r for r in self._typed("zebra").rows if r.id.startswith("workspace:")][0]
-        with mock.patch.object(palette, "own_the_tty", _pick("zebra", want=row.id)):
+        with mock.patch.object(palette, "own_the_tty", _pick("zebra", want=row.id)), \
+             mock.patch.object(commands_frame, "_start_workspace_switch") as started:
             self.assertEqual(commands_frame.cmd_palette(
                 SimpleNamespace(client="", pane=True)), 0)
+        started.assert_called_once_with(self.FID, "zebra-ui")
         self.assertEqual(state.workspace_for(self.FID), "alpha")
-        self.said.assert_called_once()
-        self.assertEqual(self.said.call_args[0][1], row.note)
+        self.said.assert_not_called()
 
     def test_the_pin_is_contained_before_it_becomes_a_note_and_a_status_line(self):
         """`$CHARTER_PERSONA` is whatever the launching environment held, so a newline in
@@ -647,12 +648,18 @@ class TheOutcomeIsWrittenToTheFrameTheOperatorEndsUpOn(_Frame, unittest.TestCase
     so it has to be written to the frame the operator will be looking at a moment from
     now — which is not always the frame the switch was computed for.
 
-    A workspace or persona switch moves the frame in place, so that is this one. A chat
-    switch does not move anything: it moves the tmux CLIENT to a sibling frame
-    (`choose.py` — "the frame IS the chat"), and a chat's name IS its frame id. Written to
-    the wrong one, a chat switch's outcome would be filed on the frame the operator just
-    left and never read by anybody, which is exactly the class of silent refusal #517 and
-    #684 exist to prevent — reached, this time, through the fix for #729.
+    A persona switch moves the frame in place, so that is this one. A chat switch does not
+    move anything: it moves the tmux CLIENT to a sibling frame (`choose.py` — "the frame
+    IS the chat"), and a chat's name IS its frame id. Written to the wrong one, a chat
+    switch's outcome would be filed on the frame the operator just left and never read by
+    anybody, which is exactly the class of silent refusal #517 and #684 exist to prevent —
+    reached, this time, through the fix for #729.
+
+    **A workspace switch that TAKES says nothing here at all** (§4b), and that is the
+    third answer rather than a gap: it ends on a chat of another tmux session — whichever
+    window tmux restores — so the frame the operator will be looking at is not known until
+    the switch has happened, and `commands_frame._switch_client` says the sentence there.
+    A refused one still lands here, because a refusal leaves the operator where they are.
 
     `display-message` had no equivalent of this bug and no equivalent of the property
     either: it drew on a CLIENT, which follows the operator by construction, and could not
@@ -671,12 +678,29 @@ class TheOutcomeIsWrittenToTheFrameTheOperatorEndsUpOn(_Frame, unittest.TestCase
         self.enterContext(mock.patch.object(
             choose, "switch_to", return_value=switch.Outcome(ok, message)))
         self.enterContext(mock.patch.object(commands_frame, "_start_chat_switch"))
+        self.started = self.enterContext(
+            mock.patch.object(commands_frame, "_start_workspace_switch"))
         self.assertEqual(
             commands_frame.cmd_palette(SimpleNamespace(client="", pane=True)), 0)
         return self.said.call_args
 
-    def test_a_workspace_switch_is_filed_on_this_frame(self):
-        self.assertEqual(self._picked(choose.WORKSPACE, "gamma")[0][0], self.FID)
+    def test_a_persona_switch_is_filed_on_this_frame(self):
+        self.assertEqual(self._picked(choose.PERSONA, "scribe")[0][0], self.FID)
+
+    def test_a_workspace_switch_that_took_is_started_and_said_by_the_switch_itself(self):
+        """§4b: this process cannot know which chat the client lands on, so it says
+        nothing and hands the name to `charter frame-switch --workspace`."""
+        self._picked(choose.WORKSPACE, "gamma")
+        self.started.assert_called_once_with(self.FID, "gamma")
+        self.said.assert_not_called()
+
+    def test_a_workspace_switch_that_was_REFUSED_stays_on_this_frame(self):
+        """A refusal leaves the operator where they are, so its sentence is filed here —
+        and nothing is started."""
+        args = self._picked(choose.WORKSPACE, "zzz", ok=False,
+                            message="no workspace 'zzz'")
+        self.assertEqual(args[0][0], self.FID)
+        self.started.assert_not_called()
 
     def test_a_chat_switch_that_took_is_filed_on_the_chat_being_switched_TO(self):
         """The client ends up in front of `api.2`'s panels, so `api.2`'s row is the one
@@ -693,8 +717,8 @@ class TheOutcomeIsWrittenToTheFrameTheOperatorEndsUpOn(_Frame, unittest.TestCase
     def test_the_outcome_carries_whether_it_happened(self):
         """`ok` is what picks the dwell, and a caller that dropped it would give every
         refusal a success's shorter one — silently, since both still say something."""
-        self.assertIs(self._picked(choose.WORKSPACE, "gamma", ok=True)[1]["ok"], True)
-        self.assertIs(self._picked(choose.WORKSPACE, "zzz", ok=False)[1]["ok"], False)
+        self.assertIs(self._picked(choose.PERSONA, "scribe", ok=True)[1]["ok"], True)
+        self.assertIs(self._picked(choose.PERSONA, "zzz", ok=False)[1]["ok"], False)
 
 
 if __name__ == "__main__":                          # pragma: no cover

--- a/tests/test_frame_pickers.py
+++ b/tests/test_frame_pickers.py
@@ -98,21 +98,22 @@ class AWorkspacePickerListsWorkspaces(_Frame, unittest.TestCase):
         self.assertEqual([(r.title, r.mark) for r in roster.rows],
                          [("alpha", True), ("beta", False), ("default", False)])
 
-    def test_choosing_a_row_is_refused_and_moves_nothing(self):
+    def test_choosing_a_row_is_allowed_and_still_moves_no_chat(self):
         """Was `test_choosing_a_row_switches_the_frame_and_bumps_it_so_panels_repaint`,
         which asserted `state.workspace_for` following the keypress — the defect §4j
-        forbids, stated as a requirement. The rows are still listed (above), because a
-        name the operator typed is a question they asked; what changed is the answer.
+        forbids, stated as a requirement — and then
+        `test_choosing_a_row_is_refused_and_moves_nothing`, which asserted #789's blanket
+        refusal.
 
-        The switch-and-bump property it measured is not lost: it is
-        `test_a_persona_picker_is_the_same_thing_one_noun_over`, which was always the
-        generic half of this pair."""
+        §4b's answer is the third one and it is both: the row is CHOSEN, and the chat's
+        workspace does not move, because what moves is the tmux client. No bump either —
+        the version a workspace switch earns is `_apply_arrangement`'s, after the client
+        has actually gone somewhere, and this call is a decision rather than an effect."""
         roster = choose.roster(choose.WORKSPACE, self.FID)
         was = state.version(self.FID)
         row = next(r for r in roster.rows if roster.name_of(r) == "beta")
         out = choose.switch_to(roster.noun, self.FID, roster.name_of(row))
-        self.assertFalse(out.ok)
-        self.assertEqual(out.message, switch.FOR_LIFE)
+        self.assertTrue(out.ok, out.message)
         self.assertEqual(state.workspace_for(self.FID), "alpha")
         self.assertEqual(state.version(self.FID), was)
 
@@ -349,13 +350,11 @@ class ThePaletteOpensThePickerAndActsOnWhatComesBack(_Frame, unittest.TestCase):
         self.assertEqual(self.said.call_args[0][0], self.FID)
         self.assertIs(self.said.call_args[1]["ok"], True)
 
-    # There is no workspace twin of the case above, and its absence is the change rather
-    # than a gap: the workspace doorway opens no picker at all now (§4j), so there is no
-    # doorway-then-name route to it from here. The two halves that remain are measured
-    # where each one lives — the refused doorway in
-    # `APinnedFrameIsToldBeforeItPressesAnything`, and the typed name that reaches
-    # `switch.FOR_LIFE` without a doorway in `tests/test_frame_palette_names.py`, which is
-    # the module that owns the `query_only` route a name row actually arrives by.
+    # The workspace twin of the case above is `test_choosing_a_row_is_allowed_and_still_
+    # moves_no_chat`, which asserts the half that differs — the chat does not move — and
+    # deliberately not the switch itself: a workspace switch is a tmux client moved
+    # between sessions, and `tests/test_a_workspace_switch_moves_the_client.py` is where
+    # that is measured against a server.
 
     def test_leaving_the_picker_without_choosing_moves_nothing(self):
         """Escape in the picker cancels the whole palette — `Surface.run` answers ``None``
@@ -442,8 +441,7 @@ class ARefusedSwitchSaysSoOnScreen(_Frame, unittest.TestCase):
         roster = choose.roster(choose.WORKSPACE, self.FID)
         row = next(r for r in roster.rows if roster.name_of(r) == "beta")
         out = choose.switch_to(roster.noun, self.FID, roster.name_of(row))
-        self.assertFalse(out.ok)
-        self.assertEqual(out.message, switch.FOR_LIFE)
+        self.assertTrue(out.ok, out.message)
         self.assertEqual(state.workspace_for(self.FID), "alpha")
         self.assertEqual(workspace.is_locked(self.FID), "alpha")
 
@@ -456,12 +454,13 @@ class APinnedFrameIsToldBeforeItPressesAnything(_Frame, unittest.TestCase):
     names none of which can be switched to would be an offer charter already knows it
     cannot honour.
 
-    **It was the WORKSPACE noun until §4j, and had to move rather than be copied.** That
-    doorway now carries `switch.FOR_LIFE` on every frame, pinned or not, so a pin-shaped
-    assertion on it would stay green with the pin taken away — measuring nothing, which
-    is the failure this repository distrusts most. The persona is where a launch pin is
-    still what decides, so it is where the rule is measured; the workspace doorway's one
-    reason has its own case at the end of this class.
+    **It was the WORKSPACE noun until §4j, and had to move rather than be copied.** A
+    workspace doorway carried #789's blanket refusal on every frame, pinned or not, so a
+    pin-shaped assertion on it would have stayed green with the pin taken away — measuring
+    nothing, which is the failure this repository distrusts most. §4b removed that refusal
+    and did **not** put the pin back (`choose.PIN` says why: the pin is about which
+    workspace this CHAT is in, and a switch moves a client), so the workspace doorway now
+    has no reason at all and the persona is the only noun a launch pin still decides.
     """
 
     PIN = {"CHARTER_WORKSPACE": "", "CHARTER_PERSONA": "forge"}
@@ -476,13 +475,12 @@ class APinnedFrameIsToldBeforeItPressesAnything(_Frame, unittest.TestCase):
         """One pin per noun. Reading a pin as "this frame cannot switch anything" would
         take another picker away for a reason that is not about it.
 
-        Asserted as "the other row's reason is not this pin" rather than as "the other
-        row has no reason": it has one now, and it is §4j's — which is exactly the
-        distinction a leak would break, by naming the persona's variable on a row that is
-        not about personas."""
+        Both halves, because either alone can be right by accident: the workspace row
+        carries no reason at all, and in particular not one naming the persona's own
+        variable on a row that is not about personas."""
         row = next(r for r in choose.open_rows(self.FID)
                    if choose.noun_of(r) == choose.WORKSPACE)
-        self.assertEqual(row.note, switch.FOR_LIFE)
+        self.assertFalse(row.refused)
         self.assertNotIn("CHARTER_PERSONA", row.note)
 
     def test_the_pin_is_contained_before_it_becomes_a_line_on_a_status_area(self):
@@ -525,23 +523,17 @@ class APinnedFrameIsToldBeforeItPressesAnything(_Frame, unittest.TestCase):
         self.assertIn("$CHARTER_PERSONA pins this frame", self.said.call_args[0][1])
         self.assertIsNone(persona.for_session(self.FID))
 
-    def test_the_workspace_doorway_opens_no_picker_either_and_says_why(self):
-        """The same shape arriving through the same field for a different reason (§4j),
-        asserted here as well as in
-        `tests/test_a_chat_belongs_to_its_workspace_for_life` because THIS is the class
-        that measures the doorway-to-screen path end to end — #732's rule that a doorway
-        with a reason is one `_picker` will not open, and that pressing it lands the note
-        on the operator's screen rather than doing nothing."""
+    def test_the_workspace_doorway_opens_a_picker_even_on_a_pinned_frame(self):
+        """The negative control for the pin, and the case that would have caught #789's
+        cost: a persona pin closes the persona doorway and must not close the workspace
+        one. THIS is the class that measures the doorway path end to end, so the assertion
+        is that `_picker` returns a surface and puts the roster in *opened* — #732's rule
+        read the other way round."""
         row = next(r for r in choose.open_rows(self.FID)
                    if choose.noun_of(r) == choose.WORKSPACE)
         opened = []
-        self.assertIsNone(commands_frame._picker(row, self.FID, opened))
-        self.assertEqual(opened, [])
-        with mock.patch.object(palette, "own_the_tty", _pane(row)):
-            self.assertEqual(commands_frame.cmd_palette(
-                SimpleNamespace(client="/dev/ttys7", pane=True)), 0)
-        self.said.assert_called_once()
-        self.assertEqual(self.said.call_args[0][1], switch.FOR_LIFE)
+        self.assertIsNotNone(commands_frame._picker(row, self.FID, opened))
+        self.assertEqual([r.noun for r in opened], [choose.WORKSPACE])
         self.assertEqual(state.workspace_for(self.FID), "alpha")
 
 

--- a/tests/test_frame_switch.py
+++ b/tests/test_frame_switch.py
@@ -45,51 +45,36 @@ def _plane_personas(*names: str) -> None:
         (d / "persona.md").write_text("# p\n")
 
 
-class SwitchingWorkspaceIsRefused(PersonaIso, unittest.TestCase):
-    """`switch.to_workspace` — §4j, and what this class used to assert instead.
+class SwitchingWorkspaceIsChecked(PersonaIso, unittest.TestCase):
+    """`switch.to_workspace` — §4b's check, and the two behaviours it has been.
 
-    **Nine cases were replaced rather than deleted, and here is the accounting**, because
-    they were the specification of a behaviour charter shipped for six days and every one
-    of them passed.
+    **This class has now specified three different functions and the accounting is worth
+    keeping**, because each one shipped and each one's tests passed.
 
-    Two pinned the defect by name and are the reason the strand in #733 and #788 could
-    form at all:
+    Until #789 it moved the CHAT. Two cases pinned that by name and are the reason the
+    strand in #733 and #788 could form at all:
+    `test_a_switch_moves_what_every_frame_surface_asks` asserted `state.workspace_for`
+    moved from `alpha` to `beta` — "the chat's workspace is a property you may set", where
+    §4j says it is identity — and
+    `test_the_launch_record_moves_too_so_a_respawned_panel_agrees` asserted the second
+    write on the grounds that a panel respawned later must agree with the panels that are
+    up. They did agree, about a workspace this chat's cwd, files and history were never in.
 
-    * `test_a_switch_moves_what_every_frame_surface_asks` asserted
-      `state.workspace_for(fid)` moved from `alpha` to `beta` — which is exactly "the
-      chat's workspace is a property you may set". §4j says it is identity.
-    * `test_the_launch_record_moves_too_so_a_respawned_panel_agrees` asserted the second
-      write, `state.frame_workspace`, on the grounds that a panel respawned later must
-      agree with the panels that are up. They did agree — about a workspace this chat's
-      cwd, files and history were never in.
+    #789 replaced both with an unconditional refusal, and
+    `test_one_refusal_and_not_a_queue_of_them` asserted the strongest form of it: the name
+    is not looked at. That was right about the chat and wrong about the operator — every
+    tab on the `workspaces` bar refused, so the bar was a directory listing with fifteen
+    dead rows.
 
-    Both are replaced by `test_a_switch_moves_nothing_that_any_frame_surface_asks` and
-    `test_the_launch_record_is_not_moved_either` below, which assert the same two rungs at
-    the same depth and in the same order, with the opposite expectation.
+    §4b keeps the first half and replaces the second: **nothing about the chat moves, and
+    the CLIENT does.** So the name is looked at again — a switcher has to know which names
+    it may be aimed at — and the two rungs #733 and #788 were about are asserted here
+    across a check that says **yes**, which is a strictly stronger statement than
+    asserting them across a refusal.
 
-    Five described the machinery of a move and have nothing left to describe: the bump
-    (`test_a_switch_bumps_the_frame_so_panels_repaint`), the switcher's own lock
-    (`test_switching_twice_is_not_refused_by_the_first_switchs_own_lock`,
-    `test_overriding_a_lock_is_said_out_loud`), the terminal pointer it must not write
-    (`test_no_terminal_pointer_is_written_for_somebody_elses_terminal`) and the refusal
-    ordering (`test_an_unknown_workspace_is_refused_and_creates_nothing`). The first four
-    are still measured one noun over, in :class:`SwitchingPersona`, which is where the
-    property was always generic; the fifth is now
-    `test_one_refusal_and_not_a_queue_of_them`.
-
-    Two were about the `$CHARTER_WORKSPACE` pin
-    (`test_a_pinned_frame_is_refused_rather_than_told_it_moved`,
-    `test_the_pin_is_read_from_the_frame_not_from_this_process`,
-    `test_an_empty_recorded_pin_is_not_a_pin`). The pin is still a pin — it is
-    `state.own_workspace`'s first rung and
-    `tests/test_frame_chat_switch.MembershipIsTheChatsOwnAnswerAndNotTheAskersAnswer`
-    measures all three properties of it there — but it is no longer what refuses a
-    switch, because an unpinned chat is refused identically.
-
-    The behaviour itself is measured in
-    `tests/test_a_chat_belongs_to_its_workspace_for_life.py`, which is where #733 and #788
-    are closed. What is here is the part that belongs beside `SwitchingPersona`: the two
-    functions sit side by side and a change to one is a plausible accident in the other.
+    The tmux half is `tests/test_a_workspace_switch_moves_the_client.py`; what is here is
+    the part that belongs beside :class:`SwitchingPersona`, since the two functions sit
+    side by side and a change to one is a plausible accident in the other.
     """
 
     FID = "f-switch"
@@ -105,14 +90,15 @@ class SwitchingWorkspaceIsRefused(PersonaIso, unittest.TestCase):
                                          "CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
         state.record_workspace(self.FID, "alpha")
 
-    def test_a_switch_moves_nothing_that_any_frame_surface_asks(self):
+    def test_a_switch_that_is_allowed_still_moves_nothing_any_frame_surface_asks(self):
         """The replacement for `test_a_switch_moves_what_every_frame_surface_asks`, asked
         of the same rule for the same reason — `state.workspace_for` is what every panel,
         the gather and the status line read, so that and not the file underneath it is
-        what "the frame moved" has to mean. Only the expectation is inverted."""
+        what "the frame moved" has to mean. The expectation is inverted AND the outcome is
+        a yes: §4j has to survive a switch that happens, not only one that is refused."""
         self.assertEqual(state.workspace_for(self.FID), "alpha")
         out = switch.to_workspace(self.FID, "beta")
-        self.assertFalse(out.ok, out.message)
+        self.assertTrue(out.ok, out.message)
         self.assertEqual(state.workspace_for(self.FID), "alpha")
 
     def test_the_launch_record_is_not_moved_either(self):
@@ -121,28 +107,53 @@ class SwitchingWorkspaceIsRefused(PersonaIso, unittest.TestCase):
         density change draws the old workspace beside the new one — true, and the answer
         is that neither moves, so a panel respawned an hour later is born into the
         workspace the launcher recorded."""
-        switch.to_workspace(self.FID, "beta")
+        self.assertTrue(switch.to_workspace(self.FID, "beta").ok)
         self.assertEqual(state.frame_workspace(self.FID), "alpha")
         self.assertIsNone(workspace.for_session(self.FID))
 
-    def test_one_refusal_and_not_a_queue_of_them(self):
-        """`test_an_unknown_workspace_is_refused_and_creates_nothing`'s replacement, and
-        the property is now stronger than "creates nothing": the name is not looked at.
-        A refusal that answered "no workspace 'beta2'" first would name a typo as the
-        thing standing between the operator and a move that cannot happen at any
-        spelling."""
+    def test_a_name_that_cannot_name_a_workspace_is_refused_by_the_alphabet(self):
+        """The first rung, and it is `workspace.valid_name` rather than a second regex
+        here — the name is about to be a `workspaces/<name>` join and a `-t` target's
+        neighbour, which is the position #442 already cost this project once."""
+        out = switch.to_workspace(self.FID, "../escape")
+        self.assertFalse(out.ok)
+        self.assertIn("cannot name a workspace", out.message)
+
+    def test_an_unknown_workspace_is_refused_and_creates_nothing(self):
+        """#518's rule, restored with the refusal it names: a picker that creates on a
+        typo leaves litter, so an unknown name is a question with the existing names
+        beside it."""
         before = sorted(p.name for p in config.WORKSPACES_DIR.iterdir())
-        for name in ("beta", "nope", "../escape"):
-            self.assertEqual(switch.to_workspace(self.FID, name).message,
-                             switch.FOR_LIFE)
+        out = switch.to_workspace(self.FID, "gamam")
+        self.assertFalse(out.ok)
+        self.assertIn("no workspace 'gamam'", out.message)
+        self.assertIn("alpha", out.message)
         self.assertEqual(sorted(p.name for p in config.WORKSPACES_DIR.iterdir()), before)
 
+    def test_the_workspace_this_chat_is_already_in_is_refused(self):
+        """`chats.check`'s "already here", one noun out and for its reason: switching a
+        client to the session it is already on would tear this chat's panels down and
+        split them again for no change on screen. The tab is drawn with `choose.MARK`
+        beside it, so the operator can see they are there before they press it."""
+        out = switch.to_workspace(self.FID, "alpha")
+        self.assertFalse(out.ok)
+        self.assertIn("already in workspace 'alpha'", out.message)
+
+    def test_a_pin_is_not_a_refusal_here_because_it_is_about_a_different_noun(self):
+        """`$CHARTER_WORKSPACE` pins which workspace THIS CHAT is in
+        (`state.own_workspace`'s first rung) and still does. A switch that moves a client
+        to another session does not touch it — refusing on it would be refusing to LOOK at
+        another workspace because this chat cannot leave the one it is in."""
+        state.record_identity(self.FID, {"CHARTER_WORKSPACE": "alpha",
+                                         "CHARTER_PERSONA": ""})
+        self.assertTrue(switch.to_workspace(self.FID, "beta").ok)
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+
     def test_the_refusal_cannot_forge_a_second_line(self):
-        """`test_a_refusal_message_cannot_forge_a_second_line`, which used to be about
-        `contain.one_line` over an echoed name and is now about the constant itself: no
-        name is interpolated, so what has to hold is that the one sentence charter wrote
-        is one line. A message is a line of charter's own output (`contain.py`, #453) and
-        this one lands on the attention panel beside others."""
+        """A name IS interpolated again, so this is `contain.one_line` over an echoed name
+        rather than a property of a constant — the shape it had before #789 and the reason
+        the call is back. A message is a line of charter's own output (`contain.py`, #453)
+        and this one lands on the attention panel beside others."""
         out = switch.to_workspace(self.FID, "beta\nrefused — everything is fine")
         self.assertFalse(out.ok)
         self.assertNotIn("\n", out.message)
@@ -402,11 +413,11 @@ class ThePaletteCannotGoStale(PersonaIso, unittest.TestCase):
         silently dropped the row would leave the operator unable to ask why a thing they
         remember is missing.
 
-        It was the WORKSPACE row until §4j: that doorway now carries `switch.FOR_LIFE` on
-        every frame, pinned or not, so a pin-shaped assertion on it would pass without the
-        pin and measure nothing (`choose.PIN` no longer has an entry for it, and
-        `tests/test_a_chat_belongs_to_its_workspace_for_life` is where its one reason is
-        measured)."""
+        It was the WORKSPACE row until §4j, and it cannot go back: `choose.PIN` has no
+        entry for that noun and §4b explains why — `$CHARTER_WORKSPACE` pins which
+        workspace this CHAT is in, and a workspace switch moves a client. A pin-shaped
+        assertion on that row would now pass with the pin taken away and measure
+        nothing."""
         state.record_identity(self.FID, {"CHARTER_PERSONA": "forge"})
         row = {r.id: r for r in _rows(self.FID)}["pick:persona"]
         self.assertIn("$CHARTER_PERSONA pins this frame", row.note)

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -774,6 +774,11 @@ class NoCharterEscapesThroughTheExecFamily(unittest.TestCase):
             "than a fixture provider's, and a mouse report still has to be put on a real "
             "client's terminal for tmux to route it anywhere. `os._exit`s in its "
             "`finally`.",
+        "tests/test_a_workspace_switch_moves_the_client.py:execvp":
+            "The same `tmux attach` inside a `pty.fork` child, for the reason a workspace "
+            "switch is ABOUT: `switch-client -c <client>` moves a CLIENT, and only a real "
+            "one on a real terminal exists to be moved — a detached session has nothing "
+            "for the switch to act on. `os._exit`s in its `finally`.",
         "tests/test_a_real_click_on_a_real_tab_bar_switches.py:execvp":
             "The same `tmux attach` inside a `pty.fork` child, for the sibling reason "
             "again: that file exercises the pointer against the two BARS, whose click "


### PR DESCRIPTION
Spec §4b — *"Many workspaces open, one visible"*.

## What this replaces

#789 made `switch.to_workspace` an unconditional refusal, because it used to re-home the chat — a violation of §4j. That was right about the chat and it left the switch doing nothing: on this plane the `workspaces` bar is fifteen tabs where **every click refuses**.

The operator's requirement is a different operation on a different noun:

> *"switching workspace — it means keep opened chat opened in background, so user can simultaneously run many harnesses in one charter environment. Changing workspace or changing sessions does not mean stopping old chat session."*

A workspace is a tmux session; your terminal is a tmux client. **Switching moves the client and kills nothing.**

## The shape

`switch.to_workspace` becomes a CHECK in `chats.check`'s sense — the refusals that need no server — and `commands_frame._switch_client` is the tmux half. It is `cmd_chat`'s four steps one scope out:

0. `_pane_place` on this chat's harness pane, and `_plane_session` for the target — **before anything is aimed anywhere** (#684).
1. `switch-client -c <client> -t <session id>`, once per client attached to this chat's session.
2. `_apply_arrangement(want=[])` on the chat being left — #686's rule, a background window keeps stale geometry.
3. `_apply_arrangement` on the chat tmux **landed on**, read back off the server rather than guessed, and re-dressed unconditionally — §4b's "#686's treatment one scope out".

The teardown is gated on charter having **read** the client on the target session, not on `switch-client` exiting 0 (#684's rule again). `display-message -p -c <client>` is deliberately not the reading: measured at the 3.2 floor it answers an empty string for a client that demonstrably moved, so a check built on it would refuse every switch on the older tmux.

Nothing is re-pointed. §4j is untouched — and `tests/test_a_chat_belongs_to_its_workspace_for_life.py` now asserts the invariant **across a switch that succeeds**, which is strictly stronger than asserting it across a refusal.

## Why it cannot cross planes

`commands_frame.SOCKET` is one tmux server per **machine**. Measured on the operator's own socket while this was written: eleven sessions from three different projects, and `default` — a name every plane has — among them. A `switch-client -t default` decided on a name can put an operator in another project's frame, across every isolation boundary charter has.

Two mechanisms, and **each covers what the other cannot**:

* the `%<pane>` id this plane's own launcher recorded for a chat in `.charter/frame/` **finds** the session (this is `_workspace_to_focus`'s existing mechanism, extracted into `_plane_session` so a focus and a switch cannot disagree about whose `default` is whose);
* a new session-scoped `@charter_plane` marker, holding this plane's `.charter` path, **vetoes** it.

A session an older charter created carries no marker — every session on this machine today — so an absent marker decides nothing and the pane record still answers. A pane id recorded for a chat that is over can name another plane's live pane after a `kill-server`, and the marker refuses that. The marker is written **once**, by the launch that CREATES a session, and never by one that joins: joining is decided on the session name, which is the collision itself, so re-marking there would relabel another plane's session as ours.

This closes the residual `_workspace_to_focus`'s own docstring called *"a stage, not a line"*.

## What a workspace with no session gets

A refusal that names the command that opens one: `workspace 'foo' is not open on this plane — open it with `charter <harness> --workspace foo``. Opening a workspace starts a harness and attaches a terminal; a switch runs detached with its streams on `/dev/null` and has no terminal to attach. `switch.py`'s standing rule (#518) is the same one.

The other refusals: a name that cannot name a workspace, one this plane does not have (with the names it does), the workspace you are already in, and a terminal that moved nowhere.

## Verification

* **Two planes, one tmux server, one shared workspace name** — the only arrangement the flaw exists in. The plane that opened it resolves it; the other resolves nothing though its workspace name, its chat id and the live session's name all match. Then the same fixture with the **recycled pane id**: resolved for the wrong plane *without* the marker (the hazard, run to prove it is reachable) and refused *with* it.
* **A real client moved between two real workspace sessions**: every pane on the server still there with the same pid and `pane_dead=0`, the `attach` process untouched, and the client landing on the window that session was last on. `switch-client` costs ~5 ms.
* **Six hand-written mutations** of the switch, all red: dropping the plane veto, dropping `-c <client>`, never verifying the client moved, dressing the matched seat instead of the landed window, leaving the old chat's panels up, and marking the plane on a joining launch.
* Real tmux on **3.7c and on the 3.2 floor**, identically on both. Full local suite green in a clean clone.

## Out of scope

Quit/reopen (§4e/§4f), the §4d durability redesign, `max_chats`, `chat: close`, and placing the `workspaces` bar in the shipped default (§4c/§4g/§4h — spec stage 9).

## A refutation worth recording

`show-options -t <session> -v @charter_plane` for an option nobody set answers **rc 1 with `invalid option:` on 3.7c and rc 0 with an empty line on 3.2** — a reader built on it would have to branch on the tmux version. A session-scoped user option resolves in a *pane's* format on both, so `_PANE_SEAT_FORMAT` carries it and the whole resolution stays one round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
