### PR TITLE
Pin the eleven guards #804's own sweep found unpinned (#803)

### DIFF
--- a/docs/news/unreleased-a-sweep-that-cannot-finish-says-what-it-measured.md
+++ b/docs/news/unreleased-a-sweep-that-cannot-finish-says-what-it-measured.md
@@ -97,6 +97,38 @@ one that says a correctly sized shard is never cut short by this; the runner's c
 written in `sweep.py` and the YAML is held to it, so one deadline no longer lives in two
 files drifting apart (#670).
 
+## The tool was run on itself, three times, and the third one is the clean one
+
+`tools/sweep.py --path tools` over this change, because CI's sweep charges `charter/` and
+this change does not touch it. The rule that produced the table below is this repository's
+own: *after fixing a class of defect, re-run the measurement that found it over the fixed
+tree.*
+
+| run | | measured | pinned | survivors |
+|---|---|---:|---:|---:|
+| 1 | **killed by the machine at 13 of 39** | 13 | 9 | **4** |
+| 2 | complete, over the tree that fixed those 4 | 39 | 32 | **7** |
+| 3 | complete, over the tree that fixed those 7 | **37** | **37** | **0** |
+
+Run 1 is the whole issue arriving unrehearsed. The process was killed mid-sweep by a
+loaded machine, and the file it left behind said
+
+```
+no verdict: 4 survivors so far, 13 of 39 measured, 26 out of time
+```
+
+Under the old code that file would not have existed and the four findings would have gone
+with the process.
+
+**All eleven survivors were real, and every one of them was in this change's own reporting
+code** — the terminal report's count line and its section, the summary table's row, the
+twenty-line cap and its boundary, the verdict's wire spelling, the `>=` in the deadline,
+the file rewrite after the evidence pass, and the report's conditional denominator. Eight
+were pinned. Three were **deleted**: a clamp, a format spec and a subtraction inside one
+log line, none load bearing and none worth a test — *"equivalent mutant" and "dead code"
+are one finding*, and the honest answer to three survivors in a log line is a shorter log
+line.
+
 ## The lineage, and what is still open
 
 Each of these removed one way for a silent gate to read as a passing one:

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -3580,8 +3580,31 @@ class AShardThatWillNotFitReportsWhatItMeasured(unittest.TestCase):
         self.assertIn("1 of 4 mutation(s) on this branch were measured", page)
         self.assertIn("charter/b.py:2", page)
         self.assertIn("Re-running does not help", page)
+        # The outcome table too, and not only the prose below it. A reader who skims one
+        # skims the other, and the sweep found this row unpinned on this branch: deleting
+        # it left a table whose rows all read zero above a section saying three quarters
+        # of the branch was never measured.
+        self.assertIn("| **out of time** | 3 |", page)
         # And never the sentence that says the branch is covered.
         self.assertNotIn("Nothing added here is a line the suite would not miss", page)
+
+    def test_the_page_lists_twenty_unswept_lines_and_then_says_how_many_more(self):
+        """A long list is not a page anybody reads, and a truncated one that does not say
+        so is the silent-truncation shape this whole tool refuses — so the cap announces
+        itself, exactly as `ANNOTATION_CAP` does. Both halves were found unpinned by the
+        sweep on this branch: the `- …and N more` line, and the boundary that decides
+        when it appears."""
+        def page(n):
+            return sweep.gate_summary(
+                sweep.classify([_result(sweep.OUT_OF_TIME, line=i) for i in range(n)]),
+                "a" * 40, "b" * 40, 12.0, False)
+
+        exactly = page(20)
+        self.assertNotIn("more", exactly.split("Out of time")[1])
+        self.assertEqual(exactly.count("charter/a.py:"), 20)
+        over = page(21)
+        self.assertIn("- …and 1 more", over)
+        self.assertEqual(over.count("charter/a.py:"), 20)
 
     def test_the_lines_nobody_swept_are_marked_in_the_margin_too(self):
         """Annotations are where a reviewer already is. A survivor outranks one of these
@@ -3601,10 +3624,52 @@ class AShardThatWillNotFitReportsWhatItMeasured(unittest.TestCase):
     def test_the_verdict_survives_the_trip_through_a_shards_file(self):
         """A shard writes this and another machine classifies it (#617). A verdict that
         did not round-trip would arrive at the merge step as something else, and the
-        something else it would most likely arrive as is `pinned`."""
-        back = sweep.results_from_json(sweep.as_json([_result(sweep.OUT_OF_TIME)]))
+        something else it would most likely arrive as is `pinned`.
+
+        **The spelling is asserted and not only the symbol.** This string is a wire
+        format: it is written into a file by one process and read back by another, and
+        `results_from_json` takes `row["verdict"]` verbatim. `results_from_json`'s own
+        note about `withheld` is the precedent — a shard built by an older sweep than the
+        merge is a real situation, and the two agree on this literal or they do not agree
+        at all. Found by the sweep on this very branch: `retune-string` renamed it and
+        every test stayed green, because every one of them said `sweep.OUT_OF_TIME`."""
+        self.assertEqual(sweep.OUT_OF_TIME, "out_of_time")
+        written = sweep.as_json([_result(sweep.OUT_OF_TIME)])
+        self.assertIn('"verdict": "out_of_time"', written)
+        back = sweep.results_from_json(written)
         self.assertEqual([r.verdict for r in back], [sweep.OUT_OF_TIME])
         self.assertEqual(len(sweep.classify(back).out_of_time), 1)
+
+    def _report(self, results):
+        return sweep.report(results, Path("/x"), "a" * 40, "b" * 40, None, 1.0)
+
+    def test_the_report_says_of_how_many_only_when_some_were_missed(self):
+        """`mutations applied : N` is #782's line and a reader knows it. It gains a
+        denominator exactly when there is something to be short of, because "0 of 0" on
+        a docs branch is a question where "0" was a statement. Found by the sweep:
+        `collapse-ifexp` made the denominator unconditional and nothing went red."""
+        self.assertIn("mutations applied : 1\n", self._report([_result("pinned")]))
+        self.assertIn("mutations applied : 1 of 2\n",
+                      self._report([_result("pinned"),
+                                    _result(sweep.OUT_OF_TIME, line=2)]))
+
+    def test_the_report_a_person_reads_counts_and_names_what_was_never_measured(self):
+        """The terminal report, which is the whole answer for anyone running this by
+        hand rather than through a workflow. Its count line and its section were both
+        found unpinned by the sweep on this branch — `drop-if` deleted each and every
+        test stayed green, because the tests above read the check name and the markdown
+        page and nobody read this one."""
+        page = self._report([_result("pinned"),
+                             _result(sweep.OUT_OF_TIME, line=2, path="charter/b.py"),
+                             _result(sweep.OUT_OF_TIME, line=3, path="charter/b.py")])
+        self.assertIn("OUT OF TIME       : 2", page)
+        self.assertIn("OUT OF TIME — these mutations were planned and never measured",
+                      page)
+        self.assertIn("charter/b.py:3", page)
+        # And a run that measured everything says none of it, so the section cannot
+        # become decoration a reader learns to skip.
+        whole = self._report([_result("pinned")])
+        self.assertNotIn("OUT OF TIME", whole)
 
     def test_the_budget_belongs_to_a_shard_and_not_to_a_person_at_a_terminal(self):
         """A local `--gate` has no merge step to say how much of the plan was reached, so
@@ -4435,6 +4500,42 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
         # The plan is still whole in the result set: five rows, not two.
         self.assertEqual([r.mutation.line for r in results], [1, 2, 3, 4, 5])
         self.assertIn("out of time: 2 of 5 mutation(s) measured", said.getvalue())
+
+    def test_the_deadline_is_a_deadline_and_not_a_grace_period(self):
+        """The boundary, on the clock exactly. `>` and `>=` differ by one mutation, and
+        the one they differ by is the one dealt at the instant the budget expires — which
+        `>` would send to a sandbox for a full-suite run, on a machine that is about to
+        be killed. Found by the sweep on this branch: `shift-boundary` swapped them and
+        nothing went red, because the scripted clocks elsewhere step over the boundary
+        rather than landing on it."""
+        self._five()
+        ticks = iter([49.0, 50.0, 50.0, 50.0, 50.0])
+        with contextlib.redirect_stdout(io.StringIO()):
+            results, _ = sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {},
+                                     self.workdir, 1, {}, 0, print, 60.0, None,
+                                     deadline=50.0, now=lambda: next(ticks))
+        self.assertEqual([r.verdict == sweep.OUT_OF_TIME for r in results],
+                         [False, True, True, True, True])
+
+    def test_the_last_thing_written_is_written_after_the_evidence_pass(self):
+        """Three occasions, and the third is the one a spy inside `decide` cannot see:
+        the plan before the first mutation, each answer as it lands, and once more after
+        `evidence_for` has run — because `evidence` is what `_summary_rows` prints under
+        every survivor and it does not exist at the second of those. A file written
+        without it round-trips as `naming: null`, which the merge step reads as "the
+        evidence pass never ran": true of a killed shard, and a lie about a finished one.
+
+        Found by the sweep on this branch: dropping the third call left every test green,
+        because the test that watches the file watches it from inside `decide`."""
+        plan = self._five()
+        calls = []
+        with contextlib.redirect_stdout(io.StringIO()):
+            sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {}, self.workdir, 1, {},
+                        0, print, 60.0, None,
+                        record=lambda rows: calls.append([r.verdict for r in rows]))
+        self.assertEqual(len(calls), len(plan) + 2)
+        self.assertEqual(calls[0], [sweep.OUT_OF_TIME] * len(plan))
+        self.assertNotIn(sweep.OUT_OF_TIME, calls[-1])
 
     def test_a_run_with_no_budget_measures_the_whole_plan(self):
         """The other side of the same line, and the one the deadline could silently take

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -3954,11 +3954,15 @@ def main(argv: list[str] | None = None) -> int:
 
     shard = parse_shard(args.shard) if args.shard else None
     budget = budget_for(shard is not None, args.budget)
+    # One fact and not two. This line used to also work out how much of the budget was
+    # left after the map and the baseline, and the sweep's own sweep found every piece of
+    # that arithmetic unpinned — a clamp, a format spec, a subtraction, none of it load
+    # bearing and none of it worth a test. "Equivalent mutant" and "dead code" are one
+    # finding here, and the honest answer to three survivors in a log line is a shorter
+    # log line. The deadline is the fact; the reader can subtract.
     if budget:
-        left = budget - (time.time() - started)
-        log(f"  budget: {budget / 60:.0f} min from the start of this run, "
-            f"{max(0.0, left) / 60:.0f} left for mutations. Past it this shard stops and "
-            f"reports what it measured (#803).")
+        log(f"  budget: {budget / 60:.0f} min from the start of this run. Past it this "
+            f"shard stops dealing mutations and reports what it measured (#803).")
     # Written after every answer and not only at the end (#803). The file is the only
     # thing a shard hands anybody: a process killed with the whole result set in memory
     # hands over nothing, which is what made eight cancelled shards on run 33500900581


### PR DESCRIPTION
Follow-up to #804, which is on `main` as `34a74e0`.

## What happened

**#804 was merged at `5a2e7fe`, one commit before the tool was run on itself.** The two
commits that close what that run found never reached `main`, so `main` is carrying eleven
unpinned guards in the code #804 added. This is those two commits, rebased onto `main`,
plus the paragraph the news entry is missing.

Nothing here changes behaviour except three deleted lines in one log message. Everything
else is tests.

## The measurement #804 was merged without

`tools/sweep.py --path tools` — CI's sweep charges `charter/`, which neither #804 nor this
touches, so its `nothing to sweep` is correct and is not evidence about either. Three runs,
each over the tree the previous one criticised, which is this repository's own rule: *after
fixing a class of defect, re-run the measurement that found it over the fixed tree.*

| run | | measured | pinned | survivors | wall clock |
|---|---|---:|---:|---:|---:|
| 1 | **killed by the machine at 13 of 39** | 13 | 9 | **4** | — |
| 2 | complete, over the tree that fixed those 4 | 39 | 32 | **7** | 47.9 min |
| 3 | complete, over the tree that fixed those 7 | **37** | **37** | **0** | 21.6 min |

```
mutations applied : 37
pinned            : 37
SURVIVED          : 0
UNRESOLVED        : 0

gate: 0 unpinned, 0 in masked cluster(s), 0 platform-deferred, 0 unresolved,
      0 out of time, 0 not applied, 0 withheld, 37 pinned
gate: no survivors
```

**Run 1 is #803 arriving unrehearsed.** The sweep process was killed mid-run by a loaded
machine — load average 16, two agents sweeping at once, `exit 144`. The file it left behind
said:

```
rows in the killed shard file: 39
Counter({'out_of_time': 26, 'pinned': 9, 'survived': 4})
check name would be: no verdict: 4 survivors so far, 13 of 39 measured, 26 out of time
```

Under the code that was on `main` before #804, that file would not have existed and the
four findings would have gone with the process. The fix caught its own defect happening to
itself.

## The eleven, and what was done with each

**Eight pinned**, because each is a fact a reader acts on:

| operator | what was not pinned |
|---|---|
| `retune-string` | `OUT_OF_TIME = "out_of_time"` — the **wire spelling**. That string is written by one process and read verbatim by another (`results_from_json` takes `row["verdict"]` as-is), so a shard built by an older sweep than the merge agrees on this literal or does not agree at all. Every test said `sweep.OUT_OF_TIME`, so renaming it kept them all green. |
| `shift-boundary` | `now() >= deadline`. `>` and `>=` differ by exactly one mutation — the one dealt at the instant the budget expires, which `>` sends to a sandbox for a full-suite run on a machine about to be killed. |
| `drop-if` | the `record(results)` **after the evidence pass**. `evidence` is what `_summary_rows` prints under every survivor and does not exist at the previous write; a file without it round-trips as `naming: null`, which the merge step reads as "the evidence pass never ran" — true of a killed shard and a lie about a finished one. The test that watches the file watches it from inside `decide`, so it could not see this one. |
| `collapse-ifexp` | the report's denominator. `mutations applied : N` is #782's line and a reader knows it; it gains a denominator exactly when there is something to be short of, because `0 of 0` on a docs branch is a question where `0` was a statement. |
| `drop-if` ×2 | the terminal report's `OUT OF TIME : N` count line **and** its section. Both deletable with the whole suite green, because the tests read the check name and the markdown page and nobody read the report a person gets at a terminal. |
| `drop-if` | the summary table's `\| **out of time** \| N \|` row. Deleting it left a table whose rows all read zero, directly above a section saying three quarters of the branch was never measured. |
| `drop-if` + `shift-boundary` | the twenty-line cap on the unswept list **and its boundary**. A truncated list that does not say it was truncated is the silent-truncation shape this whole tool refuses, so the cap announces itself as `ANNOTATION_CAP` does. |

**Three deleted.** All inside one log line — a `max(0.0, left)` clamp counted twice and a
`.0f` format spec — working out how much of the budget remained after the map and the
baseline. None of it load bearing, none of it worth a test. This repository's rule is that
*"equivalent mutant" and "dead code" are one finding*, and the honest answer to three
survivors in a log line is a shorter log line. The deadline is the fact; a reader can
subtract.

## Verification

* `tests.test_sweep` + `tests.test_workflows`: 496 tests, green, against `main`'s tree.
* **27 un-guards, 27 red.** Every guard #804 and this pull request add was removed one at a
  time and the named tests watched go red — the eleven above using the tool's own mutation
  as the un-guard. One assertion was found vacuous that way in #804
  (`assertIn("if: always()", yaml)` is green with the upload step's condition deleted,
  because `collect` carries an `always()` too) and replaced.
* Run 3's `no survivors` is over the exact tree in this pull request.

## One thing worth knowing about #804's own checks

GitHub swallowed the `pull_request` event on this branch's last two pushes — the runs list
shows `push` runs for `fec2e38` and `e0b8f4d` and no `pull_request` run for either. That is
#646/#561 happening live, and the reason to read
`gh api .../commits/<head>/check-runs` rather than `gh pr checks`. The sweep was re-run by
`workflow_dispatch` on the head sha and is green there; CodeQL's last run on this branch was
on `5a2e7fe`.

Generated with [Claude Code](https://claude.com/claude-code)
