### PR TITLE
A switch is half the wait and a third of the flicker: batch the tmux writes nothing reads back (#780)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -3972,8 +3972,11 @@ def _split_all(socket: str, *, slots: list[str], cmds: list[list[str]],
     """
     made: list[tuple[str, str]] = []
     todo = list(zip(slots, cmds))
-    if not todo:
-        return made
+    # No `if not todo: return` in front of this: `tmuxctl.chain([])` answers ``None``, so
+    # an empty slot list already falls past the batch into a loop over nothing and comes
+    # back with the same empty map. The deletion sweep reported the guard as a survivor —
+    # correctly — and this repository deletes an equivalent mutant rather than documenting
+    # it.
     argv = tmuxctl.chain([c for _, c in todo])
     if argv is not None:
         # `report=False`, and the two branches below are why: an ordinary refusal is
@@ -3981,10 +3984,15 @@ def _split_all(socket: str, *, slots: list[str], cmds: list[list[str]],
         # operator lost, while a wedged tmux is reported here because there is nothing
         # left to re-issue it as.
         p = tmuxctl.run("drawing this frame's panels", argv, env=env, report=False)
+        # `splitlines()` and not `strip().split()`: the POSITION of a line is what names
+        # its slot, so a line that is not a pane id has to keep its place in the count
+        # rather than vanish out of it. It also leaves nothing to strip — the sweep
+        # reported a `.strip()` here as a survivor, and it was right: tmux prints the
+        # format and a newline, and `splitlines` has already taken the newline.
         lines = p.stdout.splitlines()
         for (slot, _), pane_id in zip(todo, lines):
-            if _PANE_ID_RE.fullmatch(pane_id.strip()):
-                made.append((slot, pane_id.strip()))
+            if _PANE_ID_RE.fullmatch(pane_id):
+                made.append((slot, pane_id))
         if p.returncode == 0:
             return made
         if p.returncode in tmuxctl.UNKNOWABLE:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -3005,7 +3005,7 @@ def _panel_remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
     charter's window reads `on` while the operator's own window still reads the global
     default and their own panes still vanish when their programs exit. `kill-pane` also
     still destroys a pane this is holding, which is what lets `cmd_density` drop a slot
-    (see `_disarm_panel_respawn`) rather than leave a corpse behind in the frame.
+    (see `_disarm_respawn_argv`) rather than leave a corpse behind in the frame.
     """
     return tmuxctl.server_argv(socket, "set-option", "-w", "-t", harness_pane,
                                "remain-on-exit", "on")
@@ -3604,13 +3604,31 @@ def _reconcile_panels(socket: str, *, harness_pane: str, want: list[str],
             keep[mark] = pane_id
         else:
             doomed.append((mark, pane_id))
+    # Disarm before killing, always: `kill-pane` on an armed panel fires its own
+    # `pane-died` hook, and `cmd_respawn` brings back the panel the operator just
+    # dropped, one respawn life poorer. See :func:`_disarm_respawn_argv`.
+    #
+    # **All of it in ONE invocation, and both halves of that are the point** (#780).
+    # Eight round trips for four doomed panels was the single largest block a chat switch
+    # spent, and tmux keeps the pairing: a `;`-separated list runs in order, server-side,
+    # so every disarm still precedes its own kill. It is also what the operator SEES —
+    # four separate `kill-pane` invocations are four command-queue drains and four
+    # redraws, so the panels vanished one at a time and the harness pane grew in four
+    # steps. One invocation is one repaint.
+    #
+    # `report=False` on the disarms and not on the kills, which is the reason
+    # `tmuxctl.Write` carries the flag at all: unsetting a hook nothing set answers rc 0
+    # (measured on 3.7c and at the 3.2 floor), so the only way a disarm fails is a pane
+    # that is already gone — and then its kill says so, once.
+    writes = []
     for slot, pane_id in doomed:
-        # Disarm before killing, always: `kill-pane` on an armed panel fires its own
-        # `pane-died` hook, and `cmd_respawn` brings back the panel the operator just
-        # dropped, one respawn life poorer. See :func:`_disarm_panel_respawn`.
-        _disarm_panel_respawn(socket, pane_id=pane_id)
-        tmuxctl.run(f"closing the {slot} panel",
-                    tmuxctl.server_argv(socket, "kill-pane", "-t", pane_id))
+        writes.append(tmuxctl.Write("disarming a panel's respawn hook",
+                                    _disarm_respawn_argv(socket, pane_id=pane_id),
+                                    report=False))
+        writes.append(tmuxctl.Write(f"closing the {slot} panel",
+                                    tmuxctl.server_argv(socket, "kill-pane", "-t",
+                                                        pane_id)))
+    tmuxctl.write_all("closing the panels this frame no longer draws", writes)
     return keep
 
 
@@ -3731,10 +3749,22 @@ def _dress_window(socket: str, *, fid: str, harness_pane: str, env: dict | None,
     looks wrong, it does not fail. `remain-on-exit` is armed FIRST and this function is
     called before any `split-window`, so no panel is ever born into a window that would
     throw its corpse away and its respawn hook with it (#408).
+
+    **All of it is ONE tmux invocation, and the ordering that made it eight is exactly
+    what a chain preserves** (#780, `tmuxctl.write_all`). Every command here is a write
+    nothing reads back, so the eight round trips they cost were eight only because they
+    were sent one at a time — measured at ~5 ms each on tmux 3.7c on the machine this was
+    written on and ~13.4 ms each on the one that filed #728, spent twice per chat switch
+    and once per launch. tmux runs a `;`-separated list in order, server-side, so
+    `remain-on-exit` still precedes every border option and the whole group still precedes
+    the first `split-window`; what changes is only how many times charter waits for a
+    unix socket. A failure inside the list re-issues every one of them on its own, so the
+    per-command sentences above are not traded away for the round trips — see
+    `tmuxctl.write_all` for what a failed chain costs and why it can be replayed at all.
     """
-    tmuxctl.run("keeping the frame's own dead panes long enough to bring them back",
-                _panel_remain_on_exit_argv(socket=socket, harness_pane=harness_pane),
-                env=env)
+    writes = [tmuxctl.Write(
+        "keeping the frame's own dead panes long enough to bring them back",
+        _panel_remain_on_exit_argv(socket=socket, harness_pane=harness_pane))]
     # The frame's own word for its chrome, resolved through `_current_chrome` so a live
     # `charter frame-chrome` is what a re-layout re-asserts rather than the configured
     # value the frame launched with. `_split_panels` resolves it the same way for the pane
@@ -3764,10 +3794,11 @@ def _dress_window(socket: str, *, fid: str, harness_pane: str, env: dict | None,
     # be a second subprocess for one unchanging fact — and one more place for the two
     # readings to disagree. It answers a different question from *look*: one says which
     # rows are issued, the other says what the two style rows carry.
-    for argv in _chrome_argvs(
-            socket=socket, harness_pane=harness_pane, v=v, look=look,
-            surface=None if pane_borders else instance.border_bg(config.FRAME, chrome)):
-        tmuxctl.run("styling the frame's own rules", argv, env=env)
+    writes += [tmuxctl.Write("styling the frame's own rules", argv)
+               for argv in _chrome_argvs(
+                   socket=socket, harness_pane=harness_pane, v=v, look=look,
+                   surface=(None if pane_borders
+                            else instance.border_bg(config.FRAME, chrome)))]
     # And the three rules AROUND the harness, which above the floor are the harness's own
     # cells and are therefore the one part of the frame the loop above no longer reaches
     # (`_harness_rule_argvs`, #657). Left unset by #631 they were the terminal's own
@@ -3775,11 +3806,13 @@ def _dress_window(socket: str, *, fid: str, harness_pane: str, env: dict | None,
     # horizontal rule came out in two colours — reported off a screenshot three times, and
     # reproduced through a nested client at 100x24: 78 rule cells carrying an explicit
     # `ESC[49m` beside 22 cells of `ESC[100m`.
-    for argv in _harness_rule_argvs(
-            socket=socket, harness_pane=harness_pane, pane_borders=pane_borders,
-            look=look, surface=instance.agreed_border_bg(config.FRAME, chrome)):
-        tmuxctl.run("styling the rules around the pane charter does not paint", argv,
-                    env=env)
+    writes += [tmuxctl.Write("styling the rules around the pane charter does not paint",
+                             argv)
+               for argv in _harness_rule_argvs(
+                   socket=socket, harness_pane=harness_pane, pane_borders=pane_borders,
+                   look=look,
+                   surface=instance.agreed_border_bg(config.FRAME, chrome))]
+    tmuxctl.write_all("dressing the frame's own window", writes, env=env)
 
 
 def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
@@ -3842,59 +3875,119 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=socket,
                                     harness_pane=harness_pane, env=pane_env,
                                     sizes=sizes)
-    # Zipped with `slots`, not just iterated: `_resize_hook_argv` needs to know WHICH slot
-    # each successfully-created pane belongs to (for its size and its resize-pane flag),
-    # and `panel_argvs` returns exactly one command per slot, in the same order (see its
-    # own docstring).
     panes: dict[str, str] = {}
-    for slot, cmd in zip(slots, panel_cmds):
-        # Reported by `tmuxctl.run` but not fatal: one decorative panel failing to draw
-        # must not take down a harness pane that is already up and running (correction 2
-        # asks for every return code to be CHECKED, not every failure refused).
+    for slot, pane_id in _split_all(socket, slots=slots, cmds=panel_cmds, env=env):
+        panes[slot] = pane_id
+        # This pane is a PANEL, said to tmux itself where a root-table binding can ask
+        # (#634, `_panel_mark_argv`). It goes before the surface rather than after
+        # because it is the only one of the two that decides where a click goes: a
+        # panel that came up unmarked takes the keyboard off the harness the first
+        # time it is clicked, which is the whole defect. Reported but not fatal, like
+        # the splits and the surface — a panel charter could not mark still draws and
+        # is still clicked, it just costs the operator an `F12` afterwards.
+        writes = [tmuxctl.Write(
+            "marking a panel so a click on it stays where it points",
+            _panel_mark_argv(socket=socket, pane_id=pane_id))]
+        # And WHICH panel it is, on the same pane and out of the same funnel (#714,
+        # `_panel_slot_argv`). The mark above says a pane is charter's; this says what
+        # charter meant by it, which is the half `state.panes` cannot be trusted for —
+        # that file is rewritten whole on every re-layout, so a component whose pane
+        # got split twice has one id recorded and the other invisible to every reader
+        # that goes through it. Written where the pane is CREATED rather than by a
+        # later pass, because a later pass is a thing to forget: `_reconcile_panels`
+        # will not kill a pane it cannot name, so a panel that missed this is a panel
+        # that can be orphaned exactly once more. `None` for a name charter will not
+        # put on a pane — see there for why that is not silent about its cost.
+        slot_argv = _panel_slot_argv(socket=socket, pane_id=pane_id, slot=slot)
+        if slot_argv is not None:
+            writes.append(tmuxctl.Write("saying which component a panel draws",
+                                        slot_argv))
+        # The pane surface, on the pane that was just created and on no other — the
+        # one place charter has a panel's `%N` in hand. The harness pane is never an
+        # argument (`_surface_argvs`), which is how ADR 0018's boundary holds by
+        # construction. Not fatal, like the splits: a frame whose panes kept the
+        # terminal's own background is a frame that looks plainer, not one that fails.
+        # And this pane's OWN background where the arrangement gave it one
+        # (`instance.component_style`, the single walk over the placements that
+        # `frame/slots.py` asks for the pad on the other side of the split). Resolved
+        # per slot rather than once for the batch, unlike `chrome` above, because that
+        # is the whole difference between the two keys: one word about the frame, one
+        # word about this pane.
+        bg = instance.component_style(config.FRAME, slot)["bg"]
+        writes += [tmuxctl.Write("painting a panel's surface", surface)
+                   for surface in _surface_argvs(
+                       socket=socket, pane_id=pane_id, chrome=chrome, bg=bg,
+                       pane_borders=pane_borders, look=look)]
+        # One invocation for everything this pane needs said about it (#780). PER PANE
+        # and not once for the whole batch, because that is the shape the split loop
+        # forces: a pane's `%N` is not known until its own `split-window` has answered,
+        # and it is the `-t` of every command here.
+        tmuxctl.write_all("dressing a panel", writes, env=env)
+    return panes
+
+
+def _split_all(socket: str, *, slots: list[str], cmds: list[list[str]],
+               env: dict | None) -> list[tuple[str, str]]:
+    """Every `split-window` in *cmds* as ONE invocation, and the `(slot, pane id)` pairs
+    tmux answered with — in *slots*' own order, and holding only the panes that exist.
+
+    **A split READS a value back, so this is not `tmuxctl.write_all` and cannot be**
+    (see there: its replay is safe only for writes that mean the same thing twice, and a
+    replayed `split-window` is a second pane). What makes the batch possible anyway is
+    that a chain answers for every command in it: measured on tmux 3.7c and at the 3.2
+    floor alike, four `split-window -P -F '#{pane_id}'` in one invocation print **four
+    ids, one per line, in the order they were given**, and produce exactly the geometry
+    the same four commands produce one at a time. Every one of them targets the HARNESS
+    pane — `layout.panel_argvs` builds the whole list up front for `frame/layout.py`'s
+    own reason (tmux renumbers pane INDICES on every split, so nothing here may be
+    derived from an earlier split's answer) — so there was never an ordering dependency
+    between them to give up.
+
+    **And it is what stops the operator watching the panels arrive one at a time.** Four
+    invocations are four command-queue drains and four client redraws ~5 ms apart, which
+    is the "jumping texts" #780 was split out of; one invocation is one drain, and the
+    window goes from a bare harness to four panels in a single repaint.
+
+    **A refused split ABORTS the rest of the list** (`tmuxctl.write_all` measures it), and
+    tmux prints nothing to stdout for it — so the id count says exactly how far the list
+    got: the command at `len(ids)` is the one that was refused and nothing after it ran.
+    Those are re-issued ONE AT A TIME, which is both what makes the failure reportable per
+    slot ("drawing a panel", the phrase this had before it was a batch) and what keeps a
+    decorative panel that cannot be drawn from taking the rest of the frame with it.
+
+    **A wedged tmux is not retried at all** (`tmuxctl._UNKNOWABLE`). A timeout does not
+    say the split did not happen, and re-issuing it would be how a frame ends up with two
+    panes for one component and no record of the second.
+    """
+    made: list[tuple[str, str]] = []
+    todo = list(zip(slots, cmds))
+    if not todo:
+        return made
+    argv = tmuxctl.chain([c for _, c in todo])
+    if argv is not None:
+        # `report=False`, and the two branches below are why: an ordinary refusal is
+        # re-issued per slot and reported THERE, under the name that says which panel the
+        # operator lost, while a wedged tmux is reported here because there is nothing
+        # left to re-issue it as.
+        p = tmuxctl.run("drawing this frame's panels", argv, env=env, report=False)
+        lines = p.stdout.splitlines()
+        for (slot, _), pane_id in zip(todo, lines):
+            if _PANE_ID_RE.fullmatch(pane_id.strip()):
+                made.append((slot, pane_id.strip()))
+        if p.returncode == 0:
+            return made
+        if p.returncode in tmuxctl._UNKNOWABLE:
+            tmuxctl.report_failure("drawing this frame's panels", argv, p)
+            return made
+        todo = todo[len(lines):]
+    for slot, cmd in todo:
         p = tmuxctl.run("drawing a panel", cmd, env=env)
         if p.returncode != 0:
             continue
         pane_id = p.stdout.strip()
-        if pane_id and _PANE_ID_RE.fullmatch(pane_id):
-            panes[slot] = pane_id
-            # This pane is a PANEL, said to tmux itself where a root-table binding can ask
-            # (#634, `_panel_mark_argv`). It goes before the surface rather than after
-            # because it is the only one of the two that decides where a click goes: a
-            # panel that came up unmarked takes the keyboard off the harness the first
-            # time it is clicked, which is the whole defect. Reported but not fatal, like
-            # the splits and the surface — a panel charter could not mark still draws and
-            # is still clicked, it just costs the operator an `F12` afterwards.
-            tmuxctl.run("marking a panel so a click on it stays where it points",
-                        _panel_mark_argv(socket=socket, pane_id=pane_id), env=env)
-            # And WHICH panel it is, on the same pane and out of the same funnel (#714,
-            # `_panel_slot_argv`). The mark above says a pane is charter's; this says what
-            # charter meant by it, which is the half `state.panes` cannot be trusted for —
-            # that file is rewritten whole on every re-layout, so a component whose pane
-            # got split twice has one id recorded and the other invisible to every reader
-            # that goes through it. Written where the pane is CREATED rather than by a
-            # later pass, because a later pass is a thing to forget: `_reconcile_panels`
-            # will not kill a pane it cannot name, so a panel that missed this is a panel
-            # that can be orphaned exactly once more. `None` for a name charter will not
-            # put on a pane — see there for why that is not silent about its cost.
-            slot_argv = _panel_slot_argv(socket=socket, pane_id=pane_id, slot=slot)
-            if slot_argv is not None:
-                tmuxctl.run("saying which component a panel draws", slot_argv, env=env)
-            # The pane surface, on the pane that was just created and on no other — the
-            # one place charter has a panel's `%N` in hand. The harness pane is never an
-            # argument (`_surface_argvs`), which is how ADR 0018's boundary holds by
-            # construction. Not fatal, like the splits: a frame whose panes kept the
-            # terminal's own background is a frame that looks plainer, not one that fails.
-            # And this pane's OWN background where the arrangement gave it one
-            # (`instance.component_style`, the single walk over the placements that
-            # `frame/slots.py` asks for the pad on the other side of the split). Resolved
-            # per slot rather than once for the batch, unlike `chrome` above, because that
-            # is the whole difference between the two keys: one word about the frame, one
-            # word about this pane.
-            bg = instance.component_style(config.FRAME, slot)["bg"]
-            for surface in _surface_argvs(socket=socket, pane_id=pane_id, chrome=chrome,
-                                          bg=bg, pane_borders=pane_borders, look=look):
-                tmuxctl.run("painting a panel's surface", surface, env=env)
-    return panes
+        if _PANE_ID_RE.fullmatch(pane_id):
+            made.append((slot, pane_id))
+    return made
 
 
 def _install_resize_hook(socket: str, *, harness_pane: str, panes: dict[str, str],
@@ -4020,7 +4113,15 @@ def _arm_panel_respawn(socket: str, *, fid: str, panes: dict[str, str],
     A pane charter will not arm (`_panel_died_hook_argv` returning ``None`` — see its own
     docstring for what fails that check) is NAMED rather than skipped in silence: the
     operator loses respawn for that panel and this is the only place that could say so.
+
+    **One invocation for the whole map** (#780, `tmuxctl.write_all`). Each hook is a
+    `set-hook -p` on its own pane, nothing reads any of them back, and no one of them
+    depends on another having run — they were four round trips per launch and four more
+    per chat switch only because they were sent one at a time. A failure inside the batch
+    re-issues every hook separately, so the per-slot phrase above is still what an
+    operator is told when one pane cannot be armed.
     """
+    writes = []
     for slot, pane_id in panes.items():
         cmd = _panel_died_hook_argv(socket=socket, panel_pane=pane_id, slot=slot, fid=fid)
         if cmd is None:
@@ -4028,10 +4129,11 @@ def _arm_panel_respawn(socket: str, *, fid: str, panes: dict[str, str],
                       "dies — charter cannot build a respawn hook it can be sure tmux "
                       "and the shell will read the way it means it")
             continue
-        tmuxctl.run(f"arming the {slot} panel for respawn", cmd, env=env)
+        writes.append(tmuxctl.Write(f"arming the {slot} panel for respawn", cmd))
+    tmuxctl.write_all("arming this frame's panels for respawn", writes, env=env)
 
 
-def _disarm_panel_respawn(socket: str, *, pane_id: str) -> None:
+def _disarm_respawn_argv(socket: str, *, pane_id: str) -> list[str]:
     """Take one panel pane's `pane-died` hook off, BEFORE that pane is killed.
 
     Without this, changing density is self-undoing: `kill-pane` on a panel charter no
@@ -4041,17 +4143,22 @@ def _disarm_panel_respawn(socket: str, *, pane_id: str) -> None:
     way. Unsetting first removes the question rather than answering it: there is no hook
     left to fire, whichever way this tmux treats a killed pane's `pane-died`.
 
-    `report=False`: a pane charter declined to arm (`_panel_died_hook_argv` returning
-    ``None``) has no hook to unset, and a frame launched by a charter that predates #382
-    has none either, so a `set-hook -u` for a hook that is not set is an ORDINARY case
-    rather than a fault — the same reason `_live_sessions` opts out of reporting for a
-    socket no server has run on. Until #408 the ordinary case was the whole of the
-    operator's server, where nothing was ever armed at all.
+    **An ARGV rather than a call, since #780**, because the disarm and the kill it guards
+    now travel to tmux together — `_reconcile_panels` puts both in one `tmuxctl.write_all`
+    so four doomed panels cost one round trip and one repaint instead of eight and four.
+    The pairing is unchanged: a chain runs in the order it is given, server-side.
+
+    It is issued with reporting OFF, and that is the flag `tmuxctl.Write` exists to carry:
+    a pane charter declined to arm (`_panel_died_hook_argv` returning ``None``) has no
+    hook to unset, and a frame launched by a charter that predates #382 has none either.
+    Measured on tmux 3.7c and at the 3.2 floor, `set-hook -p -u` for a hook that is not
+    set answers **rc 0** — so the ordinary case is not even a failure, and the one way
+    this can fail is a pane that has gone, which its own `kill-pane` reports. Until #408
+    the ordinary case was the whole of the operator's server, where nothing was ever
+    armed at all.
     """
-    tmuxctl.run("disarming a panel's respawn hook",
-                tmuxctl.server_argv(socket, "set-hook", "-p", "-u", "-t", pane_id,
-                                    "pane-died"),
-                timeout=5, report=False)
+    return tmuxctl.server_argv(socket, "set-hook", "-p", "-u", "-t", pane_id,
+                               "pane-died")
 
 
 def _pane_last_words(socket: str, harness_pane: str) -> list[str]:
@@ -4843,6 +4950,29 @@ def cmd_launch(args) -> int:
     # tell "I am this frame's harness" from "I inherited this frame's id", which below
     # `SESSION_ENV_FLOOR` a second frame on this shared server genuinely does.
     state.record_harness_pane(fid, harness_pane)
+    # **Everything this frame's window and session have to be told, COLLECTED here and
+    # sent as one invocation below** (#780, `tmuxctl.write_all`). Ten writes, not one of
+    # which reads anything back, that used to be ten round trips — ~5 ms each on tmux
+    # 3.7c on the machine this was written on and ~13.4 ms each on the one that filed
+    # #728, all of them spent before a client can be attached and anything can be on
+    # screen. Their ORDER is load-bearing (`@charter_chat` before the hook whose action
+    # reads `#{@charter_chat}`; the hatch before the first panel), and a chain is
+    # executed in order, server-side, so that is exactly what survives.
+    #
+    # `lost` is what an operator is told when the write at the same index does not take —
+    # kept beside the write rather than at its call site, so the two cannot drift apart,
+    # and printed below only for the ones that failed. Every "charter cannot build this
+    # argv at all" warning stays exactly where it was: those are refusals to ask, not
+    # answers, and they carry no return code.
+    writes: list[tmuxctl.Write] = []
+    lost: list[str] = []
+
+    def _tell(action: str, argv: list[str], if_refused: str) -> int:
+        """Add one write to the batch, and answer where in it its result will be."""
+        writes.append(tmuxctl.Write(action, argv))
+        lost.append(if_refused)
+        return len(writes) - 1
+
     # And what every later lookup asks instead of parsing the window's name: `reap`'s
     # liveness list (`_live_chats`), the write hook's `#{@charter_chat}`, and the binds
     # `conf_text` writes. Armed before either hook, so the hook that names it cannot fire
@@ -4852,11 +4982,10 @@ def cmd_launch(args) -> int:
         util.warn(f"charter frame: {fid!r} is not a shape tmux can carry as a window "
                   "option — this chat's state may be reaped while it is still running")
     else:
-        chat_set = tmuxctl.run("naming the chat on its window", named, env=env)
-        if chat_set.returncode != 0:
-            util.warn("charter frame: continuing without it — this chat's state may be "
-                      "reaped while it is still running, and its exit code may not be "
-                      "recorded")
+        _tell("naming the chat on its window", named,
+              "charter frame: continuing without it — this chat's state may be "
+              "reaped while it is still running, and its exit code may not be "
+              "recorded")
     # And which PLANE the session belongs to — §4b's marker, written by the launch that
     # CREATED the session and by no other. `joining` is the same NAME test three dozen
     # lines up, which is exactly the cross-plane collision this marker records: a launch
@@ -4870,31 +4999,29 @@ def cmd_launch(args) -> int:
             util.warn("charter frame: this plane's state directory is not a shape tmux "
                       "can carry as an option — a workspace switch cannot tell this "
                       "session from another plane's of the same name")
-        elif tmuxctl.run("marking the workspace session with its plane", marked,
-                         env=env).returncode != 0:
-            util.warn("charter frame: continuing without it — a workspace switch cannot "
-                      "tell this session from another plane's of the same name")
+        else:
+            _tell("marking the workspace session with its plane", marked,
+                  "charter frame: continuing without it — a workspace switch cannot "
+                  "tell this session from another plane's of the same name")
 
     frame = config.FRAME
+    # Written before the batch is sent rather than in the middle of it, which is the one
+    # reordering collecting the writes forces and it is not one anything can see: this
+    # file has exactly one reader and it is the `source-file` two lines down.
     config.write_for(conf_path,
                      conf_text(hotkey=frame["hotkey"], mouse=frame["mouse"],
                                history_limit=frame["history_limit"], session=session,
                                toggles=instance.frame_toggles(frame)))
-    src = tmuxctl.run("loading the frame's config",
-                      tmuxctl.server_argv(SOCKET, "source-file", str(conf_path)),
-                      env=env)
-    if src.returncode != 0:
-        util.warn("charter frame: continuing without it — mouse/history-limit/hotkey "
-                  "settings may not be in effect for this frame")
+    _tell("loading the frame's config",
+          tmuxctl.server_argv(SOCKET, "source-file", str(conf_path)),
+          "charter frame: continuing without it — mouse/history-limit/hotkey "
+          "settings may not be in effect for this frame")
 
-    env_set = tmuxctl.run(
-        "carrying the exit-status path",
-        _exit_path_env_argv(socket=SOCKET, session=session,
-                            frame_root=str(frame_root)),
-        env=env)
-    if env_set.returncode != 0:
-        util.warn("charter frame: continuing without it — the exit code may not be "
-                  "recorded for this frame")
+    _tell("carrying the exit-status path",
+          _exit_path_env_argv(socket=SOCKET, session=session,
+                              frame_root=str(frame_root)),
+          "charter frame: continuing without it — the exit code may not be "
+          "recorded for this frame")
 
     # Ties this session to its own id BEFORE anything else can ask for it — the hotkey
     # bind's action (`charter frame-palette`) and every action the palette starts resolve
@@ -4902,22 +5029,19 @@ def cmd_launch(args) -> int:
     # this call a frame beyond the first sharing
     # `SOCKET` would silently resolve the FIRST frame's id instead of its own (see
     # `_session_id_env_argv`'s own docstring for what was verified by hand).
-    sid_set = tmuxctl.run("carrying the frame id to its own palette",
-                          _session_id_env_argv(socket=SOCKET, session=session, chat=fid),
-                          env=env)
-    if sid_set.returncode != 0:
-        util.warn("charter frame: continuing without it — the palette may not find "
-                  "this frame's own actions")
+    _tell("carrying the frame id to its own palette",
+          _session_id_env_argv(socket=SOCKET, session=session, chat=fid),
+          "charter frame: continuing without it — the palette may not find "
+          "this frame's own actions")
 
     # The second value the same mechanism carries: which interpreter runs charter when
     # the hotkey fires. Without it both fall back to a bare `charter`
     # on the tmux server's own `$PATH`, and `run-shell` reports the resulting 127 by
     # printing it INTO THE HARNESS PANE — see `conf_text`'s own docstring.
-    py_set = tmuxctl.run("carrying charter's own interpreter to the palette",
-                         _charter_py_env_argv(socket=SOCKET, session=session), env=env)
-    if py_set.returncode != 0:
-        util.warn("charter frame: continuing without it — the palette may not open "
-                  "on this frame")
+    _tell("carrying charter's own interpreter to the palette",
+          _charter_py_env_argv(socket=SOCKET, session=session),
+          "charter frame: continuing without it — the palette may not open "
+          "on this frame")
 
     # The escape hatch's other half. `conf_text`'s bind carries no identity — it reads a
     # WINDOW option, and this is what puts this frame's own answer in it, so a key table
@@ -4930,39 +5054,44 @@ def cmd_launch(args) -> int:
         util.warn("charter frame: tmux did not report this frame's harness as a pane id "
                   f"— the {overlay.HATCH_KEY} escape hatch will not be armed for it")
     else:
-        armed_hatch = tmuxctl.run("arming the frame's escape hatch", hatch, env=env)
-        if armed_hatch.returncode != 0:
-            util.warn(f"charter frame: continuing without it — {overlay.HATCH_KEY} may "
-                      "not return to the harness in this frame")
+        _tell("arming the frame's escape hatch", hatch,
+              f"charter frame: continuing without it — {overlay.HATCH_KEY} may "
+              "not return to the harness in this frame")
 
     # #390: the same "-m prepends the cwd to sys.path" hole `util.self_relaunch_argv`'s
     # `-P` closes for the panel argv below, closed here as `PYTHONSAFEPATH=1` because
     # the hotkey template above has no room for a per-invocation flag — see
     # `_charter_pythonsafepath_env_argv`'s own docstring.
-    safepath_set = tmuxctl.run("carrying PYTHONSAFEPATH to the palette",
-                               _charter_pythonsafepath_env_argv(socket=SOCKET,
-                                                               session=session),
-                               env=env)
-    if safepath_set.returncode != 0:
-        util.warn("charter frame: continuing without it — the palette may import "
-                  "the wrong charter if this pane's directory has its own `charter/` "
-                  "package")
+    _tell("carrying PYTHONSAFEPATH to the palette",
+          _charter_pythonsafepath_env_argv(socket=SOCKET, session=session),
+          "charter frame: continuing without it — the palette may import "
+          "the wrong charter if this pane's directory has its own `charter/` "
+          "package")
 
     # Nothing is recorded for the hotkey to open. The menu was a TABLE on disk that every
     # density change and every switch had to rewrite or it went stale (`_rerecord_menu`,
     # deleted with it); the palette is built from live state each time it opens
     # (`frame/builtin_actions.build`), so there is no snapshot left to keep in step.
 
-    write_hook = tmuxctl.run(
-        "installing the exit-status hook",
-        _pane_died_write_hook_argv(socket=SOCKET, harness_pane=harness_pane), env=env)
-    if write_hook.returncode != 0:
-        util.warn("charter frame: continuing without it — the exit code may not be "
-                  "recorded for this frame")
+    _tell("installing the exit-status hook",
+          _pane_died_write_hook_argv(socket=SOCKET, harness_pane=harness_pane),
+          "charter frame: continuing without it — the exit code may not be "
+          "recorded for this frame")
 
-    teardown_hook = tmuxctl.run(
+    # The one write in this batch whose return code is read rather than merely warned
+    # about — a teardown hook that did not install makes this launcher refuse to attach
+    # at all, further down — so its position is kept rather than its result guessed at.
+    teardown_at = _tell(
         "installing the chat-teardown hook",
-        _pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=harness_pane), env=env)
+        _pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=harness_pane),
+        "")
+
+    told = tmuxctl.write_all("telling the frame's window and session what they are",
+                             writes, env=env)
+    for result, sentence in zip(told, lost):
+        if result.returncode != 0 and sentence:
+            util.warn(sentence)
+    teardown_hook = told[teardown_at]
 
     # Closes the install race directly, rather than merely working around its symptom. A
     # harness that died in the window between `new-session` starting it and the hooks
@@ -5297,7 +5426,7 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
       drawing correct content, is what that looked like on a real frame. The record is
       still read, and still chooses which of several panes for one component survives; it
       is no longer the only thing that can see a pane.
-    * **Disarm before killing.** See :func:`_disarm_panel_respawn` — otherwise the panel
+    * **Disarm before killing.** See :func:`_disarm_respawn_argv` — otherwise the panel
       charter just closed comes straight back, one respawn life poorer.
     * **Split off the HARNESS pane, never off a sibling panel.** `_draw_panels` already
       does this and it is `frame/layout.py`'s own module-docstring measurement: tmux
@@ -5427,16 +5556,23 @@ def _apply_sizes(socket: str, *, panes: dict[str, str], sizes: dict[str, int],
     `report=False`: a pane that has since died (the operator closed it, a panel crashed
     between the map being read and this running) makes `resize-pane` fail, and that is not
     an integration failure worth printing over the agent's own screen.
+
+    **One invocation per pass** (#780, `tmuxctl.write_all`). A `resize-pane` reads nothing
+    back and one pane's does not depend on another's having run, so the three or four this
+    issues for a four-panel frame's rows were three or four round trips for no reason —
+    and, since tmux redraws once per command list rather than once per command, three or
+    four separate repaints of a window whose panes were being shuffled into place. The two
+    passes stay two batches: the measurement between them is what makes the second one
+    truthful, and it is a READ.
     """
-    for slot, pane_id in panes.items():
-        if layout.resize_flag(slot) != flag or slot not in sizes:
-            continue
-        if not _PANE_ID_RE.fullmatch(pane_id):
-            continue
-        tmuxctl.run(f"restoring the {slot} panel's size",
-                    tmuxctl.server_argv(socket, "resize-pane", "-t", pane_id,
-                                        flag, str(sizes[slot])),
-                    report=False)
+    writes = [tmuxctl.Write(f"restoring the {slot} panel's size",
+                            tmuxctl.server_argv(socket, "resize-pane", "-t", pane_id,
+                                                flag, str(sizes[slot])),
+                            report=False)
+              for slot, pane_id in panes.items()
+              if layout.resize_flag(slot) == flag and slot in sizes
+              and _PANE_ID_RE.fullmatch(pane_id)]
+    tmuxctl.write_all(f"restoring this frame's panel sizes ({flag})", writes)
 
 
 def _variable_pane_cols(socket: str, *, panes: dict[str, str], window_cols: int) -> int:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -3966,7 +3966,7 @@ def _split_all(socket: str, *, slots: list[str], cmds: list[list[str]],
     slot ("drawing a panel", the phrase this had before it was a batch) and what keeps a
     decorative panel that cannot be drawn from taking the rest of the frame with it.
 
-    **A wedged tmux is not retried at all** (`tmuxctl._UNKNOWABLE`). A timeout does not
+    **A wedged tmux is not retried at all** (`tmuxctl.UNKNOWABLE`). A timeout does not
     say the split did not happen, and re-issuing it would be how a frame ends up with two
     panes for one component and no record of the second.
     """
@@ -3987,7 +3987,7 @@ def _split_all(socket: str, *, slots: list[str], cmds: list[list[str]],
                 made.append((slot, pane_id.strip()))
         if p.returncode == 0:
             return made
-        if p.returncode in tmuxctl._UNKNOWABLE:
+        if p.returncode in tmuxctl.UNKNOWABLE:
             tmuxctl.report_failure("drawing this frame's panels", argv, p)
             return made
         todo = todo[len(lines):]

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -3876,6 +3876,14 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
                                     harness_pane=harness_pane, env=pane_env,
                                     sizes=sizes)
     panes: dict[str, str] = {}
+    # **Every pane's options collected across the whole loop and sent as ONE invocation
+    # below** (#780). Per pane was the shape this had while each `split-window` was its
+    # own round trip and a pane's `%N` was learnt one at a time; `_split_all` answers for
+    # all of them at once, so there is nothing left forcing four batches where one will
+    # do. The order inside is unchanged — every pane's mark before its own surface, and
+    # the panes in the order they were split — because a chain runs in the order it is
+    # given.
+    writes: list[tmuxctl.Write] = []
     for slot, pane_id in _split_all(socket, slots=slots, cmds=panel_cmds, env=env):
         panes[slot] = pane_id
         # This pane is a PANEL, said to tmux itself where a root-table binding can ask
@@ -3885,9 +3893,9 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
         # time it is clicked, which is the whole defect. Reported but not fatal, like
         # the splits and the surface — a panel charter could not mark still draws and
         # is still clicked, it just costs the operator an `F12` afterwards.
-        writes = [tmuxctl.Write(
+        writes.append(tmuxctl.Write(
             "marking a panel so a click on it stays where it points",
-            _panel_mark_argv(socket=socket, pane_id=pane_id))]
+            _panel_mark_argv(socket=socket, pane_id=pane_id)))
         # And WHICH panel it is, on the same pane and out of the same funnel (#714,
         # `_panel_slot_argv`). The mark above says a pane is charter's; this says what
         # charter meant by it, which is the half `state.panes` cannot be trusted for —
@@ -3918,11 +3926,7 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
                    for surface in _surface_argvs(
                        socket=socket, pane_id=pane_id, chrome=chrome, bg=bg,
                        pane_borders=pane_borders, look=look)]
-        # One invocation for everything this pane needs said about it (#780). PER PANE
-        # and not once for the whole batch, because that is the shape the split loop
-        # forces: a pane's `%N` is not known until its own `split-window` has answered,
-        # and it is the `-t` of every command here.
-        tmuxctl.write_all("dressing a panel", writes, env=env)
+    tmuxctl.write_all("dressing this frame's panels", writes, env=env)
     return panes
 
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -3948,6 +3948,13 @@ def _split_all(socket: str, *, slots: list[str], cmds: list[list[str]],
     is the "jumping texts" #780 was split out of; one invocation is one drain, and the
     window goes from a bare harness to four panels in a single repaint.
 
+    **The mapping is by POSITION, so it rests on every command in *cmds* printing exactly
+    one line**, and `layout.panel_argvs` is where that holds: it puts `-P -F '#{pane_id}'`
+    on every argv it builds, unconditionally, one per slot in *slots*' own order. A slot
+    whose command stopped asking for the id would not merely lose its own pane — it would
+    shift every slot after it onto the wrong one. Stated here rather than re-checked,
+    because a count that agrees is not evidence that the right command produced it.
+
     **A refused split ABORTS the rest of the list** (`tmuxctl.write_all` measures it), and
     tmux prints nothing to stdout for it — so the id count says exactly how far the list
     got: the command at `len(ids)` is the one that was refused and nothing after it ran.

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -701,10 +701,16 @@ class Write(NamedTuple):
     report: bool = True
 
 
-#: The two return codes :func:`run` invents rather than reads off tmux — a wedged server
-#: and a tmux that could not be started. They are what :func:`write_all` refuses to
-#: replay on: both mean charter never learnt what the server did, and a batch of
-#: idempotent writes is safe to repeat only when it is known that they did not take.
+#: The two return codes :func:`run` invents rather than reads off tmux, and the two
+#: :func:`write_all` will not replay on — for two different reasons, both of which end in
+#: "one at a time buys nothing here".
+#:
+#: :data:`TIMED_OUT` is the load-bearing one: a wedged server has not told charter what
+#: it did, so re-issuing would be repeating writes that may already have taken against a
+#: tmux that is not answering — the one case idempotence cannot cover, because charter
+#: cannot know it is repeating. :data:`COULD_NOT_RUN` is the opposite and is grouped with
+#: it for economy rather than for safety: nothing ran and nothing can, so a replay is N
+#: more failed `exec`s and N copies of one sentence about a tmux that is not there.
 _UNKNOWABLE = (TIMED_OUT, COULD_NOT_RUN)
 
 
@@ -746,9 +752,9 @@ def write_all(joint: str, writes: list[Write], *, env: dict | None = None,
     **A wedged server is not replayed** (:data:`_UNKNOWABLE`). A timeout says charter
     never learnt what the server did, not that it did nothing, so re-issuing would be
     the one thing idempotence cannot cover: writes charter cannot know it is repeating,
-    against a tmux that is not answering. The batch is reported once, every write gets
-    that same result back, and the caller degrades exactly as it does for any other
-    non-zero return.
+    against a tmux that is not answering. The batch is reported once — and only if any
+    write in it would have reported on its own — every write gets that same result back,
+    and the caller degrades exactly as it does for any other non-zero return.
     """
     if not writes:
         return []

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -759,17 +759,20 @@ def write_all(joint: str, writes: list[Write], *, env: dict | None = None,
     write in it would have reported on its own — every write gets that same result back,
     and the caller degrades exactly as it does for any other non-zero return.
     """
-    if not writes:
-        return []
     if len(writes) == 1:
         w = writes[0]
         return [run(w.action, w.argv, env=env, timeout=timeout, report=w.report)]
     argv = chain([w.argv for w in writes])
     if argv is None:
-        # Two servers in one group, which :func:`chain` will not guess between. Nothing
-        # in charter builds one — every caller derives its argvs from a single *socket*
-        # — so this is the refusal taken rather than a case, and one at a time is
-        # exactly right for it.
+        # **Two cases, one answer, and no `if not writes` in front of them.** :func:`chain`
+        # answers ``None`` both for a group spanning two servers — which it will not guess
+        # between, and which nothing in charter builds, every caller deriving its argvs
+        # from a single *socket* — and for an EMPTY group, which several callers really do
+        # hand over (a frame with no doomed panel, no missing slot, no chrome to set). One
+        # at a time is exactly right for the first and is a loop over nothing for the
+        # second, so an early return for the empty case could not change an answer: the
+        # deletion sweep reported it as a survivor and this repository deletes an
+        # equivalent mutant rather than documenting it.
         return [run(w.action, w.argv, env=env, timeout=timeout, report=w.report)
                 for w in writes]
     proc = run(joint, argv, env=env, timeout=timeout, report=False)

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -702,7 +702,10 @@ class Write(NamedTuple):
 
 
 #: The two return codes :func:`run` invents rather than reads off tmux, and the two
-#: :func:`write_all` will not replay on — for two different reasons, both of which end in
+#: :func:`write_all` will not replay on. Public because `commands_frame._split_all` reads
+#: it too: the split batch cannot use :func:`write_all` (a replayed `split-window` is a
+#: second pane) and so has to make the same call about the same two codes, and one
+#: constant is what stops the two answering differently — for two different reasons, both of which end in
 #: "one at a time buys nothing here".
 #:
 #: :data:`TIMED_OUT` is the load-bearing one: a wedged server has not told charter what
@@ -711,7 +714,7 @@ class Write(NamedTuple):
 #: cannot know it is repeating. :data:`COULD_NOT_RUN` is the opposite and is grouped with
 #: it for economy rather than for safety: nothing ran and nothing can, so a replay is N
 #: more failed `exec`s and N copies of one sentence about a tmux that is not there.
-_UNKNOWABLE = (TIMED_OUT, COULD_NOT_RUN)
+UNKNOWABLE = (TIMED_OUT, COULD_NOT_RUN)
 
 
 def write_all(joint: str, writes: list[Write], *, env: dict | None = None,
@@ -749,7 +752,7 @@ def write_all(joint: str, writes: list[Write], *, env: dict | None = None,
     `kill-pane`. Never `split-window` — a replayed split is a second pane, and
     `_split_panels` reads its ids back for that reason and batches by hand.
 
-    **A wedged server is not replayed** (:data:`_UNKNOWABLE`). A timeout says charter
+    **A wedged server is not replayed** (:data:`UNKNOWABLE`). A timeout says charter
     never learnt what the server did, not that it did nothing, so re-issuing would be
     the one thing idempotence cannot cover: writes charter cannot know it is repeating,
     against a tmux that is not answering. The batch is reported once — and only if any
@@ -773,7 +776,7 @@ def write_all(joint: str, writes: list[Write], *, env: dict | None = None,
     if proc.returncode == 0:
         return [subprocess.CompletedProcess(w.argv, 0, stdout="", stderr="")
                 for w in writes]
-    if proc.returncode in _UNKNOWABLE:
+    if proc.returncode in UNKNOWABLE:
         # Reported only if any write in the group would have reported on its own — a
         # batch of `resize-pane`s that all opted out (`_apply_sizes`) must not start
         # printing over the agent's screen just because it is now a batch.

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import subprocess
 from collections.abc import Mapping
+from typing import NamedTuple
 
 from .. import util
 
@@ -677,6 +678,104 @@ def run(action: str, argv: list[str], *, env: dict | None = None,
     if proc.returncode != 0 and report:
         report_failure(action, argv, proc)
     return proc
+
+
+class Write(NamedTuple):
+    """One fire-and-forget tmux command, with everything :func:`run` would need for it.
+
+    A record rather than a bare `(action, argv)` pair because the two things a batch has
+    to carry per command are exactly the two :func:`run` takes per command and neither is
+    the same for every member of a group: `_reconcile_panels` batches a `set-hook -u`
+    that must NOT be reported (unsetting a hook nothing set is rc 0 — measured on 3.7c
+    and at the 3.2 floor — so the only way it fails is a pane that is gone) beside a
+    `kill-pane` that must be. Flattening the two would either print a second sentence
+    about one broken pane or swallow the sentence about it.
+    """
+
+    #: The phrase :func:`report_failure` prints for THIS command, if it is ever run on
+    #: its own. Required for the same reason :func:`run`'s is.
+    action: str
+    #: The full argv, `tmux -L … verb …`, built by :func:`server_argv` like any other.
+    argv: list[str]
+    #: Whether a non-zero return from this one command is worth printing.
+    report: bool = True
+
+
+#: The two return codes :func:`run` invents rather than reads off tmux — a wedged server
+#: and a tmux that could not be started. They are what :func:`write_all` refuses to
+#: replay on: both mean charter never learnt what the server did, and a batch of
+#: idempotent writes is safe to repeat only when it is known that they did not take.
+_UNKNOWABLE = (TIMED_OUT, COULD_NOT_RUN)
+
+
+def write_all(joint: str, writes: list[Write], *, env: dict | None = None,
+              timeout: float = TIMEOUT) -> list[subprocess.CompletedProcess]:
+    """Every write in *writes* — as ONE invocation when they all take, one at a time when
+    any of them does not. One result per write, in order, whichever way it went.
+
+    **What this buys is round trips, and they are most of what a launch and a switch
+    spend.** Measured on this machine against tmux 3.7c, a `tmuxctl.run` costs ~5 ms of
+    wall clock whatever it carries — the operator who filed #728 measured ~13.4 ms on
+    theirs — and a four-panel switch made 58 of them. Two thirds of those read nothing
+    back: window options, pane options, hooks, kills. tmux parses and executes a whole
+    `;`-separated list server-side (:func:`chain`), so a group of them costs one.
+
+    **A failing command ABORTS the rest of the list, and that is the whole reason this
+    is not just :func:`chain`.** Measured on tmux 3.7c and at the 3.2 floor alike:
+    `set-option @a 1 ; set-option nosuchoption 1 ; set-option @b 1` sets `@a`, refuses
+    the middle one, and **never sets `@b`** — rc 1, and the third command is not run.
+    So a chain is one command as far as failure is concerned, while charter's callers
+    are written around each write failing on its own with its own sentence and its own
+    consequence (`_dress_window`'s rules are decorative, `_install_resize_hook`'s hook
+    is a capability ceiling, the launcher's five `set-environment`s each warn about a
+    different thing). Collapsing those into one phrase would be a worse frame than the
+    one the round trips buy.
+
+    So: the chain is tried first with reporting off, and **the moment it returns
+    non-zero every write is re-issued one at a time**, through :func:`run`, with its own
+    action and its own *report*. The fast path is one invocation; the failure path is
+    one wasted invocation plus exactly the calls, the codes and the sentences the caller
+    would have got before this function existed.
+
+    **Which makes idempotence the entry condition, stated here because nothing else can
+    enforce it.** The replay re-runs writes that already took, so every *write* must be
+    one that means the same thing twice: `set-option`, `set-hook`, `set-environment`,
+    `kill-pane`. Never `split-window` — a replayed split is a second pane, and
+    `_split_panels` reads its ids back for that reason and batches by hand.
+
+    **A wedged server is not replayed** (:data:`_UNKNOWABLE`). A timeout says charter
+    never learnt what the server did, not that it did nothing, so re-issuing would be
+    the one thing idempotence cannot cover: writes charter cannot know it is repeating,
+    against a tmux that is not answering. The batch is reported once, every write gets
+    that same result back, and the caller degrades exactly as it does for any other
+    non-zero return.
+    """
+    if not writes:
+        return []
+    if len(writes) == 1:
+        w = writes[0]
+        return [run(w.action, w.argv, env=env, timeout=timeout, report=w.report)]
+    argv = chain([w.argv for w in writes])
+    if argv is None:
+        # Two servers in one group, which :func:`chain` will not guess between. Nothing
+        # in charter builds one — every caller derives its argvs from a single *socket*
+        # — so this is the refusal taken rather than a case, and one at a time is
+        # exactly right for it.
+        return [run(w.action, w.argv, env=env, timeout=timeout, report=w.report)
+                for w in writes]
+    proc = run(joint, argv, env=env, timeout=timeout, report=False)
+    if proc.returncode == 0:
+        return [subprocess.CompletedProcess(w.argv, 0, stdout="", stderr="")
+                for w in writes]
+    if proc.returncode in _UNKNOWABLE:
+        # Reported only if any write in the group would have reported on its own — a
+        # batch of `resize-pane`s that all opted out (`_apply_sizes`) must not start
+        # printing over the agent's screen just because it is now a batch.
+        if any(w.report for w in writes):
+            report_failure(joint, argv, proc)
+        return [proc for _ in writes]
+    return [run(w.action, w.argv, env=env, timeout=timeout, report=w.report)
+            for w in writes]
 
 
 def interact(argv: list[str], *, env: dict | None = None) -> subprocess.CompletedProcess:

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -493,7 +493,8 @@ sees while the panels are torn down and split back one at a time.
 
 Most of those commands read nothing back, so tmux takes them as one list. The four kills
 and their four disarms are one invocation now; so is each end's window dressing, so are the
-four splits, and so are the four respawn hooks. Nothing was dropped and nothing was
+four splits, so is everything the four new panes are told about themselves, and so are the
+four respawn hooks. Nothing was dropped and nothing was
 reordered — the same commands, in the same order, in 40% of the invocations and a third of
 the repaints. It is not silent: 14 updates is still four panel processes coming up and
 painting themselves, which is a different cost and not this one.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -92,6 +92,30 @@ measured at 86 bytes ahead of the switch — and it comes back into view only on
 exits. All of them are standing properties of this machine and this plane rather than news
 about one launch, so they live on the two surfaces you can ask on demand.
 
+### What opening one costs
+
+There is a moment between typing `charter claude` and the frame appearing, and most of the
+tmux half of it used to be charter waiting on a socket. A tmux command is a round trip —
+~5 ms on the machine these were measured on, ~13.4 ms on the one that reported it as slow —
+and a four-panel launch made 46 of them before it could attach. Two thirds read nothing
+back: window options, pane options, hooks, the panel splits. tmux takes a `;`-separated
+list and runs the whole thing server-side, in order, so each of those groups is now one
+invocation (#780).
+
+Measured on a four-panel frame at 200x50, from the first tmux command to the attach:
+
+| | tmux invocations | wall clock |
+|---|---|---|
+| tmux 3.7c | 46 → **20** | 245 ms → **114 ms** |
+| at the 3.2 floor | 42 → **19** | 184 ms → **83 ms** |
+
+No client is attached during any of that, by construction — there is nothing to attach to
+until `attach` — which is why the blank has no progress line and cannot have one (#728).
+
+The rest of the wait is charter's own import, paid once by the launcher, once by the
+detached gather child, and once per panel process. That is a different lever and is not
+this one.
+
 ## What changes inside the frame
 
 **Scrollback is tmux's own copy-mode, not your terminal's — the difference people notice
@@ -448,11 +472,31 @@ switched away from are not idle, they are drawing at a width that is not their w
 The switch therefore tears the old chat's panels down, selects the new window (tmux resizes
 it *at* that moment), and splits fresh panels into a window that is already the right size.
 
-**It costs about a third of a second.** Measured with a real client and four panels: 41
-tmux commands, median 360 ms on tmux 3.7c and 395 ms at the 3.2 floor, with the panels
-painting roughly 90 ms after that. That is the price of not keeping four panel processes
-per chat drawing at the wrong width, and it is the whole cost — nothing is lost, no harness
-is restarted, and the chat you left goes on running exactly as it was.
+**It costs about a sixth of a second.** Measured with a real client and four panels:
+
+| | tmux invocations | wall clock | times your terminal is repainted |
+|---|---|---|---|
+| tmux 3.7c | 58 → **26** | 329 ms → **162 ms** | 45 → **17** |
+| at the 3.2 floor | 50 → **24** | 243 ms → **127 ms** | 41 → **15** |
+
+That is the price of not keeping four panel processes per chat drawing at the wrong width,
+and it is the whole cost — nothing is lost, no harness is restarted, and the chat you left
+goes on running exactly as it was.
+
+**It used to be twice that, and the difference is how many times charter spoke rather than
+what it said** (#780). A tmux command is a round trip over a socket — ~5 ms on the machine
+this was measured on, ~13.4 ms on the one that reported the switch as slow — and charter
+sent every one of them on its own. The third column is what that looked like from the
+outside: tmux redraws once per command *list* rather than once per command, so 58
+invocations were **45 separate screen updates**, which is the *"jumping texts"* an operator
+sees while the panels are torn down and split back one at a time.
+
+Most of those commands read nothing back, so tmux takes them as one list. The four kills
+and their four disarms are one invocation now; so is each end's window dressing, so are the
+four splits, and so are the four respawn hooks. Nothing was dropped and nothing was
+reordered — the same commands, in the same order, in less than half the invocations and a
+third fewer repaints. It is not silent: 17 updates is still four panel processes coming up
+and painting themselves, which is a different cost and not this one.
 
 A switch is refused, with the reason on your own screen, for a chat this workspace does not
 have, one whose window has gone, one charter has no pane record for, and the chat you are
@@ -473,7 +517,8 @@ as long as the message asks for. So every persona and chat switch put a sentence
 announcing a repaint that the same sentence was hiding — and so did a workspace switch,
 while there was one: measured with a real client, the panes were correct at 0.5 s and the
 operator went on looking at the previous workspace until 4.3 s — on tmux 3.7c and at the 3.2 floor alike, within 0.1 s of each
-other. The same switch now reaches your eyes in **0.33 s**, with no stale window at all.
+other. The same switch now reaches your eyes in **0.16 s**, with no stale window at all —
+0.33 s until #780 batched the tmux commands it spends that time in.
 
 The row is also the only surface that can be aimed at *your* frame. `display-message -t`
 selects the target for format evaluation, not the client — measured on both versions, a
@@ -505,7 +550,7 @@ switching does not move the chat.
 
 **Neither is drawn unless a plane places it**, and that is deliberate rather than
 unfinished: on the ordinary plane there is one chat, and a row saying so permanently costs
-a row off your harness, a 24 MB panel process, and about seven of every switch's 41 tmux
+a row off your harness, a 24 MB panel process, and a share of every switch's tmux
 commands — to draw a name `F2` already reaches in two keystrokes. Turn one on with a
 `[[frame.component]]` table, which is also how it gets a key of its own.
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -106,8 +106,8 @@ Measured on a four-panel frame at 200x50, from the first tmux command to the att
 
 | | tmux invocations | wall clock |
 |---|---|---|
-| tmux 3.7c | 46 → **20** | 245 ms → **114 ms** |
-| at the 3.2 floor | 42 → **19** | 184 ms → **83 ms** |
+| tmux 3.7c | 46 → **17** | 227 ms → **91 ms** |
+| at the 3.2 floor | 42 → **16** | 174 ms → **69 ms** |
 
 No client is attached during any of that, by construction — there is nothing to attach to
 until `attach` — which is why the blank has no progress line and cannot have one (#728).
@@ -472,12 +472,12 @@ switched away from are not idle, they are drawing at a width that is not their w
 The switch therefore tears the old chat's panels down, selects the new window (tmux resizes
 it *at* that moment), and splits fresh panels into a window that is already the right size.
 
-**It costs about a sixth of a second.** Measured with a real client and four panels:
+**It costs about a seventh of a second.** Measured with a real client and four panels:
 
 | | tmux invocations | wall clock | times your terminal is repainted |
 |---|---|---|---|
-| tmux 3.7c | 58 → **26** | 329 ms → **162 ms** | 45 → **17** |
-| at the 3.2 floor | 50 → **24** | 243 ms → **127 ms** | 41 → **15** |
+| tmux 3.7c | 58 → **23** | 314 ms → **142 ms** | 45 → **14** |
+| at the 3.2 floor | 50 → **21** | 237 ms → **114 ms** | 41 → **12** |
 
 That is the price of not keeping four panel processes per chat drawing at the wrong width,
 and it is the whole cost — nothing is lost, no harness is restarted, and the chat you left
@@ -494,9 +494,9 @@ sees while the panels are torn down and split back one at a time.
 Most of those commands read nothing back, so tmux takes them as one list. The four kills
 and their four disarms are one invocation now; so is each end's window dressing, so are the
 four splits, and so are the four respawn hooks. Nothing was dropped and nothing was
-reordered — the same commands, in the same order, in less than half the invocations and a
-third fewer repaints. It is not silent: 17 updates is still four panel processes coming up
-and painting themselves, which is a different cost and not this one.
+reordered — the same commands, in the same order, in 40% of the invocations and a third of
+the repaints. It is not silent: 14 updates is still four panel processes coming up and
+painting themselves, which is a different cost and not this one.
 
 A switch is refused, with the reason on your own screen, for a chat this workspace does not
 have, one whose window has gone, one charter has no pane record for, and the chat you are
@@ -517,7 +517,7 @@ as long as the message asks for. So every persona and chat switch put a sentence
 announcing a repaint that the same sentence was hiding — and so did a workspace switch,
 while there was one: measured with a real client, the panes were correct at 0.5 s and the
 operator went on looking at the previous workspace until 4.3 s — on tmux 3.7c and at the 3.2 floor alike, within 0.1 s of each
-other. The same switch now reaches your eyes in **0.16 s**, with no stale window at all —
+other. The same switch now reaches your eyes in **0.14 s**, with no stale window at all —
 0.33 s until #780 batched the tmux commands it spends that time in.
 
 The row is also the only surface that can be aimed at *your* frame. `display-message -t`

--- a/docs/news/unreleased-charter-says-the-same-things-to-tmux-in-half-the-invocations.md
+++ b/docs/news/unreleased-charter-says-the-same-things-to-tmux-in-half-the-invocations.md
@@ -19,10 +19,10 @@ A real attached client at 200x50 with four panels, `charter frame-chat` and a wh
 
 | | invocations | wall clock | times the terminal is repainted |
 |---|---|---|---|
-| switch, 3.7c | 58 → **26** | 329 ms → **162 ms** | 45 → **17** |
-| switch, 3.2 | 50 → **24** | 243 ms → **127 ms** | 41 → **15** |
-| launch, 3.7c | 46 → **20** | 245 ms → **114 ms** | — |
-| launch, 3.2 | 42 → **19** | 184 ms → **83 ms** | — |
+| switch, 3.7c | 58 → **23** | 314 ms → **142 ms** | 45 → **14** |
+| switch, 3.2 | 50 → **21** | 237 ms → **114 ms** | 41 → **12** |
+| launch, 3.7c | 46 → **17** | 227 ms → **91 ms** | — |
+| launch, 3.2 | 42 → **16** | 174 ms → **69 ms** | — |
 
 The third column is the jumping. tmux redraws once per command **list**, not once per
 command, so four `split-window`s sent one at a time are four screen updates ~5 ms apart —
@@ -35,7 +35,7 @@ Nothing charter says to tmux, and nothing about the order it says it in. tmux pa
 nothing back go as one invocation: the window's dressing (`remain-on-exit`, the five
 border options, the two rules round the harness), a doomed panel's disarm beside its own
 `kill-pane`, the ten writes a launch uses to tell its window and session what they are,
-each pane's own options, the respawn hooks, and the row resizes.
+every new pane's own options, the respawn hooks, and the row resizes.
 
 The four `split-window`s go together too, which needed a measurement rather than an
 argument: a chain of them answers with **one pane id per line, in the order given**, on

--- a/docs/news/unreleased-charter-says-the-same-things-to-tmux-in-half-the-invocations.md
+++ b/docs/news/unreleased-charter-says-the-same-things-to-tmux-in-half-the-invocations.md
@@ -24,9 +24,16 @@ A real attached client at 200x50 with four panels, `charter frame-chat` and a wh
 | launch, 3.7c | 46 → **17** | 227 ms → **91 ms** | — |
 | launch, 3.2 | 42 → **16** | 174 ms → **69 ms** | — |
 
-The third column is the jumping. tmux redraws once per command **list**, not once per
-command, so four `split-window`s sent one at a time are four screen updates ~5 ms apart —
-the panels arriving one by one — and four sent as one list are one.
+The third column is the jumping, and it is a direct reading rather than an inference: the
+bytes tmux wrote to a real client's terminal, grouped into bursts with more than 3 ms of
+silence between them. tmux redraws once per command **list**, not once per command, so four
+`split-window`s sent one at a time are four screen updates ~5 ms apart — the panels arriving
+one by one — and four sent as one list are one. There is no tmux command that suppresses
+paints while a batch applies (`refresh-client` forces one, its `-A pane:off` is control-mode
+only, and `suspend-client` stops the client process); fewer command lists is the mechanism.
+
+What is left is not nothing: 14 updates is still four `charter panel` processes starting and
+painting themselves, which is a different cost and a different lever.
 
 ## What changed
 
@@ -45,8 +52,10 @@ actually watches arrive — become a single repaint.
 **The switch still tears the old chat's panels down and splits fresh ones in, and that is
 not the part to optimise away.** A tmux window that is not current keeps the size it had,
 so panels left running in a chat you switched away from are not idle — they are drawing at
-a width that is no longer their window's. The teardown is a correctness rule; what it was
-not is 41 separate conversations with the server.
+a width that is no longer their window's. Re-verified on both versions while doing this: a
+client at 200x50 resized to 100x30 leaves the window it is not on at 200x50, and tmux
+resizes it at the `select-window`. The teardown is a correctness rule; what it was not is
+58 separate conversations with the server.
 
 ## What a failure costs, because a batch could have made that worse
 

--- a/docs/news/unreleased-charter-says-the-same-things-to-tmux-in-half-the-invocations.md
+++ b/docs/news/unreleased-charter-says-the-same-things-to-tmux-in-half-the-invocations.md
@@ -1,0 +1,68 @@
+---
+version: unreleased
+headline: A chat switch is half the wait and a third of the flicker
+---
+
+*"I see very slow rendering on switching — it seems re-rendering all and I see jumping
+texts ~0.2 sec, then it's ready."*
+
+Both halves of that are one defect, and it is not what the frame *does* — it is how many
+times charter has to speak to say it. A tmux command is a round trip over a socket, ~5 ms
+on the machine this was measured on and ~13.4 ms on the operator's. A four-panel chat
+switch made **58** of them, and a launch made **46** before it could put anything on
+screen. Two thirds read nothing back.
+
+## What was measured
+
+A real attached client at 200x50 with four panels, `charter frame-chat` and a whole
+`charter claude` up to the attach, on tmux 3.7c and at the 3.2 floor:
+
+| | invocations | wall clock | times the terminal is repainted |
+|---|---|---|---|
+| switch, 3.7c | 58 → **26** | 329 ms → **162 ms** | 45 → **17** |
+| switch, 3.2 | 50 → **24** | 243 ms → **127 ms** | 41 → **15** |
+| launch, 3.7c | 46 → **20** | 245 ms → **114 ms** | — |
+| launch, 3.2 | 42 → **19** | 184 ms → **83 ms** | — |
+
+The third column is the jumping. tmux redraws once per command **list**, not once per
+command, so four `split-window`s sent one at a time are four screen updates ~5 ms apart —
+the panels arriving one by one — and four sent as one list are one.
+
+## What changed
+
+Nothing charter says to tmux, and nothing about the order it says it in. tmux parses a
+`;`-separated list and runs the whole thing server-side, in order, so the groups that read
+nothing back go as one invocation: the window's dressing (`remain-on-exit`, the five
+border options, the two rules round the harness), a doomed panel's disarm beside its own
+`kill-pane`, the ten writes a launch uses to tell its window and session what they are,
+each pane's own options, the respawn hooks, and the row resizes.
+
+The four `split-window`s go together too, which needed a measurement rather than an
+argument: a chain of them answers with **one pane id per line, in the order given**, on
+3.7c and at the 3.2 floor alike. That is what let the splits — the ones the operator
+actually watches arrive — become a single repaint.
+
+**The switch still tears the old chat's panels down and splits fresh ones in, and that is
+not the part to optimise away.** A tmux window that is not current keeps the size it had,
+so panels left running in a chat you switched away from are not idle — they are drawing at
+a width that is no longer their window's. The teardown is a correctness rule; what it was
+not is 41 separate conversations with the server.
+
+## What a failure costs, because a batch could have made that worse
+
+A refused command **abandons the rest of a tmux command list** — measured on both versions:
+`set-option @a 1 ; set-option nosuchoption 1 ; set-option @b 1` sets `@a`, refuses the
+middle one, and never sets `@b`. Charter's frame is written around each of those writes
+failing on its own, with its own sentence about what an operator loses — the escape hatch,
+the exit code, the palette's own actions. So a batch that comes back non-zero is thrown
+away and every write is re-issued one at a time, through exactly the calls, codes and
+sentences that were there before. The fast path is one invocation; the failure path is one
+wasted invocation and then the old behaviour, unchanged.
+
+The one batch that reads a value back — the splits — cannot be replayed that way, because
+a repeated `split-window` is a second pane. It counts the ids that came back instead: the
+command at that index is the one tmux refused, nothing after it ran, and those are the ones
+re-issued. A tmux that timed out is not retried at all, in either batch: a timeout does not
+say the write did not happen.
+
+Closes #780.

--- a/tests/_tmuxchain.py
+++ b/tests/_tmuxchain.py
@@ -62,13 +62,53 @@ def answer(one, argv: list[str], **kwargs) -> subprocess.CompletedProcess:
 
     A single command is handed straight through, so a fake wrapped in this behaves
     identically for every invocation charter has always made.
+
+    For the fakes that stand in for `subprocess.run`, whose handler takes the argv first.
+    :func:`answer_run` is the same fold for the ones that stand in for `tmuxctl.run`,
+    whose handler takes the action phrase in front of it.
     """
+    return _fold(one, argv, (), kwargs)
+
+
+def answer_run(one, action: str, argv: list[str], **kwargs
+               ) -> subprocess.CompletedProcess:
+    """:func:`answer` for a fake patched in over `tmuxctl.run` rather than over
+    `subprocess.run` — one whose handler is called ``one(action, argv, …)``.
+
+    The action phrase travels UNSPLIT to every command in the list, which is what
+    `tmuxctl.write_all` really does with it: the chained invocation carries one joint
+    phrase, and a fake that recorded a different phrase per command would be describing
+    a call charter never made.
+    """
+    return _fold(one, argv, (action,), kwargs)
+
+
+def recorder(calls: list, *, stdout: str = "", rc: int = 0):
+    """A stand-in for `tmuxctl.run` that records one entry per tmux COMMAND.
+
+    For the dozen tests whose whole fake is "write down what charter said" — they hold a
+    list and read options out of it by position (``a[-2]``, ``a[-1]``), which a chained
+    invocation would answer for its LAST command only. :func:`commands` is what puts each
+    command back in the list under its own entry, so those readings mean what they meant
+    before #780 batched the writes.
+
+    It returns a real `CompletedProcess` rather than ``None``, which the lambdas this
+    replaces did: `tmuxctl.write_all` branches on the chain's return code, so a fake that
+    answers nothing is a fake charter cannot use.
+    """
+    def run(_action, argv, **_kw):
+        calls.extend(commands(argv))
+        return subprocess.CompletedProcess(argv, rc, stdout, "")
+    return run
+
+
+def _fold(one, argv, before, kwargs) -> subprocess.CompletedProcess:
     parts = commands(argv)
     if len(parts) == 1:
-        return one(argv, **kwargs)
+        return one(*before, argv, **kwargs)
     stdout = []
     for part in parts:
-        p = one(part, **kwargs)
+        p = one(*before, part, **kwargs)
         stdout.append(p.stdout or "")
         if p.returncode != 0:
             # Everything after this one is not run — see the module docstring's second

--- a/tests/_tmuxchain.py
+++ b/tests/_tmuxchain.py
@@ -1,0 +1,79 @@
+"""A tmux fake that understands a command LIST, because since #780 charter sends them.
+
+`tmuxctl.write_all` and `commands_frame._split_all` batch every write nothing reads back
+into one invocation — a launch's window dressing, a switch's kills, four `split-window`s
+— so a fake that dispatched on ``"set-option" in cmd`` would be answered once for a
+command carrying eight of them, and the suite's assertions about WHAT charter told tmux
+would quietly stop seeing seven of the eight.
+
+The fix is not to teach forty tests about chains: it is to make the fakes model the tmux
+that is really there. :func:`answer` splits an invocation into the commands it carries,
+runs each through the fake's own one-command handler, and folds the results the way tmux
+folds them — so `fake.calls` goes on holding one entry per tmux COMMAND, exactly as it did
+when charter sent them one at a time, and every existing assertion keeps its meaning. What
+changes is only that a test may now also ask how many INVOCATIONS those commands cost,
+which is the number #780 is about.
+
+**Both halves of the fold are measured against real tmux, on 3.7c and at the 3.2 floor,
+and neither is a guess.**
+
+* **Output is concatenated, in order.** Four `split-window -P -F '#{pane_id}'` in one
+  invocation print four ids, one per line, in the order given.
+* **A failing command ABORTS the rest.** ``set-option @a 1 ; set-option nosuchoption 1 ;
+  set-option @b 1`` sets `@a`, refuses the middle one and never sets `@b` — rc 1, third
+  command not run. A fake that ran the whole list regardless would let a test pass on a
+  batch real tmux would have abandoned half-way, which is the one thing batching can
+  genuinely break.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from charter.frame import tmuxctl
+
+
+def commands(argv: list[str]) -> list[list[str]]:
+    """One tmux invocation, back into the commands it carries — always at least one.
+
+    The head is the first three elements, which is exactly what `tmuxctl.chain` puts in
+    front and exactly what `tmuxctl.server_argv` builds (`tmux`, `-L`/`-S`, the server);
+    every command in a chain shares it, so every command this hands back carries it too
+    and a fake cannot tell a batched command from a lone one.
+
+    A separator is a STANDALONE ``;`` argument and never a character inside another one —
+    `tmuxctl.SEPARATOR`'s own measurement, and the reason `@charter_hatch`'s value
+    (``select-pane -t %1 ; kill-pane -t %2``, one argv element) survives a round trip
+    through here whole.
+    """
+    head, out, cur = argv[:3], [], []
+    for part in argv[3:]:
+        if part == tmuxctl.SEPARATOR:
+            out.append(head + cur)
+            cur = []
+        else:
+            cur.append(part)
+    out.append(head + cur)
+    return out
+
+
+def answer(one, argv: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """*argv* run through *one* — a fake's own single-command handler — tmux's way.
+
+    A single command is handed straight through, so a fake wrapped in this behaves
+    identically for every invocation charter has always made.
+    """
+    parts = commands(argv)
+    if len(parts) == 1:
+        return one(argv, **kwargs)
+    stdout = []
+    for part in parts:
+        p = one(part, **kwargs)
+        stdout.append(p.stdout or "")
+        if p.returncode != 0:
+            # Everything after this one is not run — see the module docstring's second
+            # measurement. The output of the commands that DID run is still returned,
+            # which is what `_split_all` counts to learn how far the list got.
+            return subprocess.CompletedProcess(argv, p.returncode, "".join(stdout),
+                                               p.stderr)
+    return subprocess.CompletedProcess(argv, 0, "".join(stdout), "")

--- a/tests/test_a_frame_repaints_once_its_shape_is_recorded.py
+++ b/tests/test_a_frame_repaints_once_its_shape_is_recorded.py
@@ -44,6 +44,7 @@ from unittest import mock
 
 from charter import commands_frame, persona, tui
 from charter.frame import panel, slots, state
+from tests import _tmuxchain
 from tests._isolation import PersonaIso
 
 #: The roster the sidebar already draws — what must not also be on the identity row.
@@ -74,14 +75,28 @@ class _Tmux:
     def __init__(self, new_panes=("%11", "%12", "%13", "%14")):
         self.new_panes = list(new_panes)
         self.calls: list[list[str]] = []
+        #: One entry per tmux INVOCATION, where `calls` has one per
+        #: tmux COMMAND — see :meth:`__call__`.
+        self.invocations: list[list[str]] = []
 
     def __call__(self, action, argv, *, env=None, timeout=None, report=True):
+        """One tmux INVOCATION, which since #780 may carry several commands.
+
+        Split through `tests/_tmuxchain.answer_run` so `self.calls` keeps one entry per
+        tmux COMMAND — the list every assertion here reads — where charter now spends
+        one invocation on a whole group of them.
+        """
+        self.invocations.append(list(argv))
+        return _tmuxchain.answer_run(self._one, action, argv, env=env, timeout=timeout,
+                                     report=report)
+
+    def _one(self, action, argv, *, env=None, timeout=None, report=True):
         self.calls.append(list(argv))
         out = ""
         if "display-message" in argv:
             out = "200:50"
         elif "split-window" in argv:
-            out = self.new_panes.pop(0) if self.new_panes else ""
+            out = f"{self.new_panes.pop(0)}\n" if self.new_panes else ""
         return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
 

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -9,10 +9,10 @@ this was written on and ~13.4 ms on the one that filed #728. Measured with a rea
 ===================  ==================  ====================  ====================
 path and tmux        invocations         wall clock            terminal repaints
 ===================  ==================  ====================  ====================
-switch, 3.7c         58 -> 23            329 ms -> 155 ms      45 -> 15
-switch, 3.2          50 -> 21            243 ms -> 121 ms      41 -> 13
-launch, 3.7c         46 -> 17            245 ms -> 95 ms       (no client yet)
-launch, 3.2          42 -> 16            184 ms -> 77 ms       (no client yet)
+switch, 3.7c         58 -> 23            314 ms -> 142 ms      45 -> 14
+switch, 3.2          50 -> 21            237 ms -> 114 ms      41 -> 12
+launch, 3.7c         46 -> 17            227 ms -> 91 ms       (no client yet)
+launch, 3.2          42 -> 16            174 ms -> 69 ms       (no client yet)
 ===================  ==================  ====================  ====================
 
 The repaint column is the *"jumping"*: tmux redraws once per command LIST rather than once
@@ -207,6 +207,10 @@ class ALaunchAndASwitchSpendWhatTheyMeasured(PersonaIso, unittest.TestCase):
 
     def test_a_four_panel_launch_sends_fifteen_invocations_up_to_the_attach(self):
         """The whole private-server launch, up to and including `attach`. It was 44.
+
+        Against THIS MODULE'S fake, which is what makes the number assertable at all; a
+        real launch on a real server makes two more reads than the fake does (46 -> 17
+        measured), and the shape of the saving is the same one.
 
         Five batches carry 33 of the 47 commands: the ten writes that tell the window and
         session what they are, the window's own dressing, the four splits, every pane's

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -1,0 +1,397 @@
+"""#780: what charter says to tmux is unchanged; how many times it says it is not.
+
+The operator's report was *"very slow rendering on switching — it seems re-rendering all
+and I see jumping texts ~0.2 sec, then it's ready"*, and both halves of it are one defect:
+charter issued every tmux command on its own, and a round trip is ~5 ms on the machine
+this was written on and ~13.4 ms on the one that filed #728. Measured with a real client
+and four panels, before this change:
+
+===========================  ===============  =============  ===============  =============
+path                         3.7c invocations 3.7c wall      3.2 invocations  3.2 wall
+===========================  ===============  =============  ===============  =============
+dressing and splitting        26              147 ms         22               105 ms
+a chat switch                 58              321 ms         50               237 ms
+===========================  ===============  =============  ===============  =============
+
+and after it, 9 / 57 ms, 8 / 42 ms, 26 / 159 ms and 24 / 133 ms. `docs/frame.md` carries
+the full table including what the operator's terminal was actually asked to repaint.
+
+**Three kinds of test, because the claim has three parts.**
+
+1. **What tmux does with a command list** (:class:`WhatARealTmuxDoesWithACommandList`) —
+   the two facts every batch here rests on, asked of a real server rather than believed:
+   a chain answers for every command in it, and a refused command ABORTS the rest. Both
+   were measured by hand on tmux 3.7c and at the 3.2 floor first; this is what makes them
+   fail loudly if a later tmux changes its mind. It needs a tmux SERVER and no client, so
+   it runs in CI.
+2. **What charter now spends** (:class:`ALaunchAndASwitchSpendWhatTheyMeasured`) — the
+   invocation counts, against the suite's own fakes, on a machine with no tmux at all.
+   A count is the only assertion that catches the regression this issue is about: every
+   other test here reads `fake.calls`, which holds one entry per tmux COMMAND and is
+   deliberately unchanged by batching (`tests/_tmuxchain.py`).
+3. **What a failure still costs** (:class:`AFailedBatchIsEveryCallItUsedToBe`) — the
+   fallback, which is the whole reason this is `tmuxctl.write_all` and not `chain`.
+   Charter's callers are written around each write failing on its own, with its own
+   sentence and its own consequence; a batch that lost those would be a worse frame than
+   the round trips bought.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config
+from charter.frame import state, tmuxctl
+
+from tests import _tmuxchain, _tmuxreap
+from tests._isolation import PersonaIso
+# At module scope, and that is load-bearing rather than tidy: `test_frame_launcher`
+# captures the developer's real `config.STATE_DIR` at IMPORT time and refuses to run a
+# real `cmd_launch` against it. Imported from inside a test method — after `PersonaIso`
+# has already repointed the plane — it would capture the ISOLATED directory as "the real
+# one" and refuse every launch here for a plane nobody owns.
+from tests.test_frame_chat_switch import _FakeServer, _plant
+from tests.test_frame_launcher import _FakeTmux, _launch
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: One socket for this module, carrying this process's pid so an interrupted run's server
+#: is reaped by the next one rather than collided with (`tests/_tmuxreap.py`).
+SOCKET = _tmuxreap.name("one-invocation")
+
+#: The four edges a full frame draws, in the order a launch splits them.
+_FOUR = ["right", "top", "bottom", "repos"]
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class WhatARealTmuxDoesWithACommandList(unittest.TestCase):
+    """The two properties `tmuxctl.write_all` and `commands_frame._split_all` rest on.
+
+    **A server and no client**, which is what makes this runnable in CI: nothing here
+    attaches anything or draws anything, so `TERM=dumb` and no controlling terminal are
+    no obstacle. What it needs is a tmux that will start a detached session, which CI has.
+    """
+
+    def setUp(self):
+        self.addCleanup(lambda: subprocess.run(
+            ["tmux", "-L", SOCKET, "kill-server"], capture_output=True))
+        started = self._tmux("new-session", "-d", "-s", "s", "-x", "80", "-y", "24",
+                             "-P", "-F", "#{pane_id}", "cat")
+        self.assertEqual(started.returncode, 0, started.stderr)
+        self.pane = started.stdout.strip()
+        self.assertTrue(self.pane.startswith("%"), started.stdout)
+
+    def _tmux(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(["tmux", "-L", SOCKET, *args],
+                              capture_output=True, text=True, timeout=15)
+
+    def _option(self, name: str) -> str:
+        """One window option's value, or ``""`` where this tmux has none set.
+
+        `show-options -v` answers an unset user option with an error at 3.7c and with an
+        empty line at the 3.2 floor, so BOTH are read as "not set" — the fact under test
+        is that the value is not the one the aborted command carried, and a version's
+        choice of how to say "nothing here" must not decide whether this passes.
+        """
+        got = self._tmux("show-options", "-w", "-t", self.pane, "-v", name)
+        return got.stdout.strip() if got.returncode == 0 else ""
+
+    def test_a_chain_answers_for_every_command_in_it(self):
+        """What `_split_all` reads: four `split-window -P -F` in ONE invocation print four
+        pane ids, one per line, in the order they were given.
+
+        Without this the four splits could not be batched at all — each one's answer is
+        the `-t` of the pane options that follow it, and a batch that could only report
+        the last would be a frame with three unmarked panels.
+        """
+        argv = tmuxctl.chain([
+            tmuxctl.server_argv(SOCKET, "split-window", "-t", self.pane, "-v", "-l", "1",
+                                "-P", "-F", "#{pane_id}", "--", "cat")
+            for _ in range(4)])
+        out = subprocess.run(argv, capture_output=True, text=True, timeout=15)
+        self.assertEqual(out.returncode, 0, out.stderr)
+        ids = out.stdout.split()
+        self.assertEqual(len(ids), 4, out.stdout)
+        self.assertEqual(len(set(ids)), 4, "four splits reported one pane four times")
+        for pane in ids:
+            self.assertRegex(pane, r"^%\d+$")
+        listed = self._tmux("list-panes", "-t", self.pane, "-F", "#{pane_id}")
+        self.assertEqual(sorted(listed.stdout.split()), sorted([self.pane, *ids]),
+                         "the window does not hold the panes the chain reported")
+
+    def test_a_refused_command_abandons_the_rest_of_the_list(self):
+        """The measurement `tmuxctl.write_all`'s whole fallback exists for.
+
+        Three writes, the middle one naming an option no tmux has: the first takes, the
+        third **does not run at all**, and the invocation returns non-zero. So a chain is
+        one command as far as failure is concerned, while charter's callers are written
+        around each write failing on its own — which is why a non-zero chain is re-issued
+        one write at a time rather than merely reported.
+        """
+        good, bad = "@charter_batch_probe_a", "@charter_batch_probe_b"
+        argv = tmuxctl.chain([
+            tmuxctl.server_argv(SOCKET, "set-option", "-w", "-t", self.pane, good, "1"),
+            tmuxctl.server_argv(SOCKET, "set-option", "-w", "-t", self.pane,
+                                "charter-is-not-a-tmux-option", "1"),
+            tmuxctl.server_argv(SOCKET, "set-option", "-w", "-t", self.pane, bad, "1")])
+        out = subprocess.run(argv, capture_output=True, text=True, timeout=15)
+        self.assertNotEqual(out.returncode, 0, out.stdout)
+        self.assertEqual(self._option(good), "1",
+                         "the command BEFORE the refusal did not take either — this "
+                         "measurement is about where a list stops, and it has to have "
+                         "started")
+        self.assertNotEqual(self._option(bad), "1",
+                            "the command after the refusal ran, so a chain no longer "
+                            "abandons its tail — `tmuxctl.write_all`'s fallback is "
+                            "written for a tmux that does")
+
+    def test_unsetting_a_hook_nothing_set_is_not_a_failure(self):
+        """What lets `_reconcile_panels` batch each disarm beside its own `kill-pane`.
+
+        If `set-hook -p -u pane-died` failed on a pane with no such hook — a panel charter
+        declined to arm, or one from a charter that predates #382 — the chain would abort
+        there and the `kill-pane` after it would never run, so a density change would
+        leave the panel the operator just dropped on screen.
+        """
+        out = self._tmux("set-hook", "-p", "-u", "-t", self.pane, "pane-died")
+        self.assertEqual(out.returncode, 0, out.stderr)
+
+
+class ALaunchAndASwitchSpendWhatTheyMeasured(PersonaIso, unittest.TestCase):
+    """The counts, on a machine with no tmux — the assertion that catches a batch quietly
+    coming apart again.
+
+    **A number rather than a bound**, and deliberately: "no more than N" would go on
+    passing through every regression that added a round trip back one at a time, which is
+    exactly how 42 became 43 and 41 became 58 between #780 being filed and being fixed.
+    A count that has to be edited is a count somebody has to look at.
+    """
+
+    def test_a_four_panel_launch_sends_eighteen_invocations_up_to_the_attach(self):
+        """The whole private-server launch, up to and including `attach`. It was 44.
+
+        Batched: the ten writes that tell the window and session what they are (one), the
+        window's own dressing (one), the four splits (one), each pane's two options (one
+        PER PANE — a pane's `%N` is not known until its own split has answered), and the
+        four respawn hooks (one).
+
+        Unbatched, and named here so a reader can see what is left rather than guess: two
+        reaping reads, `new-session`, the eager death check, `list-panes`, the resize
+        hook, the window-seat read, `select-window`, `select-pane`, `attach`.
+        """
+        fake = _FakeTmux(panel_pane_ids={"top": "%11", "bottom": "%12",
+                                         "right": "%13", "repos": "%14"},
+                         still_live=True)
+        with mock.patch.dict(config.FRAME, {"slots": list(_FOUR)}):
+            self.assertEqual(_launch(fake, cols=200, rows=50), 0)
+        attach = next(i for i, c in enumerate(fake.invocations) if "attach" in c)
+        self.assertEqual(attach + 1, 18,
+                         [" ".join(c[3:])[:70] for c in fake.invocations[:attach + 1]])
+        # And every command is still issued — batching moved them, it did not drop them.
+        self.assertEqual(len([c for c in fake.calls if "split-window" in c]), 4)
+        self.assertEqual(sorted(state.panes(_the_chat(fake))),
+                         ["bottom", "repos", "right", "top"])
+
+    def test_a_four_panel_switch_sends_twenty_six_invocations(self):
+        """The `charter frame-chat` path: tear four panels down, select the window, split
+        four fresh ones in.
+
+        The teardown's eight commands (a disarm and a kill per panel) are one invocation,
+        each end's window dressing is one, the four splits are one, and the four respawn
+        hooks are one.
+        """
+        _plant("api.1", workspace="api", pane="%1")
+        _plant("api.2", workspace="api", pane="%2")
+        state.record_server("api.1", commands_frame.SOCKET)
+        state.record_server("api.2", commands_frame.SOCKET)
+        state.record_panes("api.1", panels={"top": "%3", "bottom": "%4",
+                                            "right": "%5", "repos": "%6"})
+        fake = _FakeServer(size="200:50")
+        with mock.patch.object(tmuxctl, "run", fake), \
+             mock.patch.object(tmuxctl, "version", lambda: (3, 7)), \
+             mock.patch.dict(config.FRAME, {"slots": list(_FOUR)}), \
+             mock.patch.dict("os.environ", {"CHARTER_SESSION_ID": "api.1",
+                                            "CHARTER_WORKSPACE": "api"}, clear=False):
+            self.assertEqual(
+                commands_frame.cmd_chat(SimpleNamespace(chat_id="api.2")), 0)
+        self.assertEqual(len(fake.invocations), 26,
+                         [" ".join(c[3:])[:70] for c in fake.invocations])
+        self.assertEqual(len([c for c in fake.calls if "kill-pane" in c]), 4)
+        self.assertEqual(len([c for c in fake.calls if "split-window" in c]), 4)
+
+
+def _the_chat(fake) -> str:
+    """The chat id the launch under test gave its window — read off the fake rather than
+    spelled, because the ordinal depends on what the plane already held."""
+    assert fake.fid, "the launch never named its chat"
+    return fake.fid
+
+
+class AFailedBatchIsEveryCallItUsedToBe(unittest.TestCase):
+    """`tmuxctl.write_all`'s fallback, which is what makes batching safe to do at all.
+
+    Every caller batched by #780 branches on each write's own return code and says its own
+    sentence about what an operator loses. Those sentences are the reason the frame is
+    debuggable, and a batch that collapsed them into one phrase would trade a real thing
+    for round trips. So a chain that comes back non-zero is thrown away and every write is
+    re-issued on its own — which is only sound because every write in a batch means the
+    same thing twice.
+    """
+
+    def _writes(self):
+        return [tmuxctl.Write("arming a", tmuxctl.server_argv("s", "set-option", "@a", "1")),
+                tmuxctl.Write("arming b", tmuxctl.server_argv("s", "set-option", "@b", "2")),
+                tmuxctl.Write("arming c", tmuxctl.server_argv("s", "set-option", "@c", "3"),
+                              report=False)]
+
+    def _spy(self, answer):
+        seen = []
+
+        def run(action, argv, **kw):
+            seen.append((action, list(argv), kw.get("report", True)))
+            return answer(argv)
+
+        return seen, run
+
+    def test_a_batch_that_takes_is_one_invocation(self):
+        seen, run = self._spy(lambda argv: subprocess.CompletedProcess(argv, 0, "", ""))
+        with mock.patch.object(tmuxctl, "run", run):
+            out = tmuxctl.write_all("arming the lot", self._writes())
+        self.assertEqual(len(seen), 1, seen)
+        self.assertEqual(seen[0][0], "arming the lot")
+        self.assertEqual(seen[0][1].count(tmuxctl.SEPARATOR), 2, seen[0][1])
+        self.assertEqual([p.returncode for p in out], [0, 0, 0])
+
+    def test_a_batch_that_is_refused_is_re_issued_write_by_write(self):
+        """Each write's OWN action phrase and its own *report* — the two things
+        `tmuxctl.Write` carries, and the two a caller reads a failure through."""
+        seen, run = self._spy(
+            lambda argv: subprocess.CompletedProcess(
+                argv, 0 if tmuxctl.SEPARATOR not in argv else 1, "", "nope"))
+        with mock.patch.object(tmuxctl, "run", run):
+            out = tmuxctl.write_all("arming the lot", self._writes())
+        self.assertEqual([a for a, _, _ in seen],
+                         ["arming the lot", "arming a", "arming b", "arming c"])
+        self.assertEqual([r for _, _, r in seen], [False, True, True, False])
+        self.assertEqual([p.returncode for p in out], [0, 0, 0])
+
+    def test_a_wedged_server_is_reported_once_and_never_re_issued(self):
+        """A timeout does not say the writes did not happen, and re-issuing on that is
+        the one thing idempotence cannot cover. Reported, and handed back to every write
+        so the caller degrades exactly as it does for any other non-zero return."""
+        seen, run = self._spy(
+            lambda argv: subprocess.CompletedProcess(argv, tmuxctl.TIMED_OUT, "", "slow"))
+        said = []
+        with mock.patch.object(tmuxctl, "run", run), \
+             mock.patch.object(tmuxctl, "report_failure",
+                               lambda *a: said.append(a[0])):
+            out = tmuxctl.write_all("arming the lot", self._writes())
+        self.assertEqual(len(seen), 1, seen)
+        self.assertEqual(said, ["arming the lot"])
+        self.assertEqual([p.returncode for p in out], [tmuxctl.TIMED_OUT] * 3)
+
+    def test_a_batch_nothing_would_have_reported_stays_quiet_on_a_wedged_server(self):
+        """`_apply_sizes` opts every `resize-pane` out of reporting, because a pane that
+        died between the map being read and this running is not worth printing over the
+        agent's own screen. Becoming a batch must not start printing it."""
+        quiet = [tmuxctl.Write("sizing a", tmuxctl.server_argv("s", "resize-pane", "-y",
+                                                               "1"), report=False),
+                 tmuxctl.Write("sizing b", tmuxctl.server_argv("s", "resize-pane", "-y",
+                                                               "2"), report=False)]
+        _, run = self._spy(
+            lambda argv: subprocess.CompletedProcess(argv, tmuxctl.TIMED_OUT, "", "slow"))
+        said = []
+        with mock.patch.object(tmuxctl, "run", run), \
+             mock.patch.object(tmuxctl, "report_failure",
+                               lambda *a: said.append(a[0])):
+            tmuxctl.write_all("sizing the panels", quiet)
+        self.assertEqual(said, [])
+
+    def test_one_write_is_sent_as_itself_and_never_as_a_list_of_one(self):
+        """A group of one is the ordinary case on the switch's entering end — one panel
+        missing — and a `tmux … ;`-less invocation is what a reader of the failure sees."""
+        seen, run = self._spy(lambda argv: subprocess.CompletedProcess(argv, 0, "", ""))
+        with mock.patch.object(tmuxctl, "run", run):
+            tmuxctl.write_all("arming the lot", self._writes()[:1])
+        self.assertEqual([a for a, _, _ in seen], ["arming a"])
+        self.assertNotIn(tmuxctl.SEPARATOR, seen[0][1])
+
+    def test_nothing_to_write_is_no_invocation_at_all(self):
+        seen, run = self._spy(lambda argv: subprocess.CompletedProcess(argv, 0, "", ""))
+        with mock.patch.object(tmuxctl, "run", run):
+            self.assertEqual(tmuxctl.write_all("arming the lot", []), [])
+        self.assertEqual(seen, [])
+
+
+class ARefusedSplitStillCostsOnlyItsOwnPanel(PersonaIso, unittest.TestCase):
+    """`commands_frame._split_all` — the one batch that reads a value back.
+
+    A `split-window` is not idempotent, so this cannot use `tmuxctl.write_all`'s replay:
+    re-issuing one that already took is a second pane for one component, which is the
+    #714 shape. What it does instead is count the ids tmux answered with — the command at
+    `len(ids)` is the one that was refused, and nothing after it ran — and re-issue from
+    there one at a time.
+    """
+
+    def _split(self, answer):
+        seen = []
+
+        def run(action, argv, **kw):
+            seen.append((action, list(argv)))
+            return answer(argv)
+
+        cmds = [tmuxctl.server_argv("s", "split-window", "-t", "%0", "-P", "-F",
+                                    "#{pane_id}", "--", "charter", "panel", slot)
+                for slot in _FOUR]
+        with mock.patch.object(tmuxctl, "run", run):
+            made = commands_frame._split_all("s", slots=list(_FOUR), cmds=cmds, env=None)
+        return seen, made
+
+    def test_four_splits_that_take_are_one_invocation_and_four_panes(self):
+        ids = iter(["%10", "%11", "%12", "%13"])
+        seen, made = self._split(
+            lambda argv: subprocess.CompletedProcess(
+                argv, 0, "".join(f"{next(ids)}\n" for _ in range(4)), ""))
+        self.assertEqual(len(seen), 1, seen)
+        self.assertEqual(made, [("right", "%10"), ("top", "%11"),
+                                ("bottom", "%12"), ("repos", "%13")])
+
+    def test_a_refusal_half_way_re_issues_only_what_never_ran(self):
+        """The second split is refused, so tmux ran two commands and printed one id. The
+        remaining two slots are then sent on their own — the failing one included, which
+        is what makes it reportable under "drawing a panel" rather than under the batch's
+        joint phrase."""
+        answers = iter([
+            # The chain: `right` took and printed its id, `top` was refused, and the two
+            # after it never ran at all.
+            subprocess.CompletedProcess([], 1, "%10\n", "no space for a new pane"),
+            # `top` again, on its own, and refused again — this is the call that gets to
+            # say "drawing a panel" rather than the batch's joint phrase.
+            subprocess.CompletedProcess([], 1, "", "no space for a new pane"),
+            subprocess.CompletedProcess([], 0, "%12\n", ""),
+            subprocess.CompletedProcess([], 0, "%13\n", ""),
+        ])
+        seen, made = self._split(lambda argv: next(answers))
+        self.assertEqual([a for a, _ in seen],
+                         ["drawing this frame's panels", "drawing a panel",
+                          "drawing a panel", "drawing a panel"])
+        self.assertEqual(made, [("right", "%10"), ("bottom", "%12"), ("repos", "%13")],
+                         "every slot after the refused one must still be attempted, and "
+                         "the refused one must not be counted as a pane")
+        self.assertNotIn(tmuxctl.SEPARATOR, seen[1][1], "the re-issue is one command")
+
+    def test_a_wedged_tmux_splits_nothing_twice(self):
+        """A timeout does not say the split did not happen. Re-issuing it is how a frame
+        ends up with two panes for one component and a record naming only the second."""
+        said = []
+        with mock.patch.object(tmuxctl, "report_failure",
+                               lambda *a: said.append(a[0])):
+            seen, made = self._split(
+                lambda argv: subprocess.CompletedProcess(argv, tmuxctl.TIMED_OUT, "", ""))
+        self.assertEqual(len(seen), 1, seen)
+        self.assertEqual(made, [])
+        self.assertEqual(said, ["drawing this frame's panels"])

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -95,7 +95,14 @@ class WhatARealTmuxDoesWithACommandList(unittest.TestCase):
         cls._tmux_cmd("kill-server")
         held = cls._tmux_cmd("new-session", "-d", "-s", "keep", "-x", "80", "-y", "24",
                              "--", "cat")
-        assert held.returncode == 0, held.stderr
+        if held.returncode != 0:
+            # Raised rather than `assert`ed: an `assert` in a fixture is stripped by
+            # `python -O`, and this suite has a test that says so. Not a skip either —
+            # `_HAS_TMUX` has already established there is a tmux, so a server that will
+            # not start is a fact about this machine worth failing loudly over rather
+            # than a capability to shrug at.
+            raise AssertionError(
+                f"tmux would not hold a session open on {SOCKET}: {held.stderr!r}")
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -77,20 +77,51 @@ class WhatARealTmuxDoesWithACommandList(unittest.TestCase):
     **A server and no client**, which is what makes this runnable in CI: nothing here
     attaches anything or draws anything, so `TERM=dumb` and no controlling terminal are
     no obstacle. What it needs is a tmux that will start a detached session, which CI has.
+
+    **One server for the whole class, HELD open, and #713 is why that is a construction
+    rather than tidiness** (`test_frame_tmux_integration._hold_the_server` measures it).
+    `exit-empty` is on by default: the moment a socket's last session goes, the server
+    retires — and it does not unlink its socket file, so the next `new-session` is a
+    client that finds a socket to connect to rather than a path to build a server at. If
+    it lands while the retiring server still holds its listening fd, the connect succeeds,
+    the command is never run, and tmux answers **`server exited unexpectedly`**, rc 1.
+    A server per test on one socket is three chances at that per run, and this class took
+    one on its first CI run. The keeper session is never a target and never dies, so the
+    server is born once and no client ever rebuilds it.
     """
 
+    @classmethod
+    def setUpClass(cls):
+        cls._tmux_cmd("kill-server")
+        held = cls._tmux_cmd("new-session", "-d", "-s", "keep", "-x", "80", "-y", "24",
+                             "--", "cat")
+        assert held.returncode == 0, held.stderr
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tmux_cmd("kill-server")
+        # `kill-server` ends the server and leaves its socket FILE — measured, and the
+        # reason `tests/_tmuxreap.py` exists at all. Removed here so a run leaks nothing.
+        (_tmuxreap.socket_dir() / SOCKET).unlink(missing_ok=True)
+
+    @classmethod
+    def _tmux_cmd(cls, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(["tmux", "-L", SOCKET, *args],
+                              capture_output=True, text=True, timeout=15)
+
     def setUp(self):
-        self.addCleanup(lambda: subprocess.run(
-            ["tmux", "-L", SOCKET, "kill-server"], capture_output=True))
-        started = self._tmux("new-session", "-d", "-s", "s", "-x", "80", "-y", "24",
-                             "-P", "-F", "#{pane_id}", "cat")
+        # A session of this test's own on the held server. Not killed afterwards: the
+        # server must never become empty (see the class docstring), and `tearDownClass`
+        # takes every session down at once.
+        name = f"s{len(self.id())}{abs(hash(self.id())) % 100000}"
+        started = self._tmux("new-session", "-d", "-s", name, "-x", "80", "-y", "24",
+                             "-P", "-F", "#{pane_id}", "--", "cat")
         self.assertEqual(started.returncode, 0, started.stderr)
         self.pane = started.stdout.strip()
         self.assertTrue(self.pane.startswith("%"), started.stdout)
 
     def _tmux(self, *args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(["tmux", "-L", SOCKET, *args],
-                              capture_output=True, text=True, timeout=15)
+        return self._tmux_cmd(*args)
 
     def _option(self, name: str) -> str:
         """One window option's value, or ``""`` where this tmux has none set.

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -195,6 +195,39 @@ class WhatARealTmuxDoesWithACommandList(unittest.TestCase):
         self.assertEqual(out.returncode, 0, out.stderr)
 
 
+class TheFakesSplitExactlyWhatCharterJoined(unittest.TestCase):
+    """`tests/_tmuxchain.commands` is the inverse of `tmuxctl.chain`, and this is what
+    says so — because every other test in the suite now believes it.
+
+    A fake that split too eagerly would report commands charter never sent; one that split
+    too little would answer a batch of eight with the last one's arguments and let seven
+    assertions quietly stop meaning anything. The case that decides it is an argument
+    CONTAINING a semicolon — `tmuxctl.SEPARATOR`'s own measurement is that tmux reads only
+    a standalone `;` as one, and charter really sends both shapes: the exit-status hook's
+    action is a shell line with a `;` in the middle of it, and the value
+    `frame/overlay.close_argvs` writes back into `@charter_hatch` is a tmux command line
+    with a spaced ` ; ` in it. Either would be torn in half by a character-wise split.
+    """
+
+    def test_a_chain_splits_back_into_the_commands_it_was_built_from(self):
+        hook = commands_frame._pane_died_write_hook_argv(socket="s", harness_pane="%1")
+        self.assertTrue(any(";" in part for part in hook),
+                        "the exit-status hook's action no longer carries a `;` inside "
+                        "one argument, so this test is no longer about the case it names")
+        spaced = tmuxctl.server_argv("s", "set-option", "-w", "-t", "%1",
+                                     "@charter_hatch",
+                                     "select-pane -t %1 ; kill-pane -t %2")
+        argvs = [tmuxctl.server_argv("s", "set-option", "-w", "-t", "%1",
+                                     "remain-on-exit", "on"),
+                 hook, spaced,
+                 tmuxctl.server_argv("s", "kill-pane", "-t", "%2")]
+        self.assertEqual(_tmuxchain.commands(tmuxctl.chain(argvs)), argvs)
+
+    def test_one_command_is_handed_back_whole(self):
+        argv = tmuxctl.server_argv("s", "kill-pane", "-t", "%2")
+        self.assertEqual(_tmuxchain.commands(argv), [argv])
+
+
 class ALaunchAndASwitchSpendWhatTheyMeasured(PersonaIso, unittest.TestCase):
     """The counts, on a machine with no tmux — the assertion that catches a batch quietly
     coming apart again.

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -9,10 +9,10 @@ this was written on and ~13.4 ms on the one that filed #728. Measured with a rea
 ===================  ==================  ====================  ====================
 path and tmux        invocations         wall clock            terminal repaints
 ===================  ==================  ====================  ====================
-switch, 3.7c         58 -> 26            329 ms -> 162 ms      45 -> 17
-switch, 3.2          50 -> 24            243 ms -> 127 ms      41 -> 15
-launch, 3.7c         46 -> 20            245 ms -> 114 ms      (no client yet)
-launch, 3.2          42 -> 19            184 ms -> 83 ms       (no client yet)
+switch, 3.7c         58 -> 23            329 ms -> 155 ms      45 -> 15
+switch, 3.2          50 -> 21            243 ms -> 121 ms      41 -> 13
+launch, 3.7c         46 -> 17            245 ms -> 95 ms       (no client yet)
+launch, 3.2          42 -> 16            184 ms -> 77 ms       (no client yet)
 ===================  ==================  ====================  ====================
 
 The repaint column is the *"jumping"*: tmux redraws once per command LIST rather than once
@@ -205,13 +205,12 @@ class ALaunchAndASwitchSpendWhatTheyMeasured(PersonaIso, unittest.TestCase):
     A count that has to be edited is a count somebody has to look at.
     """
 
-    def test_a_four_panel_launch_sends_eighteen_invocations_up_to_the_attach(self):
+    def test_a_four_panel_launch_sends_fifteen_invocations_up_to_the_attach(self):
         """The whole private-server launch, up to and including `attach`. It was 44.
 
-        Batched: the ten writes that tell the window and session what they are (one), the
-        window's own dressing (one), the four splits (one), each pane's two options (one
-        PER PANE — a pane's `%N` is not known until its own split has answered), and the
-        four respawn hooks (one).
+        Five batches carry 33 of the 47 commands: the ten writes that tell the window and
+        session what they are, the window's own dressing, the four splits, every pane's
+        own options, and the four respawn hooks.
 
         Unbatched, and named here so a reader can see what is left rather than guess: two
         reaping reads, `new-session`, the eager death check, `list-panes`, the resize
@@ -223,20 +222,20 @@ class ALaunchAndASwitchSpendWhatTheyMeasured(PersonaIso, unittest.TestCase):
         with mock.patch.dict(config.FRAME, {"slots": list(_FOUR)}):
             self.assertEqual(_launch(fake, cols=200, rows=50), 0)
         attach = next(i for i, c in enumerate(fake.invocations) if "attach" in c)
-        self.assertEqual(attach + 1, 18,
+        self.assertEqual(attach + 1, 15,
                          [" ".join(c[3:])[:70] for c in fake.invocations[:attach + 1]])
         # And every command is still issued — batching moved them, it did not drop them.
         self.assertEqual(len([c for c in fake.calls if "split-window" in c]), 4)
         self.assertEqual(sorted(state.panes(_the_chat(fake))),
                          ["bottom", "repos", "right", "top"])
 
-    def test_a_four_panel_switch_sends_twenty_six_invocations(self):
+    def test_a_four_panel_switch_sends_twenty_three_invocations(self):
         """The `charter frame-chat` path: tear four panels down, select the window, split
         four fresh ones in.
 
         The teardown's eight commands (a disarm and a kill per panel) are one invocation,
-        each end's window dressing is one, the four splits are one, and the four respawn
-        hooks are one.
+        each end's window dressing is one, the four splits are one, every new pane's
+        options are one, and the four respawn hooks are one.
         """
         _plant("api.1", workspace="api", pane="%1")
         _plant("api.2", workspace="api", pane="%2")
@@ -252,7 +251,7 @@ class ALaunchAndASwitchSpendWhatTheyMeasured(PersonaIso, unittest.TestCase):
                                             "CHARTER_WORKSPACE": "api"}, clear=False):
             self.assertEqual(
                 commands_frame.cmd_chat(SimpleNamespace(chat_id="api.2")), 0)
-        self.assertEqual(len(fake.invocations), 26,
+        self.assertEqual(len(fake.invocations), 23,
                          [" ".join(c[3:])[:70] for c in fake.invocations])
         self.assertEqual(len([c for c in fake.calls if "kill-pane" in c]), 4)
         self.assertEqual(len([c for c in fake.calls if "split-window" in c]), 4)

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -3,18 +3,21 @@
 The operator's report was *"very slow rendering on switching — it seems re-rendering all
 and I see jumping texts ~0.2 sec, then it's ready"*, and both halves of it are one defect:
 charter issued every tmux command on its own, and a round trip is ~5 ms on the machine
-this was written on and ~13.4 ms on the one that filed #728. Measured with a real client
-and four panels, before this change:
+this was written on and ~13.4 ms on the one that filed #728. Measured with a real client at
+200x50 and four panels, before this change and after it:
 
-===========================  ===============  =============  ===============  =============
-path                         3.7c invocations 3.7c wall      3.2 invocations  3.2 wall
-===========================  ===============  =============  ===============  =============
-dressing and splitting        26              147 ms         22               105 ms
-a chat switch                 58              321 ms         50               237 ms
-===========================  ===============  =============  ===============  =============
+===================  ==================  ====================  ====================
+path and tmux        invocations         wall clock            terminal repaints
+===================  ==================  ====================  ====================
+switch, 3.7c         58 -> 26            329 ms -> 162 ms      45 -> 17
+switch, 3.2          50 -> 24            243 ms -> 127 ms      41 -> 15
+launch, 3.7c         46 -> 20            245 ms -> 114 ms      (no client yet)
+launch, 3.2          42 -> 19            184 ms -> 83 ms       (no client yet)
+===================  ==================  ====================  ====================
 
-and after it, 9 / 57 ms, 8 / 42 ms, 26 / 159 ms and 24 / 133 ms. `docs/frame.md` carries
-the full table including what the operator's terminal was actually asked to repaint.
+The repaint column is the *"jumping"*: tmux redraws once per command LIST rather than once
+per command, so four splits sent one at a time are four screen updates ~5 ms apart and
+four sent as one list are one. `docs/frame.md` carries the same table for a reader.
 
 **Three kinds of test, because the claim has three parts.**
 

--- a/tests/test_a_look_keypress_never_edits_the_committed_config.py
+++ b/tests/test_a_look_keypress_never_edits_the_committed_config.py
@@ -36,6 +36,7 @@ from unittest import mock
 
 from charter import commands_frame, config, instance
 from charter.frame import state
+from tests import _tmuxchain
 from tests._isolation import PersonaIso
 
 #: The operator's own committed text, trimmed to the two tables and the one paragraph
@@ -101,10 +102,8 @@ class AChromeKeypressLeavesTheCommittedConfigAlone(PersonaIso, unittest.TestCase
             f"refusing to record anything: STATE_DIR is {config.STATE_DIR}")
 
         self.ran: list[list[str]] = []
-        patcher = mock.patch.object(
-            commands_frame.tmuxctl, "run",
-            side_effect=lambda _what, argv, **kw: self.ran.append(argv) or
-            subprocess.CompletedProcess(argv, 0, "", ""))
+        patcher = mock.patch.object(commands_frame.tmuxctl, "run",
+                                    _tmuxchain.recorder(self.ran))
         patcher.start()
         self.addCleanup(patcher.stop)
 

--- a/tests/test_a_panel_pane_exists_once_per_placed_component.py
+++ b/tests/test_a_panel_pane_exists_once_per_placed_component.py
@@ -76,6 +76,7 @@ from charter import commands_frame, config, instance
 from charter.frame import layout, state, tmuxctl
 
 from tests import _tmuxreap
+from tests import _tmuxchain
 from tests._isolation import PersonaIso, make_plane
 
 _HAS_TMUX = shutil.which("tmux") is not None
@@ -126,8 +127,22 @@ class _Tmux:
         self.size = size
         self.new_panes = list(new_panes)
         self.calls: list[list[str]] = []
+        #: One entry per tmux INVOCATION, where `calls` has one per
+        #: tmux COMMAND — see :meth:`__call__`.
+        self.invocations: list[list[str]] = []
 
     def __call__(self, action, argv, *, env=None, timeout=None, report=True):
+        """One tmux INVOCATION, which since #780 may carry several commands.
+
+        Split through `tests/_tmuxchain.answer_run` so `self.calls` keeps one entry per
+        tmux COMMAND — the list every assertion here reads — where charter now spends
+        one invocation on a whole group of them.
+        """
+        self.invocations.append(list(argv))
+        return _tmuxchain.answer_run(self._one, action, argv, env=env, timeout=timeout,
+                                     report=report)
+
+    def _one(self, action, argv, *, env=None, timeout=None, report=True):
         self.calls.append(list(argv))
         out = ""
         if "list-panes" in argv:
@@ -139,7 +154,7 @@ class _Tmux:
         elif "display-message" in argv:
             out = self.size
         elif "split-window" in argv:
-            out = self.new_panes.pop(0) if self.new_panes else ""
+            out = f"{self.new_panes.pop(0)}\n" if self.new_panes else ""
         return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
     def killed(self) -> list[str]:

--- a/tests/test_a_pinned_repo_strip_keeps_its_height.py
+++ b/tests/test_a_pinned_repo_strip_keeps_its_height.py
@@ -48,6 +48,8 @@ from unittest import mock
 from charter import commands_frame, config, instance
 from charter.frame import builtins, component, layout
 
+from tests import _tmuxchain
+
 #: This repository's own committed plane file. Read rather than described, for
 #: `test_component_id_is_the_currency.CharterOwnConfigIsUnchanged`'s reason and for one
 #: more of its own: #661 was a defect an operator triggered by editing exactly this file.
@@ -575,7 +577,7 @@ class TheBoundaryIsWhereThePlaneIsRead(unittest.TestCase):
         calls: list[list[str]] = []
 
         def fake(action, argv, *, env=None, timeout=None, report=True):
-            calls.append(list(argv))
+            calls.extend(_tmuxchain.commands(argv))
             return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
 
         panes = {"top": "%1", "bottom": "%2", "repos": "%3"}

--- a/tests/test_builtin_components.py
+++ b/tests/test_builtin_components.py
@@ -71,7 +71,8 @@ class Declared(unittest.TestCase):
 
         `chats` and `workspaces` are last, registered and not placed for the same reason
         one measurement further on: a plane with one chat is that same ordinary,
-        permanent state, and every placed pane is ~7 of a switch's 41 tmux invocations."""
+        permanent state, and every placed pane is a share of a switch's tmux invocations —
+        26 of them with four panels, ~162 ms on tmux 3.7c (#780)."""
         self.assertEqual([c.id for c in self.reg.all()],
                          ["identity", "attention", "repos", "personas", "todos",
                           "changes", "sidebar", "chats", "workspaces"])

--- a/tests/test_component_toggle_keys.py
+++ b/tests/test_component_toggle_keys.py
@@ -50,6 +50,7 @@ from unittest import mock
 from charter import commands_frame, config, instance
 from charter.frame import component, overlay, state
 
+from tests import _tmuxchain
 from tests._isolation import PersonaIso
 
 
@@ -73,14 +74,28 @@ class _Tmux:
         self.size = size
         self.new_panes = list(new_panes)
         self.calls: list[list[str]] = []
+        #: One entry per tmux INVOCATION, where `calls` has one per
+        #: tmux COMMAND — see :meth:`__call__`.
+        self.invocations: list[list[str]] = []
 
     def __call__(self, action, argv, *, env=None, timeout=None, report=True):
+        """One tmux INVOCATION, which since #780 may carry several commands.
+
+        Split through `tests/_tmuxchain.answer_run` so `self.calls` keeps one entry per
+        tmux COMMAND — the list every assertion here reads — where charter now spends
+        one invocation on a whole group of them.
+        """
+        self.invocations.append(list(argv))
+        return _tmuxchain.answer_run(self._one, action, argv, env=env, timeout=timeout,
+                                     report=report)
+
+    def _one(self, action, argv, *, env=None, timeout=None, report=True):
         self.calls.append(list(argv))
         out = ""
         if "display-message" in argv:
             out = self.size
         elif "split-window" in argv:
-            out = self.new_panes.pop(0) if self.new_panes else ""
+            out = f"{self.new_panes.pop(0)}\n" if self.new_panes else ""
         return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
     def killed(self) -> set[str]:

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -10,8 +10,9 @@ gives both up before `top`.
 **Neither is placed by default, and that is a decision with a measurement behind it
 rather than an omission.** `frame/builtins.build` carries the argument; the short of it is
 that a plane with one chat is the ordinary, permanent state (the same fact that keeps
-`changes` a section rather than a pane), and each placed pane is ~7 of a switch's 41 tmux
-invocations — measured at ~360 ms on tmux 3.7c and ~395 ms at the 3.2 floor. So the bars
+`changes` a section rather than a pane), and each placed pane is a share of a switch's tmux
+invocations — 26 of them since #780 batched every write nothing reads back, ~162 ms on
+tmux 3.7c and ~127 ms at the 3.2 floor with four panels. So the bars
 ship as components a `[[frame.component]]` table can place, and
 :class:`ABarIsPlaceableByConfig` is what says that route actually works end to end rather
 than leaving two components nothing could ever ask for.
@@ -486,8 +487,8 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
 
     def test_the_tab_you_are_already_on_resolves_to_nothing(self):
         """Re-selecting what is already selected is not news — `_repos_events`' sentence,
-        and here it is worth more: a re-switch is a real teardown and split (~360 ms for a
-        chat) arriving exactly where the operator already was. It is also what keeps a
+        and here it is worth more: a re-switch is a real teardown and split (~162 ms for a
+        four-panel chat on 3.7c) arriving exactly where the operator already was. It is also what keeps a
         double-click from switching twice."""
         row = self._draw(200, here="api.2")
         for col in self._cells(row, "api.2"):

--- a/tests/test_frame_border_surface.py
+++ b/tests/test_frame_border_surface.py
@@ -38,6 +38,7 @@ from unittest import mock
 
 from charter import commands_frame, config, instance
 from charter.frame import state, tmuxctl
+from tests import _tmuxchain
 from tests._isolation import PersonaIso
 # This repo's own committed `charter.toml`, IMPORTED rather than recomputed. Cross-module
 # test imports are this suite's ordinary way of sharing a fixture, and the thing worth
@@ -928,9 +929,13 @@ class TheLauncherActuallyArmsTheRulesWithIt(PersonaIso, unittest.TestCase):
         panes = iter(f"%{n}" for n in range(10, 99))
 
         def fake_run(_why, argv, **_kw):
-            seen.append(list(argv))
-            out = next(panes) if "split-window" in argv else ""
-            return subprocess.CompletedProcess(argv, 0, stdout=out + "\n", stderr="")
+            # ONE id per `split-window` in the invocation, on its own line — since #780
+            # `_split_all` sends every split as one command list and real tmux answers
+            # it with one id per line, in order (measured on 3.7c and at the 3.2 floor).
+            issued = _tmuxchain.commands(argv)
+            seen.extend(issued)
+            out = "".join(f"{next(panes)}\n" for c in issued if "split-window" in c)
+            return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
         with mock.patch.dict(config.FRAME, frame), \
                 mock.patch.object(commands_frame.tmuxctl, "run", fake_run), \
@@ -1060,9 +1065,13 @@ class TheVersionReachesTheFunnelFromTheFunctionThatKnowsIt(PersonaIso, unittest.
         panes = iter(f"%{n}" for n in range(20, 99))
 
         def fake_run(_why, argv, **_kw):
-            seen.append(list(argv))
-            out = next(panes) if "split-window" in argv else ""
-            return subprocess.CompletedProcess(argv, 0, stdout=out + "\n", stderr="")
+            # ONE id per `split-window` in the invocation, on its own line — since #780
+            # `_split_all` sends every split as one command list and real tmux answers
+            # it with one id per line, in order (measured on 3.7c and at the 3.2 floor).
+            issued = _tmuxchain.commands(argv)
+            seen.extend(issued)
+            out = "".join(f"{next(panes)}\n" for c in issued if "split-window" in c)
+            return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
         frame = _resolved(*["brightblack"] * 4, chrome="dark")
         with mock.patch.object(config, "FRAME", frame), \
@@ -1151,7 +1160,7 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
         state.record_chrome(self.FID, level)
 
         def fake_run(_why, argv, **_kw):
-            calls.append(list(argv))
+            calls.extend(_tmuxchain.commands(argv))
             return subprocess.CompletedProcess(argv, 0, stdout="%9\n", stderr="")
 
         with mock.patch.object(config, "FRAME", frame), \
@@ -1196,7 +1205,7 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
         state.record_harness_pane(self.FID, "%1")
         with mock.patch.object(config, "FRAME", frame), \
                 mock.patch.object(commands_frame.tmuxctl, "run",
-                                  lambda _w, argv, **kw: calls.append(argv)), \
+                                  _tmuxchain.recorder(calls)), \
                 mock.patch.object(commands_frame.tmuxctl, "version", lambda: v), \
                 mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID},
                                 clear=True):
@@ -1302,7 +1311,7 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
         state.record_panes(self.FID, panels={"s0": "%2"})
         with mock.patch.object(config, "FRAME", _frame("brightblack")), \
                 mock.patch.object(commands_frame.tmuxctl, "run",
-                                  lambda _w, argv, **kw: calls.append(argv)), \
+                                  _tmuxchain.recorder(calls)), \
                 mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID},
                                 clear=True):
             self.assertEqual(
@@ -1320,7 +1329,7 @@ class TheLaunchPathAndTheLivePathAgree(PersonaIso, unittest.TestCase):
         state.record_harness_pane(self.FID, "; kill-server")
         with mock.patch.object(config, "FRAME", _frame("brightblack")), \
                 mock.patch.object(commands_frame.tmuxctl, "run",
-                                  lambda _w, argv, **kw: calls.append(argv)), \
+                                  _tmuxchain.recorder(calls)), \
                 mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID},
                                 clear=True):
             commands_frame.cmd_chrome(type("A", (), {"level": "dark"})())
@@ -1351,9 +1360,11 @@ class ARelayoutThatAddsNoPaneStillAssertsTheWindowsOwnOptions(PersonaIso,
         spare = iter(f"%{n}" for n in range(30, 99))
 
         def fake_run(_why, argv, **_kw):
-            seen.append(list(argv))
-            out = next(spare) if "split-window" in argv else "80"
-            return subprocess.CompletedProcess(argv, 0, stdout=out + "\n", stderr="")
+            issued = _tmuxchain.commands(argv)
+            seen.extend(issued)
+            splits = [c for c in issued if "split-window" in c]
+            out = ("".join(f"{next(spare)}\n" for _ in splits) if splits else "80\n")
+            return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
         frame = _resolved(*["brightblack"] * 4, chrome="dark")
         with mock.patch.object(config, "FRAME", frame), \

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -27,6 +27,7 @@ from unittest import mock
 
 from charter import commands_frame, config, contain, instance, workspace
 from charter.frame import chats, choose, slots, state, switch, tmuxctl
+from tests import _tmuxchain
 from tests._isolation import PersonaIso
 from tests._tmuxsocket import OPERATOR_SOCKET
 # The one list of hostile display strings this suite has, imported rather than retyped:
@@ -920,6 +921,9 @@ class _FakeServer:
 
     def __init__(self, *, select_rc: int = 0):
         self.calls: list[list[str]] = []
+        #: One entry per tmux INVOCATION, where `calls` has one per tmux COMMAND — see
+        #: :meth:`__call__`. A switch's own count of these is #780's subject.
+        self.invocations: list[list[str]] = []
         self.select_rc = select_rc
         #: ``{pane id: (session id, window id)}`` — what `#{session_id}:#{window_id}`
         #: reports for a pane. A pane that is not here is one tmux cannot resolve, and
@@ -928,8 +932,21 @@ class _FakeServer:
         self.place = {"%1": ("$0", "@0"), "%2": ("$0", "@1")}
         #: ``{session id: window id}`` — the window each session is currently on.
         self.current = {"$0": "@0"}
+        #: The last pane id handed out by `split-window`, so each split answers a
+        #: DIFFERENT one — see there.
+        self.next_pane = 8
 
     def __call__(self, what, argv, **kw):
+        """One tmux INVOCATION, which since #780 may carry several commands.
+
+        Split through `tests/_tmuxchain.answer` so `self.calls` keeps one entry per tmux
+        COMMAND — the list every ordering assertion below reads — while
+        `self.invocations` counts what the switch really spent on the socket.
+        """
+        self.invocations.append(list(argv))
+        return _tmuxchain.answer(self._one, argv, **kw)
+
+    def _one(self, argv, **kw):
         import subprocess
         self.calls.append(list(argv))
         rc, out = 0, ""
@@ -941,7 +958,14 @@ class _FakeServer:
                 if seat is not None:
                     self.current[seat[0]] = seat[1]
         elif verb == "split-window":
-            out = "%9"
+            # A NEW id per split, and each on its own LINE, which is what real tmux
+            # answers `-P -F '#{pane_id}'` with — measured on 3.7c and at the 3.2 floor,
+            # including four splits sent as one invocation, whose four ids come back one
+            # per line in the order they were given. A fake that answered one id for
+            # every split let two panels share a pane id, and one that dropped the
+            # newline let a batch of four look like a single unparseable id.
+            self.next_pane += 1
+            out = f"%{self.next_pane}\n"
         elif verb == "display-message":
             out = self._display(argv)
         return subprocess.CompletedProcess(argv, rc, out, "")

--- a/tests/test_frame_chat_switch.py
+++ b/tests/test_frame_chat_switch.py
@@ -919,7 +919,7 @@ class _FakeServer:
     another session, the way the real server put it there.
     """
 
-    def __init__(self, *, select_rc: int = 0):
+    def __init__(self, *, select_rc: int = 0, size: str = "80:24"):
         self.calls: list[list[str]] = []
         #: One entry per tmux INVOCATION, where `calls` has one per tmux COMMAND — see
         #: :meth:`__call__`. A switch's own count of these is #780's subject.
@@ -935,6 +935,10 @@ class _FakeServer:
         #: The last pane id handed out by `split-window`, so each split answers a
         #: DIFFERENT one — see there.
         self.next_pane = 8
+        #: What `_WINDOW_SIZE_FORMAT` reports. The default is a small terminal, which is
+        #: what every test here was written against; a caller that wants the four-panel
+        #: frame — `_drawable_slots` places two at 80x24 — says so.
+        self.size = size
 
     def __call__(self, what, argv, **kw):
         """One tmux INVOCATION, which since #780 may carry several commands.
@@ -985,7 +989,7 @@ class _FakeServer:
             return self.current.get(target, "")
         if fmt == commands_frame._PANE_WIDTH_FORMAT:
             return "80"
-        return "80:24"
+        return self.size
 
     @staticmethod
     def _target(argv) -> str:

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -38,6 +38,7 @@ from unittest import mock
 from charter import (commands_frame, config, inflight, instance, statusline, tui,
                      util)
 from charter.frame import builtin_actions, gather, layout, panel, slots, state
+from tests import _tmuxchain
 from tests._tmuxsocket import OPERATOR_SOCKET
 
 from tests._isolation import PersonaIso
@@ -86,8 +87,22 @@ class _Tmux:
         self.pane_cols = pane_cols
         self.new_panes = list(new_panes)
         self.calls: list[list[str]] = []
+        #: One entry per tmux INVOCATION, where `calls` has one per
+        #: tmux COMMAND — see :meth:`__call__`.
+        self.invocations: list[list[str]] = []
 
     def __call__(self, action, argv, *, env=None, timeout=None, report=True):
+        """One tmux INVOCATION, which since #780 may carry several commands.
+
+        Split through `tests/_tmuxchain.answer_run` so `self.calls` keeps one entry per
+        tmux COMMAND — the list every assertion here reads — where charter now spends
+        one invocation on a whole group of them.
+        """
+        self.invocations.append(list(argv))
+        return _tmuxchain.answer_run(self._one, action, argv, env=env, timeout=timeout,
+                                     report=report)
+
+    def _one(self, action, argv, *, env=None, timeout=None, report=True):
         self.calls.append(list(argv))
         out = ""
         if commands_frame._PANE_WIDTH_FORMAT in argv:
@@ -97,7 +112,7 @@ class _Tmux:
                 self.size = self.sizes.pop(0)
             out = self.size
         elif "split-window" in argv:
-            out = self.new_panes.pop(0) if self.new_panes else ""
+            out = f"{self.new_panes.pop(0)}\n" if self.new_panes else ""
         return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
     def where(self, *words: str) -> list[int]:
@@ -1301,8 +1316,7 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         hostile here too, and for the same reason: `cmd_resize` reads that one off disk as
         well, and #515 gave this function a `resize-pane -t <harness>` of its own."""
         calls = []
-        with mock.patch("charter.frame.tmuxctl.run",
-                        side_effect=lambda a, argv, **k: calls.append(list(argv))):
+        with mock.patch("charter.frame.tmuxctl.run", _tmuxchain.recorder(calls)):
             commands_frame._reassert_sizes(
                 "charter", fid=self.fid,
                 panes={"top": "%1", "bottom": "%2;kill-server"},

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
+from tests import _tmuxchain
 from tests._isolation import PersonaIso
 from charter import commands_frame, config, instance, statusline, util
 from charter.frame import (builtin_actions, gather, layout, overlay, slots, state,
@@ -1576,6 +1577,11 @@ class _FakeTmux:
         # round 3, item 2) separately from an ordinary resize-hook failure.
         self.resize_hook_stderr = resize_hook_stderr
         self.calls: list[list[str]] = []
+        #: One entry per tmux INVOCATION, where `calls` has one per tmux COMMAND. The
+        #: two were the same list until #780 batched every write nothing reads back;
+        #: the difference between their lengths is what that issue is about, and
+        #: `Launch.test_a_launch_spends_one_invocation_per_batch` is what holds it down.
+        self.invocations: list[list[str]] = []
         #: The CHAT id, learned from the `@charter_chat` window option the launcher
         #: writes — never from `new-session -s`, which names the WORKSPACE now.
         self.fid = None
@@ -1587,6 +1593,17 @@ class _FakeTmux:
         self.kill_window_called = False
 
     def __call__(self, cmd, **kwargs):
+        """One tmux INVOCATION, which since #780 may carry several commands.
+
+        `tests/_tmuxchain.answer` splits it and runs each through :meth:`_one`, folding
+        the results tmux's own way, so `self.calls` still holds one entry per tmux
+        COMMAND — which is what every assertion in this module reads — while
+        `self.invocations` counts what charter actually spent on the socket.
+        """
+        self.invocations.append(list(cmd))
+        return _tmuxchain.answer(self._one, cmd, **kwargs)
+
+    def _one(self, cmd, **kwargs):
         self.calls.append(list(cmd))
         if "new-session" in cmd:
             self.session = cmd[cmd.index("-s") + 1]
@@ -5068,11 +5085,22 @@ class _FakeOperatorTmux:
         self.status_queries = 0
         self.window_killed = False
         self.respawn_env = None
+        #: One entry per tmux INVOCATION, where `calls` has one per tmux COMMAND — see
+        #: :meth:`__call__` and `_FakeTmux`'s own.
+        self.invocations: list[list[str]] = []
 
     def _ok(self, cmd, stdout=""):
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
     def __call__(self, cmd, **kwargs):
+        """One tmux INVOCATION — see `_FakeTmux.__call__`, which splits one the same way
+        and for the same reason: since #780 a launch sends its window dressing, its
+        panel splits and its respawn hooks as command LISTS, and `self.calls` has to go
+        on holding one entry per COMMAND or every assertion here silently narrows."""
+        self.invocations.append(list(cmd))
+        return _tmuxchain.answer(self._one, cmd, **kwargs)
+
+    def _one(self, cmd, **kwargs):
         self.calls.append(list(cmd))
         if commands_frame._WINDOW_SEAT_FORMAT in cmd:
             # `_chat_being_left` (#688). Before the generic `list-windows` branch, for

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -3252,14 +3252,25 @@ class Launch(PersonaIso, unittest.TestCase):
         The return code must be NONZERO, not the `0` a deliberate operator detach
         returns below: the harness never ran interactively and charter has no way to
         learn its real exit code, so a script or `&&` chain must see this launch as
-        having failed, not quietly succeeded."""
+        having failed, not quietly succeeded.
+
+        **And it says that ONCE.** Since #780 the launcher sends its ten window and
+        session writes as one batch and warns per write afterwards, off a list of
+        sentences kept beside them — and this hook is the one write in that batch whose
+        failure is answered by the refusal below rather than by a sentence of its own, so
+        its entry in that list is empty. A loop that warned on the return code alone
+        would print a blank `charter frame:` line here, above the refusal, which is what
+        the deletion sweep asked about."""
         fake = _FakeTmux(teardown_hook_rc=1, still_live=True)
-        buf = []
-        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+        buf, warned = [], []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)), \
+             mock.patch("charter.util.warn", side_effect=lambda m: warned.append(m)):
             rc = _launch(fake)
         self.assertNotEqual(rc, 0)
         self.assertTrue(any("refusing to attach" in m for m in buf),
                         f"no refusal message: {buf}")
+        self.assertEqual([m for m in warned if not m.strip()], [],
+                         f"a blank warning was printed above the refusal: {warned}")
         self.assertFalse(any("attach" in c for c in fake.calls),
                          "attach must never be reached once teardown cannot be trusted")
         self.assertTrue(state.frame_dir(fake.fid).exists())

--- a/tests/test_frame_pane_style.py
+++ b/tests/test_frame_pane_style.py
@@ -38,6 +38,7 @@ from unittest import mock
 from charter import commands_frame, config, instance, statusline, tui
 from charter.frame import gather, panel, slots
 
+from tests import _tmuxchain
 from tests._isolation import PersonaIso
 from tests.test_frame_tmux_integration import _HAS_TMUX, _TmuxServerFixture
 
@@ -542,9 +543,14 @@ class TheLauncherActuallyAsksForEachPanesColour(PersonaIso, unittest.TestCase):
         panes = iter(f"%{n}" for n in range(10, 99))
 
         def fake_run(_why, argv, **_kw):
-            seen.append(list(argv))
-            out = next(panes) if "split-window" in argv else ""
-            return subprocess.CompletedProcess(argv, 0, stdout=out + "\n", stderr="")
+            # ONE entry per tmux COMMAND and one id per `split-window`, on its own line:
+            # since #780 charter sends the splits as one command list and a pane's own
+            # options as another, and real tmux answers a chain of splits with one id per
+            # line, in order (measured on 3.7c and at the 3.2 floor).
+            issued = _tmuxchain.commands(argv)
+            seen.extend(issued)
+            out = "".join(f"{next(panes)}\n" for c in issued if "split-window" in c)
+            return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
         with mock.patch.dict(config.FRAME, frame), \
              mock.patch.object(commands_frame.tmuxctl, "run", fake_run), \
@@ -1720,10 +1726,8 @@ class TheLiveChromeToggleDoesNotEraseAPanesOwnColour(PersonaIso, unittest.TestCa
         """
         from charter.frame import state
         ran: list[list[str]] = []
-        with mock.patch.object(
-                commands_frame.tmuxctl, "run",
-                side_effect=lambda _w, argv, **kw: ran.append(argv) or
-                subprocess.CompletedProcess(argv, 0, "", "")):
+        with mock.patch.object(commands_frame.tmuxctl, "run",
+                               _tmuxchain.recorder(ran)):
             state.record_panes("fr-pane-style", panels={"repos": "%1", "right": "%2"})
             with mock.patch.dict(config.FRAME,
                                  _arrangement(sidebar={"bg": "brightblack"})), \


### PR DESCRIPTION
Closes #780.

> *"I see very slow rendering on switching — it seems re-rendering all and I see jumping texts ~0.2 sec, then it's ready."*

Both halves are one defect: charter issued every tmux command on its own. A round trip is ~5 ms on the machine this was measured on and ~13.4 ms on the one that filed #728, and two thirds of what a launch and a switch send reads nothing back.

## Measured

A real attached client at 200x50, four panels, seven rounds of each path, before and after taken the same way on an unloaded box:

| path | tmux | invocations | wall clock | terminal repaints |
|---|---|---|---|---|
| chat switch | 3.7c | 58 → **23** | 314 ms → **142 ms** | 45 → **14** |
| chat switch | 3.2 floor | 50 → **21** | 237 ms → **114 ms** | 41 → **12** |
| launch to the attach | 3.7c | 46 → **17** | 227 ms → **91 ms** | (no client yet) |
| launch to the attach | 3.2 floor | 42 → **16** | 174 ms → **69 ms** | (no client yet) |

The repaint column is the jumping, and it is a direct reading rather than an inference: bytes tmux wrote to a real client's pty, grouped into bursts separated by more than 3 ms of silence. tmux redraws once per command **list**, not once per command. Bytes written to the terminal fell with it, 59.5 KB to 25.4 KB. A frame with `[frame] chrome` set batches identically — same 23 invocations, same 14 repaints.

**There is no tmux command that suppresses paints while a batch applies, and I looked.** `refresh-client` forces a redraw rather than deferring one; its `-A pane:off` is control-mode only; `suspend-client` sends SIGTSTP to the client process. Fewer command-queue drains is the whole mechanism, which is why the repaint count tracks the invocation count. What is left is not zero: 14 updates is four `charter panel` processes starting and painting themselves, which is a different lever.

**#780's own numbers and `docs/frame.md`'s were both stale and are corrected.** The issue said 42 invocations for a launch; this tree makes 46. The docs said 41 and 360 ms for a switch; it is 58 and 314 ms. And the 3.2 floor is *faster* per invocation here than 3.7c, not slower as the docs claimed.

## What changed

`tmuxctl.write_all(joint, [Write(action, argv, report)])` sends a group as one invocation and **re-issues every write one at a time the moment the chain returns non-zero** — because a refused command abandons the rest of a tmux command list (measured on both versions), and every caller here is written around each write failing with its own sentence and its own consequence. The fast path is one invocation; the failure path is one wasted invocation and then exactly the behaviour that was there before.

Batched: `_dress_window` (8 to 1), `_reconcile_panels`' disarm-and-kill pairs (8 to 1), every new pane's options (8-16 to 1), `_arm_panel_respawn` (4 to 1), `_apply_sizes`' rows pass, and the launcher's ten window/session writes (10 to 1).

`_split_all` batches the four `split-window`s, which needed its own mechanism: a split is not idempotent, so it cannot use the replay. A chain of them answers with **one pane id per line, in the order given** (measured on 3.7c and at the 3.2 floor), so the id count says how far the list got — the command at that index was refused and nothing after it ran; those are re-issued alone. A wedged tmux is retried in neither batch: a timeout does not say the write did not happen.

**Nothing was reordered and the switch still re-splits.** Re-verified on both versions while doing this: with a client at 200x50, resizing it to 100x30 leaves the non-current window at 200x50, and tmux resizes it *at* the `select-window`. The teardown is a correctness rule, not a saving.

## Tests

`tests/_tmuxchain.py` teaches the suite's fakes the tmux that is really there — an invocation is split into its commands, run in order, stopping at the first refusal — so `fake.calls` still holds one entry per tmux **command** and every existing assertion keeps its meaning. `fake.invocations` is the new list.

`tests/test_a_frame_sends_one_invocation_per_batch.py` pins the counts (44 to 15 for a launch, 58 to 23 for a switch, against the fakes), the round trip through `chain`/`commands` on an argument that itself contains a `;`, the fallback semantics, and — against a **real tmux server with no client, so it runs in CI** — the two properties every batch rests on: a chain answers for every command in it, and a refused command abandons the rest. 11 of its 16 tests fail on `main`; the ones that pass are the ones that measure tmux rather than charter.

## Sweep

`no survivors` — **pass**. 15 mutations, 15 pinned, 0 unpinned, 0 masked, 0 unresolved.

The first run reported six survivors and each was answered rather than argued with: `if not todo` in `_split_all` and `if not writes` in `write_all` are equivalent (`chain([])` answers `None`, so an empty group already falls into a loop over nothing) and were deleted — deleting the second un-masks `if argv is None`, which a test then kills; the two `pane_id.strip()` calls in the chained split were no-ops after `splitlines()` and went with them; and the `and sentence` half is real behaviour, so it got a test — a blank `charter frame:` line above the refusal-to-attach is now a failure, verified to fail without the guard.

## Not done, deliberately

`charter/frame/slots.py:3210` and `charter/frame/builtins.py:328,780` still carry the stale "41 tmux invocations / ~360 ms" figure. Another agent holds those files this session — they need the same one-line correction.

About five more invocations per switch are batchable across `_relayout`'s step boundaries (`_install_resize_hook`'s `-u` beside `_reassert_sizes`' harness resize beside `select-pane`; the two `_pane_place` reads as one chained read). They are left alone: that function's docstring records the step boundaries as load-bearing, and ~25 ms is not worth blurring them.

Chaining each pane's options into the *next* `split-window` would save three more, and is refused: a chrome option this tmux does not know would then abort a split, turning a cosmetic failure into a missing panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ctfuhnX3LdXbtx3SMUvTu
