### PR TITLE
The sweep asks about a permission once, in the base you wrote it in (#755, #787)

### DIFF
--- a/docs/news/unreleased-the-sweep-asks-once-per-constant-and-in-the-base-you-wrote.md
+++ b/docs/news/unreleased-the-sweep-asks-once-per-constant-and-in-the-base-you-wrote.md
@@ -1,0 +1,94 @@
+---
+version: unreleased
+headline: The sweep asks about a permission once, in the base you wrote it in — and a chrome keypress is now proved not to edit your comments
+---
+
+Two things about writes nobody asked for: one the sweep was making in its own report, and
+one that was reported against `charter.toml` and turns out not to exist.
+
+## `retune-constant` offered one permission twice, and the second copy was unreadable (#755)
+
+Two rules in `tools/sweep.py` recognise a module-level constant written in base 8, 16 or 2,
+and both move it by one. So the same node was planned twice:
+
+```
+charter/config.py:389       STATE_FILE_MODE = 0o600
+    after='0o601'   value=385   "is this value pinned, or would any number do?"
+    after='385'     value=385   "is `STATE_FILE_MODE`'s value pinned, or would any number do?"
+```
+
+`385` and `0o601` are two strings and one integer. The plan's de-duplication compares the
+replacement as **text**, so it could not see that, and the two rows cost two sandbox runs
+and — the part that matters — two rows in a report a person reads. A reviewer holding the
+survivor gets `STATE_FILE_MODE = 385` and has to convert it by hand to discover it is the
+mutation they were already looking at one row above.
+
+The tool already had the rule and had written it down twice. The non-decimal rule's own
+comment says why it exists:
+
+> a permission that came back `385` instead of `0o601` is a mutation nobody can check at a
+> glance
+
+and `swap-synonym`, twelve lines further on, says what to do about a duplicate:
+
+> A swap that produces the same program asks nothing, and #655's answer is that such a
+> mutation is **not offered** rather than given a verdict of its own.
+
+**Neither rule was dropped; one half of each was kept.** The module-constant rule keeps the
+node, because its question *names the constant* — which is the whole of what a reviewer
+needs to find the line — and it now spells its replacement in the base the source used, so
+the surviving row reads the way the non-decimal rule wanted it to. The non-decimal rule
+declines the nodes the rule above has already asked about, and is otherwise untouched: a
+`0o600` inside a function, or under a lowercase module-level name, still gets its own row.
+
+```
+charter/config.py:389       STATE_FILE_MODE = 0o600
+    after='0o601'   "is `STATE_FILE_MODE`'s value pinned, or would any number do?"
+```
+
+**Re-measured over the whole tree rather than over a fixture.** Two module-level
+non-decimal integer constants exist in `charter/` and `tools/` — `STATE_FILE_MODE = 0o600`
+and `_OTHERS = 0o077`, both permission bits — and both now plan one mutation where they
+planned two. The measurement that found the class was re-run over the fixed tree, because
+the previous fix in this area re-introduced the collision it was fixing and a hand-built
+fixture could not have caught it.
+
+The general property is now a test rather than a habit: no two mutants of one node may be
+the same **program**. The existing guard compared the report fields, where `385` and `0o601`
+are distinct, which is exactly why this survived it — the new one normalises both mutated
+sources through `ast` and counts.
+
+**Every shard is re-dealt by this.** `shard_of` deals the plan round-robin, so a plan two
+mutations shorter puts different mutations on different machines. Nothing is dropped that
+was ever a distinct question and nothing is added; membership simply moves.
+
+## A chrome keypress does not rewrite your comments — and now there is a test saying so (#787)
+
+Reported: `charter frame-chrome dark` records the choice in `charter.toml` by substituting
+the colour word through the whole file, so a comment that merely *mentions* the old word is
+rewritten too — turning this repository's own explanation of focus inversion into a
+sentence that says focus changes nothing.
+
+```
+committed:  # inverts on focus (`brightblack` active is `black`), so the focused panel …
+reported:   # inverts on focus (`black` active is `black`), so the focused panel …
+```
+
+**Charter makes no such write, and the design has always said so in three places.**
+`cmd_chrome` records through `state.record_chrome`, into the running frame's own state
+directory, which is deleted whole when the frame ends — the docstrings of `cmd_chrome`,
+`cmd_density` and `cmd_toggle` each say "charter.toml is not touched", and `cli` says it
+twice more. The only code in charter that writes `charter.toml` at all is the version lock
+and the default-persona key, both through one helper confined to a single section's own
+line span, and neither is a substitution. The damaged file the report was read from also
+changes six `bg` **values** in the same pass, which no chrome word would touch: it is the
+diff a `s/brightblack/black/g` makes, from outside charter.
+
+So what shipped is the guard, because the property was undefended — the loudest claim in
+that design was resting on three docstrings and nothing measured it. A chrome keypress is
+now run against a plane whose `charter.toml` carries the operator's own paragraph, and the
+committed file is asserted byte-identical and **not even rewritten** — mtimes included, so
+a rewrite that reproduces the content fails too — while the choice is still recorded and
+still overrides the committed word for that one running frame. Four of those assertions go
+red against the reported behaviour, injected; one of them is the only assertion in the file
+that catches a rewrite with identical bytes.

--- a/tests/test_a_look_keypress_never_edits_the_committed_config.py
+++ b/tests/test_a_look_keypress_never_edits_the_committed_config.py
@@ -1,0 +1,224 @@
+"""#787: recording a chrome choice must not edit `charter.toml` — comments included.
+
+`charter frame-chrome <word>` records the operator's choice, and #787 reports that it
+records it by substituting the colour word through the whole file — rewriting comments
+that merely *mention* the old word, and turning this repository's own explanation of focus
+inversion into a false sentence:
+
+    committed:  # inverts on focus (`brightblack` active is `black`), so the focused …
+    reported:   # inverts on focus (`black` active is `black`), so the focused …
+
+**Read against `main`, no such write exists.** `cmd_chrome` records through
+`state.record_chrome`, into the frame's own state directory, and the only code in charter
+that writes `charter.toml` at all is `instance._set_key` (the version lock and the default
+persona, both confined to one section's own line span) and `commands.cmd_init`'s first
+render. The docstrings of `cmd_chrome`, `cmd_density` and `cmd_toggle` each say
+"charter.toml is not touched" and `cli` says it twice more. So the damage #787 measured on
+the operator's plane came from something outside charter — the same substitution a
+`s/brightblack/black/g` makes — and the committed diff it was read from changes six `bg`
+VALUES as well, which no chrome word would touch.
+
+That makes this file a guard and not a fix. The property was undefended: no test asserted
+that the committed file survives a chrome keypress, so the design's loudest claim was
+resting on three docstrings. What is asserted here is the whole of #787's requirement —
+the choice IS recorded, the committed file is byte-identical afterwards, and the sentence
+#787 watched being falsified is still true — so that a writer added to this path in future
+has to delete an assertion to land.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import unittest
+from unittest import mock
+
+from charter import commands_frame, config, instance
+from charter.frame import state
+from tests._isolation import PersonaIso
+
+#: The operator's own committed text, trimmed to the two tables and the one paragraph
+#: #787 was measured on. `chrome = "light"` is deliberately NOT the word pressed below, so
+#: "the file was not rewritten" and "the keypress did nothing" cannot be the same green.
+_COMMITTED = '''\
+[charter]
+version = "0.54.0"
+
+[frame]
+mouse = true
+
+# How charter's own chrome READS. Three words: `off`, `dark`, `light`.
+chrome = "light"
+
+# Every pane charter draws is `brightblack` and the harness pane is left alone, which is
+# the whole look: charter's chrome is grey, the work area is the terminal's own. The pair
+# inverts on focus (`brightblack` active is `black`), so the focused panel is the one that
+# differs from its neighbours rather than the one that lights up.
+
+[[frame.component]]
+use = "identity"
+bg  = "brightblack"
+pad = 1
+
+[[frame.component]]
+use  = "workspaces"
+edge = "top"
+size = 1
+bg   = "brightblack"
+pad  = 1
+'''
+
+#: The sentence #787 watched become false, verbatim. A substitution of `brightblack` makes
+#: this read "`black` active is `black`" — a comment asserting that focus changes nothing,
+#: in a comment whose whole job is to explain why the surface is legible.
+_TRUE_SENTENCE = "inverts on focus (`brightblack` active is `black`)"
+
+
+class AChromeKeypressLeavesTheCommittedConfigAlone(PersonaIso, unittest.TestCase):
+    """`cmd_chrome` against a plane whose `charter.toml` mentions a colour in prose."""
+
+    FID = "fr-787"
+
+    def setUp(self):
+        super().setUp()
+        # `PersonaIso` derives every setting from an empty tmp dir, so the marker has to
+        # exist before the derivation for `config.FRAME` to be this fixture's arrangement.
+        # Re-derived rather than hand-patched: `config.FRAME` and `config.STATE_DIR` are
+        # two of twenty-five values that follow from the root, and patching one of them by
+        # hand is how a test comes to run against a plane that is half fixture.
+        self.toml = self.tmp / "charter.toml"
+        self.toml.write_text(_COMMITTED)
+        config.use(self.tmp)
+
+        # The standing rule this session learned the hard way: a plane-mutating call is
+        # made only once the path it will write has been asserted to be the fixture's.
+        # `state.record_chrome` writes under `config.STATE_DIR`, and a test that trusted
+        # `$CHARTER_ROOT` instead of asserting the path deleted two of the operator's own
+        # chat directories.
+        self.assertTrue(
+            pathlib.Path(config.STATE_DIR).resolve().is_relative_to(self.tmp.resolve()),
+            f"refusing to record anything: STATE_DIR is {config.STATE_DIR}")
+
+        self.ran: list[list[str]] = []
+        patcher = mock.patch.object(
+            commands_frame.tmuxctl, "run",
+            side_effect=lambda _what, argv, **kw: self.ran.append(argv) or
+            subprocess.CompletedProcess(argv, 0, "", ""))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        # Both halves of the keypress: the panels, and the frame's own rules — which is
+        # the half that reads `config.FRAME` (`instance.border_bg`) and so the half a
+        # writer would most plausibly be bolted onto.
+        state.record_panes(self.FID, panels={"identity": "%1", "workspaces": "%2"})
+        state.record_harness_pane(self.FID, "%0")
+
+    def _press(self, word="dark"):
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID}, clear=True):
+            return commands_frame.cmd_chrome(type("A", (), {"level": word})())
+
+    def test_the_keypress_really_ran(self):
+        """Asserted first and separately, because every assertion below is satisfied by a
+        command that refused. #787's subject is a keypress that DID repaint the frame and
+        edited the file on its way — so the guard is worth nothing until the repaint is
+        shown to have happened."""
+        self.assertEqual(self._press(), 0)
+        self.assertEqual({a[a.index("-t") + 1] for a in self.ran}, {"%0", "%1", "%2"})
+
+    def test_the_choice_is_recorded(self):
+        """The half #787 says must keep working: the palette's chrome rows persist the
+        choice deliberately, and a fix that stopped recording would satisfy every other
+        assertion in this class."""
+        self._press()
+        self.assertEqual(state.chrome(self.FID), "dark")
+        self.assertEqual(commands_frame._current_chrome(self.FID), "dark")
+
+    def test_the_committed_file_is_byte_identical_afterwards(self):
+        """The whole of #787, as bytes. Not "the values are right" — the FILE, so a
+        rewrite that happened to reproduce the arrangement still fails."""
+        before = self.toml.read_bytes()
+        self._press()
+        self.assertEqual(self.toml.read_bytes(), before)
+
+    def test_the_committed_file_was_not_even_rewritten(self):
+        """Bytes cannot see a rewrite that reproduces the content, and #787's compounding
+        argument is about prose rewritten again on every keypress — so the mtime is part of
+        the property. Stated over the WHOLE plane rather than over one path, because "which
+        file did it edit" is the question #726 could not answer about its own symptom, and a
+        guard that names only `charter.toml` answers it for one file.
+
+        Paired with the state directory deliberately: the same walk that proves nothing the
+        operator maintains moved proves that the keypress moved SOMETHING, so this cannot
+        go green by the command doing nothing.
+        """
+        def snapshot(where):
+            return {p: (p.read_bytes(), p.stat().st_mtime_ns)
+                    for p in sorted(pathlib.Path(where).rglob("*")) if p.is_file()}
+
+        state_dir = pathlib.Path(config.STATE_DIR)
+        committed = {p: v for p, v in snapshot(self.tmp).items()
+                     if not p.is_relative_to(state_dir)}
+        recorded = snapshot(state_dir)
+        self.assertIn(self.toml, committed)
+
+        self._press()
+
+        after = {p: v for p, v in snapshot(self.tmp).items()
+                 if not p.is_relative_to(state_dir)}
+        self.assertEqual(after, committed)
+        self.assertNotEqual(snapshot(state_dir), recorded,
+                            "the keypress recorded nothing, so this proves nothing")
+
+    def test_the_comment_that_explains_focus_inversion_is_still_true(self):
+        """#787's own measurement, as an assertion. The rewritten sentence is not merely
+        an ugly diff — it asserts that a pane painted `black` inverts to `black`, which
+        says focus changes nothing, which is false and self-refuting."""
+        self._press()
+        text = self.toml.read_text()
+        self.assertIn(_TRUE_SENTENCE, text)
+        self.assertNotIn("(`black` active is `black`)", text)
+
+    def test_the_colour_words_in_the_prose_and_in_the_values_both_survive(self):
+        """Counted rather than searched, because what #787 measured is a COUNT — six value
+        lines and two comment lines on the operator's own file — and an `assertIn` is
+        satisfied by one surviving mention.
+
+        The fixture keeps two of each, which is the distinction the reported write did not
+        make: `brightblack` in a `bg` key is the setting, `brightblack` in prose is a
+        coincidence, and both counts have to hold for the same reason.
+        """
+        self._press()
+        lines = self.toml.read_text().splitlines()
+        self.assertEqual(
+            sum("brightblack" in ln for ln in lines if ln.lstrip().startswith("#")), 2)
+        self.assertEqual(
+            sum("brightblack" in ln for ln in lines
+                if not ln.lstrip().startswith("#")), 2)
+
+    def test_the_committed_word_still_reads_as_the_committed_word(self):
+        """The recorded choice and the committed default are two answers to two different
+        questions, and the whole design rests on their staying different: `[frame] chrome`
+        says what a frame STARTS at, the record says what this frame IS. A write into
+        charter.toml would collapse them, and the collapse is invisible until relaunch."""
+        self._press()
+        # Re-READ, not `config.FRAME`: that dict was derived in `setUp` and would answer
+        # `light` however the file had been rewritten — the first version of this test did
+        # exactly that and stayed green against the injected defect.
+        fresh = instance.load(config.ROOT).get("frame") or {}
+        self.assertEqual(instance.chrome_level(fresh.get("chrome")), "light")
+        self.assertEqual(commands_frame._current_chrome(self.FID), "dark")
+
+    def test_the_word_landed_in_the_frames_own_state_directory(self):
+        """Where the design says it goes — and asserted as a PATH rather than through
+        `state.chrome`, which would be satisfied by a record kept anywhere at all. This is
+        also what makes the record temporary: `state.reap` deletes that directory entire
+        when the frame ends, so a relaunch is back to the committed word."""
+        self._press()
+        found = [p for p in pathlib.Path(config.STATE_DIR).rglob("chrome")
+                 if p.is_file() and p.read_text().strip() == "dark"]
+        self.assertTrue(found, f"nothing under {config.STATE_DIR} holds the word")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -404,6 +404,87 @@ class TheConstantShape(unittest.TestCase):
         self.assertEqual(_by(muts, "retune-constant"), [])
 
 
+class AConstantIsOfferedOnceHoweverItIsSpelled(unittest.TestCase):
+    """#755: a module-level constant written in base 8, 16 or 2 satisfies two rules.
+
+    The module-constant rule and the non-decimal rule both recognise `MODE = 0o600`, and
+    both move it by one — so they were offering one integer twice, `385` and `0o601`, and
+    `385` is the spelling the non-decimal rule's own comment says nobody can check at a
+    glance. Two rows, two sandbox runs, one value: `swap-synonym`'s rule about a mutation
+    that produces the same program, in integers instead of method names.
+
+    The answer keeps one of each half. The module-constant rule keeps the node, because
+    its question NAMES the constant — the whole of what a reviewer needs to find the line
+    — and `_moved_int` gives it the non-decimal rule's spelling on the way out. Every
+    assertion below is one half of that: either that there is exactly one row, or that the
+    row that remains is the readable one.
+    """
+
+    def test_a_module_level_permission_is_offered_once(self):
+        """`charter/config.py`'s `STATE_FILE_MODE = 0o600` and
+        `charter/secrets/base.py`'s `_OTHERS = 0o077` — measured on `main`, the only two
+        module-level non-decimal integer constants in the tree, and both were offered
+        twice."""
+        muts = _by(_mutations("STATE_FILE_MODE = 0o600\n"), "retune-constant")
+        self.assertEqual([m.after for m in muts], ["0o601"])
+
+    def test_the_row_that_remains_names_the_constant(self):
+        """The two rules differ in their question as well as their spelling, and this is
+        the half that had to be kept: "is this value pinned" leaves a reviewer holding a
+        survivor with a line number, where "is `STATE_FILE_MODE`'s value pinned" names the
+        thing to go and look at."""
+        muts = _by(_mutations("STATE_FILE_MODE = 0o600\n"), "retune-constant")
+        self.assertEqual([m.question for m in muts],
+                         ["is `STATE_FILE_MODE`'s value pinned, or would any number do?"])
+
+    def test_hex_and_binary_keep_their_own_base_too(self):
+        """The rule is about the base the source wrote, not about octal. `0x1b` is a byte
+        and `0b1010` is a bit pattern, and a report answering `28` or `11` for either is
+        the same unreadable row."""
+        for source, after in (("_ESC = 0x1b\n", "0x1c"),
+                              ("_BITS = 0b1010\n", "0b1011"),
+                              ("_UPPER = 0O600\n", "0o601")):
+            with self.subTest(source=source):
+                muts = _by(_mutations(source), "retune-constant")
+                self.assertEqual([m.after for m in muts], [after])
+
+    def test_a_decimal_module_constant_is_still_decimal(self):
+        """The spelling follows the source and nothing else — `LIMIT = 28` must not come
+        back as `0o35`, which would be this defect's mirror image."""
+        muts = _by(_mutations("LIMIT = 28\n"), "retune-constant")
+        self.assertEqual([m.after for m in muts], ["29"])
+
+    def test_a_non_decimal_that_is_not_a_module_constant_is_still_asked_about(self):
+        """The fix withholds the DUPLICATE, not the shape. A `0o600` inside a function is
+        the non-decimal rule's alone and it still gets its row — the rule is not narrowed
+        to "not a permission", it is narrowed to "not one the rule above already asked
+        about"."""
+        muts = _by(_mutations("""
+            def f(p):
+                p.chmod(0o600)
+        """), "retune-constant")
+        self.assertEqual([(m.after, m.question) for m in muts],
+                         [("0o601", "is this value pinned, or would any number do?")])
+
+    def test_a_lowercase_module_level_name_falls_to_the_non_decimal_rule(self):
+        """`timeout = 0o600` is not a constant by the module rule's own test, so the node
+        belongs to the non-decimal rule and must not be dropped by the exclusion — a
+        withheld node with no rule left to ask about it is a guard silently uncovered."""
+        muts = _by(_mutations("mode = 0o600\n"), "retune-constant")
+        self.assertEqual([(m.after, m.question) for m in muts],
+                         [("0o601", "is this value pinned, or would any number do?")])
+
+    def test_a_module_level_sum_of_non_decimals_still_asks_about_each_part(self):
+        """The exclusion is keyed on the integer NODE, so a module constant whose value is
+        not a bare literal is untouched by it — `drop-term` on the sum, and the
+        non-decimal rule on each operand, which are three different questions."""
+        muts = _mutations("_MASK = 0o700 + 0o070\n")
+        self.assertEqual(_afters(muts, "drop-term"), ["0o070", "0o700"])
+        # `0o71` and not `0o071`: `oct` does not pad, which is `oct`'s answer and not this
+        # rule's, and is the same answer the non-decimal rule has always given.
+        self.assertEqual(_afters(muts, "retune-constant"), ["0o701", "0o71"])
+
+
 # ======================================================================================
 # Splicing — line numbers are the whole output of this tool
 # ======================================================================================
@@ -2269,20 +2350,49 @@ class TwoMutantsOfOneNodeAreNeverReportedAlike(unittest.TestCase):
                         f"is satisfied by mutants meaning different things: "
                         + "  ||  ".join(sorted(seen)))
 
+    def test_no_two_mutants_of_one_node_are_the_same_program(self):
+        """The sibling property above is about the REPORT; this one is about the plan.
+
+        Two mutants of one node that compile to the same program are one question asked
+        twice, and the test above cannot see it — `385` and `0o601` are two distinct
+        strings in every field it reads. That was #755, live in this fixture on `MODE =
+        0o600` for as long as the class existed: two rows, two sandbox runs, one integer,
+        and the second row spelled the way the tool's own comment says nobody can read.
+
+        Keyed on the span alone and not on the operator, because "the same program" is not
+        an operator's business — two rules recognising one node is exactly how the
+        duplicate arose. Normalised through `ast` rather than compared as text: the
+        replacement is spliced source, and `parenthesised` alone makes two texts of one
+        program routine.
+        """
+        groups: dict[tuple, list] = {}
+        for m in _mutations(self.FIXTURE):
+            groups.setdefault(m.span, []).append(m)
+        for span, ms in sorted(groups.items()):
+            programs: dict[str, list] = {}
+            for m in ms:
+                programs.setdefault(ast.dump(ast.parse(m.source)), []).append(m)
+            for _, same in programs.items():
+                with self.subTest(line=same[0].line, before=same[0].before):
+                    self.assertEqual(
+                        len(same), 1,
+                        f"{same[0].before!r} at line {same[0].line} is offered as "
+                        f"{len(same)} mutants that are one program: "
+                        + "  ||  ".join(f"{m.operator} -> {m.after}" for m in same))
+
     def test_every_shape_that_yields_siblings_is_in_the_fixture(self):
         """A guard on the guard. The assertion above is only as general as this list, and
         a fixture that quietly stopped covering `unclamp` would still pass it.
 
-        `retune-constant` is here because a module-level constant written in a base other
-        than ten is offered twice — once by the module-constant rule as `n + 1` in decimal,
-        once by the non-decimal rule re-spelled in its own base. Those two are the same
-        VALUE, so it is a question asked twice rather than an ambiguity, and it is left
-        alone here: this test pins that the two are told apart, not that both exist.
+        `retune-constant` is NOT here, and that is #755: `MODE = 0o600` used to yield two
+        of them and now yields one. The fixture still carries the line, because the shape
+        that has to stay measured is "one row, in the readable base" — see
+        `AConstantIsOfferedOnceHoweverItIsSpelled`.
         """
         self.assertEqual(
             sorted({operator for _, operator in self.siblings()}),
             ["collapse-ifexp", "disable-branch", "drop-conjunct", "drop-term",
-             "retune-constant", "shift-boundary", "unclamp"])
+             "shift-boundary", "unclamp"])
 
     def test_the_fixture_exercises_every_operator_the_table_names(self):
         """An operator added to `_iter_operators` and not to the fixture is a shape this

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -1049,6 +1049,49 @@ def _docstrings(tree: ast.AST) -> set[int]:
     return out
 
 
+def _module_constants(tree: ast.Module):
+    """``(name, value)`` for every module-level ``NAME = <expr>`` the constant rules own.
+
+    A function rather than an inline loop because the answer is needed twice in
+    :func:`_iter_operators` — once to offer the mutation, and once, before any rule runs,
+    to know which integer nodes the non-decimal rule must keep its hands off (#755). Two
+    hand-rolled copies of "what counts as a module constant" is how the second copy comes
+    to disagree with the first, and a disagreement here is a node offered twice or not at
+    all.
+    """
+    for stmt in tree.body:
+        target = None
+        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 \
+                and isinstance(stmt.targets[0], ast.Name):
+            target = stmt.targets[0].id
+        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            target = stmt.target.id
+        value = getattr(stmt, "value", None)
+        if target is None or value is None or not target.lstrip("_").isupper():
+            continue
+        yield target, value
+
+
+def _plain_int(node: ast.AST) -> bool:
+    """Is *node* an integer literal — and not a `bool`, which `isinstance` calls one."""
+    return isinstance(node, ast.Constant) and isinstance(node.value, int) \
+        and not isinstance(node.value, bool)
+
+
+def _moved_int(sp: _Spans, node: ast.Constant) -> str:
+    """``n + 1``, spelled in the base the source spelled *node* in.
+
+    The retune of an integer is one number however it is written, so the SPELLING is not
+    a second mutation — it is how the one mutation reads in the report. #755: a
+    module-level `0o600` used to be offered twice, `385` by the module-constant rule and
+    `0o601` by the non-decimal rule, and `385` is the spelling the non-decimal rule's own
+    comment says nobody can check at a glance. One rule keeps the better question, this
+    keeps the better spelling, and there is one row.
+    """
+    base = {"0o": oct, "0x": hex, "0b": bin}.get(sp.text(node)[:2].lower())
+    return base(node.value + 1) if base else str(node.value + 1)
+
+
 def _iter_operators(tree: ast.Module, sp: _Spans):
     """Yield ``(node, replacement, operator, question)`` for every recognised shape.
 
@@ -1063,6 +1106,12 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
     modules = module_names(tree)
     in_fstring = {id(part) for node in ast.walk(tree) if isinstance(node, ast.JoinedStr)
                   for part in ast.walk(node) if part is not node}
+    # The integer nodes the module-constant rule below already asks about, so the
+    # non-decimal rule can decline to ask the same thing again (#755). Resolved here
+    # rather than accumulated as the loop runs, because this is a GENERATOR: a consumer
+    # that stopped early would leave the set half-built, and a rule reading a half-built
+    # set is a rule whose output depends on how far its caller got.
+    named_ints = {id(v) for _, v in _module_constants(tree) if _plain_int(v)}
 
     # A module-level constant is a guard too, and the spec's shape table has no row for
     # one. Five of round two's eighteen overlay findings are exactly this — `_CHROME_ROWS`,
@@ -1072,19 +1121,15 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
     # this shape used to be a declared gap ("picking 1003 over 1000 for MOUSE_ON is fitting
     # the answer key") and is now `retune-string` below, whose general form is stated at
     # :func:`retune` — the value moved, every structural property held.
-    for stmt in tree.body:
-        target = None
-        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 \
-                and isinstance(stmt.targets[0], ast.Name):
-            target = stmt.targets[0].id
-        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
-            target = stmt.target.id
-        value = getattr(stmt, "value", None)
-        if target is None or value is None or not target.lstrip("_").isupper():
-            continue
-        if isinstance(value, ast.Constant) and isinstance(value.value, int) \
-                and not isinstance(value.value, bool):
-            yield (value, str(value.value + 1), "retune-constant",
+    for target, value in _module_constants(tree):
+        if _plain_int(value):
+            # `_moved_int` and not `str(n + 1)`: a constant written in base 8 or 16 was
+            # written that way because its digits are the point, and this rule's row is
+            # the one that survives for such a node (#755) — so it has to carry the
+            # readable spelling the non-decimal rule below was invented for. The QUESTION
+            # is why this rule is the survivor: it names the constant, which is the whole
+            # of what a reviewer needs to find the line.
+            yield (value, _moved_int(sp, value), "retune-constant",
                    f"is `{target}`'s value pinned, or would any number do?")
         if isinstance(value, ast.BinOp) and isinstance(value.op, ast.Add):
             # The question names the term that WENT, not "every term": the mutated node
@@ -1264,14 +1309,20 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
         # in the tree would become a mutation, and the thresholds that matter are reached
         # instead by `shift-boundary`, which asks the same question of `x > 28` without
         # asking it of `xs[0]`.
-        if isinstance(node, ast.Constant) and isinstance(node.value, int) \
-                and not isinstance(node.value, bool) \
+        #
+        # A module-level constant in one of those bases satisfies BOTH this rule and the
+        # module-constant rule above, and until #755 was offered by both: two rows, two
+        # sandbox runs, one integer. `n + 1` is `n + 1` whichever base spells it, so the
+        # second row asked nothing — `swap-synonym`'s rule for the mutation that produces
+        # the same program, in integers instead of method names. The rule above keeps the
+        # node because its question NAMES the constant, and `_moved_int` gave it this
+        # rule's spelling on the way out, so nothing about the surviving row is worse.
+        if _plain_int(node) and id(node) not in named_ints \
                 and sp.text(node)[:2].lower() in ("0o", "0x", "0b"):
             # Re-spelled in its own base, because the report is read by a person: a
             # permission that came back `385` instead of `0o601` is a mutation nobody can
             # check at a glance.
-            base = {"0o": oct, "0x": hex, "0b": bin}[sp.text(node)[:2].lower()]
-            yield (node, base(node.value + 1), "retune-constant",
+            yield (node, _moved_int(sp, node), "retune-constant",
                    "is this value pinned, or would any number do?")
 
         # ------------------------------------------------------------------------------

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -1049,44 +1049,14 @@ def _docstrings(tree: ast.AST) -> set[int]:
     return out
 
 
-def _module_constants(tree: ast.Module):
-    """``(name, value)`` for every module-level ``NAME = <expr>`` the constant rules own.
-
-    A function rather than an inline loop because the answer is needed twice in
-    :func:`_iter_operators` — once to offer the mutation, and once, before any rule runs,
-    to know which integer nodes the non-decimal rule must keep its hands off (#755). Two
-    hand-rolled copies of "what counts as a module constant" is how the second copy comes
-    to disagree with the first, and a disagreement here is a node offered twice or not at
-    all.
-    """
-    for stmt in tree.body:
-        target = None
-        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 \
-                and isinstance(stmt.targets[0], ast.Name):
-            target = stmt.targets[0].id
-        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
-            target = stmt.target.id
-        value = getattr(stmt, "value", None)
-        if target is None or value is None or not target.lstrip("_").isupper():
-            continue
-        yield target, value
-
-
-def _plain_int(node: ast.AST) -> bool:
-    """Is *node* an integer literal — and not a `bool`, which `isinstance` calls one."""
-    return isinstance(node, ast.Constant) and isinstance(node.value, int) \
-        and not isinstance(node.value, bool)
-
-
 def _moved_int(sp: _Spans, node: ast.Constant) -> str:
     """``n + 1``, spelled in the base the source spelled *node* in.
 
-    The retune of an integer is one number however it is written, so the SPELLING is not
-    a second mutation — it is how the one mutation reads in the report. #755: a
-    module-level `0o600` used to be offered twice, `385` by the module-constant rule and
-    `0o601` by the non-decimal rule, and `385` is the spelling the non-decimal rule's own
-    comment says nobody can check at a glance. One rule keeps the better question, this
-    keeps the better spelling, and there is one row.
+    One integer is one mutation however it is written, so the SPELLING is not a second
+    question — it is how the one question reads in a report a person holds. #755: a
+    module-level `0o600` was offered twice, `385` by the module-constant rule and `0o601`
+    by the non-decimal rule, and `385` is the spelling that rule's own comment says nobody
+    can check at a glance. Both callers ask here, so the two cannot drift apart again.
     """
     base = {"0o": oct, "0x": hex, "0b": bin}.get(sp.text(node)[:2].lower())
     return base(node.value + 1) if base else str(node.value + 1)
@@ -1106,12 +1076,6 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
     modules = module_names(tree)
     in_fstring = {id(part) for node in ast.walk(tree) if isinstance(node, ast.JoinedStr)
                   for part in ast.walk(node) if part is not node}
-    # The integer nodes the module-constant rule below already asks about, so the
-    # non-decimal rule can decline to ask the same thing again (#755). Resolved here
-    # rather than accumulated as the loop runs, because this is a GENERATOR: a consumer
-    # that stopped early would leave the set half-built, and a rule reading a half-built
-    # set is a rule whose output depends on how far its caller got.
-    named_ints = {id(v) for _, v in _module_constants(tree) if _plain_int(v)}
 
     # A module-level constant is a guard too, and the spec's shape table has no row for
     # one. Five of round two's eighteen overlay findings are exactly this — `_CHROME_ROWS`,
@@ -1121,14 +1085,27 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
     # this shape used to be a declared gap ("picking 1003 over 1000 for MOUSE_ON is fitting
     # the answer key") and is now `retune-string` below, whose general form is stated at
     # :func:`retune` — the value moved, every structural property held.
-    for target, value in _module_constants(tree):
-        if _plain_int(value):
-            # `_moved_int` and not `str(n + 1)`: a constant written in base 8 or 16 was
-            # written that way because its digits are the point, and this rule's row is
-            # the one that survives for such a node (#755) — so it has to carry the
-            # readable spelling the non-decimal rule below was invented for. The QUESTION
-            # is why this rule is the survivor: it names the constant, which is the whole
-            # of what a reviewer needs to find the line.
+    named_ints: set[int] = set()
+    for stmt in tree.body:
+        target = None
+        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 \
+                and isinstance(stmt.targets[0], ast.Name):
+            target = stmt.targets[0].id
+        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            target = stmt.target.id
+        value = getattr(stmt, "value", None)
+        if target is None or value is None or not target.lstrip("_").isupper():
+            continue
+        if isinstance(value, ast.Constant) and isinstance(value.value, int) \
+                and not isinstance(value.value, bool):
+            # Written down for the non-decimal rule below, which declines the nodes this
+            # one has already asked about (#755). This loop runs to completion before that
+            # one begins, and `_iter_operators` has one caller which iterates it whole.
+            named_ints.add(id(value))
+            # `_moved_int` and not `str(n + 1)`: this rule keeps the node when both
+            # recognise it, so its row has to carry the readable spelling the non-decimal
+            # rule was invented for. The QUESTION is why it is the one that keeps it — it
+            # names the constant, which is what a reviewer needs to find the line.
             yield (value, _moved_int(sp, value), "retune-constant",
                    f"is `{target}`'s value pinned, or would any number do?")
         if isinstance(value, ast.BinOp) and isinstance(value.op, ast.Add):
@@ -1309,21 +1286,30 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
         # in the tree would become a mutation, and the thresholds that matter are reached
         # instead by `shift-boundary`, which asks the same question of `x > 28` without
         # asking it of `xs[0]`.
-        #
-        # A module-level constant in one of those bases satisfies BOTH this rule and the
-        # module-constant rule above, and until #755 was offered by both: two rows, two
-        # sandbox runs, one integer. `n + 1` is `n + 1` whichever base spells it, so the
-        # second row asked nothing — `swap-synonym`'s rule for the mutation that produces
-        # the same program, in integers instead of method names. The rule above keeps the
-        # node because its question NAMES the constant, and `_moved_int` gave it this
-        # rule's spelling on the way out, so nothing about the surviving row is worse.
-        if _plain_int(node) and id(node) not in named_ints \
+        if isinstance(node, ast.Constant) and isinstance(node.value, int) \
+                and not isinstance(node.value, bool) \
                 and sp.text(node)[:2].lower() in ("0o", "0x", "0b"):
             # Re-spelled in its own base, because the report is read by a person: a
             # permission that came back `385` instead of `0o601` is a mutation nobody can
             # check at a glance.
-            yield (node, _moved_int(sp, node), "retune-constant",
-                   "is this value pinned, or would any number do?")
+            #
+            # A nested `if` and not a fourth conjunct above, deliberately: the condition
+            # above is unchanged by #755 and a conjunct added to it would put this guard
+            # inside a `drop-conjunct` group whose other members are the type checks — so
+            # the one thing #755 added would be reported as four questions about a line it
+            # did not change.
+            #
+            # A module-level constant in one of these bases satisfies the rule above as
+            # well, and until #755 was offered by both: two rows, two sandbox runs, one
+            # integer, and the second row in the spelling this comment calls unreadable.
+            # `n + 1` is `n + 1` whichever base writes it, so that row asked nothing —
+            # `swap-synonym`'s rule for a mutation that produces the same program, in
+            # integers instead of method names. The rule above keeps the node because its
+            # question names the constant, and `_moved_int` gave it this rule's spelling on
+            # the way out, so nothing about the surviving row is worse than what went.
+            if id(node) not in named_ints:
+                yield (node, _moved_int(sp, node), "retune-constant",
+                       "is this value pinned, or would any number do?")
 
         # ------------------------------------------------------------------------------
         # Semantic near-synonyms (#569): one axis moved, everything else held.


### PR DESCRIPTION
Two unrelated defects, grouped because they touch files nobody else is holding. One is a
fix; the other turns out to be a refutation plus the guard the property never had.

## ⚠️ Shard membership moves — do not bundle this with anything that needs it stable

`shard_of` is `plan[index-1::count]`, so a plan two mutations shorter deals **every** shard
differently. #754 was verified on the property that plan order does not move, and #755 was
kept out of it for exactly this reason. Nothing that was ever a distinct question is
dropped and nothing is added.

---

## #755 — `retune-constant` offered one permission twice, and the extra copy was the unreadable spelling

Two rules in `tools/sweep.py` recognise a module-level integer constant written in base 8,
16 or 2, and both move it by one. So the node was planned twice:

```
charter/config.py:389       STATE_FILE_MODE = 0o600
    after='0o601'   value=385   "is this value pinned, or would any number do?"
    after='385'     value=385   "is `STATE_FILE_MODE`'s value pinned, or would any number do?"
```

`mutations_for` de-duplicates on `(line, col, operator, replacement)` and compares the
replacement as **text**, so `"385"` and `"0o601"` are two keys for one integer. The dedup is
doing what it says; it cannot see that the two texts name one value.

### The fix keeps one half of each rule

Not "drop one rule" — the two halves are in different rules:

* the **module-constant rule has the better question**: it *names the constant*, which is
  the whole of what a reviewer holding a survivor needs in order to find the line;
* the **non-decimal rule has the better spelling**, and says so itself at `tools/sweep.py`:
  *"a permission that came back `385` instead of `0o601` is a mutation nobody can check at a
  glance."*

So the module-constant rule keeps the node and now spells its replacement through
`_moved_int`, in the base the source used. The non-decimal rule declines the nodes that rule
has already asked about (`named_ints`) and is otherwise untouched:

```
charter/config.py:389       STATE_FILE_MODE = 0o600
    after='0o601'   "is `STATE_FILE_MODE`'s value pinned, or would any number do?"
```

The in-file precedent is `swap-synonym`'s #655 rule twelve lines below — *"a swap that
produces the same program asks nothing … not offered rather than given a verdict of its
own"* — which is this case spelled in integers instead of method names.

**The exclusion is narrow, and each edge is a test.** A `0o600` inside a function body, or
under a lowercase module-level name, is still the non-decimal rule's and still gets its row
with its own question. A module-level sum of two octals still gets `drop-term` on the sum
and the non-decimal rule on each operand. A decimal module constant is still decimal —
`LIMIT = 28` must not come back as `0o35`, which would be this defect's mirror image.

### Re-measured over the whole tree, not over the fixtures

The rule this session learned the hard way: #754's own fix re-introduced the collision it
was fixing, and a hand-built fixture could not have caught it. So the measurement that
*found* the class was re-run over the fixed tree — every mutation of every file in
`charter/` and `tools/`, grouped by `ast.dump(ast.parse(mutant_source))` so that two mutants
which normalise to one AST are one program however they are spelled.

| | `main` @ 2e6eecb | this branch |
|---|---|---|
| mutations planned (whole tree, 98 files) | 11,759 | 11,761 ¹ |
| module-level non-decimal integer constants | 2 | 2 |
| …offered twice | **2** | **0** |
| collision groups tree-wide | **4** | **2** ² |

¹ two removed, four added — this branch adds three helpers to `tools/sweep.py`, which the
tool then mutates.
² the remaining two are a **different pair of rules** and are filed as **#797**, not fixed
here: `disable-branch` and `drop-isinstance` both replace an `isinstance` test that is the
whole condition of an `if`/`else` with `True`. Same class, but both questions are real and
different, so which one to drop is a judgement call with no measurement behind it yet.

Both #755 instances, after:

```
charter/config.py:389       STATE_FILE_MODE = 0o600  -> 1 mutant, after='0o601'
charter/secrets/base.py:58  _OTHERS = 0o077          -> 1 mutant, after='0o100'
```

### The property, not just the instance

`TwoMutantsOfOneNodeAreNeverReportedAlike` (#721) compares the *report* fields — question,
tag, report line — and `385` against `0o601` is distinct in all three, which is exactly why
this lived under it. The new sibling is
`test_no_two_mutants_of_one_node_are_the_same_program`: keyed on the span alone, not on the
operator, because "two rules recognising one node" is how the duplicate arose; and
normalised through `ast`, because `parenthesised` alone makes two texts of one program
routine. It fails on `main` naming the mutants.

`test_every_shape_that_yields_siblings_is_in_the_fixture` loses `retune-constant` from its
list, which is the assertion a reviewer should look at first: that list previously carried
the defect as documented behaviour.

**Red before green:** 7 assertions across the two classes fail against `main`'s
`tools/sweep.py` with this branch's tests in place. Four more are guards that the fix does
not over-reach and are green on both sides by design.

### Sweep verdict — `--path tools`

CI's sweep charges `charter/` only, so its verdict says nothing about a `tools/sweep.py`
change. Run by hand against this commit:

```
$ python3 tools/sweep.py --gate --path tools
sweeping c06897a (paths: tools)
  diff against 2e6eecb: 1 file(s), 68 added line(s)
  14 mutations → 1 shard(s)
```

<!--SWEEP-->

---

## #787 — recording a chrome choice does not rewrite comments, and now something says so

Reported: `charter frame-chrome <word>` records the choice in `charter.toml` by substituting
the colour word through the whole file, so a comment that merely *mentions* the old word is
rewritten too — turning this repository's own explanation of focus inversion into a false
sentence.

```
committed:  # inverts on focus (`brightblack` active is `black`), so the focused panel …
reported:   # inverts on focus (`black` active is `black`), so the focused panel …
```

**Charter makes no such write, and I could not find one to fix.** Read against `main`:

* `cmd_chrome` records through `state.record_chrome`, into the running frame's own state
  directory, which `state.reap` deletes whole when the frame ends;
* `charter.toml` is written in exactly two places in the tree — `instance._set_key` (the
  version lock and the default-persona key, each confined to one section's own line span,
  with its own regression test for a substitution that once escaped a section) and
  `commands.cmd_init`'s first render. Neither is reachable from any frame command;
* the design says so in five places: the docstrings of `cmd_chrome`, `cmd_density` and
  `cmd_toggle` each say *"charter.toml is not touched"*, and `cli.py` says it twice more;
* the damaged file the report was read from changes **six `bg` values** in the same pass, and
  leaves `chrome = "dark"` as unchanged context. No chrome word would touch a component's
  `bg`. That diff is what `s/brightblack/black/g` produces, from outside charter — and it
  is consistent with the coordinator's own added comment in the same file, which says *"every
  component below says `bg = "black"`"*.

So the deliverable is the guard, because the property was genuinely undefended: **no test
asserted that the committed file survives a chrome keypress.** The design's loudest claim
was resting on three docstrings.

`tests/test_a_look_keypress_never_edits_the_committed_config.py` — a new file, so it cannot
collide with the agents holding `charter/commands_frame.py` and `charter/frame/state.py`
(nothing in this PR touches either). A chrome keypress runs against a fixture plane whose
`charter.toml` carries the operator's own paragraph, two `bg = "brightblack"` values and two
comments mentioning the word, and asserts:

* the keypress **really ran** — three panes and the harness pane got their options — stated
  first and separately, because every other assertion here is satisfied by a command that
  refused;
* the choice **is recorded** and `_current_chrome` answers it (#787's "must keep working");
* the committed file is **byte-identical**;
* the committed file was **not even rewritten** — the whole plane walked, bytes *and*
  `st_mtime_ns`, excluding the state directory, paired with an assertion that something
  under the state directory *did* move so it cannot go green by the command doing nothing.
  This is the only assertion in the file that catches a rewrite with identical content, and
  #787's compounding argument is about prose rewritten again on every keypress;
* the sentence #787 watched become false is **still true**, verbatim, and the false version
  is absent;
* the colour word survives **twice in prose and twice in values**, counted rather than
  searched;
* the committed `chrome = "light"` still reads as `light` **from the file** while the frame
  reads `dark` — re-read through `instance.load`, not `config.FRAME`, because the first
  version of that assertion read a dict derived in `setUp` and stayed green against the
  injected defect;
* the word landed under `config.STATE_DIR`, asserted as a path.

**Red before green, by injecting the reported defect.** With
`_toml.write_text(_toml.read_text().replace('brightblack', 'black'))` added to `cmd_chrome`,
4 of the 8 fail. With a no-op rewrite (`write_text(read_text())`), 1 fails — the mtime one,
alone, which is what it is for. With a `chrome = "light"` → `chrome = "dark"` write, 3 fail.
`charter/commands_frame.py` was restored to `origin/main` byte-for-byte afterwards and is
not in this diff.

`setUp` asserts `config.STATE_DIR` resolves inside the fixture before anything is recorded —
the standing rule this session learned when a research agent deleted two of the operator's
chat directories by trusting `$CHARTER_ROOT` instead of asserting the path.

---

Closes #755. Answers #787 (refutation + guard; no charter code was rewriting `charter.toml`).
Opens #797.
