### PR TITLE
The two tab strips get a keyboard route: F2, next tab, Enter (replaces #818)

### DIFF
--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -45,7 +45,7 @@ import subprocess
 
 from typing import Callable, NamedTuple
 
-from .. import contain, util
+from .. import util
 from . import action, actions, chats, choose, state, switch, tmuxctl
 
 #: What marks the density a frame is currently on. **One constant, not two**: it is
@@ -422,13 +422,27 @@ def _step_strip(ctx, strip: "_Strip", step: int, start: int):
 
     The sentence it answers with names the tab, so the palette says what it started rather
     than that it started something — `_select`'s `f"selected {name}"` one strip over.
+
+    **The name is NOT contained here, and the deletion sweep is what settled it — for the
+    third time in this file.** It was `contain.one_line(name)`, and that is a masked call:
+    **the receipt is contained by the CONTRACT**, `actions.Invocation._work` running
+    `contain.one_line(str(note), limit=REASON_LIMIT)` over whatever a `run` hands back.
+    Every surface downstream contains it again anyway — `palette.Palette._headline` over
+    the header it draws, `state.record_notice` over the whole assembled line it writes.
+
+    :func:`_regather` records the identical finding about the workspace name it returns,
+    :func:`_select` hands back a bare repo name for the same reason, and `choose._note`
+    records the trap in as many words one module over. A call whose result is provably its
+    argument is a line this repository deletes — and `_empty_lines`' warning is the sharper
+    half: a guard kept for a reason that is not the true one is how the real one gets
+    deleted later.
     """
     here = strip.here(ctx.fid)
     name = _walk(list(strip.names(ctx.fid)), here, step, start)
     if name == here:
         return strip.alone
     _spawn(util.self_relaunch_argv(*strip.command, name), fid=ctx.fid)
-    return f"{strip.noun} → {contain.one_line(name)}"
+    return f"{strip.noun} → {name}"
 
 
 #: What a workspace with nothing open is told instead of a row that does nothing.

--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -43,6 +43,8 @@ from __future__ import annotations
 import os
 import subprocess
 
+from typing import Callable, NamedTuple
+
 from .. import contain, util
 from . import action, actions, chats, choose, state, switch, tmuxctl
 
@@ -285,7 +287,34 @@ def _select(ctx, step: int, start: int):
 ONLY_WORKSPACE = ("this plane has one workspace — make another with `charter workspace "
                   "create <name>`, and every workspace row starts offering it")
 
-#: The two strips a keyboard can walk, as ``(noun, names, here, command)``.
+class _Strip(NamedTuple):
+    """One tab strip, as everything the keyboard needs to walk it.
+
+    A record rather than a five-tuple, for `chats.Chat`'s reason one module over: the
+    fields are read in two places (the row that is registered and the walk that runs) and
+    a positional unpack in each is two chances for the day a sixth field is added.
+    """
+
+    #: What the row calls it, and what it says when it has started one — `chat`,
+    #: `workspace`. The palette's own `<noun> → <name>` vocabulary
+    #: (`commands_frame._say_on_screen`'s `persona → zeb`), so a walk reports the way every
+    #: other switch on this plane reports.
+    noun: str
+    #: ``names(fid) -> list`` — the strip, in the order the BAR draws it
+    #: (`frame/chats.roster`, `frame/switch.workspaces`). Asked of the same listers so a
+    #: keyboard walk and a pointer walk cannot disagree about which tab is next.
+    names: Callable
+    #: ``here(fid) -> str`` — the tab this frame is on, from the same reading the bar's
+    #: own mark comes from.
+    here: Callable
+    #: The argv prefix the switch is started with, `frame/builtins._CHAT_SWITCH` and
+    #: `_WORKSPACE_SWITCH` — the same one a click on that tab spawns.
+    command: tuple
+    #: What a strip of one says instead of switching to where the operator already is.
+    alone: str
+
+
+#: The two strips a keyboard can walk.
 #:
 #: **Data rather than four functions**, exactly as :data:`_SELECT_STEPS` is data rather
 #: than a sign test: everything that differs between a chat strip and a workspace strip is
@@ -303,10 +332,10 @@ ONLY_WORKSPACE = ("this plane has one workspace — make another with `charter w
 #: RENDERER module that a palette process has no other reason to import, and
 #: `tests/test_the_keyboard_walks_the_tab_strips.py` holds the two spellings equal instead.
 _STRIPS = (
-    ("chat", lambda fid: [c.id for c in chats.roster(fid)], lambda fid: fid,
-     ("frame-chat",), chats.ONLY_CHAT),
-    ("workspace", lambda _fid: switch.workspaces(), switch.current_workspace,
-     ("frame-switch", "--workspace"), ONLY_WORKSPACE),
+    _Strip("chat", lambda fid: [c.id for c in chats.roster(fid)], lambda fid: fid,
+           ("frame-chat",), chats.ONLY_CHAT),
+    _Strip("workspace", lambda _fid: switch.workspaces(), switch.current_workspace,
+           ("frame-switch", "--workspace"), ONLY_WORKSPACE),
 )
 
 
@@ -364,15 +393,15 @@ def _register_strip(reg: actions.ActionRegistry) -> None:
     on no name at all, so the one workspace left IS somewhere to send it — and a count
     would refuse the only row that could.
     """
-    for noun, names_of, here_of, command, alone in _STRIPS:
+    for strip in _STRIPS:
         for word, step, start in _SELECT_STEPS:
             reg.register(action.Action(
-                id=f"{noun}.{word}", title=f"{noun}: the {word} tab",
-                run=(lambda ctx, n=names_of, h=here_of, c=command, st=step, sr=start,
-                     a=alone: _step_strip(ctx, n, h, c, st, sr, a))))
+                id=f"{strip.noun}.{word}", title=f"{strip.noun}: the {word} tab",
+                run=(lambda ctx, s=strip, st=step, sr=start:
+                     _step_strip(ctx, s, st, sr))))
 
 
-def _step_strip(ctx, names_of, here_of, command, step: int, start: int, alone: str):
+def _step_strip(ctx, strip: "_Strip", step: int, start: int):
     """Start the switch to the tab *step* along from the one this frame is on.
 
     Split out of the row above for :func:`_select`'s reason: the arithmetic can then be
@@ -394,12 +423,12 @@ def _step_strip(ctx, names_of, here_of, command, step: int, start: int, alone: s
     The sentence it answers with names the tab, so the palette says what it started rather
     than that it started something — `_select`'s `f"selected {name}"` one strip over.
     """
-    here = here_of(ctx.fid)
-    name = _walk(list(names_of(ctx.fid)), here, step, start)
+    here = strip.here(ctx.fid)
+    name = _walk(list(strip.names(ctx.fid)), here, step, start)
     if name == here:
-        return alone
-    _spawn(util.self_relaunch_argv(*command, name), fid=ctx.fid)
-    return f"{command[0].split('-')[-1]} → {contain.one_line(name)}"
+        return strip.alone
+    _spawn(util.self_relaunch_argv(*strip.command, name), fid=ctx.fid)
+    return f"{strip.noun} → {contain.one_line(name)}"
 
 
 #: What a workspace with nothing open is told instead of a row that does nothing.

--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -43,8 +43,8 @@ from __future__ import annotations
 import os
 import subprocess
 
-from .. import util
-from . import action, actions, choose, state, tmuxctl
+from .. import contain, util
+from . import action, actions, chats, choose, state, switch, tmuxctl
 
 #: What marks the density a frame is currently on. **One constant, not two**: it is
 #: `frame/choose.py`'s, which marks the workspace and the persona a frame is on for the
@@ -222,6 +222,32 @@ def _register_selection(reg: actions.ActionRegistry) -> None:
             reason_unavailable=lambda ctx: NO_REPOS))
 
 
+def _walk(names: list, here, step: int, start: int):
+    """The entry *step* along from *here* in *names*, wrapping — or from *start* if *here*
+    is not in the list.
+
+    **One walk, three callers**, and that is why it is a function rather than two lines
+    inside each: :func:`_select` moves the repo table's cursor and :func:`_register_strip`
+    moves along each of the two tab strips, and the three of them have to agree about what
+    "next" means or the palette teaches an operator two different answers.
+
+    The modulo is what wraps, and wrapping is :func:`_register_selection`'s decision
+    unchanged: stepping off the end and stopping makes a row that visibly does nothing,
+    which reads as broken and costs an operator a whole `F2` to find out.
+
+    *start* is where a walk with nothing under it begins — the entry before the first for
+    `next`, the one after the last for `previous`, so `(start + step) % len` lands on the
+    end the direction is coming from. It is :data:`_SELECT_STEPS`' third column rather than
+    something derived from the step's sign, for that constant's own recorded reason.
+
+    Never called with an empty *names*: every caller's `available` refuses the row first,
+    and `ActionRegistry._check` hands `run` the same ctx it asked about — so a guard here
+    would be a line nothing could turn red.
+    """
+    at = names.index(here) if here in names else start
+    return names[(at + step) % len(names)]
+
+
 def _select(ctx, step: int, start: int):
     """Move this frame's repo selection *step* rows through the table's display order.
 
@@ -244,15 +270,136 @@ def _select(ctx, step: int, start: int):
     be a line nothing could turn red.
     """
     names = [r.get("name") for r in ctx.repos]
-    chosen = state.selection(ctx.fid)
-    here = names.index(chosen) if chosen in names else start
-    name = names[(here + step) % len(names)]
+    name = _walk(names, state.selection(ctx.fid), step, start)
     state.record_selection(ctx.fid, name)
     # The `repos` pane redraws its highlight and the `attention` pane redraws the detail,
     # and neither is this process — see `frame/builtins._repos_events` for the same two
     # lines said from the pointer's side.
     state.bump(ctx.fid)
     return f"selected {name}"
+
+
+#: What a workspace alone on its plane is told instead of a row that does nothing.
+#: `chats.ONLY_CHAT`'s shape one noun over, and its argument: a refusal that names no way
+#: out is a row an operator reads once and never again.
+ONLY_WORKSPACE = ("this plane has one workspace — make another with `charter workspace "
+                  "create <name>`, and every workspace row starts offering it")
+
+#: The two strips a keyboard can walk, as ``(noun, names, here, command)``.
+#:
+#: **Data rather than four functions**, exactly as :data:`_SELECT_STEPS` is data rather
+#: than a sign test: everything that differs between a chat strip and a workspace strip is
+#: on this table, and what does not differ — the walk, the wrap, the start, the spawn — is
+#: written once below. `slots._bar` makes the identical trade for the two ROWS ("one
+#: function for both bars, so the two cannot degrade differently"), and this is the
+#: keyboard's half of the same strip.
+#:
+#: The listers are `frame/chats.py`'s and `frame/switch.py`'s — the same two the bars draw
+#: from — so "the next tab" is the tab drawn next, in the order it is drawn, and a keyboard
+#: walk and a pointer walk cannot come to disagree about which one that is.
+#:
+#: The commands are `frame/builtins._CHAT_SWITCH` and `_WORKSPACE_SWITCH` respelled here
+#: rather than imported, and the respelling is deliberate: `frame/builtins.py` is a
+#: RENDERER module that a palette process has no other reason to import, and
+#: `tests/test_the_keyboard_walks_the_tab_strips.py` holds the two spellings equal instead.
+_STRIPS = (
+    ("chat", lambda fid: [c.id for c in chats.roster(fid)], lambda fid: fid,
+     ("frame-chat",), chats.ONLY_CHAT),
+    ("workspace", lambda _fid: switch.workspaces(), switch.current_workspace,
+     ("frame-switch", "--workspace"), ONLY_WORKSPACE),
+)
+
+
+def _register_strip(reg: actions.ActionRegistry) -> None:
+    """Four rows that walk the chat and workspace strips — **the keyboard's half.**
+
+    **`frame/builtins._bar_events` states the gap this closes and could not close
+    itself.** A tab bar is a pointer affordance whose only route was a pointer: `key` is in
+    `component.EVENT_KINDS` and deliberately NOT in `events.DELIVERED`, because tmux routes
+    typing to the ACTIVE pane and that pane is the harness the frame exists to protect. So
+    a bar has no keyboard of its own, and `component.EVENT_KINDS` asks for exactly one
+    thing in that situation: *give every pointer affordance a key as well.*
+    :func:`_register_selection` is charter keeping that rule for the repo table; this is
+    charter keeping it for the two strips.
+
+    **It is worth more than the pickers that are already there, and the difference is the
+    gesture rather than the reach.** `F2` → `chat` → a name reaches any chat and is what a
+    narrow frame has instead of a bar at all. What it is not is *the next one*: an operator
+    cycling between two agents pays a pane cycle, a list and a choice each time, to move
+    one step along a strip they can see. These four rows are that step, and they are the
+    only route to it on the planes where `[frame] mouse` is off — which is the shipped
+    default.
+
+    **They are not `repeat=True`, unlike the repo rows, and the difference is what the row
+    does to the surface it was pressed on.** Moving a selection writes two files and leaves
+    the palette standing; a switch moves the CLIENT to another window (or another
+    workspace's session), and the palette's pane is in the window being left. A row that
+    asked to stay open would be asking to stay open somewhere the operator no longer is.
+
+    **The walk is `_walk`'s, the listers are the bars' own, and the commands are the ones
+    a tab click already spawns** — so the keyboard and the pointer cannot come to two
+    different answers about what "the next tab" is or about what happens when you get
+    there, including every refusal `chats.check` and `switch.to_workspace` can raise. That
+    is `_register_selection`'s discipline (`state.record_selection` is the same write the
+    click makes) applied to a strip that is driven from another process.
+
+    **"Nowhere else to go" is reported by the RUN and not by `available`, and that is the
+    palette's own cost promise rather than a preference.**
+    `tests/test_frame_palette_names.TheRosterIsNeverReadUntilSomethingIsTyped` pins that
+    opening the palette reads no roster at all — *`F2` on a plane with forty workspaces
+    costs what it cost with none* — and `available` is asked for every row every time the
+    surface is drawn. An availability that asked `switch.workspaces()` would enumerate the
+    plane on every `F2`, including the ones where the operator opened the palette to
+    detach and never asked a question about names.
+
+    So the walk itself reports it: :func:`_step_strip` starts nothing when the step lands
+    on the tab the frame is already on, and answers the sentence instead. That is exactly
+    the state — a strip of one — and it is read once, on the press, by an operator who
+    asked. `slots._Tabs.switch_to` refuses the same gesture for the pointer, in the same
+    words and for the same reason: re-switching to where you already are is not free.
+
+    **"The step landed where it started" is the whole test, and it is sharper than a
+    count.** `len(names) > 1` reads *is there anywhere to go* as *are there two places*,
+    and those differ on a real state: a frame whose recorded workspace has been deleted is
+    on no name at all, so the one workspace left IS somewhere to send it — and a count
+    would refuse the only row that could.
+    """
+    for noun, names_of, here_of, command, alone in _STRIPS:
+        for word, step, start in _SELECT_STEPS:
+            reg.register(action.Action(
+                id=f"{noun}.{word}", title=f"{noun}: the {word} tab",
+                run=(lambda ctx, n=names_of, h=here_of, c=command, st=step, sr=start,
+                     a=alone: _step_strip(ctx, n, h, c, st, sr, a))))
+
+
+def _step_strip(ctx, names_of, here_of, command, step: int, start: int, alone: str):
+    """Start the switch to the tab *step* along from the one this frame is on.
+
+    Split out of the row above for :func:`_select`'s reason: the arithmetic can then be
+    exercised against a list of names with no palette, no tmux server and no frame
+    directory under it.
+
+    **It STARTS the switch and returns, which is `action.Action.run`'s whole contract and
+    not a shortcut.** A chat switch is 41 tmux invocations and a workspace switch moves a
+    client; both of those outlive the pane the palette is drawn in, and both have refusals
+    that have to reach a surface this process is about to lose. `_spawn` is what every
+    other row that starts real work uses, and it is the same argv a tab click spawns.
+
+    **A step that lands where it started starts nothing and says *alone* instead**, which
+    is the row's refusal arriving on the press rather than on the listing — see
+    :func:`_register_strip` for why it cannot be on the listing. It is the exact test
+    `slots._Tabs.switch_to` applies to a click on the tab you are already on, and it is
+    reached only by a strip of one: from two names or more, one step is never a no-op.
+
+    The sentence it answers with names the tab, so the palette says what it started rather
+    than that it started something — `_select`'s `f"selected {name}"` one strip over.
+    """
+    here = here_of(ctx.fid)
+    name = _walk(list(names_of(ctx.fid)), here, step, start)
+    if name == here:
+        return alone
+    _spawn(util.self_relaunch_argv(*command, name), fid=ctx.fid)
+    return f"{command[0].split('-')[-1]} → {contain.one_line(name)}"
 
 
 #: What a workspace with nothing open is told instead of a row that does nothing.
@@ -592,6 +739,11 @@ def build(fid: str, *, current_density: str,
     reg = actions.ActionRegistry()
     _register_detach(reg)
     _register_selection(reg)
+    # Beside the repo table's own next/previous rather than among the densities, because
+    # they are the same gesture on a different list — an operator who has learned one has
+    # learned all three. Above `_register_todos` for `_register_density`'s stated reason:
+    # the rows pressed by muscle memory sit at the top of a palette nobody has typed into.
+    _register_strip(reg)
     _register_todos(reg)
     _register_density(reg, current=current_density)
     _register_chrome(reg, current=current_chrome)

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -577,6 +577,17 @@ plane declares no `[harness] default`; or charter cannot enter the workspace's d
 workspace is a directory and a *name*, which is `charter workspace create` — and a picker
 that creates on a typo leaves litter.
 
+**You do not need a mouse for the strips either.** `F2` → `chat: the next tab` (and
+`previous`, and the same pair for `workspace`) walks the strip one step, in the order it is
+drawn, running the same command a click on that tab runs. It wraps, so every press moves
+something; a plane with nowhere else to go says so rather than sending you where you
+already are. Those four rows are the only route to *the next one* on a plane with `mouse =
+false`, which is the default — and charter will not bind a bare key to it for the reason
+the repo table's own rows give: a `bind -n` is server-wide and would take the key before
+your harness sees it. Unlike the repo rows they do not leave the palette open, because a
+switch moves your terminal to another window and the palette's pane is in the one you are
+leaving.
+
 **They are tabs: with `mouse = true`, clicking a name switches to it.** A chat tab does
 exactly what `F2` → `chat` does — the same command, the same five refusals, the same
 sentence on your screen when one fires. A **workspace** tab does exactly what `charter
@@ -2083,6 +2094,10 @@ charter · 16 to choose from
     detach — leave the harness running
     repo: select the next row
     repo: select the previous row
+    chat: the next tab
+    chat: the previous tab
+    workspace: the next tab
+    workspace: the previous tab
     todo: read the next open todo
     density: minimal
     density: normal

--- a/docs/news/unreleased-the-tab-strips-have-a-keyboard-route.md
+++ b/docs/news/unreleased-the-tab-strips-have-a-keyboard-route.md
@@ -1,0 +1,53 @@
+---
+version: unreleased
+headline: The chat and workspace strips have a keyboard route — F2, next tab, Enter
+---
+
+The tab bars became clickable, and clicking was the only way to use them. That is backwards
+for charter's own rule, which the frame states to every provider author who might add a
+pointer affordance of their own:
+
+> A component whose only route to a piece of state is a click has no route to it on most
+> planes. **Give every pointer affordance a key as well.**
+
+`[frame] mouse` is off by default, and a bar can never grow a keyboard of its own: tmux
+routes your typing to the *active* pane, and that pane is the harness the frame exists to
+protect. So the keyboard route is where every other one is — the palette.
+
+```
+charter · 20 to choose from
+>   workspace: alpha — pick another
+    detach — leave the harness running
+    repo: select the next row
+    repo: select the previous row
+    chat: the next tab                 <- new
+    chat: the previous tab             <- new
+    workspace: the next tab            <- new
+    workspace: the previous tab        <- new
+```
+
+`F2`, type `next`, Enter. It walks the strip **one step in the order the strip is drawn**,
+running the same command a click on that tab runs — the same switch, the same refusals, the
+same sentence on your own screen when one fires. It wraps, so every press moves something.
+
+**Why it beats the picker that was already there.** `F2` → `chat` → a name reaches any chat
+at any width, and is what a narrow frame has instead of a bar at all. What it is not is *the
+next one*: cycling between two agents cost a pane cycle, a list and a choice each time, to
+move one step along a strip you can see.
+
+**They do not leave the palette open, unlike the repo table's own next/previous.** Those
+move a selection and write two files. These move your *terminal* to another window, and the
+palette's pane is in the window you are leaving — a row that stayed open would be staying
+open somewhere you no longer are.
+
+**A strip of one tells you when you press it, not before.** Opening the palette reads no
+roster at all — that is a promise charter keeps so `F2` on a plane with forty workspaces
+costs what it costs with none — and "is there anywhere else to go" cannot be answered
+without reading one. So the row is always offered, and a press on a plane with a single chat
+or a single workspace says so and starts nothing, rather than spending a pane cycle to
+arrive where you already were. It is the same rule a click on the tab you are on already
+follows.
+
+One thing this is *not*: a bare key. Charter will not bind `Alt-]` or an arrow to this, for
+the reason the repo table's own rows already give — a `bind -n` is server-wide in tmux, with
+no per-window form, so it would take that key before your harness ever sees it.

--- a/tests/test_the_keyboard_walks_the_tab_strips.py
+++ b/tests/test_the_keyboard_walks_the_tab_strips.py
@@ -1,0 +1,351 @@
+"""`chat: the next tab` and its three siblings — the keyboard's half of the two strips.
+
+**The gap these close is stated in the code they are the answer to.**
+`frame/builtins._bar_events` argues at length that a tab bar switches where the repo table
+only selects, and one of its three reasons is that nothing could ever finish a two-step
+gesture on a bar: `key` is in `component.EVENT_KINDS` and deliberately **not** in
+`events.DELIVERED`, because tmux routes typing to the ACTIVE pane and that pane is the
+harness the frame exists to protect. So a bar has no keyboard of its own — and
+`component.EVENT_KINDS` asks for exactly one thing in that situation: *give every pointer
+affordance a key as well.* `builtin_actions._register_selection` is charter keeping that
+rule for the repo table. These four rows are charter keeping it for the two strips.
+
+**Why they are worth more than the pickers already there.** `F2` → `chat` → a name reaches
+any chat at any width and is what a narrow frame has instead of a bar at all. What it is
+not is *the next one*: an operator cycling between two agents pays a pane cycle, a list and
+a choice to move one step along a strip they can see. And on the planes where `[frame]
+mouse` is off — the shipped default — these rows are the only route to that step at all.
+
+**What is asserted here and what is asserted elsewhere.** The walk, the wrap, the two
+starts and the argv are here. That the argv reaches a real chat switch through a real tmux
+is `tests/test_frame_chat_switch.py`'s and `tests/test_a_real_click_on_a_real_tab_bar
+_switches.py`'s — these rows spawn the command a tab click already spawns, which is the
+one property that keeps a keyboard walk and a pointer walk from teaching two answers.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import config, util
+from charter.frame import action as faction
+from charter.frame import builtin_actions, builtins, chats, state, switch
+
+from tests._isolation import PersonaIso
+from tests.test_frame_chat_switch import _plant
+
+FID = "api.2"
+
+
+class _AStripAKeyboardCanWalk(PersonaIso, unittest.TestCase):
+    """Three chats in `api`, three workspaces on the plane, and a fake `_spawn`."""
+
+    CHATS = ("api.1", "api.2", "api.3")
+
+    #: Made on top of whatever `PersonaIso` scaffolds, which is why the cases below read
+    #: `switch.workspaces()` rather than this tuple: a plane always has a `default`, so a
+    #: case that assumed its own three would be asserting about a list charter does not
+    #: return. `_plant` also makes an `api` directory for the chats.
+    WORKSPACES = ("alpha", "beta", "gamma")
+
+    def setUp(self):
+        super().setUp()
+        # **`$CHARTER_WORKSPACE` is deliberately EMPTY.** It pins which workspace this
+        # process draws (`state.workspace_for`'s first rung), and a fixture that set one
+        # would answer half of every case here for charter: `switch.current_workspace`
+        # would come back from the environment rather than from the record, so the walk
+        # would start from a name that is not on the strip at all — which is a real state
+        # (`test_a_frame_on_no_tab_at_all_…`) and must be the case that measures it, not
+        # the fixture. `tests/test_a_real_click_on_a_real_tab_bar_switches.py` empties it
+        # for the same reason.
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""},
+                                          clear=False))
+        for chat in self.CHATS:
+            _plant(chat, workspace="api")
+        for name in (*self.WORKSPACES, "api"):
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        # **One record answers both strips, and that is charter's shape rather than this
+        # fixture's shortcut.** `chats.roster` asks "which workspace is this frame
+        # drawing" and `switch.current_workspace` asks the same question — both go through
+        # `state.workspace_for` — so the chat strip is `api`'s chats and the workspace
+        # strip starts at `api`. A fixture that recorded a second workspace for this frame
+        # to make the workspace cases read prettily would be testing a state charter
+        # cannot be in.
+        self.here = "api"
+        self.spawned: list = []
+        self.enterContext(mock.patch(
+            "charter.frame.builtin_actions._spawn",
+            side_effect=lambda argv, *, fid: self.spawned.append((argv, fid))))
+
+    def _reg(self):
+        return builtin_actions.build(FID, current_density="normal", current_chrome="off")
+
+    def _run(self, aid: str, fid: str = FID):
+        a = self._reg().get(aid)
+        return a.run(faction.build(a.touches, fid=fid, snapshot={}))
+
+    def _offer(self, aid: str):
+        return next(o for o in self._reg().offers(fid=FID, snapshot={}) if o.id == aid)
+
+
+class TheFourRowsAreThere(_AStripAKeyboardCanWalk):
+    """The listing — two nouns, two directions, in the order the palette shows them."""
+
+    def test_both_strips_offer_both_directions(self):
+        rows = [(a.id, a.title) for a in self._reg().all()
+                if a.id.startswith(("chat.next", "chat.previous",
+                                    "workspace.next", "workspace.previous"))]
+        self.assertEqual(rows, [("chat.next", "chat: the next tab"),
+                                ("chat.previous", "chat: the previous tab"),
+                                ("workspace.next", "workspace: the next tab"),
+                                ("workspace.previous", "workspace: the previous tab")])
+
+    def test_they_sit_beside_the_repo_tables_own_next_and_previous(self):
+        """The same gesture on a different list, so an operator who has learned one has
+        learned all three — and they are above the densities, which
+        `_register_density` records must stay where muscle memory left them."""
+        ids = [a.id for a in self._reg().all()]
+        self.assertLess(ids.index("repo.previous"), ids.index("chat.next"))
+        self.assertLess(ids.index("workspace.previous"), ids.index("density.minimal"))
+
+    def test_none_of_them_keeps_the_palette_open(self):
+        """**Unlike the repo rows, and the difference is what the row does to the surface
+        it was pressed on.** Moving a selection writes two files and leaves the palette
+        standing; a switch moves the CLIENT to another window, and the palette's pane is in
+        the window being left. A row that asked to stay open would be asking to stay open
+        somewhere the operator no longer is."""
+        for aid in ("chat.next", "chat.previous",
+                    "workspace.next", "workspace.previous"):
+            with self.subTest(aid=aid):
+                self.assertFalse(self._reg().get(aid).repeat)
+        self.assertTrue(self._reg().get("repo.next").repeat,
+                        "the control failed — nothing in this palette repeats")
+
+
+class AWalkStartsTheSwitchATabClickStarts(_AStripAKeyboardCanWalk):
+    """What each row spawns, and that it is the same argv the pointer half spawns."""
+
+    def test_the_next_chat_is_the_one_drawn_next(self):
+        self._run("chat.next")
+        self.assertEqual(self.spawned,
+                         [(util.self_relaunch_argv("frame-chat", "api.3"), FID)])
+
+    def test_the_previous_chat_is_the_one_drawn_before(self):
+        self._run("chat.previous")
+        self.assertEqual(self.spawned,
+                         [(util.self_relaunch_argv("frame-chat", "api.1"), FID)])
+
+    def test_the_next_workspace_is_the_one_drawn_next(self):
+        """The name after this frame's own, in `switch.workspaces()`' order — which is the
+        order the `workspaces` bar draws, asked of the same function so the two cannot
+        disagree. Read off that list rather than spelled, because a plane always carries a
+        `default` this fixture did not make."""
+        names = switch.workspaces()
+        want = names[names.index(self.here) + 1]
+        self._run("workspace.next")
+        self.assertEqual(
+            self.spawned,
+            [(util.self_relaunch_argv("frame-switch", "--workspace", want), FID)])
+
+    def test_the_previous_workspace_is_the_one_drawn_before(self):
+        names = switch.workspaces()
+        want = names[names.index(self.here) - 1]
+        self._run("workspace.previous")
+        self.assertEqual(self.spawned[0][0][-1], want)
+
+    def test_it_starts_exactly_what_a_tab_click_starts(self):
+        """**One switch, two front doors**, and the property that keeps them one: the
+        keyboard row and the pointer handler spawn byte-identical argv. A row that
+        assembled its own would be a second answer to how a switch is performed, and the
+        two would drift the day either grew an option — which is the shape
+        `slots.drawable` exists to stop for a different question.
+
+        The pointer half is driven through the REAL registry rather than through
+        `_bar_events` directly, so this also says the component is still wired.
+        """
+        self._run("chat.next")
+        by_keyboard = self.spawned.pop()
+        row = builtins.build(FID).get("chats").on_event
+        from charter.frame import overlay, slots
+        slots.chats_bar(FID, 200)
+        col = next(c for c in range(200) if slots.TABS.switch_to(c) == "api.3")
+        row(overlay.Event(overlay.CLICK, "left", row=0, col=col, pressed=True))
+        self.assertEqual(by_keyboard, self.spawned.pop())
+
+    def test_the_two_commands_are_the_ones_the_bars_handler_holds(self):
+        """`_STRIPS` respells `builtins._CHAT_SWITCH` and `_WORKSPACE_SWITCH` rather than
+        importing them — `frame/builtins.py` is a RENDERER module a palette process has no
+        other reason to load. This is the assertion that stands in for the import, so the
+        two spellings cannot drift apart in silence."""
+        spellings = {noun: command for noun, _n, _h, command, _a
+                     in builtin_actions._STRIPS}
+        self.assertEqual(spellings["chat"], builtins._CHAT_SWITCH)
+        self.assertEqual(spellings["workspace"], builtins._WORKSPACE_SWITCH)
+
+    def test_the_row_says_which_tab_it_started_for(self):
+        """`_select`'s `selected <name>` one strip over: the palette says what it started
+        rather than that it started something."""
+        self.assertIn("api.3", str(self._run("chat.next")))
+        self.assertIn("api.1", str(self._run("chat.previous")))
+
+    def test_the_child_is_told_which_frame_it_is(self):
+        """`_spawn`'s `fid=` is the child's own `$CHARTER_SESSION_ID`. One tmux server is
+        shared by every frame on the machine, so a child left to read that out of an
+        inherited environment can act on somebody else's frame."""
+        self._run("chat.next")
+        self.assertEqual([fid for _argv, fid in self.spawned], [FID])
+
+
+class TheWalkWrapsAndStartsWhereTheDirectionCameFrom(_AStripAKeyboardCanWalk):
+    """`_walk` — the arithmetic, shared with the repo table's own two rows."""
+
+    def test_next_from_the_last_tab_wraps_to_the_first(self):
+        """**Wrapping rather than stopping**, which is `_register_selection`'s decision
+        unchanged: a row that visibly does nothing reads as broken and costs the operator a
+        whole `F2` to find out."""
+        self._run("chat.next", fid="api.3")
+        self.assertEqual(self.spawned[0][0][-1], "api.1")
+
+    def test_previous_from_the_first_tab_wraps_to_the_last(self):
+        self._run("chat.previous", fid="api.1")
+        self.assertEqual(self.spawned[0][0][-1], "api.3")
+
+    def test_a_frame_on_no_tab_at_all_enters_from_the_end_the_direction_came_from(self):
+        """The workspace bar draws this state for a frame whose recorded workspace has
+        been deleted. `next` must land on the first name and `previous` on the last — one
+        sentinel for both was the first version of the repo walk and was wrong, and this
+        is that decision reaching a second list."""
+        state.record_workspace(FID, "nowhere-at-all")
+        names = switch.workspaces()
+        self._run("workspace.next")
+        self._run("workspace.previous")
+        self.assertEqual([argv[-1] for argv, _fid in self.spawned],
+                         [names[0], names[-1]])
+
+    def test_the_repo_table_walks_by_the_same_function(self):
+        """One walk, three callers — so the palette cannot teach two different answers to
+        "what does next mean". Asserted by exercising `_walk` directly on both shapes of
+        list rather than by reading the source."""
+        for step, start, want in ((1, -1, "b"), (-1, 0, "c")):
+            with self.subTest(step=step):
+                self.assertEqual(
+                    builtin_actions._walk(["a", "b", "c"], "a", step, start), want)
+                self.assertEqual(
+                    builtin_actions._walk(["a", "b", "c"], "gone", step, start),
+                    "a" if step > 0 else "c")
+
+
+class AStripWithNowhereElseToGoSaysSo(_AStripAKeyboardCanWalk):
+    """A strip of one — reported by the RUN, not by `available`.
+
+    **The palette's own cost promise is why.**
+    `test_frame_palette_names.TheRosterIsNeverReadUntilSomethingIsTyped` pins that opening
+    the palette reads no roster at all — *`F2` on a plane with forty workspaces costs what
+    it cost with none* — and `available` is asked for every row every time the surface is
+    drawn. So a row that could only answer by enumerating the plane does not answer until
+    it is pressed, by an operator who asked.
+
+    The test is "did the step land where it started", which is sharper than a count and is
+    the same one `slots._Tabs.switch_to` applies to a click on the tab you are on.
+    """
+
+    def test_a_workspace_with_one_chat_says_so_and_starts_nothing(self):
+        """A row that wrapped to the chat the operator is already in would spend a whole
+        pane cycle arriving nowhere — which `slots._Tabs.switch_to` refuses for the
+        pointer, in as many words."""
+        for chat in ("api.2", "api.3"):
+            _plant(chat, workspace="other")
+        self.assertEqual(chats.of_workspace("api"), ["api.1"])
+        state.record_workspace("api.1", "api")
+        for aid in ("chat.next", "chat.previous"):
+            with self.subTest(aid=aid):
+                self.assertEqual(self._run(aid, fid="api.1"), chats.ONLY_CHAT)
+        self.assertEqual(self.spawned, [], "a strip of one started a switch")
+
+    def test_opening_the_palette_still_reads_no_workspace_roster(self):
+        """**The promise these rows must not break**, asserted where they could break it:
+        `available` runs for every row on every draw, so an availability that asked
+        `switch.workspaces()` would enumerate the plane on every `F2` — including the ones
+        opened to detach, where the operator asked no question about names at all.
+
+        Asked by counting calls rather than by reading the source, so a future edit that
+        moves the read into a helper is caught too.
+        """
+        with mock.patch.object(switch, "workspaces",
+                               side_effect=switch.workspaces) as ws:
+            self._reg().offers(fid=FID, snapshot={})
+        self.assertEqual(ws.call_count, 0,
+                         "drawing the palette enumerated this plane's workspaces")
+
+    def _leave_one_workspace(self) -> str:
+        """Every workspace directory gone, which leaves exactly one name.
+
+        `switch.workspaces()` folds `config.DEFAULT_WORKSPACE` in whether or not its
+        directory exists — a fresh plane that has never made one would otherwise offer an
+        empty list — so deleting everything is what a plane with one workspace IS, and the
+        one that survives is `default`. Deleting a hand-written pair by name was the first
+        version and left `default` and `api` standing, so the rows stayed available and
+        the case passed for the wrong reason.
+
+        The frame is then put ON that survivor, because the row is refused for having
+        nowhere ELSE to go — a frame on a workspace that no longer exists has somewhere to
+        go and is a case of its own.
+        """
+        for d in sorted(config.WORKSPACES_DIR.iterdir()):
+            for path in sorted(d.rglob("*"), reverse=True):
+                path.rmdir() if path.is_dir() else path.unlink()
+            d.rmdir()
+        self.assertEqual(switch.workspaces(), [config.DEFAULT_WORKSPACE],
+                         switch.workspaces())
+        state.record_workspace(FID, config.DEFAULT_WORKSPACE)
+        return config.DEFAULT_WORKSPACE
+
+    def test_a_plane_with_one_workspace_says_so_and_starts_nothing(self):
+        self._leave_one_workspace()
+        for aid in ("workspace.next", "workspace.previous"):
+            with self.subTest(aid=aid):
+                self.assertEqual(self._run(aid), builtin_actions.ONLY_WORKSPACE)
+        self.assertEqual(self.spawned, [], "a plane of one workspace started a switch")
+
+    def test_the_refusal_names_the_way_out(self):
+        """`NO_REPOS`' rule: a refusal that names no way out is a row an operator reads
+        once and never again."""
+        self.assertIn("charter workspace create", builtin_actions.ONLY_WORKSPACE)
+        self.assertIn("charter <harness>", chats.ONLY_CHAT)
+
+    def test_a_frame_on_a_workspace_that_is_gone_is_still_offered_the_one_that_is_not(self):
+        """**Where a count gets it wrong.** `len(names) > 1` reads "is there anywhere to
+        go" as "are there two places", and those differ on exactly this state: a frame
+        whose recorded workspace has been deleted is on no name at all, so the one
+        remaining workspace IS somewhere to send it — and a count would refuse the only
+        row that could. The workspace bar draws this state; `slots._bar` has its own case
+        for it."""
+        self._leave_one_workspace()
+        state.record_workspace(FID, "deleted-out-from-under-this-frame")
+        self._run("workspace.next")
+        self.assertEqual([argv[-1] for argv, _fid in self.spawned],
+                         [config.DEFAULT_WORKSPACE])
+
+    def test_a_plane_with_several_of_each_starts_all_four(self):
+        """The control. Every case above is a negative, and a walk that started nothing
+        ever would satisfy all of them."""
+        for aid in ("chat.next", "chat.previous",
+                    "workspace.next", "workspace.previous"):
+            with self.subTest(aid=aid):
+                self.spawned.clear()
+                self.assertNotIn("one chat", str(self._run(aid)))
+                self.assertEqual(len(self.spawned), 1)
+
+    def test_every_row_is_offered_whatever_the_plane_holds(self):
+        """The other side of the cost promise: these four are never hidden, because
+        hiding them is what would cost the read. An operator who presses one on a strip of
+        one is told; an operator who never presses one pays nothing."""
+        self._leave_one_workspace()
+        for chat in ("api.2", "api.3"):
+            _plant(chat, workspace="other")
+        offered = {o.id: o.available for o in self._reg().offers(fid=FID, snapshot={})}
+        for aid in ("chat.next", "chat.previous",
+                    "workspace.next", "workspace.previous"):
+            self.assertTrue(offered[aid], aid)

--- a/tests/test_the_keyboard_walks_the_tab_strips.py
+++ b/tests/test_the_keyboard_walks_the_tab_strips.py
@@ -179,16 +179,25 @@ class AWalkStartsTheSwitchATabClickStarts(_AStripAKeyboardCanWalk):
         importing them — `frame/builtins.py` is a RENDERER module a palette process has no
         other reason to load. This is the assertion that stands in for the import, so the
         two spellings cannot drift apart in silence."""
-        spellings = {noun: command for noun, _n, _h, command, _a
-                     in builtin_actions._STRIPS}
+        spellings = {s.noun: s.command for s in builtin_actions._STRIPS}
         self.assertEqual(spellings["chat"], builtins._CHAT_SWITCH)
         self.assertEqual(spellings["workspace"], builtins._WORKSPACE_SWITCH)
 
     def test_the_row_says_which_tab_it_started_for(self):
         """`_select`'s `selected <name>` one strip over: the palette says what it started
-        rather than that it started something."""
-        self.assertIn("api.3", str(self._run("chat.next")))
-        self.assertIn("api.1", str(self._run("chat.previous")))
+        rather than that it started something.
+
+        **In the plane's own `<noun> → <name>` vocabulary**, which is what
+        `commands_frame._say_on_screen` says for every other switch (`persona → zeb`). The
+        noun comes off `_Strip` rather than out of the argv: `frame-switch --workspace`
+        would have made the workspace row report `switch → gamma`, which names a verb
+        where every other line on the plane names a noun.
+        """
+        self.assertEqual(self._run("chat.next"), "chat → api.3")
+        self.assertEqual(self._run("chat.previous"), "chat → api.1")
+        names = switch.workspaces()
+        want = names[names.index(self.here) + 1]
+        self.assertEqual(self._run("workspace.next"), f"workspace → {want}")
 
     def test_the_child_is_told_which_frame_it_is(self):
         """`_spawn`'s `fid=` is the child's own `$CHARTER_SESSION_ID`. One tmux server is


### PR DESCRIPTION
Replaces #818, whose base was `plus-makes-a-chat` — a branch that is not on `main`, and stale enough that merging it would have reverted #819, #820, #821 and #823. This is the same three commits cherry-picked onto `origin/main` at `6e89277`, with base **main**.

**It is independent of the `+` work and no longer chained to it.** The one cherry-pick conflict was in `docs/frame.md`, where the diff context dragged in #825's `+` paragraphs; those were dropped and only this branch's own paragraph kept. So this can merge before, after, or without #825.

The check that matters, in the **three-dot** form — see the correction note at the bottom:

```
$ git diff --stat origin/main...strip-keyboard-on-main
 4 files changed, 627 insertions(+), 4 deletions(-)
$ git diff --diff-filter=D --name-only origin/main...strip-keyboard-on-main
 (empty — no file deleted)
```

All four files are ones this branch wrote or edited.

---

The tab bars became clickable in #815, and clicking was the only way to use them. That is backwards for the rule charter states to every provider author who might add a pointer affordance of their own, in `component.EVENT_KINDS`:

> A component whose only route to a piece of state is a click has no route to it on most planes. **Give every pointer affordance a key as well.**

`[frame] mouse` is off by default, and a bar can never grow a keyboard of its own — `key` is in `EVENT_KINDS` and deliberately not in `events.DELIVERED`, because tmux routes typing to the *active* pane and that pane is the harness the frame exists to protect. `builtin_actions._register_selection` is charter keeping that rule for the repo table. These four rows are charter keeping it for the two strips.

```
    repo: select the next row
    repo: select the previous row
    chat: the next tab                 <- new
    chat: the previous tab             <- new
    workspace: the next tab            <- new
    workspace: the previous tab        <- new
```

Each walks the strip **one step in the order the strip is drawn**, wrapping, and spawns the argv a click on that tab already spawns — so the keyboard and the pointer cannot come to two answers about what "the next tab" is, or about what happens on arrival, refusals included. `_walk` is factored out of `_select` so the repo table and the two strips walk by one function.

## Three decisions worth the paragraph

**They do not keep the palette open, unlike the repo rows.** Those move a selection and write two files. These move your *terminal* to another window, and the palette's pane is in the window being left.

**"Nowhere else to go" is reported by the RUN, not by `available`.** `test_frame_palette_names.TheRosterIsNeverReadUntilSomethingIsTyped` pins that opening the palette reads no roster at all — *`F2` on a plane with forty workspaces costs what it cost with none* — and `available` is asked for every row on every draw. So the walk reports it: a step landing where it started starts nothing and says the sentence instead. A new case asserts the palette still reads no workspace roster, so this cannot be reintroduced quietly.

**That test is also sharper than a count.** `len(names) > 1` reads *is there anywhere to go* as *are there two places*, and those differ on a real state: a frame whose recorded workspace has been deleted is on no name at all, so the one workspace left **is** somewhere to send it.

## What the sweep caught

`6 survivors` on the first round; five were the `+` branch's lines, charged here because the diff is measured against `main`. The sixth was this branch's own: `contain.one_line(name)` in the strip walk, a **triply masked** call — the receipt is contained by the contract (`Invocation._work`), and both surfaces contain it again. This file had already settled the identical question twice (`_regather`, `_select`). Deleted, with the import that came with it.

Re-reading separately caught the walk reporting `switch → gamma`, naming a verb where every other line on the plane names a noun; `_STRIPS` is a `_Strip` record now and the noun comes off it.

## Verification

- Full suite green; targeted 209 tests green on this rebased branch.
- Mutation-checked: no wrap, one start for both directions, the two commands swapped, a count for availability, no spawn, a flipped step, dropping the strip-of-one report, and deriving the note from the argv — each turns the suite red.
- The two argv spellings are held equal to `builtins._CHAT_SWITCH` / `_WORKSPACE_SWITCH` by a case, since `_STRIPS` respells rather than imports them.

---

## Correction: the "it would revert other people's work" claim was wrong

An earlier version of this description said the branch this replaces would have reverted #819/#820/#821/#823, on the strength of a **two-dot** `git diff --stat origin/main <branch>` showing ~2900 deletions. **That was an artifact and the claim was false.**

Two dots compares *tips*. A branch merely behind main is charged for every file main gained since the merge base, as though merging it would delete them — but a merge applies `merge-base..head`, not `tip..tip`. Measured on the branch in question:

```
$ git diff --stat            origin/main..origin/tabs-strip   ->  40 files, 1522+, 4023-
$ git diff --stat            origin/main...origin/tabs-strip  ->  16 files, 2539+,  112-
$ git diff --diff-filter=D --name-only origin/main...origin/tabs-strip  ->  (empty)
```

Nothing would have been reverted. The tell is that the two-dot deletion count *grew* from 2936 to 4023 while nothing on the branch changed — main had simply moved on. **Use three dots for this assertion**; two dots answers a different question.

What was *not* wrong, and is why this rework still stands: the content genuinely was not on main — `git merge-base --is-ancestor <merge sha> origin/main` answered NO, and the new code was absent from `origin/main`. Cutting a fresh branch and cherry-picking only my own commits was also the better call than rebasing regardless: it is why #826 came out independent of #825, which a rebase would have buried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ctfuhnX3LdXbtx3SMUvTu
