### PR TITLE
The chat bar's + makes a chat, instead of naming the command that would

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -769,7 +769,7 @@ def _add_frame_parsers(sub) -> None:
                                          "frame-probe", "frame-respawn", "frame-density",
                                          "frame-resize", "frame-gather", "frame-switch",
                                          "frame-toggle", "frame-chrome", "frame-chat",
-                                         "frame-quit", "frame-close",
+                                         "frame-new-chat", "frame-quit", "frame-close",
                                          "frame-transcript"}
 
     # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
@@ -1004,6 +1004,28 @@ def _add_frame_parsers(sub) -> None:
     ch.add_argument("chat_id")
     ch.add_argument("--chat", dest="chat", default="")
     ch.set_defaults(func=commands_frame.cmd_chat)
+
+    # The chat bar's `+`, and the one thing no other spelling of `charter <harness>` can
+    # ask for: a launch that must NOT become the operator's terminal. `cmd_launch` has
+    # taken `attach=False` since `_open_workspace` needed it (§4k), and until now it was
+    # reachable only in-process — so a panel that wanted to add a chat had `charter claude`
+    # and nothing else, which on a detached child with `/dev/null` for stdout takes
+    # `bypass` and `os.execvp`s a bare harness into the void.
+    #
+    # **A sibling of `frame-chat` rather than a flag on it.** They are two different
+    # operations that happen to share a noun: one moves this client to a window that
+    # exists, the other makes one. `frame-chat`'s positional would have to become optional
+    # to carry a `--new`, which makes `charter frame-chat` alone — a plausible typo —
+    # parse into something that CREATES.
+    #
+    # **No name and no positional at all**, which is #518's line held: the chat's id is
+    # allocated (`state.workspace_prefix`) and its workspace is the one this chat is in for
+    # life (§4j), so there is nothing here for an operator to type and nothing to validate.
+    # `--chat` is where the press happened, exactly as it is for `frame-toggle` and
+    # `frame-quit`, and it falls back to `$CHARTER_SESSION_ID`.
+    nc = sub.add_parser("frame-new-chat")
+    nc.add_argument("--chat", dest="chat", default="")
+    nc.set_defaults(func=commands_frame.cmd_new_chat)
 
     # §4i's quit. Started DETACHED by the palette's confirmation row
     # (`commands_frame._start_leaving`) and typeable by hand, which is why it warns on its

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8667,3 +8667,145 @@ def _say_it_was_quit(fid: str) -> None:
     back = len([c for c in m.all_chats() if c.resume])
     util.info(f"charter: this plane was quit — {n} chat(s) recorded, {back} with a "
               f"conversation to resume.\n  put it back with: charter reopen")
+
+
+#: What the chat bar's `+` says when this frame is a window in a tmux the operator already
+#: had, where charter cannot make a chat for them.
+#:
+#: **The refusal is `switch.to_workspace`'s shape and its reason** (`slots._top` asks the
+#: same question to decide whether to draw the hotkey hint at all): on charter's own server
+#: a workspace IS a session and a chat is a window in it, so :func:`cmd_new_chat` adds one.
+#: Inside a tmux the operator already has, charter writes no session option, no key binding
+#: and nothing session-scoped — the launcher's whole `_launch_in_operator_tmux` contract —
+#: and a chat there is a window in a session charter does not own. It names the command
+#: that DOES work there rather than saying no on its own, which is the same courtesy every
+#: other refusal in this module extends.
+NO_CHAT_HERE = ("this frame is a window in a tmux you already had, where charter does not "
+                "make chats for you — open another with `charter <harness>` in this "
+                "workspace")
+
+#: What it says when this plane cannot prove the workspace's session is its own.
+#:
+#: **§3.3's guarantee, at a new door.** One tmux server serves every plane on this machine
+#: (eleven sessions from three projects on the operator's own socket the week this was
+#: written) and `cmd_launch` decides between starting a session and joining one with
+#: `if session in live_sessions:`, a NAME test over all of them. So a `+` that ran the
+#: launcher without this check could add a window to ANOTHER plane's live session — another
+#: project's frame, across every isolation boundary charter has. `_plane_session` is the
+#: one question that answers it, matched on this plane's own chat directories rather than
+#: on a session name, and it is `_open_workspace`'s guard read the other way round: that one
+#: refuses a name it CAN see on the server, this one refuses to proceed without one it can
+#: prove is ours.
+NO_SESSION_HERE = ("charter cannot prove this workspace's tmux session is this plane's, so "
+                   "it will not add a chat to it — it is probably another plane's")
+
+
+def cmd_new_chat(args) -> int:
+    """`charter frame-new-chat` — a second chat in the workspace this chat is in.
+
+    **The `+` on the chat bar, and the command it runs.** §3.6 asks the chat bar to carry
+    an "add-chat affordance"; what it carried was the SENTENCE `charter <harness>` opens
+    another, which is true, is not a button, and was read as one — *"`+` button not working
+    for creating new session"*. `slots.ADD_CHAT` is a `+` now and this is what it starts.
+
+    **It is `charter <harness>` in this workspace, run for the operator.** `cmd_launch`
+    already builds a chat as a `new-window` in a workspace's live session — that is what
+    the second `charter claude` in a workspace has always done (`joining`, and
+    `layout.chat_window_argv`) — and it already selects the new window and drops the
+    panels of the chat being left. So nothing here is a new mechanism; what is new is
+    reaching it from a pointer, which needs the one thing no CLI spelling has: a launch
+    that does not want to BE the operator's terminal.
+
+    :func:`_open_workspace` opened that seam (`_wants_attach`, `attach=False`) and is the
+    precedent for every line below, including the measurement that it works at all: a
+    process with `start_new_session=True` and all three streams on `/dev/null` can run
+    `new-window`, a window option and `select-window` on tmux 3.7c and at the 3.2 floor,
+    with nothing killed and the client landing where it was sent.
+
+    **What is deliberately NOT shared with it.** That function refuses a workspace whose
+    name is already a live session, because it is opening a workspace this plane does not
+    have open and any session of that name is somebody else's. This one is about the
+    workspace this chat is standing in, whose session this plane certainly does have open —
+    so the guard is inverted: :data:`NO_SESSION_HERE` refuses to proceed unless
+    `_plane_session` can prove the session is ours. Same §3.3 rule, opposite sign, and
+    written out rather than shared because a helper taking a flag for which way to point
+    would be one function claiming to answer two questions.
+
+    **Four ways this stops, each with its own sentence on the frame's own attention row**
+    (:func:`_say_on_screen`), because this runs detached with its streams on `/dev/null`
+    and has no other surface: a frame inside the operator's own tmux
+    (:data:`NO_CHAT_HERE`), a session this plane cannot prove is its own
+    (:data:`NO_SESSION_HERE`), a chat recording no harness charter can launch, and a
+    workspace directory charter cannot enter. A `+` that silently did nothing is the
+    complaint this whole change is answering, so a `+` that silently fails would be the
+    same complaint one release later.
+
+    **Always 0**, for `cmd_palette`'s reason: this is started by a click and by a palette
+    row, never by a shell that reads its status, and the one caller that could see a code
+    is a `run-shell` whose non-zero prints INTO THE HARNESS PANE — charter drawing in the
+    one rectangle ADR 0018 says it never draws.
+
+    *args* carries `--chat`, which is where the click happened (`_pressers_chat`, whose
+    `$CHARTER_SESSION_ID` fallback is what a hand-typed `charter frame-new-chat` inside a
+    frame resolves through).
+    """
+    fid = _pressers_chat(args)
+    if not fid:
+        util.err("charter frame-new-chat: no frame — run it inside a charter frame, or "
+                 "pass --chat <id>")
+        return 0
+    socket = state.frame_server(fid) or SOCKET
+    if tmuxctl.is_operator_socket(socket, own=SOCKET):
+        _say_on_screen(fid, NO_CHAT_HERE)
+        return 0
+    ws = state.workspace_for(fid)
+    if _plane_session(socket, ws=ws) is None:
+        _say_on_screen(fid, NO_SESSION_HERE)
+        return 0
+    # Which harness, and it is the one question a `+` cannot carry — `_open_workspace`'s
+    # paragraph, unchanged: the chat the operator pressed FROM recorded its own
+    # (`state.record_identity`), and using it makes the click mean "another chat, same
+    # tool", which is the only answer available that they have actually expressed.
+    ident = state.identity(fid).get("CHARTER_HARNESS", "")
+    h = next((x for x in harness.all() if x.name == ident and x.cli_name), None)
+    if h is None:
+        fallback = (config.HARNESS or {}).get("default")
+        h = next((x for x in harness.all() if x.cli_name == fallback), None)
+    if h is None:
+        _say_on_screen(fid, "cannot open another chat: this chat records no harness this "
+                            "charter can launch, and this plane declares no `[harness] "
+                            "default`")
+        return 0
+    from types import SimpleNamespace
+    where = workspace.workspace_dir(ws)
+    root = where if where.is_dir() else config.ROOT
+    # Every field `cmd_launch` and `_choose_workspace` read is named rather than left to a
+    # `getattr` default — `_open_workspace`'s rule and its reasons, one noun over.
+    # `workspace` is set outright so `_picker_wanted` can never raise a prompt on a path
+    # with no operator waiting, `pick` is false for the same reason and for #518's pointer,
+    # `rest` is empty so the harness starts at its own prompt with nothing sent to it, and
+    # `attach` is the seam this command exists on the far side of.
+    launch = SimpleNamespace(harness=h.cli_name, rest=[], no_frame=False,
+                             workspace=ws, pick=False, attach=False,
+                             size=_window_size(socket, state.harness_pane(fid) or ""))
+    here_dir = os.getcwd()
+    try:
+        os.chdir(root)
+    except OSError:
+        _say_on_screen(fid, "cannot open another chat: charter cannot enter "
+                            f"{contain.readable(str(root)) or 'this workspace'}")
+        return 0
+    try:
+        rc = cmd_launch(launch)
+    finally:
+        try:
+            os.chdir(here_dir)
+        except OSError:
+            pass
+    if rc != 0:
+        # Said rather than swallowed, for `_open_workspace`'s reason: `cmd_launch`'s own
+        # `util.err` went to `/dev/null` with everything else this process writes, so
+        # without this line a press would simply do nothing — the exact complaint this
+        # command exists to answer, arriving through the door built to answer it.
+        _say_on_screen(fid, f"could not open another chat — the launcher returned {rc}")
+    return 0

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -6627,6 +6627,76 @@ def _clients_on(socket: str, session: str) -> list[str]:
     return out.stdout.split()
 
 
+#: The half of a "cannot open" that is the same whatever is being opened — said after
+#: each caller's own subject, so `_open_workspace`'s names the workspace and
+#: `cmd_new_chat`'s names nothing, and neither has to keep the rest of the sentence in step
+#: with the other. One string, because it is one FACT: this plane cannot name a harness to
+#: run.
+NO_HARNESS = ("this chat records no harness this charter can launch, and this plane "
+              "declares no `[harness] default`")
+
+
+def _same_harness_as(fid: str):
+    """The harness a chat opened FROM *fid* should run, or ``None`` when there is none.
+
+    **The one question neither a workspace tab nor a chat bar's `+` can carry.** Both are a
+    single press with nothing typed into it, so the only answer available that the operator
+    has actually expressed is the tool they are already in: the chat they pressed from
+    recorded its own (`state.record_identity`, `$CHARTER_HARNESS`), which makes the press
+    mean "another one of these".
+
+    Two rungs and no third. A chat whose identity predates that record — or whose recorded
+    harness this charter cannot launch — falls back to `[harness] default`, and a plane
+    that declares none is refused by name rather than opened under something nobody chose.
+
+    **One function because it was two identical blocks, and the deletion sweep is what
+    found that.** `cmd_new_chat` was written from :func:`_open_workspace` and copied its
+    five lines; the sweep charged the copy and reported the `or {}` below as a survivor —
+    unpinned *there*, while `tests/test_a_workspace_tab_opens_what_it_names
+    .TheOpenUsesTheHarnessTheOperatorIsAlreadyIn
+    .test_a_plane_whose_harness_table_is_missing_entirely_is_not_a_crash` had pinned it
+    *here* all along. One function, one place for that case to reach, and no second copy
+    for the next sweep to charge.
+
+    **The `or {}` stays, and it was nearly deleted.** `instance.harness_of` is annotated
+    `-> dict` and measurably answers one for `{}` and for `{"harness": None}`, so the
+    branch looks unreachable through a plane's own config — but that is an argument about
+    ONE producer of the value, and the case above asserts the whole detached path survives
+    `config.HARNESS` being `None`, where an `AttributeError` goes to `/dev/null` and the
+    press does nothing. A guard an existing case makes observable is not this function's
+    to remove.
+
+    The two callers still say their own sentences (:data:`NO_HARNESS` is the half they
+    share), because one names a workspace and the other names nothing.
+    """
+    ident = state.identity(fid).get("CHARTER_HARNESS", "")
+    h = next((x for x in harness.all() if x.name == ident and x.cli_name), None)
+    if h is not None:
+        return h
+    fallback = (config.HARNESS or {}).get("default")
+    return next((x for x in harness.all() if x.cli_name == fallback), None)
+
+
+def _launch_root(ws: str):
+    """The directory a launch for workspace *ws* should run in.
+
+    `cmd_launch` reads the frame's cwd off `os.getcwd()`, so a caller that starts one has
+    to stand in the right place first — and the right place is what `charter --workspace
+    <ws>` typed in it would have used.
+
+    **The plane's own root when that workspace has no directory yet**, which is a real
+    state rather than a defensive one: `switch.workspaces` folds
+    `config.DEFAULT_WORKSPACE` into its list whether or not its directory exists —
+    `workspace.ensure` makes it on demand — so a plane that has never made one still
+    offers a tab and a `+` for it. `config.ROOT` is where charter would have created it.
+
+    Shared by :func:`_open_workspace` and :func:`cmd_new_chat` for
+    :func:`_same_harness_as`' reason: it was the same two lines twice.
+    """
+    where = workspace.workspace_dir(ws)
+    return where if where.is_dir() else config.ROOT
+
+
 def _open_workspace(fid: str, ws: str, *, socket: str,
                     window: str) -> tuple[str, str] | None:
     """Open *ws* on this plane without attaching to it — ``(session id, chat id)``, or
@@ -6719,19 +6789,12 @@ def _open_workspace(fid: str, ws: str, *, socket: str,
                             f"hand if it is yours: tmux -L {socket} attach -t "
                             f"{state.workspace_prefix(ws)}")
         return None
-    ident = state.identity(fid).get("CHARTER_HARNESS", "")
-    h = next((x for x in harness.all() if x.name == ident and x.cli_name), None)
+    h = _same_harness_as(fid)
     if h is None:
-        fallback = (config.HARNESS or {}).get("default")
-        h = next((x for x in harness.all() if x.cli_name == fallback), None)
-    if h is None:
-        _say_on_screen(fid, f"cannot open '{ws}': this chat records no harness this "
-                            "charter can launch, and this plane declares no `[harness] "
-                            "default`")
+        _say_on_screen(fid, f"cannot open '{ws}': {NO_HARNESS}")
         return None
     from types import SimpleNamespace
-    where = workspace.workspace_dir(ws)
-    root = where if where.is_dir() else config.ROOT
+    root = _launch_root(ws)
     # Every field `cmd_launch` and `_choose_workspace` read is named rather than left to a
     # `getattr` default — `_reopen_args`'s rule, which is what makes this a contract that
     # can be read instead of a puzzle. `workspace` is set outright so `_picker_wanted` can
@@ -8767,19 +8830,12 @@ def cmd_new_chat(args) -> int:
     # paragraph, unchanged: the chat the operator pressed FROM recorded its own
     # (`state.record_identity`), and using it makes the click mean "another chat, same
     # tool", which is the only answer available that they have actually expressed.
-    ident = state.identity(fid).get("CHARTER_HARNESS", "")
-    h = next((x for x in harness.all() if x.name == ident and x.cli_name), None)
+    h = _same_harness_as(fid)
     if h is None:
-        fallback = (config.HARNESS or {}).get("default")
-        h = next((x for x in harness.all() if x.cli_name == fallback), None)
-    if h is None:
-        _say_on_screen(fid, "cannot open another chat: this chat records no harness this "
-                            "charter can launch, and this plane declares no `[harness] "
-                            "default`")
+        _say_on_screen(fid, f"cannot open another chat: {NO_HARNESS}")
         return 0
     from types import SimpleNamespace
-    where = workspace.workspace_dir(ws)
-    root = where if where.is_dir() else config.ROOT
+    root = _launch_root(ws)
     # Every field `cmd_launch` and `_choose_workspace` read is named rather than left to a
     # `getattr` default — `_open_workspace`'s rule and its reasons, one noun over.
     # `workspace` is set outright so `_picker_wanted` can never raise a prompt on a path
@@ -8816,8 +8872,14 @@ def cmd_new_chat(args) -> int:
     try:
         os.chdir(root)
     except OSError:
-        _say_on_screen(fid, "cannot open another chat: charter cannot enter "
-                            f"{contain.readable(str(root)) or 'this workspace'}")
+        # **The directory is not named, and that is one fewer thing to get right.**
+        # `_open_workspace`'s twin says `contain.readable(str(root)) or 'its directory'`,
+        # whose `or` is a branch nothing can reach — `root` is a path under `config.ROOT`
+        # and always renders as something — so it is a survivor wearing a fallback. The
+        # operator knows which workspace they pressed `+` in; what they do not know is that
+        # charter could not get into it, and that is the whole of what this says.
+        _say_on_screen(fid, "cannot open another chat: charter cannot enter this "
+                            "workspace's directory")
         return 0
     try:
         rc = cmd_launch(launch)

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8759,7 +8759,8 @@ def cmd_new_chat(args) -> int:
         _say_on_screen(fid, NO_CHAT_HERE)
         return 0
     ws = state.workspace_for(fid)
-    if _plane_session(socket, ws=ws) is None:
+    seat = _plane_session(socket, ws=ws)
+    if seat is None:
         _say_on_screen(fid, NO_SESSION_HERE)
         return 0
     # Which harness, and it is the one question a `+` cannot carry — `_open_workspace`'s
@@ -8785,9 +8786,32 @@ def cmd_new_chat(args) -> int:
     # with no operator waiting, `pick` is false for the same reason and for #518's pointer,
     # `rest` is empty so the harness starts at its own prompt with nothing sent to it, and
     # `attach` is the seam this command exists on the far side of.
+    # **The window the new chat is laid out for — and never an empty `-t`.**
+    # `_window_size` hands its target straight to `display-message -t`, and an EMPTY
+    # target does not fail: it resolves to the tmux server's CURRENT window, which on a
+    # socket serving eleven sessions from three projects is very likely another plane's.
+    # `_open_workspace` carried exactly that `state.harness_pane(fid) or ""`, the deletion
+    # sweep survived the `or ""`, and asking why is what found the hazard — there the
+    # caller had already proved a pane, so the fallback was unreachable.
+    #
+    # **Here it is reachable**, which is why this is a pair of readings and not a `or ""`:
+    # a chat launched by a charter that predates `state.record_harness_pane`, or one whose
+    # state directory was truncated, genuinely has no pane of its own. So it is this
+    # chat's pane, else the pane :func:`_plane_session` has *just proved* is live in this
+    # workspace — the window a client in this workspace is looking at, which is
+    # `_open_workspace`'s own answer to the same question — else NOTHING. `_launch_size`
+    # reads `None` as "measure your own terminal", which for a detached process is the
+    # documented 80x24. A frame charter could not measure comes up small; one measured off
+    # a stranger's terminal comes up wrong, and only one of those is recoverable by
+    # resizing the window.
+    #
+    # `chats.pane_of` and not `state.harness_pane`, because it is the reader that holds
+    # the value to `tmuxctl.PANE_ID_RE` — this is a `-t` target coming off disk, which is
+    # #475's boundary exactly.
+    pane = chats.pane_of(fid) or chats.pane_of(seat[1])
     launch = SimpleNamespace(harness=h.cli_name, rest=[], no_frame=False,
                              workspace=ws, pick=False, attach=False,
-                             size=_window_size(socket, state.harness_pane(fid) or ""))
+                             size=_window_size(socket, pane) if pane else None)
     here_dir = os.getcwd()
     try:
         os.chdir(root)

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -333,8 +333,23 @@ def _repos_events(fid: str):
 _CHAT_SWITCH = ("frame-chat",)
 _WORKSPACE_SWITCH = ("frame-switch", "--workspace")
 
+#: What a press on the chat bar's `+` starts — `commands_frame.cmd_new_chat`.
+#:
+#: **A command of its own and not `charter <harness>`**, and the reason is what a detached
+#: process is: `_spawn` gives its child all three streams on `/dev/null`, and `cmd_launch`
+#: reads a non-tty stdout as "this process cannot be the operator's terminal" and
+#: `os.execvp`s the bare harness into it. `attach=False` is the seam that says "build the
+#: frame, do not become the terminal", it has existed since `_open_workspace` needed it
+#: (§4k), and until now no CLI spelling could ask for it. This is that spelling.
+#:
+#: **No name and no `--chat`.** There is nothing to name: a chat's id is allocated and its
+#: workspace is the one this chat is in for life (§4j). And `_spawn` sets the child's own
+#: `$CHARTER_SESSION_ID` to *fid*, which `_pressers_chat` falls back to — the same reason
+#: :data:`_CHAT_SWITCH` carries no `--chat` either.
+_NEW_CHAT = ("frame-new-chat",)
 
-def _bar_events(fid: str, command: tuple[str, ...]):
+
+def _bar_events(fid: str, command: tuple[str, ...], add: tuple[str, ...] | None = None):
     """A tab bar's handler: a left click on a tab switches this frame to it.
 
     **A click here SWITCHES, where a click on the repo table only ever SELECTS, and that
@@ -423,6 +438,33 @@ def _bar_events(fid: str, command: tuple[str, ...]):
     `overlay.MOUSE_ON` for one pointer kind as for two, so declaring it would cost nothing
     and mean nothing — which is precisely what makes it wrong to declare.
 
+    **A press on the chat bar's `+` starts a new chat**, which is the third gesture this
+    one handler carries and the only one that CREATES.
+
+    *"`+` button not working for creating new session."* It was a sentence — `+ charter
+    <harness> opens another` — that named the command and began with a `+` at the end of a
+    row of clickable tabs, so it was pressed. `slots.ADD_CHAT` is a `+` now and this starts
+    :data:`_NEW_CHAT`.
+
+    **§4i is met and not waived, and it is worth checking again because this one is not
+    reversible by the same gesture.** The press is still the half that is never delivered
+    unpaired, which is the load-bearing clause. What a second press makes is a second chat
+    rather than an undo — but making one is not the irreversible half §4i is about: nothing
+    is destroyed, the chat it came from keeps running with its harness and its conversation
+    (§4b's own promise, which the workspace tabs already rest on), and closing a chat you
+    did not want is `charter frame-close`. Compare the gesture §4i actually forbids on a
+    pointer: `charter frame-quit`, which stops every harness on the plane, and which is
+    behind a palette row with a confirmation for exactly that reason.
+
+    **`add` is `None` for the workspaces bar and that is structural rather than a branch.**
+    `slots.workspaces_bar` passes no note, so no rung ever publishes an affordance column
+    for it and `add_at` cannot answer true — but the argument for a workspace `+` is a
+    DIFFERENT one and it is written where the decision is (`slots.workspaces_bar`): a chat
+    is nothing but a press, a workspace is a directory and a name #518 refuses to create on
+    a typo. So this handler is handed the answer as data rather than deriving it from what
+    the renderer happened to draw, which is what keeps the two bars from degrading
+    differently the day one of them starts drawing a note it did not have.
+
     *command* is which of the two switches this bar starts (:data:`_CHAT_SWITCH`,
     :data:`_WORKSPACE_SWITCH`). One handler and two lines of data rather than two
     handlers, because everything above is true of both bars and a second copy would be
@@ -449,6 +491,9 @@ def _bar_events(fid: str, command: tuple[str, ...]):
             return False
         name = _slots.TABS.switch_to(ev.col)
         if name is None:
+            if add is not None and _slots.TABS.add_at(ev.col):
+                _spawn(util.self_relaunch_argv(*add), fid=fid)
+                return False
             if _slots.TABS.more_at(ev.col):
                 # The same argv `_strip_events` spawns for a door, for its reasons — one
                 # answer to "how does a frame surface open the palette", shared rather than
@@ -849,7 +894,7 @@ def build(fid: str = "") -> Registry:
     reg.register(Component(
         id="chats", title="chats", edge="top", size=Fixed(1),
         needs=(), render=_chats,
-        events=("click",), on_event=_bar_events(fid, _CHAT_SWITCH)))
+        events=("click",), on_event=_bar_events(fid, _CHAT_SWITCH, add=_NEW_CHAT)))
     reg.register(Component(
         id="workspaces", title="workspaces", edge="top", size=Fixed(1),
         needs=(), render=_workspaces,

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -3209,12 +3209,13 @@ class _Tabs:
     reports and this repository deletes.
     """
 
-    __slots__ = ("_cols", "_here", "_more")
+    __slots__ = ("_cols", "_here", "_more", "_add")
 
     def __init__(self) -> None:
         self._cols: dict[int, str] = {}
         self._here = ""
         self._more: frozenset[int] = frozenset()
+        self._add: frozenset[int] = frozenset()
 
     def forget(self) -> None:
         """Back to a bar nobody has drawn — for a test, and only a test.
@@ -3225,7 +3226,7 @@ class _Tabs:
         """
         self.publish({}, "")
 
-    def publish(self, columns: dict, here: str, more=()) -> None:
+    def publish(self, columns: dict, here: str, more=(), add=()) -> None:
         """Record what the paint that just happened put on each column, and where you are.
 
         *columns* maps a column of the component's OWN canvas — the rectangle `ctx.width`
@@ -3256,6 +3257,13 @@ class _Tabs:
         leave a count inert that the paint has just drawn. There is no way to write down
         one of the three here, so there is nothing for a second method to keep in step.
 
+        *add* is the columns of the add-chat affordance (:data:`ADD_CHAT`), on the one
+        rung and the one bar that draws it. A fourth thing rather than a second sentinel
+        inside *more* for :meth:`more_at`'s own reason: they are different questions with
+        different answers — one says *show me the rest of what is here*, the other says
+        *make a new one* — and a caller told "this cell is special" would have to ask a
+        second question anyway to know which.
+
         A `frozenset` and not a range, because the two counts are two disjoint runs and
         the narrow rung's is a third — and because :meth:`more_at` asks about ONE column,
         which is the same question `_cols` answers and should be the same kind of lookup.
@@ -3263,6 +3271,7 @@ class _Tabs:
         self._cols = dict(columns)
         self._here = here
         self._more = frozenset(more)
+        self._add = frozenset(add)
 
     def switch_to(self, col: int):
         """The tab a click at canvas column *col* should switch this frame to, or ``None``.
@@ -3310,6 +3319,28 @@ class _Tabs:
         both.
         """
         return col in self._more
+
+    def add_at(self, col: int) -> bool:
+        """Whether column *col* is the affordance that makes a NEW chat.
+
+        *"`+` button not working for creating new session."* :data:`ADD_CHAT` was a
+        SENTENCE — `+ charter <harness> opens another` — which is true, which names the
+        command that does it, and which begins with a `+` on a row of clickable tabs. It
+        was read as a button, which is the only way it could have been read.
+
+        **The two things this is not.** It is not :meth:`switch_to`: there is no chat to
+        switch to yet, which is the whole point of pressing it. It is not :meth:`more_at`
+        either — that stands for chats that EXIST and are off the row, and opening a picker
+        over them is the opposite of making a new one. Three questions, three methods, and
+        a column that is none of them answers no to all three.
+
+        **They cannot be drawn on one row, which is structural rather than lucky.**
+        :func:`_bar` draws the affordance only on the rung where every name fits, and draws
+        a `+N` only on the rung where they do not — so a row carrying `+` never carries
+        `+9`, and the two fields that both begin with a `+` are never on screen together to
+        be confused with each other.
+        """
+        return col in self._add
 
 
 #: The one tab strip this process's bar draws into. See :class:`_Tabs` for why there is
@@ -3603,7 +3634,7 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     gap = _bar_gap()
     gapw = tui.width(gap)
 
-    def row(body: str = "", drawn=(), before: str = "", more=()) -> list[str]:
+    def row(body: str = "", drawn=(), before: str = "", more=(), add=()) -> list[str]:
         """This rung's row, and the column map for the tabs it actually drew.
 
         **Every way out of the ladder goes through here**, which is what keeps "the map
@@ -3628,8 +3659,10 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
         :data:`TABS` for :func:`_tab_columns`' whole reason: the rung that composed the
         row is the only thing that knows where it put them, and a second walk of the
         ladder to find them again is a second answer to what is on the row.
+
+        *add* is the same for :data:`ADD_CHAT`, on the one rung that draws it.
         """
-        TABS.publish(_tab_columns(tui.width(lead + before), drawn, gapw), here, more)
+        TABS.publish(_tab_columns(tui.width(lead + before), drawn, gapw), here, more, add)
         return [lead + before + body] if body else []
 
     if not names:
@@ -3666,7 +3699,11 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     room = width - tui.width(lead)
     joined = gap.join(marked)
     if note and tui.width(joined) + gapw + tui.width(note) <= room:
-        return row(gap.join(painted) + gap + note, zip(names, marked))
+        # The affordance's own columns, measured off this composition — :func:`_span`'s
+        # reason, and the same walk the counts get one rung down. It is the ONLY rung that
+        # draws it, which is why a `+` and a `+9` are never on one row.
+        return row(gap.join(painted) + gap + note, zip(names, marked),
+                   add=_span(tui.width(lead + joined + gap), note))
     if tui.width(joined) <= room:
         return row(gap.join(painted), zip(names, marked))
     if at >= 0:
@@ -3727,20 +3764,35 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     return row()
 
 
-#: What the chat bar says instead of a second name when this workspace has one chat.
+#: The chat bar's add-chat affordance (§3.6) — a BUTTON now, and one cell of it.
 #:
-#: §3.6: the bar "hides itself when there is one chat, showing only the add-chat
-#: affordance". It names the command that opens a second one TODAY — `charter <harness>`
-#: in this workspace joins the session as a second window, which is what Stage 5a shipped
-#: — rather than a palette row this stage does not have. A reminder naming something that
-#: does not work is worse than no reminder.
+#: *"`+` button not working for creating new session."*
 #:
-#: **Read from INSIDE the frame, which is what keeps it true.** A charter started in a
-#: frame's own pane has `$TMUX` set, so it takes `commands_frame._launch_in_operator_tmux`
-#: and adds a window to the session it is already in. From a terminal OUTSIDE the frame
-#: the same command now focuses that workspace instead of adding to it (§4k, open-or-
-#: focus) — a different question, asked somewhere this row is not on screen.
-ADD_CHAT = "+ charter <harness> opens another"
+#: **This was a sentence and the sentence was the defect.** It read `+ charter <harness>
+#: opens another`, which is true, which names the command that does it, and which begins
+#: with a `+` at the end of a row of clickable tabs. Every terminal an operator has used
+#: puts a `+` there and every one of them means *new*. So it was pressed, and a sentence
+#: cannot be pressed. `commands_frame.cmd_new_chat` is what it starts now
+#: (`frame/builtins._bar_events`), and `_Tabs.add_at` is which cell.
+#:
+#: **A bare `+` rather than `+ new`, and the cost is stated rather than hidden.** What is
+#: lost is the sentence naming the command an operator could type instead — and what is
+#: gained is that they do not have to, which is the whole change. `docs/frame.md` keeps
+#: the sentence, where it can be as long as it needs to be; a strip competing for columns
+#: is the wrong surface for a paragraph. Every extra cell here is a cell off the names,
+#: and the names are the readout.
+#:
+#: **ASCII, for :data:`_BAR_RULE`'s reason and not merely :data:`_BAR_MARK`'s.** A click on
+#: this row is resolved by COLUMN, so a glyph a terminal may draw two cells wide moves
+#: every field after it. `+` is one cell everywhere, and it is the last field on the row,
+#: so even its own width is not load-bearing — which is exactly the argument that would
+#: make somebody reach for a prettier glyph, and the reason the rule is stated as the row's
+#: rather than as this constant's.
+#:
+#: **It cannot share a row with a `+N`**, which is what keeps the two `+` fields from being
+#: confused: :func:`_bar` draws this only on the rung where every name fits, and draws a
+#: count only on the rung where they do not.
+ADD_CHAT = "+"
 
 
 def chats_bar(fid: str, width: int) -> list[str]:
@@ -3757,8 +3809,7 @@ def chats_bar(fid: str, width: int) -> list[str]:
     """
     from . import chats as chats_mod
     names = [c.id for c in chats_mod.roster(fid)]
-    return _bar("chats", names, fid, width,
-                note=ADD_CHAT if len(names) < 2 else "")
+    return _bar("chats", names, fid, width, note=ADD_CHAT)
 
 
 def workspaces_bar(fid: str, width: int) -> list[str]:
@@ -3767,6 +3818,14 @@ def workspaces_bar(fid: str, width: int) -> list[str]:
     :func:`chats_bar`'s rules and its ladder, one noun over. The name is the FRAME's
     (`switch.current_workspace` → `state.workspace_for`), never one this pane resolved for
     itself — #512, and the same rung order `_top` reads two rows up.
+
+    **No `+`, and that is a decision rather than an omission.** A new CHAT is nothing but a
+    press: its id is allocated, its workspace is the one this chat is in for life (§4j), and
+    there is nothing for an operator to type or for charter to validate. A new WORKSPACE is
+    a directory and a NAME — `workspace.valid_name`, `workspace.ensure`, and #518's whole
+    argument that "a picker that creates on a typo leaves litter". A `+` here would have to
+    open something that takes a name, which is `charter workspace create` and is not a
+    thing a one-row strip can be.
     """
     from . import switch as switch_mod
     return _bar("workspaces", switch_mod.workspaces(),

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -390,8 +390,10 @@ nothing is started and nothing moves. Where nobody is attached — you closed th
 never had one — the same command opens a chat exactly as before. It is `code <path>`'s
 behaviour: the flag means one thing whether or not the workspace happens to be running.
 
-To open a *second* chat in a workspace you are already in, run `charter <harness>` from
-inside the frame — that is the add-chat affordance the chat bar names, and it is unchanged.
+To open a *second* chat in a workspace you are already in, press the `+` at the end of the
+chat bar, or run `charter <harness>` from inside the frame. Both do the same thing: a new
+window in the workspace's session, with your terminal on it and the chat you left running
+behind you.
 
 **A launch that names something to run still runs it.** Attaching answers "put me in
 `foo`"; it cannot answer "run *this* in `foo`", so `charter frame -- <cmd>` and
@@ -512,6 +514,22 @@ per seam out of the names it can draw. The separator is an ASCII `|` and not the
 draw it two cells wide where charter measured one — and on a row whose clicks are resolved
 by *column*, ten separators drawn a cell wide each would put your press ten columns off the
 tab you aimed at.
+
+**The chat bar ends in a `+`, and pressing it opens another chat.** Same workspace, same
+harness you are already in, its id allocated for you — which is why it takes nothing and
+asks nothing. It runs `charter frame-new-chat`, which is `charter <harness>` in this
+workspace with one difference: it builds the frame without becoming your terminal, because
+the process behind a click is not one.
+
+It stops, and says why on the attention row, in four cases: your frame is a window in a
+tmux you already had (charter makes no chats for you there — `charter <harness>` in the
+workspace still does); charter cannot prove the workspace's tmux session is this plane's
+rather than another project's; this chat records no harness charter can launch and your
+plane declares no `[harness] default`; or charter cannot enter the workspace's directory.
+
+**The workspace bar has no `+`, deliberately.** A new chat is nothing but a press. A new
+workspace is a directory and a *name*, which is `charter workspace create` — and a picker
+that creates on a typo leaves litter.
 
 **They are tabs: with `mouse = true`, clicking a name switches to it.** A chat tab does
 exactly what `F2` → `chat` does — the same command, the same five refusals, the same

--- a/docs/news/unreleased-opening-a-workspace-you-already-have-open-puts-you-in-it.md
+++ b/docs/news/unreleased-opening-a-workspace-you-already-have-open-puts-you-in-it.md
@@ -28,9 +28,9 @@ session does **not** move that session's current window, which is the fact that 
 focusing safe where adding was not.
 
 To open a second chat in a workspace you are already in, run `charter <harness>` from inside
-the frame. That is what the chat bar's own `+ charter <harness> opens another` names, and it
-is unchanged — a charter started in a frame's pane is inside a tmux and takes the window
-path, not this one.
+the frame — or press the chat bar's `+`, which is what *The chat bar's `+` makes a chat* in
+this same release does for you. Either way it is unchanged by this entry: a charter started
+in a frame's pane is inside a tmux and takes the window path, not this one.
 
 **A launch that names something to run still runs it.** Attaching answers "put me in `foo`";
 it cannot answer "run *this* in `foo`", and a focus taken over one would silently throw away

--- a/docs/news/unreleased-the-chat-bars-plus-makes-a-chat.md
+++ b/docs/news/unreleased-the-chat-bars-plus-makes-a-chat.md
@@ -1,0 +1,77 @@
+---
+version: unreleased
+headline: The chat bar's + makes a chat, instead of naming the command that would
+---
+
+*"`+` button not working for creating new session."*
+
+It was never a button. The chat bar's add-chat affordance was a **sentence** —
+
+```
+  chats  *api.1  + charter <harness> opens another
+```
+
+— which is true, which names the command that does it, and which sits at the end of a row
+of clickable tabs beginning with a `+`. Every terminal an operator has ever used puts a `+`
+there and every one of them means *new*. So it got pressed, and a sentence cannot be
+pressed.
+
+```
+  chats  *api.1   api.2   +
+```
+
+Press it and you get another chat: same workspace, same harness you are already in, its id
+allocated for you, your terminal on the new window, and the chat you left running behind
+you with its harness and its conversation intact. It takes nothing and asks nothing,
+because there is nothing to ask — a chat's id is allocated and its workspace is fixed for
+life.
+
+## Why it needed a new command
+
+`charter <harness>` in the workspace has always opened a second chat, and the obvious fix
+was to have the panel run that. It does not work, and the way it fails is instructive: a
+click's work runs **detached, with all three streams on `/dev/null`**, and the launcher
+reads a non-tty stdout as *this process cannot be the operator's terminal* and replaces
+itself with a bare harness writing into the void. No frame, no chat, and no process left to
+say so.
+
+The seam that says *build the frame, do not become the terminal* has existed since
+workspace tabs needed it, and until now nothing on the command line could ask for it.
+`charter frame-new-chat` is that spelling. You can type it inside a frame; it is what the
+`+` runs.
+
+## When it will not, and what it says
+
+A `+` that silently failed would be this same report one release later, so every stop puts
+a line on the frame's own attention row:
+
+- your frame is a **window in a tmux you already had** — charter makes no chats for you
+  there, and says so with the command that does work: `charter <harness>` in the workspace;
+- charter **cannot prove the workspace's tmux session is this plane's**. One tmux server
+  serves every plane on your machine, and adding a window to a session charter cannot
+  identify would put a chat inside another project's frame;
+- this chat **records no harness** charter can launch and your plane declares no
+  `[harness] default`;
+- charter **cannot enter** the workspace's directory.
+
+## The workspace bar still has no `+`
+
+Deliberately. A new chat is nothing but a press. A new workspace is a directory and a
+*name* — `charter workspace create`, with a validation pass behind it, because a picker
+that creates on a typo leaves litter.
+
+## Verification
+
+Real tmux on **3.7c and the 3.2 floor**: a real frame, a real client on a real pty, the `+`
+pressed through the client's own terminal, and the answer coming back on the frame's own
+attention row — written there by a real detached `charter frame-new-chat` that resolved
+which frame it belonged to, established it was on charter's own server, and proved the
+workspace's session was this plane's with a real `list-panes`. Beside it: the keyboard
+stays on the harness, the cell next to the `+` reaches nothing, an unpaired release reaches
+nothing, and a press that stopped created nothing.
+
+**One limit, stated rather than left to be found.** The launch itself is asserted against a
+stand-in rather than run for real, because the launcher targets charter's own shared tmux
+server by a module constant — so a test that let it run would build a session on the
+operator's live server. What is faked is exactly one call; everything up to it is real on
+both tmux versions.

--- a/tests/test_a_click_on_a_tab_bar_switches.py
+++ b/tests/test_a_click_on_a_tab_bar_switches.py
@@ -452,3 +452,140 @@ class AClickOnTheOverflowCountOpensThePalette(_ABarThatWasDrawn, unittest.TestCa
         self._handler("chats", "api.6")(_press(self._column_of(row, counts[0])))
         self.assertEqual(self.spawned,
                          [(util.self_relaunch_argv("frame-palette"), "api.6")])
+
+
+class APressOnThePlusMakesAChat(_ABarThatWasDrawn, unittest.TestCase):
+    """*"`+` button not working for creating new session."*
+
+    **The affordance was a sentence and the sentence was the defect.** It read
+    `+ charter <harness> opens another`, which is true, which names the command that does
+    it, and which sits at the end of a row of clickable tabs beginning with a `+`. Every
+    terminal an operator has used puts a `+` there and every one of them means *new*.
+
+    `slots.ADD_CHAT` is a `+` now and this is what pressing it starts. What it starts is
+    not `charter <harness>`: `builtin_actions._spawn` hands its child all three streams on
+    `/dev/null`, and `cmd_launch` reads a non-tty stdout as "this process cannot be the
+    operator's terminal" and `os.execvp`s the bare harness into the void. `attach=False`
+    is the seam that says *build the frame, do not become the terminal*, it has existed
+    since `_open_workspace` needed it, and `charter frame-new-chat` is the first spelling
+    that can ask for it.
+
+    The tmux half — that a chat really appears, in this workspace's session, with the
+    client on it — is `tests/test_a_real_click_on_a_real_tab_bar_switches.py`; what this
+    file can say is which press starts what.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"},
+                                          clear=False))
+        for chat in ("api.1", "api.2"):
+            _plant(chat, workspace="api")
+        self.row = tui.strip_ansi(slots.chats_bar("api.1", self.WIDTH)[0])
+        self.on_event = self._handler("chats", "api.1")
+        self.plus = self._column_of(self.row, slots.ADD_CHAT)
+
+    def test_a_press_on_the_plus_starts_the_new_chat_command(self):
+        """The argv spelled out. A `--chat` would be a second spelling of a value the
+        child's environment already carries — `_spawn` sets `$CHARTER_SESSION_ID` to the
+        *fid* below, which is what `_pressers_chat` falls back to — and that is
+        `_CHAT_SWITCH`'s own recorded reason for not carrying one either."""
+        self.on_event(_press(self.plus))
+        self.assertEqual(self.spawned,
+                         [(util.self_relaunch_argv("frame-new-chat"), "api.1")])
+
+    def test_it_names_no_chat_and_no_workspace(self):
+        """**#518's line held.** There is nothing here for an operator to type: a chat's
+        id is allocated (`state.workspace_prefix`) and its workspace is the one this chat
+        is in for life (§4j). An argv carrying either would be a name charter would have to
+        validate, which is the whole reason the workspace bar has no `+` at all."""
+        self.on_event(_press(self.plus))
+        argv = self.spawned[0][0]
+        self.assertEqual(argv[-1], "frame-new-chat")
+        for word in ("api", "api.1", "api.2", "--workspace", "--chat"):
+            self.assertNotIn(word, argv[argv.index("charter"):],
+                             f"{word!r} rode along on the argv: {argv!r}")
+
+    def test_the_press_acts_and_the_release_does_not(self):
+        """§4i, and it is worth re-asking for this gesture rather than inheriting it: a
+        switch is undone by the same click and making a chat is not. What carries it is
+        the clause that always did — the press is the half that is never delivered
+        unpaired — plus the fact that a chat made by mistake destroys nothing: the chat it
+        came from keeps its harness and its conversation, and `charter frame-close` is the
+        way back. The gesture §4i really forbids on a pointer is `frame-quit`, which stops
+        every harness on the plane and lives behind a palette confirmation."""
+        self.on_event(_press(self.plus, pressed=False))
+        self.assertEqual(self.spawned, [], "an unpaired release made a chat")
+        self.on_event(_press(self.plus))
+        self.assertEqual(len(self.spawned), 1)
+
+    def test_the_middle_and_right_buttons_make_nothing(self):
+        for button in ("middle", "right"):
+            self.on_event(_press(self.plus, name=button))
+        self.assertEqual(self.spawned, [])
+
+    def test_the_cell_beside_it_makes_nothing(self):
+        """The gap belongs to neither field, exactly as it does between two tabs — and
+        here it matters more, because the neighbour is a tab and picking the nearer field
+        would switch instead of create."""
+        for col in (self.plus - 1, self.plus - 2, self.plus + 1):
+            self.on_event(_press(col))
+        self.assertEqual(self.spawned, [],
+                         f"a cell beside the `+` acted: {self.row!r}")
+
+    def test_a_press_on_a_tab_still_switches(self):
+        """The control: three answers live in one handler now, so a case that only
+        asserted the new one would pass with the other two deleted."""
+        self.on_event(_press(self._column_of(self.row, " api.2")))
+        self.assertEqual(self.spawned,
+                         [(util.self_relaunch_argv("frame-chat", "api.2"), "api.1")])
+
+    def test_the_handler_is_falsy_when_it_made_a_chat(self):
+        """Truthy means *repaint me* and nothing this process can see has changed: the
+        chat is built by another process and ends in a `state.bump` this panel's poll is
+        already watching."""
+        self.assertFalse(self.on_event(_press(self.plus)))
+        self.assertEqual(len(self.spawned), 1, "the case measured nothing")
+
+    def test_the_workspace_bar_draws_no_such_thing_to_press(self):
+        """**A chat is a press; a workspace is a name.** A new chat has nothing for an
+        operator to type — its id is allocated and its workspace is fixed for life (§4j) —
+        while a new workspace is a directory and a name #518 refuses to create on a typo.
+        So the affordance is the chat bar's, and no column of a workspace bar is one."""
+        for name in ("alpha", "beta"):
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        state.frame_dir("f1", create=True)
+        state.record_workspace("f1", "alpha")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""}):
+            row = tui.strip_ansi(slots.workspaces_bar("f1", self.WIDTH)[0])
+        self.assertNotIn(slots.ADD_CHAT, row)
+        self.spawned.clear()
+        handler = self._handler("workspaces", "f1")
+        for col in range(self.WIDTH):
+            handler(_press(col))
+        self.assertTrue(all("frame-new-chat" not in argv for argv, _fid in self.spawned),
+                        f"a workspace tab made a chat: {self.spawned!r}")
+
+    def test_the_workspace_bars_handler_is_not_wired_for_creation_either(self):
+        """**The property the case above cannot reach, and the reason the handler is handed
+        the command as DATA rather than deriving it from what the renderer drew.**
+
+        Above, no column is an affordance because `workspaces_bar` passes no note — so a
+        handler that spawned on `add_at` regardless would pass, and would start making
+        chats off the workspace bar on the day that renderer grew a note of its own. This
+        publishes the map by hand, which is what `slots.TABS` exists to let a test do, and
+        asks the handler directly.
+
+        The chat bar is asked the same question with the same hand-made map, so this is
+        not "the workspaces handler ignores everything" wearing an assertion.
+        """
+        slots.TABS.publish({}, "", add=[7])
+        self.spawned.clear()
+        self._handler("workspaces", "f1")(_press(7))
+        self.assertEqual(self.spawned, [],
+                         "the workspace bar's handler makes chats — it is only the "
+                         "renderer that is stopping it")
+        slots.TABS.publish({}, "", add=[7])
+        self._handler("chats", "f1")(_press(7))
+        self.assertEqual([argv[-1] for argv, _fid in self.spawned], ["frame-new-chat"],
+                         "the control failed: the chat bar's handler is not wired either")

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -50,7 +50,7 @@ import unittest
 from pathlib import Path
 
 from charter import commands_frame, config
-from charter.frame import layout, state, tmuxctl
+from charter.frame import chats, layout, slots, state, tmuxctl
 
 from tests import _tmuxreap
 from tests._isolation import PersonaIso, make_plane
@@ -776,3 +776,141 @@ class ARealClickOnAWINDOWEDWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
         self.assertEqual(self._panes(), before,
                          "a click on the heading opened something")
         self.assertEqual(self._active(), self.harness)
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealPressOnThePlusReachesTheCommandBehindIt(_ARealFrameWithBars,
+                                                   unittest.TestCase):
+    """The chat bar's `+`, pressed on a real terminal — #: *"`+` button not working for
+    creating new session."*
+
+    **Three processes and none of them is this one**, exactly as for a tab: the row is
+    painted by a `charter panel chats` child, the report is decoded there, and
+    `charter frame-new-chat` is started detached by that child.
+
+    **What this can and cannot say, stated rather than left to be discovered.**
+    `commands_frame.SOCKET` is a module constant — `"charter"`, the one shared server every
+    frame on this machine runs on — and `cmd_launch` uses it rather than the server the
+    frame recorded. So a case that let the launch RUN would build a session on the
+    operator's own live charter server, from a suite. That is the one thing no test in this
+    repository may do, so no test here does it: the launcher itself is asserted against a
+    stand-in by `tests/test_the_chat_bars_plus_makes_a_chat.py`, and what is real here is
+    everything up to it.
+
+    Everything is a great deal: the affordance is at the column the paint put it in, tmux
+    routes the report to a pane that is not active, the panel decodes it and tells a `+`
+    from a tab, the child resolves which frame it belongs to out of its own environment,
+    it establishes that this is charter's own server, it proves the workspace's session is
+    this plane's (`_plane_session` — a real `list-panes` against a real server), and it
+    reports on the frame's own attention row, which is the only surface a detached process
+    with `/dev/null` for stdout has. Every one of those is a link that was not there
+    before this change.
+
+    **The stop this fixture reaches is the harness one, and it is reached honestly rather
+    than arranged.** The plane declares no `[harness] default` and the chats this fixture
+    plants record none, which is the migration state of every chat launched by a charter
+    that predates `state.record_identity`. So the last link — "which harness does the new
+    chat run" — has no answer, and the command says so instead of guessing. A case that
+    passed this by faking a harness would have to let the launch happen.
+    """
+
+    WS = "alpha"
+
+    #: A word out of :data:`commands_frame.cmd_new_chat`'s harness refusal, spelled by hand
+    #: rather than imported: a constant read out of the module under test follows a
+    #: reworded sentence into a green run, which is the survivor this repository's sweep
+    #: reports. Short enough to survive a rewording that keeps the meaning, specific enough
+    #: that no other refusal on this path says it.
+    _NO_HARNESS = "records no harness this charter can launch"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.here = f"{self.WS}.1"
+        self.harness = self._start_session(self.here, session=self.WS)
+        state.frame_dir(self.here, create=True)
+        state.record_workspace(self.here, self.WS)
+        state.record_server(self.here, self.socket)
+        state.record_harness_pane(self.here, self.harness)
+        state.record_identity(self.here, {"CHARTER_SESSION_ID": self.here,
+                                          "CHARTER_ROOT": str(self.plane)})
+        self._source_conf(self.WS)
+        self.assertEqual(self._tmux("select-window", "-t", self.harness).returncode, 0)
+        self.bar = self._split_bar(self.harness, "chats", self.here)
+        self.assertEqual(self._tmux("select-pane", "-t", self.harness).returncode, 0)
+        self.fd = self._attach(self.WS)
+        self.assertTrue(
+            _await(lambda: slots.ADD_CHAT in self._bar_row(self.bar).rstrip()),
+            f"the chat bar never painted its `+`: {self._bar_row(self.bar)!r}")
+        self.assertEqual(self._active(), self.harness)
+        self.assertEqual(state.notice(self.here), "",
+                         "this frame already carries a notice, so the cases below could "
+                         "pass on something the fixture said")
+
+    def _plus(self) -> int:
+        """The column the `+` is drawn in, read off the PANE.
+
+        Not `self._column_of`, because that helper asserts the field is unique on the row
+        and a single `+` is a character an overflow count also starts with. The affordance
+        is the LAST field on the row by construction, so the last `+` is it — and the row
+        it is read off is the one tmux painted, which is what the operator's eye lands on.
+        """
+        row = self._bar_row(self.bar).rstrip()
+        self.assertTrue(row.endswith(slots.ADD_CHAT),
+                        f"the row does not end in the affordance: {row!r}")
+        return len(row) - 1
+
+    def test_a_press_on_the_plus_reaches_the_command_behind_it(self):
+        """The whole chain, end to end, with the answer coming back on the frame's own
+        row — which is where every outcome of a detached charter has to land."""
+        self._click(self.bar, col=self._plus())
+        self.assertTrue(
+            _await(lambda: self._NO_HARNESS in state.notice(self.here)),
+            f"the press never reached the command: {state.notice(self.here)!r} — "
+            f"row {self._bar_row(self.bar)!r}")
+
+    def test_the_press_leaves_the_keyboard_on_the_harness(self):
+        """`docs/frame.md`'s promise, kept for the third gesture as well as the first two:
+        a click on a PANEL acts where it points and does not move the keyboard. Nothing
+        about making a chat changes that — the new chat's own window is what a successful
+        press would select, and that is tmux moving a client, not a pointer moving focus.
+        """
+        self._click(self.bar, col=self._plus())
+        self.assertTrue(_await(lambda: self._NO_HARNESS in state.notice(self.here)),
+                        "the press never arrived, so this proves nothing about focus")
+        self.assertEqual(self._active(), self.harness,
+                         "a press on the `+` took the keyboard off the harness")
+
+    def test_a_press_that_could_not_finish_created_nothing(self):
+        """The negative that makes the refusal worth having: it stopped, and it stopped
+        BEFORE anything existed. One window on the server and one chat on the plane, after
+        a press that reached the command and declined."""
+        before = self._tmux("list-windows", "-t", self.WS, "-F", "#{window_id}").stdout
+        self._click(self.bar, col=self._plus())
+        self.assertTrue(_await(lambda: self._NO_HARNESS in state.notice(self.here)))
+        time.sleep(1.5)
+        self.assertEqual(
+            self._tmux("list-windows", "-t", self.WS, "-F", "#{window_id}").stdout,
+            before, "a refused press still added a window")
+        self.assertEqual(chats.of_workspace(self.WS), [self.here],
+                         "a refused press still made a chat directory")
+
+    def test_the_cell_beside_the_plus_reaches_nothing(self):
+        """The control every affordance case needs: a row that answers EVERY click is as
+        wrong as one that answers none. The gap before the `+` belongs to neither field —
+        and its left-hand neighbour is a TAB, so picking the nearer one would switch
+        instead of create."""
+        self._click(self.bar, col=self._plus() - 1)
+        time.sleep(2.0)
+        self.assertEqual(state.notice(self.here), "",
+                         "the gap before the `+` reached the command")
+
+    def test_a_release_with_no_press_reaches_nothing(self):
+        """§4i, measured end to end for the one gesture on this row that CREATES: a drag
+        begun on a pane border delivers exactly one release, and every charter handler acts
+        on the press for that reason."""
+        left, top = self._rect(self.bar)
+        col = self._plus()
+        os.write(self.fd, b"\x1b[<0;%d;%dm" % (left + col + 1, top + 1))
+        time.sleep(2.0)
+        self.assertEqual(state.notice(self.here), "",
+                         "an unpaired release reached the command")

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -282,16 +282,35 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
                               f"{width}: {field!r} is not a whole name, a count or a "
                               f"position — {text!r}")
 
-    def test_one_chat_carries_the_add_affordance_and_two_do_not(self):
-        row = self._row(120, names=["api.1"], here="api.1", note=slots.ADD_CHAT)
-        self.assertIn(slots.ADD_CHAT, row)
+    def test_the_affordance_is_drawn_only_when_a_caller_asks_for_one(self):
+        """`_bar` draws no note it was not handed one for. Which BARS ask is
+        `chats_bar`/`workspaces_bar`'s decision and has its own case at
+        :class:`TheChatBarReadsThePlane`; this is the arithmetic half."""
+        row = _plain(self._row(120, names=["api.1"], here="api.1", note=slots.ADD_CHAT))
+        self.assertTrue(row.rstrip().endswith(slots.ADD_CHAT), repr(row))
         self.assertNotIn(slots.ADD_CHAT, self._row(120))
 
     def test_the_affordance_is_dropped_before_any_name_is(self):
-        """It is a reminder and the names are the readout, so it goes first."""
-        row = self._row(28, names=["api.1"], here="api.1", note=slots.ADD_CHAT)
-        self.assertIn("api.1", row)
-        self.assertNotIn(slots.ADD_CHAT, row)
+        """It is one affordance and the names are the readout, so it goes first.
+
+        A `+` is one cell where the sentence it replaced was 29, so the width that drops it
+        while keeping the name is narrower than it used to be — measured off the ladder
+        below rather than written as a number, for the reason `test_rung_one_still_needs
+        _two_hundred_and_seventy_four_columns` gives: a constant here would be a second
+        copy of the arithmetic."""
+        names = ["api-staging.1", "api-standby.2"]
+        widest = max(w for w in range(0, 201)
+                     if slots.ADD_CHAT not in
+                     _plain(self._row(w, names=names, here="api-staging.1",
+                                      note=slots.ADD_CHAT))
+                     and "api-standby.2" in _plain(self._row(w, names=names,
+                                                             here="api-staging.1",
+                                                             note=slots.ADD_CHAT)))
+        row = _plain(self._row(widest, names=names, here="api-staging.1",
+                               note=slots.ADD_CHAT))
+        for name in names:
+            self.assertIn(name, row, repr(row))
+        self.assertNotIn(slots.ADD_CHAT, row, repr(row))
 
     def test_no_names_at_all_is_no_row(self):
         self.assertEqual(slots._bar("chats", [], "api.1", 200), [])
@@ -700,11 +719,58 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
             self.assertIsNone(slots.TABS.switch_to(col), f"column {col}")
 
     def test_the_add_chat_affordance_is_not_a_tab(self):
-        """It is a reminder naming a command, not a name to switch to."""
-        row = self._draw(120, names=["api.1"], here="nowhere", note=slots.ADD_CHAT)
-        self.assertIn(slots.ADD_CHAT, row)
+        """It makes a chat; it does not switch to one. There is no chat there yet, which
+        is the whole point of pressing it."""
+        row = _plain(self._draw(120, names=["api.1"], here="nowhere",
+                                note=slots.ADD_CHAT))
+        self.assertTrue(row.rstrip().endswith(slots.ADD_CHAT), repr(row))
         for col in self._cells(row, slots.ADD_CHAT):
             self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+
+    def test_the_add_chat_affordance_is_a_cell_that_makes_a_chat(self):
+        """*"`+` button not working for creating new session."*
+
+        The other half of the case above, and the reason the row has a third question:
+        the cell switches to nothing and opens no picker, and it is not therefore inert.
+        """
+        row = _plain(self._draw(120, names=["api.1"], here="nowhere",
+                                note=slots.ADD_CHAT))
+        cells = list(self._cells(row, slots.ADD_CHAT))
+        self.assertEqual([c for c in range(200) if slots.TABS.add_at(c)], cells,
+                         f"the `+` is not the one cell that makes a chat: {row!r}")
+        for col in cells:
+            self.assertFalse(slots.TABS.more_at(col),
+                             "the `+` was published as an overflow count as well")
+
+    def test_a_plus_and_a_plus_n_are_never_on_the_same_row(self):
+        """**Two fields that both begin with `+` and mean different things**, kept apart
+        by the ladder rather than by a reader's care: the affordance is drawn only on the
+        rung where every name fits and a count only on the rung where they do not.
+
+        Asked at every width on a list long enough to overflow, because "they cannot both
+        appear" is exactly the kind of claim that is true of the three widths somebody
+        checked.
+        """
+        names = [f"api.{i}" for i in range(1, 13)]
+        for width in range(0, 201):
+            row = _plain(self._draw(width, names=names, here="api.6",
+                                    note=slots.ADD_CHAT))
+            fields = [f.strip() for f in row.split(" " * slots._BAR_GAP) if f.strip()]
+            plus = [f for f in fields if f.startswith("+")]
+            self.assertLessEqual(len(plus), 2, f"{width}: {row!r}")
+            if slots.ADD_CHAT in plus:
+                self.assertEqual(plus, [slots.ADD_CHAT],
+                                 f"{width}: a `+` and a count share a row: {row!r}")
+
+    def test_a_narrowed_bar_forgets_the_affordance_it_is_no_longer_drawing(self):
+        """`_Viewport.blank`'s rule for the fourth thing `publish` writes. A bar that kept
+        its `+` cell through a resize would make a chat from a column the operator can see
+        holds a name."""
+        self._draw(120, names=["api.1"], here="api.1", note=slots.ADD_CHAT)
+        self.assertTrue(any(slots.TABS.add_at(c) for c in range(120)))
+        self._draw(120, names=["api.1"], here="api.1")
+        self.assertEqual([c for c in range(200) if slots.TABS.add_at(c)], [],
+                         "the bar kept an affordance it stopped drawing")
 
     def test_no_row_at_any_width_ever_draws_or_maps_a_column_left_of_zero(self):
         """**The property a deleted guard used to protect by accident** (#767).
@@ -1103,26 +1169,50 @@ class TheChatBarReadsThePlane(PersonaIso, unittest.TestCase):
         self._env.start()
         self.addCleanup(self._env.stop)
 
-    def test_the_bar_hides_the_second_name_when_there_is_one_chat_and_says_how(self):
+    def test_a_workspace_with_one_chat_still_says_which_and_offers_another(self):
         """Stage 5b's exit criterion, first half: "the chat bar is absent with one chat".
         Absent means it stops being a list — it still says which chat you are in and how
         to get a second, because a row that vanished would leave an operator with no way
         to learn the feature exists."""
         _plant("api.1", workspace="api")
-        row = slots.chats_bar("api.1", 200)[0]
+        row = _plain(slots.chats_bar("api.1", 200)[0])
         self.assertIn("api.1", row)
-        self.assertIn(slots.ADD_CHAT, row)
-        self.assertIn("charter <harness>", row,
-                      "the affordance must name something that works today")
+        self.assertTrue(row.rstrip().endswith(slots.ADD_CHAT), repr(row))
 
-    def test_the_bar_lists_both_chats_when_there_are_two(self):
-        """The other half: "present with two"."""
+    def test_the_bar_lists_both_chats_when_there_are_two_and_still_offers_a_third(self):
+        """The other half: "present with two" — and the `+` stays.
+
+        **It used to go**, on the argument that the affordance was a reminder for a plane
+        that had not discovered chats yet. That was right about a SENTENCE and is wrong
+        about a button: an operator with two chats wanting a third is exactly who presses
+        it, and a `+` that appears and disappears depending on how many tabs there are is
+        the one behaviour no tab strip anywhere has.
+        """
         _plant("api.1", workspace="api")
         _plant("api.2", workspace="api")
-        row = slots.chats_bar("api.2", 200)[0]
+        row = _plain(slots.chats_bar("api.2", 200)[0])
         self.assertIn("api.1", row)
         self.assertIn("*api.2", row)
-        self.assertNotIn(slots.ADD_CHAT, row)
+        self.assertTrue(row.rstrip().endswith(slots.ADD_CHAT), repr(row))
+
+    def test_the_workspace_bar_offers_no_such_thing(self):
+        """**A chat is a press; a workspace is a name.** A new chat has nothing for an
+        operator to type — its id is allocated and its workspace is fixed for life (§4j) —
+        while a new workspace is a directory and a name #518 refuses to create on a typo.
+        So the `+` is the chat bar's and the workspace bar draws none, at any width and
+        whatever the plane holds."""
+        for name in ("alpha", "beta"):
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        state.frame_dir("f1", create=True)
+        state.record_workspace("f1", "alpha")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""}):
+            for width in range(0, 201):
+                rows = slots.workspaces_bar("f1", width)
+                row = _plain(rows[0]) if rows else ""
+                self.assertFalse(row.rstrip().endswith(slots.ADD_CHAT),
+                                 f"{width}: the workspace bar drew a `+`: {row!r}")
+                self.assertEqual([c for c in range(width) if slots.TABS.add_at(c)], [],
+                                 f"{width}: the workspace bar published an affordance")
 
     def test_only_this_workspaces_chats_are_on_the_bar(self):
         _plant("api.1", workspace="api")

--- a/tests/test_the_chat_bars_plus_makes_a_chat.py
+++ b/tests/test_the_chat_bars_plus_makes_a_chat.py
@@ -223,6 +223,30 @@ class ThePressRunsTheLauncherForThisWorkspace(_APlusOnAFrameInAlpha):
                          f"a window was measured with no pane to measure it from: "
                          f"{self.calls}")
 
+    def test_a_workspace_with_no_directory_yet_runs_from_the_planes_root(self):
+        """**A real state, not a defensive one.** `switch.workspaces` folds
+        `config.DEFAULT_WORKSPACE` into its list whether or not its directory exists —
+        `workspace.ensure` makes it on demand — so a plane that has never made one still
+        draws a tab for it and still offers a `+` in it. `config.ROOT` is where charter
+        would have created it, and it is where the launcher is run from.
+
+        The `else` this reaches was a sweep survivor: every other case here runs in a
+        workspace whose directory the fixture made.
+        """
+        seen: list[str] = []
+
+        def fake_launch(args):
+            seen.append(os.getcwd())
+            self.launched.append(args)
+            return 0
+
+        (config.WORKSPACES_DIR / "alpha").rmdir()
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=self._tmux), \
+                mock.patch("charter.commands_frame.cmd_launch", side_effect=fake_launch):
+            commands_frame.cmd_new_chat(mock.Mock(chat=self.FID))
+        self.assertEqual(seen, [str(config.ROOT.resolve())],
+                         "a workspace with no directory did not fall back to the root")
+
     def test_the_launch_runs_in_the_workspaces_own_directory(self):
         """`cmd_launch` reads `os.getcwd()` for the frame's cwd, and a panel process is
         standing wherever its pane was started. Restored in a `finally` — this process goes
@@ -268,7 +292,18 @@ class ThePressSaysWhyWhenItWillNotMakeAChat(_APlusOnAFrameInAlpha):
         state.record_server(self.FID, "/nowhere/someone-elses")
         self.assertEqual(self._press(), 0)
         self.assertEqual(self.launched, [], "a chat was made in somebody else's tmux")
-        self.assertEqual(self._sentences(), [commands_frame.NO_CHAT_HERE])
+        # **The sentence spelled by hand, not read off the constant.** A case built from
+        # the constant it is about agrees with any value that constant takes — the
+        # survivor the deletion sweep reported for exactly this line. What the operator has
+        # to be told is *that charter will not do it here* and *what does work there*, so
+        # both halves are written out.
+        said = self._sentences()
+        self.assertEqual(len(said), 1, said)
+        self.assertIn("window in a tmux you already had", said[0])
+        self.assertIn("charter <harness>", said[0],
+                      "the refusal does not name the command that DOES work there")
+        self.assertEqual(said, [commands_frame.NO_CHAT_HERE],
+                         "the constant and the sentence have come apart")
 
     def test_a_session_this_plane_cannot_prove_is_its_own_is_refused(self):
         """**§3.3 at a new door.** One tmux server serves every plane on this machine, and
@@ -278,22 +313,72 @@ class ThePressSaysWhyWhenItWillNotMakeAChat(_APlusOnAFrameInAlpha):
         with mock.patch("charter.commands_frame._plane_session", return_value=None):
             self.assertEqual(self._press(), 0)
         self.assertEqual(self.launched, [])
-        self.assertEqual(self._sentences(), [commands_frame.NO_SESSION_HERE])
+        # Spelled by hand for the case above's reason. The load-bearing half is *cannot
+        # prove* — charter is not saying the session is somebody else's, it is saying it
+        # cannot show it is this plane's, and those are different claims.
+        said = self._sentences()
+        self.assertEqual(len(said), 1, said)
+        self.assertIn("cannot prove", said[0])
+        self.assertIn("another plane's", said[0])
+        self.assertEqual(said, [commands_frame.NO_SESSION_HERE],
+                         "the constant and the sentence have come apart")
 
     def test_a_chat_recording_no_launchable_harness_is_refused_by_name(self):
         with mock.patch.dict(config.HARNESS, {"default": "nothing-installed"}):
             state.record_identity(self.FID, {"CHARTER_HARNESS": "also-nothing"})
             self.assertEqual(self._press(), 0)
         self.assertEqual(self.launched, [])
-        self.assertEqual(len(self._sentences()), 1)
-        self.assertIn("harness", self._sentences()[0])
+        said = self._sentences()
+        self.assertEqual(len(said), 1, said)
+        self.assertIn("records no harness this charter can launch", said[0])
+        self.assertIn("[harness] default", said[0],
+                      "the refusal does not name the key that would fix it")
+        self.assertTrue(said[0].startswith("cannot open another chat:"),
+                        f"the refusal does not name its own subject: {said[0]!r}")
 
     def test_a_workspace_directory_charter_cannot_enter_is_refused_by_name(self):
         with mock.patch("charter.commands_frame.os.chdir", side_effect=OSError("nope")):
             self.assertEqual(self._press(), 0)
         self.assertEqual(self.launched, [])
-        self.assertEqual(len(self._sentences()), 1)
-        self.assertIn("cannot enter", self._sentences()[0])
+        said = self._sentences()
+        self.assertEqual(len(said), 1, said)
+        self.assertEqual(said[0], "cannot open another chat: charter cannot enter this "
+                                  "workspace's directory")
+
+    def test_a_cwd_that_vanished_while_the_launcher_ran_costs_nothing(self):
+        """**The `except OSError` on the way BACK, which the deletion sweep asked about.**
+
+        The launcher is run from the workspace's directory and this process is put back
+        where it was in a `finally`. That restore can fail for the same reasons the first
+        `chdir` can — the panel's own cwd removed while the launch was in flight — and it
+        happens after the work is done, so it must not turn a chat that WAS made into a
+        traceback in a process whose streams are `/dev/null`.
+
+        The second call is the one that raises, so the launch really runs; the first is the
+        one that must not, or this would be measuring the refusal above.
+        """
+        calls = {"n": 0}
+        real = os.chdir
+        # **The restore this case breaks is the one that puts THIS process back**, so the
+        # case has to do it instead — otherwise the interpreter is left standing in the
+        # workspace directory and every later case in this file resolves its plane from
+        # there. Registered before the failure is arranged, so it runs whatever happens.
+        self.addCleanup(real, os.getcwd())
+
+        def flaky(path):
+            calls["n"] += 1
+            if calls["n"] > 1:
+                raise OSError("the directory this panel was standing in is gone")
+            real(path)
+
+        with mock.patch("charter.commands_frame.os.chdir", side_effect=flaky):
+            self.assertEqual(self._press(), 0)
+        self.assertEqual(calls["n"], 2, "the restore was never attempted")
+        self.assertEqual(len(self.launched), 1,
+                         "the launch did not happen, so this measures nothing")
+        self.assertEqual(self._sentences(), [],
+                         f"a failed restore was reported as a failure: "
+                         f"{self._sentences()}")
 
     def test_no_frame_at_all_is_a_message_on_stderr_and_nothing_else(self):
         """Typed by hand outside a frame. There is no attention row to draw on — that is

--- a/tests/test_the_chat_bars_plus_makes_a_chat.py
+++ b/tests/test_the_chat_bars_plus_makes_a_chat.py
@@ -169,6 +169,60 @@ class ThePressRunsTheLauncherForThisWorkspace(_APlusOnAFrameInAlpha):
         self._press()
         self.assertEqual(self.launched[0].size, (132, 43))
 
+    def test_no_tmux_target_is_ever_the_empty_string(self):
+        """**An empty `-t` is not a failed read — it is the SERVER's current window**, and
+        on a socket serving eleven sessions from three projects that is very likely another
+        plane's. `_open_workspace` carried a `state.harness_pane(fid) or ""` into
+        `_window_size`, the deletion sweep survived the `or ""` because that caller had
+        already proved a pane, and asking why is what found this.
+
+        Asked of every argv this command sends rather than of the one line that could get
+        it wrong, so a second target added later is covered on the day it is added — and
+        asked in the state that can REACH it. With this chat's pane recorded, no fallback
+        runs and the check is vacuous; the row that matters is the chat whose pane record
+        is gone while a SIBLING's is not — the migration case, and the one an `or ""` would
+        send to the server's current window. A chat with no sibling either never gets that
+        far: `_plane_session` has nothing to match and refuses before it asks tmux
+        anything, which is why the sibling is planted rather than assumed.
+        """
+        _a_chat("alpha.9", ws="alpha", pane="%1")
+        for pane in ("%1", ""):
+            with self.subTest(recorded=pane or "<none>"):
+                state.record_harness_pane(self.FID, pane)
+                self.calls.clear()
+                self._press()
+                self.assertTrue(self.calls, "the press sent tmux nothing at all")
+                for cmd in self.calls:
+                    self.assertNotIn("", cmd[1:],
+                                     f"an empty argument reached tmux: {cmd}")
+
+    def test_a_chat_with_no_pane_of_its_own_is_sized_off_the_live_one(self):
+        """**Reachable, unlike the fallback it replaces**: a chat launched by a charter
+        that predates `state.record_harness_pane`, or one whose state directory was
+        truncated, has no pane. What it is sized for is then the pane `_plane_session` has
+        just proved is live in this workspace — the window a client in this workspace is
+        looking at, which is `_open_workspace`'s own answer to the same question."""
+        _a_chat("alpha.9", ws="alpha", pane="%1")
+        state.record_harness_pane(self.FID, "")
+        self._press()
+        self.assertEqual(self.launched[0].size, (132, 43))
+        self.assertTrue(any("%1" in cmd for cmd in self.calls),
+                        f"nothing was measured off the live pane: {self.calls}")
+
+    def test_a_workspace_whose_panes_are_all_gone_measures_nothing_at_all(self):
+        """The end of the chain: no pane anywhere means charter has no window to lay the
+        new frame out for, and `_launch_size` reads `None` as *measure your own terminal*
+        — which for a detached process is the documented 80x24. A frame charter could not
+        measure comes up small; one measured off a stranger's terminal comes up wrong, and
+        only one of those is recoverable by resizing the window."""
+        with mock.patch("charter.frame.chats.pane_of", return_value=None):
+            self._press()
+        self.assertIsNone(self.launched[0].size)
+        self.assertFalse(any("display-message" in cmd and "window_width" in cmd[-1]
+                             for cmd in self.calls),
+                         f"a window was measured with no pane to measure it from: "
+                         f"{self.calls}")
+
     def test_the_launch_runs_in_the_workspaces_own_directory(self):
         """`cmd_launch` reads `os.getcwd()` for the frame's cwd, and a panel process is
         standing wherever its pane was started. Restored in a `finally` — this process goes

--- a/tests/test_the_chat_bars_plus_makes_a_chat.py
+++ b/tests/test_the_chat_bars_plus_makes_a_chat.py
@@ -1,0 +1,307 @@
+"""`charter frame-new-chat` — what the chat bar's `+` runs, and the four ways it stops.
+
+*"`+` button not working for creating new session."*
+
+The affordance was a SENTENCE — `+ charter <harness> opens another` — which is true, which
+names the command that does it, and which sits at the end of a row of clickable tabs
+beginning with a `+`. Every terminal an operator has used puts a `+` there and every one of
+them means *new*, so it was pressed. `slots.ADD_CHAT` is a `+` now and this is the command
+behind it.
+
+**Why a command at all, rather than the panel spawning `charter <harness>`.**
+`builtin_actions._spawn` hands its child all three streams on `/dev/null`, and `cmd_launch`
+reads a non-tty stdout as *this process cannot be the operator's terminal* and `os.execvp`s
+the bare harness into the void — which is not a wrong frame, it is no frame at all and no
+process left to report it. `attach=False` is the seam that says *build the frame, do not
+become the terminal*; it has existed since `_open_workspace` needed it for §4k, and until
+now it was reachable only in-process. `charter frame-new-chat` is the spelling.
+
+**Every stop puts a line on the frame's own attention row**, and that is the whole point of
+the command existing rather than the panel calling the launcher directly: this runs
+detached with its streams on `/dev/null`, so a refusal it did not say is a `+` that did
+nothing — which is the complaint this change is answering, one release later.
+
+`tests/test_a_click_on_a_tab_bar_switches.APressOnThePlusMakesAChat` is which press starts
+this; `tests/test_a_real_click_on_a_real_tab_bar_switches.py` is the real tmux that says a
+chat really appears.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from unittest import mock
+
+from charter import commands_frame, config
+from charter.frame import state
+
+from tests._isolation import PersonaIso
+
+
+def _completed(cmd, rc=0, out=""):
+    return subprocess.CompletedProcess(list(cmd), rc, out, "")
+
+
+def _a_chat(fid: str, *, ws: str, pane: str | None = "%1",
+            harness: str = "claude-code", socket: str | None = None) -> None:
+    """A chat directory on THIS plane, in the shape a launcher leaves one.
+
+    *harness* is `$CHARTER_HARNESS` as `cmd_launch` records it — `harness.base.name`, not
+    the CLI word — because that is the record `cmd_new_chat` reads to decide which harness
+    the new chat runs. `tests/test_a_workspace_tab_opens_what_it_names.py` keeps the same
+    helper for the same reason, one noun over.
+    """
+    state.frame_dir(fid, create=True)
+    state.record_workspace(fid, ws)
+    state.record_server(fid, socket or commands_frame.SOCKET)
+    state.record_identity(fid, {"CHARTER_HARNESS": harness})
+    if pane is not None:
+        state.record_harness_pane(fid, pane)
+
+
+class _APlusOnAFrameInAlpha(PersonaIso, unittest.TestCase):
+    """One chat in `alpha`, on charter's own server, with a fake launcher and a fake tmux.
+
+    The tmux stand-in answers the two questions `cmd_new_chat` asks before it launches —
+    where this plane's `alpha` session is (`_plane_session`, through `list-panes`) and how
+    big the window is — and nothing else. What is being asked here is which namespace the
+    launcher is handed and which sentences the refusals say; whether tmux really makes a
+    window is `tests/test_a_real_click_on_a_real_tab_bar_switches.py`'s.
+    """
+
+    FID = "alpha.1"
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
+        _a_chat(self.FID, ws="alpha")
+        self.said = self.enterContext(
+            mock.patch("charter.commands_frame._say_on_screen"))
+        self.launched: list = []
+        self.calls: list[list[str]] = []
+
+    def _tmux(self, cmd, **kw):
+        self.calls.append(list(cmd))
+        if "display-message" in cmd:
+            # `_WINDOW_SIZE_FORMAT`'s own separator — a colon, not a space — read off the
+            # constant rather than re-spelled, because a stand-in that answered in the
+            # wrong shape would silently hand the launcher `_FALLBACK_SIZE` and the case
+            # about the size would be measuring this fixture's typo.
+            if "window_width" in cmd[-1]:
+                return _completed(cmd, 0, "132:43")
+            return _completed(cmd, 0, "$1\t@1")
+        if "list-panes" in cmd:
+            return _completed(cmd, 0, f"$1\t%1\t{config.STATE_DIR}\n")
+        return _completed(cmd, 0)
+
+    def _press(self, *, chat: str | None = None, rc: int = 0):
+        """Run the command the `+` runs, with the launcher faked."""
+        def fake_launch(args):
+            self.launched.append(args)
+            return rc
+
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=self._tmux), \
+                mock.patch("charter.commands_frame.cmd_launch", side_effect=fake_launch):
+            return commands_frame.cmd_new_chat(
+                mock.Mock(chat=self.FID if chat is None else chat))
+
+    def _sentences(self) -> list[str]:
+        return [c[0][1] for c in self.said.call_args_list]
+
+
+class ThePressRunsTheLauncherForThisWorkspace(_APlusOnAFrameInAlpha):
+    """The ordinary path: one launch, in this workspace, not attaching."""
+
+    def test_a_press_launches_exactly_once(self):
+        self.assertEqual(self._press(), 0)
+        self.assertEqual(len(self.launched), 1,
+                         f"the press started {len(self.launched)} launches")
+        self.assertEqual(self._sentences(), [],
+                         f"a successful press said something: {self._sentences()}")
+
+    def test_the_launch_names_the_workspace_this_chat_is_in(self):
+        """Outright, never a resolution. This runs detached in a process whose environment
+        is a panel's, and `workspace.resolve()` there would answer for whatever that
+        process happened to inherit — the trap `state.record_identity` measures, one field
+        over. §4j is the other half: a chat belongs to its workspace for life, so there is
+        no other workspace this press could mean."""
+        self._press()
+        self.assertEqual(self.launched[0].workspace, "alpha")
+
+    def test_the_launch_does_not_attach(self):
+        """**The seam this command exists on the far side of.** Left at the `getattr`
+        default this reaches `bypass`, which `os.execvp`s the bare harness over this
+        process with its output on `/dev/null` — no frame, no chat, and nothing left to
+        say so."""
+        self._press()
+        self.assertIs(self.launched[0].attach, False)
+
+    def test_the_launch_carries_no_command_and_asks_no_picker(self):
+        """`rest` empty so the harness starts at its own prompt with nothing sent to it,
+        and `pick` false so `_picker_wanted` can never raise a prompt on a path with no
+        operator waiting — `_open_workspace`'s two fields for its two reasons."""
+        self._press()
+        self.assertEqual(self.launched[0].rest, [])
+        self.assertFalse(self.launched[0].pick)
+        self.assertFalse(self.launched[0].no_frame)
+
+    def test_the_launch_uses_the_harness_this_chat_records(self):
+        """The one question a `+` cannot carry, answered the only way the operator has
+        expressed: the tool they are already in."""
+        self._press()
+        self.assertEqual(self.launched[0].harness, "claude")
+
+    def test_a_chat_with_no_recorded_harness_falls_back_to_the_planes_default(self):
+        """The migration case — a chat launched by a charter that predates
+        `state.record_identity`."""
+        state.record_identity(self.FID, {"CHARTER_HARNESS": ""})
+        with mock.patch.dict(config.HARNESS, {"default": "claude"}):
+            self._press()
+        self.assertEqual(self.launched[0].harness, "claude")
+
+    def test_the_launch_is_sized_for_the_window_the_chat_is_on(self):
+        """A launcher with no terminal of its own measures nothing, and `cmd_launch`'s own
+        fallback is 80x24 — which `_drawable_slots` reads as room for almost nothing. The
+        new chat is about to be shown on the terminal looking at THIS chat, so that window
+        is what it is sized for (`_launch_size`)."""
+        self._press()
+        self.assertEqual(self.launched[0].size, (132, 43))
+
+    def test_the_launch_runs_in_the_workspaces_own_directory(self):
+        """`cmd_launch` reads `os.getcwd()` for the frame's cwd, and a panel process is
+        standing wherever its pane was started. Restored in a `finally` — this process goes
+        on to draw — so the reading has to be taken from inside the launcher."""
+        seen: list[str] = []
+
+        def fake_launch(args):
+            seen.append(os.getcwd())
+            self.launched.append(args)
+            return 0
+
+        here = os.getcwd()
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=self._tmux), \
+                mock.patch("charter.commands_frame.cmd_launch", side_effect=fake_launch):
+            commands_frame.cmd_new_chat(mock.Mock(chat=self.FID))
+        self.assertEqual(seen, [str((config.WORKSPACES_DIR / "alpha").resolve())])
+        self.assertEqual(os.getcwd(), here, "the launcher was left in another directory")
+
+    def test_it_answers_zero_even_when_the_launcher_did_not(self):
+        """`cmd_palette`'s rule: a non-zero from a `run-shell` child is printed INTO THE
+        HARNESS PANE and drops it into copy-mode — charter drawing in the one rectangle
+        ADR 0018 says it never draws. So every outcome here is 0 and the report goes on
+        the attention row."""
+        self.assertEqual(self._press(rc=2), 0)
+        self.assertTrue(any("2" in s for s in self._sentences()),
+                        f"a launcher failure was swallowed: {self._sentences()}")
+
+
+class ThePressSaysWhyWhenItWillNotMakeAChat(_APlusOnAFrameInAlpha):
+    """The four stops, each with its own sentence. A `+` that silently failed would be the
+    same complaint this change is answering, one release later."""
+
+    def test_a_frame_in_a_tmux_you_already_had_is_refused_by_name(self):
+        """On charter's own server a workspace IS a session and a chat is a window in it.
+        Inside a tmux the operator already has, charter writes nothing session-scoped at
+        all and a chat there is a window in a session charter does not own — so the `+`
+        names the command that works there instead of guessing.
+
+        The socket is a bare absolute path rather than a real one, because
+        `tmuxctl.is_operator_socket` discriminates on the leading `/` and
+        `tests/test_no_test_bakes_a_uid_into_a_socket_path.py` refuses a `tmux-<uid>`
+        spelt into a test file."""
+        state.record_server(self.FID, "/nowhere/someone-elses")
+        self.assertEqual(self._press(), 0)
+        self.assertEqual(self.launched, [], "a chat was made in somebody else's tmux")
+        self.assertEqual(self._sentences(), [commands_frame.NO_CHAT_HERE])
+
+    def test_a_session_this_plane_cannot_prove_is_its_own_is_refused(self):
+        """**§3.3 at a new door.** One tmux server serves every plane on this machine, and
+        `cmd_launch` decides between starting a session and joining one on a NAME. A `+`
+        that ran the launcher without this check could add a window to another project's
+        live frame, across every isolation boundary charter has."""
+        with mock.patch("charter.commands_frame._plane_session", return_value=None):
+            self.assertEqual(self._press(), 0)
+        self.assertEqual(self.launched, [])
+        self.assertEqual(self._sentences(), [commands_frame.NO_SESSION_HERE])
+
+    def test_a_chat_recording_no_launchable_harness_is_refused_by_name(self):
+        with mock.patch.dict(config.HARNESS, {"default": "nothing-installed"}):
+            state.record_identity(self.FID, {"CHARTER_HARNESS": "also-nothing"})
+            self.assertEqual(self._press(), 0)
+        self.assertEqual(self.launched, [])
+        self.assertEqual(len(self._sentences()), 1)
+        self.assertIn("harness", self._sentences()[0])
+
+    def test_a_workspace_directory_charter_cannot_enter_is_refused_by_name(self):
+        with mock.patch("charter.commands_frame.os.chdir", side_effect=OSError("nope")):
+            self.assertEqual(self._press(), 0)
+        self.assertEqual(self.launched, [])
+        self.assertEqual(len(self._sentences()), 1)
+        self.assertIn("cannot enter", self._sentences()[0])
+
+    def test_no_frame_at_all_is_a_message_on_stderr_and_nothing_else(self):
+        """Typed by hand outside a frame. There is no attention row to draw on — that is
+        what "no frame" means — so this one goes to the stream a shell can read, and still
+        answers 0 for `cmd_palette`'s reason."""
+        with mock.patch("charter.util.err") as err:
+            self.assertEqual(self._press(chat=""), 0)
+        self.assertEqual(self.launched, [])
+        self.assertEqual(self._sentences(), [])
+        self.assertEqual(err.call_count, 1)
+
+    def test_each_refusal_says_a_different_thing(self):
+        """The set, asked as a set. Four stops sharing one sentence would tell the operator
+        that the `+` does not work and nothing about why — which is the state before this
+        change wearing a message."""
+        said = {commands_frame.NO_CHAT_HERE, commands_frame.NO_SESSION_HERE}
+        self.assertEqual(len(said), 2)
+        for text in said:
+            self.assertNotIn("\n", text, f"a refusal spans two rows: {text!r}")
+
+
+class TheCommandIsReachableAndReserved(unittest.TestCase):
+    """The CLI half — a word charter owns, parsed to this function."""
+
+    def test_the_word_parses_to_the_command(self):
+        from charter import cli
+        args = cli.build_parser().parse_args(["frame-new-chat", "--chat", "api.1"])
+        self.assertIs(args.func, commands_frame.cmd_new_chat)
+        self.assertEqual(args.chat, "api.1")
+
+    def test_the_chat_option_is_optional(self):
+        """A bind installed by an older charter fires with no `--chat` at all, and a
+        hand-typed `charter frame-new-chat` inside a frame has none either — both resolve
+        through `$CHARTER_SESSION_ID`, which is `_pressers_chat`'s fallback."""
+        from charter import cli
+        self.assertEqual(cli.build_parser().parse_args(["frame-new-chat"]).chat, "")
+
+    def test_it_takes_no_name_to_get_wrong(self):
+        """#518's line held. A chat's id is allocated and its workspace is fixed for life
+        (§4j), so there is nothing here for an operator to type — which is also why the
+        workspace bar has no `+`: a workspace IS a name, and creating one on a typo leaves
+        litter."""
+        from charter import cli
+        with self.assertRaises(SystemExit):
+            cli.build_parser().parse_args(["frame-new-chat", "somename"])
+
+    def test_a_harness_cannot_claim_the_word(self):
+        """`cli._core_commands` reserves it, and the reservation is asked for by BEHAVIOUR
+        rather than by reading the source: a harness whose `cli_name` is this word must be
+        refused when the parser is built.
+
+        Without the reservation nothing raises — on this repo's 3.11 floor a second
+        `add_parser` of the same name silently replaces the first — so the `+` would launch
+        a harness instead of making a chat, and every other case in this file would still
+        pass.
+        """
+        from charter import cli
+        from charter.harness import base
+        rogue = mock.Mock(spec=base.Harness, name="rogue")
+        rogue.name = "rogue"
+        rogue.cli_name = "frame-new-chat"
+        with mock.patch("charter.harness.all", return_value=[rogue]):
+            with self.assertRaises(ValueError) as caught:
+                cli.build_parser()
+        self.assertIn("frame-new-chat", str(caught.exception))


### PR DESCRIPTION
**Stacked on #815** — base is `tabs-strip`. Merge that first; this branch contains it.

> *"`+` button not working for creating new session."*

It was never a button. The chat bar's add-chat affordance was a **sentence**:

```
  chats  *api.1  + charter <harness> opens another
```

True, names the command that does it, and sits at the end of a row of clickable tabs beginning with a `+`. Every terminal an operator has used puts a `+` there and every one of them means *new*. So it got pressed.

```
  chats  *api.1   api.2   +
```

## Why it needed a new command

The obvious fix — have the panel run `charter <harness>` — does not work, and the way it fails is instructive. A click's work runs detached with all three streams on `/dev/null`, and `cmd_launch` reads a non-tty stdout as *this process cannot be the operator's terminal* and `os.execvp`s the bare harness into the void. No frame, no chat, and no process left to say so.

`attach=False` is the seam that says *build the frame, do not become the terminal*. It has existed since `_open_workspace` needed it for §4k and was reachable only in-process. `charter frame-new-chat` is the first spelling that can ask for it, and `cmd_new_chat` is `_open_workspace`'s shape with one guard **inverted**: that one refuses a workspace whose name is already a live session; this one refuses to proceed unless `_plane_session` can prove the session is this plane's. Same §3.3 rule, opposite sign, written out rather than shared because a helper taking a flag for which way to point would be one function claiming to answer two questions.

## Four stops, four sentences

All on the frame's attention row, because a `+` that silently failed would be this report one release later: a frame inside the operator's own tmux, a session this plane cannot prove is its own, a chat recording no launchable harness, and a workspace directory charter cannot enter.

## Two decisions worth the paragraph

**The `+` is drawn at every chat count now, not only at one.** The old rule was right about a *sentence* — a reminder for a plane that had not discovered chats — and wrong about a *button*: an operator with two chats wanting a third is exactly who presses it. It cannot share a row with a `+N`, structurally: the ladder draws the affordance only on the rung where every name fits and a count only on the rung where they do not.

**The workspace bar gets none.** A new chat is nothing but a press; a new workspace is a directory and a *name*, and #518 refuses to create one on a typo. The handler is handed the command as **data** rather than deriving it from what the renderer drew, so the property survives a renderer that grows a note later — pinned by a case that publishes the map by hand and asks the workspace handler directly.

## Verification

- Full suite: **10238 tests, 8 skipped, green.**
- Real tmux on **3.7c and the 3.2 floor** (20 cases in `test_a_real_click_on_a_real_tab_bar_switches`, green on both): a real client on a real pty, the `+` pressed through the client's own terminal, the answer written on the frame's own attention row by a real detached `charter frame-new-chat` that resolved which frame it belonged to, established it was on charter's own server, and proved the workspace's session was this plane's with a real `list-panes`. Plus: the keyboard stays on the harness, the cell next to the `+` reaches nothing, an unpaired release reaches nothing, and a stopped press created nothing.
- Mutation-checked: dropping either guard, `attach=True`, dropping the handler's `add` data, not publishing the affordance's columns, and not passing the note each turn the suite red.

**One stated limit.** The launcher itself is asserted against a stand-in rather than run for real: `commands_frame.SOCKET` is a module constant naming the one shared server every frame on the machine runs on, so a test that let the launch run would build a session on the operator's live charter server. Exactly one call is faked; everything up to it is real on both tmux versions.

## Note on file ownership

This touches `charter/commands_frame.py`, which another agent holds this session for the #780 tmux round-trip batching. The change is **purely additive** — one new function appended at the end of the file, plus two module constants — so it should merge cleanly, but it is worth knowing before this lands beside that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ctfuhnX3LdXbtx3SMUvTu
