### PR TITLE
A shard too big to finish says what it measured, instead of saying nothing and calling it success (#803)

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -176,20 +176,21 @@ jobs:
     name: Sweep shard ${{ matrix.shard }} of ${{ needs.plan.outputs.shards }}
     needs: plan
     runs-on: ubuntu-latest
-    # **The backstop, and since #803 nothing but the backstop.** `sweep.py` sizes a shard
-    # for `SHARD_BUDGET` — forty minutes — and now STOPS there and writes what it
-    # measured, so this number is only what catches a shard that could not keep its own
-    # deadline: a hung subprocess, a mutant that took the machine (#773).
+    # The runner's cap, and `sweep.py` reads it: `SHARD_TIMEOUT` is this number, and
+    # `SHARD_REPORT_AT` is ten minutes short of it — the point at which a shard stops
+    # dealing mutations and writes what it measured (#803). One deadline written in two
+    # files and drifting is #670, so the tool holds the constant and
+    # `test_sweep.TheReportingDeadlineSitsBetweenTheBudgetAndTheBackstop` holds this line
+    # to it. Change one and the suite asks for the other.
     #
-    # Twenty minutes behind the budget, and the gap is asserted by
-    # `test_sweep.TheWorkflowsBackstopIsBehindTheBudget` rather than left to two files
-    # agreeing by habit. **Do not close the gap by lowering this to forty.** #803 reads
-    # the mismatch as a defect and it was one — a shard that overran its budget used to
-    # get twenty further minutes of runway and *then* die with nothing — but the two
-    # numbers no longer describe one deadline, and setting them equal would have the
-    # runner kill the shard at the exact moment it stops to write its answer. The room
-    # is for the mutation still in flight when the budget expires (`FULL_TIMEOUT` bounds
-    # it) and for the file to be written and uploaded.
+    # **Do not lower this to `SHARD_BUDGET`'s forty.** #803 reads the twenty-minute gap
+    # as a defect and it was one — a shard that overran its sizing got twenty further
+    # minutes of runway and *then* died with nothing. But the two were never one
+    # deadline: forty sizes the PLAN, from an average mutation, and a shard whose slice
+    # holds five survivors pays a full-suite run for each and legitimately needs longer.
+    # Cutting it off at forty would turn complete answers into partial ones, and cutting
+    # the runner off there would kill the shard at the instant it stops to write. What
+    # closed the gap is the third number, between them.
     timeout-minutes: 60
     strategy:
       # One shard's trouble must not cancel the others: three quarters of an answer, said

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -176,11 +176,20 @@ jobs:
     name: Sweep shard ${{ matrix.shard }} of ${{ needs.plan.outputs.shards }}
     needs: plan
     runs-on: ubuntu-latest
-    # The backstop and not the budget. `sweep.py` sizes a shard for forty minutes; this is
-    # what catches a box that turned out to be slower than that, and it is deliberately
-    # the same hour the unsharded job had — the fix for running out of time is more
-    # machines, not a longer rope, because a shard cancelled here reports nothing at all
-    # and a longer rope only moves where that happens.
+    # **The backstop, and since #803 nothing but the backstop.** `sweep.py` sizes a shard
+    # for `SHARD_BUDGET` — forty minutes — and now STOPS there and writes what it
+    # measured, so this number is only what catches a shard that could not keep its own
+    # deadline: a hung subprocess, a mutant that took the machine (#773).
+    #
+    # Twenty minutes behind the budget, and the gap is asserted by
+    # `test_sweep.TheWorkflowsBackstopIsBehindTheBudget` rather than left to two files
+    # agreeing by habit. **Do not close the gap by lowering this to forty.** #803 reads
+    # the mismatch as a defect and it was one — a shard that overran its budget used to
+    # get twenty further minutes of runway and *then* die with nothing — but the two
+    # numbers no longer describe one deadline, and setting them equal would have the
+    # runner kill the shard at the exact moment it stops to write its answer. The room
+    # is for the mutation still in flight when the budget expires (`FULL_TIMEOUT` bounds
+    # it) and for the file to be written and uploaded.
     timeout-minutes: 60
     strategy:
       # One shard's trouble must not cancel the others: three quarters of an answer, said
@@ -220,13 +229,25 @@ jobs:
             --shard "$SHARD/$SHARDS" \
             --workdir "$RUNNER_TEMP/sweep" \
             --json "sweep-results-$SHARD.json"
+      # **This step already worked, and that is the measurement #803 turns on.** On run
+      # 33500900581 all eight shards were cancelled at `timeout-minutes` and this step
+      # ran on every one of them, concluding `success` — GitHub does run an `always()`
+      # step after a job timeout. It uploaded nothing because `sweep.py` held the whole
+      # result set in memory until its last line, so the killed process took the answer
+      # with it and the run published `no verdict: 8 of 8 shards did not report`.
+      #
+      # `--json` is now written as each answer arrives, so what this finds is whatever
+      # the shard had measured at the instant it died. `if-no-files-found: warn` and no
+      # longer `ignore`: a missing file used to be the ordinary outcome of a long sweep
+      # and is now an anomaly worth a line in the log — the shard died before it reached
+      # its first mutation, during the map or the baseline.
       - name: Keep the result set, whatever the sweep said
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deletion-sweep-${{ matrix.shard }}
           path: sweep-results-${{ matrix.shard }}.json
-          if-no-files-found: ignore
+          if-no-files-found: warn
 
   # ------------------------------------------------------------------------------------
   # 3. One answer, from however many shards came back.

--- a/docs/news/unreleased-a-sweep-that-cannot-finish-says-what-it-measured.md
+++ b/docs/news/unreleased-a-sweep-that-cannot-finish-says-what-it-measured.md
@@ -33,8 +33,8 @@ result regardless of what was in it**. It is not a signal about the branch.
 
 ## What was fixed, and what was deliberately not
 
-**A shard now stops at its own budget and reports what it measured.** Forty minutes after
-the run started it deals no further mutation; the ones it never reached come back
+**A shard now stops short of being killed and reports what it measured.** Ten minutes before
+the runner's own cap it deals no further mutation; the ones it never reached come back
 `out of time`, named, in the same result set as the answers. The check on the pull request
 reads
 
@@ -65,14 +65,22 @@ on questions, so it is the number written to be raised — but raising it moves 
 without removing it, and the next large diff hits the same wall having burned more runners
 on the way. The ceiling is now survivable, which is the property that was missing.
 
-**`timeout-minutes` was not lowered to match `SHARD_BUDGET` either**, and the issue is right
+**And `timeout-minutes` was not lowered to match `SHARD_BUDGET`,** though the issue is right
 that the two disagreeing by twenty minutes was a defect on its own: a shard that overran its
-budget got twenty further minutes of runway and *then* died with nothing, which is the worst
-of both. But the two no longer describe one deadline. `SHARD_BUDGET` is the deadline the
-shard keeps and reports at; `timeout-minutes` is the backstop for a shard that could not
-keep it — a hung subprocess, a mutant that took the machine. Setting them equal would have
-the runner kill the shard at the exact moment it stops to write its answer. The gap is now
-asserted against the YAML rather than left to two files agreeing by habit.
+sizing got twenty further minutes of runway and *then* died with nothing, which is the worst
+of both. The two were never one deadline. Forty minutes sizes the **plan** — how many
+mutations a machine may be dealt, computed from an average mutation — and sixty is the
+runner's cap. A shard whose slice happens to hold five survivors pays a full-suite run for
+each and legitimately needs longer than forty; stopping it there would turn a complete answer
+arriving at forty-eight minutes into a partial one, which is a regression on exactly the
+branches that have something to report, dressed as a fix.
+
+So what closed the gap is a **third** number between them, `SHARD_REPORT_AT`, ten minutes
+short of the cap. A shard uses every minute the runner will give it and stops just before
+being killed. `SHARD_REPORT_AT > SHARD_BUDGET` is asserted, because that inequality is the
+one that says a correctly sized shard is never cut short by this; the runner's cap is now
+written in `sweep.py` and the YAML is held to it, so one deadline no longer lives in two
+files drifting apart (#670).
 
 ## The lineage, and what is still open
 

--- a/docs/news/unreleased-a-sweep-that-cannot-finish-says-what-it-measured.md
+++ b/docs/news/unreleased-a-sweep-that-cannot-finish-says-what-it-measured.md
@@ -15,10 +15,25 @@ Add up what the shards found                success
 no verdict: 8 of 8 shards did not report    success      ← reports SUCCESS
 ```
 
-231 mutations, eight shards, every one killed at `timeout-minutes: 60`. Between them those
-eight had measured something close to 224 mutations by the time they died, and **every one
-of those answers was thrown away** — the result set lived in memory until the last line of
-the sweep, so a killed process took the whole thing with it.
+231 mutations, eight shards, every one killed at `timeout-minutes: 60`. How much answer that
+threw away is countable, from the shards' own logs — they print a line per mutation:
+
+```
+Sweep shard 1 of 8:  17 of 29 measured, 10 survived
+Sweep shard 2 of 8:  22 of 29 measured,  8 survived
+Sweep shard 3 of 8:  27 of 29 measured, 12 survived
+Sweep shard 4 of 8:  19 of 29 measured,  8 survived
+Sweep shard 5 of 8:  12 of 29 measured, 10 survived
+Sweep shard 6 of 8:  21 of 29 measured,  7 survived
+Sweep shard 7 of 8:  16 of 29 measured,  9 survived
+Sweep shard 8 of 8:  18 of 28 measured,  7 survived
+
+TOTAL: 152 of 231 mutations measured, 71 survivors printed
+```
+
+**Two thirds of the branch had been answered, and 71 survivors had been printed, when the
+eight processes were killed.** All of it went with them, because the result set lived in
+memory until the last line of the sweep. The pull request was told `success`.
 
 The plan job had predicted it in the same run and proceeded:
 

--- a/docs/news/unreleased-a-sweep-that-cannot-finish-says-what-it-measured.md
+++ b/docs/news/unreleased-a-sweep-that-cannot-finish-says-what-it-measured.md
@@ -1,0 +1,96 @@
+---
+version: unreleased
+headline: A deletion sweep too big to finish now reports what it measured instead of reporting nothing at all
+---
+
+The fourth time this repository has closed a way for **silence to read as success**, and the
+first one where the gate actually ran.
+
+## Measured, on run `33500900581`
+
+```
+Size the sweep        11:09:49 → 11:15:10   success
+Sweep shard 1..8      11:15:12 → 12:15:2x   cancelled   ← 60 min, to the second, all eight
+Add up what the shards found                success
+no verdict: 8 of 8 shards did not report    success      ← reports SUCCESS
+```
+
+231 mutations, eight shards, every one killed at `timeout-minutes: 60`. Between them those
+eight had measured something close to 224 mutations by the time they died, and **every one
+of those answers was thrown away** — the result set lived in memory until the last line of
+the sweep, so a killed process took the whole thing with it.
+
+The plan job had predicted it in the same run and proceeded:
+
+> `231 mutations → 8 shard(s) of at most 29 each`
+> ⚠ `231 mutations is past the 224 that 8 shards can measure inside 40 minutes each … a
+> shard may be cancelled at the job timeout, and a cancelled shard reports no verdict
+> rather than a short one.`
+
+That warning was accurate. It was also the design confessing: `MAX_SHARDS = 8`,
+`SHARD_BUDGET = 40 min`, so `8 × per_shard()` is 224, and **any branch past that got this
+result regardless of what was in it**. It is not a signal about the branch.
+
+## What was fixed, and what was deliberately not
+
+**A shard now stops at its own budget and reports what it measured.** Forty minutes after
+the run started it deals no further mutation; the ones it never reached come back
+`out of time`, named, in the same result set as the answers. The check on the pull request
+reads
+
+```
+deletion sweep / no verdict: 23 of 29 measured, 6 out of time
+```
+
+instead of `no verdict: 8 of 8 shards did not report` — which is #630's own argument turned
+on itself: *a partial answer honestly labelled beats silence.*
+
+**And the file is written as the answers arrive, not at the end.** The measurement this
+turns on is that GitHub was never the obstacle: on run `33500900581` the `if: always()`
+upload step ran on every one of the eight cancelled shards and concluded `success`. It
+uploaded nothing because there was no file to upload. So the shard now writes one before
+its first mutation — the whole plan, every row marked `out of time` — and rewrites it as
+each answer lands. Whatever a killed shard has measured is on disk at the instant it dies,
+and the file it leaves is the **complete plan with holes in it** rather than a short list
+that would read as a complete sweep of a short plan.
+
+`out of time` is its own bucket and not folded into `unresolved`, which is the same rule
+#698 established for `withheld`: the three say different things about what the tool knows,
+and a reader's next move differs for each. `unresolved` is *I looked and could not tell* —
+re-run it. `out of time` is *I never looked* — re-running the same plan on the same fan-out
+stops at the same place, so what answers it is a smaller branch or more machines.
+
+**`MAX_SHARDS` was not raised.** Its own docstring calls it a ceiling on machines and never
+on questions, so it is the number written to be raised — but raising it moves the ceiling
+without removing it, and the next large diff hits the same wall having burned more runners
+on the way. The ceiling is now survivable, which is the property that was missing.
+
+**`timeout-minutes` was not lowered to match `SHARD_BUDGET` either**, and the issue is right
+that the two disagreeing by twenty minutes was a defect on its own: a shard that overran its
+budget got twenty further minutes of runway and *then* died with nothing, which is the worst
+of both. But the two no longer describe one deadline. `SHARD_BUDGET` is the deadline the
+shard keeps and reports at; `timeout-minutes` is the backstop for a shard that could not
+keep it — a hung subprocess, a mutant that took the machine. Setting them equal would have
+the runner kill the shard at the exact moment it stops to write its answer. The gap is now
+asserted against the YAML rather than left to two files agreeing by habit.
+
+## The lineage, and what is still open
+
+Each of these removed one way for a silent gate to read as a passing one:
+
+* **#617** — a green check was not "no survivors". #630 put the verdict in the check **name**,
+  because GitHub's conclusion vocabulary cannot carry it.
+* **#646/#561** — a gate that never ran looked identical to one that found nothing. Fixed by
+  making `Add up what the shards found` a **required** check, so a missing row blocks.
+* **#782** — a sweep that planned nothing still said `no survivors`. Fixed by
+  `nothing to sweep`.
+* **This** — a sweep that ran, could not finish, and said `success`.
+
+**The name is now honest in every case, and nothing yet stops a merge on it.** `--gate` is
+still non-enforcing by deliberate design, and `no verdict` still sits on the checks list
+beside real passes wearing a green tick. That is a repository-settings decision and an
+operator's call, not a commit — it is recorded on #803 with a recommendation rather than
+taken here.
+
+Nothing to adopt: this is charter's own pull-request gate and does not reach an installed
+charter.

--- a/docs/superpowers/specs/2026-08-27-deletion-sweep-harness.md
+++ b/docs/superpowers/specs/2026-08-27-deletion-sweep-harness.md
@@ -174,7 +174,7 @@ answer at all: it destroys the apparatus, and the wreckage is charged to somebod
    a memory-eater is the one shard that died; the shard that drew the mutation which spins
    **without** allocating survived on the timeout, which is the control.
 
-   This is the only one of the six whose distinguishing property is that the mutant takes the
+   This is the only one of the seven whose distinguishing property is that the mutant takes the
    *measuring apparatus* with it rather than producing a wrong answer — and the only one that
    compounds, because the natural reading of `exit 143` is "flaky pool, re-run it", which
    reproduces the same failure on the same slice.
@@ -187,7 +187,29 @@ answer at all: it destroys the apparatus, and the wreckage is charged to somebod
    crosses it raises `MemoryError` — a red, on tests that were green unmutated, which is a
    **pin**, the correct verdict for a mutant that destroys the process.
 
-None of the six is visible from outside. Together they are the argument for why this harness
+7. **A run that cannot finish inside the machine it was given.** #4 and #6 are one mutation
+   taking the apparatus with it; this is the *plan* being larger than the fan-out can measure,
+   and it needs no mutant to misbehave at all. `MAX_SHARDS x per_shard()` is a real ceiling —
+   224 as this is written — and past it every shard carries more than it can measure. Measured
+   on run 33500900581: 231 mutations, **eight of eight shards cancelled at the job timeout to
+   the second**, and the merge step publishing `no verdict: 8 of 8 shards did not report` with
+   a conclusion of `success`. The eight had between them measured something close to 224
+   mutations, and all of it was thrown away, because the result set lived in memory until the
+   sweep's last line.
+
+   It is the only one of the seven where **the tool already had the answer and lost it**, which
+   is why the remedy is not a bigger machine. *Write the answer down as it arrives, and stop
+   before being killed.* The result file is the whole plan from the outset, every row marked
+   `out of time`, rewritten as each verdict lands; a shard killed at any instant leaves the
+   complete plan with holes in it rather than nothing, and a shard allowed to exit stops short
+   of the runner's cap on purpose.
+
+   **`out of time` is its own outcome and not a timeout**, for the reason #4 gives about
+   folding: a timeout is *I looked and could not tell*, and a re-run may answer it; this is *I
+   never looked*, and a re-run of the same plan on the same fan-out stops at the same place. A
+   reader who cannot tell them apart re-runs a gate that cannot answer.
+
+None of the seven is visible from outside. Together they are the argument for why this harness
 needs its own tests and its own sweep rather than being trusted because it is short: a gate that
 silently passes everything is worse than no gate, because it is *believed*.
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -3609,29 +3609,33 @@ class AShardThatWillNotFitReportsWhatItMeasured(unittest.TestCase):
     def test_the_budget_belongs_to_a_shard_and_not_to_a_person_at_a_terminal(self):
         """A local `--gate` has no merge step to say how much of the plan was reached, so
         a deadline there would hand somebody a truncated answer they never asked for."""
-        self.assertEqual(sweep.budget_for(sharded=True), float(sweep.SHARD_BUDGET))
+        self.assertEqual(sweep.budget_for(sharded=True), float(sweep.SHARD_REPORT_AT))
         self.assertEqual(sweep.budget_for(sharded=False), 0.0)
         self.assertEqual(sweep.budget_for(sharded=False, override=90), 90.0)
         self.assertEqual(sweep.budget_for(sharded=True, override=0), 0.0)
         self.assertEqual(sweep.budget_for(sharded=True, override=-5), 0.0)
 
 
-class TheWorkflowsBackstopIsBehindTheBudget(unittest.TestCase):
-    """`sweep.py` sizes a shard to forty minutes; `sweep.yml` used to kill it at sixty.
+class TheReportingDeadlineSitsBetweenTheBudgetAndTheBackstop(unittest.TestCase):
+    """Three numbers, and #803 is what happens when the middle one is missing.
 
-    #803 calls that mismatch a defect on its own, and it was: a shard that overran its
-    own budget got twenty further minutes of runway and *then* died with nothing, which
-    is the worst of both — the same wall clock spent inside the budget would have
-    produced a partial answer.
+    `SHARD_BUDGET` (40 min) sizes the plan — how many mutations a machine may be dealt.
+    `SHARD_TIMEOUT` (60 min) is the runner's cap, past which the job is cancelled. With
+    nothing between them, a shard that overran its sizing got twenty further minutes of
+    runway and *then* died with nothing, which is the worst of both: the same wall clock
+    spent reporting would have produced a partial answer.
 
-    **The fix is not to make the two numbers equal.** They no longer describe one
-    deadline. `SHARD_BUDGET` is the deadline the shard keeps for itself and reports at;
-    `timeout-minutes` is the backstop for a shard that could not keep it — a hung
-    subprocess, a mutant that took the machine (#773). Setting them equal would have the
-    runner kill the shard at the exact moment it stops to write its answer, which
-    destroys the fix. What has to hold is that the backstop is strictly BEHIND the
-    budget, with room for the mutation still in flight to finish and for the file to be
-    written, and that is what this asserts — against the YAML, so the two cannot drift.
+    **The tempting fix is to set the budget and the backstop equal, and it is wrong.**
+    `SHARD_BUDGET` is a sizing estimate built from an AVERAGE mutation, and a shard whose
+    slice holds five survivors pays a full-suite run for each and legitimately needs
+    longer. Stopping it at forty would turn a complete answer arriving at forty-eight
+    minutes into a partial one — a regression on exactly the branches with something to
+    report, dressed as a fix. Setting the backstop to forty is worse still: the runner
+    would kill the shard at the instant it stops to write its answer.
+
+    So `SHARD_REPORT_AT` goes between them, and the two inequalities below are the whole
+    property: late enough that a correctly sized shard is never cut short, early enough
+    that there is room to finish and write.
     """
 
     def setUp(self):
@@ -3645,24 +3649,53 @@ class TheWorkflowsBackstopIsBehindTheBudget(unittest.TestCase):
         """The reader below is green on an empty list, so it is proved first."""
         self.assertTrue(self._timeouts())
 
-    def test_the_shard_backstop_is_behind_the_budget_with_room_to_report(self):
-        backstop = max(self._timeouts()) * 60
-        self.assertIn(f"timeout-minutes: {backstop // 60}", self.yaml)
-        self.assertGreater(backstop, sweep.SHARD_BUDGET,
-                           "the runner would kill a shard at the moment it stops to "
-                           "write what it measured")
-        self.assertGreaterEqual(backstop - sweep.SHARD_BUDGET, 10 * 60,
-                                "a mutation in flight when the budget expires still has "
-                                "to finish, and the answer still has to be written")
+    def test_the_workflow_and_the_tool_agree_on_where_the_runner_gives_up(self):
+        """#670's defect is one measurement written in two files and drifting. The
+        shard job's cap is the longest one in this workflow — `plan` is 30 and `collect`
+        is 10 — and `sweep.py` derives its own deadline from this number."""
+        self.assertEqual(max(self._timeouts()) * 60, sweep.SHARD_TIMEOUT)
+
+    def test_a_shard_reports_before_the_runner_kills_it(self):
+        self.assertLess(sweep.SHARD_REPORT_AT, sweep.SHARD_TIMEOUT)
+        self.assertGreaterEqual(sweep.SHARD_TIMEOUT - sweep.SHARD_REPORT_AT, 5 * 60,
+                                "a mutation still in flight has to come back and the "
+                                "answer still has to be written")
+
+    def test_a_correctly_sized_shard_is_never_cut_short_by_its_own_deadline(self):
+        """The regression this ordering exists to prevent. A shard dealt `per_shard()`
+        mutations is sized for `SHARD_BUDGET`; if the reporting deadline were at or below
+        that, the ordinary slow-but-complete shard would start publishing partial
+        answers, which is worse than what #803 found."""
+        self.assertGreater(sweep.SHARD_REPORT_AT, sweep.SHARD_BUDGET)
+        self.assertEqual(sweep.budget_for(sharded=True), float(sweep.SHARD_REPORT_AT))
+
+    def _step(self, name):
+        """The YAML block of one named step, and nothing of its neighbours.
+
+        Written this way because the obvious assertion is vacuous: `if: always()` appears
+        on the `collect` job as well, so `assertIn` over the whole file is green with the
+        upload step's own condition deleted. Caught by removing the guard and watching
+        the test stay green, which is the only way that kind of assertion is ever found.
+        """
+        lines = self.yaml.splitlines()
+        start = next(i for i, ln in enumerate(lines) if ln.strip() == f"- name: {name}")
+        indent = len(lines[start]) - len(lines[start].lstrip())
+        out = [lines[start]]
+        for ln in lines[start + 1:]:
+            if ln.strip() and len(ln) - len(ln.lstrip()) <= indent:
+                break
+            out.append(ln)
+        return "\n".join(out)
 
     def test_the_workflow_keeps_whatever_the_shard_wrote(self):
         """Measured on run 33500900581: the `always()` upload step DID run on all eight
         cancelled shards and concluded `success` — the runner was never the problem. It
         uploaded nothing because `sweep.py` held the whole result set in memory until the
-        end, so `if-no-files-found` decided what a cancelled shard says, and it said
-        nothing. The step has to stay unconditional."""
-        self.assertIn("if: always()", self.yaml)
-        self.assertIn("Keep the result set, whatever the sweep said", self.yaml)
+        end, so there was no file for it to find. The step has to stay unconditional, or
+        the whole of #803's fix arrives on a machine that then throws it away."""
+        step = self._step("Keep the result set, whatever the sweep said")
+        self.assertIn("if: always()", step)
+        self.assertIn("path: sweep-results-", step)
 
 
 class TheSweepIsSplitAcrossMachinesAndNothingIsDropped(unittest.TestCase):
@@ -4472,7 +4505,7 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
                                "--workdir", str(self.workdir))
         self.assertEqual(code, 0, said)
         self.assertIsNotNone(seen["deadline"])
-        self.assertIn(f"budget: {sweep.SHARD_BUDGET // 60} min", said)
+        self.assertIn(f"budget: {sweep.SHARD_REPORT_AT // 60} min", said)
         seen.clear()
         code, said = self._cli("--gate", "--jobs", "1", "--base", self.base,
                                "--no-baseline", "--workdir", str(self.workdir))

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -3497,6 +3497,174 @@ class NothingToSweepIsNotNoSurvivors(unittest.TestCase):
         self.assertNotIn("Not one mutation was applied on this branch", page)
 
 
+class AShardThatWillNotFitReportsWhatItMeasured(unittest.TestCase):
+    """#803, the fourth in the lineage and the first where the sweep actually RAN.
+
+    * **#617** — a green check was not "no survivors"; #630 put the verdict in the NAME.
+    * **#646/#561** — a gate that never ran looked like one that found nothing; the
+      collect job was made required, so a missing row blocks.
+    * **#782** — a sweep that planned nothing still said `no survivors`; `nothing to
+      sweep` was added.
+    * **This** — a sweep that ran, could not finish, and reported `success`.
+
+    Measured on run 33500900581 (PR #796, head `36996e6`): 231 mutations, eight shards,
+    every one cancelled at `timeout-minutes: 60` to the second, and
+    `no verdict: 8 of 8 shards did not report` concluding `success` beside seven real
+    passes. The eight shards between them had measured roughly 224 mutations when they
+    died, and every one of those answers was thrown away.
+
+    The fix is #630's own argument applied to itself: a partial answer honestly labelled
+    beats silence. A shard stops at :data:`sweep.SHARD_BUDGET` and reports what it has,
+    and the mutations it never reached are named rather than absent.
+    """
+
+    def test_out_of_time_is_its_own_bucket_and_not_a_timeout(self):
+        """#698's rule, applied again. `unresolved` is "I looked and could not tell" and
+        a re-run may answer it; this is "I never looked", and a re-run of the same plan
+        on the same fan-out stops at the same place. A reader who cannot tell them apart
+        re-runs a gate that cannot answer."""
+        gate = sweep.classify([_result(sweep.OUT_OF_TIME)])
+        self.assertEqual(len(gate.out_of_time), 1)
+        self.assertEqual(gate.unresolved, [])
+        self.assertEqual(gate.withheld, [])
+
+    def test_a_mutation_nobody_measured_is_not_counted_as_measured(self):
+        """`measured` is #782's property — every bucket that reached a sandbox. This one
+        did not reach anything, so a shard that measured none of its thirty-eight has
+        `measured == 0` and can never wear `no survivors`."""
+        gate = sweep.classify([_result(sweep.OUT_OF_TIME)])
+        self.assertEqual(gate.measured, 0)
+        self.assertEqual(sweep.gate_conclusion(gate), sweep.NO_VERDICT)
+
+    def test_a_plan_of_nothing_but_unreached_mutations_is_not_nothing_to_sweep(self):
+        """The trap #782 left open for this one. `NOTHING` is reached only from the
+        bottom, and a shard whose budget ran out before its first mutation has zero of
+        everything — which without this check reads as a docs-only branch."""
+        gate = sweep.classify([_result(sweep.OUT_OF_TIME) for _ in range(38)])
+        self.assertNotEqual(sweep.gate_conclusion(gate), sweep.NOTHING)
+        self.assertNotIn("nothing to sweep", sweep.headline(gate))
+
+    def test_the_check_name_says_how_much_of_the_plan_was_measured(self):
+        """The sentence #630 argued for and #803 is the branch it was never reached on.
+        "6 not measured" alone tells a reader nothing about how much they may lean on
+        the page; "23 of 29 measured" tells them exactly."""
+        results = [_result("pinned", line=n) for n in range(23)]
+        results += [_result(sweep.OUT_OF_TIME, line=n) for n in range(23, 29)]
+        gate = sweep.classify(results)
+        self.assertEqual(sweep.headline(gate),
+                         "no verdict: 23 of 29 measured, 6 out of time")
+
+    def test_survivors_found_before_the_budget_ran_out_are_still_reported(self):
+        """The whole point. A branch with a survivor in the measured slice must hear
+        about it, and hear in the same breath that the count is a floor."""
+        results = [_result("survived", line=1)]
+        results += [_result(sweep.OUT_OF_TIME, line=n) for n in range(2, 8)]
+        gate = sweep.classify(results)
+        self.assertEqual(sweep.headline(gate),
+                         "no verdict: 1 survivor so far, 1 of 7 measured, 6 out of time")
+
+    def test_it_is_no_verdict_and_not_a_pass_once_the_gate_enforces(self):
+        """Same code as `unresolved` — 3 — because what the two license a reader to
+        believe is identical, which is nothing. What a person DOES about them differs,
+        and that is what the page and the name are for."""
+        gate = sweep.classify([_result(sweep.OUT_OF_TIME)])
+        self.assertEqual(sweep.gate_exit_code(gate, enforce=True), 3)
+        self.assertEqual(sweep.exit_code([_result(sweep.OUT_OF_TIME)]), 3)
+
+    def test_the_page_names_the_lines_nobody_swept_and_says_re_running_will_not_help(self):
+        results = [_result("pinned", line=1)]
+        results += [_result(sweep.OUT_OF_TIME, line=n, path="charter/b.py")
+                    for n in range(2, 5)]
+        page = sweep.gate_summary(sweep.classify(results), "a" * 40, "b" * 40, 12.0, False)
+        self.assertIn("Out of time — planned, and never measured", page)
+        self.assertIn("1 of 4 mutation(s) on this branch were measured", page)
+        self.assertIn("charter/b.py:2", page)
+        self.assertIn("Re-running does not help", page)
+        # And never the sentence that says the branch is covered.
+        self.assertNotIn("Nothing added here is a line the suite would not miss", page)
+
+    def test_the_lines_nobody_swept_are_marked_in_the_margin_too(self):
+        """Annotations are where a reviewer already is. A survivor outranks one of these
+        for the shared warning budget, because a finding beats an absence — but an
+        absence still gets drawn once the findings have had their slots."""
+        drawn = sweep.annotations(sweep.classify([_result(sweep.OUT_OF_TIME, line=7)]))
+        self.assertEqual(len(drawn), 1)
+        self.assertIn("Out of time — this line was never swept", drawn[0])
+        self.assertIn("line=7", drawn[0])
+
+    def test_a_survivor_takes_the_annotation_slot_before_an_unswept_line_does(self):
+        results = [_result("survived", line=n) for n in range(sweep.ANNOTATION_CAP + 5)]
+        results += [_result(sweep.OUT_OF_TIME, line=900)]
+        drawn = "\n".join(sweep.annotations(sweep.classify(results)))
+        self.assertNotIn("line=900", drawn)
+
+    def test_the_verdict_survives_the_trip_through_a_shards_file(self):
+        """A shard writes this and another machine classifies it (#617). A verdict that
+        did not round-trip would arrive at the merge step as something else, and the
+        something else it would most likely arrive as is `pinned`."""
+        back = sweep.results_from_json(sweep.as_json([_result(sweep.OUT_OF_TIME)]))
+        self.assertEqual([r.verdict for r in back], [sweep.OUT_OF_TIME])
+        self.assertEqual(len(sweep.classify(back).out_of_time), 1)
+
+    def test_the_budget_belongs_to_a_shard_and_not_to_a_person_at_a_terminal(self):
+        """A local `--gate` has no merge step to say how much of the plan was reached, so
+        a deadline there would hand somebody a truncated answer they never asked for."""
+        self.assertEqual(sweep.budget_for(sharded=True), float(sweep.SHARD_BUDGET))
+        self.assertEqual(sweep.budget_for(sharded=False), 0.0)
+        self.assertEqual(sweep.budget_for(sharded=False, override=90), 90.0)
+        self.assertEqual(sweep.budget_for(sharded=True, override=0), 0.0)
+        self.assertEqual(sweep.budget_for(sharded=True, override=-5), 0.0)
+
+
+class TheWorkflowsBackstopIsBehindTheBudget(unittest.TestCase):
+    """`sweep.py` sizes a shard to forty minutes; `sweep.yml` used to kill it at sixty.
+
+    #803 calls that mismatch a defect on its own, and it was: a shard that overran its
+    own budget got twenty further minutes of runway and *then* died with nothing, which
+    is the worst of both — the same wall clock spent inside the budget would have
+    produced a partial answer.
+
+    **The fix is not to make the two numbers equal.** They no longer describe one
+    deadline. `SHARD_BUDGET` is the deadline the shard keeps for itself and reports at;
+    `timeout-minutes` is the backstop for a shard that could not keep it — a hung
+    subprocess, a mutant that took the machine (#773). Setting them equal would have the
+    runner kill the shard at the exact moment it stops to write its answer, which
+    destroys the fix. What has to hold is that the backstop is strictly BEHIND the
+    budget, with room for the mutation still in flight to finish and for the file to be
+    written, and that is what this asserts — against the YAML, so the two cannot drift.
+    """
+
+    def setUp(self):
+        self.yaml = (Path(__file__).resolve().parent.parent
+                     / ".github" / "workflows" / "sweep.yml").read_text(encoding="utf-8")
+
+    def _timeouts(self):
+        return [int(n) for n in re.findall(r"timeout-minutes:\s*(\d+)", self.yaml)]
+
+    def test_the_workflow_states_a_backstop_at_all(self):
+        """The reader below is green on an empty list, so it is proved first."""
+        self.assertTrue(self._timeouts())
+
+    def test_the_shard_backstop_is_behind_the_budget_with_room_to_report(self):
+        backstop = max(self._timeouts()) * 60
+        self.assertIn(f"timeout-minutes: {backstop // 60}", self.yaml)
+        self.assertGreater(backstop, sweep.SHARD_BUDGET,
+                           "the runner would kill a shard at the moment it stops to "
+                           "write what it measured")
+        self.assertGreaterEqual(backstop - sweep.SHARD_BUDGET, 10 * 60,
+                                "a mutation in flight when the budget expires still has "
+                                "to finish, and the answer still has to be written")
+
+    def test_the_workflow_keeps_whatever_the_shard_wrote(self):
+        """Measured on run 33500900581: the `always()` upload step DID run on all eight
+        cancelled shards and concluded `success` — the runner was never the problem. It
+        uploaded nothing because `sweep.py` held the whole result set in memory until the
+        end, so `if-no-files-found` decided what a cancelled shard says, and it said
+        nothing. The step has to stay unconditional."""
+        self.assertIn("if: always()", self.yaml)
+        self.assertIn("Keep the result set, whatever the sweep said", self.yaml)
+
+
 class TheSweepIsSplitAcrossMachinesAndNothingIsDropped(unittest.TestCase):
     """#617's other half: five runs cancelled at `timeout-minutes: 60` across two branches.
 
@@ -3599,8 +3767,24 @@ class TheSweepIsSplitAcrossMachinesAndNothingIsDropped(unittest.TestCase):
         self.assertEqual(sweep.over_budget(224), "")
         loud = sweep.over_budget(225)
         self.assertIn("225 mutations", loud)
-        self.assertIn("still swept", loud)
-        self.assertIn("nothing here is dropped", loud)
+        self.assertIn("nothing here is dropped", loud.lower())
+
+    def test_past_the_ceiling_the_warning_promises_a_short_answer_and_not_a_missing_one(
+            self):
+        """#803. The old wording promised the opposite of what now happens, and it was
+        promising it accurately: "a shard may be cancelled at the job timeout, and a
+        cancelled shard reports no verdict rather than a short one" is exactly run
+        33500900581, where 231 mutations produced eight cancelled shards and
+        `no verdict: 8 of 8 shards did not report` concluding `success`.
+
+        A shard now stops at :data:`SHARD_BUDGET` and reports what it measured, so the
+        warning has to tell a reader what they will actually get. The word to look for
+        is the promise of a partial answer; the words that must be GONE are the ones
+        that told them to expect none."""
+        loud = sweep.over_budget(sweep.MAX_SHARDS * sweep.per_shard() + 1)
+        self.assertIn("PARTIAL answer", loud)
+        self.assertNotIn("cancelled", loud)
+        self.assertNotIn("no verdict", loud)
 
 
 #: Every duration a piece of prose quotes in seconds. The shape the workflow's comments
@@ -4074,7 +4258,7 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
                                "--github-output", str(self.outputs))
         self.assertEqual(code, 0, said)
         self.assertIn("::warning title=The deletion sweep is over its budget::", said)
-        self.assertIn("nothing here is dropped", said)
+        self.assertIn("Nothing here is dropped", said)
         # And it still asks about all three hundred, on the eight machines it is allowed.
         self.assertEqual(self._read_outputs()["shards"], "8")
         self.assertEqual(len([m for i in range(1, 9)
@@ -4183,6 +4367,153 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
         self.assertEqual(self._read_outputs(),
                          {"conclusion": "nothing", "headline": "nothing to sweep"})
         self.assertIn("## Deletion sweep — nothing to sweep", self.summary.read_text())
+
+    # ----------------------------------------------------------------------------------
+    # #803 — a shard that will not fit, end to end through the CLI the workflow runs.
+    # ----------------------------------------------------------------------------------
+
+    def _five(self):
+        """A five-mutation plan, and the two stubs that make measuring one free."""
+        plan = [sweep.Mutation("charter/m.py", n, n, "drop-if", "is it pinned?",
+                               "if x: pass", "", "close") for n in range(1, 6)]
+        for name, stub in (("plan_for", lambda *a, _p=plan: (_p, {})),
+                           ("load_map", lambda *a, **k: {})):
+            real = getattr(sweep, name)
+            setattr(sweep, name, stub)
+            self.addCleanup(setattr, sweep, name, real)
+        return plan
+
+    def test_the_budget_stops_the_sweep_and_the_rest_are_named_out_of_time(self):
+        """The defect, inverted. Before #803 a shard past its budget ran on to the
+        workflow's `timeout-minutes`, was cancelled, and reported nothing; now it stops
+        itself and the answers it has are the answers the branch gets.
+
+        The clock is scripted rather than real: `now` is called once per mutation, so
+        "two of five" is a boundary and not a stopwatch reading."""
+        self._five()
+        ticks = iter([0.0, 0.0, 99.0, 99.0, 99.0])
+        said = io.StringIO()
+        with contextlib.redirect_stdout(said):
+            results, _ = sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {},
+                                     self.workdir, 1, {}, 0, print, 60.0, None,
+                                     deadline=50.0, now=lambda: next(ticks))
+        self.assertEqual([r.verdict == sweep.OUT_OF_TIME for r in results],
+                         [False, False, True, True, True])
+        # The plan is still whole in the result set: five rows, not two.
+        self.assertEqual([r.mutation.line for r in results], [1, 2, 3, 4, 5])
+        self.assertIn("out of time: 2 of 5 mutation(s) measured", said.getvalue())
+
+    def test_a_run_with_no_budget_measures_the_whole_plan(self):
+        """The other side of the same line, and the one the deadline could silently take
+        away: an unsharded local `--gate` has no budget and must still sweep everything.
+        `no_shard_at_all_still_means_the_whole_plan` is the sibling of this for slicing,
+        and it exists because the sweep found the unsharded path untested."""
+        self._five()
+        with contextlib.redirect_stdout(io.StringIO()):
+            results, _ = sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {},
+                                     self.workdir, 1, {}, 0, print, 60.0, None,
+                                     deadline=None, now=lambda: 10.0 ** 9)
+        self.assertNotIn(sweep.OUT_OF_TIME, [r.verdict for r in results])
+        self.assertEqual(len(results), 5)
+
+    def test_a_shard_killed_mid_run_leaves_what_it_measured_on_disk(self):
+        """**The measurement this whole issue turns on.** On run 33500900581 the
+        `if: always()` upload step DID run on every cancelled shard and concluded
+        `success` — the runner was never the obstacle. It uploaded nothing because the
+        result set lived in memory until the last line of the sweep, so a killed process
+        took the whole answer with it and the run published
+        `no verdict: 8 of 8 shards did not report`.
+
+        So the file is written as the answers arrive. This reads it from inside `decide`,
+        which is exactly the instant a cancellation would land."""
+        plan = self._five()
+        out = self.tmp / "r.json"
+        snapshots = []
+        real = sweep.decide
+
+        def spy(box, mutation, modules):
+            snapshots.append([(r["line"], r["verdict"])
+                              for r in json.loads(out.read_text())])
+            return real(box, mutation, modules)
+
+        sweep.decide = spy
+        self.addCleanup(setattr, sweep, "decide", real)
+        with contextlib.redirect_stdout(io.StringIO()):
+            sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {}, self.workdir, 1, {},
+                        0, print, 60.0, None, record=lambda rows:
+                        out.write_text(sweep.as_json(rows)))
+        self.assertEqual(len(snapshots), len(plan))
+        # Before the first answer, the file already names the WHOLE plan. A file holding
+        # only the answers so far would read as a complete sweep of a short plan, which
+        # is the silent truncation this tool exists to refuse.
+        self.assertEqual(snapshots[0],
+                         [(n, sweep.OUT_OF_TIME) for n in range(1, 6)])
+        # And by the last one it is carrying the answers already in hand: four
+        # measured, and only the mutation about to be handed to this very call still
+        # standing at its written-down verdict.
+        self.assertNotIn(sweep.OUT_OF_TIME, [v for _, v in snapshots[-1][:4]])
+        self.assertEqual(snapshots[-1][4], (5, sweep.OUT_OF_TIME))
+
+    def test_a_shard_gets_the_budget_and_an_unsharded_run_does_not(self):
+        """What the workflow actually runs. `sweep.yml` passes `--shard` and no budget,
+        so the default is what decides whether a CI shard stops or is killed."""
+        seen = {}
+
+        def spy(*a, **k):
+            seen.update(k)
+            return [], []
+
+        for name, stub in (("sweep", spy), ("load_map", lambda *a, **k: {})):
+            real = getattr(sweep, name)
+            setattr(sweep, name, stub)
+            self.addCleanup(setattr, sweep, name, real)
+        code, said = self._cli("--gate", "--jobs", "1", "--base", self.base,
+                               "--shard", "2/3", "--no-baseline",
+                               "--workdir", str(self.workdir))
+        self.assertEqual(code, 0, said)
+        self.assertIsNotNone(seen["deadline"])
+        self.assertIn(f"budget: {sweep.SHARD_BUDGET // 60} min", said)
+        seen.clear()
+        code, said = self._cli("--gate", "--jobs", "1", "--base", self.base,
+                               "--no-baseline", "--workdir", str(self.workdir))
+        self.assertEqual(code, 0, said)
+        self.assertIsNone(seen["deadline"])
+        self.assertNotIn("budget:", said)
+
+    def test_the_partial_answer_reaches_the_check_name_the_merge_step_publishes(self):
+        """End to end and through the file, because that is how the answer travels: the
+        shard writes JSON, another machine reads it, and the NAME is the deliverable
+        (#630). What must never come back out of that trip is `no survivors`."""
+        self._five()
+        ticks = iter([0.0, 99.0, 99.0, 99.0, 99.0])
+        real = sweep.sweep
+        # The budget below is real and switches the deadline on; the boundary is pinned
+        # here so that "one of five" is a boundary and not a stopwatch reading.
+        sweep.sweep = lambda *a, **k: real(
+            *a, **{**k, "deadline": 50.0, "now": lambda: next(ticks)})
+        self.addCleanup(setattr, sweep, "sweep", real)
+        shards = self.tmp / "shards"
+        shards.mkdir()
+        code, said = self._cli("--gate", "--jobs", "1", "--base", self.base,
+                               "--shard", "1/1", "--no-baseline", "--budget", "50",
+                               "--workdir", str(self.workdir),
+                               "--json", str(shards / "sweep-results-1.json"))
+        self.assertEqual(code, 0, said)
+        self.outputs.unlink(missing_ok=True)
+        code, said = self._cli("--verdict", str(shards), "--shards", "1",
+                               "--ref", "HEAD", "--summary", str(self.summary),
+                               "--github-output", str(self.outputs))
+        self.assertEqual(code, 0, said)
+        out = self._read_outputs()
+        self.assertEqual(out["conclusion"], "no-verdict")
+        self.assertIn("1 of 5 measured, 4 out of time", out["headline"])
+        self.assertNotIn("no survivors", out["headline"])
+        self.assertNotIn("nothing to sweep", out["headline"])
+        # And not the sentence the whole run published before #803, because every shard
+        # DID report — a short answer is an answer.
+        self.assertNotIn("did not report", out["headline"])
+        self.assertIn("Out of time — planned, and never measured",
+                      self.summary.read_text())
 
     def test_a_diff_that_offers_no_mutation_is_not_a_branch_that_was_checked(self):
         """#779's own shape, run end to end, and the half `--base HEAD` cannot reach.

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -2581,7 +2581,8 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
     # never dealt in the same list, so that the plan it was given is legible. Stated as
     # the difference rather than as a second total, because two totals a reader has to
     # subtract is how "covered everything" gets read off a short run.
-    w(f"mutations applied : {len(results) - len(short)} of {len(results)}")
+    w(f"mutations applied : {len(results) - len(short)}"
+      + (f" of {len(results)}" if short else ""))
     w(f"pinned            : {len(pinned)}")
     w(f"SURVIVED          : {len(survivors)}")
     w(f"UNRESOLVED        : {len(unresolved)}")
@@ -2934,23 +2935,53 @@ def gate_exit_code(gate: Gate, enforce: bool) -> int:
 # complete question is spread across.
 
 #: What one shard is allowed to spend on mutations and fixed costs together, in seconds.
-#:
-#: **A deadline the shard keeps for itself, and no longer only a sizing input (#803).** It
-#: was written as the number `per_shard()` divides by, with `sweep.yml`'s
-#: `timeout-minutes: 60` twenty minutes behind it as a backstop — and on any plan past
-#: `MAX_SHARDS * per_shard()` the two combined produced the worst of both: a shard ran
-#: twenty minutes past the budget it was sized for, was cancelled by the runner, and
-#: reported *nothing at all* — not a partial answer, not the survivors it had already
-#: printed, nothing the merge step could read. Measured on run 33500900581: eight of eight
-#: shards cancelled to the second, and `no verdict: 8 of 8 shards did not report`
-#: concluding `success`.
-#:
-#: Now :func:`sweep` stops dealing mutations at `started + SHARD_BUDGET` and writes what
-#: it has, so the same wall clock buys a short answer instead of a silent one, and
-#: `timeout-minutes` goes back to being a backstop for a process that hung rather than a
-#: second deadline racing this one. The gap between them is deliberate and asserted:
-#: see `test_sweep.TheWorkflowsBackstopIsBehindTheBudget`.
+#: **A sizing input and not a deadline** — it is the number :func:`per_shard` divides by,
+#: and what it answers is "how many mutations may this machine be dealt". Deliberately
+#: under :data:`SHARD_TIMEOUT`, because the two failures are not symmetrical: a shard that
+#: finishes with time to spare costs a few runner-minutes, and one that does not is a
+#: machine's worth of work with nothing to show for it.
 SHARD_BUDGET = 40 * 60
+
+#: `sweep.yml`'s `timeout-minutes` for a shard job, in seconds, and the runner's own
+#: backstop: past this the job is cancelled and there is no further negotiation.
+#:
+#: Written here rather than only in the YAML so that :data:`SHARD_REPORT_AT` is derived
+#: from it instead of guessed beside it — the two files disagreeing about one deadline is
+#: #670's defect, and `test_sweep.TheReportingDeadlineSitsBetweenTheBudgetAndTheBackstop`
+#: holds the workflow to this number.
+SHARD_TIMEOUT = 60 * 60
+
+#: How long before :data:`SHARD_TIMEOUT` a shard stops and writes what it measured.
+#:
+#: Enough for the mutations still in flight to come back — a subset run, usually seconds;
+#: a survivor's full-suite confirmation, four to eight minutes — and for the result file
+#: to be written. It is best-effort and not a guarantee: `FULL_TIMEOUT` bounds one run at
+#: forty minutes, so a shard that stops with a slow survivor in flight can still be
+#: cancelled. That case is covered by the OTHER half of #803 rather than by this number —
+#: the result file is written as each answer arrives, so a shard killed here has already
+#: handed over everything it had.
+SHARD_KILL_MARGIN = 10 * 60
+
+#: When a shard stops dealing mutations and reports what it measured (#803).
+#:
+#: **Read off the backstop and not off the budget, and that distinction is the whole
+#: design.** The obvious reading of #803 is that `SHARD_BUDGET` should become the
+#: deadline, since a shard sized for forty minutes ought to stop at forty. It should not:
+#: `SHARD_BUDGET` is a *sizing estimate* built from an average mutation, and a shard whose
+#: slice happens to hold five survivors pays a full-suite run for each and legitimately
+#: needs longer. Stopping such a shard at forty would turn a complete answer that arrives
+#: at forty-eight minutes into a partial one — a regression, dressed as a fix, on exactly
+#: the branches that have something to report.
+#:
+#: So the shard uses every minute the runner will give it and stops just short of being
+#: killed. `SHARD_REPORT_AT > SHARD_BUDGET` is asserted, because that inequality is what
+#: says a correctly sized shard is never cut short by this.
+#:
+#: What run 33500900581 measured is what happens with no such line at all: eight shards
+#: ran to `timeout-minutes: 60`, were cancelled to the second, and reported *nothing* —
+#: not a partial answer, not the survivors they had already printed, nothing the merge
+#: step could read. `no verdict: 8 of 8 shards did not report`, concluding `success`.
+SHARD_REPORT_AT = SHARD_TIMEOUT - SHARD_KILL_MARGIN
 
 #: What a shard pays before it measures its first mutation, itemised, in seconds. Measured
 #: on `ubuntu-latest` and not on a workstation, because that is where the budget has to
@@ -3014,14 +3045,14 @@ def per_shard() -> int:
 def budget_for(sharded: bool, override: float | None = None) -> float:
     """Seconds this run may spend before it stops dealing mutations, or ``0`` for none.
 
-    A budget belongs to a **shard** and not to the tool: :data:`SHARD_BUDGET` is what one
-    machine in a fan-out is allowed to spend, and it is meaningful because the merge step
-    is there to say how much of the plan the fan-out reached. A person running
-    `tools/sweep.py --gate` at a terminal has no merge step and no second machine, so a
+    A deadline belongs to a **shard** and not to the tool. A shard runs on a machine with
+    a `timeout-minutes` on it and has a merge step downstream whose whole job is to say
+    how much of the plan the fan-out reached, so stopping short is a thing the run knows
+    how to report. A person running `tools/sweep.py --gate` at a terminal has neither: a
     deadline there would quietly stop a sweep they were waiting for and hand them a
-    partial answer they never asked for — which is the truncation this file refuses
+    partial answer they never asked for, which is the truncation this file refuses
     everywhere else. So it is off unless the run is a shard, and `--budget` is how a test
-    (or a person reproducing #803) turns it on anyway.
+    — or a person reproducing #803 — turns it on anyway.
 
     Out of :func:`main` for #572's reason: a rule written inside `main()` cannot be
     reached from a test, so it cannot be swept, so it is a guard this harness is unable
@@ -3029,7 +3060,7 @@ def budget_for(sharded: bool, override: float | None = None) -> float:
     """
     if override is not None:
         return max(0.0, float(override))
-    return float(SHARD_BUDGET) if sharded else 0.0
+    return float(SHARD_REPORT_AT) if sharded else 0.0
 
 
 def shards_for(mutations: int) -> int:
@@ -3299,7 +3330,8 @@ def annotations(gate: Gate) -> list[str]:
         # reviewer can do least with line by line: the count and the sentence carry it,
         # and what these mark is which part of the diff the sweep never reached.
         ("warning", gate.out_of_time, "Out of time — this line was never swept",
-         f"The shard's {SHARD_BUDGET // 60}-minute budget ran out before this mutation "
+         f"The shard stopped at {SHARD_REPORT_AT // 60} minutes, just short of the "
+         f"runner's own cap, before this mutation "
          "was measured, so nothing on this branch's sweep is a statement about this "
          "line. Re-running does not reach it; a smaller branch does."),
         ("notice", gate.platform, "Platform-deferred — never fails this gate",
@@ -3491,7 +3523,7 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float | None,
         w("")
         w(f"{gate.measured} of {gate.measured + len(gate.out_of_time)} mutation(s) on "
           "this branch were measured. The rest were dealt to no sandbox at all: a shard "
-          f"stops after {SHARD_BUDGET // 60} minutes and reports what it has, which is "
+          f"stops at {SHARD_REPORT_AT // 60} minutes and reports what it has, which is "
           "why there are numbers on this page at all — before #803 a shard past its "
           "budget was cancelled at the job timeout and everything it had already "
           "measured died with it.")
@@ -3798,7 +3830,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--budget", default=None, type=float, metavar="SECONDS",
                    help="Stop dealing mutations this many seconds after the run started "
                         "and report what was measured, marking the rest OUT OF TIME "
-                        "(#803). A --shard run gets SHARD_BUDGET by default because the "
+                        "(#803). A --shard run gets SHARD_REPORT_AT by default, which "
+                        "is just short of the runner's own cap, because the "
                         "merge step is there to say how much of the plan was reached; "
                         "an unsharded run gets none. 0 turns it off.")
     p.add_argument("--verdict", default=None, metavar="DIR",

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -2190,6 +2190,25 @@ def evidence_for(root: Path, mutation: Mutation, modules: list[str]) -> Evidence
 # 6. The sweep
 # --------------------------------------------------------------------------------------
 
+#: The verdict of a mutation this run never got to. **Not `unresolved` and not
+#: `withheld`**, and #698's argument for keeping those two apart is the same argument
+#: again: the three say different things about what the tool knows, and a reader's next
+#: move differs for each.
+#:
+#: * ``unresolved`` — a sandbox ran it and the run would not resolve. Re-run it, ideally
+#:   on a quieter machine; a second look may well answer.
+#: * ``withheld`` — the tool declined to ask, and can say why. Nothing to re-run.
+#: * ``out_of_time`` — the shard's budget expired before this mutation was dealt to a
+#:   sandbox. Re-running changes nothing on its own: the plan is bigger than the fan-out
+#:   can measure, which is a fact about :data:`MAX_SHARDS` and not about the mutation.
+#:
+#: It exists so that a shard which cannot finish can still say what it *did* measure
+#: (#803). Before it, a shard past its budget was cancelled at the workflow's
+#: `timeout-minutes` and reported nothing at all — the whole plan lost to protect nobody
+#: from a partial answer that was already in hand.
+OUT_OF_TIME = "out_of_time"
+
+
 @dataclasses.dataclass
 class Result:
     mutation: Mutation
@@ -2332,9 +2351,27 @@ def plan_for(root: Path, ref: str, scope: dict[str, set[int]], dirty: dict[str, 
 def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str, list[str]],
           workdir: Path, jobs: int, dirty: dict[str, bytes], second_order: int = 0,
           log=print, full_timeout: float = FULL_TIMEOUT,
-          shard: tuple[int, int] | None = None, cap: int = 0
+          shard: tuple[int, int] | None = None, cap: int = 0,
+          deadline: float | None = None, record=None, now=time.time
           ) -> tuple[list[Result], list["Pair"]]:
-    """Every mutation, run; every survivor, re-run against the whole suite."""
+    """Every mutation, run; every survivor, re-run against the whole suite.
+
+    *deadline* is an absolute :func:`time.time`, past which no further mutation is dealt
+    to a sandbox: the rest come back :data:`OUT_OF_TIME` and the run ends early with what
+    it measured (#803). ``None`` is the old behaviour, which is right for a run nobody is
+    holding a stopwatch on.
+
+    *record* is called with the whole plan every time an answer lands, and once before
+    the first one is measured. **The two together are what makes a shard that cannot
+    finish still able to report.** The deadline is the part that works when the process
+    is allowed to exit; *record* is the part that works when it is not — a killed shard
+    leaves the last call's file on disk, and `sweep.yml` uploads it under `always()`.
+
+    *now* is the clock the deadline is read off, and it is a parameter for one reason: a
+    test of "stops after two of five" written against the wall clock is a test that
+    measures the machine it runs on. A scripted clock makes the boundary exact, which is
+    what a boundary has to be to be worth asserting.
+    """
     plan, sources = plan_for(root, ref, scope, dirty)
     whole = len(plan)
     if shard is not None:
@@ -2354,7 +2391,20 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
     free: list[Sandbox] = list(boxes)
     import threading
     lock = threading.Lock()
-    results: list[Result] = []
+    # The whole plan, written down as :data:`OUT_OF_TIME` before a single mutation is
+    # measured and replaced in place as each answer arrives (#803). Two properties come
+    # from building it this way rather than appending answers to an empty list:
+    #
+    #   * whatever `record` has written at any instant is the COMPLETE plan with holes in
+    #     it, so a reader — the merge step, a person opening the artifact — is told how
+    #     many mutations this shard was dealt and not only how many it managed. A file
+    #     holding 23 answers and nothing about the other 6 is the silent-truncation shape
+    #     this whole tool exists to refuse: it reads as a complete sweep of a short plan.
+    #   * a killed shard's file is honest for the same reason, without the killed process
+    #     getting a chance to write anything.
+    results: list[Result] = [Result(m, OUT_OF_TIME, None, None, []) for m in plan]
+    if record:
+        record(results)
     counter = {"n": 0}
 
     def take() -> Sandbox:
@@ -2368,7 +2418,15 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
         with lock:
             free.append(box)
 
-    def run_one(mutation: Mutation) -> Result:
+    def run_one(job: tuple[int, Mutation]) -> None:
+        index, mutation = job
+        # Checked before a sandbox is taken and not after, so that a shard past its
+        # budget spends nothing further: the remaining mutations keep the verdict they
+        # were written down with. Between mutations is the only place this can be asked
+        # — a run in progress is a subprocess this thread is waiting on, and interrupting
+        # one would turn a measurement into an `unresolved`, which says the wrong thing.
+        if deadline is not None and now() >= deadline:
+            return
         modules = select_for(selection, mutation)
         box = take()
         try:
@@ -2376,9 +2434,16 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
         finally:
             box.restore()
             give(box)
+        result = Result(mutation, verdict, subset, full, modules)
         with lock:
             counter["n"] += 1
             n = counter["n"]
+            results[index] = result
+            # Under the lock with the assignment, so the file can never be written from
+            # a half-updated list, and after it, so the file always includes the answer
+            # whose log line is about to be printed.
+            if record:
+                record(results)
         # One line per mutation, always. A survivor costs a full suite run, so a sweep
         # can sit silent for a quarter of an hour, and a tool nobody can tell apart from
         # a hung one is a tool that gets killed and then not re-run.
@@ -2388,10 +2453,18 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
         label = {"survived": "SURVIVED", "pinned": "pinned  ",
                  "unresolved": "UNRESOLVED", "unapplied": "NOT APPLIED"}[verdict]
         log(f"    [{n}/{len(plan)}] {label}  {mutation}   ({how})")
-        return Result(mutation, verdict, subset, full, modules)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
-        results = list(pool.map(run_one, plan))
+        list(pool.map(run_one, enumerate(plan)))
+
+    # Said once and not once per mutation: a shard that ran out of time after four of
+    # thirty-eight would otherwise print thirty-four identical lines, and the number that
+    # matters is the one sentence, not the list.
+    short = sum(1 for r in results if r.verdict == OUT_OF_TIME)
+    if short:
+        log(f"  out of time: {len(plan) - short} of {len(plan)} mutation(s) measured. "
+            f"The remaining {short} were never dealt to a sandbox, and this shard reports "
+            f"what it has rather than nothing at all.")
 
     # A sandbox and not the checkout: the tests that are supposed to hold a guard are the
     # ones that existed AT THE REF. Reading the working tree's `tests/` instead would
@@ -2400,6 +2473,12 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
     for r in results:
         if r.verdict == "survived":
             r.evidence = evidence_for(boxes[0].path, r.mutation, r.modules)
+    # Once more, because `evidence` is what `_summary_rows` prints under every survivor
+    # and it did not exist at the last call. A file written without it round-trips as
+    # `naming: null`, which the merge step reads as "the evidence pass never ran" — true
+    # of a killed shard and a lie about one that finished.
+    if record:
+        record(results)
 
     pairs: list[Pair] = []
     if second_order:
@@ -2481,6 +2560,7 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
            elapsed: float, pairs: list["Pair"] | None = None) -> str:
     survivors = [r for r in results if r.verdict == "survived"]
     unresolved = [r for r in results if r.verdict == "unresolved"]
+    short = [r for r in results if r.verdict == OUT_OF_TIME]
     pinned = [r for r in results if r.verdict == "pinned"]
     unapplied = [r for r in results if r.verdict == "unapplied"]
     withheld = [r for r in results if r.verdict == "withheld"]
@@ -2496,10 +2576,17 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
         w(f"NOT ASKED ABOUT  : {reach()}")
     if baseline is not None:
         w(f"baseline          : Ran {baseline.ran} tests — {'OK' if baseline.green else baseline.detail}")
-    w(f"mutations applied : {len(results)}")
+    # `len(results)` was the plan length and the applied count at once, and since #803 it
+    # is only the first of those: a shard that ran out of time carries the mutations it
+    # never dealt in the same list, so that the plan it was given is legible. Stated as
+    # the difference rather than as a second total, because two totals a reader has to
+    # subtract is how "covered everything" gets read off a short run.
+    w(f"mutations applied : {len(results) - len(short)} of {len(results)}")
     w(f"pinned            : {len(pinned)}")
     w(f"SURVIVED          : {len(survivors)}")
     w(f"UNRESOLVED        : {len(unresolved)}")
+    if short:
+        w(f"OUT OF TIME       : {len(short)}  (never measured — the budget ran out)")
     if unapplied:
         w(f"NOT APPLIED       : {len(unapplied)}  (a defect in this tool, not a finding)")
     if withheld:
@@ -2520,6 +2607,20 @@ def report(results: list[Result], root: Path, ref: str, base: str, baseline: Out
             m = r.mutation
             w(f"  {m.path}:{m.line}  [{m.operator}]  "
               f"{r.subset.detail if r.subset else ''}")
+        w("")
+
+    if short:
+        w("-" * 86)
+        w("OUT OF TIME — these mutations were planned and never measured")
+        w("-" * 86)
+        w("The budget ran out before they were dealt to a sandbox, so nothing above is a")
+        w("statement about them. This is not a timeout on a mutation and not a question")
+        w("declined: they were simply not reached, and a re-run of the same plan on the")
+        w("same number of machines reaches the same point. What answers them is more")
+        w("shards or a smaller diff — not another run.")
+        for r in sorted(short, key=lambda r: (r.mutation.path, r.mutation.line)):
+            m = r.mutation
+            w(f"  {m.path}:{m.line}  [{m.operator}]  {m.question}")
         w("")
 
     if withheld:
@@ -2704,6 +2805,13 @@ class Gate:
     * ``unresolved`` — no verdict. A timeout is not a red and not a survivor. Under load
       this repository hits it repeatedly, and "I could not look" must never render as
       "nothing to see".
+    * ``out_of_time`` — the shard's budget ran out before this mutation was dealt to a
+      sandbox (#803). **Its own bucket and not folded into `unresolved`**, for #698's
+      reason once more: `unresolved` is "I looked and could not tell", and a re-run is
+      the answer to it. This is "I never looked", and a re-run of the same branch on the
+      same fan-out produces the same number — the response is more shards, or a smaller
+      diff, and reading it as a flaky timeout would send a person to re-run a gate that
+      cannot answer.
     * ``unapplied`` — the mutation never reached the tree (#586). A defect in the tool.
     * ``withheld`` — the mutation was never offered, because the mutant was not a program
       (#698). **Its own bucket and not folded into `unresolved`**, because the two say
@@ -2720,6 +2828,7 @@ class Gate:
     masked: list[Result] = dataclasses.field(default_factory=list)
     platform: list[Result] = dataclasses.field(default_factory=list)
     unresolved: list[Result] = dataclasses.field(default_factory=list)
+    out_of_time: list[Result] = dataclasses.field(default_factory=list)
     unapplied: list[Result] = dataclasses.field(default_factory=list)
     withheld: list[Result] = dataclasses.field(default_factory=list)
     pinned: int = 0
@@ -2740,6 +2849,11 @@ class Gate:
         mutation that exists. `withheld` is the one the tool declined to ask, so it never
         reached anything — and a plan of nothing but withheld mutations measured nothing,
         which is exactly what this property is for.
+
+        `out_of_time` is excluded on the same test and for the same reason (#803): the
+        budget ran out before it was dealt to a sandbox, so nothing about it was put to
+        the suite. A shard that measured none of its thirty-eight has `measured == 0`,
+        which is what keeps it from ever wearing :data:`CLEAN`.
         """
         return (self.pinned + len(self.unpinned) + len(self.masked) + len(self.platform)
                 + len(self.unresolved) + len(self.unapplied))
@@ -2758,6 +2872,8 @@ def classify(results: list[Result]) -> Gate:
             gate.pinned += 1
         elif r.verdict == "unresolved":
             gate.unresolved.append(r)
+        elif r.verdict == OUT_OF_TIME:
+            gate.out_of_time.append(r)
         elif r.verdict == "unapplied":
             gate.unapplied.append(r)
         elif r.verdict == "withheld":
@@ -2785,7 +2901,9 @@ def gate_exit_code(gate: Gate, enforce: bool) -> int:
 
     * **1** — an actionable survivor. Write the test, or delete the line.
     * **3** — nothing actionable, but something could not be measured. Re-run it; do not
-      read it as clean.
+      read it as clean. A mutation the budget never reached (#803) is the same 3: what a
+      person does about it differs — more shards rather than another run — but what it
+      licenses a reader to believe is identical, which is nothing.
     * **4** — a mutation never applied. The tool is wrong, and its numbers are not
       evidence about this branch either way.
     """
@@ -2795,7 +2913,7 @@ def gate_exit_code(gate: Gate, enforce: bool) -> int:
         return 4
     if gate.actionable:
         return 1
-    return 3 if gate.unresolved else 0
+    return 3 if gate.unresolved or gate.out_of_time else 0
 
 
 # --------------------------------------------------------------------------------------
@@ -2816,10 +2934,22 @@ def gate_exit_code(gate: Gate, enforce: bool) -> int:
 # complete question is spread across.
 
 #: What one shard is allowed to spend on mutations and fixed costs together, in seconds.
-#: Deliberately under `sweep.yml`'s `timeout-minutes`, because the two failures are not
-#: symmetrical: a shard that finishes with time to spare costs a few runner-minutes, and a
-#: shard cancelled at the cap reports *nothing at all* — not a partial answer, not the
-#: survivors it had already printed, nothing the merge step can read.
+#:
+#: **A deadline the shard keeps for itself, and no longer only a sizing input (#803).** It
+#: was written as the number `per_shard()` divides by, with `sweep.yml`'s
+#: `timeout-minutes: 60` twenty minutes behind it as a backstop — and on any plan past
+#: `MAX_SHARDS * per_shard()` the two combined produced the worst of both: a shard ran
+#: twenty minutes past the budget it was sized for, was cancelled by the runner, and
+#: reported *nothing at all* — not a partial answer, not the survivors it had already
+#: printed, nothing the merge step could read. Measured on run 33500900581: eight of eight
+#: shards cancelled to the second, and `no verdict: 8 of 8 shards did not report`
+#: concluding `success`.
+#:
+#: Now :func:`sweep` stops dealing mutations at `started + SHARD_BUDGET` and writes what
+#: it has, so the same wall clock buys a short answer instead of a silent one, and
+#: `timeout-minutes` goes back to being a backstop for a process that hung rather than a
+#: second deadline racing this one. The gap between them is deliberate and asserted:
+#: see `test_sweep.TheWorkflowsBackstopIsBehindTheBudget`.
 SHARD_BUDGET = 40 * 60
 
 #: What a shard pays before it measures its first mutation, itemised, in seconds. Measured
@@ -2881,6 +3011,27 @@ def per_shard() -> int:
     return max(1, (SHARD_BUDGET - SHARD_FIXED) // SECONDS_A_MUTATION)
 
 
+def budget_for(sharded: bool, override: float | None = None) -> float:
+    """Seconds this run may spend before it stops dealing mutations, or ``0`` for none.
+
+    A budget belongs to a **shard** and not to the tool: :data:`SHARD_BUDGET` is what one
+    machine in a fan-out is allowed to spend, and it is meaningful because the merge step
+    is there to say how much of the plan the fan-out reached. A person running
+    `tools/sweep.py --gate` at a terminal has no merge step and no second machine, so a
+    deadline there would quietly stop a sweep they were waiting for and hand them a
+    partial answer they never asked for — which is the truncation this file refuses
+    everywhere else. So it is off unless the run is a shard, and `--budget` is how a test
+    (or a person reproducing #803) turns it on anyway.
+
+    Out of :func:`main` for #572's reason: a rule written inside `main()` cannot be
+    reached from a test, so it cannot be swept, so it is a guard this harness is unable
+    to hold itself to.
+    """
+    if override is not None:
+        return max(0.0, float(override))
+    return float(SHARD_BUDGET) if sharded else 0.0
+
+
 def shards_for(mutations: int) -> int:
     """How many jobs *mutations* of them need, so that none of them runs out of time.
 
@@ -2895,19 +3046,29 @@ def over_budget(mutations: int) -> str:
     """Why this diff will be slow, said out loud, or ``""`` when it will not be.
 
     :data:`MAX_SHARDS` is a ceiling on machines and never on questions, so a diff past it
-    is still swept whole — its shards simply carry more than the budget and some of them
-    may be cancelled. That is a real risk to the run and it gets said here rather than
-    discovered in a cancelled job: the spec's rule about silent truncation is that a cap
-    the reader cannot see is worse than the cap.
+    is still dealt whole — its shards simply carry more than the budget. That is a real
+    risk to the run and it gets said here rather than discovered afterwards: the spec's
+    rule about silent truncation is that a cap the reader cannot see is worse than the
+    cap.
+
+    **What it says past the ceiling changed with #803, because what happens there did.**
+    It used to warn that a shard "may be cancelled at the job timeout, and a cancelled
+    shard reports no verdict rather than a short one", and run 33500900581 is that
+    sentence coming true on all eight at once: 231 mutations, eight shards cancelled to
+    the second at `timeout-minutes: 60`, and `no verdict: 8 of 8 shards did not report`
+    published as `success`. A shard now stops at its own budget and reports what it
+    measured, so the honest warning is that the ANSWER will be short — which is a thing
+    a reader can act on, where "there may be no answer" was only a thing to dread.
     """
     ceiling = MAX_SHARDS * per_shard()
     if mutations <= ceiling:
         return ""
     return (f"{mutations} mutations is past the {ceiling} that {MAX_SHARDS} shards can "
-            f"measure inside {SHARD_BUDGET // 60} minutes each. Every one of them is "
-            f"still swept — nothing here is dropped — but a shard may be cancelled at "
-            f"the job timeout, and a cancelled shard reports no verdict rather than a "
-            f"short one.")
+            f"measure inside {SHARD_BUDGET // 60} minutes each. Nothing here is dropped "
+            f"and every one of them is dealt to a shard — but a shard stops at its "
+            f"budget and reports what it measured, so this branch gets a PARTIAL answer "
+            f"with the unmeasured mutations named. Split the branch, or read the count "
+            f"as a floor.")
 
 
 def shard_of(plan: list[Mutation], index: int, count: int) -> list[Mutation]:
@@ -2995,12 +3156,20 @@ def gate_conclusion(gate: Gate, missing: int = 0) -> str:
     survivors, 2 not measured" is still a true statement about 8 real findings, whereas
     "8 survivors" from two thirds of a plan is a number nobody should quote.
 
+    :data:`OUT_OF_TIME` joins the missing shard at the top and not the unresolved
+    mutation below it, and getting that wrong would have made #803's fix a step backwards
+    (#803). A missing shard is exactly "two thirds of a plan", and after that fix it is
+    the mutations themselves that carry the fact — the shard now reports, so `missing` is
+    zero and `out_of_time` holds what `missing` used to. Ranked with `unresolved`, a
+    partial sweep that found three survivors would publish `3 survivors`: the true total
+    for the branch, said about a third of it.
+
     :data:`NOTHING` is last and it is reached only from the bottom — every count zero AND
     every shard in. Anything unmeasured has already answered above it, so "nothing to
     sweep" can never be worn by a run that lost a shard, and `missing` is what keeps
     `classify([])` from a cancelled sweep saying it.
     """
-    if missing or gate.unapplied:
+    if missing or gate.unapplied or gate.out_of_time:
         return NO_VERDICT
     if gate.actionable:
         return SURVIVORS
@@ -3052,6 +3221,15 @@ def headline(gate: Gate, missing: int = 0, shards: int = 1) -> str:
                       "applied")
     if gate.unresolved:
         unsure.append(f"{len(gate.unresolved)} not measured")
+    # Said with the count that WAS measured beside it, because that is the sentence #630
+    # argued for and #803 is the branch it was never reached on: "23 of 29 measured" is
+    # worth something and "6 not measured" on its own is not. `measured` is the property
+    # #782 added for exactly this — every bucket that reached a sandbox — so the two
+    # numbers here cannot drift from the table below them.
+    if gate.out_of_time:
+        whole = gate.measured + len(gate.out_of_time)
+        unsure.append(f"{gate.measured} of {whole} measured, "
+                      f"{len(gate.out_of_time)} out of time")
     if conclusion == SURVIVORS:
         return (f"{found}, {'; '.join(unsure)}{aside}" if unsure else f"{found}{aside}")
     if gate.actionable:
@@ -3117,6 +3295,13 @@ def annotations(gate: Gate) -> list[str]:
         ("warning", gate.unresolved, "No verdict — this mutation was never measured",
          "The run timed out rather than failing. That is not a red and it is not a pin; "
          "nothing here has been shown to be tested."),
+        # Last among the warnings, and behind `unresolved`, because it is the family a
+        # reviewer can do least with line by line: the count and the sentence carry it,
+        # and what these mark is which part of the diff the sweep never reached.
+        ("warning", gate.out_of_time, "Out of time — this line was never swept",
+         f"The shard's {SHARD_BUDGET // 60}-minute budget ran out before this mutation "
+         "was measured, so nothing on this branch's sweep is a statement about this "
+         "line. Re-running does not reach it; a smaller branch does."),
         ("notice", gate.platform, "Platform-deferred — never fails this gate",
          f"A narrowed catch on an exception the operating system decides. On "
          f"{sys.platform} the clause may be unreachable rather than untested, and one "
@@ -3213,6 +3398,9 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float | None,
     w(f"| platform-deferred | {len(gate.platform)} | the clause may be unreachable on "
       f"{sys.platform}; never fails this gate |")
     w(f"| unresolved | {len(gate.unresolved)} | no verdict — timed out, not measured |")
+    if gate.out_of_time:
+        w(f"| **out of time** | {len(gate.out_of_time)} | planned, never dealt to a "
+          "sandbox — the budget ran out |")
     if gate.withheld:
         w(f"| withheld | {len(gate.withheld)} | the mutant was not a program, so the "
           "question was not asked |")
@@ -3245,11 +3433,13 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float | None,
         w("### Did not report — this page is not a count")
         w("")
         if shards >= 1:
-            w(f"{missing} of {shards} shard(s) wrote no result. A shard is cancelled at "
-              "the job timeout rather than stopping short, so what it had already "
-              "measured is gone with it — the tables below are the shards that *did* "
-              "answer, and a branch with survivors in the missing slice looks exactly "
-              "like this one. Re-run the sweep; do not read it as clean.")
+            w(f"{missing} of {shards} shard(s) wrote no result at all. A shard that runs "
+              "out of time now stops and reports what it measured (#803), so this is "
+              "the narrower failure that is left: a shard that died before it reached "
+              "its first mutation, or a runner that vanished. The tables below are the "
+              "shards that *did* answer, and a branch with survivors in the missing "
+              "slice looks exactly like this one. Re-run the sweep; do not read it as "
+              "clean.")
         else:
             w("The sweep **never said how many shards it needed**, so nothing here knows "
               "how much of this branch was measured, or whether any of it was. That is "
@@ -3295,6 +3485,27 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float | None,
           "as clean.")
         for r in gate.unresolved:
             w(f"- `{r.mutation.tag}` in `{r.mutation.symbol}`")
+        w("")
+    if gate.out_of_time:
+        w("### Out of time — planned, and never measured")
+        w("")
+        w(f"{gate.measured} of {gate.measured + len(gate.out_of_time)} mutation(s) on "
+          "this branch were measured. The rest were dealt to no sandbox at all: a shard "
+          f"stops after {SHARD_BUDGET // 60} minutes and reports what it has, which is "
+          "why there are numbers on this page at all — before #803 a shard past its "
+          "budget was cancelled at the job timeout and everything it had already "
+          "measured died with it.")
+        w("")
+        w("**Read the counts above as a floor and not as a total.** A survivor in the "
+          "unmeasured slice looks exactly like this page. Re-running does not help — the "
+          f"plan is larger than {MAX_SHARDS} shards can measure — so either split the "
+          "branch, or raise the fan-out.")
+        w("")
+        for r in sorted(gate.out_of_time,
+                        key=lambda r: (r.mutation.path, r.mutation.line))[:20]:
+            w(f"- `{r.mutation.tag}` in `{r.mutation.symbol}` — _{r.mutation.question}_")
+        if len(gate.out_of_time) > 20:
+            w(f"- …and {len(gate.out_of_time) - 20} more")
         w("")
     if gate_conclusion(gate, missing) == NOTHING:
         w("### Nothing to sweep — and that is not the same as nothing wrong")
@@ -3532,7 +3743,7 @@ def exit_code(results: list[Result]) -> int:
         return 4
     if any(r.verdict == "survived" for r in results):
         return 1
-    return 3 if any(r.verdict == "unresolved" for r in results) else 0
+    return 3 if any(r.verdict in ("unresolved", OUT_OF_TIME) for r in results) else 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -3584,6 +3795,12 @@ def main(argv: list[str] | None = None) -> int:
                         "jobs. --second-order sees only its own slice and is weaker "
                         "under it; the masked-cluster BUCKET is not, because --verdict "
                         "classifies the merged results and not one shard's.")
+    p.add_argument("--budget", default=None, type=float, metavar="SECONDS",
+                   help="Stop dealing mutations this many seconds after the run started "
+                        "and report what was measured, marking the rest OUT OF TIME "
+                        "(#803). A --shard run gets SHARD_BUDGET by default because the "
+                        "merge step is there to say how much of the plan was reached; "
+                        "an unsharded run gets none. 0 turns it off.")
     p.add_argument("--verdict", default=None, metavar="DIR",
                    help="Merge every shard's --json from DIR into one answer, and say "
                         "which of the three a run found. Needs --shards.")
@@ -3702,9 +3919,29 @@ def main(argv: list[str] | None = None) -> int:
             # else, and it decides once.
             return 2 if args.enforce or not args.gate else 0
 
+    shard = parse_shard(args.shard) if args.shard else None
+    budget = budget_for(shard is not None, args.budget)
+    if budget:
+        left = budget - (time.time() - started)
+        log(f"  budget: {budget / 60:.0f} min from the start of this run, "
+            f"{max(0.0, left) / 60:.0f} left for mutations. Past it this shard stops and "
+            f"reports what it measured (#803).")
+    # Written after every answer and not only at the end (#803). The file is the only
+    # thing a shard hands anybody: a process killed with the whole result set in memory
+    # hands over nothing, which is what made eight cancelled shards on run 33500900581
+    # read as `no verdict` rather than as 224 measured mutations. `os.replace` because a
+    # reader may be a cancelled job's artifact upload, and a half-written file is a shard
+    # that did not report — `merge()` says so in as many words.
+    record = None
+    if args.json:
+        def record(rows: list[Result], path: Path = Path(args.json)) -> None:
+            part = path.with_name(path.name + ".part")
+            part.write_text(as_json(rows))
+            os.replace(part, path)
+
     results, pairs = sweep(root, ref, scope, selection, workdir, args.jobs, dirty,
-                           args.second_order, log, full_timeout,
-                           parse_shard(args.shard) if args.shard else None, cap=cap)
+                           args.second_order, log, full_timeout, shard, cap=cap,
+                           deadline=started + budget if budget else None, record=record)
     elapsed = time.time() - started
     text = report(results, root, ref, base, baseline, elapsed, pairs)
     log("")
@@ -3736,6 +3973,7 @@ def _say(args, gate: Gate, log, missing: int = 0, shards: int = 1) -> None:
     log("")
     log(f"gate: {len(gate.unpinned)} unpinned, {len(gate.masked)} in masked cluster(s), "
         f"{len(gate.platform)} platform-deferred, {len(gate.unresolved)} unresolved, "
+        f"{len(gate.out_of_time)} out of time, "
         f"{len(gate.unapplied)} not applied, {len(gate.withheld)} withheld, "
         f"{gate.pinned} pinned")
     log(f"gate: {headline(gate, missing, shards)}")


### PR DESCRIPTION
Closes #803.

## The defect, measured

Run [`33500900581`](https://github.com/diazoxide/charter/actions/runs/33500900581) (PR #796, head `36996e6`):

```
Size the sweep        11:09:49 → 11:15:10   success
Sweep shard 1..8      11:15:12 → 12:15:2x   cancelled   ← 60 min, to the second, all eight
Add up what the shards found                success
no verdict: 8 of 8 shards did not report    success      ← reports SUCCESS
```

231 mutations, eight shards, every one killed at `timeout-minutes: 60`. **How much answer
that threw away is countable, from the shards' own logs** — they print a line per mutation:

```
Sweep shard 1 of 8:  17 of 29 measured, 10 survived
Sweep shard 2 of 8:  22 of 29 measured,  8 survived
Sweep shard 3 of 8:  27 of 29 measured, 12 survived
Sweep shard 4 of 8:  19 of 29 measured,  8 survived
Sweep shard 5 of 8:  12 of 29 measured, 10 survived
Sweep shard 6 of 8:  21 of 29 measured,  7 survived
Sweep shard 7 of 8:  16 of 29 measured,  9 survived
Sweep shard 8 of 8:  18 of 28 measured,  7 survived

TOTAL: 152 of 231 mutations measured, 71 survivors printed
```

**Two thirds of the branch had been answered and 71 survivors had been printed when the
eight processes were killed.** All of it went with them, because the result set lived in
memory until the sweep's last line. The pull request was told `success`.

(71 is the raw `SURVIVED` count as each shard printed it, before the merge step sorts
survivors into `unpinned` / `masked` / `platform-deferred`. The actionable number is some
part of it, and nobody has ever seen which part.)

The plan job predicted it in the same run and proceeded — and the warning was accurate
rather than alarmist: `MAX_SHARDS = 8`, `per_shard() = 28`, so `8 x 28 = 224`, and **any
branch past that got this result regardless of what was in it.**

## Can a cancelled job report at all? Yes — measured, and it already did

This was the question that decided the design, so it was answered from the run rather than
from the documentation:

```
$ gh api repos/diazoxide/charter/actions/runs/33500900581/jobs \
    -q '.jobs[] | select(.name|test("Sweep shard 1 ")) | .steps[]'

"Sweep the guards this branch adds"              cancelled   11:15:17 -> 12:15:27
"Keep the result set, whatever the sweep said"   success     12:15:27 -> 12:15:27   <- ran
```

**The `if: always()` upload step ran on every one of the eight cancelled shards and
concluded `success`.** GitHub was never the obstacle. It uploaded nothing because there was
no file: `sweep.py` held the whole result set in memory until its last line, so
`if-no-files-found: ignore` silently decided what a cancelled shard says, and it said
nothing. `artifacts?total_count` on that run is `0`.

Reproduced locally too: a shard on a 38-mutation slice, killed 25 minutes in, left **no
`--json` at all**.

## The fix — option 3, plus a correction to option 2

**A shard reports what it measured.** The result file is written *before the first
mutation* — the whole plan, every row marked `out of time` — and rewritten (atomically, via
`os.replace`) as each answer lands. So a shard killed at any instant leaves the **complete
plan with holes in it**, not a short list that would read as a complete sweep of a short
plan. And it stops on its own ten minutes before the runner's cap, so the ordinary case is
a clean exit rather than a kill.

The check on a pull request now reads

```
deletion sweep / no verdict: 23 of 29 measured, 6 out of time
```

which is #630's own argument turned on itself: *a partial answer honestly labelled beats
silence.*

`out of time` is **its own bucket**, not folded into `unresolved` — #698's rule again.
`unresolved` is *I looked and could not tell*; re-run it. `out of time` is *I never
looked*; re-running the same plan on the same fan-out stops at the same place, so what
answers it is a smaller branch or more machines. It ranks with a **missing shard** and
above a survivor in `gate_conclusion`, because "3 survivors" said over a third of a plan is
a number nobody should quote — without that, this fix would have *downgraded* the verdict
it was written to protect.

### What was rejected

**Raising `MAX_SHARDS` (option 1).** Its docstring calls it a ceiling on machines and never
on questions, so it is the number written to be raised — but raising it moves the ceiling
without removing it, and the next large diff hits the same wall with more runners burned.
The ceiling is now *survivable*, which is the property that was missing.

**Lowering `timeout-minutes` to 40 (option 2 as stated).** The issue is right that the
twenty-minute gap was a defect — a shard that overran its sizing got twenty further minutes
of runway and *then* died with nothing. But the two never described one deadline, and
**setting them equal would have been a regression**: `SHARD_BUDGET` is a sizing estimate
built from an *average* mutation, and a shard whose slice holds five survivors pays a
full-suite run for each and legitimately needs longer. Cutting it off at forty turns a
complete answer arriving at forty-eight minutes into a partial one — on exactly the
branches that have something to report. Cutting the *runner* off at forty is worse: it
kills the shard at the instant it stops to write.

So the gap is closed by a **third** number between them:

| constant | value | what it decides |
|---|---|---|
| `SHARD_BUDGET` | 40 min | sizes the plan — how many mutations a machine may be dealt |
| `SHARD_REPORT_AT` | 50 min | when the shard stops and writes what it measured |
| `SHARD_TIMEOUT` | 60 min | the runner's cap, now in `sweep.py` and asserted against the YAML (#670) |

`SHARD_REPORT_AT > SHARD_BUDGET` is asserted, because that inequality is what says a
correctly sized shard is never cut short by this.

## Should `no verdict` block a merge?

**Recommended, and deliberately not done here** — enforcement is a repository setting and
the operator's call. The reasoning is on #803; the short version is that `collect` is
already the required check and `--enforce` already has a distinct exit code (`3`) for
exactly this, so it is one flag and no new machinery. But it should wait until a few real
branches have published a partial verdict and the numbers have been read and believed,
which is the same staging argument `gate_exit_code` makes about itself.

## Verification

* `tests.test_sweep` + `tests.test_workflows`: 491 tests, green.
* **Every guard added here was removed one at a time and the named tests watched go red** —
  18 un-guards, 18 red. One assertion was found vacuous that way
  (`assertIn("if: always()", yaml)` matches the `collect` job) and replaced with one that
  reads the step's own block.
* Ceiling reproduced before fixing: a synthetic 605-line diff planned
  `300 mutations -> 8 shard(s) of at most 28 each` with the over-budget warning, and a
  shard of that plan killed mid-run left nothing behind.
* The tool run on itself — `tools/sweep.py --path tools`, since CI's sweep charges
  `charter/` only and its verdict is worthless for this change — reported in a comment
  below.

Do not merge on CI alone: the `deletion sweep` check on this pull request charges `charter/`
and this branch does not touch it, so it will say `nothing to sweep`. That is correct and
it is not evidence about this change.

Generated with [Claude Code](https://claude.com/claude-code)
