### PR TITLE
A short terminal keeps the row that says where you are, and the sidebar's hidden todos have a keyboard route (#740, #742)

### DIFF
--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -255,6 +255,128 @@ def _select(ctx, step: int, start: int):
     return f"selected {name}"
 
 
+#: What a workspace with nothing open is told instead of a row that does nothing.
+#: :data:`NO_REPOS`' shape and its argument — the row carries the fix, because a refusal
+#: that names no way out is a row an operator reads once and never again. `charter
+#: workspace todo "…"` with a quoted argument RECORDS one; bare it lists (`cli._wire`),
+#: which is why the sentence quotes the recording form and not the reading one.
+NO_TODOS = ("this workspace has nothing open to read out — "
+            "charter workspace todo \"<what to do>\"")
+
+
+def _register_todos(reg: actions.ActionRegistry) -> None:
+    """One row that reads this workspace's open todos out, one press at a time — **the
+    keyboard route to the sidebar's `…(+N more)`** (#742).
+
+    **The defect this closes is a row with no route beside it.** `slots._todo_rows` draws
+    `…(+5 more)` on a sidebar too short for seven todos, and until this row those five were
+    reachable only by typing `charter workspace todo` into the harness — the surface the
+    frame exists to replace. The sidebar's persona column got its route in #765 (a click
+    switches, a click on the badges explains); the todo list had no gesture at all, and its
+    own overflow line must go on having none, because a row standing for items it does not
+    name cannot resolve to one (`slots._Chips.hit`'s rule).
+
+    **A KEY and not a wheel, and that ordering is the whole design.** `[frame] mouse` ships
+    off, so a pointer-only answer is inert on exactly the planes this was reported from —
+    and `docs/frame.md`'s rule runs the other way anyway: a pointer affordance always has a
+    key or a palette row beside it, so the keyboard route is the half that must exist. A
+    wheel over the section can be added on top of this later; it cannot stand in for it.
+
+    **Why the palette's HEADER rather than a list surface of its own.** `commands_frame
+    ._again` argues this in full for the repo-selection rows and every word applies: the
+    overlay pane is zoomed over the whole window, so the sidebar is not on screen behind
+    the palette, and `Invocation.note` on the header is the surface the operator is
+    actually looking at. A read-only list surface would be the nicer answer and is a real
+    change — a fifth `frame/choose.py` noun breaks that module's "a noun is a thing you
+    switch to" contract at the point where picking a row tries to switch to it.
+
+    **`repeat=True`, so five hidden todos cost five keypresses and one palette.** Without
+    it each Enter closes the pane, kills the process and re-splits for the next — the
+    fourteen-keystroke, three-cycle cost #746 measured on the repo rows.
+
+    **The cursor lives in a CELL closed over here, and that is not laziness about state.**
+    `_select` records the repo selection through `state` because a PANE has to redraw from
+    it: two processes, one fact. Nothing redraws from this — the answer is the sentence
+    `run` returns — so a `state` write plus the `state.bump` that wakes every panel would
+    be four panels repainting per keypress to move a number nobody else reads. The
+    registry is rebuilt per palette (`build`'s "a fresh registry per call") and
+    `commands_frame._again` invokes through that same registry, so the cell lives exactly
+    as long as the palette the operator is reading and starts again at the top next time —
+    which is what an operator who opened `F2` to read their todos means.
+
+    A list rather than an `itertools.count`: :func:`_read_todo` needs the value it is
+    about to report, wrapped against a list whose length it only learns from `ctx`.
+    """
+    seen = [0]
+    reg.register(action.Action(
+        id="todo.next", title="todo: read the next open todo",
+        touches=("todos", "gather"), repeat=True,
+        run=(lambda ctx: _read_todo(ctx, seen)),
+        available=lambda ctx: bool(_open_todos(ctx)),
+        reason_unavailable=lambda ctx: NO_TODOS))
+
+
+def _open_todos(ctx) -> list[dict]:
+    """The todos on *ctx* that are actually rows — `slots._todo_rows`' own filter.
+
+    A gather cache is a JSON file written by another process and may hold anything;
+    `ctx.todos` contains it no further than making the list a tuple (`ctx.SERVES` says the
+    containment is shallow in as many words). Asked in one place so `available` and
+    :func:`_read_todo` cannot disagree about whether there is a row to read — a row listed
+    as available that then answers "nothing" is the shape `ActionRegistry._check` builds one
+    ctx to prevent.
+    """
+    return [t for t in ctx.todos if isinstance(t, dict)]
+
+
+def _read_todo(ctx, seen: list[int]) -> str:
+    """The next open todo, as one sentence for the palette's header.
+
+    Split out of the row above for :func:`_select`'s reason: the walk is exercised against
+    a list of titles with no palette, no tmux server and no frame directory under it.
+
+    **The total is `slots.todo_total`, READ rather than counted here**, and #742 is why it
+    is worth a shared function: `gather._MAX_TODOS` bounds the LIST the cache holds while
+    `todo_count` records what was there before the bound, so counting `ctx.todos` would
+    report `3/20` under a sidebar heading saying `todos 400`. One answer, two surfaces.
+
+    **It wraps, and the position is what makes the wrap readable.** `_select`'s argument
+    for wrapping holds — a row that visibly does nothing at the end of a list reads as
+    broken and costs a whole `F2` to find out — and `3/7` is what stops a wrap looking like
+    a repeat. The clip is stated too: on a plane whose cache holds twenty of four hundred,
+    `3/400` over twenty readable titles would be a promise the cache cannot keep, so the
+    sentence says which list it is walking.
+
+    `open_todos` is oldest-first and that ordering is the point of it (`slots._todo_rows`),
+    so this reads in the same order the sidebar draws — the row after the last one on
+    screen is the next press, not a fresh sample.
+
+    Not contained here. `Palette.report` puts this on `Palette.heading` through
+    `_headline`, which runs `contain.one_line` over it before `tui.width` sees it, and
+    `frame/choose.py` records what a second containment on the way in costs: a line no test
+    can turn red.
+    """
+    from . import slots
+    items = _open_todos(ctx)
+    if not items:
+        # `available` refuses this row on a plane with nothing open, so the palette never
+        # reaches here — but `run` is callable without that check (a provider's own
+        # surface, and `tests.test_frame_palette` drives every built-in's `run` directly),
+        # and `% 0` is the one way this could raise instead of answering. An empty answer
+        # is `Palette.report`'s own "an action that answered nothing has nothing to
+        # report", which clears the header rather than inventing a sentence about a list
+        # that is not there. Unlike `_select`'s deliberately absent guard, this one is
+        # reachable: the modulo needs a length and the ctx is what carries it.
+        return ""
+    total = slots.todo_total(ctx.gather)
+    at = seen[0] % len(items)
+    seen[0] = at + 1
+    where = f"{at + 1}/{len(items)}"
+    if total > len(items):
+        where += f" of {total}"
+    return f"todo {where}: {items[at].get('title') or ''}"
+
+
 def _register_density(reg: actions.ActionRegistry, *, current: str) -> None:
     """One row per density level, with the level in effect marked rather than dropped.
 
@@ -359,6 +481,7 @@ def build(fid: str, *, current_density: str,
     reg = actions.ActionRegistry()
     _register_detach(reg)
     _register_selection(reg)
+    _register_todos(reg)
     _register_density(reg, current=current_density)
     _register_chrome(reg, current=current_chrome)
     for aid in reg.providers.ids():

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -46,10 +46,19 @@ from .. import util
 
 #: The order slots are dropped in as the terminal shrinks. The side first — a side panel
 #: costs the harness columns, so it goes as soon as space is tight in EITHER dimension,
-#: not only when columns themselves are the short one — then `repos`, whose table simply
-#: cannot be drawn in a pane narrower than `statusline._LEFT_W`, then the top, whose row
-#: is worth less than the status strip's alerts and which only goes when rows are the
-#: tight dimension.
+#: not only when columns themselves are the short one — then `repos`, whose table cannot
+#: be drawn in a pane narrower than `statusline._LEFT_W` or shorter than
+#: :func:`_table_min_rows`, then the two bars, then the top, whose row is worth less than
+#: the status strip's alerts and more than everything above it.
+#:
+#: **The rule the tail of this list encodes: a rung is dropped when the pane it would get
+#: cannot carry the thing the rung exists for, and among rungs that can, the ones whose
+#: facts another surface already reaches go first** (#740). That is what puts `top` last:
+#: it is one row carrying two facts nothing else on a short terminal says — which
+#: workspace you are in and which persona you are being — while `repos` spends a border
+#: and a heading before its first repo row, and the bars are reminders `F2` replaces in
+#: two keystrokes. `bottom` is past the end of the list for the same reason, one step
+#: further.
 #:
 #: **`bottom` is not here, and it is the one slot that never is.** It is the attention
 #: strip — the one alert and the command that fixes it — which is the whole reason a
@@ -70,8 +79,8 @@ from .. import util
 #: the reminder and nothing else, which is exactly what `top` cannot say for itself.
 _DROP_ORDER = ("right", "repos", "chats", "workspaces", "top")
 
-#: The entries of :data:`_DROP_ORDER` that go when ROWS are the tight dimension — its
-#: tail, after the two that answer to columns and have thresholds of their own.
+#: The entries of :data:`_DROP_ORDER` that go at `min_rows` itself — the ones with no
+#: threshold of their own, dropped whole the moment rows are the tight dimension.
 #:
 #: **This is what makes :data:`_DROP_ORDER` a constant rather than a comment.** Until
 #: Phase 5 nothing read that list: `visible_slots` spelled `s != "right"` and `s != "top"`
@@ -79,16 +88,22 @@ _DROP_ORDER = ("right", "repos", "chats", "workspaces", "top")
 #: entry added to it changed nothing at all. Derived, deleting an entry changes what a
 #: short terminal draws — which is the property the deletion sweep can see.
 #:
-#: `right` and `repos` are named as the exceptions rather than the members being listed,
-#: so a component added to `_DROP_ORDER` joins the row drops by default. That is the safe
-#: direction: a new readout that a short terminal keeps is a frame with less harness in
-#: it, and a new one it drops is a reminder the palette already replaces.
+#: The three exceptions are NAMED rather than the members being listed, so a component
+#: added to `_DROP_ORDER` joins the row drops by default. That is the safe direction: a
+#: new readout that a short terminal keeps is a frame with less harness in it, and a new
+#: one it drops is a reminder the palette already replaces.
 #:
-#: All at once and not one per threshold, because `visible_slots` has two thresholds and
-#: not five. The ORDER still decides which of them survives a future third — it is not
-#: decoration — but inventing one now to space these out would be arithmetic no
-#: measurement asked for.
-_ROW_DROPS = tuple(s for s in _DROP_ORDER if s not in ("right", "repos"))
+#: **`top` became the third exception in #740, and that is the whole of that issue's
+#: "the ladder is inverted at the bottom".** Every entry here is a reminder `F2` reaches
+#: in two keystrokes; `top`'s two facts — the workspace and the persona — are reached by
+#: nothing else on a terminal with no sidebar, so dropping it in the same breath as the
+#: bars was ranking it below a `repos` pane that had room for its heading and no repo. It
+#: now goes only at the floor below which every panel goes (`visible_slots`' last
+#: clause), and `repos` has a rows threshold of its own (:func:`repos_fits_rows`) —
+#: measured, that trade never costs the harness a row at any height between the two
+#: floors, because a `repos` pane starved to its floor costs the same border-plus-one-row
+#: that `top` does. See `visible_slots`.
+_ROW_DROPS = tuple(s for s in _DROP_ORDER if s not in ("right", "repos", "top"))
 
 #: The frame charter itself draws, as components — `frame/builtins.py`, asked ONCE at
 #: import for the edges and sizes every constant below is derived from.
@@ -467,6 +482,80 @@ def _table_min_cols() -> int:
     return sl._LEFT_W
 
 
+def _table_min_rows() -> int:
+    """The shortest `repos` pane that can say anything about a repo at all —
+    `slots._TABLE_MIN_ROWS`, READ rather than copied.
+
+    :func:`_table_min_cols`' argument on the other axis, and #740 is the measurement that
+    asked for it. `_repos` spends its first row on the `▪ repos N` heading and hands what
+    is left to `_table_lines`, which draws nothing at all on a budget of zero — so a
+    one-row pane is three rows of terminal (two tmux rules and the row itself) saying the
+    number 8, on a terminal that has just been judged too short for the one row naming the
+    workspace. Measured on tmux 3.7c and the 3.2 floor at 120 columns, on the ladder as it
+    was: at 20 rows the table pane came back 3 rows and drew two repos, at 19 it was 4 and
+    drew three, and from **16 down it was 1 and drew none** — a heading, and the two pane
+    rules around it, at every height the operator's report was written from.
+
+    Read from the renderer for the reason :func:`_table_min_cols` gives in full: the
+    height at which the table stops saying anything and the height at which the launcher
+    stops splitting a pane for it must be ONE number, or the two come apart the first time
+    the heading gains a row.
+
+    Imported inside the call, like :func:`_table_min_cols` and for the same reason.
+    """
+    from . import slots
+    return slots._TABLE_MIN_ROWS
+
+
+def repos_row_cap(slots: list[str] | tuple[str, ...], *, window_rows: int) -> int:
+    """The most rows a `repos` pane may have in a *window_rows*-row window drawing
+    *slots* — what is left after every other horizontal strip and after the harness's own
+    floor.
+
+    **One function because two decisions read it** (#740). :func:`repos_rows` applies it
+    as the cap on what the table's content wants, and :func:`repos_fits_rows` asks whether
+    it leaves room for a repo row at all. Spelled twice, the launcher would have decided
+    the pane was worth splitting from one arithmetic and sized it from another — which is
+    exactly the sizer-and-renderer disagreement `_table_min_cols` exists to prevent one
+    axis over.
+
+    Every horizontal strip in :data:`_FIXED_ROW_SLOTS` costs its own height plus
+    :data:`_BORDER_ROWS`; `right` costs columns and is not counted. `repos` itself is not
+    counted either — it is the variable-height slot this is the budget FOR — so a caller
+    may pass the whole slot list including it, which is what both callers do.
+
+    Can come out at or below zero: a 16-row window has no rows to spare at all.
+    :func:`repos_rows` floors the pane at 1 there because `panel_argvs` cannot split a
+    zero-row pane, and :func:`repos_fits_rows` is what stops one being split.
+    """
+    other = sum(_size_of(s) + _BORDER_ROWS for s in slots if _is_fixed_row(s))
+    return window_rows - other - _BORDER_ROWS - HARNESS_MIN_ROWS
+
+
+def repos_fits_rows(slots: list[str] | tuple[str, ...], *, window_rows: int) -> bool:
+    """Would a `repos` pane in a *window_rows*-row window drawing *slots* be tall enough
+    to draw a repo row in?
+
+    :func:`repos_fits` on the other axis, and the drop #740 is about. Below this the pane
+    is its heading and nothing else — `▪ repos 8` between two tmux rules, three rows of a
+    ten-row terminal spent on a number — and the slot goes the way `right` and the bars
+    go, rather than existing as a label for content there is no room for.
+
+    **Asked with the slots that SURVIVED the rungs above it**, which is what makes this
+    the precedence #740 asked for rather than a second opinion: `top` is tested after this
+    one and is not dropped by rows at all any more, so its two rows are already spent when
+    this asks what is left. A `repos` pane and the identity strip both cost a border plus
+    one row at the bottom of the ladder, so the trade is exactly even in rows and
+    lopsided in facts — one count against a workspace name and a persona.
+
+    Rows do not depend on the split ORDER the way columns do (a horizontal strip costs the
+    same rows wherever it was split), so unlike :func:`repos_fits` this needs no
+    order-of-panes caller beside `visible_slots`: `commands_frame._relayout` re-splits a
+    permutation of the same slot list, which this answers identically.
+    """
+    return repos_row_cap(slots, window_rows=window_rows) >= _table_min_rows()
+
+
 def repos_cols(slots: list[str] | tuple[str, ...], *, window_cols: int) -> int:
     """How wide the `repos` pane actually is, in a *window_cols*-column window whose
     slots were split in *slots*' order — **not the window's own width** (#500).
@@ -539,8 +628,34 @@ def visible_slots(slots: list[str], cols: int, rows: int,
     which is the same choice `statusline.render` makes when it runs out of width. Follows
     `_DROP_ORDER`: `right` is the first to go, on ANY shortage — a terminal that is short
     on rows cannot spare a side panel's own divider any more than a narrow one can spare
-    its columns — then `repos`, and then `top`, only when rows specifically are the tight
-    dimension.
+    its columns — then `repos`, on either axis, then the bars, and `top` last of all.
+
+    **What this drops LAST, which is #740's question.** A rung goes when the pane it would
+    get cannot carry the thing the rung exists for, and among rungs that still can, the
+    ones whose facts another surface reaches go first. That ordering is `_DROP_ORDER`'s and
+    it is now honoured on the rows axis as well as the columns one:
+
+    * `right` — any shortage. It costs columns AND a divider.
+    * `repos` — a pane too narrow for a table (:func:`repos_fits`) or too short for one
+      repo row (:func:`repos_fits_rows`). Both read the renderer's own numbers.
+    * `chats`, `workspaces` (:data:`_ROW_DROPS`) — at `min_rows`, whole. Readouts `F2`
+      replaces in two keystrokes.
+    * `top` — only at the floor in the last clause, with everything else. One row, two
+      facts, and on a terminal with no sidebar it is the plane's only roster (`slots._top`,
+      #530).
+    * `bottom` — never. The one alert and the command that fixes it.
+
+    **Until #740 that ladder was a cliff with `repos` standing outside it.** `_ROW_DROPS`
+    took `top` the instant rows fell below `min_rows` while `repos` had no rows test at
+    all, so at 120x10 the frame spent three rows (two tmux rules and `▪ repos 8`) on a
+    count having just decided it could not afford the one row that names the workspace.
+    A `repos` pane starved to its floor and the identity strip cost the same two rows —
+    `_BORDER_ROWS` plus one — so the harness pays nothing for the exchange. Measured on
+    tmux 3.7c and the 3.2 floor at 120 columns, eight clones, at every height from 19 down
+    to 10: the harness pane keeps exactly what it kept at 19 and from 16 down, and GAINS a
+    row at 17 and two at 18, where the table had been drawing one or two repos. Those one
+    or two repo rows are what this costs, and they are the trade `_DROP_ORDER` always
+    named.
 
     **`repos` goes on a width its own renderer cannot draw in, and that width is read
     from the renderer** (:func:`_table_min_cols`). This is the drop `bottom` did not need
@@ -570,8 +685,21 @@ def visible_slots(slots: list[str], cols: int, rows: int,
         keep = [s for s in keep if s != "right"]
     if rows < min_rows:
         keep = [s for s in keep if s not in _ROW_DROPS]
-    if "repos" in keep and not repos_fits(keep, window_cols=cols):
-        keep = [s for s in keep if s != "repos"]
+    # **One drop, two reasons** — a pane too narrow to draw a table, or too short to draw
+    # a repo row in one. Written as two `if`s with the same body, the second one's
+    # `"repos" in keep` was a conjunct nothing could ever turn red (the deletion sweep
+    # reported exactly that): a re-filter for a name that is not in the list rebuilds the
+    # identical list, so the membership half could not change an outcome. `remove` is what
+    # makes it load-bearing — it raises on a frame with no table rather than quietly doing
+    # nothing — and it says "take the table out" instead of "rebuild the list without it".
+    #
+    # Both questions are asked about `keep` rather than about *slots*: these run after the
+    # two filters above, so the width is the one this pane is actually inset to and the
+    # rows are what is left with `top` already holding its own. That ordering is the
+    # precedence #740 asked for — see :func:`repos_fits_rows`.
+    if "repos" in keep and not (repos_fits(keep, window_cols=cols)
+                                and repos_fits_rows(keep, window_rows=rows)):
+        keep.remove("repos")
     if cols < min_cols // 2 or rows < min_rows // 2:
         keep = []
     return [s for s in slots if s in keep]
@@ -601,12 +729,12 @@ def repos_rows(*, content_rows: int, window_rows: int,
       line to draw — that it has none, and the command that gets it one
       (`slots._empty_lines`). Never zero: a zero-row pane is one tmux refuses to split at
       all.
-    * **The cap leaves the harness :data:`HARNESS_MIN_ROWS`.** *window_rows* is the whole
-      window, *slots* is what else is being drawn in it, and every horizontal strip in
-      :data:`_FIXED_ROW_SLOTS` costs its own height plus :data:`_BORDER_ROWS`. `right`
-      costs columns, not rows, so it is not counted here — asking for the whole slot list
-      rather than a pre-computed number is what keeps that decision in one place instead
-      of at each call site.
+    * **The cap leaves the harness :data:`HARNESS_MIN_ROWS`**, and it is
+      :func:`repos_row_cap` — the same arithmetic :func:`repos_fits_rows` asks before the
+      pane is split at all (#740), rather than a second copy of it here. *window_rows* is
+      the whole window and *slots* is what else is being drawn in it; asking for the whole
+      slot list rather than a pre-computed number is what keeps that decision in one place
+      instead of at each call site.
     * **Between the two, the content wins — unless the plane pinned a height.**
       *content_rows* is what `slots._repos` would actually fill
       (`slots.repos_rows_wanted`), so a two-repo plane gets a two-row strip rather than a
@@ -627,14 +755,16 @@ def repos_rows(*, content_rows: int, window_rows: int,
 
     The cap can come out below the floor — a 16-row window has no rows to spare at all —
     and the floor wins then, because `panel_argvs` has to be able to split the pane at
-    all. What protects the harness in that terminal is :func:`visible_slots`, which drops
-    every slot below half the size floors.
+    all. **Since #740 no LAUNCH reaches that**: :func:`repos_fits_rows` drops the slot
+    rather than splitting a pane with room for a heading and no repo, so the floor is now
+    reached only by `cmd_resize`, which re-sizes panes and neither creates nor destroys
+    them — the same asymmetry `slots._too_narrow_lines` exists for one axis over. What
+    protects the harness at the very bottom is :func:`visible_slots`' last clause, which
+    drops every slot below half the size floors.
     """
     floor = SLOT_SIZE["repos"]
     wanted = content_rows if pinned_rows is None else pinned_rows
-    other = sum(_size_of(s) + _BORDER_ROWS for s in slots if _is_fixed_row(s))
-    cap = window_rows - other - _BORDER_ROWS - HARNESS_MIN_ROWS
-    return max(floor, min(wanted, cap))
+    return max(floor, min(wanted, repos_row_cap(slots, window_rows=window_rows)))
 
 
 def column_sizes(slots: list[str] | tuple[str, ...]) -> dict[str, int]:

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -70,6 +70,33 @@ SPINNER_PERIOD = 0.2
 #: actually has rows to give.
 _TERSE_ROWS = 4
 
+#: Rows a bordered section spends on its own `▪ <label> N` heading before it has said
+#: anything about its content — `_sidebar_head`, one row.
+#:
+#: **One constant because three places did this arithmetic and one of them is in another
+#: module** (#740). :func:`repos_rows_wanted` adds it to the rows the table wants,
+#: :func:`_repos` subtracts it from the pane it measures, and `layout._table_min_rows`
+#: reads :data:`_TABLE_MIN_ROWS` below to decide whether a pane is worth splitting at all.
+#: Spelled as `1 +` and `- 1` in the first two and as a literal in the third, the day the
+#: heading gains a row is the day the launcher sizes a pane the renderer then overflows —
+#: which is the sizer-and-renderer disagreement #500 shipped twice on the other axis.
+_HEAD_ROWS = 1
+
+#: The shortest `repos` pane that can say anything about a repo — its heading plus one
+#: table row.
+#:
+#: **Read by `layout.visible_slots` (through `layout._table_min_rows`), which is what
+#: stops a shorter one being split at all.** #740: at 120x10 the frame spent three rows
+#: — two tmux rules and `▪ repos 8` — on a count, having just decided it could not afford
+#: the one row that names the workspace and the persona. `_table_lines` answers `[]` on a
+#: budget of zero, so that pane was a label for content there was no room for; below this
+#: the slot now goes the way `right` and the two bars go.
+#:
+#: The other axis of `layout._table_min_cols`, which reads `statusline._LEFT_W` for the
+#: identical reason: the number the RENDERER stops drawing at and the number the LAUNCHER
+#: stops splitting at must be one number.
+_TABLE_MIN_ROWS = _HEAD_ROWS + 1
+
 
 def spinner_frame(now: float | None = None) -> str:
     """Which frame of :data:`SPINNER` this instant shows.
@@ -1340,10 +1367,10 @@ def repos_rows_wanted(fid: str, *, pane_cols: int) -> int:
     a frame with six blank rows in it — the same discipline `window_cols=` already
     applies one level up.
 
-    **The `+ 1` is the pane's own heading, and it is no longer the attention row.** This
-    used to add that row, because `bottom` drew it and the table into one pane; they are
-    two panes now (`bottom` is the one-row strip it was before #488, and
-    `layout.SLOT_SIZE` states its height as the constant it is). What the row buys here
+    **The :data:`_HEAD_ROWS` added is the pane's own heading, and it is no longer the
+    attention row.** This used to add that row, because `bottom` drew it and the table
+    into one pane; they are two panes now (`bottom` is the one-row strip it was before
+    #488, and `layout.SLOT_SIZE` states its height as the constant it is). What the row buys here
     is `▪ repos N` — the same heading `_right` gained in #516, from the same
     `_sidebar_head`, so the frame's two bordered components are labelled the same way and
     the tree beneath it has something to hang from. Chrome the density does not buy back,
@@ -1376,7 +1403,7 @@ def repos_rows_wanted(fid: str, *, pane_cols: int) -> int:
     if cap <= 0:
         return 0
     rows = gather.row_count(fid)
-    return 1 + min(rows, cap) if rows else 0
+    return _HEAD_ROWS + min(rows, cap) if rows else 0
 
 
 #: Columns the persona NAME cell is never squeezed below once the badges have a column
@@ -1777,6 +1804,33 @@ def _persona_rows(cells: list, width: int) -> list[str]:
     return rows
 
 
+def todo_total(data: dict) -> int:
+    """How many todos this workspace has OPEN, unclipped — the number the `▪ todos N`
+    heading carries and the number the palette's reader counts against.
+
+    `gather._MAX_TODOS` bounds the LIST the cache holds; `todo_count` is the count of what
+    was there before the bound. A cache written by an older charter has the items and no
+    count, so this falls back to what it can actually see rather than reporting zero hidden
+    todos it cannot name — and it refuses a count SMALLER than the list, which is a cache
+    whose two halves disagree.
+
+    **Named because two surfaces read it** (#742). The sidebar's heading is one, and
+    `frame/builtin_actions._read_todo` — the palette row that reads the todos the sidebar
+    had no rows for — is the other. Spelled twice, the reader would have said `3/20` under
+    a heading saying `todos 400`, which is the drift a shared answer cannot have. Takes the
+    snapshot rather than a fid: the sidebar has `gather.read`'s and an action has its
+    `ctx.gather`, and neither should reach for the other's.
+    """
+    items = [t for t in (data.get("todos") or []) if isinstance(t, dict)]
+    raw = data.get("todo_count")
+    # `max` and not `raw if raw >= len(items) else len(items)`, which is what this said
+    # while it lived inside `_todo_rows`. The two are the same function — at `raw ==
+    # len(items)` both arms answer the same number — so `>=` there could be flipped to `>`
+    # by the deletion sweep and nothing downstream could tell, which is a comparison no
+    # test can turn red. Written as the bound it is, there is no branch left to get wrong.
+    return max(raw, len(items)) if isinstance(raw, int) else len(items)
+
+
 def _todo_rows(data: dict, width: int, budget: int) -> list[str]:
     """This workspace's open todos, heading included, in at most *budget* lines.
 
@@ -1795,6 +1849,17 @@ def _todo_rows(data: dict, width: int, budget: int) -> list[str]:
     of the budget rather than appended and trimmed off the end. A budget of exactly two
     therefore says the count and how much is hidden, because "there is more here than
     fits" outranks "here is an arbitrary one of them".
+
+    **The `…(+N more)` line has a route beside it now, and it is a keypress** (#742). It
+    used to advertise hidden content that nothing on the machine could reach: no click, no
+    key, no palette row — only `charter workspace todo` typed into the harness, which is
+    the surface the frame exists to replace. `frame/builtin_actions._register_todos` is
+    that route — one repeatable palette row that reads the open todos out, in full, on the
+    palette's own header. It is deliberately a KEY and not a wheel: `[frame] mouse` is off
+    on most planes, so a pointer-only answer would be inert on exactly the frames this was
+    reported from, and the row itself must go on answering nothing (`_Chips.hit`'s rule for
+    the persona column's own overflow line — a row that stands for items it does not name
+    cannot resolve to one).
 
     **Nothing at all when there is nothing open**, unlike `_bottom`'s `0 todos`. That row
     is one row on a strip that is never blank anyway; this is a heading plus an empty
@@ -1815,14 +1880,14 @@ def _todo_rows(data: dict, width: int, budget: int) -> list[str]:
     """
     from .. import contain, statusline as sl
     items = [t for t in (data.get("todos") or []) if isinstance(t, dict)]
-    if not items or budget < 2:
+    # `_HEAD_ROWS` for the heading, and one row under it: a heading with nothing beneath
+    # claims this workspace has no todos, which is the false-clean reading this module
+    # refuses everywhere. The constant rather than a literal `2` for :data:`_HEAD_ROWS`'
+    # own reason.
+    if not items or budget <= _HEAD_ROWS:
         return []
-    # `todo_count` is the UNCLIPPED total (`gather._MAX_TODOS` bounds only the list), so a
-    # cache written by an older charter — which has the items and no count — falls back to
-    # what it can actually see rather than reporting zero hidden todos it cannot name.
-    raw = data.get("todo_count")
-    total = raw if isinstance(raw, int) and raw >= len(items) else len(items)
-    room = budget - 1                       # the heading is not negotiable
+    total = todo_total(data)
+    room = budget - _HEAD_ROWS              # the heading is not negotiable
     shown = items[:room]
     if total > len(shown):
         shown = items[:max(0, room - 1)]    # reserve the line that says how many are left
@@ -2700,9 +2765,9 @@ def _repos(fid: str) -> str:
     the sidebar has narrowed. So on an untouched frame the two agree exactly and no row
     is either blank or cut, at every width the frame is drawn at, at every level the
     palette offers, and in whatever order the operator's `[frame] slots` puts the
-    edges in. The `- 1` is the heading and nothing else — the attention row is another
-    pane's now, and a budget still reserving a row for THAT would lose the lowest-ranked
-    repo row to nothing.
+    edges in. The :data:`_HEAD_ROWS` taken off is the heading and nothing else — the
+    attention row is another pane's now, and a budget still reserving a row for THAT
+    would lose the lowest-ranked repo row to nothing.
 
     A pane that is shorter anyway — a transient mid-resize size, or a window with no rows
     to spare — costs the table its lowest-priority rows through `_pick_rows`' ranking,
@@ -2817,7 +2882,7 @@ def _repos(fid: str) -> str:
     # resize starved) is still `_pick_rows`' ranked subset — the repo you are standing
     # in, the ones with something on them — rather than whichever happened to come
     # first, the same discipline the `terse` chip list in `_right` keeps.
-    budget = min(_height() - 1, cap)
+    budget = min(_height() - _HEAD_ROWS, cap)
     # **`settle` is unconditional, and the `if budget > 0` that used to guard the call
     # below went with it.** `_table_lines` already answers `[]` for a non-positive budget
     # (its first line), so the conditional could not change an outcome — the sweep's own

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -230,6 +230,17 @@ are *not* drawn), the `no personas` line, nor anything below the column does any
 all — the todos and the changes are readouts. On a sidebar too narrow to give the badges a
 column of their own, every cell of a persona row is its name.
 
+**The todos below the personas have a keyboard route, and that is all they have.** A short
+sidebar draws `…(+5 more)` under the two or three todos it has room for, and `F2` → `todo:
+read the next open todo` reads the whole list out from there, one press per todo, on the
+palette's own header — it repeats like the two repo rows, so five hidden todos are five
+Enters and one palette. It says where you are (`todo 3/7: Cut 0.55.0`), it wraps at the end
+rather than pressing nothing, and on a plane whose cache holds only part of a very long list
+it says that too (`todo 3/20 of 400: …`). Your `▪ todos N` heading is that same total, so
+the header and the pane can never disagree. The `…(+5 more)` row itself still does nothing
+when clicked: it stands for todos it does not name, so there is no todo for a click on it to
+be about — the same case the persona column's own overflow row carries.
+
 **The `F2 palette` hint is a button now, and so are the two nouns on the identity row.**
 Click `F2 palette` on the attention strip and the palette opens; click `⬢ <workspace>` or
 `◆ <persona>` on the identity strip and the same palette opens. All three go to the same
@@ -526,8 +537,8 @@ Those first four are the shipped frame written out longhand, and
 [Writing the arrangement out](#writing-the-arrangement-out) says what each of them is. File
 order is split order, so the bar named last is split off last.
 
-Both are the first things a short terminal gives up — before the identity row, because the
-palette reaches everything they show and nothing is lost but the reminder.
+Both are given up by a short terminal well before the identity row, because the palette
+reaches everything they show and nothing is lost but the reminder.
 
 **You can edit the arrangement while the frame is running**, which is when you can see what
 you are arranging. The file is re-read at the next re-layout — a density row or a
@@ -687,13 +698,42 @@ already have, the tmux WINDOW the frame gets, which is what charter asks tmux fo
 than measuring the pane it was typed in.
 
 Below `[frame]`'s `min-cols`/`min-rows`, the side panel (`right`) is the first to drop —
-any shortage costs it, since it cannot spare its own divider. A further shortage in rows
-drops `top` too. Below half of either floor, every panel drops and the harness simply gets
-the whole terminal, the same choice `charter`'s own status line makes when it runs out of
-width. So a narrow terminal degrades to the two strips on its own; nothing has to be
-configured for it. A density change goes through the same floors, so choosing `full` in a
-terminal with no room for a side panel gives you the edges that fit rather than a failed
-split.
+any shortage costs it, since it cannot spare its own divider. Then the repo table, on
+either axis: a pane too narrow to draw a table, or too short to draw one repo row under its
+`▪ repos N` heading. Then the two tab bars, if you have placed them. The identity row goes
+**last**, with everything else, below half of either floor — where every panel drops and
+the harness simply gets the whole terminal, the same choice `charter`'s own status line
+makes when it runs out of width. So a narrow terminal degrades to the two strips on its
+own; nothing has to be configured for it. A density change goes through the same floors, so
+choosing `full` in a terminal with no room for a side panel gives you the edges that fit
+rather than a failed split.
+
+**A rung drops when the pane it would get cannot carry what the rung is for**, and among
+rungs that still can, the ones whose facts something else reaches go first. That is why
+`top` is last above `bottom`: it is one row saying which workspace you are in and which
+persona you are being, and on a terminal with no sidebar it is also the plane's only
+roster, while the bars are reminders `F2` replaces in two keystrokes and the table needs
+two rows before it can name a single repo.
+
+**This ordering changed, and the change costs the harness nothing.** A 120x10 terminal used
+to spend three rows — two pane rules and `▪ repos 8` — on a repo count, having just decided
+it could not afford the one row that names your workspace. Measured on tmux 3.7c and the
+3.2 floor, at 120 columns on a plane with eight clones:
+
+| rows | before | now |
+|---|---|---|
+| 20 | identity 1 · harness 12 · sidebar 12 · table 3 · attention 1 | *unchanged* |
+| 19 | harness 12 · table 4 · attention 1 | identity 1 · harness 12 · table 2 · attention 1 |
+| 18 | harness 12 · table 3 · attention 1 | identity 1 · **harness 14** · attention 1 |
+| 17 | harness 12 · table 2 · attention 1 | identity 1 · **harness 13** · attention 1 |
+| 16 | harness 12 · table 1 · attention 1 | identity 1 · harness 12 · attention 1 |
+| 15 | harness 11 · table 1 · attention 1 | identity 1 · harness 11 · attention 1 |
+| 10 | harness 6 · table 1 · attention 1 | identity 1 · harness 6 · attention 1 |
+
+A table pane the rows cannot afford was floored at one row and still paid for its rule, so
+from 16 rows down the exchange is exactly even — a count for a name — and at 17 and 18 the
+harness gains the rows the table was spending on two repos. Above 19 nothing about your
+frame moves.
 
 A resize goes through them too, so a *running* frame degrades and recovers the same way a
 launch would — with one exception. Dragging below half the floors does not take the last
@@ -1847,12 +1887,13 @@ remember the flags. The workspace is the session; tmux puts you back on whicheve
 chats was last in front of you.
 
 ```
-charter · 11 to choose from
+charter · 12 to choose from
 >   workspace: alpha — pick another    cannot switch: a chat belongs to its workspa…
     persona: steward — pick another
     detach — leave the harness running
     repo: select the next row
     repo: select the previous row
+    todo: read the next open todo
     density: minimal
     density: normal
   * density: full

--- a/docs/news/unreleased-a-short-terminal-keeps-the-row-that-says-where-you-are.md
+++ b/docs/news/unreleased-a-short-terminal-keeps-the-row-that-says-where-you-are.md
@@ -1,0 +1,111 @@
+---
+version: unreleased
+headline: A short terminal keeps the row that says where you are, and your hidden todos are one keypress away
+---
+
+Two reports about the bottom of the frame, from the same audit.
+
+## The ten-row terminal was spending three rows to say the number 8
+
+Shrink a framed terminal to 120x10 and this is the whole screen:
+
+```
+h$
+                        <- five rows of harness
+────────────────────────────────────────
+▪ repos 8
+────────────────────────────────────────
+7 todos · F2 palette
+```
+
+Six rows of agent session, three rows to say a repo count, one row of attention strip. The
+workspace name and the persona you are being — the two things the identity row exists to
+tell you — are gone, dropped a few rows earlier to make room. The repo table's own pane had
+by then shrunk to a single row, which is its heading and no repo at all: `▪ repos 8` between
+two pane rules.
+
+**The ladder now drops the table before the identity row, on rows as well as on columns.**
+The table already refused to be drawn in a pane too narrow for it (below 95 columns the slot
+is not split at all, rather than split for a bordered rectangle with nothing in it). It has
+the same rule on its other axis now: a pane too short to draw one repo row under its heading
+is not split either. And the identity row leaves the group that goes at `min-rows` — it is
+one row carrying two facts nothing else on a short terminal says, and on a terminal with no
+sidebar it is the plane's only persona roster, so it goes last, with everything else, below
+half the floors.
+
+**This costs your harness nothing.** Measured on real tmux — 3.7c and the 3.2 floor, a real
+client on a real pty, byte-identical on both — at 120 columns on a plane with eight clones:
+
+| rows | before | now |
+|---|---|---|
+| 20 | identity 1 · harness 12 · sidebar 12 · table 3 · attention 1 | *unchanged* |
+| 19 | harness 12 · table 4 · attention 1 | identity 1 · harness 12 · table 2 · attention 1 |
+| 18 | harness 12 · table 3 · attention 1 | identity 1 · **harness 14** · attention 1 |
+| 17 | harness 12 · table 2 · attention 1 | identity 1 · **harness 13** · attention 1 |
+| 16 | harness 12 · table 1 · attention 1 | identity 1 · harness 12 · attention 1 |
+| 15 | harness 11 · table 1 · attention 1 | identity 1 · harness 11 · attention 1 |
+| 10 | harness 6 · table 1 · attention 1 | identity 1 · harness 6 · attention 1 |
+
+A table pane the rows could not afford was floored at one row and still paid for its pane
+rule, so from 16 rows down the exchange is exactly even: two rows of terminal that said `▪
+repos 8` now say `⬢ alpha · ◆ steward`. At 17 and 18 the harness gains the rows the table
+was spending on one or two repo rows. Nothing about a frame at 20 rows or above moves.
+
+**What you lose, said plainly.** Between 17 and 19 rows the table draws fewer repos than it
+did — two fewer at 19, all of them at 17 and 18. That is the trade the ladder was always
+supposed to make and did not: the frame ranks the table below the identity row, and until now
+the table's pane was the one thing on the rows axis with no test of its own to fail.
+
+**The rule, so the next rung has one to follow.** A rung drops when the pane it would get
+cannot carry the thing the rung is for; among rungs that still can, the ones whose facts
+another surface reaches go first. `bottom` never drops — it is the one alert and the command
+that fixes it. `top` is last above it. The tab bars go at `min-rows` because `F2` reaches
+every chat and every workspace at every width. The table goes above them because it needs
+two rows before it can name a single repo.
+
+## `…(+5 more)` todos you could not get at without leaving the frame
+
+The sidebar draws your open todos under your personas, and a short pane draws two of them
+and a count:
+
+```
+│▪ todos 7
+│- Audit auth token ro…
+│- Cut 0.55.0
+│  …(+5 more)
+```
+
+Those five were reachable only by typing `charter workspace todo` into the harness — which
+is the surface the frame exists to replace. The persona column above them got its route in
+the last release (click a name to adopt it, click its badges to be told what they mean). The
+todo list had nothing: no click, no key, no palette row.
+
+**`F2` → `todo: read the next open todo`.** It reads the list out on the palette's own
+header, one press per todo:
+
+```
+charter /todo · todo 3/7: Cut 0.55.0
+>   todo: read the next open todo
+```
+
+It repeats, like the two `repo: select the …` rows, so five hidden todos are five Enters and
+one palette rather than five. It says where you are in the list, because a wrap that did not
+would read as a repeat; it wraps at the end rather than pressing nothing; and on a plane
+whose cache holds part of a very long list it says that too — `todo 3/20 of 400: …`, counted
+against the same total your `▪ todos N` heading carries, so the header and the pane cannot
+disagree.
+
+**A key rather than a wheel, deliberately.** `[frame] mouse` ships off, so a pointer-only
+answer would be inert on exactly the frames this was reported from — and charter's own rule
+runs that way anyway: a pointer affordance always has a key or a palette row beside it, so
+the keyboard route is the half that has to exist. A wheel over the section can be added on
+top of this. It could not have stood in for it.
+
+**The `…(+5 more)` row still does nothing when you click it**, and that is not an omission.
+It stands for todos it does not name, so there is no todo for a click on it to be about —
+the same case the persona column's own overflow row has carried since it became clickable.
+What changed is that the content behind the count has a route, not that the count became a
+door.
+
+It costs nothing when you are not pressing it: the row reads the plane snapshot the palette
+had already loaded to draw itself, writes no file, bumps no version and starts no process.

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -852,6 +852,11 @@ class BothBarsGoWhenTheRowsRunOut(unittest.TestCase):
     the palette makes redundant. `layout._ROW_DROPS` derives the row-edge half from it, so
     the list is now the mechanism and these assertions are about behaviour rather than
     about a tuple.
+
+    **`top` left `_ROW_DROPS` in #740 and the bars stayed**, which is the same argument
+    carried one step further: the bars go at `min_rows` because `F2` reaches every chat
+    and every workspace at every width, and `top` does not go there because nothing
+    reaches the workspace and the persona it names. See `layout.visible_slots`.
     """
 
     ALL = ["chats", "workspaces", "top", "bottom", "repos", "right"]
@@ -864,10 +869,17 @@ class BothBarsGoWhenTheRowsRunOut(unittest.TestCase):
     def test_a_roomy_terminal_keeps_both_bars(self):
         self.assertEqual(self._kept(200, 50), self.ALL)
 
-    def test_a_short_terminal_gives_up_both_bars_with_the_identity_row(self):
+    def test_a_short_terminal_gives_up_both_bars_and_keeps_the_identity_row(self):
+        """**The identity row's half of this reversed in #740**, and the bars' half did
+        not. A bar is a readout the palette reaches in two keystrokes at every width, so a
+        short terminal loses the reminder and nothing else; `top`'s workspace and persona
+        are reached by nothing else once the sidebar has gone, which is why ranking it
+        beside them was the inversion that issue is about."""
         kept = self._kept(200, 16)
-        for gone in ("chats", "workspaces", "top", "right"):
+        for gone in ("chats", "workspaces", "right"):
             self.assertNotIn(gone, kept)
+        self.assertIn("top", kept,
+                      "the identity row is above both bars in _DROP_ORDER")
         self.assertIn("bottom", kept,
                       "the attention strip is the one slot that never goes")
 
@@ -877,4 +889,7 @@ class BothBarsGoWhenTheRowsRunOut(unittest.TestCase):
         kept = self._kept(200, 16)
         for name in layout._ROW_DROPS:
             self.assertNotIn(name, kept, f"{name} is in _ROW_DROPS and survived")
-        self.assertEqual(layout._ROW_DROPS, ("chats", "workspaces", "top"))
+        self.assertEqual(layout._ROW_DROPS, ("chats", "workspaces"))
+        self.assertEqual(layout._DROP_ORDER[-1], "top",
+                         "`top` left _ROW_DROPS and must still be last in the order it "
+                         "is derived from — see layout.visible_slots (#740)")

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -51,10 +51,102 @@ class VisibleSlots(unittest.TestCase):
             layout.visible_slots(["top", "bottom", "right"], 80, 50, 100, 20),
             ["top", "bottom"])
 
-    def test_the_top_goes_next_when_the_terminal_is_short(self):
+    def test_the_identity_row_outlives_every_row_drop_but_the_floor(self):
+        """**#740, and this test used to assert the opposite.** `top` went in the same
+        breath as the two bars, the instant rows fell below `min_rows` — while `repos` had
+        no rows test at all and so kept a pane with room for its heading and no repo. One
+        row carrying the workspace and the persona is the last thing above `bottom` worth
+        keeping (on a short terminal it is also the plane's only roster, `slots._top`), so
+        it now goes only where everything goes: below half the floors.
+
+        Both sides, because the absence assertion alone is satisfied by a `visible_slots`
+        that keeps `top` at every size and then keeps it below the floor too."""
         self.assertEqual(
             layout.visible_slots(["top", "bottom", "right"], 200, 12, 100, 20),
-            ["bottom"])
+            ["top", "bottom"])
+        self.assertEqual(
+            layout.visible_slots(["top", "bottom", "right"], 200, 9, 100, 20), [])
+
+    def test_the_table_goes_when_its_pane_would_be_too_short_for_a_repo_row(self):
+        """#740's own drop, and the other axis of the width one below. `slots._repos`
+        spends its first row on `▪ repos N` and `_table_lines` draws nothing on what is
+        left of a one-row pane, so the pane was two tmux rules and a count — three rows
+        of a ten-row terminal, on a terminal that had just been judged too short for the
+        one row naming the workspace.
+
+        Asserted at the boundary from both sides. With `top` and `bottom` on screen the
+        cap `layout.repos_row_cap` answers reaches `_table_min_rows` at 19 rows and falls
+        below it at 18, which is `19 - 4 - 1 - 12 = 2` against `18 - 4 - 1 - 12 = 1`."""
+        slots_ = ["top", "bottom", "repos"]
+        self.assertEqual(layout.repos_row_cap(slots_, window_rows=19), 2)
+        self.assertIn("repos", layout.visible_slots(slots_, 200, 19, 100, 20))
+        self.assertNotIn("repos", layout.visible_slots(slots_, 200, 18, 100, 20))
+
+    def test_the_identity_row_gets_its_row_before_the_table_does(self):
+        """The precedence #740 asks for, and the reason the rows test is asked about the
+        slots that SURVIVED rather than about the configured list. At ten rows the table
+        is asked what is left after `top` has its row — nothing — so what the frame draws
+        is the workspace and the persona, not the number 8."""
+        self.assertEqual(
+            layout.visible_slots(["top", "bottom", "repos"], 200, 10, 100, 20),
+            ["top", "bottom"])
+
+    #: What the HARNESS pane gets at each height between the two floors, before #740 and
+    #: after it — the measurement the drop-order choice rests on rather than a preference
+    #: between two panels. 120 columns, a nine-row table's worth of content, the shipped
+    #: `[frame] slots`, `min-cols`/`min-rows` at their defaults.
+    #:
+    #: **The harness never loses a row and gains one at 17 and two at 18**, because a
+    #: `repos` pane the rows cannot afford was floored at `SLOT_SIZE["repos"]` and still
+    #: paid `_BORDER_ROWS` — two rows to draw `▪ repos 8` between two tmux rules. At 19
+    #: the table survives its new rows test with two rows (its heading and one repo), so
+    #: the harness is unchanged there and the trade is two repo rows for the workspace and
+    #: the persona.
+    #:
+    #: Literals, not a formula: a table computed from the thing under test is the shape
+    #: that survives every mutation of it.
+    _HARNESS_BEFORE_AND_AFTER = {
+        10: (6, 6), 11: (7, 7), 12: (8, 8), 13: (9, 9), 14: (10, 10),
+        15: (11, 11), 16: (12, 12), 17: (12, 13), 18: (12, 14), 19: (12, 12),
+    }
+
+    def test_the_swap_never_costs_the_harness_a_row(self):
+        """#740's own justification, at every height between the floors."""
+        for rows, (was, now) in self._HARNESS_BEFORE_AND_AFTER.items():
+            with self.subTest(rows=rows):
+                # Before: `top` went with the bars and `repos` kept whatever the rows left
+                # it — its own floor from 16 down, where it could draw no repo at all.
+                before = {"bottom": 1,
+                          "repos": layout.repos_rows(content_rows=9, window_rows=rows,
+                                                     slots=["bottom", "repos"])}
+                self.assertEqual(layout.harness_rows(before, window_rows=rows), was)
+                kept = layout.visible_slots(["top", "bottom", "repos", "right"],
+                                            200, rows, 100, 20)
+                self.assertIn("top", kept, "the identity row is what this buys")
+                sizes = layout.slot_sizes(kept, window_rows=rows, content_rows=9)
+                self.assertEqual(layout.harness_rows(sizes, window_rows=rows), now)
+                self.assertGreaterEqual(now, was, "the harness paid for this")
+
+    def test_the_table_is_the_one_that_survives_at_the_top_of_the_band(self):
+        """The other end of the same table: at 19 rows both fit, so the ladder keeps both
+        and the table draws its heading and one repo rather than four rows of table with no
+        identity strip above it."""
+        self.assertEqual(
+            layout.visible_slots(["top", "bottom", "repos", "right"], 200, 19, 100, 20),
+            ["top", "bottom", "repos"])
+        self.assertEqual(
+            layout.slot_sizes(["top", "bottom", "repos"], window_rows=19,
+                              content_rows=9)["repos"], 2)
+
+    def test_the_height_the_table_needs_is_read_from_the_renderer_not_copied(self):
+        """`test_the_width_the_table_needs_is_read_from_the_renderer_not_copied`'s
+        argument on the other axis, and the constant is MOVED for the same reason: read
+        where it stands, a `_table_min_rows` whose body is `return 2` is indistinguishable
+        from one that asks the renderer."""
+        from charter.frame import slots as frame_slots
+        with mock.patch.object(frame_slots, "_TABLE_MIN_ROWS",
+                               frame_slots._TABLE_MIN_ROWS + 5):
+            self.assertEqual(layout._table_min_rows(), frame_slots._TABLE_MIN_ROWS)
 
     def test_the_bottom_is_never_dropped_whatever_the_shortage(self):
         """The reason `bottom` is absent from every filter above. It is the attention

--- a/tests/test_frame_switch.py
+++ b/tests/test_frame_switch.py
@@ -295,7 +295,13 @@ class ThePaletteOffersAPickerForEach(PersonaIso, unittest.TestCase):
         ids = [r.id for r in _rows(self.FID)]
         self.assertEqual(ids[:5], ["pick:workspace", "pick:persona", "pick:change",
                                    "pick:chat", "frame.detach"])
-        self.assertTrue(any(i.startswith("density.") for i in ids[5:8]), ids)
+        # The list rows (`repo.next`, `repo.previous`, `todo.next` — #742) sit between
+        # `detach` and the densities, so the densities are named by prefix rather than by
+        # index: what this test is about is the four doorways coming first.
+        self.assertTrue(any(i.startswith("density.") for i in ids[5:]), ids)
+        self.assertLess([i for i, v in enumerate(ids) if v == "frame.detach"][0],
+                        [i for i, v in enumerate(ids)
+                         if v.startswith("density.")][0], ids)
 
     def test_each_doorway_says_which_name_the_frame_is_on(self):
         """So the palette still answers "which workspace am I on" without opening

--- a/tests/test_the_sidebars_todos_have_a_keyboard_route.py
+++ b/tests/test_the_sidebars_todos_have_a_keyboard_route.py
@@ -1,0 +1,247 @@
+"""The sidebar's `…(+N more)` todos are reachable without leaving the frame — #742.
+
+The issue reported the sidebar as a list that looks like a list you can act on and handles
+nothing: *"Click `forge` → nothing. Wheel over the todo list → nothing. `F2` has no todo
+action of any kind."* #765 answered the persona half — a click on a name switches, a click
+on the badges explains them — and left this half open on the record, because every cheap
+route to the hidden todos was worse than the honest count.
+
+**What ships here is a KEY, and the ordering is the design rather than an easier subset.**
+`[frame] mouse` is off on the shipped default, so a pointer-only answer would be inert on
+exactly the planes this was reported from; and `docs/frame.md`'s rule runs the same way —
+a pointer affordance always has a key or a palette row beside it, so the keyboard route is
+the half that has to exist. A wheel over the section can be added on top of this later. It
+could not have stood in for it.
+
+**What is asserted here is the SENTENCE, not that something happened.** The row's whole
+output is one line on the palette's header (`commands_frame._again`), so "it reported
+something" is satisfied by every wrong answer this could give — the wrong todo, the wrong
+position, a position counted against the clipped list rather than the plane's own total.
+Each of those is a literal below.
+
+**And the row that must go on answering nothing is asserted too.** `…(+N more)` stands for
+todos it does not name, so it cannot resolve to one — `slots._Chips.hit`'s rule for the
+persona column's own overflow line, one section down. This closes #742 by giving the
+CONTENT a route, not by making that row a door.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+from charter import statusline, tui
+from charter.frame import action as faction
+from charter.frame import builtin_actions, gather, slots, state
+from tests._isolation import PersonaIso
+
+FID = "f-todo-route"
+
+
+def _snapshot(titles, *, total=None) -> dict:
+    return {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+            "repos": [], "worktrees": [],
+            "todos": [{"title": t} for t in titles],
+            "todo_count": len(titles) if total is None else total}
+
+
+class TheTodosHaveAPaletteRow(PersonaIso, unittest.TestCase):
+    """`builtin_actions._register_todos` — `F2`, `todo`, Enter, Enter, Enter."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        state.frame_dir(FID, create=True)
+
+    def _reg(self):
+        return builtin_actions.build(FID, current_density="normal", current_chrome="off")
+
+    def _run(self, reg, snapshot):
+        a = reg.get("todo.next")
+        return a.run(faction.build(a.touches, fid=FID, snapshot=snapshot))
+
+    def test_the_palette_offers_one_row_for_the_todos(self):
+        self.assertEqual([a.title for a in self._reg().all() if a.id.startswith("todo.")],
+                         ["todo: read the next open todo"])
+
+    def test_it_reads_the_todos_out_in_the_order_the_sidebar_draws_them(self):
+        """`open_todos` is oldest-first and the sidebar's rows are its own top, so the row
+        after the last one on screen is the next press — not a fresh sample. Asserted as
+        the three exact sentences, because "it said something" is satisfied by any order."""
+        reg, snap = self._reg(), _snapshot(["oldest", "middle", "newest"])
+        self.assertEqual([self._run(reg, snap) for _ in range(3)],
+                         ["todo 1/3: oldest", "todo 2/3: middle", "todo 3/3: newest"])
+
+    def test_it_wraps_rather_than_pressing_nothing_at_the_end(self):
+        """`_select`'s argument for wrapping: a row that visibly does nothing reads as
+        broken and costs a whole `F2` to find out. The POSITION is what stops a wrap
+        looking like a repeat, which is why the fraction is in the sentence."""
+        reg, snap = self._reg(), _snapshot(["one", "two"])
+        self.assertEqual([self._run(reg, snap) for _ in range(3)],
+                         ["todo 1/2: one", "todo 2/2: two", "todo 1/2: one"])
+
+    def test_the_cursor_belongs_to_one_palette_and_starts_again_at_the_top(self):
+        """The cell is closed over in the registry, and `build` makes a fresh registry per
+        palette. An operator who opens `F2` to read their todos means the first one — a
+        cursor that survived the last palette would answer from a list they have stopped
+        looking at."""
+        snap = _snapshot(["one", "two"])
+        first = self._reg()
+        self.assertEqual(self._run(first, snap), "todo 1/2: one")
+        self.assertEqual(self._run(first, snap), "todo 2/2: two")
+        self.assertEqual(self._run(self._reg(), snap), "todo 1/2: one")
+
+    def test_it_writes_nothing_and_bumps_nothing(self):
+        """`_select` records the repo selection through `state` because a PANE redraws
+        from it. Nothing redraws from this — the answer is the sentence — so a `state`
+        write plus the `state.bump` that wakes every panel would be four panels repainting
+        per keypress to move a number nobody else reads."""
+        was = state.version(FID)
+        self._run(self._reg(), _snapshot(["one", "two"]))
+        self.assertEqual(state.version(FID), was)
+
+    def test_it_starts_no_process_at_all(self):
+        """Unlike the density and surface rows, and for `_select`'s measured reason: this
+        is arithmetic over a snapshot the palette already read, and `cmd_palette` joins the
+        invocation before it closes the pane."""
+        with mock.patch.object(builtin_actions.subprocess, "Popen",
+                               side_effect=AssertionError("started a process")):
+            self.assertEqual(self._run(self._reg(), _snapshot(["one"])), "todo 1/1: one")
+
+    def test_the_position_is_counted_against_the_planes_own_total(self):
+        """`gather._MAX_TODOS` bounds the LIST the cache holds and `todo_count` records
+        what was there before the bound, so a plane with four hundred open todos and
+        twenty cached must not be told `3/20` under a sidebar heading saying `todos 400`.
+        The row says which list it is walking and how long the real one is."""
+        snap = _snapshot([f"todo {i}" for i in range(20)], total=400)
+        self.assertEqual(self._run(self._reg(), snap), "todo 1/20 of 400: todo 0")
+
+    def test_an_unclipped_list_says_so_by_saying_nothing_extra(self):
+        """The `of N` clause is the CLIP, not decoration: on the ordinary plane the cache
+        holds everything and a second number would be the same number twice."""
+        self.assertEqual(self._run(self._reg(), _snapshot(["one", "two"])),
+                         "todo 1/2: one")
+
+    def test_a_workspace_with_nothing_open_is_told_why_rather_than_pressing_nothing(self):
+        reg = self._reg()
+        offers = {o.id: o for o in reg.offers(fid=FID, snapshot=_snapshot([]))}
+        self.assertFalse(offers["todo.next"].available)
+        self.assertIn("charter workspace todo", offers["todo.next"].reason)
+        self.assertTrue({o.id: o for o in reg.offers(
+            fid=FID, snapshot=_snapshot(["one"]))}["todo.next"].available)
+
+    def test_run_on_an_empty_list_answers_nothing_rather_than_raising(self):
+        """`available` refuses the row, so the palette never reaches this — but `run` is
+        callable without that check and `% 0` is the one way this could raise instead of
+        answer. `Palette.report`'s own contract for an empty answer is "an action that
+        answered nothing has nothing to report"."""
+        self.assertEqual(self._run(self._reg(), _snapshot([])), "")
+        self.assertEqual(self._run(self._reg(), {}), "")
+
+    def test_a_todo_with_no_title_reads_as_nothing_and_never_as_the_word_None(self):
+        """The other half of "a gather cache is JSON another process wrote". A row with no
+        `title` key is a row, so it is counted and walked — and the sentence ends after the
+        colon rather than reporting Python's `None` as the thing you are supposed to do."""
+        snap = _snapshot([])
+        snap["todos"] = [{}, {"title": "real"}]
+        snap["todo_count"] = 2
+        said = self._run(self._reg(), snap)
+        self.assertEqual(said, "todo 1/2: ")
+        self.assertNotIn("None", said)
+
+    def test_a_row_that_is_not_a_row_is_skipped_by_both_halves(self):
+        """A gather cache is JSON another process wrote; `ctx` contains it no further than
+        making the list a tuple. `available` and the walk ask the same filter, so a row
+        listed as available cannot then answer "nothing"."""
+        snap = _snapshot([])
+        snap["todos"] = ["not a mapping", {"title": "real"}, 7]
+        reg = self._reg()
+        self.assertTrue({o.id: o for o in reg.offers(
+            fid=FID, snapshot=snap)}["todo.next"].available)
+        self.assertEqual(self._run(reg, snap), "todo 1/1: real")
+
+    def test_it_survives_being_repeated_which_is_what_makes_it_one_palette(self):
+        """`repeat=True`. Without it each Enter closes the pane, kills the process and
+        re-splits for the next — the fourteen-keystroke, three-cycle cost #746 measured on
+        the repo rows, paid once per hidden todo."""
+        self.assertTrue(self._reg().get("todo.next").repeat)
+
+
+class TheCountTheHeadingDrawsIsTheCountTheRowWalks(PersonaIso, unittest.TestCase):
+    """`slots.todo_total` — one answer, read by the sidebar's heading and by the palette
+    row, because two spellings of "how many are open" is the drift #742's fix cannot have.
+    """
+
+    def _render(self, *, cols=40, rows=26) -> list[str]:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return [tui.strip_ansi(ln)
+                    for ln in slots.render("right", FID).split("\n")]
+
+    def test_the_heading_and_the_row_agree_on_a_clipped_cache(self):
+        snap = _snapshot([f"todo {i}" for i in range(20)], total=400)
+        gather.save(FID, snap)
+        self.assertIn(f"{statusline._HEAD_PAD}todos 400", self._render())
+        reg = builtin_actions.build(FID, current_density="normal", current_chrome="off")
+        a = reg.get("todo.next")
+        said = a.run(faction.build(a.touches, fid=FID, snapshot=snap))
+        self.assertIn("of 400", said)
+
+    def test_a_count_smaller_than_the_list_is_refused_by_the_shared_answer(self):
+        """A cache whose two halves disagree — `todo_count` below the number of items it
+        actually holds. Falling back to the list is what stops the frame reporting fewer
+        todos than it is drawing."""
+        self.assertEqual(slots.todo_total({"todos": [{"title": "a"}, {"title": "b"}],
+                                           "todo_count": 1}), 2)
+
+    def test_a_cache_written_before_the_count_existed_answers_what_it_holds(self):
+        self.assertEqual(slots.todo_total({"todos": [{"title": "a"}]}), 1)
+
+    def test_nothing_at_all_is_zero_rather_than_a_raise(self):
+        self.assertEqual(slots.todo_total({}), 0)
+
+    def test_a_count_that_is_not_a_number_answers_the_list_rather_than_raising(self):
+        """The `isinstance` is what stands between a corrupt cache and a `TypeError` on a
+        SIDEBAR REPAINT. `gather`'s cache is JSON another process wrote, so `todo_count` is
+        whatever is in that file; the arithmetic below it is a `max` against an `int`, and
+        `max("many", 2)` raises rather than answering. A pane that raises is a dead pane
+        the operator has to relaunch to be rid of, so anything that is not a count is
+        treated as no count at all — which is the same answer an older cache gets."""
+        for junk in ("many", None, [7], {"n": 7}, 4.5):
+            with self.subTest(todo_count=junk):
+                self.assertEqual(
+                    slots.todo_total({"todos": [{"title": "a"}], "todo_count": junk}), 1)
+
+
+class TheOverflowRowStillAnswersNothing(PersonaIso, unittest.TestCase):
+    """#742 is closed by giving the CONTENT a route, never by making that row a door.
+
+    `slots._Chips.hit` is the sidebar's one resolver and it publishes a row per persona;
+    every row below the persona column — the blank separators, every todo row and its
+    `…(+N more)` — is out of bounds. A row that stands for todos it does not name cannot
+    resolve to one, which is the same case the persona column's own overflow line carries.
+    """
+
+    def test_no_row_of_the_todo_section_resolves_to_anything(self):
+        for i in range(6):
+            self.make_persona(f"p{i}")
+        gather.save(FID, _snapshot([f"todo {i}" for i in range(9)]))
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((22, 20))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = slots.render("right", FID)
+        lines = [tui.strip_ansi(ln) for ln in out.split("\n")]
+        first_todo = next(i for i, ln in enumerate(lines) if "todos" in ln)
+        self.assertTrue(any("…(+" in ln for ln in lines[first_todo:]),
+                        f"this pane is not overflowing its todos: {lines}")
+        for row in range(first_todo, len(lines)):
+            for col in (0, 2, 10, 21):
+                self.assertIsNone(slots.CHIPS.hit(row, col),
+                                  f"row {row} col {col} of the todo section resolved: "
+                                  f"{lines[row]!r}")
+
+
+if __name__ == "__main__":      # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Closes #740. Closes #742.

Two frame-UX reports from the same audit. The third, #766, is closed separately as *measured, deliberately not shipped* — its numbers and mine are on the issue so the next person does not re-measure it.

## #740 — the ladder was inverted at the bottom

`_ROW_DROPS` took `top` the instant rows fell below `min-rows`, while `repos` had **no rows threshold at all**. So a 120x10 frame spent three rows — two pane rules and `▪ repos 8` — on a repo count, having just decided it could not afford the one row that names the workspace and the persona.

**The rule I chose, stated because the old one was unexamined rather than wrong:** *a rung drops when the pane it would get cannot carry the thing the rung is for; among rungs that still can, the ones whose facts another surface reaches go first.*

That gives the ladder `_DROP_ORDER` always claimed, now honoured on both axes:

| rung | goes when |
|---|---|
| `right` | any shortage — it costs columns *and* a divider |
| `repos` | its pane is too narrow for a table (`repos_fits`) **or too short for one repo row** (`repos_fits_rows`, new) |
| `chats`, `workspaces` | at `min-rows`, whole — `F2` reaches every chat and workspace in two keystrokes |
| `top` | only at the floor, with everything else |
| `bottom` | never |

Two changes:

* **`repos` gets a rows threshold, the mirror of its columns one.** `repos_fits_rows` over a new `repos_row_cap`, tested against `_table_min_rows()` which READS `slots._TABLE_MIN_ROWS` exactly the way `_table_min_cols()` reads `statusline._LEFT_W`. `repos_rows` applies the same `repos_row_cap`, so "is this pane worth splitting" and "how tall is it" come from one arithmetic instead of two.
* **`top` leaves `_ROW_DROPS`.** Nothing else on a short terminal says which workspace you are in or which persona you are being, and with the sidebar gone it is also the plane's only roster (#530).

### Measured, on real tmux

3.7c and the 3.2 floor (`~/.local/share/charter-testing/tmux-3.2`), own socket, 120 columns, a plane with eight clones. Byte-identical on both versions. The splits are built from `layout`'s own edge and size answers and the panes read back with `list-panes`.

| rows | before | now |
|---|---|---|
| 20 | identity 1 · harness 12 · sidebar 12 · table 3 · attention 1 | *unchanged* |
| 19 | harness 12 · table 4 · attention 1 | identity 1 · harness 12 · table 2 · attention 1 |
| 18 | harness 12 · table 3 · attention 1 | identity 1 · **harness 14** · attention 1 |
| 17 | harness 12 · table 2 · attention 1 | identity 1 · **harness 13** · attention 1 |
| 16 | harness 12 · table 1 · attention 1 | identity 1 · harness 12 · attention 1 |
| 15 | harness 11 · table 1 · attention 1 | identity 1 · harness 11 · attention 1 |
| 10 | harness 6 · table 1 · attention 1 | identity 1 · harness 6 · attention 1 |

The "before" column reproduces the issue's own measurements exactly. **The harness never loses a row** — a table pane starved to its floor paid a border plus one row, which is what `top` costs — and it gains one at 17 and two at 18. **What this costs is one or two repo rows between 17 and 19**, which is the trade `_DROP_ORDER` already ranked and the rows axis had no test to make.

`tests/test_frame_layout.py` pins that whole table as literals through `harness_rows`.

## #742 — what remained, and how it closes

Confirmed before touching anything: **#765 shipped the persona half** — the sidebar declares `click`, `slots.persona_section` publishes a row→persona map on every rung, a click on a name runs `charter frame-switch --persona`, and a click on the badges puts the glyph legend on the attention row through #729's dwell. Only the todo overflow remained, which is why it was not auto-closed.

`F2` → **`todo: read the next open todo`** is the route. One repeatable palette row that reads the open todos out on the palette's own header:

```
charter /todo · todo 3/7: cut 0.55.0
```

It repeats like the two `repo: select the …` rows, so five hidden todos are five Enters and one palette. It wraps rather than pressing nothing; it says where in the list it is, because a wrap that did not would read as a repeat; and on a plane whose gather cache holds part of a very long list it says that too — `todo 3/20 of 400: …`, counted through a new shared `slots.todo_total` so the row and the `▪ todos N` heading cannot disagree about a clipped cache.

**A key rather than a wheel, and that ordering is the design.** `[frame] mouse` ships off, so a pointer-only answer would be inert on exactly the planes this was reported from — and `docs/frame.md`'s own rule runs that way anyway: a pointer affordance always has a key or a palette row beside it, so the keyboard half is the one that has to exist. A wheel over the section can be added on top of this; it could not have stood in for it.

**The `…(+N more)` row still answers nothing**, and a test asserts it: it stands for todos it does not name, so there is no todo for a click on it to be about — the same case the persona column's own overflow row carries.

It is free when nobody presses it: `cmd_palette` already loads the gather snapshot to draw itself, and the row writes no file, bumps no version and starts no process. The cursor is a cell closed over in the registry, which `build` makes fresh per palette — so it starts at the top each time `F2` is pressed, and no `state.bump` wakes four panels to move a number nobody else reads.

## Verification

* Full suite green on the rebased tree: **9,808 tests, 0 failures** (`python3 -B -m unittest discover -s tests`). `test_frame_border_surface` now passes — #785's fix in #799 landed, so that failure is no longer an expected worktree artefact and this branch does not produce one.
* **Every new guard was checked to fail without its change**, not merely to pass with it: `_ROW_DROPS` with `top` back in (16 failures), `visible_slots` without the rows test (11), `_table_min_rows` as a literal `2` (1), `todo.next` unregistered (13), the fraction counted off the clipped list (2), no wrap (1), `repeat=False` (1), `todo_total` ignoring `todo_count` (3), `_HEAD_ROWS = 2` (45), `_TABLE_MIN_ROWS = _HEAD_ROWS` (2), the title fallback dropped (1), `max`→`min` in `todo_total` (4), the `isinstance` guard dropped (4).
* **Two lines were rewritten because the sweep would have been right about them.** `todo_total` moved out of `_todo_rows` carrying `raw if raw >= len(items) else len(items)` — at `raw == len(items)` both arms answer the same number, so `>=` versus `>` is unobservable and no test could ever turn it red. It is `max(raw, len(items))` now, with no branch to get wrong. And the `isinstance` beside it survived its own deletion until a test fed a `todo_count` that is not a number — which a JSON cache another process wrote can be, and which would otherwise have raised `TypeError` on a sidebar repaint.
* No rendered string was changed by this branch, so no `assertNotIn` needle was deleted out from under an absence assertion. The one absence assertion added (`assertNotIn("repos", …)`) is paired with the `assertIn` from the other side of the same boundary, and the `top` entry removed from a `gone` tuple in `test_frame_bars.py` is replaced by an explicit `assertIn("top", kept)`.
* Real tmux on 3.7c and the 3.2 floor, own socket, reaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
