### PR TITLE
The sweep asks about a type filter once, and keeps the row that names it (#797)

### DIFF
--- a/docs/news/unreleased-the-sweep-asks-about-a-type-filter-once.md
+++ b/docs/news/unreleased-the-sweep-asks-about-a-type-filter-once.md
@@ -1,0 +1,108 @@
+---
+version: unreleased
+headline: The sweep asks about a type filter once, and the row it keeps is the one that names the filter
+---
+
+The second of two rule pairs in `tools/sweep.py` that were planning one edit twice, and the
+same answer as the first: neither rule is dropped, one half of each is kept.
+
+## Two rules, one program, two rows (#797)
+
+An `isinstance` call that **is** the whole `test` of an `if` with somewhere else for control
+to go satisfies two rules at once. `disable-branch` forces the test both ways, because a
+branch in a chain cannot be excised; `drop-isinstance` forces it one way, because that is
+what removing a type filter means. When the test *is* the call, one of those three mutants
+is a second copy of another — one span, one replacement, one program:
+
+```
+charter/hooks.py:6250   before='isinstance(node, dict)'
+    disable-branch   after='True'   "is the rest of the chain pinned, or does nothing
+                                     change when this condition always holds?"
+    drop-isinstance  after='True'   "is the type filter pinned?"
+
+tools/sweep.py:847      before='isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))'
+    disable-branch   after='True'
+    drop-isinstance  after='True'
+```
+
+Both rows survive the plan's de-duplication, which is keyed on
+`(line, col, operator, replacement)` — two operators, two keys — and both survive the
+report guard added with #721, which asks that sibling mutants carry distinct questions,
+tags and lines. These do. That is exactly the point: the two rows are told apart perfectly
+well and they are still **one question asked twice**. The cost is an extra sandbox run at
+each site and a second row in a report a person reads, where a reviewer has to work out
+that two rows are one edit before deciding they are one finding.
+
+## The row that stays is the one whose question is about this node
+
+Not "drop a rule". `drop-isinstance` keeps the forced direction, because
+*"is the type filter pinned?"* names what the mutant deleted, where *"is the rest of the
+chain pinned…?"* is true of any condition whatsoever and tells a reviewer nothing they
+could not read off the line. `disable-branch` stands down for that one direction and keeps
+the opposite one, so the pair is still a pair:
+
+```
+charter/hooks.py:6250 [disable-branch]  isinstance(node, dict) — is this branch pinned, or
+                                        does nothing change when its condition never holds?
+charter/hooks.py:6250 [drop-isinstance] isinstance(node, dict) — is the type filter pinned?
+```
+
+Two rows on the line, one per direction, each with its own question, and no direction
+asked twice. It is #755's trade made the same way — there the module-constant rule had the
+better *question* and the non-decimal rule the better *spelling*, and the fix kept one half
+of each — and the rule both rest on is `swap-synonym`'s, from #655: a mutation that
+produces a program another mutation already produces is **not offered** rather than given a
+verdict of its own.
+
+**The exclusion is narrow and structural.** The two rules read one helper, so what
+`disable-branch` declines is exactly what `drop-isinstance` produces and nothing more.
+`if isinstance(x, str) and x:` is not this shape — the test is the `and`, `drop-isinstance`
+never fires, and both branch directions are still asked. A bare `if isinstance(…)` with no
+`else` is still the type filter rule's alone. `while isinstance(…)` is untouched, because
+`disable-branch` does not reach a `while` at all.
+
+**The negated spelling is fixed too, and the tree has no instance of it.** `not isinstance(…)`
+is the same shape forced the other way, so its collision is on `False` rather than `True`.
+Writing the fix from the two sites that were measured rather than from the shape would have
+left half of it undone.
+
+## Re-measured over the whole tree, not over the fixture
+
+Every mutation planned for `charter/` and `tools/`, grouped by file and by
+`ast.dump(ast.parse(mutant_source))` so that two mutants which normalise to one AST are one
+program however they are spelled:
+
+| | `main` @ `34a74e0` | this branch, same sources |
+|---|---|---|
+| mutations over 98 files | 11,829 | 11,827 |
+| groups of two mutants of one node that are one program | **2** | **0** |
+
+The two rows that go are the two `disable-branch -> True` rows above. Nothing else moves and
+nothing is added.
+
+The two roots are kept apart in that table for a reason: `tools/sweep.py` is itself one of
+the swept sources, so running the changed rule over its own changed file would confound
+"mutations the rule stopped planning" with "mutations the fix's new lines added". Over the
+branch's own tree the count is 11,831 — two *more* than `main`, because the fix is four
+mutable lines longer than the code it replaces — and still **0** colliding groups. Neither
+of those is the number a pull request's sweep charges, which is the diff in `charter/` and
+nothing else.
+
+This is the third time in a row the tree-wide re-enumeration has been worth more than the
+fixtures: it is what found #797 while #755 was being fixed, and #754's own fix had
+re-introduced the very collision it was fixing because the fixture was written from the
+shapes rather than from the tree. The general guard now carries both `isinstance` chains, in
+both spellings — its only `isinstance` before was a bare `if`, where the two rules do not
+overlap, which is how a defect of this class sat inside the test written to catch it.
+
+## Every shard is re-dealt by this
+
+`shard_of` deals the plan round-robin — `plan[index - 1::count]` — so a plan two mutations
+shorter puts different mutations on different machines. Measured over the same sources:
+the first plan position that differs is the 7,515th of 11,829, and over eight shards
+**4,313 of the 11,827 remaining mutations land on a different shard**; the 7,514 before the
+first removal stay where they were.
+
+Nothing that was ever a distinct question is dropped and nothing is added; membership simply
+moves. #754 was verified on the property that plan order does not move, which is why that
+work and this are deliberately separate commits.

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -485,6 +485,178 @@ class AConstantIsOfferedOnceHoweverItIsSpelled(unittest.TestCase):
         self.assertEqual(_afters(muts, "retune-constant"), ["0o701", "0o71"])
 
 
+class ATypeFilterThatIsAWholeBranchIsAskedAboutOnce(unittest.TestCase):
+    """#797: an `isinstance` call that IS the `test` of an `if` with somewhere else to go.
+
+    `disable-branch` forces such a test both ways and `drop-isinstance` forces it one way,
+    and when the test is the call the two are one span with one replacement — so one of
+    the three rows was a second copy of another. It is #755's class in a different pair of
+    rules: not an ambiguity (the tags and the questions are perfectly distinct, which is
+    why `TwoMutantsOfOneNodeAreNeverReportedAlike` could not see it) but **one question
+    asked twice** — an extra sandbox run per site, and a second row in a report a person
+    reads, where the reviewer has to work out that the two rows are one edit.
+
+    **The row that stays is `drop-isinstance`'s, because its question is about this node.**
+    "is the type filter pinned?" names what the mutant deleted; "is the rest of the chain
+    pinned, or does nothing change when this condition always holds?" is true of any
+    condition whatever, and says nothing a reviewer could not have read off the line. So
+    `disable-branch` stands down for that one direction and keeps the other — which is
+    #755's trade made the same way, one half of each rule, and leaves the pair still a
+    pair: two rows on the line, one per direction, each with a distinct question.
+
+    The rule both fixes rest on is `swap-synonym`'s, from #655: a mutation that produces a
+    program another mutation already produces is *not offered* rather than given a verdict
+    of its own.
+    """
+
+    #: Both spellings of the shape, and the direction `drop-isinstance` forces each to.
+    #: The negated one is the half the tree had no instance of on `main` — the collision
+    #: is `disable-branch`'s `False` there rather than its `True` — and writing the fix
+    #: from the two sites that were MEASURED rather than from the shape would have left it.
+    BOTH_WAYS = (("isinstance(node, dict)", "True", "False"),
+                 ("not isinstance(node, dict)", "False", "True"))
+
+    def _branch(self, test: str):
+        return _mutations(f"""
+            def walk(node):
+                if {test}:
+                    return 1
+                else:
+                    return 2
+        """)
+
+    def test_the_forced_test_is_offered_once_in_each_direction(self):
+        """The whole issue, as counted rows: three mutants of one node became two, and
+        the two that remain are the two directions the node can be forced."""
+        for test, _, _ in self.BOTH_WAYS:
+            with self.subTest(test=test):
+                on_test = [m for m in self._branch(test)
+                           if m.operator in ("disable-branch", "drop-isinstance")]
+                self.assertEqual(sorted(m.after for m in on_test), ["False", "True"])
+
+    def test_the_row_that_keeps_the_forced_direction_asks_about_the_type_filter(self):
+        """Which of the two rules kept it, and that it kept the specific question. A fix
+        that dropped `drop-isinstance` at these sites would satisfy the count above and
+        lose the only question that names what the edit removed."""
+        for test, drops, _ in self.BOTH_WAYS:
+            with self.subTest(test=test):
+                muts = _by(self._branch(test), "drop-isinstance")
+                self.assertEqual([(m.after, m.question) for m in muts],
+                                 [(drops, "is the type filter pinned?")])
+
+    def test_the_other_direction_is_still_asked_and_still_disable_branchs(self):
+        """Nothing that was ever a distinct question is dropped. `disable-branch` declines
+        exactly the direction the other rule already produces and keeps the opposite one,
+        so the chain question is still on the line."""
+        chain = {"False": "is this branch pinned, or does nothing change when its "
+                          "condition never holds?",
+                 "True": "is the rest of the chain pinned, or does nothing change when "
+                         "this condition always holds?"}
+        for test, _, kept in self.BOTH_WAYS:
+            with self.subTest(test=test):
+                muts = _by(self._branch(test), "disable-branch")
+                self.assertEqual([(m.after, m.question) for m in muts],
+                                 [(kept, chain[kept])])
+
+    def test_a_branch_whose_test_is_not_a_type_filter_keeps_both_directions(self):
+        """The exclusion is narrow. `disable-branch` is a pair by design and stays one
+        everywhere the other rule does not already own a direction — which is every `if`
+        chain in the tree but the handful this issue is about."""
+        muts = _by(_mutations("""
+            def f(y):
+                if y:
+                    return 1
+                else:
+                    return 2
+        """), "disable-branch")
+        self.assertEqual(sorted(m.after for m in muts), ["False", "True"])
+
+    def test_a_type_filter_that_is_only_half_the_condition_declines_nothing(self):
+        """`if isinstance(x, str) and x:` is not this shape: the test is the `and`, so
+        forcing it `True` is not the same edit as dropping the type filter — indeed
+        `drop-isinstance` does not fire here at all, and a `disable-branch` that stood
+        down for it would leave the direction unasked by anybody."""
+        muts = _mutations("""
+            def f(x):
+                if isinstance(x, str) and x:
+                    return 1
+                else:
+                    return 2
+        """)
+        self.assertEqual(_by(muts, "drop-isinstance"), [])
+        self.assertEqual(_afters(muts, "disable-branch"), ["False", "True"])
+
+    def test_a_bare_type_filter_still_gets_its_row(self):
+        """A withheld node with no rule left to ask about it is a guard silently
+        uncovered. `disable-branch` never fires on a chain with no `else`, so nothing is
+        declined here and the type filter is asked about exactly as before."""
+        muts = _mutations("""
+            def f(name):
+                if isinstance(name, str):
+                    use(name)
+        """)
+        self.assertEqual(_afters(muts, "drop-isinstance"), ["True"])
+
+    def test_a_type_filter_on_a_while_still_gets_its_row(self):
+        """`drop-isinstance` reaches `while` and `disable-branch` does not, so the two
+        rules do not overlap here either — and the shared helper must not narrow the rule
+        that keeps the row to the `if` the other one cares about."""
+        muts = _mutations("""
+            def f(node):
+                while isinstance(node, list):
+                    node = node[0]
+                return node
+        """)
+        self.assertEqual(_afters(muts, "drop-isinstance"), ["True"])
+
+    def test_the_two_sites_the_issue_measured_plan_two_mutants_and_not_three(self):
+        """The tree's own instances, transcribed: `charter/hooks.py`'s `walk` and this
+        file's own `annotation_positions`. Both are `if isinstance(…): … elif …`, which is
+        an `if` with an `orelse` and so the shape exactly."""
+        for source in ("""
+            def walk(node):
+                if isinstance(node, dict):
+                    for k, v in node.items():
+                        walk(v)
+                elif isinstance(node, list):
+                    for item in node:
+                        walk(item)
+        """, """
+            def annotations(node):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    annotation = node.returns
+                elif isinstance(node, (ast.arg, ast.AnnAssign)):
+                    annotation = node.annotation
+                else:
+                    annotation = None
+                return annotation
+        """):
+            with self.subTest(source=source.split("\n")[1].strip()):
+                muts = [m for m in _mutations(source)
+                        if m.operator in ("disable-branch", "drop-isinstance")]
+                by_span: dict[tuple, list] = {}
+                for m in muts:
+                    by_span.setdefault(m.span, []).append(m)
+                # Keyed on the span, because a chain's `elif` is its own `ast.If` with its
+                # own test — and one with no `else` of its own, where `disable-branch`
+                # never fires and there is nothing to decline. So the count differs
+                # between the two tests of one chain, and what does not differ is that no
+                # direction is offered twice.
+                for _, ms in by_span.items():
+                    afters = sorted(m.after for m in ms)
+                    self.assertEqual(
+                        afters, sorted(set(afters)),
+                        f"{ms[0].before!r} at line {ms[0].line} is forced the same way "
+                        "by two rules: " + ", ".join(f"{m.operator} -> {m.after}"
+                                                     for m in ms))
+                # The chain's OWN test is the one both rules reach, and it keeps both
+                # directions — one row each, which is the whole of what the fix preserves.
+                head = by_span[min(by_span)]
+                self.assertEqual(sorted(m.after for m in head), ["False", "True"])
+                self.assertEqual({m.operator for m in head},
+                                 {"disable-branch", "drop-isinstance"})
+
+
 # ======================================================================================
 # Splicing — line numbers are the whole output of this tool
 # ======================================================================================
@@ -2281,6 +2453,13 @@ class TwoMutantsOfOneNodeAreNeverReportedAlike(unittest.TestCase):
     #: measured over all of them and not over the ones somebody remembered. The seven
     #: shapes that yield siblings for one node are all here; the rest are here so that an
     #: operator added to `_iter_operators` without a line here fails the coverage test.
+    #:
+    #: **It also has to hold the shapes where two RULES meet on one node**, which is a
+    #: different thing from one rule yielding siblings and is not implied by the coverage
+    #: test — `MODE = 0o600` is #755's and the two `isinstance` chains are #797's. That
+    #: issue was found by re-enumerating the whole tree and not by this fixture, precisely
+    #: because the fixture had every operator and not every MEETING: its one `isinstance`
+    #: was a bare `if` with no `else`, where the two rules do not overlap.
     FIXTURE = """
         LIMIT = 28
         MODE = 0o600
@@ -2296,6 +2475,14 @@ class TwoMutantsOfOneNodeAreNeverReportedAlike(unittest.TestCase):
                 return []
             if text.startswith("focus:"):
                 return []
+            if isinstance(d, dict):
+                keys = 1
+            else:
+                keys = 2
+            if not isinstance(rows, list):
+                keys = 3
+            else:
+                keys = 4
             if x == 1:
                 head = 1
             else:
@@ -2358,6 +2545,14 @@ class TwoMutantsOfOneNodeAreNeverReportedAlike(unittest.TestCase):
         strings in every field it reads. That was #755, live in this fixture on `MODE =
         0o600` for as long as the class existed: two rows, two sandbox runs, one integer,
         and the second row spelled the way the tool's own comment says nobody can read.
+
+        #797 is the same class in a different pair of rules and it was NOT live in this
+        fixture, which is how it survived the guard's first day: `disable-branch` and
+        `drop-isinstance` both force an `isinstance` test to a constant, and the fixture's
+        only `isinstance` was a bare `if` where `disable-branch` does not fire at all. Both
+        chains are here now, in both spellings — the plain call, where the collision is on
+        `True`, and the negated one, where it is on `False` and the tree happened to have
+        no instance.
 
         Keyed on the span alone and not on the operator, because "the same program" is not
         an operator's business — two rules recognising one node is exactly how the

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -1139,17 +1139,36 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
         # happen and a mutation that reddens the suite for that reason is a false pin —
         # the one outcome worse than no signal.
         if isinstance(node, ast.If) and node.orelse:
+            # One direction of this pair is `drop-isinstance`'s when the test IS an
+            # `isinstance` call, and forcing that test to a constant is one edit however
+            # it is tagged — the same span, the same replacement, the same program, and
+            # two rows in a report a person reads (#797). The rule that keeps the row is
+            # the one whose question is about THIS node: "is the type filter pinned?"
+            # names what the mutant deleted, where "is the rest of the chain pinned?" is
+            # true of any condition at all. So the row stays, the pair stays a pair — one
+            # row per direction on the same line — and only the tag and the question on
+            # the forced-`True` half change. #755 is the same trade made the same way, and
+            # #655 is the rule both rest on: a mutation that produces a program another
+            # mutation already produces is not offered rather than given a verdict of its
+            # own.
+            #
+            # Structural and local, not a set built by an earlier pass: the shape is
+            # readable off this node, so `_isinstance_forced_to` decides it for both rules
+            # and neither has to run first.
+            owned = _isinstance_forced_to(node.test)
             # "this" and "the other" are two different questions and they are also not
             # self-locating: which is which is knowable only by reading this file, and the
             # reviewer holding the report does not have it open. Naming the direction the
             # condition was forced makes each one checkable against the printed line,
             # which is what #721 asks of a question that has to carry the disambiguation.
-            yield (node.test, "False", "disable-branch",
-                   "is this branch pinned, or does nothing change when its condition "
-                   "never holds?")
-            yield (node.test, "True", "disable-branch",
-                   "is the rest of the chain pinned, or does nothing change when this "
-                   "condition always holds?")
+            if owned != "False":
+                yield (node.test, "False", "disable-branch",
+                       "is this branch pinned, or does nothing change when its condition "
+                       "never holds?")
+            if owned != "True":
+                yield (node.test, "True", "disable-branch",
+                       "is the rest of the chain pinned, or does nothing change when this "
+                       "condition always holds?")
 
         # The same refusal in expression clothes: `[x for x in xs if C]`. Round two's
         # first finding, `harness_rows`' `if _edge_of(slot) not in _COLUMN_EDGES`, lives
@@ -1179,13 +1198,14 @@ def _iter_operators(tree: ast.Module, sp: _Spans):
                        f"is the `{_oneline(sp.text(part), 48)}` half pinned?")
 
         # `if isinstance(x, str)` as the whole condition — the type filter, dropped.
-        if isinstance(node, (ast.If, ast.While)) and _is_isinstance(node.test):
-            yield (node.test, "True", "drop-isinstance",
-                   "is the type filter pinned?")
-        if isinstance(node, (ast.If, ast.While)) and isinstance(node.test, ast.UnaryOp) \
-                and isinstance(node.test.op, ast.Not) and _is_isinstance(node.test.operand):
-            yield (node.test, "False", "drop-isinstance",
-                   "is the type filter pinned?")
+        # `not isinstance(…)` is the same shape forced the other way, and both spellings
+        # are read off one helper so that the `disable-branch` rule above can decline
+        # precisely what this one claims and no more (#797).
+        if isinstance(node, (ast.If, ast.While)):
+            forced = _isinstance_forced_to(node.test)
+            if forced is not None:
+                yield (node.test, forced, "drop-isinstance",
+                       "is the type filter pinned?")
 
         # `x = max(a, b)` / `min(…)` — dropped to each operand in turn. `_window`'s
         # `n = max(1, height - _CHROME_ROWS)` and its `_top` clamp are both this shape.
@@ -1420,6 +1440,26 @@ def span_is_sound(sp: _Spans, node: ast.AST) -> bool:
 def _is_isinstance(node: ast.AST) -> bool:
     return (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
             and node.func.id == "isinstance")
+
+
+def _isinstance_forced_to(test: ast.AST) -> str | None:
+    """The constant `drop-isinstance` forces *test* to, or ``None`` if it declines it.
+
+    Both rules that can force an `if`'s test to a constant read this one function, so the
+    two cannot drift apart into a shape only one of them recognises. `drop-isinstance`
+    yields exactly this; `disable-branch` declines exactly this direction and keeps the
+    other (#797).
+
+    The two spellings are one shape and not two: `isinstance(x, str)` is dropped by
+    forcing the test `True`, and `not isinstance(x, str)` by forcing it `False`, and in
+    both cases what the mutant deletes is the type filter and nothing else.
+    """
+    if _is_isinstance(test):
+        return "True"
+    if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not) \
+            and _is_isinstance(test.operand):
+        return "False"
+    return None
 
 
 def _is_get(node: ast.AST) -> bool:


### PR DESCRIPTION
Closes #797.

## ⚠️ Shard membership moves — do not bundle this with anything that needs it stable

`shard_of` is `plan[index - 1::count]`, so a plan two mutations shorter deals **every**
shard differently. Measured over the same sources: the first plan position that differs is
the **7,515th of 11,829**, and over eight shards **4,313 of the 11,827 remaining mutations
land on a different shard**; the 7,514 before the first removal stay where they were.

Nothing that was ever a distinct question is dropped and nothing is added — membership
simply moves. #754 was verified on the property that plan order does not move, and #755
was kept separate for exactly this reason; this is the same kind of change.

---

## The defect

An `isinstance` call that **is** the whole `test` of an `if` with somewhere else for control
to go satisfies two rules at once. `disable-branch` forces such a test both ways (a branch
in a chain cannot be excised, so it is disabled instead); `drop-isinstance` forces it one
way (that is what removing a type filter means). When the test *is* the call, one of those
three mutants is a second copy of another — one span, one replacement, one program:

```
charter/hooks.py:6250   before='isinstance(node, dict)'
    disable-branch   after='True'   "is the rest of the chain pinned, or does nothing
                                     change when this condition always holds?"
    drop-isinstance  after='True'   "is the type filter pinned?"

tools/sweep.py:847      before='isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))'
    disable-branch   after='True'
    drop-isinstance  after='True'
```

Both rows survive `mutations_for`'s de-duplication, keyed on
`(line, col, operator, replacement)` — two operators, two keys — and both survive #721's
report guard, which asks that sibling mutants carry distinct questions, tags and lines.
These do, and that is the point: it is not an ambiguity, it is **one question asked twice**.
An extra sandbox run per site, and a second row in a report a person reads.

## The fix keeps the question that is about this node

Not "drop a rule", and #755's answer was not that either. Here both rules have a real
question, and the one that keeps the forced direction is `drop-isinstance`:

| | forced `True` | question |
|---|---|---|
| `disable-branch` | yes | *"is the rest of the chain pinned…?"* — true of **any** condition; a reviewer learns nothing they could not read off the line |
| `drop-isinstance` | yes | *"is the type filter pinned?"* — **names what the mutant deleted** |

So `disable-branch` stands down for that one direction and keeps the opposite one. The pair
is still a pair:

```
charter/hooks.py:6250 [disable-branch]  isinstance(node, dict) — is this branch pinned, or
                                        does nothing change when its condition never holds?
charter/hooks.py:6250 [drop-isinstance] isinstance(node, dict) — is the type filter pinned?
```

Two rows on the line, one per direction, each with its own question, and no direction asked
twice — one half of each rule, which is exactly the trade #755 made. The rule both rest on
is `swap-synonym`'s, from #655: *"a mutation that produces the same program asks nothing …
not offered rather than given a verdict of its own."*

Of the issue's three candidates this is **candidate 2**, with its stated objection
answered. It said it "makes one rule's output depend on another's, which nothing in
`_iter_operators` does today" — #755 landed exactly that dependency (`named_ints`) after the
issue was written, and this one is weaker still: the shape is readable off the node, so both
rules call one helper, `_isinstance_forced_to`, and neither has to run first.

**The exclusion is narrow, and each edge is a test.**

* `if isinstance(x, str) and x:` — the test is the `and`, `drop-isinstance` never fires,
  and both branch directions are still asked. A `disable-branch` that stood down here would
  leave a direction unasked by anybody.
* A bare `if isinstance(…)` with no `else` is still the type filter rule's alone.
* `while isinstance(…)` is untouched — `disable-branch` does not reach a `while` at all.
* **The negated spelling is fixed too, and the tree has no instance of it.**
  `not isinstance(…)` is the same shape forced the other way, so its collision is on
  `False`. Writing the fix from the two sites that were *measured* rather than from the
  shape would have left half of it undone.

## Re-measured over the whole tree, not over the fixtures

Every mutation planned for `charter/` and `tools/`, grouped by file and by
`ast.dump(ast.parse(mutant_source))` so that two mutants which normalise to one AST are one
program however they are spelled.

| | `main` @ `34a74e0` | this branch, **same sources** |
|---|---|---|
| mutations, 98 `.py` files walked | 11,829 | 11,827 |
| groups of two mutants of one node that are one program | **2** | **0** |

The only difference between the two plans is the removal of the two `disable-branch -> True`
rows above; `difflib` over the ordered `(path, line, operator, after)` lists reports two
deletions and no other opcode.

The two roots are held apart on purpose: `tools/sweep.py` is itself one of the swept
sources, so running the changed rule over its own changed file confounds *"mutations the
rule stopped planning"* with *"mutations the fix's new lines added"*. Over the branch's own
tree the count is **11,831 — two more than `main`**, because the fix is four mutable lines
longer than the code it replaces, and still **0** colliding groups. So "this shortens the
plan" is true of the rule and **false of the branch**; the consequence that matters, that
every shard is re-dealt, holds either way.

## The general guard now contains the shape it was written for

`test_no_two_mutants_of_one_node_are_the_same_program` shipped with #755 and could not have
caught this: its fixture's only `isinstance` was a bare `if` with no `else`, where the two
rules do not overlap. Both chains are in it now, in both spellings.

Verification that the new assertions measure something, run against `main`'s `sweep.py` with
this branch's tests: **8 subtests across 4 test methods go red**, including the general
guard on both new fixture lines. Run against the issue's *other* candidate (drop-isinstance
stands down instead), **6 go red** — among them
`test_the_row_that_keeps_the_forced_direction_asks_about_the_type_filter`, so the suite
measures the *choice* and not only the count.

## What CI can and cannot say about this

`DEFAULT_PATHS = ("charter",)`, so a pull request's sweep charges the diff in `charter/` and
nothing else. This branch touches `tools/sweep.py`, `tests/` and `docs/`, so the check on
this PR is named **`nothing to sweep`** — which is the honest answer and is *not* evidence
about the change. The tool was therefore run on itself.

### `tools/sweep.py --gate --path tools` — 8 mutations, 8 pinned, 0 survived

```
sweeping 0dfcecd2e94e (paths: tools)
  diff against 34a74e0d1997: 1 file(s), 53 added line(s)
  baseline: full suite, unmutated…  Ran 9892 tests — OK in 541s
  8 mutations across 1 file(s)
    [1/8] pinned  sweep.py:1168 [drop-if]         if owned != "True":  — is the refusal pinned?
    [2/8] pinned  sweep.py:1164 [drop-if]         if owned != "False": — is the refusal pinned?
    [3/8] pinned  sweep.py:1168 [retune-string]   "True"   — is this literal pinned?
    [4/8] pinned  sweep.py:1204 [drop-isinstance] isinstance(node, (ast.If, ast.While))
    [5/8] pinned  sweep.py:1206 [drop-if]         if forced is not None:
    [6/8] pinned  sweep.py:1164 [retune-string]   "False"  — is this literal pinned?
    [7/8] pinned  sweep.py:1459 [drop-if]         if isinstance(test, ast.UnaryOp) and …
    [8/8] pinned  sweep.py:1457 [drop-if]         if _is_isinstance(test): return "True"

mutations applied : 8      pinned : 8      SURVIVED : 0      UNRESOLVED : 0
gate: no survivors
```

Both `retune-string` mutants matter here and are the reason the two guards compare against
string constants: `owned != "Gbmtf"` is always true, so a misspelled constant is a guard
that silently declines nothing — the same shape as a guard deleted outright, and pinned by
the same tests.

Local full suite on 3.14: `Ran 9892 tests — OK (skipped=8)`. CI green on 3.11–3.14.
