### PR TITLE
The suite reads the checkout it is in, and the reaper can see every socket it hands out (#785, #770, #781)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,15 @@ command.
   that fails without the fix. The suite is plain `unittest` — no fixtures framework, no
   network, no writing outside a tempdir. That last one is enforced rather than asked for:
   a checkout inside a control plane resolves to *that* plane, so `tests/_planeguard.py`
-  refuses any write into the real `.charter/` and fails the test that tried. The same file
+  refuses any write into the real `.charter/` — and into the real `charter.toml`, the one
+  file outside that directory whose loss changes what your next launch draws (#726) — and
+  fails the test that tried. Working in a **linked worktree** the same file pins the suite
+  to the checkout it was loaded from, because `root._plane_of` sends a worktree's plane back
+  to the clone it was cut from: right for charter, wrong for a suite, whose assertions would
+  otherwise read the operator's uncommitted `charter.toml` instead of the branch's committed
+  one (#785). A case that wants this repository's own committed config reads the file off
+  disk from the repository root, as `test_frame_config._COMMITTED` does, never through
+  `config`. The same file
   refuses one kind of *read*: a setting your own `charter.toml` declares — today
   `[update] channel` — because a test that reads it is asserting against a fixture written
   by whoever happens to run the suite. `tests/_envguard.py` is the third of the same
@@ -67,7 +75,10 @@ command.
   `tests._isolation.no_background_refresh(self)`; if it is *about* the child, call
   `tests._planeguard.allow_background_children(self)`. A test that starts a real tmux
   server names its socket with `tests._tmuxreap.name("<slug>")`, so the next run can reap
-  it when this one is killed before its cleanup runs. **Nor does it spend a credential.**
+  it when this one is killed before its cleanup runs — **every** socket it starts, including
+  a second one, and never by decorating a name that helper already produced (#770). The slug
+  is lowercase letters, digits and single hyphens; `name()` refuses anything else rather than
+  handing back a socket the reaper cannot see. **Nor does it spend a credential.**
   `doctor`'s preflight asks a forge whether your token is still good, and eighteen modules
   reach that line — 28 authenticated round trips to github.com and gitlab.com per run, and
   the sweep gate spends that again per mutation. `tests/_forgeprobe.py` answers the probe

--- a/docs/news/unreleased-the-suite-knows-which-checkout-it-is-in.md
+++ b/docs/news/unreleased-the-suite-knows-which-checkout-it-is-in.md
@@ -1,0 +1,155 @@
+---
+version: unreleased
+headline: charter's own test suite stops asserting against whichever checkout the machine happens to have open — and the reaper stops losing half of each run's tmux servers
+---
+
+Four reports, one sentence: **the suite could not be trusted about where it was running.**
+Which control plane its assertions read, which `charter.toml` it was allowed to write, and
+which tmux sockets it could still find afterwards were all answered by the machine rather
+than by the repository. They are fixed together because they are one property, and because
+three of the four were found on the same day by three different agents who each spent a
+control run learning the failure was not theirs.
+
+## A run in a worktree was reading somebody else's plane
+
+`root._plane_of` sends a linked worktree's plane back to the tree it was cut from. That is
+right for the *product* and load-bearing: a worktree of your plane is still your plane, so
+personas, the vault and every written memory must not fork per worktree — before that
+redirect existed they resolved into a directory `git worktree remove` deletes.
+
+What it means for the *suite* is that a run in a worktree asserts against the operator's own
+`charter.toml`, uncommitted edits and all, while the same tree on CI asserts against the
+branch. Measured from a pristine detached worktree of `origin/main`: `config.ROOT` is the
+operator's clone, and `test_frame_border_surface.test_this_planes_own_committed_frame_
+answers_the_report` fails there and passes on CI — naming a file the branch never touched,
+so the first reading is always "did I break this?". It reproduces on a clean worktree of
+`main`, and it also fails in the operator's own clone whenever they have edited their plane's
+`[frame]` block and not yet committed it. The only place it was green was CI.
+
+The fix is production's own seam rather than a second copy of it. `config.in_tree` already
+states the plane/tree split in one line — everything `derive` computes from the root follows
+the *tree*, and the per-developer state directory stays with the *plane* — and
+`root.tree_of` already answers "is this a linked worktree of that plane". The suite's guard
+asks both, at import, and pins itself to the checkout its own modules were loaded from. So a
+worktree run reads the branch, exactly as CI does; the state directory does not move, so the
+write tripwire still names the operator's real `.charter/`; and the pin declines on a
+checkout that carries no committed marker, which is `_plane_of`'s own condition read the
+other way round.
+
+**What must not weaken is the spawn tripwire, and this is the part worth stating.** A child
+charter resolves its own plane from its own environment, so in a worktree it resolves the
+operator's clone. If the pin had merely *swapped* which root counted as real, every spawned
+child would have gone unrefused — which is #527 reopened, and #527 was 131 detached
+`charter _version-check` / `charter gl-refresh` children in one run, each refreshing forge
+state and rewriting caches on a live machine. So the plane the pin redirected away from stays
+in the refusal set beside the worktree. The guard gets wider, never narrower, and two cases
+say so by name.
+
+The second half is the test itself. It now reads the file off disk from the repository root —
+`test_frame_config` had already made that call, with the worktree redirect named in its
+comment, for the two cases next door — and it asserts the *property* rather than the
+operator's word. `bg = "brightblack"` was spelled in as the expectation, so the day this
+plane's operator painted their panels `black`, a legal choice out of the same seventeen words
+made through the key charter gave them for it, the case went red on a colour. That is #661's
+shape inside a test: a config read turning an operator's own choice into a failure. What is
+asserted now is the agreement — one word across the committed arrangement, and the rule
+answering that word — which is the claim the class name makes. Verified against a hand
+mutation: with `border_bg` no longer taking the components' agreed surface, the case goes red.
+
+### The false-green half, measured
+
+The loud direction is a failing test. The quiet one is a test that *passes* because the
+machine's own configuration happens to satisfy it, and nobody had checked. So the suite was
+pointed at a plane whose `charter.toml` was deliberately wrong in nineteen values — forge
+owner, memory posture, default persona, the `slots` line, `mouse`, `chrome`, all six
+components' `bg`, four of their `key`s, one `size`, the update channel and the default
+harness — and run whole against it.
+
+**Two tests out of 9761 noticed.** One is the case above. The other is
+`test_frame_appearance.ThisPlaneOptsIntoTheSurface`, which already read the file off disk and
+asserts that this plane declares a surface — a real claim, correctly sourced, and the one
+test in the suite that measures the committed file on purpose. Everything else was
+indifferent: `[update]` and `[harness]` because the read guard already refuses them, and the
+rest because no test reads them unisolated at all.
+
+That is a smaller blast radius than the report supposed, and it is worth writing down in both
+directions. The dangerous half of this defect was narrow. The expensive half was the loud
+one, and it cost three agents a control run each in one day.
+
+## `charter.toml` is now a file no test may write
+
+A running plane was observed rewriting `charter.toml` inside sibling worktrees of its own
+clone — the `workspaces` and `chats` strips gone from a file the agent had never opened — and
+a `git add -A` committed the deletion under a message about something else. This repository's
+own history carries the same shape landing on `main`: commit `3935987`, "charter save: 1
+file(s)", deleted the entire 57-line `[[frame.component]]` arrangement, and a later commit
+put it back.
+
+The write path is not established and this does not claim one. `instance._set_key` — the only
+thing in `charter/` that writes the file — is a confined textual edit that preserves comments
+and ordering, which does not match "the strips vanished", and it writes `config.ROOT`'s copy,
+which in a worktree is the clone's and not the worktree's. So the containment ships and the
+question stays open.
+
+The containment is one entry in the guard that already exists. `charter.toml` is refused as a
+guarded **path**, not a prefix: the file cannot be opened for writing, truncated, unlinked or
+renamed over, and the directory holding it — `personas/`, `docs/`, `workspaces/`, committed
+content some tests legitimately generate — stays writable. Both markers when the suite is in
+a worktree, because the two are different files and the wrong one to write is the one nobody
+is looking at. The refusal names the file and the issue rather than talking about a state
+directory, because it arrives on a line whose author did not think they were touching a plane
+at all.
+
+## Half of each run's tmux servers were invisible to the reaper
+
+`tests/_tmuxreap` exists because a suite run killed before its cleanup leaks a socket file
+and, sometimes, a live tmux server: #564 counted 14 resident servers and 658 socket files on
+one machine. It reaps at import, and it only touches names the suite hands out —
+`charter-<slug>-<pid>`, matched with `fullmatch`, the pid last.
+
+`ChromeIsOneColour` owns a second server, and it named it by decorating the first:
+`f"{SOCKET}-host"`. The pid is no longer last, so `owns("charter-integration-test-1474-host")`
+is False and the reaper never reached the "is that pid alive" question at all. **Six live tmux
+servers were found on this machine**, from interrupted campaign runs of that one class, each
+holding the `keep` session #713 gives it on purpose — so nothing retires it on `exit-empty`
+any more — and each with its owning python long gone. The inner socket of every one of those
+runs had been reaped correctly. Half of each run's mess cleaned, half invisible.
+
+The census that exists to catch exactly this looked straight past it, because it read only
+module-level `SOCKET = f"…"` assignments and this was an attribute, inside a method. It now
+reads any scope and any spelling, and it goes red on the line as it stood.
+
+**And a second instance, which no scan could ever have caught, because that caller had
+followed the rule.** `test_a_planes_frame_really_reads_that_way` builds its slug from the
+tmux binary's own filename so the 3.7c and 3.2 servers never meet — and at the floor that
+filename is `tmux-3.2`. `charter-frame-reads-in-tmux-3.2-<pid>` has a `.` in it, which the
+pattern does not accept. Two unreapable live servers per floor test, from a module that
+called the one producer.
+
+So the rule is enforced where it is stated: `_tmuxreap.name` refuses a slug whose result the
+reaper would not recognise, and says so. A refusal rather than a repair — `tmux-3.2` and
+`tmux-3-2` would be one socket if it normalised, and a socket name is something a human reads
+in `ps` output. Going through the one producer was never the property; the property is that
+what comes out is reapable.
+
+## The reaper's own test stops failing for its neighbour's success
+
+`TheReaperEndsWhatAKilledRunLeftRunning` plants a real tmux server on a socket named for a
+dead pid and asserts that *this* run's `reap()` is what removed it. But `reap()` scans
+`/tmp/tmux-<uid>/`, which is per-user and not per-run, so a second copy of the suite reaching
+its own `reap()` a moment earlier removes this one's plant too. The victim sees `[]` and
+reports that the reaper did nothing — the opposite of what happened, and an accusation of the
+exact defect (#564) the test exists to prevent. Three of its cases were exposed, not one.
+
+Measured cold: six runs of that class, two at a time, with the fix removed — **five failed**,
+in both directions ("a sibling reaped my plant" and "I reaped a sibling's"). With the fix,
+six for six green, including one pair run while a full second suite was going.
+
+The fix is the idiom the two scan classes in the same file already use: `$TMUX_TMPDIR` points
+tmux and the reaper at a directory nothing else on the machine is looking at. That makes
+every `reap()` there **exact** rather than merely tolerant, so the assertions got stronger
+rather than being narrowed to survive the race. The one case that is genuinely about the
+machine's own directory — nothing reapable survives a reap — keeps it, and now says why in a
+class of its own: given a private directory it would assert nothing at all.
+
+None of this reaches you unless you run charter's own test suite. Nothing to adopt.

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -16,11 +16,29 @@ the `tests` package — before any test module is collected, so no test can opt 
 forgetting a base class. A test that reaches the real plane now fails, by name, on the
 line that reached it, having changed nothing.
 
-**Only the state directory, for writes.** ``.charter/`` is per-developer, gitignored, and
-holds live session state — frame directories, the vault registry, session pointers. The
-rest of the plane (``personas/``, ``docs/``, ``workspaces/``) is committed content some
-tests do legitimately generate into a tmp root, and guarding the real copies of those
-would trade this defect for a stream of false alarms.
+**Only the state directory, for writes — and one file.** ``.charter/`` is per-developer,
+gitignored, and holds live session state — frame directories, the vault registry, session
+pointers. The rest of the plane (``personas/``, ``docs/``, ``workspaces/``) is committed
+content some tests do legitimately generate into a tmp root, and guarding the real copies of
+those would trade this defect for a stream of false alarms.
+
+The exception is ``charter.toml`` itself, and #726 is why: a running plane was observed
+rewriting it inside sibling *worktrees* of its own clone — the ``workspaces`` and ``chats``
+strips gone from a file the agent had never opened — and a ``git add -A`` committed the
+deletion under a message about something else. It is one file rather than a tree, it is what
+makes the directory a plane at all, and a lost ``[[frame.component]]`` changes what the next
+launch draws. No test has business writing the real one; the fixtures write
+``config.ROOT / "charter.toml"`` with `PersonaIso`'s tmp root under them.
+
+**Which plane the suite reads, when the suite is in a worktree.** `root._plane_of` sends a
+linked worktree's plane back to the tree it was cut from, which is right for identity and
+wrong for a test suite: the assertions then read the operator's own uncommitted
+``charter.toml`` instead of the branch's committed one — loudly in one direction (a case that
+fails in every worktree and passes on CI) and silently in the other (a case that passes
+because that machine's configuration happens to satisfy it). See
+:func:`_pin_the_suite_to_its_own_tree`, which hands the committed half back to the checkout
+the suite is in through `config.in_tree`, leaves the state directory with the plane, and
+widens the spawn refusal to cover both roots rather than swapping one for the other (#785).
 
 **Reads of the state directory stay untouched**, for the same reason: a test may
 legitimately look at the real plane (that `render()` survives a real environment, say),
@@ -231,6 +249,12 @@ from pathlib import Path
 # `install()` would have given it one line later.
 from charter import hooks as _hooks      # noqa: E402
 
+# `charter.root` for the same reason and with more room: it imports `os`, `pathlib` and
+# nothing else — in particular not `charter.config` — so asking it where a plane is cannot
+# pull a plane resolution in ahead of `_envguard`'s scrub. It is the module that owns both
+# halves of the worktree question this file now asks (`tree_of`, `MARKER`).
+from charter import root as _root        # noqa: E402
+
 #: The state directory of the plane this test PROCESS resolved at import — before any
 #: `setUp` could repoint `charter.config`, so unavoidably the developer's real one.
 #:
@@ -247,6 +271,16 @@ class RealPlaneWrite(BaseException):
 
 
 def _explain(op: str, path) -> str:
+    if str(path).endswith(_root.MARKER):
+        return (
+            f"REFUSED: {op} {path}\n"
+            f"This test is writing the file that MAKES that directory a control plane — "
+            f"the developer's own committed `{_root.MARKER}`, which decides what their "
+            f"next `charter` launch draws. A rewrite of it is silent, is not a file the "
+            f"test opened, and gets swept into a commit by a `git add -A` under a message "
+            f"about something else (#726). Derive the test case from "
+            f"`tests._isolation.PersonaIso`, whose `config.ROOT` is a tmp plane, and write "
+            f"THAT root's marker.")
     return (
         f"REFUSED: {op} {path}\n"
         f"This test is writing into the developer's REAL control-plane state directory "
@@ -420,17 +454,102 @@ class _RefusesToBeRead(dict):
 
 #: The control-plane root this test PROCESS resolved at import, in both spellings, for the
 #: same reason :data:`_REAL` carries two.
+#:
+#: PLURAL in a second sense since #785: run from a linked worktree, the suite reads its own
+#: checkout (:func:`_pin_the_suite_to_its_own_tree`) and the plane it was redirected away
+#: from is still a real plane a spawned child would resolve — so both are in here, and the
+#: refusals below reach a child aimed at either.
 _REAL_ROOT: tuple[str, ...] = ()
 
 
-def _guard_reads(config) -> None:
-    """Arm :data:`_GUARDED_SETTINGS` on every derivation that lands on the real plane."""
+def _both_spellings(path) -> tuple[str, ...]:
+    """*path* as written and with every symlink resolved, deduplicated.
+
+    :data:`_REAL`'s own rule, factored out once it had three callers: a checkout under a
+    symlinked home (or under macOS's ``/tmp`` → ``/private/tmp``) makes the two differ, and
+    a guard that knew only one spelling would wave through everything spelled the other way.
+    """
+    written = os.path.abspath(str(path))
+    resolved = os.path.realpath(written)
+    return (written,) if written == resolved else (written, resolved)
+
+
+#: Held for the life of the process. `config.in_tree` is a context manager and this one is
+#: entered and never exited — deliberately, like every other wrapper `install` puts in — but
+#: a generator-based CM that gets garbage collected runs its own ``finally``, which here is
+#: the ``restore()`` that would silently undo the pin. So the object is kept.
+_TREE_PIN = None
+
+
+def _pin_the_suite_to_its_own_tree(config) -> tuple[str, ...]:
+    """Point the suite's committed settings at the checkout the suite is IN, and answer with
+    the plane it was reading before — or ``()`` when there was nothing to move.
+
+    **#785.** `root._plane_of` redirects a linked worktree's plane to the tree it was cut
+    from, and for the PRODUCT that is right and load-bearing: a worktree of your plane is
+    still your plane, so personas, the vault and every written memory must not fork per
+    worktree. What it means for the SUITE is that a run in a worktree asserts against the
+    operator's own ``charter.toml`` — the file on their disk, uncommitted edits and all —
+    while the same tree on CI asserts against the branch. Measured from a pristine detached
+    worktree of `origin/main`: ``config.ROOT`` is the operator's clone, and
+    ``test_frame_border_surface.test_this_planes_own_committed_frame_answers_the_report``
+    fails there and passes on CI, naming a file the branch never touched. Three agents hit
+    it independently in one day from three directions.
+
+    The false RED is the loud half. The quiet half is a case that PASSES because the
+    operator's uncommitted configuration happens to satisfy it, and a third cost is that two
+    agents on one machine get different answers from the same tree.
+
+    **Production's own seam, not a second copy of it.** `config.in_tree` exists for exactly
+    this distinction — everything `derive` computes from the root follows the *tree*, and the
+    per-developer state directory stays with the *plane* — and `root.tree_of` is the question
+    "is this a linked worktree of that plane". Asking those two rather than re-deriving them
+    is what keeps this from drifting away from the walk it is standing on. It also means the
+    state directory does not move, so :data:`_REAL` still names the operator's real
+    ``.charter/`` and the write tripwire is untouched.
+
+    **What must NOT weaken is the spawn tripwire.** A child charter resolves its own plane
+    from its own environment, so in a worktree it resolves the operator's clone — which,
+    once this pin has moved ``config.ROOT``, is no longer what `_REAL_ROOT` would name. That
+    is #527's hole reopened (131 detached children landing on the operator's live plane in
+    one run), so the plane is returned here and folded into :data:`_REAL_ROOT` beside the
+    worktree. Both are refused; the guard gets wider, never narrower.
+
+    Asked of THIS FILE's location rather than of the cwd: which checkout the suite is is a
+    fact about where these modules were loaded from, and `unittest discover` can be run from
+    anywhere.
+
+    **And only when the worktree carries the marker**, which is `_plane_of`'s own condition
+    read the other way round: "if it is not present there too, this is not one plane seen
+    from two directories". A worktree cut from a branch that predates the committed
+    ``charter.toml`` has no committed settings to pin to, and pinning to it would hand the
+    suite a plane-less root — a different wrong answer, not a fix.
+    """
+    global _TREE_PIN
+    try:
+        tree = _root.tree_of(config.ROOT, Path(__file__).resolve().parents[1])
+        if tree is not None and not (tree / _root.MARKER).is_file():
+            tree = None
+    except (OSError, RuntimeError):       # never raise at suite boot; see `install`
+        return ()
+    if tree is None:
+        return ()
+    plane = _both_spellings(config.ROOT)
+    _TREE_PIN = config.in_tree(tree)
+    _TREE_PIN.__enter__()
+    return plane
+
+
+def _guard_reads(config, *also: str) -> None:
+    """Arm :data:`_GUARDED_SETTINGS` on every derivation that lands on the real plane.
+
+    *also* names further roots that count as real — the plane a worktree pin redirected the
+    suite away from, which nothing else would put back.
+    """
     global _REAL_ROOT
     if _REAL_ROOT:                        # idempotent: never wrap `derive` twice
         return
-    written = os.path.abspath(str(config.ROOT))
-    resolved = os.path.realpath(written)
-    _REAL_ROOT = (written,) if written == resolved else (written, resolved)
+    _REAL_ROOT = tuple(dict.fromkeys(_both_spellings(config.ROOT) + also))
 
     def _is_real(where) -> bool:
         try:
@@ -1463,14 +1582,37 @@ def install() -> None:
     if _REAL:
         return
     from charter import config
-    _guard_reads(config)
+    # BEFORE `_guard_reads`, which snapshots `config.ROOT`, and before `_REAL` below, which
+    # snapshots `config.STATE_DIR` — the pin moves the first and deliberately not the second.
+    plane = _pin_the_suite_to_its_own_tree(config)
+    _guard_reads(config, *plane)
     _guard_spawns()
     try:
         written = os.path.abspath(str(config.STATE_DIR))
         resolved = os.path.realpath(written)
     except (OSError, ValueError):         # no resolvable plane: nothing to protect
         return
-    _REAL = (written,) if written == resolved else (written, resolved)
+    # The state directory, and the one FILE outside it no test may replace: the plane's own
+    # `charter.toml`.
+    #
+    # A deliberate exception to "only the state directory", and #726 is the measurement. A
+    # running plane was observed rewriting `charter.toml` inside sibling worktrees of its own
+    # clone — the `workspaces` and `chats` strips gone from a file the agent never opened —
+    # and a `git add -A` committed the deletion under a message about something else. This
+    # repo's own history carries the same shape landing on `main`: `3935987`, "charter save: 1
+    # file(s)", deleted the entire 57-line `[[frame.component]]` arrangement.
+    #
+    # It is not `personas/` or `docs/`, which tests legitimately generate into a tmp root and
+    # whose real copies this refuses to guard for that reason. It is ONE file, it is what
+    # makes the directory a plane at all, a lost `[[frame.component]]` changes what the next
+    # launch draws, and no test has any business writing the real one — the fixtures write
+    # `config.ROOT / "charter.toml"` under `PersonaIso`, where `config.ROOT` is a tmp dir.
+    # Both markers, because in a worktree the two are different files and the wrong one to
+    # write is the one nobody is looking at.
+    markers = tuple(dict.fromkeys(
+        m for r in (str(config.ROOT), *plane)
+        for m in _both_spellings(Path(r) / _root.MARKER)))
+    _REAL = ((written,) if written == resolved else (written, resolved)) + markers
 
     # `os.mkdir` covers `Path.mkdir` AND `os.makedirs` (which calls the module global by
     # name, so it goes through this wrapper too) — one wrapper, both spellings.

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -271,7 +271,9 @@ class RealPlaneWrite(BaseException):
 
 
 def _explain(op: str, path) -> str:
-    if str(path).endswith(_root.MARKER):
+    # The BASENAME, not a suffix: `.charter/x-charter.toml` is a file inside the state
+    # directory and gets the state directory's message, which is the one that helps.
+    if os.path.basename(str(path)) == _root.MARKER:
         return (
             f"REFUSED: {op} {path}\n"
             f"This test is writing the file that MAKES that directory a control plane — "

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -482,6 +482,13 @@ def _both_spellings(path) -> tuple[str, ...]:
 #: the ``restore()`` that would silently undo the pin. So the object is kept.
 _TREE_PIN = None
 
+#: What :func:`_pin_the_suite_to_its_own_tree` answered, so a second call answers the same
+#: thing instead of pinning twice. `install` promises idempotence and gives up early on a
+#: machine with no resolvable state directory — which is a return BEFORE :data:`_REAL` is
+#: set, so its own guard would not stop a second call reaching here. Re-entering `in_tree`
+#: would drop the first CM, whose collection runs the ``restore()`` that undoes the pin.
+_PINNED_PLANE: tuple[str, ...] | None = None
+
 
 def _pin_the_suite_to_its_own_tree(config) -> tuple[str, ...]:
     """Point the suite's committed settings at the checkout the suite is IN, and answer with
@@ -527,19 +534,22 @@ def _pin_the_suite_to_its_own_tree(config) -> tuple[str, ...]:
     ``charter.toml`` has no committed settings to pin to, and pinning to it would hand the
     suite a plane-less root — a different wrong answer, not a fix.
     """
-    global _TREE_PIN
+    global _TREE_PIN, _PINNED_PLANE
+    if _PINNED_PLANE is not None:         # idempotent; see :data:`_PINNED_PLANE`
+        return _PINNED_PLANE
     try:
         tree = _root.tree_of(config.ROOT, Path(__file__).resolve().parents[1])
         if tree is not None and not (tree / _root.MARKER).is_file():
             tree = None
     except (OSError, RuntimeError):       # never raise at suite boot; see `install`
-        return ()
+        tree = None
     if tree is None:
-        return ()
-    plane = _both_spellings(config.ROOT)
+        _PINNED_PLANE = ()
+        return _PINNED_PLANE
+    _PINNED_PLANE = _both_spellings(config.ROOT)
     _TREE_PIN = config.in_tree(tree)
     _TREE_PIN.__enter__()
-    return plane
+    return _PINNED_PLANE
 
 
 def _guard_reads(config, *also: str) -> None:

--- a/tests/_tmuxreap.py
+++ b/tests/_tmuxreap.py
@@ -90,8 +90,30 @@ def name(slug: str) -> str:
     ``f"charter-…-{os.getpid()}"``. Four spellings of a rule is four chances for the fifth
     to be spelled in a way the reaper does not recognise — and a socket the reaper does not
     recognise is exactly the leak this exists to end.
+
+    **And the producer CHECKS, because going through it was not enough (#770).** One
+    producer only helps if what comes out is reapable, and a *slug* the caller computed can
+    take a name out of the namespace as thoroughly as a hand-rolled f-string does. Measured
+    on this tree, from a module that does call this function:
+    ``test_a_planes_frame_really_reads_that_way`` builds its slug from the tmux binary's own
+    filename, which at the 3.2 floor is ``tmux-3.2`` — and ``charter-frame-reads-in-tmux-3.
+    2-<pid>`` has a ``.`` in it, which :data:`_OURS` does not accept. Two live servers per
+    test at the floor, invisible to `owns` and so to every reap after them, from a caller
+    that had followed the rule. So the rule is enforced HERE, where it is stated, rather
+    than left to a scan that by construction cannot see a computed slug.
+
+    A refusal rather than a repair: ``tmux-3.2`` and ``tmux-3-2`` are one socket if this
+    normalised them, and a name is read by a human in `ps` output. The caller says what its
+    slug is; this says whether the reaper will ever see it.
     """
-    return f"charter-{slug}-{os.getpid()}"
+    made = f"charter-{slug}-{os.getpid()}"
+    if not owns(made):
+        raise ValueError(
+            f"{made!r} is not a name the reaper recognises, so a run killed before its "
+            f"cleanup would leave its tmux server running with nothing able to find it "
+            f"(#564, #770). A slug is lowercase letters, digits and single hyphens: "
+            f"{slug!r} is not. Spell it as one — a `.` becomes a `-`.")
+    return made
 
 
 def owns(candidate: str) -> bool:

--- a/tests/test_a_planes_frame_really_reads_that_way.py
+++ b/tests/test_a_planes_frame_really_reads_that_way.py
@@ -50,6 +50,11 @@ _HAS_TMUX = shutil.which("tmux") is not None
 #: installs no tmux at all, so every floor test here skips there and says so.
 _FLOOR_BIN = Path.home() / ".local/share/charter-testing" / f"tmux-{tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]}"
 
+#: Everything a `tests._tmuxreap.name` slug may not contain, in one class. The socket name
+#: is what the reaper matches on, so a tag built from a filename has to be folded into the
+#: namespace before it goes in — see `setUp`.
+_SLUG_UNSAFE = re.compile(r"[^a-z0-9]+")
+
 #: One SGR escape as it comes back out of `capture-pane -e`.
 _SGR = re.compile(r"\x1b\[([0-9;]*)m")
 
@@ -124,7 +129,13 @@ class _NestedClient(PersonaIso):
         # eight of fifteen failing on one run and none on the next, which is the signature
         # `#713` and `#719` both chased in the neighbouring harness. One socket per
         # binary per process, so the two versions never meet.
-        tag = Path(self.BIN).name
+        #
+        # Hyphenated, not spelled: the floor's filename is `tmux-3.2`, and a `.` is not a
+        # character `_tmuxreap._OURS` accepts — so `charter-frame-reads-in-tmux-3.2-<pid>`
+        # went through the one producer and came out UNREAPABLE anyway, leaving two live
+        # servers per floor test that no later reap could see (#770). `_tmuxreap.name` now
+        # refuses such a slug at the source; this is the slug it wants.
+        tag = _SLUG_UNSAFE.sub("-", Path(self.BIN).name)
         self._inner = _tmuxreap.name(f"frame-reads-in-{tag}")
         self._outer = _tmuxreap.name(f"frame-reads-out-{tag}")
         self.addCleanup(self._teardown)

--- a/tests/test_a_planes_frame_really_reads_that_way.py
+++ b/tests/test_a_planes_frame_really_reads_that_way.py
@@ -52,7 +52,9 @@ _FLOOR_BIN = Path.home() / ".local/share/charter-testing" / f"tmux-{tmuxctl.FLOO
 
 #: Everything a `tests._tmuxreap.name` slug may not contain, in one class. The socket name
 #: is what the reaper matches on, so a tag built from a filename has to be folded into the
-#: namespace before it goes in — see `setUp`.
+#: namespace before it goes in — see `setUp`. Written as a run (``+``) so a `3.2` folds to
+#: one hyphen and not two, and applied to a lowercased name with the ends stripped, because
+#: the two shapes `_OURS` refuses either side of a fold are a doubled and a trailing hyphen.
 _SLUG_UNSAFE = re.compile(r"[^a-z0-9]+")
 
 #: One SGR escape as it comes back out of `capture-pane -e`.
@@ -135,7 +137,7 @@ class _NestedClient(PersonaIso):
         # went through the one producer and came out UNREAPABLE anyway, leaving two live
         # servers per floor test that no later reap could see (#770). `_tmuxreap.name` now
         # refuses such a slug at the source; this is the slug it wants.
-        tag = _SLUG_UNSAFE.sub("-", Path(self.BIN).name)
+        tag = _SLUG_UNSAFE.sub("-", Path(self.BIN).name.lower()).strip("-")
         self._inner = _tmuxreap.name(f"frame-reads-in-{tag}")
         self._outer = _tmuxreap.name(f"frame-reads-out-{tag}")
         self.addCleanup(self._teardown)

--- a/tests/test_frame_border_surface.py
+++ b/tests/test_frame_border_surface.py
@@ -31,7 +31,9 @@ rule takes ONE colour, set `-w`, exactly as `_chrome_argvs` already sets the oth
 from __future__ import annotations
 
 import os
+import pathlib
 import subprocess
+import tomllib
 import unittest
 from unittest import mock
 
@@ -40,6 +42,15 @@ from charter.frame import state, tmuxctl
 from tests._isolation import PersonaIso
 
 _STYLES = ("pane-border-style", "pane-active-border-style")
+
+#: This checkout's own `charter.toml`, read off disk — `test_frame_config._COMMITTED`'s
+#: idiom, imported by spelling rather than by import because the two files claim different
+#: things about the same bytes and neither should be able to break the other's reading.
+#:
+#: `config.ROOT` is deliberately NOT this path: `root._plane_of` redirects a linked
+#: worktree's plane to the tree it was cut from, so through `config` this would be the
+#: operator's checkout and not the branch under test (#785).
+_COMMITTED = pathlib.Path(__file__).resolve().parents[1] / "charter.toml"
 
 #: A tmux old enough to have every option `_CHROME` names — the version the cases that are
 #: about the SURFACE are asked at, so a row dropped for its own floor cannot quietly change
@@ -212,14 +223,42 @@ class TheRuleTakesTheSurfaceTheComponentsAgreeOn(unittest.TestCase):
                          "bg=brightblack")
 
     def test_this_planes_own_committed_frame_answers_the_report(self):
-        """The operator's charter.toml, asked directly. Four components, one word, and
-        their own comment for it: "charter's chrome is grey, the work area is the
-        terminal's own". Grey is `brightblack`, and until this key existed the rules
-        between those grey panes were the terminal's black."""
-        if not (config.FRAME.get("components") or ()):
+        """THIS checkout's committed `charter.toml`, read off disk. Every component one
+        word, and the file's own comment for it: "charter's chrome is grey, the work area
+        is the terminal's own". Until this key existed the rules between those panes were
+        the terminal's black, which is the report.
+
+        **Off disk, and not through `config` — #785.** `root._plane_of` redirects a linked
+        worktree's plane to the tree it was cut from, deliberately and correctly: a
+        worktree of your plane is still your plane. But `config.FRAME` then answers with
+        the *operator's* file, so this case asserted against a machine's uncommitted state
+        rather than against the branch it was running on. It failed in every worktree of
+        this repo and passed on CI, naming a file the branch never touched — and the same
+        mechanism can make a case PASS because an operator's own config happens to satisfy
+        it, which is the half nothing reports. `test_frame_config._COMMITTED` had already
+        made this call for the two cases next door; this one had not.
+
+        **And the word is READ, not written down, which is the other half of the same
+        defect.** `bg = "brightblack"` was spelled here as the expectation, so the day this
+        plane's operator painted their panels `black` — a legal choice out of the same
+        seventeen words, made through the key charter gave them for it — this case went red
+        on a colour. That is #661's shape exactly: a config read turning an operator's own
+        choice into a failure. The claim the class name makes is *the rule takes the surface
+        the components agree on*, so what is asserted is the agreement: one word across the
+        arrangement, and the rule answering that word. Which word is the plane's business.
+        """
+        frame = instance.frame_of(tomllib.loads(_COMMITTED.read_text(encoding="utf-8")))
+        placed = frame.get("components") or ()
+        if not placed:
             self.skipTest("this plane's charter.toml writes no arrangement")
-        self.assertEqual(instance.border_bg(config.FRAME, config.FRAME.get("chrome")),
-                         "bg=brightblack")
+        agreed = {c.get("bg") for c in placed}
+        self.assertEqual(len(agreed), 1,
+                         f"this plane paints its panels {sorted(agreed)}, so there is no "
+                         f"one surface for the rules between them to take — the frame-wide "
+                         f"`chrome` fallback is what it gets, and this case is about the "
+                         f"other branch")
+        self.assertEqual(instance.border_bg(frame, frame.get("chrome")),
+                         f"bg={agreed.pop()}")
 
 
 class TheRuleIsDrawnInIt(unittest.TestCase):

--- a/tests/test_frame_border_surface.py
+++ b/tests/test_frame_border_surface.py
@@ -31,7 +31,6 @@ rule takes ONE colour, set `-w`, exactly as `_chrome_argvs` already sets the oth
 from __future__ import annotations
 
 import os
-import pathlib
 import subprocess
 import tomllib
 import unittest
@@ -40,17 +39,14 @@ from unittest import mock
 from charter import commands_frame, config, instance
 from charter.frame import state, tmuxctl
 from tests._isolation import PersonaIso
+# This repo's own committed `charter.toml`, IMPORTED rather than recomputed. Cross-module
+# test imports are this suite's ordinary way of sharing a fixture, and the thing worth
+# sharing here is not the one-line path — it is the *reason* that path is not `config.ROOT`
+# (`root._plane_of` redirects a worktree, #785), which should exist in one comment rather
+# than in two that can drift apart. `test_frame_config` is where it already lives.
+from tests.test_frame_config import _COMMITTED
 
 _STYLES = ("pane-border-style", "pane-active-border-style")
-
-#: This checkout's own `charter.toml`, read off disk — `test_frame_config._COMMITTED`'s
-#: idiom, imported by spelling rather than by import because the two files claim different
-#: things about the same bytes and neither should be able to break the other's reading.
-#:
-#: `config.ROOT` is deliberately NOT this path: `root._plane_of` redirects a linked
-#: worktree's plane to the tree it was cut from, so through `config` this would be the
-#: operator's checkout and not the branch under test (#785).
-_COMMITTED = pathlib.Path(__file__).resolve().parents[1] / "charter.toml"
 
 #: A tmux old enough to have every option `_CHROME` names — the version the cases that are
 #: about the SURFACE are asked at, so a row dropped for its own floor cannot quietly change

--- a/tests/test_frame_config.py
+++ b/tests/test_frame_config.py
@@ -25,6 +25,11 @@ from tests import _envguard
 #: :class:`CharterOwnPlaneDrawsEveryEdgeItShips`. Read off disk rather than through
 #: `config`, which resolves a WORKTREE back to the main tree it was cut from
 #: (`root._plane_of`) and would therefore test the operator's checkout, not this one.
+#:
+#: That paragraph is why this is the one place the path is written and
+#: `test_frame_border_surface` imports it: the same case reading through `config.FRAME`
+#: instead failed in every worktree of this repo and passed on CI, and would have gone on
+#: passing on a machine whose own configuration happened to satisfy it (#785).
 _COMMITTED = pathlib.Path(__file__).resolve().parents[1] / "charter.toml"
 
 

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -4470,6 +4470,20 @@ _INDICATOR_GLYPHS = frozenset("←→↑↓")
 #: paragraph, asserted rather than promised.
 _PAINT_MARK = "~painted~"
 
+#: `ChromeIsOneColour`'s OUTER server — the one whose single pane holds a client attached
+#: to the frame, which is what makes the frame's borders capturable at all.
+#:
+#: Asked of `_tmuxreap.name` like every other server this suite starts, and it was not:
+#: this used to be `f"{SOCKET}-host"`, decorating a name the helper had already made. The
+#: helper's rule puts the pid LAST, so a suffix took the result out of the reaper's
+#: namespace entirely — `owns("charter-integration-test-1474-host")` is False — and #770
+#: counted **six live tmux servers** on this machine from interrupted campaign runs of this
+#: class, each holding the `keep` session #713 gives it on purpose, each with its owning
+#: python long gone. The inner socket of every one of those runs had been reaped correctly:
+#: half of each run's mess cleaned, half invisible. A caller that needs a SECOND socket asks
+#: for one.
+HOST_SOCKET = _tmuxreap.name("integration-test-host")
+
 
 class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
     """#514, asked of the SCREEN: charter's own frame must draw every rule the same.
@@ -4506,7 +4520,7 @@ class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self._outer_socket = f"{self.SOCKET_NAME}-host"
+        self._outer_socket = HOST_SOCKET
         self.addCleanup(self._teardown_outer)
         # **Both servers are held for the whole test, and #713 is what the version that
         # held neither cost.** This is the one class in this module that kills its own

--- a/tests/test_plane_write_guard.py
+++ b/tests/test_plane_write_guard.py
@@ -42,6 +42,50 @@ class WhatIsGuarded(unittest.TestCase):
         self.assertIn(os.path.abspath(state), _planeguard._REAL,
                       "the guard is watching a directory that is not this plane's state")
 
+    def test_the_guarded_file_is_this_planes_own_marker(self):
+        """The one file outside the state directory the guard refuses, and #726 is the
+        measurement: a running plane rewriting `charter.toml` inside a sibling worktree of
+        its own clone, the strips gone from a file nobody had opened, and a `git add -A`
+        committing the deletion. Both markers when the suite is in a worktree — the two are
+        different files, and the wrong one to write is the one nobody is looking at."""
+        for real in _planeguard._REAL_ROOT:
+            with self.subTest(plane=real):
+                self.assertIn(os.path.join(real, root.MARKER), _planeguard._REAL,
+                              "a test could rewrite the file that makes that directory a "
+                              "control plane")
+
+    def test_the_suite_reads_the_checkout_these_modules_were_loaded_from(self):
+        """#785. `root._plane_of` sends a linked worktree's plane back to the tree it was
+        cut from, so without the pin in `_planeguard.install` a run in a worktree asserts
+        against the operator's own `charter.toml` — their uncommitted edits included —
+        while the same tree on CI asserts against the branch.
+
+        Stated as one claim that holds in all three places rather than as a case that
+        skips outside a worktree: the checkout these modules were imported from is a root
+        the guard treats as real. In the main clone and on CI that is true because the
+        checkout IS the plane; in a worktree it is true only because the pin ran.
+        """
+        tree = Path(_planeguard.__file__).resolve().parents[1]
+        if not (tree / root.MARKER).is_file():
+            # `_plane_of`'s own condition, read the other way: a checkout with no marker is
+            # not this plane seen from a second directory, and there are no committed
+            # settings there to pin to. The pin declines, and so does this.
+            self.skipTest(f"this checkout carries no committed {root.MARKER}")
+        self.assertIn(os.path.abspath(str(tree)), _planeguard._REAL_ROOT,
+                      "the suite is asserting against a checkout that is not the one it "
+                      "was loaded from")
+
+    def test_the_plane_a_worktree_redirects_to_is_still_one_the_guard_refuses(self):
+        """The half the pin must not cost, and #527 is what it costs if it does. A child
+        charter resolves its own plane from its own environment, so in a worktree it
+        resolves the operator's clone — and if moving `config.ROOT` merely *swapped* which
+        root counted as real, every spawned child would land on the operator's live plane
+        unrefused. That was 131 detached children in one run, refreshing forge state and
+        rewriting caches. The pin widens the refusal; it does not move it."""
+        tree = Path(_planeguard.__file__).resolve().parents[1]
+        self.assertIn(os.path.abspath(str(root._plane_of(tree))),
+                      _planeguard._REAL_ROOT)
+
     def test_every_write_primitive_is_wrapped_at_package_import(self):
         """No test can opt out by forgetting a base class, because nothing opted IN.
 
@@ -153,6 +197,57 @@ class WritesAreRefused(_FakePlane):
             os.link(self.plane / "vaults.json", self.plane / "hard")
         self.assertFalse((self.plane / "planted").is_symlink())
         self.assertFalse((self.plane / "hard").exists())
+
+    def _a_guarded_marker(self) -> Path:
+        """A `charter.toml` in a directory that is otherwise NOT guarded, so the cases below
+        can tell a guarded path from a guarded prefix — which is the whole shape of this
+        entry: the plane's tracked content stays writable and one file does not."""
+        marker = self.elsewhere / root.MARKER
+        marker.write_text("schema = 1\n")
+        self.enterContext(mock.patch.object(
+            _planeguard, "_REAL", (*_planeguard._REAL, str(marker))))
+        return marker
+
+    def test_the_planes_own_marker_cannot_be_rewritten(self):
+        """#726, contained. Every spelling a rewrite arrives as: `charter.toml` is
+        hand-maintained, so a writer that means to keep the comments reads it, edits the
+        text and writes it back (`instance._set_key`), and one that does not truncates it or
+        renames a new file over it."""
+        marker = self._a_guarded_marker()
+        for mode in ("w", "a", "r+"):
+            with self.subTest(mode=mode), self.assertRaises(_planeguard.RealPlaneWrite):
+                builtins.open(marker, mode)
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            marker.write_text("")
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.truncate(marker, 0)
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.unlink(marker)
+        (self.elsewhere / "spare").write_text("new file")
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.replace(self.elsewhere / "spare", marker)
+        self.assertEqual(marker.read_text(), "schema = 1\n")
+
+    def test_it_is_that_one_file_and_not_the_directory_holding_it(self):
+        """The boundary this entry has to keep, or it becomes the "stream of false alarms"
+        the module docstring refuses: `personas/`, `docs/` and `workspaces/` are committed
+        content tests do legitimately generate, and only the marker is refused."""
+        marker = self._a_guarded_marker()
+        (self.elsewhere / "personas").mkdir()
+        (self.elsewhere / "personas" / "x.md").write_text("generated")
+        (self.elsewhere / "charter.toml.bak").write_text("a backup is not the marker")
+        self.assertEqual(marker.read_text(), "schema = 1\n")
+
+    def test_the_message_for_the_marker_names_the_marker(self):
+        """A refusal that read "you are writing into the state directory" while pointing at
+        `charter.toml` would send its reader looking in the wrong place — and this refusal
+        arrives on a line whose author did not think they were touching a plane at all."""
+        with self.assertRaises(_planeguard.RealPlaneWrite) as caught:
+            self._a_guarded_marker().write_text("x")
+        said = str(caught.exception)
+        self.assertIn(root.MARKER, said)
+        self.assertIn("#726", said)
+        self.assertNotIn("state directory", said)
 
     def test_a_relative_path_reaches_the_plane_too(self):
         """A test that `chdir`s into the plane writes with no plane prefix in the string

--- a/tests/test_the_suite_reaps_its_own_tmux_servers.py
+++ b/tests/test_the_suite_reaps_its_own_tmux_servers.py
@@ -96,11 +96,32 @@ class TheNameIsWhatMakesASocketReapable(unittest.TestCase):
     def test_what_the_helper_produces_is_what_the_reaper_recognises(self):
         """The derivation, not its contents: a slug nobody has invented yet is reapable on
         the commit that invents it, because the producer and the pattern live together."""
-        for slug in ("integration-test", "overlay-hatch", "palette-integ", "a", "x9-y7"):
+        for slug in ("integration-test", "overlay-hatch", "palette-integ", "a", "x9-y7",
+                     "integration-test-host", "frame-reads-in-tmux-3-2"):
             with self.subTest(slug=slug):
                 made = _tmuxreap.name(slug)
                 self.assertTrue(_tmuxreap.owns(made), made)
                 self.assertTrue(made.endswith(f"-{os.getpid()}"))
+
+    def test_a_slug_the_reaper_could_not_recognise_is_refused_at_the_source(self):
+        """#770's second half, and the one a scan cannot reach: the slug was COMPUTED.
+
+        `test_a_planes_frame_really_reads_that_way` builds its slug from the tmux binary's
+        filename, which at the 3.2 floor is ``tmux-3.2`` — so it called this helper, as the
+        rule says, and got ``charter-frame-reads-in-tmux-3.2-<pid>``: a `.`, which
+        :data:`_tmuxreap._OURS` does not accept, and therefore two live servers per floor
+        test that no later reap can see. Going through the one producer is not the property;
+        the property is that what comes out is reapable, so the producer checks.
+
+        The last two are what a caller reaches for without thinking: an empty slug collapses
+        the name to ``charter--<pid>``, and a trailing hyphen to ``charter-x--<pid>``.
+        """
+        for slug in ("tmux-3.2", "frame-reads-in-tmux-3.2", "Integration-Test",
+                     "integration_test", "has space", "", "x-"):
+            with self.subTest(slug=slug):
+                with self.assertRaises(ValueError) as caught:
+                    _tmuxreap.name(slug)
+                self.assertIn("#770", str(caught.exception))
 
     def test_the_operators_own_frame_socket_is_not_ours(self):
         """`commands_frame.SOCKET` — asked of production, not spelled — is the socket the
@@ -373,7 +394,46 @@ class WhereTmuxPutsItsSockets(unittest.TestCase):
 
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
 class TheReaperEndsWhatAKilledRunLeftRunning(unittest.TestCase):
-    """A real server on a real socket, killed and unlinked — or deliberately not."""
+    """A real server on a real socket, killed and unlinked — or deliberately not.
+
+    **In a socket directory of this class's own, and #781 is why.** ``reap()`` is a scan of
+    a SHARED directory: ``/tmp/tmux-<uid>/`` is per-user, not per-run. Every case here
+    plants a socket and then asks *this* run's `reap()` what it removed — and a second copy
+    of the suite reaching its own `reap()` a moment earlier removes this one's plant too, so
+    the victim sees ``[]`` and reports that the reaper did nothing. That is the opposite of
+    what happened: the socket was reaped twice as eagerly as the test expected, and the
+    failure accuses the reaper of the exact defect (#564) these cases exist to prevent.
+    Measured with three other `unittest` processes live and 204 sockets in the directory:
+    one failure, here, on a tree whose `main` is clean.
+
+    Three of the cases below are exposed to it and not one — ``assertIn(name, removed)``
+    twice, and a ``reap() == []`` that a sibling's unrelated stale socket also breaks. So it
+    is fixed for the class rather than assertion by assertion, the way the two scan classes
+    above already do it: ``$TMUX_TMPDIR`` points tmux and the reaper at a directory nothing
+    else on this machine is looking at, which makes every `reap()` here EXACT rather than
+    merely tolerant.
+
+    `NothingReapableSurvivesOnThisMachine` keeps the real directory, deliberately: that
+    claim is about the machine, and a private directory would make it true by having nothing
+    in it.
+    """
+
+    def setUp(self) -> None:
+        tmp = Path(tempfile.mkdtemp(prefix="charter-reapkill-", dir=_SHORT_TMP))
+        self.addCleanup(shutil.rmtree, tmp, True)
+        # Created rather than left to tmux: `reapable()` needs to be able to LIST it before
+        # anything has been planted, and a case that asserts a refusal never starts a server.
+        #
+        # `0o700` is not tidiness — tmux REFUSES a socket directory anyone else can reach
+        # ("directory … has unsafe permissions", rc 1, measured on 3.7c), and the default
+        # umask here makes one at 0o755. The two scan classes above create the same
+        # directory without it and are unaffected, because they never start a server in it.
+        (tmp / f"tmux-{os.getuid()}").mkdir(mode=0o700)
+        # Through `os.environ`, not a `tmux` argument: the reaper reads the variable and so
+        # does every `tmux` this class spawns, which is the only way the two agree about
+        # where the socket is. `_envguard` treats a set as a declaration, so this is also
+        # what tells it the read below is deliberate.
+        self.enterContext(mock.patch.dict(os.environ, {"TMUX_TMPDIR": str(tmp)}))
 
     def _plant(self, pid: int) -> tuple[str, Path]:
         """Start a real tmux server on a socket named for *pid*, and return both."""
@@ -430,7 +490,7 @@ class TheReaperEndsWhatAKilledRunLeftRunning(unittest.TestCase):
 
         removed = _tmuxreap.reap()
 
-        self.assertIn(name, removed)
+        self.assertEqual(removed, [name])
         self.assertFalse(path.exists(), f"{path} survived the reap")
         deadline = time.monotonic() + 10.0
         while time.monotonic() < deadline and _tmuxreap._alive(server):
@@ -460,8 +520,8 @@ class TheReaperEndsWhatAKilledRunLeftRunning(unittest.TestCase):
         self.addCleanup(lambda: path.unlink(missing_ok=True))
         sock.bind(str(path))
 
-        self.assertNotIn(path, _tmuxreap.reapable())
-        self.assertNotIn(path.name, _tmuxreap.reap())
+        self.assertEqual(_tmuxreap.reapable(), [])
+        self.assertEqual(_tmuxreap.reap(), [])
         self.assertTrue(path.exists(), f"{path} is not a name this suite hands out, and "
                                        f"the reaper deleted it anyway")
 
@@ -500,27 +560,39 @@ class TheReaperEndsWhatAKilledRunLeftRunning(unittest.TestCase):
 
         removed = _tmuxreap.reap()
 
-        self.assertNotIn(name, removed)
+        self.assertEqual(removed, [])
         self.assertTrue(path.exists(), f"{path} was reaped out from under a live run")
         self.assertTrue(_tmuxreap._listening(path), "a live run's server was killed")
 
+    def test_reaping_twice_removes_nothing_the_second_time(self):
+        pid = _a_pid_that_is_gone(self)
+        name, _ = self._plant(pid)
+        self.assertEqual(_tmuxreap.reap(), [name])
+        self.assertEqual(_tmuxreap.reap(), [])
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class NothingReapableSurvivesOnThisMachine(unittest.TestCase):
+    """The zero, asked of the directory every tmux on this machine shares.
+
+    The one claim here that is about the MACHINE rather than about the reaper's rules, so
+    the one that keeps the real socket directory while
+    `TheReaperEndsWhatAKilledRunLeftRunning` moved to a private one (#781). Given a
+    directory of its own this case would assert nothing at all: `before` would be empty and
+    the intersection empty for free.
+    """
+
     def test_nothing_that_was_reapable_survives_the_reap(self):
-        """The zero, and it is stated against what was there BEFORE rather than against
-        the directory afterwards. Several suites run on this machine at once and one of
-        them can be killed while this case is between two calls; a socket that arrived
-        after the reap is not something the reap failed to remove, and asserting an empty
-        directory would make this case fail for the very event it exists to describe."""
+        """Stated against what was there BEFORE rather than against the directory
+        afterwards. Several suites run on this machine at once and one of them can be
+        killed while this case is between two calls; a socket that arrived after the reap
+        is not something the reap failed to remove, and asserting an empty directory would
+        make this case fail for the very event it exists to describe."""
         before = {p.name for p in _tmuxreap.reapable()}
         _tmuxreap.reap()
         survived = before & {p.name for p in _tmuxreap.reapable()}
         self.assertEqual(survived, set(),
                          f"{sorted(survived)} was reapable before the reap and still is")
-
-    def test_reaping_twice_removes_nothing_the_second_time(self):
-        pid = _a_pid_that_is_gone(self)
-        name, _ = self._plant(pid)
-        self.assertIn(name, _tmuxreap.reap())
-        self.assertNotIn(name, _tmuxreap.reap())
 
 
 class EverySocketTheSuiteStartsGoesThroughTheHelper(unittest.TestCase):
@@ -538,6 +610,7 @@ class EverySocketTheSuiteStartsGoesThroughTheHelper(unittest.TestCase):
                            test_frame_tmux_integration)
         for module, attr in ((test_frame_tmux_integration, "SOCKET"),
                              (test_frame_tmux_integration, "OP_SOCKET"),
+                             (test_frame_tmux_integration, "HOST_SOCKET"),
                              (test_frame_overlay_escape_hatch, "SOCKET"),
                              (test_frame_palette_integration, "SOCKET")):
             with self.subTest(module=module.__name__, attribute=attr):
@@ -545,12 +618,22 @@ class EverySocketTheSuiteStartsGoesThroughTheHelper(unittest.TestCase):
 
     @staticmethod
     def _hand_built(source: str) -> list[str]:
-        """``NAME`` for every module-level ``*SOCKET`` bound to an f-string in *source*.
+        """``NAME`` for every ``*socket`` in *source* bound to an f-string, at any scope.
 
         Parsed, not grepped: a `mock.patch("...SOCKET")` in a docstring is a string. An
         f-string is what "built by hand" looks like — `f"charter-overlay-hatch-{os.getpid()}"`
         is how all four of the leaking modules spelled it — and `SOCKET_PATH` is exempt
-        because that is a PATH derived from a name, and the name is what this is about.
+        because that is a PATH derived from a name, and the name is what this is about (it
+        falls out of the rule rather than being listed: it does not END in ``socket``).
+
+        **At any scope, and to an ATTRIBUTE as readily as to a name, because the first cut
+        read only module-level `ast.Name` targets and #770 was neither.**
+        `ChromeIsOneColour.setUp` said ``self._outer_socket = f"{self.SOCKET_NAME}-host"`` —
+        inside a method, onto an attribute, decorating a name the helper had already made.
+        `_tmuxreap._OURS` wants the pid LAST, so the suffix took the whole server out of the
+        reaper's namespace, and #770 found six live tmux servers from interrupted runs of
+        that one class, each with a dead owner. The scan that was supposed to prevent
+        exactly this looked straight past it for three months.
 
         A function of its own so that :meth:`test_it_recognises_a_hand_built_name` can hand
         it one and watch it answer. Without that control, a reader that quietly stopped
@@ -559,32 +642,52 @@ class EverySocketTheSuiteStartsGoesThroughTheHelper(unittest.TestCase):
         this case that only ever ran the reader over a clean tree.
         """
         found = []
-        for node in ast.parse(source).body:
+        for node in ast.walk(ast.parse(source)):
             if not isinstance(node, ast.Assign):
                 continue
+            if not isinstance(node.value, ast.JoinedStr):
+                continue
             for target in node.targets:
-                if (isinstance(target, ast.Name) and target.id.endswith("SOCKET")
-                        and isinstance(node.value, ast.JoinedStr)):
-                    found.append(target.id)
+                for part in ast.walk(target):
+                    if isinstance(part, ast.Name):
+                        written = part.id
+                    elif isinstance(part, ast.Attribute):
+                        written = part.attr
+                    else:
+                        continue
+                    if written.upper().endswith("SOCKET"):
+                        found.append(written)
         return found
 
     def test_it_recognises_a_hand_built_name(self):
-        """The control, and the one shape it must see: exactly what the four modules that
-        leaked used to say."""
+        """The control, and the shapes it must see: what the four modules that leaked used
+        to say, and what #770 said — a socket name assembled inside a method, onto an
+        attribute, out of a name the helper had already produced."""
         self.assertEqual(
             self._hand_built('import os\nSOCKET = f"charter-overlay-hatch-{os.getpid()}"\n'),
             ["SOCKET"])
         self.assertEqual(
             self._hand_built('OP_SOCKET = f"charter-integration-operator-{PID}"\n'),
             ["OP_SOCKET"])
+        self.assertEqual(
+            self._hand_built('class C:\n    def setUp(self):\n'
+                             '        self._outer_socket = f"{self.SOCKET_NAME}-host"\n'),
+            ["_outer_socket"])
 
     def test_it_passes_over_the_shapes_that_are_not_one(self):
         """The other half of the control: a reader that answered "offender" to everything
-        would satisfy the case above and fail every module in the tree."""
+        would satisfy the case above and fail every module in the tree.
+
+        The last two are the boundary this rule draws now that scope is not part of it. A
+        PATH built from a name is not a name — that is `SOCKET_PATH`, and it is what half
+        the real-tmux modules teardown through — and a local that is not a socket at all
+        may be any f-string it likes."""
         for benign in ('from tests import _tmuxreap\nSOCKET = _tmuxreap.name("x")\n',
                        'SOCKET = "charter"\n',
+                       'def f():\n    s = _tmuxreap.name(f"tabbar{next(_SERVERS)}")\n',
                        'SOCKET_PATH = f"/tmp/tmux-{UID}/{SOCKET}"\n',
-                       'def f():\n    SOCKET = f"charter-x-{1}"\n'):
+                       'def f(self):\n    self.socket_path = f"/tmp/tmux-{UID}/{S}"\n',
+                       'def f():\n    session = f"probe-{os.getpid()}"\n'):
             with self.subTest(source=benign):
                 self.assertEqual(self._hand_built(benign), [])
 

--- a/tests/test_the_suite_reaps_its_own_tmux_servers.py
+++ b/tests/test_the_suite_reaps_its_own_tmux_servers.py
@@ -413,6 +413,13 @@ class TheReaperEndsWhatAKilledRunLeftRunning(unittest.TestCase):
     else on this machine is looking at, which makes every `reap()` here EXACT rather than
     merely tolerant.
 
+    Reproduced cold before it was fixed rather than inferred from the report: six runs of
+    this class, two at a time, without the directory — **five failed**, and in BOTH
+    directions ("a sibling reaped my plant" and "I reaped a sibling's"). Six for six with
+    it, including a pair run beside a full second suite. The second direction only appears
+    once the claims are the equalities below, which is the argument for the directory rather
+    than for narrowing them: a shared directory makes the exact claim unstateable.
+
     `NothingReapableSurvivesOnThisMachine` keeps the real directory, deliberately: that
     claim is about the machine, and a private directory would make it true by having nothing
     in it.
@@ -429,10 +436,11 @@ class TheReaperEndsWhatAKilledRunLeftRunning(unittest.TestCase):
         # umask here makes one at 0o755. The two scan classes above create the same
         # directory without it and are unaffected, because they never start a server in it.
         (tmp / f"tmux-{os.getuid()}").mkdir(mode=0o700)
-        # Through `os.environ`, not a `tmux` argument: the reaper reads the variable and so
-        # does every `tmux` this class spawns, which is the only way the two agree about
-        # where the socket is. `_envguard` treats a set as a declaration, so this is also
-        # what tells it the read below is deliberate.
+        # Through `os.environ` rather than a `tmux` argument, and there is no argument that
+        # would do: `-L` names a socket, not a directory, and tmux computes the directory
+        # from this variable — the same rule `_tmuxreap.socket_dir` copies. Setting it is
+        # the only thing that makes the reaper and every `tmux` this class spawns agree
+        # about where the socket is.
         self.enterContext(mock.patch.dict(os.environ, {"TMUX_TMPDIR": str(tmp)}))
 
     def _plant(self, pid: int) -> tuple[str, Path]:


### PR DESCRIPTION
Four reports, one property: **the suite could not be trusted about where it was running.**
Which control plane its assertions read, which `charter.toml` it was allowed to write, and
which tmux sockets it could still find afterwards were all answered by the machine rather
than the repository.

Closes #785, #770, #781. **#726 is not closed** — see below.

## #785 — a run from a worktree read the parent clone's live plane

`root._plane_of` deliberately redirects a linked worktree's plane to the tree it was cut
from, and that is right for the product. For the suite it means a worktree run asserts
against the operator's own `charter.toml`, uncommitted edits included, while the same tree
on CI asserts against the branch.

Two halves, both fixed:

* **The boundary.** `tests/_planeguard.install` now pins the suite to the checkout its own
  modules were loaded from, through production's own `config.in_tree` seam and
  `root.tree_of`'s own question — not a second copy of either. The state directory stays
  with the plane, so the write tripwire still names the operator's real `.charter/`, and
  the plane the pin redirected away from stays in the **spawn** refusal set so #527's hole
  does not reopen. The pin declines on a checkout with no committed marker, which is
  `_plane_of`'s own condition read the other way round.
* **The case.** `test_this_planes_own_committed_frame_answers_the_report` reads the file off
  disk from the repository root — `test_frame_config._COMMITTED`'s existing idiom, whose
  comment already named this redirect — and asserts the *agreement* its class claims (one
  word across the committed arrangement, and the rule answering that word) instead of one
  operator's colour. It was red in every worktree **and** in the operator's own clone, and
  green only on CI.

### The false-green audit

Pointed at a plane whose `charter.toml` was deliberately wrong in **nineteen** values —
forge owner, memory posture, default persona, the `slots` line, `mouse`, `chrome`, all six
components' `bg`, four `key`s, one `size`, update channel, default harness — and run whole:

**2 tests of 9761 noticed.** The case above, and
`test_frame_appearance.ThisPlaneOptsIntoTheSurface`, which already reads the file off disk
and is the one test that measures the committed file on purpose. A second, narrower pass
using the *exact* operator-vs-committed delta on this machine (`bg = "black"` plus
`text`/`dim`/`warn`) over 2846 tests in 71 frame/plane modules: **1 test noticed** — the
same one.

So the dangerous half of #785 is narrow, and the expensive half was the loud one.

## #770 — half of each run's tmux servers were invisible to the reaper

`ChromeIsOneColour` named its outer socket `f"{SOCKET}-host"`, which puts the pid where
`owns()` does not look. It asks `_tmuxreap.name("integration-test-host")` for it now.

**A second instance was found that no scan could have caught**, because that caller *did*
go through the producer: `test_a_planes_frame_really_reads_that_way` builds its slug from
the tmux binary's filename, which at the 3.2 floor is `tmux-3.2` — and
`charter-frame-reads-in-tmux-3.2-<pid>` has a `.` in it, which the pattern rejects. Two
unreapable live servers per floor test.

So `_tmuxreap.name` now **refuses** a slug whose result `owns()` would not recognise, and
the AST census reads any scope and any spelling (the old one read module-level `ast.Name`
targets only; #770 was an attribute, inside a method). Verified: with the old line put
back, `test_no_module_builds_a_socket_name_by_hand` goes red and names it.

## #781 — the reaper's own test raced a sibling suite

`TheReaperEndsWhatAKilledRunLeftRunning` gets a `$TMUX_TMPDIR` of its own — the idiom the
two scan classes in the same file already use — so every `reap()` there is **exact**
instead of tolerant. Three of its cases were exposed, not one.

Reproduced cold, six runs two at a time with the fix removed: **5 failed**, in both
directions. With the fix: **6/6 green**, including a pair run beside a full second suite.

The one case that is genuinely about the machine's shared directory keeps it, in a class of
its own that says why: given a private directory it would assert nothing at all.

## #726 — containment only, issue stays open

The production write path is **not** established, so this does not claim one.
`instance._set_key` is the only thing in `charter/` that writes the file; it is a confined
textual edit that preserves comments and ordering (which does not match "the strips
vanished"), and it writes `config.ROOT`'s copy, which in a worktree is the clone's and not
the worktree's.

New evidence worth having on the issue: this repository's own history carries the same
shape landing on `main` — commit `3935987`, *"charter save: 1 file(s)"*, deleted the entire
57-line `[[frame.component]]` arrangement from `charter.toml`; a later commit restored it.

What ships is the containment the issue asks for: `charter.toml` is a guarded **path** (not
a prefix) in the suite's write tripwire, both markers when the suite is in a worktree, with
a refusal that names the file and the issue rather than talking about a state directory.
`personas/`, `docs/` and `workspaces/` stay writable, which is the boundary the guard's own
docstring draws.

## Measurement

| run | result |
|---|---|
| full suite, CI-equivalent clone at `origin/main` | 9761 tests, OK (8 skipped) |
| full suite, same clone, plane wrong in 19 values | 2 failures |
| full suite, this branch, from a linked worktree | green |
| reaper class, 6 runs 2-at-a-time, fix removed | 5 failures |
| reaper class, 6 runs 2-at-a-time, with fix | 6/6 OK |

## Sweep

```
gate: 0 unpinned, 0 in masked cluster(s), 0 platform-deferred, 0 unresolved, 0 not applied, 0 withheld, 0 pinned
gate: nothing to sweep
```

`nothing to sweep` because the branch charges **0 added lines** under `charter/` — every
change is in `tests/`, `docs/` and `CONTRIBUTING.md`. Per #782 that verdict means the sweep
planned nothing rather than found nothing, so the guards were hand-mutated instead:

| mutation | result |
|---|---|
| `border_bg`'s "components agree" branch made unreachable | the rewritten committed-frame case goes red |
| `ChromeIsOneColour`'s `-host` f-string restored | `test_no_module_builds_a_socket_name_by_hand` goes red and names it |
| `TheReaperEndsWhatAKilledRunLeftRunning`'s private socket directory removed | 5 failures in 6 concurrent runs |
| `_tmuxreap.owns()` asked directly | False for both unreapable names this branch found |

Worth reporting separately: `tools/sweep.py --path tests` plans 38 mutations and then
reports **`Ran 0 tests` / "the tree is RED before any mutation"** — the selection map is
source-file-to-test-module, so a path under `tests/` selects nothing and the unmutated
baseline runs an empty suite. Not a defect this branch introduces, but `--path` reads as if
it took any directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
