### PR TITLE
A workspace tab is not a one-way door: two spellings of one socket are one server (#812)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1944,8 +1944,10 @@ def _frame_is_live(socket: str, fid: str) -> bool:
     A frame is a WINDOW on either server now — one of a workspace session's chats on
     charter's own, one of the operator's own windows in theirs — and `@charter_chat` is
     what it answers to on both, so `_live_chats` is asked either way.
-    `tmuxctl.is_operator_socket` is the same single discriminator that already turns a
-    server into `-L` or `-S`, and it still decides what the SECOND question is:
+    `tmuxctl.is_operator_socket` is the single question "whose server is this" — since
+    #812 a comparison of SERVERS rather than of spellings, so charter's own socket read
+    out of `$TMUX` as a path is not mistaken for somebody else's — and it decides what
+    the SECOND question is:
     `cmd_respawn` asked `_live_sessions(SOCKET)` unconditionally, which on the operator's
     server is a question about a server that is not theirs: it answers "no such session"
     for a frame that is on screen, so a panel that died there could never have been
@@ -4557,8 +4559,35 @@ def cmd_launch(args) -> int:
     # names often enough to matter (`env` captures, a `tmux kill-server` under a running
     # script), and charter is then not inside a tmux whatever it says. `None` back means
     # exactly that, and the private-server path below is the right one after all.
+    #
+    # **`is_operator_socket`, not `inside is not None`, and that is #812's other half.**
+    # `$TMUX` says which tmux this process is INSIDE; it does not say whose it is. A
+    # launch reached from a workspace tab runs in a panel process of charter's own frame
+    # (`_open_workspace` calls this function in-process), so its `$TMUX` is charter's own
+    # socket spelled as a path — and this branch, asked only whether the variable parsed,
+    # built the new workspace's chat as a `new-window` in whatever session the CALLER was
+    # in. Measured on tmux 3.7c against a real server, before this line changed: clicking
+    # `beta` from a chat in `alpha` left `list-sessions` reporting only `alpha` and
+    # `list-windows -a` reporting `[alpha] win=beta.1` — so `_open_workspace`'s closing
+    # `_plane_session(socket, ws=ws)` could never find the session it had just asked for,
+    # and this launcher blocked in `_wait_for_harness` for the life of that chat rather
+    # than returning to the switch at all. On charter's own server a workspace IS a
+    # session (§2.1), so the private path below is the right one however `$TMUX` spells
+    # the socket.
+    #
+    # **What this changes for a launch that WILL be a terminal, stated rather than
+    # discovered.** `charter <harness>` typed at a shell inside a charter frame now builds
+    # its own session and reaches the `attach` below, from a process already inside that
+    # very server — a NESTED client, which `_frame_env` makes possible by popping `$TMUX`
+    # and which was measured to succeed on tmux 3.7c and at the 3.2 floor (a client on the
+    # inner pane's tty, `list-clients` reporting it against the new session). That is the
+    # pre-ADR-0018 shape and it stacks two prefix layers on one terminal, so it is not
+    # good — but what it replaces is not "working": that launch used to land a chat for
+    # one workspace as a window inside ANOTHER workspace's session, whose every workspace
+    # tab then refused with #812's own sentence. The one-way door was reachable by typing
+    # as well as by clicking, and both doors are the same defect.
     inside = tmuxctl.operator_server()
-    if inside is not None:
+    if inside is not None and tmuxctl.is_operator_socket(inside[0], own=SOCKET):
         rc = _launch_in_operator_tmux(inside[0], inside[1], ws=ws, argv=argv,
                                       h=h, v=v, picked=picked)
         if rc is not None:
@@ -6805,9 +6834,18 @@ def _switch_client(fid: str, ws: str, *, said: str) -> None:
     deletes.
     """
     socket = state.frame_server(fid) or SOCKET
-    if tmuxctl.is_operator_socket(socket):
-        # **A workspace is a tmux session only on charter's OWN server** (§2.1), and this
-        # frame is not on it. Inside an operator's tmux every chat charter opens is a
+    if tmuxctl.is_operator_socket(socket, own=SOCKET):
+        # **This is #812's refusal, and it is still here because the reasoning was never
+        # the defect.** What was wrong was the premise: `is_operator_socket` was a
+        # leading-slash test, and a chat launched inside one of charter's own panes
+        # records charter's own socket as the absolute path `$TMUX` spells it with — so
+        # every tab in that chat, the one back included, was refused by this line for a
+        # server charter had started itself. It asks about the SERVER now, so a frame on
+        # charter's private socket reaches the switch whichever way its record spells it,
+        # and a frame genuinely inside somebody else's tmux is refused exactly as before.
+        #
+        # **A workspace is a tmux session only on charter's OWN server** (§2.1), and such
+        # a frame is not on it. Inside an operator's tmux every chat charter opens is a
         # `new-window` in the session that operator was already in (`layout.window_argv`,
         # `_launch_in_operator_tmux`) — whatever workspace it names — so there is no
         # session for another workspace to be, and the two things `switch-client` could
@@ -8290,7 +8328,17 @@ def cmd_reopen(args) -> int:
         util.err(tmuxctl.absent_message())
         return 1
     # **Refused inside a tmux the operator already has, and stated rather than half-done.**
-    # `cmd_launch` builds a frame there as a WINDOW on THEIR server
+    #
+    # **The test is `operator_server`, deliberately, and NOT #812's `is_operator_socket`.**
+    # This is not a question about whose server it is; it is a question about whether this
+    # process is already inside ONE, and both answers refuse. On somebody else's server
+    # the reason is the paragraph below. On charter's own — reached when a `charter
+    # reopen` is typed at a shell inside a frame — every chat would build correctly and
+    # the single `_attach_after_reopen` at the end would then attach a NESTED client
+    # inside the pane it was typed in, which is the pre-ADR-0018 shape ADR 0018 removed.
+    # Refusing costs one message; the operator's own shell is one `detach` away.
+    #
+    # `cmd_launch` builds a frame in somebody else's tmux as a WINDOW on THEIR server
     # (`_launch_in_operator_tmux`), and that path is awake for the whole life of the frame —
     # it reads the harness's exit status itself instead of installing the `pane-died` hooks,
     # which is what makes it correct there and what makes it BLOCK exactly as `attach` does.

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4566,14 +4566,17 @@ def cmd_launch(args) -> int:
     # (`_open_workspace` calls this function in-process), so its `$TMUX` is charter's own
     # socket spelled as a path — and this branch, asked only whether the variable parsed,
     # built the new workspace's chat as a `new-window` in whatever session the CALLER was
-    # in. Measured on tmux 3.7c against a real server, before this line changed: clicking
-    # `beta` from a chat in `alpha` left `list-sessions` reporting only `alpha` and
-    # `list-windows -a` reporting `[alpha] win=beta.1` — so `_open_workspace`'s closing
+    # in. Measured on tmux 3.7c against a real server, before this line changed, with
+    # `$TMUX` naming charter's own socket by path and a launch asking for workspace
+    # `beta`: `list-sessions` reported only the caller's own session and never a `beta`,
+    # `list-windows -a` reported `beta.1` as a window INSIDE it, `state.record_server`
+    # wrote the absolute spelling, and the launcher was still inside `_wait_for_harness`
+    # when the harness was still alive. So `_open_workspace`'s closing
     # `_plane_session(socket, ws=ws)` could never find the session it had just asked for,
-    # and this launcher blocked in `_wait_for_harness` for the life of that chat rather
-    # than returning to the switch at all. On charter's own server a workspace IS a
-    # session (§2.1), so the private path below is the right one however `$TMUX` spells
-    # the socket.
+    # and the switch never got its answer back at all. With this line as it now stands,
+    # the same launch recorded the short NAME and left a real `beta` session behind. On
+    # charter's own server a workspace IS a session (§2.1), so the private path below is
+    # the right one however `$TMUX` spells the socket.
     #
     # **What this changes for a launch that WILL be a terminal, stated rather than
     # discovered.** `charter <harness>` typed at a shell inside a charter frame now builds

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -267,35 +267,140 @@ def operator_server(env: Mapping[str, str] | None = None) -> tuple[str, str] | N
     return m.group(1), f"${m.group(2)}"
 
 
+#: tmux's ``_PATH_TMP``, verbatim: a literal in its own source, and **not** ``$TMPDIR``.
+#:
+#: Measured rather than read, on tmux 3.7c and at the 3.2 floor, by starting a server
+#: with ``TMPDIR`` pointed at a scratch directory and asking it where it actually is:
+#: both answered ``/private/tmp/tmux-502/<name>``, and the scratch directory stayed
+#: empty. The same pair of runs with ``TMUX_TMPDIR`` set DID build
+#: ``<that dir>/tmux-502/``, so the variable tmux honours is that one alone. The
+#: distinction is load-bearing on macOS, where `tempfile.gettempdir()` answers a per-user
+#: ``/var/folders/…`` that tmux never puts a socket in.
+DEFAULT_TMPDIR = "/tmp"
+
+
+def socket_path(name: str) -> str:
+    """The socket FILE tmux computes for ``-L name`` — ``<tmpdir>/tmux-<uid>/<name>``.
+
+    **The other half of :func:`server_argv`'s split, and the reason it needs one.** That
+    function turns a NAME into ``-L`` and a PATH into ``-S``, which is right for aiming a
+    command; it says nothing about whether two spellings aim at the SAME server. They
+    routinely do: `commands_frame.SOCKET` is ``charter``, and a process started in one of
+    that server's own panes reads ``/private/tmp/tmux-502/charter`` out of ``$TMUX``.
+    #812 is what happens when those two are compared as strings.
+
+    **The result is RESOLVED, and that is not tidiness.** tmux calls ``realpath()`` on the
+    base directory before it uses it, which on macOS turns ``/tmp`` into ``/private/tmp``
+    — measured: a server started as ``-L <name>`` reports ``socket_path`` as
+    ``/private/tmp/tmux-502/<name>`` on 3.7c and on 3.2 alike, while
+    `tests/test_frame_tmux_integration.OP_SOCKET_PATH` builds the ``/tmp`` spelling of
+    that same file and reaches the same server with it. Two spellings of one socket that
+    differ only by a symlink must not read as two servers, so both sides go through
+    `os.path.realpath` and no caller has to know which form it is holding.
+
+    Nothing here touches the filesystem beyond that resolution: `os.path.realpath` leaves
+    what does not exist lexical, so a socket directory tmux has not created yet still gets
+    the right answer and asking the question starts no server.
+    """
+    base = os.environ.get("TMUX_TMPDIR") or DEFAULT_TMPDIR
+    return os.path.join(os.path.realpath(os.path.join(base, f"tmux-{os.getuid()}")), name)
+
+
+def same_server(a: str | None, b: str | None) -> bool:
+    """Do *a* and *b* name ONE tmux server, whichever way each is spelled?
+
+    The question `is_operator_socket` could not ask while it was a leading-slash test.
+    Each side is resolved to the socket FILE it names — a name through
+    :func:`socket_path`, a path through `os.path.realpath` — and the files are compared.
+
+    Empty on either side is never the same server as anything, including another empty:
+    ``""`` is not a spelling of a socket, it is the absence of one, and the callers that
+    can produce it (`state.frame_server` reading a truncated marker) mean "unknown".
+    """
+    if not a or not b:
+        return False
+    return _resolved(a) == _resolved(b)
+
+
+def _resolved(server: str) -> str:
+    """*server* as the socket FILE it names, whichever of the two spellings it is."""
+    return os.path.realpath(server if is_socket_path(server) else socket_path(server))
+
+
+def is_socket_path(server: str | None) -> bool:
+    """Is *server* spelled as a socket PATH rather than as a `-L` name?
+
+    A leading ``/`` is the whole discriminator, and it is total rather than a heuristic: a
+    socket path only ever reaches charter from `$TMUX`, which tmux writes absolute, and a
+    `-L` name may not contain a separator at all — tmux joins that name onto its own
+    socket directory to build the path, so a name with a `/` in it names a directory that
+    does not exist.
+
+    **This is the SPELLING, and it is no longer the same question as "whose server is
+    it".** It was both until #812: a frame launched inside one of charter's own panes
+    records the path spelling of charter's own socket, and every reader that asked
+    :func:`is_operator_socket` was told it was a guest on somebody else's tmux. Splitting
+    the two leaves `server_argv` exactly the test it always had — which flag aims at this
+    string — and gives the ownership question a comparison that can see through a
+    spelling.
+    """
+    return bool(server) and server.startswith("/")
+
+
 def server_argv(server: str, *args: str) -> list[str]:
     """`tmux`, the flags that select ONE server, then *args* — every element separate.
 
     Charter talks to two different servers now, and this is the one place that difference
     is spelled: its own private one by NAME (`-L charter`, see `commands_frame.SOCKET`),
     and the operator's existing one by SOCKET PATH (`-S /private/tmp/tmux-502/default`,
-    read out of `$TMUX` by :func:`operator_server`). A leading `/` is the whole
-    discriminator, and it is total rather than a heuristic: a socket path only ever
-    reaches charter from `$TMUX`, which tmux writes absolute, and a `-L` name may not
-    contain a separator at all — tmux joins that name onto its own socket directory to
-    build the path, so a name with a `/` in it names a directory that does not exist.
+    read out of `$TMUX` by :func:`operator_server`). :func:`is_socket_path` is the whole
+    discriminator and says why it is total.
 
     Nothing is ever joined, here or anywhere downstream of here: a joined string is
     shell-interpreted by tmux and a separate argv is not (pinned against 3.7c, see
     `frame/layout.py`'s module docstring).
     """
-    return ["tmux", "-S" if is_operator_socket(server) else "-L", server, *args]
+    return ["tmux", "-S" if is_socket_path(server) else "-L", server, *args]
 
 
-def is_operator_socket(server: str | None) -> bool:
+def is_operator_socket(server: str | None, *, own: str | None = None) -> bool:
     """Is *server* a tmux charter did not start — one it is a guest on?
 
-    The same leading-slash test :func:`server_argv` turns into `-S`, named so the two
-    places that care about the difference cannot answer it differently. The second is
-    `frame/slots.py`: charter binds no hotkey on a server it is a guest on (a key table
-    is server-wide in tmux, with no per-window form), so the bottom panel must not
-    advertise one there.
+    Two readers care and each would be wrong in its own way for a wrong answer.
+    `frame/slots.py` drops the hotkey hint on a server charter is a guest on (a key table
+    is server-wide in tmux, with no per-window form, so charter binds none there);
+    `commands_frame._switch_workspace` refuses a workspace switch there, because inside an
+    operator's tmux every chat is a `new-window` in the session they were already in and
+    there is no session for another workspace to BE (§2.1).
+
+    **It was a leading-slash test, and #812 is the bug that was.** The operator's own
+    ``$TMUX`` on the machine this was written for is
+    ``/private/tmp/tmux-502/charter,18923,83`` — charter's OWN socket, spelled as an
+    absolute path, because the process reading it was started in one of charter's own
+    panes. So a chat opened from a workspace tab recorded that spelling, every tab in it
+    (including the one back) read it as a guest tmux, and the operator was told *"this
+    chat is a window in your own tmux, where a workspace is not a session"* about a frame
+    sitting on charter's private server. **Two spellings of one socket are not the same
+    string.** The refusal itself is not the defect and is still here; what was wrong was
+    concluding that this frame was in one.
+
+    So the question is asked of the SERVER (:func:`same_server`) rather than of the
+    string. *own* is charter's own private socket and defaults to it; it is a parameter so
+    a caller that has already resolved which server it means can say so rather than have
+    this reach for a module global.
+
+    Imported lazily for `frame/builtin_actions._server`'s reason, and reached at CALL time
+    rather than bound at import: `commands_frame` imports this module at load, so a
+    top-level import would be a cycle — and a value bound once would not follow the
+    `commands_frame.SOCKET` a test patches, which is exactly how a suite ends up proving
+    the wrong socket's ownership.
     """
-    return bool(server) and server.startswith("/")
+    if not is_socket_path(server):
+        return False
+    if own is None:
+        from ..commands_frame import SOCKET
+        own = SOCKET
+    return not same_server(server, own)
 
 
 #: tmux's own separator between commands sent in ONE invocation. A standalone argument,

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -209,9 +209,12 @@ _VERSION = re.compile(r"^tmux (\d+)\.(\d+)")
 #: `<socket path>,<server pid>,<session id>`, the session id being the NUMBER off
 #: tmux's own `#{session_id}` (`$1` is written `1`). Measured against tmux 3.7c by
 #: printing the variable from inside a real pane. The socket path is required to be
-#: ABSOLUTE here because :func:`server_argv` discriminates on a leading `/` alone — a
+#: ABSOLUTE here because :func:`is_socket_path` discriminates on a leading `/` alone — a
 #: relative path would be handed to tmux as a `-L` server NAME and quietly start a
-#: brand-new server, which is the nesting `commands_frame` reads this to avoid.
+#: brand-new server, which is the nesting `commands_frame` reads this to avoid. What the
+#: absolute form does NOT establish is whose server it is: it is exactly how tmux writes
+#: charter's OWN socket into charter's own panes, which is #812 — see
+#: :func:`is_operator_socket`.
 _TMUX_ENV = re.compile(r"^(/[^,]*),\d+,(\d+)$")
 
 #: The variable itself, named once so :func:`operator_server` and the tests that fake it

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -326,8 +326,23 @@ def same_server(a: str | None, b: str | None) -> bool:
 
 
 def _resolved(server: str) -> str:
-    """*server* as the socket FILE it names, whichever of the two spellings it is."""
-    return os.path.realpath(server if is_socket_path(server) else socket_path(server))
+    """*server* as the socket FILE it names, whichever of the two spellings it is.
+
+    **One expression and no branch, because `os.path.join` already is the branch.** This
+    read ``server if is_socket_path(server) else socket_path(server)``, and the deletion
+    sweep found that `if` to be exactly equivalent to its else — correctly, and the reason
+    is worth writing down rather than the line being quietly deleted:
+    `os.path.join(base, tail)` throws every earlier component away when *tail* is absolute
+    (CPython's documented rule), so :func:`socket_path` handed a socket PATH answers with
+    that path unchanged and handed a `-L` NAME builds the file for it. Measured on this
+    machine: ``socket_path("/private/tmp/tmux-<uid>/charter")`` is that string back.
+
+    That property is pinned by name in `tests/test_frame_tmuxctl.py`, because it is the
+    whole of why there is no branch here and a future :func:`socket_path` that stopped
+    honouring it would silently turn every guest comparison into nonsense rather than
+    failing.
+    """
+    return os.path.realpath(socket_path(server))
 
 
 def is_socket_path(server: str | None) -> bool:

--- a/docs/news/unreleased-a-workspace-tab-is-not-a-one-way-door.md
+++ b/docs/news/unreleased-a-workspace-tab-is-not-a-one-way-door.md
@@ -1,0 +1,97 @@
+---
+version: unreleased
+headline: A workspace tab is no longer a one-way door — the tab back works too
+---
+
+*"I switched to `fleet` workspace, it switched with a new empty chat session, then when I
+want to switch back — I get an error. When I tried to terminate the chat session with
+Ctrl-C, charter closed and I see our current session, so the first session survived and was
+not closed."*
+
+The change before this one made every workspace tab open the workspace it names. It opened
+one. It did not let you leave it: in the chat the tab had just opened, every tab — including
+the one you came from — answered
+
+```
+cannot switch: this chat is a window in your own tmux, where a workspace is not a session
+```
+
+Nothing was lost. `Ctrl-C` closed the new chat and put the original one back, exactly as
+that operator found. But the only way out of a workspace you had clicked into was to kill
+the chat you had clicked into it with.
+
+Both tabs work now, in both directions.
+
+## Two spellings of one socket
+
+Charter runs its frames on a private tmux server of its own, which it starts and reaches by
+name: `charter`. Every other server — the tmux you had open before charter existed — it
+reaches by the path of the socket file, and it treats a frame there completely differently:
+your window, your prefix key, no charter hotkey, and no workspace switching, because inside
+a tmux you already have, a workspace is not a session and there is nothing correct for a
+switch to do.
+
+Charter told those two apart by asking whether the name started with a `/`.
+
+Which is true of the operator's own server, and *also* true of charter's own — because tmux
+writes the socket into every process it starts in a pane, and it writes it absolute. So a
+click, which runs in a process tmux started in one of charter's own panes, read
+`/private/tmp/tmux-502/charter` where an ordinary launch reads `charter`, and every later
+question about that chat was answered for a server charter had started itself.
+
+The refusal was not the bug and it has not been deleted — inside a tmux you already have it
+is still exactly right. What was wrong was believing this frame was in one. Charter now
+compares the *servers*, resolving either spelling to the socket file it names, so `charter`
+and `/private/tmp/tmux-<uid>/charter` are one server and a tmux you started yourself is
+still yours.
+
+## The tab was opening the workspace in the wrong place, too
+
+The same false premise reached further than the message. The launcher chose between
+"a session on charter's own server" and "a window in the session I am already in" on whether
+`$TMUX` could be read at all — so a tab click opened its chat as a window *inside the
+workspace you were leaving*. There was never a session for the workspace you clicked, which
+is why nothing could switch you into it, and the launcher on that path stays awake for the
+life of the harness, so the click never even finished. That is what a "new empty chat
+session" with no way back actually was.
+
+On charter's own server a workspace is a session. The launcher now asks whose server it is
+in, not merely whether it is in one.
+
+## What this changes if you type `charter <harness>` inside a frame
+
+Rare, and worth stating rather than leaving you to find. Typed at a shell *inside* a charter
+frame, `charter claude` used to make a window in the session you were standing in — a chat
+for one workspace living inside another workspace's session, whose own workspace tabs then
+refused with the message above. It was the same one-way door, reached by typing instead of
+clicking.
+
+It now builds the workspace's own session, correctly, and then attaches to it from a
+terminal that is already inside that server — a tmux nested in a tmux, which works (measured
+on 3.7c and at the 3.2 floor) and stacks two prefix layers on one terminal. That is worse to
+look at than what it replaces and better than what it replaces was doing. Opening a second
+workspace from inside a frame is what the workspace tabs are for.
+
+## Verification
+
+The end-to-end case that was missing, and the reason this shipped broken: every real-tmux
+test charter has starts from a socket charter created, reaches it by the name it created it
+under, and runs with `$TMUX` unset. A click never happens in that environment. It happens in
+a process tmux started in a pane.
+
+So the whole of the previous change's end-to-end suite is now re-run with the environment a
+click really has — a real server, a real client on a real 132-column pty, a real launch — and
+with the trip the operator actually reported: click `beta`, land in `beta`, click `alpha`,
+arrive in `alpha`, with the chat left behind keeping its pid through both legs. The click
+runs under a deadline, because on the old code it did not return a wrong answer, it did not
+return at all.
+
+The refusal keeps its own test: a frame genuinely inside a tmux charter did not start is
+still refused by name, and asks the server nothing at all before it refuses.
+
+Run against real tmux on **3.7c and on tmux 3.2**, the floor charter promises. CI has tmux
+and runs everything that needs only a tmux server; the cases that need a client on a real pty
+skip there, because the runner has no terminal tmux will hand one.
+
+Nothing to adopt — the `workspaces` bar is still off by default (`[frame] slots`), and a tab
+is still one click.

--- a/docs/news/unreleased-opening-a-workspace-you-already-have-open-puts-you-in-it.md
+++ b/docs/news/unreleased-opening-a-workspace-you-already-have-open-puts-you-in-it.md
@@ -73,7 +73,10 @@ attaches to `$0`, adds no window and leaves the client on `shared.1`; on `main` 
 second launch adds `shared.2` and moves the attached client onto it. The third launch, from
 the other plane, opens its own chat on both.
 
-Run by hand on **tmux 3.7c and on tmux 3.2** — 29/29 on each. CI installs no tmux, so none
-of it runs there.
+Run by hand on **tmux 3.7c and on tmux 3.2** — 29/29 on each. CI has tmux and runs every
+case that needs only a tmux SERVER; the ones that need a client on a real pty skip there,
+because the runner has no terminal tmux will hand one. (This paragraph used to say "CI
+installs no tmux, so none of it runs there", which is false and cost #811 a red run on all
+four Pythons — see #812.)
 
 Nothing to adopt.

--- a/docs/news/unreleased-switching-workspace-moves-your-terminal-and-stops-nothing.md
+++ b/docs/news/unreleased-switching-workspace-moves-your-terminal-and-stops-nothing.md
@@ -89,8 +89,10 @@ veto, dropping `-c <client>` from `switch-client`, never verifying the client mo
 the seat charter matched instead of the window tmux landed on, leaving the old chat's panels
 up, and writing the plane marker on a launch that joined a session rather than made one.
 
-Run against real tmux on **3.7c and on tmux 3.2**, the floor charter promises. CI installs no
-tmux, so the real-server half runs only by hand.
+Run against real tmux on **3.7c and on tmux 3.2**, the floor charter promises. CI has tmux
+and really runs the real-server half; what it cannot run is the half that needs a client on
+a real pty, which skips there. (This paragraph used to say "CI installs no tmux", which is
+false — believing it cost #811 a red run on all four Pythons, and #812 is what found it.)
 
 Nothing to adopt — the `workspaces` bar is still off by default (`[frame] slots`), and a
 switch is the same command it always was.

--- a/tests/test_a_planes_frame_really_reads_that_way.py
+++ b/tests/test_a_planes_frame_really_reads_that_way.py
@@ -557,7 +557,7 @@ class TheLivePaneIsMarkedOnASurfacelessFrame(_NestedClient, unittest.TestCase):
 
 @unittest.skipUnless(_FLOOR_BIN.exists(),
                      f"no {_FLOOR_BIN.name} built on this machine — `docs/frame.md` says "
-                     "how, and CI installs no tmux at all")
+                     "how, and CI has no build of the floor version")
 class TheFloorHasNoSuchCueAndSaysSo(TheLivePaneIsMarkedOnASurfacelessFrame):
     """`pane-border-indicators` arrived in tmux 3.3 and charter's floor is 3.2, so every
     test above SKIPS here rather than passing or failing.
@@ -578,7 +578,7 @@ class TheFloorHasNoSuchCueAndSaysSo(TheLivePaneIsMarkedOnASurfacelessFrame):
 
 @unittest.skipUnless(_FLOOR_BIN.exists(),
                      f"no {_FLOOR_BIN.name} built on this machine — `docs/frame.md` says "
-                     "how, and CI installs no tmux at all")
+                     "how, and CI has no build of the floor version")
 class TheFloorAnswersIdentically(TheHiddenRuleIsDrawnAndCannotBeSeen):
     """Every rendering above, re-run against `tmuxctl.FLOOR`.
 

--- a/tests/test_a_workspace_switch_moves_the_client.py
+++ b/tests/test_a_workspace_switch_moves_the_client.py
@@ -348,6 +348,26 @@ class TheSwitchItself(PersonaIso, unittest.TestCase):
         self.assertIn("a window in your own tmux", said)
         self.assertIn("charter <harness> --workspace beta", said)
 
+    def test_charters_own_socket_written_the_long_way_is_not_that_frame(self):
+        """**#812, and the pair to the case above rather than a replacement for it.**
+
+        The refusal is right; the premise was not. `is_operator_socket` was a
+        leading-slash test, and tmux writes its socket into every pane it opens as an
+        ABSOLUTE path — so a chat launched from inside one of charter's own panes recorded
+        `/private/tmp/tmux-<uid>/charter` for the server `-L charter` reaches, and every
+        tab in it was told it was a window in somebody else's tmux. The operator's report
+        is exactly that: switch to `fleet`, land in a new chat, and then no tab, including
+        the one back, would move them.
+
+        Two spellings of one socket are not the same string, so this asserts on the
+        SWITCH: the same fixture as the ordinary case, with the server recorded the way
+        `$TMUX` spells it, still moves the client."""
+        state.record_server(self.FID, _tmuxsocket.socket_path(commands_frame.SOCKET))
+        s = self._switch(self._ordinary())
+        self.assertEqual(s.switched, [("/dev/ttys001", "$2")],
+                         "a frame on charter's own socket was refused as a guest's")
+        self.said.assert_called_once_with("beta.1", "workspace → beta", ok=True)
+
     def test_a_chat_whose_own_window_cannot_be_found_refuses_before_anything_moves(self):
         """`cmd_chat`'s own sentence for its own reason: with no reading of where this
         client is standing there is no way to tell afterwards whether it moved, and a

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -45,16 +45,18 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import threading
+import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import commands_frame, config
+from charter import commands_frame, config, root
 from charter.frame import state
 
-from tests import _tmuxreap, _ttyguard
-from tests._isolation import PersonaIso, no_background_refresh
+from tests import _tmuxreap, _tmuxsocket, _ttyguard
+from tests._isolation import PersonaIso, make_plane, no_background_refresh
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
@@ -551,6 +553,61 @@ class TheLauncherCanBuildAFrameWithNoTerminalOfItsOwn(PersonaIso, unittest.TestC
         self.assertTrue(commands_frame._wants_attach(SimpleNamespace()))
 
 
+class TheLauncherAsksWhoseTmuxItIsIn(PersonaIso, unittest.TestCase):
+    """`cmd_launch`'s guest branch, in the one form that runs everywhere (#812).
+
+    :class:`ATabClickedInsideCharactersOwnTmux` is the truth of this and it needs a real
+    tmux and a real attached client, so it SKIPS wherever no pty can be handed one — CI
+    among them. This is the same decision asked with nothing running: does `$TMUX` naming
+    charter's OWN socket send the launch down `_launch_in_operator_tmux`?
+
+    It answers in milliseconds, and that matters twice over. `_launch_in_operator_tmux`
+    stays awake for the life of the harness it starts, so the real-tmux class catches a
+    regression here as a click that never returns — a 30-second deadline, and a deletion
+    sweep that would rather kill a hanging suite than record the mutation. This case
+    fails outright instead.
+    """
+
+    #: A socket name no server is running on, so the fall-through path below reaches tmux
+    #: and finds nothing rather than reading the operator's own live `charter` server.
+    SOCKET = _tmuxreap.name("whose-tmux")
+
+    def _guest_path_taken(self, tmux_socket: str) -> bool:
+        """Whether a launch whose ``$TMUX`` names *tmux_socket* builds a guest window."""
+        (config.WORKSPACES_DIR / "beta").mkdir(parents=True, exist_ok=True)
+        _ttyguard.no_terminal()
+        args = SimpleNamespace(harness="frame", rest=["--", "true"], no_frame=False,
+                               workspace="beta", pick=False, attach=False,
+                               size=(120, 40))
+        empty = subprocess.CompletedProcess([], 0, "", "")
+        with mock.patch.object(commands_frame, "SOCKET", self.SOCKET), \
+                mock.patch.dict(os.environ,
+                                {"TMUX": _tmuxsocket.tmux_env(tmux_socket)}), \
+                mock.patch.object(commands_frame.tmuxctl, "version",
+                                  return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "run", return_value=empty), \
+                mock.patch.object(commands_frame.state, "new_chat_id",
+                                  return_value=None), \
+                mock.patch.object(commands_frame, "_launch_in_operator_tmux",
+                                  return_value=0) as guest:
+            commands_frame.cmd_launch(args)
+        return guest.called
+
+    def test_charters_own_socket_read_out_of_tmux_is_not_somebody_elses_server(self):
+        """**#812's launch half.** A tab click runs `cmd_launch` in-process from a panel
+        of charter's own frame (`_open_workspace`), and tmux exports its socket into that
+        process as an absolute path. Read as a guest, the chat for the workspace being
+        opened is built as a window inside the session the click came FROM — so the
+        workspace never becomes a session and the switch has nothing to switch to."""
+        self.assertFalse(self._guest_path_taken(_tmuxsocket.socket_path(self.SOCKET)))
+
+    def test_a_tmux_charter_did_not_start_still_builds_a_window_in_it(self):
+        """The branch is narrowed, not removed: ADR 0018's whole point is that a frame
+        inside somebody else's tmux is a WINDOW on their server, with no second tmux under
+        it and no second prefix key on top."""
+        self.assertTrue(self._guest_path_taken(_tmuxsocket.OPERATOR_SOCKET))
+
+
 @unittest.skipUnless(_HAS_TMUX, "needs a real tmux")
 class ADetachedProcessCanBuildAWorkspace(unittest.TestCase):
     """The measurement the old refusal's reason was wrong about, against a real server.
@@ -836,6 +893,234 @@ class ARealTabOpensARealWorkspace(PersonaIso, unittest.TestCase):
                            "#{window_width}").stdout.strip()
         self.assertEqual(width, str(self.CLIENT_SIZE[0]),
                          "the opened workspace was laid out for the wrong terminal")
+
+
+class ATabClickedInsideCharactersOwnTmux(ARealTabOpensARealWorkspace):
+    """#812: the same click, from the ``$TMUX`` a real one actually has.
+
+    **The shape no case above had, and the gap #811 shipped through.** Every real-tmux
+    test in this suite starts from a socket charter created and reaches it by the NAME it
+    created it under, with ``$TMUX`` unset — which is what `tests/_envguard.py` leaves and
+    what CI hands you. A click never happens there. It happens in a `charter frame-switch`
+    started from a PANEL PANE of charter's own frame, and tmux exports ``$TMUX`` into
+    every process it starts in a pane — as ``<socket path>,<server pid>,<session id>``,
+    the socket ABSOLUTE. The operator's own read
+    ``/private/tmp/tmux-502/charter,18923,83``: charter's own private server, spelled the
+    one way `is_operator_socket` used to call somebody else's.
+
+    So this class is its parent with one thing changed — the environment the click runs in
+    — and every test above is re-run through it. What that buys is stated rather than
+    implied: on the code as it stood, `cmd_launch` read that variable, concluded it was a
+    guest, and built the new workspace's chat as a `new-window` in the session the click
+    came FROM. `test_the_workspace_opens_and_the_terminal_arrives_in_it` fails there
+    (`list-sessions` never grows a `beta`), and the two cases below name the halves the
+    operator actually reported.
+
+    **The operator's report was the round trip, not the open.** *"I switched to `fleet`
+    workspace, it switched with a new empty chat session, then when I want to switch back
+    — I get an error."* :meth:`test_a_tab_in_the_opened_chat_takes_the_terminal_back` is
+    that sentence, and it is the case that can only be written here: a chat opened from
+    inside charter's own tmux is the only chat that ever recorded the absolute spelling,
+    so it is the only one whose own tabs were refused.
+
+    Verified on tmux 3.7c and at the 3.2 floor. Skipped where no tmux client can attach —
+    a switch is a decision about an ATTACHED client, and CI has a tmux server but no pty
+    it will hand one (`_attach`).
+    """
+
+    def setUp(self):
+        super().setUp()
+        # tmux is the authority on where its own socket is; `_tmuxsocket` computes the
+        # same thing without asking. Both are here because the FIXTURE has to be built
+        # before any server answers in the real case this stands in for, and because two
+        # implementations of one rule that quietly drift apart is the defect underneath
+        # #812 arriving in the suite instead of the product.
+        self.socket_file = _tmuxsocket.socket_path(self.socket)
+        self.assertEqual(
+            self._tmux("display-message", "-p", "#{socket_path}").stdout.strip(),
+            self.socket_file,
+            "this tmux does not put its socket where charter computes it would")
+        self.server_pid = self._tmux("display-message", "-p", "#{pid}").stdout.strip()
+        # **The standing chat is marked the way a launcher marks one, and the round trip
+        # is what needed it.** `_chat_option_argv` writes `@charter_chat` on every window
+        # `cmd_launch` opens; this fixture builds the chat it starts in by hand and did
+        # not. Nothing above notices — but a real `cmd_launch` reaps on its way in
+        # (`_live_chats` reads exactly that option), so the open triggered by the FORWARD
+        # click deleted `alpha.1`'s state directory as a chat with no live window, and the
+        # way back could no longer prove the session it wanted was this plane's. The chat
+        # left standing looks like a real one here because in production it always is.
+        marked = self._tmux("set-option", "-w", "-t", self.pane,
+                            commands_frame._CHAT_OPTION, self.fid)
+        self.assertEqual(marked.returncode, 0, marked.stderr)
+        # A plane a CHILD can find, not merely one this process believes in. The way back
+        # re-dresses the chat it lands on (`_apply_arrangement`), and the chat this
+        # fixture starts in was built by hand with no panels — so the round trip really
+        # does split real `charter panel` processes, and each resolves its own plane. See
+        # :meth:`_in_a_pane_of`.
+        make_plane(self)
+
+    def _in_a_pane_of(self, session: str):
+        """The environment a `charter frame-switch` really runs in — the two variables
+        that decide which tmux it is inside and which plane it belongs to.
+
+        ``$TMUX`` is the subject: ``<socket path>,<server pid>,<session id>``, tmux's own
+        spelling, exported into every process it starts in a pane.
+
+        ``$CHARTER_ROOT`` is not, and it is here because leaving it out would have this
+        fixture's panel children resolve a plane by walking up from the test runner's cwd
+        — the checkout, which is the developer's REAL plane (`tests/_planeguard.py`
+        refuses exactly that). A real one gets the answer from the frame's own cwd, which
+        `_open_workspace` chdirs into and a switch does not; the pointer says the same
+        thing across a process boundary. `make_plane` in `setUp` is what makes it a plane
+        a child can actually find.
+        """
+        return {"TMUX": self._tmux_env(session), root.ENV_VAR: str(config.ROOT)}
+
+    def _tmux_env(self, session: str) -> str:
+        """``$TMUX`` exactly as tmux writes it into a pane of *session* on this server."""
+        sid = self._tmux("display-message", "-p", "-t", session,
+                         "#{session_id}").stdout.strip()
+        self.assertTrue(sid.startswith("$"), sid)
+        return f"{self.socket_file},{self.server_pid},{sid[1:]}"
+
+    #: How long a click gets before this class calls it stuck. A click is `switch-client`
+    #: plus, at most, one `cmd_launch` that does not attach — tenths of a second on both
+    #: tmux versions, measured. Generous enough that a loaded CI runner is not called a
+    #: hang, and finite because a click that never returns is exactly what regressing this
+    #: looks like (see :meth:`_click_the_tab`).
+    CLICK_DEADLINE = 30.0
+
+    def _click_the_tab(self):
+        """The click, on a thread, with a deadline — because the failure this class
+        catches is a HANG and not a wrong answer.
+
+        On the code #812 was filed against, `cmd_launch` read this `$TMUX`, decided it was
+        a guest, and took `_launch_in_operator_tmux` — which does not install the
+        `pane-died` hooks and instead stays awake for the whole life of the harness
+        (`_wait_for_harness`). The harness here is `exec sleep 300`. So the click never
+        returned at all: measured, this class run against `ff228a4` did not fail, it sat
+        there until it was killed, which is not a pass, not a fail and not a report — and
+        the deletion sweep kills a suite that hangs rather than recording the mutation.
+
+        A daemon thread is what makes the deadline honest rather than cosmetic: the click
+        that has not returned is left where it is, said so by name, and `_teardown`'s
+        `kill-server` is what finally releases it.
+        """
+        out: list[BaseException | None] = []
+
+        def go():
+            try:
+                with mock.patch.dict(os.environ, self._in_a_pane_of(self.HERE)):
+                    ARealTabOpensARealWorkspace._click_the_tab(self)
+                out.append(None)
+            except BaseException as e:                  # noqa: BLE001 - reported below
+                out.append(e)
+
+        clicking = threading.Thread(target=go, daemon=True)
+        clicking.start()
+        clicking.join(self.CLICK_DEADLINE)
+        if not out:
+            # The server goes BEFORE the failure is raised, not in `_teardown` after it.
+            # `_wait_for_harness` is watching a pane on it, so killing it is what lets the
+            # stuck click unwind — and a click still inside `_open_workspace` when
+            # `PersonaIso` removes this case's tmp tree takes the NEXT case down with an
+            # `os.getcwd()` that has no directory to answer. Measured exactly that way
+            # against `ff228a4`: one honest failure here, one unrelated `FileNotFoundError`
+            # in the case after it.
+            self._tmux("kill-server")
+            clicking.join(10)
+            self.fail(f"the click has not returned after {self.CLICK_DEADLINE:g}s — a "
+                      f"workspace tab that opens its workspace as a window in the session "
+                      f"it was clicked from blocks in `_wait_for_harness` for the life of "
+                      f"the harness, and the switch never happens (#812)")
+        if out[0] is not None:
+            raise out[0]
+
+    def _click_back(self, opened: str):
+        """The second half of the operator's report: a tab in the chat they arrived at.
+
+        Run from inside charter's tmux too, and naming the session it is standing in NOW
+        — a panel in the chat they landed on is as much inside charter's server as the one
+        they left, and a round trip that only set the variable on the way out would not be
+        the trip that was reported.
+        """
+        with mock.patch.dict(os.environ, self._in_a_pane_of(self.THERE)):
+            commands_frame._switch_client(opened, self.HERE,
+                                          said=f"workspace → {self.HERE}")
+        time.sleep(0.3)
+
+    def _opened_chat(self) -> str:
+        """The chat id the click's own launch claimed, read off the server."""
+        chats = [c for c in self._tmux("list-windows", "-t", self.THERE,
+                                       "-F", "#{@charter_chat}").stdout.split() if c]
+        self.assertEqual(len(chats), 1, f"expected one chat in {self.THERE}: {chats}")
+        return chats[0]
+
+    def test_the_opened_workspace_is_a_session_of_its_own(self):
+        """**The launch, not the switch, and this is what a fix to `is_operator_socket`
+        alone would not have reached.** `cmd_launch` decided between "session on charter's
+        own server" and "window in the session I am already in" on whether ``$TMUX``
+        parsed at all. From a panel pane it always parses, so a tab click opened its chat
+        inside the workspace it was leaving — measured before the fix as `list-sessions`
+        reporting only `alpha` with `list-windows -a` reporting `[alpha] win=beta.1`."""
+        self._attach(self.HERE)
+        self._click_the_tab()
+        self.assertIn(self.THERE,
+                      self._tmux("list-sessions", "-F", "#{session_name}").stdout.split())
+        self.assertEqual(
+            [w for w in self._tmux("list-windows", "-t", self.HERE,
+                                   "-F", "#{window_name}").stdout.split() if w],
+            [self.fid],
+            f"the chat for '{self.THERE}' was opened as a window inside '{self.HERE}'")
+
+    def test_the_opened_chat_records_the_server_by_the_name_charter_launches_it_under(
+            self):
+        """The record every later tab reads (`state.frame_server`).
+
+        Spelled by hand rather than compared to `commands_frame.SOCKET`, because the
+        failure this pins is precisely a second, equal-but-different spelling of one
+        socket: a round trip through the same constant would have agreed with itself
+        while the operator was stuck."""
+        self._attach(self.HERE)
+        self._click_the_tab()
+        recorded = state.frame_server(self._opened_chat())
+        self.assertEqual(recorded, self.socket,
+                         "the chat recorded a spelling of the socket, not the socket")
+        self.assertNotEqual(recorded, self.socket_file)
+        self.assertFalse(recorded.startswith("/"),
+                         f"{recorded} is the absolute spelling #812 is about")
+
+    def test_a_tab_in_the_opened_chat_takes_the_terminal_back(self):
+        """**The operator's report, end to end.** Click `beta`, land there, click `alpha`,
+        arrive — where the second click used to answer *"cannot switch: this chat is a
+        window in your own tmux, where a workspace is not a session"* about a chat sitting
+        on charter's private server.
+
+        The way back runs with ``$TMUX`` set too, and to the session it is standing in
+        now: a panel in the chat the operator arrived at is as much inside charter's tmux
+        as the one they left, and a round trip that only set the variable on the way out
+        would not be the trip that was reported."""
+        client = self._attach(self.HERE)
+        self._click_the_tab()
+        self.assertEqual(self._clients(self.THERE), [client])
+        opened = self._opened_chat()
+        self._click_back(opened)
+        self.assertEqual(self._clients(self.HERE), [client],
+                         "the tab back did not take the terminal back")
+        self.assertEqual(self._clients(self.THERE), [])
+        self.assertNotIn("a window in your own tmux", state.notice(opened) or "")
+
+    def test_the_chat_it_came_from_is_still_running_after_the_round_trip(self):
+        """§4b's own requirement across both legs: switching keeps the other chat's
+        harness alive, and a trip out and back must leave the pane it started in with the
+        pid it started with."""
+        self._attach(self.HERE)
+        before = [p for p in self._panes() if p.startswith(self.pane + " ")]
+        self._click_the_tab()
+        opened = self._opened_chat()
+        self._click_back(opened)
+        self.assertEqual([p for p in self._panes() if p.startswith(self.pane + " ")],
+                         before, "the round trip killed the chat it started in")
 
 
 if __name__ == "__main__":

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -913,8 +913,10 @@ class ATabClickedInsideCharactersOwnTmux(ARealTabOpensARealWorkspace):
     implied: on the code as it stood, `cmd_launch` read that variable, concluded it was a
     guest, and built the new workspace's chat as a `new-window` in the session the click
     came FROM. `test_the_workspace_opens_and_the_terminal_arrives_in_it` fails there
-    (`list-sessions` never grows a `beta`), and the two cases below name the halves the
-    operator actually reported.
+    (`list-sessions` never grows a `beta`), and the four cases below name what that cost:
+    the workspace was not a session, the chat recorded the spelling rather than the
+    socket, the way back was refused, and the round trip had to leave the chat it started
+    in running.
 
     **The operator's report was the round trip, not the open.** *"I switched to `fleet`
     workspace, it switched with a new empty chat session, then when I want to switch back

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -905,7 +905,7 @@ class ATabClickedInsideCharactersOwnTmux(ARealTabOpensARealWorkspace):
     started from a PANEL PANE of charter's own frame, and tmux exports ``$TMUX`` into
     every process it starts in a pane — as ``<socket path>,<server pid>,<session id>``,
     the socket ABSOLUTE. The operator's own read
-    ``/private/tmp/tmux-502/charter,18923,83``: charter's own private server, spelled the
+    ``/private/tmp/tmux-<uid>/charter,18923,83``: charter's own private server, spelled the
     one way `is_operator_socket` used to call somebody else's.
 
     So this class is its parent with one thing changed — the environment the click runs in

--- a/tests/test_frame_palette.py
+++ b/tests/test_frame_palette.py
@@ -30,6 +30,7 @@ from charter import commands_frame, contain, tui
 from charter.frame import (action, actions, builtin_actions, component, overlay, palette,
                            state)
 
+from tests import _tmuxsocket
 from tests._isolation import PersonaIso
 
 
@@ -577,6 +578,30 @@ class TheActionsCharterOffersItself(PersonaIso, unittest.TestCase):
     def test_a_frame_with_a_real_harness_pane_can_move_its_density(self):
         """The other direction, so the reason above cannot pass by never being available."""
         self.assertTrue(self._offers()["density.normal"].available)
+
+    def test_a_frame_on_charters_own_socket_by_path_is_still_detachable(self):
+        """#812 at a second reader, and the one an operator would have SEEN.
+
+        A chat opened by a workspace tab records charter's own socket the way `$TMUX`
+        spells it — absolute — because it was launched from a process tmux started in one
+        of charter's own panes. `_detachable` read that as "somebody else's tmux, where a
+        frame is a window and `detach-client -s <fid>` names nothing", so the palette in
+        that chat quietly dropped its Detach row. It is a session on charter's own server
+        and `detach-client -s` names it exactly.
+
+        The path is built by `tests/_tmuxsocket.py`, which computes tmux's rule
+        independently of the code under test (#601 — never a spelled uid, and never the
+        production function confirming itself)."""
+        state.record_server(self.FID,
+                            _tmuxsocket.socket_path(commands_frame.SOCKET))
+        self.assertTrue(self._offers()["frame.detach"].available)
+
+    def test_a_frame_in_a_tmux_charter_did_not_start_is_still_not_detachable(self):
+        """The pair, so the case above cannot pass by making every frame detachable:
+        inside an operator's own tmux a frame really is a WINDOW, and `-s <fid>` targets a
+        session that does not exist."""
+        state.record_server(self.FID, _tmuxsocket.OPERATOR_SOCKET)
+        self.assertFalse(self._offers()["frame.detach"].available)
 
     def test_a_frame_whose_server_is_unrecorded_is_charters_own_and_detachable(self):
         """`state.frame_server` answers `None` for a frame launched by a charter that

--- a/tests/test_frame_tmuxctl.py
+++ b/tests/test_frame_tmuxctl.py
@@ -251,7 +251,7 @@ class TwoSpellingsOfOneSocket(unittest.TestCase):
     """#812: `<name>` and `<tmpdir>/tmux-<uid>/<name>` are ONE server, and the guest test
     could not tell them apart.
 
-    The operator's own ``$TMUX`` reads ``/private/tmp/tmux-502/charter,18923,83`` — the
+    The operator's own ``$TMUX`` reads ``/private/tmp/tmux-<uid>/charter,18923,83`` — the
     socket charter started itself, spelled absolute because tmux writes it that way into
     every pane it opens. A chat launched from inside one of those panes recorded that
     spelling, and `is_operator_socket` — a leading-slash test — answered "somebody else's
@@ -259,7 +259,7 @@ class TwoSpellingsOfOneSocket(unittest.TestCase):
     back included, was then refused by name.
 
     **The socket paths here come from `tests/_tmuxsocket.py`, which computes tmux's rule
-    independently of the module under test** (#601: never a spelled ``tmux-502``, and never
+    independently of the module under test** (#601: never a spelled uid, and never
     the production function asked to confirm itself). If the two implementations of "where
     tmux puts a socket" ever disagree, that is this class going red rather than a round
     trip agreeing with itself.

--- a/tests/test_frame_tmuxctl.py
+++ b/tests/test_frame_tmuxctl.py
@@ -13,7 +13,7 @@ import unittest
 from unittest import mock
 
 from charter.frame import tmuxctl
-from tests._tmuxsocket import OPERATOR_SOCKET, OPERATOR_TMUX
+from tests._tmuxsocket import OPERATOR_SOCKET, OPERATOR_TMUX, socket_path
 
 
 class Version(unittest.TestCase):
@@ -234,6 +234,136 @@ class ServerArgv(unittest.TestCase):
         argv = tmuxctl.server_argv("charter", "new-window", "--", "claude", "-p", "a;b")
         self.assertEqual(argv[-1], "a;b")
         self.assertTrue(all(isinstance(a, str) for a in argv))
+
+    def test_charters_own_socket_spelled_as_a_path_still_gets_dash_s(self):
+        """**The spelling test is unchanged by #812 and this is the case that proves
+        it.** `-S` is the only flag that can reach a socket named by path — a `-L` may
+        not contain a separator at all — so a value that happens to be charter's own
+        server written the long way must still be aimed with `-S`, however the
+        OWNERSHIP question (`is_operator_socket`) now answers for it."""
+        own = socket_path("charter")
+        self.assertFalse(tmuxctl.is_operator_socket(own, own="charter"))
+        self.assertEqual(tmuxctl.server_argv(own, "list-sessions"),
+                         ["tmux", "-S", own, "list-sessions"])
+
+
+class TwoSpellingsOfOneSocket(unittest.TestCase):
+    """#812: `<name>` and `<tmpdir>/tmux-<uid>/<name>` are ONE server, and the guest test
+    could not tell them apart.
+
+    The operator's own ``$TMUX`` reads ``/private/tmp/tmux-502/charter,18923,83`` — the
+    socket charter started itself, spelled absolute because tmux writes it that way into
+    every pane it opens. A chat launched from inside one of those panes recorded that
+    spelling, and `is_operator_socket` — a leading-slash test — answered "somebody else's
+    tmux" for charter's own private server. Every workspace tab in that chat, the one
+    back included, was then refused by name.
+
+    **The socket paths here come from `tests/_tmuxsocket.py`, which computes tmux's rule
+    independently of the module under test** (#601: never a spelled ``tmux-502``, and never
+    the production function asked to confirm itself). If the two implementations of "where
+    tmux puts a socket" ever disagree, that is this class going red rather than a round
+    trip agreeing with itself.
+    """
+
+    def test_a_name_and_its_socket_file_are_one_server(self):
+        self.assertTrue(tmuxctl.same_server("charter", socket_path("charter")))
+
+    def test_two_names_are_two_servers(self):
+        self.assertFalse(tmuxctl.same_server("charter", "default"))
+
+    def test_two_socket_files_are_two_servers(self):
+        self.assertFalse(tmuxctl.same_server(socket_path("charter"),
+                                             socket_path("default")))
+
+    def test_the_symlinked_spelling_of_one_file_is_one_server(self):
+        """``/tmp`` is a symlink to ``/private/tmp`` on macOS, and BOTH spellings reach
+        the same running server — `test_frame_tmux_integration.OP_SOCKET_PATH` builds the
+        ``/tmp`` form and talks to a server tmux reports at the ``/private/tmp`` one. A
+        comparison that read those as two servers would answer #812 on Linux and not on
+        the platform the report came from."""
+        unresolved = os.path.join("/tmp", f"tmux-{os.getuid()}", "charter")
+        self.assertTrue(tmuxctl.same_server(unresolved, "charter"),
+                        f"{unresolved} and `charter` are the same socket file")
+
+    def test_an_unknown_side_is_never_the_same_server_as_anything(self):
+        """``""`` is `state.frame_server` reading a marker that is not there — the absence
+        of an answer, not a spelling of one. Two absences are not a match either, which is
+        the case a bare equality would have got wrong."""
+        self.assertFalse(tmuxctl.same_server("", "charter"))
+        self.assertFalse(tmuxctl.same_server("charter", ""))
+        self.assertFalse(tmuxctl.same_server("", ""))
+        self.assertFalse(tmuxctl.same_server(None, None))
+
+    def test_the_socket_directory_is_tmuxs_own_rule_and_not_dollar_tmpdir(self):
+        """``$TMUX_TMPDIR`` or tmux's ``_PATH_TMP`` literal — **never** ``$TMPDIR``.
+
+        Measured on tmux 3.7c and at the 3.2 floor, on the machine this was written on: a
+        server started with ``TMPDIR`` pointed at a scratch directory reported its own
+        ``#{socket_path}`` as ``/private/tmp/tmux-<uid>/<name>`` and left that directory
+        empty, while the same run with ``TMUX_TMPDIR`` set built ``<it>/tmux-<uid>/``. On
+        macOS `tempfile.gettempdir()` answers a per-user ``/var/folders/…`` that tmux
+        never puts a socket in, so reading the wrong variable would put every socket path
+        charter computes somewhere no server has ever listened."""
+        with mock.patch.dict(os.environ, {"TMPDIR": "/nowhere-tmpdir"}, clear=False):
+            os.environ.pop("TMUX_TMPDIR", None)
+            self.assertEqual(tmuxctl.socket_path("charter"),
+                             os.path.realpath(f"/tmp/tmux-{os.getuid()}") + "/charter")
+        with mock.patch.dict(os.environ, {"TMUX_TMPDIR": "/nowhere-tmux"}, clear=False):
+            self.assertEqual(tmuxctl.socket_path("charter"),
+                             f"/nowhere-tmux/tmux-{os.getuid()}/charter")
+
+
+class WhoseServerIsIt(unittest.TestCase):
+    """`is_operator_socket` — the question `frame/slots.py` and
+    `commands_frame._switch_workspace` ask, and the one #812 was answered wrongly.
+
+    The refusal it gates is not the defect and is asserted still to fire below: inside a
+    genuine operator tmux a workspace really is not a session, and `switch-client` has
+    nothing correct to do there.
+    """
+
+    def test_charters_own_socket_by_name_is_not_a_guests(self):
+        self.assertFalse(tmuxctl.is_operator_socket("charter", own="charter"))
+
+    def test_charters_own_socket_by_absolute_path_is_not_a_guests_either(self):
+        """**#812 itself, in one line.** This answered True, and every workspace tab in a
+        chat that recorded this spelling refused."""
+        self.assertFalse(tmuxctl.is_operator_socket(socket_path("charter"),
+                                                    own="charter"))
+
+    def test_a_socket_charter_did_not_start_is_still_a_guests(self):
+        """The other half, and the reason this is a comparison rather than a deletion:
+        ``default`` is the socket an operator's own `tmux` starts, in the same directory
+        as charter's, and a frame there is a WINDOW in their session."""
+        self.assertTrue(tmuxctl.is_operator_socket(OPERATOR_SOCKET, own="charter"))
+        self.assertNotEqual(OPERATOR_SOCKET, socket_path("charter"))
+
+    def test_another_planes_private_socket_is_a_guests_too(self):
+        """Not merely "is it in tmux's socket directory": a second charter-shaped socket
+        that is not the one THIS charter starts is somebody else's server."""
+        self.assertTrue(tmuxctl.is_operator_socket(socket_path("charter-elsewhere"),
+                                                   own="charter"))
+
+    def test_nothing_recorded_is_not_a_guests_server(self):
+        """`state.frame_server` answers ``None`` for a frame launched by a charter that
+        predates the marker, and the fallback beside every call is charter's own socket."""
+        self.assertFalse(tmuxctl.is_operator_socket(None, own="charter"))
+        self.assertFalse(tmuxctl.is_operator_socket("", own="charter"))
+
+    def test_the_socket_it_compares_against_is_the_one_charter_launches_on(self):
+        """*own* defaults to `commands_frame.SOCKET`, read at CALL time.
+
+        Bound at import instead, this would answer for the socket the suite was loaded
+        with rather than the throwaway one a real-tmux test patches in — so every such
+        test would be measuring ownership of a server it never touched, which is the
+        shape of mistake #812 is."""
+        from charter import commands_frame
+        self.assertEqual(commands_frame.SOCKET, "charter")
+        self.assertFalse(tmuxctl.is_operator_socket(socket_path("charter")))
+        with mock.patch.object(commands_frame, "SOCKET", "charter-somewhere-else"):
+            self.assertTrue(tmuxctl.is_operator_socket(socket_path("charter")))
+            self.assertFalse(
+                tmuxctl.is_operator_socket(socket_path("charter-somewhere-else")))
 
 
 

--- a/tests/test_frame_tmuxctl.py
+++ b/tests/test_frame_tmuxctl.py
@@ -285,6 +285,24 @@ class TwoSpellingsOfOneSocket(unittest.TestCase):
         self.assertTrue(tmuxctl.same_server(unresolved, "charter"),
                         f"{unresolved} and `charter` are the same socket file")
 
+    def test_a_socket_file_asked_for_by_its_own_path_is_that_path(self):
+        """**Why `_resolved` has no branch in it, pinned where a change would be caught.**
+
+        `os.path.join` throws every earlier component away when the tail is absolute, so
+        `socket_path` handed a socket PATH answers with that path and handed a `-L` NAME
+        builds the file for it — one expression covering both spellings. The deletion
+        sweep found the `if` that used to stand in `_resolved` to be exactly equivalent to
+        its else, which is this property being true; the line went, and the property is
+        asserted here instead of being relied on silently.
+
+        Both spellings of the same file, because the second is the one that carries a
+        symlink: `socket_path` resolves the DIRECTORY it builds and does not touch a path
+        handed to it, and `_resolved` is what resolves the whole thing afterwards."""
+        for spelled in (f"/tmp/tmux-{os.getuid()}/charter",
+                        os.path.realpath(f"/tmp/tmux-{os.getuid()}") + "/charter"):
+            with self.subTest(spelled=spelled):
+                self.assertEqual(tmuxctl.socket_path(spelled), spelled)
+
     def test_an_unknown_side_is_never_the_same_server_as_anything(self):
         """``""`` is `state.frame_server` reading a marker that is not there — the absence
         of an answer, not a spelling of one. Two absences are not a match either, which is


### PR DESCRIPTION
Closes the first half of #812. **Do not merge without the operator's word on the second half** — it is a design question and it is written out below.

## The report

> *"I switched to `fleet` workspace, it switched with a new empty chat session, then when I want to switch back — I get an error. When I tried to terminate the chat session with Ctrl-C, charter closed and I see our current session, so the first session survived and was not closed."*

#811's workspace tab was a one-way door. Every tab in the opened chat, including the one back, answered `cannot switch: this chat is a window in your own tmux, where a workspace is not a session`.

## The mechanism

`is_operator_socket` was a leading-slash test. The operator's `$TMUX` is `/private/tmp/tmux-502/charter,18923,83` — **charter's own socket, spelled absolute**, because tmux writes it that way into every process it starts in a pane. So a chat opened by the tab recorded that spelling and every reader concluded it was a guest on somebody else's tmux.

The refusal is right and is **not** deleted: inside a genuine operator tmux a workspace really is not a session. What was wrong was concluding this frame was in one.

## The fix

* `is_socket_path` — the spelling test `server_argv` keeps (`-S` for a path, `-L` for a name). Unchanged behaviour, new name, because it is no longer the same question as ownership.
* `socket_path(name)` / `same_server(a, b)` — tmux's own rule (`$TMUX_TMPDIR` or its `_PATH_TMP` literal, **never** `$TMPDIR`; then `tmux-<uid>/<name>`; realpath'd). Measured on 3.7c and at the 3.2 floor, including that `/tmp/...` and `/private/tmp/...` reach one server.
* `is_operator_socket(server, *, own=None)` — asks the server, not the string. `own` defaults to `commands_frame.SOCKET`, read at call time.
* **`cmd_launch` gates the guest branch on it.** This is the half the issue did not name and the measurement that found it: `_open_workspace` calls `cmd_launch` in-process from a panel of charter's own frame, so its `$TMUX` always parses — and the branch, asked only whether it parsed, built the new workspace's chat as a `new-window` in the session the click came *from*. Measured against `ff228a4` on a real tmux 3.7c server, with `$TMUX` naming charter's own socket by path and a launch asking for workspace `beta`: `list-sessions` reported only the caller's own session and never a `beta`, `list-windows -a` reported `beta.1` as a window inside it, `state.record_server` wrote the absolute spelling, and the launcher was still inside `_wait_for_harness` while the harness lived — so the click never returned. The same launch on this branch recorded the short name and left a real `beta` session. **Fixing `is_operator_socket` alone would not have made the round trip work.**

## The regression test, in the shape that was missing

Every real-tmux test in this suite starts from a socket charter created, reaches it by the name it created it under, and runs with `$TMUX` unset. A click never happens there.

`ATabClickedInsideCharactersOwnTmux` is `ARealTabOpensARealWorkspace` with one thing changed — the environment the click runs in — so all four of #811's end-to-end cases are re-run through the operator's real one, plus the round trip they reported. The click runs on a thread with a deadline, because on `ff228a4` it does not give a wrong answer, it never returns. `TheLauncherAsksWhoseTmuxItIsIn` asks the same branch with nothing running, so it fails in milliseconds where the real-tmux class skips (CI has a tmux server but no pty it will hand a client).

The guest refusal keeps its own case and gains a pair: charter's own socket written the long way switches; `.../default` is still refused by name, having asked the server nothing.

## The second half — a decision, not a fix, and its premise is refuted

#812 says the same one-way door exists in a real guest tmux: *"that open still succeeds and the switch still cannot"*, so the tab must be made to *"refuse before opening"*.

**It already does.** `_switch_client`'s guest refusal is the first thing in the function, computed from `state.frame_server(fid)` before `_pane_place`, before `_plane_session` and long before `_open_workspace` — and `test_a_frame_inside_the_operators_own_tmux_is_refused_by_name` asserts the guest frame asks the server *nothing at all* (`s.calls == []`). Nothing is opened, no harness is spent, no chat ordinal is claimed, no window is left in the operator's own window list. So there is no door there and nothing to close.

What is actually left is the opposite question: **should a workspace tab in a guest tmux do something instead of refusing?** Today, an operator running charter inside their own tmux gets a `workspaces` bar where every tab refuses — which is the complaint #811 exists to answer, still standing for them.

**Which way I would go: make it act, don't harden the refusal.** In a guest tmux there are no charter sessions, but a chat still *belongs* to a workspace (`state.record_workspace` — it is what the frame draws repos, todos and persona from). So the workspace there is a property of the CHAT, not of a session, and §4k translates cleanly: *if a live chat of that workspace is a window on this server, `select-window` to it; if not, open one there and select it.* That is the same sentence ADR 0018 already applies to every other frame concept in a guest tmux — sessions become windows — and it needs no new mechanism: `_launch_in_operator_tmux` already ends in `select-window`, and `_live_chats` already answers which windows are chats.

**The obstacle, so the cost is not a surprise.** `_launch_in_operator_tmux` is the process that watches the harness pane, so it blocks for the life of the chat — the tab cannot call it in-process the way `_open_workspace` calls `cmd_launch` today, or the switching process never returns (that is exactly the bug fixed above, and it is why the guest launcher cannot simply be reused). It needs either a detached `charter <harness> --workspace <ws>` followed by a `select-window` on the result, or the same non-blocking seam `_wants_attach` opened on the private path. That is real work, and it is why "keep refusing" is the cheap answer if the tabs-do-nothing complaint is acceptable for guest-tmux operators.

## What this changes for `charter <harness>` typed inside a frame

Typed at a shell inside a charter frame it used to make a window in the session you were standing in — a chat for one workspace inside another workspace's session, whose own tabs then refused with #812's sentence. The same door, reached by typing. It now builds the workspace's own session and attaches from a terminal already inside that server: a nested client, measured working on 3.7c and 3.2, which stacks two prefix layers on one terminal. Worse to look at than what it replaces; better than what it replaces was doing.

## Also in here

`"CI installs no tmux"` is false and still stood in two news entries and two skip reasons. CI has tmux and runs everything needing only a server; what it lacks is a pty it will hand a *client*. Believing the coarser sentence cost #811 a red run on all four Pythons.

## Verification

Full local suite: **10170 tests, OK, 8 skipped** on tmux 3.7c. The four modules this touches re-run at the **3.2 floor**: 199 tests, OK. Own socket per test process, reaped.

Every new assertion was checked against the unfixed code before it was trusted: the `is_operator_socket` cases (3 red with the leading-slash test restored), the `cmd_launch` branch (red with the gate removed), the Detach row (red), the switch (red), and the real-tmux round trip (fails by name on the deadline, having hung on `ff228a4` until it was killed).

**Deletion sweep: `no survivors` — 10 pinned, 0 unpinned.** The first run said `1 survivor`, and it was right: `_resolved` branched on the spelling before resolving, and that `if` was already `os.path.join`'s (a tail that is absolute throws the base away, so `socket_path` handed a PATH answers with that path). The branch is gone and the property it rested on is asserted by name instead of relied on silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
