### PR TITLE
charter's NO_COLOR rule is charter's own, not a quote of a page that changed

### DIFF
--- a/charter/frame/chrome.py
+++ b/charter/frame/chrome.py
@@ -129,10 +129,41 @@ def no_colour() -> bool:
     site — here, in :func:`colour_ok`, and in `commands_frame._surface_argvs`, which is a
     different process on a different path asking the same thing.
 
-    Honoured by **presence**, per the `no-color.org` convention: any value, including the
-    empty string and ``0``, means no colour. Matching a *value* (``== "1"``) would be the
-    spelling-not-property mistake in the one file that is about that mistake — and it is
-    the reading that breaks first, because a shell that exports ``NO_COLOR=`` has set it.
+    Honoured by **presence**: any value, including the empty string and ``0``, means no
+    colour. Matching a *value* (``== "1"``) would be the spelling-not-property mistake in
+    the one file that is about that mistake — and it is the reading that breaks first,
+    because a shell that exports ``NO_COLOR=`` has set it.
+
+    **That is charter's rule, not the standard's, and this docstring used to say
+    otherwise.** It cited `no-color.org` for it. The page's normative sentence reads, as
+    of 2026-09-02:
+
+        *Command-line software which adds ANSI color to its output by default should check
+        for a ``NO_COLOR`` environment variable that, when present **and not an empty
+        string** (regardless of its value), prevents the addition of ANSI color.*
+
+    The exclusion arrived in ``jcs/no_color`` commit ``99f90e27`` (2022-06-27), whose diff
+    replaced the older *"when present (regardless of its value)"* — which is the sentence
+    this docstring was paraphrasing, four years after it stopped being the text. So the
+    authority named here disagreed with the behaviour beneath it, on exactly one input,
+    ``NO_COLOR=""``, and read as a measurement while doing it.
+
+    The behaviour stands; only the justification changes, because the argument above is
+    charter's own and does not need borrowed authority. The field is genuinely split on
+    that input — ripgrep's own manual says *"when the NO_COLOR environment variable is set
+    (regardless of value)"*, and `rich` moved the other way in its PR #3675 (*"an empty
+    NO_COLOR env var is now considered disabled"*) — so there is no convention left to
+    defer to, only a rule to state and be judged on.
+
+    **charter is also stricter than that standard in a second way, deliberately.** The
+    same page answers *"No. This standard only signals the user's intention regarding
+    adding ANSI color to text output"* about bold, underline and italic — they may still
+    be emitted under ``NO_COLOR``. Charter emits none of them: :func:`recipes` serves the
+    empty string for **every** role, including ``heading``'s bold, and `panel._write`
+    escapes a hard-coded escape a component wrote. §3.2's rule is that charter emits no
+    SGR from the frame at all, and the reason is one the standard is not about — see the
+    paragraph below on the pane background. An attribute charter still emitted would be
+    charter still painting.
 
     **It reaches the tmux surface too**, which is the half that is easy to miss. The pane
     background is painted by tmux rather than by charter, so gating only charter's own

--- a/docs/news/unreleased-charters-no-color-rule-is-charters-own.md
+++ b/docs/news/unreleased-charters-no-color-rule-is-charters-own.md
@@ -1,0 +1,74 @@
+---
+version: unreleased
+headline: charter's `NO_COLOR` rule is stated as charter's own, because the page it cited stopped saying it in 2022
+---
+
+No behaviour changes. What changes is that charter no longer attributes its `NO_COLOR`
+reading to a standard that says something else.
+
+## The stale quote
+
+`chrome.no_colour` is `os.environ.get("NO_COLOR") is not None` — **presence**, so `""` and
+`0` both mean no colour. Its docstring justified that as *"per the `no-color.org`
+convention: any value, including the empty string and `0`, means no colour."*
+
+That was the page's wording once. `jcs/no_color` commit `99f90e27` changed it on
+2022-06-27, and the diff is the whole finding:
+
+```diff
+-check for the presence of a `NO_COLOR` environment variable that, when present
+-(regardless of  its value), prevents the addition of ANSI color.**
++check for a `NO_COLOR` environment variable that, when present and not an empty
++string (regardless of its value), prevents the addition of ANSI color.**
+```
+
+So charter cited, as its authority, a sentence that had been replaced four years earlier —
+and the replacement disagrees with charter on exactly one input, `NO_COLOR=""`. A citation
+reads as a measurement; this one was a quote of something no longer on the page.
+
+## The rule stands, and now says whose it is
+
+A shell that exports `NO_COLOR=` has set it, and the operator who typed that asked for
+something. Matching a *value* (`== "1"`) is the spelling-not-property mistake in the one
+file that is about that mistake, and `NO_COLOR=` is the input it breaks on first. That
+argument is charter's own and needs no borrowed authority, which is how it is written now.
+
+There is also no convention left to defer to. Both readings are in the field, from their
+own sources: ripgrep's manual says *"when the `NO_COLOR` environment variable is set
+(regardless of value)"*, and `rich` moved the other way in PR #3675 — *"an empty NO_COLOR
+env var is now considered disabled."*
+
+## And charter is stricter than that standard in a second way
+
+The same page answers, about bold, underline and italic: *"No. This standard only signals
+the user's intention regarding adding ANSI color to text output."* They may still be
+emitted under `NO_COLOR`.
+
+Charter emits none of them. `chrome.recipes` serves the empty string for **every** role
+including `heading`'s bold, and `panel._write` escapes a hard-coded escape a component
+wrote. That is deliberate and the reason is one the standard is not about: the frame's
+background is painted by tmux at charter's request, so the property charter keeps is *no
+colour on your screen caused by charter, whichever process puts the bytes there* — and an
+attribute charter still emitted would be charter still painting. It is stated now instead
+of waiting to be discovered.
+
+**If you set `NO_COLOR=""` expecting current-standard semantics, charter will give you no
+colour.** That is the one operator-visible consequence, and it is the same as it was.
+
+## Where the citation was, and what happened to the dated one
+
+Three live sites are corrected — `chrome.no_colour`, `test_frame_chrome` and
+`test_frame_provider_recipes`. The fourth is `docs/superpowers/specs/2026-08-28-frame-
+visual-design.md`, which is a dated record; it keeps what it recorded and carries a dated
+correction beside it rather than being rewritten.
+
+## Verification
+
+The commit, its date and its diff were read from `jcs/no_color` rather than taken on
+report; the current normative sentence and the bold/underline/italic answer were read off
+`no-color.org`; ripgrep's wording came from its own manual source and `rich`'s from its
+changelog. The behaviour is pinned as before, and confirmed still pinned: switching
+`no_colour` to the current-standard reading (`bool(os.environ.get("NO_COLOR"))`) turns 12
+existing cases red.
+
+Nothing to adopt.

--- a/docs/superpowers/specs/2026-08-28-frame-visual-design.md
+++ b/docs/superpowers/specs/2026-08-28-frame-visual-design.md
@@ -236,6 +236,16 @@ at all** — and the property is `os.environ.get("NO_COLOR") is not None`, per t
 `no-color.org` convention, not `== "1"`, because matching a value rather than presence is the
 spelling-not-property mistake again.
 
+> **Correction, 2026-09-02.** The rule above stands; the citation does not. `no-color.org`
+> has said *"when present **and not an empty string** (regardless of its value)"* since
+> `jcs/no_color` commit `99f90e27` (2022-06-27) — so this spec quoted the sentence that
+> commit replaced, and charter's presence-only reading is charter's own choice rather than
+> the convention's. It differs on exactly one input, `NO_COLOR=""`. The same page also says
+> the standard is only about colour and not about bold, underline or italic; charter empties
+> every SGR role regardless, which is stricter than it asks and is argued for in
+> `chrome.no_colour`. Left in place rather than rewritten: this file is dated, and what it
+> recorded on 2026-08-28 is part of the record.
+
 **And `NO_COLOR` forces `[frame] chrome` to `off`, which is the half that is easy to miss.**
 The surface is painted by tmux, not by charter, so gating only charter's own SGR would leave
 an operator who asked for no colour looking at a coloured frame — charter having asked

--- a/tests/test_frame_chrome.py
+++ b/tests/test_frame_chrome.py
@@ -304,10 +304,17 @@ class ColourIsARequestTheOperatorCanRefuse(unittest.TestCase):
     unconditionally — measured, `panel.run` with stdout a `StringIO` wrote a
     clear-screen and full SGR into it.
 
-    The property is `os.environ.get("NO_COLOR") is not None`, per the no-color.org
-    convention. `== "1"` is the spelling-not-property mistake in the one file that is
-    about that mistake, and it breaks first on `NO_COLOR=` — which is what a shell that
-    exports the variable with no value has set.
+    The property is `os.environ.get("NO_COLOR") is not None`. `== "1"` is the
+    spelling-not-property mistake in the one file that is about that mistake, and it
+    breaks first on `NO_COLOR=` — which is what a shell that exports the variable with no
+    value has set.
+
+    **This is charter's rule and it used to be cited as no-color.org's.** That page has
+    said "present *and not an empty string*" since `jcs/no_color` `99f90e27` (2022-06-27),
+    so the citation was a quote of the sentence that commit replaced, and the one input it
+    disagrees about is the `NO_COLOR=""` this class asserts on first. The behaviour is
+    unchanged and the argument for it is in `chrome.no_colour`; what these cases pin is
+    charter's rule, which is the only thing they were ever able to pin.
     """
 
     def _tty(self, answer: bool):

--- a/tests/test_frame_provider_recipes.py
+++ b/tests/test_frame_provider_recipes.py
@@ -220,8 +220,12 @@ class NoColourReachesTheRecipesToo(unittest.TestCase):
                 self.assertEqual(r[role], "")
 
     def test_presence_and_not_a_value(self):
-        """`NO_COLOR=` and `NO_COLOR=0` both count, per no-color.org. Matching a value
-        would be the spelling-not-property mistake in the file that is about it."""
+        """`NO_COLOR=` and `NO_COLOR=0` both count — charter's rule, not no-color.org's.
+        That page has excluded the empty string since 2022 (`jcs/no_color` `99f90e27`);
+        this line used to cite it and was quoting the sentence it replaced. Matching a
+        value would be the spelling-not-property mistake in the file that is about it, and
+        `NO_COLOR=` is what a shell exporting the name with no value has set — which is
+        the whole of the disagreement. See `chrome.no_colour` for the argument."""
         for value in ("", "0", "1", "false"):
             with self.subTest(value=value):
                 with mock.patch.dict(os.environ, {"NO_COLOR": value}, clear=True), _tty():


### PR DESCRIPTION
No behaviour changes. `chrome.no_colour` still honours `NO_COLOR` by **presence**, so `NO_COLOR=""` and `NO_COLOR=0` both mean no colour. What changes is that charter stops attributing that reading to a standard which says the opposite.

## The stale quote

The docstring justified the rule as *"per the `no-color.org` convention: any value, including the empty string and `0`, means no colour."* `jcs/no_color` commit `99f90e27` replaced that sentence on 2022-06-27 — read from the repo, not from report:

```diff
-check for the presence of a `NO_COLOR` environment variable that, when present
-(regardless of  its value), prevents the addition of ANSI color.**
+check for a `NO_COLOR` environment variable that, when present and not an empty
+string (regardless of its value), prevents the addition of ANSI color.**
```

So the named authority disagreed with the behaviour beneath it on exactly one input, `NO_COLOR=""`, while reading as a measurement.

## What it says instead

The rule is stated as charter's own, with charter's own argument: a shell that exports `NO_COLOR=` has set it, and matching a *value* is the spelling-not-property mistake in the one file that is about that mistake. There is no convention left to defer to either — both readings are live, from their own sources: ripgrep's manual says *"when the `NO_COLOR` environment variable is set (regardless of value)"*, and `rich` moved the other way in PR #3675.

## A second divergence, now stated rather than left to be found

`no-color.org` is explicit that the standard *"only signals the user's intention regarding adding ANSI color"* — bold, underline and italic may still be emitted. Charter emits none of them: `recipes` serves the empty string for every role including `heading`'s bold, and `panel._write` escapes a hard-coded escape. That is deliberate, for a reason the standard is not about (the pane background is painted by tmux at charter's request), and it is now written down.

## Scope

Three live sites corrected — `chrome.no_colour`, `test_frame_chrome`, `test_frame_provider_recipes`. The fourth, `docs/superpowers/specs/2026-08-28-frame-visual-design.md`, is a dated record: it keeps what it recorded and carries a dated correction beside it rather than being rewritten.

## Verification

302 tests green across the news, claims, docs and frame-chrome modules. The behaviour is confirmed still pinned rather than assumed: switching `no_colour` to the current-standard reading (`bool(os.environ.get("NO_COLOR"))`) turns **12** existing cases red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ctfuhnX3LdXbtx3SMUvTu
