### PR TITLE
A workspace tab opens the workspace it names, so every tab does something (§4k)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4425,13 +4425,45 @@ def _reopening(args) -> "Reopening | None":
 def _wants_attach(args) -> bool:
     """Whether this launch should become the operator's terminal.
 
-    Every launch except a reopen's does. Asked as its own function rather than inline as
-    ``_reopening(args) is None`` because the two are genuinely different questions that
-    happen to have one answer today — "am I restoring" and "am I the terminal" — and the
-    day a third caller wants one without the other, a shared expression would have to be
-    unpicked at two call sites at once.
+    Asked as its own function rather than inline as ``_reopening(args) is None`` because
+    the two are genuinely different questions that happen to have had one answer — "am I
+    restoring" and "am I the terminal". **That day arrived**: :func:`_open_workspace`
+    opens a workspace a tab named, from a `frame-switch` running detached with its streams
+    on `/dev/null`, and it is neither restoring nor a terminal. So the expression is
+    unpicked here, once, rather than at the three call sites that read it.
+
+    ``attach`` is deliberately a `getattr` default rather than a required field, for
+    `_reopening`'s own reason: every other caller of `cmd_launch` in this codebase — the
+    CLI's own namespace, `cmd_reopen`'s, and every test's — constructs an `args` without
+    it, and each of them IS the terminal. Absent means yes.
     """
+    if not getattr(args, "attach", True):
+        return False
     return _reopening(args) is None
+
+
+def _launch_size(args) -> tuple[int, int] | None:
+    """The window size this launch was HANDED, or ``None`` to measure its own terminal.
+
+    `cmd_launch` sizes the frame from `os.get_terminal_size()`, which is right for every
+    launch that has a terminal and raises `OSError` for one that does not — and the
+    `_FALLBACK_SIZE` underneath it is 80x24, which `_drawable_slots` reads as room for
+    almost nothing. A workspace opened by :func:`_open_workspace` has no terminal of its
+    own and yet is about to be shown on one charter can already measure (the client is
+    looking at the switching chat's window this instant), so the number is passed in
+    rather than guessed.
+
+    Validated rather than trusted: it reaches `layout.session_argv` as `-x`/`-y`, and a
+    non-positive or non-integer pair there is a tmux parse error that would take the whole
+    launch down with nothing on screen to say why.
+    """
+    got = getattr(args, "size", None)
+    if not isinstance(got, tuple) or len(got) != 2:
+        return None
+    cols, rows = got
+    if not isinstance(cols, int) or not isinstance(rows, int):
+        return None
+    return (cols, rows) if cols > 0 and rows > 0 else None
 
 
 def cmd_launch(args) -> int:
@@ -4456,7 +4488,19 @@ def cmd_launch(args) -> int:
         util.err("charter frame: nothing to run — `charter frame -- <command>`")
         return 2
 
-    if args.no_frame or not sys.stdout.isatty():
+    # **`_wants_attach` is in this guard, and it is a correctness fix rather than a
+    # widening.** A non-tty stdout means exactly one thing — "this process cannot be the
+    # operator's terminal" — and the conclusion drawn from it, run the harness bare, is
+    # right only for a launch that was going to BE that terminal. `_open_workspace` starts
+    # one from a `frame-switch` running detached with all three streams on `/dev/null`
+    # (`builtin_actions._spawn`), and it never attaches: arriving is `switch-client`.
+    #
+    # Left un-gated this is not a wrong frame, it is an `os.execvp` — `bypass` execs — so
+    # the switching process would have been REPLACED by a bare harness writing to
+    # `/dev/null`: no frame, no session, no switch, no exit code, and no surface left to
+    # report any of it on. That, and not the `attach` the old refusal named, is what
+    # actually stopped a detached process opening a workspace.
+    if args.no_frame or (not sys.stdout.isatty() and _wants_attach(args)):
         return bypass(argv)
 
     # A REGISTERED harness whose binary is not installed never reaches tmux — and the
@@ -4674,13 +4718,24 @@ def cmd_launch(args) -> int:
     # start rather than in front of it. See `_spawn_gather`.
     _spawn_gather(fid, ws)
 
-    try:
-        cols, rows = os.get_terminal_size()
-    except OSError:
-        # `os.get_terminal_size()` raises even when `isatty()` said yes — a tty with
-        # nothing behind it to answer `TIOCGWINSZ`. Falling back rather than propagating
-        # is the deliberate choice; see `_FALLBACK_SIZE`'s own docstring for why 80x24.
-        cols, rows = _FALLBACK_SIZE
+    given = _launch_size(args)
+    if given is not None:
+        # Handed a size by a caller that has no terminal of its own but knows which one
+        # this frame is about to be shown on — see :func:`_launch_size`. Measured in a
+        # process with its streams on `/dev/null`, on tmux 3.7c and at the 3.2 floor
+        # alike: `os.get_terminal_size()` raises there, so without this the frame would be
+        # laid out for `_FALLBACK_SIZE` and `_drawable_slots` would drop every panel the
+        # operator's real terminal has room for.
+        cols, rows = given
+    else:
+        try:
+            cols, rows = os.get_terminal_size()
+        except OSError:
+            # `os.get_terminal_size()` raises even when `isatty()` said yes — a tty with
+            # nothing behind it to answer `TIOCGWINSZ`. Falling back rather than
+            # propagating is the deliberate choice; see `_FALLBACK_SIZE`'s own docstring
+            # for why 80x24.
+            cols, rows = _FALLBACK_SIZE
 
     slots = _drawable_slots(cols, rows)
     env = _frame_env(fid, h)
@@ -6540,6 +6595,129 @@ def _clients_on(socket: str, session: str) -> list[str]:
     return out.stdout.split()
 
 
+def _open_workspace(fid: str, ws: str, *, socket: str) -> tuple[str, str] | None:
+    """Open *ws* on this plane without attaching to it — ``(session id, chat id)``, or
+    ``None`` having said why.
+
+    **§4k's other half, reached from a tab instead of from a command line.** `charter -w
+    foo` "opens or focuses": `_workspace_to_focus` is the focus, and this is the open, for
+    the surface where the operator did not type a command. The old refusal here named
+    ``charter <harness> --workspace foo`` for the operator to type by hand; this runs it.
+
+    **Why the reason the old refusal gave was wrong.** It said opening needs "a directory,
+    an ordinal, a harness process and an `attach`", and that a switch running detached with
+    its streams on `/dev/null` has "no terminal to attach anything to". The first three
+    need no terminal, and the fourth is not wanted: arriving is `switch-client`, which
+    #793 already does and which needs no tty at all. Measured on tmux 3.7c and at the 3.2
+    floor, in a process with `start_new_session=True` and all three streams on
+    `/dev/null`: `new-session -d`, `split-window`, a session option and `switch-client`
+    all succeed, and the client lands with nothing killed. `_wants_attach` is what carries
+    that decision into the launcher, and its docstring had already reserved the seam.
+
+    **And #518 does not reach this, which is worth stating rather than assuming.** #518 is
+    about `charter <harness>` resolving a workspace *silently*, and its "creating is not
+    free" paragraph is about `charter workspace create` making a workspace DIRECTORY from a
+    name the operator typed — "a picker that creates on a typo leaves litter". Nothing here
+    types a name or creates a workspace: `switch.to_workspace` has already refused any name
+    that is not already a directory under `workspaces/`, so the set of workspaces is the
+    same after this call as before it. What is created is a CHAT in a workspace that
+    exists, which is the thing §4k says `-w foo` creates. `_pin_workspace` is still not
+    reached with ``picked``, so the launcher's own pointer — #518's "never ask twice" — is
+    not written by a click either.
+
+    **Which harness**, and it is the one question a tab cannot carry. The chat the operator
+    clicked FROM recorded its own (`state.record_identity`, `$CHARTER_HARNESS`), and using
+    it makes the click mean "another workspace, same tool" — the only answer available that
+    the operator has actually expressed. A chat whose identity predates that record, or
+    names a harness this charter cannot launch, falls back to `[harness] default` and, with
+    neither, is refused by name rather than opened under something nobody chose.
+
+    **Where.** The workspace's own directory, which is what `charter --workspace foo` typed
+    in it would have used and what `state.record_cwd` is for. `cmd_launch` reads it from
+    `os.getcwd()`, so it is `os.chdir`'d into and restored in a `finally` — `cmd_reopen`'s
+    own arrangement, for its reason: this process goes on to re-lay-out two frames, and a
+    launcher left standing in somebody else's directory is exactly the silent wrongness
+    §4e's cwd item exists to close.
+
+    **The answer is re-asked, never inferred.** `_plane_session` is the same question that
+    returned ``None`` a moment ago, put again now the session exists — so a launch that
+    reported success but left nothing on the server is caught here rather than switching a
+    client at a session id charter made up.
+    """
+    # **The name must be free on the whole MACHINE, not merely unresolved on this plane**,
+    # and this guard is what keeps #793's cross-plane guarantee across the new door into
+    # the launcher. `_plane_session` answered ``None`` a moment ago, and that means "this
+    # plane cannot prove a session of this name is its own" — NOT "no such session". One
+    # tmux server serves every plane on this machine (eleven sessions from three projects
+    # on the operator's own socket the week this was written), and `cmd_launch` decides
+    # between starting a session and joining one with `if session in live_sessions:`, a
+    # NAME test over all of them. So an open that skipped this would add a chat window to
+    # another plane's live session — another project's frame, across every isolation
+    # boundary charter has — and then fail the `@charter_plane` veto on the way back out,
+    # leaving the operator told the open failed with a window sitting in somebody else's
+    # session. §3.3: "Open-or-focus must match on this plane's chat directories, never on a
+    # live session name."
+    #
+    # Deliberately refusing a session this plane may actually own but cannot PROVE it owns
+    # — a chat whose `harness_pane` record was lost, or one an older charter left unmarked.
+    # Both are recoverable by attaching to it by hand; a window in another project's frame
+    # is not, and the asymmetry decides which way an uncertain answer falls.
+    if state.workspace_prefix(ws) in _live_sessions(socket):
+        _say_on_screen(fid, f"cannot open '{ws}': a session of that name is already "
+                            "running on this machine and this plane cannot prove it is "
+                            f"its own — it is probably another plane's. Attach to it by "
+                            f"hand if it is yours: tmux -L {socket} attach -t "
+                            f"{state.workspace_prefix(ws)}")
+        return None
+    ident = state.identity(fid).get("CHARTER_HARNESS", "")
+    h = next((x for x in harness.all() if x.name == ident and x.cli_name), None)
+    if h is None:
+        fallback = (config.HARNESS or {}).get("default")
+        h = next((x for x in harness.all() if x.cli_name == fallback), None)
+    if h is None:
+        _say_on_screen(fid, f"cannot open '{ws}': this chat records no harness this "
+                            "charter can launch, and this plane declares no `[harness] "
+                            "default`")
+        return None
+    from types import SimpleNamespace
+    where = workspace.workspace_dir(ws)
+    root = where if where.is_dir() else config.ROOT
+    # Every field `cmd_launch` and `_choose_workspace` read is named rather than left to a
+    # `getattr` default — `_reopen_args`'s rule, which is what makes this a contract that
+    # can be read instead of a puzzle. `workspace` is set outright so `_picker_wanted` can
+    # never raise a prompt on a path with no operator waiting, `pick` is false for the same
+    # reason and for #518's pointer, `rest` is empty so §4k's open-or-focus gate stays
+    # reachable and the harness starts at its own prompt with nothing sent to it, and
+    # `attach` is the seam.
+    args = SimpleNamespace(harness=h.cli_name, rest=[], no_frame=False,
+                           workspace=ws, pick=False, attach=False,
+                           size=_window_size(socket, state.harness_pane(fid) or ""))
+    here_dir = os.getcwd()
+    try:
+        os.chdir(root)
+    except OSError:
+        _say_on_screen(fid, f"cannot open '{ws}': charter cannot enter "
+                            f"{contain.readable(str(root)) or 'its directory'}")
+        return None
+    try:
+        rc = cmd_launch(args)
+    finally:
+        try:
+            os.chdir(here_dir)
+        except OSError:
+            pass
+    opened = _plane_session(socket, ws=ws)
+    if opened is None:
+        # Said rather than swallowed, and this is the one outcome an operator cannot see
+        # for themselves: `cmd_launch`'s own `util.err` went to `/dev/null` with everything
+        # else this process writes, so without this line a click would simply do nothing —
+        # the exact complaint this change exists to answer, arriving through a new door.
+        _say_on_screen(fid, f"could not open workspace '{ws}' — the launcher returned "
+                            f"{rc} and started no session")
+        return None
+    return opened
+
+
 def _switch_client(fid: str, ws: str, *, said: str) -> None:
     """Move the client(s) reading chat *fid* to this plane's workspace *ws* — §4b.
 
@@ -6634,15 +6812,19 @@ def _switch_client(fid: str, ws: str, *, said: str) -> None:
         return
     there = _plane_session(socket, ws=ws)
     if there is None:
-        # **What a workspace with no session yet is answered with**, and it is a refusal
-        # rather than a launch. Opening one is `cmd_launch` — a directory, an ordinal, a
-        # harness process and an `attach` — and this runs detached with its streams on
-        # `/dev/null` (`builtin_actions._spawn`), with no terminal to attach anything to.
-        # `switch.py`'s rule is the same one: nothing there creates anything either, and
-        # #518 is why. So the refusal names the command that does.
-        _say_on_screen(fid, f"workspace '{ws}' is not open on this plane — open it with "
-                            f"`charter <harness> --workspace {ws}`")
-        return
+        # **What a workspace with no session yet is answered with, and it is now an OPEN
+        # rather than a refusal** — §4k's "if it is live, attach to it; if not, open it and
+        # leave the others", reached from a tab instead of a command line. This used to
+        # print `charter <harness> --workspace <ws>` for the operator to go and type, on
+        # the grounds that opening ends in an `attach` and a detached switch has no
+        # terminal for one. Measured on 3.7c and at the 3.2 floor, that is false twice
+        # over: a tty-less process creates sessions and panes perfectly well, and the
+        # attach is not wanted anyway — arriving is `switch-client`, three lines below.
+        # See :func:`_open_workspace`, which also says why #518 does not reach a name the
+        # operator picked off a list of workspaces that already exist.
+        there = _open_workspace(fid, ws, socket=socket)
+        if there is None:
+            return
     if there[0] == here[0]:
         # Records can disagree with tmux: `switch.to_workspace` refused this by NAME a
         # moment ago, off `state.workspace_for`, and this is the same question asked of

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -6595,7 +6595,8 @@ def _clients_on(socket: str, session: str) -> list[str]:
     return out.stdout.split()
 
 
-def _open_workspace(fid: str, ws: str, *, socket: str) -> tuple[str, str] | None:
+def _open_workspace(fid: str, ws: str, *, socket: str,
+                    window: str) -> tuple[str, str] | None:
     """Open *ws* on this plane without attaching to it — ``(session id, chat id)``, or
     ``None`` having said why.
 
@@ -6638,6 +6639,23 @@ def _open_workspace(fid: str, ws: str, *, socket: str) -> tuple[str, str] | None
     own arrangement, for its reason: this process goes on to re-lay-out two frames, and a
     launcher left standing in somebody else's directory is exactly the silent wrongness
     §4e's cwd item exists to close.
+
+    **How big, and why *window* is a parameter rather than another read of disk.** The frame
+    is laid out for the terminal it is about to be shown on, which is the one looking at the
+    switching chat right now — so the size is measured off THAT window and handed to the
+    launcher, which has no terminal of its own to measure (`_launch_size`).
+
+    It arrives as an argument because the caller has already proved it. This was
+    ``_window_size(socket, state.harness_pane(fid) or "")`` and the deletion sweep was right
+    to survive the ``or ""``: it is unreachable, and asking why the two sides cannot differ
+    is what found the real problem. `_switch_client` has already required
+    `_pane_place(socket, state.harness_pane(fid))` to answer, and `_pane_place` refuses an
+    empty target for its own measured reason — **an empty `-t` resolves to the tmux server's
+    CURRENT window**, which on a socket serving eleven sessions from three projects is very
+    likely another plane's. So the fallback could never fire, and if it ever had it would
+    have sized this plane's new frame off another project's terminal. Taking the window
+    `_pane_place` returned removes the unreachable branch and the second read of a record
+    that could disagree with the one the caller checked.
 
     **The answer is re-asked, never inferred.** `_plane_session` is the same question that
     returned ``None`` a moment ago, put again now the session exists — so a launch that
@@ -6691,7 +6709,7 @@ def _open_workspace(fid: str, ws: str, *, socket: str) -> tuple[str, str] | None
     # `attach` is the seam.
     args = SimpleNamespace(harness=h.cli_name, rest=[], no_frame=False,
                            workspace=ws, pick=False, attach=False,
-                           size=_window_size(socket, state.harness_pane(fid) or ""))
+                           size=_window_size(socket, window))
     here_dir = os.getcwd()
     try:
         os.chdir(root)
@@ -6837,7 +6855,7 @@ def _switch_client(fid: str, ws: str, *, said: str) -> None:
                                 f"workspace, so charter will not open '{ws}' — there "
                                 "would be no client to move into it")
             return
-        there = _open_workspace(fid, ws, socket=socket)
+        there = _open_workspace(fid, ws, socket=socket, window=here[1])
         if there is None:
             return
     if there[0] == here[0]:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -6822,6 +6822,21 @@ def _switch_client(fid: str, ws: str, *, said: str) -> None:
         # attach is not wanted anyway — arriving is `switch-client`, three lines below.
         # See :func:`_open_workspace`, which also says why #518 does not reach a name the
         # operator picked off a list of workspaces that already exist.
+        #
+        # **Asked before the open, because an open is not free.** The refusal below for
+        # "nobody is attached" is #411's shape — reporting a switch that moved nothing —
+        # and it used to sit after a `_plane_session` read that costs one tmux call. An
+        # open costs a harness process and a chat ordinal, so a frame nobody is looking
+        # at (the operator detached, or an agent with no terminal is driving it) must be
+        # refused BEFORE anything is started rather than after. Spelled here rather than
+        # hoisted over the whole function: the order of the other refusals is #793's and
+        # pinned by its own tests, and moving this one over `already in workspace` would
+        # change what a detached frame is told about a workspace it is already in.
+        if not _clients_on(socket, here[0]):
+            _say_on_screen(fid, "cannot switch: no terminal is attached to this "
+                                f"workspace, so charter will not open '{ws}' — there "
+                                "would be no client to move into it")
+            return
         there = _open_workspace(fid, ws, socket=socket)
         if there is None:
             return

--- a/charter/frame/choose.py
+++ b/charter/frame/choose.py
@@ -247,12 +247,13 @@ def pin_reason(noun: str, fid: str) -> str:
     which the picker is dishonest, and a `$CHARTER_WORKSPACE` pin does not make one: it
     pins which workspace this CHAT is in, and nothing here proposes to change that.
 
-    **The one refusal a workspace row can still earn is not asked here, deliberately.**
-    "That workspace is not open" is a question about live tmux sessions, and `pin_reason`
-    runs when the palette OPENS — so an answer taken here would be a reading of the server
-    from before the operator had chosen anything, drawn as though it were about the name
-    they went on to press. `commands_frame._switch_client` asks it at the instant it
-    matters, which is `cmd_chat`'s own split one noun out.
+    **What a workspace row does about "not open" is not asked here, deliberately — and it
+    is no longer a refusal.** Whether a workspace has a live session is a question about
+    tmux, and `pin_reason` runs when the palette OPENS, so an answer taken here would be a
+    reading of the server from before the operator had chosen anything, drawn as though it
+    were about the name they went on to press. `commands_frame._switch_client` asks at the
+    instant it matters — `cmd_chat`'s own split one noun out — and a workspace with no
+    session is opened there (§4k) rather than refused.
 
     For a persona it is the launch pin: the same sentence `switch.to_persona` refuses
     with, built from the same read (`switch._pin`), for the same reason.

--- a/charter/frame/switch.py
+++ b/charter/frame/switch.py
@@ -171,11 +171,14 @@ def to_workspace(fid: str, name: str) -> Outcome:
     and is still not a switch. They are asked in that order for :func:`to_persona`'s
     reason: the narrower answer is the one the operator can do something with.
 
-    **The fourth refusal is deliberately not here, because it is tmux's.** "That workspace
-    is not open" is a question about live sessions on a shared server, and answering it
-    here would answer it at the instant a palette opened rather than at the instant the
-    switch runs — `chats.check`'s own split, one noun out. `commands_frame._switch_client`
-    owns it, together with every other reading only a server can give.
+    **"Is it open" is deliberately not asked here, because it is tmux's — and since a tab
+    OPENS a workspace it is no longer a refusal at all.** A name that passes the three
+    checks above is a workspace this plane has, and `commands_frame._switch_client` either
+    finds its session or starts one (`_open_workspace`, §4k). Either way the answer belongs
+    to the instant the switch runs rather than the instant a palette opened —
+    `chats.check`'s own split, one noun out — and the readings it needs, which of this
+    plane's sessions is `ws` and whether its NAME is already taken on this shared machine
+    by a plane that is not this one, are ones only a server can give.
 
     **`$CHARTER_WORKSPACE` is no longer a pin on this noun, and its absence is a
     decision.** The variable pins which workspace THIS CHAT is in

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -2120,11 +2120,17 @@ clicks would be the "select, then confirm" that clicking a tab is supposed to re
 undo is `F2` → `chat` → close.
 
 A switch is still refused, with the reason on your own screen, for a name that cannot name a
-workspace, a workspace this plane does not have, the workspace you are already in, and — the
-one that is new — a workspace whose **name is already running on this machine under another
-plane**. One tmux server serves every plane on this machine, so `default` usually exists
-several times over; charter will not add your chat to another project's session, and tells
-you to attach to it by hand if it turns out to be yours.
+workspace, a workspace this plane does not have, the workspace you are already in, and a
+terminal that has moved nowhere. Two refusals are new, and both exist because opening is not
+free:
+
+* **A workspace whose name is already running on this machine under another plane.** One
+  tmux server serves every plane on this machine, so `default` usually exists several times
+  over. Charter will not add your chat to another project's session, and tells you to attach
+  to it by hand if it turns out to be yours.
+* **Nothing attached to the frame you are switching from.** If you have detached, or an
+  agent with no terminal is driving the frame, the click is refused before anything starts
+  rather than launching a harness into a workspace with no client to move into it.
 
 **Switching a persona from the picker moves the frame, and says so.** Choosing one writes
 the choice under the frame's own id and bumps the frame so every panel repaints, and a

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -430,8 +430,8 @@ set once, by the launch that creates a workspace's session, and holds that plane
 `.charter` path. Sessions started by a charter older than this carry no marker; those are
 still found by the pane record, which is what they were always found by.
 
-A workspace with no session yet is **not open**, and the switch says so rather than opening
-one — see *Switching a workspace moves your terminal* below for why.
+A workspace with no session yet is **opened**, and then you are taken to it — see
+*Switching a workspace moves your terminal* below for what that costs.
 
 ### Switching between them
 
@@ -2102,12 +2102,29 @@ its history — so nothing about the chat you left changes. It keeps running, ke
 whatever it was burning, and is still there when you switch back. That is the point:
 several workspaces open at once, one on screen.
 
-A switch is refused, with the reason on your own screen, for a name that cannot name a
-workspace, a workspace this plane does not have, the workspace you are already in, and a
-workspace that **is not open** — nothing on this plane has a session for it yet. Charter
-does not open one for you: opening a workspace starts a harness and attaches a terminal,
-and the switch runs detached with no terminal to attach. The refusal names the command that
-does it: `charter <harness> --workspace <name>`.
+**A workspace that is not open yet is opened, and you are taken to it.** Most of the tabs
+in the bar are like this — the bar lists every workspace the plane has, and only the ones
+you have been in today are running. Clicking one starts it: a chat, a harness, the panels,
+and then your terminal moves there. It is the same thing `charter <harness> --workspace
+<name>` does, which is what this used to print for you to go and type.
+
+The harness it opens with is **the one this chat is running**, because that is the only
+answer a tab can carry — a tab names a workspace and nothing else. If charter has no record
+of it, the plane's `[harness] default` is used, and with neither the click is refused by
+name rather than starting something you did not choose.
+
+What a click costs: one harness process at its own prompt with nothing sent to it, one chat
+directory, and a set of panels. Nothing is asked first, deliberately — the frame delivers no
+key events to a panel, so there is no confirmer available to one, and a tab that needed two
+clicks would be the "select, then confirm" that clicking a tab is supposed to replace. The
+undo is `F2` → `chat` → close.
+
+A switch is still refused, with the reason on your own screen, for a name that cannot name a
+workspace, a workspace this plane does not have, the workspace you are already in, and — the
+one that is new — a workspace whose **name is already running on this machine under another
+plane**. One tmux server serves every plane on this machine, so `default` usually exists
+several times over; charter will not add your chat to another project's session, and tells
+you to attach to it by hand if it turns out to be yours.
 
 **Switching a persona from the picker moves the frame, and says so.** Choosing one writes
 the choice under the frame's own id and bumps the frame so every panel repaints, and a

--- a/docs/news/unreleased-a-workspace-tab-opens-the-workspace-it-names.md
+++ b/docs/news/unreleased-a-workspace-tab-opens-the-workspace-it-names.md
@@ -1,0 +1,113 @@
+---
+version: unreleased
+headline: A workspace tab opens the workspace it names, so every tab in the bar does something
+---
+
+*"when I want to switch to another workspace it should switch and keep my current sessions
+open in background, but I can't switch — I get `charter: workspace 'default' is not open on
+this plane — open it with charter <harness> --workspace default`"*
+
+Thirteen of that operator's fifteen workspace tabs did nothing. The previous change made
+switching between workspaces that are *already open* work, and kill nothing. This is the
+other half: a tab for a workspace that is not open yet now **opens it and takes you there**
+— a chat, a harness, the panels, and then your terminal moves. It is exactly what the
+refusal used to print for you to go and type by hand.
+
+## The reason the refusal gave was wrong
+
+It said opening a workspace ends in an `attach`, and that a click runs detached with its
+streams on `/dev/null` and so has no terminal to attach anything to.
+
+The first half is true and the second half does not follow. A process with no controlling
+terminal and all three streams on `/dev/null` creates a tmux session, splits panes and sets
+session options perfectly well — measured on tmux 3.7c and at the 3.2 floor charter
+promises, identically on both. And the `attach` is not wanted: arriving somewhere is
+`switch-client`, which is what a switch between two open workspaces already does and which
+needs no terminal at all. So the workspace is built detached and the client is moved onto
+it, and the operator's own requirement — *keep my current sessions open in background* —
+holds through the open exactly as it holds through a switch. The chat you left keeps its
+pid.
+
+**What actually needed a terminal was somewhere else**, and it is worth naming because the
+failure would have been silent. The launcher's second guard is "no tty on stdout ⇒ run the
+harness with no frame", and that path calls `execvp`: a click reaching it would have
+*replaced* the switching process with a bare harness writing to `/dev/null`. No frame, no
+session, no switch, no exit code, and no surface left to report any of it on. That guard is
+now asked only of a launch that was going to be your terminal in the first place.
+
+There is a size to get right, too. A detached launcher cannot measure a terminal —
+`os.get_terminal_size()` raises there — and the fallback is 80x24, which charter reads as
+room for almost no panels. The size handed to the launch is the window your client is on at
+the moment you click, which is the size tmux will resize the new session to anyway.
+
+## What a click costs, plainly
+
+One harness process sitting at its own prompt, one chat directory, and a set of panels.
+Charter sends the harness nothing — no prompt, no resume, no arguments — so the click starts
+a program, it does not start a turn.
+
+**Nothing is asked first, and that is a decision rather than an omission.** The frame
+delivers `focus`, `blur`, `resize`, `click` and `scroll` to a panel and deliberately not
+`key`, because the harness owns the keyboard — so there is no keyboard confirmer available
+to a bar, and a tab that needed two clicks would be the select-then-confirm that clicking a
+tab exists to replace. Opening is also the reversible direction: `F2` → `chat` → close undoes
+it, and nothing is destroyed on the way in.
+
+The harness it opens with is **the one the chat you clicked from is running**, because a tab
+names a workspace and nothing else, and that is the only answer available that you actually
+expressed. Failing that, the plane's `[harness] default`. With neither, the click is refused
+by name rather than starting something nobody chose.
+
+## No workspace is created by a click
+
+Charter's standing rule is that a switch surface never creates: an unknown name is a
+question, because a picker that creates on a typo leaves litter.
+
+That rule is kept, and it was never the thing standing in the way. It is about creating a
+**workspace** — a directory on the plane — from a name somebody typed. A tab types nothing:
+the name comes off the list charter itself drew from the directories that already exist, and
+any other name has already been refused before this point. The set of workspaces on your
+plane is the same after a click as before it. What a click makes is a **chat** in a workspace
+that already exists, which is the same thing `charter --workspace <name>` makes, and no
+pointer is written for it either — that is still reserved for a workspace you picked at the
+launcher's own prompt.
+
+## It still will not put you in another project's workspace
+
+One tmux server serves every plane on this machine — eleven sessions from three different
+projects on the day this was written — and `default` is a name every plane has whether
+anybody chose it or not.
+
+Charter decides which session is yours from your own plane's records and a marker on the
+session, never from a name. That was already true for switching. Opening needed a guard of
+its own, because the launcher decides whether to start a session or join one **on the
+name**: "this plane cannot prove a session of that name is its own" is not the same fact as
+"that name is free", and without the guard a click would have added your chat window to
+another plane's live session and then failed the marker check on the way back out — leaving
+you told the open had failed, with a window sitting in somebody else's frame. So a name
+already running on this machine that this plane cannot claim is refused, and the message
+tells you how to attach to it by hand if it turns out to be yours.
+
+## Verification
+
+The tmux claim is measured directly, with charter out of the room: a process with
+`start_new_session=True` and all three streams on `/dev/null` builds a session, splits it,
+marks it and moves a real client attached to a real pty onto it, with nothing killed.
+
+Then the whole path end to end, with nothing faked but the harness binary — a real server, a
+real client on a real 132-column terminal, a real switch, a real launch underneath it, real
+panel processes. The workspace opens, the client arrives, the chat left behind keeps its pid,
+the session carries this plane's marker, and the new window is 132 columns wide rather than
+the 80 a detached launcher would otherwise have guessed.
+
+Three hand-written mutations were run against it and each goes red: dropping the size the
+launch is handed, ignoring the "do not attach" flag, and removing the cross-plane name guard.
+The second is the interesting one — it does not fail an assertion so much as `execvp` the test
+runner away into the fake harness, which is precisely the silent failure the guard exists to
+stop.
+
+Run against real tmux on **3.7c and on tmux 3.2**, the floor charter promises. CI installs no
+tmux, so the real-server half runs only by hand.
+
+Nothing to adopt — the `workspaces` bar is still off by default (`[frame] slots`), and a
+switch is the same command it always was.

--- a/docs/news/unreleased-a-workspace-tab-opens-the-workspace-it-names.md
+++ b/docs/news/unreleased-a-workspace-tab-opens-the-workspace-it-names.md
@@ -107,8 +107,13 @@ the interesting one — beyond failing those three assertions it `execvp`s the e
 test runner away into the fake harness, which is exactly the silent failure the guard exists
 to stop.
 
-Run against real tmux on **3.7c and on tmux 3.2**, the floor charter promises. CI installs no
-tmux, so the real-server half runs only by hand.
+Run against real tmux on **3.7c and on tmux 3.2**, the floor charter promises.
+
+CI does have tmux, and these tests really run there — what it does not have is a terminal
+tmux will hand a *client*, which is measured rather than assumed: the first version of this
+work asserted a client attached and went red on all four CI Pythons while passing here. The
+cases that need a real client try three `TERM`s and then skip, so the client half is verified
+by hand and the rest of it on every run.
 
 Nothing to adopt — the `workspaces` bar is still off by default (`[frame] slots`), and a
 switch is the same command it always was.

--- a/docs/news/unreleased-a-workspace-tab-opens-the-workspace-it-names.md
+++ b/docs/news/unreleased-a-workspace-tab-opens-the-workspace-it-names.md
@@ -53,6 +53,11 @@ to a bar, and a tab that needed two clicks would be the select-then-confirm that
 tab exists to replace. Opening is also the reversible direction: `F2` → `chat` → close undoes
 it, and nothing is destroyed on the way in.
 
+**And nothing is opened for nobody.** If no terminal is attached to the frame doing the
+switching — you detached, or an agent with no terminal is driving it — the click is refused
+before anything starts, rather than launching a harness into a workspace with no client to
+move into it.
+
 The harness it opens with is **the one the chat you clicked from is running**, because a tab
 names a workspace and nothing else, and that is the only answer available that you actually
 expressed. Failing that, the plane's `[harness] default`. With neither, the click is refused

--- a/docs/news/unreleased-a-workspace-tab-opens-the-workspace-it-names.md
+++ b/docs/news/unreleased-a-workspace-tab-opens-the-workspace-it-names.md
@@ -100,11 +100,12 @@ panel processes. The workspace opens, the client arrives, the chat left behind k
 the session carries this plane's marker, and the new window is 132 columns wide rather than
 the 80 a detached launcher would otherwise have guessed.
 
-Three hand-written mutations were run against it and each goes red: dropping the size the
-launch is handed, ignoring the "do not attach" flag, and removing the cross-plane name guard.
-The second is the interesting one — it does not fail an assertion so much as `execvp` the test
-runner away into the fake harness, which is precisely the silent failure the guard exists to
-stop.
+Four hand-written mutations were run against it and each goes red: dropping the size the
+launch is handed (1 failure), ignoring the "do not attach" flag (3), removing the cross-plane
+name guard (2), and dropping the fall back to the plane's default harness (1). The second is
+the interesting one — beyond failing those three assertions it `execvp`s the end-to-end's own
+test runner away into the fake harness, which is exactly the silent failure the guard exists
+to stop.
 
 Run against real tmux on **3.7c and on tmux 3.2**, the floor charter promises. CI installs no
 tmux, so the real-server half runs only by hand.

--- a/docs/news/unreleased-switching-workspace-moves-your-terminal-and-stops-nothing.md
+++ b/docs/news/unreleased-switching-workspace-moves-your-terminal-and-stops-nothing.md
@@ -60,14 +60,13 @@ pane record, exactly as they were before. The marker is written once, by the lau
 the session name, which is the collision itself, so re-marking there could relabel another
 plane's session as yours.
 
-## A workspace with no session yet is not open, and charter says so
+## A workspace with no session yet is opened
 
 The bar lists every workspace the plane has, and most of them are not running. Clicking one
-answers `workspace 'foo' is not open on this plane — open it with `charter <harness>
---workspace foo``. Charter does not open it for you: opening a workspace starts a harness and
-attaches a terminal, and a switch runs detached with no terminal to attach — a picker that
-creates on a typo leaves litter, which is the same rule every other switch in the palette
-follows.
+opens it and takes you there — see *A workspace tab opens the workspace it names*, which
+replaced the refusal this section used to describe and explains why the reason it gave
+("opening ends in an attach, and a switch has no terminal to attach") was measured to be
+false.
 
 The other refusals are a name that cannot name a workspace, a name this plane does not have
 (with the names it does have beside it), the workspace you are already in, and a terminal

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -59,16 +59,23 @@ _HAS_TMUX = shutil.which("tmux") is not None
 
 
 def _NOT_OPEN(ws: str) -> str:
-    """What `commands_frame._switch_client` says for a workspace with no session on this
-    server — the answer every click in this module gets, because a test fixture builds one
-    workspace session and clicks the tab of another.
+    """What a click on a not-open workspace's tab puts on this fixture's attention row.
+
+    **This used to be a flat refusal and is now as far as an OPEN gets here.** A tab for a
+    workspace with no session opens it (`commands_frame._open_workspace`); what stops it in
+    *this* module is the next question along — which harness to open it with. The chats
+    these cases build record no `$CHARTER_HARNESS` and the isolated plane declares no
+    `[harness] default`, so the open refuses by name rather than starting something nobody
+    chose. That is deliberate and load-bearing for a test suite: **no case in this file may
+    ever start a real harness process**, and the assertion below is what would notice if
+    one became reachable.
 
     Spelled here rather than imported, deliberately: it is the operator-visible sentence
     and this module's whole subject is that a click PRODUCES one. A constant read out of
     the module under test would follow a reworded sentence silently, and the wording is
     the thing. It carries the name, so a click that landed on the wrong tab fails here.
     """
-    return f"workspace '{ws}' is not open on this plane"
+    return f"cannot open '{ws}': this chat records no harness"
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 

--- a/tests/test_a_workspace_switch_moves_the_client.py
+++ b/tests/test_a_workspace_switch_moves_the_client.py
@@ -283,24 +283,28 @@ class TheSwitchItself(PersonaIso, unittest.TestCase):
 
     # -- the refusals, and what each one leaves standing ---------------------------------
 
-    def test_a_workspace_with_no_session_is_refused_and_nothing_is_launched(self):
-        """**What a workspace nobody has opened is answered with.** Opening one is
-        `cmd_launch` — a directory, an ordinal, a harness and an `attach` — and this runs
-        detached with its streams on `/dev/null`, with no terminal to attach anything to.
-        `switch.py`'s standing rule is the same one (#518), so the refusal names the
-        command that does."""
-        s = self._switch(self._ordinary(panes=[_seat("$1", "%1")]))
+    def test_a_workspace_with_no_session_is_opened_rather_than_refused(self):
+        """**What a workspace nobody has opened is answered with**, and it is no longer a
+        refusal. This used to print `charter <harness> --workspace beta` for the operator
+        to type, on the grounds that opening ends in an `attach` and a detached switch has
+        no terminal for one — measured false on 3.7c and at the 3.2 floor, and beside the
+        point, because arriving is `switch-client`. The open itself is
+        `tests/test_a_workspace_tab_opens_what_it_names.py`; what belongs HERE is that the
+        switch reaches it, and that an open which produces nothing moves nothing."""
+        with mock.patch.object(commands_frame, "_open_workspace",
+                               return_value=None) as opener:
+            s = self._switch(self._ordinary(panes=[_seat("$1", "%1")]))
+        opener.assert_called_once()
+        self.assertEqual(opener.call_args[0][1], "beta")
         self.assertEqual(s.switched, [])
         self.laid_out.assert_not_called()
-        said = self.said.call_args[0][1]
-        self.assertIn("workspace 'beta' is not open on this plane", said)
-        self.assertIn("charter <harness> --workspace beta", said)
 
     def test_a_workspace_this_plane_has_never_opened_reaches_no_tmux_call_for_it(self):
-        """The ordinary case of the same refusal, and the property that keeps it cheap:
-        with no chat directory there is nothing to compare against, so the answer is on
-        disk. `_pane_place` is still asked, because charter has to know where it is
-        standing before it can say it is not going anywhere."""
+        """The ordinary case, and the property that keeps it cheap: with no chat directory
+        there is nothing to compare against, so "is it open" is answered on disk without
+        asking tmux to list a single pane. `_pane_place` is still asked, because charter
+        has to know where it is standing before it can move — or, now, before it opens
+        somewhere to move to."""
         for chat in chats.of_workspace("beta"):
             state.record_harness_pane(chat, "")
         s = self._switch(self._ordinary())
@@ -736,6 +740,8 @@ class TwoPlanesOnOneMachine(_RealServer):
         """
         self._mark(self.a_state)
         client = self._attach(SHARED)
+        windows_before = _tmux("list-windows", "-t", SHARED,
+                               "-F", "#{window_id}").stdout.split()
         with _plane(self.plane_b):
             _a_chat("shared.2", ws=SHARED, pane="%9001", server=SOCKET)
             state.record_harness_pane("shared.2", "%9001")
@@ -746,9 +752,21 @@ class TwoPlanesOnOneMachine(_RealServer):
                                    side_effect=lambda fid, msg, **kw: said.append(msg)):
                 commands_frame._switch_client("shared.2", SHARED,
                                               said="workspace → shared")
-        self.assertTrue(any("is not open on this plane" in m for m in said), said)
+        self.assertTrue(any("is already running on this machine" in m for m in said),
+                        said)
         self.assertEqual(self._clients(SHARED), [client],
                          "another plane's switch moved this plane's client")
+        # **The window count is the assertion that matters now that a tab OPENS.** The
+        # refusal this used to get was free; an open is not, and `cmd_launch` decides
+        # between starting a session and joining one on a NAME that both planes have. A
+        # missing guard would not have moved the client either — it would have quietly
+        # added plane B's chat window to plane A's session and then failed the marker veto,
+        # which reads on screen as "the open failed" and on the server as litter in another
+        # project's frame.
+        self.assertEqual(
+            _tmux("list-windows", "-t", SHARED, "-F", "#{window_id}").stdout.split(),
+            windows_before,
+            "an open from another plane added a window to this plane's session")
 
 
 if __name__ == "__main__":

--- a/tests/test_a_workspace_switch_moves_the_client.py
+++ b/tests/test_a_workspace_switch_moves_the_client.py
@@ -735,8 +735,15 @@ class TwoPlanesOnOneMachine(_RealServer):
         """**End to end, and it is the operator's decision made observable**: switching is
         restricted to workspaces of THIS plane, and anything else is refused by name.
         Plane B clicks `shared`; there is a live session called `shared` with plane B's
-        own operator's terminal nowhere near it; the switch says the workspace is not open
-        *on this plane* and the client that is attached to plane A's session stays there.
+        own operator's terminal nowhere near it; the switch refuses because that session
+        is not one plane B can prove is its own, and the client attached to plane A's
+        session stays there.
+
+        **Plane B is given a terminal of its own, and the fixture is not honest without
+        it.** Since a tab OPENS, `_switch_client` refuses first — before spending a harness
+        process — when nothing is attached to the frame doing the switching. Plane B's
+        `$9000` is a session this test invented and nobody is on it, so without this the
+        case would stop one refusal early and prove nothing about planes at all.
         """
         self._mark(self.a_state)
         client = self._attach(SHARED)
@@ -748,6 +755,9 @@ class TwoPlanesOnOneMachine(_RealServer):
             said = []
             with mock.patch.object(commands_frame, "_pane_place",
                                    return_value=("$9000", "@9000")), \
+                 mock.patch.object(commands_frame, "_clients_on",
+                                   side_effect=lambda _s, sess:
+                                   ["/dev/ttyplaneb"] if sess == "$9000" else []), \
                  mock.patch.object(commands_frame, "_say_on_screen",
                                    side_effect=lambda fid, msg, **kw: said.append(msg)):
                 commands_frame._switch_client("shared.2", SHARED,

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -163,6 +163,25 @@ class _OpensBeta(PersonaIso, unittest.TestCase):
             commands_frame._switch_client(self.FID, "beta", said="workspace → beta")
         return server
 
+    def _run_watching_cwd(self, seen: list) -> None:
+        """Run a click, recording the launcher's cwd at the moment it is called.
+
+        The `chdir` is only in effect inside `cmd_launch`; the `finally` has restored it
+        before the test could look, so the reading has to be taken from in there."""
+        server = _Server()
+
+        def fake_launch(args):
+            seen.append(os.getcwd())
+            self.launched.append(args)
+            _a_chat("beta.1", ws="beta", pane="%9")
+            server.opened.append("%9")
+            return 0
+
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=server), \
+                mock.patch("charter.commands_frame.cmd_launch",
+                           side_effect=fake_launch):
+            commands_frame._switch_client(self.FID, "beta", said="workspace → beta")
+
 
 class TheTabOpensTheWorkspaceItNames(_OpensBeta):
     """The report, answered. A tab for a workspace with no session builds one and moves
@@ -343,6 +362,31 @@ class TheOpenUsesTheHarnessTheOperatorIsAlreadyIn(_OpensBeta):
             self._run()
         self.assertEqual(self.launched[0].harness, "codex")
 
+    def test_the_launch_runs_in_the_workspaces_own_directory(self):
+        """Where `charter --workspace beta` typed in it would have run, and what
+        `state.record_cwd` goes on to hold. Read INSIDE the fake launcher, because that is
+        the only moment the `chdir` is in effect — the `finally` has put it back by the
+        time the test could look."""
+        seen = []
+        self._run_watching_cwd(seen)
+        # `os.path.realpath` on the expected side, never on the reading: `os.getcwd()`
+        # hands back a RESOLVED path, and on macOS the plane lives under a `/tmp` that
+        # is a symlink to `/private/tmp`. Comparing the constructed spelling would
+        # fail on the platform that resolves and pass on the one that does not
+        # (`tests/_tmuxsocket.py` measures the same trap for a socket path).
+        self.assertEqual(seen, [os.path.realpath(config.WORKSPACES_DIR / "beta")])
+
+    def test_a_workspace_with_no_directory_of_its_own_falls_back_to_the_plane_root(self):
+        """The other half of the same expression. A workspace can be named by a chat
+        record and by the bar without having a directory yet, and a `chdir` into a path
+        that is not there would refuse the open for a workspace that is perfectly usable —
+        so the plane root is the answer, which is where a bare `charter` starts."""
+        import shutil as _sh
+        _sh.rmtree(config.WORKSPACES_DIR / "beta")
+        seen = []
+        self._run_watching_cwd(seen)
+        self.assertEqual(seen, [os.path.realpath(config.ROOT)])
+
     def test_a_directory_charter_cannot_enter_is_refused_before_the_launch(self):
         """`cmd_launch` reads its cwd with `os.getcwd()`, so the open has to `os.chdir`
         into the workspace — and a `chdir` that fails must stop the launch rather than
@@ -354,6 +398,53 @@ class TheOpenUsesTheHarnessTheOperatorIsAlreadyIn(_OpensBeta):
         self.assertEqual(self.launched, [])
         self.assertIn("cannot enter", self.said.call_args[0][1])
 
+    def test_the_refused_directory_is_contained_before_it_reaches_the_screen(self):
+        """A path is the one value in that sentence charter did not choose the shape of,
+        and the attention row is a pane charter paints — a newline in it writes a second
+        line into the frame's own chrome. `contain.readable` is what stops that.
+
+        The literal is spelled out by hand rather than round-tripped through the same
+        constant the code interpolates, which would be green under any containment at
+        all: the raw two-line form must not appear, and the message must stay one line.
+        """
+        # It has to EXIST, and getting that wrong is what this comment is for: `root` is
+        # `where if where.is_dir() else config.ROOT`, so a bad path that is not a real
+        # directory is replaced by the plane root and never reaches the sentence at all.
+        # The first version of this test made exactly that mistake and passed against an
+        # uncontained message. A newline is legal in a POSIX filename, so the directory is
+        # real.
+        bad = Path(str(config.WORKSPACES_DIR / "beta") + "\nworkspace → evil")
+        bad.mkdir(parents=True, exist_ok=True)
+        self.addCleanup(bad.rmdir)
+        self.assertTrue(bad.is_dir(), "the fixture's bad path must be a real directory")
+        with mock.patch("charter.commands_frame.workspace.workspace_dir",
+                        return_value=bad), \
+                mock.patch("charter.commands_frame.os.chdir",
+                           side_effect=OSError(13, "denied")):
+            self._run()
+        said = self.said.call_args[0][1]
+        self.assertNotIn("\nworkspace → evil", said)
+        self.assertEqual(said.count("\n"), 0, said)
+
+    def test_a_directory_that_cannot_be_returned_to_does_not_lose_the_open(self):
+        """The `finally`'s own `except OSError`. Restoring the cwd is best effort — the
+        directory this process started in can be gone by the time the launch returns
+        (a sibling `reap` removed a chat directory, a worktree was deleted) — and a
+        raise there would take down a switch whose workspace is already open and
+        running, leaving the operator's client where it was with no message at all."""
+        calls = []
+
+        def chdir(path):
+            calls.append(str(path))
+            if len(calls) > 1:                 # the restore, not the way in
+                raise OSError(2, "gone")
+
+        with mock.patch("charter.commands_frame.os.chdir", side_effect=chdir):
+            s = self._run()
+        self.assertEqual(len(calls), 2, "the launcher never tried to go back")
+        self.assertEqual(s.switched, [("/dev/ttys001", "$2")],
+                         "a cwd charter could not return to lost the switch")
+
     def test_the_launcher_is_left_standing_where_it_started(self):
         """The `finally` half of the same `chdir`, and `cmd_reopen`'s own rule: this
         process goes on to re-lay-out two frames, and a launcher left in somebody else's
@@ -361,6 +452,17 @@ class TheOpenUsesTheHarnessTheOperatorIsAlreadyIn(_OpensBeta):
         was = os.getcwd()
         self._run()
         self.assertEqual(os.getcwd(), was)
+
+    def test_a_plane_whose_harness_table_is_missing_entirely_is_not_a_crash(self):
+        """`config.HARNESS` is ``None`` on a plane whose config has no `[harness]` table at
+        all — a different state from one that has the table with no `default` in it, and
+        the `or {}` is the only thing between the two and an `AttributeError` on the
+        detached side, where a traceback goes to `/dev/null` and the click does nothing."""
+        _a_chat(self.FID, ws="alpha", pane="%1", harness="")
+        with mock.patch.object(config, "HARNESS", None):
+            self._run()
+        self.assertEqual(self.launched, [])
+        self.assertIn("no harness", self.said.call_args[0][1])
 
     def test_with_neither_it_refuses_by_name_rather_than_guessing(self):
         _a_chat(self.FID, ws="alpha", pane="%1", harness="")
@@ -576,6 +678,15 @@ class ARealTabOpensARealWorkspace(PersonaIso, unittest.TestCase):
         # than the forks allowed — `tests/_planeguard.py`'s own first suggestion.
         no_background_refresh(self)
         self.enterContext(mock.patch("charter.commands_frame._spawn_gather"))
+        # **`bypass` is stubbed so this case can FAIL rather than vanish, and that is a
+        # measurement fix rather than a convenience.** `bypass` calls `os.execvp`: on the
+        # unmutated code it is never reached from here, but the deletion sweep's whole job
+        # is to reach it — and when it did, the exec replaced this test runner with the
+        # fake harness below, so the shard reported `no tests ran` and TWO mutations of
+        # `_wants_attach` came back "not measured" instead of killed. Returning 127 keeps
+        # the meaning exactly (a launch that bypassed the frame started no session, so
+        # every assertion below fails) while leaving a process alive to say so.
+        self.enterContext(mock.patch("charter.commands_frame.bypass", return_value=127))
         self.socket = _tmuxreap.name("open-ws-tab")
         self.enterContext(mock.patch.object(commands_frame, "SOCKET", self.socket))
         self.addCleanup(self._teardown)

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -326,6 +326,25 @@ class TheOpenUsesTheHarnessTheOperatorIsAlreadyIn(_OpensBeta):
             self._run()
         self.assertEqual(self.launched[0].harness, "codex")
 
+    def test_a_directory_charter_cannot_enter_is_refused_before_the_launch(self):
+        """`cmd_launch` reads its cwd with `os.getcwd()`, so the open has to `os.chdir`
+        into the workspace — and a `chdir` that fails must stop the launch rather than
+        run it from wherever this process happened to be standing, which is a chat in
+        ANOTHER workspace. Refused before `cmd_launch` is called at all."""
+        with mock.patch("charter.commands_frame.os.chdir",
+                        side_effect=OSError(13, "denied")):
+            self._run()
+        self.assertEqual(self.launched, [])
+        self.assertIn("cannot enter", self.said.call_args[0][1])
+
+    def test_the_launcher_is_left_standing_where_it_started(self):
+        """The `finally` half of the same `chdir`, and `cmd_reopen`'s own rule: this
+        process goes on to re-lay-out two frames, and a launcher left in somebody else's
+        directory is the silent wrongness §4e's cwd item exists to close."""
+        was = os.getcwd()
+        self._run()
+        self.assertEqual(os.getcwd(), was)
+
     def test_with_neither_it_refuses_by_name_rather_than_guessing(self):
         _a_chat(self.FID, ws="alpha", pane="%1", harness="")
         with mock.patch.dict(config.HARNESS, {"default": ""}):
@@ -381,6 +400,24 @@ class TheLauncherCanBuildAFrameWithNoTerminalOfItsOwn(PersonaIso, unittest.TestC
             out.isatty.return_value = False
             commands_frame.cmd_launch(args)
         byp.assert_called_once()
+
+    def test_a_size_that_is_not_two_positive_integers_is_measured_instead(self):
+        """The handed-in size reaches `layout.session_argv` as `-x`/`-y`, where a
+        malformed pair is a tmux parse error that would take the whole launch down with
+        nothing on screen to say why — so it is validated rather than trusted, and an
+        unusable one falls back to the terminal reading `cmd_launch` always did.
+
+        Each shape is its own row because each is a separate `and`/`isinstance` in the
+        guard, and a single case would leave the rest of them free to be deleted."""
+        for bad in (None, (80,), (80, 24, 3), "80x24", (80.0, 24), ("80", 24),
+                    (0, 24), (80, 0), (-1, 24), (80, -1)):
+            with self.subTest(size=bad):
+                self.assertIsNone(
+                    commands_frame._launch_size(SimpleNamespace(size=bad)))
+
+    def test_a_size_of_two_positive_integers_is_taken(self):
+        self.assertEqual(
+            commands_frame._launch_size(SimpleNamespace(size=(132, 43))), (132, 43))
 
     def test_wants_attach_is_false_when_a_caller_says_so(self):
         """`_wants_attach`'s own docstring anticipated this: *"the day a third caller

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -53,7 +53,8 @@ from unittest import mock
 from charter import commands_frame, config
 from charter.frame import state
 
-from tests._isolation import PersonaIso
+from tests import _tmuxreap, _ttyguard
+from tests._isolation import PersonaIso, no_background_refresh
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
@@ -411,7 +412,15 @@ class ADetachedProcessCanBuildAWorkspace(unittest.TestCase):
         tm("new-session", "-d", "-s", "home", "sh")
         pid, _fd = pty.fork()
         if pid == 0:                                    # pragma: no cover - the child
-            os.execvp("tmux", ["tmux", "-L", sock, "attach", "-t", "home"])
+            # `os._exit` in a `finally`, which every other `pty.fork` in this suite spells
+            # for the same reason: an `execvp` that RAISES leaves the child running the
+            # test framework, and a second runner that goes on to fork is how one failed
+            # exec becomes a machine full of them. Never `sys.exit` — that unwinds, and
+            # unittest catches `SystemExit`.
+            try:
+                os.execvp("tmux", ["tmux", "-L", sock, "attach", "-t", "home"])
+            finally:
+                os._exit(127)
         self.addCleanup(lambda: os.waitpid(pid, os.WNOHANG))
 
         deadline = time.time() + 10
@@ -447,6 +456,193 @@ class ADetachedProcessCanBuildAWorkspace(unittest.TestCase):
         self.assertEqual(
             len(tm("list-panes", "-t", "home", "-F", "#{pane_id}").stdout.split()), 1,
             "building a workspace killed something")
+
+
+@unittest.skipUnless(_HAS_TMUX, "needs a real tmux")
+class ARealTabOpensARealWorkspace(PersonaIso, unittest.TestCase):
+    """**The operator's report, end to end, with nothing faked but the harness binary.**
+
+    Every class above stops somewhere: the unit cases stop at a mock `cmd_launch`, and
+    :class:`ADetachedProcessCanBuildAWorkspace` measures tmux without charter in the room.
+    This one runs the whole thing — a real tmux server, a real client on a real pty, a real
+    `_switch_client`, a real `cmd_launch` underneath it building a real session with real
+    panel processes, and a real `switch-client` landing the client on it.
+
+    **The harness is a script that sleeps**, and that is the only substitution. A test may
+    not start a real `claude`: it costs money, it needs credentials, and it would make this
+    file's result depend on a network. What the script has to be is a real executable on
+    `$PATH` that tmux really runs, because the claim being tested is that a detached
+    process can start one at all.
+
+    Verified on tmux 3.7c and at the 3.2 floor, identically on both.
+    """
+
+    HERE, THERE = "alpha", "beta"
+
+    def setUp(self):
+        super().setUp()
+        # **The declaration is the point of the fixture, not paperwork around it.** The
+        # process this stands in for is a `charter frame-switch` started by
+        # `builtin_actions._spawn`: `start_new_session=True`, all three streams on
+        # `/dev/null`. Saying so out loud is what makes the launch below take the branches
+        # a real click takes — no #518 picker, and `os.get_terminal_size()` raising, which
+        # is exactly the condition the size seam exists for.
+        _ttyguard.no_terminal()
+        # The repo scan and the version/forge pollers are real detached charter children
+        # that `cmd_launch` kicks off and nothing here waits for. This test is about the
+        # SESSION the launch builds, not about them, so the spawners are stopped rather
+        # than the forks allowed — `tests/_planeguard.py`'s own first suggestion.
+        no_background_refresh(self)
+        self.enterContext(mock.patch("charter.commands_frame._spawn_gather"))
+        self.socket = _tmuxreap.name("open-ws-tab")
+        self.enterContext(mock.patch.object(commands_frame, "SOCKET", self.socket))
+        self.addCleanup(self._teardown)
+        self.kids: list[tuple[int, int]] = []
+
+        # A harness that is a real binary and starts no conversation.
+        binroot = Path(self.enterContext(__import__("tempfile").TemporaryDirectory()))
+        fake = binroot / "codex"
+        fake.write_text("#!/bin/sh\nexec sleep 300\n")
+        fake.chmod(0o755)
+        self.enterContext(mock.patch.dict(
+            os.environ, {"PATH": f"{binroot}{os.pathsep}{os.environ.get('PATH', '')}"}))
+
+        for n in (self.HERE, self.THERE):
+            (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
+
+        # The chat the operator is standing in, built by hand so the fixture does not
+        # depend on the code path under test.
+        self.fid = f"{self.HERE}.1"
+        started = self._tmux("new-session", "-d", "-s", self.HERE, "-n", self.fid,
+                             "-x", "132", "-y", "43", "-P", "-F", "#{pane_id}",
+                             "sleep 300")
+        self.assertEqual(started.returncode, 0, started.stderr)
+        self.pane = started.stdout.strip()
+        _a_chat(self.fid, ws=self.HERE, pane=self.pane, harness="codex")
+        self.assertEqual(self._tmux("set-option", "-t", self.pane,
+                                    commands_frame._PLANE_OPTION,
+                                    str(config.STATE_DIR)).returncode, 0)
+
+    def _teardown(self):
+        for pid, fd in self.kids:
+            try:
+                os.kill(pid, 9)
+                os.waitpid(pid, 0)
+            except OSError:
+                pass
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        self._tmux("kill-server")
+
+    def _tmux(self, *a):
+        return subprocess.run(["tmux", "-L", self.socket, *a],
+                              capture_output=True, text=True)
+
+    def _clients(self, session):
+        return [c for c in self._tmux("list-clients", "-t", session,
+                                      "-F", "#{client_name}").stdout.split() if c]
+
+    #: The terminal this fixture's operator is sitting at. Deliberately NOT 80x24: the
+    #: whole point of the size seam is that the frame is built for the real terminal, and
+    #: a fixture at the fallback size could not tell the two apart.
+    CLIENT_SIZE = (132, 43)
+
+    def _attach(self, session):
+        import fcntl
+        import pty
+        import struct
+        import termios
+        import time
+        for term in ("xterm-256color", "screen", "vt100"):
+            pid, fd = pty.fork()
+            if pid == 0:                                # pragma: no cover - the child
+                try:
+                    os.environ["TERM"] = term
+                    os.execvp("tmux", ["tmux", "-L", self.socket, "attach",
+                                       "-t", session])
+                finally:
+                    os._exit(127)
+            # Sized BEFORE the client is waited for: a pty is born 80x24, and tmux resizes
+            # the session it attaches to to whatever the client is. Left at the default
+            # this fixture would be measuring `_FALLBACK_SIZE` against itself.
+            cols, rows = self.CLIENT_SIZE
+            fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+            end = time.time() + 10
+            while time.time() < end and not self._clients(session):
+                time.sleep(0.05)
+            if self._clients(session):
+                self.kids.append((pid, fd))
+                return self._clients(session)[-1]
+            try:
+                os.kill(pid, 9)
+                os.waitpid(pid, 0)
+            except OSError:
+                pass
+        self.skipTest("no tmux client can attach on this machine, and opening a "
+                      "workspace to switch into is a decision about an ATTACHED client")
+
+    def _panes(self):
+        """Every pane on the server with its pid and whether tmux calls it dead."""
+        return sorted(self._tmux("list-panes", "-a", "-F",
+                                 "#{pane_id} #{pane_pid} #{pane_dead}").stdout.split("\n"))
+
+    def _click_the_tab(self):
+        """What the panel's handler does, minus the pointer: `charter frame-switch
+        --workspace <name>` in a process of its own. Called in-process so the assertions
+        can be made after it has finished rather than polled for."""
+        import time
+        commands_frame._switch_client(self.fid, self.THERE,
+                                      said=f"workspace → {self.THERE}")
+        time.sleep(0.3)
+
+    def test_the_workspace_opens_and_the_terminal_arrives_in_it(self):
+        """**The report, answered.** A tab for a workspace that was not open now opens it
+        and takes the operator there — which is what the refusal it replaces told them to
+        go and type by hand."""
+        client = self._attach(self.HERE)
+        self._click_the_tab()
+        self.assertIn(self.THERE,
+                      self._tmux("list-sessions", "-F", "#{session_name}").stdout.split(),
+                      "the click did not open the workspace it named")
+        self.assertEqual(self._clients(self.THERE), [client],
+                         "the workspace opened and the terminal never arrived in it")
+        self.assertEqual(self._clients(self.HERE), [])
+
+    def test_the_chat_left_behind_keeps_running(self):
+        """The operator's own sentence — *"keep my current sessions open in background"* —
+        measured rather than argued: the pane they left has the same pid afterwards and
+        tmux does not call it dead."""
+        self._attach(self.HERE)
+        before = [p for p in self._panes() if p.startswith(self.pane + " ")]
+        self._click_the_tab()
+        self.assertEqual([p for p in self._panes() if p.startswith(self.pane + " ")],
+                         before, "opening a workspace killed the chat it left")
+
+    def test_the_opened_workspace_is_marked_with_this_plane(self):
+        """§4b's marker, written by the launch that CREATED the session — so the next
+        switch can tell this session from another plane's of the same name."""
+        self._attach(self.HERE)
+        self._click_the_tab()
+        pane = self._tmux("list-panes", "-t", self.THERE,
+                          "-F", "#{pane_id}").stdout.split()[0]
+        self.assertEqual(
+            self._tmux("display-message", "-p", "-t", pane,
+                       "#{%s}" % commands_frame._PLANE_OPTION).stdout.strip(),
+            str(config.STATE_DIR))
+
+    def test_the_new_workspace_is_laid_out_for_the_terminal_and_not_for_eighty_columns(
+            self):
+        """The size seam, measured where it matters. A detached launcher cannot read a
+        terminal, so without a size handed in this window would have been built at
+        `_FALLBACK_SIZE` — and `_drawable_slots` reads 80x24 as room for almost nothing."""
+        self._attach(self.HERE)
+        self._click_the_tab()
+        width = self._tmux("display-message", "-p", "-t", self.THERE,
+                           "#{window_width}").stdout.strip()
+        self.assertEqual(width, str(self.CLIENT_SIZE[0]),
+                         "the opened workspace was laid out for the wrong terminal")
 
 
 if __name__ == "__main__":

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -1,0 +1,453 @@
+"""A workspace tab for a workspace that is not open yet OPENS it, and takes you there.
+
+The operator's report, which is the whole requirement:
+
+> *"when I want to switch to another workspace it should switch and keep my current
+> sessions open in background, but I can't switch — I get `charter: workspace 'default'
+> is not open on this plane — open it with charter <harness> --workspace default`"*
+
+Thirteen of their fifteen workspace tabs did nothing. #793 shipped the half where the
+workspace is already open (`switch-client`, and nothing dies); this is the other half.
+
+**The refusal it replaces gave a reason, and the reason was measured to be false.** It
+read: *"Opening one is `cmd_launch` — a directory, an ordinal, a harness process and an
+`attach` — and this runs detached with its streams on `/dev/null`
+(`builtin_actions._spawn`), with no terminal to attach anything to."* A detached process
+with no controlling terminal creates a tmux session, splits panes and sets session options
+perfectly well; what needs a terminal is the `attach`, and the way to arrive somewhere
+without one is `switch-client`, which is what #793 already does. Measured on tmux 3.7c and
+at the 3.2 floor, identically — :class:`ADetachedProcessCanBuildAWorkspace` is that
+measurement, and it is the foundation the rest of this module stands on.
+
+**What actually needed a terminal was somewhere else entirely**, and this is the finding
+that matters for anybody reading the old comment: `cmd_launch`'s second guard is ``if
+args.no_frame or not sys.stdout.isatty(): return bypass(argv)``, and `bypass` **execs**.
+Reached from a detached switch it would have replaced the switching process with a bare
+harness on `/dev/null` — no frame, no session, no switch, and nothing on screen to say so.
+:class:`TheLauncherCanBuildAFrameWithNoTerminalOfItsOwn` pins that gate open only for a
+launch that was never going to be a terminal anyway.
+
+**#518 is not what the old comment said it was.** #518 asks that `charter <harness>` stop
+resolving a workspace *silently*, and its "creating is not free" paragraph is about
+`charter workspace create` making a **workspace directory** on a name the operator TYPED:
+*"a picker that creates on a typo leaves litter, so the create path needs confirmation or
+a validation pass."* A tab click types nothing. The name comes off a list charter itself
+drew from `switch.workspaces()` — every directory already under `workspaces/` — so there
+is no typo to create on and no workspace is created at all. What a click makes is a
+**chat** in a workspace that already exists, which is precisely what §4k
+(*"if `foo` is live, attach to it; if not, open it and leave the others"*) says
+`charter -w foo` does, and precisely what the old refusal told the operator to go and type
+by hand. :class:`NoWorkspaceIsEverCreatedByAClick` pins the half of #518 that does apply.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config
+from charter.frame import state
+
+from tests._isolation import PersonaIso
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: What `_switch_client` used to say instead of opening. Spelled by hand rather than
+#: imported, because its ABSENCE is what several cases here assert and a constant read out
+#: of the module under test would follow a reworded sentence into a green run.
+_OLD_REFUSAL = "is not open on this plane"
+
+
+def _completed(cmd, rc=0, out=""):
+    return subprocess.CompletedProcess(list(cmd), rc, out, "")
+
+
+def _a_chat(fid: str, *, ws: str, pane: str | None, harness="claude-code") -> None:
+    """A chat directory on THIS plane, in the shape a launcher leaves one.
+
+    *harness* is `$CHARTER_HARNESS` as `cmd_launch` records it — `harness.base.name`, not
+    the CLI word — because that is the record :func:`_open_workspace` reads to decide what
+    to open the next workspace with. ``""`` is a chat launched by a charter that predates
+    `state.record_identity`.
+    """
+    state.frame_dir(fid, create=True)
+    state.record_workspace(fid, ws)
+    state.record_server(fid, commands_frame.SOCKET)
+    state.record_identity(fid, {"CHARTER_HARNESS": harness})
+    if pane is not None:
+        state.record_harness_pane(fid, pane)
+
+
+class _Server:
+    """The tmux a switch reads, with the target workspace appearing only once opened.
+
+    *opened_pane* is the pane id `cmd_launch` is pretended to have created. Until the
+    fake launcher runs, `list-panes` reports only this plane's `alpha` chat — which is
+    exactly the state the old refusal fired on.
+    """
+
+    def __init__(self, *, size="132:43", clients=("/dev/ttys001",)):
+        self.size = size
+        self.clients = list(clients)
+        self.opened: list[str] = []
+        self.calls: list[list[str]] = []
+        self.switched: list[tuple[str, str]] = []
+
+    def _seats(self) -> str:
+        rows = [f"$1\t%1\t{config.STATE_DIR}"]
+        rows += [f"$2\t{p}\t{config.STATE_DIR}" for p in self.opened]
+        return "".join(r + "\n" for r in rows)
+
+    def __call__(self, cmd, **kw):
+        self.calls.append(list(cmd))
+        if "display-message" in cmd:
+            fmt = cmd[-1]
+            if "window_width" in fmt:
+                return _completed(cmd, 0, self.size)
+            return _completed(cmd, 0, "$1\t@1")
+        if "list-panes" in cmd:
+            return _completed(cmd, 0, self._seats())
+        if "list-clients" in cmd:
+            target = cmd[cmd.index("-t") + 1]
+            moved = [c for c, t in self.switched if t == target]
+            return _completed(cmd, 0, "".join(c + "\n" for c in
+                                              (moved if target == "$2"
+                                               else [c for c in self.clients
+                                                     if c not in moved])))
+        if "switch-client" in cmd:
+            self.switched.append((cmd[cmd.index("-c") + 1], cmd[cmd.index("-t") + 1]))
+            return _completed(cmd, 0)
+        if "list-windows" in cmd:
+            return _completed(cmd, 0, "$2\t1\tbeta.1\n")
+        return _completed(cmd, 0)
+
+
+class _OpensBeta(PersonaIso, unittest.TestCase):
+    """A frame in `alpha`, a `beta` that exists on disk and is not open, and a fake
+    launcher that records how it was called."""
+
+    FID = "alpha.1"
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        for n in ("alpha", "beta"):
+            (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
+        _a_chat(self.FID, ws="alpha", pane="%1")
+        self.said = self.enterContext(
+            mock.patch("charter.commands_frame._say_on_screen"))
+        self.enterContext(mock.patch("charter.commands_frame._apply_arrangement"))
+        self.enterContext(
+            mock.patch("charter.commands_frame._relayout_target", return_value=None))
+        self.launched: list = []
+
+    def _run(self, server=None, *, opens=True):
+        server = server or _Server()
+
+        def fake_launch(args):
+            self.launched.append(args)
+            if opens:
+                _a_chat("beta.1", ws="beta", pane="%9")
+                server.opened.append("%9")
+            return 0
+
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=server), \
+                mock.patch("charter.commands_frame.cmd_launch",
+                           side_effect=fake_launch):
+            commands_frame._switch_client(self.FID, "beta", said="workspace → beta")
+        return server
+
+
+class TheTabOpensTheWorkspaceItNames(_OpensBeta):
+    """The report, answered. A tab for a workspace with no session builds one and moves
+    the terminal onto it, instead of printing a command for the operator to type."""
+
+    def test_a_workspace_with_no_session_is_opened_instead_of_refused(self):
+        self._run()
+        self.assertEqual(len(self.launched), 1,
+                         "the click did not open the workspace it named")
+        for call in self.said.call_args_list:
+            self.assertNotIn(_OLD_REFUSAL, call[0][1])
+
+    def test_the_launch_names_the_workspace_that_was_clicked(self):
+        """`--workspace` outright, never a resolution: the launcher runs detached in a
+        process whose cwd is the chat the operator clicked FROM, and `workspace.resolve`
+        would answer `alpha` from it."""
+        self._run()
+        self.assertEqual(self.launched[0].workspace, "beta")
+
+    def test_the_launch_does_not_attach(self):
+        """The whole seam. `attach` is what needs a terminal and there is none; arriving
+        is `switch-client`, which needs none."""
+        self._run()
+        self.assertFalse(commands_frame._wants_attach(self.launched[0]))
+
+    def test_the_launch_carries_no_command_of_its_own(self):
+        """`rest` empty, so `cmd_launch`'s §4k open-or-focus gate stays reachable and the
+        harness starts at its own prompt with nothing sent to it."""
+        self._run()
+        self.assertEqual(list(self.launched[0].rest), [])
+
+    def test_the_client_is_moved_onto_the_session_the_open_created(self):
+        s = self._run()
+        self.assertEqual(s.switched, [("/dev/ttys001", "$2")])
+
+    def test_the_operator_is_told_they_arrived(self):
+        self._run()
+        self.assertTrue(self.said.called)
+        self.assertEqual(self.said.call_args[0][1], "workspace → beta")
+
+    def test_an_open_that_starts_no_session_moves_nothing_and_says_so(self):
+        """A launch can fail — a harness that is not installed, a state directory that
+        cannot be made. The switch must then leave this chat exactly as it was rather
+        than report a move that did not happen (#411's shape through a success)."""
+        s = self._run(opens=False)
+        self.assertEqual(len(self.launched), 1, "it never tried to open")
+        self.assertEqual(s.switched, [])
+        said = self.said.call_args[0][1]
+        self.assertIn("beta", said)
+        self.assertIn("could not open", said)
+
+
+class TheOpenIsSizedForTheTerminalThatWillSeeIt(_OpensBeta):
+    """A detached launcher cannot measure a terminal, and the number decides the frame.
+
+    `os.get_terminal_size()` raises `OSError` in a process with its streams on
+    `/dev/null` — measured on both tmux versions — so `cmd_launch` would fall back to
+    `_FALLBACK_SIZE` (80x24) and `_drawable_slots` would drop every panel a real terminal
+    has room for. The size that matters is the size of the client about to be switched,
+    and that client is looking at THIS chat's window right now, so tmux already knows it.
+    """
+
+    def test_the_launch_is_given_the_size_of_the_window_the_client_is_on(self):
+        self._run(_Server(size="132:43"))
+        self.assertEqual(self.launched[0].size, (132, 43))
+
+    def test_it_is_not_the_eighty_by_twenty_four_fallback(self):
+        """Pinned as its own case because 80x24 is what a silent failure looks like: a
+        frame that came up with one panel where the operator has room for four."""
+        self._run(_Server(size="200:60"))
+        self.assertNotEqual(self.launched[0].size, commands_frame._FALLBACK_SIZE)
+        self.assertEqual(self.launched[0].size, (200, 60))
+
+
+class NoWorkspaceIsEverCreatedByAClick(_OpensBeta):
+    """#518's rule, kept where it actually applies.
+
+    #518 is about `charter workspace create` making a directory on a name somebody typed
+    wrong. A tab carries a name charter drew from the directories that already exist, so
+    the click cannot name one that is not there — and this asserts the listing is
+    unchanged rather than trusting that argument.
+    """
+
+    def test_the_set_of_workspaces_is_the_same_after_a_click_as_before(self):
+        before = sorted(p.name for p in config.WORKSPACES_DIR.iterdir())
+        self._run()
+        self.assertEqual(sorted(p.name for p in config.WORKSPACES_DIR.iterdir()),
+                         before)
+
+    def test_no_pointer_is_written_for_a_workspace_nobody_picked(self):
+        """`_pin_workspace` writes only when the operator PICKED at the launcher's own
+        prompt (#518: a launch that resolved silently must write no pointer). A click is
+        not that prompt, so `picked` must stay false."""
+        self._run()
+        self.assertFalse(getattr(self.launched[0], "pick", False))
+
+
+class AnOpenNeverLandsInAnotherPlanesSession(_OpensBeta):
+    """The cross-plane guarantee #793 built, kept across the new door into `cmd_launch`.
+
+    **This is the hazard the open introduces, and it is not hypothetical.** One tmux server
+    serves every plane on the machine — eleven sessions from three projects on the
+    operator's own socket the week this was written — and `cmd_launch` decides whether to
+    start a session or add a window to one with ``if session in live_sessions:``, which is
+    a **name** test over that whole machine. `_plane_session` having just answered ``None``
+    does not mean the name is free; it means *this plane cannot prove the session is its
+    own*, and those are different facts whenever two planes share a workspace name.
+
+    Left unguarded, a click on `shared` in plane B would have added a chat window to plane
+    A's live `shared` session — another project's frame, across every isolation boundary
+    charter has — and then failed the `@charter_plane` veto on the way back out, so the
+    operator would have been told the open failed while a window sat in somebody else's
+    session. §3.3 names exactly this: *"Open-or-focus must match on this plane's chat
+    directories, never on a live session name."*
+    """
+
+    def _run_with_live_name(self, names, **kw):
+        with mock.patch("charter.commands_frame._live_sessions",
+                        return_value=set(names)):
+            return self._run(**kw)
+
+    def test_a_name_already_live_on_the_machine_is_not_opened(self):
+        s = self._run_with_live_name({"beta"})
+        self.assertEqual(self.launched, [], "it launched into a session it does not own")
+        self.assertEqual(s.switched, [])
+
+    def test_it_says_the_name_is_taken_rather_than_that_the_open_failed(self):
+        """The operator can act on this one — it is their own machine and their own other
+        project — so the sentence has to say which fact stopped it."""
+        self._run_with_live_name({"beta"})
+        said = self.said.call_args[0][1]
+        self.assertIn("beta", said)
+        self.assertIn("another plane", said)
+
+    def test_an_unrelated_live_session_does_not_block_the_open(self):
+        """The guard is the workspace's OWN session name and nothing broader: a machine
+        with other charter frames running on it is the ordinary case, not a refusal."""
+        self._run_with_live_name({"alpha", "something-else"})
+        self.assertEqual(len(self.launched), 1)
+
+
+class TheOpenUsesTheHarnessTheOperatorIsAlreadyIn(_OpensBeta):
+    """Which harness a tab opens with — the one question a click cannot carry.
+
+    A tab names a workspace and nothing else. The chat it was clicked FROM recorded its own
+    harness, and using that makes the click mean "another workspace, same tool" — the only
+    answer available that the operator actually expressed.
+    """
+
+    def test_it_is_the_harness_this_chat_records(self):
+        _a_chat(self.FID, ws="alpha", pane="%1", harness="codex")
+        self._run()
+        self.assertEqual(self.launched[0].harness, "codex")
+
+    def test_a_chat_with_no_recorded_harness_falls_back_to_the_planes_default(self):
+        """A chat launched by a charter that predates `state.record_identity`. The plane's
+        `[harness] default` is a thing somebody chose, so it is a better answer than
+        refusing — and the fallback is named in `cmd_reopen`'s own words."""
+        _a_chat(self.FID, ws="alpha", pane="%1", harness="")
+        with mock.patch.dict(config.HARNESS, {"default": "codex"}):
+            self._run()
+        self.assertEqual(self.launched[0].harness, "codex")
+
+    def test_with_neither_it_refuses_by_name_rather_than_guessing(self):
+        _a_chat(self.FID, ws="alpha", pane="%1", harness="")
+        with mock.patch.dict(config.HARNESS, {"default": ""}):
+            self._run()
+        self.assertEqual(self.launched, [])
+        self.assertIn("no harness", self.said.call_args[0][1])
+
+
+class TheLauncherCanBuildAFrameWithNoTerminalOfItsOwn(PersonaIso, unittest.TestCase):
+    """`cmd_launch`'s two tty-shaped assumptions, opened exactly as far as the seam needs.
+
+    Both are correct for every launch that IS the operator's terminal, and neither is
+    correct for one that will never attach.
+    """
+
+    def test_a_launch_that_will_not_attach_is_not_execd_away_by_the_non_tty_guard(self):
+        """**The guard that actually blocked this**, and the reason it is dangerous
+        rather than merely wrong: `bypass` calls `os.execvp`, so a detached switch that
+        reached it would have been REPLACED by a bare harness with its streams on
+        `/dev/null` — no frame, no session, no switch, and no surface left to report it
+        on. Gated on `_wants_attach`, because a non-tty stdout only means "this process
+        cannot be the operator's terminal", which such a launch was never going to be.
+        """
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False,
+                               workspace="beta", pick=False, attach=False,
+                               size=(120, 40))
+        with mock.patch("charter.commands_frame.sys.stdout") as out, \
+                mock.patch("charter.commands_frame.bypass") as byp, \
+                mock.patch("charter.commands_frame.tmuxctl.version", return_value=None):
+            out.isatty.return_value = False
+            commands_frame.cmd_launch(args)
+        byp.assert_not_called()
+
+    def test_a_launch_that_wants_a_terminal_is_still_bypassed_without_one(self):
+        """The guard is opened for one case and left standing for every other: a piped
+        `charter claude > file` must still run the harness with no frame."""
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False,
+                               workspace=None, pick=False)
+        with mock.patch("charter.commands_frame.sys.stdout") as out, \
+                mock.patch("charter.commands_frame.bypass",
+                           return_value=0) as byp:
+            out.isatty.return_value = False
+            commands_frame.cmd_launch(args)
+        byp.assert_called_once()
+
+    def test_wants_attach_is_false_when_a_caller_says_so(self):
+        """`_wants_attach`'s own docstring anticipated this: *"the day a third caller
+        wants one without the other, a shared expression would have to be unpicked at two
+        call sites at once."* This is that caller — not restoring, and not a terminal."""
+        self.assertFalse(commands_frame._wants_attach(
+            SimpleNamespace(attach=False)))
+
+    def test_every_existing_caller_still_attaches(self):
+        """An `args` with no `attach` field is every production and test caller that
+        predates the seam, and each of them is the operator's terminal."""
+        self.assertTrue(commands_frame._wants_attach(SimpleNamespace()))
+
+
+@unittest.skipUnless(_HAS_TMUX, "needs a real tmux")
+class ADetachedProcessCanBuildAWorkspace(unittest.TestCase):
+    """The measurement the old refusal's reason was wrong about, against a real server.
+
+    Nothing charter is in here on purpose: this is a claim about **tmux**, and it is the
+    one the design rests on. A process with `start_new_session=True` and all three streams
+    on `/dev/null` — `builtin_actions._spawn`'s exact shape — creates a session, splits it,
+    marks it, and moves an attached client onto it.
+
+    Run against tmux 3.7c and against tmux 3.2 (`tmuxctl.FLOOR`), identically on both.
+    CI installs no tmux, so this runs by hand.
+    """
+
+    def test_a_detached_creator_builds_a_session_and_switches_a_client_onto_it(self):
+        import pty
+        import time
+
+        sock = "openws-t-%d" % os.getpid()
+        self.assertNotEqual(sock, "charter")
+
+        def tm(*a):
+            return subprocess.run(["tmux", "-L", sock, *a],
+                                  capture_output=True, text=True)
+
+        self.addCleanup(tm, "kill-server")
+        tm("new-session", "-d", "-s", "home", "sh")
+        pid, _fd = pty.fork()
+        if pid == 0:                                    # pragma: no cover - the child
+            os.execvp("tmux", ["tmux", "-L", sock, "attach", "-t", "home"])
+        self.addCleanup(lambda: os.waitpid(pid, os.WNOHANG))
+
+        deadline = time.time() + 10
+        client = ""
+        while time.time() < deadline and not client:
+            client = tm("list-clients", "-F", "#{client_tty}").stdout.strip()
+            time.sleep(0.05)
+        self.assertTrue(client, "no client ever attached")
+
+        script = (
+            '{ [ -t 0 ] || [ -t 1 ] || [ -t 2 ]; } && exit 91; '
+            f'tmux -L {sock} new-session -d -s ws || exit 92; '
+            f'tmux -L {sock} split-window -t ws -d || exit 93; '
+            f'tmux -L {sock} set -t ws @charter_plane /a/plane || exit 94; '
+            f'tmux -L {sock} switch-client -c "{client}" -t ws || exit 95; exit 0')
+        rc = subprocess.Popen(["/bin/sh", "-c", script], start_new_session=True,
+                              stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+                              stderr=subprocess.DEVNULL).wait(timeout=30)
+        self.assertEqual(rc, 0, "a detached, tty-less process could not build a session")
+
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            if tm("display-message", "-p", "-t", client,
+                  "#{client_session}").stdout.strip() == "ws":
+                break
+            time.sleep(0.05)
+        self.assertEqual(tm("display-message", "-p", "-t", client,
+                            "#{client_session}").stdout.strip(), "ws")
+        self.assertEqual(
+            len(tm("list-panes", "-t", "ws", "-F", "#{pane_id}").stdout.split()), 2)
+        self.assertEqual(tm("show-options", "-t", "ws", "-v",
+                            "@charter_plane").stdout.strip(), "/a/plane")
+        self.assertEqual(
+            len(tm("list-panes", "-t", "home", "-F", "#{pane_id}").stdout.split()), 1,
+            "building a workspace killed something")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -203,6 +203,23 @@ class TheTabOpensTheWorkspaceItNames(_OpensBeta):
         self.assertTrue(self.said.called)
         self.assertEqual(self.said.call_args[0][1], "workspace → beta")
 
+    def test_nothing_is_opened_when_there_is_no_terminal_to_take_there(self):
+        """**A switch that cannot happen must not spend first.** `_switch_client` already
+        refuses when no client is attached to this chat's session — the operator detached,
+        or an agent with no terminal is driving the frame — and that refusal used to come
+        after a free `_plane_session` read. An open is not free: it starts a harness
+        process and claims a chat ordinal. Asked BEFORE the open, so a frame nobody is
+        looking at cannot be made to launch things into the dark.
+
+        Deliberately inside the not-open branch rather than hoisted over the whole
+        function: the order of the existing refusals is #793's and pinned by its own
+        tests, and moving this one over `already in workspace` would change what a
+        detached frame is told about a workspace it is already in."""
+        s = self._run(_Server(clients=()))
+        self.assertEqual(self.launched, [], "it started a harness for nobody")
+        self.assertEqual(s.switched, [])
+        self.assertIn("no terminal", self.said.call_args[0][1])
+
     def test_an_open_that_starts_no_session_moves_nothing_and_says_so(self):
         """A launch can fail — a harness that is not installed, a state directory that
         cannot be made. The switch must then leave this chat exactly as it was rather

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -339,6 +339,13 @@ class TheLauncherCanBuildAFrameWithNoTerminalOfItsOwn(PersonaIso, unittest.TestC
 
     Both are correct for every launch that IS the operator's terminal, and neither is
     correct for one that will never attach.
+
+    **`shutil.which` is pinned in both cases, and that is not decoration.** `cmd_launch`
+    has an EARLIER `bypass` for a registered harness whose binary is not installed, so
+    without the pin these cases ask whether the developer running them happens to have
+    `claude` on `$PATH` — green on a laptop, red on CI, and measuring the machine rather
+    than the repo either way. Caught exactly that way: both passed locally and failed on
+    all four CI Pythons.
     """
 
     def test_a_launch_that_will_not_attach_is_not_execd_away_by_the_non_tty_guard(self):
@@ -354,6 +361,8 @@ class TheLauncherCanBuildAFrameWithNoTerminalOfItsOwn(PersonaIso, unittest.TestC
                                size=(120, 40))
         with mock.patch("charter.commands_frame.sys.stdout") as out, \
                 mock.patch("charter.commands_frame.bypass") as byp, \
+                mock.patch("charter.commands_frame.shutil.which",
+                           return_value="/nowhere/claude"), \
                 mock.patch("charter.commands_frame.tmuxctl.version", return_value=None):
             out.isatty.return_value = False
             commands_frame.cmd_launch(args)
@@ -365,6 +374,8 @@ class TheLauncherCanBuildAFrameWithNoTerminalOfItsOwn(PersonaIso, unittest.TestC
         args = SimpleNamespace(harness="claude", rest=[], no_frame=False,
                                workspace=None, pick=False)
         with mock.patch("charter.commands_frame.sys.stdout") as out, \
+                mock.patch("charter.commands_frame.shutil.which",
+                           return_value="/nowhere/claude"), \
                 mock.patch("charter.commands_frame.bypass",
                            return_value=0) as byp:
             out.isatty.return_value = False
@@ -410,25 +421,40 @@ class ADetachedProcessCanBuildAWorkspace(unittest.TestCase):
 
         self.addCleanup(tm, "kill-server")
         tm("new-session", "-d", "-s", "home", "sh")
-        pid, _fd = pty.fork()
-        if pid == 0:                                    # pragma: no cover - the child
-            # `os._exit` in a `finally`, which every other `pty.fork` in this suite spells
-            # for the same reason: an `execvp` that RAISES leaves the child running the
-            # test framework, and a second runner that goes on to fork is how one failed
-            # exec becomes a machine full of them. Never `sys.exit` — that unwinds, and
-            # unittest catches `SystemExit`.
-            try:
-                os.execvp("tmux", ["tmux", "-L", sock, "attach", "-t", "home"])
-            finally:
-                os._exit(127)
-        self.addCleanup(lambda: os.waitpid(pid, os.WNOHANG))
 
-        deadline = time.time() + 10
+        # **Several `TERM`s, then a skip — never an assertion.** CI has tmux but the
+        # terminal it offers a client is not the developer's: measured, a client that
+        # attaches on a laptop refuses on all four CI Pythons, and a bare `assertTrue`
+        # there reports "charter is broken" for "this machine has no terminal tmux will
+        # talk to". The sibling real-tmux modules all spell this ladder; so does this one.
         client = ""
-        while time.time() < deadline and not client:
-            client = tm("list-clients", "-F", "#{client_tty}").stdout.strip()
-            time.sleep(0.05)
-        self.assertTrue(client, "no client ever attached")
+        for term in ("xterm-256color", "screen", "vt100"):
+            pid, _fd = pty.fork()
+            if pid == 0:                                # pragma: no cover - the child
+                # `os._exit` in a `finally`, which every other `pty.fork` in this suite
+                # spells for the same reason: an `execvp` that RAISES leaves the child
+                # running the test framework, and a second runner that goes on to fork is
+                # how one failed exec becomes a machine full of them. Never `sys.exit` —
+                # that unwinds, and unittest catches `SystemExit`.
+                try:
+                    os.environ["TERM"] = term
+                    os.execvp("tmux", ["tmux", "-L", sock, "attach", "-t", "home"])
+                finally:
+                    os._exit(127)
+            self.addCleanup(lambda p=pid: os.waitpid(p, os.WNOHANG))
+            deadline = time.time() + 10
+            while time.time() < deadline and not client:
+                client = tm("list-clients", "-F", "#{client_tty}").stdout.strip()
+                time.sleep(0.05)
+            if client:
+                break
+            try:
+                os.kill(pid, 9)
+            except OSError:
+                pass
+        if not client:
+            self.skipTest("no tmux client can attach on this machine, and the claim "
+                          "under test is that a detached process can move a real one")
 
         script = (
             '{ [ -t 0 ] || [ -t 1 ] || [ -t 2 ]; } && exit 91; '

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -442,7 +442,9 @@ class ADetachedProcessCanBuildAWorkspace(unittest.TestCase):
     marks it, and moves an attached client onto it.
 
     Run against tmux 3.7c and against tmux 3.2 (`tmuxctl.FLOOR`), identically on both.
-    CI installs no tmux, so this runs by hand.
+    CI has tmux and really runs this; what it does not have is a terminal tmux will hand a
+    CLIENT, so the case skips there and the `switch-client` half is verified by hand. See
+    the `TERM` ladder below, which is the measurement that established that.
     """
 
     def test_a_detached_creator_builds_a_session_and_switches_a_client_onto_it(self):

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -779,6 +779,12 @@ class NoCharterEscapesThroughTheExecFamily(unittest.TestCase):
             "switch is ABOUT: `switch-client -c <client>` moves a CLIENT, and only a real "
             "one on a real terminal exists to be moved — a detached session has nothing "
             "for the switch to act on. `os._exit`s in its `finally`.",
+        "tests/test_a_workspace_tab_opens_what_it_names.py:execvp":
+            "The same `tmux attach` inside a `pty.fork` child, for the reason opening a "
+            "workspace from a tab is ABOUT: the claim under test is that a process with "
+            "no controlling terminal can still build a session and `switch-client` a "
+            "real client onto it, and only a real client on a real terminal is a thing "
+            "that can be moved. `os._exit`s in its `finally`.",
         "tests/test_a_real_click_on_a_real_tab_bar_switches.py:execvp":
             "The same `tmux attach` inside a `pty.fork` child, for the sibling reason "
             "again: that file exercises the pointer against the two BARS, whose click "


### PR DESCRIPTION
*"when I want to switch to another workspace it should switch and keep my current sessions open in background, but I can't switch — I get `charter: workspace 'default' is not open on this plane — open it with charter <harness> --workspace default`"*

**13 of the operator's 15 workspace tabs did nothing.** #793 shipped the half where the workspace is already open; this is the other half. A tab for a workspace with no session now **opens it and takes you there** — which is exactly what the refusal printed for the operator to go and type by hand.

## The refusal's stated reason was false, and I measured it

> *"Opening one is `cmd_launch` — a directory, an ordinal, a harness process and an `attach` — and this runs detached with its streams on `/dev/null`, with no terminal to attach anything to."*

A process with `start_new_session=True` and all three streams on `/dev/null` — `builtin_actions._spawn`'s exact shape — creates a session, splits panes, sets session options and `switch-client`s a real attached client onto it, with nothing killed. **Measured on tmux 3.7c and at the 3.2 floor, identically.** The `attach` is not wanted: arriving is `switch-client`, which #793 already does and which needs no tty.

`_wants_attach`'s own docstring had already reserved the seam — *"the day a third caller wants one without the other, a shared expression would have to be unpicked at two call sites at once."* This is that caller. `cmd_reopen` has also been building sessions without attaching since #796, so the detached-build path was already shipped and exercised.

## What actually blocked it was somewhere else, and it would have failed silently

`cmd_launch`'s second guard is `if args.no_frame or not sys.stdout.isatty(): return bypass(argv)` — and **`bypass` calls `os.execvp`**. A detached switch reaching it would have been *replaced* by a bare harness writing to `/dev/null`: no frame, no session, no switch, no exit code, and no surface left to report any of it on. It is now asked only of a launch that was going to be the operator's terminal.

Not theoretical: the mutation that ignores `attach=False` `execvp`s the end-to-end's own test runner away into the fake harness.

## And a cross-plane guard #793's guarantee needed

`_plane_session` answering `None` means *"this plane cannot prove a session of this name is its own"*, **not** *"the name is free"*. `cmd_launch` decides between starting a session and joining one with `if session in live_sessions:` — a name test over the whole machine, where `default` exists several times over. Unguarded, a click in plane B would have added a chat window to plane A's live session and then failed the `@charter_plane` veto on the way out: the operator told the open failed, with a window in another project's frame. §3.3 names exactly this. An uncertain answer now falls towards refusing, because "attach by hand" is recoverable and a window in someone else's frame is not.

## #518 does not reach this

#518 asks that `charter <harness>` stop resolving a workspace *silently*; its "creating is not free" paragraph is about `charter workspace create` making a **workspace directory** from a name the operator typed — *"a picker that creates on a typo leaves litter, so the create path needs confirmation or a validation pass."* It explicitly **wants** a create path, gated. Nowhere does the repo state "charter never creates as a side effect" as a universal law; the universal-sounding sentence that exists, `switch.py`'s *"Nothing here creates anything"*, is scoped to that module by its own next sentence.

A tab types nothing. The name comes off the list charter drew from directories that already exist, `switch.to_workspace` has already refused any other, and the set of workspaces is provably the same after a click as before. What a click makes is a **chat** in a workspace that exists — which is what §4k says `-w foo` makes: *"if `foo` is live, attach to it; if not, open it and leave the others. That is `code <path>`'s behaviour."* No pointer is written, so #518's "never ask twice" is untouched.

## What a click costs, and why nothing confirms it

One harness process at its own prompt, one chat directory, a set of panels. **Charter sends the harness nothing** — `rest` is empty, so `launch_argv` is the bare binary: no prompt, no `--resume`. A click starts a program, not a turn. The brief's "a click that spends is a first for charter" does not hold; spending starts when the operator types.

**And nothing is opened for nobody.** `_switch_client` already refused when no client is attached to this chat's session; that refusal sat *after* the workspace lookup, which was free when the lookup ended in a refusal and is not free now. It is asked before the open, so a frame nobody is looking at cannot be made to launch into the dark and then be told there was no client to move.

Single click, deliberately: `key` is not in `events.DELIVERED` so a panel has no keyboard confirmer; a two-click confirm is the select-then-confirm #725 rejected; §4k models on `code <path>`; and opening is the reversible direction (`F2` → `chat` → close).

## Changes

- `_wants_attach` honours an explicit `attach=False`; `_launch_size` lets a caller hand in a size, because `os.get_terminal_size()` raises with streams on `/dev/null` and `_FALLBACK_SIZE` (80x24) would drop every panel a real terminal has room for. The size passed is the window the switching client is on — what tmux resizes the new session to anyway.
- `_open_workspace` — harness from the clicked-from chat's `$CHARTER_HARNESS`, else `[harness] default`, else refused by name; cwd the workspace's own directory; the answer re-asked from `_plane_session` rather than inferred.
- The "nobody is attached" refusal moved ahead of the open, deliberately inside that branch rather than hoisted over the whole function — the order of the other refusals is #793's and pinned by its own tests.
- Two comments in `switch.py` / `choose.py` that named the refusal this removes.

## Verification

- `ADetachedProcessCanBuildAWorkspace` — the tmux claim, charter out of the room.
- `ARealTabOpensARealWorkspace` — the whole path, nothing faked but the harness binary (a script that sleeps; a test may not start a real `claude`). Real server, real client on a real 132-column pty, real `_switch_client`, real `cmd_launch`, real panel processes. Workspace opens, client arrives, the chat left behind keeps its pid, the session carries this plane's marker, the window is 132 columns not 80.
- Four hand mutations, re-measured against the final tree, all red: dropped size (1 failure), ignored `attach=False` (3), removed cross-plane guard (2), dropped the default-harness fallback (1).
- Full suite green locally on 3.7c and at the 3.2 floor: **10139 tests, OK**. CI does have tmux and runs these; what it lacks is a terminal tmux will hand a *client*, so the client half skips there and was run by hand. That is itself a measurement — the sibling modules' "CI installs no tmux" is wrong, and believing it is what made the first version of this assert instead of skip.

**A finding CI caught, worth recording:** two of the launcher cases passed here and failed on all four CI Pythons, because `cmd_launch` has an earlier `bypass` for a harness binary that is not installed — so they were asking whether the developer happens to have `claude` on `$PATH`. `shutil.which` is pinned in both now, and the pin was checked not to blunt them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf

