### PR TITLE
A byte charter cannot decode is one odd character, not a traceback out of a quit (#828)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8062,6 +8062,16 @@ def _capture_transcript(socket: str, pane_id: str, dest) -> bool:
     # edge, and a partial character there is dropped rather than written as a replacement
     # glyph the pager would show as noise. It is also cheaper than what it replaces — one
     # encode rather than an encode for the length plus a slice.
+    #
+    # The `"replace"` on the ENCODE is a floor rather than a live handler, and it is coupled
+    # to one line in another module: `tmuxctl.DECODE_ERRORS`. That decode substitutes U+FFFD,
+    # which encodes, so nothing this function can be handed today is unencodable — the only
+    # string that would be is one holding a lone surrogate, which is what `surrogateescape`
+    # there would produce. Deliberately kept and pinned (#810 group C,
+    # `tests/test_what_a_quit_says_is_spelled_where_it_is_asserted
+    # .ACaptureCharterCannotEncodeStillLands`) because a quit is the one path that cannot
+    # afford a raise: §4e writes the manifest before anything is stopped, and the operator
+    # has already asked for the plane to be recorded.
     text = text.encode("utf-8", "replace")[-_TRANSCRIPT_BYTES:].decode("utf-8", "ignore")
     try:
         config.write_for(dest, text)

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -530,18 +530,33 @@ COULD_NOT_RUN = 127
 #: end badly (#828). `text=True` with no `errors=` decodes the pipe **strictly**, so a child
 #: whose output is not valid UTF-8 raised `UnicodeDecodeError` — a `ValueError`, which
 #: neither :func:`run`'s `TimeoutExpired` clause nor its `OSError` one catches — out of the
-#: one function documented as never raising. The sharp caller is
-#: `commands_frame._capture_transcript`, which runs `capture-pane` over a HARNESS pane at
-#: the moment §4e has promised to record the plane and is about to kill it: arbitrary bytes
-#: a coding agent printed, read on the one path that cannot afford a traceback. Its own
-#: `False`-for-everything contract could not help, because the raise happens before it has
-#: an answer to branch on.
+#: one function documented as never raising.
+#:
+#: **Which tmux output can do that, measured on 3.7c rather than reasoned about.** #828
+#: files the sharp caller as `commands_frame._capture_transcript`, reading a HARNESS pane
+#: during a quit, on the grounds that a pane holds arbitrary bytes. It does not reach
+#: charter that way: under `LANG=C.UTF-8` and again under `LC_ALL=C`, a pane that prints
+#: `\377` is stored in tmux's own screen as U+FFFD, and `capture-pane -p -e -N` hands back
+#: valid UTF-8. tmux sanitises it first. Two other paths do reach charter, both measured on
+#: the same binary:
+#:
+#: * A tmux USER OPTION round-trips its bytes untouched — `set-option -w @charter_chat` with
+#:   a raw `\377` in it comes back out of ``list-windows -a -F '#{@charter_chat}'`` and out
+#:   of `display-message -p` exactly as it went in. That listing is
+#:   `commands_frame._chat_seats`, which `cmd_quit` asks BEFORE it kills anything, so the
+#:   raise does land in a quit — one call to the left of where the issue put it. §3.3 is why
+#:   it is not hypothetical: one tmux server serves every plane on the machine, so charter
+#:   reads windows it did not create.
+#: * tmux's own stderr echoes the raw bytes of an argument it refuses (`invalid window name:
+#:   BAD\377NAME`), which is :func:`report_failure`'s input — so the decode could take
+#:   charter down while it was REPORTING a failure.
 #:
 #: **Not a third invented return code beside :data:`TIMED_OUT`.** Those two say *charter
-#: never got an answer*. Here tmux answered — rc 0, the whole capture — and only charter
+#: never got an answer*. Here tmux answered — rc 0, the whole listing — and only charter
 #: could not read one byte of it. Reporting that as a refusal would name tmux in a failure
-#: message for a command it ran correctly, and would cost the transcript the other two
-#: thousand lines over one byte.
+#: message for a command it ran correctly, and would throw away every row charter CAN read
+#: over one it cannot. What the callers do with the replaced byte is what they already do
+#: with anything they cannot read: the chat id fails `_FRAME_ID_RE` and its row is dropped.
 #:
 #: **And not `surrogateescape`, which was the shape #828 suggested.** It would stop the
 #: raise HERE and move it: a lone surrogate has no UTF-8 encoding at all, so it raises

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -526,13 +526,53 @@ TIMED_OUT = 124
 #: missing harness binary.
 COULD_NOT_RUN = 127
 
+#: How every captured child in this module is decoded, and the THIRD way one of them could
+#: end badly (#828). `text=True` with no `errors=` decodes the pipe **strictly**, so a child
+#: whose output is not valid UTF-8 raised `UnicodeDecodeError` — a `ValueError`, which
+#: neither :func:`run`'s `TimeoutExpired` clause nor its `OSError` one catches — out of the
+#: one function documented as never raising. The sharp caller is
+#: `commands_frame._capture_transcript`, which runs `capture-pane` over a HARNESS pane at
+#: the moment §4e has promised to record the plane and is about to kill it: arbitrary bytes
+#: a coding agent printed, read on the one path that cannot afford a traceback. Its own
+#: `False`-for-everything contract could not help, because the raise happens before it has
+#: an answer to branch on.
+#:
+#: **Not a third invented return code beside :data:`TIMED_OUT`.** Those two say *charter
+#: never got an answer*. Here tmux answered — rc 0, the whole capture — and only charter
+#: could not read one byte of it. Reporting that as a refusal would name tmux in a failure
+#: message for a command it ran correctly, and would cost the transcript the other two
+#: thousand lines over one byte.
+#:
+#: **And not `surrogateescape`, which was the shape #828 suggested.** It would stop the
+#: raise HERE and move it: a lone surrogate has no UTF-8 encoding at all, so it raises
+#: `UnicodeEncodeError` on any strict encode a caller later performs — `sys.stdout` under a
+#: normal `LANG=en_US.UTF-8` is exactly that (measured: `sys.stdout.errors` is `strict`
+#: there, and writing one raises), as is any `Path.write_text`. A function whose contract is
+#: that it never raises has to hand back a value that does not raise either, or the promise
+#: covers only its own frame. The round trip is not cashed anywhere either: the one caller
+#: that PERSISTS the text encodes it with `errors="replace"` first, which writes `?` — 0x3F,
+#: measured — so the bytes would be lost at the sink regardless, and lost as a character
+#: indistinguishable from a question mark the agent really printed. U+FFFD says instead that
+#: something unreadable was there, which is both true and what a terminal shows anyway.
+#:
+#: Read by the two captured children here and by nothing else. `interact` captures nothing
+#: — it IS the operator's terminal — so it has no pipe to decode.
+DECODE_ERRORS = "replace"
+
 
 def _probe() -> str | None:
-    """`tmux -V`'s output, or ``None`` when there is no tmux to ask."""
+    """`tmux -V`'s output, or ``None`` when there is no tmux to ask.
+
+    Decoded like :func:`run`'s pipes and for the same reason: this gates the whole launch
+    and is asked before anything is drawn, so a `tmux` on `$PATH` answering in some other
+    encoding would be a traceback in place of a frame. It already has an answer for a
+    `tmux -V` it cannot parse, and "could not read it" is that same fact.
+    """
     if not shutil.which("tmux"):
         return None
     try:
-        out = subprocess.run(["tmux", "-V"], capture_output=True, text=True, timeout=5)
+        out = subprocess.run(["tmux", "-V"], capture_output=True, text=True, timeout=5,
+                             errors=DECODE_ERRORS)
     except (OSError, subprocess.SubprocessError):
         return None
     return out.stdout.strip() or None
@@ -658,6 +698,11 @@ def run(action: str, argv: list[str], *, env: dict | None = None,
     reattach line. Every caller already branches on a non-zero return, so a wedged server
     now degrades down the same path a refusal does — see :data:`TIMED_OUT`.
 
+    **And output charter cannot read comes back as text, not an exception** —
+    :data:`DECODE_ERRORS`, which is #828 and the third way this could end badly. That one
+    is not a refusal: tmux answered, and what charter could not read is one codepoint of
+    what it said.
+
     *report* is opt-out for the two callers that read the failure themselves: a query
     whose whole answer is "cannot tell" (`_query_pane_dead_status`), and one whose
     non-zero return is the ORDINARY case rather than a fault (`_live_sessions` against a
@@ -668,7 +713,7 @@ def run(action: str, argv: list[str], *, env: dict | None = None,
                         "— see frame/layout.py")
     try:
         proc = subprocess.run(argv, env=env, capture_output=True, text=True,
-                              timeout=timeout)
+                              errors=DECODE_ERRORS, timeout=timeout)
     except subprocess.TimeoutExpired:
         proc = subprocess.CompletedProcess(
             argv, TIMED_OUT, stdout="",

--- a/docs/news/unreleased-a-byte-charter-cannot-decode-is-one-odd-character.md
+++ b/docs/news/unreleased-a-byte-charter-cannot-decode-is-one-odd-character.md
@@ -1,0 +1,79 @@
+---
+version: unreleased
+headline: A byte charter cannot decode is one odd character in a listing, not a traceback out of a quit
+---
+
+`frame/tmuxctl.run` is the one place charter promises that a tmux which misbehaves degrades
+down the path a refusal does. It caught two ways for a tmux command to end badly — a wedged
+server (`subprocess.TimeoutExpired`) and a tmux that could not be started at all (`OSError`)
+— and there was a third it did not catch:
+
+```
+UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 15: invalid start byte
+```
+
+`capture_output=True, text=True` with no `errors=` decodes the pipe **strictly**. The raise
+happens inside `subprocess.run`, before charter has a return code to branch on, and
+`UnicodeDecodeError` is a `ValueError` — so neither existing clause saw it, and it came out
+of the function whose docstring says it never raises. `_probe`, the module's other captured
+child, had the same hole: it catches `OSError` and `subprocess.SubprocessError`, and
+`version()` gates the whole launch, so a `tmux` on `$PATH` answering in another encoding was
+a traceback in place of a frame.
+
+## Which tmux output can actually do this, measured rather than assumed
+
+#828 files the sharp caller as `_capture_transcript`, reading a harness pane during a quit,
+on the grounds that a pane holds arbitrary bytes. **Measured on tmux 3.7c, that path does
+not reach charter** — under `LANG=C.UTF-8` and again under `LC_ALL=C`, a pane that prints
+`\377` is stored in tmux's own screen as U+FFFD, and `capture-pane -p -e -N` hands back
+valid UTF-8. tmux sanitises it before charter ever sees it.
+
+Two other paths do, both measured on the same binary:
+
+* **A user option round-trips its bytes untouched.** `set-option -w @charter_chat` with a
+  raw `\377` in it comes back out of `list-windows -a -F '#{@charter_chat}'`, and out of
+  `display-message -p`, exactly as it went in. That listing is `_chat_seats` — what
+  `charter frame-quit` asks before it kills anything — and §3.3 is why it is not
+  hypothetical: one tmux server serves every plane on the machine, so charter reads windows
+  it did not create, and the agent inside a harness pane can reach the same socket.
+* **tmux's own stderr echoes the raw bytes of an argument it refuses**:
+  `invalid window name: BAD\377NAME`. That is `report_failure`'s input, so the decode could
+  take charter down *while it was reporting a failure*.
+
+## What it does now, and the two shapes that were not chosen
+
+Both captured children decode with `tmuxctl.DECODE_ERRORS`, which is `"replace"`: a byte
+charter cannot read becomes U+FFFD and the rest of the answer arrives intact. A chat id with
+one in it fails `_FRAME_ID_RE` and its row is dropped, which is what that listing already
+does with rows it cannot read; a transcript keeps its other two thousand lines.
+
+**Not a third invented return code beside `TIMED_OUT` and `COULD_NOT_RUN`.** Those two say
+*charter never got an answer*. Here tmux answered — rc 0, the whole listing — and only
+charter could not read one byte of it. Reporting that as a refusal would name tmux in a
+failure message for a command it ran correctly, and would cost `_capture_transcript` a whole
+transcript over one byte.
+
+**And not `errors="surrogateescape"`, which is what #828 suggests.** It stops the raise in
+`run` and moves it: a lone surrogate has no UTF-8 encoding at all, so it raises
+`UnicodeEncodeError` on any strict encode a caller performs later — `sys.stdout` under a
+normal `LANG=en_US.UTF-8` is exactly that (measured: `sys.stdout.errors` is `strict` there,
+and writing one raises), as is any `write_text`. A function documented as never raising has
+to hand back a value that does not raise either, or the promise covers only its own frame.
+The round trip it is chosen for is never cashed anywhere either: the one caller that
+persists the text encodes it with `errors="replace"` first, which writes `?` — 0x3F,
+measured — so the bytes are lost at the sink regardless, and lost as a character
+indistinguishable from a question mark the agent really printed. U+FFFD at least says
+something unreadable was there, which is what a terminal shows for the same byte anyway.
+
+## The floor one module over keeps its job and changes its reason
+
+`_capture_transcript`'s `text.encode("utf-8", "replace")` is #810 group C's odd survivor,
+pinned last release by a case that hands it a capture holding a lone surrogate. #828 reads
+it as dead code to delete once the decode is settled. It is not dead — it is *unreachable in
+production and observable in the suite*, deliberately, and the test that pins it says so.
+What changed is the sentence underneath: it used to be a floor for the day the read path
+stopped raising, and it is now a floor for the day the read path stops replacing. Both
+spellings of that coupling — the comment on the encode and the docstring on the case — now
+name `tmuxctl.DECODE_ERRORS`, so a change to one is a change somebody makes on purpose.
+
+Nothing to adopt.

--- a/tests/test_frame_tmuxctl.py
+++ b/tests/test_frame_tmuxctl.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from charter.frame import tmuxctl
@@ -157,6 +160,109 @@ class RunGuardsTheTimeout(unittest.TestCase):
         self.assertNotIn("timeout", kwargs)
         self.assertNotIn("capture_output", kwargs)
         self.assertEqual(kwargs["env"], {"A": "b"})
+
+
+#: A child that writes one byte no UTF-8 decoder can read, between two markers that survive
+#: it. Driven as a REAL subprocess and not a `mock.patch("subprocess.run")`, because the
+#: raise this class is about happens **inside** `subprocess.run` — in the decode of the pipe
+#: it opened — so a stub standing in for it is a stub standing in for the defect. Written
+#: with this interpreter rather than `sh -c "printf ..."` so nothing rests on which shell
+#: `/bin/sh` is or how its `printf` reads an octal escape.
+_PRINTS_A_BYTE_UTF8_CANNOT_READ = [
+    sys.executable, "-c", r"import sys; sys.stdout.buffer.write(b'ONE\xffTWO')"]
+
+#: The same, on the other pipe and with a non-zero exit — `report_failure` reads `stderr`,
+#: so the two streams are two separate ways for one decode to take a launch down.
+_FAILS_SAYING_A_BYTE_UTF8_CANNOT_READ = [
+    sys.executable, "-c",
+    r"import sys; sys.stderr.buffer.write(b'no such session: \xff'); sys.exit(1)"]
+
+
+class RunNeverRaisesOnWhatItCannotDecode(unittest.TestCase):
+    """#828: `run` caught two ways for a tmux command to end badly and there were three.
+
+    `capture_output=True, text=True` with no `errors=` decodes both pipes **strictly**, so a
+    child whose output is not valid UTF-8 raised `UnicodeDecodeError` — a `ValueError`, which
+    neither the `TimeoutExpired` clause nor the `OSError` one sees — out of the one function
+    whose whole contract is that a misbehaving tmux degrades down the path a refusal does.
+
+    **The sharp caller is a quit.** `commands_frame._capture_transcript` runs `capture-pane`
+    over a HARNESS pane, which holds whatever a coding agent printed, at the moment §4e has
+    promised to record the plane and is about to kill it — and its own `False`-for-everything
+    contract cannot help, because the raise happens before it has an answer to branch on.
+
+    Charter now decodes with :data:`tmuxctl.DECODE_ERRORS`, and the assertions here spell the
+    substitute character by hand: reading it off the constant would agree with any value the
+    constant took, including `strict`.
+    """
+
+    def test_a_pane_charter_cannot_decode_comes_back_rather_than_raising(self):
+        with self.assertRaises(UnicodeDecodeError):
+            b"ONE\xffTWO".decode("utf-8")   # or this case is not about what it says it is
+
+        proc = tmuxctl.run("capturing what this chat had on screen",
+                           _PRINTS_A_BYTE_UTF8_CANNOT_READ, timeout=20)
+
+        self.assertEqual(proc.returncode, 0, "the child succeeded; only charter could not read it")
+        self.assertEqual(proc.stdout, "ONE\ufffdTWO")
+
+    def test_the_text_around_the_byte_is_kept_rather_than_thrown_away(self):
+        """The reason this is not a third invented return code beside `TIMED_OUT`.
+
+        tmux answered — rc 0, a complete capture — so calling it a refusal would blame tmux
+        for a command it ran correctly, and would cost `_capture_transcript` the whole
+        transcript over one byte in two thousand lines. What charter cannot read is one
+        codepoint wide; what it can read is the rest of the pane.
+        """
+        proc = tmuxctl.run("capturing what this chat had on screen",
+                           _PRINTS_A_BYTE_UTF8_CANNOT_READ, timeout=20)
+
+        self.assertTrue(proc.stdout.startswith("ONE"))
+        self.assertTrue(proc.stdout.endswith("TWO"))
+
+    def test_the_value_handed_back_is_one_a_caller_can_print(self):
+        """`errors="surrogateescape"` would also stop the raise HERE, and move it.
+
+        A lone surrogate has no UTF-8 encoding at all, so it raises `UnicodeEncodeError` on
+        any strict encode downstream — `sys.stdout` under a normal `LANG=en_US.UTF-8` is
+        exactly that (measured: `sys.stdout.errors == "strict"`, and writing one raises). A
+        function documented as never raising has to hand back a value that does not raise
+        either, or the promise is only about its own frame.
+        """
+        proc = tmuxctl.run("reading what the harness printed before it died",
+                           _PRINTS_A_BYTE_UTF8_CANNOT_READ, timeout=20)
+
+        proc.stdout.encode("utf-8")        # raises if a surrogate got through
+
+    def test_a_failure_charter_cannot_decode_is_still_reported(self):
+        """The failure REPORT is why this wrapper exists, and it reads `stderr`."""
+        said = []
+        with mock.patch("charter.util.err", side_effect=said.append):
+            proc = tmuxctl.run("ending the frame after an early death",
+                               _FAILS_SAYING_A_BYTE_UTF8_CANNOT_READ, timeout=20)
+
+        self.assertEqual(proc.returncode, 1)
+        self.assertEqual(proc.stderr, "no such session: \ufffd")
+        self.assertTrue(any("ending the frame" in m and "no such session" in m for m in said),
+                        said)
+
+    def test_a_version_charter_cannot_decode_is_unreadable_rather_than_a_crash(self):
+        """`_probe` is the module's other captured child, and it caught the same two things.
+
+        `version()` gates the whole launch and is asked before anything is drawn, so a raise
+        here is a traceback in place of a frame. It already has an answer for a `tmux -V` it
+        cannot parse — `None`, which reads as "charter could not find out" — and a `tmux` on
+        `$PATH` that is a wrapper script answering in some other encoding is the same fact.
+        """
+        d = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        shim = d / "tmux"
+        shim.write_text(f"#!{sys.executable}\n"
+                        r"import sys; sys.stdout.buffer.write(b'tmux 3.\xffc')" + "\n")
+        shim.chmod(0o755)
+        self.enterContext(mock.patch.dict(os.environ,
+                                          {"PATH": f"{d}{os.pathsep}{os.environ['PATH']}"}))
+
+        self.assertIsNone(tmuxctl.version())
 
 
 class OperatorServer(unittest.TestCase):

--- a/tests/test_frame_tmuxctl.py
+++ b/tests/test_frame_tmuxctl.py
@@ -259,6 +259,11 @@ class RunNeverRaisesOnWhatItCannotDecode(unittest.TestCase):
         here is a traceback in place of a frame. It already has an answer for a `tmux -V` it
         cannot parse — `None`, which reads as "charter could not find out" — and a `tmux` on
         `$PATH` that is a wrapper script answering in some other encoding is the same fact.
+
+        `_probe` is asserted as well as `version`, and not only because it is the line that
+        changed: `assertIsNone(version())` alone passes just as well against a shim that
+        never ran at all, which is a case that would go quietly green the day the fixture
+        breaks rather than the day the code does.
         """
         d = Path(self.enterContext(tempfile.TemporaryDirectory()))
         shim = d / "tmux"
@@ -268,6 +273,7 @@ class RunNeverRaisesOnWhatItCannotDecode(unittest.TestCase):
         self.enterContext(mock.patch.dict(os.environ,
                                           {"PATH": f"{d}{os.pathsep}{os.environ['PATH']}"}))
 
+        self.assertEqual(tmuxctl._probe(), "tmux 3.\ufffdc")
         self.assertIsNone(tmuxctl.version())
 
 

--- a/tests/test_frame_tmuxctl.py
+++ b/tests/test_frame_tmuxctl.py
@@ -186,35 +186,41 @@ class RunNeverRaisesOnWhatItCannotDecode(unittest.TestCase):
     neither the `TimeoutExpired` clause nor the `OSError` one sees — out of the one function
     whose whole contract is that a misbehaving tmux degrades down the path a refusal does.
 
-    **The sharp caller is a quit.** `commands_frame._capture_transcript` runs `capture-pane`
-    over a HARNESS pane, which holds whatever a coding agent printed, at the moment §4e has
-    promised to record the plane and is about to kill it — and its own `False`-for-everything
-    contract cannot help, because the raise happens before it has an answer to branch on.
+    **It does land in a quit — through the window listing, not through the capture.** #828
+    files the sharp caller as `commands_frame._capture_transcript` reading a harness pane, and
+    tmux sanitises that one: measured on 3.7c, a pane that prints `\\377` is stored in tmux's
+    own screen as U+FFFD and `capture-pane` hands back valid UTF-8. What does not get
+    sanitised is a user OPTION, which round-trips its bytes untouched out of `list-windows -a
+    -F '#{@charter_chat}'` — `_chat_seats`, which `cmd_quit` asks before it kills anything.
+    The real-tmux half of that is in
+    `tests/test_quit_and_reopen_on_a_real_tmux.ARealQuitStopsRealChats`; the cases here drive
+    the decode itself.
 
     Charter now decodes with :data:`tmuxctl.DECODE_ERRORS`, and the assertions here spell the
     substitute character by hand: reading it off the constant would agree with any value the
     constant took, including `strict`.
     """
 
-    def test_a_pane_charter_cannot_decode_comes_back_rather_than_raising(self):
+    def test_an_answer_charter_cannot_decode_comes_back_rather_than_raising(self):
         with self.assertRaises(UnicodeDecodeError):
             b"ONE\xffTWO".decode("utf-8")   # or this case is not about what it says it is
 
-        proc = tmuxctl.run("capturing what this chat had on screen",
+        proc = tmuxctl.run("listing the chats this plane has open",
                            _PRINTS_A_BYTE_UTF8_CANNOT_READ, timeout=20)
 
-        self.assertEqual(proc.returncode, 0, "the child succeeded; only charter could not read it")
+        self.assertEqual(proc.returncode, 0,
+                         "the child succeeded; only charter could not read it")
         self.assertEqual(proc.stdout, "ONE\ufffdTWO")
 
     def test_the_text_around_the_byte_is_kept_rather_than_thrown_away(self):
         """The reason this is not a third invented return code beside `TIMED_OUT`.
 
-        tmux answered — rc 0, a complete capture — so calling it a refusal would blame tmux
-        for a command it ran correctly, and would cost `_capture_transcript` the whole
-        transcript over one byte in two thousand lines. What charter cannot read is one
-        codepoint wide; what it can read is the rest of the pane.
+        tmux answered — rc 0, the whole listing — so calling it a refusal would blame tmux
+        for a command it ran correctly, and would throw away every row charter CAN read over
+        one it cannot. What charter cannot read is one codepoint wide; what it can read is
+        the rest of the answer.
         """
-        proc = tmuxctl.run("capturing what this chat had on screen",
+        proc = tmuxctl.run("listing the chats this plane has open",
                            _PRINTS_A_BYTE_UTF8_CANNOT_READ, timeout=20)
 
         self.assertTrue(proc.stdout.startswith("ONE"))

--- a/tests/test_quit_and_reopen_on_a_real_tmux.py
+++ b/tests/test_quit_and_reopen_on_a_real_tmux.py
@@ -150,6 +150,42 @@ class ARealQuitStopsRealChats(PersonaIso, unittest.TestCase):
 
         self.assertIsNone(commands_frame._chat_seats(self.socket))
 
+    def test_a_window_charter_cannot_decode_is_dropped_rather_than_raised(self):
+        """#828 on a real server, and **not through the caller the issue names.**
+
+        The issue's reproduction is `capture-pane` over a harness pane, on the grounds that
+        a pane holds arbitrary bytes. Measured on tmux 3.7c — under `LANG=C.UTF-8` and again
+        under `LC_ALL=C` — it does not reach charter that way: a pane that prints `\\377` is
+        stored in tmux's own screen as U+FFFD, and `capture-pane -p -e -N` hands back valid
+        UTF-8. tmux sanitised it first.
+
+        Two real paths do reach charter, and this is the one a quit walks. A tmux USER
+        OPTION round-trips its bytes untouched — `set-option -w @charter_chat` with a raw
+        `\\377` in it comes back out of ``list-windows -a -F '#{@charter_chat}'`` and out of
+        `display-message -p` exactly as it went in, measured on 3.7c — and that listing is
+        `_chat_seats`, which `cmd_quit` asks before it kills anything. §3.3 is why this is
+        not hypothetical: one tmux server serves every plane on the machine, so charter
+        reads windows it did not create, and the harness agent inside a pane can reach the
+        same socket. (The other path is tmux's own stderr, which echoes the raw bytes of an
+        argument it refuses: `invalid window name: BAD\\377NAME`, straight into
+        `report_failure`.)
+
+        What the row does once it decodes is what this class already documents: it fails
+        `_FRAME_ID_RE` and is dropped, *rows charter cannot read are dropped rather than
+        guessed at* — and the chats charter CAN read are still answered for.
+        """
+        self._chat("alpha.1", ws="alpha", session="alpha", first=True, says="ONE")
+        pane = self._tmux("new-window", "-d", "-t", "alpha", "-P", "-F", "#{pane_id}",
+                          "sh", "-c", "exec cat")
+        # A lone surrogate in argv is how a raw byte reaches a child: `os.fsencode` writes
+        # it back out with `surrogateescape`, so tmux stores 0xFF and not the escape.
+        self._tmux("set-option", "-w", "-t", pane, commands_frame._CHAT_OPTION,
+                   "al\udcffpha.9")
+
+        seats = commands_frame._chat_seats(self.socket)
+
+        self.assertEqual(sorted(c for c, _w, _a in seats), ["alpha.1"])
+
     def test_quit_stops_both_chats_records_both_and_ends_the_session(self):
         self._chat("alpha.1", ws="alpha", session="alpha", first=True, says="ONE")
         self._chat("alpha.2", ws="alpha", session="alpha", first=False, says="TWO")

--- a/tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.py
+++ b/tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.py
@@ -422,13 +422,18 @@ class ACaptureCharterCannotEncodeStillLands(PersonaIso):
 
     So the case that pins it hands `_capture_transcript` a capture that cannot be encoded,
     through the seam every other case in `TheCaptureIsBoundedAndNeverRaises` already uses.
-    **Stated honestly: today's decode path cannot produce such a string** — `tmuxctl.run`
-    runs `subprocess.run(..., text=True)`, whose default `errors` is `strict`, so a pane
-    charter cannot decode raises there rather than arriving here as surrogates. The handler
-    is a floor for the day that changes, and this is the invariant the class one file over
-    is named for: **the capture never raises.** A quit that tracebacks on the way out is
-    the one failure §4e cannot afford, because the operator has already asked for the plane
-    to be recorded.
+    **Stated honestly: today's decode path cannot produce such a string** — and the reason
+    moved with #828. It used to be that `tmuxctl.run` decoded STRICTLY, so a pane charter
+    could not read raised there rather than arriving here as surrogates; that was the defect
+    #828 fixed, because the raise landed in the middle of a quit. It now decodes with
+    `tmuxctl.DECODE_ERRORS`, which substitutes U+FFFD — a character that encodes perfectly
+    well — so a lone surrogate still cannot reach this line, and the handler is still a
+    floor. What it is a floor FOR is what changed: not "the day the read stops raising", but
+    "the day the read stops replacing".
+
+    The invariant is the one the class one file over is named for: **the capture never
+    raises.** A quit that tracebacks on the way out is the one failure §4e cannot afford,
+    because the operator has already asked for the plane to be recorded.
     """
 
     def setUp(self):


### PR DESCRIPTION
Closes #828.

## The defect, confirmed

`frame/tmuxctl` captures both its children with `text=True` and no `errors=`, so the pipe is decoded **strictly**. A child whose output is not valid UTF-8 raises `UnicodeDecodeError` *inside* `subprocess.run` — a `ValueError`, which neither the `TimeoutExpired` clause nor the `OSError` one sees — out of `run`, whose docstring says it never raises, and out of `_probe`, which gates the whole launch.

One correction to the filing: the pasted reproduction does not reproduce as written. `python3 -c "… printf \"a\\377b\" …"` loses a level of quoting, so Python's own octal escape turns `\377` into `ÿ` and the child prints valid UTF-8. With the escape reaching `sh`, it raises exactly as filed.

## Which tmux output can actually do this — measured on 3.7c, not assumed

#828 names `_capture_transcript` (a harness pane, during a quit) as the sharp caller. **That path does not reach charter.** Under `LANG=C.UTF-8` and again under `LC_ALL=C`, a pane that prints `\377` is stored in tmux's own screen as U+FFFD, and `capture-pane -p -e -N` hands back valid UTF-8. tmux sanitises it first.

Two other paths do, both measured on the same binary:

* **A user option round-trips its bytes untouched.** `set-option -w @charter_chat` holding a raw `\377` comes back out of `list-windows -a -F '#{@charter_chat}'` and out of `display-message -p` byte for byte. That listing is `_chat_seats` — what `cmd_quit` asks *before it kills anything* — so the raise does land in a quit, one call to the left of where the issue put it. §3.3 is why it is reachable rather than theoretical: one tmux server serves every plane on the machine, so charter reads windows it did not create.
* **tmux's stderr echoes the raw bytes of an argument it refuses**: `invalid window name: BAD\377NAME` — i.e. `report_failure`'s input, so the decode could take charter down *while it was reporting a failure*.

## The decision

`DECODE_ERRORS = "replace"`, on `run` and on `_probe`.

**Not a third invented return code beside `TIMED_OUT`/`COULD_NOT_RUN`.** Those two mean *charter got no answer*. Here tmux answered — rc 0, the whole listing — and only charter could not read one byte of it. A refusal would name tmux in a failure message for a command it ran correctly, and would cost `_capture_transcript` a whole transcript over one byte in two thousand lines. What the callers do with a replaced byte is what they already do: the row fails `_FRAME_ID_RE` and is dropped (*rows charter cannot read are dropped rather than guessed at*), and the rest of the answer survives.

**Not `errors="surrogateescape"`, which is what the issue suggests.** It stops the raise *here* and moves it. A lone surrogate has no UTF-8 encoding at all, so it raises `UnicodeEncodeError` on any strict encode a caller performs later — `sys.stdout` under a normal `LANG=en_US.UTF-8` is exactly that (measured: `sys.stdout.errors` is `strict`, and writing one raises), as is any `write_text`. A function documented as never raising has to hand back a value that does not raise either, or the promise covers only its own frame. And the round trip it is chosen for is never cashed: the one caller that persists the text encodes it with `errors="replace"` first, which writes `?` (0x3F — measured), so the bytes are lost at the sink regardless, and lost as a character indistinguishable from a question mark the agent really printed. U+FFFD at least says something unreadable was there, which is what a terminal shows for the same byte anyway.

## What the issue asks for and the tree already refutes

#828 asks for the pair to be closed by **deleting** `_capture_transcript`'s `text.encode("utf-8", "replace")` if the decode replaces. It is not dead code: it is unreachable in production and **observable in the suite**. `tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.ACaptureCharterCannotEncodeStillLands` drives it with a surrogate-bearing capture through the same stub seam that class already uses — merged in #820 (0ac694b, 17:44 +04) about an hour *before* #828 was filed (18:51 +04), which is why the issue still describes it as "a survivor the suite cannot redden".

So it is kept, and its reason is updated in both places that carry the coupling: it was a floor for the day the read path stopped raising, and it is now a floor for the day the read path stops replacing. Deleting it would have deleted a pinned, documented guard — the exact shape of *unreachable and unobservable are different things*.

## Tests

* `tests/test_frame_tmuxctl.RunNeverRaisesOnWhatItCannotDecode` — five cases driving **real children** through `run` and `version()`. Deliberately not `mock.patch("subprocess.run")`: the raise happens inside `subprocess.run`, so a stub for it is a stub for the defect. Substitute characters are hand-spelled as literals (`"ONE�TWO"`), never read off `DECODE_ERRORS`.
* `tests/test_quit_and_reopen_on_a_real_tmux` — one real-tmux case that builds a window whose `@charter_chat` holds a raw `\377` and asserts `_chat_seats` drops that row and still answers for the chat it can read.

All six confirmed red on the unfixed line (`UnicodeDecodeError` raised from `tmuxctl.py`) and green after. Full suite via the CI loader (`python -m unittest discover -s tests`): 10441 tests, OK, 8 skipped.

News: `docs/news/unreleased-a-byte-charter-cannot-decode-is-one-odd-character.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
