### PR TITLE
A recycled chat ordinal starts from nothing: reap a chat's session state with its frame (#731)

### DIFF
--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -1996,6 +1996,61 @@ def is_live(fid: str, *, pane: str | None = None) -> bool:
     return True
 
 
+def _forget_session(fid: str) -> None:
+    """Remove every per-session marker keyed on *fid* from ``SESSIONS_DIR`` (#731).
+
+    **A frame's directory is not all of a frame's state, and an ordinal is recycled.**
+    :func:`new_chat_id` hands out the lowest FREE ordinal and an ordinal is free the
+    moment :func:`reap` removes its directory, so a "fresh" chat id is very often a
+    recycled NAME. Inside a frame the frame **is** the charter session (ADR 0019), so
+    every file charter keys on a session id — one directory over, in
+    ``.charter/sessions/<sid>.*`` — is keyed on that name too, and the next tenant of the
+    ordinal inherits all of it. Measured on the reported case: a relaunched `alpha.1`
+    whose predecessor had chosen `gamma` answers `workspace.resolve` → `gamma`,
+    `is_locked` → `gamma`, and refuses `charter workspace use alpha` as **locked** — to
+    the operator who had just launched with `--workspace alpha`. Minting a new id is not
+    isolation; reaping the state keyed on the old one is.
+
+    **The prefix, not a list of suffixes**, and that is `workspace._prune`'s lesson taken
+    at its word rather than re-learned (#366): it enumerated five marker families,
+    drifted three times, and was replaced by "every file in the directory". Eight
+    families are keyed this way today across five modules (`workspace`'s `.workspace` and
+    `.lock`, `persona`'s `.persona`, `statusline`'s `.usage`, `toolgate`'s `.tools` and
+    `.gate`, `hooks`' `.configver`, `.memnudge`, `.route-pending` and
+    `.<tool-use-id>.<kind>.ask-pending`), and a ninth written tomorrow is covered the day
+    it is written. Nothing in either directory is a member for which surviving its own
+    session is the right answer.
+
+    The dot is part of the prefix and load-bearing: `alpha.1` must not reap `alpha.10`'s
+    markers. Never raises, on the same terms as everything else in this module: a marker
+    that could not be removed costs exactly what it cost before this function existed.
+
+    **No `is_file()` filter, and its absence is measured rather than assumed.**
+    `_prune` has one, where it is load-bearing (it guards a `stat` whose `st_mtime` is
+    the whole decision); here it would be the identity. `unlink` on a directory refuses
+    on every platform charter runs on — ``EISDIR`` on Linux, ``EPERM`` on macOS, both
+    ``OSError`` — so the `except` below already leaves it exactly where the filter would
+    have, and a branch no input can distinguish is a survivor waiting to be written.
+
+    Called only where a directory was actually removed, so it inherits `reap`'s scope for
+    free: a live frame keeps its selection, and so does a frame on another server.
+    """
+    try:
+        entries = list(Path(config.SESSIONS_DIR).iterdir())
+    except OSError:
+        # No sessions directory yet, or one this process cannot list. Same side every
+        # unreadable answer in this module falls on: no proof, no deletion.
+        return
+    prefix = f"{fid}."
+    for f in entries:
+        if not f.name.startswith(prefix):
+            continue
+        try:
+            f.unlink()
+        except OSError:
+            continue
+
+
 def reap(live: set[str], *, server: str) -> list[str]:
     """Remove state for frames of *server* that are gone. Returns what was removed.
 
@@ -2134,5 +2189,8 @@ def reap(live: set[str], *, server: str) -> list[str]:
         if pid is not None and _launcher_is_alive(pid):
             continue
         shutil.rmtree(d, ignore_errors=True)
+        # The frame's directory is half its state; the other half is keyed on the same
+        # name one directory over, and the ordinal is about to be handed out again (#731).
+        _forget_session(d.name)
         removed.append(d.name)
     return removed

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1001,6 +1001,17 @@ One consequence worth stating: a chat's workspace is now fixed at launch, so **r
 workspace orphans its chats** — their record still names the old name. That was already
 true of any chat nobody had typed `workspace use` in, and it is now true of all of them.
 
+**That pointer, and everything else keyed on a chat, dies with the chat.** A chat id is
+`<workspace>.<n>` and the ordinal is handed back when the chat's state is reaped, so the
+next chat in that workspace very often gets the same *name* — and a pointer, a lock, a
+persona selection or a tool-gate marker left under it would be inherited by a conversation
+that never chose any of them. What that cost, before it was fixed, was a chat launched with
+`--workspace alpha` whose every command acted on `gamma` and which refused
+`charter workspace use alpha` as **locked** (#731). So reaping a chat removes
+`.charter/sessions/<chat id>.*` along with `.charter/frame/<chat id>/`. Sessions that are
+not chats — a bare harness outside a frame, keyed by its own id — are untouched, and so is
+every live chat.
+
 The pin comes first because that is what it means everywhere else in charter: it ranks
 above every pointer in `charter`'s own resolution, and `charter workspace use` warns you
 that it will not stick while the variable is set. A frame is not an exception to that —

--- a/docs/news/unreleased-a-new-chat-is-not-the-last-ones-leftovers.md
+++ b/docs/news/unreleased-a-new-chat-is-not-the-last-ones-leftovers.md
@@ -1,0 +1,74 @@
+---
+version: unreleased
+headline: A new chat no longer inherits the last chat's workspace lock
+---
+
+*"I launched with `--workspace alpha`, and `charter workspace use alpha` told me the
+session was locked to `gamma`."*
+
+## What was happening
+
+A chat id is `<workspace>.<n>`, and `n` is **allocated, not minted**: charter hands out the
+lowest free ordinal, and an ordinal is free the moment the chat's state is reaped. So the
+"new" chat you open after closing one very often has the same *name* as the one you closed.
+
+Everything charter keys on a session id lives in `.charter/sessions/<id>.*`, and inside a
+frame the frame **is** the charter session — so that `<id>` is the chat id. Reaping removed
+`.charter/frame/<id>/` and nothing else, which meant the next tenant of the ordinal
+inherited the previous one's pointer, its lock, its persona selection and its tool-gate
+markers.
+
+Measured, reproduced without tmux — one chat that selected `gamma`, reaped, then relaunched
+onto the same ordinal:
+
+```
+is_locked      : gamma
+for_session    : gamma
+resolve        : gamma          <- what every `charter` command in that shell acts on
+set_active a   : locked         <- `charter workspace use alpha`, refused
+```
+
+The release before this one closed the visible half (#794): the panels draw `alpha` and the
+chat belongs to `alpha`, because membership stopped reading that pointer. What that left was
+arguably worse to be on the receiving end of — the panels and the commands disagreed, and
+the refusal named a lock nobody in that chat had set.
+
+## What changed
+
+Reaping a chat now removes `.charter/sessions/<chat id>.*` along with
+`.charter/frame/<chat id>/`.
+
+**The sweep is the id prefix, not a list of suffixes**, and that is a lesson this codebase
+already paid for once: `workspace._prune` enumerated five marker families, drifted three
+times, and was replaced by "every file in the directory" (#366). Eight families are keyed on
+a session id today, across five modules — the workspace pointer and the lock, the persona
+pointer, the usage record, the tool-gate's two files, and three of the hooks' markers — and
+a ninth written next year is covered the day it is written rather than the day somebody
+remembers this function.
+
+Nothing else moves. The match is anchored and dot-terminated, so `alpha.1` does not touch
+`alpha.10`'s files or `xalpha.1`'s (a real collision: chat ids have no boundary character
+between the workspace and the dot, so one workspace's name can end with another's). A live
+chat keeps its selection, a chat on another tmux server keeps its selection, and a harness
+session outside a frame — keyed by its own id — is never in the sweep at all.
+
+## The alternative, and why not
+
+#731 offered a second fix: let the launcher's `--workspace` outrank a pointer it did not
+write. That only ever helps a launch carrying the flag, and bare `charter` is now the
+ordinary way in — and it leaves the lock, which no flag addresses, exactly where it is.
+PR #757's body named this fix instead, and this is that.
+
+## Verification
+
+Twelve cases, no tmux — the defect reproduces on two directories. Six were red before the
+change; the other six are the blast radius, and each was confirmed to fail against a
+deliberately over-wide implementation rather than assumed to be measuring something:
+
+- dropping the `.` from the prefix reddens the `alpha.10` case;
+- `startswith` → `in` reddens the `xalpha.1` case;
+- hoisting the sweep out of the keep-rules reddens both the live-chat and other-server cases;
+- both `except OSError` clauses are entered by patching the exact call that raises, and each
+  turns red when its exception type is changed.
+
+Nothing to adopt.

--- a/tests/test_a_reaped_chat_leaves_its_session_behind.py
+++ b/tests/test_a_reaped_chat_leaves_its_session_behind.py
@@ -1,0 +1,292 @@
+"""#731, the surviving half: a recycled chat ordinal inherits the previous frame's
+per-session state.
+
+`state.new_chat_id` counts up from 1 and hands out the lowest FREE ordinal, and an
+ordinal is free the moment `state.reap` removes its directory — so a "fresh" chat id is
+very often a recycled NAME. Minting a new id is therefore not isolation; what makes the
+name mean a new chat is reaping the state keyed on the old one.
+
+`reap` removed `.charter/frame/<fid>/` and nothing else. Everything charter keys on the
+charter session id lives one directory over, in `.charter/sessions/<fid>.*` — and inside
+a frame the frame **is** the charter session (ADR 0019), so `<fid>` is that key. The
+measured result, reproduced below without tmux: a relaunched `alpha.1` whose predecessor
+had selected `gamma` comes up `is_locked: gamma`, `workspace.resolve: gamma`, and
+`charter workspace use alpha` — typed by the operator who just launched with
+`--workspace alpha` — is **refused as locked**.
+
+#794 closed the visible half: the panels draw `alpha` and the chat belongs to `alpha`,
+because `state.own_workspace` no longer reads that pointer. What that leaves is worse to
+read than a wrong label — the panels and the commands now disagree, and the operator is
+told `locked` by a lock nobody in this chat set.
+
+**The sweep is the directory prefix, not a list of two suffixes**, and that is
+`workspace._prune`'s lesson taken at its word rather than re-learned (#366): its allowlist
+of marker families drifted three times before it was replaced by "every file in the
+directory". `<fid>.workspace` and `<fid>.lock` are the two #731 measured; `<fid>.persona`,
+`<fid>.usage`, `<fid>.tools`, `<fid>.gate`, `<fid>.configver`, `<fid>.memnudge`,
+`<fid>.route-pending` and `<fid>.<tuid>.<kind>.ask-pending` are keyed the same way by four
+other modules, and every one of them is inherited by the same recycled name. A remedy that
+names two of eight is a remedy that has to be edited every time a ninth is written.
+
+**The other fix #731 offered is rejected here for the reason its own comment thread
+gives.** Letting the launcher's `--workspace` outrank a pointer it did not write only ever
+helps a launch that carries the flag, and bare `charter` is now the ordinary way in; it
+also leaves the lock — which no flag addresses — exactly where it is.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import config, workspace
+from charter.frame import state
+from tests._isolation import PersonaIso
+
+SERVER = "charter-test-731"
+
+
+class _ReapedChat(PersonaIso):
+    """One chat, one workspace selection inside it, and then a real reap.
+
+    The launcher is patched dead rather than a pid being hand-written into the claim
+    file: `reap`'s third keep-rule is "is the process that claimed this directory still
+    running", and in this test that process is the test runner itself. Patching the
+    predicate is what a real exit answers; writing a number is a guess about which pids
+    the machine has free.
+    """
+
+    def open_chat(self, ws: str = "alpha") -> str:
+        fid = state.new_chat_id(ws)
+        assert fid is not None
+        state.record_server(fid, SERVER)
+        state.record_workspace(fid, ws)
+        return fid
+
+    def reap_all(self) -> list[str]:
+        # `config.STATE_DIR` is asserted, not assumed: this test's whole subject is a
+        # recursive delete under the state directory, and `PersonaIso` repointing it is
+        # the only thing between that and the developer's own plane.
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        with mock.patch.object(state, "_launcher_is_alive", return_value=False):
+            return state.reap(set(), server=SERVER)
+
+
+class ARecycledOrdinalStartsFromNothing(_ReapedChat):
+    def test_the_next_chat_takes_the_reaped_ordinal_back(self):
+        """The premise every case below rests on, stated once so the rest are about
+        consequences rather than about whether the ordinal really is recycled."""
+        first = self.open_chat()
+        self.assertEqual(first, "alpha.1")
+        self.assertEqual(self.reap_all(), ["alpha.1"])
+        self.assertEqual(self.open_chat(), "alpha.1")
+
+    def test_the_workspace_pointer_does_not_outlive_the_frame(self):
+        fid = self.open_chat()
+        workspace.set_active("gamma", session_id=fid, terminal_id="")
+        self.assertEqual(workspace.for_session(fid), "gamma")
+
+        self.reap_all()
+
+        again = self.open_chat()
+        self.assertEqual(again, fid, "the ordinal must be recycled or this measures nothing")
+        self.assertIsNone(workspace.for_session(again))
+
+    def test_the_lock_does_not_outlive_the_frame(self):
+        """The half that survived #794, and the one the operator meets as a refusal."""
+        fid = self.open_chat()
+        workspace.set_active("gamma", session_id=fid, terminal_id="")
+        self.assertEqual(workspace.is_locked(fid), "gamma")
+
+        self.reap_all()
+        again = self.open_chat()
+
+        self.assertIsNone(workspace.is_locked(again))
+
+    def test_the_new_chat_can_select_the_workspace_it_was_launched_with(self):
+        """`charter claude --workspace alpha`, then `charter workspace use alpha` — the
+        exact sequence #731 reports, and the one that answered `locked`."""
+        fid = self.open_chat()
+        workspace.set_active("gamma", session_id=fid, terminal_id="")
+
+        self.reap_all()
+        again = self.open_chat()
+
+        self.assertEqual(
+            workspace.set_active("alpha", session_id=again, terminal_id=""), "session")
+
+    def test_resolution_in_the_new_chats_shell_is_not_the_old_chats_choice(self):
+        """`workspace.resolve` is what every `charter` command in the frame's own shell
+        acts on — `charter clone`, `charter repos`, `charter ws current`."""
+        fid = self.open_chat()
+        workspace.set_active("gamma", session_id=fid, terminal_id="")
+        self.assertEqual(workspace.resolve(session_id=fid), "gamma")
+
+        self.reap_all()
+        again = self.open_chat()
+
+        self.assertNotEqual(workspace.resolve(session_id=again), "gamma")
+
+
+class TheWholeFamilyGoesNotTwoSuffixes(_ReapedChat):
+    """`.workspace` and `.lock` are the two #731 measured; eight modules key on this id.
+
+    Written as a loop over the families that exist today **and** as a guard that the loop
+    is not the list: a marker family added tomorrow is covered the day it is written,
+    which is the property `workspace._prune` was rewritten to have (#366).
+    """
+
+    #: Every suffix charter writes into `SESSIONS_DIR` keyed on a session id, with the
+    #: module that owns it. Spelled here by hand rather than imported: a test that asked
+    #: the same constant the writer asks would move with a rename and pin nothing.
+    FAMILIES = [
+        ("workspace", "charter.workspace"),
+        ("lock", "charter.workspace"),
+        ("persona", "charter.persona"),
+        ("usage", "charter.statusline"),
+        ("tools", "charter.toolgate"),
+        ("gate", "charter.toolgate"),
+        ("configver", "charter.hooks"),
+        ("memnudge", "charter.hooks"),
+        ("route-pending", "charter.hooks"),
+        ("toolu_a1.PreToolUse.ask-pending", "charter.hooks"),
+    ]
+
+    def test_every_marker_keyed_on_the_chat_id_goes_with_it(self):
+        fid = self.open_chat()
+        config.private_mkdir(config.SESSIONS_DIR)
+        written = []
+        for suffix, owner in self.FAMILIES:
+            p = config.SESSIONS_DIR / f"{fid}.{suffix}"
+            p.write_text(f"{owner}\n")
+            written.append(p)
+
+        self.reap_all()
+
+        still_there = sorted(p.name for p in written if p.exists())
+        self.assertEqual(still_there, [])
+
+    def test_a_family_nobody_has_written_yet_is_covered_too(self):
+        """The point of sweeping the prefix rather than the suffixes: this name is not in
+        `FAMILIES`, is not in charter, and is reaped anyway."""
+        fid = self.open_chat()
+        config.private_mkdir(config.SESSIONS_DIR)
+        invented = config.SESSIONS_DIR / f"{fid}.a-marker-written-next-year"
+        invented.write_text("x\n")
+
+        self.reap_all()
+
+        self.assertFalse(invented.exists())
+
+    def test_another_sessions_markers_are_left_alone(self):
+        """The match is anchored AND dot-terminated, and both halves are reachable.
+
+        `alpha.10` is the tail half: `state.new_chat_id` counts to `_CHAT_ORDINAL_MAX`,
+        so a plane with ten chats in one workspace has `alpha.1` and `alpha.10` side by
+        side and one of them is live.
+
+        `xalpha.1` is the head half, and it is why `startswith` rather than `in`: a chat
+        id is `{workspace_prefix}.{n}`, `workspace_prefix` only maps characters into
+        ``[A-Za-z0-9_-]`` and never inserts a boundary, so two workspaces whose names end
+        the same way — `alpha` and `xalpha`, `api` and `legacy-api` — mint ids where one
+        is a suffix of the other. An unanchored match reaps the live one's pointer.
+        """
+        fid = self.open_chat()          # alpha.1
+        config.private_mkdir(config.SESSIONS_DIR)
+        neighbour = config.SESSIONS_DIR / "alpha.10.workspace"
+        neighbour.write_text("beta\n")
+        sibling_workspace = config.SESSIONS_DIR / "xalpha.1.workspace"
+        sibling_workspace.write_text("beta\n")
+        stranger = config.SESSIONS_DIR / "8f14e45f-ea3a-4b71-9a2c-000000000001.workspace"
+        stranger.write_text("beta\n")
+        prefixless = config.SESSIONS_DIR / "alpha.1"
+        prefixless.write_text("beta\n")
+
+        self.assertEqual(self.reap_all(), [fid])
+
+        self.assertTrue(neighbour.exists(), "`alpha.1.` must not match `alpha.10.…`")
+        self.assertTrue(sibling_workspace.exists(),
+                        "the match is anchored: `xalpha.1.workspace` CONTAINS `alpha.1.`")
+        self.assertTrue(stranger.exists())
+        self.assertTrue(prefixless.exists(),
+                        "the id itself is not a marker for the id — only `<fid>.<suffix>`")
+
+    def test_a_chat_that_is_still_live_keeps_its_selection(self):
+        """The direction that would cost the operator their working state: reaping is
+        keyed on the directory that was actually removed, never on the sweep running."""
+        kept = self.open_chat()
+        workspace.set_active("gamma", session_id=kept, terminal_id="")
+
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        with mock.patch.object(state, "_launcher_is_alive", return_value=False):
+            self.assertEqual(state.reap({kept}, server=SERVER), [])
+
+        self.assertEqual(workspace.for_session(kept), "gamma")
+        self.assertEqual(workspace.is_locked(kept), "gamma")
+
+    def test_a_frame_on_another_server_keeps_its_selection(self):
+        """`reap` is scoped to one server (#381); the marker sweep inherits that scope
+        because it happens only where the directory was removed."""
+        fid = self.open_chat()
+        workspace.set_active("gamma", session_id=fid, terminal_id="")
+
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        with mock.patch.object(state, "_launcher_is_alive", return_value=False):
+            self.assertEqual(state.reap(set(), server="a-different-server"), [])
+
+        self.assertEqual(workspace.for_session(fid), "gamma")
+
+
+class AFilesystemThatRefuses(_ReapedChat):
+    """The two `except OSError` clauses in `_forget_session`, entered on purpose.
+
+    `chmod` is not the seam — CI runs some jobs as a user for whom mode bits are advice —
+    so the failure is injected at the exact call that can raise it. Both clauses are
+    asserted by their CONSEQUENCE rather than by "it did not raise": `reap` still reports
+    the directory it removed, and the caller still gets a list.
+    """
+
+    def test_a_sessions_directory_that_cannot_be_listed_costs_nothing_else(self):
+        fid = self.open_chat()
+        workspace.set_active("gamma", session_id=fid, terminal_id="")
+
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        real = state.Path.iterdir
+
+        def refuse(self_):
+            if self_ == state.Path(config.SESSIONS_DIR):
+                raise PermissionError(13, "refused")
+            return real(self_)
+
+        with mock.patch.object(state, "_launcher_is_alive", return_value=False), \
+                mock.patch.object(state.Path, "iterdir", refuse):
+            self.assertEqual(state.reap(set(), server=SERVER), [fid])
+
+        self.assertFalse((config.STATE_DIR / "frame" / fid).exists(),
+                         "the frame's own directory still goes")
+        self.assertEqual(workspace.for_session(fid), "gamma",
+                         "no proof, no deletion — the marker is left where it was")
+
+    def test_one_marker_that_cannot_be_unlinked_does_not_strand_the_rest(self):
+        fid = self.open_chat()
+        workspace.set_active("gamma", session_id=fid, terminal_id="")
+        stuck = config.SESSIONS_DIR / f"{fid}.lock"
+        real = state.Path.unlink
+
+        def refuse(self_, *a, **kw):
+            if self_.name == stuck.name:
+                raise PermissionError(13, "refused")
+            return real(self_, *a, **kw)
+
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        with mock.patch.object(state, "_launcher_is_alive", return_value=False), \
+                mock.patch.object(state.Path, "unlink", refuse):
+            self.assertEqual(state.reap(set(), server=SERVER), [fid])
+
+        self.assertTrue(stuck.exists())
+        self.assertIsNone(workspace.for_session(fid),
+                          "the loop continues past the one it could not remove")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #731.

## The defect

A chat id is `<workspace>.<n>` and `n` is **allocated, not minted** — `state.new_chat_id`
hands out the lowest FREE ordinal, and an ordinal is free the moment `state.reap` removes
its directory. So a "fresh" chat id is very often a recycled *name*, and minting one is not
isolation.

Inside a frame the frame **is** the charter session (ADR 0019), so every file charter keys
on a session id — one directory over, in `.charter/sessions/<sid>.*` — is keyed on the chat
id too. `reap` removed `.charter/frame/<fid>/` and nothing else.

Reproduced without tmux (one chat that chose `gamma`, reaped, relaunched onto the same
ordinal):

```
after reap, sessions/ holds: ['alpha.1.lock', 'alpha.1.workspace']
is_locked      : gamma
for_session    : gamma
resolve        : gamma          <- what every `charter` command in that shell acts on
set_active a   : locked         <- `charter workspace use alpha`, refused
```

#794 closed the half the issue's title is about — the panels draw `alpha` and the chat
belongs to `alpha`, because `state.own_workspace` no longer reads that pointer (confirmed
here: `own_workspace` and `workspace_for` both answer `alpha`). What that left is arguably
worse to be on the receiving end of: the panels and the commands disagree, and the refusal
names a lock nobody in that chat set.

## The fix

`state.reap` removes `.charter/sessions/<fid>.*` where it removes `.charter/frame/<fid>/`.

**The sweep is the id prefix, not a list of suffixes.** `workspace._prune` enumerated five
marker families, drifted three times, and was replaced by "every file in the directory"
(#366). Eight families are keyed on a session id today across five modules — `.workspace`
and `.lock` (`workspace`), `.persona` (`persona`), `.usage` (`statusline`), `.tools` and
`.gate` (`toolgate`), `.configver`, `.memnudge`, `.route-pending` and
`.<tool-use-id>.<kind>.ask-pending` (`hooks`) — and a ninth written next year is covered
the day it is written. A remedy naming two of eight is one that has to be edited every
time a ninth is added.

Because it runs only where a directory was actually removed, it inherits `reap`'s scope
for free: a live chat keeps its selection, and so does a frame on another tmux server
(#381).

**The other fix #731 offered is rejected**, for the reason PR #757's body already gave:
letting the launcher's `--workspace` outrank a pointer it did not write only helps a
launch carrying the flag — and bare `charter` is now the ordinary way in — while leaving
the lock, which no flag addresses, exactly where it is.

## Verification

Twelve cases in `tests/test_a_reaped_chat_leaves_its_session_behind.py`, no tmux. **Six
were red before the change.** The other six are the blast radius, and none of them is
trusted for being green — each was confirmed to fail against a deliberately over-wide or
wrong implementation:

| hand-mutation | what turns red |
|---|---|
| `prefix = fid` (drop the dot) | `alpha.1` reaps `alpha.10`'s pointer |
| `startswith` → `in` | `alpha.1` reaps `xalpha.1`'s pointer — a real collision, since a chat id has no boundary character between the workspace and the dot |
| sweep hoisted out of `reap`'s keep-rules | a live chat, and a frame on another server, lose their selection |
| outer `except OSError` → `ValueError` | the unlistable-directory case errors |
| inner `except OSError` → `ValueError` | the unremovable-marker case errors |

The `is_file()` filter every neighbouring loop carries is deliberately **not** here, and
the docstring says why: `unlink` on a directory refuses on every platform charter runs on
(`EISDIR` / `EPERM`, both `OSError`), so the filter would be the identity — a branch no
input can distinguish, which is a sweep survivor waiting to be written.

`tests/` full `test_frame*` discovery: 1900 tests, OK. `test_workspace*` 171, `test_session*`
36, `test_state*` 17, news/docs modules all OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ctfuhnX3LdXbtx3SMUvTu
