### PR TITLE
Two survivors the issue never named, found by re-running the operators (#810)

### DIFF
--- a/docs/news/unreleased-the-branch-not-taken-is-still-a-promise.md
+++ b/docs/news/unreleased-the-branch-not-taken-is-still-a-promise.md
@@ -84,4 +84,24 @@ refuses the same value the writer does, a manifest read back through a function 
 the empty frame it was about to prove, a workspace ordering that happened to agree with the
 chat ordinals. Every one of those is now a case whose fixture disagrees on purpose.
 
+## And two survivors nobody had named
+
+#810's own author warned that a survivor list is *a union across runs, not a snapshot*, so
+the sweep's operators were re-run over these functions on today's file rather than the
+issue's list being worked as gospel. **116 mutations over the 30 functions groups A and B
+are about**, and two of them were survivors the issue never mentions:
+
+- **`.decode("utf-8", "ignore")` on the transcript cut.** The byte cut is taken from the
+  end, so the only edge it can land inside is the leading one — and every existing case
+  builds its capture out of characters whose byte length divides the cap evenly, so the cut
+  always landed on a boundary and the handler was never read. A capture one byte off that
+  boundary now pins it: the partial character is dropped rather than written as a `U+FFFD`
+  the pager would show as noise.
+- **`state.record_cwd`'s `if d is None` guard.** #810 named this function's `except OSError`
+  and not the refusal two lines above it. The value is a chat id off the manifest, and what
+  it records is the directory a later reopen will `os.chdir` into.
+
+With both closed, those 116 mutations leave **one** survivor: the `strip` pair above, which
+is the same program.
+
 Nothing to adopt.

--- a/tests/test_the_branch_not_taken_is_still_a_promise.py
+++ b/tests/test_the_branch_not_taken_is_still_a_promise.py
@@ -775,6 +775,43 @@ class TheCaptureRefusesAServerThatSaidNothing(PersonaIso):
 
         self.assertFalse(dest.exists())
 
+    def test_a_cut_that_lands_inside_a_character_drops_it_rather_than_mangling_it(self):
+        """`.decode("utf-8", "ignore")`, and **this one is not on #810's list.**
+
+        It was found by re-running the sweep's own operators over these functions rather
+        than working the issue's survivor list, which is what its author asked for: *a
+        survivor list is a union across runs, not a snapshot.*
+
+        The byte cut is taken from the END, so the only edge it can land inside is the
+        LEADING one — and every existing case builds its capture out of characters whose
+        byte length divides the cap evenly, so the cut always landed on a boundary and the
+        handler was never read. (`str.decode` looks an error handler up lazily, exactly
+        like `str.encode`: a re-tuned name is a `LookupError` only when a decode actually
+        fails.)
+
+        This capture is one byte off that boundary, so the slice begins on a continuation
+        byte. What `ignore` buys is that the partial character is DROPPED rather than
+        written as a `U+FFFD` the pager would show as noise — which is the sentence the
+        comment above the line already makes and nothing measured.
+        """
+        cap = commands_frame._TRANSCRIPT_BYTES
+        text = "é" * cap + "x"          # 2·cap + 1 bytes, so the cut lands mid-character
+        raw = text.encode("utf-8")
+        self.assertTrue(0x80 <= raw[len(raw) - cap] < 0xC0,
+                        "or this case is not about a cut inside a character")
+        dest = reopen.transcript_path("alpha.1")
+        answer = SimpleNamespace(returncode=0, stdout=text, stderr="")
+
+        with mock.patch.object(commands_frame.tmuxctl, "run", return_value=answer):
+            self.assertTrue(commands_frame._capture_transcript(
+                commands_frame.SOCKET, "%1", dest))
+
+        got = dest.read_text()          # would raise if half a character were written
+        self.assertNotIn("\ufffd", got, "dropped, not replaced with a noise glyph")
+        self.assertTrue(got.startswith("é"))
+        self.assertTrue(got.endswith("x"))
+        self.assertLessEqual(len(dest.read_bytes()), cap)
+
     def test_a_capture_with_something_in_it_keeps_its_surrounding_blank_lines(self):
         """The other half of the same call, and the reason it is `strip()` on the TEST and
         not on the text: what is written is `out.stdout`, whitespace and all."""
@@ -923,6 +960,19 @@ class AChatIdCharterCannotResolveWritesAndReadsNothing(PersonaIso):
 
         self.assertEqual(sorted(p.name for p in state._root().iterdir()), before,
                          "nothing was created outside, and nothing inside either")
+
+    def test_a_name_that_cannot_be_a_directory_records_no_cwd(self):
+        """`state.record_cwd`'s own `if d is None` — **also not on #810's list**, and found
+        the same way: the issue named this function's `except OSError` and not the guard
+        two lines above it. The value is a chat id off the manifest, and what it records is
+        the directory a later reopen will `os.chdir` into."""
+        before = sorted(p.name for p in state._root().iterdir())
+
+        for bad in ("../elsewhere", "", "a/b", "."):
+            self.assertIsNone(state.record_cwd(bad, "/some/where"), repr(bad))
+            self.assertIsNone(state.chat_cwd(bad), repr(bad))
+
+        self.assertEqual(sorted(p.name for p in state._root().iterdir()), before)
 
     def test_a_name_that_cannot_be_a_directory_reads_as_not_closed(self):
         for bad in ("../elsewhere", "", "a/b", "."):


### PR DESCRIPTION
The tail of #810, and it exists because the issue's own warning turned out to be right:
**a survivor list is a union across runs, not a snapshot.**

Rather than re-running the full 225-mutation sweep of #796's diff — hours, and most of it
already answered by #820, #823 and #824 — `tools/sweep.mutations_for` was run over exactly
the **30 functions groups A and B are about**: 10 in `commands_frame.py`, 4 in
`frame/reopen.py`, 12 in `frame/leave.py`, 4 in `frame/state.py`. Every mutation it offered
was applied one at a time. **116 mutations.** Two were survivors #810 does not name.

## `.decode("utf-8", "ignore")` on the transcript cut

The byte cut is taken from the **end**, so the only edge it can land inside is the leading
one — and every existing case builds its capture out of characters whose byte length divides
the cap evenly (`"x" * cap`, `"é" * cap`), so the cut always landed on a character boundary
and the handler was never read.

That is the same laziness this issue's group C turned up on the encode side: `str.decode`
looks an error handler up only when a decode actually fails, so a re-tuned name is a
`LookupError` on some inputs and invisible on all the others.

A capture one byte off that boundary pins it, and the assertion is the sentence the comment
above the line already makes and nothing measured:

> the only place a byte cut can land inside a character is the leading edge, and a partial
> character there is dropped rather than written as a replacement glyph the pager would show
> as noise

`ignore` → `replace` reddens too, so what is pinned is the **handler** and not merely the
fact that one was named.

## `state.record_cwd`'s `if d is None` guard

#810 lists that function's `except OSError` and not the refusal two lines above it. The
value is a chat id off the manifest — a plain file that outlives the process and can be
older than the charter reading it — and what it records is the directory a later reopen will
`os.chdir` into. `frame_dir` answers `None` for a name `contain.child` refuses; every
existing case hands it an id charter minted.

## Where that leaves the 116

With these two closed and #823 in, those 116 mutations leave **one** survivor:

```
charter/commands_frame.py:7975 [swap-synonym] 'out.stdout.strip' -> 'out.stdout.lstrip'
```

which is the same program — `s.strip()` is empty **iff** `s.lstrip()` is empty, so inside a
truthiness test the mutation asks nothing. Measured on a throwaway branch carrying both test
modules. That one is reported in #824 rather than covered by a test that would pass either
way; the place to fix it is `tools/sweep.indistinguishable`, and #655's bar for adding a rule
there means it deserves its own change.

## Verification

Tests and a news paragraph only — no production code. Three mutations applied by hand
(`ignore` → a re-tuned name, `ignore` → `replace`, and `drop-if` on the `frame_dir` guard);
three reds. 139 tests across this module, `test_a_filesystem_that_refuses_costs_what_it_says`,
`test_claims`, `test_news` and `test_news_gate`: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ctfuhnX3LdXbtx3SMUvTu
