### PR TITLE
The tab bars become a tab strip: a block on the tab you are on, a clickable overflow count, and rules between tabs

### DIFF
--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -366,9 +366,43 @@ def _bar_events(fid: str, command: tuple[str, ...]):
       under a feature's name.
 
     **A click on the tab you are already on does nothing**, and that rule lives in
-    `slots._Tabs.switch_to` rather than here — see it for why, and for the two other
-    things that answer nothing: the `+14` overflow, which stands for names that are not
-    on the row, and every cell this bar drew no tab into.
+    `slots._Tabs.switch_to` rather than here — see it for why, and for the other thing
+    that answers nothing: every cell this bar drew no tab into.
+
+    **A click on the `+14` opens the palette, and that is a second gesture on one row
+    rather than a widening of the first.** The overflow counts stand for names that are
+    NOT on the row, so there is nothing there to switch to and there never will be — that
+    much is unchanged. What changed is the conclusion drawn from it. Answering nothing was
+    right while the alternative was picking one of the names it stands for; it is not
+    right when the operator can see a field that says *nine more* and press it, which is
+    what the operator this change is for did.
+
+    So the count hands off to the palette, which is §3.6 arriving where it was always
+    heading: *the bar is a readout, never the mechanism*, and the palette reaches every
+    chat and every workspace in two keystrokes at every width — including the widths where
+    this bar can draw no name at all. That last part is why the narrow rung's `2/3` is a
+    count here too: it is the same field at the width where the strip reaches nothing.
+
+    **It is :func:`_strip_events`' gesture, not this one's**, and the difference is worth
+    keeping straight because both live in this handler now. A tab click completes on the
+    pointer: it switches, and the tab you left is one click away. A count click cannot —
+    it names no chat — so it can only mean *let me see the rest*, and seeing needs a
+    chooser. `key` is in `component.EVENT_KINDS` and deliberately not in
+    `events.DELIVERED`, so charter cannot grow a pointer-driven chooser inside a one-row
+    pane; the palette IS the chooser and it makes itself the active pane
+    (`overlay.modal_argvs`), so the keyboard reaches the list it just drew.
+
+    **The palette it opens is the top-level one, not the picker for this bar's noun**, and
+    that is an honest cost rather than a design. `charter frame-palette` has no way to say
+    "open in the `workspaces` picker": the option would live in `commands_frame.cmd_palette`
+    and `cli.py`, and what the operator gets meanwhile is the doorway row for their noun
+    with the name they are on already in it, one keystroke from the list. That is one
+    keystroke more than it should be and infinitely fewer than a field that does nothing.
+
+    **`switch_to` is asked first and `more_at` second, and the two cannot both answer.**
+    A count is not in the column map and a tab is not in the overflow set — `slots._bar`
+    builds them from one walk of one composition — so the order is a reading order rather
+    than a precedence. It is written this way round because the tab is the common case.
 
     **It answers falsy even when it started a switch**, which is the one place this reads
     differently from the table's handler. Truthy means *repaint me* (§4f), and nothing
@@ -415,6 +449,12 @@ def _bar_events(fid: str, command: tuple[str, ...]):
             return False
         name = _slots.TABS.switch_to(ev.col)
         if name is None:
+            if _slots.TABS.more_at(ev.col):
+                # The same argv `_strip_events` spawns for a door, for its reasons — one
+                # answer to "how does a frame surface open the palette", shared rather than
+                # copied. Falsy afterwards for this handler's own reason: the palette's
+                # pane is carved off the harness, so nothing in THIS rectangle changed.
+                _spawn(util.self_relaunch_argv(*_PALETTE), fid=fid)
             return False
         # `builtin_actions._spawn` and not a `Popen` of this module's own — one answer to
         # "how does a frame surface start work that must outlive it", shared with every

--- a/charter/frame/chrome.py
+++ b/charter/frame/chrome.py
@@ -923,6 +923,46 @@ def reverse(row: str, width: int) -> str:
     return fill(_REVERSE + body, width) + _OFF
 
 
+def block(text: str) -> str:
+    """*text* drawn as a reverse-video block — ONE FIELD of a row, never a whole row.
+
+    :func:`reverse`'s sibling and deliberately not a call to it. That one answers "this
+    ROW is the one you picked": it fills to the pane's last column, so the highlight is a
+    band across the frame, and it takes a *width* because a band that stops short or runs
+    one cell long is #553. This one answers "this FIELD is the one you are on", which is
+    what a tab strip needs — the highlight has to end where the tab ends, because the cells
+    on either side belong to other tabs and a band would say the operator is on all of
+    them.
+
+    **No re-assertion pass, and that is a fact about the caller rather than a shortcut.**
+    :func:`reverse` runs `_SGR.sub(_restated, …)` because it wraps a row a renderer already
+    finished, and charter's rows carry `statusline._R` after every coloured span — a full
+    reset inside the run cancels reverse for the rest of it (the measured defect in that
+    function's docstring). A tab field is `slots._BAR_MARK` plus a name that has been
+    through `contain.one_line`, which turns an `ESC` into the four characters `\x1b`. There
+    is no SGR inside it to cancel anything, so a substitution here would be a pass whose
+    output is provably its input — the survivor the deletion sweep reports and this
+    repository deletes rather than keeps as insurance.
+
+    That is also why there is no colour deletion (#736): the run sets none.
+
+    **No `[frame] chrome` gate and no `colour_ok` gate**, for the two reasons this module
+    already gives one function up. What leaves here names no colour, so there is no theme
+    it can be wrong on — including a plane at `chrome = "off"`, which is the shipped
+    default and is about the pane's BACKGROUND, not about what a renderer may write into
+    its own row. And `NO_COLOR` is honoured in `panel._write`, the one place anything
+    reaches a pane's screen, so a gate here would be a second answer to a question that is
+    already answered once for every row in the frame. Under it the strip still says which
+    tab you are on, because `slots._BAR_MARK` is a character and not an attribute.
+
+    An empty *text* comes back as a bare `\x1b[7m\x1b[0m` rather than `""`, and there is
+    deliberately no guard: no caller can reach it — a tab field always carries a mark —
+    so the guard would be a line no input could turn red, which is `fill`'s own recorded
+    reason for not having one either.
+    """
+    return _REVERSE + text + _OFF
+
+
 def _restated(m: re.Match) -> str:
     """One SGR inside a reversed run, rewritten: its colours gone and reverse put back if
     it turned reverse off.

--- a/charter/frame/overlay.py
+++ b/charter/frame/overlay.py
@@ -162,6 +162,27 @@ OVERLAY_OPTION = "@charter_overlay"
 #: without `drag`). Measured: tmux propagates this pane's exact request to the outer
 #: terminal when tmux's own `mouse` is off, and coordinates arrive pane-relative and
 #: 1-based, with any `pane-border-status` row already subtracted.
+#:
+#: **The 1006 is load-bearing at `tmuxctl.FLOOR`, and it is the one thing standing between
+#: charter and the only "fires wrongly" this project has found.** tmux synthesises a
+#: report for a pane in whatever mode that pane asked for, and X10 spells a coordinate as
+#: one byte at ``value + 32`` — so column 224 needs byte 256 and wraps. tmux clamps that
+#: from 3.3 ("Do not report mouse positions (incorrectly) above the maximum of 223"); 3.2
+#: does not. Measured on both, a 244-column pty, against a pane asking for **1000 alone**::
+#:
+#:     3.2   col 240 -> b'\\x1b[M \\x10!'   wrapped, and 16 is a REAL column of the pane
+#:     3.2   col 244 -> b'\\x1b[M \\x14!'   wrapped
+#:     3.7c  col 240 -> b'\\x1b[M \\xff!'   clamped at 223
+#:
+#: With this constant as written, both versions hand the pane ``\\x1b[<0;240;1M`` — the
+#: column that was pressed. A tab bar is the widest single row in the frame, so on a
+#: 244-column window a wrapped column is a click on a real but wrong tab.
+#: `tests/test_frame_input_reaches_a_component.APointerPastColumnTwoTwentyThree
+#: LandsWhereItWasAimed` is the standing form of the whole measurement, and its unit half
+#: is what refuses a "simplification" of this line.
+#:
+#: The ORDER is part of it: 1006 is asked for first so there is no instant in which the
+#: pane has asked to be reported to and not yet said how.
 MOUSE_ON = "\x1b[?1006h\x1b[?1000h"
 
 #: And the withdrawal, in the reverse order it was asked for. Written before

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -3114,7 +3114,59 @@ _BAR_MARK = ("*", " ")
 
 #: Columns a bar spends between two names. Two, so a name reads as one name — a single
 #: space runs `api.1 api.2` together at the widths where this matters most.
+#:
+#: **The floor rather than the whole answer now**: :func:`_bar_gap` is what a rung actually
+#: joins with, and on a plane that draws its rules it is one cell wider. This constant
+#: stays the blank form because it is also the gap between the heading and the first tab —
+#: a seam between a label and a strip, which is not the seam a rule is about.
 _BAR_GAP = 2
+
+#: What a bar draws between two tabs on a plane whose seams are visible.
+#:
+#: **ASCII, and this one is not the same argument as :data:`_BAR_MARK`'s — it is a harder
+#: one.** `│` (U+2502) is what an IDE draws here and it is East-Asian *Ambiguous*: a
+#: terminal may draw it one cell or two, and `tui.width` says one. The repo table draws
+#: box glyphs (`statusline._TREE_MID` and its neighbours) and can afford to, because its
+#: click map is per ROW — a glyph that comes out two cells wide makes a row ragged and
+#: moves no row index. **A bar's map is per COLUMN.** One separator drawn a cell wider than
+#: it was measured shifts every tab right of it by one, ten separators shift the tenth tab
+#: by ten, and the operator presses `fleet` and lands on `default`. That is `EVENT_KINDS`'
+#: "fires wrongly", reached through a glyph rather than through a protocol.
+#:
+#: So the rule the bar draws is the one glyph whose width no terminal disagrees about.
+#: `▏`, `▎`, `●` and the pointing triangles are the same refusal for the same reason, and
+#: `statusline._persona_chips` records two of them breaking this layout already.
+_BAR_RULE = "|"
+
+
+def _bar_gap() -> str:
+    """The cells a bar puts between two of its own fields.
+
+    Two blanks on a plane whose seams are hidden — charter's shipped default, and byte for
+    byte what every bar drew before rules reached this row. `" | "` on a plane that asked
+    for visible rules, which is one cell more.
+
+    **The same key, one scope in.** ``[frame] rules`` is the operator saying whether they
+    want to see the structure of the frame or a surface with no seams in it
+    (`instance.FRAME_RULES` carries the four reports that produced it). The seam between
+    two tabs is that question about a row instead of about a pane, and answering it from a
+    second key would let one frame draw pane borders and no tab rules, which is exactly the
+    disagreement that key exists to end.
+
+    **It costs nothing on the shipped default**, which is what makes it affordable at all:
+    a plane at ``rules = "hidden"`` spends not one column on this, and a plane that asked
+    for rules pays one cell per gap — fourteen of them on this project's own fifteen
+    workspaces, which the ladder gives up a whole name for rather than overflowing.
+
+    Read at call time through `config.FRAME` rather than cached, exactly as
+    `chrome.dim_ok` and :func:`pad_of` read the keys they need: a panel is a long-lived
+    process and `charter.toml` is re-read when the frame relaunches. The import is
+    function-level for this module's own repaint-path reason.
+    """
+    from .. import config, instance
+    if instance.look_of(config.FRAME).rules == "visible":
+        return f" {_BAR_RULE} "
+    return " " * _BAR_GAP
 
 
 class _Tabs:
@@ -3227,22 +3279,33 @@ class _Tabs:
 TABS = _Tabs()
 
 
-def _tab_columns(start: int, drawn) -> dict:
+def _tab_columns(start: int, drawn, gap: int) -> dict:
     """Which canvas column each drawn tab owns — the map :meth:`_Tabs.publish` takes.
 
     *drawn* is the ``(name, field)`` pairs the rung actually put on the row, in the order
     it put them: the raw name a click switches to, and the text that was drawn for it.
-    *start* is the column the first field begins in. So this walks the composition once
-    more rather than guessing at it, and the two things that could have been guessed wrong
+    *start* is the column the first field begins in, and *gap* is how many cells the rung
+    put between two of them (:func:`_bar_gap`). So this walks the composition once more
+    rather than guessing at it, and the two things that could have been guessed wrong
     are settled here in one place: **the mark belongs to the tab it marks** (it is drawn
-    against that name and there is nothing else it could be a click on), and **the
-    :data:`_BAR_GAP` between two tabs belongs to neither** — those cells are separator,
-    the operator can see they are empty, and picking the nearer name for them would be the
-    clamp `events.Dispatcher._on_canvas` refuses one rectangle out.
+    against that name and there is nothing else it could be a click on), and **the gap
+    between two tabs belongs to neither** — those cells are separator, the operator can
+    see they are not a name, and picking the nearer one for them would be the clamp
+    `events.Dispatcher._on_canvas` refuses one rectangle out. That holds for a gap holding
+    a :data:`_BAR_RULE` exactly as it did for a gap of two blanks: a rule is a seam
+    somebody drew *between* two tabs, and a click on the seam has no tab to be about.
+
+    *gap* is a parameter rather than a read of :func:`_bar_gap` here, and it is the same
+    discipline the rest of this pass keeps: :func:`_bar` resolves the plane's answer ONCE
+    and hands the same number to the cut, the composition and this map. Three readings of
+    a key `charter.toml` is re-read behind is three chances for the map to describe a row
+    the operator is not looking at.
 
     ``tui.width`` and never ``len``, for the reason every other measurement in this module
     gives: a field is display text that has already been through `contain.one_line`, and
-    the column a name ENDS in is a question about cells.
+    the column a name ENDS in is a question about cells. It is also what makes the
+    highlight free: :func:`_bar` paints the marked field in reverse video, `tui.width`
+    counts no SGR, and the map comes out the same either way.
 
     The walk starts one gap behind *start* and pays the gap at the top of every iteration,
     so there is no "first field is different" branch to get wrong or to test — the same
@@ -3250,9 +3313,9 @@ def _tab_columns(start: int, drawn) -> dict:
     down as data rather than deriving them from a sign.
     """
     cols: dict[int, str] = {}
-    at = start - _BAR_GAP
+    at = start - gap
     for name, field in drawn:
-        at += _BAR_GAP
+        at += gap
         width = tui.width(field)
         for col in range(at, at + width):
             cols[col] = name
@@ -3260,18 +3323,26 @@ def _tab_columns(start: int, drawn) -> dict:
     return cols
 
 
-def _page(fields: list[str], at: int, room: int) -> tuple[int, int]:
+def _page(fields: list[str], at: int, room: int, gap: int) -> tuple[int, int]:
     """The half-open run of *fields* the tab at index *at* is drawn with, inside *room*.
 
     :func:`_bar`'s windowed rung. *fields* are the already-marked, already-contained tab
     texts; the answer is a slice of them wide enough to draw, with room left for the two
     counts that stand for what it leaves out.
 
+    *gap* is how many cells go between two fields — :func:`_bar_gap`, resolved once by
+    :func:`_bar` and handed to the cut, the composition and the map together, so that a
+    plane which draws its rules cannot cut a page for one gap and draw it with another.
+
     **The pages do not depend on *at*, and that is the whole design.** The list is cut
     into consecutive pages left to right — greedily, as many whole names as fit, then the
     next page from where that one stopped — and this returns whichever page the marked tab
-    falls in. So the page is a pure function of the NAMES and the WIDTH, and switching to a
-    tab that is on the page redraws that page unchanged with only the `*` moved.
+    falls in. So the page is a pure function of the NAMES, the WIDTH and the gap, and
+    switching to a tab that is on the page redraws that page unchanged with only the `*`
+    moved. The gap belongs in that list and changes nothing about the property: it is
+    fixed for the life of a frame, so it cannot move a page out from under a pointer — the
+    same standard the WIDTH is held to, which moves only on a resize that redraws the row
+    anyway.
 
     That property is what makes a windowed strip safe to click, and the alternative is
     where it was measured. A window CENTRED on the marked tab moves every column each time
@@ -3304,18 +3375,18 @@ def _page(fields: list[str], at: int, room: int) -> tuple[int, int]:
     """
     # The widest count either end can carry: every name but one left out. Measured with
     # `tui.width` for this module's own reason, even though charter mints the digits.
-    tail = _BAR_GAP + tui.width(f"+{len(fields) - 1}")
+    tail = gap + tui.width(f"+{len(fields) - 1}")
 
     def room_for(start: int) -> int:
         """What a page beginning at *start* may spend on names and the gaps between."""
-        return room - tail - (_BAR_GAP + tui.width(f"+{start}") if start else 0)
+        return room - tail - (gap + tui.width(f"+{start}") if start else 0)
 
     def reach(start: int) -> int:
         """Where a page beginning at *start* ends when it is filled to the brim."""
         used, stop = tui.width(fields[start]), start + 1
         budget = room_for(start)
-        while stop < len(fields) and used + _BAR_GAP + tui.width(fields[stop]) <= budget:
-            used += _BAR_GAP + tui.width(fields[stop])
+        while stop < len(fields) and used + gap + tui.width(fields[stop]) <= budget:
+            used += gap + tui.width(fields[stop])
             stop += 1
         return stop
 
@@ -3466,7 +3537,16 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     # call whose result is provably its argument. The sweep found both as survivors for
     # exactly that reason: no input could make the mutation differ. The NAMES are
     # contained, below, which is where the open alphabet actually is.
+    from . import chrome
     lead = _inset() + head + " " * _BAR_GAP
+    # **Resolved ONCE, here, and handed to everything below it.** The cut
+    # (:func:`_page`), the composition and the map (:func:`_tab_columns`) all need to
+    # agree about how wide the seam between two tabs is, and `charter.toml` is re-read
+    # behind :func:`_bar_gap` — so three readings is three chances for the map to describe
+    # a row that was drawn with a different gap. This is `_Viewport.blank`'s discipline
+    # said about a number instead of about a pair of fields.
+    gap = _bar_gap()
+    gapw = tui.width(gap)
 
     def row(body: str = "", drawn=(), before: str = "") -> list[str]:
         """This rung's row, and the column map for the tabs it actually drew.
@@ -3488,7 +3568,7 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
         the operator pressed. Every other rung starts its tabs at the lead and says so by
         not passing it.
         """
-        TABS.publish(_tab_columns(tui.width(lead + before), drawn), here)
+        TABS.publish(_tab_columns(tui.width(lead + before), drawn, gapw), here)
         return [lead + before + body] if body else []
 
     if not names:
@@ -3506,19 +3586,35 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     shown = [contain.one_line(n) for n in names]
     marked = [f"{_BAR_MARK[0] if i == at else _BAR_MARK[1]}{n}"
               for i, n in enumerate(shown)]
+    # **The same fields twice: one set to MEASURE and one set to DRAW.** `chrome.block`
+    # adds no cell — `tui.width` counts no SGR — so the two are the same width by
+    # construction and either could have been measured. Measuring the plain one is what
+    # makes that a property of the code rather than a fact a reader has to know about
+    # `tui.width`, and it is the same split `chrome`'s module docstring insists on
+    # everywhere else: compose and measure, THEN paint.
+    #
+    # **The block covers the mark and the name together**, which is exactly what
+    # :func:`_tab_columns` gives that tab as its columns and what `_Tabs.switch_to`
+    # answers for — so what the operator sees highlighted is what a click there is about.
+    # And it is reverse video rather than a colour for `chrome`'s stated reason: it is the
+    # operator's own two colours exchanged, so it cannot be wrong on a theme charter
+    # cannot see, and `[frame] chrome = "off"` — the shipped default — has nothing to do
+    # with it. Under `NO_COLOR` `panel._write` strips it and the `*` is still there, which
+    # is why the mark stays and was not replaced by the highlight.
+    painted = [chrome.block(f) if i == at else f for i, f in enumerate(marked)]
     room = width - tui.width(lead)
-    joined = (" " * _BAR_GAP).join(marked)
-    if note and tui.width(joined) + _BAR_GAP + tui.width(note) <= room:
-        return row(joined + " " * _BAR_GAP + note, zip(names, marked))
+    joined = gap.join(marked)
+    if note and tui.width(joined) + gapw + tui.width(note) <= room:
+        return row(gap.join(painted) + gap + note, zip(names, marked))
     if tui.width(joined) <= room:
-        return row(joined, zip(names, marked))
+        return row(gap.join(painted), zip(names, marked))
     if at >= 0:
         # **No `if len(names) > 1` here, and it is unreachable rather than merely
         # untested.** With ONE name the page is that name, both counts are absent, and the
         # body this composes IS `joined` — so the rung above asks exactly what this one
         # asks and always answers first. The sweep found the old conditional as a survivor
         # for that reason and the shape has not changed.
-        first, last = _page(marked, at, room)
+        first, last = _page(marked, at, room, gapw)
         # Neither count is a tab. `+9` stands for names that are not on the row, so there
         # is nothing there to switch to and saying so is better than picking one of them —
         # `_Viewport.publish`'s rule for `…(+N more)`, one axis over. **Two of them, and
@@ -3527,14 +3623,17 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
         # row are the FIRST fourteen, which is false. `+5  *harness-wrapper  …  +9` says
         # where in the plane's fifteen this page sits, which is the readout `n/N` gives
         # one rung down and the reason that rung was worth keeping.
-        before = f"+{first}{' ' * _BAR_GAP}" if first else ""
-        after = f"{' ' * _BAR_GAP}+{len(names) - last}" if last < len(names) else ""
-        body = (" " * _BAR_GAP).join(marked[first:last]) + after
+        before = f"+{first}{gap}" if first else ""
+        after = f"{gap}+{len(names) - last}" if last < len(names) else ""
+        body = gap.join(marked[first:last]) + after
         # Measured, not assumed. :func:`_page` puts at least one name on a page, so a name
         # wider than the whole row composes a body that overflows — and this ladder gives a
-        # rung up rather than drawing part of anything.
+        # rung up rather than drawing part of anything. Measured on the PLAIN body for the
+        # reason `painted` states: the two are the same width, and the one that is the same
+        # width by construction is the one to hold a refusal on.
         if tui.width(before + body) <= room:
-            return row(body, zip(names[first:last], marked[first:last]), before=before)
+            return row(gap.join(painted[first:last]) + after,
+                       zip(names[first:last], marked[first:last]), before=before)
     counted = f"{at + 1}/{len(names)}" if at >= 0 else str(len(names))
     if tui.width(counted) <= room:
         return row(counted)

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -3209,11 +3209,12 @@ class _Tabs:
     reports and this repository deletes.
     """
 
-    __slots__ = ("_cols", "_here")
+    __slots__ = ("_cols", "_here", "_more")
 
     def __init__(self) -> None:
         self._cols: dict[int, str] = {}
         self._here = ""
+        self._more: frozenset[int] = frozenset()
 
     def forget(self) -> None:
         """Back to a bar nobody has drawn — for a test, and only a test.
@@ -3224,7 +3225,7 @@ class _Tabs:
         """
         self.publish({}, "")
 
-    def publish(self, columns: dict, here: str) -> None:
+    def publish(self, columns: dict, here: str, more=()) -> None:
         """Record what the paint that just happened put on each column, and where you are.
 
         *columns* maps a column of the component's OWN canvas — the rectangle `ctx.width`
@@ -3246,9 +3247,22 @@ class _Tabs:
         is display text and what goes into `choose.switch_to` or `charter frame-chat`
         has to be the name on disk. The mark is matched on the raw name for the same
         reason one function down; this is that decision arriving at the other end.
+
+        *more* is the columns of the fields that stand for names NOT on the row — both
+        `+N` counts, and the `n/N` of the rung that has no names at all. **A third thing
+        this call writes rather than a second method**, for the reason the class docstring
+        gives about the pair it already held: a rung that published its columns and left
+        a stale overflow behind would open a picker from a cell that is now a tab, or
+        leave a count inert that the paint has just drawn. There is no way to write down
+        one of the three here, so there is nothing for a second method to keep in step.
+
+        A `frozenset` and not a range, because the two counts are two disjoint runs and
+        the narrow rung's is a third — and because :meth:`more_at` asks about ONE column,
+        which is the same question `_cols` answers and should be the same kind of lookup.
         """
         self._cols = dict(columns)
         self._here = here
+        self._more = frozenset(more)
 
     def switch_to(self, col: int):
         """The tab a click at canvas column *col* should switch this frame to, or ``None``.
@@ -3270,6 +3284,32 @@ class _Tabs:
         """
         name = self._cols.get(col)
         return None if name == self._here else name
+
+    def more_at(self, col: int) -> bool:
+        """Whether column *col* is a field standing for names this row could not draw.
+
+        **The other half of "a click on a cell nothing was drawn into does nothing".** A
+        `+9` is not nothing: the operator can see it, it says there are nine more, and it
+        is drawn precisely where the row ran out of names to show. It was inert — pressed,
+        and reported, by the operator this change is for — and answering nothing there was
+        the one place the rule was serving the code rather than the reader.
+
+        What it opens is the palette rather than a page of its own, and that is §3.6
+        arriving where it was always heading: *the bar is a readout, never the mechanism*,
+        and the palette reaches every chat and every workspace at every width including
+        the widths where the bar can draw no name at all. So a count hands off to the
+        mechanism at exactly the point where the readout ran out of room.
+        `frame/builtins._bar_events` is what performs the hand-off; this is only which
+        cells it is about.
+
+        **It is not `switch_to`'s answer wearing a sentinel**, and the separation is the
+        point: that method answers "which name", and every caller of it feeds the name to
+        a command that switches. A count has no name — that is what makes it a count — so
+        a sentinel would be a value every one of those callers would have to learn to not
+        switch to. Two questions, two methods, and a column that is neither answers no to
+        both.
+        """
+        return col in self._more
 
 
 #: The one tab strip this process's bar draws into. See :class:`_Tabs` for why there is
@@ -3321,6 +3361,21 @@ def _tab_columns(start: int, drawn, gap: int) -> dict:
             cols[col] = name
         at += width
     return cols
+
+
+def _span(start: int, text: str) -> range:
+    """The columns *text* occupies when it is drawn starting at column *start*.
+
+    Two lines, and it exists so the fields that are NOT tabs are measured by the same rule
+    the tabs are (:func:`_tab_columns`): `tui.width` and never `len`, off the string the
+    rung actually composed and never off a search of the finished row.
+
+    **An absent field is an empty range rather than a special case.** ``_span(n, "")``
+    contributes no column, so :func:`_bar` can hand both counts to the same expression
+    whether or not the page it cut carries either — which is the branch that would
+    otherwise have to be written twice and got right twice.
+    """
+    return range(start, start + tui.width(text))
 
 
 def _page(fields: list[str], at: int, room: int, gap: int) -> tuple[int, int]:
@@ -3548,7 +3603,7 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     gap = _bar_gap()
     gapw = tui.width(gap)
 
-    def row(body: str = "", drawn=(), before: str = "") -> list[str]:
+    def row(body: str = "", drawn=(), before: str = "", more=()) -> list[str]:
         """This rung's row, and the column map for the tabs it actually drew.
 
         **Every way out of the ladder goes through here**, which is what keeps "the map
@@ -3567,8 +3622,14 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
         cells left of the names it drew, which is a click landing on the tab beside the one
         the operator pressed. Every other rung starts its tabs at the lead and says so by
         not passing it.
+
+        *more* is the columns of the fields that stand for names this rung could NOT draw
+        — both `+N` counts, and the `n/N`. Passed here rather than worked out inside
+        :data:`TABS` for :func:`_tab_columns`' whole reason: the rung that composed the
+        row is the only thing that knows where it put them, and a second walk of the
+        ladder to find them again is a second answer to what is on the row.
         """
-        TABS.publish(_tab_columns(tui.width(lead + before), drawn, gapw), here)
+        TABS.publish(_tab_columns(tui.width(lead + before), drawn, gapw), here, more)
         return [lead + before + body] if body else []
 
     if not names:
@@ -3623,9 +3684,28 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
         # row are the FIRST fourteen, which is false. `+5  *harness-wrapper  …  +9` says
         # where in the plane's fifteen this page sits, which is the readout `n/N` gives
         # one rung down and the reason that rung was worth keeping.
-        before = f"+{first}{gap}" if first else ""
-        after = f"{gap}+{len(names) - last}" if last < len(names) else ""
-        body = gap.join(marked[first:last]) + after
+        #
+        # **Both are CLICKABLE now and neither is a tab**, which are two statements that
+        # sit together rather than in tension. `+9` still names no chat and still switches
+        # nothing; what it does is open the palette, because the palette is what the bar
+        # hands off to when the readout runs out of room (`_Tabs.more_at`). The operator
+        # who reported this had pressed one, which is the strongest evidence available
+        # about what a `+9` looks like it does.
+        leading = f"+{first}" if first else ""
+        trailing = f"+{len(names) - last}" if last < len(names) else ""
+        before = f"{leading}{gap}" if leading else ""
+        tabs = gap.join(marked[first:last])
+        after = f"{gap}{trailing}" if trailing else ""
+        body = tabs + after
+        # Where the two counts landed, taken from the composition above rather than
+        # searched for in the finished string — :func:`_tab_columns`' discipline for the
+        # names, kept for the fields that are not names. :func:`_span` answers an empty
+        # range for a count this page does not carry, so there is no branch here to get
+        # wrong: a page at the start of the list has no leading count and contributes no
+        # columns.
+        start = tui.width(lead)
+        counts = [*_span(start, leading),
+                  *_span(start + tui.width(before + tabs + gap), trailing)]
         # Measured, not assumed. :func:`_page` puts at least one name on a page, so a name
         # wider than the whole row composes a body that overflows — and this ladder gives a
         # rung up rather than drawing part of anything. Measured on the PLAIN body for the
@@ -3633,10 +3713,17 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
         # width by construction is the one to hold a refusal on.
         if tui.width(before + body) <= room:
             return row(gap.join(painted[first:last]) + after,
-                       zip(names[first:last], marked[first:last]), before=before)
+                       zip(names[first:last], marked[first:last]), before=before,
+                       more=counts)
     counted = f"{at + 1}/{len(names)}" if at >= 0 else str(len(names))
     if tui.width(counted) <= room:
-        return row(counted)
+        # **The narrow rung is a count too, and it is the one where this matters most.**
+        # `2/3` stands for every name the row could not draw — all of them — so it is the
+        # widest form of the same field, on the only rung where the bar reaches nothing at
+        # all. A frame narrow enough to fall here had a strip that could be pointed at and
+        # not pressed; it opens the palette now, which is the surface that works at every
+        # width.
+        return row(counted, more=_span(tui.width(lead), counted))
     return row()
 
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -201,10 +201,16 @@ reach a panel at all — tmux gives your typing to the active pane, which is the
 
 Clicking the tab you are already on does nothing at all, rather than tearing the panels down
 and putting them back to arrive where you were. So does clicking the heading, the gap between
-two names, either `+N` count where names did not fit, or the empty space past the last tab:
-those are cells no tab was drawn into, and charter will not pick the nearest name for you. On
-a bar narrow enough that only your own name is drawn, nothing on it is clickable — `F2` is
-what reaches the rest at any width, which is what the bar being a readout means.
+two names, or the empty space past the last tab: those are cells no tab was drawn into, and
+charter will not pick the nearest name for you.
+
+**The `+N` counts are the exception, and they open the palette.** A `+9` stands for names
+that are not on the row, so there is nothing there to switch *to* — but it is the field
+you are most likely to try, and charter now hands off to the surface that can answer:
+pressing either count, or the `n/N` a very narrow bar draws instead of names, opens `F2`.
+It is the top-level palette rather than the picker for that bar's noun, so it is one
+keystroke more than it should be; the doorway row for your noun is already there with the
+name you are on in it.
 
 **The names on a narrow bar do not move when you switch between them.** Where the whole list
 does not fit, the bar cuts it into pages and draws the page yours falls on — and that cut is
@@ -493,15 +499,29 @@ are (`2/3`). It never shows half a name.
 Fifteen workspaces need 274 columns to fit on one row, so on a real terminal the bar is
 usually drawing a page. At 120 columns it draws six of them, at 160 eight, at 200 ten.
 
+**The tab you are on is drawn as a block**, in reverse video — your own terminal's two
+colours exchanged, so it is right on every theme and needs no `[frame] chrome`. The `*`
+beside the name stays, which is what keeps the bar readable with `NO_COLOR` set, on a
+console that has no highlight to give, and with the pane's output redirected to a file.
+
+**`rules = "visible"` puts a separator between tabs.** The same key that decides whether
+you see the seams between panes decides whether you see them between tabs; at the shipped
+`hidden` the strip is exactly the row it always was, and at `visible` it spends one column
+per seam out of the names it can draw. The separator is an ASCII `|` and not the box-drawing
+`│` an IDE would use, deliberately: that glyph is East-Asian *Ambiguous*, so a terminal may
+draw it two cells wide where charter measured one — and on a row whose clicks are resolved
+by *column*, ten separators drawn a cell wide each would put your press ten columns off the
+tab you aimed at.
+
 **They are tabs: with `mouse = true`, clicking a name switches to it.** A chat tab does
 exactly what `F2` → `chat` does — the same command, the same five refusals, the same
 sentence on your screen when one fires. A **workspace** tab does exactly what `charter
 frame-switch --workspace <name>` does: your terminal moves to that workspace, and the chat
 you were in keeps running behind you. *Mouse is off by default* above has the rules a click
 follows and why a tab switches where a repo row only selects; the short of it is that
-clicking the tab you are on, the `+N`, or anything that is not a drawn name does nothing at
-all. The mark stays on the workspace **this chat** is in, because that is what it names —
-switching does not move the chat.
+clicking the tab you are on, or anything that is not a drawn name and not a count, does
+nothing at all. The mark stays on the workspace **this chat** is in, because that is what it
+names — switching does not move the chat.
 
 **Neither is drawn unless a plane places it**, and that is deliberate rather than
 unfinished: on the ordinary plane there is one chat, and a row saying so permanently costs

--- a/docs/news/unreleased-a-click-past-column-223-lands-where-you-pointed.md
+++ b/docs/news/unreleased-a-click-past-column-223-lands-where-you-pointed.md
@@ -1,0 +1,50 @@
+---
+version: unreleased
+headline: A click past column 223 lands on the tab you pointed at, and now there is a test that says so
+---
+
+Nothing changed in charter for this one. What changed is that a hazard nobody had measured
+is now measured, and the line that protects you from it is pinned so it cannot be tidied
+away.
+
+**The hazard.** Every terminal limitation the frame has run into so far degrades the same
+safe way: the event never happens. You click a panel with `[frame] mouse` off, and no bytes
+are produced at all. You click one from a Linux console, which speaks none of the mouse
+protocols, and nothing arrives. A dead affordance is annoying; it is not wrong.
+
+This one was different. The original mouse protocol spells a column as a single byte at
+`column + 32`, so column 224 needs byte 256 — and wraps. tmux's own release notes say it
+got that wrong until 3.3: *"Do not report mouse positions (incorrectly) above the maximum
+of 223"*. tmux 3.2 is the floor charter promises to run on, and a tab bar is the widest
+single row the frame draws. On a 244-column window, a wrapped column is not a click that
+does nothing — it is a click on a **real but different tab**, which would switch you to a
+workspace you never pointed at.
+
+**Measured on the real 3.2 binary and on 3.7c, at 244 columns, with a real client on a real
+pty.** There are two legs and only one of them can wrap:
+
+| | tmux 3.2 | tmux 3.7c |
+|---|---|---|
+| your terminal → tmux | tmux asks for SGR (`?1006h`) **unconditionally** | same |
+| tmux → a pane asking for SGR | `col 240` arrives as `col 240` | `col 240` arrives as `col 240` |
+| tmux → a pane asking *without* SGR | `col 240` arrives as **col ~16** | clamped to 223 |
+
+So the wrap is real, it is on the third row, and the single thing keeping charter off that
+row is that every panel asks for SGR *first*: `\x1b[?1006h` then `\x1b[?1000h`. That looks
+like belt-and-braces and is load-bearing at the floor.
+
+Two things worth knowing that the measurement also settled:
+
+- **tmux does not consult terminfo for this.** Stock macOS ships a 2015 `xterm-256color`
+  with no `XM`/`xm` capability at all, and tmux 3.2 still asked for SGR. A terminfo-driven
+  program would have fallen back to the wrapping encoding *inside* a modern terminal.
+- **The old-terminal fallback is silent, not wrong.** A terminal too old to speak SGR sends
+  the original form into tmux, tmux forwards it to the pane verbatim, and charter reads the
+  payload bytes as stray keypresses — which the frame never delivers to a component. Never
+  fires, rather than fires wrongly.
+
+**No refusal was written.** A guard declining clicks past column 223 on tmux 3.2 would have
+been declining clicks that measurably arrive correctly. What shipped instead is the test:
+a real 244-column frame on both versions, clicking columns 100, 222, 223 and the last
+column of the pane, each of which must come back as the column it was aimed at. Delete the
+SGR request and all four fail.

--- a/docs/news/unreleased-the-tab-strip-looks-and-behaves-like-a-tab-strip.md
+++ b/docs/news/unreleased-the-tab-strip-looks-and-behaves-like-a-tab-strip.md
@@ -1,0 +1,104 @@
+---
+version: unreleased
+headline: The tab bars look like tabs, the +N opens the palette, and rules put a seam between them
+---
+
+*"now we are showing plain text, no colors, no active tab/session color, `+N` in tabs —
+but user can't click and see other workspaces, we don't have any separator borders. All
+together we need to have one intuitive and harmonic design."*
+
+Three of those, and the `+N` is the one with real evidence behind it: **the operator
+clicked it.** That is the strongest thing anyone can know about what a field looks like it
+does, and what it did was nothing at all.
+
+## The tab you are on is drawn as one
+
+```
+  workspaces   authority-audit   autonomy   default   fleet  ██*harness-wrapper██   showcase  +9
+```
+
+Reverse video — your own terminal's foreground and background exchanged — and not a colour
+charter picked. That is the same decision the sidebar's active persona row and the repo
+table's selected row already run on, and it is why the block is right on a Solarized
+palette, on a light theme, and on a client tmux has downsampled to sixteen colours. It is
+also unrelated to `[frame] chrome`, which paints a pane's *background* through a tmux
+option and has nothing to say about what a renderer writes into its own row — so the
+shipped `chrome = "off"` still gets the block.
+
+**The `*` stays.** With `NO_COLOR` set, on a Linux console, or with a panel's output
+redirected to a file, every escape charter writes is stripped — so a strip whose only
+answer to *which tab am I on* was the highlight would have no answer at all there. The
+block goes on top of the mark, never instead of it.
+
+The paint costs the row no column, which is why it could be added to a strip that is
+already short of them.
+
+## `+N` opens the palette
+
+```
+  workspaces  +5   fleet  ██*harness-wrapper██   news-dispatch-guard  +8
+              ^^^                                                     ^^
+```
+
+Both counts, and the `n/N` that a very narrow bar draws instead of names — the rung where
+the strip reaches nothing at all and the hand-off is worth the most.
+
+**Not a page turn, and the reason is the one that made the pages safe to click.** The bar
+cuts a long list into pages decided by the names and the width alone, never by history: no
+remembered window means a tab cannot slide out from under your pointer between two presses,
+which is what stops a double-click switching twice. A `+N` that paged would need exactly
+that memory, and a panel does not survive a respawn, a density change re-splits the panes,
+and two frames on one plane at one width would then disagree about where a tab is.
+
+So the count hands off to the mechanism instead. The bar has always been a readout; `F2`
+has always been what reaches every chat and every workspace at every width. Pressing the
+count is that sentence made clickable at exactly the point where the readout ran out of
+room.
+
+**One honest cost.** It opens the top-level palette, not the picker for that bar's noun —
+`charter frame-palette` has no way to be told which picker to land in yet. What you get is
+the doorway row for your noun with the name you are on already in it, one keystroke from
+the list. One keystroke more than it should be; infinitely fewer than a field that does
+nothing.
+
+Everything else on the row still does nothing, and that is the half a feature like this
+gets wrong: the heading, the gap between two names, the space past the last tab, and the
+tab you are already on.
+
+## `rules = "visible"` puts a seam between tabs
+
+```
+  workspaces   authority-audit |  autonomy |  default |  fleet | ██*harness-wrapper██ | +9
+```
+
+The key that already decides whether you see the rule between two panes now decides whether
+you see one between two tabs. At the shipped `hidden` the row is **byte for byte what it
+was** — this costs the default plane nothing — and at `visible` it spends one column per
+seam out of the names it can draw, which the ladder pays for by dropping a whole name
+exactly as it does for a narrower pane.
+
+**It is an ASCII `|` and not the `│` an IDE would draw, and that is not an aesthetic
+choice.** The box-drawing vertical is East-Asian *Ambiguous*: charter measures it as one
+cell and a terminal may draw it as two. The repo table draws box glyphs happily, because a
+click there is resolved by *row* — a wide glyph makes a row ragged and moves no row index.
+A tab bar's clicks are resolved by *column*. One separator a cell wider than it was measured
+shifts every tab to its right by one; ten shift the tenth by ten, and you press `fleet` and
+land on `default`. Charter's rule for pointer affordances is that they may fail to fire and
+must never fire wrongly, so the strip is held to the one glyph no terminal disagrees about —
+asserted over the whole row at every width from 0 to 260, not just on the constant.
+
+## Verification
+
+Real tmux, **3.7c and the 3.2 floor**: a real 120-column client on a real pty, fifteen real
+workspace names, the count pressed through the client's own terminal, and a real pane carved
+off the harness by a real detached `charter frame-palette` — with the heading beside it still
+opening nothing. The click map is re-asserted column by column on a painted row and on a
+ruled one, at four widths each.
+
+Every new case was checked against a mutant that should break it: dropping the block,
+dropping the separator, spelling the separator `│`, publishing the click map with the old
+gap width, moving the trailing count's cells by one, leaving the narrow rung inert, and
+removing the handler branch — each turns the suite red.
+
+Nothing to adopt. Both bars are still off unless your plane places them with a
+`[[frame.component]]` table, and clicking any of it still needs `[frame] mouse = true`.

--- a/tests/test_a_click_on_a_tab_bar_switches.py
+++ b/tests/test_a_click_on_a_tab_bar_switches.py
@@ -316,3 +316,139 @@ class AClickIsTheWholeGesture(_ABarThatWasDrawn, unittest.TestCase):
                 d._deliver(overlay.Event(overlay.SCROLL, direction, row=0,
                                          col=self.beta)))
         self.assertEqual(self.spawned, [])
+
+
+class AClickOnTheOverflowCountOpensThePalette(_ABarThatWasDrawn, unittest.TestCase):
+    """*"when workspaces are more we are showing `+N` now in tabs — but user can't click
+    and see other workspaces."*
+
+    The operator pressed the `+9`. It is the strongest evidence available about what that
+    field looks like it does, and what it did was nothing at all: the count is drawn for
+    names that are NOT on the row, so `slots._Tabs.switch_to` correctly refused to pick
+    one of them, and the refusal was the whole of the behaviour.
+
+    **It opens the palette rather than turning a page**, and the alternative is worth
+    saying out loud because it is the obvious one. `slots._page` cuts the list into
+    consecutive pages that depend on the NAMES and the WIDTH and on nothing remembered —
+    that is what makes a drawn tab safe to press twice, and its own docstring measures what
+    a remembered window costs (a panel does not survive `cmd_respawn`, a density change
+    re-splits the panes, and two frames on one plane at one width would then disagree). A
+    `+N` that paged would need exactly that memory.
+
+    What the palette gives instead is §3.6's own sentence — *the bar is a readout, never
+    the mechanism* — with the hand-off happening where the readout runs out of room.
+
+    The COLUMN half of this (which cells are a count, and that nothing else is) is
+    `tests/test_frame_bars.AClickResolvesAgainstWhatWasDrawn`; this file is what happens
+    once one is pressed.
+    """
+
+    #: Narrow enough that this plane's names do not all fit, so the row carries a count at
+    #: each end. Chosen against `NAMES` below rather than as a round number — the case
+    #: asserts there are two counts, so a width that drew none fails loudly.
+    WIDTH = 80
+
+    NAMES = [f"workspace-{i:02d}" for i in range(15)]
+    HERE = "workspace-07"
+
+    def setUp(self):
+        super().setUp()
+        for name in self.NAMES:
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        state.frame_dir("f1", create=True)
+        state.record_workspace("f1", self.HERE)
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""},
+                                          clear=False))
+        self.row = tui.strip_ansi(slots.workspaces_bar("f1", self.WIDTH)[0])
+        self.on_event = self._handler("workspaces", "f1")
+        self.counts = [f.strip() for f in self.row.split(" " * slots._BAR_GAP)
+                       if f.strip().startswith("+")]
+        self.assertEqual(len(self.counts), 2,
+                         f"this width draws no page in the middle: {self.row!r}")
+
+    def _column_of_count(self, count: str) -> int:
+        return self._column_of(self.row, count)
+
+    def test_a_press_on_either_count_opens_the_palette(self):
+        """Both ends, and the argv spelled out. `frame-palette` with no arguments is what
+        `F2` runs and what a click on a door runs (`builtins._strip_events`) — one answer
+        to "how does a frame surface open the palette", shared rather than copied."""
+        for count in self.counts:
+            with self.subTest(count=count):
+                self.spawned.clear()
+                self.on_event(_press(self._column_of_count(count)))
+                self.assertEqual(
+                    self.spawned,
+                    [(util.self_relaunch_argv("frame-palette"), "f1")])
+
+    def test_it_opens_exactly_the_door_a_strip_click_opens(self):
+        """One palette, two front doors on one frame. A count that assembled its own argv
+        would be a second answer to a question `_strip_events` already answers, and the
+        two would drift the day either grew an option."""
+        self.on_event(_press(self._column_of_count(self.counts[0])))
+        by_count = self.spawned.pop()
+        slots.DOORS.forget()
+        slots.render("top", "f1")
+        door = next(c for c in range(self.WIDTH) if slots.DOORS.opens_palette(c))
+        builtins.build("f1").get("identity").on_event(_press(door))
+        self.assertEqual(by_count, self.spawned.pop())
+
+    def test_no_switch_is_started_by_a_count(self):
+        """The count names no workspace, so nothing may be switched to on the strength of
+        one. A handler that fell through to `frame-switch` with an empty name would reach
+        `cmd_switch`, which is the class of wrongness §4i is about."""
+        for count in self.counts:
+            self.on_event(_press(self._column_of_count(count)))
+        self.assertTrue(all(argv[-2:-1] != ["--workspace"] or argv[-1] in self.NAMES
+                            for argv, _fid in self.spawned))
+        self.assertTrue(all("frame-switch" not in argv for argv, _fid in self.spawned),
+                        f"a count started a switch: {self.spawned!r}")
+
+    def test_a_press_on_a_tab_still_switches_and_opens_nothing(self):
+        """The control. Both answers live in one handler now, so a case that only asserted
+        the new one would pass with the old one deleted."""
+        drawn = [n for n in self.NAMES if n in self.row and n != self.HERE]
+        self.assertTrue(drawn, f"no switchable tab on this page: {self.row!r}")
+        self.on_event(_press(self._column_of(self.row, f" {drawn[0]}")))
+        self.assertEqual(
+            self.spawned,
+            [(util.self_relaunch_argv("frame-switch", "--workspace", drawn[0]), "f1")])
+
+    def test_the_release_opens_nothing_either(self):
+        """§4i, kept for the second gesture as well as the first: the press is where the
+        operator pointed, and a drag that began on a pane border and ended over this row
+        delivers only a release."""
+        for count in self.counts:
+            self.on_event(_press(self._column_of_count(count), pressed=False))
+        self.assertEqual(self.spawned, [])
+
+    def test_the_middle_and_right_buttons_open_nothing(self):
+        """Middle-click is paste and right-click is the terminal's own menu, exactly as for
+        a tab — the count did not get its own button rule."""
+        for button in ("middle", "right"):
+            self.on_event(_press(self._column_of_count(self.counts[0]), name=button))
+        self.assertEqual(self.spawned, [])
+
+    def test_the_handler_is_still_falsy_when_it_opened_the_palette(self):
+        """Truthy means *repaint me* and nothing in this rectangle changed: the palette
+        carves its pane off the HARNESS. `_strip_events` answers the same way for the same
+        reason."""
+        self.assertFalse(self.on_event(_press(self._column_of_count(self.counts[0]))))
+        self.assertEqual(len(self.spawned), 1, "the case measured nothing")
+
+    def test_the_chat_bar_hands_off_to_the_same_place(self):
+        """One function draws both bars, so one handler answers for both — and the palette
+        is the door for either noun. A count that opened a workspace picker from the chat
+        bar would be the two bars degrading differently, which `slots._bar` exists to stop.
+        """
+        for chat in [f"api.{i}" for i in range(1, 13)]:
+            _plant(chat, workspace="api")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"}):
+            row = tui.strip_ansi(slots.chats_bar("api.6", 44)[0])
+        counts = [f.strip() for f in row.split(" " * slots._BAR_GAP)
+                  if f.strip().startswith("+")]
+        self.assertTrue(counts, f"this width draws no count: {row!r}")
+        self.spawned.clear()
+        self._handler("chats", "api.6")(_press(self._column_of(row, counts[0])))
+        self.assertEqual(self.spawned,
+                         [(util.self_relaunch_argv("frame-palette"), "api.6")])

--- a/tests/test_a_click_on_a_tab_bar_switches.py
+++ b/tests/test_a_click_on_a_tab_bar_switches.py
@@ -34,7 +34,7 @@ import os
 import unittest
 from unittest import mock
 
-from charter import commands_frame, config, util
+from charter import commands_frame, config, tui, util
 from charter.frame import (builtin_actions, builtins, chats, component, events, overlay,
                            slots, state)
 
@@ -86,9 +86,18 @@ class _ABarThatWasDrawn(PersonaIso):
         return builtins.build(fid).get(cid).on_event
 
     def _column_of(self, row: str, field: str) -> int:
+        """Which COLUMN of the drawn *row* the field *field* starts in.
+
+        **`tui.width` of what comes before it, never the character index.** The bar paints
+        the tab you are on as a reverse-video block (`chrome.block`), so a field to the
+        right of it sits further into the STRING than it sits into the pane — and a case
+        that pressed the character index would be pressing a column the operator's eye is
+        not on, which is the one mistake every case in this file exists to catch. `width`
+        counts no SGR, so this is the same number it always was on an unpainted row.
+        """
         at = row.index(field)
         self.assertNotIn(field, row[at + 1:], f"{field!r} is not unique in {row!r}")
-        return at
+        return tui.width(row[:at])
 
 
 class AClickOnAChatTabStartsTheChatSwitch(_ABarThatWasDrawn, unittest.TestCase):

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -312,6 +312,17 @@ class _ARealFrameWithBars(PersonaIso):
     def _active(self) -> str:
         return self._tmux("display-message", "-p", "#{pane_id}").stdout.strip()
 
+    def _panes(self, session: str | None = None) -> list[str]:
+        """Every pane of this frame's window, asked of tmux.
+
+        How a case says whether the palette opened: it is a real pane carved off the
+        harness by a real detached `charter frame-palette`, so a pane appearing is the
+        observable — `tests/test_a_real_click_opens_the_real_palette.py` uses the same one
+        for the doorway on the attention row.
+        """
+        return self._tmux("list-panes", "-t", session or self.fid,
+                          "-F", "#{pane_id}").stdout.split()
+
     def _current_window(self, session: str) -> str:
         return self._tmux("display-message", "-p", "-t", f"{session}:",
                      "#{window_id}").stdout.strip()
@@ -703,9 +714,15 @@ class ARealClickOnAWINDOWEDWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
         self.assertEqual(state.frame_workspace(self.fid), self.HERE,
                          "the second press at the same column moved the chat")
 
-    def test_neither_overflow_count_is_a_tab(self):
-        """`+9` stands for names that are not on the row. It is the field an operator is
-        most likely to try, and it has to do nothing rather than pick one of them."""
+    def test_neither_overflow_count_switches_the_frame_to_a_workspace(self):
+        """`+9` stands for names that are not on the row, so it must not pick one of them.
+
+        It is no longer inert — see the case below, which is the same two clicks asked
+        the other way round — and this is what keeps the two answers apart on a real
+        terminal: whatever a count does, it does not switch. A handler that fell through
+        from `more_at` to the switch would name whichever workspace happened to be under
+        the map, which is the class of wrongness this whole file exists to catch.
+        """
         row = self._bar_row(self.bar)
         counts = [f.strip() for f in row.split("  ") if f.strip().startswith("+")]
         self.assertTrue(counts, f"this row carries no count to click: {row!r}")
@@ -713,3 +730,49 @@ class ARealClickOnAWINDOWEDWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
             self._click(self.bar, col=self._column_of(self.bar, count))
         time.sleep(2.0)
         self.assertEqual(state.frame_workspace(self.fid), self.HERE)
+
+    def test_clicking_the_overflow_count_opens_a_real_palette(self):
+        """*"when workspaces are more we are showing `+N` now in tabs — but user can't
+        click and see other workspaces."*
+
+        The operator pressed this field on their own frame and nothing happened. This is
+        that press, on a real 120-column terminal, with the fifteen workspaces that make
+        the count appear in the first place — and three processes, none of them this one:
+        the row is painted by a `charter panel workspaces` child, the report is decoded
+        there, and the palette is carved by a detached `charter frame-palette` that child
+        starts.
+
+        **The pane is the observable**, exactly as it is for a click on the attention row's
+        doorway, and the keyboard following it is `overlay.modal_argvs` doing what `F2`
+        does: a modal surface you cannot type into is not one. That is not the pointer
+        moving the keyboard — a click on a TAB leaves it on the harness, which is
+        `test_the_click_leaves_the_keyboard_on_the_harness`'s job two classes up and stays
+        true.
+        """
+        before = self._panes()
+        self.assertEqual(self._active(), self.harness)
+        row = self._bar_row(self.bar)
+        counts = [f.strip() for f in row.split("  ") if f.strip().startswith("+")]
+        self.assertTrue(counts, f"this row carries no count to click: {row!r}")
+        self._click(self.bar, col=self._column_of(self.bar, counts[0]))
+        self.assertTrue(
+            _await(lambda: len(self._panes()) > len(before)),
+            f"no pane was carved off the harness, so the {counts[0]} is still inert — "
+            f"row {self._bar_row(self.bar)!r}")
+        opened = [p for p in self._panes() if p not in before]
+        self.assertEqual(len(opened), 1, f"expected one new pane, got {opened}")
+        self.assertTrue(
+            _await(lambda: "workspace" in self._shown(opened[0])
+                   or "chat" in self._shown(opened[0])),
+            f"the new pane is not the palette: {self._shown(opened[0])!r}")
+
+    def test_clicking_the_heading_still_opens_nothing(self):
+        """The control the case above cannot do without: a row that answers EVERY click is
+        as wrong as one that answers none. `workspaces` is a label — the frame naming what
+        the row is about — and the cells it occupies were measured, not made live."""
+        before = self._panes()
+        self._click(self.bar, col=self._column_of(self.bar, "workspaces"))
+        time.sleep(2.0)
+        self.assertEqual(self._panes(), before,
+                         "a click on the heading opened something")
+        self.assertEqual(self._active(), self.harness)

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -30,6 +30,21 @@ from tests._isolation import PersonaIso
 from tests.test_frame_chat_switch import _plant
 
 
+def _plain(row: str) -> str:
+    """*row* with the frame's own paint taken off.
+
+    The bar draws the tab you are on as a reverse-video block (`chrome.block`), so the
+    string a rung returns is no longer the string a terminal shows — and every question
+    below that is about TEXT (is this field a whole name? is `chats  2/3` the whole row?)
+    is about the second one. `tui.strip_ansi` is what `panel._write` runs for a plane
+    under `NO_COLOR`, so this is also literally what such a plane is shown.
+
+    Questions about COLUMNS do not go through here and must not: `tui.width` already
+    counts no SGR, so a width taken off the painted row is the width the pane sees.
+    """
+    return tui.strip_ansi(row)
+
+
 class TheLadderGivesUpWholeThings(unittest.TestCase):
     """`slots._bar` alone, against a list of names and a width — no plane underneath it.
 
@@ -128,7 +143,7 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
             narrowest = min(w for w in range(201)
                             if here in self._row(w, names=names, here=here))
             row = self._row(narrowest, names=names, here=here)
-            self.assertEqual(row.strip(), expected)
+            self.assertEqual(_plain(row).strip(), expected)
             self.assertEqual(tui.width(row), narrowest,
                              "the row does not fill the width it is first drawn at, so "
                              "this measures no boundary")
@@ -251,7 +266,7 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         positions = {f"{i}/{len(names)}" for i in range(1, len(names) + 1)}
         for width in range(0, 201):
             row = slots._bar("chats", list(names), "api-standby.2", width)
-            text = row[0] if row else ""
+            text = _plain(row[0]) if row else ""
             self.assertLessEqual(tui.width(text), width, repr(text))
             if not text:
                 continue
@@ -370,7 +385,7 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         (`chats.ID_RE` and `workspace.valid_name` both refuse those characters), which is
         why the index is taken before containment rather than left to be found later."""
         names = ["api x", "apix"]
-        row = slots._bar("chats", list(names), "apix", 200)[0]
+        row = _plain(slots._bar("chats", list(names), "apix", 200)[0])
         marks = [f for f in row.split(" " * slots._BAR_GAP)
                  if f.strip().startswith(slots._BAR_MARK[0])]
         self.assertEqual(len(marks), 1,
@@ -397,7 +412,8 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
     columns it clicks by looking for the field in the string `_bar` returned, which is the
     thing the operator points at; asking `TABS` where it put something and then asking
     `TABS` what is there would agree with itself whatever the ladder did. The fixtures are
-    ASCII on purpose, so a character index into that string IS a terminal column — the one
+    ASCII on purpose, so what separates a character index from a terminal column is only
+    the frame's own paint — :meth:`_cells` is where the two are reconciled, and the one
     case that is about a name needing repair says so and measures with `tui.width`.
 
     **A bar is horizontal, so the map is per column, and the ladder is why it has to exist
@@ -421,10 +437,20 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         return rows[0] if rows else ""
 
     def _cells(self, row, field):
-        """Every column *field* occupies in *row*, taken from the drawn row itself."""
+        """Every column *field* occupies in *row*, taken from the drawn row itself.
+
+        **A character index is not a column, and this is where the two stopped being one
+        number.** The bar paints the tab you are on (`chrome.block`), so every field right
+        of it sits some escape bytes further into the string than it sits into the pane —
+        and a case that clicked the character index would be clicking a column left of the
+        one it read, which is precisely the off-by-a-tab this class exists to catch.
+        `tui.width` of the text BEFORE the field is the column, and it counts no SGR, so
+        it is right whether or not anything on the row is painted.
+        """
         at = row.index(field)
         self.assertNotIn(field, row[at + 1:], f"{field!r} is not unique in {row!r}")
-        return range(at, at + len(field))
+        start = tui.width(row[:at])
+        return range(start, start + tui.width(field))
 
     def test_every_tab_on_a_wide_row_resolves_to_its_own_name(self):
         """The whole feature, at the rung that draws every name: point at a tab, get that
@@ -655,6 +681,241 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
                         f"{width}: pressing column {col} twice switched twice — "
                         f"{name} then {slots.TABS.switch_to(col)}\n"
                         f"  before {row!r}\n  after  {after!r}")
+
+
+class TheTabYouAreOnIsDrawnAsOne(unittest.TestCase):
+    """The strip's own paint: a block on the tab you are on, and nothing anywhere else.
+
+    *"now we are showing plain text, no colors, no active tab/session color"* — the report
+    this class is the standing form of. The bar drew a `*` and nothing else, which is a
+    caption's way of saying "you are here" and not a strip's.
+
+    **Reverse video and not a colour, which is `frame/chrome.py`'s decision and not a
+    fresh one.** Reverse is the operator's own foreground and background exchanged, so it
+    is right on every theme charter cannot see — including the Solarized palettes, where
+    every named grey charter could have picked IS somebody's background. It also survives
+    every terminal tier tmux downsamples for. And it is orthogonal to `[frame] chrome`,
+    which is the shipped `off`: that key paints the pane's BACKGROUND through a tmux pane
+    option and says nothing about what a renderer writes into its own row.
+
+    **`slots._BAR_MARK` stays, and that is what makes the design read with no colour at
+    all.** `panel._write` strips every escape from every row on a plane under `NO_COLOR`,
+    and the Linux console can carry no highlight worth the name — so a strip whose only
+    answer to "which tab am I on" was the paint would have no answer there. The `*` is a
+    character. The block is on top of it, never instead of it.
+    """
+
+    NAMES = ["api.1", "api.2", "api.3"]
+    #: Spelled out rather than read off `chrome._REVERSE` and `chrome._OFF`. A case built
+    #: from the constants it is about agrees with any value they take, which is the
+    #: survivor `commands_change.BLOCK_END` produced — so the escape a terminal actually
+    #: receives is written here, by hand, a second time.
+    ON, OFF = "\x1b[7m", "\x1b[0m"
+
+    def setUp(self):
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+
+    def _row(self, width=200, names=None, here="api.2"):
+        rows = slots._bar("chats", list(names or self.NAMES), here, width)
+        return rows[0] if rows else ""
+
+    def test_the_tab_you_are_on_is_a_block_and_no_other_tab_is(self):
+        row = self._row()
+        self.assertIn(f"{self.ON}*api.2{self.OFF}", row)
+        self.assertEqual(row.count(self.ON), 1, f"more than one block: {row!r}")
+
+    def test_the_block_covers_the_mark_and_the_name_and_stops(self):
+        """**Exactly the cells `slots.TABS` gives that tab, which is the point.** A block
+        one cell wide either way would highlight a column that answers for a different tab
+        — or for no tab — and the operator would be pointing at what they can see is lit.
+        """
+        row = self._row()
+        painted = row.split(self.ON, 1)[1].split(self.OFF, 1)[0]
+        self.assertEqual(painted, "*api.2")
+        start = tui.width(row[:row.index(self.ON)])
+        for col in range(start, start + tui.width(painted)):
+            self.assertIsNone(slots.TABS.switch_to(col),
+                              f"column {col} is inside the block and is not the tab you "
+                              f"are on: {row!r}")
+        self.assertEqual(slots.TABS.switch_to(start - 1), None)
+        self.assertEqual(slots.TABS.switch_to(start + tui.width(painted)), None)
+
+    def test_the_paint_costs_the_row_no_cell_at_all(self):
+        """Which is why it could be added to a strip that is already competing for columns.
+        Asked at every width, so a rung that measured the painted body instead of the
+        plain one would be caught at the boundary where it overflows rather than only at
+        the wide end."""
+        for width in range(0, 201):
+            painted = self._row(width)
+            plain = _plain(painted)
+            self.assertEqual(tui.width(painted), tui.width(plain), repr(painted))
+            self.assertLessEqual(tui.width(painted), width, repr(painted))
+
+    def test_a_row_that_is_on_no_tab_paints_nothing(self):
+        """`here` naming nothing in the list is a real state — the workspace bar draws it
+        for a frame whose recorded workspace has been deleted. Nothing is marked, so
+        nothing is lit; a block on a tab the frame is not on would be the row claiming a
+        position it has just declined to claim one field over."""
+        row = self._row(here="nowhere")
+        self.assertNotIn(self.ON, row, f"an unmarked row painted something: {row!r}")
+
+    def test_with_every_escape_stripped_the_row_still_says_where_you_are(self):
+        """`NO_COLOR`, the Linux console, `charter panel chats --session x > /tmp/log`.
+        The strip has to keep working on all three, and this is the property that says it
+        does: the answer survives the paint being deleted."""
+        row = _plain(self._row())
+        self.assertIn(f"{slots._BAR_MARK[0]}api.2", row)
+        self.assertNotIn(f"{slots._BAR_MARK[0]}api.1", row)
+        self.assertNotIn(f"{slots._BAR_MARK[0]}api.3", row)
+
+    def test_every_column_of_a_painted_row_still_answers_for_the_tab_under_it(self):
+        """**The regression the paint could actually cause**, asked directly and at both
+        the rung that draws every name and the rung that draws a page.
+
+        Escapes make the string longer than the row, so a map measured off character
+        positions would hand every tab right of the block to its left-hand neighbour — a
+        real name, a plausible switch, and wrong. The map is built from `tui.width` of the
+        fields, which counts no SGR, and this is what says so.
+        """
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        for width in (200, 120, 80, 60):
+            with self.subTest(width=width):
+                row = self._row(width, names=names, here="workspace-07")
+                if not row:
+                    continue
+                plain = _plain(row)
+                for name in (n for n in names if n in plain):
+                    at = plain.index(name) - tui.width(slots._BAR_MARK[0])
+                    want = None if name == "workspace-07" else name
+                    for col in range(at, at + 1 + tui.width(name)):
+                        self.assertEqual(slots.TABS.switch_to(col), want,
+                                         f"{width}: column {col} of {plain!r}")
+
+
+class TheSeamBetweenTwoTabsIsThePlanesOwnAnswer(unittest.TestCase):
+    """`[frame] rules`, one scope in — the seam between two TABS rather than two panes.
+
+    *"we don't have any separator borders."* The key that answers that question already
+    exists and the operator has already been asked it: `rules = "hidden"` (shipped) means
+    "I want a surface with no seams in it", `rules = "visible"` means "show me the
+    structure". A second key for the tab strip would let one frame draw pane borders and
+    no tab rules, which is the disagreement `instance.FRAME_RULES` exists to end.
+
+    **The glyph is ASCII and that is the sharp end of this class.** `│` is what an IDE
+    draws and it is East-Asian *Ambiguous*: `tui.width` says one cell, a terminal may draw
+    two. The repo table draws box glyphs and can afford to because its click map is per
+    ROW. A bar's map is per COLUMN, so a separator that comes out a cell wider than it was
+    measured shifts every tab right of it — ten separators, ten columns, and the operator
+    presses one workspace and lands on another. `component.EVENT_KINDS`' "fires wrongly",
+    reached through a glyph.
+    """
+
+    NAMES = ["api.1", "api.2", "api.3"]
+
+    def setUp(self):
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+
+    def _with(self, rules):
+        return mock.patch.dict(config.FRAME, {"rules": rules})
+
+    def _row(self, width=200, names=None, here="api.2", rules="hidden"):
+        with self._with(rules):
+            rows = slots._bar("chats", list(names or self.NAMES), here, width)
+        return rows[0] if rows else ""
+
+    def test_a_plane_whose_rules_are_hidden_draws_the_row_it_always_drew(self):
+        """**The shipped default costs nothing**, which is what made this affordable on a
+        row that is already short of columns. Byte for byte the old composition: two
+        blanks between two tabs and no glyph anywhere."""
+        row = _plain(self._row(rules="hidden"))
+        self.assertEqual(row.strip(), "chats   api.1  *api.2   api.3")
+        self.assertNotIn(slots._BAR_RULE, row)
+
+    def test_a_plane_whose_rules_are_visible_puts_one_between_every_pair(self):
+        row = _plain(self._row(rules="visible"))
+        self.assertEqual(row.strip(), "chats   api.1 | *api.2 |  api.3")
+        self.assertEqual(row.count(slots._BAR_RULE), len(self.NAMES) - 1)
+
+    def test_the_rule_is_a_glyph_no_terminal_draws_two_cells_wide(self):
+        """Asked as the PROPERTY rather than as `== "|"`: what matters is that no terminal
+        may disagree with `tui.width` about it, and every character outside ASCII is a
+        character some terminal might. A future edit reaching for `│` because it looks
+        better fails here, which is where the reason is written down."""
+        self.assertEqual(tui.width(slots._BAR_RULE), 1)
+        self.assertTrue(slots._BAR_RULE.isascii(),
+                        f"{slots._BAR_RULE!r} is outside ASCII, so a terminal may draw it "
+                        f"a different width than this row was measured at — and every tab "
+                        f"right of it then answers a click meant for its neighbour")
+
+    def test_nothing_the_strip_draws_is_outside_ascii(self):
+        """The rule above, asked of the WHOLE row rather than of one constant — the mark,
+        the separator, the counts and the position. A name is not charter's to hold to
+        this and is excluded by construction: these fixtures are ASCII, so anything else
+        on the row came from this module."""
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        for width in range(0, 261):
+            row = _plain(self._row(width, names=names, here="workspace-07",
+                                   rules="visible"))
+            self.assertTrue(row.isascii(), f"{width}: {row!r}")
+
+    def test_the_rule_belongs_to_neither_tab(self):
+        """A seam is a cell the operator can see is not a name. Picking the nearer one for
+        it would be the clamp `events.Dispatcher._on_canvas` refuses one rectangle out —
+        and here it would be worse than for a blank gap, because a rule LOOKS like an
+        edge and the tab it would be read as is the one on the far side of it."""
+        row = self._row(rules="visible", here="nowhere")
+        plain = _plain(row)
+        self.assertIn(slots._BAR_RULE, plain)
+        for col, ch in enumerate(plain):
+            if ch == slots._BAR_RULE:
+                self.assertIsNone(slots.TABS.switch_to(col),
+                                  f"the seam at column {col} answered for a tab: {plain!r}")
+
+    def test_every_column_of_a_ruled_row_answers_for_the_tab_under_it(self):
+        """The whole map, on a plane that draws rules, at four widths and on a list long
+        enough to reach the windowed rung. A gap read as two cells in the cut and drawn as
+        three would put every tab one column left of where the map says it is."""
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        for width in (300, 200, 120, 80):
+            with self.subTest(width=width):
+                row = self._row(width, names=names, here="workspace-07",
+                                rules="visible")
+                if not row:
+                    continue
+                plain = _plain(row)
+                self.assertLessEqual(tui.width(plain), width, repr(plain))
+                for name in (n for n in names if n in plain):
+                    at = plain.index(name) - tui.width(slots._BAR_MARK[0])
+                    want = None if name == "workspace-07" else name
+                    for col in range(at, at + 1 + tui.width(name)):
+                        self.assertEqual(slots.TABS.switch_to(col), want,
+                                         f"{width}: column {col} of {plain!r}")
+
+    def test_the_ladder_pays_for_the_rules_rather_than_overflowing(self):
+        """**A rule costs a column and the ladder is what finds it.** At the width where
+        every name fits without rules, the same row with rules on cannot hold them all —
+        so it must give up a whole name, exactly as it does for a narrower pane, and never
+        run past the width it was given.
+
+        Asked at every width from 0 to 300 on this project's own fifteen workspaces, which
+        is where fourteen extra cells is a name and a half.
+        """
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        for width in range(0, 301):
+            with self._with("visible"):
+                rows = slots._bar("workspaces", list(names), "workspace-07", width)
+            text = _plain(rows[0]) if rows else ""
+            self.assertLessEqual(tui.width(text), width, f"{width}: {text!r}")
+        widest = next(w for w in range(500)
+                      if all(n in _plain(self._row(w, names=names, here="workspace-07",
+                                                   rules="visible")) for n in names))
+        without = next(w for w in range(500)
+                       if all(n in _plain(self._row(w, names=names, here="workspace-07",
+                                                    rules="hidden")) for n in names))
+        self.assertEqual(widest - without, len(names) - 1,
+                         "a plane that draws rules pays exactly one cell per seam")
 
 
 class ThisPlaneIsWhyTheRungIsWindowed(unittest.TestCase):

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -519,21 +519,64 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         for col in self._cells(row, "api.2"):
             self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
 
-    def test_neither_overflow_count_resolves_to_anything(self):
+    def test_neither_overflow_count_switches_to_anything(self):
         """A `+N` stands for names that are NOT on the row, so there is nothing there to
         switch to — `…(+N more)`'s rule one axis over. **Both ends**, and the LEADING one
         is the new half: it sits between the heading and the first tab, so a map measured
         from the lead rather than from where the tabs actually start would hand its cells
         to the first name on the page — a click landing one tab off where the operator
-        pressed."""
+        pressed.
+
+        This is still exactly true and it is no longer the whole answer: a count is a
+        `more_at` cell now, which is the case below. The two are separate methods for
+        `_Tabs.more_at`'s reason, so they get separate cases: what would be wrong is a
+        count that started SWITCHING somewhere, and that is what this keeps out.
+        """
         names = [f"workspace-{i:02d}" for i in range(15)]
-        row = self._draw(80, names=names, here="workspace-07")
+        row = _plain(self._draw(80, names=names, here="workspace-07"))
         counts = [f.strip() for f in row.split(" " * slots._BAR_GAP)
                   if f.strip().startswith("+")]
         self.assertEqual(len(counts), 2, f"this width is not a page in the middle: {row!r}")
         for count in counts:
             for col in self._cells(row, count):
                 self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+
+    def test_both_overflow_counts_are_a_cell_that_opens_the_picker(self):
+        """*"when workspaces are more we are showing `+N` now in tabs — but user can't
+        click and see other workspaces."*
+
+        The operator pressed one. That is the strongest evidence available about what a
+        `+9` looks like it does, and the answer was nothing at all.
+
+        **Both ends, measured off the drawn row**, for the reason every case in this class
+        gives: the leading count is the one a map built from the heading rather than from
+        the composition would put in the wrong place, and it is drawn at a different width
+        than the trailing one (`+13` against `+1`), so a `_span` measured with `len` would
+        pass on one and fail on the other only for names that sort late.
+        """
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        row = _plain(self._draw(80, names=names, here="workspace-07"))
+        counts = [f.strip() for f in row.split(" " * slots._BAR_GAP)
+                  if f.strip().startswith("+")]
+        self.assertEqual(len(counts), 2, f"this width is not a page in the middle: {row!r}")
+        for count in counts:
+            for col in self._cells(row, count):
+                self.assertTrue(slots.TABS.more_at(col),
+                                f"the {count} is still inert at column {col}: {row!r}")
+
+    def test_nothing_but_a_count_is_a_cell_that_opens_the_picker(self):
+        """The negative, and it is the one that keeps the two answers apart. A tab, the
+        heading, a gap and the space past the last name must all answer `more_at` no —
+        otherwise a click meant for a workspace would open a palette instead of switching,
+        which is the same class of wrong as switching to the neighbour."""
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        row = _plain(self._draw(80, names=names, here="workspace-07"))
+        counts = [f.strip() for f in row.split(" " * slots._BAR_GAP)
+                  if f.strip().startswith("+")]
+        opening = {c for c in range(200) if slots.TABS.more_at(c)}
+        expected = {col for count in counts for col in self._cells(row, count)}
+        self.assertEqual(opening, expected,
+                         f"a cell that is not a count opens the picker: {row!r}")
 
     def test_a_page_that_starts_in_the_middle_still_maps_its_tabs_where_they_are(self):
         """The leading count moves every tab right of where a bar without one puts them.
@@ -563,10 +606,39 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
 
     def test_the_rung_that_says_only_where_you_are_has_no_tabs_at_all(self):
         """`2/3` is a position, not a name, and there is no name on the row to click."""
-        row = self._draw(16, here="api.2")
+        row = _plain(self._draw(16, here="api.2"))
         self.assertEqual(row.strip(), "chats  2/3", repr(row))
         for col in range(0, 200):
             self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+
+    def test_the_rung_that_says_only_where_you_are_still_opens_the_picker(self):
+        """**The width where this matters most.** A frame narrow enough to fall to `2/3`
+        has a strip that can be pointed at and not pressed — the whole list is off the row,
+        so every rule above about clicking a tab is vacuous here. `2/3` is the same field
+        the counts are, saying the same thing about all three names instead of about nine
+        of fifteen, so it opens the same chooser.
+
+        The heading and the space past it stay inert, which is what says the cells were
+        measured rather than the whole row being made live."""
+        row = _plain(self._draw(16, here="api.2"))
+        for col in self._cells(row, "2/3"):
+            self.assertTrue(slots.TABS.more_at(col), f"column {col} of {row!r}")
+        for col in self._cells(row, "chats"):
+            self.assertFalse(slots.TABS.more_at(col), f"the heading opened a picker")
+        self.assertFalse(slots.TABS.more_at(tui.width(row) + 5),
+                         "the space past the row opened a picker")
+
+    def test_a_rung_that_draws_nothing_opens_nothing(self):
+        """`_Viewport.blank`'s half, for the third thing `publish` writes. A bar narrowed
+        past its last rung draws no row — so there is no count on screen, and a `more_at`
+        that survived the narrowing would open a palette from a cell the operator can see
+        is empty."""
+        self._draw(80, names=[f"workspace-{i:02d}" for i in range(15)],
+                   here="workspace-07")
+        self.assertTrue(any(slots.TABS.more_at(c) for c in range(80)))
+        self.assertEqual(self._draw(11), "")
+        self.assertEqual([c for c in range(200) if slots.TABS.more_at(c)], [],
+                         "a bar that drew no row kept the counts it is no longer drawing")
 
     def test_a_narrowed_bar_forgets_the_tabs_it_is_no_longer_drawing(self):
         """**The `_Viewport.blank` half, one axis over.** A pane that drew every name and

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -378,6 +378,43 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         self.assertEqual(row, row.rstrip(),
                          "an absent note still spent its separator")
 
+    def test_a_page_that_ends_the_list_spends_no_columns_on_a_count_it_has_not_got(self):
+        """The same rule one rung down, for the TRAILING `+N` — and the deletion sweep is
+        what asked for it.
+
+        A page whose last name is the last name in the list draws no trailing count, and
+        the separator that would have gone in front of it must go with it. The sweep found
+        `f"{gap}{trailing}" if trailing else ""` surviving: with the `else` collapsed, such
+        a page ends in the gap alone, which is two blank cells on a plane whose rules are
+        hidden and ` | ` on one whose rules are visible — a seam drawn between a tab and
+        nothing.
+
+        **It is not only cosmetic**, which is why it is asserted as a width rather than as
+        a strip. Those cells are measured: `_bar` refuses the whole rung when the composed
+        body will not fit, so a page carrying a phantom separator is given up one to three
+        columns earlier than it should be — a name lost from a pane that had room for it.
+
+        Asked over every width and every name, because which pages end the list depends on
+        both, and asked on a plane whose rules are VISIBLE as well, where the phantom is a
+        glyph rather than whitespace and `rstrip` alone would not see it.
+        """
+        names = [f"workspace-{i:02d}" for i in range(15)]
+        for rules in ("hidden", "visible"):
+            with mock.patch.dict(config.FRAME, {"rules": rules}):
+                for here in names:
+                    for width in range(0, 201):
+                        row = _plain(self._row(width, names=names, here=here))
+                        if not row:
+                            continue
+                        self.assertEqual(
+                            row, row.rstrip(),
+                            f"{rules} at {width} on {here}: the row ends in the "
+                            f"separator of a count it did not draw — {row!r}")
+                        self.assertFalse(
+                            row.rstrip().endswith(slots._BAR_RULE),
+                            f"{rules} at {width} on {here}: a seam was drawn between the "
+                            f"last tab and nothing — {row!r}")
+
     def test_the_mark_follows_the_raw_name_and_not_the_repaired_one(self):
         """`contain.one_line` is a REPAIR, so two names differing only in what it repairs
         are one string after it — and a mark matched on the drawn text would follow the

--- a/tests/test_frame_input_reaches_a_component.py
+++ b/tests/test_frame_input_reaches_a_component.py
@@ -71,7 +71,7 @@ import unittest
 from pathlib import Path
 
 from charter import commands_frame, config
-from charter.frame import layout, state, tmuxctl
+from charter.frame import layout, overlay, state, tmuxctl
 
 from tests import _tmuxreap
 from tests._isolation import PersonaIso
@@ -242,6 +242,16 @@ class _AFrameWithProviderPanels(PersonaIso):
     #: the pointer cases are about.
     MOUSE = False
 
+    #: How big the window — and therefore the pty the client is born on — is made.
+    #:
+    #: A class attribute rather than a literal in `setUp` because
+    #: :class:`APointerPastColumnTwoTwentyThreeLandsWhereItWasAimed` needs a window WIDER
+    #: than 223 columns and everything else about that fixture is identical. 100x24 is
+    #: what every case here has always run at and stays the default, so no existing case
+    #: changes size to make room for the new one — `_fork_pty`'s measurement is about the
+    #: client agreeing with the window, not about which size they agree on.
+    COLS, ROWS = 100, 24
+
     def setUp(self) -> None:
         super().setUp()
         v = tmuxctl.version()
@@ -264,7 +274,8 @@ class _AFrameWithProviderPanels(PersonaIso):
         self.env.pop("CHARTER_HOME", None)
 
         started = _tmux("-f", "/dev/null", "new-session", "-d", "-s", self.fid,
-                        "-x", "100", "-y", "24", "-P", "-F", "#{pane_id}", "cat",
+                        "-x", str(self.COLS), "-y", str(self.ROWS),
+                        "-P", "-F", "#{pane_id}", "cat",
                         env=self.env)
         self.assertEqual(started.returncode, 0, started.stderr)
         self.harness = started.stdout.strip()
@@ -837,6 +848,123 @@ class APointerWithTmuxsOwnMouseOn(_AFrameWithProviderPanels):
                         f"the wheel never reached it: {self._pointed()!r}")
         self.assertEqual(self._active(), self.harness,
                          "the wheel moved the keyboard")
+
+
+class APointerPastColumnTwoTwentyThreeLandsWhereItWasAimed(_AFrameWithProviderPanels):
+    """A click on the 240th column of a 244-column pane is a click on the 240th column.
+
+    **The one terminal limit found so far that could degrade to "fires wrongly".** Every
+    other one degrades to *never fires*, which `component.EVENT_KINDS` asks for and which
+    costs an operator a dead affordance and nothing else. This one would hand a component
+    a real column that is not the one the pointer was over — and the widest single row in
+    the frame is a tab bar, so on the 244-column window this was measured for it would
+    switch the operator to a **real but wrong workspace**.
+
+    The suspicion came from tmux's own CHANGES for 3.3: *"Do not report mouse positions
+    (incorrectly) above the maximum of 223"*, which says in as many words that before 3.3
+    tmux got this wrong — and 3.2 is `tmuxctl.FLOOR`. 223 is where the X10 mouse encoding
+    runs out: it spells a coordinate as one byte at ``value + 32``, so column 224 needs
+    byte 256 and wraps.
+
+    **Measured on the real 3.2 floor binary and on 3.7c, and the suspicion is refuted for
+    charter — on the leg it was aimed at.** There are two legs and only one of them is
+    charter's::
+
+        terminal -> tmux   what the outer terminal reports, in whatever mode tmux asked
+                           it for.
+        tmux -> pane       what tmux synthesises for the pane's program, in whatever mode
+                           the PANE asked for.
+
+    On the first leg, at a 244-column pty with ``TERM=xterm-256color``, **tmux 3.2 asks
+    the outer terminal for ``?1006h``** — unconditionally, alongside ``?1000h``/``?1002h``,
+    and with no ``XM``/``xm`` capability in that terminfo entry to have asked for it
+    (stock macOS ships a 2015 entry that has neither). So the terminal reports in SGR and
+    no wrap is possible, on either version::
+
+        tmux 3.2   SGR col 240 in  ->  pane read b'\\x1b[<0;240;1M'
+        tmux 3.7c  SGR col 240 in  ->  pane read b'\\x1b[<0;240;1M'
+
+    The second leg is where the CHANGES entry lives, and it is reached only by a pane that
+    asks for ``1000`` **without** ``1006``. Measured with exactly such a pane::
+
+        tmux 3.2   SGR col 240 in  ->  pane read b'\\x1b[M \\x10!'   <- WRAPPED, col 16-ish
+        tmux 3.2   SGR col 244 in  ->  pane read b'\\x1b[M \\x14!'   <- WRAPPED
+        tmux 3.7c  SGR col 240 in  ->  pane read b'\\x1b[M \\xff!'   <- clamped at 223
+        tmux 3.7c  SGR col 244 in  ->  pane read b'\\x1b[M \\xff!'   <- clamped at 223
+
+    So the wrap is real at the floor, and `overlay.MOUSE_ON` asking for **1006 before
+    1000** is the single line that keeps charter off it. That is what
+    :meth:`test_the_request_is_what_keeps_a_wide_column_honest` pins, and why it is
+    spelled as a literal: the constant looks like belt-and-braces and is load-bearing on
+    the floor tmux charter declares.
+
+    **And the fallback is safe rather than merely unreached.** A terminal too old to speak
+    SGR sends X10 into tmux, tmux forwards that form verbatim (`overlay.decode`'s own
+    measurement), and `decode` reads the payload bytes as stray single-byte KEYS — which
+    `events.DELIVERED` never delivers. Never fires, not fires wrongly.
+
+    No refusal was written into charter for any of this, and that is the finding: a guard
+    refusing clicks past column 223 on 3.2 would have refused clicks that measurably
+    arrive correctly.
+    """
+
+    #: Wide enough that the interesting columns are past where X10 runs out, and the width
+    #: the operator this was measured for actually runs.
+    COLS, ROWS = 244, 24
+
+    def _pointed(self) -> str:
+        return self._shown(POINT_CID)
+
+    def test_the_request_is_what_keeps_a_wide_column_honest(self):
+        """`overlay.MOUSE_ON` asks for SGR, and asks for it FIRST.
+
+        A literal, and both halves matter. Dropping ``?1006h`` puts every panel on the
+        X10 leg above, where the 3.2 floor wraps a column past 223 onto a real, wrong one.
+        Asking for it *after* ``?1000h`` is the same hazard with a race in front of it.
+        """
+        self.assertEqual(overlay.MOUSE_ON, "\x1b[?1006h\x1b[?1000h")
+        self.assertLess(overlay.MOUSE_ON.index("1006"), overlay.MOUSE_ON.index("1000"),
+                        "the pane asks for press/release before it asks for SGR, so tmux "
+                        "may synthesise an X10 report for it — which wraps past column "
+                        "223 at the 3.2 floor")
+
+    def test_an_x10_report_reaches_no_component_at_all(self):
+        """The other end of the same measurement, as an assertion rather than a paragraph.
+
+        These are the exact bytes tmux 3.2 forwarded for a wrapped column. `decode` must
+        produce no `click` from them — a `key` is fine, because `events.DELIVERED` carries
+        none, and the whole point is that the wrap can only ever be silence.
+        """
+        for payload in (b"\x1b[M \x105", b"\x1b[M \x145", b"\x1b[M \xff!"):
+            with self.subTest(payload=payload):
+                evs, rest = overlay.decode(payload, final=True)
+                self.assertEqual(rest, b"")
+                self.assertEqual([e for e in evs if e.kind != overlay.KEY], [],
+                                 f"a wrapped X10 report became a pointer event: {evs!r}")
+
+    def test_a_click_past_two_hundred_and_twenty_three_is_the_column_it_was_aimed_at(self):
+        """The whole finding, end to end, through a real tmux on a real 244-column pty.
+
+        Aimed at four columns rather than one, because the failure this is about is an
+        arithmetic one and a single sample cannot tell "the column survived" from "the
+        column happened to be right". 100 is the control below the boundary; 223 is the
+        last column X10 can spell; 224 is the first it cannot; and the last column of the
+        pane is where the operator's `+N` sits on a full-width tab bar.
+        """
+        self._select(self.harness)
+        left, _top, width, _h = self._rect(self.pane[POINT_CID])
+        self.assertEqual(left, 0, "this pane does not start at the window's left edge, so "
+                                  "the columns below are not the ones being asked about")
+        self.assertGreater(width, 223,
+                           f"this pane is {width} columns wide, so nothing here is past "
+                           f"the boundary the case is about")
+        for col in (100, 222, 223, width - 1):
+            with self.subTest(col=col):
+                self._point(self.pane[POINT_CID], row=0, col=col)
+                want = "POINT-click:left:0,%d:up" % col
+                self.assertTrue(_await(lambda w=want: w in self._pointed()),
+                                f"a click aimed at column {col} of a {width}-column pane "
+                                f"arrived somewhere else: {self._pointed()!r}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> *"now we are showing plain text, no colors, no active tab/session color, `+N` in tabs — but user can't click and see other workspaces, we don't have any separator borders. All together we need to have one intuitive and harmonic design."*

Three of the operator's six complaints, plus the measurement that had to come first.

## The 223 measurement, and what it refuted

tmux's own CHANGES says it reported mouse positions above column 223 incorrectly until 3.3, and 3.2 is `tmuxctl.FLOOR`. A tab bar is the widest single row the frame draws, so on the operator's 244-column window a wrapped column would be a click on a **real but wrong tab** — the one thing `EVENT_KINDS` forbids. Every other terminal limitation found so far degrades to *never fires*, which is safe.

**Measured on the real 3.2 floor binary and on 3.7c, at 244 columns, with a real client on a real pty.** Two legs, and only one can wrap:

| | tmux 3.2 | tmux 3.7c |
|---|---|---|
| terminal to tmux | asks for `?1006h` **unconditionally** | same |
| tmux to a pane asking 1006 | `col 240` arrives as `col 240` | `col 240` arrives as `col 240` |
| tmux to a pane asking 1000 alone | `col 240` arrives as **byte 0x10** (wrapped) | clamped to 223 |

So the wrap is real at the floor, it is on the third row, and the single line keeping charter off it is that `overlay.MOUSE_ON` asks for SGR **first**. **No refusal was written** — one would have declined clicks that measurably arrive correctly. What shipped is the test, plus the measurement in the constant's own comment. Dropping the 1006 turns the real-tmux case red at all four columns on the 3.2 floor.

Two corrections to the premise fell out of it: tmux does **not** consult terminfo for the outer request (stock macOS `xterm-256color` has no `XM`/`xm` and 3.2 still sent 1006), and an X10 report reaches a component as stray *keys*, which `events.DELIVERED` never carries — silence, not a wrong tab.

## The tab you are on is drawn as one

Reverse video, via a new `chrome.block` — `chrome.reverse`'s sibling for a **field** rather than a row, because the cells either side of a tab belong to other tabs and a full-width band would say you are on all of them. No colour is named, so it is right on every theme and orthogonal to `[frame] chrome = "off"`. The `*` stays, which is what keeps the strip readable under `NO_COLOR`, on a Linux console, and with the pane redirected to a file. It costs the row no column.

## The overflow count opens the palette

The operator clicked it. That is the strongest available evidence about what the field looks like it does, and it did nothing. Both counts are live now, and so is the narrow rung's `n/N` — the width where the strip reaches nothing at all.

It opens the palette rather than turning a page: paging needs remembered state, and `_page`'s docstring already measures what that costs (no respawn survival, a density change re-splits, two frames at one width disagree). The palette needs nothing remembered and is section 3.6's own sentence — *the bar is a readout, never the mechanism* — with the hand-off where the readout runs out of room.

**Stated cost:** it is the top-level palette, not the picker for that bar's noun. `charter frame-palette` has no way to be told which picker to land in; that option lives in `commands_frame.py`, which another agent holds this session.

## Visible rules put a seam between tabs

The same key that decides the seam between two panes, one scope in. At the shipped `hidden` the row is byte for byte what it was; at `visible` it spends one cell per seam and the ladder gives up a whole name for it.

**The glyph is ASCII, not the box-drawing vertical, and that is a correction to the brief.** U+2502 is East-Asian *Ambiguous* — `tui.width` says one cell, a terminal may draw two. The repo table draws box glyphs and can afford to because its click map is per **row**; a bar's is per **column**, so ten separators drawn a cell wide each put a press ten columns off the tab it aimed at. Asserted as the property (`isascii` over the whole row at every width 0 to 260), not as an equality on the constant.

## Verification

- Full suite: **10201 tests, 8 skipped, green.**
- Real tmux on **3.7c and the 3.2 floor**: the whole `test_a_real_click_on_a_real_tab_bar_switches` file (15 cases) green on both, including the new "clicking the overflow count opens a real palette" on a real 120-column pty with three real processes, and its control that the heading still opens nothing.
- Mutation-checked: dropping the block, dropping the separator, spelling the separator with the box glyph, publishing the map with the old gap, moving the trailing count's span by one, leaving the narrow rung inert, and removing the handler branch each turn the suite red.
- Two test helpers that took a character index for a terminal column now measure with `tui.width` and say why — the paint made those two different numbers.

## Not in this PR

Hover, activity marks, keyboard next/previous, multi-row, and the chats affordance that starts a new chat. The last of those needs a new seam in `commands_frame.py` (there is no CLI spelling for a non-attaching launch), which another agent holds; it is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ctfuhnX3LdXbtx3SMUvTu
