### PR TITLE
A corrupt repo cache says so, instead of gathering forever (#735)

### DIFF
--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 import os
 import subprocess
 
-from .. import contain, util
+from .. import util
 from . import action, actions, choose, state, tmuxctl
 
 #: What marks the density a frame is currently on. **One constant, not two**: it is
@@ -370,16 +370,22 @@ def _regather(fid: str):
     `commands_frame._spawn_gather`'s, verbatim — two ways to start the same gather that
     must not drift apart.
 
-    `contain.one_line` on the way back and not on the way out. The argv is a list, so a
-    name carrying a newline reaches `cmd_gather` as one argument whatever is in it; the
-    RECEIPT is text drawn on the operator's screen, and `frame/slots.py`'s `_empty_lines`
-    records that `workspace_for`'s last rung hands back `$CHARTER_WORKSPACE` stripped and
-    otherwise unchecked.
+    **No `contain.one_line` over *ws*, and the sweep is what settled that.** The name is
+    genuinely unchecked — `frame/slots.py`'s `_empty_lines` records that `workspace_for`'s
+    last rung hands back `$CHARTER_WORKSPACE` stripped and otherwise untouched — so both
+    places it reaches were measured rather than assumed. The argv is a LIST, so a name
+    carrying a newline arrives at `cmd_gather` as one argument whatever is in it. The
+    RECEIPT is contained by the contract: `actions.Invocation._work` runs
+    `contain.one_line(str(note), limit=REASON_LIMIT)` over whatever this returns, which is
+    the same reason `_select` hands back a bare repo name. A second call here changed no
+    outcome — the deletion sweep found it surviving, correctly — and `_empty_lines`' own
+    warning is exactly this shape: a guard kept for a reason that is not the true one is
+    how the real one gets deleted later.
     """
     ws = state.workspace_for(fid)
     _spawn(util.self_relaunch_argv("frame-gather", "--session", fid, "--workspace", ws),
            fid=fid)
-    return f"gathering {contain.one_line(ws)}…"
+    return f"gathering {ws}…"
 
 
 def build(fid: str, *, current_density: str,

--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 import os
 import subprocess
 
-from .. import util
+from .. import contain, util
 from . import action, actions, choose, state, tmuxctl
 
 #: What marks the density a frame is currently on. **One constant, not two**: it is
@@ -320,6 +320,68 @@ def _run_chrome(fid: str, level: str):
     return f"chrome → {level}"
 
 
+def _register_regather(reg: actions.ActionRegistry) -> None:
+    """One row that re-runs this frame's gather — **#735's route out.**
+
+    `charter frame-gather` already existed and already fixed a broken cache instantly. What
+    it wants is `--session` and `--workspace`, and an operator sitting in front of a repo
+    pane that will not draw can discover neither: the frame id is charter's own
+    `{workspace}-{hash}`, and the flags are required precisely because a detached child
+    must never guess at them (#512, and `cmd_gather`'s own docstring). The palette knows
+    both, so the row is the command with its two answers already filled in.
+
+    **Always available, and it is the one row that has to be.** Every other refusal this
+    module reports is about a record charter lost — a harness pane, a pane map — and this
+    is the action an operator reaches for when a pane has already failed. `cmd_gather`
+    needs nothing but the two names, and a row that refused on somebody else's
+    precondition would be refusing exactly when it is needed.
+
+    **Registered LAST among charter's own**, which is the one thing about it that is a
+    choice. Nearer the top would read better on the day you need it and would move every
+    density and chrome row down one — and `_register_density`'s own note is that a list
+    whose rows move is a list nobody learns. This is a row you reach for once, typed at,
+    by an operator who is already looking for it; the rows above it are pressed by muscle
+    memory.
+
+    **It refreshes the whole snapshot and the title says so.** `gather.refresh` writes
+    repos, worktrees, todos and changes under one timestamp (§4f's clock rule), so a title
+    naming only the repo table would be describing a third of what the row does — and the
+    todo count in `bottom` is drawn from the same file the broken table is.
+    """
+    reg.register(action.Action(
+        id="frame.gather",
+        title="refresh — gather this workspace's repos, todos and changes again",
+        run=lambda ctx: _regather(ctx.fid)))
+
+
+def _regather(fid: str):
+    """Start `charter frame-gather` for *fid*, detached, and say so.
+
+    **`state.workspace_for` and never `workspace.resolve`** — the one rule every frame
+    surface asks (#512). This runs in the palette's process, which is a tmux child with
+    no terminal of the operator's and a cwd that is not theirs, so resolving for itself
+    would refill the cache from whatever workspace THAT process landed on. A gather that
+    answered `default` on a plane that is not on it is the defect this row exists to
+    repair, arriving by a different door.
+
+    Detached through :func:`_spawn` like the density and surface rows, and for the module
+    docstring's reason: the palette closes the instant it has invoked, and a git sweep
+    running in the pane being killed dies with it. The argv is
+    `commands_frame._spawn_gather`'s, verbatim — two ways to start the same gather that
+    must not drift apart.
+
+    `contain.one_line` on the way back and not on the way out. The argv is a list, so a
+    name carrying a newline reaches `cmd_gather` as one argument whatever is in it; the
+    RECEIPT is text drawn on the operator's screen, and `frame/slots.py`'s `_empty_lines`
+    records that `workspace_for`'s last rung hands back `$CHARTER_WORKSPACE` stripped and
+    otherwise unchecked.
+    """
+    ws = state.workspace_for(fid)
+    _spawn(util.self_relaunch_argv("frame-gather", "--session", fid, "--workspace", ws),
+           fid=fid)
+    return f"gathering {contain.one_line(ws)}…"
+
+
 def build(fid: str, *, current_density: str,
           current_chrome: str) -> actions.ActionRegistry:
     """Charter's own actions, plus every action an installed provider supplies.
@@ -361,6 +423,7 @@ def build(fid: str, *, current_density: str,
     _register_selection(reg)
     _register_density(reg, current=current_density)
     _register_chrome(reg, current=current_chrome)
+    _register_regather(reg)
     for aid in reg.providers.ids():
         reg.add(aid)
     return reg

--- a/charter/frame/gather.py
+++ b/charter/frame/gather.py
@@ -431,6 +431,37 @@ def read(fid: str, *, workspace: str | None = None, cwd: str | None = None) -> d
         return _empty(workspace)
 
 
+def _load(fid: str) -> tuple[dict | None, bool]:
+    """*fid*'s cache, and whether the file that holds it is UNREADABLE.
+
+    One reader under :func:`cached` and :func:`unreadable`, so the two cannot answer from
+    two different readings of the same bytes — the defect #735 is at one remove. A panel
+    asks both in the same repaint, and a version that read the file twice through two
+    functions could tell an operator "this cache is broken" about a file the other half
+    had just accepted.
+
+    The bool is **not** "there is no cache". Those are the two states #735 exists to keep
+    apart, and this is the narrower of them: a file that IS there and cannot be read as a
+    scan. No directory and no file are both ``(None, False)`` — a gather that has not
+    landed yet, which is the ordinary cold start.
+
+    An ``OSError`` that is not :class:`FileNotFoundError` — a permission, an ``EISDIR``, a
+    truncated read — counts as unreadable rather than absent, because it is: the path is
+    occupied by something this frame cannot read a scan out of, and a re-gather is still
+    the remedy.
+    """
+    f = _cache_file(fid, create=False)
+    if f is None:
+        return None, False
+    try:
+        data = json.loads(f.read_text())
+    except FileNotFoundError:
+        return None, False
+    except (OSError, ValueError):
+        return None, True
+    return (data, False) if _shaped_like_a_scan(data) else (None, True)
+
+
 def cached(fid: str) -> dict | None:
     """Whatever *fid*'s cache file holds, if it holds something a renderer can index
     into — ``None`` for every way that can fail.
@@ -442,15 +473,45 @@ def cached(fid: str) -> dict | None:
     cache file yet, a file that is not valid JSON (``json.JSONDecodeError``, a
     ``ValueError`` subclass), and — because ``json.loads`` succeeding says nothing about
     what it produced — one that parses to something not :func:`_shaped_like_a_scan`.
+
+    **Still ``None`` for all four, and #735 did not change that.** Five call sites read this
+    — :func:`read`, :func:`row_count`, `slots._repos`, `slots._selected_detail` and
+    `commands_frame`'s palette snapshot — and every one wants a value it can draw or a
+    value it cannot; raising at the two that are corruption would push a ``try`` onto
+    :func:`row_count`'s launch path and into a hook. What #735 added is a SECOND
+    question — :func:`unreadable` — asked only by the one caller that says something
+    different about the answer.
     """
-    f = _cache_file(fid, create=False)
-    if f is None:
-        return None
-    try:
-        data = json.loads(f.read_text())
-    except (OSError, ValueError):
-        return None
-    return data if _shaped_like_a_scan(data) else None
+    return _load(fid)[0]
+
+
+def unreadable(fid: str) -> bool:
+    """Whether *fid* HAS a cache file that cannot be read as a scan.
+
+    The fact `frame/slots.py`'s `_repos` needs and :func:`cached`'s ``None`` throws away.
+    Four different readings collapse into that ``None`` — no frame directory, no cache
+    file, a file that is not JSON, a file that parses to something that is not a scan —
+    and the first two are a gather that has not landed while the last two are a gather
+    that never will. Drawn identically they were the same sentence, so a corrupt
+    ``gather.json`` read as `⋯ gathering this workspace's repos…` forever (#735): a panel
+    "never gathers on its own — it reads the cache or says it has none" (docs/frame.md),
+    so nothing was coming to correct it.
+
+    **A fact at the moment it is asked, never a duration.** The alternative was to
+    time-box the gathering message — after N seconds of no cache, say something else —
+    and that is a guess wearing a fact's clothes: a plane with forty clones on a cold
+    mount crosses any N that a corrupt file crosses, and the pane would call a slow
+    gather broken. This asks the filesystem instead, of the same file the caller has just
+    failed to read, and :func:`save`'s ``os.replace`` is what makes the answer stable —
+    "a reader must never observe a half-written cache", so there is no window in which a
+    gather that IS running looks like this.
+
+    Asked only when :func:`cached` has already answered ``None``, which is where the two
+    compose into three states. It is not the negation of that call and must not be used
+    as one: a cache that reads perfectly well is ``False`` here for the same reason a
+    frame that has never gathered is.
+    """
+    return _load(fid)[1]
 
 
 def row_count(fid: str) -> int:

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -1178,6 +1178,51 @@ def _unknown_lines(width: int) -> list[str]:
     return [tui.truncate(f"  {sl._DIM}⋯ gathering this workspace's repos…{sl._R}", width)]
 
 
+def _unreadable_lines(fid: str, ws: str, width: int) -> list[str]:
+    """What the `repos` pane draws when this frame HAS a cache file and cannot read it.
+
+    **The third state, and #735 is the cost of not having had one.** `gather.cached`
+    answers ``None`` four ways — no frame directory, no cache file, a file that is not
+    JSON, a file that parses to something that is not a scan — and :func:`_unknown_lines`
+    was drawn for all four. The first two are a gather that has not landed yet, which is
+    a five-second wait; the last two are a gather that will never land, because a panel
+    "never gathers on its own — it reads the cache or says it has none"
+    (`docs/frame.md`). Spelled identically, `⋯ gathering this workspace's repos…` was
+    permanent on a pane with nothing else on it.
+
+    **What separates them is a fact, not a duration** — `gather.unreadable`, which asks
+    the filesystem about the same file the caller has just failed to read. The rejected
+    alternative was to time-box the gathering message, and that is a guess wearing a
+    fact's clothes: a plane with forty clones on a cold mount crosses any N that a corrupt
+    file crosses, and this pane would then call a slow gather broken, which is worse than
+    calling a broken one slow. `gather.save` replaces the file atomically, so there is no
+    half-written moment for this line to appear in either.
+
+    **It names the command, because the operator inside a stuck frame cannot derive it.**
+    `charter frame-gather` requires `--session` and `--workspace` — required on purpose, so
+    a detached child never guesses a frame's workspace (#512) — and neither is discoverable
+    from a pane. Both are filled in here from the frame being drawn, which is the shape
+    :func:`_empty_lines` already has and the reason it has it: a line that names a problem
+    and not its fix costs a row and settles nothing. The palette carries the same command as
+    a row (`frame/builtin_actions._register_regather`); this line is what an operator who
+    has not opened the palette reads, and it does not name a key because a frame running
+    as a window in an operator's own tmux has no `F2` of charter's to name.
+
+    **Nothing is repaired here.** A renderer that deleted the file would put a write on the
+    repaint path #387 pinned at one `stat`, and would destroy the evidence of whatever wrote
+    it. The pane says what is true and the operator decides.
+
+    One line, bounded through `tui.truncate` like every other line in this module — *fid*
+    and *ws* are both arbitrary length, and `tui.sanitize` under that truncate is what
+    contains a `$CHARTER_WORKSPACE` no rung ever checked (see :func:`_empty_lines`).
+    """
+    from .. import statusline as sl
+
+    return [tui.truncate(
+        f"  {sl._DIM}unreadable repo cache · charter frame-gather --session{sl._R} "
+        f"{fid}{sl._DIM} --workspace{sl._R} {ws}", width)]
+
+
 def _empty_lines(ws: str, width: int) -> list[str]:
     """What the `repos` pane draws once the gather HAS run and found no clones.
 
@@ -2804,6 +2849,15 @@ def _repos(fid: str) -> str:
     data = gather.cached(fid)
     if data is None:
         VIEWPORT.blank()
+        # **Two states, not one** (#735). `cached` collapses "nothing has been written
+        # yet" and "what was written cannot be read" into the same `None`, and drawing
+        # both as :func:`_unknown_lines` made a permanent failure indistinguishable from a
+        # five-second wait — on a pane that has no other route out, because nothing
+        # repaints its way back to a readable cache. `gather.unreadable` is the second
+        # question, asked ONLY here and only once `cached` has already said `None`: it is
+        # a fact about a file on disk at the moment this line is drawn, never a timeout.
+        if gather.unreadable(fid):
+            return "\n".join(_unreadable_lines(fid, _frame_workspace(fid), w))
         return "\n".join(_unknown_lines(w))
     repos = data.get("repos") or []
     if not repos:

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -857,6 +857,25 @@ command that changes it: `no clones in <workspace> · charter clone <repo> -w
 <workspace>`. A panel never gathers on its own — it reads the cache or says it has
 none.
 
+**A cache that exists and cannot be read gets its own line**, because "it has not landed
+yet" and "it will never land" are different facts and a panel that never gathers on its own
+has nothing coming to correct the second one. If `gather.json` is truncated, hand-edited or
+left behind by an older charter, `repos` says so and names the command that rebuilds it:
+
+```
+  unreadable repo cache · charter frame-gather --session <chat> --workspace <workspace>
+```
+
+Both flags are filled in from the frame you are looking at — they are required on the
+command line precisely so a detached gather never guesses which frame it is for, which is
+not a question you can answer from inside a pane. `F2 → refresh — gather this workspace's
+repos, todos and changes again` runs the same thing without the typing. What charter does
+not do is delete the file for you: a repaint reads, and the evidence of whatever wrote it
+stays where it is.
+
+The wait and the failure are told apart by a fact rather than by a clock — the file is
+there and does not parse — so a gather that is merely slow is never called broken.
+
 ## Configuring it
 
 ```toml

--- a/docs/news/unreleased-a-repo-cache-that-cannot-be-read-says-so.md
+++ b/docs/news/unreleased-a-repo-cache-that-cannot-be-read-says-so.md
@@ -1,0 +1,92 @@
+---
+version: unreleased
+headline: A repo cache that cannot be read says so, instead of gathering forever
+---
+
+*"The repo panel has said `⋯ gathering this workspace's repos…` for forty minutes. Nothing
+is gathering."*
+
+Overwrite a frame's `gather.json` with anything that is not a scan and the repo pane
+draws this, permanently:
+
+```
+────────────────────────────────────────
+    ⋯ gathering this workspace's repos…
+────────────────────────────────────────
+```
+
+That sentence is correct for a frame whose gather has not landed yet — a five-second
+window at launch. It was also what a frame drew when the cache was corrupt, and `docs/frame.md`
+is explicit about why that never resolves: *a panel never gathers on its own — it reads the
+cache or says it has none.* Nothing was coming.
+
+## One `None`, four readings
+
+`gather.cached` degrades rather than raising, deliberately, and answers `None` for every
+way a read can fail:
+
+| on disk | what it means |
+|---|---|
+| no frame directory | never gathered — cold start |
+| directory, no `gather.json` | gather has not landed yet |
+| `gather.json` that is not JSON | **it will never land** |
+| JSON that is not a scan (`42`, `"a string"`, `{"foo": "bar"}`) | **it will never land** |
+
+The renderer only ever saw the `None`, so a permanent failure was spelled exactly like a
+normal wait. That is the whole defect: not that the read fails — it is supposed to — but
+that two very different states shared one sentence.
+
+## Told apart by a fact, not by a clock
+
+`gather.unreadable(fid)` asks the filesystem, at the moment the pane is drawn, of the same
+file the renderer has just failed to read: *is there a cache file here, and does it refuse
+to read as a scan?* A frame with no file yet is `False`; a frame with a broken one is
+`True`.
+
+**The rejected design was a timeout** — "no cache for N seconds, so call it broken". That
+is a guess wearing a fact's clothes. A plane with forty clones on a cold mount crosses any
+N that a corrupt file crosses, and the pane would start calling a slow gather broken, which
+is worse than the message it replaces. Charter does not guess, and a line that says
+"broken" when the truth is "slow" is not an improvement.
+
+Nothing about the timing is load-bearing either way: `gather.save` writes through
+`os.replace`, so no reader ever sees a half-written cache, and there is no moment in which
+a gather that IS running looks like this one.
+
+## What you see now
+
+```
+  unreadable repo cache · charter frame-gather --session alpha.1 --workspace alpha
+```
+
+Both flags are filled in from the frame the pane is drawing. They are *required* on the
+command line so that a detached gather never guesses which frame it is for — which also
+makes them the two things an operator sitting in front of a stuck pane cannot work out.
+
+`F2` now carries the same command as a row:
+
+```
+refresh — gather this workspace's repos, todos and changes again
+```
+
+It is offered on every frame, because it is the one row you reach for when a pane has
+already failed, and it names the whole snapshot because that is what a gather writes:
+`bottom`'s todo count comes out of the same file the broken table does.
+
+## What did not change
+
+**`gather.cached` still answers `None` for all four.** Five call sites read it — the repo
+table, the attention pane's detail, `row_count` on the launch path, the palette's own
+snapshot and `gather.read` itself — and every one of them wants a value it can draw or a
+value it cannot. Making it raise on the two that are corruption would push a `try` onto a
+launch and into a hook. The reason is a *second* question, asked only by the caller that
+says something different about the answer.
+
+**A repaint still repairs nothing.** Deleting the file for you would put a write on the
+path pinned at one `stat` per idle tick, and would destroy the evidence of whatever wrote
+it. The pane says what is true; you decide.
+
+**The cold-start line is untouched.** `⋯ gathering this workspace's repos…` still appears
+for the five seconds it was always right for, and still goes the moment the rows arrive.
+
+Closes #735.

--- a/tests/test_a_corrupt_repo_cache_is_not_a_gather_in_progress.py
+++ b/tests/test_a_corrupt_repo_cache_is_not_a_gather_in_progress.py
@@ -23,14 +23,13 @@ re-gathers without the operator having to know `--session`/`--workspace`.
 
 from __future__ import annotations
 
-
 import os
 import sys
 import unittest
 from unittest import mock
 
 from charter import statusline as sl
-from charter import tui, util
+from charter import commands_frame, tui, util
 from charter.frame import action as faction
 from charter.frame import builtin_actions, gather, slots, state
 
@@ -70,7 +69,7 @@ class TheCacheSaysWhichKindOfNothingItIs(PersonaIso, unittest.TestCase):
     """`gather.unreadable` — the fact `cached()`'s ``None`` throws away.
 
     `cached()` stays exactly as it is (its docstring promises ``None`` for every way
-    reading can fail, and four callers depend on that); this is the second question, asked
+    reading can fail, and every caller depends on that); this is the second question, asked
     only by the caller that needs to say something different about the answer.
     """
 
@@ -271,9 +270,7 @@ class ThePaletteCanReGather(PersonaIso, unittest.TestCase):
 
     def test_running_it_starts_the_command_with_both_flags_filled_in(self):
         """The whole value of the row. Asserted against `builtin_actions._spawn`, the one
-        place a palette row becomes a second charter, and against the exact argv
-        `commands_frame._spawn_gather` uses at launch — two ways to start the same gather
-        that must not drift apart."""
+        place a palette row becomes a second charter."""
         a = self._reg().get("frame.gather")
         with mock.patch.object(builtin_actions, "_spawn") as spawn:
             said = a.run(faction.build(a.touches, fid=self.FID, snapshot={}))
@@ -284,6 +281,27 @@ class ThePaletteCanReGather(PersonaIso, unittest.TestCase):
             "frame-gather", "--session", self.FID, "--workspace", ws))
         self.assertEqual(spawn.call_args.kwargs, {"fid": self.FID})
         self.assertTrue(said)
+
+    def test_it_is_the_same_command_the_launch_already_detaches(self):
+        """Two ways to start the same gather, and the docstrings say they must not drift —
+        so the drift is measured rather than asserted in prose. `commands_frame._spawn_gather`
+        is what the LAUNCH fires (#512); this row is what the palette fires. The
+        `charter`-side arguments are compared, not the interpreter prefix: `_spawn_gather`
+        goes through `util.detach_self` and this goes through `util.self_relaunch_argv`,
+        which is a difference about how a child is started rather than about what it is
+        asked to do."""
+        with mock.patch.object(commands_frame.util, "detach_self",
+                               return_value=True) as detach:
+            commands_frame._spawn_gather(self.FID, "alpha")
+        a = self._reg().get("frame.gather")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "alpha"}, clear=True), \
+             mock.patch.object(builtin_actions, "_spawn") as spawn:
+            a.run(faction.build(a.touches, fid=self.FID, snapshot={}))
+        launch = detach.call_args.args[0]
+        row = spawn.call_args.args[0]
+        self.assertEqual(launch, ["frame-gather", "--session", self.FID,
+                                  "--workspace", "alpha"])
+        self.assertEqual(row[row.index("frame-gather"):], launch)
 
     def test_it_names_the_frames_workspace_and_not_this_process_s(self):
         """#512's rule, on the one path that would otherwise re-resolve it: a detached

--- a/tests/test_a_corrupt_repo_cache_is_not_a_gather_in_progress.py
+++ b/tests/test_a_corrupt_repo_cache_is_not_a_gather_in_progress.py
@@ -1,0 +1,307 @@
+"""#735 — a `gather.json` that cannot be read says so, and there is a route out.
+
+The repo panel had ONE sentence for four different readings of the cache. `gather.cached`
+degrades to ``None`` for a frame directory that does not exist, a directory with no cache
+file in it, a file that is not valid JSON, and a file that parses to something that is not
+a scan — and `slots._repos` drew `⋯ gathering this workspace's repos…` for every one of
+them. The first two are a gather that has not landed yet and the message is right; the
+last two are a gather that will never land, and the message is a permanent lie on a pane
+with no other route out of it.
+
+**What tells them apart is a fact, not a duration.** The cache file is on disk and cannot
+be read as a scan — asked at the moment the pane is drawn, of the same file the renderer
+just failed to read. A time-box ("no cache for N seconds") would answer with a probability
+instead: a plane with forty clones on a cold NFS mount crosses any N a corrupt file
+crosses, and the pane would call a slow gather broken. `gather.save` writes through
+``os.replace`` (its own docstring: "a reader must never observe a half-written cache"), so
+there is no window in which a real gather looks unreadable either — which is what makes
+the fact stable enough to draw.
+
+Both halves of the issue are pinned here: the third message, and the palette row that
+re-gathers without the operator having to know `--session`/`--workspace`.
+"""
+
+from __future__ import annotations
+
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+from charter import statusline as sl
+from charter import tui, util
+from charter.frame import action as faction
+from charter.frame import builtin_actions, gather, slots, state
+
+from tests._isolation import PersonaIso
+
+
+def _seed(fid: str, **overrides) -> dict:
+    """A cache a renderer can read — the shape `gather._entry`/`scan` writes."""
+    data = {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+            "repos": [], "worktrees": []}
+    data.update(overrides)
+    gather.save(fid, data)
+    return data
+
+
+def _corrupt(fid: str, text: str):
+    """Put *text* where the cache belongs, whatever it says."""
+    d = state.frame_dir(fid, create=True)
+    assert d is not None
+    f = d / "gather.json"
+    f.write_text(text)
+    return f
+
+
+#: The two ways a cache file that EXISTS is still unreadable, which are two different
+#: paths through `gather.cached` — `json.loads` raising, and `json.loads` returning
+#: something `_shaped_like_a_scan` refuses. Spelled as data so every case below runs
+#: against both: a fix that caught only the parse error would pass a test written against
+#: one of them and leave the other drawing the old lie.
+BROKEN = (("invalid json", "not json {{{"),
+          ("parses, but is not a scan", '{"foo": "bar"}'),
+          ("parses to a bare list", "[1, 2, 3]"),
+          ("a dict whose repos is not a list", '{"repos": 7, "worktrees": []}'))
+
+
+class TheCacheSaysWhichKindOfNothingItIs(PersonaIso, unittest.TestCase):
+    """`gather.unreadable` — the fact `cached()`'s ``None`` throws away.
+
+    `cached()` stays exactly as it is (its docstring promises ``None`` for every way
+    reading can fail, and four callers depend on that); this is the second question, asked
+    only by the caller that needs to say something different about the answer.
+    """
+
+    def test_a_cache_file_that_will_not_read_is_unreadable(self):
+        for name, text in BROKEN:
+            with self.subTest(name):
+                fid = f"f-{abs(hash(name))}"
+                _corrupt(fid, text)
+                self.assertIsNone(gather.cached(fid))
+                self.assertTrue(gather.unreadable(fid))
+
+    def test_a_frame_that_has_never_gathered_is_not_unreadable(self):
+        """The cold-start pair, and the reason this is asserted beside the case above: a
+        function that answered True whenever there was no cache would satisfy every
+        assertion above and turn the launch window into a permanent error message."""
+        self.assertIsNone(gather.cached("f-never"))
+        self.assertFalse(gather.unreadable("f-never"))
+        state.frame_dir("f-dir-only", create=True)
+        self.assertIsNone(gather.cached("f-dir-only"))
+        self.assertFalse(gather.unreadable("f-dir-only"))
+
+    def test_a_cache_that_reads_is_not_unreadable(self):
+        _seed("f-good", repos=[{"name": "demo"}])
+        self.assertIsNotNone(gather.cached("f-good"))
+        self.assertFalse(gather.unreadable("f-good"))
+
+    def test_a_hostile_frame_id_names_no_cache_and_no_error(self):
+        """`state.frame_dir` refuses it, so there is no file to call unreadable — the same
+        degrade `cached()` makes one line up."""
+        self.assertFalse(gather.unreadable("../../etc"))
+
+    def test_the_gather_that_lands_clears_it(self):
+        """A statement about now. Same frame id, one real `gather.save` between the two
+        readings — which is what a re-gather actually does."""
+        _corrupt("f-heals", "not json {{{")
+        self.assertTrue(gather.unreadable("f-heals"))
+        _seed("f-heals", repos=[{"name": "demo"}])
+        self.assertFalse(gather.unreadable("f-heals"))
+
+    def test_it_reads_the_same_file_cached_reads(self):
+        """One reader underneath both, so the pane cannot be told "unreadable" about a
+        file `cached()` would have accepted. Asserted by moving the file out from under
+        the pair and checking they agree, rather than by reading the implementation."""
+        f = _corrupt("f-same", '{"repos": [], "worktrees": []}')
+        self.assertIsNotNone(gather.cached("f-same"))
+        self.assertFalse(gather.unreadable("f-same"))
+        f.unlink()
+        self.assertIsNone(gather.cached("f-same"))
+        self.assertFalse(gather.unreadable("f-same"))
+
+
+class TheRepoPaneSaysWhichStateItIsIn(PersonaIso, unittest.TestCase):
+    """The renderer's half — through the real `slots.render("repos", …)`, because what
+    #735 is about is what an operator READS, not what a helper returns."""
+
+    def _render(self, fid, *, cols=200, rows=24) -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return slots.render("repos", fid)
+
+    def test_a_corrupt_cache_is_not_drawn_as_a_gather_in_progress(self):
+        """The defect, at the pane. Asserted as a PAIR against the cold-start frame in the
+        same test: "says something else" alone would pass on a renderer that had simply
+        stopped saying `gathering` at all, which would make the launch window silent."""
+        for name, text in BROKEN:
+            with self.subTest(name):
+                fid = f"f-r-{abs(hash(name))}"
+                _corrupt(fid, text)
+                broken = tui.strip_ansi(self._render(fid))
+                cold = tui.strip_ansi(self._render("f-cold"))
+                self.assertIn("gathering", cold)
+                self.assertNotIn("gathering", broken)
+                self.assertIn("unreadable", broken)
+
+    def test_the_line_names_the_command_that_fixes_it(self):
+        """The shape `_empty_lines` already has: a line that names a problem and not its
+        fix costs a row and settles nothing. Both flags, both filled in from the frame the
+        pane is drawing — an operator inside a stuck frame can discover neither."""
+        _corrupt("f-remedy", "not json {{{")
+        out = tui.strip_ansi(self._render("f-remedy"))
+        self.assertIn("charter frame-gather", out)
+        self.assertIn("--session f-remedy", out)
+        self.assertIn(f"--workspace {state.workspace_for('f-remedy')}", out)
+
+    def test_it_is_one_line_and_it_fits_the_pane(self):
+        """Every other line in this pane is one row bounded by `tui.truncate`, and a
+        `repos` pane that quietly became two rows tall pushes the attention strip off the
+        bottom of the window. Measured at `statusline._LEFT_W`, the narrowest width at
+        which this pane draws anything at all.
+
+        **The names are long on purpose, and the first version of this test was vacuous
+        without them.** `f-width` plus `default` composes to about 80 cells, which fits a
+        95-column pane untruncated — so the bound passed identically on a renderer with no
+        `tui.truncate` in it at all. A workspace name is arbitrary length (`_empty_lines`
+        says so at length about the same pane) and so is a frame id, so the line is
+        measured with names that make the unbounded version overflow: the assertion is red
+        the moment the truncate goes."""
+        fid = "f-" + "w" * 60
+        ws = "a" * 60
+        _corrupt(fid, "not json {{{")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ws}, clear=True):
+            self.assertEqual(state.workspace_for(fid), ws)
+            out = self._render(fid, cols=sl._LEFT_W)
+        self.assertEqual(len(out.split("\n")), 1, out)
+        for line in out.split("\n"):
+            self.assertLessEqual(tui.width(tui.strip_ansi(line)), sl._LEFT_W, line)
+
+    def test_a_workspace_name_the_rungs_never_checked_is_still_one_line(self):
+        """`_empty_lines`' hostile-name case, for the line beside it. `state.workspace_for`
+        rung 0 name-checks the pin, but its LAST rung is `workspace.resolve()`, which hands
+        back `$CHARTER_WORKSPACE` stripped and otherwise untouched — so a name with a
+        newline in it arrives at this renderer verbatim. `tui.truncate` runs `tui.sanitize`
+        first, which is what keeps a `repos` pane one row tall.
+
+        The hostile value is asserted to have got THROUGH as well as to have been
+        contained: containment alone would pass just as well on a build where a rung had
+        rejected it and the line said `default`."""
+        hostile = "ev\nil\x1b[31m;rm -rf /"
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": hostile}, clear=True):
+            self.assertEqual(state.workspace_for("f-hostile"), hostile)
+            _corrupt("f-hostile", "not json {{{")
+            out = self._render("f-hostile")
+        self.assertEqual(len(out.split("\n")), 1, repr(out))
+        self.assertIn("rm -rf /", tui.strip_ansi(out))
+
+    def test_a_gathered_cache_still_draws_its_table(self):
+        """The other three states are untouched — the new branch is reached only from
+        `cached() is None`, and a renderer that reached it otherwise would replace every
+        pane on the plane."""
+        _seed("f-full", repos=[{"name": "demo", "branch": "main", "dirty": False,
+                                "tracked_dirty": False, "ahead": 0, "behind": 0,
+                                "ci": None, "change": None, "sigil": "",
+                                "current": False, "worktree_count": 0}])
+        out = tui.strip_ansi(self._render("f-full"))
+        self.assertIn("demo", out)
+        self.assertNotIn("unreadable", out)
+        _seed("f-none")
+        empty = tui.strip_ansi(self._render("f-none"))
+        self.assertIn("no clones", empty)
+        self.assertNotIn("unreadable", empty)
+
+    def test_a_pane_too_narrow_for_the_table_says_nothing_new_either(self):
+        """`_table_cap` answers 0 below `statusline._LEFT_W` and `_repos` composes nothing
+        on a budget of 0, so this line cannot appear where a table never will — the same
+        rule the gathering line keeps, asserted for the new one because it is a new
+        early-return past the same cap."""
+        _corrupt("f-narrow", "not json {{{")
+        out = tui.strip_ansi(self._render("f-narrow", cols=90))
+        self.assertNotIn("unreadable", out)
+        self.assertIn("too narrow", out)
+
+    def test_drawing_the_line_repairs_nothing(self):
+        """A renderer does not write. Deleting the operator's file would remove the
+        evidence and put a filesystem write on the repaint path that #387 pinned at one
+        `stat` — so the file is exactly where it was after the pane has said so."""
+        f = _corrupt("f-intact", "not json {{{")
+        self._render("f-intact")
+        self.assertEqual(f.read_text(), "not json {{{")
+
+    def test_a_repaint_still_runs_no_gather_of_its_own(self):
+        """`gather.read`'s live-`scan` fallback is what `_repos` refuses (#512), and a new
+        branch that reached for it to "just fix it" would put a git sweep on every repaint
+        of a broken frame."""
+        _corrupt("f-noscan", "not json {{{")
+        with mock.patch.object(gather, "scan",
+                               side_effect=AssertionError("a repaint gathered")):
+            self.assertIn("unreadable", tui.strip_ansi(self._render("f-noscan")))
+
+
+class ThePaletteCanReGather(PersonaIso, unittest.TestCase):
+    """The route out. `charter frame-gather` already exists and already fixes this
+    instantly; what it wants is two flags an operator inside a stuck frame has no way to
+    learn. The palette knows both."""
+
+    FID = "f-palette"
+
+    def setUp(self) -> None:
+        super().setUp()
+        state.frame_dir(self.FID, create=True)
+
+    def _reg(self):
+        return builtin_actions.build(self.FID, current_density="normal",
+                                     current_chrome="off")
+
+    def test_the_palette_offers_a_re_gather(self):
+        a = self._reg().get("frame.gather")
+        self.assertIsNotNone(a)
+        self.assertIn("gather", a.title)
+
+    def test_it_is_offered_on_a_frame_whose_cache_is_corrupt(self):
+        """Availability is the point: this is the ONE row that has to be there on exactly
+        the frame every other route has failed on."""
+        _corrupt(self.FID, "not json {{{")
+        offered = [r.id for r in self._reg().offers(fid=self.FID, snapshot={})
+                   if r.available]
+        self.assertIn("frame.gather", offered)
+
+    def test_running_it_starts_the_command_with_both_flags_filled_in(self):
+        """The whole value of the row. Asserted against `builtin_actions._spawn`, the one
+        place a palette row becomes a second charter, and against the exact argv
+        `commands_frame._spawn_gather` uses at launch — two ways to start the same gather
+        that must not drift apart."""
+        a = self._reg().get("frame.gather")
+        with mock.patch.object(builtin_actions, "_spawn") as spawn:
+            said = a.run(faction.build(a.touches, fid=self.FID, snapshot={}))
+        spawn.assert_called_once()
+        argv = spawn.call_args.args[0]
+        ws = state.workspace_for(self.FID)
+        self.assertEqual(argv, util.self_relaunch_argv(
+            "frame-gather", "--session", self.FID, "--workspace", ws))
+        self.assertEqual(spawn.call_args.kwargs, {"fid": self.FID})
+        self.assertTrue(said)
+
+    def test_it_names_the_frames_workspace_and_not_this_process_s(self):
+        """#512's rule, on the one path that would otherwise re-resolve it: a detached
+        child has no terminal of the operator's, so a gather that guessed its own
+        workspace would refill the cache from `default` on a plane that is not on it."""
+        state.record_workspace(self.FID, "alpha")
+        a = self._reg().get("frame.gather")
+        with mock.patch.object(builtin_actions, "_spawn") as spawn:
+            a.run(faction.build(a.touches, fid=self.FID, snapshot={}))
+        self.assertIn("alpha", spawn.call_args.args[0])
+
+    def test_listing_the_row_starts_nothing(self):
+        """`Action.run` is what spawns. Building the registry and reading the row must
+        not — a palette that gathered on open would sweep git every `F2`."""
+        with mock.patch.object(builtin_actions, "_spawn") as spawn:
+            self._reg().offers(fid=self.FID, snapshot={})
+        spawn.assert_not_called()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_a_corrupt_repo_cache_is_not_a_gather_in_progress.py
+++ b/tests/test_a_corrupt_repo_cache_is_not_a_gather_in_progress.py
@@ -313,6 +313,30 @@ class ThePaletteCanReGather(PersonaIso, unittest.TestCase):
             a.run(faction.build(a.touches, fid=self.FID, snapshot={}))
         self.assertIn("alpha", spawn.call_args.args[0])
 
+    def test_the_receipt_is_one_line_whatever_the_workspace_is_called(self):
+        """`_regather` hands back `gathering <ws>…` with no `contain.one_line` of its own,
+        and this is the measurement that says it does not need one. `state.workspace_for`'s
+        last rung returns `$CHARTER_WORKSPACE` stripped and otherwise unchecked, so a name
+        with a newline in it really does reach the receipt — and `actions.Invocation._work`
+        contains every receipt on the way to the surface, which is why `_select` hands back
+        a bare repo name too.
+
+        Asserted through the real `registry.invoke`, not by calling `run` directly: the
+        containment lives on the path between the two, so a test that stopped at `run`
+        would be measuring the string this function composes rather than the line an
+        operator reads. The hostile value is asserted to have got THROUGH as well as to
+        have been contained — containment alone would pass on a build where a rung had
+        rejected the name."""
+        hostile = "ev\nil-ws"
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": hostile}, clear=True), \
+             mock.patch.object(builtin_actions, "_spawn"):
+            self.assertEqual(state.workspace_for(self.FID), hostile)
+            inv = self._reg().invoke("frame.gather", fid=self.FID, snapshot={})
+            self.assertTrue(inv.join(5))
+        self.assertEqual(inv.error, "")
+        self.assertIn("il-ws", inv.note)
+        self.assertEqual(len(inv.note.split("\n")), 1, repr(inv.note))
+
     def test_listing_the_row_starts_nothing(self):
         """`Action.run` is what spawns. Building the registry and reading the row must
         not — a palette that gathered on open would sweep git every `F2`."""


### PR DESCRIPTION
Closes #735.

## The defect

`gather.cached` degrades to `None` for **four** different readings of a frame's cache, and
`slots._repos` drew the same sentence for all four:

| on disk | what it means | what the pane said |
|---|---|---|
| no frame directory | never gathered — cold start | `⋯ gathering this workspace's repos…` |
| directory, no `gather.json` | gather has not landed yet | `⋯ gathering this workspace's repos…` |
| `gather.json` that is not JSON | **it will never land** | `⋯ gathering this workspace's repos…` |
| JSON that is not a scan | **it will never land** | `⋯ gathering this workspace's repos…` |

Reproduced before any fix, on all four paths. The last two never resolve: `docs/frame.md`
is explicit that *a panel never gathers on its own — it reads the cache or says it has
none*, so nothing was coming to correct the message. A permanent failure was spelled
identically to a five-second wait.

## How the panel tells them apart

`gather.unreadable(fid)` — **a fact, not a duration.** It asks the filesystem, at the
moment the pane is drawn, of the same file the renderer has just failed to read: is a cache
file there, and does it refuse to read as a scan? Asked only after `cached()` has already
answered `None`, which is where the two compose into three states.

Both come off one private `_load(fid) -> (data, unreadable)`, so `cached` and `unreadable`
cannot answer from two different readings of the same bytes.

### What was rejected

* **A time-box** — "no cache for N seconds, so call it broken". A guess wearing a fact's
  clothes: a plane with forty clones on a cold mount crosses any N that a corrupt file
  crosses, and the pane would start calling a slow gather broken, which is worse than the
  message it replaces.
* **Making `cached()` raise.** Its `None` is deliberate and five call sites depend on it,
  including `row_count` on the launch path and a hook. The reason is a second question, not
  a changed answer.
* **Repairing the file from the renderer.** A repaint reads. Deleting it would put a write
  on the path #387 pinned at one `stat` and would destroy the evidence of whatever wrote it.
* **A module-level "last reason" recorded by `cached()`.** Five call sites, several inside
  one repaint — a global written by whichever ran last is a fact about a call, not about a
  frame.

Timing is not load-bearing either way: `gather.save` writes through `os.replace`, so no
reader ever observes a half-written cache and no gather in flight can look like this.

## What is drawn

```
  unreadable repo cache · charter frame-gather --session alpha.1 --workspace alpha
```

82 cells, so it fits the 95-column floor this pane draws at. Both flags are filled in from
the frame being drawn — they are *required* on the command line precisely so a detached
gather never guesses which frame it is for (#512), which is what makes them the two things
an operator inside a stuck pane cannot supply.

The line names no key, deliberately: a frame running as a window in an operator's own tmux
has no `F2` of charter's to name.

## The palette route was needed — neither half existed

Verified: no re-gather row was registered anywhere. `frame.gather` is now offered as
`refresh — gather this workspace's repos, todos and changes again`, spawning exactly
`commands_frame._spawn_gather`'s argv.

* **Always available.** Measured on the frame in the issue, every other charter row refuses
  (no harness pane, no pane map, no repos) and this one does not. It is the row you reach
  for once everything else has already failed.
* **Registered last among charter's own**, so no existing row moves — a list whose rows move
  is a list nobody learns. Confirmed by mutation: registering it first turns two existing
  ordering tests red.
* **Named for the whole snapshot**, because `gather.refresh` writes repos, worktrees, todos
  and changes under one timestamp; `bottom`'s todo count comes out of the same file.

## Verification

* Failing tests written first — 7 failures + 12 errors before the fix, across both corrupt
  paths.
* Full suite: **9803 tests, OK (8 skipped)**, `python3 -B -m unittest discover -s tests`.
* **Eleven mutations run against the new tests.** Ten were killed. One survived — the width
  bound passed with `tui.truncate` removed, because `f-width`/`default` fits 95 columns
  untruncated — so that test now measures a 60-character workspace name and a 60-character
  frame id, and is red without the truncate. A hostile-`$CHARTER_WORKSPACE` case was added
  beside it.
* The old rendered strings were grepped in both directions: no `assertIn`/`assertNotIn`
  needle was deleted or reworded, and every existing `gathering` assertion still measures
  what it measured.

## Files

`charter/frame/slots.py` carries one new renderer and a two-line branch in `_repos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
