### PR TITLE
A clone says which submodules it left empty, and a sync stops calling it up to date (#817)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -403,6 +403,10 @@ def cmd_clone(args) -> int:
             util.err(f"{r['name']}: clone failed — no access, network, or {cli} isn't authed "
                      f"(`{cli} auth status`). Skipping.\n" + res["stderr"])
             continue
+        # A clone that fetched less than the repo records says so BEFORE the docs hint —
+        # an empty submodule directory is the thing that breaks the next command, and the
+        # exit code stays 0 because the repo really is cloned (#817).
+        report_submodule_drift(dest, r["name"])
         _hint_repo_docs(dest, r)
     return 1 if failures else 0
 
@@ -515,6 +519,138 @@ def _hint_repo_docs(dest: Path, r: dict) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# submodules: reported, never fetched (#817)                                   #
+# --------------------------------------------------------------------------- #
+#: ``git submodule status`` marks each recorded submodule with ONE leading character:
+#: ``-`` nothing checked out, ``+`` checked out at a commit other than the one the
+#: superproject records, ``U`` unmerged, and a space for in sync. Only the first two are
+#: drift charter reports. ``U`` is a conflict the operator is standing in the middle of,
+#: and a second voice on a live merge is noise, not a finding.
+_SUBMODULE_ABSENT = "-"
+_SUBMODULE_MOVED = "+"
+
+#: The one command charter names, and the only one it names. ``--init`` covers the paths
+#: with nothing checked out, the update itself moves the ones left behind, and
+#: ``--recursive`` covers a submodule that has submodules of its own — so one line is the
+#: remedy for every state below rather than three lines the reader has to choose between.
+SUBMODULE_REMEDY = "submodule update --init --recursive"
+
+
+def submodule_drift(d: Path) -> tuple[list[str], list[str]]:
+    """``(nothing checked out, not at the recorded commit)`` — submodule paths in the tree
+    at *d*, in the order git lists them.
+
+    ``([], [])`` for a tree with no submodules and for anything this cannot read: a
+    directory that is not a repository, a `git` that failed, an unparseable line. This
+    feeds three REPORTS (`clone`, `sync`, `status`); none of them is the place to raise,
+    and a workspace holds whatever somebody put in it.
+
+    **The `.gitmodules` stat comes first and is not an optimisation detail.** `status`
+    already spends two `git` invocations per row and prints the table as it goes; a third
+    on every clone would be paid by every plane, and almost every clone has no submodules
+    at all. The stat is also EXACT rather than approximate: `git submodule status` lists
+    what `.gitmodules` maps, so with no such file there is nothing it could have said —
+    measured, a gitlink with no `.gitmodules` makes it exit 128 (`no submodule mapping
+    found in .gitmodules for path 'gl'`) and print nothing, which is the same answer this
+    returns.
+
+    Not ``--recursive``. A submodule with nothing checked out has no submodules charter
+    can see, so recursion would cost a process per level to re-report the paths already
+    named — and the remedy this pairs with is recursive, so nothing is lost by saying it
+    once at the top.
+    """
+    d = Path(d)
+    if not (d / ".gitmodules").exists():
+        return [], []
+    proc = _git(["submodule", "status"], cwd=d)
+    if proc.returncode != 0:
+        return [], []
+    absent: list[str] = []
+    moved: list[str] = []
+    for line in (proc.stdout or "").splitlines():
+        mark, rest = line[:1], line[1:]
+        if mark not in (_SUBMODULE_ABSENT, _SUBMODULE_MOVED):
+            continue
+        # ``<mark><sha> <path>``, and for a CHECKED-OUT one a trailing `` (<describe>)``.
+        # The path is everything between, so it is taken from the first space rather than
+        # split on every space — a submodule path may contain them.
+        path = rest.partition(" ")[2]
+        if path.endswith(")") and " (" in path:
+            path = path[:path.rindex(" (")]
+        if not path:
+            continue
+        (absent if mark == _SUBMODULE_ABSENT else moved).append(path)
+    return absent, moved
+
+
+def _submodule_remedy(d: Path) -> str:
+    """The exact command, rooted at *d* — relative to the plane when it is inside one, so
+    it can be pasted from wherever the operator is reading this."""
+    try:
+        where = Path(d).relative_to(config.ROOT)
+    except ValueError:
+        where = Path(d)
+    return f"git -C {where} {SUBMODULE_REMEDY}"
+
+
+def report_submodule_drift(d: Path, label: str, branch: str | None = None,
+                           lead: str | None = None) -> bool:
+    """Say what *d*'s submodules are not, and name the command that fixes it. Returns
+    whether anything was said, so a caller can drop its own success line rather than print
+    a tick beside this (`_sync_one`).
+
+    ONE warning line and one remedy line, whatever the mix of states — a caller that wants
+    to open with its own situation (`sync` has just claimed something about the branch)
+    passes *lead*, and the facts follow it in the same sentence. Two commands reporting the
+    same finding in two shapes is how the shapes drift apart.
+
+    **charter reports and does not initialise, and the sentence says so.** Two reasons,
+    and the second is the one that settles it.
+
+    A submodule URL comes out of `.gitmodules` — a file inside the repo charter has just
+    cloned. `_https_url` refuses to hand `git clone` a string charter did not build (#335,
+    where `ext::sh -c '…'` is a transport that runs a command); fetching whatever
+    `.gitmodules` names, recursively, would put that same string back one layer down where
+    that allowlist cannot see it.
+
+    And charter could not do it under its own rule anyway. **`git clone` does not read the
+    local config of the repository it is standing in** — system, global and `-c` only. A
+    submodule fetch IS a nested `git clone`, so `gitpolicy.apply`'s ``--local``
+    `credential.helper` and ``url.<https>.insteadOf`` never reach it. Measured on git
+    2.50.1 against a superproject whose submodule needs a config to be fetchable at all::
+
+        LOCAL  protocol.file.allow in the superproject -> submodule init rc = 1
+        -c     on the command line                     -> submodule init rc = 0
+        GLOBAL protocol.file.allow                     -> submodule init rc = 0
+        LOCAL  submodule.<name>.url override           -> submodule init rc = 0
+
+    The last line is the asymmetry: the PARENT resolves the URL from local config, the
+    CHILD consumes the transport config and cannot see it. So golden rule 0 — every git
+    operation over that repo's own forge's token — **does not hold for a submodule fetch**,
+    and an auto-init would be charter fetching outside its own credential policy, quietly,
+    on the operator's behalf. Saying so leaves that call where it belongs.
+    """
+    absent, moved = submodule_drift(d)
+    if not absent and not moved:
+        return False
+    bits = []
+    if absent:
+        bits.append(f"{len(absent)} submodule(s) recorded but not initialised "
+                    f"({', '.join(absent)}) — nothing is checked out there, so anything "
+                    f"that runs from them fails with 'no such file or directory'")
+    if moved:
+        bits.append(f"{len(moved)} submodule(s) not at the commit "
+                    f"{branch or 'this branch'} records ({', '.join(moved)})")
+    facts = "; ".join(bits)
+    util.warn(f"{label}: {facts}." if lead is None else f"{label}: {lead} — {facts}.")
+    util.info(f"  charter does not fetch them: a submodule URL comes out of the cloned "
+              f"repo's own .gitmodules and can point anywhere, and charter's token-only "
+              f"policy does not reach a submodule fetch. Yours to run: "
+              f"{_submodule_remedy(d)}")
+    return True
+
+
+# --------------------------------------------------------------------------- #
 # sync                                                                         #
 # --------------------------------------------------------------------------- #
 def cmd_sync(args) -> int:
@@ -545,10 +681,24 @@ def _sync_one(d: Path, ws: str) -> None:
         util.err(f"{label}: fetch failed (access or network) — skipping.")
         return
     ff = _git(["merge", "--ff-only", f"origin/{branch}"], cwd=d)
-    if ff.returncode == 0:
-        util.ok(f"{label}: up to date on {branch}")
-    else:
+    if ff.returncode != 0:
         util.warn(f"{label}: {branch} won't fast-forward (diverged/local commits) — left as-is.")
+        return
+    # The tick is not printed over a tree the fast-forward left behind (#817). A
+    # fast-forward moves the GITLINK and never touches the submodule's own checkout, so
+    # the commonest outcome here is a branch that is up to date beside a submodule that is
+    # not — and `up to date on main` was the whole of what charter said about it. Measured
+    # on a clone whose upstream moved one submodule pointer and added a second submodule:
+    # `✓ ws/repo: up to date on main`, with the first still at the old commit and an empty
+    # directory where the second should be.
+    #
+    # The branch half of that sentence was true, which is exactly why it had to be said
+    # differently rather than merely followed by a warning — a tick is what an operator
+    # scans for and stops reading at.
+    if report_submodule_drift(d, label, branch,
+                              lead=f"{branch} is up to date, its submodules are not"):
+        return
+    util.ok(f"{label}: up to date on {branch}")
 
 
 # --------------------------------------------------------------------------- #
@@ -639,9 +789,25 @@ def _status_for_workspace(ws: str, inv_by_name: dict, active: str) -> None:
 
 
 def _clone_note(d: Path) -> str:
+    """The NOTE column of `charter status`'s repo table.
+
+    A submodule that was never initialised leaves an EMPTY DIRECTORY and a clean
+    `git status --porcelain` — measured — so without this third fact the row reads
+    ``main · clean`` over a tree that is missing the scripts every build target calls.
+    The whole point of #817 is that nothing said so, and `status` is where an operator
+    looks when something already went wrong.
+
+    It costs a `git submodule status` only for a clone that has a `.gitmodules` at all
+    (see `submodule_drift`), so the common row is still the two calls it always was."""
     branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=d).stdout.strip()
     dirty = "dirty" if _git(["status", "--porcelain"], cwd=d).stdout.strip() else "clean"
-    return f"{branch} · {dirty}"
+    note = f"{branch} · {dirty}"
+    absent, moved = submodule_drift(d)
+    if absent:
+        note += f" · {len(absent)} submodule not initialised"
+    if moved:
+        note += f" · {len(moved)} out of date"
+    return note
 
 
 # --------------------------------------------------------------------------- #

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -624,8 +624,9 @@ def report_submodule_drift(d: Path, label: str, branch: str | None = None,
         GLOBAL protocol.file.allow                     -> submodule init rc = 0
         LOCAL  submodule.<name>.url override           -> submodule init rc = 0
 
-    The last line is the asymmetry: the PARENT resolves the URL from local config, the
-    CHILD consumes the transport config and cannot see it. So golden rule 0 — every git
+    The last line is the asymmetry: the PARENT resolves the URL from local config, while
+    the CHILD consumes the transport config and its config search skips the surrounding
+    repository's local file. So golden rule 0 — every git
     operation over that repo's own forge's token — **does not hold for a submodule fetch**,
     and an auto-init would be charter fetching outside its own credential policy, quietly,
     on the operator's behalf. Saying so leaves that call where it belongs.

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -540,10 +540,16 @@ def submodule_drift(d: Path) -> tuple[list[str], list[str]]:
     """``(nothing checked out, not at the recorded commit)`` — submodule paths in the tree
     at *d*, in the order git lists them.
 
-    ``([], [])`` for a tree with no submodules and for anything this cannot read: a
-    directory that is not a repository, a `git` that failed, an unparseable line. This
-    feeds three REPORTS (`clone`, `sync`, `status`); none of them is the place to raise,
-    and a workspace holds whatever somebody put in it.
+    ``([], [])`` for a tree with no submodules, for a directory that is not a repository,
+    and for a `git` that exited non-zero. This feeds three REPORTS (`clone`, `sync`,
+    `status`); none of them is the place to raise, and a workspace holds whatever somebody
+    put in it.
+
+    **The non-zero check is not a formality, and it is not satisfied by an empty stdout.**
+    `git submodule status` prints the submodules it mapped and THEN fails on one it did
+    not: measured, an index carrying a gitlink that `.gitmodules` does not map exits 128
+    having already written ``-<sha> mapped`` to stdout. Without the check those lines are
+    reported as findings out of a run git itself disowned.
 
     **The `.gitmodules` stat comes first and is not an optimisation detail.** `status`
     already spends two `git` invocations per row and prints the table as it goes; a third
@@ -567,18 +573,25 @@ def submodule_drift(d: Path) -> tuple[list[str], list[str]]:
         return [], []
     absent: list[str] = []
     moved: list[str] = []
-    for line in (proc.stdout or "").splitlines():
+    for line in proc.stdout.splitlines():
         mark, rest = line[:1], line[1:]
         if mark not in (_SUBMODULE_ABSENT, _SUBMODULE_MOVED):
             continue
         # ``<mark><sha> <path>``, and for a CHECKED-OUT one a trailing `` (<describe>)``.
-        # The path is everything between, so it is taken from the first space rather than
-        # split on every space — a submodule path may contain them.
+        # The path starts at the FIRST space, because a submodule path may contain more of
+        # them — and the describe is taken off **by the mark**, never by looking at what
+        # the path ends with. Those two cannot be told apart by inspection: measured, a
+        # submodule at ``tools (x)`` reports as ``-<sha> tools (x)`` while absent and
+        # ``+<sha> tools (x) (remotes/origin/HEAD)`` while checked out, so a rule that
+        # trims whatever resembles a suffix reads the first one's path as ``tools``.
+        #
+        # `rpartition` rather than a search for the first ``" ("``: the describe is always
+        # LAST, which is what makes ``tools (x) (heads/main)`` come back as ``tools (x)``.
+        # A checked-out line always carries one — measured on a submodule with no tags,
+        # detached, which still prints ``(remotes/origin/HEAD)`` — so this never guesses.
         path = rest.partition(" ")[2]
-        if path.endswith(")") and " (" in path:
-            path = path[:path.rindex(" (")]
-        if not path:
-            continue
+        if mark == _SUBMODULE_MOVED:
+            path = path.rpartition(" (")[0]
         (absent if mark == _SUBMODULE_ABSENT else moved).append(path)
     return absent, moved
 

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -676,6 +676,14 @@ def _sync_one(d: Path, ws: str) -> None:
     label = f"{ws}/{d.name}"
     if _git(["status", "--porcelain"], cwd=d).stdout.strip():
         util.warn(f"{label}: uncommitted changes — skipping (your work is left untouched).")
+        # …and this is the one case where "your work" may be nobody's work. A submodule
+        # left behind the commit the branch records IS an unstaged change to the gitlink,
+        # so the previous sync's own fast-forward is enough to make this branch fire
+        # forever after: the repo silently stops being synced, and the only sentence
+        # charter had for it named changes the operator never made. Reported here for the
+        # same reason it is reported below — the skip is honest and unexplained, and the
+        # explanation is one `git submodule status` away.
+        report_submodule_drift(d, label)
         return
     branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=d).stdout.strip()
     if _git(["fetch", "--prune"], cwd=d).returncode != 0:

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -626,10 +626,10 @@ def report_submodule_drift(d: Path, label: str, branch: str | None = None,
 
     The last line is the asymmetry: the PARENT resolves the URL from local config, while
     the CHILD consumes the transport config and its config search skips the surrounding
-    repository's local file. So golden rule 0 — every git
-    operation over that repo's own forge's token — **does not hold for a submodule fetch**,
-    and an auto-init would be charter fetching outside its own credential policy, quietly,
-    on the operator's behalf. Saying so leaves that call where it belongs.
+    repository's local file. So golden rule 0 — every git operation over that repo's own
+    forge's token — **does not hold for a submodule fetch**, and an auto-init would be
+    charter fetching outside its own credential policy, quietly, on the operator's behalf.
+    Saying so leaves that call where it belongs.
     """
     absent, moved = submodule_drift(d)
     if not absent and not moved:
@@ -813,7 +813,7 @@ def _clone_note(d: Path) -> str:
     note = f"{branch} · {dirty}"
     absent, moved = submodule_drift(d)
     if absent:
-        note += f" · {len(absent)} submodule not initialised"
+        note += f" · {len(absent)} submodule(s) not initialised"
     if moved:
         note += f" · {len(moved)} out of date"
     return note

--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -145,6 +145,21 @@ def cmd_worktree_add(args) -> int:
     util.info(f"  base:   {base}{' (detached)' if detached else ''}")
     util.info(f"  branch: {args.branch or args.piece}")
 
+    # #817's third surface, and the one that hits EVERY time. `git worktree add` gives the
+    # new tree the superproject's gitlinks and initialises none of them — measured, a
+    # worktree cut from a clone whose `dev-scripts` was checked out and in sync:
+    #
+    #     source:   +038cbf7… dev-scripts (heads/main)
+    #     worktree: -a8320ac… dev-scripts          <- and the directory is empty
+    #
+    # So unlike `clone`, where it depends on the repo, a worktree of a repo with submodules
+    # is always missing them, and this is the line an agent reads immediately before `cd`
+    # ing in and running the build. Imported here rather than at module scope: `commands`
+    # imports a good deal of the package, and this module is on the import path of the CLI
+    # for every subcommand.
+    from .commands import report_submodule_drift
+    report_submodule_drift(path, f"{args.repo} · {args.piece}")
+
     # `root.find_root` now resolves a plane-less worktree back to its main tree, so this
     # is an invariant assertion rather than the fix — kept because it catches the same
     # failure one step earlier, right beside the `enter:` line the user is about to run,

--- a/docs/git-policy.md
+++ b/docs/git-policy.md
@@ -52,6 +52,55 @@ secret in the transcript. Those are the accidental roads, and they are the only 
 name-based guard can close — a command you chose to run is not one of them. See
 [secrets.md](secrets.md) and [SECURITY.md](../SECURITY.md).
 
+## Submodules are outside the rule, and charter says so rather than reaching past it
+
+`charter clone` clones the repo you named and **does not initialise its submodules**.
+`charter clone`, `charter sync` and `charter status` each say when a clone has submodules
+with nothing checked out, name them, and print the one command that fixes it:
+
+```bash
+git -C workspaces/<ws>/<repo> submodule update --init --recursive
+```
+
+It is yours to run, and that is a decision rather than an omission.
+
+**A submodule URL is not a URL charter built.** It comes out of `.gitmodules`, a file
+inside the repo that was just cloned, and it can name any host, recursively.
+`commands._https_url` already refuses to hand `git clone` a string charter did not
+build — `ext::sh -c '…'` is a transport that runs a command — and fetching whatever
+`.gitmodules` names would put that string back one layer down, where the allowlist above
+it cannot see it.
+
+**And the policy on this page does not reach a submodule fetch anyway.** Everything
+`--apply` writes goes into a repo's *local* config, and **`git clone` does not read the
+local config of the repository it is standing in** — system, global and `-c` only. A
+submodule fetch *is* a nested `git clone`. Measured on git 2.50.1, against a superproject
+whose submodule cannot be fetched at all without the config under test:
+
+| where `protocol.file.allow` was set | `git submodule update --init` |
+| --- | --- |
+| the superproject's **local** config | fails — never read |
+| `-c` on the command line | succeeds |
+| **global** config | succeeds |
+| **local** `submodule.<name>.url` override | succeeds |
+
+The last row is the asymmetry: the *parent* (`git submodule update`) resolves the URL from
+local config, so a `submodule.<name>.url` override works; the *child* (`git clone`)
+consumes `credential.helper` and `url.<https>.insteadOf`, and its config search skips the
+local file that holds them. So a submodule fetch runs **without** charter's credential
+helper and **without** its SSH→HTTPS rewrite, whoever starts it. A charter that
+initialised submodules for you would be fetching outside its own credential policy,
+quietly, with your token in reach.
+
+Two practical consequences if your repos keep tooling in a submodule:
+
+- A submodule whose `.gitmodules` URL is SSH will go over SSH — the rewrite is not there.
+  `git config submodule.<name>.url https://…` in that clone is read by the parent and
+  fixes it for good.
+- The guard is **not** what stops you. It reads the command line, never `.gitmodules`, so
+  `git submodule update --init` is not denied by anything. What it *does* deny is typing an
+  SSH URL while you configure the override — write the HTTPS form instead.
+
 ## When you are not using charter for git
 
 The policy is applied per repo, in that repo's local config, and never to your global git

--- a/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
+++ b/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
@@ -143,15 +143,55 @@ answer in its NOTE column, so an unexplained `dirty` names its cause.
 `git fetch` recurses into submodules on demand, so `charter sync` was already fetching
 submodule objects; what it never did was check anything out. Nothing here changes that.
 
+## What the deletion sweep found, and the defect inside it
+
+The first green run came back **`7 survivors`** — the verdict is the check NAME, and every
+one sat in `submodule_drift`. Two were deleted and five are now pinned, and one of them was
+not a missing test at all.
+
+**The parse was wrong, and the sweep's question is what showed it.** Asked whether
+`path.endswith(")")` was pinned, the answer was that neither half of
+
+```python
+if path.endswith(")") and " (" in path:      # trim the ` (<describe>)` suffix
+```
+
+could be, because the rule itself is unsound: a submodule whose PATH is `tools (x)` is
+reported as
+
+```
+absent      -<sha> tools (x)
+checked out +<sha> tools (x) (remotes/origin/HEAD)
+```
+
+and a rule that trims whatever resembles a suffix reads the first path as `tools` — a
+directory that does not exist, in the one sentence whose whole job is to name the directory
+that does. The describe is now taken off **by the mark**, never by inspecting the path, and
+`rpartition` takes the LAST ` (` because that is where the describe always is. A
+checked-out line always carries one: measured on a submodule with no tags, detached, which
+still prints `(remotes/origin/HEAD)`.
+
+**And the non-zero check was a real guard sitting on a test that already passed without
+it.** `git submodule status` prints the submodules it mapped and THEN fails on one it did
+not — measured, rc 128 with `-000…001 mapped` already on stdout. The case that was supposed
+to cover it built a directory that is not a repository, where stdout is empty and dropping
+the check changes nothing. It is now pinned on the state that actually distinguishes them.
+
+The two deletions were fallbacks with nothing behind them: `proc.stdout or ""` (nothing in
+charter passes `capture=False`, so stdout is always a string, and every neighbour in this
+file reads `.stdout` plainly) and `if not path: continue` (git emits no line without a
+space after the mark). The docstring stopped promising to handle "an unparseable line",
+because the code no longer does.
+
 ## Verification
 
 Reproduced first, in a throwaway plane with `config.ROOT` and `config.STATE_DIR` asserted
-into a scratch directory, never against a real one. 28 new cases: submodules planted by
+into a scratch directory, never against a real one. 36 new cases: submodules planted by
 hand as index gitlinks (a recorded submodule needs no network, no second repository and no
 `protocol.file.allow`), and real `git submodule add` fixtures for the two states that
 genuinely need a checked-out submodule.
 
-Eighteen hand-mutations, all killed: dropping the `.gitmodules` short-circuit, collapsing
+Twenty-six hand-mutations, all killed: dropping the `.gitmodules` short-circuit, collapsing
 the two drift marks onto one, removing the report from `clone`, from `sync` and from each
 half of the `status` row, flattening the remedy path, and trimming `--init --recursive`
 off the remedy, silencing the dirty-skip branch, and narrowing the clone report to freshly

--- a/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
+++ b/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
@@ -191,7 +191,7 @@ hand as index gitlinks (a recorded submodule needs no network, no second reposit
 `protocol.file.allow`), and real `git submodule add` fixtures for the two states that
 genuinely need a checked-out submodule.
 
-Twenty-seven hand-mutations, all killed: dropping the `.gitmodules` short-circuit, collapsing
+Twenty-eight hand-mutations, all killed: dropping the `.gitmodules` short-circuit, collapsing
 the two drift marks onto one, removing the report from `clone`, from `sync` and from each
 half of the `status` row, flattening the remedy path, and trimming `--init --recursive`
 off the remedy, silencing the dirty-skip branch, and narrowing the clone report to freshly

--- a/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
+++ b/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
@@ -112,12 +112,17 @@ denial from a shell command of its own.)
 command that touches a working tree — it asks each clone's forge for the open change and
 last CI and writes the cache the status line reads (`glstate.refresh`).
 
-## What this changes that was not a defect
+## The trap the first fix set, and the second one that closes it
 
-A submodule left behind is an unstaged change to the gitlink, so `charter status` already
-said `dirty` for it and said nothing about why. The row now names the cause — and that
-matters more than it reads, because `_sync_one` **skips a dirty tree**: a submodule nobody
-was told about silently stops that repo being synced at all.
+A submodule left behind is an **unstaged change to the gitlink**. So the fast-forward that
+produces one also makes every later `charter sync` take the `uncommitted changes —
+skipping (your work is left untouched)` branch: the repo quietly stops being synced at
+all, under a sentence about work the operator never did. Reporting only on the paths that
+reach the merge would have shipped the finding once and then hidden it forever after.
+
+That branch now explains itself too — the same one warning line and remedy — and a dirty
+tree with no submodules says exactly what it always said. `charter status` gains the same
+answer in its NOTE column, so an unexplained `dirty` names its cause.
 
 `git fetch` recurses into submodules on demand, so `charter sync` was already fetching
 submodule objects; what it never did was check anything out. Nothing here changes that.
@@ -125,16 +130,18 @@ submodule objects; what it never did was check anything out. Nothing here change
 ## Verification
 
 Reproduced first, in a throwaway plane with `config.ROOT` and `config.STATE_DIR` asserted
-into a scratch directory, never against a real one. 21 new cases: submodules planted by
+into a scratch directory, never against a real one. 24 new cases: submodules planted by
 hand as index gitlinks (a recorded submodule needs no network, no second repository and no
 `protocol.file.allow`), and real `git submodule add` fixtures for the two states that
 genuinely need a checked-out submodule.
 
-Thirteen hand-mutations, all killed: dropping the `.gitmodules` short-circuit, collapsing
+Fifteen hand-mutations, all killed: dropping the `.gitmodules` short-circuit, collapsing
 the two drift marks onto one, removing the report from `clone`, from `sync` and from each
 half of the `status` row, flattening the remedy path, and trimming `--init --recursive`
-off the remedy. One was killed for the wrong reason — splitting the git output on every
-space rather than the first survives any fixture whose submodule paths are single words —
+off the remedy, silencing the dirty-skip branch, and narrowing the clone report to freshly
+cloned repos so an already-cloned one is not told. One was killed for the wrong reason —
+splitting the git output on every space rather than the first survives any fixture whose
+submodule paths are single words —
 so two cases now use a submodule path with a space in it, and that mutation is measured
 where it is made.
 

--- a/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
+++ b/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
@@ -112,6 +112,22 @@ denial from a shell command of its own.)
 command that touches a working tree — it asks each clone's forge for the open change and
 last CI and writes the cache the status line reads (`glstate.refresh`).
 
+## The surface that misses them every time is not `clone`
+
+`git worktree add` hands the new tree the superproject's gitlinks and initialises none of
+them. Measured, from a clone whose submodule was checked out and in sync:
+
+```
+source:   +038cbf7… dev-scripts (heads/main)
+worktree: -a8320ac… dev-scripts          <- and the directory is empty
+```
+
+So unlike `clone`, where it depends on the repo, a worktree of a repo with submodules is
+missing them **always** — and `charter worktree add` prints its `enter: cd …` line
+directly into an agent's next command. It says so now, on the same two lines as everywhere
+else. Every clone path already routed through `cmd_clone` (`workspace restore`, `workspace
+create --repos`, `workspace fork --restore`), so those needed nothing.
+
 ## The trap the first fix set, and the second one that closes it
 
 A submodule left behind is an **unstaged change to the gitlink**. So the fast-forward that
@@ -130,16 +146,18 @@ submodule objects; what it never did was check anything out. Nothing here change
 ## Verification
 
 Reproduced first, in a throwaway plane with `config.ROOT` and `config.STATE_DIR` asserted
-into a scratch directory, never against a real one. 25 new cases: submodules planted by
+into a scratch directory, never against a real one. 28 new cases: submodules planted by
 hand as index gitlinks (a recorded submodule needs no network, no second repository and no
 `protocol.file.allow`), and real `git submodule add` fixtures for the two states that
 genuinely need a checked-out submodule.
 
-Fifteen hand-mutations, all killed: dropping the `.gitmodules` short-circuit, collapsing
+Eighteen hand-mutations, all killed: dropping the `.gitmodules` short-circuit, collapsing
 the two drift marks onto one, removing the report from `clone`, from `sync` and from each
 half of the `status` row, flattening the remedy path, and trimming `--init --recursive`
 off the remedy, silencing the dirty-skip branch, and narrowing the clone report to freshly
-cloned repos so an already-cloned one is not told. One was killed for the wrong reason —
+cloned repos so an already-cloned one is not told, returning a failure exit code from
+`clone`, dropping the worktree report, and pointing the worktree report at the clone
+instead of the worktree. One was killed for the wrong reason —
 splitting the git output on every space rather than the first survives any fixture whose
 submodule paths are single words —
 so two cases now use a submodule path with a space in it, and that mutation is measured

--- a/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
+++ b/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
@@ -130,7 +130,7 @@ submodule objects; what it never did was check anything out. Nothing here change
 ## Verification
 
 Reproduced first, in a throwaway plane with `config.ROOT` and `config.STATE_DIR` asserted
-into a scratch directory, never against a real one. 24 new cases: submodules planted by
+into a scratch directory, never against a real one. 25 new cases: submodules planted by
 hand as index gitlinks (a recorded submodule needs no network, no second repository and no
 `protocol.file.allow`), and real `git submodule add` fixtures for the two states that
 genuinely need a checked-out submodule.

--- a/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
+++ b/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
@@ -1,0 +1,141 @@
+---
+version: unreleased
+headline: A clone says which submodules it left empty, and a sync stops calling it up to date
+---
+
+*"After `charter clone`, `git submodule status` shows a leading `-` and the submodule
+directory is empty, so EVERY one of those targets fails on line one with a bare 'no such
+file or directory'. Nothing in the clone output hints that a submodule was skipped."*
+(#817)
+
+## What was measured
+
+A throwaway plane, a repo carrying one `dev-scripts` submodule, and the real
+`commands._clone_one`:
+
+```
+clone status: ok
+--- charter output during clone ---
+(nothing)
+--- ls dest ---            ['.git', '.gitmodules', 'README.md', 'dev-scripts']
+--- ls dest/dev-scripts --- []
+--- git submodule status --- '-038cbf71a398dadefbaad26e157b70ade2e2f2db dev-scripts\n'
+--- what a dev target would hit ---
+rc= 127 stderr= sh: dev-scripts/docker-build.sh: No such file or directory
+```
+
+`git clone` does not fetch submodules unless asked, and charter never asked. The clone is
+a success by every measure charter had, and the tree is missing the scripts every build
+target calls.
+
+**`charter sync` was the same silence carrying a stronger claim.** On a clone whose
+upstream moved one submodule pointer and added a second submodule:
+
+```
+✓ ws/sync_clone: up to date on main
+--- git submodule status after sync ---
++038cbf71a398dadefbaad26e157b70ade2e2f2db dev-scripts (heads/main)
+-bb34671f3cf1e95aa8ce95d575f561c96065809b extra-tools
+--- extra-tools on disk? --- True []
+```
+
+A fast-forward moves the *gitlink* and never touches the submodule's own checkout, so the
+commonest outcome of a sync is a branch that is up to date beside a submodule that is not.
+The branch half of that tick was true, which is exactly why it had to be said differently
+rather than followed by a warning — a tick is what an operator scans for and stops reading
+at.
+
+## charter says, and does not do
+
+`clone`, `sync` and `status` now name every submodule with nothing checked out, and every
+one left behind the commit the branch records, with the one command that fixes both:
+
+```
+! super: 1 submodule(s) recorded but not initialised (dev-scripts) — nothing is checked
+  out there, so anything that runs from them fails with 'no such file or directory'.
+  charter does not fetch them: a submodule URL comes out of the cloned repo's own
+  .gitmodules and can point anywhere, and charter's token-only policy does not reach a
+  submodule fetch. Yours to run: git -C workspaces/ws/super submodule update --init --recursive
+```
+
+The issue asked for either initialising or reporting. **Reporting, and the second reason
+is the one that settles it.**
+
+A submodule URL comes out of `.gitmodules` — a file inside the repo charter has just
+cloned — and can name any host, recursively. `_https_url` already refuses to hand `git
+clone` a string charter did not build (#335, where `ext::sh -c '…'` is a transport that
+runs a command); fetching whatever `.gitmodules` names would put that string back one
+layer down, where that allowlist cannot see it.
+
+**And charter could not have done it under its own rule anyway.** Golden rule 0 is written
+with `git config --local`, and **`git clone` does not read the local config of the
+repository it is standing in** — system, global and `-c` only. A submodule fetch *is* a
+nested `git clone`. Measured on git 2.50.1, against a superproject whose submodule cannot
+be fetched at all without the config under test:
+
+```
+LOCAL  protocol.file.allow in the superproject -> submodule init rc = 1   (never read)
+-c     on the command line                     -> submodule init rc = 0
+GLOBAL protocol.file.allow                     -> submodule init rc = 0
+LOCAL  submodule.<name>.url override           -> submodule init rc = 0
+```
+
+The last line is the asymmetry: the *parent* resolves the URL from local config, so a
+`submodule.<name>.url` override works; the *child* consumes `credential.helper` and
+`url.<https>.insteadOf`, and its config search skips the local file that holds them. So a
+submodule fetch runs without charter's credential helper and without its SSH→HTTPS
+rewrite, whoever starts it — and a charter
+that initialised submodules for you would be fetching outside its own credential policy,
+quietly, with your token in reach. `docs/git-policy.md` states that boundary now, because
+it was true before this release too and nothing said so.
+
+## Two things in the report that measurement contradicted
+
+**The guard is not what denies a submodule init.** #817 reports that `git-policy` says
+"all repos are token-only" while a submodule init "is correctly denied by the PreToolUse
+guard, which reads as a guard bug". The guard reads the command line and never
+`.gitmodules`, and it was asked directly:
+
+```
+allowed  git submodule update --init --recursive
+allowed  git -C workspaces/ws/super submodule update --init --recursive
+allowed  git config submodule.dev-scripts.url https://gitlab.com/eg/dev-scripts.git
+DENIED   git config submodule.dev-scripts.url git@gitlab.com:eg/dev-scripts.git
+```
+
+Nothing stops the init. What fires is the *manual workaround* — typing the SSH URL while
+configuring the override — and there the guard is right, and the HTTPS form works. (This
+was confirmed the hard way: the first attempt to build a fixture for this ran into that
+denial from a shell command of its own.)
+
+**`gl-refresh` does not share the gap**, so it is deliberately unchanged. It runs no git
+command that touches a working tree — it asks each clone's forge for the open change and
+last CI and writes the cache the status line reads (`glstate.refresh`).
+
+## What this changes that was not a defect
+
+A submodule left behind is an unstaged change to the gitlink, so `charter status` already
+said `dirty` for it and said nothing about why. The row now names the cause — and that
+matters more than it reads, because `_sync_one` **skips a dirty tree**: a submodule nobody
+was told about silently stops that repo being synced at all.
+
+`git fetch` recurses into submodules on demand, so `charter sync` was already fetching
+submodule objects; what it never did was check anything out. Nothing here changes that.
+
+## Verification
+
+Reproduced first, in a throwaway plane with `config.ROOT` and `config.STATE_DIR` asserted
+into a scratch directory, never against a real one. 21 new cases: submodules planted by
+hand as index gitlinks (a recorded submodule needs no network, no second repository and no
+`protocol.file.allow`), and real `git submodule add` fixtures for the two states that
+genuinely need a checked-out submodule.
+
+Thirteen hand-mutations, all killed: dropping the `.gitmodules` short-circuit, collapsing
+the two drift marks onto one, removing the report from `clone`, from `sync` and from each
+half of the `status` row, flattening the remedy path, and trimming `--init --recursive`
+off the remedy. One was killed for the wrong reason — splitting the git output on every
+space rather than the first survives any fixture whose submodule paths are single words —
+so two cases now use a submodule path with a space in it, and that mutation is measured
+where it is made.
+
+Nothing to adopt.

--- a/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
+++ b/docs/news/unreleased-a-clone-says-which-submodules-it-left-empty.md
@@ -186,12 +186,12 @@ because the code no longer does.
 ## Verification
 
 Reproduced first, in a throwaway plane with `config.ROOT` and `config.STATE_DIR` asserted
-into a scratch directory, never against a real one. 36 new cases: submodules planted by
+into a scratch directory, never against a real one. 37 new cases: submodules planted by
 hand as index gitlinks (a recorded submodule needs no network, no second repository and no
 `protocol.file.allow`), and real `git submodule add` fixtures for the two states that
 genuinely need a checked-out submodule.
 
-Twenty-six hand-mutations, all killed: dropping the `.gitmodules` short-circuit, collapsing
+Twenty-seven hand-mutations, all killed: dropping the `.gitmodules` short-circuit, collapsing
 the two drift marks onto one, removing the report from `clone`, from `sync` and from each
 half of the `status` row, flattening the remedy path, and trimming `--init --recursive`
 off the remedy, silencing the dirty-skip branch, and narrowing the clone report to freshly

--- a/tests/test_a_clone_says_which_submodules_it_left_empty.py
+++ b/tests/test_a_clone_says_which_submodules_it_left_empty.py
@@ -389,7 +389,17 @@ class TestStatusRowSaysSo(SubmoduleCase):
         r = self.repo()
         plant_submodule(r, "dev-scripts")
         self.assertEqual(commands._clone_note(r),
-                         "main · clean · 1 submodule not initialised")
+                         "main · clean · 1 submodule(s) not initialised")
+
+    def test_two_uninitialised_submodules_are_counted_not_just_named(self):
+        """The count is what makes the row worth a column, and `(s)` is this repo's form
+        for a number it does not know at write time (`{len(targets)} repo(s)`). Pinned at
+        two because one reads correctly under either spelling."""
+        r = self.repo()
+        plant_submodule(r, "dev-scripts")
+        plant_submodule(r, "extra-tools")
+        self.assertEqual(commands._clone_note(r),
+                         "main · clean · 2 submodule(s) not initialised")
 
     def test_both_kinds_of_drift_fit_in_one_note(self):
         """`dirty` here is not incidental — a submodule left behind IS an unstaged change
@@ -406,7 +416,7 @@ class TestStatusRowSaysSo(SubmoduleCase):
         git("commit", "-qm", "bump", cwd=r)
         git("checkout", "-q", "HEAD~1", cwd=r / "extra-tools")
         self.assertEqual(commands._clone_note(r),
-                         "main · dirty · 1 submodule not initialised · 1 out of date")
+                         "main · dirty · 1 submodule(s) not initialised · 1 out of date")
 
 
 if __name__ == "__main__":

--- a/tests/test_a_clone_says_which_submodules_it_left_empty.py
+++ b/tests/test_a_clone_says_which_submodules_it_left_empty.py
@@ -164,6 +164,53 @@ class TestWhatTheTreeReports(SubmoduleCase):
         git("checkout", "-q", "HEAD~1", cwd=r / "dev-scripts")
         self.assertEqual(commands.submodule_drift(r), ([], ["dev-scripts"]))
 
+    def test_a_path_that_looks_like_a_describe_suffix_is_not_trimmed(self):
+        """The two cannot be told apart by inspecting the path, so the mark decides.
+        Measured, a submodule at `tools (x)` reports as::
+
+            absent      -<sha> tools (x)
+            checked out +<sha> tools (x) (remotes/origin/HEAD)
+
+        A rule that trims whatever ends in `)` after a ` (` reads the first path as
+        `tools` — a directory that does not exist, in the one sentence whose whole job is
+        to name the directory that does."""
+        r = self.repo()
+        plant_submodule(r, "tools (x)")
+        self.assertEqual(commands.submodule_drift(r), (["tools (x)"], []))
+
+    def test_the_describe_is_still_taken_off_a_checked_out_one(self):
+        """The other direction of the same decision: `+` lines DO carry the suffix, and
+        the path in front of it may itself end in `)`."""
+        r, sub = self.repo(), make_repo(self.tmp / "sub")
+        git("submodule", "add", "-q", str(sub), "tools (x)", cwd=r)
+        git("commit", "-qm", "add", cwd=r)
+        git("commit", "-q", "--allow-empty", "-m", "v2", cwd=r / "tools (x)")
+        moved = git("rev-parse", "HEAD", cwd=r / "tools (x)").stdout.strip()
+        git("update-index", "--cacheinfo", f"160000,{moved},tools (x)", cwd=r)
+        git("commit", "-qm", "bump", cwd=r)
+        git("checkout", "-q", "HEAD~1", cwd=r / "tools (x)")
+        self.assertEqual(commands.submodule_drift(r), ([], ["tools (x)"]))
+
+    def test_a_git_that_failed_reports_nothing_even_though_it_printed_findings(self):
+        """The non-zero check is not satisfied by an empty stdout, which is why dropping
+        it survives a test that only builds a broken directory. `git submodule status`
+        prints the submodules it mapped and THEN fails on one it did not — measured::
+
+            rc = 128
+            stdout = '-000…001 mapped\n'
+            stderr = "fatal: no submodule mapping found in .gitmodules for path 'unmapped'"
+
+        Without the check, `mapped` is reported as a finding out of a run git disowned."""
+        r = self.repo()
+        plant_submodule(r, "mapped")
+        # A SECOND gitlink that `.gitmodules` does not map — the state git refuses on.
+        git("update-index", "--add", "--cacheinfo", f"160000,{UNREACHABLE},unmapped", cwd=r)
+        git("commit", "-qm", "an unmapped gitlink", cwd=r)
+        proc = git("submodule", "status", cwd=r)
+        self.assertNotEqual(proc.returncode, 0, "fixture no longer makes git fail")
+        self.assertIn("mapped", proc.stdout, "fixture no longer prints a parseable line")
+        self.assertEqual(commands.submodule_drift(r), ([], []))
+
     def test_a_submodule_path_with_a_space_in_it_survives_the_parse(self):
         """`git submodule status` is `<mark><sha> <path>` and, for a checked-out one, a
         trailing ` (<describe>)`. Splitting on every space reads the describe — or the last
@@ -200,6 +247,65 @@ class TestWhatTheTreeReports(SubmoduleCase):
                                side_effect=AssertionError("ran git anyway")) as spy:
             self.assertEqual(commands.submodule_drift(r), ([], []))
         spy.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# the sentence, spelled out                                                    #
+# --------------------------------------------------------------------------- #
+class TestTheSentenceItself(SubmoduleCase):
+    def say(self, d: Path, **kw) -> list[str]:
+        out = []
+        with mock.patch.object(commands.util, "warn", lambda m, *a: out.append(m)), \
+             mock.patch.object(commands.util, "info", lambda m, *a: out.append(m)):
+            commands.report_submodule_drift(d, "super", **kw)
+        return out
+
+    def test_with_no_lead_the_facts_are_the_whole_sentence(self):
+        """Hand-spelled, because the alternative — building the expected string from the
+        same f-string the code uses — agrees with any wording that f-string takes. It is
+        also the half a caller can drop silently: always taking the `lead` branch renders
+        `super: None — 1 submodule(s) …` and every substring check still passes."""
+        r = self.repo()
+        plant_submodule(r, "dev-scripts")
+        self.assertEqual(
+            self.say(r)[0],
+            "super: 1 submodule(s) recorded but not initialised (dev-scripts) — nothing "
+            "is checked out there, so anything that runs from them fails with 'no such "
+            "file or directory'.")
+
+    def test_a_lead_is_joined_to_the_facts_and_does_not_replace_them(self):
+        r = self.repo()
+        plant_submodule(r, "dev-scripts")
+        self.assertEqual(
+            self.say(r, branch="main", lead="main is up to date, its submodules are not")[0],
+            "super: main is up to date, its submodules are not — 1 submodule(s) recorded "
+            "but not initialised (dev-scripts) — nothing is checked out there, so "
+            "anything that runs from them fails with 'no such file or directory'.")
+
+    def test_nothing_is_said_about_a_tree_with_no_drift(self):
+        self.assertEqual(self.say(self.repo()), [])
+
+
+class TestTheRemedyNamesAPathTheReaderCanUse(SubmoduleCase):
+    def test_a_tree_inside_the_plane_is_named_relative_to_it(self):
+        r = self.repo()
+        self.assertEqual(commands._submodule_remedy(r),
+                         "git -C workspaces/ws/super submodule update --init --recursive")
+
+    def test_a_tree_outside_the_plane_is_named_absolutely(self):
+        """Not hypothetical: `[plane] worktrees` and `$CHARTER_WORKTREES` relocate the
+        worktree root to a SIBLING of the plane (`config.worktrees_root_for`), and
+        `charter worktree add` reports on the tree it just created. `relative_to` raises
+        `ValueError` there, and without the catch the command that says how to fix a
+        submodule is itself a traceback."""
+        outside = self.tmp.parent / f"{self.tmp.name}.worktrees" / "ws" / "super.p1"
+        # The precondition, asserted as the condition the catch is FOR rather than as a
+        # string test — `<tmp>.worktrees` has `<tmp>` as a string prefix and is not under
+        # it as a path, which is the whole reason `relative_to` is the right question.
+        with self.assertRaises(ValueError):
+            outside.relative_to(config.ROOT)
+        self.assertEqual(commands._submodule_remedy(outside),
+                         f"git -C {outside} submodule update --init --recursive")
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_a_clone_says_which_submodules_it_left_empty.py
+++ b/tests/test_a_clone_says_which_submodules_it_left_empty.py
@@ -282,6 +282,26 @@ class TestTheSentenceItself(SubmoduleCase):
             "but not initialised (dev-scripts) — nothing is checked out there, so "
             "anything that runs from them fails with 'no such file or directory'.")
 
+    def test_both_kinds_are_joined_into_the_one_line_not_the_first_of_them(self):
+        """Every other case here carries a single fact, so a join that kept only the first
+        would read correctly in all of them and drop half the finding exactly when there is
+        most to say."""
+        r, sub = self.repo(), make_repo(self.tmp / "sub")
+        plant_submodule(r, "dev-scripts")
+        git("submodule", "add", "-q", str(sub), "extra-tools", cwd=r)
+        git("commit", "-qm", "add", cwd=r)
+        git("commit", "-q", "--allow-empty", "-m", "v2", cwd=r / "extra-tools")
+        moved = git("rev-parse", "HEAD", cwd=r / "extra-tools").stdout.strip()
+        git("update-index", "--cacheinfo", f"160000,{moved},extra-tools", cwd=r)
+        git("commit", "-qm", "bump", cwd=r)
+        git("checkout", "-q", "HEAD~1", cwd=r / "extra-tools")
+        self.assertEqual(
+            self.say(r, branch="main")[0],
+            "super: 1 submodule(s) recorded but not initialised (dev-scripts) — nothing "
+            "is checked out there, so anything that runs from them fails with 'no such "
+            "file or directory'; 1 submodule(s) not at the commit main records "
+            "(extra-tools).")
+
     def test_nothing_is_said_about_a_tree_with_no_drift(self):
         self.assertEqual(self.say(self.repo()), [])
 

--- a/tests/test_a_clone_says_which_submodules_it_left_empty.py
+++ b/tests/test_a_clone_says_which_submodules_it_left_empty.py
@@ -256,6 +256,32 @@ class TestCloneSaysWhatItLeftEmpty(SubmoduleCase):
         self.assertIn("charter does not fetch them", said)
         self.assertIn(".gitmodules", said)
 
+    def test_a_repo_that_was_already_cloned_is_told_about_too(self):
+        """`already cloned in 'ws'` is the line an operator gets on every re-run of a
+        `workspace restore`, and the submodule is no more initialised for being old. The
+        report sits after the whole status branch on purpose, not inside the `ok` arm."""
+        r = self.repo()
+        plant_submodule(r, "dev-scripts")
+        out = []
+        rec = {"repo": {"name": r.name}, "dest": r, "status": "exists"}
+        with mock.patch.object(commands, "_clone_one", lambda rr, wd: {**rec, "repo": rr}), \
+             mock.patch.object(commands.util, "info", lambda m, *a: out.append(m)), \
+             mock.patch.object(commands.util, "ok", lambda m, *a: out.append(m)), \
+             mock.patch.object(commands.util, "warn", lambda m, *a: out.append(m)), \
+             mock.patch.object(commands.workspace, "resolve", lambda *a, **k: "ws"), \
+             mock.patch.object(commands.workspace, "banner", lambda *a, **k: None), \
+             mock.patch.object(commands.workspace, "ensure",
+                               lambda *a: config.ROOT / "workspaces" / "ws"), \
+             mock.patch.object(commands.inventory, "load", lambda: {}), \
+             mock.patch.object(commands.inventory, "repos",
+                               lambda d=None: [{"name": r.name}]), \
+             mock.patch.object(commands, "_resolve_targets",
+                               lambda a, d: [{"name": r.name}]):
+            commands.cmd_clone(SimpleNamespace(repos=[r.name], workspace="ws"))
+        said = "\n".join(out)
+        self.assertIn("already cloned", said)
+        self.assertIn("dev-scripts", said)
+
     def test_the_clone_still_succeeded(self):
         """This is a report, not a failure: the repo IS cloned, and an exit code that said
         otherwise would break every `workspace restore` that has a submodule in it."""
@@ -303,6 +329,30 @@ class TestSyncStopsCallingItUpToDate(SubmoduleCase):
         plant_submodule(seed, "dev-scripts")
         said = self.said(commands._sync_one, self.clone_of(seed), "ws")
         self.assertIn("submodule update --init --recursive", said)
+
+    def test_the_skip_over_a_dirty_tree_explains_itself(self):
+        """The trap the previous case sets. A submodule left behind is an unstaged change
+        to the gitlink, so the FF that produced it makes every later sync take the
+        `uncommitted changes` branch — the repo quietly stops being synced, under a
+        sentence about work the operator never did."""
+        seed, sub = make_repo(self.tmp / "seed"), make_repo(self.tmp / "sub")
+        git("submodule", "add", "-q", str(sub), "dev-scripts", cwd=seed)
+        git("commit", "-qm", "add", cwd=seed)
+        dest = self.clone_of(seed)
+        git("submodule", "update", "--init", cwd=dest)
+        git("checkout", "-q", "--detach", "HEAD", cwd=dest / "dev-scripts")
+        git("commit", "-q", "--allow-empty", "-m", "local", cwd=dest / "dev-scripts")
+        said = self.said(commands._sync_one, dest, "ws")
+        self.assertIn("uncommitted changes", said)
+        self.assertIn("dev-scripts", said)
+        self.assertIn("not at the commit this branch records", said)
+
+    def test_a_dirty_tree_with_no_submodules_says_only_what_it_always_said(self):
+        dest = self.clone_of(make_repo(self.tmp / "seed"))
+        (dest / "README.md").write_text("edited\n")
+        said = self.said(commands._sync_one, dest, "ws")
+        self.assertIn("uncommitted changes", said)
+        self.assertNotIn("submodule", said)
 
     def test_a_submodule_the_merge_moved_past_is_reported_too(self):
         """The commonest sync case, and the one a fix for `clone` alone would miss: the

--- a/tests/test_a_clone_says_which_submodules_it_left_empty.py
+++ b/tests/test_a_clone_says_which_submodules_it_left_empty.py
@@ -543,6 +543,10 @@ class TestAWorktreeSaysSoToo(SubmoduleCase):
         self.assertIn("dev-scripts", said)
         self.assertIn("1 submodule(s) recorded but not initialised", said)
         self.assertIn("submodule update --init --recursive", said)
+        # The label names the PIECE as well as the repo: a worktree add prints one repo's
+        # name several times and the piece is what tells the reader which tree this is
+        # about. Hand-spelled rather than built from the args.
+        self.assertIn("super · p1: 1 submodule(s)", said)
 
     def test_a_worktree_of_an_INITIALISED_submodule_still_says_so(self):
         """The case that makes this surface different from `clone`: the source tree is

--- a/tests/test_a_clone_says_which_submodules_it_left_empty.py
+++ b/tests/test_a_clone_says_which_submodules_it_left_empty.py
@@ -383,6 +383,56 @@ class TestSyncStopsCallingItUpToDate(SubmoduleCase):
 
 
 # --------------------------------------------------------------------------- #
+# and a worktree, which is the surface that misses them every time             #
+# --------------------------------------------------------------------------- #
+class TestAWorktreeSaysSoToo(SubmoduleCase):
+    """`git worktree add` gives the new tree the superproject's gitlinks and initialises
+    none of them — measured, from a clone whose submodule was checked out and in sync::
+
+        source:   +038cbf7… dev-scripts (heads/main)
+        worktree: -a8320ac… dev-scripts          <- and the directory is empty
+
+    So unlike `clone`, where it depends on the repo, a worktree of a repo with submodules
+    is missing them ALWAYS. It is also the line an agent reads immediately before `cd`ing
+    in and running the build, which is where #817's report started."""
+
+    def add(self, repo: Path, piece: str = "p1") -> str:
+        from charter import commands_worktree
+        buf = io.StringIO()
+        args = SimpleNamespace(workspace="ws", repo=repo.name, piece=piece, branch=None,
+                               force=False, delete_branch=False)
+        with redirect_stdout(buf), redirect_stderr(buf):
+            self.rc = commands_worktree.cmd_worktree_add(args)
+        return buf.getvalue()
+
+    def test_a_worktree_of_a_plain_repo_says_nothing_extra(self):
+        said = self.add(self.repo())
+        self.assertEqual(self.rc, 0, said)
+        self.assertNotIn("submodule", said)
+
+    def test_a_worktree_names_the_submodule_it_did_not_bring(self):
+        r = self.repo()
+        plant_submodule(r, "dev-scripts")
+        said = self.add(r)
+        self.assertEqual(self.rc, 0, said)
+        self.assertIn("dev-scripts", said)
+        self.assertIn("1 submodule(s) recorded but not initialised", said)
+        self.assertIn("submodule update --init --recursive", said)
+
+    def test_a_worktree_of_an_INITIALISED_submodule_still_says_so(self):
+        """The case that makes this surface different from `clone`: the source tree is
+        complete, and the worktree is not."""
+        r, sub = self.repo(), make_repo(self.tmp / "sub")
+        git("submodule", "add", "-q", str(sub), "dev-scripts", cwd=r)
+        git("commit", "-qm", "add", cwd=r)
+        self.assertEqual(commands.submodule_drift(r), ([], []))
+        said = self.add(r)
+        self.assertEqual(self.rc, 0, said)
+        self.assertIn("dev-scripts", said)
+        self.assertIn("recorded but not initialised", said)
+
+
+# --------------------------------------------------------------------------- #
 # status says so                                                               #
 # --------------------------------------------------------------------------- #
 class TestStatusRowSaysSo(SubmoduleCase):

--- a/tests/test_a_clone_says_which_submodules_it_left_empty.py
+++ b/tests/test_a_clone_says_which_submodules_it_left_empty.py
@@ -59,8 +59,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands, config
-
-from ._isolation import PersonaIso
+from tests._isolation import PersonaIso
 
 
 def git(*args, cwd) -> subprocess.CompletedProcess:

--- a/tests/test_a_clone_says_which_submodules_it_left_empty.py
+++ b/tests/test_a_clone_says_which_submodules_it_left_empty.py
@@ -164,6 +164,27 @@ class TestWhatTheTreeReports(SubmoduleCase):
         git("checkout", "-q", "HEAD~1", cwd=r / "dev-scripts")
         self.assertEqual(commands.submodule_drift(r), ([], ["dev-scripts"]))
 
+    def test_a_submodule_path_with_a_space_in_it_survives_the_parse(self):
+        """`git submodule status` is `<mark><sha> <path>` and, for a checked-out one, a
+        trailing ` (<describe>)`. Splitting on every space reads the describe — or the last
+        word of the path — as the name. Nothing stops a repo naming a directory this way,
+        and the sweep cannot tell a parse that only ever sees single-word paths from a
+        correct one."""
+        r = self.repo()
+        plant_submodule(r, "dev scripts")
+        self.assertEqual(commands.submodule_drift(r), (["dev scripts"], []))
+
+    def test_a_checked_out_submodule_is_not_named_after_its_describe(self):
+        r, sub = self.repo(), make_repo(self.tmp / "sub")
+        git("submodule", "add", "-q", str(sub), "dev scripts", cwd=r)
+        git("commit", "-qm", "add", cwd=r)
+        git("commit", "-q", "--allow-empty", "-m", "v2", cwd=r / "dev scripts")
+        moved = git("rev-parse", "HEAD", cwd=r / "dev scripts").stdout.strip()
+        git("update-index", "--cacheinfo", f"160000,{moved},dev scripts", cwd=r)
+        git("commit", "-qm", "bump", cwd=r)
+        git("checkout", "-q", "HEAD~1", cwd=r / "dev scripts")
+        self.assertEqual(commands.submodule_drift(r), ([], ["dev scripts"]))
+
     def test_a_directory_that_is_not_a_repository_reports_nothing(self):
         """Called from `status` on whatever sits in a workspace — it must not raise."""
         d = config.ROOT / "workspaces" / "ws" / "notarepo"
@@ -317,7 +338,8 @@ class TestStatusRowSaysSo(SubmoduleCase):
     def test_the_row_names_the_uninitialised_count(self):
         r = self.repo()
         plant_submodule(r, "dev-scripts")
-        self.assertEqual(commands._clone_note(r), "main · clean · 1 submodule not initialised")
+        self.assertEqual(commands._clone_note(r),
+                         "main · clean · 1 submodule not initialised")
 
     def test_both_kinds_of_drift_fit_in_one_note(self):
         """`dirty` here is not incidental — a submodule left behind IS an unstaged change

--- a/tests/test_a_clone_says_which_submodules_it_left_empty.py
+++ b/tests/test_a_clone_says_which_submodules_it_left_empty.py
@@ -1,0 +1,341 @@
+"""A clone that fetched less than the repo records says so, and a sync stops calling it
+up to date.
+
+`git clone` does not fetch submodules unless asked, and `charter clone` never asked. So a
+repo whose tooling lives in a submodule arrived with an EMPTY directory where the tooling
+should be, and charter's own output was a green tick. Reproduced against the real
+`commands._clone_one` — the clone succeeds, `git submodule status` answers a leading `-`,
+and the first thing that runs from the submodule dies:
+
+    ✓ super → workspaces/ws/super (main via gh, HTTPS)
+    $ git -C .../super submodule status
+    -038cbf71a398dadefbaad26e157b70ade2e2f2db dev-scripts
+    $ sh dev-scripts/docker-build.sh
+    sh: dev-scripts/docker-build.sh: No such file or directory        (rc 127)
+
+**charter says, and does not do.** Initialising means charter fetching a URL it did not
+build, out of `.gitmodules` — a file inside the repo it just cloned — over the network,
+recursively, with a forge token in the credential helper. `_https_url` already refuses to
+hand git a string charter did not build (#335); auto-initialising would put that same
+string back one layer down, where the allowlist cannot see it.
+
+It could not even do it under its own rule. Measured on git 2.50.1: **`git clone` does not
+read the local config of the repository it is standing in** — only system, global and
+`-c`. A submodule fetch IS a nested `git clone`, so `gitpolicy.apply`'s `--local`
+`credential.helper` and `url.<https>.insteadOf` never reach it:
+
+    LOCAL protocol.file.allow in the superproject -> submodule init rc = 1  (not read)
+    -c on the command line                        -> submodule init rc = 0
+    GLOBAL protocol.file.allow                    -> submodule init rc = 0
+    LOCAL submodule.<name>.url override           -> submodule init rc = 0  (parent reads it)
+
+The last line is the asymmetry: the PARENT resolves the URL from local config, the CHILD
+consumes the transport config and cannot see it. So golden rule 0 does not hold for a
+submodule fetch, and a charter that initialised them would be quietly fetching outside
+its own credential policy.
+
+`sync` is the same silence with a stronger claim on it. Measured on a clone whose upstream
+moved one submodule pointer and added a second submodule, `charter sync` printed
+
+    ✓ ws/sync_clone: up to date on main
+
+with `dev-scripts` still at the old commit and an empty `extra-tools/` beside it. The
+branch was up to date; the tree was not, and only the branch was mentioned.
+
+`gl-refresh` does NOT share the gap and is deliberately left alone: it runs no git command
+that touches a working tree — it asks each clone's forge for the open change and last CI
+and writes a cache the status line reads (`glstate.refresh`).
+"""
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, config
+
+from ._isolation import PersonaIso
+
+
+def git(*args, cwd) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True,
+                          check=False)
+
+
+def make_repo(d: Path) -> Path:
+    """A one-commit git repository at *d*."""
+    d.mkdir(parents=True, exist_ok=True)
+    git("init", "-q", "-b", "main", ".", cwd=d)
+    (d / "README.md").write_text("top\n")
+    git("add", "README.md", cwd=d)
+    git("commit", "-qm", "top", cwd=d)
+    return d
+
+
+#: A gitlink points at a commit; nothing requires that commit to be reachable, or the
+#: submodule's repository to exist at all. Planting one by hand is what lets these cases
+#: build the state under test — a recorded-but-absent submodule — without a network, a
+#: second repository, or `protocol.file.allow`, none of which is the thing being asserted.
+UNREACHABLE = "0" * 39 + "1"
+
+
+def plant_submodule(repo: Path, path: str, url: str = "https://example.invalid/g/s.git",
+                    sha: str = UNREACHABLE, name: str | None = None) -> None:
+    """Record a submodule at *path* in *repo* and commit it, fetching nothing.
+
+    The empty directory is created because a real `git clone` creates one — measured, and
+    it matters: without it `git status --porcelain` answers `` D dev-scripts``, so the
+    fixture would be DIRTY and every assertion below would be reading a state no clone
+    ever produces (`_sync_one` skips a dirty tree outright)."""
+    git("update-index", "--add", "--cacheinfo", f"160000,{sha},{path}", cwd=repo)
+    with (repo / ".gitmodules").open("a") as fh:
+        fh.write(f'[submodule "{name or path}"]\n\tpath = {path}\n\turl = {url}\n')
+    git("add", ".gitmodules", cwd=repo)
+    git("commit", "-qm", f"record {path}", cwd=repo)
+    (repo / path).mkdir(parents=True, exist_ok=True)
+
+
+class SubmoduleCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        # Every fixture submodule below has a PATH for its origin, and git has refused the
+        # `file` transport for submodules since 2.38 (CVE-2022-39253). Passing
+        # `-c protocol.file.allow=always` covers the calls this module makes by hand and
+        # NOT the ones charter makes for itself — and `_sync_one`'s own `git fetch --prune`
+        # needs it, because git recurses into submodules on demand while fetching
+        # (measured: `Fetching submodule dev-scripts` in its stderr). git's
+        # `GIT_CONFIG_KEY_n` mechanism reaches every child of this process, charter's
+        # included, which is the only spelling that does.
+        self.enterContext(mock.patch.dict(os.environ, {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "protocol.file.allow",
+            "GIT_CONFIG_VALUE_0": "always",
+        }))
+
+    def repo(self, name: str = "super") -> Path:
+        return make_repo(config.ROOT / "workspaces" / "ws" / name)
+
+    def said(self, fn, *a, **kw) -> str:
+        buf = io.StringIO()
+        with redirect_stdout(buf), redirect_stderr(buf):
+            fn(*a, **kw)
+        return buf.getvalue()
+
+
+# --------------------------------------------------------------------------- #
+# what a tree actually reports                                                 #
+# --------------------------------------------------------------------------- #
+class TestWhatTheTreeReports(SubmoduleCase):
+    def test_a_repo_with_no_submodules_reports_none(self):
+        self.assertEqual(commands.submodule_drift(self.repo()), ([], []))
+
+    def test_a_recorded_submodule_with_nothing_checked_out_is_named(self):
+        r = self.repo()
+        plant_submodule(r, "dev-scripts")
+        self.assertEqual(commands.submodule_drift(r), (["dev-scripts"], []))
+
+    def test_every_uninitialised_submodule_is_named_not_just_the_first(self):
+        r = self.repo()
+        plant_submodule(r, "dev-scripts")
+        plant_submodule(r, "extra-tools")
+        self.assertEqual(commands.submodule_drift(r), (["dev-scripts", "extra-tools"], []))
+
+    def test_a_submodule_at_the_recorded_commit_is_not_drift(self):
+        r, sub = self.repo(), make_repo(self.tmp / "sub")
+        git("submodule", "add", "-q", str(sub), "dev-scripts", cwd=r)
+        git("commit", "-qm", "add", cwd=r)
+        self.assertEqual(commands.submodule_drift(r), ([], []))
+
+    def test_a_submodule_left_behind_the_commit_the_branch_records_is_named(self):
+        """The state `sync` itself creates: a fast-forward moves the gitlink and never
+        touches the submodule's own checkout."""
+        r, sub = self.repo(), make_repo(self.tmp / "sub")
+        git("submodule", "add", "-q", str(sub), "dev-scripts", cwd=r)
+        git("commit", "-qm", "add", cwd=r)
+        git("commit", "-q", "--allow-empty", "-m", "v2", cwd=r / "dev-scripts")
+        moved = git("rev-parse", "HEAD", cwd=r / "dev-scripts").stdout.strip()
+        git("update-index", "--cacheinfo", f"160000,{moved},dev-scripts", cwd=r)
+        git("commit", "-qm", "bump", cwd=r)
+        git("checkout", "-q", "HEAD~1", cwd=r / "dev-scripts")
+        self.assertEqual(commands.submodule_drift(r), ([], ["dev-scripts"]))
+
+    def test_a_directory_that_is_not_a_repository_reports_nothing(self):
+        """Called from `status` on whatever sits in a workspace — it must not raise."""
+        d = config.ROOT / "workspaces" / "ws" / "notarepo"
+        d.mkdir(parents=True)
+        (d / ".gitmodules").write_text("[submodule \"x\"]\n\tpath = x\n\turl = u\n")
+        self.assertEqual(commands.submodule_drift(d), ([], []))
+
+    def test_no_gitmodules_file_costs_no_git_process(self):
+        """`status` already runs two git calls per row and the table draws as it goes; a
+        third on every clone that has no submodules at all is a cost with no answer."""
+        r = self.repo()
+        with mock.patch.object(commands, "_git",
+                               side_effect=AssertionError("ran git anyway")) as spy:
+            self.assertEqual(commands.submodule_drift(r), ([], []))
+        spy.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# clone says so                                                                #
+# --------------------------------------------------------------------------- #
+class TestCloneSaysWhatItLeftEmpty(SubmoduleCase):
+    def clone_output(self, dest: Path) -> str:
+        r = {"name": dest.name, "default_branch": "main", "forge": "github",
+             "path_with_namespace": f"g/{dest.name}"}
+        out = []
+        with mock.patch.object(commands, "_clone_one",
+                               lambda rr, wd: {"repo": rr, "dest": dest, "status": "ok",
+                                               "forge": SimpleNamespace(cli="gh")}), \
+             mock.patch.object(commands.util, "info", lambda m, *a: out.append(m)), \
+             mock.patch.object(commands.util, "ok", lambda m, *a: out.append(m)), \
+             mock.patch.object(commands.util, "warn", lambda m, *a: out.append(m)), \
+             mock.patch.object(commands.util, "err", lambda m, *a: out.append(m)), \
+             mock.patch.object(commands.workspace, "resolve", lambda *a, **k: "ws"), \
+             mock.patch.object(commands.workspace, "banner", lambda *a, **k: None), \
+             mock.patch.object(commands.workspace, "ensure",
+                               lambda *a: config.ROOT / "workspaces" / "ws"), \
+             mock.patch.object(commands.inventory, "load", lambda: {}), \
+             mock.patch.object(commands.inventory, "repos", lambda d=None: [r]), \
+             mock.patch.object(commands, "_resolve_targets", lambda a, d: [r]):
+            commands.cmd_clone(SimpleNamespace(repos=[r["name"]], workspace="ws"))
+        return "\n".join(out)
+
+    def test_a_clone_with_no_submodules_says_nothing_extra(self):
+        said = self.clone_output(self.repo())
+        self.assertNotIn("submodule", said)
+
+    def test_the_uninitialised_submodule_is_named(self):
+        r = self.repo()
+        plant_submodule(r, "dev-scripts")
+        said = self.clone_output(r)
+        self.assertIn("dev-scripts", said)
+        # Spelled out by hand, a second time: this sentence is the whole fix, and a test
+        # that builds it from the same f-string the code does would pass on any wording.
+        self.assertIn("1 submodule(s) recorded but not initialised", said)
+        self.assertIn("nothing is checked out there", said)
+
+    def test_it_names_the_command_that_initialises_them(self):
+        r = self.repo()
+        plant_submodule(r, "dev-scripts")
+        said = self.clone_output(r)
+        self.assertIn("submodule update --init --recursive", said)
+        self.assertIn(f"git -C workspaces/ws/{r.name}", said)
+
+    def test_it_says_charter_will_not_fetch_them_and_why(self):
+        """A refusal that does not say why reads as a bug — and this one is a decision."""
+        r = self.repo()
+        plant_submodule(r, "dev-scripts")
+        said = self.clone_output(r)
+        self.assertIn("charter does not fetch them", said)
+        self.assertIn(".gitmodules", said)
+
+    def test_the_clone_still_succeeded(self):
+        """This is a report, not a failure: the repo IS cloned, and an exit code that said
+        otherwise would break every `workspace restore` that has a submodule in it."""
+        r = self.repo()
+        plant_submodule(r, "dev-scripts")
+        said = self.clone_output(r)
+        self.assertIn("→", said)
+
+
+# --------------------------------------------------------------------------- #
+# sync stops saying "up to date"                                               #
+# --------------------------------------------------------------------------- #
+class TestSyncStopsCallingItUpToDate(SubmoduleCase):
+    def clone_of(self, seed: Path, name: str = "super") -> Path:
+        self.bare = self.tmp / f"{name}.git"
+        self.seed = seed
+        git("clone", "-q", "--bare", str(seed), str(self.bare), cwd=self.tmp)
+        dest = config.ROOT / "workspaces" / "ws" / name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        git("clone", "-q", "--branch", "main", "--", str(self.bare), str(dest), cwd=self.tmp)
+        return dest
+
+    def publish(self) -> None:
+        """Push the seed's `main` to the bare origin the clone fetches from. By path: the
+        seed was created with `git init` and has no remote of its own."""
+        p = git("push", "-q", str(self.bare), "main", cwd=self.seed)
+        self.assertEqual(p.returncode, 0, p.stderr)
+
+    def test_a_clean_repo_still_gets_its_tick(self):
+        said = self.said(commands._sync_one, self.clone_of(make_repo(self.tmp / "seed")), "ws")
+        self.assertIn("up to date on main", said)
+        self.assertNotIn("submodule", said)
+
+    def test_it_does_not_report_a_bare_success_over_an_empty_submodule(self):
+        seed = make_repo(self.tmp / "seed")
+        plant_submodule(seed, "dev-scripts")
+        said = self.said(commands._sync_one, self.clone_of(seed), "ws")
+        self.assertIn("dev-scripts", said)
+        # By hand, again — the point of the change is that this line replaces the tick.
+        self.assertIn("main is up to date, its submodules are not", said)
+        self.assertNotIn("up to date on main", said)
+
+    def test_it_names_the_command_there_too(self):
+        seed = make_repo(self.tmp / "seed")
+        plant_submodule(seed, "dev-scripts")
+        said = self.said(commands._sync_one, self.clone_of(seed), "ws")
+        self.assertIn("submodule update --init --recursive", said)
+
+    def test_a_submodule_the_merge_moved_past_is_reported_too(self):
+        """The commonest sync case, and the one a fix for `clone` alone would miss: the
+        submodule IS initialised, the fast-forward moved the pointer, and the checkout
+        stayed where it was."""
+        seed, sub = make_repo(self.tmp / "seed"), make_repo(self.tmp / "sub")
+        git("submodule", "add", "-q", str(sub), "dev-scripts", cwd=seed)
+        git("commit", "-qm", "add", cwd=seed)
+        dest = self.clone_of(seed)
+        git("submodule", "update", "--init", cwd=dest)
+        # The new commit is made in the submodule's ORIGIN, not in the seed's checkout of
+        # it: `git fetch` recurses into submodules on demand, so `_sync_one`'s own fetch
+        # goes looking for this commit there and a `not our ref` is a fixture that fails
+        # for the wrong reason.
+        git("commit", "-q", "--allow-empty", "-m", "v2", cwd=sub)
+        moved = git("rev-parse", "HEAD", cwd=sub).stdout.strip()
+        git("update-index", "--cacheinfo", f"160000,{moved},dev-scripts", cwd=seed)
+        git("commit", "-qm", "bump", cwd=seed)
+        self.publish()
+        said = self.said(commands._sync_one, dest, "ws")
+        self.assertIn("dev-scripts", said)
+        self.assertIn("not at the commit main records", said)
+        self.assertNotIn("up to date on main", said)
+
+
+# --------------------------------------------------------------------------- #
+# status says so                                                               #
+# --------------------------------------------------------------------------- #
+class TestStatusRowSaysSo(SubmoduleCase):
+    def test_a_clean_row_is_unchanged(self):
+        self.assertEqual(commands._clone_note(self.repo()), "main · clean")
+
+    def test_the_row_names_the_uninitialised_count(self):
+        r = self.repo()
+        plant_submodule(r, "dev-scripts")
+        self.assertEqual(commands._clone_note(r), "main · clean · 1 submodule not initialised")
+
+    def test_both_kinds_of_drift_fit_in_one_note(self):
+        """`dirty` here is not incidental — a submodule left behind IS an unstaged change
+        to the gitlink, so this row already said `dirty` and said nothing about why. It is
+        also why the row matters: `_sync_one` skips a dirty tree, so the next `charter
+        sync` stops syncing this repo at all, over a submodule nobody was told about."""
+        r, sub = self.repo(), make_repo(self.tmp / "sub")
+        plant_submodule(r, "dev-scripts")
+        git("submodule", "add", "-q", str(sub), "extra-tools", cwd=r)
+        git("commit", "-qm", "add", cwd=r)
+        git("commit", "-q", "--allow-empty", "-m", "v2", cwd=r / "extra-tools")
+        moved = git("rev-parse", "HEAD", cwd=r / "extra-tools").stdout.strip()
+        git("update-index", "--cacheinfo", f"160000,{moved},extra-tools", cwd=r)
+        git("commit", "-qm", "bump", cwd=r)
+        git("checkout", "-q", "HEAD~1", cwd=r / "extra-tools")
+        self.assertEqual(commands._clone_note(r),
+                         "main · dirty · 1 submodule not initialised · 1 out of date")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_clone_says_which_submodules_it_left_empty.py
+++ b/tests/test_a_clone_says_which_submodules_it_left_empty.py
@@ -29,10 +29,11 @@ read the local config of the repository it is standing in** — only system, glo
     GLOBAL protocol.file.allow                    -> submodule init rc = 0
     LOCAL submodule.<name>.url override           -> submodule init rc = 0  (parent reads it)
 
-The last line is the asymmetry: the PARENT resolves the URL from local config, the CHILD
-consumes the transport config and cannot see it. So golden rule 0 does not hold for a
-submodule fetch, and a charter that initialised them would be quietly fetching outside
-its own credential policy.
+The last line is the asymmetry: the PARENT resolves the URL from local config, while the
+CHILD consumes the transport config and its config search skips the surrounding
+repository's local file. So golden rule 0 does not hold for a submodule fetch, and a
+charter that initialised them would be quietly fetching outside its own credential
+policy.
 
 `sync` is the same silence with a stronger claim on it. Measured on a clone whose upstream
 moved one submodule pointer and added a second submodule, `charter sync` printed
@@ -224,7 +225,7 @@ class TestCloneSaysWhatItLeftEmpty(SubmoduleCase):
              mock.patch.object(commands.inventory, "load", lambda: {}), \
              mock.patch.object(commands.inventory, "repos", lambda d=None: [r]), \
              mock.patch.object(commands, "_resolve_targets", lambda a, d: [r]):
-            commands.cmd_clone(SimpleNamespace(repos=[r["name"]], workspace="ws"))
+            self.rc = commands.cmd_clone(SimpleNamespace(repos=[r["name"]], workspace="ws"))
         return "\n".join(out)
 
     def test_a_clone_with_no_submodules_says_nothing_extra(self):
@@ -282,13 +283,16 @@ class TestCloneSaysWhatItLeftEmpty(SubmoduleCase):
         self.assertIn("already cloned", said)
         self.assertIn("dev-scripts", said)
 
-    def test_the_clone_still_succeeded(self):
-        """This is a report, not a failure: the repo IS cloned, and an exit code that said
-        otherwise would break every `workspace restore` that has a submodule in it."""
+    def test_the_clone_still_succeeds_and_says_so(self):
+        """This is a report, not a failure: the repo IS cloned. The EXIT CODE is asserted
+        as well as the line, because it is the half that would break `workspace restore`
+        for every repo that has a submodule in it, and a check on the arrow alone would
+        stay green through a `return 1`."""
         r = self.repo()
         plant_submodule(r, "dev-scripts")
         said = self.clone_output(r)
         self.assertIn("→", said)
+        self.assertEqual(self.rc, 0)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #817.

## What a clone with submodules does today

Reproduced in a throwaway plane against the real `commands._clone_one`, with `config.ROOT` and `config.STATE_DIR` asserted into a scratch directory:

```
clone status: ok
--- charter output during clone ---
(nothing)
--- ls dest ---             ['.git', '.gitmodules', 'README.md', 'dev-scripts']
--- ls dest/dev-scripts --- []
--- git submodule status --- '-038cbf71a398dadefbaad26e157b70ade2e2f2db dev-scripts\n'
--- what a dev target would hit ---
rc= 127 stderr= sh: dev-scripts/docker-build.sh: No such file or directory
```

The reporter's account, line for line. `git clone` does not fetch submodules unless asked and charter never asked; the clone is a success by every measure charter had.

**`charter sync` was the same silence with a stronger claim on it.** On a clone whose upstream moved one submodule pointer and added a second submodule:

```
✓ ws/sync_clone: up to date on main
+038cbf71a398dadefbaad26e157b70ade2e2f2db dev-scripts (heads/main)
-bb34671f3cf1e95aa8ce95d575f561c96065809b extra-tools
--- extra-tools on disk? --- True []
```

A fast-forward moves the *gitlink* and never touches the submodule's checkout, so the commonest sync outcome is a branch that is up to date beside a submodule that is not — and only the branch was mentioned.

## Say, not do — and the deciding reason is mechanical, not stylistic

#817 asks for either. This reports.

1. **A submodule URL is not a URL charter built.** It comes out of `.gitmodules`, a file inside the repo just cloned, and can name any host, recursively. `_https_url` already refuses to hand `git clone` a string charter did not build (#335 — `ext::sh -c '…'` is a transport that runs a command). Auto-initialising puts that string back one layer down, where the allowlist above it does not reach.

2. **charter could not do it under its own rule anyway.** Golden rule 0 is written with `git config --local`, and **`git clone` does not read the local config of the repository it is standing in** — system, global and `-c` only. A submodule fetch *is* a nested `git clone`. Measured on git 2.50.1, against a superproject whose submodule cannot be fetched at all without the config under test:

| where `protocol.file.allow` was set | `git submodule update --init` |
| --- | --- |
| the superproject's **local** config | fails — never read |
| `-c` on the command line | succeeds |
| **global** config | succeeds |
| **local** `submodule.<name>.url` override | succeeds |

The last row is the asymmetry: the *parent* resolves the URL from local config (so a `submodule.<name>.url` override works — that is why the reporter's manual workaround does), while the *child* consumes `credential.helper` and `url.<https>.insteadOf` and its config search skips the local file holding them. **A submodule fetch therefore runs outside charter's token-only policy, whoever starts it.** A charter that initialised submodules would be fetching outside its own credential policy, quietly, with the operator's token in reach. That boundary was true before this PR and nothing said so; `docs/git-policy.md` states it now.

Frequency was checked and does not move the decision: 0 of 11 clones in this plane carry a `.gitmodules`, but this plane clones one repo which has none by construction, so the sample says nothing. Frequency changes how often the message is useful, not whether the fetch is charter's to make.

## What changes

`clone`, `sync` and `status` each name every submodule with nothing checked out, and every one left behind the commit the branch records, with the one command that fixes both:

```
! super: 1 submodule(s) recorded but not initialised (dev-scripts) — nothing is checked
  out there, so anything that runs from them fails with 'no such file or directory'.
  charter does not fetch them: a submodule URL comes out of the cloned repo's own
  .gitmodules and can point anywhere, and charter's token-only policy does not reach a
  submodule fetch. Yours to run: git -C workspaces/ws/super submodule update --init --recursive
```

`sync` no longer prints a tick it cannot stand behind — the branch half of `up to date on main` was true, which is why it had to be *said differently* rather than followed by a warning: a tick is what an operator scans for and stops reading at.

`clone` still exits 0. This is a report, not a failure; an exit code would break every `workspace restore` that has a submodule in it.

## Two claims in the issue that measurement contradicted

**The guard does not deny a submodule init.** #817 reports that a submodule init "is correctly denied by the PreToolUse guard, which reads as a guard bug". The guard reads the command line and never `.gitmodules`. Asked directly:

```
allowed  git submodule update --init --recursive
allowed  git -C workspaces/ws/super submodule update --init --recursive
allowed  git config submodule.dev-scripts.url https://gitlab.com/eg/dev-scripts.git
DENIED   git config submodule.dev-scripts.url git@gitlab.com:eg/dev-scripts.git
```

Nothing stops the init. What fires is the *manual workaround* — typing the SSH URL while configuring the override — and there the guard is right, and the HTTPS form works. So the second half of the issue is not a `git-policy` gap of the shape reported; whether `--apply` should write `submodule.<name>.url` overrides is a separate decision (it would work, per the table above, and it is charter rewriting a repo's own recorded URLs), left for its own argument.

**`gl-refresh` does not share the gap**, so it is deliberately unchanged: it runs no git command that touches a working tree — it asks each clone's forge for the open change and last CI and writes the cache the status line reads (`glstate.refresh`).

## A third surface, and it is the one that misses them every time

`git worktree add` hands the new tree the superproject's gitlinks and initialises none of them. Measured, from a clone whose submodule was checked out and in sync:

```
source:   +038cbf7… dev-scripts (heads/main)
worktree: -a8320ac… dev-scripts          <- and the directory is empty
```

Unlike `clone`, where it depends on the repo, a worktree of a repo with submodules is missing them **always** — and `charter worktree add` prints its `enter: cd …` line straight into an agent's next command. `commands_worktree` reports on the same two lines as everywhere else. Every other clone path already routed through `cmd_clone` (`workspace restore`, `workspace create --repos`, `workspace fork --restore`), so those needed nothing.

## The trap the first fix set, and the second one that closes it

A submodule left behind is an **unstaged change to the gitlink**. So the fast-forward that produces one also makes every later `charter sync` take the `uncommitted changes — skipping (your work is left untouched)` branch: the repo quietly stops being synced at all, under a sentence about work the operator never did. Reporting only on the paths that reach the merge would have shipped the finding once and then hidden it forever after — so that branch explains itself too, and a dirty tree with no submodules says exactly what it always said.

`charter status` gains the same answer in its NOTE column, so an unexplained `dirty` names its cause. An already-cloned repo is reported too: `already cloned in 'ws'` is what a re-run of `workspace restore` prints, and the submodule is no more initialised for being old.

## Not a defect, but worth knowing

`git fetch` recurses into submodules on demand, so `charter sync` was already fetching submodule objects; it never checked anything out. Unchanged here.

## What the deletion sweep found, and the defect inside it

The first green run came back **`7 survivors`** — the verdict is the check NAME, and every
one sat in `submodule_drift`. Two were deleted and five are now pinned, and one of them was
not a missing test at all.

**The parse was wrong, and the sweep's question is what showed it.** Asked whether
`path.endswith(")")` was pinned, the answer was that neither half of

```python
if path.endswith(")") and " (" in path:      # trim the ` (<describe>)` suffix
```

could be, because the rule itself is unsound: a submodule whose PATH is `tools (x)` is
reported as

```
absent      -<sha> tools (x)
checked out +<sha> tools (x) (remotes/origin/HEAD)
```

and a rule that trims whatever resembles a suffix reads the first path as `tools` — a
directory that does not exist, in the one sentence whose whole job is to name the directory
that does. The describe is now taken off **by the mark**, never by inspecting the path, and
`rpartition` takes the LAST ` (` because that is where the describe always is. A
checked-out line always carries one: measured on a submodule with no tags, detached, which
still prints `(remotes/origin/HEAD)`.

**And the non-zero check was a real guard sitting on a test that already passed without
it.** `git submodule status` prints the submodules it mapped and THEN fails on one it did
not — measured, rc 128 with `-000…001 mapped` already on stdout. The case that was supposed
to cover it built a directory that is not a repository, where stdout is empty and dropping
the check changes nothing. It is now pinned on the state that actually distinguishes them.

The two deletions were fallbacks with nothing behind them: `proc.stdout or ""` (nothing in
charter passes `capture=False`, so stdout is always a string, and every neighbour in this
file reads `.stdout` plainly) and `if not path: continue` (git emits no line without a
space after the mark). The docstring stopped promising to handle "an unparseable line",
because the code no longer does.

## Verification

37 new cases. Submodules are planted by hand as index gitlinks where the state under test allows it — a recorded submodule needs no network, no second repository and no `protocol.file.allow` — with real `git submodule add` fixtures for the two states that genuinely need a checked-out submodule.

**Twenty-eight hand-mutations, all killed**: dropping the `.gitmodules` short-circuit, collapsing the two drift marks onto one, reporting every drift as absent, removing the report from `clone`, from `sync`, and from each half of the `status` row, flattening the remedy path, trimming `--init --recursive` off the remedy, dropping the `(describe)` trim, making the reporter claim it spoke when it did not, silencing the dirty-skip branch, narrowing the clone report to freshly cloned repos, returning a failure exit code from `clone`, dropping the worktree report, and pointing the worktree report at the clone instead of the worktree (caught only by the case built for it — a worktree cut from an already-initialised submodule).

One was killed for the wrong reason — splitting git's output on every space rather than the first survives any fixture whose submodule paths are single words — so two cases now use a submodule path with a space in it, and that mutation is measured where it is made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ctfuhnX3LdXbtx3SMUvTu
