### PR TITLE
The text you typed is the text charter saves (#778), and the commit-message limit is settled (#711)

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -3946,6 +3946,257 @@ def _forge_substitution_hit(cmd: str) -> tuple[str, str] | None:
 
 
 # --------------------------------------------------------------------------- #
+# A6: charter's OWN text-taking commands, same rule, different remedy (#778)     #
+# --------------------------------------------------------------------------- #
+# A5 covers somebody else's tools. The same defect reaches a committed file through
+# charter's own commands, and it did so immediately: while writing up A5's findings the
+# coordinating agent ran `charter persona remember "… `pending` …"`. zsh ran the word,
+# printed `command not found`, spliced its empty output, and the saved memory read
+# "appending to  each pass" with the word silently gone. That file is under
+# `personas/_shared/memory/`, which this plane commits and pushes — the same defect
+# reaching a public repository by an INDIRECT route, which is why nobody saw it. The blast
+# radius that day was one word; the identical slip in a `--body` published sixty-four
+# environment variables (#703).
+#
+# **What made this a guard rather than a third documented limit is a measurement, and it
+# came out the opposite way from the one #778 predicted.** #778 expected charter's own
+# prose to be "similar or worse" than the commit-message figure that keeps #711 out. Over
+# the 284 committed memory bodies on `main`:
+#
+#   * **13 would meet a liveness-keyed guard — 5%**, not the 87% #778 assumed. 9 carry a
+#     backtick, 4 carry `$(`. **254 of the 284 predate the working rule** that tells agents
+#     to avoid the shape, so this is charter's natural prose and not an effect of the rule.
+#   * The reason is structural rather than lucky. A commit message is rendered as markdown
+#     by a forge, so agents write code spans in them; a memory body is read back by
+#     `charter recall` in a terminal, so agents write *"the $( branch"* and *"a backtick"*
+#     as words. Two corpora, two conventions, and the guard's calibration follows the
+#     corpus rather than the character.
+#   * **And the 13 are not false positives.** 283 of the 284 bodies are single-line, so
+#     none came through the `"$(cat <<'EOF' …)"` spelling that makes a backtick inert. A
+#     live backtick in a single-line double-quoted operand is a command that was going to
+#     corrupt its own text — refusing it is the correct answer, not a cost.
+#
+# **The remedy is not A5's, and that had to be measured too.** 221 of the 284 bodies
+# contain an apostrophe — and *all nine* of the backtick-carrying ones do — so "use single
+# quotes", the obvious answer, fails on exactly the population this refuses. What works is
+# **one backslash per backtick**: inside double quotes `` \` `` is a literal backtick and
+# the apostrophes keep working, verified against a real bash. `report bug|gap` additionally
+# has `--from-file`/`--stdin`, which is A5's `--body-file` by another name; the memory
+# commands have no file input at all, so a denial that named one would send the reader to a
+# usage error. The remedy is therefore **per row**, and the table carries it.
+#
+# **`git commit` and charter's own commit-message commands stay out** — that is #711, whose
+# measurement runs the other way: 29 of the last 30 messages on `main` carry a backtick,
+# all 30 of the last 30 are multi-line, and the spelling that writes them,
+# `-m "$(cat <<'EOF' … EOF)"`, is itself a live `$(`. A guard there would refuse the very
+# form that makes the backticks inside it harmless — its trigger would be the prescribed
+# workflow, which is the inversion #371 deleted a guard for. `charter save`,
+# `workspace save -m` and `workspace rename -m` write commit messages, so they are out for
+# that reason and not by oversight.
+
+#: `workspace`/`ws` and `worktree`/`wt` are the same command word to argparse. Written here
+#: once and applied below, because a hand-copied second half of the table is a row that
+#: drifts the day somebody adds a verb to one of them.
+_CHARTER_NOUN_ALIASES = {"workspace": "ws", "worktree": "wt"}
+
+#: `(noun, verb) -> (what charter does with the text, the file input it accepts or None)`.
+#:
+#: **Verified against `charter.cli.build_parser()` itself**, which is stronger than the
+#: `--help` #710 had to read by hand — the parser is the thing that generates the help.
+#: `tests/test_the_text_you_typed_is_the_text_charter_saves.py` re-derives every row from
+#: it, so a renamed verb fails a test rather than silently emptying the guard.
+#:
+#: **The line for inclusion is #710's own**, which kept `gh pr merge --body` out because
+#: "its `--body` is a merge-commit message rather than the point of the command": the free
+#: text has to be **required or the primary operand**, and what holds it has to be read back
+#: as prose by a later reader. That keeps out `workspace create --vision`,
+#: `workspace snapshot --description`, `persona create --role/--delegate-when` and
+#: `vault add`, where the prose is a secondary attribute of creating a thing. Widening on
+#: evidence is cheap; a guard that over-blocks gets switched off once and then covers
+#: nothing (:data:`_BRANCH_MOVERS`, #371).
+#:
+#: The second element is the remedy the denial may name, and it is per row because it is
+#: not uniform: only `report bug|gap` has a file input. Offering `--from-file` on
+#: `persona remember`, which has none, would answer a refusal with a usage error.
+_CHARTER_PROSE_ROWS = {
+    ("persona", "remember"): (
+        "a memory file under `personas/`, which this plane commits and pushes", None),
+    ("persona", "log"): (
+        "the persona's activity log under `personas/`, committed with it", None),
+    ("workspace", "remember"): (
+        "a memory file under `workspaces/`, committed once the workspace is LIVE", None),
+    ("workspace", "note"): (
+        "a memory file under `workspaces/` (`note` is `remember`)", None),
+    ("workspace", "todo"): (
+        "the workspace's todo list under `workspaces/`", None),
+    ("workspace", "vision"): (
+        "the workspace's Vision in `workspace.md`, committed once it is LIVE", None),
+    ("worktree", "abandon"): (
+        "the worktree's history — what whoever picks the piece up reads first", None),
+    ("change", "create"): (
+        "the change record's `why`, which `charter change push` writes into every "
+        "request body on the forge", None),
+    ("change", "drop"): (
+        "the exclusion's `why`, which `charter change push` writes into every "
+        "request body on the forge", None),
+    ("report", "bug"): (
+        "a report draft that `charter report send` publishes as a PUBLIC issue on "
+        "charter's own tracker", "--from-file"),
+    ("report", "gap"): (
+        "a report draft that `charter report send` publishes as a PUBLIC issue on "
+        "charter's own tracker", "--from-file"),
+}
+
+_CHARTER_PROSE = {
+    **_CHARTER_PROSE_ROWS,
+    **{(_CHARTER_NOUN_ALIASES[noun], verb): facts
+       for (noun, verb), facts in _CHARTER_PROSE_ROWS.items()
+       if noun in _CHARTER_NOUN_ALIASES},
+}
+
+
+def _charter_words(prog: str, argv: list[str]) -> list[str] | None:
+    """The words after `charter` on this segment, or ``None`` if it is not charter.
+
+    **Two spellings, and the second is not exotic in this repository — it is the one an
+    agent working ON charter types all day.** `CONTRIBUTING.md` and shared persona memory
+    both say to live-test a checkout with `python3 -m charter …`, and on that line
+    `os.path.basename(prog)` is `python3`, so :func:`_forge_prose_command`'s reader would
+    see no `charter` at all. `-B`, `-u` and an `env -u …` prefix all sit between the
+    interpreter and `-m`, which is why the module is looked for by scanning rather than at a
+    fixed index (`_split_env` has already removed the `VAR=value` prefix).
+
+    **`-m` as its own word, and no getopt behind it.** Python accepts `-mcharter` and
+    `-Bm charter`, and neither is matched here. That is a fail-OPEN hole and it is named
+    rather than closed: taking it would mean a short-option cluster parser inside a guard
+    whose whole stated risk is being a parser somebody has to re-derive, bought for a
+    spelling `CONTRIBUTING.md` does not use and nothing in this repository writes. It sits
+    with the holes the forge guard lists — `sh -c '…'`, an alias, a program name arriving in
+    a variable — and, like those, it is a reason this is a guard against a mistake rather
+    than a boundary.
+    """
+    # `prog` is never None: `_split_env_chdir` returns `toks[0] if toks else ""`, and the
+    # eight other readers in this file all write this line without a fallback. An `or ""`
+    # here was a survivor the sweep could not kill in either direction, which is this
+    # project's definition of dead code — and defensive code that reads as though it
+    # matters is worse than none in a guard somebody has to re-derive.
+    base = os.path.basename(prog).lower()
+    if base == "charter":
+        return argv[1:]
+    if base.startswith("python"):
+        for k in range(1, len(argv) - 1):
+            if argv[k] == "-m":
+                return argv[k + 2:] if argv[k + 1] == "charter" else None
+    return None
+
+
+def _charter_prose_command(cmd: str | None) -> tuple[str, str, str | None] | None:
+    """``("charter persona remember", what it does with the text, its file input)`` — or
+    ``None`` when no segment of *cmd* is one.
+
+    **The FIRST two words, where :func:`_forge_prose_command` has to walk adjacent pairs.**
+    That difference is a measured fact about charter rather than a shortcut: `gh --repo o/r
+    issue create` puts a flag's value in front of the noun, and charter's root parser has
+    **no option that takes a value** — only `-h` and `--version`. Reading two words is
+    strictly narrower, and what it buys is real: `charter recall --scope persona remember`
+    is a search whose `persona` and `remember` genuinely are adjacent argv words, and every
+    pair walker refuses it. A test asserts the root parser stays that way, so if a
+    value-taking global option is ever added this goes red instead of quietly under-reading.
+
+    No `cmd or ""` here, matching :func:`_forge_prose_command`: the hit function normalises
+    before it calls, and `_segment_argv(None)` yields nothing anyway. The sweep called that
+    fallback a survivor, correctly — the one at the hot-path filter below is load-bearing
+    and is pinned, this one was not.
+    """
+    for _toks in _segment_argv(cmd):
+        prog, _env, argv = _split_env(_toks)
+        words = _charter_words(prog, argv)
+        # BOTH halves decide, and they fail differently — which is why two tests pin this
+        # one line. Without `not words`, `charter "…"` with a single operand reaches
+        # `words[1]` and raises **IndexError**, the outcome this module may least have:
+        # `dispatch` runs the handler as a bare `rc = fn()`, so a raise takes the turn down
+        # instead of producing a verdict. With `< 2` widened to `<= 2`, a bare
+        # `charter ws note` on a line whose substitution sits in another segment is
+        # **allowed** — a fail-open on exactly the two-word form the table is keyed on.
+        if not words or len(words) < 2:
+            continue
+        facts = _CHARTER_PROSE.get((words[0], words[1]))
+        if facts:
+            dest, from_file = facts
+            return f"charter {words[0]} {words[1]}", dest, from_file
+    return None
+
+
+def _charter_substitution_hit(cmd: str | None) -> tuple[str, str] | None:
+    """``(the substitution's spelling, the denial)`` for a charter command that persists
+    prose whose line carries a live substitution — or ``None``.
+
+    Shares :func:`_live_substitution` with A5 rather than re-deciding what a shell would
+    run: that walk is the part checked against a real bash, and a second copy of it is a
+    second thing to be wrong. What differs is the table, the destination named, and the
+    remedy — which is why this is a separate guard and not two questions asked of one
+    constant (the #555 defect this file has a name for).
+
+    **Scoped to the whole Bash call**, with A5 and for its reason. So
+    `cd "$(git rev-parse --show-toplevel)" && charter persona remember 'x'` is refused too,
+    and the remedy the denial names covers it: compute the value in a SEPARATE Bash call and
+    pass `"$VAR"` — a parameter expansion is not a substitution and a shell does not
+    re-expand a parameter's value.
+
+    Both cheap tests come first because this is a per-Bash-call hot path — but **in the
+    opposite order to A5's, and that is measured rather than copied.** A5 tests for a
+    substitution first because its own name test is weak: `gh` and `glab` are two- and
+    four-character substrings that fall inside ordinary English (`through`, `night`), so
+    they reject almost nothing. `charter` is seven characters and rare, so it rejects
+    essentially every command:
+
+    ======================================  ============  ==============
+    command                                 `$` first     `charter` first
+    ======================================  ============  ==============
+    `git status --porcelain`                0.197 µs      **0.056 µs**
+    a long ordinary pipeline                0.256 µs      **0.063 µs**
+    `echo "$(git rev-parse HEAD)"`          0.210 µs      **0.057 µs**
+    `charter workspace list --json`         0.205 µs      0.208 µs
+    the denial path                         24.9 µs       25.4 µs
+    ======================================  ============  ==============
+
+    Three and a half times cheaper on everything that is not a charter command, which is
+    almost every Bash call, and inside the noise on the two that are. Both filters survive
+    the deletion sweep — neither can change a verdict, the table lookup and
+    :func:`_live_substitution` decide — and both are kept on those numbers, which is the
+    rule A5's own section states for a surviving prefilter.
+    """
+    text = cmd or ""
+    if "charter" not in text:
+        return None
+    if not any(s in text for s in _SUBSTITUTIONS):
+        return None
+    spelling = _live_substitution(text)
+    if not spelling:
+        return None
+    found = _charter_prose_command(text)
+    if not found:
+        return None
+    where, dest, from_file = found
+    shown = "`…`" if spelling == "`" else "$(…)"
+    fix = (f", or pass `{from_file} <path>` (or `--stdin`) and keep the text out of argv "
+           f"altogether" if from_file else "")
+    return spelling, (
+        f"`{where}` takes text charter PERSISTS — {dest} — and this line carries a LIVE "
+        f"{shown} command substitution. The shell runs it and splices its OUTPUT in before "
+        f"charter is started, so what gets saved is not what you typed: charter is handed "
+        f"the command, never the value it becomes. This is #778 — the memory that read "
+        f"\"appending to  each pass\" with the word gone — and #703, where the same slip on "
+        f"a forge body published sixty-four environment variables. Keep the character "
+        f"literal instead: backslash-escape each one (`\\`code\\``), which leaves "
+        f"apostrophes working, or single-quote the whole argument when it holds none{fix}. "
+        f"If you meant to interpolate a computed value, compute it in a SEPARATE Bash call "
+        f"and pass it as \"$VAR\" — a parameter expansion is not a substitution. This guard "
+        f"reads the SHAPE of the line; it does not know what the command would print, and "
+        f"does not claim to keep a credential out of a file.")
+
+
+# --------------------------------------------------------------------------- #
 # B: the clone-commit nudge — REMOVED in #371                                   #
 # --------------------------------------------------------------------------- #
 # It asked before a git write inside a workspace clone, recommending a repo-rooted session.
@@ -4299,6 +4550,18 @@ def pretooluse() -> int:
         spelling, why = subst
         rc = _deny("PreToolUse", why)
         _trace("deny", sid, reason="forge-substitution", shape=spelling, cmd=head)
+        return rc
+    # A6: and the same rule on charter's OWN text-taking commands (#778). Separate from A5
+    # rather than folded into it: the table, the destination the denial names and the remedy
+    # it offers are all different, and one constant answering two questions is the #555
+    # defect this file already has a name for. Ungated for A5's reason. It runs AFTER A5 so
+    # that a line which is both — `charter …` piped into `gh issue create` — is explained by
+    # the one that publishes to a forge.
+    own = _charter_substitution_hit(cmd)
+    if own:
+        spelling, why = own
+        rc = _deny("PreToolUse", why)
+        _trace("deny", sid, reason="charter-substitution", shape=spelling, cmd=head)
         return rc
     # B WAS HERE: the clone-commit nudge, removed in #371 — see the note where it lived.
     # Nothing on this handler asks any more; every remaining verdict is a deny or an allow.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -17,7 +17,7 @@ one thing a hook is allowed to shout about.
 | --- | --- | --- |
 | `SessionStart` | — | reconcile workspace state, GC persona scratch, inject context, run `doctor`, refresh forge state |
 | `UserPromptSubmit` | — | the commitment gate (below) |
-| `PreToolUse` | `Bash` | four of the five guards (below) |
+| `PreToolUse` | `Bash` | every guard below except the vault read |
 | `PreToolUse` | `Read\|Grep` | keeps a vault file from being read into context |
 | `PreToolUse` | `Task\|Agent` | notes a dispatch about to happen |
 | `PostToolUse` | `Write\|Edit\|MultiEdit` | the record-memory nudge |
@@ -207,17 +207,39 @@ rule while one who reads a bare refusal files an issue.
   which means putting a shell inside the guard — the failure the leak guard already
   documents. Run the substitution in a **separate** Bash call instead; each is judged alone.
 
-  The commit-message limit is worth one more sentence, because the obvious reason for it is
-  wrong. It is **not** that a commit matters less. On the axis #703 turns on — *can this be
-  undone* — a commit message is **worse** than an issue body: a body is replaced in one
-  call, while a pushed commit needs a history rewrite, and a rewrite reaches neither forks
-  nor existing clones nor the forge's caches. Visibility is not reversibility. It is out of
-  scope because the commit surface has not been verified the way the `gh`/`glab` verbs
-  were, and because it is dense with the character the guard keys on: **most commit
-  messages on charter's own `main` carry a backtick** — 26 of 30 consecutive ones when
-  this was measured, nineteen of them around text that reads as a command — and inside
-  `-m "…"` every one of those is live. A guard that fires
-  constantly on legitimate work is one that gets switched off, and then it covers nothing.
+  The commit-message limit is worth its own paragraphs, because the obvious reason for it is
+  wrong and the real one took a measurement. It is **not** that a commit matters less. On
+  the axis #703 turns on — *can this be undone* — a commit message is **worse** than an
+  issue body: a body is replaced in one call, while a pushed commit needs a history rewrite,
+  and a rewrite reaches neither forks nor existing clones nor the forge's caches. Visibility
+  is not reversibility.
+
+  **The commit surface has since been enumerated**, against real `git … --help` output
+  rather than recalled, so the gap #711 opened with is closed. These write a message: `commit`
+  (`-m`, which repeats and concatenates; `-F`; `-t`; `-C`/`--reuse-message`;
+  `-c`/`--reedit-message`; `--squash`; `--fixup`), `tag` (`-m`, `-F`), `merge` (`-m`, `-F`),
+  `notes add|append|edit` (`-m`, `-F`, `-C`, `-c`) and `stash push|store` (`-m`). `revert`
+  and `cherry-pick` have a `-m`, and it is `--mainline` — a parent number, not prose, which
+  is the kind of thing a recalled list gets wrong.
+
+  **It stays out anyway, and the reason is calibration.** Measured on `main`:
+
+  - **29 of the last 30 commit messages carry a backtick** (160 of 200), and inside
+    `-m "…"` every one of those is live;
+  - **all 30 of the last 30 are multi-line**, which a single `-m "…"` cannot produce. The
+    spelling that writes them is `-m "$(cat <<'EOF' … EOF)"` — and that line **is itself a
+    live `$(`**, while the backticks inside the quoted heredoc are inert.
+
+  So a liveness-keyed guard on `git commit` would refuse the exact form that makes those
+  backticks harmless: its trigger would be the prescribed workflow, which is not a
+  miscalibrated guard but an inverted one — and that is the argument which deleted the
+  clone-commit nudge outright rather than narrowing it (see *What charter stopped asking*).
+  Exempting `$(cat <<'QUOTED')` by name
+  would mean the guard deciding which substitutions are *safe* rather than which are *live*,
+  and a parser that gets that wrong fails open. `charter save`, `charter workspace save -m`
+  and `charter workspace rename -m` write commit messages too, so they are out for the same
+  reason rather than by oversight. `git commit` is therefore a **stated limit, not an open
+  question** ([#711](https://github.com/diazoxide/charter/issues/711)).
 
   **What it does not reach, checked rather than assumed.** The guard matches a
   `(tool, noun, verb)` triple, so every route that publishes without spelling one is
@@ -242,7 +264,63 @@ rule while one who reads a bare refusal files an issue.
   and its remedy is plain `gh`/`glab` usage — the same reason the secret-leak guard is
   ungated.
 
-A seventh path is not a guard but an allowance: a program the **active persona** declares in
+- **charter's own text substitution.** The same rule on charter's own text-taking commands
+  ([#778](https://github.com/diazoxide/charter/issues/778)). The guard above covers somebody
+  else's tools; these persist prose that this plane commits and pushes, so the same defect
+  reaches a public repository by an indirect route:
+
+  ```bash
+  charter persona remember "the marker is appended to `pending` each pass"   # DENIED
+  charter persona remember "the marker is appended to \`pending\` each pass"  # allowed
+  ```
+
+  That is not a constructed example. It happened while #710's own findings were being
+  written up: zsh ran the word, printed `command not found`, spliced its empty output, and
+  the saved memory read *"appending to  each pass"* with the word silently gone — into
+  `personas/_shared/memory/`, which is committed and pushed.
+
+  **The rows, verified against `charter`'s own parser rather than its rendered help:**
+  `persona remember|log`, `workspace remember|note|todo|vision` (and the `ws` alias),
+  `worktree abandon` (`wt`), `change create|drop` — whose `--why` is written into every
+  request body by `charter change push` — and `report bug|gap`, whose text
+  `charter report send` publishes as a **public** issue on charter's own tracker. The line
+  for inclusion is the one that keeps `gh pr merge --body` out above: the free text has to be
+  required or the primary operand, and what holds it has to be read back as prose. So
+  `workspace create --vision`, `workspace snapshot --description` and
+  `persona create --role` are outside it, where the prose is a secondary attribute of
+  creating a thing.
+
+  **The remedy is not the forge guard's, and that took measuring.** Of the 284 committed
+  memory bodies on `main`, **221 contain an apostrophe** — and *all nine* of the
+  backtick-carrying ones do — so "single-quote it", the obvious answer, fails on exactly the
+  text this refuses. **Backslash-escape each backtick** instead: inside double quotes
+  `` \` `` is a literal backtick and the apostrophes keep working. `report bug|gap`
+  additionally takes `--from-file` and `--stdin`, which is `--body-file` by another name;
+  the memory commands have no file input, so the denial names a flag only where one exists.
+  And if you *meant* to interpolate a computed value, compute it in a **separate** Bash call
+  and pass `"$VAR"` — a parameter expansion is not a substitution, and a shell does not
+  re-expand a parameter's value.
+
+  **Why this one is a guard where `git commit` is a limit** is the same question answered by
+  two different corpora. 13 of those 284 bodies would meet this guard — **5%**, not the
+  87% the issue predicted, and 254 of the 284 predate the working rule that warns against
+  the shape, so that is charter's natural prose. The reason is structural: a commit message
+  is rendered as markdown by a forge, so agents write code spans in them, while a memory
+  body is read back by `charter recall` in a terminal, so they write *"the `$(` branch"* as
+  words. And **283 of the 284 bodies are single-line**, so none came through the
+  `"$(cat <<'EOF' …)"` spelling that makes a backtick inert — a live backtick in a
+  single-line double-quoted operand is a command that was going to corrupt its own text.
+
+  **What it does not reach**, on the same terms as the guard above: `python3 -m charter …`
+  is covered, because that is how `CONTRIBUTING.md` says to run a checkout, but a shell
+  wrapper (`sh -c 'charter …'`), an alias, and a program name arriving in a variable are
+  not — nor is `python3 -mcharter`, a fail-open hole named in the guard rather than closed
+  with a short-option parser inside it. It reads the first two words after `charter`, which
+  is exact only because charter's root parser has no option that takes a value — a test
+  asserts that, so if one is ever added the guard is told rather than quietly
+  under-reading. Ungated on there being a control plane, for the reason above.
+
+An eighth path is not a guard but an allowance: a program the **active persona** declares in
 `tools:` runs without a prompt while that persona is active, and only then. It approves the
 **program**, so every argument rides along — which is why seven things are not smoothed
 whatever `tools:` says: destructive subcommands (`kubectl delete`, `charter secret`,
@@ -384,13 +462,15 @@ fd digit. That pattern is the finding. Deciding what a shell will execute, witho
 it, is not winnable in a Python tokeniser, so the honest move is to say what is open:
 
 - **a quoted command substitution** — the example above, and `` "`cat <vault>`" ``,
-  `"$(<vault>)"`, `"$(charter secret get v k --reveal)"`. One command family is the
-  exception, and it is an exception for a different reason rather than a fix for this one:
-  a `gh`/`glab` command that publishes prose is refused whenever a live substitution stands
-  on its line, so `gh issue create --body "$(cat <vault>)"` stops — see *Forge body
-  substitution* above. That guard never looks inside the substitution and knows nothing
-  about vaults; it refuses the shape. Everywhere else on this page, a quoted substitution
-  is still open;
+  `"$(<vault>)"`, `"$(charter secret get v k --reveal)"`. Two command families are the
+  exception, and they are an exception for a different reason rather than a fix for this
+  one: a `gh`/`glab` command that publishes prose, and a charter command that persists it,
+  are refused whenever a live substitution stands on the line — so
+  `gh issue create --body "$(cat <vault>)"` and
+  `charter persona remember "$(cat <vault>)"` both stop. See *Forge body substitution* and
+  *charter's own text substitution* above. Neither guard looks inside the substitution or
+  knows anything about vaults; they refuse the shape. Everywhere else on this page, a quoted
+  substitution is still open;
 - **any expansion between the guard and `open()`** — globs (`.charter/vault?/x.json`,
   `.charter/*/x.json`), brace expansion (`.charter/{vaults,}/x.json`), `$'\x73'` quoting,
   and a path that arrives in a variable (`V=<vault>; cat $V`). The path check matches text,
@@ -427,11 +507,14 @@ the harness's tools — they govern what an agent does with your authority insid
 Your own shell is on the other side of that boundary and always was. Open a terminal and run
 it. Nothing is being worked around: the rule never applied to you.
 
-Four guards name a narrower move first, and it is usually the one you want:
+Five guards name a narrower move first, and it is usually the one you want:
 
 - **Forge body substitution** — `--body-file <path>`, or `--body-file -` with a quoted
   heredoc. This one is rarely wrong about the shape and often wrong about the intent: the
   body you meant is exactly the body you get, and it is the shorter line to type anyway.
+- **charter's own text substitution** — backslash-escape each backtick, which is one
+  character and leaves the apostrophes in your prose working. Where the command takes a
+  file (`report bug|gap`), `--from-file` or `--stdin` keeps the text out of argv entirely.
 - **Release floor** — re-run the step **attended**. This is a mode, and it is yours to set.
 - **One credential** — `charter git-policy --apply` configures every clone for the token
   transport, which is what most denials of it are actually asking for.

--- a/docs/news/unreleased-the-text-you-typed-is-the-text-charter-saves.md
+++ b/docs/news/unreleased-the-text-you-typed-is-the-text-charter-saves.md
@@ -1,0 +1,99 @@
+---
+version: unreleased
+headline: charter's own text commands stop letting the shell edit your prose, and the commit-message limit is settled rather than open
+---
+
+#710 refused a live shell substitution in a `gh`/`glab` body and documented three limits
+rather than half-covering them. Two of those were issues. Both are now answered, and the
+answers go in opposite directions — which is the point, because what separates them is a
+measurement rather than a judgement.
+
+## charter's own commands are covered now (#778)
+
+The guard matched `gh`/`glab`. **charter's own text-taking commands were not in that
+table**, and it bit within the hour: while #710's findings were being written up, the
+coordinating agent ran
+
+```bash
+charter persona remember "the marker is appended to `pending` each pass"
+```
+
+zsh ran the word, printed `command not found`, spliced its empty output, and the saved
+memory read *"appending to  each pass"* with the word silently gone. That file lives under
+`personas/_shared/memory/`, which this plane commits and pushes — **the same defect reaching
+a public repository by an indirect route**, which is exactly why nobody saw it. The blast
+radius that day was one word. The identical slip on a `--body` published sixty-four
+environment variables, four vault tokens among them (#703).
+
+Covered now, on the rows where free text is required-or-primary and what holds it is read
+back as prose: `persona remember|log`, `workspace remember|note|todo|vision` (and `ws`),
+`worktree abandon` (`wt`), `change create|drop` — whose `--why` `charter change push` writes
+into every request body — and `report bug|gap`, whose text `charter report send` publishes
+as a **public** issue on charter's own tracker. Every row is re-derived from
+`charter.cli.build_parser()` by a test, so a renamed verb fails rather than quietly emptying
+the guard.
+
+**The remedy is not the forge guard's, and that is a measurement too.** Of the 284 committed
+memory bodies on `main`, **221 contain an apostrophe** — and *all nine* of the
+backtick-carrying ones do — so "single-quote it", the obvious answer, fails on precisely the
+text this refuses. One backslash per backtick is what works, and it leaves the apostrophes
+alone:
+
+```bash
+charter persona remember "the flag's default is \`id -un\` here"
+```
+
+`report bug|gap` also takes `--from-file` and `--stdin`, which is `--body-file` by another
+name; the memory commands have no file input, so the denial names a flag only where one
+exists rather than answering a refusal with a usage error. And if a computed value really
+belongs in the text, it is a separate Bash call and `"$VAR"` — a parameter expansion is not
+a substitution.
+
+`python3 -m charter …` is covered too, because that is how `CONTRIBUTING.md` says to run a
+checkout: on that line the program is `python3`, so the forge guard's own reader would have
+seen no charter at all.
+
+## `git commit -m` is a stated limit, and now it has the reason it was missing (#711)
+
+#711 asked for two things before a guard could be considered: the message surface
+enumerated the way the nineteen forge verbs were, and a false-positive rate that a guard
+could survive.
+
+**The surface is enumerated.** Against real `git … --help`: `commit` (`-m`, which repeats
+and concatenates; `-F`; `-t`; `-C`; `-c`; `--squash`; `--fixup`), `tag` (`-m`, `-F`),
+`merge` (`-m`, `-F`), `notes add|append|edit` (`-m`, `-F`, `-C`, `-c`) and
+`stash push|store` (`-m`). `revert` and `cherry-pick` have a `-m` and it is `--mainline` —
+a parent number, not prose, which is the sort of thing a recalled list gets wrong.
+
+**And the rate says no, more decisively than #711 expected.** On `main`, 29 of the last 30
+commit messages carry a backtick (160 of 200). But the number that settles it is a different
+one: **all 30 of the last 30 are multi-line**, which a single `-m "…"` cannot produce. The
+spelling that writes them is `-m "$(cat <<'EOF' … EOF)"`, and **that line is itself a live
+`$(`** while the backticks inside the quoted heredoc are inert. A liveness-keyed guard on
+`git commit` would refuse the exact form that makes them harmless.
+
+So its trigger would be the prescribed workflow — not a miscalibrated guard but an inverted
+one, and the argument that deleted the clone-commit nudge outright rather than narrowing it
+(#371). Exempting `$(cat <<'QUOTED')` by name would mean the guard deciding which
+substitutions are *safe* instead of which are *live*, and a parser that gets that wrong
+fails open. `charter save`, `charter workspace save -m` and `charter workspace rename -m`
+write commit messages, so they are out for the same reason rather than by oversight.
+
+`docs/hooks.md` carries all of it, because a limit that lives only in a PR body is gone the
+moment the PR merges.
+
+## Why the two corpora disagree
+
+Worth writing down, because the intuition that both surfaces are "prose with code spans in
+it" is what made #778 predict 87% and get 5%.
+
+A **commit message is rendered as markdown by a forge**, so agents write code spans in them.
+A **memory body is read back by `charter recall` in a terminal**, so they write *"the `$(`
+branch"* and *"a backtick"* as words. Two conventions, two densities — 9 backticks in 284
+bodies against 29 in 30 messages — and 254 of those 284 predate the working rule that warns
+against the shape, so it is charter's natural prose rather than an effect of the rule.
+
+The last piece is that the 13 bodies this guard would have refused are **not false
+positives**. 283 of the 284 are single-line, so none came through the spelling that makes a
+backtick inert: a live backtick in a single-line double-quoted operand is a command that was
+going to corrupt its own text, and refusing it is the correct answer rather than a cost.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -278,10 +278,17 @@ shell history**, while still letting an agent *use* the credential:
   ([#703](https://github.com/diazoxide/charter/issues/703)). A separate guard refuses that
   shape now, and its limits are its own: it sees the command line, never the value; a
   `--body-file` whose file already holds the text is outside it; and so is
-  `git commit -m` ([#711](https://github.com/diazoxide/charter/issues/711)).
+  `git commit -m` — a **stated** limit rather than an open question, because the spelling
+  that writes this repository's own multi-line messages,
+  `-m "$(cat <<'EOF' … EOF)"`, is itself a live substitution, so a guard there would refuse
+  the safe form ([#711](https://github.com/diazoxide/charter/issues/711)).
+  **charter's own text-taking commands are covered** — `persona remember`,
+  `workspace remember|note|todo|vision`, `change create|drop`, `report bug|gap` and the
+  rest — because the same slip corrupted a committed memory file
+  ([#778](https://github.com/diazoxide/charter/issues/778)).
   The rule that covers what no guard can see is to write bodies with `--body-file -` and a
-  **quoted** heredoc (`<<'BODY'`), never `--body "…"` with backticks in it. See
-  [hooks.md](hooks.md) for the full scope.
+  **quoted** heredoc (`<<'BODY'`), never `--body "…"` with backticks in it; in a charter
+  argument, backslash-escape them. See [hooks.md](hooks.md) for the full scope.
 
 ## Setting one up
 

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -154,6 +154,24 @@ vaults' own lines — never a line from a value you supplied.
   text sitting in a file it never expands is yours to get right. A published body cannot be
   withdrawn — a forge keeps public edit history — so rotation, not redaction, is the
   remedy, and that is the operator's work rather than yours.
+- **The same rule on charter's own commands, where the remedy is different.**
+  `charter persona remember`, `workspace remember|note|todo|vision`, `change create|drop`,
+  `worktree abandon` and `report bug|gap` all take prose charter persists, and this plane
+  commits and pushes it. A backtick in a double-quoted argument corrupted a committed memory
+  file this way, silently — the shell ran the word, spliced its empty output, and the saved
+  sentence read *"appending to  each pass"* with the word gone
+  ([#778](https://github.com/diazoxide/charter/issues/778)). These commands take a positional
+  string rather than a body file, so **backslash-escape each backtick**; single-quoting is
+  the shorter fix but it fails the moment your prose contains an apostrophe, which most of
+  it does.
+
+  ```bash
+  charter persona remember "the flag's default is \`id -un\` here"
+  ```
+
+  charter refuses the live shape on those commands. If you really want a computed value in
+  the text, assign it in a **separate** Bash call and pass `"$VAR"` — a parameter expansion
+  is not a substitution.
 - If the vault or key does not exist, say so and ask for it to be added — do not work
   around it with a value pasted into the conversation.
 

--- a/tests/test_a_denial_names_its_override.py
+++ b/tests/test_a_denial_names_its_override.py
@@ -23,9 +23,12 @@ the agent — and there is deliberately no switch charter can read. That is not 
 * A `PreToolUse` hook governs the harness's tools. The operator's own shell was never on
   that side of the line, so running it there works around nothing.
 
-**Appended in `_deny`, not at the six call sites**, which is the assertion with the most
-value here: a seventh guard added tomorrow carries the override without anyone remembering to,
+**Appended in `_deny`, not at the call sites**, which is the assertion with the most
+value here: the next guard added carries the override without anyone remembering to,
 and the trace tally keys — computed from the reason BEFORE it reaches `_deny` — cannot drift.
+That is not a hypothetical any more: #710 and #778 each added a guard without a row in
+`DENIALS` below, and each carried the note regardless. The rows were added afterwards, so
+the enumeration says what it claims to.
 """
 
 from __future__ import annotations
@@ -58,6 +61,15 @@ DENIALS = {
     "release-floor": (hooks.pretooluse,
                       {"tool_input": {"command": "gh release create v9.9.9"},
                        "permission_mode": "bypassPermissions"}),
+    # The two substitution guards. Added late — #710 shipped the first without a row here,
+    # which is the omission this enumeration exists to make impossible: `_deny` gave it the
+    # override note anyway, so nothing was broken and nothing said so either.
+    "forge-substitution": (hooks.pretooluse,
+                           {"tool_input": {"command":
+                                           'gh issue create --body "a `id -un` span"'}}),
+    "charter-substitution": (hooks.pretooluse,
+                             {"tool_input": {"command":
+                                             'charter persona remember "a `id -un` span"'}}),
 }
 
 
@@ -112,9 +124,9 @@ class DenialCase(InAControlPlane):
 
 
 class TestEveryDenialNamesTheOverride(DenialCase):
-    def test_all_six_of_them(self):
-        """The precondition is the count: six guards deny, and all six must say it."""
-        self.assertEqual(6, len(DENIALS))
+    def test_all_eight_of_them(self):
+        """The precondition is the count: eight guards deny, and all eight must say it."""
+        self.assertEqual(8, len(DENIALS))
         for name in DENIALS:
             with self.subTest(guard=name):
                 self.assertIn(hooks._OVERRIDE_NOTE, self.reason(name))

--- a/tests/test_the_text_you_typed_is_the_text_charter_saves.py
+++ b/tests/test_the_text_you_typed_is_the_text_charter_saves.py
@@ -1,0 +1,500 @@
+"""charter's own text-taking commands may not carry a live command substitution (#778).
+
+#710 refused the shape on `gh`/`glab` bodies. **charter's own commands were not in that
+table**, and it bit immediately: while writing up #710's findings, the coordinating agent
+ran ``charter persona remember "… `pending` …"``. zsh ran the word, printed `command not
+found`, spliced its empty output, and the saved memory read *"appending to  each pass"*
+with the word silently gone. That file lives under `personas/_shared/memory/`, which this
+plane commits and pushes — the same defect reaching a public repository by an indirect
+route, which is exactly why nobody saw it.
+
+**What decided that this becomes a guard rather than a third documented limit is a
+measurement**, and it came out the opposite way from the one #778 predicted. #778 expected
+charter's own prose to be "similar or worse" than the commit-message figure of 26 of 30.
+Measured over the 284 committed memory bodies on `main`:
+
+* **9 carry a backtick and 4 carry `$(`; 13 would meet a liveness-keyed guard — 5%.**
+  Not 87%. 254 of the 284 predate the working rule that tells agents to avoid the shape,
+  so this is charter's natural prose, not an effect of the rule.
+* The reason is real rather than lucky: a commit message is rendered as markdown by a
+  forge, so agents write code spans in them; a memory body is read back by
+  `charter recall` in a terminal, so agents write *"the $( branch"* and *"a backtick"* as
+  words.
+* And the 13 are not false positives at all. **283 of the 284 bodies are single-line**, so
+  none of them came through the `"$(cat <<'EOF' …)"` spelling that makes a backtick inert;
+  a live backtick in a single-line double-quoted operand is a command that was going to
+  corrupt its own text.
+
+**The remedy had to be checked too, because it is not the one #710 names.** 221 of the 284
+bodies contain an apostrophe — and *all nine* of the backtick-carrying ones do — so "use
+single quotes" fails on the exact population this refuses. What works is one backslash per
+backtick, verified against a real `bash` in `TheRemedyItSteersToward` rather than believed:
+inside double quotes a backslashed backtick is a literal backtick and the apostrophes keep
+working.
+
+The commit-message surface stays out, and `CommitMessagesAreStillTheDocumentedLimit` pins
+it. That is #711, and the measurement there says the opposite of this one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import tempfile
+import unittest
+
+from charter import cli, config, hooks
+from tests._isolation import PersonaIso, run_hook
+
+#: The #778 case with the payload replaced. `id -un` is a substitution and nothing else,
+#: which is the only property under test; a runnable reproduction of an exfiltration does
+#: not belong in a committed file.
+INCIDENT = 'charter persona remember "the marker is appended to `id -un` each pass"'
+
+
+def _decision(r) -> str | None:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+def _reason(r) -> str:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
+
+
+class CharterProseCase(PersonaIso):
+    """Helpers only — the hook driven end to end, with a plane present.
+
+    Split out rather than subclassed for its tests, following the forge guard's own file:
+    inheriting a TestCase re-runs every parent case once per child, which turns one real
+    failure into four and makes the count say nothing.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+
+    def deny_reason(self, cmd: str) -> str:
+        r = run_hook(hooks.pretooluse, {"tool_name": "Bash",
+                                        "tool_input": {"command": cmd},
+                                        "cwd": str(config.ROOT)})
+        self.assertEqual(_decision(r), "deny", f"expected a refusal for {cmd!r}")
+        return _reason(r)
+
+    def allowed(self, cmd: str) -> None:
+        r = run_hook(hooks.pretooluse, {"tool_name": "Bash",
+                                        "tool_input": {"command": cmd},
+                                        "cwd": str(config.ROOT)})
+        self.assertNotEqual(_decision(r), "deny", f"expected {cmd!r} to be allowed")
+
+
+class TheTextThatWasLost(CharterProseCase):
+    """The #778 case is refused, and the refusal explains itself."""
+
+    def test_the_incident_is_refused(self) -> None:
+        why = self.deny_reason(INCIDENT)
+        # The four things the reader needs, none of which is "denied": which command, what
+        # it does with the text, what the shell is about to do, and what to type instead.
+        self.assertIn("charter persona remember", why)
+        self.assertIn("personas/", why)
+        self.assertIn("substitution", why)
+        self.assertIn("\\`", why)
+
+    def test_the_modern_spelling_is_refused_too(self) -> None:
+        self.assertIn("$(…)", self.deny_reason('charter persona remember "at $(date) today"'))
+        self.assertIn("`…`", self.deny_reason(INCIDENT))
+
+    def test_the_shared_flag_does_not_change_the_answer(self) -> None:
+        """`--shared` writes to `personas/_shared/memory/`, which is where the #778 memory
+        landed. A guard that read the flag would have missed the actual incident."""
+        self.deny_reason('charter persona remember --shared "a `id -un` span"')
+
+    def test_every_row_in_the_table_is_refused(self) -> None:
+        # The count is the precondition: a loop over a table that emptied proves nothing,
+        # and half this table is generated.
+        self.assertEqual(len(hooks._CHARTER_PROSE), 16)
+        for (noun, verb), _facts in sorted(hooks._CHARTER_PROSE.items()):
+            with self.subTest(f"{noun} {verb}"):
+                self.deny_reason(f'charter {noun} {verb} x --why "`id -un`"')
+
+    def test_the_alias_spellings_are_refused_end_to_end(self) -> None:
+        """`ws` and `wt` written out, not walked. The table's alias half is *generated*, so
+        every assertion that loops over it goes quiet rather than red when the generator
+        produces nothing — which the deletion sweep demonstrated by corrupting the alias
+        map's keys and surviving the whole suite. These five lines are what an agent
+        actually types, and they cannot be satisfied by an empty table.
+        """
+        for cmd in ('charter ws note "a `id -un` span"',
+                    'charter ws remember "a `id -un` span"',
+                    'charter ws todo "a `id -un` span"',
+                    'charter ws vision "a `id -un` span"',
+                    'charter wt abandon "a `id -un` span"'):
+            with self.subTest(cmd):
+                self.deny_reason(cmd)
+
+    def test_a_verb_that_is_not_in_the_table_is_allowed(self) -> None:
+        """Reading, listing and searching are not writing. `recall` in particular takes a
+        query that an agent has every reason to compute."""
+        for cmd in ("charter recall", "charter persona recall", "charter workspace recall",
+                    "charter status", "charter report list", "charter change list",
+                    "charter persona list", "charter news"):
+            with self.subTest(cmd):
+                self.allowed(f'{cmd} --query "`id -un`"')
+
+    def test_a_flags_value_cannot_supply_the_pair(self) -> None:
+        """`charter recall --scope persona remember "…"` is a SEARCH, and `persona` and
+        `remember` really are adjacent argv words on it. A guard that walked adjacent pairs
+        the way the forge guard must would refuse it; reading the first two words after
+        `charter` cannot, because charter's root parser has no option that takes a value.
+
+        This is the test that makes that design choice load-bearing rather than incidental —
+        switch the reader to pairs and it goes red.
+        """
+        self.allowed('charter recall --scope persona remember "`id -un`"')
+        self.allowed('charter persona lint --only remember "`id -un`"')
+
+
+class TheRemedyItSteersToward(CharterProseCase):
+    """A denial with no cheap remedy is a denial that gets switched off (#371).
+
+    The remedy here is **not** the one #710 names. 221 of the 284 committed memory bodies
+    contain an apostrophe and all nine backtick-carrying ones do, so single-quoting — the
+    obvious answer — fails on precisely the text this refuses. One backslash per backtick
+    is what works, and this checks that against a real `bash` rather than asserting it,
+    because a fix for a class of bug is unusually likely to contain that bug.
+    """
+
+    #: A real body's shape: prose with an apostrophe AND a code span. All nine of the
+    #: backtick-carrying bodies in the corpus look like this, which is why the escaped form
+    #: rather than the single-quoted one is the remedy the denial has to name.
+    APOSTROPHE_AND_SPAN = "the flag's default is `id -un` here"
+
+    def test_a_backslash_escaped_backtick_is_allowed(self) -> None:
+        escaped = self.APOSTROPHE_AND_SPAN.replace("`", "\\`")
+        self.allowed(f'charter persona remember "{escaped}"')
+
+    def test_bash_agrees_the_escaped_form_is_inert_and_keeps_the_backtick(self) -> None:
+        """The remedy has to be *correct*, not merely permitted: the shell must not run the
+        word, and the character the author meant must survive into the argument.
+
+        A sentinel file is the oracle for "did it run" — asking whether output reached
+        stdout is a different question, and the forge guard's own differential test records
+        what happens when the two are confused.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            sentinel = os.path.join(d, "ran")
+            body = f"the flag's default is \\`touch {sentinel}\\` here"
+            r = subprocess.run(["bash", "-c", f'printf %s "{body}"'],
+                               capture_output=True, text=True, timeout=20)
+            self.assertFalse(os.path.exists(sentinel), "bash RAN the escaped substitution")
+            self.assertIn("`", r.stdout, "the backtick did not survive into the argument")
+            self.assertIn("flag's", r.stdout, "the apostrophe did not survive")
+
+    def test_single_quoting_is_allowed_where_the_text_permits_it(self) -> None:
+        self.allowed("charter persona remember 'a `id -un` span'")
+
+    def test_a_parameter_expansion_is_not_a_substitution(self) -> None:
+        """The denial's answer for a value that really must be interpolated: compute it in a
+        separate Bash call and pass `"$VAR"`. That has to be allowed, or the advice is a
+        dead end — and it is genuinely safe, because a shell does not re-expand a
+        parameter's value."""
+        self.allowed('charter persona remember "release $NOTES shipped"')
+        self.allowed('charter persona remember "release ${NOTES} shipped"')
+
+    def test_a_bug_report_about_this_guard_can_still_be_filed(self) -> None:
+        """#183 is this repository's record of a guard that **blocked its own bug report**:
+        the plane-root guard read prose inside `charter report bug '…'` as a command, and the
+        reporter had to file through a file. `report bug|gap` is in this table, so the same
+        trap is one apostrophe away.
+
+        It is not the same failure — that refusal was false, and a live backtick here is a
+        command the shell really would run, so the text would arrive corrupted either way.
+        But the *route out* has to exist and has to be the one the denial names, or the first
+        person to report a fault in this guard cannot report it.
+        """
+        text = "charter refuses a code span in report bug"
+        self.allowed(f"charter report bug '{text}: `id -un`'")
+        self.allowed(f'charter report bug "{text}: \\`id -un\\`"')
+        self.allowed("charter report bug --from-file /tmp/report.md")
+        self.allowed("charter report bug - < /tmp/report.md")
+
+    def test_report_names_its_own_file_input_and_the_memory_commands_do_not(self) -> None:
+        """`report bug|gap` really has `--from-file` and `--stdin`; `persona remember` has
+        neither. A denial that offered a flag the command does not accept would send the
+        reader to a usage error, so the remedy is per-row and not one sentence for all.
+
+        **The absence is asserted on the whole clause, not on the flag's spelling.** Testing
+        only for `--from-file` passes against a guard that emits ``or pass `None <path>``` —
+        which is exactly what the deletion sweep built, by collapsing the conditional so the
+        file clause is always taken. `None` is not `--from-file`, so the assertion held
+        while the denial had become nonsense.
+        """
+        why_report = self.deny_reason('charter report bug "a `id -un` span"')
+        self.assertIn("--from-file", why_report)
+        self.assertIn("--stdin", why_report)
+        why_memory = self.deny_reason(INCIDENT)
+        for absent in ("--from-file", "--stdin", "or pass", "None"):
+            with self.subTest(absent):
+                self.assertNotIn(absent, why_memory)
+
+
+class TheCommandWordItAnswersTo(CharterProseCase):
+    """`charter`, and the one other spelling this repository actually uses."""
+
+    def test_the_module_invocation_is_covered(self) -> None:
+        """`python3 -m charter …` is what CONTRIBUTING tells you to run against a checkout,
+        so it is not an exotic spelling here — it is the one an agent working ON charter
+        types all day. `os.path.basename(prog)` is `python3` on that line, so the forge
+        guard's reader would have seen no `charter` at all."""
+        self.deny_reason('python3 -m charter persona remember "a `id -un` span"')
+
+    def test_interpreter_flags_before_the_module_do_not_hide_it(self) -> None:
+        self.deny_reason('python3 -B -m charter persona remember "a `id -un` span"')
+        self.deny_reason('env -u PYTHONSAFEPATH python3 -B -m charter persona remember "`id -un`"')
+
+    def test_another_module_is_not_charter(self) -> None:
+        """**The word `charter` has to appear on the line, or this test measures nothing.**
+
+        The obvious spelling — `python3 -m pytest persona remember "…"` — never reaches the
+        module check at all: `_charter_substitution_hit`'s hot-path filter answers first
+        because the string holds no `charter`. So the assertion passed on a path that could
+        not have failed, and the deletion sweep proved it by removing the `else None` and
+        surviving. That is this repository's signature defect — *a case two arms can both
+        satisfy, tests neither* — and it is the second time this exact module has produced
+        it.
+
+        The word sits in the *prose* here, which is where it would sit in real use.
+        """
+        cmd = 'python3 -m pytest persona remember "check the charter `id -un`"'
+        self.assertIn("charter", cmd, "precondition: the hot-path filter must let this "
+                                      "reach the module check")
+        self.allowed(cmd)
+
+    def test_a_path_to_the_program_still_matches(self) -> None:
+        self.deny_reason('/usr/local/bin/charter persona remember "a `id -un` span"')
+
+    def test_a_charter_call_with_too_few_words_does_not_raise(self) -> None:
+        """`charter "`x`"` has ONE word after the program, so a reader that indexes
+        `words[1]` raises **IndexError** — and a raise is the outcome this module may least
+        have, because `dispatch` runs the handler as a bare `rc = fn()` and an exception
+        takes the turn down instead of producing a verdict. #710's own sweep found two of
+        these; this is the third.
+
+        The command has to carry a substitution AND the word `charter`, or the hot-path
+        filters answer before the reader is ever reached and the assertion measures nothing.
+        """
+        for cmd in ('charter "`id -un`"', "charter `id -un`", 'charter'):
+            with self.subTest(cmd):
+                self.assertIsNone(hooks._charter_substitution_hit(cmd))
+                self.allowed(cmd)
+
+    def test_exactly_two_words_is_inside_the_boundary_not_outside_it(self) -> None:
+        """`charter ws note` is the whole command — a noun and a verb and nothing else — so
+        the guard's `len(words) < 2` must admit it. Widen that to `<= 2` and this line is
+        **allowed**, which is a fail-open on precisely the two-word shape the table is keyed
+        on.
+
+        The substitution sits in a different segment, which is what makes a two-word segment
+        reachable at all and is the coarseness the guard documents: the scope is the whole
+        Bash call.
+        """
+        why = self.deny_reason('cd "$(pwd)" && charter ws note')
+        self.assertIn("charter ws note", why)
+
+
+class TheTableIsVerifiedAgainstTheRealParser(unittest.TestCase):
+    """#710's bar: every row checked against real `--help`, not recalled — and here the
+    parser itself can be asked, which is stronger than its rendered help.
+
+    These are the two facts the guard's shape rests on. If either stops being true, this
+    goes red and the next reader is told which part of the design moved.
+    """
+
+    def test_every_row_is_a_real_charter_subcommand_taking_free_text(self) -> None:
+        p = cli.build_parser()
+        for (noun, verb), _facts in sorted(hooks._CHARTER_PROSE.items()):
+            with self.subTest(f"{noun} {verb}"):
+                sub = self._sub(p, noun)
+                self.assertIsNotNone(sub, f"charter has no `{noun}` command")
+                leaf = self._sub(sub, verb)
+                self.assertIsNotNone(leaf, f"charter {noun} has no `{verb}` verb")
+                self.assertTrue(self._takes_free_text(leaf),
+                                f"charter {noun} {verb} takes no free-text operand")
+
+    def test_charter_has_no_global_option_that_takes_a_value(self) -> None:
+        """Which is what makes reading the FIRST two words exact, where the forge guard has
+        to walk adjacent pairs: `gh --repo o/r issue create` puts a flag's value in front of
+        the noun, and charter's root parser has no flag that can do that.
+
+        Reading two words instead of every pair is strictly narrower — it is what keeps
+        `charter recall --scope persona remember`, where `persona` and `remember` really are
+        adjacent argv words, out of the table. If a value-taking global option is ever added
+        to charter, this test fails and the guard has to move to adjacent pairs.
+        """
+        for a in cli.build_parser()._actions:
+            if isinstance(a, (argparse._HelpAction, argparse._VersionAction,
+                              argparse._SubParsersAction)):
+                continue
+            self.assertEqual(a.nargs, 0,
+                             f"root option {a.option_strings} takes a value — the guard "
+                             f"must switch to adjacent pairs")
+
+    def test_the_alias_map_names_the_two_pairs_charter_actually_has(self) -> None:
+        """**Named, not iterated.** The loop below walks `_CHARTER_NOUN_ALIASES`, so
+        misspelling a KEY makes it iterate a map that matches no row and the whole thing
+        passes having compared nothing — which the deletion sweep proved by retuning
+        `"workspace"` to `'xpsltqbdf'` and surviving. A vacuous test over a table is this
+        module's signature failure and it does not get to happen twice.
+
+        The mapping is checked against the real parser: `ws` and `wt` have to be genuine
+        aliases of `workspace` and `worktree`, not names somebody assumed.
+        """
+        self.assertEqual(hooks._CHARTER_NOUN_ALIASES,
+                         {"workspace": "ws", "worktree": "wt"})
+        p = cli.build_parser()
+        for full, short in hooks._CHARTER_NOUN_ALIASES.items():
+            with self.subTest(f"{full}/{short}"):
+                self.assertIs(self._sub(p, full), self._sub(p, short),
+                              f"`{short}` is not the same parser as `{full}`")
+
+    def test_every_alias_row_exists_by_name(self) -> None:
+        """The generated half of the table, asserted row by row rather than by walking the
+        thing that generates it. A generator that produces nothing passes any test written
+        as a loop over its own output."""
+        for pair in (("ws", "remember"), ("ws", "note"), ("ws", "todo"), ("ws", "vision"),
+                     ("wt", "abandon")):
+            with self.subTest(pair):
+                self.assertIn(pair, hooks._CHARTER_PROSE)
+                self.assertEqual(hooks._CHARTER_PROSE[pair],
+                                 hooks._CHARTER_PROSE[(dict(zip(
+                                     hooks._CHARTER_NOUN_ALIASES.values(),
+                                     hooks._CHARTER_NOUN_ALIASES.keys()))[pair[0]],
+                                     pair[1])])
+
+    def test_the_aliases_are_generated_from_the_rows_not_typed_out(self) -> None:
+        """`workspace`/`ws` and `worktree`/`wt` are the same command. A hand-written second
+        copy is a row that drifts the day somebody adds a verb to one of them."""
+        checked = 0
+        for full, short in hooks._CHARTER_NOUN_ALIASES.items():
+            for (noun, verb), facts in sorted(hooks._CHARTER_PROSE.items()):
+                if noun != full:
+                    continue
+                with self.subTest(f"{short} {verb}"):
+                    self.assertEqual(hooks._CHARTER_PROSE.get((short, verb)), facts)
+                checked += 1
+        # the precondition, without which the loop above proves nothing
+        self.assertEqual(checked, 5, "the alias rows were not generated at all")
+
+    @staticmethod
+    def _sub(parser, name):
+        for a in parser._actions:
+            if isinstance(a, argparse._SubParsersAction) and name in a.choices:
+                return a.choices[name]
+        return None
+
+    @staticmethod
+    def _takes_free_text(parser) -> bool:
+        for a in parser._actions:
+            if isinstance(a, (argparse._HelpAction, argparse._VersionAction,
+                              argparse._StoreTrueAction, argparse._StoreFalseAction)):
+                continue
+            if a.choices or a.type not in (None, str) or a.nargs == 0:
+                continue
+            return True
+        return False
+
+
+class CommitMessagesAreStillTheDocumentedLimit(CharterProseCase):
+    """#711 stays out of scope, and it is pinned here so the boundary is a decision rather
+    than an omission.
+
+    The measurement runs the other way from this guard's. On `main`, **29 of the last 30
+    commit messages carry a backtick** (160 of 200), and **all 30 of the last 30 are
+    multi-line** — which a single `-m "…"` cannot produce. The spelling that writes them,
+    ``-m "$(cat <<'EOF' … EOF)"``, is itself a live `$(`, so a liveness-keyed guard on
+    `git commit` would refuse the very form that makes the backticks inside it harmless.
+    Its trigger would be the prescribed workflow, which is the inversion #371 deleted a
+    guard for. `charter save` and `workspace save -m` write commit messages too, so they
+    are out for the same reason and not by oversight.
+    """
+
+    def test_git_commit_is_not_covered(self) -> None:
+        self.allowed('git commit -m "fix the `id -un` path"')
+
+    def test_the_sibling_message_verbs_are_not_covered_either(self) -> None:
+        for cmd in ('git tag -a v1 -m "`id -un`"',
+                    'git merge --no-ff -m "`id -un`" topic',
+                    'git notes add -m "`id -un`"',
+                    'git stash push -m "`id -un`"'):
+            with self.subTest(cmd):
+                self.allowed(cmd)
+
+    def test_charters_own_commit_message_commands_are_out_for_the_same_reason(self) -> None:
+        for cmd in ('charter save "fix the `id -un` path"',
+                    'charter workspace save w --message "`id -un`"',
+                    'charter workspace rename a b -m "`id -un`"'):
+            with self.subTest(cmd):
+                self.allowed(cmd)
+
+    def test_the_prescribed_commit_spelling_carries_a_live_substitution(self) -> None:
+        """The fact that settles #711, stated as a test rather than as prose in a PR body.
+        A guard on `git commit` would have to allow this line or refuse every commit this
+        repository makes."""
+        idiom = 'git commit -m "$(cat <<\'EOF\'\nsubject with a `code` span\nEOF\n)"'
+        self.assertEqual(hooks._live_substitution(idiom), "$(")
+
+
+class WhatItDoesNotClaim(CharterProseCase):
+    """Per #370: the claim is small and the denial says so.
+
+    It reads the SHAPE of a command line. It never sees the value — at `PreToolUse` the
+    substitution has not run — so it must not be described as keeping a credential out of a
+    file, and the sentence is held to that here.
+    """
+
+    def test_the_denial_says_it_reads_the_shape(self) -> None:
+        why = self.deny_reason(INCIDENT)
+        self.assertIn("SHAPE", why)
+        self.assertIn("does not claim", why)
+
+    def test_an_inert_substitution_is_not_refused(self) -> None:
+        """One character's difference, and the whole calibration: prose that merely mentions
+        a shell is prose."""
+        self.allowed("charter persona remember 'run `env` before the build'")
+        self.allowed('charter persona remember "set $HOME first"')
+        self.allowed('charter persona remember "charter 0.54.0 shipped"')
+
+    def test_it_is_not_gated_on_a_control_plane(self) -> None:
+        """With `_leak_reason` and the forge guard, and for their reason: what it refuses is
+        a fact about the SHELL. A plane-gated version would corrupt the same memory from one
+        directory and refuse it from another."""
+        old = config.HAS_CONTROL_PLANE
+        config.HAS_CONTROL_PLANE = False
+        try:
+            self.assertIsNotNone(hooks._charter_substitution_hit(INCIDENT))
+        finally:
+            config.HAS_CONTROL_PLANE = old
+
+    def test_it_does_not_raise_on_a_none_command(self) -> None:
+        """`dispatch` runs the handler as a bare `rc = fn()`, so an exception takes the turn
+        down instead of producing a verdict. The forge guard's sweep found exactly this.
+
+        Only `_charter_substitution_hit` normalises — its `cmd or ""` is load-bearing,
+        because the filter below it would be the thing that raises, and the sweep confirms
+        it by killing the mutant that removes it. `_charter_prose_command` carries no
+        fallback of its own, matching `_forge_prose_command`: it tolerates `None` because
+        `_segment_argv` does, and that is asserted here rather than assumed.
+        """
+        self.assertIsNone(hooks._charter_substitution_hit(None))
+        self.assertIsNone(hooks._charter_prose_command(None))
+        self.assertEqual(list(hooks._segment_argv(None)), [])
+
+    def test_the_spelling_is_reported_for_the_trace(self) -> None:
+        """#289: the field that says WHICH shape tripped a guard is what makes "what fired
+        this 335 times" answerable from the records."""
+        self.assertEqual(hooks._charter_substitution_hit(INCIDENT)[0], "`")
+        self.assertEqual(
+            hooks._charter_substitution_hit('charter persona remember "$(date)"')[0], "$(")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#710 shipped the forge-body guard and documented three limits rather than
half-covering them. Two were issues. Both are answered here, and the answers go
opposite ways — what separates them is a measurement, not a judgement.

## #778 — charter's own text commands are covered

The guard matched `gh`/`glab`. charter's own text-taking commands were not in
that table, and it bit within the hour: while #710's findings were being written
up, an agent wrote a markdown code span inside a double-quoted
`charter persona remember` argument. zsh ran the word, printed `command not
found` and spliced its empty output, so the saved memory read
"appending to  each pass" with the word gone.
That file is under `personas/_shared/memory/`, which this plane commits and
pushes. Same defect as #703, reaching a public repository by an indirect route.

A6, beside A5, sharing `_live_substitution` rather than re-deciding what a shell
would run. Eleven `(noun, verb)` rows plus the `ws`/`wt` aliases, generated from
the rows so they cannot drift, and **every row re-derived from
`charter.cli.build_parser()` by a test** — stronger than the `--help` #710 had to
read by hand, and a renamed verb now fails a test instead of quietly emptying the
guard. The line for inclusion is #710's own (the one that keeps `gh pr merge
--body` out): the free text has to be required or primary, and what holds it has
to be read back as prose.

`python3 -m charter …` is covered, because CONTRIBUTING says to run a checkout
that way and on that line the program is `python3`.

It reads the **first two words** after `charter`, where A5 must walk adjacent
pairs — exact because charter's root parser has no option taking a value, which
a test asserts so the design fact is pinned rather than assumed. That is what
keeps `charter recall --scope persona remember` allowed.

## The remedy is not A5's, and that took measuring

Of the 284 committed memory bodies on `main`, **221 contain an apostrophe** — and
all nine backtick-carrying ones do — so single-quoting, the obvious answer, fails
on exactly the text this refuses. One backslash per backtick is what works, and
it is verified against a real bash with a sentinel oracle, not asserted:
the shell does not run it and the character survives into the argument.
`report bug|gap` also takes `--from-file`/`--stdin`, so the denial names a flag
only where one exists rather than answering a refusal with a usage error.

`test_a_bug_report_about_this_guard_can_still_be_filed` is #183's lesson applied
in advance: `report bug` is in this table, and #183 is this repo's record of a
guard that blocked its own bug report.

## #711 — the commit surface is enumerated, and it still stays out

The surface, against real `git … --help`: `commit` (`-m` repeating, `-F`, `-t`,
`-C`, `-c`, `--squash`, `--fixup`), `tag`, `merge`, `notes add|append|edit`,
`stash push|store`. `revert` and `cherry-pick` have a `-m` and it is
`--mainline` — a parent number, not prose, which is what a recalled list gets
wrong. So #711's first blocker is closed.

The rate is what settles it, and more decisively than #711 expected: 29 of the
last 30 messages on `main` carry a backtick (160 of 200), and **all 30 of the
last 30 are multi-line** — which a single `-m` cannot produce. The spelling that
writes them, `-m "$(cat <<'EOF' … EOF)"`, is **itself a live `$(`** while the
backticks inside the quoted heredoc are inert. A liveness-keyed guard there would
refuse the exact form that makes them harmless: its trigger would be the
prescribed workflow, which is #371's inversion. Exempting `$(cat <<'QUOTED')` by
name means deciding which substitutions are *safe* rather than *live*, and that
parser fails open. `charter save`, `workspace save -m` and `workspace rename -m`
are out for the same reason, and pinned as such.

## Why the two corpora disagree

The intuition that both are "prose with code spans" is what made #778 predict 87%
and get 5%. A commit message is rendered as markdown by a forge, so agents write
code spans; a memory body is read back by `charter recall` in a terminal, so they
write "the $( branch" as words. 254 of the 284 bodies predate the working rule
warning against the shape, so it is charter's natural prose. And the 13 that
would meet this guard are not false positives: 283 of 284 bodies are single-line,
so none came through the spelling that makes a backtick inert.

## What the deletion sweep found, decomposed

28 mutations on the one charged file. The first run left **ten survivors and one
unresolved**, and eight of them were real:

| survivor | verdict |
|---|---|
| `if not words or len(words) < 2` dropped | **IndexError** — `charter "`x`"` has one word and reaches `words[1]` |
| its boundary widened to `<= 2` | **fail-open** — a bare `charter ws note` stops being refused |
| the `-m` module check's `else None` dropped | **false DENY** on `python3 -m pytest persona remember` |
| the alias map's key `"workspace"` retuned | **fail-open** — every `ws` row silently ungenerated |
| the same for `"worktree"` | **fail-open** — every `wt` row, likewise |
| the per-row file clause always taken | the denial offers ``--from-file`` where none exists |
| `prog or ""` dropped | equivalent — **dead code**, removed |
| `cmd or ""` in `_charter_prose_command` dropped | equivalent — **dead code**, removed |
| both hot-path prefilters dropped | equivalent — kept, on measurement |

A raise matters most: `dispatch` runs the handler as a bare `rc = fn()`, so an
exception takes the turn down instead of producing a verdict — the same class
#710's own sweep found twice.

**Three of my own tests were vacuous, and all three are one shape** — *a case two
arms can both satisfy, tests neither*, which is the defect this repository named
and which this module produced three more instances of:

- `test_another_module_is_not_charter` asserted
  `python3 -m pytest persona remember "…"` was allowed. That string holds no
  `charter`, so the hot-path filter answered first and the module check was never
  reached. The word now sits in the test's prose, where it would sit in real use.
- Two alias tests **walked `_CHARTER_NOUN_ALIASES` itself**, so corrupting a KEY
  made them iterate a map matching no row and pass having compared nothing. The
  alias rows are now asserted **by name**, end to end, plus a count precondition —
  a loop over a generated table cannot be the only thing testing the generator.
- The per-row remedy test asserted only that `--from-file` was absent from the
  memory denial. The mutant emits ``or pass `None <path>```, which does not contain
  `--from-file`, so the assertion held while the sentence had become nonsense. It
  now asserts the whole clause is absent.

**Two survivors were better code.** `prog or ""` and `_charter_prose_command`'s
`cmd or ""` could not be killed in either direction: `_split_env_chdir` returns
`toks[0] if toks else ""` so `prog` is never `None`, the eight other readers in
this file write that line without a fallback, and `_segment_argv(None)` yields
nothing. Both deleted. The `cmd or ""` at the hot-path filter *is* load-bearing
and the sweep kills its mutant, which is exactly what tells the two apart.

**And the prefilters produced a real change.** Asking what they buy showed the
order was wrong — copied from A5 rather than measured. A5 tests for a
substitution first because `gh`/`glab` are two- and four-character substrings
that fall inside ordinary English; `charter` is seven characters and rare:

```
git status --porcelain            0.197 us -> 0.056 us
a long ordinary pipeline          0.256 us -> 0.063 us
echo "$(git rev-parse HEAD)"      0.210 us -> 0.057 us
charter workspace list --json     0.205 us -> 0.208 us   (noise)
```

Three and a half times cheaper on everything that is not a charter command,
which is almost every Bash call. Both filters are kept on those numbers, which
is the rule A5's own section states for a surviving prefilter, and their verdicts
were checked identical over every string up to length four on `" \' ` $ ( < - B x`
and a newline rather than argued.

The one **unresolved** mutation drops the alias comprehension's filter. It has no
verdict because it selects 199 modules and the runner timed out — but it is not
unmeasured: applied by hand it raises `KeyError: 'persona'` at **import**, so
every test that imports `hooks` kills it.

## Verification

Failing tests first; 33 in the new module. Five hand-written mutants were also run against
it — liveness ignored, adjacent pairs instead of two words, the module
invocation dropped, the per-row remedy flattened, a commit-message row added —
and **every one is killed**, so the calibration tests discriminate rather than
passing by construction.

`test_a_denial_names_its_override.py` gains rows for both substitution guards.
#710 shipped without one and carried the override note anyway, via `_deny` — the
property that file exists to assert; the enumeration now says what it claims.

Full suite green apart from `test_frame_border_surface`, which is the operator's
uncommitted `charter.toml` (#785), not this branch.

## Not included, deliberately

No version bump, no stamp, no tag. `persona remember` and `workspace remember`
still have no `--from-file` the way `report bug` does; the remedy set is complete
without one (escape, single quotes, or a separate call and `"$VAR"`), so that is
noted rather than filed.

Closes #778. Closes #711 as a documented limit.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
