### PR TITLE
Quitting charter records the plane, so reopening puts it back — and says, per chat, what it cannot (§4e, §4f, §4i)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -359,6 +359,18 @@ def build_parser() -> argparse.ArgumentParser:
     tr.add_argument("-n", type=int, default=0, help="Show only the last N raw events.")
     tr.set_defaults(func=commands_persona.cmd_trace)
 
+    # §4e/§4i's third verb, and the only one of the three an operator types rather than
+    # presses: quit and close are palette rows in a running frame, and by the time a reopen
+    # is wanted there is no frame to press a key in. Registered HERE, above
+    # `_add_frame_parsers`, so it is one of the commands the harness collision guard checks
+    # a `cli_name` against rather than one added after that snapshot is taken.
+    ro = sub.add_parser(
+        "reopen",
+        help="Put back the plane your last `F2 → charter: quit` recorded: every "
+             "workspace, chat, persona and directory, and — for Claude Code — the "
+             "conversation.")
+    ro.set_defaults(func=commands_frame.cmd_reopen)
+
     _add_harness_parser(sub)
     _add_workspace_parser(sub)
     _add_worktree_parser(sub)
@@ -756,7 +768,9 @@ def _add_frame_parsers(sub) -> None:
     _core_commands = set(sub.choices) | {"frame", "panel", "frame-palette",
                                          "frame-probe", "frame-respawn", "frame-density",
                                          "frame-resize", "frame-gather", "frame-switch",
-                                         "frame-toggle", "frame-chrome", "frame-chat"}
+                                         "frame-toggle", "frame-chrome", "frame-chat",
+                                         "frame-quit", "frame-close",
+                                         "frame-transcript"}
 
     # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
     # already claimed each word, so a SECOND harness wanting it is told who got there
@@ -990,6 +1004,43 @@ def _add_frame_parsers(sub) -> None:
     ch.add_argument("chat_id")
     ch.add_argument("--chat", dest="chat", default="")
     ch.set_defaults(func=commands_frame.cmd_chat)
+
+    # §4i's quit. Started DETACHED by the palette's confirmation row
+    # (`commands_frame._start_leaving`) and typeable by hand, which is why it warns on its
+    # own stderr as well as on the surface that confirmed it: §4i is explicit that quit
+    # *warns and proceeds*, so the record of what was lost has to survive the keypress.
+    #
+    # **It takes no target, and that is the design rather than an omission.** Quit is
+    # plane-scoped — the operator's own words were "all harness sessions will be closed" —
+    # and §3.3 bounds it from the other side: one tmux server serves every plane on the
+    # machine and session names carry no plane, so the set of things it stops can only come
+    # from this plane's own chat directories. `--chat` is where the keypress came FROM, for
+    # `frame-toggle`'s reason, and is used only to decide which workspace a later
+    # `charter reopen` puts the operator back on.
+    qt = sub.add_parser("frame-quit")
+    qt.add_argument("--chat", dest="chat", default="")
+    qt.set_defaults(func=commands_frame.cmd_quit)
+
+    # §4d's `chat: close`, which is stage 4's new reaper arriving on its own. Quit's
+    # teardown with one target and one file more (`state.record_closed`), because a missing
+    # `exit` file means "was open" and closing writes no exit either — see `cmd_close`.
+    #
+    # **Two chat ids, and they are two different questions**, exactly as `frame-chat` has:
+    # the POSITIONAL is which chat to close, optional so the bare command closes the one
+    # you are in; `--chat` is where the keypress came from. Deliberately NOT `choices=`,
+    # for `frame-chat`'s reason — which chats exist is a property of the frame root at the
+    # moment the key fires, so there is no set for argparse to hold.
+    cl = sub.add_parser("frame-close")
+    cl.add_argument("chat_id", nargs="?", default="")
+    cl.add_argument("--chat", dest="chat", default="")
+    cl.set_defaults(func=commands_frame.cmd_close)
+
+    # §4f's other half: the captured scrollback, offered rather than replayed. Opens a
+    # pager in a window of its own; nothing is ever written into the harness's pane. See
+    # the ADR 0018 amendment this change carries.
+    tr = sub.add_parser("frame-transcript")
+    tr.add_argument("--chat", dest="chat", default="")
+    tr.set_defaults(func=commands_frame.cmd_transcript)
 
     # A TOP-LEVEL sibling of `frame` for a DIFFERENT reason than `frame-palette` above:
     # that one exists because `_split_frame_argv` eats everything

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -7659,7 +7659,7 @@ def _plane_servers() -> list[str]:
     live there" by the caller.
     """
     found = [SOCKET]
-    for fid in leave._plane_chats():
+    for fid in leave.plane_chats():
         server = state.frame_server(fid) or SOCKET
         if server not in found:
             found.append(server)
@@ -7774,6 +7774,17 @@ def _record_the_plane(doomed, *, focus: str, active, windows) -> int | None:
     entries: dict[str, list] = {}
     order: list[str] = []
     for c in doomed:
+        if not c.workspace:
+            # **Stopped, and honestly not recorded.** A reopen rebuilds one tmux session per
+            # workspace and hands the launcher a `--workspace`; there is nothing to rebuild a
+            # chat into that says nothing about its workspace, and choosing one for it would
+            # be §4j's re-homing arriving as a convenience. `reopen.read` refuses such a
+            # record anyway (`_usable` holds the workspace to `valid_name`), so writing one
+            # would put a line in the manifest that every reader discards — a record that
+            # looks like a promise and is not. The warning already told the operator
+            # (`leave.NOT_REOPENED`), and `cmd_quit`'s own line says how many of how many
+            # were kept.
+            continue
         server = state.frame_server(c.chat) or SOCKET
         transcript = ""
         dest = reopen_state.transcript_path(c.chat)
@@ -7793,7 +7804,10 @@ def _record_the_plane(doomed, *, focus: str, active, windows) -> int | None:
         frames.append(reopen_state.Frame(workspace=ws, chats=tuple(entries[ws])))
     if not reopen_state.write(frames, focus=focus):
         return None
-    reopen_state.prune_transcripts({c.chat for c in doomed})
+    # Keyed on what was RECORDED and not on what was stopped: a transcript is a file in the
+    # frame root, and the only collector it has is this call. Keeping one for a chat no
+    # manifest names would leave it there for good.
+    reopen_state.prune_transcripts({c.chat for f in frames for c in f.chats})
     return sum(len(f.chats) for f in frames)
 
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8020,10 +8020,13 @@ def cmd_reopen(args) -> int:
     whichever session tmux happened to make current would put the operator somewhere they
     did not leave.
 
-    **The manifest is consumed.** A record describes one quit, and a second `charter reopen`
-    against the same file would open every chat a second time with nothing on screen to tell
-    the duplicates apart. It is dropped after the launches and before the attach, because
-    the attach does not return until the operator leaves.
+    **The manifest is consumed, chat by chat.** A record describes one quit, and a second
+    `charter reopen` against the same file would open every chat a second time with nothing
+    on screen to tell the duplicates apart — but deleting it whole would throw away the
+    record of the chats that did NOT come back, which is exactly the state an operator would
+    want to retry. So what is left behind is precisely the retry (:func:`_consume`), and it
+    is written after the launches and before the attach, because the attach does not return
+    until the operator leaves.
     """
     m = reopen_state.read()
     if m is None or not m.frames:
@@ -8070,8 +8073,34 @@ def cmd_reopen(args) -> int:
                  "record is left in place so this can be tried again.")
         return 1
     util.ok(f"charter: reopened {len(back)} of {len(m.all_chats())} chats")
-    reopen_state.forget()
+    _consume(m, {r.chat.chat for r in back})
     return _attach_after_reopen(m, back)
+
+
+def _consume(m, done) -> None:
+    """Take the chats in *done* out of the manifest, and drop it when nothing is left.
+
+    **Consumed rather than deleted, because a partial reopen has two halves and only one of
+    them is over.** A record describes one quit: leaving it whole would open every chat a
+    second time on the next `charter reopen`, with nothing on screen to tell the duplicates
+    apart — but deleting it whole would throw away the record of the chats that did *not*
+    come back, which is exactly the state an operator would want to retry. So what is left
+    behind is precisely the retry: the chats still owed, in their own frames, with the same
+    focus.
+
+    Called after the launches and before the attach, because the attach does not return
+    until the operator leaves.
+    """
+    left = [reopen_state.Frame(workspace=f.workspace,
+                               chats=tuple(c for c in f.chats if c.chat not in done))
+            for f in m.frames]
+    left = [f for f in left if f.chats]
+    if not left:
+        reopen_state.forget()
+        return
+    if reopen_state.write(left, focus=m.focus, at=m.at):
+        util.warn(f"charter reopen: {sum(len(f.chats) for f in left)} chat(s) still "
+                  "recorded — `charter reopen` again to retry just those")
 
 
 def _reopen_one(c) -> "Reopening | None":

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -147,10 +147,14 @@ import subprocess
 import sys
 import time
 
-from . import config, contain, harness, instance, tui, util, workspace
+from . import config, contain, harness, inflight, instance, tui, util, workspace
 from .frame import (actions as frame_actions, builtin_actions, chats, choose, component,
-                    gather, layout, overlay, pane, palette, picker, state, switch,
+                    gather, layout, leave, overlay, pane, palette, picker, state, switch,
                     tmuxctl)
+# Aliased because `cmd_reopen` is a function in this module and `reopen` reads as one: the
+# module answers what a quit RECORDED and the command is what puts it back, and a bare
+# `reopen.read()` beside `cmd_reopen` invites a reader to think one is the other.
+from .frame import reopen as reopen_state
 # Aliased: `cmd_launch` already has a local variable named `slots` (the VISIBLE slot
 # list `layout.visible_slots` returns) — importing the renderer registry under its own
 # name would be shadowed by that local the moment it's assigned, and a `slots.SLOTS`
@@ -3152,6 +3156,14 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     # one's.
     state.record_identity(fid, _frame_identity_env(env))
     cwd = os.getcwd()
+    # And WHERE, which until now was read on this line, handed to tmux and dropped
+    # (`state.record_cwd`). It is the fourth of §4e's four restore items and the only one
+    # with nowhere to live: `workspace` is a file, `identity` carries the harness and the
+    # persona pin, and a cwd could not join `identity` because every value in that record
+    # goes onto a world-readable tmux `-e` argv. Recorded on BOTH launch paths, from the
+    # same `os.getcwd()` each one already reads, because a chat reopened out of the wrong
+    # directory is a harness given a different plane to look at.
+    state.record_cwd(fid, cwd)
     opened = tmuxctl.run(
         "opening a window for the frame",
         layout.window_argv(socket=socket, session=session, window=fid, cwd=cwd))
@@ -4369,6 +4381,59 @@ def _focus_workspace(session_id: str, chat: str, *, ws: str, picked: bool) -> in
     return 0
 
 
+class Reopening:
+    """One recorded chat on its way back, and the id it came back as.
+
+    **The whole of the seam between `charter reopen` and the launcher**, carried on the
+    `args` namespace `cmd_reopen` builds and read with `getattr` — which is `--probe`'s own
+    shape (`cmd_launch`'s first line) and the reason there is no new CLI surface here. A
+    reopen is not a thing an operator types at a launcher; it is `charter reopen` driving
+    one, so it has no business in `charter claude --help`, and every existing caller of
+    `cmd_launch` (production and test) constructs an `args` without this field.
+
+    **Mutable, and that is what it is for.** `cmd_launch` allocates the new chat id, and
+    the driver needs it back: to put the operator on the right tab at the end, and to
+    report which recorded chat became which live one. The alternative — reading the frame
+    root before and after and taking the difference — would be inferring an id from a
+    directory listing that a sibling launcher on the same plane is free to change, for a
+    fact the launcher itself has in hand.
+
+    :attr:`fid` stays ``""`` for a launch that never got as far as claiming one, which is
+    exactly what makes "this chat did not come back" reportable rather than silent.
+    """
+
+    def __init__(self, chat) -> None:
+        #: The `frame/reopen.Chat` this is restoring.
+        self.chat = chat
+        #: The chat id the launcher allocated, or ``""`` if it never got one.
+        self.fid = ""
+
+
+def _reopening(args) -> "Reopening | None":
+    """The reopen this launch is part of, or ``None`` for an ordinary launch.
+
+    Four things in :func:`cmd_launch` turn on it, and each would be a defect on the reopen
+    path rather than a saving: open-or-focus (§4k) would swallow every chat after the first
+    of a workspace, `select-window` would move a client that does not exist yet,
+    `_drop_panels` would strip the panels off the sibling this same reopen had just drawn,
+    and `attach` would block on the first chat and never build the second.
+    """
+    got = getattr(args, "reopening", None)
+    return got if isinstance(got, Reopening) else None
+
+
+def _wants_attach(args) -> bool:
+    """Whether this launch should become the operator's terminal.
+
+    Every launch except a reopen's does. Asked as its own function rather than inline as
+    ``_reopening(args) is None`` because the two are genuinely different questions that
+    happen to have one answer today — "am I restoring" and "am I the terminal" — and the
+    day a third caller wants one without the other, a shared expression would have to be
+    unpicked at two call sites at once.
+    """
+    return _reopening(args) is None
+
+
 def cmd_launch(args) -> int:
     """One launcher, shared by every registered harness and by `charter frame --`."""
     if getattr(args, "probe", False):
@@ -4514,7 +4579,14 @@ def cmd_launch(args) -> int:
     # already ended the launch with "nothing to run" — so by here a launch with no `h` is
     # a launch with a non-empty `rest`, and the second half of that condition could never
     # decide anything. The deletion sweep found it as a survivor for exactly that reason.
-    if not rest:
+    #
+    # **And never for a reopen**, which is the same gate one case wider. Attaching answers
+    # "put me in `foo`"; a reopen is answering "put back the four chats `foo` had", and the
+    # second of those four would be swallowed by a focus onto the session the first one had
+    # just created. It cannot be spelled as "reopen always carries a `rest`" either — only
+    # a Claude chat with a recorded id carries `--resume`, and a chat with nothing to resume
+    # is exactly the one that must still come back as a tab.
+    if not rest and _reopening(args) is None:
         focus = _workspace_to_focus(SOCKET, ws=ws)
         if focus is not None:
             return _focus_workspace(*focus, ws=ws, picked=picked)
@@ -4580,6 +4652,22 @@ def cmd_launch(args) -> int:
     # thing here no process inside the frame can work out for itself (#512; see
     # `state.record_workspace`).
     state.record_workspace(fid, ws)
+    # And WHERE — see the identical call on the operator's-tmux path, and
+    # `state.record_cwd` for why this fact could not ride in `identity`. Read once here
+    # and used twice: recorded, and handed to `chat_window_argv` below.
+    launch_cwd = os.getcwd()
+    state.record_cwd(fid, launch_cwd)
+    # **And the two restore items that are not this launch's own to write** — the persona
+    # the recorded chat had chosen, and the transcript captured off its pane before it was
+    # killed. Both are keyed on a chat ID, and the id has just changed: `new_chat_id`
+    # allocates a fresh ordinal, so the pointer and the file that named the old chat name
+    # nothing a moment from now. Done HERE, before the harness is started, because the
+    # persona is resolved inside the pane at run time and a pointer written afterwards
+    # would be read one turn late. See :func:`_restore_recorded_chat`.
+    restoring = _reopening(args)
+    if restoring is not None:
+        restoring.fid = fid
+        _restore_recorded_chat(restoring.chat, fid)
     state.clear_respawn(fid)
     state.bump(fid)
     # Kicked before tmux is asked for anything, so the gather runs alongside the session
@@ -4647,7 +4735,7 @@ def cmd_launch(args) -> int:
     joining = session in live_sessions
     if joining:
         start_cmd = layout.chat_window_argv(
-            socket=SOCKET, session=session, chat=fid, cwd=os.getcwd(),
+            socket=SOCKET, session=session, chat=fid, cwd=launch_cwd,
             harness_argv=argv, env=_frame_identity_env(env))
         started_what = "adding a chat to the workspace"
     else:
@@ -4866,21 +4954,32 @@ def cmd_launch(args) -> int:
             # off it (#688). `new-window -d` did not move them, so the session's current
             # window is still the chat being left. A no-op for the launch that created
             # the session, whose only window is the one it just built.
-            leaving = _chat_being_left(SOCKET, beside=fid)
-            selected = tmuxctl.run(
-                "selecting the chat",
-                tmuxctl.server_argv(SOCKET, "select-window", "-t", harness_pane),
-                env=env)
-            # And the chat the client has just left loses its panels — `cmd_chat` step 2's
-            # rule, applied where the situation is made rather than only where it is
-            # managed. Gated on the select having WORKED, which here is what the return
-            # code honestly says: both windows are in one session by construction (this
-            # launch created its own in `session`), so unlike #684's cross-session case
-            # there is no way for `select-window` to succeed against a window the client
-            # cannot be moved to. A teardown ahead of a failed select would kill the
-            # panels of the chat the operator is still looking at.
-            if selected.returncode == 0:
-                _drop_panels(SOCKET, leaving)
+            #
+            # **A reopen does neither**, and the reason is this pair's own argument turned
+            # around (`_reopening`). `charter reopen` builds several chats back to back
+            # with no client attached anywhere: the "chat being left" is then the sibling
+            # this same reopen created a moment ago, and dropping ITS panels would strip
+            # the frame charter has just finished drawing. Nothing is being taken off a
+            # window it was looking at, because nobody is looking yet — the one
+            # `select-window` a reopen wants is the one `cmd_reopen` issues at the end, at
+            # the chat the manifest says was active.
+            if _reopening(args) is None:
+                leaving = _chat_being_left(SOCKET, beside=fid)
+                selected = tmuxctl.run(
+                    "selecting the chat",
+                    tmuxctl.server_argv(SOCKET, "select-window", "-t", harness_pane),
+                    env=env)
+                # And the chat the client has just left loses its panels — `cmd_chat` step
+                # 2's rule, applied where the situation is made rather than only where it
+                # is managed. Gated on the select having WORKED, which here is what the
+                # return code honestly says: both windows are in one session by
+                # construction (this launch created its own in `session`), so unlike
+                # #684's cross-session case there is no way for `select-window` to succeed
+                # against a window the client cannot be moved to. A teardown ahead of a
+                # failed select would kill the panels of the chat the operator is still
+                # looking at.
+                if selected.returncode == 0:
+                    _drop_panels(SOCKET, leaving)
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
             # after every slot has been drawn, the LAST panel drawn — not the harness —
@@ -4893,11 +4992,20 @@ def cmd_launch(args) -> int:
                         tmuxctl.server_argv(SOCKET, "select-pane", "-t", harness_pane),
                         env=env)
 
-            # `tmuxctl.interact`, not `tmuxctl.run`: no capture and no timeout — this
-            # IS the operator's own terminal for as long as the harness runs, not an
-            # admin command whose output (or lifetime) charter should own.
-            attach_cmd = tmuxctl.server_argv(SOCKET, "attach", "-t", session)
-            attach = tmuxctl.interact(attach_cmd, env=env)
+            # **A reopen does not attach either, and exactly once rather than N times.**
+            # `attach` is what makes this function the operator's terminal for the life of
+            # the harness, so a reopen calling it per chat would block on the first one and
+            # never build the second. `cmd_reopen` attaches itself, after every chat is up,
+            # to the workspace the manifest recorded as the one in front of the operator
+            # when they quit. Everything below this point already handles "we did not
+            # attach": `attach` stays ``None``, `code` stays ``None``, and the tail reports
+            # a detached chat, which is precisely what this is.
+            if _wants_attach(args):
+                # `tmuxctl.interact`, not `tmuxctl.run`: no capture and no timeout — this
+                # IS the operator's own terminal for as long as the harness runs, not an
+                # admin command whose output (or lifetime) charter should own.
+                attach_cmd = tmuxctl.server_argv(SOCKET, "attach", "-t", session)
+                attach = tmuxctl.interact(attach_cmd, env=env)
 
             code = state.exit_code(fid)
             if code is None:
@@ -4928,6 +5036,12 @@ def cmd_launch(args) -> int:
         # quiet success an operator's own deliberate detach is allowed to be.
         return 1
     if fid in live_after:
+        if not _wants_attach(args):
+            # The reopen path, and it says nothing HERE on purpose. This launch was never
+            # the operator's terminal, so "detached" would be describing something that
+            # did not happen; `cmd_reopen` is the one process that knows how many chats it
+            # asked for and what each one could bring back, so it owns the sentence.
+            return 0
         # Detach, not completion — the chat tmux still lists is this launch's own.
         # Silence here is exactly what the spec calls out: "an agent surviving a closed
         # lid is a feature, and returning silently to a shell with it still running is
@@ -6814,8 +6928,13 @@ def _draw_palette(args) -> int:
     opened: list[choose.Roster] = []
     try:
         surface = palette.Palette(
+            # `leave.open_rows` LAST, and that ordering is the guard §4i's "warns and
+            # proceeds" needs: the cursor starts on the first row that can run, so a
+            # destructive row at the top of the list would be one `F2 Enter` from stopping
+            # the plane. Every harmless row charter has keeps the top.
             catalogue=(choose.open_rows(fid)
-                       + palette.rows(reg.offers(fid=fid, snapshot=snapshot))),
+                       + palette.rows(reg.offers(fid=fid, snapshot=snapshot))
+                       + leave.open_rows(fid)),
             query_only=lambda: _name_rows(fid, opened),
             mouse=True)
         def _then(row):
@@ -6862,6 +6981,22 @@ def _draw_palette(args) -> int:
             # A picker row that never opened its picker: `_picker` refused it, which it
             # does for exactly one reason and always with that reason in the row's note.
             _say_on_screen(fid, chosen.note)
+            return 0
+        # **The confirmation's own rows, and they are asked about before `invoke`** — none
+        # of them is an action id, and handing `leave:quit:go` to `ActionRegistry.invoke`
+        # would report "no such action" for a keypress that means "stop the plane". The
+        # per-chat rows are `refused=True`, so Enter does not land on one; a mouse click
+        # still can, and it says nothing rather than doing something.
+        for verb in (leave.QUIT, leave.CLOSE):
+            if leave.goes_through(chosen, verb):
+                _start_leaving(fid, verb)
+                return 0
+        if leave.is_row(chosen):
+            # A doorway `_picker` refused (its note says why) or one of the warning's own
+            # per-chat rows, which are `refused=True` and describe rather than do. The note
+            # is said in the first case and there is nothing to say in the second.
+            if chosen.note and leave.verb_of(chosen) is not None:
+                _say_on_screen(fid, chosen.note)
             return 0
         inv = reg.invoke(chosen.id, fid=fid, snapshot=snapshot)
         inv.join(timeout=_ACTION_START_GRACE)
@@ -6949,6 +7084,25 @@ def _picker(row, fid: str, opened: list) -> "palette.Palette | None":
     from there rather than from `choose.roster` directly, so a noun the operator already
     typed against is not listed a second time — see that function.
     """
+    verb = leave.verb_of(row)
+    if verb is not None and row.note:
+        # A refused doorway does not open — `choose.open_rows`' rule, and the same one: a
+        # confirmation over a target charter cannot name would be an offer it already knows
+        # it cannot honour. `None` sends the row back to :func:`_draw_palette`, which says
+        # the note on the operator's own screen.
+        return None
+    if verb is not None:
+        # **§4f's warning, drawn at the moment the operator is deciding.** The plan is built
+        # HERE and not when the palette opened, so the rows describe the plane as it is
+        # under the keypress — and so an `F2` pressed to reach `detach` never pays for a
+        # scan of the frame root. The confirming row is the last one, under the list it is
+        # about, and every chat row above it is `refused` (see `frame/leave.py`).
+        servers = _plane_servers()
+        live, _windows = _plane_live(servers)
+        p = leave.plan(live=live, focus=state.own_workspace(fid) or "",
+                       only=fid if verb == leave.CLOSE else "")
+        return palette.Palette(catalogue=leave.confirm_rows(p, verb=verb),
+                               label=verb, mouse=True)
     noun = choose.noun_of(row)
     if noun is None or row.note:
         return None
@@ -7316,3 +7470,791 @@ def cmd_respawn(args) -> int:
     return 0
 
 
+
+#: How much of a chat's pane a quit captures, in lines from the bottom.
+#:
+#: **Bounded at tmux rather than in Python, and the number came off a measurement.** One
+#: 200-column pane at charter's shipped `history_limit = 50000` took the shared tmux server
+#: from 3.7 MB to **130 MB** (Phase 5's own §6.2 figure, re-measured for this change), and
+#: `capture-pane -p -S -` pipes that whole history through this process. Asking tmux for the
+#: last N lines instead means the bound is applied where the memory is, not after it has
+#: been copied twice.
+#:
+#: Two thousand lines is far more than the last thing an operator was reading and far less
+#: than a session's whole history. §4f is explicit that this preserves a **record** and is
+#: never replayed, so what it has to be is enough to answer "what was it doing", not enough
+#: to reconstruct the run.
+_TRANSCRIPT_LINES = 2000
+
+#: A second bound, in bytes, because a line has no length limit. A pane full of one very
+#: long line is not a hypothetical — a `git log --oneline` of a big repo, a base64 blob, a
+#: minified stack trace — and the line bound above says nothing about it. Applied to what
+#: came back, keeping the END, because the end is what was on screen.
+_TRANSCRIPT_BYTES = 512 * 1024
+
+#: What tmux is asked for. `-e` keeps the escape sequences, so the captured text still has
+#: its colours when a pager shows it; `-N` is what stops `-e` **trimming trailing spaces**,
+#: which would silently rewrite the alignment of anything drawn in columns; `-J` is
+#: deliberately absent, because joining wrapped lines would reflow a transcript captured at
+#: one width into paragraphs at another.
+_CAPTURE_FLAGS = ("-p", "-e", "-N")
+
+
+def _capture_transcript(socket: str, pane_id: str, dest) -> bool:
+    """Write *pane_id*'s scrollback to *dest*. ``True`` when something was written.
+
+    **This reads the harness's own pane, which ADR 0018 forbids — and it is the SECOND
+    exception, not the first.** `_pane_last_words` already runs `capture-pane -p -S -` on
+    exactly this pane on both launch paths. The ADR's own closing words are that conflating
+    rendering with observation *"is how a boundary like this erodes one convenient exception
+    at a time"*, so this change amends the ADR rather than quietly adding to it: see
+    `docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md`, which now states the
+    rule as *charter may READ that pane at two moments it is about to be destroyed, and
+    never draws in it*.
+
+    The write goes through `config.write_for`: the destination is under `config.STATE_DIR`
+    and holds whatever the harness printed, which on a coding-agent's pane can include a
+    file it was shown. 0600 is not a boundary (`SECURITY.md:43-46` is honest about that) and
+    it is the same floor every other file charter writes there gets.
+
+    ``False`` for every way this can fail — a server that would not answer, a pane that is
+    already gone, a capture that came back empty, a write that could not land — because the
+    caller does one thing with all of them: record no transcript for that chat, and say so
+    in the manifest by leaving the field empty. A quit is never worth failing over a
+    diagnostic, which is `_pane_last_words`' own `report=False` argument.
+    """
+    out = tmuxctl.run("capturing what this chat had on screen",
+                      tmuxctl.server_argv(socket, "capture-pane", *_CAPTURE_FLAGS,
+                                          "-S", f"-{_TRANSCRIPT_LINES}",
+                                          "-t", pane_id),
+                      timeout=10, report=False)
+    if out.returncode != 0 or not out.stdout.strip():
+        return False
+    text = out.stdout
+    try:
+        # The frame root, which is `dest`'s parent: `config.write_for` opens a file and does
+        # not make directories, and a transcript is the FIRST thing a plane might ever write
+        # there that is not inside a chat's own directory. In production the root exists
+        # because a chat's directory is in it; asked for anyway, because the alternative is
+        # a capture that fails with ENOENT on the one path that has no other reader.
+        config.private_mkdir(dest.parent)
+    except OSError:
+        return False
+    if len(text.encode("utf-8", "replace")) > _TRANSCRIPT_BYTES:
+        # Cut from the END, on a character boundary, because the end is what the operator
+        # was looking at. Encoding first and slicing bytes would be able to split a
+        # multi-byte character; slicing the string and re-measuring cannot.
+        text = text[-_TRANSCRIPT_BYTES:]
+    try:
+        config.write_for(dest, text)
+    except OSError:
+        return False
+    return True
+
+
+#: What every window on a server is asked, in one call, when a quit needs to know which
+#: windows are this plane's chats.
+#:
+#: The chat comes from the OPTION and never from `#{window_name}`, for `_live_chats`' own
+#: measured reason: with `allow-rename on` a pane's own output renamed a `-n`-named window
+#: to `PWNED` on 3.7c and on 3.2 while the option was untouched. The window ID is what the
+#: kill is aimed at — never a session name, which in another plane is another plane's
+#: session (§3.3: `default` is a name every plane has), and never the chat's own recorded
+#: pane id, which is a value from before the server may have restarted.
+_CHAT_WINDOW_FORMAT = f"#{{{_CHAT_OPTION}}}\t#{{window_id}}\t#{{window_active}}"
+
+
+def _chat_windows(socket: str) -> dict[str, str] | None:
+    """Every chat id *socket* reports, mapped to the window it is drawn in.
+
+    ``None`` when the server would not answer at all, which is `_live_chats`' tri-state and
+    is carried for the same reason: a server that answers "no windows" because it was
+    wedged is not a server with nothing on it, and a quit that read the two the same would
+    record nothing and kill nothing while reporting that it had done both.
+
+    Rows charter cannot read are dropped rather than guessed at, and the chat id is held to
+    :data:`_FRAME_ID_RE` and the window id to :data:`_WINDOW_ID_RE` on the way out — this
+    value came off a tmux option and is about to be a `-t` target, which is #475's boundary
+    exactly.
+    """
+    out = tmuxctl.run("listing the chats this plane has open",
+                      tmuxctl.server_argv(socket, "list-windows", "-a", "-F",
+                                          _CHAT_WINDOW_FORMAT),
+                      timeout=5, report=False)
+    if out.returncode != 0:
+        return None
+    found: dict[str, str] = {}
+    for line in out.stdout.splitlines():
+        fields = line.split("\t")
+        if len(fields) != 3:
+            continue
+        chat, window, _active = fields
+        if _FRAME_ID_RE.fullmatch(chat) and _WINDOW_ID_RE.fullmatch(window):
+            found[chat] = window
+    return found
+
+
+def _active_chats(socket: str) -> set[str]:
+    """The chats that are the CURRENT window of their own tmux session.
+
+    Read in the same listing shape as :func:`_chat_windows` rather than folded into it,
+    because the two answers have different lifetimes: the window map is what a kill is
+    aimed at and must be as fresh as possible, while "which one was on screen" is a note
+    for the manifest and is allowed to be a moment old. Keeping them apart also keeps the
+    tuple `_CHAT_WINDOW_FORMAT` returns readable — three fields, three questions.
+
+    An empty set for a server that would not answer: what is lost is which chat a reopen
+    puts the operator back on, and the fallback (the first chat of the focused workspace)
+    is a place they can get to in one keypress.
+    """
+    out = tmuxctl.run("asking which chat each workspace was showing",
+                      tmuxctl.server_argv(socket, "list-windows", "-a", "-F",
+                                          _CHAT_WINDOW_FORMAT),
+                      timeout=5, report=False)
+    if out.returncode != 0:
+        return set()
+    seen = set()
+    for line in out.stdout.splitlines():
+        fields = line.split("\t")
+        if len(fields) == 3 and fields[2] == "1" and _FRAME_ID_RE.fullmatch(fields[0]):
+            seen.add(fields[0])
+    return seen
+
+
+def _plane_live(servers) -> tuple[set[str] | None, dict[str, dict[str, str]]]:
+    """Which of this plane's chats are live, and where each one's window is.
+
+    *servers* is every tmux server this plane's chats record. Asked once per server rather
+    than once per chat, because that is one round trip against a list charter already has
+    to read whole: a chat's liveness is not a question about the chat, it is a question
+    about its server's window list.
+
+    The set is ``None`` when **any** server refused to answer, and that is the conservative
+    direction rather than a shortcut. `_live_chats` documents why a wedged server must not
+    read as an empty one; with two servers in play, a quit that trusted the half that
+    answered would record only the chats of one server and kill only those — and then tell
+    the operator it had stopped the plane. ``None`` makes `leave.plan` mark every chat
+    "charter could not ask", which the warning says out loud.
+    """
+    windows: dict[str, dict[str, str]] = {}
+    known: set[str] = set()
+    unknown = False
+    for server in servers:
+        found = _chat_windows(server)
+        if found is None:
+            unknown = True
+            continue
+        windows[server] = found
+        known |= set(found)
+    return (None if unknown else known), windows
+
+
+def _plane_servers() -> list[str]:
+    """Every tmux server this plane's chats say they are on, charter's own first.
+
+    Charter's own socket is always included, even on a plane whose every chat records
+    another: it is where a chat with no recorded server will be (`builtin_actions._server`'s
+    own fallback, spelled the same way), and asking it costs one `list-windows` against a
+    socket that may not even have a server — which answers rc 1 and is read as "nothing
+    live there" by the caller.
+    """
+    found = [SOCKET]
+    for fid in leave._plane_chats():
+        server = state.frame_server(fid) or SOCKET
+        if server not in found:
+            found.append(server)
+    return found
+
+
+def _warn_about(p, *, on: str) -> None:
+    """Put the per-chat warning where whoever asked for the quit can read it.
+
+    **§4f's rule is that the warning names, per chat, what will and will not come back — at
+    the moment the operator is deciding.** For the palette that moment is
+    `leave.confirm_rows`, drawn before any keypress commits anything, and this is the
+    same sentences said again on the way past for the OTHER caller: `charter frame-quit`
+    typed by hand, which has no confirmation surface in front of it.
+
+    Said again rather than only once, deliberately. §4i is explicit that quit *"warns and
+    proceeds; it does not refuse"*, so the record of what was lost has to survive the
+    keypress — and stderr is the only surface left once the frame's own panes are about to
+    stop existing.
+
+    *on* names the chat the notice row belongs to, or ``""`` when this was typed outside a
+    frame. It is only used for the summary: the per-chat lines go to stderr either way,
+    because the attention row is one line and this is one line per chat.
+    """
+    util.warn(leave.summary(p))
+    for c in leave.stopping(p):
+        util.warn(f"  {leave.title(c)} — {leave.note(c)}")
+    if on:
+        _say_on_screen(on, leave.summary(p))
+
+
+def cmd_quit(args) -> int:
+    """`F2 → charter: quit` — record this plane, then stop every harness on it.
+
+    **The order is the design, and it is `trace`'s rule rather than a preference**
+    (§4e/§4i): the manifest is written BEFORE anything is killed, because a record that
+    depends on the thing it records succeeding is not a record. So:
+
+    1. read the plane off disk — every chat directory, its workspace, persona, harness,
+       cwd and durable session id (`leave.plan`);
+    2. ask each server which of them is live, and which window each one is in;
+    3. **capture each live chat's scrollback** while its pane still exists (§4f);
+    4. **write the manifest** (`frame/reopen.py`) — a FILE in the frame root, which `reap`
+       skips because it is not a directory, which is the only reason any of this survives a
+       restart at all;
+    5. drop the transcripts of chats the manifest no longer names;
+    6. **kill**, one `kill-window` per chat, aimed at a window id tmux itself just reported;
+    7. **prune `inflight`** — after the kills, not before, so a record is only discarded
+       once the work behind it is genuinely stopped.
+
+    **Plane-scoped, and that is §3.3's doing rather than a widening.** One tmux server
+    serves every plane on the machine and session names carry no plane, so `kill-server`
+    would take another plane's frames and `kill-session -t default` would take whichever
+    plane's `default` tmux resolved first. The set of things this stops is exactly *the
+    chats this plane has directories for*, which is the only filter that can be trusted.
+
+    That is also what makes the `inflight` prune honest. Those records carry no fid, no chat
+    and no workspace (§2.15), so a per-FRAME quit could not prune at all; a plane-scoped one
+    prunes exactly what it killed. The two facts are one fact.
+
+    **It warns and proceeds** (§4i). Refusing would leave an operator unable to quit while
+    any agent was working, which on a control plane is most of the time. The one thing that
+    stops it is being unable to RECORD: a quit that killed the plane after failing to write
+    the manifest is the invasive quit this whole design exists to prevent, so that is a
+    refusal with its own sentence.
+    """
+    fid = _pressers_chat(args)
+    servers = _plane_servers()
+    live, windows = _plane_live(servers)
+    focus = state.own_workspace(fid) or "" if fid else ""
+    p = leave.plan(live=live, focus=focus)
+    doomed = leave.stopping(p)
+    if not doomed:
+        util.warn(leave.NOTHING_OPEN)
+        return 0
+    _warn_about(p, on=fid)
+    active = set()
+    for server in servers:
+        active |= _active_chats(server)
+    kept = _record_the_plane(doomed, focus=focus, active=active, windows=windows)
+    if kept is None:
+        util.err("charter frame: refusing to quit — this plane could not be recorded, so "
+                 "nothing here would come back. Nothing was stopped.")
+        return 1
+    stopped = _stop_chats(doomed, windows=windows)
+    # AFTER the kills. `inflight` clears only on `finish()` (§2.15), so every record
+    # belonging to a harness this quit just stopped is stranded — `still_running` reports
+    # one for 30 minutes and `live` holds it for 24 hours, which would leave the frame's
+    # spinner animating for a plane doing nothing and the dispatch-overlap nudge naming
+    # agents this quit killed. Pruning BEFORE the kills would discard the record of work
+    # that is still running if a kill then failed; pruning after is the only order in which
+    # the tracker cannot end up quieter than the plane.
+    pruned = inflight.prune_all()
+    util.ok(f"charter: stopped {stopped} of {len(doomed)} chats and recorded "
+            f"{kept} to reopen — bring them back with `charter reopen`"
+            + (f" ({pruned} in-flight records cleared)" if pruned else ""))
+    return 0
+
+
+def _record_the_plane(doomed, *, focus: str, active, windows) -> int | None:
+    """Capture and record *doomed*. The number of chats recorded, or ``None``.
+
+    Split out of :func:`cmd_quit` so that "what a quit writes down" is one function a test
+    can drive with no tmux underneath it — the capture is the only part that needs a server,
+    and it is the part that is allowed to fail per chat.
+
+    ``None`` for a manifest that did not land, which is the one thing that stops a quit.
+    Everything else degrades per chat and is visible in what comes back: a capture that
+    failed leaves the transcript field empty, so the reopen simply has nothing to offer.
+    """
+    frames: list = []
+    entries: dict[str, list] = {}
+    order: list[str] = []
+    for c in doomed:
+        server = state.frame_server(c.chat) or SOCKET
+        transcript = ""
+        dest = reopen_state.transcript_path(c.chat)
+        pane_id = state.harness_pane(c.chat) or ""
+        if dest is not None and _PANE_ID_RE.fullmatch(pane_id) and c.chat in windows.get(
+                server, {}):
+            if _capture_transcript(server, pane_id, dest):
+                transcript = dest.name
+        if c.workspace not in entries:
+            entries[c.workspace] = []
+            order.append(c.workspace)
+        entries[c.workspace].append(reopen_state.Chat(
+            chat=c.chat, workspace=c.workspace, persona=c.persona, harness=c.harness,
+            cwd=c.cwd, resume=c.resume, transcript=transcript,
+            active=c.chat in active))
+    for ws in order:
+        frames.append(reopen_state.Frame(workspace=ws, chats=tuple(entries[ws])))
+    if not reopen_state.write(frames, focus=focus):
+        return None
+    reopen_state.prune_transcripts({c.chat for c in doomed})
+    return sum(len(f.chats) for f in frames)
+
+
+def _stop_chats(doomed, *, windows) -> int:
+    """`kill-window` each of *doomed*, on its own server. How many tmux accepted.
+
+    **A WINDOW id, and never a session name or a recorded pane.** A session name in another
+    plane is another plane's session (§3.3), and a pane id recorded before a server restart
+    can name a pane that is now somebody else's — while a window id from the listing taken
+    moments ago on that very server names this chat's window and nothing else. Killing a
+    session's LAST window destroys the session, measured on 3.7c and at the 3.2 floor and
+    already relied on by `cmd_launch`'s early-death path, so a workspace whose chats are all
+    stopped ends exactly as it would have.
+
+    A chat whose window is not in the listing is not counted and not aimed at: it is already
+    stopped, and it stays in the manifest because it was open when the plane was last read.
+    """
+    stopped = 0
+    for c in doomed:
+        server = state.frame_server(c.chat) or SOCKET
+        window = windows.get(server, {}).get(c.chat, "")
+        if not window:
+            continue
+        out = tmuxctl.run(f"stopping chat {c.chat}",
+                          tmuxctl.server_argv(server, "kill-window", "-t", window),
+                          timeout=10, report=False)
+        if out.returncode == 0:
+            stopped += 1
+    return stopped
+
+
+def cmd_close(args) -> int:
+    """`F2 → chat: close` — stop this one chat and do not bring it back.
+
+    **Quit's teardown, one target, and one file more.** The plan, the warning and the kill
+    are `cmd_quit`'s, asked with `leave.plan(only=…)` so that "what does stopping this cost"
+    has one answer rather than one per verb. What close adds is `state.record_closed`, and
+    that file is the whole difference between the two commands:
+
+    * quit RECORDS the chat, so a reopen brings it back;
+    * close MARKS it, so no reopen — this one's or a later quit's — ever does.
+
+    The marker exists because a missing `exit` file means *"was open"* (§2.17: `kill-pane`,
+    `kill-window` and `kill-session` write nothing, measured), and that default is
+    deliberately towards restoring. Without a mark, closing a chat and then quitting would
+    bring the closed chat back, because closing wrote no exit code either.
+
+    **It also drops the chat's transcript**, which quit deliberately keeps: a transcript
+    exists to be offered on the way back, and this chat is not coming back.
+
+    **No refusal for a busy chat, and that is a limit rather than a decision.** §4i asks
+    `workspace: close` to refuse while its harness is working; `inflight` cannot answer it —
+    its records carry no fid, no chat and no workspace (§2.15) — so a refusal here would
+    have to be based on a reading charter does not have. Saying so is the honest option: the
+    confirmation row says the chat will not come back, and that is the sentence an operator
+    needs before pressing it.
+    """
+    fid = _pressers_chat(args)
+    target = (getattr(args, "chat_id", None) or "").strip() or fid
+    if not target:
+        return outside_a_frame("charter frame-close")
+    if not chats.ID_RE.fullmatch(target):
+        util.err(f"charter frame-close: '{contain.one_line(target)}' cannot name a chat")
+        return 1
+    servers = _plane_servers()
+    live, windows = _plane_live(servers)
+    p = leave.plan(live=live, focus="", only=target)
+    if not p.chats:
+        util.err(f"charter frame-close: no open chat '{contain.one_line(target)}' on this "
+                 "plane")
+        return 1
+    doomed = leave.stopping(p)
+    if not doomed:
+        # Its window is already gone, so there is nothing to stop — but the MARK is still
+        # worth writing, and that is the whole reason this is not an early refusal: a chat
+        # whose harness ended on its own is exactly the one a later quit would record as
+        # "was open" and bring back uninvited.
+        state.record_closed(target)
+        _forget_transcript(target)
+        util.ok(f"charter: chat {target} was already stopped — marked closed, so it will "
+                "not come back")
+        return 0
+    _warn_about(p, on=fid if fid != target else "")
+    # The mark FIRST, for `cmd_quit`'s ordering reason turned around: this is the record,
+    # and a record written after the kill it describes is one a crash in between loses.
+    # Losing it here is not merely untidy — it is the chat coming back after the operator
+    # closed it.
+    state.record_closed(target)
+    _forget_transcript(target)
+    stopped = _stop_chats(doomed, windows=windows)
+    if not stopped:
+        util.err(f"charter frame-close: tmux would not stop chat {target} — it is marked "
+                 "closed and will not be reopened, but its harness may still be running")
+        return 1
+    util.ok(f"charter: closed {target} — it will not be reopened")
+    return 0
+
+
+def _forget_transcript(fid: str) -> None:
+    """Drop *fid*'s captured scrollback, and drop it from any manifest naming it.
+
+    **Both halves, because either one alone leaves the chat half-closed.** The file is what
+    `chat: previous transcript` offers, and a manifest entry is what `charter reopen` acts
+    on — so a close that removed only the file would still reopen the chat with nothing to
+    offer, and one that removed only the entry would leave a transcript in the frame root
+    with nothing left to collect it (`reopen.prune_transcripts` is that collector, and it
+    keeps whatever the manifest names).
+
+    Rewriting the manifest here is the one place a command other than a quit writes it, and
+    it is a REMOVAL rather than a merge: what goes back is the manifest that was read with
+    one chat's entry gone, so a manifest charter could not read is left exactly as it was
+    rather than replaced by charter's reading of it.
+    """
+    m = reopen_state.read()
+    if m is not None and any(c.chat == fid for c in m.all_chats()):
+        frames = [reopen_state.Frame(workspace=f.workspace,
+                                     chats=tuple(c for c in f.chats if c.chat != fid))
+                  for f in m.frames]
+        reopen_state.write([f for f in frames if f.chats], focus=m.focus, at=m.at)
+    reopen_state.prune_transcripts(
+        {c.chat for c in (reopen_state.read() or reopen_state.Manifest(
+            at=0, focus="", frames=())).all_chats()})
+
+
+def _restore_recorded_chat(rec, fid: str) -> None:
+    """Move the two id-keyed things a recorded chat owns onto its new id *fid*.
+
+    **The persona pointer.** `state.identity`'s `CHARTER_PERSONA` is the launch PIN, which
+    is empty for every chat that was not launched with one — so a chat's actual persona
+    lives in `persona.for_session(<chat id>)`, a file keyed on an id that is about to stop
+    existing. `persona.set_active(..., terminal_id="")` is `switch.to_persona`'s own call:
+    the session's pointer and nothing else, so a reopen does not repoint the terminal the
+    operator happens to be typing `charter reopen` in.
+
+    **The transcript.** `chat: previous transcript` looks the file up by the chat id it is
+    offered on, so a capture named for the old chat would be invisible to the new one. It is
+    RENAMED rather than pointed at, for `frame/reopen.TRANSCRIPT_SUFFIX`'s reason: one
+    naming rule and no second file to keep in step. `os.replace` and not a copy, so the
+    move is atomic and there is never a moment with two copies of one capture.
+
+    A recycled ordinal is the case worth naming rather than discovering: `new_chat_id` walks
+    upward from 1 and `reap` frees the ordinal a quit's chats held, so a reopen very often
+    gets the SAME id back. Then the source and destination are one path and there is nothing
+    to move — which is what the equality test says, and why it is an equality test rather
+    than an `exists` check.
+
+    Never raises. A persona that could not be pointed at leaves the chat on the plane's
+    default, which is visible on its own panel; a transcript that could not be moved leaves
+    the row with nothing to offer. Neither is worth failing a relaunch over, which is the
+    promise every writer in `frame/state.py` makes for the same reason.
+    """
+    from . import persona as persona_mod
+    if rec.persona and persona_mod.valid_name(rec.persona):
+        try:
+            persona_mod.set_active(rec.persona, session_id=fid, terminal_id="")
+        except (OSError, ValueError):
+            pass
+    old = reopen_state.transcript_path(rec.chat)
+    new = reopen_state.transcript_path(fid)
+    if old is None or new is None or old == new:
+        return
+    try:
+        os.replace(old, new)
+    except OSError:
+        return
+
+
+#: What `charter reopen` says when there is nothing recorded. It names the thing that
+#: writes one, because "nothing to reopen" on its own reads like a defect to an operator who
+#: has just restarted their machine and lost a frame — the honest answer is that a plane is
+#: recorded by QUITTING it, and a terminal that merely died detaches (§4i).
+NOTHING_RECORDED = (
+    "charter reopen: nothing recorded to put back. A plane is recorded when you quit it "
+    "(`F2 → charter: quit`); a terminal that closed on its own only detached, so its "
+    "harnesses are still running — `tmux -L charter attach` reaches them.")
+
+
+def cmd_reopen(args) -> int:
+    """`charter reopen` — put back the plane the last quit recorded.
+
+    **What comes back, per chat: the workspace, the persona, the harness and the
+    directory** — §4e's own four — plus, for Claude Code alone, the conversation, by
+    appending ``--resume <id>`` to the harness's own argv. **What does not: the selection,
+    the pane map, and the live scrollback.** §2.5's reasons for destroying the first two are
+    still right, `panes` names tmux ids that died with the server, and §4f is explicit that a
+    captured transcript is *offered and never replayed* — the reopened pane starts clean and
+    `chat: previous transcript` is where the old one went.
+
+    **A chat that cannot be resumed still comes back, empty, and says so.** Silently not
+    reopening it would make a chat vanish across a restart, which is the opposite of what
+    "less invasive" asked for. The directory, the workspace and the persona are restored
+    either way; only the conversation is gone, and the line this prints for that chat names
+    which of the reasons it was (§4f's own four sentences, in `frame/leave.py`).
+
+    **Each chat is launched through `cmd_launch` and none of them attaches.** One launcher
+    rather than a second path, because everything a chat needs — the session, the window,
+    the hooks, the panels, the options, the identity `-e` overlay — is that function's, and
+    a reopen with its own copy of it would be a second answer to "what a chat is" that
+    drifts on the first change to either. `Reopening` is the whole of the difference:
+    it suppresses open-or-focus, the client move and the attach, and carries the new chat id
+    back out.
+
+    **The attach happens once, at the end, to the workspace the quit was invoked from.** A
+    reopen that attached per chat would block on the first one; one that attached to
+    whichever session tmux happened to make current would put the operator somewhere they
+    did not leave.
+
+    **The manifest is consumed.** A record describes one quit, and a second `charter reopen`
+    against the same file would open every chat a second time with nothing on screen to tell
+    the duplicates apart. It is dropped after the launches and before the attach, because
+    the attach does not return until the operator leaves.
+    """
+    m = reopen_state.read()
+    if m is None or not m.frames:
+        util.err(NOTHING_RECORDED)
+        return 1
+    # **Before anything is started**, and it is the #687/#690 shape rather than politeness:
+    # `cmd_launch` answers a non-tty stdout with `bypass(argv)`, which is an `os.execvp`.
+    # A `charter reopen` in a pipeline would therefore not report anything at all — it
+    # would BECOME the first recorded harness, in this process, with the rest of the plane
+    # unrestored and the manifest still on disk.
+    if not sys.stdout.isatty():
+        util.err("charter reopen: needs a terminal — it starts a tmux frame and attaches "
+                 "to it. Nothing was reopened.")
+        return 1
+    if tmuxctl.version() is None:
+        util.err(tmuxctl.absent_message())
+        return 1
+    back: list[Reopening] = []
+    for f in m.frames:
+        for c in f.chats:
+            r = _reopen_one(c)
+            if r is not None:
+                back.append(r)
+    if not back:
+        util.err("charter reopen: none of the recorded chats could be started — the "
+                 "record is left in place so this can be tried again.")
+        return 1
+    util.ok(f"charter: reopened {len(back)} of {len(m.all_chats())} chats")
+    reopen_state.forget()
+    return _attach_after_reopen(m, back)
+
+
+def _reopen_one(c) -> "Reopening | None":
+    """Put one recorded chat back. The launch's own record, or ``None`` when it did not run.
+
+    **The harness is resolved off the registry by its own `name`**, which is what
+    `state.identity` recorded (`harness.base.name` — ``claude-code``, not ``claude``), and
+    a chat whose harness this charter no longer registers falls back to the plane's
+    ``[harness] default``. That fallback is reported rather than silent: the operator asked
+    for their plane back and is getting one chat of it under a different runtime, which is a
+    thing to be told.
+
+    **`--resume` is appended to the harness's own argv and nowhere else.** `Harness.launch_argv`
+    is ``[self.binary, *extra]`` with no override in the registry, so the pass-through IS
+    the seam — there is no resume member on `Harness` and Phase 5's Task 9 Step 4 refuses one
+    on `harness/base.py`'s own bar. It is gated on `leave.resumable_harness`, so a recorded
+    id belonging to a harness that does not take the flag is not handed to it.
+
+    **The directory is `os.chdir`'d into rather than passed**, because that is where
+    `cmd_launch` reads it from — one `os.getcwd()` on each of its two paths — and adding a
+    parameter for it would be a second way to say the same thing. Restored in a `finally`:
+    the next chat in the manifest has its own directory, and a launcher left standing in
+    somebody else's is exactly the silent wrongness §4e's cwd item exists to close.
+    """
+    h = next((x for x in harness.all() if x.name == c.harness), None)
+    if h is None or not h.cli_name:
+        fallback = (config.HARNESS or {}).get("default")
+        h = next((x for x in harness.all() if x.cli_name == fallback), None)
+        if h is None:
+            util.warn(f"charter reopen: {c.chat} recorded harness "
+                      f"{contain.readable(c.harness) or 'nothing'}, which this charter "
+                      f"cannot launch, and this plane declares no `[harness] default` — "
+                      f"not reopened")
+            return None
+        util.warn(f"charter reopen: {c.chat} recorded harness "
+                  f"{contain.readable(c.harness) or 'nothing'} — reopening it under "
+                  f"{h.cli_name}, this plane's default")
+    rest: list[str] = []
+    if c.resume and leave.resumable_harness(c.harness):
+        rest = ["--resume", c.resume]
+    where = c.cwd if c.cwd and os.path.isdir(c.cwd) else str(config.ROOT)
+    if where != c.cwd:
+        util.warn(f"charter reopen: {c.chat}'s directory "
+                  f"{contain.readable(c.cwd) or 'was never recorded'} — reopening in "
+                  f"{where}")
+    r = Reopening(c)
+    argv_args = _reopen_args(c, harness_name=h.cli_name, rest=rest, reopening=r)
+    here = os.getcwd()
+    try:
+        os.chdir(where)
+    except OSError:
+        util.warn(f"charter reopen: cannot enter {contain.readable(where)} — {c.chat} not "
+                  "reopened")
+        return None
+    try:
+        rc = cmd_launch(argv_args)
+    finally:
+        try:
+            os.chdir(here)
+        except OSError:
+            pass
+    if rc != 0 or not r.fid:
+        util.warn(f"charter reopen: {c.chat} did not come back (launcher returned {rc})")
+        return None
+    util.info(f"  {c.chat} → {r.fid} · {leave.RESUMES if rest else 'empty'}"
+              + (" · workspace is missing" if c.workspace
+                 and not workspace.workspace_dir(c.workspace).is_dir() else ""))
+    return r
+
+
+def _reopen_args(c, *, harness_name: str, rest, reopening):
+    """The namespace `cmd_launch` is driven with, built once so its fields are visible.
+
+    Every field `cmd_launch` and `_choose_workspace` read is named here rather than left to
+    a `getattr` default, which is what makes this a readable contract instead of a puzzle:
+    ``workspace`` is the recorded one — set explicitly, so `_picker_wanted` never asks a
+    question on a path with no operator waiting — ``pick`` is false for the same reason,
+    ``no_frame`` is false because a reopen without a frame is a bare harness, and
+    ``reopening`` is the seam.
+    """
+    from types import SimpleNamespace
+    return SimpleNamespace(harness=harness_name, rest=list(rest), no_frame=False,
+                           workspace=c.workspace or None, pick=False,
+                           reopening=reopening)
+
+
+def _attach_after_reopen(m, back) -> int:
+    """Put the operator on the chat they left, then hand them the terminal.
+
+    The chat is the one the manifest marked `active` in the FOCUS workspace — the session
+    that had the client when the quit ran. Failing that, the first chat of that workspace;
+    failing that, the first chat reopened at all. Each fallback is one step further from
+    "where you were" and none of them is nowhere, which matters because the alternative is
+    attaching to whichever window tmux made current — an answer nobody chose.
+
+    `select-window` is aimed at the new chat's own harness PANE, because a pane id resolves
+    to its window on 3.7c and at the 3.2 floor (measured, and already relied on by
+    `cmd_chat`), and because a session NAME as a `-t` is parsed by tmux as ``window.pane``
+    for any workspace with a dot in it.
+
+    The attach is `tmuxctl.interact` for `cmd_launch`'s own reason: this IS the operator's
+    terminal now, not an admin command whose output charter should own.
+    """
+    wanted = next((r for r in back
+                   if r.chat.active and r.chat.workspace == m.focus), None)
+    if wanted is None:
+        wanted = next((r for r in back if r.chat.workspace == m.focus), None)
+    if wanted is None:
+        wanted = next((r for r in back if r.chat.active), back[0])
+    session = state.workspace_prefix(wanted.chat.workspace)
+    pane_id = state.harness_pane(wanted.fid) or ""
+    if _PANE_ID_RE.fullmatch(pane_id):
+        tmuxctl.run("putting you back on the chat you left",
+                    tmuxctl.server_argv(SOCKET, "select-window", "-t", pane_id),
+                    report=False)
+    attach_cmd = tmuxctl.server_argv(SOCKET, "attach", "-t", session)
+    attached = tmuxctl.interact(attach_cmd)
+    if attached.returncode != 0:
+        tmuxctl.report_failure("attaching to the reopened frame", attach_cmd, attached)
+        return attached.returncode
+    return 0
+
+
+#: The pager a captured transcript is shown in, and the ONE thing charter will run for it.
+#:
+#: **`$PAGER` is deliberately not honoured**, and that is a containment decision rather than
+#: a limitation. A `$PAGER` is conventionally a COMMAND LINE (`less -R`, `bat --paging
+#: always`), so honouring it means either splitting a string the operator's environment
+#: supplied — which is shell parsing charter would be reimplementing — or handing it to a
+#: shell, which is the injection `harness.base.launch_argv` returns a list to prevent. What
+#: charter runs here is one argv it wrote itself.
+#:
+#: `-R` because the capture keeps its escape sequences (`_CAPTURE_FLAGS`' `-e`), so without
+#: it the transcript reads as a wall of `ESC[0m`. `-+X` and no other flags: charter does not
+#: get to decide how somebody's `less` behaves beyond making the colours work.
+_PAGER = ("less", "-R")
+
+#: What a chat with no captured transcript is told, instead of a row that does nothing.
+#: It names WHY there is none rather than only that there is none: a chat that has never
+#: been quit has no capture, and that is the ordinary state of every chat that is running
+#: normally.
+NO_TRANSCRIPT = ("no previous transcript for this chat — one is captured when a plane is "
+                 "quit, and offered on the chat that comes back")
+
+#: What an operator is told when charter has the transcript and no pager to show it in.
+#: The path is given, because a file the operator can open themselves is a strictly better
+#: answer than a refusal, and because leaving a dead `cat` pane in their frame would be
+#: worse than either (§2.14: a dead pane with `remain-on-exit` is a window that does not
+#: close, in a frame whose prefix key charter hides).
+NO_PAGER = "charter cannot find `less` to show it in — the captured text is at {path}"
+
+
+def cmd_transcript(args) -> int:
+    """`F2 → chat: previous transcript` — open what this chat had on screen before.
+
+    **Offered, never replayed** (§4f). The text goes into a NEW tmux window running a pager;
+    nothing is written into the harness's own pane. Replaying bytes into the live pane would
+    present a session that is not running as though it were — the convincing-empty this
+    project refuses everywhere else — and it would put a previous run's output above a new
+    run's prompt with nothing marking the seam.
+
+    **This is the READING half of the ADR 0018 amendment this change carries.** The capture
+    is the other half (`_capture_transcript`); between them, charter now reads the harness's
+    pane at two moments and still draws in it at none. See the ADR.
+
+    **Always 0**, like every other `frame-*` command: this runs detached with its streams on
+    `/dev/null` (`builtin_actions._spawn`), so a non-zero exit is read by nothing — and
+    inside a `run-shell` a non-zero exit is what makes tmux print into the harness pane, the
+    one rectangle ADR 0018 says charter never draws in. Every refusal goes to
+    :func:`_say_on_screen` instead.
+    """
+    fid = _pressers_chat(args)
+    if not fid:
+        return outside_a_frame("charter frame-transcript")
+    path = reopen_state.transcript_path(fid)
+    if path is None or not path.is_file():
+        _say_on_screen(fid, NO_TRANSCRIPT)
+        return 0
+    if shutil.which(_PAGER[0]) is None:
+        _say_on_screen(fid, NO_PAGER.format(path=path))
+        return 0
+    target = chats.pane_of(fid)
+    if target is None:
+        _say_on_screen(fid, "charter has no usable record of this chat's harness pane, so "
+                            "it cannot place a window beside it — relaunch this chat")
+        return 0
+    socket = state.frame_server(fid) or SOCKET
+    # `-t <pane id>`: a pane resolves to its own window on 3.7c and at the 3.2 floor, so the
+    # new window lands in THIS chat's session — never `-t <session name>`, which tmux parses
+    # as `window.pane` for any workspace with a dot in it (#695).
+    #
+    # `--` and an argv, never a joined string: tmux shell-interprets a single argument and
+    # does not interpret separate ones (`harness.base.launch_argv`'s own measured rule), and
+    # the path here is charter's own file under a state directory whose name carries the
+    # plane's.
+    opened = tmuxctl.run(
+        "opening this chat's previous transcript",
+        tmuxctl.server_argv(socket, "new-window", "-t", target, "-n",
+                            f"transcript {fid}", "--", *_PAGER, str(path)))
+    if opened.returncode != 0:
+        _say_on_screen(fid, f"tmux would not open a window for the transcript — it is at "
+                            f"{path}")
+    return 0
+
+
+def _start_leaving(fid: str, verb: str) -> None:
+    """Start the quit or the close, detached, and return having started it.
+
+    :func:`_start_chat_switch`'s argument, one verb over, and every word of it applies:
+    the palette closes the instant it has invoked, `kill-pane` hands SIGHUP to that pane's
+    process group, and a teardown that ran in this process would be racing its own — with
+    a sharper edge here, because one of the windows it kills is very likely the one this
+    palette is drawn over.
+
+    `builtin_actions._spawn` and never a bare `Popen`, so `$CHARTER_SESSION_ID` is STATED
+    rather than inherited: this is a `run-shell` child of a tmux server shared between
+    every frame on the machine, and its own variable may be another chat's
+    (`state.record_identity` measures exactly that). `--chat` carries the presser's own
+    chat, which is the only value that can tell two chats of one workspace apart — the
+    same split `frame-toggle` already makes.
+    """
+    builtin_actions._spawn(
+        util.self_relaunch_argv(f"frame-{verb}", "--chat", fid), fid=fid)

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -5036,7 +5036,15 @@ def cmd_launch(args) -> int:
     # below, because a quit lands on more than one of them: a `kill-window` writes no `exit`
     # (§2.17), so the ordinary quit reaches the bare `return 0` at the bottom, while a
     # harness that had already recorded a code reaches the first.
-    _say_it_was_quit(fid)
+    #
+    # **Only for a launch that WAS the operator's terminal**, and this gate is a defect fix
+    # rather than a tidiness. `new_chat_id` walks upward from 1 and `reap` frees the ordinals
+    # a quit's chats held, so a reopen very often gets the SAME ids back — and every one of
+    # its own launches would then find itself named in the manifest it is in the middle of
+    # acting on, and print "this plane was quit; put it back with `charter reopen`" while
+    # `charter reopen` was putting it back.
+    if _wants_attach(args):
+        _say_it_was_quit(fid)
     if code is not None:
         return code
     if refused_to_attach:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -5027,6 +5027,16 @@ def cmd_launch(args) -> int:
     live_after = after_sessions | (after_chats or set())
     if after_chats is not None or not after_sessions:
         state.reap(live_after, server=SOCKET)
+    # **The one place the operator can be told a quit happened, and it is not the quit.**
+    # `charter: quit` runs detached with its three streams on `/dev/null`
+    # (`builtin_actions._spawn`), so whatever it prints is read by nothing; and by the time
+    # it has finished there is no frame, no attention row and no client left to draw on.
+    # THIS process is where the operator gets their shell back from, so it is the one that
+    # can say what happened and name the command that undoes it. Said before every return
+    # below, because a quit lands on more than one of them: a `kill-window` writes no `exit`
+    # (§2.17), so the ordinary quit reaches the bare `return 0` at the bottom, while a
+    # harness that had already recorded a code reaches the first.
+    _say_it_was_quit(fid)
     if code is not None:
         return code
     if refused_to_attach:
@@ -7729,7 +7739,10 @@ def cmd_quit(args) -> int:
     fid = _pressers_chat(args)
     servers = _plane_servers()
     live, windows = _plane_live(servers)
-    focus = state.own_workspace(fid) or "" if fid else ""
+    # Parenthesised, because the two readings differ and only one is right: `focus` is the
+    # workspace of the chat the quit was PRESSED in, and `""` for a `charter frame-quit`
+    # typed outside a frame — where a reopen falls back to the first frame it recorded.
+    focus = (state.own_workspace(fid) or "") if fid else ""
     p = leave.plan(live=live, focus=focus)
     doomed = leave.stopping(p)
     if not doomed:
@@ -8272,3 +8285,32 @@ def _start_leaving(fid: str, verb: str) -> None:
     """
     builtin_actions._spawn(
         util.self_relaunch_argv(f"frame-{verb}", "--chat", fid), fid=fid)
+
+
+def _say_it_was_quit(fid: str) -> None:
+    """Tell the operator their plane was recorded, on the shell they are back in.
+
+    **The gap this closes was found by asking where the quit's own sentence goes, and the
+    answer was nowhere.** `charter: quit` is started detached with `stdout` and `stderr` on
+    `/dev/null` — that is `builtin_actions._spawn`'s measured requirement, because the
+    palette's pane is killed the instant a row is invoked and a write to a closed pty is an
+    `EIO` in a process that was working correctly. And it cannot use the frame's attention
+    row either (`_say_on_screen`), because the frame it would draw on is the one it just
+    stopped. So the operator pressed a row, their screen went back to a shell, and nothing
+    anywhere named `charter reopen`.
+
+    `cmd_launch` is the process that hands them that shell, so it is the one that can say
+    it. Gated on the MANIFEST naming this chat, which is what makes the sentence true rather
+    than likely: a launcher whose harness merely exited, or whose operator detached, reaches
+    the same lines and says nothing.
+
+    Never raises and never guesses: a manifest charter cannot read is one it says nothing
+    about, exactly as `reopen.read` answers `None` for it.
+    """
+    m = reopen_state.read()
+    if m is None or not any(c.chat == fid for c in m.all_chats()):
+        return
+    n = len(m.all_chats())
+    back = len([c for c in m.all_chats() if c.resume])
+    util.info(f"charter: this plane was quit — {n} chat(s) recorded, {back} with a "
+              f"conversation to resume.\n  put it back with: charter reopen")

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -7760,10 +7760,14 @@ def cmd_quit(args) -> int:
     fid = _pressers_chat(args)
     servers = _plane_servers()
     live, windows, active = _plane_live(servers)
-    # Parenthesised, because the two readings differ and only one is right: `focus` is the
-    # workspace of the chat the quit was PRESSED in, and `""` for a `charter frame-quit`
+    # The workspace of the chat the quit was PRESSED in, and `""` for a `charter frame-quit`
     # typed outside a frame — where a reopen falls back to the first frame it recorded.
-    focus = (state.own_workspace(fid) or "") if fid else ""
+    #
+    # `or ""` and no `if fid` in front of it: the deletion sweep could not turn that
+    # conditional red and it was right, because `own_workspace("")` already answers `None`
+    # (`frame_dir` refuses the empty id) and the `or` converts it. A guard that passes only
+    # because a DIFFERENT guard caught the case is the shape this repository deletes.
+    focus = state.own_workspace(fid) or ""
     p = leave.plan(live=live, focus=focus)
     doomed = leave.stopping(p)
     if not doomed:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8282,23 +8282,41 @@ def cmd_transcript(args) -> int:
     if shutil.which(_PAGER[0]) is None:
         _say_on_screen(fid, NO_PAGER.format(path=path))
         return 0
-    target = chats.pane_of(fid)
-    if target is None:
+    pane_id = chats.pane_of(fid)
+    if pane_id is None:
         _say_on_screen(fid, "charter has no usable record of this chat's harness pane, so "
                             "it cannot place a window beside it — relaunch this chat")
         return 0
     socket = state.frame_server(fid) or SOCKET
-    # `-t <pane id>`: a pane resolves to its own window on 3.7c and at the 3.2 floor, so the
-    # new window lands in THIS chat's session — never `-t <session name>`, which tmux parses
-    # as `window.pane` for any workspace with a dot in it (#695).
+    # **The target is the SESSION ID, and every other spelling was measured failing.** This
+    # is the #664/#695 shape and it cost a hand-run to find: `kill-window -t %N` resolves a
+    # pane to its own window, so `new-window -t %N` looks like it should too. It does not.
+    # On tmux 3.7c **and** at the 3.2 floor, with a session called `alpha.2` and its own
+    # `$0`/`@0`/`%0`:
     #
+    #     new-window -t %0        rc 1   can't specify pane here
+    #     new-window -t @0        rc 1   create window failed: index 0 in use
+    #     new-window -t alpha.2   rc 1   can't specify pane here      <- #695, again
+    #     new-window -t $0        rc 0
+    #
+    # `-t` here is a target-WINDOW and a window id is read as the index to insert at, which
+    # is by definition taken; a session NAME with a dot in it is parsed as `window.pane`,
+    # which is the collision `state._UNSAFE` already exists for. The session id is the one
+    # unambiguous spelling, and `_pane_place` is what turns this chat's recorded pane into
+    # one — held to `_SESSION_ID_RE` on the way out, at #475's boundary.
+    place = _pane_place(socket, pane_id)
+    if place is None:
+        _say_on_screen(fid, f"tmux would not say which session this chat is in, so charter "
+                            f"cannot place a window there — the captured text is at {path}")
+        return 0
+    session_id, _window_id = place
     # `--` and an argv, never a joined string: tmux shell-interprets a single argument and
     # does not interpret separate ones (`harness.base.launch_argv`'s own measured rule), and
     # the path here is charter's own file under a state directory whose name carries the
     # plane's.
     opened = tmuxctl.run(
         "opening this chat's previous transcript",
-        tmuxctl.server_argv(socket, "new-window", "-t", target, "-n",
+        tmuxctl.server_argv(socket, "new-window", "-t", session_id, "-n",
                             f"transcript {fid}", "--", *_PAGER, str(path)))
     if opened.returncode != 0:
         _say_on_screen(fid, f"tmux would not open a window for the transcript — it is at "

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -7108,7 +7108,7 @@ def _picker(row, fid: str, opened: list) -> "palette.Palette | None":
         # scan of the frame root. The confirming row is the last one, under the list it is
         # about, and every chat row above it is `refused` (see `frame/leave.py`).
         servers = _plane_servers()
-        live, _windows = _plane_live(servers)
+        live, _windows, _active = _plane_live(servers)
         p = leave.plan(live=live, focus=state.own_workspace(fid) or "",
                        only=fid if verb == leave.CLOSE else "")
         return palette.Palette(catalogue=leave.confirm_rows(p, verb=verb),
@@ -7574,18 +7574,25 @@ def _capture_transcript(socket: str, pane_id: str, dest) -> bool:
 _CHAT_WINDOW_FORMAT = f"#{{{_CHAT_OPTION}}}\t#{{window_id}}\t#{{window_active}}"
 
 
-def _chat_windows(socket: str) -> dict[str, str] | None:
-    """Every chat id *socket* reports, mapped to the window it is drawn in.
+def _chat_seats(socket: str) -> list[tuple[str, str, bool]] | None:
+    """Every chat *socket* reports, as ``(chat id, window id, is its session's current)``.
 
     ``None`` when the server would not answer at all, which is `_live_chats`' tri-state and
-    is carried for the same reason: a server that answers "no windows" because it was
-    wedged is not a server with nothing on it, and a quit that read the two the same would
-    record nothing and kill nothing while reporting that it had done both.
+    is carried for the same reason: a server that answers "no windows" because it was wedged
+    is not a server with nothing on it, and a quit that read the two the same would record
+    nothing and kill nothing while reporting that it had done both.
+
+    **One listing for all three questions, because it is one listing.** An earlier version
+    of this asked twice — once for the window map a kill is aimed at, once for which chat was
+    on screen — on the grounds that the two answers have different lifetimes. They do not
+    have different SOURCES, and `cmd_launch`'s own note about asking `tmux -V` twice applies
+    unchanged: *two subprocesses for one unchanging fact*. The three fields arrive together
+    or not at all.
 
     Rows charter cannot read are dropped rather than guessed at, and the chat id is held to
-    :data:`_FRAME_ID_RE` and the window id to :data:`_WINDOW_ID_RE` on the way out — this
-    value came off a tmux option and is about to be a `-t` target, which is #475's boundary
-    exactly.
+    :data:`_FRAME_ID_RE` and the window id to :data:`_WINDOW_ID_RE` on the way out — these
+    values came off a tmux option and are about to be a `-t` target and a state directory's
+    name, which is #475's boundary exactly.
     """
     out = tmuxctl.run("listing the chats this plane has open",
                       tmuxctl.server_argv(socket, "list-windows", "-a", "-F",
@@ -7593,51 +7600,24 @@ def _chat_windows(socket: str) -> dict[str, str] | None:
                       timeout=5, report=False)
     if out.returncode != 0:
         return None
-    found: dict[str, str] = {}
+    seats: list[tuple[str, str, bool]] = []
     for line in out.stdout.splitlines():
         fields = line.split("\t")
         if len(fields) != 3:
             continue
-        chat, window, _active = fields
+        chat, window, active = fields
         if _FRAME_ID_RE.fullmatch(chat) and _WINDOW_ID_RE.fullmatch(window):
-            found[chat] = window
-    return found
+            seats.append((chat, window, active == "1"))
+    return seats
 
 
-def _active_chats(socket: str) -> set[str]:
-    """The chats that are the CURRENT window of their own tmux session.
-
-    Read in the same listing shape as :func:`_chat_windows` rather than folded into it,
-    because the two answers have different lifetimes: the window map is what a kill is
-    aimed at and must be as fresh as possible, while "which one was on screen" is a note
-    for the manifest and is allowed to be a moment old. Keeping them apart also keeps the
-    tuple `_CHAT_WINDOW_FORMAT` returns readable — three fields, three questions.
-
-    An empty set for a server that would not answer: what is lost is which chat a reopen
-    puts the operator back on, and the fallback (the first chat of the focused workspace)
-    is a place they can get to in one keypress.
-    """
-    out = tmuxctl.run("asking which chat each workspace was showing",
-                      tmuxctl.server_argv(socket, "list-windows", "-a", "-F",
-                                          _CHAT_WINDOW_FORMAT),
-                      timeout=5, report=False)
-    if out.returncode != 0:
-        return set()
-    seen = set()
-    for line in out.stdout.splitlines():
-        fields = line.split("\t")
-        if len(fields) == 3 and fields[2] == "1" and _FRAME_ID_RE.fullmatch(fields[0]):
-            seen.add(fields[0])
-    return seen
-
-
-def _plane_live(servers) -> tuple[set[str] | None, dict[str, dict[str, str]]]:
-    """Which of this plane's chats are live, and where each one's window is.
+def _plane_live(servers) -> tuple[set[str] | None, dict[str, dict[str, str]], set[str]]:
+    """Which of this plane's chats are live, where each one's window is, and which was shown.
 
     *servers* is every tmux server this plane's chats record. Asked once per server rather
-    than once per chat, because that is one round trip against a list charter already has
-    to read whole: a chat's liveness is not a question about the chat, it is a question
-    about its server's window list.
+    than once per chat, because that is one round trip against a list charter has to read
+    whole anyway: a chat's liveness is not a question about the chat, it is a question about
+    its server's window list.
 
     The set is ``None`` when **any** server refused to answer, and that is the conservative
     direction rather than a shortcut. `_live_chats` documents why a wedged server must not
@@ -7645,18 +7625,25 @@ def _plane_live(servers) -> tuple[set[str] | None, dict[str, dict[str, str]]]:
     answered would record only the chats of one server and kill only those — and then tell
     the operator it had stopped the plane. ``None`` makes `leave.plan` mark every chat
     "charter could not ask", which the warning says out loud.
+
+    The third value is which chats were their session's CURRENT window, so a reopen can put
+    the operator back on the tab they were looking at rather than on whichever window it
+    created first. An empty set costs that and nothing else: the fallback is the first chat
+    of the focused workspace, which is one keypress away.
     """
     windows: dict[str, dict[str, str]] = {}
     known: set[str] = set()
+    active: set[str] = set()
     unknown = False
     for server in servers:
-        found = _chat_windows(server)
-        if found is None:
+        seats = _chat_seats(server)
+        if seats is None:
             unknown = True
             continue
-        windows[server] = found
-        known |= set(found)
-    return (None if unknown else known), windows
+        windows[server] = {chat: window for chat, window, _ in seats}
+        known |= set(windows[server])
+        active |= {chat for chat, _, showing in seats if showing}
+    return (None if unknown else known), windows, active
 
 
 def _plane_servers() -> list[str]:
@@ -7676,7 +7663,7 @@ def _plane_servers() -> list[str]:
     return found
 
 
-def _warn_about(p, *, on: str) -> None:
+def _warn_about(p, *, on: str, verb: str) -> None:
     """Put the per-chat warning where whoever asked for the quit can read it.
 
     **§4f's rule is that the warning names, per chat, what will and will not come back — at
@@ -7694,11 +7681,11 @@ def _warn_about(p, *, on: str) -> None:
     frame. It is only used for the summary: the per-chat lines go to stderr either way,
     because the attention row is one line and this is one line per chat.
     """
-    util.warn(leave.summary(p))
+    util.warn(leave.summary(p, verb=verb))
     for c in leave.stopping(p):
         util.warn(f"  {leave.title(c)} — {leave.note(c)}")
     if on:
-        _say_on_screen(on, leave.summary(p))
+        _say_on_screen(on, leave.summary(p, verb=verb))
 
 
 def cmd_quit(args) -> int:
@@ -7738,7 +7725,7 @@ def cmd_quit(args) -> int:
     """
     fid = _pressers_chat(args)
     servers = _plane_servers()
-    live, windows = _plane_live(servers)
+    live, windows, active = _plane_live(servers)
     # Parenthesised, because the two readings differ and only one is right: `focus` is the
     # workspace of the chat the quit was PRESSED in, and `""` for a `charter frame-quit`
     # typed outside a frame — where a reopen falls back to the first frame it recorded.
@@ -7748,10 +7735,7 @@ def cmd_quit(args) -> int:
     if not doomed:
         util.warn(leave.NOTHING_OPEN)
         return 0
-    _warn_about(p, on=fid)
-    active = set()
-    for server in servers:
-        active |= _active_chats(server)
+    _warn_about(p, on=fid, verb=leave.QUIT)
     kept = _record_the_plane(doomed, focus=focus, active=active, windows=windows)
     if kept is None:
         util.err("charter frame: refusing to quit — this plane could not be recorded, so "
@@ -7886,7 +7870,7 @@ def cmd_close(args) -> int:
         util.err(f"charter frame-close: '{contain.one_line(target)}' cannot name a chat")
         return 1
     servers = _plane_servers()
-    live, windows = _plane_live(servers)
+    live, windows, _active = _plane_live(servers)
     p = leave.plan(live=live, focus="", only=target)
     if not p.chats:
         util.err(f"charter frame-close: no open chat '{contain.one_line(target)}' on this "
@@ -7903,7 +7887,7 @@ def cmd_close(args) -> int:
         util.ok(f"charter: chat {target} was already stopped — marked closed, so it will "
                 "not come back")
         return 0
-    _warn_about(p, on=fid if fid != target else "")
+    _warn_about(p, on=fid if fid != target else "", verb=leave.CLOSE)
     # The mark FIRST, for `cmd_quit`'s ordering reason turned around: this is the record,
     # and a record written after the kill it describes is one a crash in between loses.
     # Losing it here is not merely untidy — it is the chat coming back after the operator

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -7012,8 +7012,13 @@ def _draw_palette(args) -> int:
         if leave.is_row(chosen):
             # A doorway `_picker` refused (its note says why) or one of the warning's own
             # per-chat rows, which are `refused=True` and describe rather than do. The note
-            # is said in the first case and there is nothing to say in the second.
-            if chosen.note and leave.verb_of(chosen) is not None:
+            # is said in the first case and there is nothing to say in the second — and
+            # `verb_of` alone tells them apart, because a per-chat row's id is
+            # `leave:<verb>:c<n>` and only a DOORWAY's is `leave:<verb>`. A `chosen.note and`
+            # in front of this was the sweep's finding and its own answer: a doorway that
+            # `_picker` refused always carries the note that says why, so the conjunct could
+            # never decide anything.
+            if leave.verb_of(chosen) is not None:
                 _say_on_screen(fid, chosen.note)
             return 0
         inv = reg.invoke(chosen.id, fid=fid, snapshot=snapshot)
@@ -7102,13 +7107,19 @@ def _picker(row, fid: str, opened: list) -> "palette.Palette | None":
     from there rather than from `choose.roster` directly, so a noun the operator already
     typed against is not listed a second time — see that function.
     """
-    verb = leave.verb_of(row)
-    if verb is not None and row.note:
-        # A refused doorway does not open — `choose.open_rows`' rule, and the same one: a
-        # confirmation over a target charter cannot name would be an offer it already knows
-        # it cannot honour. `None` sends the row back to :func:`_draw_palette`, which says
-        # the note on the operator's own screen.
+    # **A refused row does not open, whichever doorway it is** — `choose.open_rows`' rule,
+    # and the same one: a surface over a target charter cannot name would be an offer it
+    # already knows it cannot honour. `None` sends the row back to :func:`_draw_palette`,
+    # which says the note on the operator's own screen.
+    #
+    # `row.note` alone, and the `verb is not None and` that used to be in front of it is
+    # gone: the deletion sweep could not turn it red, and it was right — the branch below
+    # already answers `None` for every noun row with a note, so the conjunct only ever
+    # restated a decision the next four lines make. A guard that passes because a DIFFERENT
+    # guard caught the case is the shape this repository deletes rather than documents.
+    if row.note:
         return None
+    verb = leave.verb_of(row)
     if verb is not None:
         # **§4f's warning, drawn at the moment the operator is deciding.** The plan is built
         # HERE and not when the palette opened, so the rows describe the plane as it is
@@ -7117,12 +7128,16 @@ def _picker(row, fid: str, opened: list) -> "palette.Palette | None":
         # about, and every chat row above it is `refused` (see `frame/leave.py`).
         servers = _plane_servers()
         live, _windows, _active = _plane_live(servers)
-        p = leave.plan(live=live, focus=state.own_workspace(fid) or "",
+        # `focus` is not read on this path — the confirmation draws rows and writes no
+        # manifest — so the `or ""` that used to be here was a fallback nothing could
+        # observe, and the sweep said so. The one caller that DOES record a focus is
+        # `cmd_quit`, which spells its own.
+        p = leave.plan(live=live, focus=state.own_workspace(fid),
                        only=fid if verb == leave.CLOSE else "")
         return palette.Palette(catalogue=leave.confirm_rows(p, verb=verb),
                                label=verb, mouse=True)
     noun = choose.noun_of(row)
-    if noun is None or row.note:
+    if noun is None:
         return None
     return palette.Palette(catalogue=_roster(noun, fid, opened).rows,
                            label=noun, mouse=True)
@@ -7558,11 +7573,22 @@ def _capture_transcript(socket: str, pane_id: str, dest) -> bool:
         config.private_mkdir(dest.parent)
     except OSError:
         return False
-    if len(text.encode("utf-8", "replace")) > _TRANSCRIPT_BYTES:
-        # Cut from the END, on a character boundary, because the end is what the operator
-        # was looking at. Encoding first and slicing bytes would be able to split a
-        # multi-byte character; slicing the string and re-measuring cannot.
-        text = text[-_TRANSCRIPT_BYTES:]
+    # **Cut from the END, in BYTES, with no comparison to get the boundary wrong in.** The
+    # end is what the operator was looking at, so that is the half that is kept.
+    #
+    # This was `if len(text.encode(...)) > _TRANSCRIPT_BYTES: text = text[-_TRANSCRIPT_BYTES:]`
+    # and the deletion sweep found the comparison unpinnable — `>` and `>=` cannot differ,
+    # because at exactly the cap `text[-N:]` returns the whole string either way. Chasing
+    # that found the real defect underneath it: **it measured BYTES and then trimmed
+    # CHARACTERS**, so a capture of two-byte characters was left at twice the cap. Measured
+    # at a cap of 16: `"é" * 16` is 16 characters and 32 bytes, and the old line answered 32.
+    #
+    # Slicing the encoded form is byte-exact, and `errors="ignore"` on the way back is what
+    # makes it safe: the only place a byte cut can land inside a character is the leading
+    # edge, and a partial character there is dropped rather than written as a replacement
+    # glyph the pager would show as noise. It is also cheaper than what it replaces — one
+    # encode rather than an encode for the length plus a slice.
+    text = text.encode("utf-8", "replace")[-_TRANSCRIPT_BYTES:].decode("utf-8", "ignore")
     try:
         config.write_for(dest, text)
     except OSError:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8041,6 +8041,24 @@ def cmd_reopen(args) -> int:
     if tmuxctl.version() is None:
         util.err(tmuxctl.absent_message())
         return 1
+    # **Refused inside a tmux the operator already has, and stated rather than half-done.**
+    # `cmd_launch` builds a frame there as a WINDOW on THEIR server
+    # (`_launch_in_operator_tmux`), and that path is awake for the whole life of the frame —
+    # it reads the harness's exit status itself instead of installing the `pane-died` hooks,
+    # which is what makes it correct there and what makes it BLOCK exactly as `attach` does.
+    # A reopen driving it would stop on the first chat and never build the second, and the
+    # `Reopening` seam is not wired through it either: `restoring.fid` would stay ``""`` and
+    # every chat would be reported as "did not come back" having actually come back. Two
+    # honest options existed and this is the smaller one — the alternative is suppressing
+    # `_wait_for_harness` on a path whose exit-code contract depends on it, which is its own
+    # change with its own two-version verification.
+    if tmuxctl.operator_server() is not None:
+        util.err("charter reopen: not from inside a tmux you already have — charter builds "
+                 "a frame there as a window on your own server, and that launcher stays "
+                 "awake for the life of each frame, so reopening several chats would stop "
+                 "at the first. Run it from an ordinary shell. Nothing was reopened, and "
+                 "the record is left in place.")
+        return 1
     back: list[Reopening] = []
     for f in m.frames:
         for c in f.chats:

--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -508,6 +508,49 @@ def _regather(fid: str):
     _spawn(util.self_relaunch_argv("frame-gather", "--session", fid, "--workspace", ws),
            fid=fid)
     return f"gathering {ws}…"
+def _register_transcript(reg: actions.ActionRegistry) -> None:
+    """One row: open what this chat had on screen before it was last stopped — §4f.
+
+    **The only row charter offers that reads the harness's pane, and it reads a FILE.** The
+    pane itself was read once, by the quit that captured it, at the moment it was about to be
+    destroyed; this row opens the result in a pager in a window of its own. Nothing is ever
+    written back into the harness's pane, which is the half of ADR 0018 that this change
+    leaves exactly as it was.
+
+    Availability is one `is_file`, which is `builtin_actions`' own rule — *availability is
+    read off state, never off a subprocess* — and it is honest in both directions: a chat
+    that has never been quit has no capture, and that is the ordinary state of a chat that is
+    running normally rather than a fault.
+
+    `_spawn` like the density and surface rows, and for the same measured reason: the palette
+    closes the instant it has invoked, `kill-pane` hands SIGHUP to that pane's process group,
+    and `new-window` is a tmux round trip this process would not survive to make.
+    """
+    reg.register(action.Action(
+        id="chat.transcript", title="chat: previous transcript",
+        run=lambda ctx: _run_transcript(ctx.fid),
+        available=lambda ctx: _has_transcript(ctx.fid),
+        reason_unavailable=lambda ctx: NO_TRANSCRIPT))
+
+
+def _has_transcript(fid: str) -> bool:
+    """Whether a capture exists for *fid*. One `is_file`, no subprocess."""
+    from . import reopen
+    path = reopen.transcript_path(fid)
+    return path is not None and path.is_file()
+
+
+def _run_transcript(fid: str):
+    _spawn(util.self_relaunch_argv("frame-transcript", "--chat", fid), fid=fid)
+    return "opening this chat's previous transcript"
+
+
+#: What a chat with no captured transcript is told instead of nothing happening. Its own
+#: sentence rather than `NO_LAYOUT`'s or `NO_PANES`': those are about records charter LOST,
+#: and this is about a capture that was never taken — which is the ordinary state of a chat
+#: nobody has quit, so the row says when one appears rather than sending anyone to relaunch.
+NO_TRANSCRIPT = ("no previous transcript for this chat — one is captured when a plane is "
+                 "quit (`F2 → charter: quit`) and offered on the chat that comes back")
 
 
 def build(fid: str, *, current_density: str,
@@ -552,6 +595,17 @@ def build(fid: str, *, current_density: str,
     _register_todos(reg)
     _register_density(reg, current=current_density)
     _register_chrome(reg, current=current_chrome)
+    # **After the rows pressed by muscle memory, and before `refresh`.** A transcript is a
+    # row you reach for once, deliberately, about the chat you are in — so it does not
+    # belong among the densities and surfaces, which `_register_density` notes must not
+    # move. `_register_regather` keeps the bottom of charter's own list, which its own
+    # docstring argues for and which this does not disturb.
+    #
+    # The two DESTRUCTIVE rows (`charter: quit`, `chat: close`) are deliberately not here
+    # at all: they are doorways onto a confirmation, they are appended after every action by
+    # `commands_frame._draw_palette`, and `frame/leave.open_rows` records why that placement
+    # is a guard rather than a taste.
+    _register_transcript(reg)
     _register_regather(reg)
     for aid in reg.providers.ids():
         reg.add(aid)

--- a/charter/frame/leave.py
+++ b/charter/frame/leave.py
@@ -1,0 +1,486 @@
+"""Leaving: what a quit is about to stop, and what it says before it does.
+
+§4i's rule is *detach is the default, quit is a choice*, and §4f's is that the warning
+**names, per chat, what will and will not come back — at the moment the operator is
+deciding, not after.** This module is that sentence, per chat, as data.
+
+**Nothing here touches tmux and nothing here kills anything** — `frame/chats.py`'s rule,
+kept for a sharper reason: this is what the confirmation surface draws, and a module that
+shelled out per row would put ~one round trip per chat in front of a palette the operator
+is waiting on. Liveness arrives as an ARGUMENT (`live`), asked once by
+`commands_frame`, which is where every other tmux question in the frame is asked.
+
+**Quit is plane-scoped, and that is a correction to the brief this shipped under rather
+than an interpretation of it.** §4i asks for *"a warning naming every workspace and chat
+that will stop"* and the operator's own words are *"all harness sessions will be closed"*.
+§3.3 then bounds it from the other side: one tmux server serves every plane on the machine
+and session names carry no plane, so the blast radius has to be filtered, and **the filter
+can only come from disk.** So the set is exactly *this plane's chat directories*, and the
+kill is per WINDOW — never `kill-server`, and never `kill-session` on a workspace name,
+which in another plane is another plane's session (`default` is a name every plane has).
+
+The consequence for `inflight` is worth stating here rather than discovering later: because
+the quit is plane-scoped and `inflight` is plane-scoped, the prune is exactly co-extensive
+with what was killed. A genuinely per-FRAME quit could not prune at all — `inflight`
+records carry no fid, no chat and no workspace (§2.15) — so the two facts are the same
+fact, not a coincidence.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import NamedTuple
+
+from . import chats, reopen, state
+
+#: What the operator is told when a quit would stop nothing.
+NOTHING_OPEN = "no chats are open on this plane — nothing to quit"
+
+#: How the pieces of one chat's note are joined. One line per chat, whatever charter has
+#: to say about it, because the confirmation surface draws one row per chat and
+#: `overlay.Row` has exactly one note.
+JOIN = " · "
+
+
+class Doomed(NamedTuple):
+    """One chat a quit is about to stop, with everything the warning needs about it.
+
+    Assembled once and handed to both the warning and the teardown, so what the operator
+    was told and what charter then did cannot come from two readings of the plane. That is
+    `chats.Chat`'s reason and `_draw_palette`'s: an offer charter cannot honour is worse
+    than no offer.
+    """
+
+    #: The chat id — the frame directory's name, and `@charter_chat` on its window.
+    chat: str
+    #: The workspace it says it is in (`state.own_workspace`, the membership question), or
+    #: ``""`` when it says nothing. A chat that says nothing is still stopped and still
+    #: recorded; what it loses is a session to be rebuilt into, which :attr:`homeless` is.
+    workspace: str
+    #: The persona resolved under this chat's own id, or ``""``.
+    persona: str
+    #: `harness.base.name`, or ``""`` when charter has no identity record for the chat.
+    harness: str
+    #: The recorded cwd, or ``""``.
+    cwd: str
+    #: The harness's own session id, or ``""`` when there is none to resume from.
+    resume: str
+    #: Which tmux server the chat is recorded on — charter's own, or an operator's.
+    server: str
+    #: Whether tmux still reports a window for this chat. ``None`` when charter could not
+    #: ask its server at all, which is a third answer and not a "no": a quit that read a
+    #: wedged server as "nothing is live" would record nothing and kill nothing while
+    #: telling the operator it had done both.
+    live: bool | None
+    #: Whether this chat was the one on screen in its session.
+    active: bool
+    #: The exit code the pane hook recorded, or ``None``. Per §2.17 the file means
+    #: precisely *"this harness ended on its own"* — `kill-pane`, `kill-window` and
+    #: `kill-session` write nothing — so ``None`` is the ordinary answer for a running
+    #: chat AND for one the machine took down, and the two are not distinguishable.
+    exit_code: int | None
+    #: Whether the operator closed this chat (`state.was_closed`). A closed chat is not
+    #: recorded and not brought back; it is listed by nothing and appears here only so
+    #: :func:`plan` has one place that drops it.
+    closed: bool
+    #: Whether the workspace this chat belongs to still has a directory on disk. §4j
+    #: forbids re-homing a chat, so a missing workspace is *reported*, never repaired.
+    homeless: bool
+    #: Whether the recorded cwd is still a directory.
+    cwd_gone: bool
+
+
+class Plan(NamedTuple):
+    """Every chat a quit would stop, grouped as the manifest will hold it."""
+
+    chats: tuple[Doomed, ...]
+    #: The workspace the quit was invoked from — where a reopen puts the operator back.
+    focus: str
+
+    def workspaces(self) -> tuple[str, ...]:
+        """The workspaces this plan touches, in first-appearance order.
+
+        Order off the chat list rather than sorted, so the summary sentence names them in
+        the order the rows below it are drawn — a list an operator reads twice in two
+        orders is a list they have to re-read.
+        """
+        seen: list[str] = []
+        for c in self.chats:
+            if c.workspace and c.workspace not in seen:
+                seen.append(c.workspace)
+        return tuple(seen)
+
+    def resumable(self) -> tuple[Doomed, ...]:
+        """The chats whose conversation charter can actually ask for back."""
+        return tuple(c for c in self.chats if c.resume)
+
+
+def plan(*, live, focus: str, only: str = "") -> Plan:
+    """Every chat on THIS PLANE that a quit would stop, read off disk.
+
+    *live* is the set of chat ids the frame's tmux server reports, or ``None`` when it
+    would not answer — `commands_frame._live_chats`' own tri-state, carried through rather
+    than collapsed, for the reason that function documents at length: a server that answers
+    "no windows" because it was wedged is not a server with nothing on it, and treating the
+    two the same would make a quit silently record nothing.
+
+    *only* narrows the plan to one chat, which is the whole of what `chat: close` is —
+    **same plan, same warning, same teardown, one target.** A second enumeration for the
+    single-chat case would be a second answer to "what does stopping this cost".
+
+    **A chat the operator CLOSED is not here**, and that is the one filter with a direction
+    to it. Everything else this includes on the restoring side: a chat with no `exit` file
+    is recorded because *nothing means we do not know it stopped* (`state.was_closed`'s own
+    note), a chat whose workspace has gone is recorded and flagged rather than dropped
+    (§4j: re-homing is forbidden and #789 removed the last of it), and a chat with an
+    unreadable identity is recorded under its id alone.
+
+    Order is `chats.of_workspace`'s — ordinal within a workspace — with workspaces in the
+    order their first chat appears, so the rows the operator reads are the tabs they had.
+    """
+    from .. import persona as p_mod
+    from .. import workspace as ws_mod
+    out: list[Doomed] = []
+    for fid in _plane_chats():
+        if only and fid != only:
+            continue
+        if state.was_closed(fid):
+            continue
+        ws = state.own_workspace(fid) or ""
+        ident = state.identity(fid)
+        cwd = state.chat_cwd(fid) or ""
+        out.append(Doomed(
+            chat=fid,
+            workspace=ws,
+            persona=p_mod.for_session(fid) or "",
+            harness=ident.get("CHARTER_HARNESS", "").strip(),
+            cwd=cwd,
+            resume=state.kept_harness_session(fid) or "",
+            server=state.frame_server(fid) or "",
+            live=None if live is None else (fid in live),
+            active=False,
+            exit_code=state.exit_code(fid),
+            closed=False,
+            homeless=bool(ws) and not ws_mod.workspace_dir(ws).is_dir(),
+            cwd_gone=bool(cwd) and not os.path.isdir(cwd),
+        ))
+    return Plan(chats=tuple(out), focus=focus)
+
+
+def _plane_chats() -> list[str]:
+    """Every chat directory on this plane, in tab order, whatever workspace it says.
+
+    **`chats.of_workspace` cannot answer this**, and the difference is the point: that
+    function asks "which chats say they are in *this* workspace", so a chat whose
+    `workspace` record was lost — or whose workspace has been deleted — belongs to no
+    workspace and would be invisible to every one of its calls. A quit that skipped such a
+    chat would kill it (its window is on this plane's server) and record nothing about it,
+    which is the one outcome this whole design exists to prevent.
+
+    So the scan is the frame root itself, with `chats.is_chat` as the only filter — Stage
+    5a's version discriminator, asked rather than re-derived — and `is_dir()` beside it for
+    `chats.of_workspace`'s own measured reason (#733): the frame root also holds the
+    manifest, the transcripts, and whatever a half-finished `os.replace` left behind, and a
+    loose FILE called `api.2` there is a name that would otherwise reach a tmux target.
+
+    Sorted by `chats._order`, so the ordering is the bar's rather than the filesystem's,
+    and the two cannot drift: it is the same function `of_workspace` sorts with.
+    """
+    try:
+        names = [e.name for e in os.scandir(state._root()) if e.is_dir()]
+    except OSError:
+        return []
+    inside = sorted((n for n in names if chats.is_chat(n)), key=chats._order)
+    # Grouped by workspace WITHOUT losing the ordinal order inside a group, which is what
+    # a second `sorted` on a stable sort buys: `sorted` is guaranteed stable, so this
+    # re-orders the groups and leaves each group's chats exactly as `chats._order` left
+    # them. A chat that says nothing about its workspace sorts last, deliberately — it is
+    # the migration and truncation case (`_plane_chats`' whole reason for existing), and a
+    # nameless group at the end reads as the leftovers it is rather than as a workspace
+    # called "".
+    return sorted(inside, key=lambda n: (0, state.own_workspace(n))
+                  if state.own_workspace(n) else (1, ""))
+
+
+def stopping(p: Plan) -> tuple[Doomed, ...]:
+    """The chats a quit will actually try to stop.
+
+    Everything in the plan whose server has not told charter the chat is gone. A chat tmux
+    reports as absent is already stopped, and a chat charter could not ASK about
+    (``live is None``) is attempted anyway — the kill is a `kill-window` on a window tmux
+    itself named, so an attempt against a chat that is no longer there costs one rc that
+    charter ignores, while skipping one that IS there leaves a harness running behind a
+    manifest that says it was stopped.
+    """
+    return tuple(c for c in p.chats if c.live is not False)
+
+
+def summary(p: Plan) -> str:
+    """The one line above the rows: what stops, and how much of it comes back.
+
+    Counted from the plan rather than composed by the caller, so the number in the
+    confirmation's heading and the rows under it are one reading of the plane.
+    """
+    doomed = stopping(p)
+    if not doomed:
+        return NOTHING_OPEN
+    wss = p.workspaces()
+    back = len([c for c in doomed if c.resume])
+    return (f"quit — stop {_count(len(doomed), 'chat')} in "
+            f"{_count(len(wss), 'workspace')}; "
+            f"{back} of {len(doomed)} can resume the conversation")
+
+
+def _count(n: int, noun: str) -> str:
+    """``1 chat`` / ``3 chats``. Spelled once, because the summary says it twice and a
+    second spelling is a second plural rule."""
+    return f"{n} {noun}" if n == 1 else f"{n} {noun}s"
+
+
+#: What a chat with a session id to resume from is promised. The verb is deliberately
+#: about the CONVERSATION and not about the pane: §4f is explicit that
+#: `claude --resume` re-renders the conversation and restores no scrollback, and a note
+#: saying "comes back" full stop would be promising the screen.
+RESUMES = "conversation resumes"
+
+#: What a chat charter cannot resume is told, and it names the reason rather than the
+#: symptom. §2.8: the context gauge and the session id have exactly one writer, Claude
+#: Code's `statusLine` hook, so no other harness has an id to ask with. An operator reading
+#: "reopens empty" alone would reasonably file a bug.
+NO_RESUME_HARNESS = "reopens empty — {harness} records no session id to resume from"
+
+#: The same outcome for the harness that CAN resume, when this particular chat has no id
+#: yet — a chat whose harness had not taken a turn, or one already running when the charter
+#: that keeps the id was installed (`state.kept_harness_session`'s own migration case).
+NO_RESUME_YET = "reopens empty — no session id recorded for this chat yet"
+
+#: Said when charter does not know which harness a chat was, which is the migration case
+#: and an ordinary one.
+NO_RESUME_UNKNOWN = "reopens empty — charter has no record of this chat's harness"
+
+
+def note(c: Doomed) -> str:
+    """The one line that says what this chat loses and what it keeps.
+
+    **Resume first, because it is the thing the operator is deciding about.** The rest are
+    qualifications, and each is present only when it is TRUE of this chat — a note that
+    listed every possible caveat would make the one that applies impossible to find.
+
+    Every clause is a fact charter has already read off disk, and none of them is a
+    prediction it cannot check: whether an id exists, whether the workspace directory is
+    there, whether the recorded directory is there, and whether a transcript was captured
+    is decided by the caller and appended, because only the quit knows if its capture
+    landed.
+    """
+    parts = [_resume_clause(c)]
+    if not c.workspace:
+        parts.append("charter has no record of its workspace — reopens unplaced")
+    elif c.homeless:
+        parts.append(f"workspace '{c.workspace}' is gone — reopens saying so")
+    if c.cwd_gone:
+        parts.append(f"its directory {c.cwd} is gone — reopens in the plane root")
+    elif not c.cwd:
+        parts.append("no directory recorded — reopens in the plane root")
+    if c.exit_code is not None:
+        parts.append(f"already ended on its own ({c.exit_code})")
+    return JOIN.join(parts)
+
+
+def _resume_clause(c: Doomed) -> str:
+    """Which of the four resume sentences this chat gets.
+
+    Split out so the four are a table a test can walk rather than a chain inside a longer
+    function, and so the ORDER of the two "cannot" cases is explicit: an unknown harness is
+    asked about before a missing id, because "charter does not know what this was" is a
+    different thing to tell an operator than "this one has not taken a turn yet", and the
+    second would be a guess dressed as a fact.
+    """
+    if c.resume:
+        return RESUMES
+    if not c.harness:
+        return NO_RESUME_UNKNOWN
+    if resumable_harness(c.harness):
+        return NO_RESUME_YET
+    return NO_RESUME_HARNESS.format(harness=c.harness)
+
+
+def resumable_harness(name: str) -> bool:
+    """Whether *name* is a harness charter can ask for a conversation back.
+
+    **Claude Code alone, and asked of the registry rather than spelled here** (§2.8 and
+    §4e): `record_harness_session` has exactly one caller, Claude Code's `statusLine` hook,
+    so it is the only harness that has ever written an id. A literal ``"claude-code"`` in
+    this module would be a second place that knows which harness resumes, and the day a
+    second one starts writing an id the two would disagree.
+
+    Deliberately NOT a member on `Harness`. Phase 5's Task 9 Step 4 refuses one on
+    `harness/base.py`'s own bar — *"a fifth member needs the same kind of argument, not just
+    a use"* — and the bar is not met: `launch_argv` is `[self.binary, *extra]` with no
+    subclass override anywhere in the registry, so the pass-through **is** the seam, and
+    what decides whether to use it is whether charter has an id, which is this question.
+    """
+    from ..harness import claude_code
+    return name == claude_code.NAME
+
+
+def title(c: Doomed) -> str:
+    """The left-hand side of one chat's row: its id, and what it was running.
+
+    The id first because it is what the operator has been looking at on the `chats` bar all
+    day, and the harness after it because two chats of one workspace are told apart by
+    nothing else. Display text with an open alphabet on the harness half — it is a
+    harness's own display name — contained by `overlay.Surface.render` where every other
+    title is, and never here (`chats.py`'s rule, and the masked-containment finding behind
+    it).
+    """
+    return f"{c.chat} · {c.harness}" if c.harness else c.chat
+
+
+def transcript_of(c: Doomed) -> str:
+    """The file name a capture of *c* would be written under, or ``""``.
+
+    Through `reopen.transcript_path` so the name is minted in exactly one place, and
+    answered as a bare name rather than a path because that is what the manifest carries:
+    a path recorded today and read on a plane whose `STATE_DIR` has moved would name a
+    directory that is not this plane's.
+    """
+    p = reopen.transcript_path(c.chat)
+    return p.name if p is not None else ""
+
+
+#: The two things this module offers, as the words their rows and their commands are
+#: spelled with. One constant per verb rather than a literal at each of the four places
+#: (the doorway id, the confirm id, the command name, the sentence) so a rename cannot
+#: half-land.
+QUIT, CLOSE = "quit", "close"
+
+#: The row that OPENS the confirmation, the row that goes through with it, and one row per
+#: chat in between. All three carry a `:`, which is `frame/choose.py`'s trick and the whole
+#: of why these cannot collide with an action: `frame/action.py` holds every action id to
+#: `component.usable_id` — lower-case letters, digits, underscores and at most one dot —
+#: so a provider cannot ship an action called `leave:quit:go` and take the keypress.
+#: None of them is ever drawn and none reaches tmux.
+OPEN_ID = "leave:{}"
+GO_ID = "leave:{}:go"
+CHAT_ID = "leave:{}:c{}"
+
+#: The doorway rows' titles. `charter:` and `chat:` because that is the noun each one is
+#: about — quit stops the plane, close stops one tab — and the palette is read by an
+#: operator scanning left edges.
+OPEN_QUIT = "charter: quit — stop every harness on this plane"
+OPEN_CLOSE = "chat: close — stop this chat and do not bring it back"
+
+
+def open_rows(fid: str) -> tuple:
+    """The two doorway rows the palette carries, and neither one costs a scan.
+
+    **A doorway and not an action**, for `choose.open_rows`' reason exactly: an `Action`'s
+    contract is *fire-and-report*, and opening a confirmation starts nothing — it replaces
+    the surface in the pane the operator is already looking at. An action whose ``run``
+    merely drew something would pass every test in that contract and describe nothing that
+    happens.
+
+    **They are the LAST rows in the catalogue**, which `commands_frame._draw_palette`
+    arranges by appending them, and that placement is a guard rather than a taste: the
+    palette's cursor starts on the first row that can run, and a destructive row at the top
+    would be one `F2 Enter` away. Charter's own harmless rows keep the top of the list.
+
+    No plan is built here. The confirmation is where the per-chat warning is drawn (§4f:
+    *at the moment the operator is deciding*), and the operator is not deciding while the
+    palette is merely open — a scan of the frame root and three files per chat on every
+    `F2` would be `choose.open_rows`' own measured mistake, made again.
+
+    *fid* decides one thing and only one: **`chat: close` needs to know which chat it is
+    about, and quit does not.** A palette that could not resolve its own chat — a frame
+    launched by a charter that predates `@charter_chat`, so the shared bind's `--chat`
+    arrives empty and `$CHARTER_SESSION_ID` is another chat's — has no target to close, and a
+    confirmation opened over "every chat on the plane" would be quit wearing close's title.
+    So the row is listed with its reason, which is #512's rule (an option you cannot see is
+    one you cannot ask about) and is exactly how a pinned `workspace:` doorway already
+    behaves.
+    """
+    from . import overlay
+    return (overlay.Row(id=OPEN_ID.format(QUIT), title=OPEN_QUIT),
+            overlay.Row(id=OPEN_ID.format(CLOSE), title=OPEN_CLOSE,
+                        note="" if fid else NO_CHAT_HERE, refused=not fid))
+
+
+#: What the close row says on a frame whose own chat charter cannot resolve. Its own sentence
+#: rather than `builtin_actions.NO_LAYOUT`'s: that one is about a lost pane record and sends
+#: the operator to relaunch, and this is about an id — the same gap `cmd_palette` and
+#: `cmd_chat` already answer, said where the row is drawn.
+NO_CHAT_HERE = ("charter cannot tell which chat this palette was opened in, so it has no "
+                "chat to close — `charter frame-close <chat>` names one")
+
+
+def verb_of(row) -> str | None:
+    """Which confirmation *row* opens, or ``None`` when it opens none.
+
+    Matched against the two ids this module mints rather than by splitting on `:`, so a row
+    id that merely contains a colon cannot be read as an instruction — `choose.noun_of`'s
+    rule, and the reason it is a function rather than a `startswith`.
+    """
+    for verb in (QUIT, CLOSE):
+        if row.id == OPEN_ID.format(verb):
+            return verb
+    return None
+
+
+def goes_through(row, verb: str) -> bool:
+    """Whether *row* is *verb*'s confirming row — the one Enter acts on."""
+    return row.id == GO_ID.format(verb)
+
+
+def is_row(row) -> bool:
+    """Whether *row* belongs to a confirmation surface at all.
+
+    What tells `commands_frame._draw_palette` that a chosen row is one of these and must
+    NOT be handed to `ActionRegistry.invoke` as an action id. Asked of the two ids that do
+    something and of the per-chat prefix, rather than of any id containing a colon: the
+    palette also draws `frame/choose.py`'s rows, and one module claiming every colon would
+    swallow the other's.
+    """
+    if verb_of(row) is not None:
+        return True
+    return any(row.id == GO_ID.format(v) or row.id.startswith(CHAT_ID.format(v, ""))
+               for v in (QUIT, CLOSE))
+
+
+def confirm_rows(p: Plan, *, verb: str) -> tuple:
+    """The confirmation surface: one row per chat, then the row that goes through.
+
+    **The per-chat rows are `refused=True`, and that is what makes them a warning rather
+    than a menu.** `overlay.Row.refused` means "this row cannot run right now" (#732) —
+    which is exactly true of them: they are the sentence §4f asks for, and pressing one
+    does nothing. It is also what puts the cursor on the row that CAN run, so the operator
+    is never left with Enter bound to nothing.
+
+    **The confirming row is last**, under the list it is about. A confirmation whose button
+    is above the thing being confirmed is one an operator can press before reading, and
+    this is the one surface in charter where that matters.
+
+    A plan with nothing to stop gets one refused row saying so and no confirming row at
+    all, so there is no keypress that quietly succeeds at nothing.
+    """
+    from . import overlay
+    doomed = stopping(p)
+    if not doomed:
+        return (overlay.Row(id=CHAT_ID.format(verb, 0), title=NOTHING_OPEN,
+                            refused=True),)
+    rows = [overlay.Row(id=CHAT_ID.format(verb, i), title=title(c), note=note(c),
+                        refused=True, mark=c.active)
+            for i, c in enumerate(doomed)]
+    rows.append(overlay.Row(id=GO_ID.format(verb), title=summary(p)
+                            if verb == QUIT else _close_summary(doomed)))
+    return tuple(rows)
+
+
+def _close_summary(doomed) -> str:
+    """The confirming row's title for `chat: close`, and what it says that quit does not.
+
+    Close is the one verb that is deliberately NOT recorded: a chat charter brought back
+    after the operator closed it would make closing meaningless, and the accepted cost of
+    "a missing exit record means it was open" is exactly this row's existence
+    (`state.was_closed`). So the title says *forget*, where quit's says *resume*.
+    """
+    return f"close {doomed[0].chat} — stop it and forget it; it will not come back"

--- a/charter/frame/leave.py
+++ b/charter/frame/leave.py
@@ -41,6 +41,12 @@ NOTHING_OPEN = "no chats are open on this plane — nothing to quit"
 #: `overlay.Row` has exactly one note.
 JOIN = " · "
 
+#: The two things this module offers, as the words their rows and their commands are
+#: spelled with. One constant per verb rather than a literal at each of the four places
+#: (the doorway id, the confirm id, the command name, the sentence) so a rename cannot
+#: half-land.
+QUIT, CLOSE = "quit", "close"
+
 
 class Doomed(NamedTuple):
     """One chat a quit is about to stop, with everything the warning needs about it.
@@ -198,8 +204,19 @@ def plane_chats() -> list[str]:
     # the migration and truncation case (`plane_chats`' whole reason for existing), and a
     # nameless group at the end reads as the leftovers it is rather than as a workspace
     # called "".
-    return sorted(inside, key=lambda n: (0, state.own_workspace(n))
-                  if state.own_workspace(n) else (1, ""))
+    return sorted(inside, key=_group)
+
+
+def _group(fid: str) -> tuple[int, str]:
+    """Which workspace group *fid* sorts into, asked once.
+
+    Its own function rather than an inline lambda because `state.own_workspace` reads three
+    files per call (the identity record, the per-session pointer, the workspace record —
+    `chats.of_workspace` measures it), and a lambda that tested it and then returned it
+    would read all three twice for every chat on the plane.
+    """
+    ws = state.own_workspace(fid)
+    return (0, ws) if ws else (1, "")
 
 
 def stopping(p: Plan) -> tuple[Doomed, ...]:
@@ -215,15 +232,24 @@ def stopping(p: Plan) -> tuple[Doomed, ...]:
     return tuple(c for c in p.chats if c.live is not False)
 
 
-def summary(p: Plan) -> str:
+def summary(p: Plan, *, verb: str = QUIT) -> str:
     """The one line above the rows: what stops, and how much of it comes back.
 
     Counted from the plan rather than composed by the caller, so the number in the
-    confirmation's heading and the rows under it are one reading of the plane.
+    confirmation's heading, the rows under it and the line `commands_frame` prints on stderr
+    are one reading of the plane.
+
+    *verb* decides which sentence, and it has a default because `confirm_rows` asks for
+    quit's by name while the stderr warning asks for whichever verb it is running — a
+    `chat: close` that printed *"quit — stop 1 chat"* above its own row would be describing
+    the wrong command, which is exactly the confusion `_close_summary` exists to prevent one
+    surface over.
     """
     doomed = stopping(p)
     if not doomed:
         return NOTHING_OPEN
+    if verb == CLOSE:
+        return _close_summary(doomed)
     wss = p.workspaces()
     back = len([c for c in doomed if c.resume])
     return (f"quit — stop {_count(len(doomed), 'chat')} in "
@@ -371,12 +397,6 @@ def transcript_of(c: Doomed) -> str:
     return p.name if p is not None else ""
 
 
-#: The two things this module offers, as the words their rows and their commands are
-#: spelled with. One constant per verb rather than a literal at each of the four places
-#: (the doorway id, the confirm id, the command name, the sentence) so a rename cannot
-#: half-land.
-QUIT, CLOSE = "quit", "close"
-
 #: The row that OPENS the confirmation, the row that goes through with it, and one row per
 #: chat in between. All three carry a `:`, which is `frame/choose.py`'s trick and the whole
 #: of why these cannot collide with an action: `frame/action.py` holds every action id to
@@ -500,8 +520,7 @@ def confirm_rows(p: Plan, *, verb: str) -> tuple:
     if not doomed:
         return (overlay.Row(id=CHAT_ID.format(verb, 0), title=NOTHING_OPEN,
                             refused=True),)
-    go = overlay.Row(id=GO_ID.format(verb),
-                     title=summary(p) if verb == QUIT else _close_summary(doomed))
+    go = overlay.Row(id=GO_ID.format(verb), title=summary(p, verb=verb))
     return (go, *(overlay.Row(id=CHAT_ID.format(verb, i), title=title(c), note=note(c),
                               refused=True, mark=c.active)
                   for i, c in enumerate(doomed)))

--- a/charter/frame/leave.py
+++ b/charter/frame/leave.py
@@ -141,7 +141,7 @@ def plan(*, live, focus: str, only: str = "") -> Plan:
     from .. import persona as p_mod
     from .. import workspace as ws_mod
     out: list[Doomed] = []
-    for fid in _plane_chats():
+    for fid in plane_chats():
         if only and fid != only:
             continue
         if state.was_closed(fid):
@@ -167,7 +167,7 @@ def plan(*, live, focus: str, only: str = "") -> Plan:
     return Plan(chats=tuple(out), focus=focus)
 
 
-def _plane_chats() -> list[str]:
+def plane_chats() -> list[str]:
     """Every chat directory on this plane, in tab order, whatever workspace it says.
 
     **`chats.of_workspace` cannot answer this**, and the difference is the point: that
@@ -195,7 +195,7 @@ def _plane_chats() -> list[str]:
     # a second `sorted` on a stable sort buys: `sorted` is guaranteed stable, so this
     # re-orders the groups and leaves each group's chats exactly as `chats._order` left
     # them. A chat that says nothing about its workspace sorts last, deliberately — it is
-    # the migration and truncation case (`_plane_chats`' whole reason for existing), and a
+    # the migration and truncation case (`plane_chats`' whole reason for existing), and a
     # nameless group at the end reads as the leftovers it is rather than as a workspace
     # called "".
     return sorted(inside, key=lambda n: (0, state.own_workspace(n))
@@ -272,18 +272,41 @@ def note(c: Doomed) -> str:
     is decided by the caller and appended, because only the quit knows if its capture
     landed.
     """
-    parts = [_resume_clause(c)]
     if not c.workspace:
-        parts.append("charter has no record of its workspace — reopens unplaced")
-    elif c.homeless:
+        # **The one chat this design cannot bring back, and the note says so instead of
+        # promising anything.** A reopen rebuilds a tmux session per workspace and hands the
+        # launcher a `--workspace`; a chat that says nothing about its workspace has nothing
+        # to be rebuilt into, and inventing one would be the re-homing §4j forbids arriving
+        # as a convenience. So `reopen.read` refuses the record and this row promises no
+        # resume, whatever id the chat happens to hold. It is the migration and truncation
+        # case (`plane_chats`' own reason for scanning the frame root) rather than a state
+        # charter mints.
+        return JOIN.join([NOT_REOPENED] + _ended(c))
+    parts = [_resume_clause(c)]
+    if c.homeless:
         parts.append(f"workspace '{c.workspace}' is gone — reopens saying so")
     if c.cwd_gone:
         parts.append(f"its directory {c.cwd} is gone — reopens in the plane root")
     elif not c.cwd:
         parts.append("no directory recorded — reopens in the plane root")
-    if c.exit_code is not None:
-        parts.append(f"already ended on its own ({c.exit_code})")
-    return JOIN.join(parts)
+    return JOIN.join(parts + _ended(c))
+
+
+#: What a chat charter cannot place is told. Its own constant because two callers need the
+#: same words — the note, and `commands_frame._record_the_plane`, which is what actually
+#: leaves it out of the manifest.
+NOT_REOPENED = "charter has no record of its workspace — it cannot be reopened"
+
+
+def _ended(c: Doomed) -> list[str]:
+    """The clause a chat that already finished carries, or nothing.
+
+    Its own function because both branches of :func:`note` end with it and a chat that
+    cannot be reopened is still a chat whose exit code is worth reading — §2.17's file means
+    precisely *"this harness ended on its own"*, which is the one ending charter can
+    distinguish and the one an operator most often wants to know about.
+    """
+    return [] if c.exit_code is None else [f"already ended on its own ({c.exit_code})"]
 
 
 def _resume_clause(c: Doomed) -> str:
@@ -447,32 +470,41 @@ def is_row(row) -> bool:
 
 
 def confirm_rows(p: Plan, *, verb: str) -> tuple:
-    """The confirmation surface: one row per chat, then the row that goes through.
+    """The confirmation surface: the row that goes through, then one row per chat.
 
     **The per-chat rows are `refused=True`, and that is what makes them a warning rather
     than a menu.** `overlay.Row.refused` means "this row cannot run right now" (#732) —
     which is exactly true of them: they are the sentence §4f asks for, and pressing one
-    does nothing. It is also what puts the cursor on the row that CAN run, so the operator
-    is never left with Enter bound to nothing.
+    does nothing.
 
-    **The confirming row is last**, under the list it is about. A confirmation whose button
-    is above the thing being confirmed is one an operator can press before reading, and
-    this is the one surface in charter where that matters.
+    **The confirming row is FIRST, and an earlier draft had it last.** Under the list it is
+    about reads better and was measured to be wrong: `frame/palette.narrow` puts the cursor
+    on the first row when nothing has been typed, refused or not, so the surface opened with
+    `> alpha.1 · claude-code` selected and Enter bound to nothing at all. *"A palette row
+    that visibly does nothing reads as broken and costs the operator a whole `F2` to find
+    out"* is `builtin_actions._register_selection`'s own finding, and it applies here more
+    than anywhere: the one surface where the operator has just asked a question and is
+    waiting for the keypress that answers it.
 
-    A plan with nothing to stop gets one refused row saying so and no confirming row at
-    all, so there is no keypress that quietly succeeds at nothing.
+    So the shape is the shape of every confirmation an operator has ever used: the thing you
+    press at the top, what it will do underneath it, and the whole list on screen before the
+    first keypress that commits anything. §4f's requirement is that the warning is drawn *at
+    the moment of deciding*, and it is — the doorway's Enter draws this surface and nothing
+    else.
+
+    A plan with nothing to stop gets one refused row saying so and **no confirming row at
+    all**, so there is no keypress that quietly succeeds at nothing.
     """
     from . import overlay
     doomed = stopping(p)
     if not doomed:
         return (overlay.Row(id=CHAT_ID.format(verb, 0), title=NOTHING_OPEN,
                             refused=True),)
-    rows = [overlay.Row(id=CHAT_ID.format(verb, i), title=title(c), note=note(c),
-                        refused=True, mark=c.active)
-            for i, c in enumerate(doomed)]
-    rows.append(overlay.Row(id=GO_ID.format(verb), title=summary(p)
-                            if verb == QUIT else _close_summary(doomed)))
-    return tuple(rows)
+    go = overlay.Row(id=GO_ID.format(verb),
+                     title=summary(p) if verb == QUIT else _close_summary(doomed))
+    return (go, *(overlay.Row(id=CHAT_ID.format(verb, i), title=title(c), note=note(c),
+                              refused=True, mark=c.active)
+                  for i, c in enumerate(doomed)))
 
 
 def _close_summary(doomed) -> str:

--- a/charter/frame/leave.py
+++ b/charter/frame/leave.py
@@ -116,11 +116,6 @@ class Plan(NamedTuple):
                 seen.append(c.workspace)
         return tuple(seen)
 
-    def resumable(self) -> tuple[Doomed, ...]:
-        """The chats whose conversation charter can actually ask for back."""
-        return tuple(c for c in self.chats if c.resume)
-
-
 def plan(*, live, focus: str, only: str = "") -> Plan:
     """Every chat on THIS PLANE that a quit would stop, read off disk.
 
@@ -294,9 +289,11 @@ def note(c: Doomed) -> str:
 
     Every clause is a fact charter has already read off disk, and none of them is a
     prediction it cannot check: whether an id exists, whether the workspace directory is
-    there, whether the recorded directory is there, and whether a transcript was captured
-    is decided by the caller and appended, because only the quit knows if its capture
-    landed.
+    there, whether the recorded directory is there. **The capture is deliberately NOT one of
+    them**: whether a transcript landed is only known after the pane has been read, which is
+    after this row was drawn — so promising one here would be promising something charter has
+    not done yet, and `chat: previous transcript` is refused with its own reason on the way
+    back if it did not.
     """
     if not c.workspace:
         # **The one chat this design cannot bring back, and the note says so instead of
@@ -383,18 +380,6 @@ def title(c: Doomed) -> str:
     it).
     """
     return f"{c.chat} · {c.harness}" if c.harness else c.chat
-
-
-def transcript_of(c: Doomed) -> str:
-    """The file name a capture of *c* would be written under, or ``""``.
-
-    Through `reopen.transcript_path` so the name is minted in exactly one place, and
-    answered as a bare name rather than a path because that is what the manifest carries:
-    a path recorded today and read on a plane whose `STATE_DIR` has moved would name a
-    directory that is not this plane's.
-    """
-    p = reopen.transcript_path(c.chat)
-    return p.name if p is not None else ""
 
 
 #: The row that OPENS the confirmation, the row that goes through with it, and one row per

--- a/charter/frame/leave.py
+++ b/charter/frame/leave.py
@@ -205,10 +205,16 @@ def plane_chats() -> list[str]:
 def _group(fid: str) -> tuple[int, str]:
     """Which workspace group *fid* sorts into, asked once.
 
-    Its own function rather than an inline lambda because `state.own_workspace` reads three
-    files per call (the identity record, the per-session pointer, the workspace record —
-    `chats.of_workspace` measures it), and a lambda that tested it and then returned it
-    would read all three twice for every chat on the plane.
+    Its own function rather than an inline lambda because `state.own_workspace` reads two
+    files per call — the identity record and the workspace record — and a lambda that tested
+    the answer and then returned it would read both twice for every chat on the plane.
+
+    It was three until #791 took the per-session pointer out of that ladder, which is the
+    same change that makes this module's whole design work: a reopened chat gets a FRESH
+    ordinal, `new_chat_id` walks upward from 1, and `reap` frees the ordinals a quit's chats
+    held — so a reopen very often gets the same NAME back, and while the pointer was a rung
+    the previous chat's `charter workspace use` would have decided the reopened chat's
+    membership over the manifest. It cannot now.
     """
     ws = state.own_workspace(fid)
     return (0, ws) if ws else (1, "")

--- a/charter/frame/reopen.py
+++ b/charter/frame/reopen.py
@@ -89,9 +89,14 @@ class Chat(NamedTuple):
     #: screen, never a directory a reopen writes into.
     chat: str
     #: The workspace it belonged to — `state.own_workspace`, the membership question
-    #: (#733), never `workspace_for`. It is the authoritative answer on the way back:
-    #: #791 drops the stale `.charter/sessions/<fid>.workspace` rung that would otherwise
-    #: have decided a reopened chat's membership over this.
+    #: (#733), never `workspace_for`. **It is the authoritative answer on the way back, and
+    #: #791 is what makes that true rather than hopeful**: that change took the per-session
+    #: `.charter/sessions/<fid>.workspace` pointer out of `own_workspace`'s ladder, which
+    #: matters here for a reason that is easy to miss — a reopen gets a FRESH ordinal, but
+    #: `new_chat_id` walks upward from 1 and `reap` frees the ordinals a quit's chats held,
+    #: so it very often gets the same NAME back. While the pointer was a rung, a previous
+    #: chat's `charter workspace use` would have outranked this record for the chat that
+    #: inherited its ordinal.
     workspace: str
     #: The persona resolved for it, or ``""``. Its own per-session pointer, which a reopen
     #: re-writes under the NEW id — an unpinned chat's persona lives nowhere else, and the

--- a/charter/frame/reopen.py
+++ b/charter/frame/reopen.py
@@ -1,0 +1,337 @@
+"""What a quit wrote down, and what a reopen may believe of it.
+
+**One FILE under `.charter/frame/`, and that is the whole trick.** `state.reap` skips
+anything that is not a directory (``if not d.is_dir() or d.name in live``) and
+`chats.of_workspace` scans with the same filter, so a plain file in the frame root is
+invisible to both: it survives every reap, it is never mistaken for a chat, and — this is
+the half that matters — **the chat DIRECTORY goes on being a liveness marker and goes on
+being reaped exactly as it is today.** Nothing here inverts `reap`, which is stage 4 of
+the IDE spec's own delivery order and six edits wide (`chat: close`, `max_chats`, the
+ghost-tab collector, `cmd_workspace_remove`, `clear_claim`, and ~60 tests that assert the
+current rule).
+
+**Which is also why the manifest is not optional.** #757 keeps a chat's harness session id
+in `session.durable` so `clear_shape` cannot delete it — but `reap` deletes the whole
+directory when the chat's launcher pid is dead, and **after a restart every launcher pid is
+dead**. Measured on the plane this was written for: the operator's own frame directories
+were removed by the next launch. So the id #757 kept is gone by the time a reopen could ask
+for it, and a resume that reads it off the chat's own directory reads nothing. The manifest
+is the copy that outlives the directory it came from.
+
+**Every value in here came off disk and is going onto a tmux argv, an `os.chdir` or a
+`--resume` flag**, so every value is checked on the way OUT rather than trusted because
+charter wrote it. That is `state.frame_workspace`'s rule (#442) and `chats.of_workspace`'s
+(#475), applied at the one boundary this module owns: a hand-edited or half-written
+`reopen.json` must degrade to "fewer chats reopened, and charter said which", never to a
+name reaching a shell.
+
+**No lock, deliberately** (§4d). Two quits may write this; last writer wins. A lock file is
+a thing that gets stranded, and #685 spent a whole PR on that class of problem.
+
+**Bounded like the chats are.** A transcript is one file per chat, replaced rather than
+accumulated, and :func:`prune_transcripts` removes the ones no manifest names any more —
+because a `.transcript` is a file in the frame root and therefore, by the same rule that
+makes the manifest durable, has no other collector.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import NamedTuple
+
+from .. import config, contain
+from . import chats, state
+
+#: The manifest's own name. A plain name beside the chat directories, not a dotfile, for
+#: `state._CLAIM_FILE`'s reason: everything in the frame root is charter's own bookkeeping
+#: and none of it hides from `ls`.
+#:
+#: **It cannot collide with a chat id**, and that is arithmetic rather than luck:
+#: `state.new_chat_id` mints ``{prefix}.{digits}`` where the prefix is
+#: `state.workspace_prefix`'s alphabet (no dots — a workspace called `api.2` mints `api_2`),
+#: so ``reopen.json`` is not a shape the allocator can produce. `reap`'s and
+#: `chats.of_workspace`'s `is_dir()` filters make that belt and braces.
+MANIFEST = "reopen.json"
+
+#: What a manifest this charter wrote says it is. Refused rather than guessed at on the way
+#: back in: a directory under `.charter/frame/` can be months old (the IDE spec's §5 names
+#: exactly this as a cost the durability redesign creates), and a reopen driven by a shape
+#: it does not recognise would restore a plane out of fields it is inventing meanings for.
+VERSION = 1
+
+#: What a captured pane is written under — ``<chat id>.transcript`` in the frame root.
+#:
+#: The chat id is the whole name because a chat has at most ONE (§4f: *"the last capture per
+#: chat, not a history of them"*), and because a reopen RENAMES the file onto the new chat's
+#: id rather than writing a pointer to the old one. One naming rule, no second file to keep
+#: in step, and `.transcript` cannot be an ordinal so it cannot be a chat id either.
+TRANSCRIPT_SUFFIX = ".transcript"
+
+
+class Chat(NamedTuple):
+    """One chat a quit recorded, as a reopen reads it back.
+
+    Carried as a record rather than a dict so the writer and the reader cannot come to
+    disagree about what a chat's restore items are — `chats.Chat`'s reason, one lifetime
+    further out.
+
+    Every field is the value at the moment of the QUIT. None of them is re-derived at
+    reopen time, because the plane the reopen runs against no longer holds the chat that
+    would answer.
+    """
+
+    #: The chat id this WAS. Not the id it comes back as: `state.new_chat_id` allocates a
+    #: fresh ordinal on the way in (the old directory is reaped — see the module
+    #: docstring), so this is a name for the transcript and for what charter says on
+    #: screen, never a directory a reopen writes into.
+    chat: str
+    #: The workspace it belonged to — `state.own_workspace`, the membership question
+    #: (#733), never `workspace_for`. It is the authoritative answer on the way back:
+    #: #791 drops the stale `.charter/sessions/<fid>.workspace` rung that would otherwise
+    #: have decided a reopened chat's membership over this.
+    workspace: str
+    #: The persona resolved for it, or ``""``. Its own per-session pointer, which a reopen
+    #: re-writes under the NEW id — an unpinned chat's persona lives nowhere else, and the
+    #: pointer is keyed on a fid that is about to stop existing.
+    persona: str
+    #: `harness.base.name` — ``claude-code``, ``opencode``, ``codex`` — or ``""``. The
+    #: harness's own identity and not its `cli_name`, because that is what
+    #: `state.identity` recorded and what decides whether a resume is even possible.
+    harness: str
+    #: Where the harness was started, or ``""`` when charter never recorded one (a chat
+    #: launched by a charter that predates `state.record_cwd`).
+    cwd: str
+    #: The harness's own session id, or ``""``. Claude Code only: nothing else writes one
+    #: (§2.8), so nothing else can be asked for its conversation back.
+    resume: str
+    #: The captured scrollback's file name in the frame root, or ``""``.
+    transcript: str
+    #: Whether this chat was the one on screen in its tmux session when the quit ran, so a
+    #: reopen can put the operator back on it rather than on whichever window it created
+    #: first.
+    active: bool
+
+
+class Frame(NamedTuple):
+    """One workspace's worth of chats — a tmux session, before the quit killed it.
+
+    Grouped rather than flat because a reopen has to rebuild them one session at a time:
+    the first chat of a workspace CREATES the session and every later one joins it
+    (`cmd_launch`'s `joining` branch), and interleaving two workspaces' chats would make
+    that ordering depend on the manifest's sort.
+    """
+
+    workspace: str
+    chats: tuple[Chat, ...]
+
+
+class Manifest(NamedTuple):
+    """Everything one quit wrote, ready to be acted on.
+
+    *focus* is the workspace whose session the reopen attaches to — the one the quit was
+    invoked FROM, which is where the operator was standing when they asked to stop. It is
+    recorded rather than derived because by reopen time there is no client anywhere to ask.
+    """
+
+    at: int
+    focus: str
+    frames: tuple[Frame, ...]
+
+    def all_chats(self) -> tuple[Chat, ...]:
+        """Every chat in every frame, in the order a reopen rebuilds them."""
+        return tuple(c for f in self.frames for c in f.chats)
+
+
+def path() -> Path:
+    """Where the manifest lives. One expression, so the writer and the reader cannot
+    disagree — and never exported as a bare constant, because `state._root()` reads
+    `config.STATE_DIR` at CALL time (see that module's docstring: the test harness
+    repoints it after import)."""
+    return state._root() / MANIFEST
+
+
+def transcript_path(fid: str) -> Path | None:
+    """Where *fid*'s captured scrollback lives, or ``None`` when *fid* cannot name one.
+
+    Through `contain.child`, exactly like `state.frame_dir`: a chat id may have come off
+    `os.scandir` or out of the manifest, and this path is about to be opened for writing
+    and later handed to a pager. Resolved, never sanitised — rewriting a hostile name into
+    a safe-looking one invents a second identity for it (the failure `contain.child`
+    documents).
+
+    The id is held to `chats.ID_RE` as well, because `contain.child` bounds *shape* and not
+    alphabet, and a name that cannot be a chat has no transcript by definition.
+    """
+    if not chats.ID_RE.fullmatch(fid or ""):
+        return None
+    return contain.child(state._root(), f"{fid}{TRANSCRIPT_SUFFIX}")
+
+
+def _usable(chat: Chat) -> bool:
+    """Whether *chat* is one a reopen may act on.
+
+    **Two names and nothing else**, because those two are the ones that become paths and
+    tmux targets: the chat id (a transcript file name, and what charter prints) and the
+    workspace (a `-t` session target, a `workspace_dir()` join — #442's own position).
+    Everything else on the record degrades on its own terms: an unusable `cwd` falls back
+    and says so, a `resume` that no longer names a conversation is the harness's answer to
+    give, a missing `transcript` is simply not offered, and a `persona` that no longer
+    exists is refused by `switch.to_persona`'s own name check.
+
+    A chat this refuses is REPORTED and skipped, never silently dropped — see
+    `commands_frame.cmd_reopen`.
+    """
+    from .. import workspace as ws_mod
+    return bool(chats.ID_RE.fullmatch(chat.chat or "")
+                and ws_mod.valid_name(chat.workspace))
+
+
+def write(frames, *, focus: str, at: int | None = None) -> bool:
+    """Record *frames* as the plane to put back. ``True`` when it landed.
+
+    **Called BEFORE anything is killed**, and that ordering is the record rather than a
+    tidiness — the same rule `trace._trace_secret_use` keeps for the same reason: a record
+    that depends on the thing it records succeeding is not a record. A quit that wrote this
+    after its kills would lose the whole plane to any failure in between, and the failure
+    it would lose it to is precisely the one an operator cannot undo.
+
+    Atomic: written to a sibling temp file and `os.replace`d, so a reader either sees the
+    previous manifest whole or this one whole. `config.write_for` for the temp file and not
+    `Path.write_text`, because `os.replace` carries the SOURCE's mode onto the target
+    (#582) and this is a state path.
+
+    ``False`` for every way it can fail to land — no frame root, a filesystem that refuses
+    the write, a value `json` cannot serialise. One answer, because the caller does the same
+    thing with each: tell the operator the plane was not recorded, and let them decide
+    whether to quit anyway.
+    """
+    root = state._root()
+    try:
+        config.private_mkdir(root)
+    except OSError:
+        return False
+    payload = {
+        "version": VERSION,
+        "at": int(time.time() if at is None else at),
+        "focus": focus,
+        "frames": [{"workspace": f.workspace,
+                    "chats": [c._asdict() for c in f.chats]} for f in frames],
+    }
+    tmp = root / f"{MANIFEST}.tmp"
+    try:
+        config.write_for(tmp, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        os.replace(tmp, root / MANIFEST)
+    except (OSError, TypeError, ValueError):
+        return False
+    return True
+
+
+def read() -> Manifest | None:
+    """The last quit's manifest, or ``None`` when there is nothing to reopen.
+
+    ``None`` for a plane that has never quit, for a file that cannot be read, for one that
+    is not JSON, for one whose ``version`` this charter does not speak, and for one whose
+    shape is not the two nested lists this writes. Five reasons, one answer, because the
+    caller does the same thing with all of them: say there is nothing recorded to put back.
+    **Never a partial guess** — a manifest charter cannot read whole is not a plane charter
+    may half-restore.
+
+    A chat whose two load-bearing names do not check out is dropped from the frame it was
+    in rather than taking the manifest down with it (:func:`_usable`), and a frame left with
+    no chats is dropped in turn. `commands_frame.cmd_reopen` reports the difference between
+    what was recorded and what came back, so a dropped chat is a sentence rather than a
+    silence.
+    """
+    try:
+        raw = json.loads(path().read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(raw, dict) or raw.get("version") != VERSION:
+        return None
+    frames_raw = raw.get("frames")
+    if not isinstance(frames_raw, list):
+        return None
+    frames: list[Frame] = []
+    for f in frames_raw:
+        if not isinstance(f, dict) or not isinstance(f.get("chats"), list):
+            return None
+        kept = tuple(c for c in (_chat(x) for x in f["chats"])
+                     if c is not None and _usable(c))
+        if kept:
+            frames.append(Frame(workspace=str(f.get("workspace") or ""), chats=kept))
+    focus = raw.get("focus")
+    at = raw.get("at")
+    return Manifest(at=at if isinstance(at, int) else 0,
+                    focus=focus if isinstance(focus, str) else "",
+                    frames=tuple(frames))
+
+
+def _chat(raw) -> Chat | None:
+    """One recorded chat, or ``None`` when the entry is not one.
+
+    Field by field with a type per field, rather than ``Chat(**raw)``: the mapping comes
+    off disk, and splatting it would let an unexpected key raise `TypeError` out of a
+    reader whose whole contract is that it degrades. A missing key is the migration case —
+    a manifest written by a charter one field older — and answers with that field's own
+    empty value, which every caller already handles (a chat with no `resume` reopens empty
+    and says so).
+    """
+    if not isinstance(raw, dict):
+        return None
+    text = {k: (raw.get(k) if isinstance(raw.get(k), str) else "")
+            for k in ("chat", "workspace", "persona", "harness", "cwd", "resume",
+                      "transcript")}
+    return Chat(active=raw.get("active") is True, **text)
+
+
+def forget() -> None:
+    """Drop the manifest, because it has been acted on.
+
+    **A manifest describes one quit and is consumed by one reopen.** Left in place, a second
+    `charter reopen` would open every chat a second time — and the operator would have no
+    way to tell the duplicate tabs from the real ones, because a reopened chat is a fresh
+    ordinal either way.
+
+    Never raises: a manifest that could not be removed costs a duplicated tab the operator
+    can close, and a reopen that had already relaunched every harness must not report
+    failure over a file.
+    """
+    try:
+        path().unlink(missing_ok=True)
+    except OSError:
+        return
+
+
+def prune_transcripts(keep) -> None:
+    """Remove every ``*.transcript`` in the frame root whose chat is not in *keep*.
+
+    **The collector a file in the frame root does not otherwise have.** The same rule that
+    makes the manifest survive `reap` — it is not a directory — means a transcript survives
+    it too, so the thing that bounds them has to be the thing that writes them. §4f asks
+    for *"the last capture per chat, not a history of them"*; naming the file after the
+    chat gives that per chat, and this gives it across chats that no longer exist.
+
+    Called with the ids the manifest now names, from the quit that just wrote it, and with
+    the one id being closed removed, from `chat: close`. Never raises, and never touches
+    anything but that suffix: the frame root also holds the manifest and every chat's
+    directory, and a sweep that reached wider would be `state.reap`'s job being done twice
+    by something that does not know `reap`'s four keep-rules.
+    """
+    root = state._root()
+    try:
+        entries = list(os.scandir(root))
+    except OSError:
+        return
+    wanted = {str(k) for k in keep}
+    for e in entries:
+        if e.is_dir() or not e.name.endswith(TRANSCRIPT_SUFFIX):
+            continue
+        if e.name[:-len(TRANSCRIPT_SUFFIX)] in wanted:
+            continue
+        try:
+            os.unlink(e.path)
+        except OSError:
+            continue

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -1596,6 +1596,135 @@ def exit_code(fid: str) -> int | None:
         return None
 
 
+#: The directory the launcher started this chat's harness in — the fourth of §4e's four
+#: restore items, and the only one that had nowhere to live.
+#:
+#: **It could not ride in `identity`, and that is a security property rather than a
+#: preference.** :func:`record_identity` holds the five names of
+#: `commands_frame._FRAME_IDENTITY`, and every value in it goes straight onto a tmux
+#: ``-e NAME=VALUE`` argv, which `_frame_identity_env` measures as world-readable in
+#: `/proc/<pid>/cmdline`. That list is a PROMISE about what reaches an argv — *"none of
+#: the five is ever a credential"* — and a sixth name added for a convenience is how that
+#: promise stops being checkable. A cwd is not a credential either, but it is also not
+#: identity: nothing inside the frame needs it in its environment, so putting it there
+#: would widen an argv for a reader that does not exist.
+#:
+#: `workspace` beside it is the model: one fact, one file, written by the one process that
+#: knows it. `os.getcwd()` was read on both launch paths (`cmd_launch`,
+#: `_launch_in_operator_tmux`), handed to tmux, and dropped.
+_CWD_FILE = "cwd"
+
+
+def record_cwd(fid: str, path: str) -> None:
+    """Write down the directory this chat's harness was started in.
+
+    Same atomic-write, never-raise, rewrite-on-every-launch shape as
+    :func:`record_workspace`, and for the identical reason: an adopted directory's value is
+    another frame's answer, so it is overwritten rather than merged.
+
+    Deliberately NOT deleted by :func:`clear_shape`. The four files that list argues about
+    are all *readings* — a density somebody pressed, a highlight somebody clicked, a pane
+    map, a gauge — and every one of them is wrong for the next frame. A cwd is where the
+    conversation was, which is the same kind of fact as `workspace`: durable per-chat
+    state, and one of the four things a reopen restores.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "cwd.tmp"
+    try:
+        config.write_for(tmp, f"{path}\n")
+        os.replace(tmp, d / _CWD_FILE)
+    except OSError:
+        return
+
+
+def chat_cwd(fid: str) -> str | None:
+    """The directory recorded for *fid*, or ``None`` when charter has no usable one.
+
+    **Absolute or nothing, checked here**, because of where this value goes next: a
+    reopen hands it to `os.chdir` and to `layout.chat_window_argv`'s ``-c`` argv. A
+    relative path would be resolved against whatever directory `charter reopen` happened
+    to be typed in — which is precisely the "silently somewhere else" a restore must not
+    do — and is indistinguishable on disk from a truncated write.
+
+    ``None`` for a chat launched by a charter that predates :func:`record_cwd`, for a
+    directory that is not a chat's, for a file that cannot be read, and for a value that
+    is not an absolute path. Four reasons, one answer, because every caller does the same
+    thing with it: fall back to somewhere it can name, and SAY that it did (§4e's own
+    rule — a restore that quietly substitutes is worse than one that reports).
+
+    Never checked for EXISTENCE here. Whether the directory is still there is a question
+    about the machine at the moment of the reopen, not about the record, and the caller is
+    the one that has an operator to tell.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        val = (d / _CWD_FILE).read_text().strip()
+    except (OSError, ValueError):
+        return None
+    return val if val and os.path.isabs(val) else None
+
+
+#: What :func:`record_closed` writes, and the whole difference between a chat the operator
+#: CLOSED and a chat that merely stopped (§4i, and the accepted cost in the reopen design).
+#:
+#: **A missing `exit` file means "was open", so "closed" needs a file of its own.**
+#: `record_exit` is written by a pane hook and only ever for a harness that ended on its
+#: own; `kill-pane`, `kill-window` and `kill-session` write nothing (§2.17, measured). A
+#: reopen therefore reads "no exit" as *bring this chat back*, which is what "less
+#: invasive" means — and which would bring back a chat the operator had deliberately
+#: closed, because closing it also writes no exit. This is the one bit that tells them
+#: apart.
+#:
+#: **In the chat's own directory rather than beside the manifest**, and that placement is
+#: the bound: this marker only has to outlive the chat's WINDOW, never the chat's
+#: directory. Once `reap` has taken the directory the chat is gone from every surface, so
+#: there is nothing left for a plane-scoped marker to protect and it would be litter with
+#: no collector.
+_CLOSED_FILE = "closed"
+
+
+def record_closed(fid: str) -> None:
+    """Mark *fid* as closed by the operator, so a later quit does not record it as open.
+
+    Never raises, like everything else here. What a failed write costs is stated rather
+    than guarded against: the chat's window is killed either way, and the only loss is
+    that a quit landing before `reap` collects the directory would put it in the manifest
+    and a reopen would bring it back. That is the same cost §4i already accepts for a chat
+    closed by some other route, and it is recoverable with one more `chat: close`.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    try:
+        config.write_for(d / _CLOSED_FILE, "1\n")
+    except OSError:
+        return
+
+
+def was_closed(fid: str) -> bool:
+    """Whether the operator closed *fid* — one ``stat``, like :func:`exit_code` beside it.
+
+    A bool rather than :func:`exit_code`'s tri-state, and that is the difference between
+    the two questions: an exit code has a VALUE somebody wants to read (finished, or
+    crashed with N), while closing has none — a chat is closed or it is not.
+
+    ``Path.exists`` answers ``False`` for a marker charter cannot stat as well as for one
+    that is not there, and here those two fall on the *restoring* side: an unreadable
+    marker means the chat is recorded and comes back. That is the deliberate direction of
+    this whole design — nothing means "we do not know it stopped, bring it back" — and the
+    cost is one uninvited tab that `chat: close` closes again, against the alternative of
+    silently dropping a chat charter could not read one file of.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return False
+    return (d / _CLOSED_FILE).exists()
+
+
 #: The subdirectory :func:`respawn_attempt` counts in, named once so
 #: :func:`clear_respawn` cannot drift away from it — the two are only correct together.
 _RESPAWN_DIR = "respawn"

--- a/charter/inflight.py
+++ b/charter/inflight.py
@@ -317,3 +317,47 @@ def _matches_kind(p: Path, kind: str) -> bool:
         return _kind_of(json.loads(p.read_text())) == kind
     except (OSError, TypeError, ValueError):
         return False
+
+
+def prune_all() -> int:
+    """Discard every record on this plane. How many were removed.
+
+    **The one caller is `charter frame-quit`, and it is the one moment that can honestly do
+    this.** Records clear only on :func:`finish`, which the worker that started them calls —
+    so killing every harness on a plane strands every record it was holding:
+    :func:`still_running` reports one for :data:`PRESUMED_DEAD_SECONDS` (30 minutes) and
+    :func:`live` holds it for :data:`PRUNE_SECONDS` (24 hours). The frame's spinner reads
+    `live(kind=None)`, so it would animate for a plane doing nothing, and the
+    dispatch-overlap nudge reads :func:`still_running`, so it would name agents the quit
+    itself killed.
+
+    **Plane-scoped, because a record cannot say anything narrower.** Every record is
+    ``{"agent", "kind", "ts"}`` — no fid, no chat, no workspace — so there is no filter a
+    per-frame caller could apply, and inventing one here would be a second reading of a fact
+    the file does not hold. That is exactly co-extensive with what a quit stops: `cmd_quit`
+    kills every chat this PLANE has a directory for, which is every process that could have
+    written one of these. The two scopes are the same scope, and that is why this is safe
+    rather than merely convenient.
+
+    **Not an age sweep, and not `PRUNE_SECONDS` brought forward.** :func:`live_records`
+    already drops records past that horizon opportunistically, and #308 is explicit that
+    deleting a record for being OLD destroys the single most interesting thing this tracker
+    holds. This deletes for a different reason entirely: the work is over, because the caller
+    just ended it.
+
+    Everything here is best-effort, like the rest of this module: a record that could not be
+    removed is one stale row in a frame that is about to stop existing, and a tracker that
+    broke a quit would be worse than one that missed a file.
+    """
+    try:
+        records = list(_dir().glob("*.json"))
+    except OSError:
+        return 0
+    gone = 0
+    for p in records:
+        try:
+            p.unlink(missing_ok=True)
+            gone += 1
+        except OSError:
+            continue
+    return gone

--- a/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
+++ b/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
@@ -100,3 +100,54 @@ charter never has to understand what is in that pane to draw around it.
   what it printed) needs its own measurement and its own ADR — this one settles rendering,
   not observation, and conflating the two is how a boundary like this erodes one convenient
   exception at a time.
+
+## Amendment, 2026-09-01: charter reads that pane at two moments, and draws in it at none
+
+The bullet above asked for a measurement and its own record before charter read the
+harness's pane. **The measurement showed charter was already reading it**, and had been
+since #384 — so what follows is a correction to this ADR's own description of the code
+rather than a new permission granted to it.
+
+`commands_frame._pane_last_words` runs `tmux capture-pane -p -S -` on the harness pane on
+**both** launch paths, and its docstring records the 3.7c measurement that put it there: a
+registered harness whose binary is missing produced *zero bytes* of output and exit 127, and
+that capture is the only thing that turns it into a sentence. §4f of
+`docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md` then asked for a second
+read: tmux history dies with its session, so quitting a plane discards every visible
+transcript, and *"less invasive"* cannot mean that.
+
+So the rule is stated as it actually holds, rather than as a prohibition with two
+undocumented exceptions:
+
+**tmux composes the rectangles and does every part of terminal emulation. Charter draws only
+its own panels — the edges — and never draws in the harness's own pane, never parses its
+escape sequences, and never decides what a cursor or a colour means inside it. It READS that
+pane at exactly two moments, both of which are moments the pane is about to stop existing:**
+
+1. **a harness that died before the frame was drawn** (`_pane_last_words`) — the only chance
+   to say anything at all, because nothing is ever drawn on that path;
+2. **a chat being stopped by `charter: quit`** (`_capture_transcript`) — bounded to the last
+   2,000 lines and 512 KB, written to that chat's own file under `.charter/frame/`, and
+   **offered on the way back rather than replayed**. `F2 → chat: previous transcript` opens
+   it in a pager in a window of its own; the reopened harness's pane starts clean.
+
+**Both exceptions are bounded by the same property, and it is the property that keeps this a
+boundary rather than a preference: charter reads only what is about to be destroyed, and
+writes nothing back.** The two failures this ADR was written against — owning a terminal
+parser, and drawing where tmux draws — are untouched by either. Nothing here parses an
+escape sequence: `-e` keeps them and `-N` keeps the trailing spaces `-e` alone trims, and the
+bytes go to a file and to `less -R`, both of which understand them better than charter would.
+
+**What is still refused, sharpened rather than repeated.** Reading that pane to *react* to
+what it printed — a hook on its output, a parse of its state, a decision made from its
+content — is still a different feature and still needs its own measurement and its own
+record. The distinguishing question is now written down so the next reader does not have to
+infer it: *does charter read this pane at a moment it is ending, and does it write nothing
+back?* Two yeses is this amendment. Anything else is a new one.
+
+**Measured cost, because "capture it" is not free.** One 200-column pane at charter's shipped
+`history_limit = 50000` took the shared tmux server from 3.7 MB to **130 MB**, and
+`capture-pane -p -S -` pipes that whole history through charter's own process. That is why
+the capture asks tmux for the last N lines (`-S -2000`) rather than for everything and
+trimming afterwards: the bound belongs where the memory is. Verified on tmux 3.7c and at the
+3.2 floor.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -633,6 +633,72 @@ A `$TMUX` that names a server nothing answers on — one captured by `env` and r
 or a `tmux kill-server` under a running script — is not a tmux you are inside. Charter
 checks before it builds anything, and falls back to its own private server.
 
+## Leaving: detach, close, quit — and reopen
+
+**Closing the window detaches, and that is the exit that costs nothing.** tmux sessions
+survive a client leaving, so the common way out loses nothing and needs no resume: the
+harnesses keep running and `tmux -L charter attach -t <workspace>` puts you back. A terminal
+that dies, a lid that closes and an ssh connection that drops all do this. `F2 → detach` is
+the same thing without needing to know tmux's prefix key.
+
+**`F2 → charter: quit` stops everything on this plane, and records it first.** It is the only
+route — never a signal, never a closing terminal. Enter on that row opens a confirmation
+rather than doing anything: one row per chat, saying what that chat will and will not get
+back, with the row that goes through at the bottom.
+
+```
+quit · 5 to choose from
+    alpha.1 · claude-code       conversation resumes
+  * alpha.2 · claude-code       reopens empty — no session id recorded for this chat yet
+    api.1 · opencode            reopens empty — opencode records no session id to resume …
+    gone.3 · claude-code        conversation resumes · workspace 'gone' is gone — reopen…
+>   quit — stop 4 chats in 3 workspaces; 2 of 4 can resume the conversation
+
+  up/down move   enter choose   esc cancel   F12 back to the harness
+```
+
+It **warns and proceeds** — it does not refuse. Refusing would leave you unable to quit
+while any agent was working, which on a control plane is most of the time. The one thing that
+stops it is being unable to write the record down: a quit that killed the plane after failing
+to record it is exactly the invasive quit this exists to prevent, so that refuses and stops
+nothing.
+
+**`charter reopen` puts the recorded plane back.** Every workspace, every chat, each one's
+persona and the directory it was started in — and, for Claude Code, the conversation, by
+resuming it. It attaches you to the workspace you pressed quit in, on the chat that was in
+front of you. The record describes one quit and is consumed by one reopen, so running it
+twice does not double your tabs.
+
+**Resume is Claude Code only, and the warning says so per chat.** Charter records a harness's
+own session id from Claude Code's status-line hook, which is the only harness that supplies
+one — so it is the only harness whose conversation charter can ask for back. A chat that
+cannot be resumed still comes back: its directory, its workspace and its persona return, and
+only the conversation is gone. A chat whose *workspace* has been deleted comes back too, and
+says the workspace is missing; charter never quietly re-homes a chat.
+
+**`F2 → chat: previous transcript`** opens what a chat had on screen before it was last
+stopped, in a pager, in a window of its own. tmux history dies with its session and
+`claude --resume` re-renders the conversation rather than the screen, so a quit captures the
+last 2,000 lines of each pane (at most 512 KB) into `.charter/frame/<chat>.transcript`. It is
+**offered, never replayed** — the reopened harness's pane starts clean, because replaying a
+previous run's output above a new run's prompt would present a session that is not running as
+though it were. The row is refused, with its reason, until a quit has captured one.
+
+**`F2 → chat: close` stops one chat and marks it so nothing brings it back.** That is the
+whole difference from quit: quit records, close forgets. It exists because charter reads "no
+recorded exit code" as *"we do not know it stopped — bring it back"*, which is what makes a
+restart cheap and which would otherwise resurrect a chat you had deliberately finished with.
+It also drops that chat's captured transcript, since a capture exists to be offered on the way
+back. Closing does **not** refuse while that chat's harness is working: charter's in-flight
+tracker records no chat on any of its entries, so there is no reading to refuse on, and the
+confirmation says the chat will not come back instead of pretending to check.
+
+**What quit stops is this plane, and nothing else on the machine.** One tmux server serves
+every frame on a machine and session names carry no plane — `default` is a name every plane
+has — so quit works from *this* plane's chat directories and kills one window at a time, never
+`kill-server` and never a session by name. Two planes with a workspace of the same name can
+share one tmux session, and quitting one leaves the other's chats running.
+
 ## Exit codes
 
 The launcher does not `exec` tmux — an attached `tmux new-session` reports 0 regardless of
@@ -1906,7 +1972,7 @@ remember the flags. The workspace is the session; tmux puts you back on whicheve
 chats was last in front of you.
 
 ```
-charter · 12 to choose from
+charter · 16 to choose from
 >   workspace: alpha — pick another    cannot switch: a chat belongs to its workspa…
     persona: steward — pick another
     detach — leave the harness running
@@ -1919,7 +1985,18 @@ charter · 12 to choose from
   * chrome: off
     chrome: dark
     chrome: light
+    chat: previous transcript          no previous transcript for this chat — one …
+    refresh — gather this workspace's repos, todos and changes again
+    charter: quit — stop every harness on this plane
+    chat: close — stop this chat and do not bring it back
+```
 
+**The two rows that stop something are last, and that is a guard rather than an ordering
+taste.** The cursor starts on the first row that can run, so a destructive row at the top of
+the list would be one `F2` `Enter` away. Every harmless row charter has keeps the top of the
+list; see *Leaving* below for what those two do.
+
+```
   up/down move   enter choose   esc cancel   F12 back to the harness
 ```
 
@@ -1934,9 +2011,10 @@ for the cursor and two for the "you are on this one" mark, in that order, whethe
 the row has either. So `detach` and `density: full` start in the same column, and the
 distance from the cursor to the text is the same on every row of the list.
 
-**Two of those rows are doorways.** `workspace:` and `persona:` say which one this frame is
-on, and Enter opens the list of the others **in the same pane** — a picker, which is this
-same surface over a different set of rows. Type to narrow it exactly as you would the
+**Four of those rows are doorways.** `workspace:` and `persona:` say which one this frame is
+on, and `charter: quit` and `chat: close` open a confirmation; Enter on any of them replaces
+the surface **in the same pane** with a picker, which is this same surface over a different
+set of rows. Type to narrow it exactly as you would the
 palette, Enter to switch, Escape to leave having changed nothing:
 
 ```

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -643,19 +643,23 @@ the same thing without needing to know tmux's prefix key.
 
 **`F2 → charter: quit` stops everything on this plane, and records it first.** It is the only
 route — never a signal, never a closing terminal. Enter on that row opens a confirmation
-rather than doing anything: one row per chat, saying what that chat will and will not get
-back, with the row that goes through at the bottom.
+rather than doing anything: the row that goes through, and under it one row per chat saying
+what that chat will and will not get back.
 
 ```
 quit · 5 to choose from
+>   quit — stop 4 chats in 3 workspaces; 2 of 4 can resume the conversation
     alpha.1 · claude-code       conversation resumes
   * alpha.2 · claude-code       reopens empty — no session id recorded for this chat yet
     api.1 · opencode            reopens empty — opencode records no session id to resume …
     gone.3 · claude-code        conversation resumes · workspace 'gone' is gone — reopen…
->   quit — stop 4 chats in 3 workspaces; 2 of 4 can resume the conversation
 
   up/down move   enter choose   esc cancel   F12 back to the harness
 ```
+
+The chat rows are listed refused — they are the warning, and pressing one does nothing. The
+row that runs is where the cursor lands, because the palette puts the cursor on the first
+row and a confirmation whose Enter does nothing reads as broken.
 
 It **warns and proceeds** — it does not refuse. Refusing would leave you unable to quit
 while any agent was working, which on a control plane is most of the time. The one thing that

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -673,6 +673,11 @@ resuming it. It attaches you to the workspace you pressed quit in, on the chat t
 front of you. The record describes one quit and is consumed by one reopen, so running it
 twice does not double your tabs.
 
+Run it from an ordinary shell. **Inside a tmux you already have it refuses**, because charter
+builds a frame there as a window on your own server and that launcher stays awake for the
+life of each frame — so reopening several chats would stop at the first. It says so and
+leaves the record alone.
+
 **Resume is Claude Code only, and the warning says so per chat.** Charter records a harness's
 own session id from Claude Code's status-line hook, which is the only harness that supplies
 one — so it is the only harness whose conversation charter can ask for back. A chat that

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -670,8 +670,9 @@ nothing.
 **`charter reopen` puts the recorded plane back.** Every workspace, every chat, each one's
 persona and the directory it was started in — and, for Claude Code, the conversation, by
 resuming it. It attaches you to the workspace you pressed quit in, on the chat that was in
-front of you. The record describes one quit and is consumed by one reopen, so running it
-twice does not double your tabs.
+front of you. The record describes one quit and is consumed chat by chat, so running it
+twice does not double your tabs — and if some chat could not be started, exactly that chat
+stays recorded, so a second `charter reopen` retries just it.
 
 Run it from an ordinary shell. **Inside a tmux you already have it refuses**, because charter
 builds a frame there as a window on your own server and that launcher stays awake for the

--- a/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
+++ b/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
@@ -263,6 +263,35 @@ name can have — and quitting one leaves the other's harness running.
   versions charter promises**, so it is a third machine's opinion on top of the hand-runs
   rather than a substitute for them.
 
+## What the deletion sweep found, and the defect it led to
+
+CI's sweep could not answer this branch at all — 231 mutations against a gate that tops out
+near 224 at eight shards, so all eight hit their 60-minute timeout and it reported `no
+verdict: 8 of 8 shards did not report`, exactly the third state it exists to be able to
+report. Run locally without that cap, it found **22 survivors in the first 38 mutations**, and
+every one was the same shape: a guard whose happy path was tested and whose refusal was not.
+The window listing was only ever driven against a real `list-windows`, which never produces a
+malformed row or a hostile chat id; the tri-state was only ever asked of servers that
+answered; the capture was only ever handed text that fitted.
+
+**One of them was a real defect.** The transcript's byte cap measured BYTES and then trimmed
+CHARACTERS, so a capture made of two-byte characters was left at twice the cap — measured at a
+cap of 16, `"é" * 16` is 16 characters and 32 bytes and the old line answered 32. The sweep did
+not find that directly; it found that the `>` in front of it could not be turned red, because
+at exactly the cap `text[-N:]` returns the whole string either way. Chasing an unpinnable
+comparison is what surfaced the thing underneath it. It is byte-exact now, in one expression
+with no comparison to get the boundary wrong in, and cheaper than what it replaced.
+
+**Three more were guards that only passed because another guard had already caught the
+case** — `verb is not None and row.note`, an `or ""` on a value no reader of that plan can
+observe, and a `chosen.note and` in front of a test that already excluded every row with no
+note. Deleted rather than documented, which is what this repository does with them.
+
+The rest are pinned: the listing's field-count and both regex guards, the "one server refused
+means the whole plane is unknown" tri-state in both directions, which chat was on screen, the
+capture's four refusals and its two bounds, the launcher's three reopen gates, and the two
+surfaces the warning is said on.
+
 ## What this does not do
 
 * **Make the chat directory durable.** Stage 4, six edits, unchanged here — which is why a

--- a/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
+++ b/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
@@ -135,6 +135,14 @@ reader discards is a record that looks like a promise and is not. Its warning ro
 `charter has no record of its workspace — it cannot be reopened`, and the quit's own summary
 says how many of how many were kept.
 
+**The workspace a chat comes back in is the one recorded, and #791 is what makes that a
+fact.** A reopen mints a fresh chat id — but `new_chat_id` counts up from 1 and `reap` frees
+the ordinals a quit's chats held, so it very often gets the same *name* back. While the
+per-session `.charter/sessions/<id>.workspace` pointer was a rung of `state.own_workspace`, a
+`charter workspace use` typed in the chat that previously held that ordinal would have
+outranked the manifest for the chat that inherited it. That rung is gone, and the case is
+pinned with the stale pointer deliberately planted.
+
 **`cwd` had nowhere to live and now has a file.** `os.getcwd()` was read on both launch paths,
 handed to tmux, and dropped. It could not join the identity record: every value in that record
 goes onto a tmux `-e NAME=VALUE` argv, measured as world-readable in `/proc/<pid>/cmdline`,

--- a/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
+++ b/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
@@ -241,9 +241,16 @@ name can have — and quitting one leaves the other's harness running.
   over-determined and is documented as such rather than claimed.
 * **With a real tmux, on 3.7c and at the 3.2 floor:** the capture is real bytes off a real
   pane with its trailing spaces intact; the kill really ends the chats and, with the last
-  window, the session and then the server; and the two-plane case above. Per the design's own
-  §2.12 **none of this runs in CI** — there is no tmux there — so every tmux claim in this
-  entry is a hand-run on a real machine on both versions.
+  window, the session and then the server; the pager window really opens beside the chat; and
+  the two-plane case above.
+* **And a correction to the design's own §2.12, measured on this branch: the real-tmux tests
+  DO run in CI.** `.github/workflows/test.yml` installs no tmux, but `ubuntu-latest` ships
+  one — so they ran there, and one of them failed on 3.11 and 3.13 while passing on 3.14 in
+  the same run. That is a race (a pane's process has not exec'd when `new-window` returns),
+  found by CI and not by this machine. The honest statement is narrower than "no tmux in CI":
+  **CI answers on whatever tmux the runner image happens to ship, which is neither of the two
+  versions charter promises**, so it is a third machine's opinion on top of the hand-runs
+  rather than a substitute for them.
 
 ## What this does not do
 

--- a/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
+++ b/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
@@ -190,6 +190,23 @@ ADR is amended in this change rather than quietly added to. The rule now reads: 
 reads that pane at exactly two moments, both of them moments the pane is about to stop
 existing, and writes nothing back into it.**
 
+**The window it opens is targeted by SESSION ID, and every other spelling was measured
+failing.** This is the #664/#695 shape and it cost a hand-run to find: `kill-window -t %N`
+resolves a pane to its own window — charter's early-death path already relies on that — so
+`new-window -t %N` looks like it should too. It does not. On tmux 3.7c *and* at the 3.2 floor,
+on a session called `alpha.2` holding its own `$0`/`@0`/`%0`:
+
+```
+new-window -t %0        rc 1   can't specify pane here
+new-window -t @0        rc 1   create window failed: index 0 in use
+new-window -t alpha.2   rc 1   can't specify pane here      <- #695, again
+new-window -t $0        rc 0
+```
+
+`-t` there is a target-*window*, a window id is read as the index to insert at (which is by
+definition taken), and a dotted session name is parsed as `window.pane`. The first version of
+this shipped `-t <pane>` and was correct against nothing.
+
 Reopening **offers** the capture; it never replays it. Replaying bytes would present a session
 that is not running as though it were, and put a previous run's output above a new run's
 prompt with nothing marking the seam.

--- a/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
+++ b/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
@@ -88,18 +88,24 @@ have written one. A genuinely per-frame quit could not prune at all.
 
 ## The warning is per chat, and it is drawn before the keypress commits anything
 
-`F2 → charter: quit` opens a confirmation, not an action. One row per chat, each carrying that
-chat's own sentence; the row that goes through is last, under the list it is about; and every
-chat row is marked refused, so the cursor lands on the row that runs and pressing a chat row
-does nothing.
+`F2 → charter: quit` opens a confirmation, not an action. The row that goes through, and
+under it one row per chat carrying that chat's own sentence — every chat row marked refused,
+because it is the warning and pressing it does nothing.
 
 ```
+> quit — stop 4 chats in 3 workspaces; 2 of 4 can resume the conversation
   alpha.1 · claude-code    conversation resumes
   alpha.2 · claude-code    reopens empty — no session id recorded for this chat yet
   api.1 · opencode         reopens empty — opencode records no session id to resume from
   gone.3 · claude-code     conversation resumes · workspace 'gone' is gone — reopens saying so
-quit — stop 4 chats in 3 workspaces; 2 of 4 can resume the conversation
 ```
+
+*An earlier draft put the confirming row at the bottom, under the list it is about, which
+reads better and was measured to be wrong:* `palette.narrow` puts the cursor on the first row
+when nothing has been typed, refused or not, so the surface opened with a chat row selected
+and Enter bound to nothing at all. A palette row that visibly does nothing reads as broken,
+and this is the one surface where the operator has just asked a question and is waiting for
+the keypress that answers it.
 
 **Four sentences and not one**, because "reopens empty" on its own would reasonably be filed
 as a bug. Charter can resume Claude Code and nothing else: `record_harness_session` has
@@ -116,9 +122,18 @@ working, which on a control plane is most of the time.
 
 Its directory, its workspace and its persona return either way; only the conversation is gone.
 Silently not reopening it would make a chat vanish across a restart, which is the opposite of
-what was asked for. A chat whose **workspace** has been deleted comes back too, and says the
+what was asked for. A chat whose **workspace has been deleted** comes back too, and says the
 workspace is missing — it is never quietly re-homed, which is the rule §4j sets and #789
 enforced.
+
+**One chat cannot come back, and it says so rather than promising.** A chat with no
+*workspace record at all* — the migration and truncation case, which is exactly why the quit
+scans the frame root rather than asking any workspace's roster — has no session to be rebuilt
+into. It is stopped like the rest and deliberately not recorded, because choosing a workspace
+for it would be the re-homing §4j forbids arriving as a convenience, and a manifest line every
+reader discards is a record that looks like a promise and is not. Its warning row says
+`charter has no record of its workspace — it cannot be reopened`, and the quit's own summary
+says how many of how many were kept.
 
 **`cwd` had nowhere to live and now has a file.** `os.getcwd()` was read on both launch paths,
 handed to tmux, and dropped. It could not join the identity record: every value in that record

--- a/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
+++ b/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
@@ -1,0 +1,231 @@
+---
+version: unreleased
+headline: Quitting charter writes the plane down first, so reopening puts it back — and says, per chat, what it cannot
+---
+
+*"when user closing charter session we need to show warning, that all harness sessions will
+be closed, and when opening again we need to resume harness sessions as well. so for user it
+should be 'less invasive' — to not lose sessions, state etc."*
+
+The operator restarted their machine, got an empty frame, and recovered their conversation by
+typing `/resume` by hand. Three verbs were missing and none of them existed anywhere:
+`charter --help` had ten `frame-*` commands and neither a quit nor a close, and the palette
+registered detach, two repo-selection rows, three densities and three surfaces.
+
+**All three ship here.**
+
+* **`F2 → charter: quit`** stops every harness on this plane — after writing the plane down,
+  and after showing you, one row per chat, what will and will not come back.
+* **`F2 → chat: close`** stops one chat and marks it so nothing brings it back.
+* **`charter reopen`** puts the recorded plane back: every workspace, every chat, each one's
+  persona and directory, and — for Claude Code — the conversation, by resuming it.
+* **`F2 → chat: previous transcript`** opens what a chat had on screen before it was
+  stopped, in a pager, in a window of its own.
+
+## The record has to survive the thing that deletes chats, and one already did not
+
+Charter has kept a chat's harness session id since #757 — `session.durable`, deliberately not
+in `clear_shape`'s list, so the id a resume needs survives a frame ending. **Measured, it does
+not survive a restart**, and the reason is one line up: `state.reap` deletes a chat's whole
+directory when its launcher pid is dead, and after a restart *every* launcher pid is dead. So
+the id was gone by the time anything could ask for it — deleted by the next launch, in a
+directory nobody had noticed was temporary.
+
+Inverting `reap` is the fix, and it is not a fix that fits in this change: it is stage 4 of
+the design's own delivery order, six edits wide (`chat: close`, a `max_chats` cap and its
+config field, a ghost-tab collector, `cmd_workspace_remove`'s leak, `state.clear_claim`) with
+~60 tests asserting the current rule, four of them by name.
+
+So the record is a **file**, not a directory:
+
+```
+.charter/frame/
+  alpha.1/                  <- a chat: still a liveness marker, still reaped exactly as now
+  alpha.1.transcript        <- what was on its screen
+  reopen.json               <- the plane
+```
+
+`reap` skips anything that is not a directory, and so does the scan that reads the tab bar —
+so a file there is invisible to both, outlives every reap, and is never mistaken for a chat.
+**The chat directory goes on meaning exactly what it means today**, which is what makes this
+shippable ahead of the redesign rather than after it.
+
+*Recorded because it changes what a test can prove:* that durability turned out to be
+**over-determined**. Three independent rules in `reap` keep a non-directory entry — the
+`is_dir()` filter, the "a directory I cannot list is one I have no reading of" keep-rule (a
+`NotADirectoryError` is an `OSError`), and `shutil.rmtree(ignore_errors=True)`, which cannot
+remove a file even if it were reached. Deleting the filter leaves the suite green. The tests
+assert the outcome the design rests on and say so rather than claiming a guard they cannot
+turn red.
+
+## What quit does, in order, and why the order is the feature
+
+1. **Read the plane off disk** — every chat directory on *this* plane, with its workspace,
+   persona, harness, directory and durable session id.
+2. **Ask each tmux server which of them is live**, and which window each one is in.
+3. **Capture each live chat's scrollback** while its pane still exists.
+4. **Write the manifest.**
+5. Drop the transcripts of chats the manifest no longer names.
+6. **Kill** — one `kill-window` per chat.
+7. **Prune the in-flight tracker.**
+
+**4 before 6 is the whole point.** A record that depends on the thing it records succeeding
+is not a record, which is the rule `charter trace` already keeps for a secret: it writes
+before the value leaves. A quit that could not write the manifest **refuses**, and stops
+nothing — the one thing that stops a quit, because killing a plane nothing will bring back is
+the invasive quit this change exists to prevent.
+
+**7 after 6, for the mirror of the same reason.** `inflight` records clear only on
+`finish()`, so stopping every harness strands every record: `still_running` reports one for 30
+minutes and `live` holds it for 24 hours, which would leave the frame's spinner animating for
+a plane doing nothing and the dispatch-overlap nudge naming agents the quit itself killed.
+Pruning first would discard the record of work that is still running if a kill then failed.
+
+**The prune is plane-wide, and it can be, because the quit is.** Those records carry no chat,
+no frame and no workspace, so nothing narrower is expressible — and it does not need to be:
+the quit stops every chat this plane has a directory for, which is every process that could
+have written one. A genuinely per-frame quit could not prune at all.
+
+## The warning is per chat, and it is drawn before the keypress commits anything
+
+`F2 → charter: quit` opens a confirmation, not an action. One row per chat, each carrying that
+chat's own sentence; the row that goes through is last, under the list it is about; and every
+chat row is marked refused, so the cursor lands on the row that runs and pressing a chat row
+does nothing.
+
+```
+  alpha.1 · claude-code    conversation resumes
+  alpha.2 · claude-code    reopens empty — no session id recorded for this chat yet
+  api.1 · opencode         reopens empty — opencode records no session id to resume from
+  gone.3 · claude-code     conversation resumes · workspace 'gone' is gone — reopens saying so
+quit — stop 4 chats in 3 workspaces; 2 of 4 can resume the conversation
+```
+
+**Four sentences and not one**, because "reopens empty" on its own would reasonably be filed
+as a bug. Charter can resume Claude Code and nothing else: `record_harness_session` has
+exactly one caller, Claude Code's own status-line hook, so no other harness has ever written
+an id to ask with. The row says which of the four reasons applies to *that* chat — it has an
+id, charter does not know what harness it was, it is Claude Code and has not taken a turn yet,
+or its harness records no id at all — and it is asked of the harness registry rather than
+written down, so the day a second harness starts writing an id there is one place to change.
+
+It **warns and proceeds**. Refusing would leave you unable to quit while any agent was
+working, which on a control plane is most of the time.
+
+## A chat that cannot be resumed still comes back, empty, and says so
+
+Its directory, its workspace and its persona return either way; only the conversation is gone.
+Silently not reopening it would make a chat vanish across a restart, which is the opposite of
+what was asked for. A chat whose **workspace** has been deleted comes back too, and says the
+workspace is missing — it is never quietly re-homed, which is the rule §4j sets and #789
+enforced.
+
+**`cwd` had nowhere to live and now has a file.** `os.getcwd()` was read on both launch paths,
+handed to tmux, and dropped. It could not join the identity record: every value in that record
+goes onto a tmux `-e NAME=VALUE` argv, measured as world-readable in `/proc/<pid>/cmdline`,
+and that list is a promise about what reaches an argv rather than a convenient bag.
+
+**The resume flag rides the harness's existing pass-through.** `Harness.launch_argv` is
+`[self.binary, *extra]` with no override anywhere in the registry, so the pass-through *is*
+the seam; no member was added, which is what Phase 5's Task 9 asked for and the one thing in
+that task that survived unchanged.
+
+**No token-gauge gate, and the spec asked for one.** It specified gating the gauge on
+`state.exit_code(fid) is None`, which is wrong in the direction that matters: for a chat
+`kill-window` ended there IS no exit code, so the gate would show the gauge for exactly the
+case it was written to suppress. And nothing needs suppressing — a reopened chat gets a fresh
+chat id, so its directory has no gauge mapping at all and draws nothing until its own first
+turn writes one. The ordering hazard the spec named ("this stage must ship before that one")
+disappears with the gate.
+
+## `chat: close` is the same teardown with one file more
+
+Same plan, same warning, same kill, one target — and `closed` written into that chat's
+directory. That file is the whole difference, and it exists because of a measurement: a
+harness that ends on its own leaves an exit code, while `kill-pane`, `kill-window` and
+`kill-session` leave nothing. This design reads "nothing" as **"we do not know it stopped —
+bring it back"**, because that is what less invasive means. The stated cost is that a chat
+stopped some other way may come back uninvited; `chat: close` is what pays it. Without the
+mark, closing a chat and then quitting the plane brings the closed chat back, and there is
+nothing you could do about it — which is asserted as a test, by removing the mark and watching
+it happen.
+
+Close also drops that chat's transcript, where quit keeps it: a capture exists to be offered
+on the way back, and a closed chat is not coming back.
+
+What close **cannot** do is refuse a busy chat. The design asks `workspace: close` to refuse
+while its harness is working, and `inflight` cannot answer that question — its records name no
+chat. Rather than refuse on a reading charter does not have, the confirmation row says the
+chat will not come back, which is the sentence you need before pressing it.
+
+## Scrollback: kept, offered, never replayed — and that needed an ADR amendment
+
+tmux history dies with its session. `claude --resume` re-renders the *conversation*; it
+restores no scrollback, and for the other harnesses it restores nothing at all. For a design
+whose headline requirement is "less invasive", losing every visible transcript was a hole in
+the premise.
+
+Quit is the one moment charter knows a pane is about to be destroyed, so it reads it. **ADR
+0018 says charter never touches the harness's pane — and the measurement showed charter had
+been reading it since #384**: `_pane_last_words` runs `capture-pane -p -S -` on both launch
+paths, and it is the only reason a harness that dies before the frame is drawn produces a
+sentence instead of zero bytes. The ADR's own closing words are that conflating rendering with
+observation *"is how a boundary like this erodes one convenient exception at a time"*, so the
+ADR is amended in this change rather than quietly added to. The rule now reads: **charter
+reads that pane at exactly two moments, both of them moments the pane is about to stop
+existing, and writes nothing back into it.**
+
+Reopening **offers** the capture; it never replays it. Replaying bytes would present a session
+that is not running as though it were, and put a previous run's output above a new run's
+prompt with nothing marking the seam.
+
+**Bounded, because "capture it" is not free.** One 200-column pane at charter's shipped
+`history_limit = 50000` took the shared tmux server from 3.7 MB to **130 MB**, and
+`capture-pane -S -` pipes all of it through charter. So the capture asks tmux for the last
+2,000 lines and keeps at most 512 KB of what comes back, tail first — the bound belongs where
+the memory is. `-e` keeps the colours; `-N` is what stops `-e` trimming trailing spaces, which
+are the alignment of anything drawn in columns.
+
+## Quit's blast radius is this plane, and only disk can say what that is
+
+One tmux server serves every plane on the machine, session names carry no plane, and `default`
+is a name every plane has — so `kill-server` would stop somebody else's frames and
+`kill-session -t default` would stop whichever plane's `default` tmux resolved first. The set
+quit stops is exactly *this plane's chat directories*, and the kill is aimed at a **window id
+tmux itself just reported**, never at a session name and never at a pane id recorded before the
+server may have restarted.
+
+That is the one thing a single-plane test is blind to, so it is tested with two: two plane
+roots, both with a workspace called `default`, both with a window in the one tmux session that
+name can have — and quitting one leaves the other's harness running.
+
+## Verification
+
+* **Without tmux:** 69 new cases across four modules — what a quit records and in what order,
+  the four warning sentences, what a reopen restores and what it reports instead, what close
+  marks and drops, and every way the manifest refuses a value it cannot use.
+* **Two guards mutated and confirmed RED:** dropping `state.record_cwd` from the launch path,
+  and pruning `inflight` before the kill instead of after. A third property was found
+  over-determined and is documented as such rather than claimed.
+* **With a real tmux, on 3.7c and at the 3.2 floor:** the capture is real bytes off a real
+  pane with its trailing spaces intact; the kill really ends the chats and, with the last
+  window, the session and then the server; and the two-plane case above. Per the design's own
+  §2.12 **none of this runs in CI** — there is no tmux there — so every tmux claim in this
+  entry is a hand-run on a real machine on both versions.
+
+## What this does not do
+
+* **Make the chat directory durable.** Stage 4, six edits, unchanged here — which is why a
+  reopened chat is a new tab with a new id rather than the same directory woken up.
+* **Reopen automatically.** Bare `charter` opens the frame (0.54.0); it does not consume the
+  manifest. `charter reopen` is a thing you ask for.
+* **Resume anything but Claude Code**, and the warning says so per chat.
+* **Restore a selection, a pane map, or live scrollback.** The first two are destroyed on
+  purpose; the third is offered as a file.
+* **Refuse a close while that chat is working** — `inflight` cannot say which chat is.
+
+## Adopting it
+
+Nothing to configure. `charter reopen` appears in `charter --help`; the three palette rows
+appear on any plane whose frame is on. `chat: previous transcript` is refused with its reason
+until a quit has captured one.

--- a/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
+++ b/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
@@ -246,8 +246,11 @@ name can have — and quitting one leaves the other's harness running.
 * **And a correction to the design's own §2.12, measured on this branch: the real-tmux tests
   DO run in CI.** `.github/workflows/test.yml` installs no tmux, but `ubuntu-latest` ships
   one — so they ran there, and one of them failed on 3.11 and 3.13 while passing on 3.14 in
-  the same run. That is a race (a pane's process has not exec'd when `new-window` returns),
-  found by CI and not by this machine. The honest statement is narrower than "no tmux in CI":
+  the same run. That was a race — two of them, in the same assertion: a pane's process has not
+  exec'd when `new-window` returns, and a pager that HAS exec'd has not necessarily painted.
+  Both were found by CI and by neither hand-run, and the second needed a second CI run,
+  because fixing the first made 3.11 and 3.13 green while 3.14 came back with an empty
+  capture. The honest statement is narrower than "no tmux in CI":
   **CI answers on whatever tmux the runner image happens to ship, which is neither of the two
   versions charter promises**, so it is a third machine's opinion on top of the hand-runs
   rather than a substitute for them.

--- a/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
+++ b/docs/news/unreleased-quitting-charter-records-the-plane-so-reopening-puts-it-back.md
@@ -238,6 +238,13 @@ name can have — and quitting one leaves the other's harness running.
 * **Restore a selection, a pane map, or live scrollback.** The first two are destroyed on
   purpose; the third is offered as a file.
 * **Refuse a close while that chat is working** — `inflight` cannot say which chat is.
+* **Reopen from inside a tmux you already have.** Charter builds a frame there as a window on
+  your own server, and that launcher stays awake for the life of each frame — it reads the
+  harness's exit status itself instead of installing the `pane-died` hooks, which is what
+  makes it correct there and what makes it block exactly as `attach` does. A reopen driving
+  it would stop at the first chat, so `charter reopen` refuses with that sentence and leaves
+  the record in place. Suppressing that wait is its own change, on a path whose exit-code
+  contract depends on it.
 
 ## Adopting it
 

--- a/docs/superpowers/plans/2026-08-28-phase5-workspace-and-chat-tabs.md
+++ b/docs/superpowers/plans/2026-08-28-phase5-workspace-and-chat-tabs.md
@@ -330,9 +330,17 @@ Nothing visible changes. Everything underneath does.
 > pid is dead, and after a restart every launcher pid is dead, so `session.durable` does not
 > survive to be read. A reopen therefore mints a FRESH chat id and seeds it from a
 > plane-scoped manifest (`.charter/frame/reopen.json`, a file, which `reap` does not collect).
-> One consequence worth stating: because the id is fresh, the stale
-> `.charter/sessions/<fid>.workspace` rung #791 removes cannot decide a reopened chat's
-> membership — **except** where the ordinal is recycled onto the same name, which is common.
+>
+> One consequence worth stating, and **#791 is what settles it.** A fresh id is not on its
+> own enough: `new_chat_id` walks upward from 1 and `reap` frees the ordinals a quit's chats
+> held, so a reopen very often gets the same NAME back. While
+> `.charter/sessions/<fid>.workspace` was a rung of `state.own_workspace`, a
+> `charter workspace use gamma` typed in the OLD `alpha.1` would have decided the NEW
+> `alpha.1`'s membership over the manifest and over the launcher's own record. #791 removed
+> that rung, so the manifest is authoritative; pinned by
+> `tests/test_a_reopen_says_what_it_cannot_bring_back.WhatAReopenPutsBack.
+> test_the_manifest_outranks_a_stale_pointer_left_on_a_recycled_ordinal`, which goes red
+> against a `state.py` with the rung put back.
 >
 > **Step 4 stands unchanged and is now load-bearing.** `Harness.launch_argv` is
 > `[self.binary, *extra]` with no override anywhere in the registry, so the pass-through IS

--- a/docs/superpowers/plans/2026-08-28-phase5-workspace-and-chat-tabs.md
+++ b/docs/superpowers/plans/2026-08-28-phase5-workspace-and-chat-tabs.md
@@ -275,19 +275,91 @@ Nothing visible changes. Everything underneath does.
 
 ### Task 9: Cold chats, and the sentence that admits what is lost
 
-- [ ] **Step 1:** write the failing test — closing a chat kills its window and keeps its record;
-      reopening restores the workspace, the persona, the harness and the cwd, **starts a fresh
-      harness session**, and says so **before** the relaunch.
-- [ ] **Step 2:** run it, confirm it fails.
-- [ ] **Step 3:** implement. `state.clear_shape` already unlinks `session` for this reason
-      (#413) — the reopened chat must not inherit the closed one's token gauge.
-- [ ] **Step 4:** **do not add a resume member to `Harness`.** `harness/base.py`'s docstring sets
-      the bar — *"A fifth member needs the same kind of argument, not just a use."* Charter can
-      verify resume for one of three harnesses; a resume that silently starts a new conversation
-      is worse than a sentence saying it will.
-- [ ] **Step 5:** mutation — reopen without clearing `session`, and confirm the stale gauge is
-      caught RED. Second mutation: drop the message and confirm the test asserting **which**
-      sentence appears goes RED.
+> **AMENDED 2026-09-01 — steps 1, 3 and 5 are superseded; step 4 stands.** This task said a
+> reopened chat *"starts a fresh harness session"* and *"must not inherit the closed one's
+> token gauge"*. The operator reversed the first, and the second turned out to be wrong on
+> its own terms. Both reversals are recorded here rather than left to be inferred from a
+> later document, because §4j of the IDE spec was silently violated for five days by exactly
+> that — a later document citing an earlier one without re-reading it, which shipped a bug
+> the operator had to report.
+>
+> **1. Resume, not fresh.** `docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md`
+> §4e settles it and the operator settled it again in their own words: *"when opening again
+> we need to resume harness sessions as well… to not lose sessions, state etc."* #757 keeps
+> the id (`session.durable`) for exactly this, and a reopen appends `--resume <id>` to the
+> harness's own argv. This task's *"starts a fresh harness session"* is no longer true and
+> was never argued for — it was written when nothing recorded an id to resume from.
+>
+> **2. Resume is Claude-only, which is what this task was really right about.** §2.8:
+> `record_harness_session` has exactly one caller, Claude Code's `statusLine` hook. So the
+> honest form of *"a resume that silently starts a new conversation is worse than a sentence
+> saying it will"* is not "do not resume" — it is **resume where charter has an id, and say
+> per chat which of the four reasons it has none**. That sentence is `frame/leave.py`'s four
+> notes, drawn in the quit's confirmation before any keypress commits anything.
+>
+> **3. The gauge gate is DROPPED, and there are three reasons, the third of which is the
+> one that actually settles it.** §4e specified gating the gauge on
+> `state.exit_code(fid) is None`.
+>
+> * **It reads a killed chat as live.** For a chat `kill-window` ended, `exit_code` is
+>   `None` (§2.17 — `kill-pane`, `kill-window` and `kill-session` write nothing, measured),
+>   so the gate answers "show the gauge" for precisely the case it was written to suppress.
+>   That is the inverse of the intent, and it is a fact about charter's own files.
+> * **It would blank a correct gauge.** `claude --resume` preserves the harness's session id
+>   — one `sessionId` carried across the gap a restart made, in the operator's own
+>   transcript — so after a resume the usage history the gauge reads is that same
+>   conversation's own. *(Recorded as the operator's measurement; not re-run here, and see
+>   the next point for why nothing shipped depends on it.)*
+> * **Nothing needs suppressing, because there is nothing to inherit.** A reopen mints a
+>   FRESH chat id (point 4), so the reopened chat's directory has no `session` file at all:
+>   `state.harness_session` answers `None`, `frame/slots.py`'s own rule draws no gauge, and
+>   Claude Code's `statusLine` hook writes the mapping on the chat's first turn from the
+>   live payload. Pinned by
+>   `tests/test_a_reopen_says_what_it_cannot_bring_back.WhatAReopenPutsBack.
+>   test_a_reopened_chat_draws_no_gauge_until_its_own_first_turn`, which is also the
+>   assertion that will go red at the stage that relaunches into a chat's own directory —
+>   which is where the second point above stops being decoration and starts being the
+>   argument.
+>
+> **The ordering hazard §4e names disappears with the gate**: there is no stage that has to
+> ship before another.
+>
+> **4. Reopening does not relaunch into the chat's OWN directory, and cannot yet.** That
+> needs stage 4 of the IDE spec's delivery order — the chat directory becoming durable —
+> which is six edits wide and not done. `reap` still deletes a chat directory whose launcher
+> pid is dead, and after a restart every launcher pid is dead, so `session.durable` does not
+> survive to be read. A reopen therefore mints a FRESH chat id and seeds it from a
+> plane-scoped manifest (`.charter/frame/reopen.json`, a file, which `reap` does not collect).
+> One consequence worth stating: because the id is fresh, the stale
+> `.charter/sessions/<fid>.workspace` rung #791 removes cannot decide a reopened chat's
+> membership — **except** where the ordinal is recycled onto the same name, which is common.
+>
+> **Step 4 stands unchanged and is now load-bearing.** `Harness.launch_argv` is
+> `[self.binary, *extra]` with no override anywhere in the registry, so the pass-through IS
+> the seam; `frame/leave.resumable_harness` asks the registry which harness records an id,
+> and no member was added.
+
+- [x] **Step 1:** ~~closing a chat kills its window and keeps its record; reopening restores
+      the workspace, the persona, the harness and the cwd, **starts a fresh harness session**,
+      and says so **before** the relaunch.~~ Amended: `chat: close` kills the window and marks
+      the chat closed so nothing brings it back; a **quit** is what keeps the record; a reopen
+      restores the workspace, the persona, the harness and the cwd, and **resumes** the
+      conversation where charter has an id. `tests/test_a_reopen_says_what_it_cannot_bring_back.py`.
+- [x] **Step 2:** the tests were written first and failed first; the two guards that could be
+      mutated away were each verified RED without them (see step 5).
+- [x] **Step 3:** implemented. **`state.clear_shape` is untouched** — it still unlinks
+      `session` for #413's reason, which is an argument about a *reading*; the ID survives in
+      `session.durable` (#757) and, across a reap, in the manifest. No gauge gate: see the
+      amendment above for the two measurements that killed it.
+- [x] **Step 4:** **no resume member was added to `Harness`.** The flag rides the existing
+      `extra` pass-through, and which harness may be handed it is asked of the registry
+      (`frame/leave.resumable_harness`).
+- [x] **Step 5:** mutations run and RED: dropping `state.record_cwd` from the private-server
+      launch path (`BothLaunchPathsRecordIt`), and pruning `inflight` before the kill instead
+      of after (`TheTrackerIsPrunedAfterTheKill`). One property was found to be
+      **over-determined** and is recorded as such rather than claimed as guarded: three
+      independent rules in `reap` keep a non-directory entry in the frame root, so no single
+      mutation can take the manifest's durability away.
 - [ ] **Step 6:** commit.
 
 ### Task 10: Measure at 5 and 10 chats — §4j's instruction, discharged

--- a/docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md
+++ b/docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md
@@ -302,6 +302,28 @@ until the operator closes the chat.** Closing is the only reaper — `chat: clos
 
 ### 4e. Resume, and the file that must stop being deleted
 
+> **AMENDED 2026-09-01, by the change that shipped §4e's restore and §4f's capture.** Three
+> things below are now wrong and one is unreachable; each is corrected where it appears, and
+> the reasoning is in `docs/superpowers/plans/2026-08-28-phase5-workspace-and-chat-tabs.md`'s
+> Task 9 amendment.
+>
+> * **The gauge gate is DROPPED.** *"Gate the gauge on `state.exit_code(fid) is None`"* reads
+>   a `kill-window`ed chat as live (§2.17 — that call writes no `exit`), which is the inverse
+>   of the case it was written for; and nothing needs suppressing, because a reopened chat
+>   gets a FRESH chat id and its directory therefore holds no `session` mapping to inherit.
+>   **The ordering hazard this section names disappears with the gate.**
+> * **`cwd` was added**, not dropped: `state.record_cwd` / `state.chat_cwd`, written by both
+>   launch paths from the `os.getcwd()` each already read. It is deliberately not in
+>   `identity`, whose every value reaches a world-readable tmux argv.
+> * **`session.durable` is not enough on its own, and §6 stage 2 could not have known.**
+>   `reap` deletes a chat's whole directory when its launcher pid is dead, and after a
+>   restart every launcher pid is dead — so #757's id is deleted by the next launch. What
+>   makes it durable is a plane-scoped **file** in the frame root (`reopen.json`), which
+>   `reap` does not collect because it is not a directory. That is what let stage 7 ship
+>   ahead of stage 4 rather than behind it.
+> * **What a reopen restores into is a new directory, not the chat's own.** Relaunching into
+>   the existing directory needs stage 4, which is not done.
+
 Charter already records the harness's own session id (`.charter/frame/<fid>/session`). It is
 exactly what a resume needs, and `clear_shape` deliberately deletes it (§2.5).
 
@@ -367,7 +389,9 @@ transcript on quit is a hole in the premise — and eight rounds of grilling did
 Quit is the one moment charter knows a pane is about to be destroyed, and
 `tmux capture-pane -p -S -` hands back the whole history.
 
-**On quit, each chat's scrollback is written to its own directory. On reopen it is offered,
+**On quit, each chat's scrollback is written to its own directory** *(amended: to its own
+**file** in the frame root, `<chat>.transcript` — the chat's directory is reaped, and a file
+there is not; the reopen renames it onto the new chat's id)*. **On reopen it is offered,
 never replayed.** `F2 → chat: previous transcript` opens the captured text; the live pane
 starts clean. Replaying bytes into a pane would present a session that is not running as
 though it were, which is the convincing-empty this project refuses everywhere else — and it
@@ -565,6 +589,21 @@ makes it expensive is everything that leaves with it:
    `pane-died[1]` and charter's exit-code contract (§2.14).
 7. **Quit, the warning, the scrollback capture, and pruning `inflight` (§4i, §4f, §4e).** Quit
    is what makes the capture necessary and the prune possible.
+
+   > **SHIPPED 2026-09-01, and it moved AHEAD of stages 4, 5 and 6 rather than behind them.**
+   > The ordering above assumed a reopen needs a durable chat directory (stage 4) and a gauge
+   > gate (stage 2's successor). Neither turned out to be true: a plane-scoped **file** in the
+   > frame root survives `reap` untouched, so the record does not need the directory to be
+   > durable, and a reopen into a FRESH chat id has no gauge mapping to inherit, so there is
+   > no gate to ship first. `chat: close` — listed as one of stage 4's six edits — shipped
+   > here alone, because it is what pays for "a missing exit record means it was open".
+   > **`reap` was NOT inverted; stage 4 is untouched and still six edits wide.**
+   >
+   > Two further corrections this stage produced: the `inflight` prune is plane-scoped
+   > because the quit is (a per-frame quit could not prune at all — those records name no
+   > chat), and §4f's *"each chat's scrollback is written to its own directory"* had to become
+   > *"to its own file in the frame root"*, for the same reason the manifest is a file: the
+   > directory is reaped.
 8. **Bare `charter` and `[harness] default` (§4a)**, including the non-tty hazard.
 9. **Place the `workspaces` bar with activity and stale marks (§4b, §4g, §4h), and
    `charter status` (§4m).** One change, not three.

--- a/docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md
+++ b/docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md
@@ -108,19 +108,20 @@ ships.** One residual worth stating: `-s` detaches *every* client of the session
 deliberately-multi-client design is a choice rather than an accident.
 
 **2.12 CI never runs a real tmux.** `.github/workflows/test.yml` installs none, so the 95
-real-tmux tests skip there.
-
-> **AMENDED 2026-09-01 — this is wrong, and it was measured on the branch that shipped §4f.**
-> `test.yml` installs no tmux; `ubuntu-latest` ships one anyway, so `shutil.which("tmux")` is
-> true there and the real-tmux tests RUN. Found because a new one of them failed on 3.11 and
-> 3.13 while passing on 3.14 in the same run — a race no hand-run on this machine had
-> produced. The honest statement is narrower and more useful than the original: **CI answers
-> on whatever tmux the runner image happens to ship, which is neither of the two versions
-> charter promises**, so it is a third machine's opinion on top of the hand-runs rather than a
-> substitute for them. What still holds is the rule this section exists for: a green gate is
-> not evidence for a claim about 3.7c or about the 3.2 floor. **Every tmux claim in this spec has to be hand-verified on this
+real-tmux tests skip there. **Every tmux claim in this spec has to be hand-verified on this
 machine, on both versions**, and a green gate says nothing about any of them. The 3.2 floor
 binary is preserved at `~/.local/share/charter-testing/tmux-3.2`.
+
+> **AMENDED 2026-09-01 — the first sentence is wrong, and it was measured on the branch that
+> shipped §4f.** `test.yml` installs no tmux; `ubuntu-latest` ships one anyway, so
+> `shutil.which("tmux")` is true there and the real-tmux tests RUN. Found because a new one of
+> them failed on 3.11 and 3.13 while passing on 3.14 in the same run — a race no hand-run on
+> this machine had produced. The honest statement is narrower and more useful than the
+> original: **CI answers on whatever tmux the runner image happens to ship, which is neither
+> of the two versions charter promises.** So it is a third machine's opinion on top of the
+> hand-runs rather than a substitute for them — valuable precisely because it is a different
+> machine — and the rest of this section stands unchanged: a green gate is still not evidence
+> for a claim about 3.7c or about the 3.2 floor.
 
 **2.13 One tmux server serves every plane on the machine, and session names carry no plane.**
 `SOCKET = "charter"` (`commands_frame.py:167`), documented as *"one shared tmux server for every

--- a/docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md
+++ b/docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md
@@ -108,7 +108,17 @@ ships.** One residual worth stating: `-s` detaches *every* client of the session
 deliberately-multi-client design is a choice rather than an accident.
 
 **2.12 CI never runs a real tmux.** `.github/workflows/test.yml` installs none, so the 95
-real-tmux tests skip there. **Every tmux claim in this spec has to be hand-verified on this
+real-tmux tests skip there.
+
+> **AMENDED 2026-09-01 — this is wrong, and it was measured on the branch that shipped §4f.**
+> `test.yml` installs no tmux; `ubuntu-latest` ships one anyway, so `shutil.which("tmux")` is
+> true there and the real-tmux tests RUN. Found because a new one of them failed on 3.11 and
+> 3.13 while passing on 3.14 in the same run — a race no hand-run on this machine had
+> produced. The honest statement is narrower and more useful than the original: **CI answers
+> on whatever tmux the runner image happens to ship, which is neither of the two versions
+> charter promises**, so it is a third machine's opinion on top of the hand-runs rather than a
+> substitute for them. What still holds is the rule this section exists for: a green gate is
+> not evidence for a claim about 3.7c or about the 3.2 floor. **Every tmux claim in this spec has to be hand-verified on this
 machine, on both versions**, and a green gate says nothing about any of them. The 3.2 floor
 binary is preserved at `~/.local/share/charter-testing/tmux-3.2`.
 

--- a/tests/test_a_chat_records_where_it_was_started.py
+++ b/tests/test_a_chat_records_where_it_was_started.py
@@ -25,7 +25,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, config
-from charter.frame import state
+from charter.frame import reopen, state
 
 from tests._isolation import PersonaIso
 
@@ -154,6 +154,191 @@ class BothLaunchPathsRecordIt(PersonaIso, unittest.TestCase):
         recorded = [state.chat_cwd(d.name) for d in state._root().iterdir()
                     if d.is_dir()]
         self.assertEqual(recorded, [os.getcwd()])
+
+
+class _Answered:
+    """One `tmuxctl.run` answer. `stdout` is a pane id, because that is what the launcher
+    reads back from the call that starts the session."""
+
+    def __init__(self, stdout="%0", returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+class TheLauncherSTailIsWhereAReopenDiffers(PersonaIso, unittest.TestCase):
+    """`cmd_launch` driven all the way to its return, on both paths.
+
+    **Written because the deletion sweep asked for it.** Three branches in that tail are the
+    whole of what `Reopening` changes, and every one of them was unpinned: open-or-focus,
+    the `attach`, and the sentence `cmd_launch` says on the operator's behalf when their
+    plane was quit. `TheReopenPathSuppressesFourThingsInTheLauncher` asserts the PREDICATE
+    those branch on and says in its own docstring that the tail "cannot be reached without a
+    real tmux session and a real `attach`". The sweep disagreed, and it was right: the tail
+    is reachable with every tmux call answered and `attach` stubbed, which is what this does.
+
+    Nothing here starts a server. `tmuxctl.run` answers `%0` to everything and
+    `tmuxctl.interact` is the attach — so what is under test is charter's own branching,
+    which is exactly what the mutations were about.
+    """
+
+    def _launch(self, *, reopening=None, live_workspace=False, rest=()):
+        """Run `cmd_launch` to its return. Answers what it asked, and records the calls."""
+        calls = {"attached": False, "focused": False, "said": []}
+
+        def _interact(argv, **kw):
+            calls["attached"] = True
+            return _Answered(stdout="", returncode=0)
+
+        def _focus(socket, *, ws):
+            calls["focused"] = True
+            return None            # never actually focus; the call is the observation
+
+        args = SimpleNamespace(harness="claude", rest=list(rest), no_frame=False,
+                               workspace="alpha", pick=False)
+        if reopening is not None:
+            args.reopening = reopening
+        sessions = {"alpha"} if live_workspace else set()
+
+        def _live_chats(_socket):
+            """What a real server says: the chats that exist, asked when it is asked.
+
+            A fixed empty set here is not a cheaper fake, it is a different plane — the
+            launcher reaps on this answer twice, and the closing reap would collect the very
+            chat it had just built (`state.clear_claim` has already run by then, so nothing
+            else is holding it). That is correct behaviour against a server with nothing on
+            it, and it is not the server this test means.
+            """
+            try:
+                return {d.name for d in state._root().iterdir() if d.is_dir()}
+            except OSError:
+                return set()
+
+        with mock.patch.object(commands_frame.tmuxctl, "version", return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=None), \
+                mock.patch.object(commands_frame.shutil, "which",
+                                  return_value="/bin/true"), \
+                mock.patch.object(commands_frame.sys.stdout, "isatty",
+                                  return_value=True), \
+                mock.patch("sys.stdin.isatty", return_value=False), \
+                mock.patch.object(commands_frame, "_live_sessions",
+                                  return_value=sessions), \
+                mock.patch.object(commands_frame, "_live_chats",
+                                  side_effect=_live_chats), \
+                mock.patch.object(commands_frame, "_spawn_gather"), \
+                mock.patch.object(commands_frame, "_workspace_to_focus",
+                                  side_effect=_focus), \
+                mock.patch.object(commands_frame, "_draw_panels", return_value={}), \
+                mock.patch.object(commands_frame, "_arm_panel_respawn"), \
+                mock.patch.object(commands_frame, "_query_pane_dead_status",
+                                  return_value=None), \
+                mock.patch.object(commands_frame, "_chat_being_left", return_value=""), \
+                mock.patch.object(commands_frame, "_drop_panels"), \
+                mock.patch.object(commands_frame.tmuxctl, "run",
+                                  return_value=_Answered()), \
+                mock.patch.object(commands_frame.tmuxctl, "interact",
+                                  side_effect=_interact):
+            calls["rc"] = commands_frame.cmd_launch(args)
+        return calls
+
+    def _reopening(self, chat="alpha.9", workspace="alpha"):
+        rec = reopen.Chat(chat=chat, workspace=workspace, persona="", harness="claude-code",
+                          cwd="", resume="", transcript="", active=False)
+        return commands_frame.Reopening(rec)
+
+    def test_an_ordinary_launch_attaches_and_asks_about_open_or_focus(self):
+        calls = self._launch()
+
+        self.assertTrue(calls["attached"], "a launch IS the operator's terminal")
+        self.assertTrue(calls["focused"], "§4k is asked on every launch with no argv")
+
+    def test_a_reopen_never_attaches(self):
+        # The sweep's `if _wants_attach(args):` mutation. Without it a reopen blocks on its
+        # first chat and never builds the second.
+        calls = self._launch(reopening=self._reopening())
+
+        self.assertFalse(calls["attached"])
+        self.assertEqual(calls["rc"], 0)
+
+    def test_a_reopen_never_takes_the_open_or_focus_branch(self):
+        # The sweep's `not rest and _reopening(args) is None` mutation. With a live
+        # workspace and no argv, an ordinary launch focuses; a reopen must still open a
+        # chat, or every chat after the first of a workspace is swallowed.
+        ordinary = self._launch(live_workspace=True)
+        self.assertTrue(ordinary["focused"])
+
+        reopened = self._launch(reopening=self._reopening(), live_workspace=True)
+
+        self.assertFalse(reopened["focused"])
+
+    def test_a_reopen_hands_the_new_chat_id_back_to_its_driver(self):
+        r = self._reopening()
+
+        self._launch(reopening=r)
+
+        self.assertTrue(r.fid, "the driver needs the id to attach and to report")
+        self.assertEqual(state.chat_cwd(r.fid), os.getcwd())
+
+    def test_an_ordinary_detach_says_how_to_get_back_in(self):
+        import io
+        from contextlib import redirect_stderr
+        buf = io.StringIO()
+
+        with redirect_stderr(buf):
+            self._launch()
+
+        said = buf.getvalue()
+        self.assertIn("detached", said)
+        self.assertIn("attach -t alpha", said,
+                      "the reattach line names the WORKSPACE, because that is the session")
+
+    def test_a_reopens_own_launch_says_nothing_about_detaching(self):
+        # It was never the operator's terminal, so "detached — the harness is still running"
+        # would be describing something that did not happen — once per chat, in front of
+        # `cmd_reopen`'s own summary. The sweep found this branch unpinned because both
+        # halves of it return 0 and only the sentence differs.
+        import io
+        from contextlib import redirect_stderr
+        buf = io.StringIO()
+
+        with redirect_stderr(buf):
+            self._launch(reopening=self._reopening())
+
+        self.assertNotIn("detached", buf.getvalue())
+
+    def test_a_launch_whose_plane_was_quit_names_the_command_that_undoes_it(self):
+        # `if _wants_attach(args): _say_it_was_quit(fid)`. The chat this launch is about has
+        # to BE in the manifest, which for an ordinary launch means the ordinal it is handed
+        # is one a quit recorded — the recycled-ordinal case, which is the common one.
+        import io
+        from contextlib import redirect_stderr
+        reopen.write([reopen.Frame(workspace="alpha", chats=(
+            reopen.Chat(chat="alpha.1", workspace="alpha", persona="",
+                        harness="claude-code", cwd="", resume="conv-1", transcript="",
+                        active=True),))], focus="alpha")
+        buf = io.StringIO()
+
+        with redirect_stderr(buf):
+            self._launch()
+
+        self.assertIn("charter reopen", buf.getvalue())
+
+    def test_a_reopens_own_launch_stays_silent_about_the_quit_it_is_undoing(self):
+        # The other half, and the reason that call is gated: a reopen usually gets the same
+        # ordinals back, so every one of its launches is named in the manifest it is acting
+        # on and would announce the quit it is in the middle of reversing.
+        import io
+        from contextlib import redirect_stderr
+        reopen.write([reopen.Frame(workspace="alpha", chats=(
+            reopen.Chat(chat="alpha.1", workspace="alpha", persona="",
+                        harness="claude-code", cwd="", resume="conv-1", transcript="",
+                        active=True),))], focus="alpha")
+        buf = io.StringIO()
+
+        with redirect_stderr(buf):
+            self._launch(reopening=self._reopening())
+
+        self.assertNotIn("charter reopen", buf.getvalue())
 
 
 if __name__ == "__main__":       # pragma: no cover

--- a/tests/test_a_chat_records_where_it_was_started.py
+++ b/tests/test_a_chat_records_where_it_was_started.py
@@ -1,0 +1,160 @@
+"""§4e: `cwd` is the fourth restore item and it had nowhere to live — now it has a file.
+
+`os.getcwd()` was read on both launch paths, handed to tmux, and dropped. It could not join
+`state.record_identity`, and that is a security property rather than a preference: every
+value in that record goes onto a tmux ``-e NAME=VALUE`` argv, which
+`commands_frame._frame_identity_env` measures as world-readable in `/proc/<pid>/cmdline` —
+138 argv elements and 7,696 bytes on a real environment, two live service-account tokens
+among them. That list is a PROMISE about what reaches an argv, and a sixth name added for a
+convenience is how a promise like that stops being checkable.
+
+**Two files here, and the second is the one that keeps `chat: close` meaningful.**
+`state.record_closed` is asserted in `tests/test_close_is_the_one_teardown_that_forgets.py`;
+what this module adds is that neither file is in `clear_shape`'s list. That list argues about
+four *readings* — a density somebody pressed, a highlight somebody clicked, a pane map, a
+gauge — and every one of them is wrong for the next frame. A cwd is where the conversation
+was, which is the same kind of fact as `workspace`, and #757 already had to state the same
+distinction for `session.durable`.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config
+from charter.frame import state
+
+from tests._isolation import PersonaIso
+
+
+class TheDirectoryIsRecordedAndReadBack(PersonaIso, unittest.TestCase):
+
+    def test_it_round_trips(self):
+        state.frame_dir("alpha.1", create=True)
+
+        state.record_cwd("alpha.1", "/some/where")
+
+        self.assertEqual(state.chat_cwd("alpha.1"), "/some/where")
+
+    def test_a_chat_that_never_recorded_one_answers_none(self):
+        state.frame_dir("alpha.1", create=True)
+
+        self.assertIsNone(state.chat_cwd("alpha.1"))
+
+    def test_a_relative_path_is_refused_rather_than_resolved_later(self):
+        # It would otherwise be resolved against whatever directory `charter reopen`
+        # happened to be typed in, which is the "silently somewhere else" a restore must
+        # never do — and it is indistinguishable on disk from a truncated write.
+        state.frame_dir("alpha.1", create=True)
+
+        state.record_cwd("alpha.1", "some/where")
+
+        self.assertIsNone(state.chat_cwd("alpha.1"))
+
+    def test_a_directory_that_no_longer_exists_is_still_returned(self):
+        # Existence is a question about the machine at reopen time, not about the record,
+        # and the caller is the one with an operator to tell.
+        state.frame_dir("alpha.1", create=True)
+
+        state.record_cwd("alpha.1", "/definitely/not/here")
+
+        self.assertEqual(state.chat_cwd("alpha.1"), "/definitely/not/here")
+
+    def test_a_frame_id_that_cannot_name_a_directory_answers_none(self):
+        self.assertIsNone(state.chat_cwd("../escape"))
+        # And writing is refused the same way, rather than landing somewhere else.
+        state.record_cwd("../escape", "/tmp")
+        self.assertIsNone(state.chat_cwd("../escape"))
+
+
+class NeitherFileIsPartOfAFramesShape(PersonaIso, unittest.TestCase):
+    """`clear_shape` argues about readings; these two are durable per-chat facts."""
+
+    def test_clear_shape_keeps_the_directory_and_the_closed_mark(self):
+        state.frame_dir("alpha.1", create=True)
+        state.record_cwd("alpha.1", "/some/where")
+        state.record_closed("alpha.1")
+        state.record_density("alpha.1", "minimal")
+
+        state.clear_shape("alpha.1")
+
+        self.assertIsNone(state.density("alpha.1"), "the shape did go")
+        self.assertEqual(state.chat_cwd("alpha.1"), "/some/where")
+        self.assertTrue(state.was_closed("alpha.1"))
+
+
+class BothLaunchPathsRecordIt(PersonaIso, unittest.TestCase):
+    """Recorded where `os.getcwd()` was already read, on both paths, or it is half a fact.
+
+    Driven through `cmd_launch` far enough to reach the record and no further: the launcher
+    is stopped at its first tmux call, which is after every one of its own writes. That is
+    the same shape `tests/test_frame_launcher.py` uses to assert what a launch records
+    without starting a server.
+    """
+
+    def _run_launch(self, harness_absent=False):
+        calls = {}
+
+        class _Out:
+            returncode = 1
+            stdout = ""
+
+        def _run(why, argv, **kw):
+            calls.setdefault("first", why)
+            return _Out()
+
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False,
+                               workspace="alpha", pick=False)
+        with mock.patch.object(commands_frame.tmuxctl, "version", return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=None), \
+                mock.patch.object(commands_frame.shutil, "which", return_value="/bin/true"), \
+                mock.patch.object(commands_frame.sys.stdout, "isatty",
+                                  return_value=True), \
+                mock.patch("sys.stdin.isatty", return_value=False), \
+                mock.patch.object(commands_frame, "_live_sessions", return_value=set()), \
+                mock.patch.object(commands_frame, "_live_chats", return_value=set()), \
+                mock.patch.object(commands_frame, "_spawn_gather"), \
+                mock.patch.object(commands_frame.tmuxctl, "run", side_effect=_run):
+            commands_frame.cmd_launch(args)
+        return calls
+
+    def test_the_private_server_path_records_the_directory_it_launched_in(self):
+        self._run_launch()
+
+        recorded = [state.chat_cwd(d.name) for d in state._root().iterdir()
+                    if d.is_dir()]
+        self.assertEqual(recorded, [os.getcwd()])
+
+    def test_the_operators_tmux_path_records_it_too(self):
+        class _Out:
+            returncode = 1
+            stdout = ""
+
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False,
+                               workspace="alpha", pick=False)
+        with mock.patch.object(commands_frame.tmuxctl, "version", return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=("/tmp/sock", "s0")), \
+                mock.patch.object(commands_frame.shutil, "which",
+                                  return_value="/bin/true"), \
+                mock.patch.object(commands_frame.sys.stdout, "isatty",
+                                  return_value=True), \
+                mock.patch("sys.stdin.isatty", return_value=False), \
+                mock.patch.object(commands_frame, "_live_windows", return_value=set()), \
+                mock.patch.object(commands_frame, "_live_chats", return_value=set()), \
+                mock.patch.object(commands_frame, "_spawn_gather"), \
+                mock.patch.object(commands_frame.tmuxctl, "run",
+                                  return_value=_Out()):
+            commands_frame.cmd_launch(args)
+
+        recorded = [state.chat_cwd(d.name) for d in state._root().iterdir()
+                    if d.is_dir()]
+        self.assertEqual(recorded, [os.getcwd()])
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -364,6 +364,48 @@ class TheTrackerIsPrunedAfterTheKill(PersonaIso, unittest.TestCase):
                          "the record was still there while the kill was attempted")
 
 
+class TheQuitsOwnSentenceIsSaidByTheLauncher(PersonaIso, unittest.TestCase):
+    """The gap found by asking where the quit's own message goes: nowhere.
+
+    `charter: quit` is spawned with its three streams on `/dev/null` — `_spawn`'s measured
+    requirement, since the palette's pane is killed the instant a row is invoked — and by the
+    time it has finished there is no frame left to draw a notice on. `cmd_launch` is the
+    process that hands the operator their shell back, so it is the one that can name
+    `charter reopen`.
+    """
+
+    def _said(self, fid):
+        import io
+        from contextlib import redirect_stderr
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            commands_frame._say_it_was_quit(fid)
+        return buf.getvalue()
+
+    def test_a_launcher_whose_chat_was_quit_names_the_command_that_undoes_it(self):
+        reopen.write([reopen.Frame(workspace="alpha", chats=(
+            reopen.Chat(chat="alpha.1", workspace="alpha", persona="",
+                        harness="claude-code", cwd="", resume="conv-1", transcript="",
+                        active=True),))], focus="alpha")
+
+        said = self._said("alpha.1")
+
+        self.assertIn("charter reopen", said)
+        self.assertIn("1 with a conversation to resume", said)
+
+    def test_a_launcher_whose_chat_merely_ended_says_nothing(self):
+        # The gate that makes the sentence true rather than likely: a detach and an ordinary
+        # harness exit reach the same lines of `cmd_launch`.
+        reopen.write([reopen.Frame(workspace="alpha", chats=(
+            reopen.Chat(chat="alpha.2", workspace="alpha", persona="", harness="c",
+                        cwd="", resume="", transcript="", active=True),))], focus="alpha")
+
+        self.assertEqual(self._said("alpha.1"), "")
+
+    def test_no_manifest_at_all_says_nothing(self):
+        self.assertEqual(self._said("alpha.1"), "")
+
+
 class TheManifestRefusesWhatItCannotRead(PersonaIso, unittest.TestCase):
     """Every value in it came off disk and is going onto an argv, a `chdir` or a flag."""
 

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -410,6 +410,70 @@ class TheQuitsOwnSentenceIsSaidByTheLauncher(PersonaIso, unittest.TestCase):
         self.assertEqual(self._said("alpha.1"), "")
 
 
+class EachServerIsAskedOnceAndTheFocusIsWhereYouWere(PersonaIso, unittest.TestCase):
+    """`_plane_servers`' dedupe and `cmd_quit`'s focus, both found unpinned by the sweep."""
+
+    def test_a_server_several_chats_share_is_listed_once(self):
+        # Not tidiness: the list is what `_plane_live` iterates, and a duplicate is a second
+        # `list-windows` against the same server whose answer overwrites the first — one
+        # round trip bought for nothing, on the path a quit is waiting on.
+        for fid in ("alpha.1", "alpha.2", "alpha.3"):
+            _plant(fid, ws="alpha")
+
+        servers = commands_frame._plane_servers()
+
+        self.assertEqual(servers, [SERVER])
+        self.assertEqual(len(servers), len(set(servers)))
+
+    def test_charters_own_socket_is_listed_even_when_no_chat_records_it(self):
+        # It is where a chat with no recorded server will be — `builtin_actions._server`'s
+        # own fallback, spelled the same way.
+        state.frame_dir("alpha.9", create=True)
+        state.record_server("alpha.9", "somebody-elses-socket")
+        state.record_workspace("alpha.9", "alpha")
+
+        servers = commands_frame._plane_servers()
+
+        self.assertEqual(servers[0], SERVER)
+        self.assertIn("somebody-elses-socket", servers)
+
+    def test_a_quit_typed_outside_a_frame_records_no_focus(self):
+        # `(state.own_workspace(fid) or "") if fid else ""` — the `else`. Without it the
+        # focus comes from `own_workspace("")`, which is a question about no chat at all.
+        _plant("alpha.1", ws="alpha")
+
+        with mock.patch.multiple(commands_frame, _chat_seats=mock.DEFAULT,
+                                 _capture_transcript=mock.DEFAULT,
+                                 _stop_chats=mock.DEFAULT) as m:
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0"}, set())
+            m["_capture_transcript"].return_value = False
+            m["_stop_chats"].return_value = 1
+            self.assertEqual(commands_frame.cmd_quit(SimpleNamespace(chat="")), 0)
+
+        self.assertEqual(reopen.read().focus, "",
+                         "nowhere to put you back is an honest answer; a guess is not")
+        # And it is written as a STRING, not as `null`. `reopen.read` would normalise a
+        # `null` back to `""` and no charter would notice — but `Manifest.focus` is declared
+        # `str`, the file is a documented format, and a JSON `null` where a string belongs is
+        # a shape every future reader and every human looking at the file has to handle.
+        # That is the whole of what the `or ""` in `cmd_quit` buys, and it is why it stayed.
+        self.assertEqual(json.loads(reopen.path().read_text())["focus"], "")
+
+    def test_a_quit_pressed_in_a_chat_records_that_chats_workspace(self):
+        _plant("alpha.1", ws="alpha")
+        _plant("beta.1", ws="beta")
+
+        with mock.patch.multiple(commands_frame, _chat_seats=mock.DEFAULT,
+                                 _capture_transcript=mock.DEFAULT,
+                                 _stop_chats=mock.DEFAULT) as m:
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0", "beta.1": "@1"}, set())
+            m["_capture_transcript"].return_value = False
+            m["_stop_chats"].return_value = 2
+            commands_frame.cmd_quit(SimpleNamespace(chat="beta.1"))
+
+        self.assertEqual(reopen.read().focus, "beta")
+
+
 class TheWarningIsSaidOnStderrAndOnTheScreenTheOperatorHas(PersonaIso, unittest.TestCase):
     """`_warn_about`'s two surfaces, and the `if on:` the sweep found unpinned.
 

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -578,9 +578,9 @@ class TheParserAnswersForEveryShapeAJsonFileCanHold(PersonaIso, unittest.TestCas
     CONTAINER, so no type guard was ever handed the wrong container.** A bad version, a
     chat id with a semicolon in it, a workspace that is `../etc` — all of them arrive as
     the dict-of-lists-of-dicts charter itself writes. Nothing fed a top level that is a
-    list, a frame that is not a dict, a `chats` that is not a list, a chat entry that is
-    not a dict, an `at` that is a string or a `focus` that is a number, and the deletion
-    sweep reddened one guard for each of those.
+    list, a `frames` that is absent, a frame that is not a dict, a `chats` that is not a
+    list, a chat entry that is not a dict, an `at` that is a string or a `focus` that is a
+    number, and the deletion sweep reddened one guard for each of those.
 
     **This is the #442/#475 position, and on this branch it is the only cluster whose blast
     radius leaves the frame.** `cwd` reaches `os.chdir` and `workspace` reaches a tmux `-t`
@@ -610,6 +610,20 @@ class TheParserAnswersForEveryShapeAJsonFileCanHold(PersonaIso, unittest.TestCas
 
     def test_a_top_level_that_is_a_list_is_nothing_to_reopen(self):
         self._on_disk([self._wrapping([{"workspace": "alpha", "chats": [self.GOOD]}])])
+
+        self.assertIsNone(reopen.read())
+
+    def test_a_manifest_with_no_frames_key_at_all_is_nothing_to_reopen(self):
+        # The `frames` gate and the per-frame gate below it mask each other for every
+        # shape that is ITERABLE — a string or a dict walks into the frame loop and is
+        # refused there instead, with the same answer. What tells them apart is a `frames`
+        # that cannot be iterated at all, which is what an absent key is: `None`.
+        self._on_disk({"version": reopen.VERSION, "at": 1, "focus": "alpha"})
+
+        self.assertIsNone(reopen.read())
+
+    def test_a_frames_field_that_is_not_even_a_sequence_is_nothing_to_reopen(self):
+        self._on_disk(self._wrapping(7))
 
         self.assertIsNone(reopen.read())
 

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -410,6 +410,53 @@ class TheQuitsOwnSentenceIsSaidByTheLauncher(PersonaIso, unittest.TestCase):
         self.assertEqual(self._said("alpha.1"), "")
 
 
+class TheWarningIsSaidOnStderrAndOnTheScreenTheOperatorHas(PersonaIso, unittest.TestCase):
+    """`_warn_about`'s two surfaces, and the `if on:` the sweep found unpinned.
+
+    §4i is explicit that quit *warns and proceeds*, so the record of what was lost has to
+    survive the keypress — and once the frame's panes are about to stop existing, stderr is
+    the only surface left. The attention row is the OTHER caller's, and it is written only
+    when there is a frame to write it to: `charter frame-quit` typed in an ordinary shell has
+    no chat, and `state.say("")` would be a notice under a frame id that names nothing.
+    """
+
+    def setUp(self):
+        super().setUp()
+        _plant("alpha.1", ws="alpha", sid="conv-1")
+        self.plan = leave.plan(live={"alpha.1"}, focus="alpha")
+
+    def _warn(self, on):
+        import io
+        from contextlib import redirect_stderr
+        buf = io.StringIO()
+        with redirect_stderr(buf), \
+                mock.patch.object(commands_frame, "_say_on_screen") as said:
+            commands_frame._warn_about(self.plan, on=on, verb=leave.QUIT)
+        return buf.getvalue(), said
+
+    def test_every_chat_gets_its_own_line_on_stderr(self):
+        out, _said = self._warn("alpha.1")
+
+        self.assertIn(leave.summary(self.plan), out)
+        self.assertIn("alpha.1", out)
+        self.assertIn(leave.RESUMES, out)
+
+    def test_the_summary_also_lands_on_the_frame_that_asked(self):
+        _out, said = self._warn("alpha.1")
+
+        said.assert_called_once()
+        self.assertEqual(said.call_args[0][0], "alpha.1")
+        self.assertEqual(said.call_args[0][1], leave.summary(self.plan))
+
+    def test_a_quit_typed_outside_a_frame_writes_no_notice_anywhere(self):
+        # The `if on:` guard. There is no frame to draw on, and a notice written under an
+        # empty id is one nothing can ever show.
+        out, said = self._warn("")
+
+        said.assert_not_called()
+        self.assertIn("alpha.1", out, "and stderr still carries the whole warning")
+
+
 class TheManifestRefusesWhatItCannotRead(PersonaIso, unittest.TestCase):
     """Every value in it came off disk and is going onto an argv, a `chdir` or a flag."""
 
@@ -505,6 +552,251 @@ class TranscriptsAreBounded(PersonaIso, unittest.TestCase):
         text = dest.read_text()
         self.assertTrue(text.endswith("TAIL"))
         self.assertLessEqual(len(text.encode()), commands_frame._TRANSCRIPT_BYTES)
+
+
+class _Answered:
+    """One `tmuxctl.run` answer, so a parser can be driven without a server.
+
+    The three fields `tmuxctl.run` callers actually read. A class rather than a
+    `SimpleNamespace` so a field nobody set is an `AttributeError` here rather than a
+    silently-`None` somewhere downstream.
+    """
+
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def _answers(stdout="", returncode=0):
+    """A `tmuxctl.run` stand-in that always gives the same answer, and records the argv."""
+    seen = []
+
+    def _run(why, argv, **kw):
+        seen.append(argv)
+        return _Answered(stdout, returncode)
+
+    return _run, seen
+
+
+class TheWindowListingRefusesWhatItCannotRead(PersonaIso, unittest.TestCase):
+    """`_chat_seats`, driven against fabricated tmux output rather than a server.
+
+    **Every assertion here exists because the deletion sweep asked for it.** The real-tmux
+    module drives this function against a real `list-windows`, which only ever produces
+    well-formed rows — so the three refusals below were unpinned, and the sweep said so:
+    dropping the field-count guard, and dropping either half of the regex pair, all left the
+    whole 9,895-test suite green.
+
+    They are #475's boundary: these values come off a tmux option and go on to be a `-t`
+    target and a state directory's name. `%1;kill-server` in that position is the shape that
+    already cost this project a `kill-server` armed on every window resize.
+    """
+
+    def _seats_from(self, stdout):
+        run, _seen = _answers(stdout)
+        with mock.patch.object(commands_frame.tmuxctl, "run", side_effect=run):
+            return commands_frame._chat_seats(SERVER)
+
+    def test_a_well_formed_listing_is_read_whole(self):
+        seats = self._seats_from("alpha.1\t@0\t1\nalpha.2\t@3\t0\n")
+
+        self.assertEqual(seats, [("alpha.1", "@0", True), ("alpha.2", "@3", False)])
+
+    def test_a_row_with_the_wrong_number_of_fields_is_dropped(self):
+        # A window with no `@charter_chat` prints an empty first field, and a format that
+        # ever changed shape would arrive here as a row of the wrong width. Neither is a
+        # seat, and neither may be read as one by index.
+        seats = self._seats_from("alpha.1\t@0\t1\n"
+                                 "only-two\t@1\n"
+                                 "a\tb\tc\td\n"
+                                 "\n")
+
+        self.assertEqual(seats, [("alpha.1", "@0", True)])
+
+    def test_a_chat_id_outside_the_alphabet_is_dropped(self):
+        seats = self._seats_from("alpha.1;kill-server\t@0\t1\nalpha.2\t@1\t0\n")
+
+        self.assertEqual(seats, [("alpha.2", "@1", False)])
+
+    def test_a_window_id_that_is_not_tmuxs_own_shape_is_dropped(self):
+        # The window id is what `_stop_chats` aims `kill-window` at. Anything that is not
+        # `@<digits>` is a target charter did not get from tmux.
+        seats = self._seats_from("alpha.1\t$0\t1\n"
+                                 "alpha.2\tnot-a-window\t1\n"
+                                 "alpha.3\t@7\t1\n")
+
+        self.assertEqual(seats, [("alpha.3", "@7", True)])
+
+    def test_only_the_exact_active_flag_means_active(self):
+        # `#{window_active}` is `0` or `1`. Anything else is not a claim charter may read as
+        # "this is the chat the operator was looking at" — that answer decides which tab a
+        # reopen puts them back on.
+        seats = self._seats_from("alpha.1\t@0\t1\nalpha.2\t@1\t0\nalpha.3\t@2\ttrue\n")
+
+        self.assertEqual([c for c, _w, showing in seats if showing], ["alpha.1"])
+
+    def test_a_server_that_would_not_answer_is_none_and_not_empty(self):
+        run, _seen = _answers("", returncode=1)
+        with mock.patch.object(commands_frame.tmuxctl, "run", side_effect=run):
+            self.assertIsNone(commands_frame._chat_seats(SERVER))
+
+    def test_a_live_server_with_no_chats_is_an_empty_list(self):
+        # The opposite fact from the line above, and the whole reason the tri-state exists.
+        self.assertEqual(self._seats_from(""), [])
+
+    def test_the_listing_is_one_call_asking_for_all_three_fields(self):
+        run, seen = _answers("")
+        with mock.patch.object(commands_frame.tmuxctl, "run", side_effect=run):
+            commands_frame._chat_seats(SERVER)
+
+        self.assertEqual(len(seen), 1, "two calls for one listing is two answers")
+        self.assertIn("list-windows", seen[0])
+        self.assertIn(commands_frame._CHAT_WINDOW_FORMAT, seen[0])
+
+
+class OneServerRefusingMakesTheWholePlaneUnknown(PersonaIso, unittest.TestCase):
+    """`_plane_live`'s tri-state, which the sweep found unpinned in both directions.
+
+    With two servers in play, a quit that trusted the half that answered would record only
+    one server's chats and kill only those — and then tell the operator it had stopped the
+    plane. So ``None`` is the answer when **any** server refuses, and the sweep's mutations
+    (collapse the conditional either way) both have to go red.
+    """
+
+    def _live(self, answers):
+        """Drive `_plane_live` over servers whose answers are stated per server."""
+        def _seats(server):
+            return answers[server]
+
+        with mock.patch.object(commands_frame, "_chat_seats", side_effect=_seats):
+            return commands_frame._plane_live(list(answers))
+
+    def test_every_server_answering_gives_the_union_and_never_none(self):
+        live, windows, active = self._live({
+            "s1": [("alpha.1", "@0", True)],
+            "s2": [("beta.1", "@5", False)]})
+
+        self.assertEqual(live, {"alpha.1", "beta.1"})
+        self.assertEqual(windows, {"s1": {"alpha.1": "@0"}, "s2": {"beta.1": "@5"}})
+        self.assertEqual(active, {"alpha.1"})
+
+    def test_one_server_refusing_makes_the_liveness_answer_none(self):
+        live, windows, _active = self._live({
+            "s1": [("alpha.1", "@0", True)],
+            "s2": None})
+
+        self.assertIsNone(live, "the half that answered is not the plane")
+        self.assertEqual(windows, {"s1": {"alpha.1": "@0"}},
+                         "and what did answer is still aimed at")
+
+    def test_every_server_refusing_is_also_none(self):
+        live, windows, active = self._live({"s1": None, "s2": None})
+
+        self.assertIsNone(live)
+        self.assertEqual((windows, active), ({}, set()))
+
+    def test_only_the_shown_chat_is_reported_active(self):
+        # The `showing` filter the sweep dropped: without it every chat would be marked as
+        # the one on screen, and a reopen would pick whichever came first.
+        _live, _windows, active = self._live({
+            "s1": [("alpha.1", "@0", False), ("alpha.2", "@1", True),
+                   ("alpha.3", "@2", False)]})
+
+        self.assertEqual(active, {"alpha.2"})
+
+
+class TheCaptureIsBoundedAndNeverRaises(PersonaIso, unittest.TestCase):
+    """`_capture_transcript`'s four refusals, each unpinned until the sweep asked."""
+
+    def setUp(self):
+        super().setUp()
+        config.private_mkdir(state._root())
+        self.dest = reopen.transcript_path("alpha.1")
+
+    def _capture(self, stdout, returncode=0):
+        run, seen = _answers(stdout, returncode)
+        with mock.patch.object(commands_frame.tmuxctl, "run", side_effect=run):
+            return commands_frame._capture_transcript(SERVER, "%1", self.dest), seen
+
+    def test_the_line_bound_is_the_shipped_number_and_it_is_asked_of_tmux(self):
+        # Asserted as the LITERAL, not as an f-string over the constant: the sweep retunes
+        # the constant, and an assertion that reads the constant follows it and stays green.
+        # The bound belongs where the memory is (one 200-column pane at `history_limit =
+        # 50000` took a tmux server from 3.7 MB to 130 MB), so what matters is that tmux is
+        # asked for a bounded window at all — and which one.
+        self.assertEqual(commands_frame._TRANSCRIPT_LINES, 2000)
+        _ok, seen = self._capture("something\n")
+        self.assertIn("-2000", seen[0])
+        self.assertIn("-S", seen[0])
+
+    def test_a_capture_at_the_byte_cap_is_kept_whole(self):
+        text = "x" * commands_frame._TRANSCRIPT_BYTES
+        ok, _seen = self._capture(text)
+
+        self.assertTrue(ok)
+        self.assertEqual(self.dest.read_bytes(), text.encode(),
+                         "exactly at the cap loses nothing")
+
+    def test_one_byte_over_the_cap_is_trimmed_from_the_front(self):
+        text = "HEAD" + "x" * commands_frame._TRANSCRIPT_BYTES + "TAIL"
+        ok, _seen = self._capture(text)
+
+        self.assertTrue(ok)
+        got = self.dest.read_text()
+        self.assertTrue(got.endswith("TAIL"), "the end is what was on screen")
+        self.assertNotIn("HEAD", got)
+        self.assertLessEqual(len(got.encode()), commands_frame._TRANSCRIPT_BYTES)
+
+    def test_the_cap_holds_for_multi_byte_text_too(self):
+        """The defect the sweep led to, and the reason the comparison is gone.
+
+        The first version measured BYTES and then trimmed CHARACTERS, so a capture made of
+        two-byte characters was left at twice the cap — measured at a cap of 16, `"é" * 16`
+        is 16 characters and 32 bytes and the old line answered 32. It is byte-exact now.
+        """
+        ok, _seen = self._capture("é" * commands_frame._TRANSCRIPT_BYTES)
+
+        self.assertTrue(ok)
+        self.assertLessEqual(len(self.dest.read_bytes()),
+                             commands_frame._TRANSCRIPT_BYTES)
+
+    def test_the_cut_never_writes_half_a_character(self):
+        # A byte cut can land inside a character, and the only edge it can land inside is
+        # the leading one. That partial character is dropped rather than written as a
+        # replacement glyph the pager would show as noise.
+        ok, _seen = self._capture("é" * commands_frame._TRANSCRIPT_BYTES)
+
+        self.assertTrue(ok)
+        got = self.dest.read_text()    # would raise if the cut split a character
+        self.assertNotIn("\ufffd", got)
+        self.assertTrue(got.startswith("é"))
+
+    def test_a_pane_that_answered_nothing_writes_no_file(self):
+        for empty in ("", "   \n\n"):
+            self.dest.unlink(missing_ok=True)
+            ok, _seen = self._capture(empty)
+            self.assertFalse(ok, repr(empty))
+            self.assertFalse(self.dest.exists(), repr(empty))
+
+    def test_a_server_that_would_not_answer_writes_no_file(self):
+        ok, _seen = self._capture("text\n", returncode=1)
+
+        self.assertFalse(ok)
+        self.assertFalse(self.dest.exists())
+
+    def test_a_frame_root_that_cannot_be_made_is_reported_not_raised(self):
+        run, _seen = _answers("text\n")
+        with mock.patch.object(commands_frame.tmuxctl, "run", side_effect=run), \
+                mock.patch.object(commands_frame.config, "private_mkdir",
+                                  side_effect=OSError("no")):
+            self.assertFalse(commands_frame._capture_transcript(SERVER, "%1", self.dest))
+
+    def test_a_write_that_cannot_land_is_reported_not_raised(self):
+        run, _seen = _answers("text\n")
+        with mock.patch.object(commands_frame.tmuxctl, "run", side_effect=run), \
+                mock.patch.object(commands_frame.config, "write_for",
+                                  side_effect=OSError("full")):
+            self.assertFalse(commands_frame._capture_transcript(SERVER, "%1", self.dest))
 
 
 if __name__ == "__main__":       # pragma: no cover

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -138,7 +138,7 @@ class TheRecordOutlivesTheChatItDescribes(PersonaIso, unittest.TestCase):
         # Both scans filter on `is_dir()`, and this is the assertion that says so rather
         # than the comment that claims it.
         self.assertEqual(chats.of_workspace("alpha"), ["alpha.1"])
-        self.assertEqual(leave._plane_chats(), ["alpha.1"])
+        self.assertEqual(leave.plane_chats(), ["alpha.1"])
 
 
 class WhatAQuitWritesDown(PersonaIso, unittest.TestCase):
@@ -189,6 +189,33 @@ class WhatAQuitWritesDown(PersonaIso, unittest.TestCase):
 
         self.assertEqual([c.chat for c in p.chats], ["alpha.9"])
         self.assertEqual(p.chats[0].workspace, "")
+
+    def test_a_chat_with_no_workspace_is_stopped_and_honestly_not_recorded(self):
+        # Recorded would be a lie: `reopen.read` holds a manifest entry's workspace to
+        # `valid_name`, so a line written for a chat that says nothing would be discarded by
+        # every reader — a record that looks like a promise and is not. The warning names it
+        # (`leave.NOT_REOPENED`) and the quit's own line says how many of how many were kept.
+        _plant("alpha.1", ws="alpha")
+        state.frame_dir("alpha.9", create=True)
+        state.record_server("alpha.9", SERVER)
+        state.record_harness_pane("alpha.9", "%9")
+
+        with mock.patch.multiple(commands_frame,
+                                 _chat_windows=mock.DEFAULT, _active_chats=mock.DEFAULT,
+                                 _capture_transcript=mock.DEFAULT,
+                                 _stop_chats=mock.DEFAULT) as m:
+            m["_chat_windows"].return_value = {"alpha.1": "@0", "alpha.9": "@1"}
+            m["_active_chats"].return_value = set()
+            m["_capture_transcript"].return_value = False
+            m["_stop_chats"].return_value = 2
+            self.assertEqual(commands_frame.cmd_quit(
+                SimpleNamespace(chat="alpha.1")), 0)
+            # Both were aimed at — it is the RECORD that leaves one out, not the teardown.
+            self.assertEqual(
+                sorted(c.chat for c in m["_stop_chats"].call_args[0][0]),
+                ["alpha.1", "alpha.9"])
+
+        self.assertEqual([c.chat for c in reopen.read().all_chats()], ["alpha.1"])
 
     def test_a_wedged_server_is_not_an_empty_one(self):
         _plant("alpha.1", ws="alpha")

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -48,6 +48,17 @@ from tests._isolation import PersonaIso
 SERVER = commands_frame.SOCKET
 
 
+def _seats(windows, active):
+    """`commands_frame._chat_seats`' answer, built from what a case means to say.
+
+    One listing answers three questions — which chats are live, which window each is in, and
+    which was its session's current — so a fake for it is one value rather than three
+    patches. Written as a helper rather than spelled per case so a case says
+    ``{"alpha.1": "@0"}`` and ``{"alpha.1"}`` and nothing about tuple order.
+    """
+    return [(chat, window, chat in active) for chat, window in windows.items()]
+
+
 def _plant(fid: str, *, ws: str, harness: str = "claude-code", pane: str = "%1",
            sid: str = "", cwd: str = "", persona: str = "") -> None:
     """Make *fid* look like a chat charter launched — through the production writers.
@@ -201,11 +212,10 @@ class WhatAQuitWritesDown(PersonaIso, unittest.TestCase):
         state.record_harness_pane("alpha.9", "%9")
 
         with mock.patch.multiple(commands_frame,
-                                 _chat_windows=mock.DEFAULT, _active_chats=mock.DEFAULT,
+                                 _chat_seats=mock.DEFAULT,
                                  _capture_transcript=mock.DEFAULT,
                                  _stop_chats=mock.DEFAULT) as m:
-            m["_chat_windows"].return_value = {"alpha.1": "@0", "alpha.9": "@1"}
-            m["_active_chats"].return_value = set()
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0", "alpha.9": "@1"}, set())
             m["_capture_transcript"].return_value = False
             m["_stop_chats"].return_value = 2
             self.assertEqual(commands_frame.cmd_quit(
@@ -248,13 +258,13 @@ class TheOrderIsRecordThenKill(PersonaIso, unittest.TestCase):
     def _no_tmux(self):
         """Answer every tmux question the way a server with this one chat on it would.
 
-        Patched at `_chat_windows`/`_active_chats` rather than at `tmuxctl.run`, because
+        Patched at `_chat_seats` rather than at `tmuxctl.run`, because
         what these tests are about is the ORDER of charter's own writes — and a fake at the
         subprocess boundary would make every one of them depend on a format string.
         """
         return mock.patch.multiple(
             commands_frame,
-            _chat_windows=mock.DEFAULT, _active_chats=mock.DEFAULT,
+            _chat_seats=mock.DEFAULT,
             _capture_transcript=mock.DEFAULT, _stop_chats=mock.DEFAULT)
 
     def test_the_manifest_is_on_disk_before_anything_is_stopped(self):
@@ -265,8 +275,7 @@ class TheOrderIsRecordThenKill(PersonaIso, unittest.TestCase):
             return len(doomed)
 
         with self._no_tmux() as m:
-            m["_chat_windows"].return_value = {"alpha.1": "@0"}
-            m["_active_chats"].return_value = {"alpha.1"}
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0"}, {"alpha.1"})
             m["_capture_transcript"].return_value = False
             m["_stop_chats"].side_effect = _stop
             self.assertEqual(commands_frame.cmd_quit(self.args), 0)
@@ -276,8 +285,7 @@ class TheOrderIsRecordThenKill(PersonaIso, unittest.TestCase):
 
     def test_a_record_that_will_not_land_refuses_the_quit_and_kills_nothing(self):
         with self._no_tmux() as m, mock.patch.object(reopen, "write", return_value=False):
-            m["_chat_windows"].return_value = {"alpha.1": "@0"}
-            m["_active_chats"].return_value = set()
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0"}, set())
             m["_capture_transcript"].return_value = False
             self.assertEqual(commands_frame.cmd_quit(self.args), 1)
             m["_stop_chats"].assert_not_called()
@@ -285,8 +293,7 @@ class TheOrderIsRecordThenKill(PersonaIso, unittest.TestCase):
     def test_the_focus_is_the_workspace_the_quit_was_pressed_in(self):
         _plant("beta.1", ws="beta")
         with self._no_tmux() as m:
-            m["_chat_windows"].return_value = {"alpha.1": "@0", "beta.1": "@1"}
-            m["_active_chats"].return_value = set()
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0", "beta.1": "@1"}, set())
             m["_capture_transcript"].return_value = False
             m["_stop_chats"].return_value = 2
             commands_frame.cmd_quit(SimpleNamespace(chat="beta.1"))
@@ -297,9 +304,8 @@ class TheOrderIsRecordThenKill(PersonaIso, unittest.TestCase):
         _plant("alpha.2", ws="alpha")
         _plant("beta.1", ws="beta")
         with self._no_tmux() as m:
-            m["_chat_windows"].return_value = {"alpha.1": "@0", "alpha.2": "@1",
-                                               "beta.1": "@2"}
-            m["_active_chats"].return_value = set()
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0", "alpha.2": "@1",
+                                               "beta.1": "@2"}, set())
             m["_capture_transcript"].return_value = False
             m["_stop_chats"].return_value = 3
             commands_frame.cmd_quit(self.args)
@@ -315,8 +321,7 @@ class TheOrderIsRecordThenKill(PersonaIso, unittest.TestCase):
                 import shutil
                 shutil.rmtree(d)
         with self._no_tmux() as m:
-            m["_chat_windows"].return_value = {}
-            m["_active_chats"].return_value = set()
+            m["_chat_seats"].return_value = []
             m["_capture_transcript"].return_value = False
             self.assertEqual(commands_frame.cmd_quit(self.args), 0)
             m["_stop_chats"].assert_not_called()
@@ -350,12 +355,11 @@ class TheTrackerIsPrunedAfterTheKill(PersonaIso, unittest.TestCase):
             return 1
 
         with mock.patch.multiple(commands_frame,
-                                 _chat_windows=mock.DEFAULT, _active_chats=mock.DEFAULT,
+                                 _chat_seats=mock.DEFAULT,
                                  _capture_transcript=mock.DEFAULT) as m, \
                 mock.patch.object(commands_frame, "_stop_chats", side_effect=_stop), \
                 mock.patch.object(inflight, "prune_all", side_effect=_prune):
-            m["_chat_windows"].return_value = {"alpha.1": "@0"}
-            m["_active_chats"].return_value = set()
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0"}, set())
             m["_capture_transcript"].return_value = False
             commands_frame.cmd_quit(SimpleNamespace(chat="alpha.1"))
 

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -571,6 +571,124 @@ class TheManifestRefusesWhatItCannotRead(PersonaIso, unittest.TestCase):
                          ("", "", "", "", "", False))
 
 
+class TheParserAnswersForEveryShapeAJsonFileCanHold(PersonaIso, unittest.TestCase):
+    """Every type guard in `reopen.read`, fed the type it was written to refuse.
+
+    **The cause, in one line: every case above feeds a bad VALUE inside the right
+    CONTAINER, so no type guard was ever handed the wrong container.** A bad version, a
+    chat id with a semicolon in it, a workspace that is `../etc` — all of them arrive as
+    the dict-of-lists-of-dicts charter itself writes. Nothing fed a top level that is a
+    list, a frame that is not a dict, a `chats` that is not a list, a chat entry that is
+    not a dict, an `at` that is a string or a `focus` that is a number, and the deletion
+    sweep reddened one guard for each of those.
+
+    **This is the #442/#475 position, and on this branch it is the only cluster whose blast
+    radius leaves the frame.** `cwd` reaches `os.chdir` and `workspace` reaches a tmux `-t`
+    argv (`_reopen_one`, `_attach_after_reopen`); the manifest is a plain file that outlives
+    the process it was written by and may be OLDER than the charter reading it, or hand
+    edited, or half written by a machine that went down; and `read()` sits on the path of
+    every `charter` launch, because `cmd_launch` asks it whether this chat was named by a
+    quit. A guard missing here is therefore not a wrong answer that degrades — it is an
+    `AttributeError` or a `KeyError` out of a function whose entire contract is that it
+    degrades, raised in the process that hands the operator their shell back.
+
+    Written against files rather than through `reopen.write`, for
+    `WhatIsOnDiskIsAFormatAndNotAnImplementationDetail`'s reason one step on: a writer
+    cannot produce these shapes at all, so a round trip cannot ask the question.
+    """
+
+    #: One chat entry that IS readable, so each case is about the shape around it rather
+    #: than about whether anything survives the read at all.
+    GOOD = {"chat": "alpha.1", "workspace": "alpha"}
+
+    def _on_disk(self, raw) -> None:
+        config.private_mkdir(state._root())
+        config.write_for(reopen.path(), json.dumps(raw) + "\n")
+
+    def _wrapping(self, frames) -> dict:
+        return {"version": reopen.VERSION, "at": 1, "focus": "alpha", "frames": frames}
+
+    def test_a_top_level_that_is_a_list_is_nothing_to_reopen(self):
+        self._on_disk([self._wrapping([{"workspace": "alpha", "chats": [self.GOOD]}])])
+
+        self.assertIsNone(reopen.read())
+
+    def test_a_frame_that_is_not_a_dict_takes_the_whole_manifest_down(self):
+        self._on_disk(self._wrapping(["alpha"]))
+
+        self.assertIsNone(reopen.read())
+
+    def test_a_chats_field_that_is_not_a_list_takes_the_whole_manifest_down(self):
+        # A string is iterable, so without the second half of the guard this reads as seven
+        # one-character chats, drops all seven as unusable, and answers with an EMPTY
+        # manifest — "nothing was recorded" — instead of refusing a shape it cannot read.
+        self._on_disk(self._wrapping([{"workspace": "alpha", "chats": "alpha.1"}]))
+
+        self.assertIsNone(reopen.read())
+
+    def test_a_chat_entry_that_is_not_a_dict_is_dropped_and_the_rest_is_read(self):
+        # Refused per ENTRY rather than per manifest, because a chat is the unit a reopen
+        # can honestly skip: `cmd_reopen` reports the difference between what was recorded
+        # and what came back, so a dropped one is a sentence rather than a silence.
+        self._on_disk(self._wrapping([{"workspace": "alpha", "chats": [
+            "alpha.2", ["alpha.3"], 4, None, dict(self.GOOD, chat="alpha.5")]}]))
+
+        m = reopen.read()
+
+        self.assertEqual([c.chat for c in m.all_chats()], ["alpha.5"])
+
+    def test_a_frame_that_never_recorded_a_workspace_is_read_as_an_unnamed_frame(self):
+        # The migration case — a manifest written by a charter one field older — and the
+        # one the missing fallback turns into a `KeyError` on the launch path.
+        self._on_disk(self._wrapping([{"chats": [self.GOOD]}]))
+
+        self.assertEqual([f.workspace for f in reopen.read().frames], [""])
+
+    def test_a_frame_whose_workspace_is_null_is_read_as_an_unnamed_frame(self):
+        # And `null` rather than absent, because `str()` around it would otherwise make the
+        # frame's name the four characters `None`.
+        self._on_disk(self._wrapping([{"workspace": None, "chats": [self.GOOD]}]))
+
+        self.assertEqual([f.workspace for f in reopen.read().frames], [""])
+
+    def test_the_recorded_at_is_the_number_that_comes_back(self):
+        # The read side of `at`, spelled as a literal on both ends: the key is looked up by
+        # name and the value comes back whole. Nothing else here reads it, because
+        # everything else writes with `reopen.write` and reads with `reopen.read`.
+        raw = self._wrapping([{"workspace": "alpha", "chats": [self.GOOD]}])
+        self._on_disk(dict(raw, at=1700000000))
+
+        self.assertEqual(reopen.read().at, 1700000000)
+
+    def test_an_at_that_is_not_a_number_reads_as_no_time_at_all(self):
+        raw = self._wrapping([{"workspace": "alpha", "chats": [self.GOOD]}])
+        self._on_disk(dict(raw, at="yesterday"))
+
+        self.assertEqual(reopen.read().at, 0)
+
+    def test_a_focus_that_is_not_a_name_reads_as_no_focus(self):
+        # `focus` decides which reopened chat the operator is put back ON
+        # (`_attach_after_reopen`), and `_consume` writes it straight back out again, so a
+        # number kept here would outlive the reopen that read it.
+        raw = self._wrapping([{"workspace": "alpha", "chats": [self.GOOD]}])
+        self._on_disk(dict(raw, focus=7))
+
+        self.assertEqual(reopen.read().focus, "")
+
+    def test_a_record_whose_chat_id_is_not_even_text_is_refused_not_raised_on(self):
+        # `_usable` called directly, and deliberately: no shipped caller can hand it a
+        # non-string, because `_chat` normalises all seven text fields on the way in. The
+        # fallback is there so the predicate is TOTAL over `Chat` — it is the last gate
+        # before a recorded name becomes a transcript path and a tmux target, and a gate
+        # that raises on the one input it was written to refuse is not a gate. Pinned here
+        # rather than deleted for that reason.
+        blank = reopen.Chat(chat="", workspace="alpha", persona="", harness="", cwd="",
+                            resume="", transcript="", active=False)
+
+        self.assertFalse(reopen._usable(blank))
+        self.assertFalse(reopen._usable(blank._replace(chat=None)))
+
+
 class TranscriptsAreBounded(PersonaIso, unittest.TestCase):
     """A file in the frame root has no collector but the thing that writes it."""
 

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -35,6 +35,7 @@ fixture (#519/#521/#528).
 from __future__ import annotations
 
 import json
+import time
 
 import unittest
 from types import SimpleNamespace
@@ -949,6 +950,96 @@ class AChatThatRecordedNothingIsStillAChat(PersonaIso, unittest.TestCase):
         self.assertNotIn("null", json.dumps(raw["frames"]),
                          "a null where the record type promises text is a shape every "
                          "reader has to handle")
+
+
+class WhatIsOnDiskIsAFormatAndNotAnImplementationDetail(PersonaIso, unittest.TestCase):
+    """Every name and key a quit writes, asserted as the literal it is.
+
+    **The deletion sweep found this whole cluster at once, and the reason is worth stating
+    rather than fixing quietly: a round trip cannot pin a name.** Every other test here
+    writes with `reopen.write` and reads with `reopen.read`, so renaming `reopen.json`, the
+    `.transcript` suffix, the `cwd` file, the `closed` marker or any JSON key moves both
+    sides together and stays green — while on a real plane it silently orphans everything
+    already on disk. The manifest survives `reap` precisely so it can be older than the
+    charter that reads it, which is what makes these names a compatibility surface and not
+    an implementation detail.
+
+    So the literals are spelled out here, once, deliberately — the same reason
+    `test_a_real_click_on_a_real_tab_bar_switches` spells its own refusal sentence instead
+    of importing it. If a rename is wanted, this is the file that says what it costs.
+    """
+
+    def _one(self):
+        return reopen.Frame(workspace="alpha", chats=(reopen.Chat(
+            chat="alpha.1", workspace="alpha", persona="steward", harness="claude-code",
+            cwd="/some/where", resume="conv-1", transcript="alpha.1.transcript",
+            active=True),))
+
+    def test_the_manifest_is_reopen_json_in_the_frame_root(self):
+        reopen.write([self._one()], focus="alpha", at=1700000000)
+
+        self.assertEqual(reopen.MANIFEST, "reopen.json")
+        self.assertTrue((state._root() / "reopen.json").is_file())
+
+    def test_a_transcript_is_the_chat_id_and_a_dot_transcript_suffix(self):
+        self.assertEqual(reopen.TRANSCRIPT_SUFFIX, ".transcript")
+        self.assertEqual(reopen.transcript_path("alpha.1").name, "alpha.1.transcript")
+
+    def test_the_recorded_version_is_one(self):
+        # A manifest carries its version so a much newer charter can refuse a shape it does
+        # not speak. Bumping it is a decision, and reading it back through `VERSION` on both
+        # sides would let the number drift without anyone choosing.
+        reopen.write([self._one()], focus="alpha")
+
+        self.assertEqual(reopen.VERSION, 1)
+        self.assertEqual(json.loads(reopen.path().read_text())["version"], 1)
+
+    def test_the_manifests_keys_are_the_ones_a_later_charter_will_look_for(self):
+        reopen.write([self._one()], focus="alpha", at=1700000000)
+
+        raw = json.loads(reopen.path().read_text())
+        self.assertEqual(sorted(raw), ["at", "focus", "frames", "version"])
+        self.assertEqual(raw["at"], 1700000000)
+        self.assertEqual(raw["focus"], "alpha")
+        self.assertEqual(sorted(raw["frames"][0]), ["chats", "workspace"])
+        self.assertEqual(
+            sorted(raw["frames"][0]["chats"][0]),
+            ["active", "chat", "cwd", "harness", "persona", "resume", "transcript",
+             "workspace"])
+
+    def test_at_is_a_whole_number_of_seconds_and_defaults_to_now(self):
+        # `int(...)`, so a float clock never reaches the file: `at` is read back through an
+        # `isinstance(at, int)` gate, and a float would be discarded as unreadable by the
+        # very charter that wrote it.
+        before = int(time.time())
+        reopen.write([self._one()], focus="alpha")
+
+        got = json.loads(reopen.path().read_text())["at"]
+        self.assertIsInstance(got, int)
+        self.assertGreaterEqual(got, before)
+
+    def test_the_cwd_file_is_called_cwd(self):
+        state.frame_dir("alpha.1", create=True)
+        state.record_cwd("alpha.1", "/some/where")
+
+        self.assertEqual((state.frame_dir("alpha.1") / "cwd").read_text().strip(),
+                         "/some/where")
+
+    def test_the_closed_marker_is_called_closed(self):
+        state.frame_dir("alpha.1", create=True)
+        state.record_closed("alpha.1")
+
+        self.assertTrue((state.frame_dir("alpha.1") / "closed").exists())
+
+    def test_neither_file_hides_from_ls(self):
+        # `state._CLAIM_FILE`'s rule: everything in a frame's directory is charter's own
+        # bookkeeping and none of it is a dotfile.
+        state.frame_dir("alpha.1", create=True)
+        state.record_cwd("alpha.1", "/some/where")
+        state.record_closed("alpha.1")
+
+        for name in (p.name for p in state.frame_dir("alpha.1").iterdir()):
+            self.assertFalse(name.startswith("."), name)
 
 
 if __name__ == "__main__":       # pragma: no cover

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -1,0 +1,438 @@
+"""§4e/§4i: a quit writes the plane down BEFORE it stops anything, in a file `reap` cannot
+take.
+
+Three claims, and each one is load-bearing rather than a nicety.
+
+**1. The record survives everything that deletes a chat.** `state.reap` skips anything that
+is not a directory, so a plain file in the frame root outlives every reap — and it has to,
+because the thing #757 kept (`session.durable`, the id a resume needs) lives INSIDE the
+chat's directory and `reap` deletes that whole directory when the launcher pid is dead.
+After a restart every launcher pid is dead, so the id #757 kept is gone by the time a reopen
+could ask for it. `TheRecordOutlivesTheChatItDescribes` is that fact as a test, driven
+through the real `reap` with the real keep-rules rather than by asserting that a file exists.
+
+**2. The record comes first.** `_stop_chats` is patched to assert the manifest is already on
+disk when it is called, which is the same rule `trace._trace_secret_use` keeps for the same
+reason: a record that depends on the thing it records succeeding is not a record. The
+inverse is asserted too — a manifest that could not be written REFUSES the quit rather than
+killing a plane nothing would bring back.
+
+**3. Nothing means "was open".** `state.exit_code` answers ``None`` for a chat that never
+started, for one the machine took down, and for one `kill-window` ended — §2.17, measured —
+so a quit that read "no exit file" as "already over" would silently drop the ordinary case.
+The one thing that opts out is `state.was_closed`, which is what `chat: close` writes.
+
+**No tmux here, deliberately.** Everything above reproduces on directories: liveness enters
+`leave.plan` as an argument, and the teardown is the one part that needs a server. The real
+thing is exercised in `tests/test_quit_and_reopen_on_a_real_tmux.py`.
+
+`PersonaIso` on every case, and `os.environ` is already cleared by it: `state.own_workspace`
+and `state.workspace_for` both read `$CHARTER_WORKSPACE` and `$CHARTER_SESSION_ID`, so a
+developer running the suite inside a live frame would otherwise be supplying half of every
+fixture (#519/#521/#528).
+"""
+
+from __future__ import annotations
+
+import json
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config, inflight
+from charter.frame import chats, leave, reopen, state
+
+from tests._isolation import PersonaIso
+
+SERVER = commands_frame.SOCKET
+
+
+def _plant(fid: str, *, ws: str, harness: str = "claude-code", pane: str = "%1",
+           sid: str = "", cwd: str = "", persona: str = "") -> None:
+    """Make *fid* look like a chat charter launched — through the production writers.
+
+    Never a hand-written file: `record_workspace` is what `frame_workspace` reads back, so a
+    fixture that stopped agreeing with the launcher fails here rather than passing against
+    itself. That is `tests/test_frame_chat_switch._plant`'s rule and this is the same one.
+    """
+    state.frame_dir(fid, create=True)
+    state.record_server(fid, SERVER)
+    state.record_workspace(fid, ws)
+    state.record_harness_pane(fid, pane)
+    state.record_identity(fid, {"CHARTER_HARNESS": harness, "CHARTER_WORKSPACE": "",
+                                "CHARTER_PERSONA": persona})
+    if sid:
+        state.record_harness_session(fid, sid)
+    if cwd:
+        state.record_cwd(fid, cwd)
+
+
+class TheRecordOutlivesTheChatItDescribes(PersonaIso, unittest.TestCase):
+    """The manifest is a FILE in the frame root, and that is the whole durability story.
+
+    **Measured while writing this: the property is over-determined in `reap`, and no single
+    mutation can take it away.** Three independent things keep a non-directory entry there —
+    the `if not d.is_dir()` filter, the `except OSError: continue` keep-rule (a
+    `NotADirectoryError` out of `d.iterdir()` IS an `OSError`), and `shutil.rmtree` with
+    `ignore_errors=True`, which cannot remove a file even if it were reached. Removing the
+    `is_dir()` half alone leaves these tests green. That is recorded rather than papered
+    over: the assertions below are about the OUTCOME the design depends on, and the
+    last-line case pins it against the hostile shape a chat-named file is.
+    """
+
+    def test_reap_never_removes_a_non_directory_from_the_frame_root(self):
+        # The property, stated on its own and against the shape that would be a chat if it
+        # were a directory. Nothing in `.charter/frame/` that is not a directory is `reap`'s
+        # to collect — which is what makes the manifest and the transcripts durable, and
+        # which `chats.of_workspace` relies on from the other side.
+        config.private_mkdir(state._root())
+        for name in (reopen.MANIFEST, "alpha.1.transcript", "alpha.2"):
+            config.write_for(state._root() / name, "not a chat\n")
+
+        self.assertEqual(state.reap(set(), server=SERVER), [])
+
+        for name in (reopen.MANIFEST, "alpha.1.transcript", "alpha.2"):
+            self.assertTrue((state._root() / name).is_file(), name)
+
+    def test_reap_takes_the_chat_directory_and_leaves_the_manifest(self):
+        _plant("alpha.1", ws="alpha", sid="conv-1")
+        # The claim marker names THIS process, which `reap` keeps a directory for — so it
+        # goes, exactly as it does at the end of a real launch (`state.clear_claim`).
+        # Without this the reap below would keep the directory for the right reason and
+        # prove nothing about the manifest.
+        state.clear_claim("alpha.1")
+        self.assertTrue(reopen.write(
+            [reopen.Frame(workspace="alpha", chats=(reopen.Chat(
+                chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
+                cwd=str(config.ROOT), resume="conv-1", transcript="", active=True),))],
+            focus="alpha"))
+        # And the thing #757 kept is in the directory that is about to go.
+        self.assertEqual(state.kept_harness_session("alpha.1"), "conv-1")
+
+        removed = state.reap(set(), server=SERVER)
+
+        self.assertEqual(removed, ["alpha.1"])
+        self.assertIsNone(state.kept_harness_session("alpha.1"),
+                          "reap took session.durable with the directory — which is why "
+                          "the manifest has to hold the id too")
+        m = reopen.read()
+        self.assertIsNotNone(m)
+        self.assertEqual([c.resume for c in m.all_chats()], ["conv-1"])
+
+    def test_a_transcript_is_a_file_in_the_frame_root_and_survives_too(self):
+        _plant("alpha.1", ws="alpha")
+        state.clear_claim("alpha.1")
+        path = reopen.transcript_path("alpha.1")
+        config.write_for(path, "what was on screen\n")
+
+        state.reap(set(), server=SERVER)
+
+        self.assertTrue(path.is_file())
+
+    def test_neither_file_is_ever_mistaken_for_a_chat(self):
+        _plant("alpha.1", ws="alpha")
+        reopen.write([], focus="alpha")
+        config.write_for(reopen.transcript_path("alpha.1"), "text\n")
+
+        # Both scans filter on `is_dir()`, and this is the assertion that says so rather
+        # than the comment that claims it.
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.1"])
+        self.assertEqual(leave._plane_chats(), ["alpha.1"])
+
+
+class WhatAQuitWritesDown(PersonaIso, unittest.TestCase):
+    """The four restore items, the resume id, and who is left out."""
+
+    def test_the_four_restore_items_are_all_recorded(self):
+        _plant("alpha.1", ws="alpha", sid="conv-1", cwd=str(config.ROOT),
+               persona="")
+        from charter import persona as persona_mod
+        persona_mod.set_active("steward", session_id="alpha.1", terminal_id="")
+
+        p = leave.plan(live={"alpha.1"}, focus="alpha")
+
+        self.assertEqual(len(p.chats), 1)
+        c = p.chats[0]
+        self.assertEqual(c.workspace, "alpha")
+        self.assertEqual(c.persona, "steward")
+        self.assertEqual(c.harness, "claude-code")
+        self.assertEqual(c.cwd, str(config.ROOT))
+        self.assertEqual(c.resume, "conv-1")
+
+    def test_a_chat_with_no_exit_file_is_recorded_because_nothing_means_was_open(self):
+        _plant("alpha.1", ws="alpha")
+        self.assertIsNone(state.exit_code("alpha.1"),
+                          "the premise: kill-window writes no exit (§2.17)")
+
+        p = leave.plan(live={"alpha.1"}, focus="alpha")
+
+        self.assertEqual([c.chat for c in p.chats], ["alpha.1"])
+
+    def test_a_closed_chat_is_the_one_thing_left_out(self):
+        _plant("alpha.1", ws="alpha")
+        _plant("alpha.2", ws="alpha")
+        state.record_closed("alpha.2")
+
+        p = leave.plan(live={"alpha.1", "alpha.2"}, focus="alpha")
+
+        self.assertEqual([c.chat for c in p.chats], ["alpha.1"])
+
+    def test_a_chat_whose_workspace_record_is_gone_is_still_recorded(self):
+        # `chats.of_workspace` cannot see this chat at all — it says it is in no
+        # workspace — which is exactly why the quit scans the frame root itself.
+        state.frame_dir("alpha.9", create=True)
+        state.record_server("alpha.9", SERVER)
+        state.record_harness_pane("alpha.9", "%9")
+
+        p = leave.plan(live={"alpha.9"}, focus="")
+
+        self.assertEqual([c.chat for c in p.chats], ["alpha.9"])
+        self.assertEqual(p.chats[0].workspace, "")
+
+    def test_a_wedged_server_is_not_an_empty_one(self):
+        _plant("alpha.1", ws="alpha")
+
+        # `None` is `_live_chats`' third answer: charter could not ask. Every chat is then
+        # attempted rather than skipped, because skipping one that IS running would leave a
+        # harness alive behind a manifest saying it was stopped.
+        p = leave.plan(live=None, focus="alpha")
+
+        self.assertIsNone(p.chats[0].live)
+        self.assertEqual([c.chat for c in leave.stopping(p)], ["alpha.1"])
+
+    def test_a_chat_tmux_says_is_gone_is_recorded_but_not_stopped(self):
+        _plant("alpha.1", ws="alpha")
+
+        p = leave.plan(live=set(), focus="alpha")
+
+        self.assertEqual([c.chat for c in p.chats], ["alpha.1"])
+        self.assertEqual(leave.stopping(p), ())
+
+
+class TheOrderIsRecordThenKill(PersonaIso, unittest.TestCase):
+    """§4e's ordering, asserted from inside the teardown rather than around it."""
+
+    def setUp(self):
+        super().setUp()
+        _plant("alpha.1", ws="alpha", sid="conv-1", cwd=str(config.ROOT))
+        self.args = SimpleNamespace(chat="alpha.1")
+
+    def _no_tmux(self):
+        """Answer every tmux question the way a server with this one chat on it would.
+
+        Patched at `_chat_windows`/`_active_chats` rather than at `tmuxctl.run`, because
+        what these tests are about is the ORDER of charter's own writes — and a fake at the
+        subprocess boundary would make every one of them depend on a format string.
+        """
+        return mock.patch.multiple(
+            commands_frame,
+            _chat_windows=mock.DEFAULT, _active_chats=mock.DEFAULT,
+            _capture_transcript=mock.DEFAULT, _stop_chats=mock.DEFAULT)
+
+    def test_the_manifest_is_on_disk_before_anything_is_stopped(self):
+        seen = {}
+
+        def _stop(doomed, *, windows):
+            seen["manifest"] = reopen.read()
+            return len(doomed)
+
+        with self._no_tmux() as m:
+            m["_chat_windows"].return_value = {"alpha.1": "@0"}
+            m["_active_chats"].return_value = {"alpha.1"}
+            m["_capture_transcript"].return_value = False
+            m["_stop_chats"].side_effect = _stop
+            self.assertEqual(commands_frame.cmd_quit(self.args), 0)
+
+        self.assertIsNotNone(seen["manifest"], "the kill ran before the record landed")
+        self.assertEqual([c.chat for c in seen["manifest"].all_chats()], ["alpha.1"])
+
+    def test_a_record_that_will_not_land_refuses_the_quit_and_kills_nothing(self):
+        with self._no_tmux() as m, mock.patch.object(reopen, "write", return_value=False):
+            m["_chat_windows"].return_value = {"alpha.1": "@0"}
+            m["_active_chats"].return_value = set()
+            m["_capture_transcript"].return_value = False
+            self.assertEqual(commands_frame.cmd_quit(self.args), 1)
+            m["_stop_chats"].assert_not_called()
+
+    def test_the_focus_is_the_workspace_the_quit_was_pressed_in(self):
+        _plant("beta.1", ws="beta")
+        with self._no_tmux() as m:
+            m["_chat_windows"].return_value = {"alpha.1": "@0", "beta.1": "@1"}
+            m["_active_chats"].return_value = set()
+            m["_capture_transcript"].return_value = False
+            m["_stop_chats"].return_value = 2
+            commands_frame.cmd_quit(SimpleNamespace(chat="beta.1"))
+
+        self.assertEqual(reopen.read().focus, "beta")
+
+    def test_the_chats_are_grouped_by_workspace_one_frame_each(self):
+        _plant("alpha.2", ws="alpha")
+        _plant("beta.1", ws="beta")
+        with self._no_tmux() as m:
+            m["_chat_windows"].return_value = {"alpha.1": "@0", "alpha.2": "@1",
+                                               "beta.1": "@2"}
+            m["_active_chats"].return_value = set()
+            m["_capture_transcript"].return_value = False
+            m["_stop_chats"].return_value = 3
+            commands_frame.cmd_quit(self.args)
+
+        m = reopen.read()
+        self.assertEqual([(f.workspace, [c.chat for c in f.chats]) for f in m.frames],
+                         [("alpha", ["alpha.1", "alpha.2"]), ("beta", ["beta.1"])])
+
+    def test_nothing_open_is_not_a_quit(self):
+        state.reap({"nothing"}, server=SERVER)
+        for d in state._root().iterdir():
+            if d.is_dir():
+                import shutil
+                shutil.rmtree(d)
+        with self._no_tmux() as m:
+            m["_chat_windows"].return_value = {}
+            m["_active_chats"].return_value = set()
+            m["_capture_transcript"].return_value = False
+            self.assertEqual(commands_frame.cmd_quit(self.args), 0)
+            m["_stop_chats"].assert_not_called()
+        self.assertIsNone(reopen.read())
+
+
+class TheTrackerIsPrunedAfterTheKill(PersonaIso, unittest.TestCase):
+    """§2.15: records clear only on `finish()`, so a quit strands every one of them."""
+
+    def test_prune_all_removes_every_record_and_says_how_many(self):
+        self.assertIsNotNone(inflight.start("steward"))
+        self.assertIsNotNone(inflight.start("forge", kind=inflight.CLONE))
+        self.assertEqual(len(inflight.live(kind=None)), 2)
+
+        self.assertEqual(inflight.prune_all(), 2)
+
+        self.assertEqual(inflight.live(kind=None), [])
+        self.assertEqual(inflight.prune_all(), 0, "and it is idempotent")
+
+    def test_the_prune_runs_after_the_kill_not_before(self):
+        _plant("alpha.1", ws="alpha")
+        inflight.start("steward")
+        order = []
+
+        def _stop(doomed, *, windows):
+            order.append(("kill", len(inflight.live(kind=None))))
+            return 1
+
+        def _prune():
+            order.append(("prune", None))
+            return 1
+
+        with mock.patch.multiple(commands_frame,
+                                 _chat_windows=mock.DEFAULT, _active_chats=mock.DEFAULT,
+                                 _capture_transcript=mock.DEFAULT) as m, \
+                mock.patch.object(commands_frame, "_stop_chats", side_effect=_stop), \
+                mock.patch.object(inflight, "prune_all", side_effect=_prune):
+            m["_chat_windows"].return_value = {"alpha.1": "@0"}
+            m["_active_chats"].return_value = set()
+            m["_capture_transcript"].return_value = False
+            commands_frame.cmd_quit(SimpleNamespace(chat="alpha.1"))
+
+        self.assertEqual([step for step, _ in order], ["kill", "prune"])
+        self.assertEqual(order[0][1], 1,
+                         "the record was still there while the kill was attempted")
+
+
+class TheManifestRefusesWhatItCannotRead(PersonaIso, unittest.TestCase):
+    """Every value in it came off disk and is going onto an argv, a `chdir` or a flag."""
+
+    def test_a_version_this_charter_does_not_speak_is_nothing_to_reopen(self):
+        config.private_mkdir(state._root())
+        config.write_for(reopen.path(), json.dumps({"version": 99, "frames": []}) + "\n")
+
+        self.assertIsNone(reopen.read())
+
+    def test_a_file_that_is_not_json_is_nothing_to_reopen(self):
+        config.private_mkdir(state._root())
+        config.write_for(reopen.path(), "{not json\n")
+
+        self.assertIsNone(reopen.read())
+
+    def test_a_chat_whose_name_could_not_be_a_chat_is_dropped_from_the_frame(self):
+        config.private_mkdir(state._root())
+        config.write_for(reopen.path(), json.dumps({
+            "version": reopen.VERSION, "at": 1, "focus": "alpha",
+            "frames": [{"workspace": "alpha", "chats": [
+                {"chat": "alpha.1;kill-server", "workspace": "alpha"},
+                {"chat": "alpha.2", "workspace": "alpha"}]}]}) + "\n")
+
+        m = reopen.read()
+
+        self.assertEqual([c.chat for c in m.all_chats()], ["alpha.2"])
+
+    def test_a_chat_whose_workspace_could_not_be_a_workspace_is_dropped(self):
+        config.private_mkdir(state._root())
+        config.write_for(reopen.path(), json.dumps({
+            "version": reopen.VERSION, "at": 1, "focus": "",
+            "frames": [{"workspace": "../etc", "chats": [
+                {"chat": "alpha.1", "workspace": "../etc"}]}]}) + "\n")
+
+        self.assertEqual(reopen.read().frames, ())
+
+    def test_a_missing_field_is_that_field_empty_and_not_a_crash(self):
+        config.private_mkdir(state._root())
+        config.write_for(reopen.path(), json.dumps({
+            "version": reopen.VERSION, "at": 1, "focus": "alpha",
+            "frames": [{"workspace": "alpha",
+                        "chats": [{"chat": "alpha.1", "workspace": "alpha"}]}]}) + "\n")
+
+        c = reopen.read().all_chats()[0]
+
+        self.assertEqual((c.resume, c.cwd, c.persona, c.harness, c.transcript, c.active),
+                         ("", "", "", "", "", False))
+
+
+class TranscriptsAreBounded(PersonaIso, unittest.TestCase):
+    """A file in the frame root has no collector but the thing that writes it."""
+
+    def test_a_transcript_no_manifest_names_is_pruned(self):
+        config.private_mkdir(state._root())
+        for fid in ("alpha.1", "alpha.2"):
+            config.write_for(reopen.transcript_path(fid), "text\n")
+
+        reopen.prune_transcripts({"alpha.1"})
+
+        self.assertTrue(reopen.transcript_path("alpha.1").is_file())
+        self.assertFalse(reopen.transcript_path("alpha.2").exists())
+
+    def test_the_prune_touches_nothing_but_transcripts(self):
+        _plant("alpha.1", ws="alpha")
+        reopen.write([], focus="")
+        config.write_for(reopen.transcript_path("alpha.2"), "text\n")
+
+        reopen.prune_transcripts(set())
+
+        self.assertTrue(state.frame_dir("alpha.1").is_dir())
+        self.assertTrue(reopen.path().is_file())
+
+    def test_a_capture_is_bounded_in_lines_at_tmux_and_in_bytes_here(self):
+        # The line bound is a tmux argument, so it is asserted on the argv rather than on
+        # the answer; the byte bound is applied to what came back, keeping the END.
+        seen = {}
+
+        class _Out:
+            returncode = 0
+            stdout = "x" * (commands_frame._TRANSCRIPT_BYTES + 10) + "TAIL"
+
+        def _run(why, argv, **kw):
+            seen["argv"] = argv
+            return _Out()
+
+        config.private_mkdir(state._root())
+        dest = reopen.transcript_path("alpha.1")
+        with mock.patch.object(commands_frame.tmuxctl, "run", side_effect=_run):
+            self.assertTrue(commands_frame._capture_transcript(SERVER, "%1", dest))
+
+        self.assertIn(f"-{commands_frame._TRANSCRIPT_LINES}", seen["argv"])
+        self.assertIn("-N", seen["argv"])
+        text = dest.read_text()
+        self.assertTrue(text.endswith("TAIL"))
+        self.assertLessEqual(len(text.encode()), commands_frame._TRANSCRIPT_BYTES)
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -863,5 +863,93 @@ class TheCaptureIsBoundedAndNeverRaises(PersonaIso, unittest.TestCase):
             self.assertFalse(commands_frame._capture_transcript(SERVER, "%1", self.dest))
 
 
+class AChatThatRecordedNothingIsStillAChat(PersonaIso, unittest.TestCase):
+    """The fixture that lies, and the cluster the deletion sweep found with it.
+
+    **`_plant` above always writes a server, a workspace, a harness pane and an identity**,
+    because that is what a launch writes — so every `X or ""` in `leave.plan` read a truthy
+    value in every test on this branch, and the sweep found the whole block unpinned at once.
+    That is not six separate gaps; it is one fixture that never lies.
+
+    A chat CAN have recorded nothing: `new_chat_id` makes the directory before anything is
+    written into it, a launch can die between the `mkdir` and its first record, and a chat
+    launched by a charter that predates any one of these files has that file missing for
+    good. `plane_chats` exists precisely so those are stopped and reported rather than
+    skipped, so what they read back has to be the empty string the record type declares —
+    not `None`, which would reach `json.dumps` and put a `null` in the manifest where
+    `Chat.persona: str` promises text.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Everything `new_chat_id` guarantees, and not one byte more.
+        state.frame_dir("alpha.1", create=True)
+
+    def test_every_field_reads_back_as_the_empty_string_it_declares(self):
+        p = leave.plan(live={"alpha.1"}, focus="")
+
+        self.assertEqual([c.chat for c in p.chats], ["alpha.1"])
+        c = p.chats[0]
+        self.assertEqual(
+            (c.workspace, c.persona, c.harness, c.cwd, c.resume, c.server),
+            ("", "", "", "", "", ""))
+        for name, value in zip(
+                ("workspace", "persona", "harness", "cwd", "resume", "server"),
+                (c.workspace, c.persona, c.harness, c.cwd, c.resume, c.server)):
+            self.assertIsInstance(value, str, name)
+
+    def test_it_is_neither_homeless_nor_missing_a_directory(self):
+        # Both are `bool(x) and …`: a chat that recorded no workspace is not a chat whose
+        # workspace has been DELETED, and a chat that recorded no cwd is not one whose
+        # directory has gone. Reporting either would be charter inventing a loss.
+        c = leave.plan(live={"alpha.1"}, focus="").chats[0]
+
+        self.assertFalse(c.homeless)
+        self.assertFalse(c.cwd_gone)
+
+    def test_a_harness_recorded_as_whitespace_reads_as_no_harness(self):
+        # `.strip()` and not `.lstrip()`: `_frame_identity_env` emits every name present or
+        # absent, so a truncated or padded value is a real shape here — and a harness of
+        # `"  "` must not become a chat that says it was running a harness called nothing.
+        state.record_identity("alpha.1", {"CHARTER_HARNESS": "  \t ",
+                                          "CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
+
+        state.record_workspace("alpha.1", "alpha")
+
+        c = leave.plan(live={"alpha.1"}, focus="").chats[0]
+
+        self.assertEqual(c.harness, "")
+        self.assertTrue(leave.note(c).startswith(leave.NO_RESUME_UNKNOWN),
+                        "a chat charter cannot identify says so, rather than naming a "
+                        f"harness called nothing — got {leave.note(c)!r}")
+
+    def test_a_harness_with_trailing_space_is_the_harness_it_names(self):
+        # The other half, and the one `lstrip` gets wrong: a trailing space is what a
+        # truncated write leaves, and `claude-code ` is Claude Code.
+        state.record_identity("alpha.1", {"CHARTER_HARNESS": "claude-code ",
+                                          "CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
+
+        c = leave.plan(live={"alpha.1"}, focus="").chats[0]
+
+        self.assertEqual(c.harness, "claude-code")
+        self.assertTrue(leave.resumable_harness(c.harness))
+
+    def test_it_is_recorded_by_a_quit_with_no_nulls_in_the_manifest(self):
+        # The whole point of the empty strings: they are what reaches `json.dumps`.
+        _plant("beta.1", ws="beta")
+        with mock.patch.multiple(commands_frame, _chat_seats=mock.DEFAULT,
+                                 _capture_transcript=mock.DEFAULT,
+                                 _stop_chats=mock.DEFAULT) as m:
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0", "beta.1": "@1"}, set())
+            m["_capture_transcript"].return_value = False
+            m["_stop_chats"].return_value = 2
+            commands_frame.cmd_quit(SimpleNamespace(chat="beta.1"))
+
+        raw = json.loads(reopen.path().read_text())
+        self.assertNotIn("null", json.dumps(raw["frames"]),
+                         "a null where the record type promises text is a shape every "
+                         "reader has to handle")
+
+
 if __name__ == "__main__":       # pragma: no cover
     unittest.main()

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -81,8 +81,18 @@ class TheWarningNamesWhatEachChatLoses(PersonaIso, unittest.TestCase):
         self.assertIn("gone", note)
         self.assertIn(leave.RESUMES, note)
 
-    def test_a_chat_with_no_workspace_record_says_it_reopens_unplaced(self):
-        self.assertIn("unplaced", leave.note(_doomed(resume="c", workspace="")))
+    def test_a_chat_with_no_workspace_record_is_told_it_cannot_be_reopened(self):
+        # The one chat this design cannot bring back, and the note promises nothing —
+        # not even the resume it has an id for, because there is no session to rebuild it
+        # into and choosing one would be §4j's re-homing arriving as a convenience.
+        note = leave.note(_doomed(resume="c", workspace=""))
+
+        self.assertEqual(note, leave.NOT_REOPENED)
+        self.assertNotIn(leave.RESUMES, note)
+
+    def test_a_chat_it_cannot_place_still_reports_the_code_it_ended_with(self):
+        self.assertEqual(leave.note(_doomed(workspace="", exit_code=3)),
+                         f"{leave.NOT_REOPENED} · already ended on its own (3)")
 
     def test_a_directory_that_has_gone_names_the_fallback(self):
         note = leave.note(_doomed(resume="c", cwd="/nowhere", cwd_gone=True))
@@ -103,14 +113,28 @@ class TheConfirmationIsAWarningNotAMenu(PersonaIso, unittest.TestCase):
     def _plan(self, *chats_):
         return leave.Plan(chats=tuple(chats_), focus="alpha")
 
-    def test_every_chat_row_is_refused_and_the_only_row_that_runs_is_last(self):
+    def test_every_chat_row_is_refused_and_the_row_that_runs_is_where_the_cursor_lands(self):
+        # `palette.narrow` puts the cursor on the FIRST row when nothing has been typed,
+        # refused or not — so the confirming row has to be first or the surface opens with
+        # Enter bound to nothing. Measured, with the earlier last-row ordering.
         rows = leave.confirm_rows(
             self._plan(_doomed(chat="alpha.1", resume="c"),
                        _doomed(chat="alpha.2", harness="opencode")),
             verb=leave.QUIT)
 
-        self.assertEqual([r.refused for r in rows], [True, True, False])
-        self.assertTrue(leave.goes_through(rows[-1], leave.QUIT))
+        self.assertEqual([r.refused for r in rows], [False, True, True])
+        self.assertTrue(leave.goes_through(rows[0], leave.QUIT))
+
+    def test_the_cursor_really_lands_on_the_row_that_runs(self):
+        # The property the ordering exists for, asserted through the surface rather than
+        # through the list: this is what an operator sees selected when it opens.
+        from charter.frame import palette
+        p = self._plan(_doomed(chat="alpha.1", resume="c", active=True))
+        surface = palette.Palette(catalogue=leave.confirm_rows(p, verb=leave.QUIT),
+                                  label=leave.QUIT)
+        surface.render(80, 12)
+
+        self.assertTrue(leave.goes_through(surface.selected, leave.QUIT))
 
     def test_each_chat_row_carries_that_chats_own_sentence(self):
         rows = leave.confirm_rows(
@@ -118,13 +142,13 @@ class TheConfirmationIsAWarningNotAMenu(PersonaIso, unittest.TestCase):
                        _doomed(chat="alpha.2", harness="opencode")),
             verb=leave.QUIT)
 
-        self.assertEqual(rows[0].note, leave.RESUMES)
-        self.assertIn("opencode", rows[1].note)
+        self.assertEqual(rows[1].note, leave.RESUMES)
+        self.assertIn("opencode", rows[2].note)
 
     def test_the_chat_you_are_looking_at_is_marked(self):
         rows = leave.confirm_rows(self._plan(_doomed(active=True)), verb=leave.QUIT)
 
-        self.assertTrue(rows[0].mark)
+        self.assertTrue(rows[1].mark)
 
     def test_a_plane_with_nothing_open_gets_no_row_that_runs(self):
         rows = leave.confirm_rows(self._plan(), verb=leave.QUIT)
@@ -143,8 +167,8 @@ class TheConfirmationIsAWarningNotAMenu(PersonaIso, unittest.TestCase):
     def test_closes_summary_says_forget_where_quits_says_resume(self):
         rows = leave.confirm_rows(self._plan(_doomed(resume="c")), verb=leave.CLOSE)
 
-        self.assertIn("not come back", rows[-1].title)
-        self.assertTrue(leave.goes_through(rows[-1], leave.CLOSE))
+        self.assertIn("not come back", rows[0].title)
+        self.assertTrue(leave.goes_through(rows[0], leave.CLOSE))
 
     def test_close_is_listed_with_its_reason_when_there_is_no_chat_to_close(self):
         # #512's rule: an option you cannot see is one you cannot ask about. Quit needs no

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -1,0 +1,396 @@
+"""§4e/§4f: what comes back, what does not, and the sentence that says which — per chat.
+
+**The warning is the feature, not the decoration.** §4f asks for it *at the moment the
+operator is deciding, not after*, and §4e is explicit that resume is Claude-only because
+nothing else writes a session id (§2.8). So there are four sentences and not one, and which
+one a chat gets is a fact about that chat rather than a hedge:
+
+* it has an id → the conversation resumes;
+* charter does not know what harness it was → say that, do not guess;
+* it is Claude Code with no id yet → say that, because the harness CAN resume;
+* it is a harness that records no id → name the harness, because "reopens empty" alone
+  would reasonably be filed as a bug.
+
+**And a chat that cannot be resumed still comes back.** Silently not reopening it would make
+a chat vanish across a restart, which is the opposite of what the requirement asked for. The
+directory, the workspace and the persona return either way; only the conversation is gone.
+
+`cmd_launch` is patched throughout the reopen cases, and that is the point of the split
+rather than a convenience: what `_reopen_one` owes the launcher is an argv, a workspace, a
+directory to stand in and a `Reopening` to fill in — and those four are exactly what is
+asserted. The launcher's own behaviour is covered by its own tests and, on a real server, by
+`tests/test_quit_and_reopen_on_a_real_tmux.py`.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config, persona
+from charter.frame import leave, reopen, state
+
+from tests._isolation import PersonaIso
+
+SERVER = commands_frame.SOCKET
+
+
+def _doomed(**kw):
+    """One `leave.Doomed` with every field defaulted, so a case states only what it is about.
+
+    A helper rather than a fixture object: the record is a NamedTuple and the thing under
+    test is a pure function of it, so the shortest honest test is one that hands it a value.
+    """
+    base = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
+                cwd="/tmp", resume="", server=SERVER, live=True, active=False,
+                exit_code=None, closed=False, homeless=False, cwd_gone=False)
+    base.update(kw)
+    return leave.Doomed(**base)
+
+
+class TheWarningNamesWhatEachChatLoses(PersonaIso, unittest.TestCase):
+    """Four resume sentences, and the qualifications that only appear when they are true."""
+
+    def test_a_chat_with_an_id_is_promised_its_conversation(self):
+        self.assertEqual(leave.note(_doomed(resume="conv-1")), leave.RESUMES)
+
+    def test_a_chat_charter_cannot_identify_says_so(self):
+        self.assertEqual(leave.note(_doomed(harness="")), leave.NO_RESUME_UNKNOWN)
+
+    def test_claude_code_with_no_id_yet_says_it_is_the_id_that_is_missing(self):
+        self.assertEqual(leave.note(_doomed(harness="claude-code")),
+                         leave.NO_RESUME_YET)
+
+    def test_another_harness_is_named_rather_than_left_as_reopens_empty(self):
+        note = leave.note(_doomed(harness="opencode"))
+
+        self.assertIn("opencode", note)
+        self.assertEqual(note, leave.NO_RESUME_HARNESS.format(harness="opencode"))
+
+    def test_only_claude_code_is_resumable_and_it_is_asked_of_the_registry(self):
+        from charter.harness import claude_code
+        self.assertTrue(leave.resumable_harness(claude_code.NAME))
+        self.assertFalse(leave.resumable_harness("opencode"))
+        self.assertFalse(leave.resumable_harness("codex"))
+        self.assertFalse(leave.resumable_harness(""))
+
+    def test_a_missing_workspace_is_reported_and_never_re_homed(self):
+        note = leave.note(_doomed(resume="c", workspace="gone", homeless=True))
+
+        self.assertIn("gone", note)
+        self.assertIn(leave.RESUMES, note)
+
+    def test_a_chat_with_no_workspace_record_says_it_reopens_unplaced(self):
+        self.assertIn("unplaced", leave.note(_doomed(resume="c", workspace="")))
+
+    def test_a_directory_that_has_gone_names_the_fallback(self):
+        note = leave.note(_doomed(resume="c", cwd="/nowhere", cwd_gone=True))
+
+        self.assertIn("/nowhere", note)
+        self.assertIn("plane root", note)
+
+    def test_a_chat_that_already_ended_says_with_which_code(self):
+        self.assertIn("(7)", leave.note(_doomed(resume="c", exit_code=7)))
+
+    def test_a_clean_chat_says_only_the_one_thing_it_is_about(self):
+        self.assertEqual(leave.note(_doomed(resume="c")), leave.RESUMES)
+
+
+class TheConfirmationIsAWarningNotAMenu(PersonaIso, unittest.TestCase):
+    """The rows the operator reads before the keypress commits anything."""
+
+    def _plan(self, *chats_):
+        return leave.Plan(chats=tuple(chats_), focus="alpha")
+
+    def test_every_chat_row_is_refused_and_the_only_row_that_runs_is_last(self):
+        rows = leave.confirm_rows(
+            self._plan(_doomed(chat="alpha.1", resume="c"),
+                       _doomed(chat="alpha.2", harness="opencode")),
+            verb=leave.QUIT)
+
+        self.assertEqual([r.refused for r in rows], [True, True, False])
+        self.assertTrue(leave.goes_through(rows[-1], leave.QUIT))
+
+    def test_each_chat_row_carries_that_chats_own_sentence(self):
+        rows = leave.confirm_rows(
+            self._plan(_doomed(chat="alpha.1", resume="c"),
+                       _doomed(chat="alpha.2", harness="opencode")),
+            verb=leave.QUIT)
+
+        self.assertEqual(rows[0].note, leave.RESUMES)
+        self.assertIn("opencode", rows[1].note)
+
+    def test_the_chat_you_are_looking_at_is_marked(self):
+        rows = leave.confirm_rows(self._plan(_doomed(active=True)), verb=leave.QUIT)
+
+        self.assertTrue(rows[0].mark)
+
+    def test_a_plane_with_nothing_open_gets_no_row_that_runs(self):
+        rows = leave.confirm_rows(self._plan(), verb=leave.QUIT)
+
+        self.assertEqual([r.refused for r in rows], [True])
+        self.assertEqual(rows[0].title, leave.NOTHING_OPEN)
+
+    def test_the_summary_counts_what_can_come_back(self):
+        p = self._plan(_doomed(chat="alpha.1", resume="c"),
+                       _doomed(chat="alpha.2", harness="opencode"))
+
+        self.assertEqual(leave.summary(p),
+                         "quit — stop 2 chats in 1 workspace; 1 of 2 can resume the "
+                         "conversation")
+
+    def test_closes_summary_says_forget_where_quits_says_resume(self):
+        rows = leave.confirm_rows(self._plan(_doomed(resume="c")), verb=leave.CLOSE)
+
+        self.assertIn("not come back", rows[-1].title)
+        self.assertTrue(leave.goes_through(rows[-1], leave.CLOSE))
+
+    def test_close_is_listed_with_its_reason_when_there_is_no_chat_to_close(self):
+        # #512's rule: an option you cannot see is one you cannot ask about. Quit needs no
+        # target and stays available; close does, and says so.
+        quit_row, close_row = leave.open_rows("")
+
+        self.assertFalse(quit_row.refused)
+        self.assertTrue(close_row.refused)
+        self.assertEqual(close_row.note, leave.NO_CHAT_HERE)
+        # And with a chat, neither is refused and neither carries a note.
+        self.assertEqual([r.refused for r in leave.open_rows("alpha.1")], [False, False])
+        self.assertEqual([r.note for r in leave.open_rows("alpha.1")], ["", ""])
+
+    def test_the_two_doorways_cannot_be_confused_with_an_action(self):
+        from charter.frame import component
+        for row in leave.open_rows("alpha.1"):
+            self.assertFalse(component.usable_id(row.id),
+                             "a provider could ship an action with this id and steal the "
+                             "keypress")
+            self.assertIsNotNone(leave.verb_of(row))
+            self.assertTrue(leave.is_row(row))
+
+    def test_an_action_row_is_not_read_as_one_of_these(self):
+        from charter.frame import overlay
+        self.assertIsNone(leave.verb_of(overlay.Row(id="frame.detach", title="x")))
+        self.assertFalse(leave.is_row(overlay.Row(id="frame.detach", title="x")))
+        # A row whose id merely CONTAINS a colon is not this module's either.
+        self.assertFalse(leave.is_row(overlay.Row(id="pick:workspace", title="x")))
+
+
+class WhatAReopenPutsBack(PersonaIso, unittest.TestCase):
+    """The four items, the resume flag, and the honest fallbacks."""
+
+    def setUp(self):
+        super().setUp()
+        self.calls = []
+        config.private_mkdir(state._root())
+
+    def _launch(self, args):
+        """Stand in for the launcher: claim an id, record what a launch records, report.
+
+        It writes the same three records `cmd_launch` writes for the reopen path, because
+        the assertions below are about what the reopened chat's own directory then says —
+        which is the reading every surface of the frame does.
+        """
+        self.calls.append(SimpleNamespace(harness=args.harness, rest=list(args.rest),
+                                          workspace=args.workspace, cwd=__import__(
+                                              "os").getcwd()))
+        fid = state.new_chat_id(args.workspace or "default")
+        state.record_workspace(fid, args.workspace or "default")
+        state.record_cwd(fid, __import__("os").getcwd())
+        state.record_harness_pane(fid, "%7")
+        args.reopening.fid = fid
+        commands_frame._restore_recorded_chat(args.reopening.chat, fid)
+        return 0
+
+    def _record(self, *chats_, focus="alpha"):
+        by_ws: dict = {}
+        for c in chats_:
+            by_ws.setdefault(c.workspace, []).append(c)
+        reopen.write([reopen.Frame(workspace=w, chats=tuple(cs))
+                      for w, cs in by_ws.items()], focus=focus)
+
+    def _chat(self, **kw):
+        base = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
+                    cwd=str(config.ROOT), resume="", transcript="", active=True)
+        base.update(kw)
+        return reopen.Chat(**base)
+
+    def _reopen(self):
+        with mock.patch.object(commands_frame, "cmd_launch", side_effect=self._launch), \
+                mock.patch.object(commands_frame.sys.stdout, "isatty",
+                                  return_value=True), \
+                mock.patch.object(commands_frame.tmuxctl, "version",
+                                  return_value=(3, 7)), \
+                mock.patch.object(commands_frame, "_attach_after_reopen",
+                                  return_value=0):
+            return commands_frame.cmd_reopen(SimpleNamespace())
+
+    def test_resume_is_appended_to_the_harness_argv_for_claude_with_an_id(self):
+        self._record(self._chat(resume="conv-1"))
+
+        self.assertEqual(self._reopen(), 0)
+
+        self.assertEqual(self.calls[0].rest, ["--resume", "conv-1"])
+        self.assertEqual(self.calls[0].harness, "claude")
+
+    def test_a_harness_that_records_no_id_is_never_handed_the_flag(self):
+        self._record(self._chat(harness="opencode", resume="conv-1"))
+
+        self.assertEqual(self._reopen(), 0)
+
+        self.assertEqual(self.calls[0].rest, [])
+
+    def test_a_chat_with_no_id_still_comes_back_empty(self):
+        self._record(self._chat(resume=""))
+
+        self.assertEqual(self._reopen(), 0)
+
+        self.assertEqual(self.calls[0].rest, [])
+        self.assertEqual(len(self.calls), 1, "it was reopened rather than dropped")
+
+    def test_the_workspace_and_the_directory_are_the_recorded_ones(self):
+        where = config.ROOT / "somewhere"
+        where.mkdir()
+        self._record(self._chat(workspace="alpha", cwd=str(where)))
+
+        self.assertEqual(self._reopen(), 0)
+
+        self.assertEqual(self.calls[0].workspace, "alpha")
+        self.assertEqual(self.calls[0].cwd, str(where.resolve()))
+
+    def test_a_directory_that_has_gone_falls_back_to_the_plane_root(self):
+        self._record(self._chat(cwd="/nowhere-at-all"))
+
+        self.assertEqual(self._reopen(), 0)
+
+        self.assertEqual(self.calls[0].cwd, str(config.ROOT.resolve()))
+
+    def test_the_launcher_is_left_standing_where_it_started(self):
+        import os
+        here = os.getcwd()
+        self._record(self._chat())
+
+        self._reopen()
+
+        self.assertEqual(os.getcwd(), here)
+
+    def test_the_persona_pointer_follows_the_chat_onto_its_new_id(self):
+        # The recorded chat was `alpha.9`, so the pointer under `alpha.9` is about to name
+        # nothing — the reopened chat gets a fresh ordinal (`alpha.1` here) and the pointer
+        # has to be written under THAT id or the persona is silently lost.
+        self._record(self._chat(chat="alpha.9", persona="steward"))
+        self.assertIsNone(persona.for_session("alpha.1"))
+
+        self.assertEqual(self._reopen(), 0)
+
+        self.assertEqual(persona.for_session("alpha.1"), "steward")
+
+    def test_the_captured_transcript_follows_the_chat_onto_its_new_id(self):
+        # The old chat's directory is gone (reaped), so the transcript is the only thing
+        # left of it — and the row that offers it looks the file up by the NEW chat's id.
+        config.write_for(reopen.transcript_path("alpha.9"), "what was on screen\n")
+        self._record(self._chat(chat="alpha.9", transcript="alpha.9.transcript"))
+
+        self.assertEqual(self._reopen(), 0)
+
+        self.assertFalse(reopen.transcript_path("alpha.9").exists())
+        self.assertEqual(reopen.transcript_path("alpha.1").read_text(),
+                         "what was on screen\n")
+
+    def test_a_reopened_chat_draws_no_gauge_until_its_own_first_turn(self):
+        """#413, and the reason §4e's gauge gate is not needed at all.
+
+        The spec asked for the gauge to be gated on `state.exit_code(fid) is None`, on the
+        grounds that a restored `session` mapping would draw another conversation's `ctx
+        78%`. This reopen restores no such mapping and cannot: a reopened chat is a FRESH
+        chat id, so its directory has no `session` file, `state.harness_session` answers
+        ``None``, and `frame/slots.py`'s rule — no gauge rather than a wrong one — applies
+        on its own. The mapping is written on the chat's first turn by Claude Code's own
+        `statusLine` hook, from the live payload.
+
+        That makes the argument independent of whether `claude --resume` preserves the
+        harness's session id, which is the measurement the gate was traded against. It
+        stops being independent at the stage that relaunches into a chat's OWN directory
+        (Phase 5 Task 9's amendment says so), and this assertion is what will go red there.
+        """
+        self._record(self._chat(chat="alpha.9", resume="conv-1"))
+
+        self.assertEqual(self._reopen(), 0)
+
+        newest = self.calls and "alpha.1"
+        self.assertIsNone(state.harness_session(newest))
+        self.assertIsNone(state.kept_harness_session(newest))
+
+    def test_the_record_is_consumed_so_a_second_reopen_does_not_double_the_tabs(self):
+        self._record(self._chat())
+
+        self.assertEqual(self._reopen(), 0)
+
+        self.assertIsNone(reopen.read())
+
+    def test_several_workspaces_all_come_back(self):
+        self._record(self._chat(chat="alpha.1", workspace="alpha"),
+                     self._chat(chat="alpha.2", workspace="alpha"),
+                     self._chat(chat="beta.1", workspace="beta"))
+
+        self.assertEqual(self._reopen(), 0)
+
+        self.assertEqual([c.workspace for c in self.calls], ["alpha", "alpha", "beta"])
+
+    def test_nothing_recorded_is_a_refusal_that_names_what_records_one(self):
+        with mock.patch.object(commands_frame.sys.stdout, "isatty", return_value=True):
+            self.assertEqual(commands_frame.cmd_reopen(SimpleNamespace()), 1)
+
+    def test_a_pipeline_is_refused_before_anything_is_started(self):
+        self._record(self._chat())
+        with mock.patch.object(commands_frame.sys.stdout, "isatty",
+                               return_value=False), \
+                mock.patch.object(commands_frame, "cmd_launch") as launch:
+            self.assertEqual(commands_frame.cmd_reopen(SimpleNamespace()), 1)
+            launch.assert_not_called()
+        self.assertIsNotNone(reopen.read(), "and the record is left to try again")
+
+    def test_a_harness_this_charter_cannot_launch_is_reported_not_guessed(self):
+        self._record(self._chat(harness="clyde"))
+        with mock.patch.object(config, "HARNESS", {"default": None, "refused": None}):
+            self.assertEqual(self._reopen(), 1)
+        self.assertEqual(self.calls, [])
+        self.assertIsNotNone(reopen.read(), "left in place so it can be tried again")
+
+    def test_a_harness_this_charter_cannot_launch_falls_back_to_the_planes_default(self):
+        self._record(self._chat(harness="clyde"))
+        with mock.patch.object(config, "HARNESS",
+                               {"default": "claude", "refused": None}):
+            self.assertEqual(self._reopen(), 0)
+        self.assertEqual(self.calls[0].harness, "claude")
+
+
+class TheReopenPathSuppressesThreeThingsInTheLauncher(PersonaIso, unittest.TestCase):
+    """`Reopening` is the whole of the difference, and it is asked for by name."""
+
+    def test_an_ordinary_launch_is_not_a_reopen_and_does_attach(self):
+        args = SimpleNamespace()
+
+        self.assertIsNone(commands_frame._reopening(args))
+        self.assertTrue(commands_frame._wants_attach(args))
+
+    def test_a_field_that_is_not_a_reopening_is_not_read_as_one(self):
+        # A namespace carrying a truthy `reopening` of the wrong type must not turn the
+        # launcher's three suppressions on — the seam is a type, not a flag.
+        args = SimpleNamespace(reopening=True)
+
+        self.assertIsNone(commands_frame._reopening(args))
+        self.assertTrue(commands_frame._wants_attach(args))
+
+    def test_a_reopen_carries_the_recorded_chat_and_takes_the_new_id_back(self):
+        rec = reopen.Chat(chat="alpha.9", workspace="alpha", persona="", harness="",
+                          cwd="", resume="", transcript="", active=False)
+        r = commands_frame.Reopening(rec)
+        args = SimpleNamespace(reopening=r)
+
+        self.assertIs(commands_frame._reopening(args), r)
+        self.assertFalse(commands_frame._wants_attach(args))
+        self.assertEqual(r.fid, "", "empty until a launcher claims one")
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -255,9 +255,24 @@ class WhatAReopenPutsBack(PersonaIso, unittest.TestCase):
                                   return_value=True), \
                 mock.patch.object(commands_frame.tmuxctl, "version",
                                   return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=None), \
                 mock.patch.object(commands_frame, "_attach_after_reopen",
                                   return_value=0):
             return commands_frame.cmd_reopen(SimpleNamespace())
+
+    def test_inside_the_operators_own_tmux_it_refuses_rather_than_half_reopening(self):
+        self._record(self._chat())
+        with mock.patch.object(commands_frame.sys.stdout, "isatty",
+                               return_value=True), \
+                mock.patch.object(commands_frame.tmuxctl, "version",
+                                  return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=("/tmp/sock", "s0")), \
+                mock.patch.object(commands_frame, "cmd_launch") as launch:
+            self.assertEqual(commands_frame.cmd_reopen(SimpleNamespace()), 1)
+            launch.assert_not_called()
+        self.assertIsNotNone(reopen.read(), "and the record is left to try again")
 
     def test_resume_is_appended_to_the_harness_argv_for_claude_with_an_id(self):
         self._record(self._chat(resume="conv-1"))

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -377,6 +377,34 @@ class WhatAReopenPutsBack(PersonaIso, unittest.TestCase):
 
         self.assertIsNone(reopen.read())
 
+    def test_a_partial_reopen_leaves_behind_exactly_the_retry(self):
+        # Deleting the record whole would throw away the chats that did NOT come back,
+        # which is precisely the state an operator would want to try again; leaving it whole
+        # would open the ones that did a second time.
+        self._record(self._chat(chat="alpha.1", workspace="alpha"),
+                     self._chat(chat="beta.1", workspace="beta"))
+        real = self._launch
+
+        def _launch(args):
+            if args.workspace == "beta":
+                return 1
+            return real(args)
+
+        with mock.patch.object(commands_frame, "cmd_launch", side_effect=_launch), \
+                mock.patch.object(commands_frame.sys.stdout, "isatty",
+                                  return_value=True), \
+                mock.patch.object(commands_frame.tmuxctl, "version",
+                                  return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=None), \
+                mock.patch.object(commands_frame, "_attach_after_reopen",
+                                  return_value=0):
+            self.assertEqual(commands_frame.cmd_reopen(SimpleNamespace()), 0)
+
+        m = reopen.read()
+        self.assertEqual([c.chat for c in m.all_chats()], ["beta.1"])
+        self.assertEqual(m.focus, "alpha", "and the focus is the one the quit recorded")
+
     def test_several_workspaces_all_come_back(self):
         self._record(self._chat(chat="alpha.1", workspace="alpha"),
                      self._chat(chat="alpha.2", workspace="alpha"),

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -370,6 +370,34 @@ class WhatAReopenPutsBack(PersonaIso, unittest.TestCase):
         self.assertIsNone(state.harness_session(newest))
         self.assertIsNone(state.kept_harness_session(newest))
 
+    def test_the_manifest_outranks_a_stale_pointer_left_on_a_recycled_ordinal(self):
+        """The dependency this design was written around, closed by #791 and pinned here.
+
+        **A reopen mints a FRESH chat id — and very often the SAME one.** `new_chat_id`
+        walks upward from 1 and `reap` frees the ordinals a quit's chats held, so
+        `alpha.1` quit and reopened is `alpha.1` again. That made the per-session pointer a
+        live hazard rather than a theoretical one: while `.charter/sessions/<fid>.workspace`
+        was a rung of `state.own_workspace`, a `charter workspace use gamma` typed inside
+        the OLD `alpha.1` would have decided the NEW `alpha.1`'s membership, over the
+        workspace the manifest recorded and the launcher wrote.
+
+        #791 took that rung out (`own_workspace` is now the launch pin, then the record), so
+        the manifest is authoritative. This plants exactly that stale pointer and asserts the
+        chat comes back in the workspace it was recorded in.
+        """
+        from charter import workspace as ws_mod
+        # The pointer the previous chat left behind, under the id the new one will inherit.
+        ws_mod.set_active("gamma", session_id="alpha.1", terminal_id="", force=True)
+        self.assertEqual(ws_mod.for_session("alpha.1"), "gamma")
+        self._record(self._chat(chat="alpha.1", workspace="alpha"))
+
+        self.assertEqual(self._reopen(), 0)
+
+        self.assertEqual(self.calls[0].workspace, "alpha")
+        self.assertEqual(state.own_workspace("alpha.1"), "alpha",
+                         "a pointer from the chat that held this ordinal must not decide "
+                         "the membership of the chat that inherited it")
+
     def test_the_record_is_consumed_so_a_second_reopen_does_not_double_the_tabs(self):
         self._record(self._chat())
 

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -488,9 +488,6 @@ class TheReopenPathSuppressesFourThingsInTheLauncher(PersonaIso, unittest.TestCa
         self.assertEqual(r.fid, "", "empty until a launcher claims one")
 
 
-if __name__ == "__main__":       # pragma: no cover
-    unittest.main()
-
 
 class TheKeypressReachesTheTeardown(PersonaIso, unittest.TestCase):
     """`F2` → the doorway → the confirming row → the detached command. **The wiring.**
@@ -585,3 +582,7 @@ class TheKeypressReachesTheTeardown(PersonaIso, unittest.TestCase):
         self.assertEqual(started, [])
         said.assert_called_once()
         self.assertIn(leave.NO_CHAT_HERE, said.call_args[0][1])
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -170,6 +170,17 @@ class TheConfirmationIsAWarningNotAMenu(PersonaIso, unittest.TestCase):
         self.assertIn("not come back", rows[0].title)
         self.assertTrue(leave.goes_through(rows[0], leave.CLOSE))
 
+    def test_the_summary_a_close_prints_is_closes_and_not_quits(self):
+        # The stderr warning and the confirming row share one function, so a close that
+        # printed "quit — stop 1 chat" above its own row would be describing the wrong
+        # command — the exact confusion the two titles exist to keep apart.
+        p = self._plan(_doomed(resume="c"))
+
+        self.assertTrue(leave.summary(p, verb=leave.QUIT).startswith("quit —"))
+        self.assertTrue(leave.summary(p, verb=leave.CLOSE).startswith("close alpha.1 —"))
+        self.assertEqual(leave.summary(p), leave.summary(p, verb=leave.QUIT),
+                         "quit is the default, because it is the caller with no verb")
+
     def test_close_is_listed_with_its_reason_when_there_is_no_chat_to_close(self):
         # #512's rule: an option you cannot see is one you cannot ask about. Quit needs no
         # target and stays available; close does, and says so.

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -612,5 +612,140 @@ class TheKeypressReachesTheTeardown(PersonaIso, unittest.TestCase):
         self.assertIn(leave.NO_CHAT_HERE, said.call_args[0][1])
 
 
+class TheDoorwayScopesAndRefusesWhereItSaysItDoes(PersonaIso, unittest.TestCase):
+    """`_picker`'s two `leave` branches, and `_draw_palette`'s note.
+
+    **Every case here was asked for by the deletion sweep.** `TheKeypressReachesTheTeardown`
+    drives the four hops end to end and that is what it is for — but it only ever walks the
+    path where everything works, so five refusals underneath it were unpinned: dropping
+    `verb is not None` from the refusal, dropping the refusal itself, collapsing the
+    `only=` scoping either way, and dropping the `own_workspace` fallback all left the whole
+    9,895-test suite green.
+
+    They are asked here at `_picker`'s own seam rather than through the palette, because
+    what each one decides is a property of the surface it builds: which chats the
+    confirmation lists, and whether it opens at all.
+    """
+
+    def setUp(self):
+        super().setUp()
+        for fid, ws in (("alpha.1", "alpha"), ("alpha.2", "alpha"), ("beta.1", "beta")):
+            state.frame_dir(fid, create=True)
+            state.record_server(fid, SERVER)
+            state.record_workspace(fid, ws)
+            state.record_harness_pane(fid, "%1")
+            state.record_identity(fid, {"CHARTER_HARNESS": "claude-code",
+                                        "CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
+        self.live = ({"alpha.1", "alpha.2", "beta.1"},
+                     {SERVER: {"alpha.1": "@0", "alpha.2": "@1", "beta.1": "@2"}},
+                     set())
+
+    def _open(self, row, fid="alpha.1"):
+        with mock.patch.object(commands_frame, "_plane_live", return_value=self.live):
+            return commands_frame._picker(row, fid, [])
+
+    def _titles(self, surface):
+        return [r.title for r in surface.rows]
+
+    def test_quits_confirmation_lists_every_chat_on_the_plane(self):
+        surface = self._open(leave.open_rows("alpha.1")[0])
+
+        self.assertIsNotNone(surface)
+        listed = " ".join(self._titles(surface))
+        for fid in ("alpha.1", "alpha.2", "beta.1"):
+            self.assertIn(fid, listed)
+
+    def test_closes_confirmation_lists_only_the_chat_it_was_opened_in(self):
+        # The `only=` scoping. Collapsed either way this becomes quit wearing close's title,
+        # or a close that can never name a chat.
+        surface = self._open(leave.open_rows("alpha.2")[1], fid="alpha.2")
+
+        self.assertIsNotNone(surface)
+        listed = " ".join(self._titles(surface))
+        self.assertIn("alpha.2", listed)
+        self.assertNotIn("alpha.1", listed)
+        self.assertNotIn("beta.1", listed)
+
+    def test_a_refused_doorway_opens_nothing(self):
+        # `leave.open_rows("")` refuses the close row, because there is no chat to close.
+        # Without the refusal the surface would open over every chat on the plane under a
+        # title that says it is about one.
+        refused = leave.open_rows("")[1]
+        self.assertTrue(refused.note)
+
+        self.assertIsNone(self._open(refused))
+
+    def test_an_action_row_is_not_a_doorway_and_opens_nothing_here(self):
+        from charter.frame import overlay
+        self.assertIsNone(self._open(overlay.Row(id="frame.detach", title="detach")))
+
+    def test_a_chat_with_no_workspace_of_its_own_still_gets_a_confirmation(self):
+        # `state.own_workspace(fid) or ""` — the fallback the sweep dropped. `leave.plan`
+        # takes `focus` as text, and `None` would reach the manifest as the workspace a
+        # reopen attaches to.
+        state.frame_dir("ghost.9", create=True)
+        state.record_server("ghost.9", SERVER)
+        self.assertIsNone(state.own_workspace("ghost.9"))
+
+        surface = self._open(leave.open_rows("ghost.9")[0], fid="ghost.9")
+
+        self.assertIsNotNone(surface)
+
+
+class ARefusedDoorwaySaysItsReasonOnScreen(PersonaIso, unittest.TestCase):
+    """`_draw_palette`'s `if chosen.note and leave.verb_of(chosen) is not None`.
+
+    The sweep found the `chosen.note` half unpinned: without it, choosing one of the
+    warning's own per-chat rows — which are `refused=True`, so a click can still land on one
+    — would put that chat's note on the frame's attention row as though something had been
+    refused. Nothing was refused; the row is the warning.
+    """
+
+    def setUp(self):
+        super().setUp()
+        state.frame_dir("alpha.1", create=True)
+        state.record_server("alpha.1", SERVER)
+        state.record_workspace("alpha.1", "alpha")
+        state.record_harness_pane("alpha.1", "%1")
+        state.record_identity("alpha.1", {"CHARTER_HARNESS": "claude-code",
+                                          "CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
+
+    def _choose(self, pick_first, pick_second=None):
+        from charter.frame import palette
+
+        def _own(surface, *, fd=None, out=None, then=None):
+            row = next(r for r in surface.rows if pick_first(r))
+            nxt = then(row) if then is not None else None
+            if pick_second is None:
+                return row
+            self.assertIsNotNone(nxt)
+            return next(r for r in nxt.rows if pick_second(r))
+
+        with mock.patch.dict("os.environ", {"CHARTER_SESSION_ID": "alpha.1"}), \
+                mock.patch.object(palette, "own_the_tty", side_effect=_own), \
+                mock.patch.object(commands_frame, "_close_palette"), \
+                mock.patch.object(commands_frame, "_plane_live",
+                                  return_value=({"alpha.1"},
+                                                {SERVER: {"alpha.1": "@0"}},
+                                                {"alpha.1"})), \
+                mock.patch.object(commands_frame, "_start_leaving"), \
+                mock.patch.object(commands_frame, "_say_on_screen") as said:
+            commands_frame._draw_palette(SimpleNamespace(chat="alpha.1"))
+        return said
+
+    def test_a_refused_doorway_puts_its_reason_on_the_attention_row(self):
+        with mock.patch.object(leave, "open_rows", return_value=leave.open_rows("")):
+            said = self._choose(lambda r: leave.verb_of(r) == leave.CLOSE)
+
+        said.assert_called_once()
+        self.assertEqual(said.call_args[0][1], leave.NO_CHAT_HERE)
+
+    def test_a_per_chat_warning_row_says_nothing_because_nothing_was_refused(self):
+        said = self._choose(lambda r: leave.verb_of(r) == leave.QUIT,
+                            lambda r: r.refused)
+
+        said.assert_not_called()
+
+
 if __name__ == "__main__":       # pragma: no cover
     unittest.main()

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -399,8 +399,26 @@ class WhatAReopenPutsBack(PersonaIso, unittest.TestCase):
         self.assertEqual(self.calls[0].harness, "claude")
 
 
-class TheReopenPathSuppressesThreeThingsInTheLauncher(PersonaIso, unittest.TestCase):
-    """`Reopening` is the whole of the difference, and it is asked for by name."""
+class TheReopenPathSuppressesFourThingsInTheLauncher(PersonaIso, unittest.TestCase):
+    """`Reopening` is the whole of the difference, and it is asked for by name.
+
+    Four things in `cmd_launch` turn on it: open-or-focus (§4k) would swallow every chat
+    after the first of a workspace, `select-window` would move a client that does not exist
+    yet, `_drop_panels` would strip the panels off the sibling this same reopen had just
+    drawn, and `attach` would block on the first chat and never build the second.
+
+    **A fifth is gated on `_wants_attach` and is worth naming because the trap is common
+    rather than exotic:** `cmd_launch` says *"this plane was quit — put it back with
+    `charter reopen`"* when the manifest names its own chat, and `new_chat_id` walks upward
+    from 1 while `reap` frees the ordinals a quit's chats held — so a reopen usually gets the
+    SAME ids back, and every one of its own launches is named in the manifest it is in the
+    middle of acting on. The sentence belongs to a launch that WAS the operator's terminal,
+    which is what `_wants_attach` answers and what the two cases below pin.
+
+    The tail those five sit in cannot be reached without a real tmux session and a real
+    `attach`, so what is asserted here is the predicate the launcher branches on. The rest is
+    exercised on a real server in `tests/test_quit_and_reopen_on_a_real_tmux.py`.
+    """
 
     def test_an_ordinary_launch_is_not_a_reopen_and_does_attach(self):
         args = SimpleNamespace()

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -462,3 +462,98 @@ class TheReopenPathSuppressesFourThingsInTheLauncher(PersonaIso, unittest.TestCa
 
 if __name__ == "__main__":       # pragma: no cover
     unittest.main()
+
+
+class TheKeypressReachesTheTeardown(PersonaIso, unittest.TestCase):
+    """`F2` → the doorway → the confirming row → the detached command. **The wiring.**
+
+    Everything else in this file tests a function. This tests the four hops between a
+    keypress and `charter frame-quit`, and it is the one part with no other coverage: the
+    doorway's id has to be recognised by `_picker` (which builds the confirmation), the
+    confirming row's id has to be recognised by `_draw_palette` (which must NOT hand it to
+    `ActionRegistry.invoke`, where it is not an action at all), and the per-chat rows have
+    to do nothing when one is clicked.
+
+    `palette.own_the_tty` is replaced by a script rather than a terminal: it is handed the
+    surface and the `then` callback, exactly as the real one is, and it plays the two
+    choices an operator would make. That keeps the hops real — the same `_picker`, the same
+    `_draw_palette` — with no pty and no tmux under either.
+    """
+
+    def setUp(self):
+        super().setUp()
+        state.frame_dir("alpha.1", create=True)
+        state.record_server("alpha.1", SERVER)
+        state.record_workspace("alpha.1", "alpha")
+        state.record_harness_pane("alpha.1", "%1")
+        state.record_identity("alpha.1", {"CHARTER_HARNESS": "claude-code",
+                                          "CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
+        state.record_harness_session("alpha.1", "conv-1")
+
+    def _press(self, pick_first, pick_second=None):
+        """Drive `_draw_palette` through *pick_first*, then *pick_second* on what it opens."""
+        from charter.frame import palette
+        started = []
+
+        def _own(surface, *, fd=None, out=None, then=None):
+            row = next(r for r in surface.rows if pick_first(r))
+            nxt = then(row) if then is not None else None
+            if pick_second is None:
+                return row
+            self.assertIsNotNone(nxt, "the doorway opened nothing")
+            return next(r for r in nxt.rows if pick_second(r))
+
+        with mock.patch.dict("os.environ", {"CHARTER_SESSION_ID": "alpha.1"}), \
+                mock.patch.object(palette, "own_the_tty", side_effect=_own), \
+                mock.patch.object(commands_frame, "_close_palette"), \
+                mock.patch.object(commands_frame, "_plane_live",
+                                  return_value=({"alpha.1"},
+                                                {SERVER: {"alpha.1": "@0"}},
+                                                {"alpha.1"})), \
+                mock.patch.object(commands_frame, "_start_leaving",
+                                  side_effect=lambda fid, verb: started.append(
+                                      (fid, verb))), \
+                mock.patch.object(commands_frame, "_say_on_screen") as said:
+            rc = commands_frame._draw_palette(SimpleNamespace(chat="alpha.1"))
+        return rc, started, said
+
+    def test_quit_reaches_the_detached_command_it_is_meant_to_start(self):
+        rc, started, _said = self._press(
+            lambda r: leave.verb_of(r) == leave.QUIT,
+            lambda r: leave.goes_through(r, leave.QUIT))
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(started, [("alpha.1", leave.QUIT)])
+
+    def test_close_reaches_its_own_command_and_not_quits(self):
+        rc, started, _said = self._press(
+            lambda r: leave.verb_of(r) == leave.CLOSE,
+            lambda r: leave.goes_through(r, leave.CLOSE))
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(started, [("alpha.1", leave.CLOSE)])
+
+    def test_a_chat_row_inside_the_confirmation_starts_nothing(self):
+        # It is `refused=True` so Enter never lands on it, but a click still can — and a
+        # click that stopped the plane because it landed on the warning would be the worst
+        # available outcome of this whole surface.
+        rc, started, said = self._press(
+            lambda r: leave.verb_of(r) == leave.QUIT,
+            lambda r: r.refused and not leave.goes_through(r, leave.QUIT))
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(started, [])
+        said.assert_not_called()
+
+    def test_the_doorway_row_itself_starts_nothing_if_it_is_chosen_and_refused(self):
+        # A close doorway on a palette that cannot resolve its own chat carries a note and
+        # `_picker` refuses to open it; the note is said and nothing is started.
+        with mock.patch.object(leave, "open_rows",
+                               return_value=leave.open_rows("")):
+            rc, started, said = self._press(
+                lambda r: leave.verb_of(r) == leave.CLOSE)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(started, [])
+        said.assert_called_once()
+        self.assertIn(leave.NO_CHAT_HERE, said.call_args[0][1])

--- a/tests/test_close_is_the_one_teardown_that_forgets.py
+++ b/tests/test_close_is_the_one_teardown_that_forgets.py
@@ -1,0 +1,262 @@
+"""§4d/§4i: `chat: close` is quit's teardown with one target and one file more.
+
+**The one file is the whole difference, and it exists because of a measurement.** §2.17:
+`kill-pane`, `kill-window` and `kill-session` write no `exit` file, so `state.exit_code`
+answers ``None`` for a chat that was killed exactly as it does for one that never started.
+This design deliberately reads that ``None`` as *"we do not know it stopped — bring it
+back"*, because that is what "less invasive" means. The cost is stated in the design rather
+than hidden: a chat stopped outside the quit path would come back uninvited.
+
+`chat: close` is what pays that cost. It writes `state.record_closed`, and a quit skips
+whatever carries it. Without that file, closing a chat and then quitting the plane would
+bring the closed chat back — and the operator would have no way to make it stop.
+
+**And it drops the transcript, where quit keeps it.** A capture exists to be offered on the
+way back; a closed chat is not coming back, so keeping its capture would leave a file in the
+frame root that nothing will ever collect (`reopen.prune_transcripts` keeps whatever the
+manifest names, and a closed chat is in no manifest).
+
+**What it cannot do is refuse a busy chat**, and that is asserted here as a limit rather than
+left to be discovered: `inflight` records carry no fid, no chat and no workspace (§2.15), so
+there is no reading charter could refuse on. The confirmation row says the chat will not come
+back, which is the sentence an operator needs before pressing it.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config
+from charter.frame import leave, reopen, state
+
+from tests._isolation import PersonaIso
+
+SERVER = commands_frame.SOCKET
+
+
+def _plant(fid: str, *, ws: str, pane: str = "%1") -> None:
+    state.frame_dir(fid, create=True)
+    state.record_server(fid, SERVER)
+    state.record_workspace(fid, ws)
+    state.record_harness_pane(fid, pane)
+    state.record_identity(fid, {"CHARTER_HARNESS": "claude-code",
+                                "CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
+
+
+class ClosingMarksAndQuittingSkipsTheMark(PersonaIso, unittest.TestCase):
+    """The pair, asserted as a pair: neither half means anything alone."""
+
+    def test_the_mark_is_written_and_read_by_the_state_module(self):
+        _plant("alpha.1", ws="alpha")
+        self.assertFalse(state.was_closed("alpha.1"))
+
+        state.record_closed("alpha.1")
+
+        self.assertTrue(state.was_closed("alpha.1"))
+
+    def test_a_closed_chat_is_not_recorded_by_a_later_quit(self):
+        _plant("alpha.1", ws="alpha")
+        _plant("alpha.2", ws="alpha")
+
+        with mock.patch.multiple(commands_frame,
+                                 _chat_windows=mock.DEFAULT, _active_chats=mock.DEFAULT,
+                                 _capture_transcript=mock.DEFAULT,
+                                 _stop_chats=mock.DEFAULT) as m:
+            m["_chat_windows"].return_value = {"alpha.1": "@0", "alpha.2": "@1"}
+            m["_active_chats"].return_value = set()
+            m["_capture_transcript"].return_value = False
+            m["_stop_chats"].return_value = 1
+            self.assertEqual(commands_frame.cmd_close(
+                SimpleNamespace(chat="alpha.1", chat_id="alpha.2")), 0)
+            self.assertEqual(commands_frame.cmd_quit(
+                SimpleNamespace(chat="alpha.1")), 0)
+
+        self.assertEqual([c.chat for c in reopen.read().all_chats()], ["alpha.1"])
+
+    def test_without_the_mark_the_closed_chat_would_come_back(self):
+        # The guard, verified by removing it: this is the same plane as the case above with
+        # `record_closed` patched out, and the closed chat is then recorded as "was open".
+        _plant("alpha.1", ws="alpha")
+        _plant("alpha.2", ws="alpha")
+
+        with mock.patch.multiple(commands_frame,
+                                 _chat_windows=mock.DEFAULT, _active_chats=mock.DEFAULT,
+                                 _capture_transcript=mock.DEFAULT,
+                                 _stop_chats=mock.DEFAULT) as m, \
+                mock.patch.object(state, "record_closed"):
+            m["_chat_windows"].return_value = {"alpha.1": "@0", "alpha.2": "@1"}
+            m["_active_chats"].return_value = set()
+            m["_capture_transcript"].return_value = False
+            m["_stop_chats"].return_value = 1
+            commands_frame.cmd_close(SimpleNamespace(chat="alpha.1", chat_id="alpha.2"))
+            commands_frame.cmd_quit(SimpleNamespace(chat="alpha.1"))
+
+        self.assertEqual(sorted(c.chat for c in reopen.read().all_chats()),
+                         ["alpha.1", "alpha.2"])
+
+
+class CloseDropsWhatQuitKeeps(PersonaIso, unittest.TestCase):
+    """The transcript, and the manifest entry if a quit had already written one."""
+
+    def setUp(self):
+        super().setUp()
+        _plant("alpha.1", ws="alpha")
+        _plant("alpha.2", ws="alpha")
+        config.private_mkdir(state._root())
+
+    def _close(self, target):
+        with mock.patch.multiple(commands_frame,
+                                 _chat_windows=mock.DEFAULT, _active_chats=mock.DEFAULT,
+                                 _stop_chats=mock.DEFAULT) as m:
+            m["_chat_windows"].return_value = {"alpha.1": "@0", "alpha.2": "@1"}
+            m["_active_chats"].return_value = set()
+            m["_stop_chats"].return_value = 1
+            return commands_frame.cmd_close(
+                SimpleNamespace(chat="alpha.1", chat_id=target))
+
+    def test_the_closed_chats_transcript_is_dropped(self):
+        config.write_for(reopen.transcript_path("alpha.2"), "text\n")
+
+        self.assertEqual(self._close("alpha.2"), 0)
+
+        self.assertFalse(reopen.transcript_path("alpha.2").exists())
+
+    def test_a_siblings_transcript_is_left_alone(self):
+        reopen.write([reopen.Frame(workspace="alpha", chats=(
+            reopen.Chat(chat="alpha.1", workspace="alpha", persona="",
+                        harness="claude-code", cwd="", resume="",
+                        transcript="alpha.1.transcript", active=True),))], focus="alpha")
+        config.write_for(reopen.transcript_path("alpha.1"), "keep me\n")
+        config.write_for(reopen.transcript_path("alpha.2"), "drop me\n")
+
+        self.assertEqual(self._close("alpha.2"), 0)
+
+        self.assertEqual(reopen.transcript_path("alpha.1").read_text(), "keep me\n")
+        self.assertFalse(reopen.transcript_path("alpha.2").exists())
+
+    def test_closing_a_chat_a_quit_recorded_takes_it_out_of_the_manifest(self):
+        reopen.write([reopen.Frame(workspace="alpha", chats=(
+            reopen.Chat(chat="alpha.1", workspace="alpha", persona="", harness="c",
+                        cwd="", resume="", transcript="", active=True),
+            reopen.Chat(chat="alpha.2", workspace="alpha", persona="", harness="c",
+                        cwd="", resume="", transcript="", active=False)))],
+            focus="alpha")
+
+        self.assertEqual(self._close("alpha.2"), 0)
+
+        self.assertEqual([c.chat for c in reopen.read().all_chats()], ["alpha.1"])
+
+    def test_a_frame_left_with_no_chats_leaves_no_empty_frame_behind(self):
+        reopen.write([reopen.Frame(workspace="alpha", chats=(
+            reopen.Chat(chat="alpha.2", workspace="alpha", persona="", harness="c",
+                        cwd="", resume="", transcript="", active=True),))], focus="alpha")
+
+        self.assertEqual(self._close("alpha.2"), 0)
+
+        self.assertEqual(reopen.read().frames, ())
+
+
+class WhatCloseRefusesAndWhatItDoesNot(PersonaIso, unittest.TestCase):
+    """A name it cannot use, a chat it cannot find, and a busy chat it cannot judge."""
+
+    def test_a_name_that_cannot_be_a_chat_is_refused_before_any_scan(self):
+        with mock.patch.object(commands_frame, "_plane_live") as live:
+            rc = commands_frame.cmd_close(
+                SimpleNamespace(chat="alpha.1", chat_id="alpha.1;kill-server"))
+        self.assertEqual(rc, 1)
+        live.assert_not_called()
+
+    def test_an_unknown_chat_is_refused_rather_than_marked(self):
+        _plant("alpha.1", ws="alpha")
+
+        with mock.patch.multiple(commands_frame, _chat_windows=mock.DEFAULT,
+                                 _active_chats=mock.DEFAULT) as m:
+            m["_chat_windows"].return_value = {"alpha.1": "@0"}
+            m["_active_chats"].return_value = set()
+            rc = commands_frame.cmd_close(
+                SimpleNamespace(chat="alpha.1", chat_id="beta.4"))
+
+        self.assertEqual(rc, 1)
+        self.assertFalse(state.was_closed("beta.4"))
+
+    def test_a_chat_that_has_already_stopped_is_still_marked(self):
+        # The case the mark is most needed for: its harness ended on its own, so a quit
+        # would otherwise record it as open and bring it back.
+        _plant("alpha.1", ws="alpha")
+        state.record_exit("alpha.1", 0)
+
+        with mock.patch.multiple(commands_frame, _chat_windows=mock.DEFAULT,
+                                 _active_chats=mock.DEFAULT,
+                                 _stop_chats=mock.DEFAULT) as m:
+            m["_chat_windows"].return_value = {}
+            m["_active_chats"].return_value = set()
+            rc = commands_frame.cmd_close(
+                SimpleNamespace(chat="alpha.1", chat_id="alpha.1"))
+            m["_stop_chats"].assert_not_called()
+
+        self.assertEqual(rc, 0)
+        self.assertTrue(state.was_closed("alpha.1"))
+
+    def test_the_bare_command_closes_the_chat_it_was_pressed_in(self):
+        _plant("alpha.1", ws="alpha")
+
+        with mock.patch.multiple(commands_frame, _chat_windows=mock.DEFAULT,
+                                 _active_chats=mock.DEFAULT,
+                                 _stop_chats=mock.DEFAULT) as m:
+            m["_chat_windows"].return_value = {"alpha.1": "@0"}
+            m["_active_chats"].return_value = set()
+            m["_stop_chats"].return_value = 1
+            self.assertEqual(commands_frame.cmd_close(
+                SimpleNamespace(chat="alpha.1", chat_id="")), 0)
+
+        self.assertTrue(state.was_closed("alpha.1"))
+
+    def test_the_plan_it_warns_from_is_the_one_quit_uses_narrowed_to_one_chat(self):
+        _plant("alpha.1", ws="alpha")
+        _plant("alpha.2", ws="alpha")
+
+        p = leave.plan(live={"alpha.1", "alpha.2"}, focus="alpha", only="alpha.2")
+
+        self.assertEqual([c.chat for c in p.chats], ["alpha.2"])
+
+
+class TheKillIsAimedAtAWindowTmuxJustNamed(PersonaIso, unittest.TestCase):
+    """§3.3: a session NAME in another plane is another plane's session."""
+
+    def test_the_target_is_the_window_id_from_the_listing(self):
+        _plant("alpha.1", ws="alpha", pane="%1")
+        seen = []
+
+        class _Out:
+            returncode = 0
+            stdout = ""
+
+        def _run(why, argv, **kw):
+            seen.append(argv)
+            return _Out()
+
+        doomed = leave.stopping(leave.plan(live={"alpha.1"}, focus="alpha"))
+        with mock.patch.object(commands_frame.tmuxctl, "run", side_effect=_run):
+            self.assertEqual(
+                commands_frame._stop_chats(doomed, windows={SERVER: {"alpha.1": "@3"}}), 1)
+
+        self.assertEqual(len(seen), 1)
+        self.assertIn("kill-window", seen[0])
+        self.assertIn("@3", seen[0])
+        self.assertNotIn("alpha", seen[0], "a session name would be another plane's")
+        self.assertNotIn("kill-server", seen[0])
+        self.assertNotIn("kill-session", seen[0])
+
+    def test_a_chat_with_no_window_in_the_listing_is_not_aimed_at(self):
+        _plant("alpha.1", ws="alpha")
+        doomed = leave.stopping(leave.plan(live=None, focus="alpha"))
+
+        with mock.patch.object(commands_frame.tmuxctl, "run") as run:
+            self.assertEqual(commands_frame._stop_chats(doomed, windows={}), 0)
+            run.assert_not_called()
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()

--- a/tests/test_close_is_the_one_teardown_that_forgets.py
+++ b/tests/test_close_is_the_one_teardown_that_forgets.py
@@ -36,6 +36,17 @@ from tests._isolation import PersonaIso
 SERVER = commands_frame.SOCKET
 
 
+def _seats(windows, active):
+    """`commands_frame._chat_seats`' answer, built from what a case means to say.
+
+    One listing answers three questions — which chats are live, which window each is in, and
+    which was its session's current — so a fake for it is one value rather than three
+    patches. Written as a helper rather than spelled per case so a case says
+    ``{"alpha.1": "@0"}`` and ``{"alpha.1"}`` and nothing about tuple order.
+    """
+    return [(chat, window, chat in active) for chat, window in windows.items()]
+
+
 def _plant(fid: str, *, ws: str, pane: str = "%1") -> None:
     state.frame_dir(fid, create=True)
     state.record_server(fid, SERVER)
@@ -61,11 +72,10 @@ class ClosingMarksAndQuittingSkipsTheMark(PersonaIso, unittest.TestCase):
         _plant("alpha.2", ws="alpha")
 
         with mock.patch.multiple(commands_frame,
-                                 _chat_windows=mock.DEFAULT, _active_chats=mock.DEFAULT,
+                                 _chat_seats=mock.DEFAULT,
                                  _capture_transcript=mock.DEFAULT,
                                  _stop_chats=mock.DEFAULT) as m:
-            m["_chat_windows"].return_value = {"alpha.1": "@0", "alpha.2": "@1"}
-            m["_active_chats"].return_value = set()
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0", "alpha.2": "@1"}, set())
             m["_capture_transcript"].return_value = False
             m["_stop_chats"].return_value = 1
             self.assertEqual(commands_frame.cmd_close(
@@ -82,12 +92,11 @@ class ClosingMarksAndQuittingSkipsTheMark(PersonaIso, unittest.TestCase):
         _plant("alpha.2", ws="alpha")
 
         with mock.patch.multiple(commands_frame,
-                                 _chat_windows=mock.DEFAULT, _active_chats=mock.DEFAULT,
+                                 _chat_seats=mock.DEFAULT,
                                  _capture_transcript=mock.DEFAULT,
                                  _stop_chats=mock.DEFAULT) as m, \
                 mock.patch.object(state, "record_closed"):
-            m["_chat_windows"].return_value = {"alpha.1": "@0", "alpha.2": "@1"}
-            m["_active_chats"].return_value = set()
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0", "alpha.2": "@1"}, set())
             m["_capture_transcript"].return_value = False
             m["_stop_chats"].return_value = 1
             commands_frame.cmd_close(SimpleNamespace(chat="alpha.1", chat_id="alpha.2"))
@@ -108,10 +117,9 @@ class CloseDropsWhatQuitKeeps(PersonaIso, unittest.TestCase):
 
     def _close(self, target):
         with mock.patch.multiple(commands_frame,
-                                 _chat_windows=mock.DEFAULT, _active_chats=mock.DEFAULT,
+                                 _chat_seats=mock.DEFAULT,
                                  _stop_chats=mock.DEFAULT) as m:
-            m["_chat_windows"].return_value = {"alpha.1": "@0", "alpha.2": "@1"}
-            m["_active_chats"].return_value = set()
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0", "alpha.2": "@1"}, set())
             m["_stop_chats"].return_value = 1
             return commands_frame.cmd_close(
                 SimpleNamespace(chat="alpha.1", chat_id=target))
@@ -171,10 +179,8 @@ class WhatCloseRefusesAndWhatItDoesNot(PersonaIso, unittest.TestCase):
     def test_an_unknown_chat_is_refused_rather_than_marked(self):
         _plant("alpha.1", ws="alpha")
 
-        with mock.patch.multiple(commands_frame, _chat_windows=mock.DEFAULT,
-                                 _active_chats=mock.DEFAULT) as m:
-            m["_chat_windows"].return_value = {"alpha.1": "@0"}
-            m["_active_chats"].return_value = set()
+        with mock.patch.multiple(commands_frame, _chat_seats=mock.DEFAULT) as m:
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0"}, set())
             rc = commands_frame.cmd_close(
                 SimpleNamespace(chat="alpha.1", chat_id="beta.4"))
 
@@ -187,11 +193,9 @@ class WhatCloseRefusesAndWhatItDoesNot(PersonaIso, unittest.TestCase):
         _plant("alpha.1", ws="alpha")
         state.record_exit("alpha.1", 0)
 
-        with mock.patch.multiple(commands_frame, _chat_windows=mock.DEFAULT,
-                                 _active_chats=mock.DEFAULT,
+        with mock.patch.multiple(commands_frame, _chat_seats=mock.DEFAULT,
                                  _stop_chats=mock.DEFAULT) as m:
-            m["_chat_windows"].return_value = {}
-            m["_active_chats"].return_value = set()
+            m["_chat_seats"].return_value = []
             rc = commands_frame.cmd_close(
                 SimpleNamespace(chat="alpha.1", chat_id="alpha.1"))
             m["_stop_chats"].assert_not_called()
@@ -202,11 +206,9 @@ class WhatCloseRefusesAndWhatItDoesNot(PersonaIso, unittest.TestCase):
     def test_the_bare_command_closes_the_chat_it_was_pressed_in(self):
         _plant("alpha.1", ws="alpha")
 
-        with mock.patch.multiple(commands_frame, _chat_windows=mock.DEFAULT,
-                                 _active_chats=mock.DEFAULT,
+        with mock.patch.multiple(commands_frame, _chat_seats=mock.DEFAULT,
                                  _stop_chats=mock.DEFAULT) as m:
-            m["_chat_windows"].return_value = {"alpha.1": "@0"}
-            m["_active_chats"].return_value = set()
+            m["_chat_seats"].return_value = _seats({"alpha.1": "@0"}, set())
             m["_stop_chats"].return_value = 1
             self.assertEqual(commands_frame.cmd_close(
                 SimpleNamespace(chat="alpha.1", chat_id="")), 0)

--- a/tests/test_quit_and_reopen_on_a_real_tmux.py
+++ b/tests/test_quit_and_reopen_on_a_real_tmux.py
@@ -186,6 +186,118 @@ class ARealQuitStopsRealChats(PersonaIso, unittest.TestCase):
 
 
 @unittest.skipUnless(_HAS_TMUX, "needs a real tmux")
+class TheTranscriptOpensInAWindowOfItsOwn(PersonaIso, unittest.TestCase):
+    """§4f's other half, and **the one target only a hand-run could have found.**
+
+    `kill-window -t %N` resolves a pane to its own window — measured, and `cmd_launch`'s
+    early-death path already relies on it — so `new-window -t %N` looks like it should too.
+    It does not. Measured on tmux 3.7c **and** at the 3.2 floor, on a session called
+    `alpha.2` holding its own `$0`/`@0`/`%0`:
+
+        new-window -t %0        rc 1   can't specify pane here
+        new-window -t @0        rc 1   create window failed: index 0 in use
+        new-window -t alpha.2   rc 1   can't specify pane here      <- #695, again
+        new-window -t $0        rc 0
+
+    `-t` here is a target-WINDOW and a window id is read as the index to insert at, which is
+    by definition taken; a dotted session name is parsed as `window.pane`. The session ID is
+    the one unambiguous spelling. The first version of this shipped `-t <pane>`, was correct
+    against nothing, and reported its own failure into the frame's notice row — which is
+    exactly the *"ten lines and a tmux semantics claim is not cheap"* the delivery plan warns
+    about (#664, #687, #690).
+    """
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)
+        self.socket = _tmuxreap.name(f"transcript-{next(_SERVERS)}")
+        self.addCleanup(self._kill_server)
+
+    def _kill_server(self):
+        subprocess.run(["tmux", "-L", self.socket, "kill-server"],
+                       capture_output=True, text=True)
+
+    def _tmux(self, *argv, check=True):
+        out = subprocess.run(["tmux", "-L", self.socket, *argv],
+                             capture_output=True, text=True, timeout=20)
+        if check:
+            self.assertEqual(out.returncode, 0, f"{argv}: {out.stderr}")
+        return out.stdout.strip()
+
+    def _chat_with_a_transcript(self, text="LINE-ONE\n\x1b[31mRED\x1b[0m\nLINE-THREE\n"):
+        """A real chat in a session whose NAME has a dot in it, which is the hostile case.
+
+        A workspace may be called `api.2` (`instance.WORKSPACE_NAME_RE` accepts a dot), and
+        `state.workspace_prefix` is what keeps the SESSION name out of that alphabet — so the
+        session here is `alpha_2` and the recorded workspace is `alpha.2`, exactly as a real
+        launch would have it. The point is that nothing on this path ever hands tmux a name.
+        """
+        pane = self._tmux("new-session", "-d", "-s", "alpha_2", "-P", "-F", "#{pane_id}",
+                          "-x", "80", "-y", "24", "sh", "-c", "exec cat")
+        self._tmux("set-option", "-w", "-t", pane, commands_frame._CHAT_OPTION, "alpha_2.1")
+        state.frame_dir("alpha_2.1", create=True)
+        state.record_server("alpha_2.1", self.socket)
+        state.record_workspace("alpha_2.1", "alpha.2")
+        state.record_harness_pane("alpha_2.1", pane)
+        config.write_for(reopen.transcript_path("alpha_2.1"), text)
+        return pane
+
+    def _windows(self):
+        return dict(line.split("\t", 1) for line in self._tmux(
+            "list-windows", "-a", "-F", "#{window_id}\t#{window_name}").splitlines())
+
+    def test_it_opens_a_pager_window_beside_the_chat_and_shows_the_text(self):
+        self._chat_with_a_transcript()
+        before = self._windows()
+
+        with mock.patch.object(commands_frame, "SOCKET", self.socket):
+            self.assertEqual(commands_frame.cmd_transcript(
+                SimpleNamespace(chat="alpha_2.1")), 0)
+
+        after = self._windows()
+        new = [w for w in after if w not in before]
+        self.assertEqual(len(new), 1, f"{before} -> {after}")
+        self.assertIn("transcript alpha_2.1", after[new[0]])
+        # A pager, not a dead pane: `less` is what makes `q` close the window, and a dead
+        # pane under `remain-on-exit` is a window that does not close in a frame whose
+        # prefix key charter hides (§2.14).
+        panes = self._tmux("list-panes", "-t", new[0], "-F",
+                           "#{pane_current_command}\t#{pane_dead}")
+        self.assertEqual(panes.split("\t")[0], commands_frame._PAGER[0])
+        self.assertEqual(panes.split("\t")[1], "0")
+        # And the text really reached it, with the escape sequence rendered rather than
+        # printed — which is what `-R` on the pager and `-e` on the capture are both for.
+        seen = self._tmux("capture-pane", "-p", "-t", new[0])
+        self.assertIn("LINE-ONE", seen)
+        self.assertIn("RED", seen)
+        self.assertNotIn("\x1b[31m", seen)
+
+    def test_the_chats_own_window_is_left_exactly_as_it_was(self):
+        pane = self._chat_with_a_transcript()
+
+        with mock.patch.object(commands_frame, "SOCKET", self.socket):
+            commands_frame.cmd_transcript(SimpleNamespace(chat="alpha_2.1"))
+
+        # Nothing is written into the harness's pane — ADR 0018's half that this change
+        # leaves untouched — and its own process is still the one that was there.
+        self.assertEqual(self._tmux("display-message", "-p", "-t", pane,
+                                    "#{pane_current_command}:#{pane_dead}"), "cat:0")
+
+    def test_a_chat_with_no_capture_says_so_and_opens_nothing(self):
+        self._chat_with_a_transcript()
+        reopen.transcript_path("alpha_2.1").unlink()
+        before = self._windows()
+
+        with mock.patch.object(commands_frame, "SOCKET", self.socket), \
+                mock.patch.object(commands_frame, "_say_on_screen") as said:
+            self.assertEqual(commands_frame.cmd_transcript(
+                SimpleNamespace(chat="alpha_2.1")), 0)
+
+        self.assertEqual(self._windows(), before)
+        said.assert_called_once()
+        self.assertEqual(said.call_args[0][1], commands_frame.NO_TRANSCRIPT)
+
+@unittest.skipUnless(_HAS_TMUX, "needs a real tmux")
 class TwoPlanesOnOneServer(PersonaIso, unittest.TestCase):
     """§3.3, and the one case a single-plane test is blind to.
 

--- a/tests/test_quit_and_reopen_on_a_real_tmux.py
+++ b/tests/test_quit_and_reopen_on_a_real_tmux.py
@@ -276,24 +276,55 @@ class TheTranscriptOpensInAWindowOfItsOwn(PersonaIso, unittest.TestCase):
         self.assertEqual(self._settled(new[0]), (commands_frame._PAGER[0], "0"))
         # And the text really reached it, with the escape sequence rendered rather than
         # printed — which is what `-R` on the pager and `-e` on the capture are both for.
-        seen = self._tmux("capture-pane", "-p", "-t", new[0])
+        seen = self._shows(new[0], "LINE-ONE")
         self.assertIn("LINE-ONE", seen)
         self.assertIn("RED", seen)
         self.assertNotIn("\x1b[31m", seen)
 
+    #: How long the two polls below will wait. Generous, because what they are waiting for is
+    #: another process starting and painting on a shared runner, and the cost of a too-short
+    #: wait is a red that says nothing about charter.
+    _WAIT = 15.0
+
     def _settled(self, window):
         """``(command, dead)`` for *window*'s pane, once its process has exec'd.
+
+        **Polled, and CI is what taught this** — twice, in two places. `new-window` returns
+        when tmux has created the pane, not when the process in it has exec'd, so
+        `#{pane_current_command}` is `tmux` for a moment: asserted immediately it passed on
+        3.14 and failed on 3.11 and 3.13 in the same run.
 
         Returns whatever the last reading was when the deadline runs out, so a genuine
         failure is reported as the value it actually had rather than as a timeout.
         """
-        deadline = time.time() + 10
+        deadline = time.time() + self._WAIT
         seen = ("", "")
         while time.time() < deadline:
             fields = self._tmux("list-panes", "-t", window, "-F",
                                 "#{pane_current_command}\t#{pane_dead}").split("\t")
             seen = (fields[0], fields[1] if len(fields) > 1 else "")
             if seen[0] == commands_frame._PAGER[0]:
+                return seen
+            time.sleep(0.05)
+        return seen
+
+    def _shows(self, window, needle):
+        """*window*'s pane contents, once *needle* is in them.
+
+        **The second half of the same lesson, and the one that needed a second CI run to
+        find.** A pager that has exec'd has not necessarily PAINTED: with `_settled` alone,
+        3.11 and 3.13 went green and 3.14 came back with an empty capture. "Has the process
+        started" and "has it drawn" are two facts and neither implies the other on a loaded
+        runner.
+
+        Returns the last capture either way, so the assertion that follows fails on what was
+        actually on screen rather than on a timeout.
+        """
+        deadline = time.time() + self._WAIT
+        seen = ""
+        while time.time() < deadline:
+            seen = self._tmux("capture-pane", "-p", "-t", window)
+            if needle in seen:
                 return seen
             time.sleep(0.05)
         return seen

--- a/tests/test_quit_and_reopen_on_a_real_tmux.py
+++ b/tests/test_quit_and_reopen_on_a_real_tmux.py
@@ -14,10 +14,15 @@ order; none of that needs a server. What needs one:
   chat directories*. `TwoPlanesOnOneServer` is two plane roots with a workspace name in
   common, and it asserts that quitting one leaves the other's window running.
 
-Per §2.12 **none of this runs in CI** — `.github/workflows/test.yml` installs no tmux, so
-every case here skips there and a green gate says nothing about any of them. Hand-verified on
-tmux 3.7c and at the 3.2 floor (`tmuxctl.FLOOR`), which is why nothing here carries a version
-gate.
+**§2.12 says none of this runs in CI, and that is wrong** — measured by this very module.
+`.github/workflows/test.yml` installs no tmux, but `ubuntu-latest` has one, so `_HAS_TMUX` is
+true there and every case here RAN: one of them failed on 3.11 and 3.13 and passed on 3.14 in
+the same run, which is a race CI found and this machine did not. So the useful statement is
+narrower and sharper than the spec's: **CI runs these on whatever tmux the runner image
+happens to ship, which is neither of the two versions charter promises.** The floor and the
+version charter is developed on are still hand-run — 3.7c and the 3.2 floor
+(`tmuxctl.FLOOR`), which is why nothing here carries a version gate — and CI is a third
+machine's answer on top of that, worth having precisely because it is a different one.
 
 **Its own socket, reaped.** `commands_frame.SOCKET` is patched per class: the operator's own
 frame runs on the bare `charter` socket with sessions from several projects on it, and a test
@@ -261,16 +266,37 @@ class TheTranscriptOpensInAWindowOfItsOwn(PersonaIso, unittest.TestCase):
         # A pager, not a dead pane: `less` is what makes `q` close the window, and a dead
         # pane under `remain-on-exit` is a window that does not close in a frame whose
         # prefix key charter hides (§2.14).
-        panes = self._tmux("list-panes", "-t", new[0], "-F",
-                           "#{pane_current_command}\t#{pane_dead}")
-        self.assertEqual(panes.split("\t")[0], commands_frame._PAGER[0])
-        self.assertEqual(panes.split("\t")[1], "0")
+        #
+        # **Polled, and CI is what taught this.** `new-window` returns when tmux has created
+        # the pane, not when the process in it has exec'd — so `#{pane_current_command}` is
+        # still `tmux` for a moment. Asserted immediately it passed on 3.14 and failed on
+        # 3.11 and 3.13 in the same run, which is the signature of a race and not of a
+        # version difference. Same shape as `_chat_with_a_transcript`'s own wait, for the
+        # same reason.
+        self.assertEqual(self._settled(new[0]), (commands_frame._PAGER[0], "0"))
         # And the text really reached it, with the escape sequence rendered rather than
         # printed — which is what `-R` on the pager and `-e` on the capture are both for.
         seen = self._tmux("capture-pane", "-p", "-t", new[0])
         self.assertIn("LINE-ONE", seen)
         self.assertIn("RED", seen)
         self.assertNotIn("\x1b[31m", seen)
+
+    def _settled(self, window):
+        """``(command, dead)`` for *window*'s pane, once its process has exec'd.
+
+        Returns whatever the last reading was when the deadline runs out, so a genuine
+        failure is reported as the value it actually had rather than as a timeout.
+        """
+        deadline = time.time() + 10
+        seen = ("", "")
+        while time.time() < deadline:
+            fields = self._tmux("list-panes", "-t", window, "-F",
+                                "#{pane_current_command}\t#{pane_dead}").split("\t")
+            seen = (fields[0], fields[1] if len(fields) > 1 else "")
+            if seen[0] == commands_frame._PAGER[0]:
+                return seen
+            time.sleep(0.05)
+        return seen
 
     def test_the_chats_own_window_is_left_exactly_as_it_was(self):
         pane = self._chat_with_a_transcript()
@@ -279,7 +305,12 @@ class TheTranscriptOpensInAWindowOfItsOwn(PersonaIso, unittest.TestCase):
             commands_frame.cmd_transcript(SimpleNamespace(chat="alpha_2.1"))
 
         # Nothing is written into the harness's pane — ADR 0018's half that this change
-        # leaves untouched — and its own process is still the one that was there.
+        # leaves untouched — and its own process is still the one that was there. Read after
+        # the new window has settled, so this is not asserting about a moment before
+        # `new-window` had finished doing anything at all.
+        new = [w for w in self._windows() if "transcript" in self._windows()[w]]
+        if new:
+            self._settled(new[0])
         self.assertEqual(self._tmux("display-message", "-p", "-t", pane,
                                     "#{pane_current_command}:#{pane_dead}"), "cat:0")
 

--- a/tests/test_quit_and_reopen_on_a_real_tmux.py
+++ b/tests/test_quit_and_reopen_on_a_real_tmux.py
@@ -1,0 +1,327 @@
+"""The three things about quit that only a real tmux can answer.
+
+`tests/test_a_quit_records_the_plane_before_it_kills.py` says what a quit writes and in what
+order; none of that needs a server. What needs one:
+
+* **the capture is real bytes off a real pane** — that `capture-pane -p -e -N -S -<n>` hands
+  back what a harness printed, including its trailing spaces, which `-e` alone trims and
+  which are the alignment of anything drawn in columns;
+* **the kill really ends the chat**, and killing a session's LAST window really destroys the
+  session, which is the property that makes a per-window kill enough;
+* **§3.3, which is the only thing in this whole design a single-plane test cannot see.** One
+  tmux server serves every plane on the machine, session names carry no plane, and `default`
+  is a name every plane has — so a quit's blast radius has to be filtered by *this plane's
+  chat directories*. `TwoPlanesOnOneServer` is two plane roots with a workspace name in
+  common, and it asserts that quitting one leaves the other's window running.
+
+Per §2.12 **none of this runs in CI** — `.github/workflows/test.yml` installs no tmux, so
+every case here skips there and a green gate says nothing about any of them. Hand-verified on
+tmux 3.7c and at the 3.2 floor (`tmuxctl.FLOOR`), which is why nothing here carries a version
+gate.
+
+**Its own socket, reaped.** `commands_frame.SOCKET` is patched per class: the operator's own
+frame runs on the bare `charter` socket with sessions from several projects on it, and a test
+that killed windows there would kill their work. `tests/_tmuxreap` collects what a killed run
+leaves behind.
+"""
+
+from __future__ import annotations
+
+import itertools
+import shutil
+import subprocess
+import time
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config
+from charter.frame import leave, reopen, state, tmuxctl
+
+from tests import _tmuxreap
+from tests._isolation import PersonaIso, make_plane
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: A socket per class. Shared inside one class because every case there builds and tears
+#: down its own windows; never shared between classes, for
+#: `test_a_real_click_on_a_real_tab_bar_switches._SERVERS`' measured reason.
+_SERVERS = itertools.count()
+
+
+@unittest.skipUnless(_HAS_TMUX, "needs a real tmux")
+class ARealQuitStopsRealChats(PersonaIso, unittest.TestCase):
+    """One plane, two chats in one workspace, and a real teardown."""
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)
+        self.socket = _tmuxreap.name(f"quit-{next(_SERVERS)}")
+        self.enterContext(mock.patch.object(commands_frame, "SOCKET", self.socket))
+        self.addCleanup(self._kill_server)
+
+    def _kill_server(self):
+        subprocess.run(["tmux", "-L", self.socket, "kill-server"],
+                       capture_output=True, text=True)
+
+    def _tmux(self, *argv, check=True):
+        out = subprocess.run(["tmux", "-L", self.socket, *argv],
+                             capture_output=True, text=True, timeout=20)
+        if check:
+            self.assertEqual(out.returncode, 0, f"{argv}: {out.stderr}")
+        return out.stdout.strip()
+
+    def _chat(self, fid: str, *, ws: str, session: str, first: bool, says: str):
+        """One real chat: a real window, the `@charter_chat` option, and the real records.
+
+        The harness stand-in prints *says* and then holds the pane open with `cat`, which is
+        what makes the capture a measurement rather than a guess: something is genuinely on
+        screen and the pane genuinely still exists when the quit reads it.
+
+        The records go through the production writers, so a fixture that stopped agreeing
+        with the launcher fails here rather than passing against itself.
+        """
+        cmd = f"printf '{says}   \\n'; exec cat"
+        if first:
+            pane = self._tmux("new-session", "-d", "-s", session, "-P", "-F",
+                              "#{pane_id}", "-x", "80", "-y", "24", "sh", "-c", cmd)
+        else:
+            pane = self._tmux("new-window", "-d", "-t", session, "-P", "-F",
+                              "#{pane_id}", "sh", "-c", cmd)
+        self._tmux("set-option", "-w", "-t", pane, commands_frame._CHAT_OPTION, fid)
+        state.frame_dir(fid, create=True)
+        state.record_server(fid, self.socket)
+        state.record_workspace(fid, ws)
+        state.record_harness_pane(fid, pane)
+        state.record_cwd(fid, str(config.ROOT))
+        state.record_identity(fid, {"CHARTER_HARNESS": "claude-code",
+                                    "CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
+        state.record_harness_session(fid, f"conv-{fid}")
+        # The pane has to have PRINTED before anything captures it, and a poll is the only
+        # honest way to know: `new-window` returns when tmux has created the pane, not when
+        # the process in it has run.
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            if says in self._tmux("capture-pane", "-p", "-t", pane):
+                return pane
+            time.sleep(0.05)
+        self.fail(f"the stand-in harness for {fid} never printed")
+
+    def test_the_capture_is_the_real_pane_with_its_trailing_spaces(self):
+        pane = self._chat("alpha.1", ws="alpha", session="alpha", first=True,
+                          says="HELLO-FROM-THE-PANE")
+        dest = reopen.transcript_path("alpha.1")
+
+        self.assertTrue(commands_frame._capture_transcript(self.socket, pane, dest))
+
+        text = dest.read_text()
+        self.assertIn("HELLO-FROM-THE-PANE", text)
+        self.assertIn("HELLO-FROM-THE-PANE   ", text,
+                      "-N is what keeps the trailing spaces `-e` alone trims")
+
+    def test_a_pane_that_is_already_gone_captures_nothing_and_says_so(self):
+        pane = self._chat("alpha.1", ws="alpha", session="alpha", first=True, says="X")
+        self._tmux("kill-pane", "-t", pane, check=False)
+        dest = reopen.transcript_path("alpha.1")
+
+        self.assertFalse(commands_frame._capture_transcript(self.socket, pane, dest))
+        self.assertFalse(dest.exists())
+
+    def test_the_window_listing_maps_chats_to_windows_and_names_the_active_one(self):
+        self._chat("alpha.1", ws="alpha", session="alpha", first=True, says="ONE")
+        self._chat("alpha.2", ws="alpha", session="alpha", first=False, says="TWO")
+
+        found = commands_frame._chat_windows(self.socket)
+
+        self.assertEqual(sorted(found), ["alpha.1", "alpha.2"])
+        self.assertTrue(all(w.startswith("@") for w in found.values()))
+        # `new-window -d` did not move the session's current window, so the first chat is
+        # still the one on screen — which is what a reopen puts the operator back on.
+        self.assertEqual(commands_frame._active_chats(self.socket), {"alpha.1"})
+
+    def test_a_server_that_is_not_running_answers_none_rather_than_empty(self):
+        self._kill_server()
+
+        self.assertIsNone(commands_frame._chat_windows(self.socket))
+
+    def test_quit_stops_both_chats_records_both_and_ends_the_session(self):
+        self._chat("alpha.1", ws="alpha", session="alpha", first=True, says="ONE")
+        self._chat("alpha.2", ws="alpha", session="alpha", first=False, says="TWO")
+
+        self.assertEqual(commands_frame.cmd_quit(SimpleNamespace(chat="alpha.1")), 0)
+
+        # The kill: both windows gone, and with the last one the session — and with the
+        # last session the SERVER, which is measured here rather than assumed. It is why
+        # `_chat_windows` comes back `None` and not `{}`: there is nothing left to answer,
+        # which is the same tri-state `_live_chats` documents and the right one, because
+        # "charter could not ask" and "the server is empty" are different facts.
+        self.assertIsNone(commands_frame._chat_windows(self.socket))
+        self.assertEqual(self._tmux("list-sessions", "-F", "#{session_name}",
+                                    check=False), "")
+        # The record: both chats, both resumable, both with a captured transcript.
+        m = reopen.read()
+        self.assertEqual([c.chat for c in m.all_chats()], ["alpha.1", "alpha.2"])
+        self.assertEqual(m.focus, "alpha")
+        self.assertEqual([c.resume for c in m.all_chats()],
+                         ["conv-alpha.1", "conv-alpha.2"])
+        for c in m.all_chats():
+            self.assertEqual(c.transcript, f"{c.chat}{reopen.TRANSCRIPT_SUFFIX}")
+            self.assertIn("ONE" if c.chat == "alpha.1" else "TWO",
+                          reopen.transcript_path(c.chat).read_text())
+        self.assertTrue([c for c in m.all_chats() if c.active],
+                        "the chat that was on screen is marked")
+
+    def test_the_directory_survives_the_quit_and_the_manifest_survives_the_reap(self):
+        self._chat("alpha.1", ws="alpha", session="alpha", first=True, says="ONE")
+        commands_frame.cmd_quit(SimpleNamespace(chat="alpha.1"))
+
+        # A quit does NOT invert `reap`, which is stage 4 of the delivery order and six
+        # edits wide. So the next launch's reap takes the chat's directory exactly as it
+        # does today — and the manifest, which is a file, stays.
+        state.clear_claim("alpha.1")
+        self.assertEqual(state.reap(set(), server=self.socket), ["alpha.1"])
+        self.assertIsNotNone(reopen.read())
+        self.assertTrue(reopen.transcript_path("alpha.1").is_file())
+
+
+@unittest.skipUnless(_HAS_TMUX, "needs a real tmux")
+class TwoPlanesOnOneServer(PersonaIso, unittest.TestCase):
+    """§3.3, and the one case a single-plane test is blind to.
+
+    Both planes have a workspace called `default` — `config.DEFAULT_WORKSPACE`, a name every
+    plane has — so both have a tmux session called `default` on one server... which tmux
+    itself will not allow twice. That is the whole hazard: the SECOND plane's launch joins
+    the FIRST plane's session (`cmd_launch`'s `if session in live_sessions`), so one session
+    holds windows belonging to two different planes, and a quit that targeted the session
+    would stop somebody else's work.
+
+    So the assertion is per WINDOW: plane A's quit kills plane A's window and leaves plane
+    B's running, in the same session, on the same server.
+    """
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)
+        self.socket = _tmuxreap.name(f"quit-planes-{next(_SERVERS)}")
+        self.addCleanup(self._kill_server)
+        self.plane_a = config.use(self.tmp)
+        # A second plane root beside the first. `config.use` is how a test moves between
+        # them, which is the same call `PersonaIso` itself uses — never a hand-set attribute
+        # (`make_plane`'s own note: a plane a test claims to have must be one a subprocess
+        # could find too).
+        self.b_root = self.tmp.parent / f"{self.tmp.name}-plane-b"
+        self.b_root.mkdir()
+        (self.b_root / "charter.toml").write_text("schema = 1\n")
+        self.addCleanup(shutil.rmtree, self.b_root, True)
+
+    def _kill_server(self):
+        subprocess.run(["tmux", "-L", self.socket, "kill-server"],
+                       capture_output=True, text=True)
+
+    def _tmux(self, *argv, check=True):
+        out = subprocess.run(["tmux", "-L", self.socket, *argv],
+                             capture_output=True, text=True, timeout=20)
+        if check:
+            self.assertEqual(out.returncode, 0, f"{argv}: {out.stderr}")
+        return out.stdout.strip()
+
+    def _use(self, root):
+        config.use(root)
+
+    def _plant_chat(self, fid: str, *, session: str, first: bool) -> str:
+        cmd = "exec cat"
+        if first:
+            pane = self._tmux("new-session", "-d", "-s", session, "-P", "-F",
+                              "#{pane_id}", "-x", "80", "-y", "24", "sh", "-c", cmd)
+        else:
+            pane = self._tmux("new-window", "-d", "-t", session, "-P", "-F",
+                              "#{pane_id}", "sh", "-c", cmd)
+        self._tmux("set-option", "-w", "-t", pane, commands_frame._CHAT_OPTION, fid)
+        state.frame_dir(fid, create=True)
+        state.record_server(fid, self.socket)
+        state.record_workspace(fid, config.DEFAULT_WORKSPACE)
+        state.record_harness_pane(fid, pane)
+        state.record_identity(fid, {"CHARTER_HARNESS": "claude-code",
+                                    "CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
+        return pane
+
+    def test_a_quit_on_one_plane_leaves_the_other_planes_chat_running(self):
+        ws = config.DEFAULT_WORKSPACE
+        # Plane A's chat creates the session; plane B's joins it, exactly as a real second
+        # launch does when both planes have a workspace of the same name.
+        self._use(self.tmp)
+        a_pane = self._plant_chat(f"{ws}.1", session=ws, first=True)
+        self._use(self.b_root)
+        b_pane = self._plant_chat(f"{ws}.2", session=ws, first=False)
+
+        # Both windows are in one session, on one server, with two different planes' state.
+        with mock.patch.object(commands_frame, "SOCKET", self.socket):
+            self._use(self.tmp)
+            self.assertEqual(commands_frame.cmd_quit(
+                SimpleNamespace(chat=f"{ws}.1")), 0)
+
+            found = commands_frame._chat_windows(self.socket)
+
+        self.assertNotIn(f"{ws}.1", found, "plane A's chat was stopped")
+        self.assertIn(f"{ws}.2", found, "plane B's chat is still running")
+        self.assertEqual(self._tmux("display-message", "-p", "-t", b_pane,
+                                    "#{pane_dead}"), "0")
+        del a_pane
+
+    def test_the_quit_records_only_its_own_planes_chats(self):
+        ws = config.DEFAULT_WORKSPACE
+        self._use(self.tmp)
+        self._plant_chat(f"{ws}.1", session=ws, first=True)
+        self._use(self.b_root)
+        self._plant_chat(f"{ws}.2", session=ws, first=False)
+
+        with mock.patch.object(commands_frame, "SOCKET", self.socket):
+            self._use(self.tmp)
+            commands_frame.cmd_quit(SimpleNamespace(chat=f"{ws}.1"))
+            recorded_a = [c.chat for c in reopen.read().all_chats()]
+            self._use(self.b_root)
+            recorded_b = reopen.read()
+
+        self.assertEqual(recorded_a, [f"{ws}.1"])
+        self.assertIsNone(recorded_b, "plane B was never quit and has nothing recorded")
+
+    def test_neither_planes_quit_ever_reaches_for_kill_server(self):
+        ws = config.DEFAULT_WORKSPACE
+        self._use(self.tmp)
+        self._plant_chat(f"{ws}.1", session=ws, first=True)
+        seen = []
+        real = tmuxctl.run
+
+        def _watch(why, argv, **kw):
+            seen.append(argv)
+            return real(why, argv, **kw)
+
+        with mock.patch.object(commands_frame, "SOCKET", self.socket), \
+                mock.patch.object(commands_frame.tmuxctl, "run", side_effect=_watch):
+            commands_frame.cmd_quit(SimpleNamespace(chat=f"{ws}.1"))
+
+        flat = [" ".join(a) for a in seen]
+        self.assertFalse([c for c in flat if "kill-server" in c])
+        self.assertFalse([c for c in flat if "kill-session" in c])
+        self.assertTrue([c for c in flat if "kill-window" in c])
+
+    def test_the_plan_a_plane_builds_holds_only_its_own_chats(self):
+        # The same claim one layer down, and without tmux in it at all: `leave.plan` scans
+        # THIS plane's frame root, so a chat id live on the shared server but belonging to
+        # another plane is simply not there to be stopped.
+        ws = config.DEFAULT_WORKSPACE
+        self._use(self.tmp)
+        state.frame_dir(f"{ws}.1", create=True)
+        state.record_workspace(f"{ws}.1", ws)
+        self._use(self.b_root)
+        state.frame_dir(f"{ws}.2", create=True)
+        state.record_workspace(f"{ws}.2", ws)
+
+        self._use(self.tmp)
+        p = leave.plan(live={f"{ws}.1", f"{ws}.2"}, focus=ws)
+
+        self.assertEqual([c.chat for c in p.chats], [f"{ws}.1"])
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()

--- a/tests/test_quit_and_reopen_on_a_real_tmux.py
+++ b/tests/test_quit_and_reopen_on_a_real_tmux.py
@@ -131,18 +131,19 @@ class ARealQuitStopsRealChats(PersonaIso, unittest.TestCase):
         self._chat("alpha.1", ws="alpha", session="alpha", first=True, says="ONE")
         self._chat("alpha.2", ws="alpha", session="alpha", first=False, says="TWO")
 
-        found = commands_frame._chat_windows(self.socket)
+        seats = commands_frame._chat_seats(self.socket)
 
-        self.assertEqual(sorted(found), ["alpha.1", "alpha.2"])
-        self.assertTrue(all(w.startswith("@") for w in found.values()))
+        self.assertEqual(sorted(c for c, _w, _a in seats), ["alpha.1", "alpha.2"])
+        self.assertTrue(all(w.startswith("@") for _c, w, _a in seats))
         # `new-window -d` did not move the session's current window, so the first chat is
-        # still the one on screen — which is what a reopen puts the operator back on.
-        self.assertEqual(commands_frame._active_chats(self.socket), {"alpha.1"})
+        # still the one on screen — which is what a reopen puts the operator back on. One
+        # listing answers all three, which is why there is one call rather than two.
+        self.assertEqual({c for c, _w, showing in seats if showing}, {"alpha.1"})
 
     def test_a_server_that_is_not_running_answers_none_rather_than_empty(self):
         self._kill_server()
 
-        self.assertIsNone(commands_frame._chat_windows(self.socket))
+        self.assertIsNone(commands_frame._chat_seats(self.socket))
 
     def test_quit_stops_both_chats_records_both_and_ends_the_session(self):
         self._chat("alpha.1", ws="alpha", session="alpha", first=True, says="ONE")
@@ -152,10 +153,10 @@ class ARealQuitStopsRealChats(PersonaIso, unittest.TestCase):
 
         # The kill: both windows gone, and with the last one the session — and with the
         # last session the SERVER, which is measured here rather than assumed. It is why
-        # `_chat_windows` comes back `None` and not `{}`: there is nothing left to answer,
+        # `_chat_seats` comes back `None` and not `[]`: there is nothing left to answer,
         # which is the same tri-state `_live_chats` documents and the right one, because
         # "charter could not ask" and "the server is empty" are different facts.
-        self.assertIsNone(commands_frame._chat_windows(self.socket))
+        self.assertIsNone(commands_frame._chat_seats(self.socket))
         self.assertEqual(self._tmux("list-sessions", "-F", "#{session_name}",
                                     check=False), "")
         # The record: both chats, both resumable, both with a captured transcript.
@@ -260,7 +261,7 @@ class TwoPlanesOnOneServer(PersonaIso, unittest.TestCase):
             self.assertEqual(commands_frame.cmd_quit(
                 SimpleNamespace(chat=f"{ws}.1")), 0)
 
-            found = commands_frame._chat_windows(self.socket)
+            found = {c for c, _w, _a in commands_frame._chat_seats(self.socket) or []}
 
         self.assertNotIn(f"{ws}.1", found, "plane A's chat was stopped")
         self.assertIn(f"{ws}.2", found, "plane B's chat is still running")


### PR DESCRIPTION
**Rebased onto `9c0d0a9`.** Three commits landed under this branch, and one of them matters
to it: `2e6eecb` (#791/#794) took the per-session `.charter/sessions/<id>.workspace` pointer
out of `state.own_workspace`. That was this design's stated dependency and the residual it
could previously only *report* — see the last bullet under *Six things this found about
itself*. It is now a test.

Closes nothing on its own — this is §4e, §4f and §4i of
`docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md`, plus the one edit of
stage 4 that had to come with them (`chat: close`).

> *"when user closing charter session we need to show warning, that all harness sessions
> will be closed, and when opening again we need to resume harness sessions as well. so for
> user it should be 'less invasive' — to not lose sessions, state etc."*

The operator restarted, got an empty frame, and recovered their conversation by typing
`/resume` by hand. **Three verbs were missing and none existed anywhere**: `charter --help`
had ten `frame-*` commands and neither a quit nor a close, and the palette registered
detach, two repo rows, three densities and three surfaces.

## What ships

| verb | what it does |
|---|---|
| `F2 → charter: quit` | records the plane, then stops every harness on it |
| `F2 → chat: close` | stops one chat and marks it so nothing brings it back |
| `charter reopen` | puts the recorded plane back — and resumes what it can |
| `F2 → chat: previous transcript` | opens what a chat had on screen before it stopped |

## The load-bearing trick, and why it was necessary

#757 keeps a chat's harness session id in `session.durable` so `clear_shape` cannot delete
it. **Measured: it does not survive a restart.** `reap` deletes a chat's whole directory
when its launcher pid is dead, and after a restart *every* launcher pid is dead — so the id
a resume needs is removed by the next launch.

Inverting `reap` is stage 4 of the delivery order, six edits wide, with ~60 tests asserting
the current rule. So the record is a **file**:

```
.charter/frame/
  alpha.1/                  <- a chat: still a liveness marker, still reaped exactly as now
  alpha.1.transcript        <- what was on its screen
  reopen.json               <- the plane
```

`reap` skips anything that is not a directory, and so does the tab bar's own scan. **`reap`
is not inverted and stage 4 is untouched.**

## Order is the feature

1. read the plane off disk (workspace, persona, harness, cwd, durable id per chat)
2. ask each tmux server which chats are live and where each window is
3. **capture each pane** while it still exists
4. **write the manifest**
5. drop transcripts no manifest names
6. **kill**, one `kill-window` per chat
7. **prune `inflight`**

4 before 6 because a record that depends on the thing it records succeeding is not a record
— a quit that cannot write the manifest **refuses and stops nothing**. 7 after 6 so the
tracker cannot end up quieter than the plane.

## Three things the spec got wrong, corrected in writing rather than by overriding

* **The gauge gate is dropped.** §4e's `exit_code(fid) is None` reads a `kill-window`ed chat
  as *live* (§2.17: that call writes no `exit`), which is the inverse of the case it was
  written for — and nothing needs suppressing anyway, because a reopened chat gets a fresh
  chat id and has no `session` mapping to inherit. The ordering hazard §4e names disappears
  with the gate.
* **Phase 5 Task 9 is amended in this PR**, so one of the two documents stops being true on
  paper: it said a reopened chat *"starts a fresh harness session"* and *"must not inherit
  the closed one's token gauge"*. Its Step 4 — *do not add a resume member to `Harness`* —
  **stands and is now load-bearing**: the flag rides the existing `extra` pass-through.
* **ADR 0018 is amended in this PR.** It said charter never touches the harness's pane; the
  measurement showed charter has been reading it since #384 (`_pane_last_words`, on both
  launch paths). The rule now says charter reads that pane at exactly **two** moments, both
  of them moments the pane is about to be destroyed, and writes nothing back — with the
  distinguishing question written down so the next exception has to argue for itself.

## Six things this found about itself, after the first commit

Recorded because each was found by looking rather than by a test failing, and each is a
commit of its own on this branch:

* **The confirming row had to move to the top.** Under the list it is about reads better and
  is wrong: `palette.narrow` puts the cursor on the first row when nothing has been typed,
  refused or not, so the confirmation opened with a *chat* row selected and Enter bound to
  nothing at all. Found by rendering the real surface.
* **The quit had nowhere to say its own sentence.** It runs detached with all three streams
  on `/dev/null` (the palette's pane is killed the instant a row is invoked) and by the time
  it finishes there is no frame left for a notice either. `cmd_launch` — the process that
  hands the operator their shell back — now says it, gated on the manifest naming its own
  chat.
* **…and that gate needed a second one.** `new_chat_id` walks upward from 1 and `reap` frees
  the ordinals a quit's chats held, so a reopen usually gets the *same* ids back — every one
  of its own launches was named in the manifest it was in the middle of acting on, and
  announced the quit it was undoing.
* **`charter reopen` refuses inside a tmux you already have.** That launcher stays awake for
  the life of each frame (it reads the exit status itself rather than installing the
  `pane-died` hooks), so it blocks exactly as `attach` does and a reopen would stop at the
  first chat. Suppressing that wait is its own change on a path whose exit-code contract
  depends on it.
* **A chat with no workspace record cannot be reopened**, and now says so instead of
  promising a resume: `reopen.read` holds a manifest entry's workspace to `valid_name`, so
  such a line would be discarded by every reader. It is stopped like the rest and honestly
  not recorded.
* **Two identical `list-windows` calls became one**, and two helpers with no caller were
  deleted.
* **A partial reopen now leaves behind exactly the retry.** Dropping the manifest whole once
  anything had launched threw away the record of the chats that did *not* come back; leaving
  it whole would have opened the ones that did a second time.
* **`chat: previous transcript` was targeting the wrong thing entirely**, and only a
  hand-run found it. `kill-window -t %N` resolves a pane to its own window — charter's
  early-death path relies on that — so `new-window -t %N` looked like it should too. It does
  not, on either version:

  ```
  new-window -t %0        rc 1   can't specify pane here
  new-window -t @0        rc 1   create window failed: index 0 in use
  new-window -t alpha.2   rc 1   can't specify pane here      <- #695, again
  new-window -t $0        rc 0
  ```

  `-t` there is a target-*window*; a window id is read as the index to insert at, and a
  dotted session name is parsed as `window.pane`. The session id is the one unambiguous
  spelling, and it is pinned on a real server now — a pager window really opens beside the
  chat, really shows the captured text with its colours rendered rather than printed, and the
  harness's own pane is left exactly as it was.
* **The stale-pointer residual is closed, and it was sharper than "a pointer might win".**
  A reopen mints a *fresh* chat id — but `new_chat_id` counts up from 1 and `reap` frees the
  ordinals a quit's chats held, so it very often gets the same *name* back. While the
  per-session pointer was a rung of `own_workspace`, a `charter workspace use gamma` typed in
  the OLD `alpha.1` decided the NEW `alpha.1`'s membership, over the manifest *and* over the
  launcher's own record. #791 removed that rung; pinned here with the stale pointer
  deliberately planted, and verified RED against a `state.py` with the rung put back.
* **And one this branch's own guard caught rather than a human**: a test class appended after
  a module's `if __name__` trailer, which `unittest.main()`'s `SystemExit` makes invisible to
  `python3 tests/<module>.py`. `test_no_test_hides_below_the_main_trailer` failed on CI 3.11
  and 3.12 and nothing local had seen it, because running a module *by name* is the spelling
  that runs them all. Fixed in `58d954e`; the guard is exactly the kind of thing it exists
  for and it worked.

## Verification

* **112 new cases in five modules**, 102 of them with no tmux at all — including one that
  drives the four hops from the keypress to the detached command through the real `_picker`
  and the real `_draw_palette`, with `own_the_tty` replaced by a script rather than a pty.
* **Two guards mutated and confirmed RED**: dropping `state.record_cwd` from the launch
  path, and pruning `inflight` before the kill instead of after.
* **A third property is over-determined and is documented as such** rather than claimed:
  three independent rules in `reap` keep a non-directory entry, so no single mutation can
  take the manifest's durability away.
* **A correction to the design's own §2.12, amended in this PR: the real-tmux tests DO run in
  CI.** `test.yml` installs no tmux, but `ubuntu-latest` ships one — so they ran there, and
  one of them failed on 3.11 and 3.13 while passing on 3.14 in the same run. A race (a pane's
  process has not exec'd when `new-window` returns), found by CI and not by this machine. The
  honest statement is narrower than "no tmux in CI": **CI answers on whatever tmux the runner
  image happens to ship, which is neither of the two versions charter promises** — a third
  machine's opinion on top of the hand-runs rather than a substitute for them.
* **Real tmux on 3.7c and at the 3.2 floor** — the capture is real bytes off a real pane
  with its trailing spaces intact (`-N`, which `-e` alone trims); the kill really ends the
  chats and, with the last window, the session and then the server; and **two planes on one
  server, both with a workspace called `default`, both with a window in the one tmux session
  that name can have — quitting one leaves the other's harness running** (§3.3, the case a
  single-plane test is blind to).
* **Full local suite green.** Before the rebase it ran three times at 9844 / 9852 / 9861
  tests with one failure each — `test_frame_border_surface`, which reproduced at `9cd519e` in
  a clean worktree but **not** in the sweep sandbox's fresh `git clone` (9852 green). That
  observation is now closed upstream: #799 fixed #785, so a suite run from a linked worktree
  no longer reads the operator's live plane, and this branch runs clean.
* Per §2.12, **none of the tmux half runs in CI**; every tmux claim above is a hand-run on
  this machine on both versions.

## The deletion sweep: 225 mutations, every one of them with a verdict

**Including the 39 the CI shards ran out of time before reaching** — those were run locally
by explicit line number, same tool, same sandboxes, same full-suite confirmation for a
survivor, just a smaller plan. The arithmetic, so it can be checked:

```
100  survivor mutants   (77 from the CI shards, 23 from the local 39-line run)
-23  pinned since, each re-run against the branch head rather than assumed
────
 77  residual from those two runs
 +2  first seen in this head's own sweep, which measured a different subset
────
 79  merging unpinned, named and filed as #810
```

**This head's sweep is a partial, and its check name says so** — `no verdict: 54 survivors
so far, 171 of 225 measured, 54 out of time` (#803/#804 doing exactly its job: six of eight
shards hit the hour and reported what they had rather than a verdict they had not earned).
Two of its 54 had never appeared in the earlier run, which is worth stating plainly: **each
run samples a different subset, so a survivor list is a union across runs and never a
snapshot.** Both new ones are in #810.

Three clusters were closed here, and each is recorded by its **cause** rather than by its
line list, because each was one missing habit and not N missing tests:

* **The fallback cluster (5) — not five gaps, one fixture that never lies.** `_plant` always
  wrote a server, a workspace, a harness pane and an identity, so every fallback in
  `leave.record` (`leave.py:152/156/157/159/160`) read a truthy value in every test. Closed
  by a fixture that records nothing at all.
* **The on-disk names (8), and this is the rule worth carrying off this branch: a round trip
  cannot pin a name.** Every test wrote with `reopen.write` and read with `reopen.read`, so
  renaming the manifest, the `.transcript` suffix, the `cwd` file, the `closed` marker or any
  JSON key moved both sides together and stayed green — while on a real plane it silently
  orphans everything already on disk. The fix is to spell the literal a second time, by hand,
  in the test: **the duplication *is* the assertion.**
* **The manifest parser (10).** Every case fed a bad **value** inside the right **container**
  — a bad version, a chat id with a semicolon in it, a workspace that is `../etc` — so no
  type guard was ever handed the wrong container.

**And one real defect, found by a mutant that could not be reddened at all.** A `>` in the
transcript byte cap resisted every test, because at exactly the cap `text[-N:]` returns the
whole string either way. An unpinnable comparison is a pointer, not a line to delete, and
what this one pointed at was bytes-versus-characters. Fixed, with the multi-byte case pinned.

### Why the parser is the cluster that had to close before merge

It is the only one on this branch whose blast radius leaves the frame. Those values drive
`os.chdir` and a tmux argv (`_reopen_one`, `_attach_after_reopen`), and the manifest is a
plain file that outlives the process that wrote it and can be **older than the charter
reading it** — §5 of the IDE spec names exactly that as a cost the durability design creates,
and a hand-edited or half-written one is the ordinary case, not the exotic one. A guard
missing there is not a wrong answer that degrades; it is an `AttributeError` or a `KeyError`
out of a function whose entire contract is that it degrades, raised in the process that hands
the operator their shell back — `cmd_launch` asks `read()` whether this chat was named by a
quit. This is `state.frame_workspace`'s position (#442) and `chats.of_workspace`'s (#475), at
the one boundary this module owns.

Ten mutants, each confirmed RED against the shipped file by hand — one mutant at a time,
before its test was trusted:

| line | mutant | the case that kills it |
|---|---|---|
| `reopen.py:193` | `chat.chat or ""` → `chat.chat` | a record whose chat id is not even text |
| `reopen.py:260` ×2 | the `frames` type gate, deleted / `False` | a manifest with no `frames` key, and one where it is a number |
| `reopen.py:264` | the frame and `chats` type gate, deleted | a frame that is not a dict, and a `chats` that is not a list |
| `reopen.py:269` | `f.get("workspace") or ""` → `f["workspace"]` | a frame that never recorded a workspace, and one whose workspace is `null` |
| `reopen.py:272` ×2 | `at if isinstance(…)` → `0`, and → `at` | the recorded `at` read back whole, and an `at` that is a string |
| `reopen.py:273` | `focus if isinstance(…)` → `focus` | a `focus` that is a number |
| `reopen.py:287` ×2 | the chat-entry type gate, deleted / `False` | a chat entry that is not a dict |

**CI reached five of these ten on this head and calls all five pinned** — `264`, `269`,
`272`, `273` and `287` come back `pinned` in the shard logs, where four of them were
survivors before. The other five were among the 54 the shards ran out of time on, which is
the same set that forced the local by-line run in the first place; those rest on the hand-run
above, which is the stronger evidence anyway because it applies one mutant at a time to the
shipped file and names the case that kills it.

`260` nearly stayed open, and the reason is worth keeping: **two guards in sequence mask each
other.** It and the per-frame gate below it answer identically for every `frames` that is
*iterable* — a string or a dict walks into the loop and is refused one line further down with
the same `None`. What tells them apart is a `frames` that cannot be iterated at all: an absent
key, and a number.

**The refusal is asymmetric, and the tests now pin both halves of it.** A bad *shape* — a
top level that is not a dict, a `frames` that is not a list, a frame that is not a dict, a
`chats` that is not a list — takes the WHOLE manifest down, because *a manifest charter
cannot read whole is not a plane charter may half-restore*. A bad *value* — a chat entry
that is not a dict, a chat id or workspace that could not be one — drops that record and
leaves the rest, because `cmd_reopen` reports the difference between what was recorded and
what came back, so a dropped chat is a sentence rather than a silence. Both rules were
already written down in `read()`'s docstring; neither had a test on the wrong-container side
until now.

Worth stating for a reader who will notice it: the **frame's** own `workspace` is bounded by
`str(… or "")` and not by `valid_name`, unlike the chat's. That is deliberate and was
re-checked here — `f.workspace` is read in exactly two places, both of which copy it straight
back into a rewritten manifest. Every operative use is the CHAT's workspace (`_reopen_one`'s
launch argument, `_attach_after_reopen`'s `workspace_prefix`), and that one *is* held to
`valid_name` by `_usable`. The frame label is a grouping key that round-trips and reaches
nothing.

One case calls `_usable` directly and says why in full: no shipped caller can hand it a
non-string, because `_chat` normalises all seven text fields on the way in. The fallback is
there so the predicate is **total** over `Chat` — it is the last gate before a recorded name
becomes a transcript path and a tmux target, and a gate that raises on the one input it was
written to refuse is not a gate.

### What merges unpinned, and why these are the acceptable ones

**79 survivors, named rather than left to be rediscovered — #810**, in four groups, each with
its cause:

| group | cause, in one line |
|---|---|
| `except OSError` (13) | no test in the suite makes the filesystem refuse, so the clause is never entered — and the sweep's own `PLATFORM` note says some of these are *unreachable* on darwin rather than unpinned, which CI has to answer before a test is worth writing |
| refusal branches (45) | every case drives the working path and asserts what came back, so a refusal is only ever the branch NOT taken — the fixture is always well-formed enough to get past the gate |
| operator-visible sentences (16) | the round-trip rule again, with a sentence in place of a file name: every assertion goes through the module constant on **both** sides (`assertEqual(rows[0].title, leave.NOTHING_OPEN)`), so rewording moves the test with it |
| `contain` wrappers (5) | every `harness`, `cwd` and chat id in the suite is already one line of printable ASCII, so `one_line` and `readable` are the identity function on every input the tests supply |

**The line here is not a count, it is a question: does this decide where a process runs, or
what gets executed?** For all 79, no. A missing `except OSError` costs a traceback where a
warning belonged. An untested refusal costs one chat not reopened, on a path whose working
half is tested and whose failure the operator is told about. An unpinned sentence costs
wording. An unpinned `contain` costs a report line, and only for a value hostile enough to
carry an escape. **The two that would have answered yes are the two that are pinned** — the
parser, whose values reach `chdir` and an argv, and the on-disk names, whose drift orphans
every plane already recorded.

Three of the 79 are flagged in #810 as the ones to take first, and they are not in the
biggest group: `leave.py:397–399` are palette **action ids**, and an action id is a binding
surface a `charter.toml` can name. Renaming one silently breaks an operator's keybinding,
which puts them with the manifest's names rather than with a warning's wording.

## Not done here, stated rather than implied

* **The chat directory is not durable** (stage 4, six edits) — which is why a reopened chat
  is a new tab with a new id rather than the same directory woken up.
* **Bare `charter` does not reopen.** `charter reopen` is a thing you ask for.
* **Resume is Claude Code only**, and the warning says so per chat.
* **`chat: close` cannot refuse a busy chat** — `inflight` records name no chat, so there is
  no reading to refuse on. Said out loud rather than faked.
* **A chat with no workspace record cannot be reopened.** Stopped like the rest, honestly not
  recorded, and its warning row says so; choosing a workspace for it would be §4j's
  re-homing arriving as a convenience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

