### PR TITLE
Typing a workspace command inside a chat no longer moves the chat (#791)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -6095,9 +6095,12 @@ def _pane_place(socket: str, pane: str | None) -> tuple[str, str] | None:
 
     **The question `chats.py` cannot ask and `select-window`'s return code does not
     answer.** `chats.of_workspace` decides membership from RECORDS — `state.own_workspace`,
-    which reads the pin the launcher wrote down, then the per-session pointer `charter
-    workspace use` writes, then the workspace the launch recorded — so two chats can share
-    a roster while their windows are in two different tmux sessions.
+    which reads the pin the launcher wrote down, then the workspace the launch recorded —
+    so two chats can share a roster while their windows are in two different tmux
+    sessions. (Both records are a launch's; the per-session pointer `charter workspace use`
+    writes was a third rung until #791, and this guard is what stood between it and a
+    `select-window` across sessions. It is not softened by the rung going away — a
+    migration or a hand-edited record reaches the same state.)
     The session is where a chat actually lives (`cmd_launch` makes the workspace the
     session), it is not written down anywhere charter can read, and it moves at runtime.
     So it is asked of tmux, at the moment it matters.
@@ -6190,7 +6193,9 @@ def cmd_chat(args) -> int:
        :func:`_pane_place`). Not one of the four, and it is here because every one of them
        assumes something no record on disk can promise: that the target's window is a
        window this client can be moved to. `chats.of_workspace` matches RECORDS
-       (`state.own_workspace`), whose pointer rung `charter workspace use` writes, so two
+       (`state.own_workspace`), and a record can name a workspace whose tmux session this
+       chat's window is not in — a migration, a hand-edited file, or (until #791) a
+       pointer `charter workspace use` wrote — so two
        chats can share a roster with their windows in two different tmux sessions — and
        `select-window` at another session's pane returns **0**, moves that session, and
        leaves this client exactly where it was. Steps 1 and 2 then reported a switch that
@@ -6290,12 +6295,15 @@ def cmd_chat(args) -> int:
     # anything** (#684). `chats.check` has established that both are chats of one
     # workspace and — since this issue — that both are on one tmux SERVER, and neither of
     # those is "in one tmux session". `cmd_launch` makes the workspace the session, but
-    # what membership is read from is RECORDS that move (`state.own_workspace`): `charter
-    # workspace use beta` typed inside chat `api.1` writes its pointer rung, and after
-    # that `of_workspace("beta")` returns `api.1` — a window of session `api` — beside
-    # `beta.1`, in one roster. (`switch.to_workspace` wrote that rung and the launch
-    # record both until §4j made it a refusal; this guard is what stood between that and a
-    # `select-window` across sessions, and it is not softened by the writer going away.)
+    # what membership is read from is RECORDS (`state.own_workspace`), and a record naming
+    # a workspace whose tmux session this chat's window is not in puts `api.1` — a window
+    # of session `api` — into `of_workspace("beta")` beside `beta.1`, in one roster.
+    # (Two writers reached that state and both are gone: `switch.to_workspace` wrote the
+    # pointer and the launch record until §4j made it a refusal, and `charter workspace
+    # use beta` typed inside `api.1` wrote the pointer until #791 stopped membership
+    # reading it. This guard is what stood between them and a `select-window` across
+    # sessions, and it is not softened by either writer going away — a migration or a
+    # hand-edited record reaches the same state with nothing having written anything.)
     here_place = _pane_place(socket, chats.pane_of(fid))
     there_place = _pane_place(socket, pane)
     if there_place is None:

--- a/charter/frame/chats.py
+++ b/charter/frame/chats.py
@@ -116,13 +116,21 @@ def of_workspace(workspace: str) -> list[str]:
     the fix for a chat missing from a roster is never to call it here.**
 
     What was wrong was the DEPTH, not the direction. This read `state.frame_workspace`
-    alone — the launch record, rung 2 — while `roster` keyed on all four, and
-    `charter workspace use <name>` typed at the agent writes rung 1 and never rung 2. So a
-    chat repaired that way was DRAWING `alpha` and excluded from `alpha`'s roster at the
-    same time, and the chats it had left could never see it again however it was repaired.
-    `state.own_workspace` is those chat-owned rungs — the recorded pin, the pointer, the
-    record — in the ladder's own order, so this and `roster` now ask one question at one
-    depth.
+    alone — the launch record — while `roster` keyed on every rung above it, so a chat
+    could be DRAWING `alpha` and excluded from `alpha`'s roster at the same time, and the
+    chats it had left could never see it again however it was repaired.
+    `state.own_workspace` is the chat-owned rungs — the recorded pin, then the record — in
+    the ladder's own order, so this and `roster` now ask one question at one depth.
+
+    **The per-session pointer is NOT one of those rungs, and #791 is why.** It was, for
+    one release. `charter workspace use <name>` typed at the agent writes it under the
+    CHAT's id (inside a frame `session.current()` is the chat — ADR 0019), so while it was
+    a rung that command re-homed the chat: measured, `charter workspace use gamma` inside
+    `alpha.1` took it out of `alpha`'s roster and put `gamma`'s chats on its bar, where
+    `check` approved rows `cmd_chat` then refuses. That is #733 and #788 through a door
+    neither issue named, and §4j settles it — a chat's workspace is its identity, and a
+    pointer written by whoever last typed a command is a property. Both rungs left are
+    written by the LAUNCH, so nothing after a launch moves a chat between workspaces.
 
     **Ordinal order, and it is not `created`'s.** Spec §3.5 asks for a `created` stamp
     per chat "so tab order and the ordinal allocator do not depend on directory mtime".
@@ -144,32 +152,38 @@ def of_workspace(workspace: str) -> list[str]:
     when a bar repaints, not on a tick — `frame/panel.py` polls `state.version`, which is
     one `stat`, and only renders when it moved. `state.reap` is what bounds the entries.
 
-    **What the ladder costs, measured rather than assumed**: one entry now reads three
-    small files where it read one — the identity record, the per-session pointer, the
-    workspace record — so 30 chats is 90 reads per call instead of 30. That is paid on a
-    repaint and never on a tick, and it is the price of the two halves of one question
-    being asked at one depth. Deliberately NOT cached: a cache here is a second source of
-    truth for a fact `.charter/frame/` already holds and free to disagree with it, which
-    is the #411 shape this module's own opening paragraph refuses.
+    **What the ladder costs, measured rather than assumed**: one entry reads two small
+    files where it read one — the identity record and the workspace record — so 30 chats is
+    60 reads per call instead of 30 (it was 90 while the per-session pointer was a rung,
+    and #791 gave that one back). That is paid on a repaint and never on a tick, and it is
+    the price of the two halves of one question being asked at one depth. Deliberately NOT
+    cached: a cache here is a second source of truth for a fact `.charter/frame/` already
+    holds and free to disagree with it, which is the #411 shape this module's own opening
+    paragraph refuses.
     """
     try:
-        # **`is_dir()`, and it came BACK with #733 — measured, not restored on taste.** A
-        # deletion sweep had removed it on the grounds that it could not change the answer:
-        # a frame's workspace was a FILE inside its directory, so `frame_workspace` already
-        # answered ``None`` for a loose file whatever its name was, and a guard that passes
-        # only because a different guard caught it is the shape this repository deletes.
+        # **`is_dir()` — kept, and honestly no longer measurable from out here.** A
+        # deletion sweep once removed it on the grounds that it could not change the
+        # answer: a frame's workspace was a FILE inside its directory, so
+        # `frame_workspace` already answered ``None`` for a loose file whatever the filter
+        # did, and a guard that passes only because a different guard caught it is the
+        # shape this repository deletes. #733 brought it back with a measurement, because
+        # membership had grown a rung that did NOT live in the frame's directory — the
+        # per-session pointer under `SESSIONS_DIR/<id>.workspace`, which knows nothing
+        # about whether the frame root holds a directory or a stray byte of a half-written
+        # temp file. With that rung planted, a loose FILE called `api.2` joined the roster
+        # and then refused when pressed, having no harness pane to aim at.
         #
-        # That stopped being true the moment membership grew a rung that does NOT live in
-        # the frame's directory. `state.own_workspace`'s pointer rung is
-        # `workspace.for_session`, whose file is `SESSIONS_DIR/<id>.workspace` — so an
-        # interrupted `os.replace` leaving a loose FILE called `api.2` under the frame
-        # root, beside a per-session pointer some earlier `api.2` wrote, is a name this
-        # would put on a bar and in a picker: measured, it joins the roster and then
-        # refuses when pressed, because it has no harness pane to aim at.
-        #
-        # `os.DirEntry.is_dir` is answered from `readdir`'s own `d_type` on Linux and macOS,
-        # so on the ~30 entries this scans it is ordinarily not a `stat` at all — and where
-        # it is one, it is the one the pointer read no longer pays on its behalf.
+        # **#791 removed that rung, so the measurement is gone again**: every rung of
+        # `state.own_workspace` now reads a file inside the frame's own directory, and a
+        # loose file answers ``None`` through the read whatever this filter does — checked,
+        # nothing in the suite goes red without it. It stays because it is the correct
+        # predicate rather than a second guard for the same fact (a chat IS a directory;
+        # this is the scan deciding what it is looking at, not a membership rule), and
+        # because it is free: `os.DirEntry.is_dir` is answered from `readdir`'s own
+        # `d_type` on Linux and macOS, so on the ~30 entries this scans it is ordinarily
+        # not a `stat` at all. A reader deleting it should know it costs nothing and
+        # protects the next out-of-directory rung, not that a test is watching it.
         names = [e.name for e in os.scandir(state._root()) if e.is_dir()]
     except OSError:
         # No frame root at all is the ordinary answer on a plane that has never launched

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -952,10 +952,10 @@ def own_workspace(fid: str) -> str | None:
     existed, and why swapping it for `workspace_for(n)` is the wrong fix rather than the
     obvious one. What was wrong was the DEPTH, not the direction: the roster asked four
     rungs and membership asked one, so a chat could be drawing `alpha` and be excluded
-    from `alpha`'s roster at the same time — `charter workspace use alpha` writes rung 1
-    and membership could only see rung 2.
+    from `alpha`'s roster at the same time.
 
-    The three rungs, in :func:`workspace_for`'s own order because they ARE its middle:
+    **Both rungs are written at LAUNCH, and #791 is why there is no third** (see below).
+    They are given in :func:`workspace_for`'s own order because they ARE its middle:
 
     1. **The pin the launcher recorded.** `state.identity` holds what the launch put on
        tmux's ``-e`` (`commands_frame._frame_identity_env`), which is `os.environ` inside
@@ -968,18 +968,45 @@ def own_workspace(fid: str) -> str | None:
        nothing draws. Take this rung away and a
        pinned chat that ran `charter workspace use other` is stranded in exactly the shape
        #733 describes, on a plane where it is coherent today.
-    2. **What was chosen inside the chat** — `workspace.for_session(fid)`, which takes the
-       id explicitly and reads one file under it. Never `workspace.chosen(session_id=fid)`,
-       which looks like the same thing and is not: its rungs fall through to a cwd read and
-       a terminal pointer that are the ASKER's.
-    3. **What the launcher resolved** — :func:`frame_workspace`, #512's seed.
+    2. **What the launcher resolved** — :func:`frame_workspace`, #512's seed.
 
-    ``None`` where every rung is empty, and that is a real answer rather than a failure:
+    **The per-session pointer used to sit between them and #791 took it out.** That rung
+    was `workspace.for_session(fid)`, and the writer that reaches it is
+    `workspace.set_active(..., session_id=session.current())` — which is
+    `charter workspace use <name>` typed at the agent, because inside a frame
+    `session.current()` is the CHAT's id (ADR 0019). So a command whose whole subject is
+    "which workspace is this session working in" was also answering "which workspace does
+    this chat belong to", and the measured outcome was #733 and #788 verbatim: two chats
+    in one tmux session, `charter workspace use gamma` typed in the first, and the second
+    could no longer see it (`chats.others` empty, `frame-chat alpha.1` answering `no chat
+    'alpha.1' here`) while the first was offered `gamma`'s chats, which `cmd_chat` then
+    refuses. #789 closed that shape through `switch.to_workspace`; this door stayed open
+    because both issues named the switch as the cause.
+
+    **Refusing the command inside a frame was the alternative and it is rejected on
+    evidence.** The only available test for "inside a frame" is `session.current()`, and
+    every agent spawned from a frame inherits `$CHARTER_SESSION_ID` — measured, a subagent
+    shell three levels down still reports the frame's id. A refusal keyed on that fires on
+    agents doing ordinary CLI work in isolated worktrees, none of which is in a frame in
+    any meaningful sense. Dropping the rung needs no detection and breaks no command:
+    `set_active` still writes the pointer and the lock, `workspace.resolve` still reads
+    them, so every `charter` command in that session still acts on the name that was
+    typed. What it stops is a pointer deciding a chat's IDENTITY, which §4j settles —
+    ``{workspace}-{hash}`` is identity, not a property, and a pointer written by whoever
+    last typed a command is the definition of a property.
+
+    Two consequences, both deliberate. `docs/frame.md` no longer promises that `ws use`
+    "moves the panels too", because it no longer does. And a chat with a pointer used to
+    follow a workspace RENAME (#752) while a chat without one was orphaned; every chat now
+    behaves like the second kind — more uniform, and a behaviour change rather than a
+    repair.
+
+    ``None`` where both rungs are empty, and that is a real answer rather than a failure:
     "this chat says nothing" belongs in nobody's roster, while :func:`workspace_for` still
     has to hand a panel a name to draw and falls through to its own last rung for it.
 
     Name-checked on the pin like every other rung that hands a value to `workspace_dir()`'s
-    join (#442); rungs 2 and 3 are checked by the functions that own them. `valid_name`
+    join (#442); the record below it is checked by the function that owns it. `valid_name`
     alone with no truthiness test in front of it — `valid_name("")` is already False, and
     `_frame_identity_env` emits an empty value for every name a launch did not have, so an
     unpinned launch falls through here on the name check's own terms.
@@ -988,7 +1015,7 @@ def own_workspace(fid: str) -> str | None:
     pin = identity(fid).get("CHARTER_WORKSPACE", "").strip()
     if ws_mod.valid_name(pin):
         return pin
-    return ws_mod.for_session(fid) or frame_workspace(fid)
+    return frame_workspace(fid)
 
 
 def workspace_for(fid: str) -> str:
@@ -1006,11 +1033,10 @@ def workspace_for(fid: str) -> str:
        every command it runs acts on the pinned name — a panel naming a workspace nothing
        in the session touches, wearing `slots`' `*` that says the environment chose it.
     1. **What the frame itself says** — :func:`own_workspace`, which is the recorded pin,
-       then `charter workspace use <name>` typed at the agent (the per-session pointer
-       under the FRAME's id, because inside a frame the frame is the charter session —
-       `docs/frame.md`, ADR 0019 — and "it moves the panels too" is a documented promise),
        then what the launcher resolved (:func:`record_workspace`, #512's seed: the launch's
-       own answer to a question nothing inside the frame can ask).
+       own answer to a question nothing inside the frame can ask). Both are written by the
+       LAUNCH, which is what makes a chat's workspace a fact about the chat rather than
+       about whoever typed last (§4j, #791).
     2. **Whatever this process resolves for itself**, for a frame launched by a charter
        that predates the record and still running across the upgrade — today's behaviour,
        so this is never worse than what it replaces.
@@ -1024,23 +1050,34 @@ def workspace_for(fid: str) -> str:
     could be drawing `alpha` and be excluded from `alpha`'s roster at the same time. A rung
     added below is now a rung both readers ask.
 
+    **`charter workspace use <name>` typed at the agent no longer moves the panels, and
+    that is #791 rather than an oversight.** It wrote the per-session pointer under the
+    CHAT's id, so the rung it moved was a membership rung and the command re-homed the
+    chat — #733 and #788 line for line, through a door neither issue named. The pointer is
+    still written and every `charter` command in that session still acts on the new name;
+    the panels draw the chat's own workspace, which is the one thing about a chat that does
+    not move. `docs/frame.md` is corrected to say so. See :func:`own_workspace` for why a
+    refusal was rejected instead.
+
     Rung 0 and the pin inside :func:`own_workspace` hold the same value on an ordinary
     launch — `_frame_identity_env` puts the launcher's `$CHARTER_WORKSPACE` on the pane's
     `-e` and records it — so the recorded one shows itself only where this process's
     environment is not the frame's, which on a tmux server shared between every frame on
     the machine is a real case and the one `switch._pin` already reads the record for.
 
-    The pointer and the record inside :func:`own_workspace` are the only two rungs below
-    the pin that can ever disagree, and it is worth saying why the others cannot.
-    `$CHARTER_WORKSPACE` reaches a panel exactly when the launcher had it
-    (`commands_frame._frame_identity_env` carries it, empty when absent), and the launcher
-    resolves it first — so the record holds the same value; rung 0 is therefore invisible
-    on an ordinary pinned launch and only shows itself when something inside the frame
-    tried to move off the pin. The cwd rung is the same story: a panel's cwd is the
-    launcher's, and the launcher asked `from_path` about it before anything else. The
-    per-terminal pointer and the declared default are the two rungs a panel reaches that
-    answer for the PANEL rather than for the frame, and those are exactly the two the
-    record is here to outrank.
+    **Since #791 the two rungs inside :func:`own_workspace` cannot disagree at all** —
+    they are one launch's two records, so rung 0, the recorded pin and the recorded
+    workspace hold one value on every ordinary launch and the whole ladder above rung 2 is
+    invisible. It is still worth saying why the rungs BELOW cannot be trusted, because
+    that is why rung 2 is the last one and not the first. `$CHARTER_WORKSPACE` reaches a
+    panel exactly when the launcher had it (`commands_frame._frame_identity_env` carries
+    it, empty when absent), and the launcher resolves it first — so the record holds the
+    same value. The cwd rung is the same story: a panel's cwd is the launcher's, and the
+    launcher asked `from_path` about it before anything else. The per-session pointer, the
+    per-terminal pointer and the declared default are the three rungs a panel reaches that
+    answer for the PANEL or for whoever typed last rather than for the frame, and those are
+    exactly the ones the record is here to outrank — the first of them by having stopped
+    being a rung of the middle at all.
 
     **Name-checked, and `valid_name` alone with no `env and` in front of it** — the same
     rule and the same reasoning as :func:`frame_workspace`, since this value ends up in

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -63,14 +63,29 @@ def for_session(sid: str) -> str | None:
     necessarily this process's — which is the whole reason it is public. Inside a charter
     frame the frame **is** the charter session (`docs/frame.md`, ADR 0019), so
     `charter workspace use <name>` typed at the agent writes this file under the FRAME's
-    id, and that is the documented mechanism by which it "moves the panels too".
+    id — and that decides what every `charter` command in that frame's own shell acts on.
 
-    A panel needs to tell that choice apart from the frame's launch-time answer
-    (`frame/state.py`'s `record_workspace`, #512): the launcher's answer is a SEED, and an
-    operator choosing inside the running frame outranks it. Asking this directly is what
-    keeps that distinction a property rather than a spelling — the alternative was reading
-    :func:`source`'s human-facing label and matching the string ``"session"``, which is a
-    sentence written for a status line, not an API.
+    **It does NOT decide what the frame's panels draw, and it did until #791.** That was
+    the documented mechanism behind "it moves the panels too", and what made it work was
+    this file being a rung of `frame/state.own_workspace` — which since #733 is also what
+    decides a chat's MEMBERSHIP of a workspace. So the command re-homed the chat:
+    measured, `charter workspace use gamma` typed inside `alpha.1` took it out of `alpha`'s
+    roster, made it invisible to the chat beside it in the same tmux session, and put
+    `gamma`'s chats on its bar where `cmd_chat` refuses them. Spec §4j settles which of the
+    two has to give: a chat belongs to its workspace for life, so what a pointer moves is
+    the session's work and never the chat's identity.
+
+    **Refusing the command inside a frame was the alternative and it was rejected on
+    evidence**: the only test for "inside a frame" is `session.current()`, and every agent
+    spawned from a frame inherits `$CHARTER_SESSION_ID` — so the refusal would fire on
+    agents doing ordinary CLI work in isolated worktrees. Nothing here changed; the reader
+    that stopped asking was `own_workspace`.
+
+    Still public, still read by :func:`chosen` and :func:`source`, and still keyed on an id
+    handed in rather than resolved — the caller is not always the session being described.
+    Asking this directly is what keeps that a property rather than a spelling: the
+    alternative was reading :func:`source`'s human-facing label and matching the string
+    ``"session"``, which is a sentence written for a status line, not an API.
 
     Name-checked like every other rung that hands a value to :func:`workspace_dir`'s join.
     The ``val and`` in front of it is a None-guard rather than a second name check —
@@ -106,10 +121,14 @@ def for_frame(sid: str | None) -> str | None:
 
     * **Below the per-session pointer.** `charter workspace use <name>` typed inside the
       frame writes that pointer under the frame's id, so an operator's explicit choice
-      still wins and the panels still follow it — the direction #517 asks for, and the
-      documented promise that `ws use` "moves the panels too". The launcher's answer is a
-      SEED, never a pin; nothing here takes `ws use` away from a framed session, which is
-      exactly what handing the harness `$CHARTER_WORKSPACE` would have done.
+      still wins **for this session's own commands** — the direction #517 asks for. The
+      launcher's answer is a SEED, never a pin; nothing here takes `ws use` away from a
+      framed session, which is exactly what handing the harness `$CHARTER_WORKSPACE` would
+      have done. What the pointer no longer moves is the frame's PANELS (#791): that read
+      goes through `frame/state.own_workspace`, which is also what decides a chat's
+      membership of a workspace, and a command deciding a chat's identity is what §4j
+      forbids. This rung's position is unaffected — the two readers were always different
+      functions, and only one of them stopped asking.
     * **Above the per-terminal pointer.** That rung is not merely absent inside a frame,
       it is *wrong*: it is keyed on `$TMUX_PANE`, and the harness's pane is one charter
       created — not the operator's terminal, whose pointer it would otherwise read or

--- a/docs/adr/0019-the-frame-owns-the-surface.md
+++ b/docs/adr/0019-the-frame-owns-the-surface.md
@@ -125,10 +125,21 @@ worth more there than two extra rows are to a sidebar that is already truncating
 
 The frame launcher exports the frame id under `$CHARTER_SESSION_ID` — the variable
 `charter.session.current()` already owns. That collision was load-bearing and
-undocumented: panels follow `charter ws use` **only** because of it, since
-`workspace.set_active` writes a per-session pointer under `session.current()` and a panel
-reads it back under the same name. (The per-*terminal* pointer cannot do this job: it is
-keyed by `$TMUX_PANE`, and the harness and each panel are different panes.)
+undocumented: a choice made inside the frame is recorded under `session.current()`, and
+every panel reads it back under the same name — the frame's persona
+(`persona.set_active`), its workspace lock, the harness-session mapping the `ctx` gauge
+needs, and `workspace.for_frame`'s ability to find the frame's own directory at all. (The
+per-*terminal* pointer cannot do this job: it is keyed by `$TMUX_PANE`, and the harness and
+each panel are different panes.)
+
+**Corrected by #791.** This paragraph used to say that panels follow `charter ws use`
+*only* because of the collision, and that was true when it was written. It is no longer:
+the pointer `workspace.set_active` writes lands under the CHAT's id, and while the panels
+read that pointer the command also re-homed the chat — the ladder the panels read is the
+one that decides which chats a workspace has (`frame/state.own_workspace`), which spec §4j
+forbids a typed command from moving. So membership and the panels now read the launch's
+own records, and `ws use` moves what the session's commands act on. The collision itself is
+unchanged and still load-bearing for everything above.
 
 **Kept, deliberately: one variable, one meaning — "the charter session this process
 belongs to". Inside a frame, that is the frame.** Every process the frame contains — the
@@ -156,7 +167,10 @@ has a consequence the comfortable version hides:
   environment**: the token-usage history this ADR keeps alive, and the session trace.
 
 Pinned by `tests/test_frame_owns_the_surface.py`, which asserts that a panel follows a
-`ws use` made under the frame's id and does *not* follow one made under any other.
+`ws use` made under the frame's id and does *not* follow one made under any other — on a
+frame that recorded no workspace of its own, which since #791 is the only frame whose
+panels a pointer reaches. The class is named for that, and its last case pins the boundary:
+write the launch record and the same switch moves nothing.
 
 That rule sends a bill, and #411 was it: charter's private tmux server is shared by every
 frame on the machine, so only the first launch's `new-session` starts it, and tmux builds

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -800,9 +800,9 @@ has no numbers to show without a payload.)
 `charter <harness>` exports the frame's id as `$CHARTER_SESSION_ID`, the same variable
 every charter command reads to answer "which session am I". That is on purpose: inside a
 frame, the frame **is** the charter session. The agent's shell, each panel and any
-`charter` command typed inside the frame all agree on one identity, which is why
-`charter workspace use <name>` typed at the agent moves the panels too — the pointer is
-written under the frame's id and the panels read it back under the same one.
+`charter` command typed inside the frame all agree on one identity — so a workspace, a
+persona or a lock chosen inside the frame is one thing chosen for the whole frame, not one
+per pane.
 
 Claude Code's own session id has not gone anywhere; it arrives in the status line's stdin
 payload and keys what comes with it (the usage history, the session trace). Two ids, two
@@ -817,11 +817,27 @@ instead. Nothing is pinned into the environment to achieve it, deliberately: exp
 `$CHARTER_WORKSPACE` would rank above every pointer and take `charter workspace use` away
 from every framed session.
 
-So the order the panels read is: `$CHARTER_WORKSPACE` if you pinned one, then what you
-chose **inside** this frame, then what the launch resolved, then whatever the panel can
-resolve for itself (a frame launched by an older charter, still running across the
-upgrade). `charter workspace use <name>` at the agent still moves the panels, and still
-moves them for the same reason as before.
+So the order the panels read is: `$CHARTER_WORKSPACE` if you pinned one, then what the
+launch recorded — the pin it was launched under, then the workspace it resolved — then
+whatever the panel can resolve for itself (a frame launched by an older charter, still
+running across the upgrade).
+
+**`charter workspace use <name>` typed at the agent does not move the panels, and this
+line used to say the opposite.** It writes the per-session pointer under the frame's id,
+which is what makes every `charter` command in that shell act on the new name — `charter
+clone`, `charter repos`, `charter ws current`, all of it. What it does *not* do is change
+which workspace the chat is in, and for one release it did: that pointer was a rung of the
+ladder the panels read, and the same ladder decides which chats a workspace has. So the
+command quietly re-homed the chat — the chat beside it in the same tmux session could no
+longer see it, and its own tab bar filled with the other workspace's chats, which the
+palette then refused to open. **A chat belongs to its workspace for life** (spec §4j); a
+conversation wanted elsewhere is a new chat, opened with `charter <harness>` in that
+workspace. If you want the panels on another workspace, `F2 → workspace` moves your
+terminal to it and leaves every chat where it is.
+
+One consequence worth stating: a chat's workspace is now fixed at launch, so **renaming a
+workspace orphans its chats** — their record still names the old name. That was already
+true of any chat nobody had typed `workspace use` in, and it is now true of all of them.
 
 The pin comes first because that is what it means everywhere else in charter: it ranks
 above every pointer in `charter`'s own resolution, and `charter workspace use` warns you

--- a/docs/news/unreleased-typing-a-workspace-command-no-longer-moves-your-chat.md
+++ b/docs/news/unreleased-typing-a-workspace-command-no-longer-moves-your-chat.md
@@ -1,0 +1,122 @@
+---
+version: unreleased
+headline: Typing `charter workspace use` inside a chat no longer moves the chat
+---
+
+*"I typed `charter workspace use gamma` in one chat to point my commands at gamma, and the
+chat next to it stopped existing."*
+
+The release before this one closed that same strand twice — `F2 → workspace` no longer
+re-homes a chat (#733, #788, #789). **It was still reachable by typing a command**, and
+both issues had named the palette's switcher as the cause, so closing them closed one
+writer and left the other standing.
+
+## What was measured
+
+Three chat directories, no tmux, `charter workspace use gamma` typed inside `alpha.1`:
+
+```
+alpha.1 draws: gamma    alpha.1 owns: gamma    frame record: alpha
+alpha.2 sees: []        alpha.1 sees: ['gamma.1']
+check alpha.2 -> alpha.1: no chat 'alpha.1' here — have: alpha.2
+check alpha.1 -> gamma.1: chat → gamma.1        <- and `cmd_chat` then refuses it
+```
+
+Both symptoms, line for line. `alpha.2` is a live window of the very tmux session the
+operator is looking at and could not see `alpha.1` at all; `alpha.1`'s own tab bar filled
+with `gamma`'s chats, which the pre-flight approved and the switch then refused.
+
+## Why one command could do that
+
+`commands_workspace` calls `workspace.set_active(...)`, which keys its pointer on
+`session.current()`. **Inside a frame `session.current()` is the CHAT's id** (ADR 0019, and
+that collision is load-bearing) — so the write landed on
+`workspace.for_session(<chat>)`, which was the middle rung of `frame/state.own_workspace`,
+the ladder that decides *which chats a workspace has*. A command whose subject is "which
+workspace is this session working in" was also answering "which workspace does this chat
+belong to".
+
+Spec §4j settles which of those has to give: **`{workspace}-{hash}` is identity, not a
+property.** A pointer written by whoever last typed a command is the definition of a
+property, and identity cannot be one.
+
+**So membership is now the launch's own records** — the pin the launcher recorded, then the
+workspace it resolved — and nothing written after a launch moves a chat between workspaces.
+
+## The alternative was refusing the command, and it is rejected on evidence
+
+The obvious fix is to refuse `charter workspace use` inside a frame. The only available
+test for "inside a frame" is `session.current()`, which reads `$CHARTER_SESSION_ID` — and
+**every agent spawned from a frame inherits it.** Measured: a subagent shell three levels
+down still reports `CHARTER_SESSION_ID=harness-wrapper.1`. A refusal keyed on that fires on
+agents doing ordinary CLI work in isolated worktrees, none of which is in a frame in any
+meaningful sense.
+
+Dropping the rung needs no detection and takes no command away. `set_active` still writes
+the pointer and the lock, `workspace.resolve` still reads them, so `charter clone`,
+`charter repos` and `charter ws current` in the frame's own shell all act on the name you
+typed. What stopped is the pointer deciding a chat's identity.
+
+## Two things this changes that were not defects
+
+**`charter workspace use <name>` no longer moves the panels.** `docs/frame.md` promised it
+did, in as many words, and that promise is corrected rather than quietly broken: it was
+true, and what made it true was the write this release removes. If you want the panels on
+another workspace, `F2 → workspace` moves your terminal to it and leaves every chat where
+it is; a conversation wanted in another workspace is a new chat, which is what §4j says.
+(One frame still follows the pointer and it is the migration case: a frame launched by a
+charter that recorded no workspace at all, where the panels fall through to resolving for
+themselves. `tests/test_frame_owns_the_surface` is named for that now, and pins the
+boundary.)
+
+**A workspace rename now orphans every chat, not just some of them.** `workspace.rename`
+rewrites every per-session pointer holding the old name, so a chat that had one followed a
+rename automatically and a chat that never had one was left naming a workspace that no
+longer exists. Membership no longer reads that pointer, so every chat behaves like the
+second kind — more uniform, and a real behaviour change. The repair route went with it:
+typing `charter workspace use <newname>` inside an orphaned chat used to fix it and now
+does nothing. Making `rename` repoint the frame records is the fix and it is not in here —
+it is a decision about whether a rename moves a chat's identity, which deserves its own
+argument next to #752 rather than a line in this one.
+
+## What this does not close
+
+**#731 is not closed, and half of it is.** A chat id is reallocated when a frame exits,
+while `.charter/sessions/<fid>.workspace` and `.lock` are not reaped with the frame — so a
+recycled ordinal inherits the previous tenant's pointer. The half that is gone is the one
+the issue's title is about: a relaunch asked for `alpha` explicitly and came up **labelled
+`gamma`**, in `gamma`'s roster, with `gamma`'s todo count and a repo pane sized for
+`gamma`'s rows. Measured after this change, the same fixture draws `alpha` and belongs to
+`alpha`.
+
+What survives is the lock and the frame shell's own resolution, neither of which this
+touches: measured on a relaunched `alpha.1` with a reaped predecessor's files still on
+disk, `workspace.is_locked` answers `gamma`, `workspace.resolve` answers `gamma`, and
+`charter workspace use alpha` — typed by the operator who just asked for `alpha` on the
+command line — is **refused as locked**. #731 is now exactly "reap the session pointer and
+the lock with the frame", which is what PR #757's body recommended in the first place.
+
+## Verification
+
+Reproduced without tmux and pinned as tests: three chat directories, the real
+`workspace.set_active` with the chat's id in the environment (never a hand-written pointer
+file, and never an explicit `session_id=` — the defect is *which id the command resolves
+for itself*), then the roster from each side. Seven new cases, five of which were red before
+the change.
+
+Every rung of the shortened ladder was hand-mutated to confirm it is load-bearing:
+restoring the pointer rung, dropping the pin rung, checking the pin for truth instead of
+for a name, `strip` → `lstrip`, and dropping `workspace_for`'s own rung 0 each turn the
+suite red on the case that names them.
+
+**Four tests near the change stopped measuring their own guards, and all four are fixed
+rather than left green.** The pin's `.strip()`, `workspace_for`'s rung 0 (twice), and
+`of_workspace`'s `is_dir()` filter had all been pinned by fixtures that leaned on the
+pointer being the disagreeing rung; with the pointer gone, three of them passed either way
+and were restaged on a launch record that names a different workspace. The fourth —
+`is_dir()` — has no measurement left at all: every rung now reads a file inside the frame's
+own directory, so a loose file is refused by the read whatever the filter does. It stays,
+and its comment says plainly that it is a floor rather than a measured guard, so the next
+deletion sweep decides on the facts.
+
+Nothing to adopt.

--- a/tests/test_a_chat_belongs_to_its_workspace_for_life.py
+++ b/tests/test_a_chat_belongs_to_its_workspace_for_life.py
@@ -1,4 +1,4 @@
-"""§4j, restored: `{workspace}-{hash}` is identity, not a property — #733 and #788.
+"""§4j, restored: `{workspace}-{hash}` is identity, not a property — #733, #788, #791.
 
 Spec `2026-08-25-agentic-ide-foundation.md:661` settled it and
 `2026-08-28-phase5-workspace-and-chat-tabs.md:442` reaffirmed it:
@@ -34,6 +34,26 @@ would have caught it.
 Neither is a subset of the other and both have one cause, so both are asserted against
 the cause rather than against their symptoms: **nothing re-points a chat's workspace.**
 
+**#791 is the same two symptoms through a door neither issue named**, and it is why
+asserting against the cause was not enough on its own: both issues named
+`switch.to_workspace`, so closing them closed one writer and left the other standing.
+`charter workspace use gamma` typed at the agent calls
+`workspace.set_active(..., session_id=session.current())`, and inside a frame
+`session.current()` is the CHAT's id (ADR 0019) — so the write landed on
+`workspace.for_session(<chat>)`, which was the middle rung of `state.own_workspace`. A
+command that answers "which workspace is this session working in" was answering "which
+workspace does this chat belong to" as well, and the measured outcome was #733 and #788
+line for line.
+
+**Refusing `workspace use` inside a frame was rejected on evidence, and the rejection is
+why the rung went instead.** The only available test for "inside a frame" is
+`session.current()`, which reads `$CHARTER_SESSION_ID` — and every agent spawned from a
+frame inherits it (measured: a subagent shell three levels down still reports the frame's
+id). A refusal keyed on that fires on agents doing ordinary CLI work in isolated
+worktrees, none of which is in a frame in any meaningful sense. So the pointer is still
+written and `workspace use` still works everywhere; what changed is that
+`state.own_workspace` no longer reads it, and membership is the launch records alone.
+
 **No tmux here, deliberately** — the strand is a state defect and reproduces on two
 directories. `tests/test_frame_chat_switch.TheSwitchEstablishesTheWindowItIsMovingTo`
 keeps the tmux half: a plane that arrived in the split state by some other route (a
@@ -49,6 +69,7 @@ suite inside a live frame would otherwise be supplying half of every fixture
 from __future__ import annotations
 
 import os
+import shutil
 import unittest
 from unittest import mock
 
@@ -255,3 +276,129 @@ class TheDoorwayOpensAgainAndStillMovesNoChat(PersonaIso, unittest.TestCase):
         self.assertTrue(rows)
         self.assertTrue(all(not r.refused and r.note == choose.WORKSPACE
                             for r in rows))
+
+
+class TheOtherDoorMovesNoChatEither(PersonaIso, unittest.TestCase):
+    """#791: `charter workspace use <name>`, typed at the agent inside a chat.
+
+    Every case here is #733's or #788's own reading, made through the writer #789 left
+    standing. The fixture is the one both issues reproduce with — two chats in `alpha`,
+    one in `gamma`, no tmux — and the door is `workspace.set_active` with no `session_id`,
+    which is exactly what `commands_workspace.cmd_use` calls: the id it lands on is
+    whatever `session.current()` answers, and inside a frame that is the chat.
+
+    **`$CHARTER_SESSION_ID` is set here on purpose and it is the whole fixture.** The
+    class above clears the environment because the switch takes the chat id as an
+    argument; this command does not, and a case that passed the id explicitly would be
+    testing a call `charter workspace use` never makes.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        for n in ("alpha", "gamma"):
+            (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
+        _plant("alpha.1", ws="alpha", pane="%1")
+        _plant("alpha.2", ws="alpha", pane="%2")
+        _plant("gamma.1", ws="gamma", pane="%3")
+
+    def _use(self, name: str) -> str:
+        """`charter workspace use <name>` typed inside `alpha.1`, and nothing else.
+
+        No `session_id=`, no `terminal_id=`: the point of the defect is which id the
+        command resolves for itself, so supplying one would remove the thing under test.
+        """
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "alpha.1"}):
+            return workspace.set_active(name, force=True)
+
+    def test_the_chat_is_still_in_the_workspace_it_was_launched_for(self):
+        """The invariant, asked of both halves of the one ladder: what the frame DRAWS
+        (`state.workspace_for`) and what it IS (`state.own_workspace`). Measured before
+        the fix, both answered `gamma`."""
+        self._use("gamma")
+        self.assertEqual(state.own_workspace("alpha.1"), "alpha")
+        self.assertEqual(state.workspace_for("alpha.1"), "alpha")
+
+    def test_the_sibling_still_holds_it_in_its_roster(self):
+        """#733, backward, through this door: `alpha.2` is a live window of the very tmux
+        session the operator is looking at, and it could not see `alpha.1` at all —
+        measured, `chats.others('alpha.2')` came back empty and `charter frame-chat
+        alpha.1` answered `no chat 'alpha.1' here — have: alpha.2`."""
+        self._use("gamma")
+        self.assertEqual(chats.others("alpha.2"), ["alpha.1"])
+        self.assertTrue(chats.check("alpha.2", "alpha.1").ok,
+                        chats.check("alpha.2", "alpha.1").message)
+
+    def test_it_is_not_offered_the_other_workspaces_chats(self):
+        """#788, forward, through this door. Measured before the fix,
+        `chats.others('alpha.1')` was `['gamma.1']` and `chats.check` approved it — a row
+        whose window is in tmux session `gamma` while this client is in `alpha`, which
+        `cmd_chat` then refuses (#684). A pre-flight that approves what the action
+        refuses is worse than no pre-flight."""
+        self._use("gamma")
+        self.assertNotIn("gamma.1", chats.others("alpha.1"))
+        self.assertFalse(chats.check("alpha.1", "gamma.1").ok)
+
+    def test_both_workspaces_hold_exactly_the_chats_they_were_launched_with(self):
+        """Membership from both ends, because the defect moved a name from one list to
+        the other and either list alone can be right by accident. Measured before:
+        `alpha` held `['alpha.2']` and `gamma` held `['alpha.1', 'gamma.1']`."""
+        self._use("gamma")
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.2"])
+        self.assertEqual(chats.of_workspace("gamma"), ["gamma.1"])
+
+    def test_the_command_still_does_its_own_job_and_that_is_the_point(self):
+        """**The fix is not "stop writing the pointer", and this is the case that says
+        so.** `charter workspace use` answers "which workspace is this session working
+        in": the pointer and the lock are what it exists to write, and a shell inside the
+        frame that types it must still find `workspace.resolve` answering the new name —
+        that is what makes every `charter clone`, `charter repos` and `charter ws current`
+        in that session act on it.
+
+        Deleting the write instead would have taken the command away from every framed
+        session and from every agent that inherits `$CHARTER_SESSION_ID` from one, which
+        is the refusal this fix exists to avoid. What stopped is the pointer deciding a
+        chat's IDENTITY, not the pointer existing.
+        """
+        self.assertEqual(self._use("gamma"), "session")
+        self.assertEqual(workspace.for_session("alpha.1"), "gamma")
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "alpha.1"}):
+            self.assertEqual(workspace.resolve(cwd=config.ROOT), "gamma")
+
+    def test_a_pointer_left_behind_by_a_reaped_chat_decides_nothing(self):
+        """#731's first half, and the reason a reopened chat (§4e/§4f) can trust its own
+        launch record.
+
+        `state.new_chat_id` allocates the lowest free ordinal from `.charter/frame/`, so
+        an id is free the moment its directory is reaped — while `state.reap` leaves
+        `sessions/<fid>.workspace` behind. The next `charter claude --workspace alpha`
+        that lands on `alpha.1` therefore inherits the previous frame's pointer, and while
+        that pointer was a membership rung it OUTRANKED the launcher that had just been
+        told `alpha` explicitly: measured, the relaunched chat drew `gamma`, joined
+        `gamma`'s roster and left `alpha`'s.
+
+        Nothing here reaps the pointer — #731's remaining half — and nothing needs to for
+        identity: a stale pointer is no longer a rung of `own_workspace`, so a chat's
+        workspace is what its launch recorded whatever an earlier tenant of its ordinal
+        wrote.
+        """
+        self._use("gamma")
+        shutil.rmtree(state.frame_dir("alpha.1"))
+        self.assertEqual(workspace.for_session("alpha.1"), "gamma",
+                         "the stale pointer this case is about was reaped after all")
+        _plant("alpha.1", ws="alpha", pane="%9")    # the relaunch, same ordinal
+        self.assertEqual(state.own_workspace("alpha.1"), "alpha")
+        self.assertEqual(state.workspace_for("alpha.1"), "alpha")
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.2"])
+        self.assertEqual(chats.of_workspace("gamma"), ["gamma.1"])
+
+    def test_a_pinned_chat_is_unmoved_for_the_rung_above_rather_than_this_one(self):
+        """The pin is still the first rung and still outranks everything below it, which
+        is what keeps this fix from being "membership is `frame_workspace`". Stated here
+        because a reader of the diff sees one rung removed and the obvious next deletion
+        is the other one — `tests/test_frame_chat_switch.Membership…` measures why that
+        strands a pinned chat."""
+        state.record_identity("alpha.1", {"CHARTER_HARNESS": "Claude Code",
+                                          "CHARTER_WORKSPACE": "gamma"})
+        self.assertEqual(state.own_workspace("alpha.1"), "gamma")
+        self.assertEqual(chats.of_workspace("gamma"), ["alpha.1", "gamma.1"])

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -211,20 +211,26 @@ class TheRosterIsTheDirectory(PersonaIso, unittest.TestCase):
         temp file a write was interrupted mid-`os.replace`, anything — none of them has a
         frame directory's shape and none may become a row.
 
-        **The per-session pointer is planted deliberately, and without it this test cannot
-        see its own guard** (#733). Membership used to be a file INSIDE the frame's
-        directory, so a loose file was refused by the read whatever the filter did; it now
-        also asks `workspace.for_session`, whose file lives under `SESSIONS_DIR` and knows
-        nothing about whether the frame root holds a directory or a stray byte of a
-        half-written temp file. Measured: without the `is_dir()` filter this case goes red
-        on the second name and green on the first, which is the same test passing against
-        the defect it exists to catch.
+        **The per-session pointer is planted deliberately and it no longer turns the
+        case, which is worth saying rather than leaving to be discovered.** #733 gave
+        membership a rung outside the frame's directory — `workspace.for_session`, under
+        `SESSIONS_DIR` — and with it planted this case could see the `is_dir()` filter:
+        without the filter it went red here and green on the first name. #791 took that
+        rung out again, so every rung reads a file inside the frame's own directory and a
+        loose file is refused by the read whatever the filter does. Checked: nothing in
+        the suite goes red without `is_dir()` now.
+
+        What this case still pins is its own name — a loose file is not a chat, and a
+        stale pointer beside one does not make it one — which is a property of the whole
+        function rather than of one line in it. `chats.of_workspace`'s comment says the
+        same thing about the filter, so a later sweep deleting it does so knowing what it
+        is deleting.
         """
         _plant("api.1", workspace="api")
         (state._root() / "api.2").write_text("not a chat\n")
         workspace.set_active("api", session_id="api.2", force=True, terminal_id="")
         self.assertEqual(workspace.for_session("api.2"), "api",
-                         "the pointer this case turns on was not written")
+                         "the pointer this case plants was not written")
         self.assertEqual(chats.of_workspace("api"), ["api.1"])
 
     def test_a_chat_with_no_recorded_workspace_belongs_to_none(self):
@@ -288,21 +294,23 @@ class MembershipIsTheChatsOwnAnswerAndNotTheAskersAnswer(PersonaIso,
     `workspace_for` alike. One ladder asked twice — the shape `workspace.chosen` already
     names — rather than two that agree today.
 
-    **The writer in these fixtures changed and the ladder did not.** They used to reach
-    the pointer rung through `switch.to_workspace`, which wrote it and the record both;
-    §4j has since made that a refusal (`tests/test_a_chat_belongs_to_its_workspace_for_
-    life.py`), so what is left writing a per-session pointer under a chat's id is
-    `workspace.set_active(..., session_id=<chat>)` — which is `charter workspace use`
-    typed at the agent, and `commands_frame._pin_workspace` at launch. That is the
-    production writer these cases now use, and every rung and every ordering below is
-    unchanged.
+    **The middle rung this class was written around is GONE, and #791 is why.** The
+    pointer was reached first through `switch.to_workspace` and then, once §4j made that a
+    refusal, through `workspace.set_active(..., session_id=<chat>)` — which is
+    `charter workspace use` typed at the agent, because inside a frame `session.current()`
+    is the chat's id (ADR 0019). That writer put #733 and #788 straight back: measured,
+    `charter workspace use gamma` inside `alpha.1` left `alpha.2` unable to see it and put
+    `gamma`'s chats on `alpha.1`'s bar. So membership is now the launch's two records —
+    the recorded pin, then the recorded workspace — and a pointer decides nothing about a
+    chat's identity. `tests/test_a_chat_belongs_to_its_workspace_for_life.
+    TheOtherDoorMovesNoChatEither` is that door.
 
-    **What #733's other half decided, and it was not decided here.** Whether `F2 →
-    workspace` moves the chat or the frame is settled: neither. A chat belongs to its
-    workspace for life (spec §4j), which is why the strand cannot form that way any more.
-    This class is the half that survives it — a chat may still be DRAWING a workspace its
-    record does not name, because a pin or a pointer says so, and it must be in that
-    workspace's roster when it is.
+    **What survives here is the DEPTH argument, which was always the point.** Two rungs
+    rather than three, and the two questions still walk one ladder: a chat may be DRAWING
+    a workspace its launch record does not name — because a recorded pin says so — and it
+    must be in that workspace's roster when it is. What may never happen is membership
+    reaching a rung that answers for the process ASKING, and the two cases that measure
+    that are unchanged by anything #791 did.
     """
 
     def setUp(self):
@@ -317,38 +325,49 @@ class MembershipIsTheChatsOwnAnswerAndNotTheAskersAnswer(PersonaIso,
         _plant("alpha.2", workspace="alpha", pane="%2")
 
     def test_a_chat_that_is_drawing_a_workspace_is_in_that_workspaces_roster(self):
-        """The incoherence, stated as the invariant it broke.
+        """The incoherence, stated as the invariant it broke, on the rung that can still
+        produce it.
 
-        After `charter workspace use gamma` typed inside `alpha.1`, that chat draws
-        `gamma` — its panels, its status line and every command it runs say `gamma` —
-        while `of_workspace` read the launch record and left it in `alpha`.
+        A chat launched under `CHARTER_WORKSPACE=gamma` draws `gamma` — its panels, its
+        status line and every command it runs say `gamma` — while `of_workspace` read the
+        launch record, which holds `alpha`, and left it there. That is the whole defect,
+        and it does not need a pointer to happen: `_frame_identity_env` records the pin
+        the launch had, and a launch can be pinned to one workspace while
+        `workspace.resolve` answered another.
 
         Both halves are asserted because either list alone can be right by accident: the
         chat has to arrive in the roster it is drawing AND leave the one it is not.
+
+        Staged on `charter workspace use` until #791 took the pointer out of the ladder.
         """
-        workspace.set_active("gamma", session_id="alpha.1", force=True, terminal_id="")
+        state.record_identity("alpha.1", {"CHARTER_HARNESS": "Claude Code",
+                                          "CHARTER_WORKSPACE": "gamma"})
+        self.assertEqual(state.frame_workspace("alpha.1"), "alpha",
+                         "the fixture no longer has two rungs to disagree")
         self.assertEqual(state.workspace_for("alpha.1"), "gamma")
         self.assertIn("alpha.1", chats.of_workspace("gamma"))
         self.assertNotIn("alpha.1", chats.of_workspace("alpha"))
 
-    def test_the_pointer_is_read_from_the_chat_on_the_other_side_too(self):
-        """The asymmetry, which is the defect #733 actually had, restated on the writer
-        that is left.
+    def test_the_pin_is_read_from_the_chat_on_the_other_side_too(self):
+        """The asymmetry, which is the defect #733 actually had, restated on the rung that
+        is left.
 
-        The issue says the moved chat "has no route back". It had one — `charter workspace
-        use alpha`, typed inside it — and what it did not have was any way to become
-        visible AGAIN to the chats it left, because the repair writes the pointer and
-        membership read only the record. So the property is that the pointer is read from
-        BOTH sides at once: `alpha.2` sees `alpha.1` leave and sees it come back, with
-        nothing typed inside `alpha.2` either time.
+        The issue says the moved chat "has no route back", and what it really lacked was
+        any way to become visible AGAIN to the chats it left, because the repair moved a
+        rung membership could not see. So the property is that the rung is read from BOTH
+        sides at once: `alpha.2` sees `alpha.1` leave and sees it come back, with nothing
+        typed inside `alpha.2` either time.
 
-        Was `test_the_repair_is_visible_from_the_chat_that_was_left_behind`, whose fixture
-        opened the strand with `switch.to_workspace` — §4j's refusal now.
+        Was `test_the_pointer_is_read_from_the_chat_on_the_other_side_too` until #791; the
+        writer moved from `workspace.set_active` to the launcher's own identity record,
+        and the property did not.
         """
-        workspace.set_active("gamma", session_id="alpha.1", force=True, terminal_id="")
+        state.record_identity("alpha.1", {"CHARTER_HARNESS": "Claude Code",
+                                          "CHARTER_WORKSPACE": "gamma"})
         self.assertEqual(chats.others("alpha.2"), [],
-                         "the pointer rung this test is about is not being read")
-        workspace.set_active("alpha", session_id="alpha.1", force=True, terminal_id="")
+                         "the pin rung this test is about is not being read")
+        state.record_identity("alpha.1", {"CHARTER_HARNESS": "Claude Code",
+                                          "CHARTER_WORKSPACE": "alpha"})
         self.assertEqual(chats.others("alpha.2"), ["alpha.1"])
         self.assertTrue(chats.check("alpha.2", "alpha.1").ok,
                         chats.check("alpha.2", "alpha.1").message)
@@ -397,26 +416,28 @@ class MembershipIsTheChatsOwnAnswerAndNotTheAskersAnswer(PersonaIso,
         self.assertEqual(state.workspace_for("alpha.9"), workspace.resolve())
 
     def test_a_pinned_chat_belongs_to_its_pin_and_not_to_what_was_typed_inside_it(self):
-        """The rung a two-rung membership test would have got WRONG, measured.
+        """**The rung a "membership is `frame_workspace` alone" reading would get wrong,
+        measured — and the reason #791 removed one rung and not two.**
 
-        `$CHARTER_WORKSPACE` at launch is in every panel pane's process environment for
-        as long as the pane lives, so `charter workspace use gamma` inside a pinned chat
-        writes a pointer nothing draws — `commands_workspace` warns exactly that.
-        Membership follows the pin because the screen does; a `for_session or
-        frame_workspace` pair would strand a pinned chat in precisely the way #733
-        describes, on a plane where it is coherent today.
+        `$CHARTER_WORKSPACE` at launch is in every panel pane's process environment for as
+        long as the pane lives, so a pinned chat draws its pin whatever else is recorded
+        under it: `workspace_for`'s rung 0 reads that variable, and `commands_workspace`
+        warns that `ws use` will not stick while it is set. Membership follows the pin
+        because the screen does; the launch record alone would strand a pinned chat whose
+        launcher resolved a different name in precisely the way #733 describes, on a plane
+        where it is coherent today.
 
         Read from `state.identity` — the launcher's own record — and never from
         `os.environ`, for `switch._pin`'s reason: this runs as a child of a tmux server
         shared between every frame on the machine.
         """
         state.record_identity("alpha.1", {"CHARTER_HARNESS": "Claude Code",
-                                          "CHARTER_WORKSPACE": "alpha"})
-        workspace.set_active("gamma", session_id="alpha.1", force=True, terminal_id="")
-        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "alpha"}, clear=False):
-            self.assertEqual(state.workspace_for("alpha.1"), "alpha")
-        self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.2"])
-        self.assertEqual(chats.of_workspace("gamma"), [])
+                                          "CHARTER_WORKSPACE": "gamma"})
+        state.record_workspace("alpha.1", "alpha")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "gamma"}, clear=False):
+            self.assertEqual(state.workspace_for("alpha.1"), "gamma")
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.2"])
+        self.assertEqual(chats.of_workspace("gamma"), ["alpha.1"])
 
     def test_an_empty_recorded_pin_is_not_a_pin_here_either(self):
         """`commands_frame._frame_identity_env` emits every name, present or not, so an
@@ -433,20 +454,25 @@ class MembershipIsTheChatsOwnAnswerAndNotTheAskersAnswer(PersonaIso,
 
         Padding on the left is what a whitespace-only record has, and for that both
         answers agree on `""`. Padding on the RIGHT is what an operator who exported
-        `CHARTER_WORKSPACE="alpha "` leaves, and there the two diverge: `lstrip` keeps the
+        `CHARTER_WORKSPACE="gamma "` leaves, and there the two diverge: `lstrip` keeps the
         trailing space, `workspace.valid_name` refuses the name, and membership falls
-        through to the pointer — while `workspace_for`'s own rung 0 strips the same value
-        and reads it as a pin. That is a chat whose panels draw `alpha` sitting in
-        `gamma`'s roster: #733 rebuilt out of one missing character. Stripped here on the
+        through to the launch record — while `workspace_for`'s own rung 0 strips the same
+        value and reads it as a pin. That is a chat whose panels draw `gamma` sitting in
+        `alpha`'s roster: #733 rebuilt out of one missing character. Stripped here on the
         same terms as that rung, because both are reading one variable.
+
+        **The pin has to name the OTHER workspace for this to measure anything, and it did
+        not have to before #791.** The fixture used to pad the name the launch record
+        already held and let the pointer be the disagreeing rung; with the pointer gone,
+        `lstrip` and `strip` would both have answered `alpha` and the case would have
+        stopped testing its own guard while staying green.
         """
-        state.record_identity("alpha.1", {"CHARTER_WORKSPACE": "alpha "})
-        workspace.set_active("gamma", session_id="alpha.1", force=True, terminal_id="")
-        self.assertEqual(state.own_workspace("alpha.1"), "alpha")
-        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "alpha "}, clear=False):
-            self.assertEqual(state.workspace_for("alpha.1"), "alpha")
-        self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.2"])
-        self.assertEqual(chats.of_workspace("gamma"), [])
+        state.record_identity("alpha.1", {"CHARTER_WORKSPACE": "gamma "})
+        self.assertEqual(state.own_workspace("alpha.1"), "gamma")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "gamma "}, clear=False):
+            self.assertEqual(state.workspace_for("alpha.1"), "gamma")
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.2"])
+        self.assertEqual(chats.of_workspace("gamma"), ["alpha.1"])
 
     def test_a_recorded_pin_that_cannot_name_a_workspace_is_not_a_pin(self):
         """The record is charter's own file, but the value lands in `workspace_dir()`'s
@@ -458,28 +484,58 @@ class MembershipIsTheChatsOwnAnswerAndNotTheAskersAnswer(PersonaIso,
         self.assertEqual(state.own_workspace("alpha.1"), "alpha")
         self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.2"])
 
-    def test_the_pointer_outranks_the_record_here_exactly_as_it_does_there(self):
-        """The rung ORDER is the fix, not merely the rung set. `charter workspace use`
-        outranks what the launcher resolved in `workspace_for`, so it has to outrank it
-        in membership too — reversed, a repaired chat would stay in the workspace the
-        switch left it in while its own panels drew the other one."""
-        workspace.set_active("gamma", session_id="alpha.1", force=True, terminal_id="")
+    def test_the_pin_outranks_the_record_here_exactly_as_it_does_there(self):
+        """The rung ORDER is half the fix, not merely the rung set. A recorded pin
+        outranks what the launcher resolved in `workspace_for` — rung 0 reads the live
+        variable, which on a pinned launch is the recorded one — so it has to outrank it
+        in membership too. Reversed, a pinned chat would sit in the roster of the
+        workspace its launcher happened to resolve while its own panels drew the pin.
+
+        Was `test_the_pointer_outranks_the_record…` until #791 removed the rung it named.
+        """
+        state.record_identity("alpha.1", {"CHARTER_HARNESS": "Claude Code",
+                                          "CHARTER_WORKSPACE": "gamma"})
         self.assertEqual(state.frame_workspace("alpha.1"), "alpha")
         self.assertEqual(state.own_workspace("alpha.1"), "gamma")
         self.assertEqual(chats.of_workspace("gamma"), ["alpha.1"])
         self.assertEqual(chats.of_workspace("alpha"), ["alpha.2"])
 
+    def test_a_pointer_written_under_a_chats_id_is_not_a_rung_of_either_ladder(self):
+        """**#791, at the layer that decides it.** `charter workspace use gamma` typed at
+        the agent lands on `workspace.for_session(<chat>)`, because inside a frame
+        `session.current()` is the chat's id (ADR 0019) — and while that was a rung, the
+        command re-homed the chat.
+
+        Asserted on BOTH functions and on the pointer file itself, because "the pointer is
+        written and read by nobody" and "the pointer is not written" are different states
+        and only the first is the fix: `workspace.resolve` still has to answer the new name
+        for the frame's own shell. `tests/test_a_chat_belongs_to_its_workspace_for_life.
+        TheOtherDoorMovesNoChatEither` is the same property at the surfaces the operator
+        sees.
+        """
+        workspace.set_active("gamma", session_id="alpha.1", force=True, terminal_id="")
+        self.assertEqual(workspace.for_session("alpha.1"), "gamma",
+                         "the write this case is about no longer happens")
+        self.assertEqual(state.own_workspace("alpha.1"), "alpha")
+        self.assertEqual(state.workspace_for("alpha.1"), "alpha")
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.2"])
+        self.assertEqual(chats.of_workspace("gamma"), [])
+
     def test_the_two_questions_walk_one_ladder(self):
         """`workspace_for` is `own_workspace` with the asking process's rungs on either
         end, rather than a second copy of the middle — the shape `workspace.chosen`
         already names in as many words ("one ladder, asked twice, not two ladders that
-        agree today"). A rung added to one is a rung the other asks."""
+        agree today"). A rung added to one is a rung the other asks.
+
+        Walked across the rung that can still move (the recorded pin) rather than across a
+        pointer write, which since #791 moves neither answer and would leave this case
+        comparing two functions that had not been asked anything."""
         for fid in ("alpha.1", "alpha.2"):
             self.assertEqual(state.workspace_for(fid), state.own_workspace(fid))
-        workspace.set_active("gamma", session_id="alpha.1", force=True, terminal_id="")
+        state.record_identity("alpha.1", {"CHARTER_WORKSPACE": "gamma"})
         self.assertEqual(state.workspace_for("alpha.1"),
                          state.own_workspace("alpha.1"))
-        workspace.set_active("alpha", session_id="alpha.1", force=True, terminal_id="")
+        state.record_identity("alpha.1", {"CHARTER_WORKSPACE": "alpha"})
         self.assertEqual(state.workspace_for("alpha.1"),
                          state.own_workspace("alpha.1"))
 
@@ -1237,14 +1293,17 @@ class TheSwitchEstablishesTheWindowItIsMovingTo(PersonaIso, unittest.TestCase):
     on screen, having reported a switch that did not happen.
 
     Reachable because membership is a RECORD. `chats.of_workspace` matches
-    `state.own_workspace`, whose pointer rung `charter workspace use <other>` typed at the
-    agent writes ("it moves the panels too" is a documented promise) — so after one
-    `charter workspace use beta` inside chat `api.1`, `of_workspace("beta")` returns
-    `api.1` (a window of tmux session `api`) beside `beta.1`, in one roster, and
-    `chats.check` says ok. §4j closed the other route into this state — `F2 → workspace`
-    is a refusal now (#733, #788) — and this guard is not softened by that: a plane can
-    still arrive here through the pointer, through a migration, or through a record
-    charter did not write.
+    `state.own_workspace`, so a chat whose record names `beta` joins `of_workspace("beta")`
+    beside `beta.1` — a window of tmux session `api` in a roster with a window of session
+    `beta` — and `chats.check` says ok.
+
+    **Both writers that used to put a plane in that state are gone, and this guard is not
+    softened by either.** §4b made `F2 → workspace` move the tmux client instead of the
+    chat (#733, #788), and #791 stopped `charter workspace use <other>` typed at the agent
+    deciding membership at all — its pointer was `own_workspace`'s middle rung. What is
+    left is a migration, a hand-edited record, or a record charter did not write, and the
+    fixture below is that plane: it plants the records directly, which is why this case
+    keeps measuring the guard rather than the writers.
 
     The fixture is that plane: both chats say workspace `beta`, both are on charter's own
     server, and their windows are in two different tmux sessions — which is the one fact

--- a/tests/test_frame_owns_the_surface.py
+++ b/tests/test_frame_owns_the_surface.py
@@ -332,8 +332,9 @@ class SuppressionSaysSoOnDemand(PersonaIso, unittest.TestCase):
         self.assertNotIn("blank", (row.hint or "").lower())
 
 
-class PanelFollowsWorkspaceUse(PersonaIso, unittest.TestCase):
-    """`charter ws use` inside a frame moves that frame's panels (#411).
+class PanelFollowsWorkspaceUseOnAFrameWithNoRecord(PersonaIso, unittest.TestCase):
+    """`charter ws use` inside a frame that recorded nothing moves that frame's panels
+    (#411), and **only** such a frame since #791.
 
     This is the collision #386 had to decide, pinned. The launcher exports the frame id
     under `$CHARTER_SESSION_ID` — the variable `charter.session.current` already owns —
@@ -343,6 +344,21 @@ class PanelFollowsWorkspaceUse(PersonaIso, unittest.TestCase):
     Nothing else connects the two: the per-TERMINAL pointer is keyed by `$TMUX_PANE`, and
     the harness and each panel are different panes, so it is structurally unable to carry
     a switch from one to the other.
+
+    **Which rung of `state.workspace_for` carries it has changed, and the class was
+    renamed rather than left to read as a promise it no longer makes.** The pointer used to
+    be rung 1, inside `state.own_workspace`, and #791 took it out: a chat's workspace is
+    its identity (§4j) and `own_workspace` is also what decides membership of a workspace,
+    so a typed command moving that rung re-homed the chat (#733, #788 verbatim). What is
+    left is rung 2 — a local `workspace.resolve()` for a frame that recorded no workspace
+    of its own, which is the migration case `docs/frame.md` names. The fixture here is
+    exactly that frame: a `{workspace}-{pid}` id with no directory under `.charter/frame/`,
+    which is what #411 was reported on.
+
+    The chat case — a frame WITH a launch record, which is every frame charter mints today
+    — is the opposite assertion and lives with the surface it is about:
+    `tests/test_frame_slots.EveryPanelDrawsTheFramesOwnWorkspace`. The last case below
+    pins the boundary between the two so neither file can move without the other noticing.
     """
 
     def _top(self, fid: str) -> str:
@@ -379,6 +395,29 @@ class PanelFollowsWorkspaceUse(PersonaIso, unittest.TestCase):
                              {"CHARTER_SESSION_ID": "someone-elses-frame-1234"},
                              clear=True):
             workspace.set_active("beta")
+        self.assertIn("alpha", self._top(fid))
+        self.assertNotIn("beta", self._top(fid))
+
+    def test_the_moment_the_frame_records_a_workspace_the_pointer_stops_reaching_it(self):
+        """**The boundary #791 drew, asserted from the side that used to cross it.**
+
+        The two cases above pass through rung 2 of `state.workspace_for` — a local
+        `workspace.resolve()`, reached only because this frame recorded nothing. Write the
+        launch record and rung 1 answers instead, and rung 1 is `state.own_workspace`,
+        which no longer reads a pointer at all. So the same switch that moved the panel a
+        line ago moves nothing: the panel draws what the launch recorded.
+
+        Without this, both cases above read as "panels follow `ws use`" — which is what
+        their class was called and what `docs/frame.md` promised — on a plane where that is
+        true for the migration case alone."""
+        fid = f"demo-{os.getpid()}"
+        workspace.ensure("alpha")
+        workspace.ensure("beta")
+        state.record_workspace(fid, "alpha")
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": fid}, clear=True):
+            workspace.set_active("beta")
+            self.assertEqual(workspace.for_session(fid), "beta",
+                             "the pointer this case is about was not written")
         self.assertIn("alpha", self._top(fid))
         self.assertNotIn("beta", self._top(fid))
 

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -449,34 +449,62 @@ class EveryPanelDrawsTheFramesOwnWorkspace(PersonaIso, unittest.TestCase):
         self.assertIsNone(state.frame_workspace("f-1"))
         self.assertIn(config.DEFAULT_WORKSPACE, self._render("top"))
 
-    def test_a_workspace_chosen_inside_the_frame_still_moves_the_panels(self):
-        """`docs/frame.md`'s own promise, and the regression #512's first cut shipped:
-        "`charter workspace use <name>` typed at the agent moves the panels too — the
-        pointer is written under the frame's id and the panels read it back under the same
-        one." The launcher's recorded answer is a SEED, not an override; a choice made
-        while the frame is running outranks it.
+    def test_a_workspace_chosen_inside_the_frame_no_longer_moves_the_panels(self):
+        """**This case was the inverse until #791, and `docs/frame.md` is corrected with
+        it.** The promise it used to assert was: "`charter workspace use <name>` typed at
+        the agent moves the panels too — the pointer is written under the frame's id and
+        the panels read it back under the same one."
 
-        Through the real `workspace.set_active`, with the frame's id in the environment,
-        because that is exactly what `charter workspace use` does — a hand-written pointer
-        file would prove that `state.workspace_for` reads a file, not that the two ends of
-        this promise still meet."""
+        What that made the pointer was a rung of `state.own_workspace`, which since #733
+        is also what decides MEMBERSHIP — so the command re-homed the chat. Measured on
+        three chat directories: `charter workspace use gamma` typed inside `alpha.1` left
+        `alpha.2` unable to see it (`chats.others` empty, `frame-chat alpha.1` answering
+        `no chat 'alpha.1' here`) and put `gamma`'s chats on `alpha.1`'s bar, where
+        `cmd_chat` refuses every one of them. That is #733 and #788 verbatim, and §4j
+        forbids it: `{workspace}-{hash}` is identity, not a property.
+
+        So the panels draw what the LAUNCH recorded, and only a launch can move it. Same
+        writer as before — the real `workspace.set_active` with the frame's id in the
+        environment, because that is exactly what `charter workspace use` does — and the
+        assertion is the one that is now true.
+        """
         state.record_workspace("f-1", self.OTHER)
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
             self.assertNotEqual(workspace.set_active("chosen-later"), "locked")
         out = self._render("top")
-        self.assertIn("chosen-later", out)
-        self.assertNotIn(self.OTHER, out,
-                         "the panel ignored a workspace chosen inside the running frame")
+        self.assertIn(self.OTHER, out)
+        self.assertNotIn("chosen-later", out,
+                         "a pointer typed inside the frame moved the chat's own workspace")
 
-    def test_the_frames_repo_table_follows_that_choice_too(self):
+    def test_the_command_still_moves_what_the_frames_own_shell_acts_on(self):
+        """**The other half, and without it the case above would be satisfied by deleting
+        the write.** `charter workspace use` answers "which workspace is this session
+        working in", and that is a live question inside a frame: it is what every
+        `charter clone`, `charter repos` and `charter ws current` in the agent's own shell
+        then acts on.
+
+        Refusing the command inside a frame was the alternative and it is rejected on
+        evidence: the only test for "inside a frame" is `session.current()`, and every
+        agent spawned from a frame inherits `$CHARTER_SESSION_ID` — so the refusal would
+        fire on agents doing ordinary CLI work in isolated worktrees. The pointer is
+        written, the panels ignore it, and those are two different questions rather than
+        one broken answer."""
+        state.record_workspace("f-1", self.OTHER)
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
+            workspace.set_active("chosen-later")
+            self.assertEqual(workspace.resolve(cwd=config.ROOT), "chosen-later")
+        self.assertEqual(workspace.for_session("f-1"), "chosen-later")
+
+    def test_the_frames_repo_table_does_not_follow_that_choice_either(self):
         """The same rung, on the surface #512 is actually about — a header that moved and
-        a table that did not would be the disagreement this class exists to prevent."""
+        a table that did not would be the disagreement this class exists to prevent, and
+        that is as true of the direction #791 turned it as of the old one."""
         clone = config.WORKSPACES_DIR / "chosen-later" / "arepo"
         (clone / ".git").mkdir(parents=True)
         state.record_workspace("f-1", self.OTHER)
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
             workspace.set_active("chosen-later")
-        self.assertEqual(slots.repos_rows_wanted("f-1", pane_cols=200), 1 + 1)
+        self.assertEqual(slots.repos_rows_wanted("f-1", pane_cols=200), 0)
 
     def test_the_pane_is_sized_from_the_frames_workspace_too(self):
         """`gather.row_count`'s no-cache path is the third surface that used to resolve
@@ -539,9 +567,15 @@ class TheChipAndItsStarNameTheSameWorkspace(PersonaIso, unittest.TestCase):
         """Through the real `workspace.set_active` with the frame's id in the
         environment, because that is what `charter workspace use` does — a hand-written
         pointer file would prove the reader reads a file, not that a real in-frame command
-        can no longer move the header off the pin."""
+        can no longer move the header off the pin.
+
+        **The launch record names a THIRD workspace, and since #791 it has to.** The
+        fixture used to record the pin's own name and let the pointer be the only
+        disagreeing rung; with the pointer no longer a rung, `state.workspace_for` would
+        have answered `zeta` from the record whether the pin was read or not, and this case
+        would have gone on passing while measuring neither the pin nor the star."""
         os.environ["CHARTER_WORKSPACE"] = "zeta"
-        state.record_workspace("f-1", "zeta")
+        state.record_workspace("f-1", "recorded-at-launch")
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
             workspace.set_active("other", force=True)
         self.assertEqual(workspace.for_session("f-1"), "other",
@@ -550,6 +584,8 @@ class TheChipAndItsStarNameTheSameWorkspace(PersonaIso, unittest.TestCase):
         self.assertIn("⬢ zeta*", out)
         self.assertNotIn("other", out,
                          "the header named a workspace no command in the session acts on")
+        self.assertNotIn("recorded-at-launch", out,
+                         "the header named the launch record over the pin above it")
         self.assertEqual(workspace.resolve(), "zeta",
                          "the header and the session's own commands disagree")
 

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -1149,11 +1149,24 @@ class ThePinOutranksTheFramesOwnRungs(PersonaIso, unittest.TestCase):
     def _pin(self, name: str) -> None:
         os.environ["CHARTER_WORKSPACE"] = name
 
-    def test_the_pin_beats_a_workspace_chosen_inside_the_frame(self):
-        """The regression. Both rungs answer, they disagree, and the pin wins — the same
-        way `workspace.resolve` decides it for every command the session runs."""
+    def test_a_workspace_chosen_inside_the_frame_reaches_neither_it_nor_its_commands(self):
+        """The regression, and since #791 it is a statement about the pointer rather than
+        about the pin's rank over it.
+
+        A pin is set, `charter workspace use other` is typed inside the frame, and neither
+        the frame's own answer nor the session's own commands move: the pointer is not a
+        rung of `state.own_workspace` at all any more, and `workspace.resolve` ranks
+        `$CHARTER_WORKSPACE` above it — which is what `commands_workspace` warns about in as
+        many words when it says `ws use` will not stick while the variable is set.
+
+        **The launch record names a third workspace deliberately.** Without that the pin
+        rung is unmeasurable here: `frame_workspace` would answer `zeta` too, and this case
+        would pass whether or not anything read the pin. Was
+        `test_the_pin_beats_a_workspace_chosen_inside_the_frame`, whose fixture leaned on
+        the pointer being the disagreeing rung."""
         from charter import workspace as ws
         self._pin("zeta")
+        state.record_workspace("f-1", "recorded-at-launch")
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
             ws.set_active("other", force=True)
         self.assertEqual(ws.for_session("f-1"), "other",

--- a/tests/test_workspace_scope_honesty.py
+++ b/tests/test_workspace_scope_honesty.py
@@ -88,13 +88,19 @@ class TestAskingWhatOneSessionChose(ScopeBase):
     """`workspace.for_session` — the per-session pointer rung, asked about a session that
     is not this process's.
 
-    Public since #512, for one caller that genuinely has to distinguish it from the rest of
-    the chain: a frame panel. Inside a frame the frame IS the charter session, so `charter
-    workspace use` writes this pointer under the FRAME's id and `docs/frame.md` promises
-    that "moves the panels too". The panels also carry a launch-time answer the launcher
-    recorded for them, and an operator's live choice has to outrank it — which is only
-    askable if this rung can be asked ON ITS OWN. `resolve()` cannot answer it: it returns
-    a workspace whatever happened, and `source()`'s label is a sentence for a status line.
+    Public since #512, for callers that genuinely have to distinguish it from the rest of
+    the chain: inside a frame the frame IS the charter session, so `charter workspace use`
+    writes this pointer under the FRAME's id, and a reader has to be able to tell "this
+    session chose it" apart from "the launcher resolved it" without reading `source()`'s
+    human-facing label and matching a string. `resolve()` cannot answer it either: it
+    returns a workspace whatever happened.
+
+    **The frame's panels were the original caller and are no longer a caller at all
+    (#791).** They read this rung through `frame/state.own_workspace`, which is also what
+    decides a chat's membership of a workspace — so `charter workspace use` typed at the
+    agent re-homed the chat, which spec §4j forbids. The panels now read the launch's own
+    records; this function still answers for `resolve`, for `source`, and for anything
+    asking what one session chose, which is what the cases below measure.
     """
 
     def test_it_names_the_workspace_that_session_chose(self):


### PR DESCRIPTION
Closes #791. **Does NOT close #731** — measured; see below.

## The defect

`#789` removed `switch.to_workspace`'s two writes, so `F2 → workspace` can no longer
re-home a chat. **The same defect was still reachable by typing a command**, and #733/#788
closed without covering it because both named the switcher as the cause.

`commands_workspace` calls `workspace.set_active(...)`, which keys its pointer on
`session.current()`. Inside a frame `session.current()` is **the chat's id** (ADR 0019), so
the write landed on `workspace.for_session(<chat>)` — which `e590566` had made the **middle
rung of `state.own_workspace`**, the membership ladder. A command whose subject is "which
workspace is this session working in" was also answering "which workspace does this chat
belong to".

Measured on three chat directories, no tmux, `charter workspace use gamma` typed inside
`alpha.1`:

```
alpha.1 draws: gamma    alpha.1 owns: gamma    frame record: alpha
alpha.2 sees: []        alpha.1 sees: ['gamma.1']
check alpha.2 -> alpha.1: no chat 'alpha.1' here — have: alpha.2
check alpha.1 -> gamma.1: chat → gamma.1     <- and cmd_chat then refuses it
```

The last two lines are #733 and #788 verbatim. After this change, same fixture:

```
alpha.1 draws: alpha    alpha.1 owns: alpha    frame record: alpha
alpha.2 sees: ['alpha.1']   alpha.1 sees: ['alpha.2']
check alpha.2 -> alpha.1: True   check alpha.1 -> gamma.1: False
of_workspace alpha: ['alpha.1', 'alpha.2']   of_workspace gamma: ['gamma.1']
```

## What the ladder looks like now

`state.own_workspace` — the membership question — loses its middle rung:

| | before | after |
|---|---|---|
| 1 | the pin the launcher recorded (`state.identity`) | the pin the launcher recorded |
| 2 | `workspace.for_session(<chat>)` — the per-session pointer | *(gone)* |
| 3 | `state.frame_workspace` — what the launch resolved | what the launch resolved |

Both remaining rungs are written by the **launch**, so nothing typed after a launch moves a
chat between workspaces — which is §4j: *"`{workspace}-{hash}` is identity, not a
property."* `state.workspace_for` is unchanged in shape (rung 0 `$CHARTER_WORKSPACE`, then
`own_workspace`, then a local resolve), so the roster and the panels still walk **one**
ladder — #733's actual fix — it is just one rung shorter.

**Refusing `workspace use` inside a frame was the alternative and it is rejected on
evidence.** The only available test for "inside a frame" is `session.current()`, which reads
`$CHARTER_SESSION_ID`, and **every agent spawned from a frame inherits it** (measured: a
subagent shell three levels down still reports the frame's id). A refusal keyed on that
fires on agents doing ordinary CLI work in isolated worktrees. Dropping the rung needs no
detection and breaks no command: `set_active` still writes the pointer and the lock,
`workspace.resolve` still reads them, so `charter clone`, `charter repos` and
`charter ws current` in the frame's own shell all act on the name that was typed. A test
pins that explicitly, so a later "fix" cannot satisfy this by deleting the write.

## Two behaviour changes, stated rather than left to be found

**1. `charter workspace use <name>` no longer moves a frame's panels.** `docs/frame.md:804`
promised it did; the promise is corrected in this PR rather than quietly broken. #789
deliberately did not correct it because at that point the write making it true was the one
still standing. `F2 → workspace` moves your terminal instead and leaves every chat where it
is. One frame still follows the pointer and it is the migration case — a frame that recorded
no workspace at all, where the panels fall through to resolving for themselves;
`tests/test_frame_owns_the_surface` is renamed for that and its new last case pins the
boundary. ADR 0019's illustrative claim ("panels follow `ws use` *only* because of the id
collision") is corrected too; the decision itself is unchanged and still load-bearing for
the persona, the lock and the harness-session mapping.

**2. A workspace rename now orphans every chat, not just some of them.**
`workspace._rename_active_pointers` rewrites every per-session pointer holding the old name,
so a chat that had one followed a rename automatically while a chat that never had one was
left naming a workspace that no longer exists (#752's neighbourhood). Membership no longer
reads that pointer, so **every** chat behaves like the second kind — more uniform, and a real
change. The repair route went with it: typing `charter workspace use <newname>` inside an
orphaned chat used to fix it and now does nothing. Making `rename` repoint the frame records
is the fix and it is deliberately **not** in here — whether a rename moves a chat's identity
is a decision that deserves its own argument beside #752, not a line in a bugfix.

## Does this close #731? No — and which half survives

#731 is that `.charter/sessions/<fid>.workspace` and `.lock` are not reaped with the frame,
so a recycled chat ordinal inherits the previous frame's pointer *and outranks its own
launcher*. Measured both ways on the same fixture (write the pointer, `rmtree` the frame
directory, relaunch onto the same ordinal):

**Gone — the half the issue's title is about.** Before: the relaunch that asked for `alpha`
explicitly drew `gamma`, joined `gamma`'s roster and left `alpha`'s — which is the identity
row, the todo count and the repo pane height in the issue's screenshot. After:

```
relaunched alpha.1 draws: alpha   owns: alpha   frame record: alpha
of_workspace alpha: ['alpha.1', 'alpha.2']   of_workspace gamma: ['gamma.1']
```

**Survives — the lock and the frame shell's own resolution**, neither of which this touches:

```
is_locked: gamma
shell resolve (cwd=plane root): gamma
set_active('alpha') now returns: locked
```

So the operator who just typed `--workspace alpha` gets a frame drawing `alpha` whose
commands act on `gamma` and which **refuses** `charter workspace use alpha` as locked. #731
is now exactly *"reap the session pointer and the lock with the frame"*, which is what PR
#757's body already recommended as the right fix. Leaving it open.

## This is a prerequisite for quit → reopen (spec §4e/§4f)

A reopened chat relaunches into its **existing** directory, so before this change a stale
`.charter/sessions/<fid>.workspace` would have decided its membership over whatever the
reopen manifest said — silently, and only for chats somebody had once typed
`workspace use` in. **This PR unblocks that work**, and one of the new cases is written as
that scenario (`test_a_pointer_left_behind_by_a_reaped_chat_decides_nothing`).

## Four tests near the change had stopped measuring their own guards

All four are restaged rather than left green — three had leaned on the pointer being the
disagreeing rung, and with the pointer gone they passed whichever way the guard went:

- the recorded pin's `.strip()` (`test_a_recorded_pin_with_a_TRAILING_space_is_still_that_pin`) — the padded pin now names a *different* workspace from the launch record
- `workspace_for`'s rung 0, twice (`test_frame_state.ThePinOutranksTheFramesOwnRungs`, `test_frame_slots.TheChipAndItsStarNameTheSameWorkspace`) — the launch record now names a third workspace
- `of_workspace`'s `is_dir()` filter — **no measurement left at all.** #733 restored that
  line on the grounds that membership had grown a rung outside the frame's directory; #791
  removes that rung, so a loose file is refused by the read whatever the filter does
  (checked: nothing in the suite goes red without it). It stays, and its comment now says
  plainly that it is a floor rather than a measured guard, so the next deletion sweep decides
  on the facts instead of on a stale paragraph.

## Verification

- **Reproduced without tmux first**, through the real `workspace.set_active` with the chat's
  id in the environment and no explicit `session_id=` — the defect is *which id the command
  resolves for itself*, so passing one would remove the thing under test.
- **7 new cases** in `tests/test_a_chat_belongs_to_its_workspace_for_life.py`
  (`TheOtherDoorMovesNoChatEither`), **5 of them red before the change**; the two that were
  green are the ones asserting what must NOT change (the pointer is still written; the pin
  still wins).
- **Full suite: 9761 tests, OK** in the sweep's clean sandbox. Locally one failure,
  `test_frame_border_surface.test_this_planes_own_committed_frame_answers_the_report`, which
  is #785 — it reads the operator's uncommitted `charter.toml` through `$CHARTER_ROOT`;
  reproduced at `9cd519e` with this branch's changes stashed, and green in the sandbox that
  has no such env.
- **Real tmux: 177 tests, 0 skipped, OK** (`test_frame_tmux_integration`,
  `test_a_real_click_on_a_real_tab_bar_switches`, `test_a_workspace_switch_moves_the_client`,
  `test_a_second_launch_focuses_instead_of_dragging`), on the tests' own sockets.
- **Deletion sweep: `NOTHING TO SWEEP` — 0 mutations applied**, and per #782 that is the
  count to read rather than the verdict: the sweep's own words are *"a record of a question
  nobody asked rather than of an answer"*. The change is one deleted disjunct plus prose, and
  `return frame_workspace(fid)` offers no operator anything. Baseline in that run: 9761 tests
  OK.
- **So the mutation evidence is by hand**, five mutations, `python3 -B` with `__pycache__`
  cleared, each one red on the case that names it:

  | mutation | result |
  |---|---|
  | restore `for_session(fid) or …` (the defect) | 8 failures |
  | drop the pin rung — membership is the record alone | 6 failures |
  | pin `.strip()` → `.lstrip()` | 1 failure |
  | pin checked for truth instead of for a name | 1 failure |
  | drop `workspace_for`'s rung 0 | 4 failures |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
