### PR TITLE
A random directory name is not a charter spawn (#830)

### DIFF
--- a/docs/news/unreleased-a-random-directory-name-is-not-a-charter-spawn.md
+++ b/docs/news/unreleased-a-random-directory-name-is-not-a-charter-spawn.md
@@ -1,0 +1,86 @@
+---
+version: unreleased
+headline: charter's own suite stops refusing a `bash -c printf` because `tempfile` happened to spell `edm` in a random directory name — the plane tripwire now says which plane it objected to and where that value came from
+---
+
+`#826`'s head was built twice, eight seconds apart, on identical trees. One run failed and
+one passed:
+
+```
+ERROR: test_the_guard_and_bash_agree_on_every_spelling
+tests._planeguard.RealPlaneSpawn: REFUSED: spawning charter against the real control plane
+  ... is about to run `bash -c printf %s $'a\'...`
+```
+
+The refused command spawns no charter. It runs `printf`.
+
+## It was never a race
+
+`tests/_planeguard.py` refuses a `subprocess.Popen` that would start charter against the
+developer's real plane — the tripwire that exists because an agent once destroyed two of
+the operator's real chats. To read a `bash -c` it has to decide whether the command STRING
+starts charter, and that begins with a cheap gate: is the name in the string at all.
+
+The gate is deliberately loose, and its own docstring says why — `env -Scharter doctor`
+glues the name to an option letter, so a boundaried test would answer "charter is not named
+here" about a string whose entire content is a charter invocation. The promise underneath
+that looseness is that "the word test still decides what is a COMMAND once the string is
+lexed".
+
+Both halves of the failure follow from that promise having a hole in it:
+
+* the name it searches for is `charter` **or `edm`**, charter's pre-rename binary — three
+  characters, with no boundary asked for on either side;
+* `tempfile` had drawn the directory `tmpq71ovzj50hedm9za`, and three of its eight random
+  characters are `edm`;
+* the string was `printf %s $'a\'b' && …`, and `$'…'` is bash's ANSI-C quoting. `shlex`
+  does not know it, reads the backslash as an ordinary character and is left holding an
+  unbalanced quote — so the string **never lexed**, and nothing ever reached the word test;
+* "will not lex" answers *charter*, which is the safe direction to be wrong in — except
+  that here the loose gate was the entire decision, which is precisely what its docstring
+  says it must never be.
+
+Six of the eight random characters can start an `edm`, at roughly one directory name in
+8,400. That is the coin the two runs flipped differently.
+
+**And it was not only a coin.** Every throwaway plane the suite builds is named
+`edm-test-…` on purpose, so those three letters are already in the argv of anything that
+hands such a path to a shell. The failure was one unlexable string away from being
+reproducible on demand, and there is no boundary rule that could have kept `-Scharter` and
+dropped `edm-test-`: the `edm` there is bounded on both sides.
+
+## What changed
+
+The three places that answer "charter" without ever having read a command position —
+nesting past the fourth level, a string that will not lex, a command word the shell
+computes — now answer with the **word** test rather than with the gate. The gate goes back
+to deciding nothing on its own, and the lexed path keeps its full reach: every spelling the
+guard recognises is still recognised, including the glued `env -Scharter` the looseness
+exists for, which lexes and is caught the way it always was.
+
+**What that gives up, stated rather than left to be found:** a shell string that bash can
+run, `shlex` cannot read, *and* names charter only glued to another word is no longer
+refused. It is the intersection of two rare things, and
+`test_an_unlexable_string_that_names_charter_only_glued_to_a_word_is_the_price` holds it
+where it costs something.
+
+## The refusal now says which plane, and where it came from
+
+The message named the argv it objected to and the plane it objected on behalf of, but never
+where that plane came from — and `_child_plane` has three answers with three different bugs
+behind them. A plane reached by walking up from a cwd nobody overrode is the guard's steady
+answer. A plane that arrived as a handed `$CHARTER_ROOT` is a fixture aimed at the wrong
+place. A plane that is only `find_root_or_cwd`'s unwalked fallback is neither. `RealPlaneSpawn`
+now prints the one it used:
+
+```
+That plane came from the walk up from this process's cwd, which the spawn did not
+override: /home/runner/work/charter/charter.
+```
+
+Which is the answer for this failure, and the reason the guard's fail-closed direction is
+less forgiving than it looks: the suite runs from the checkout, so *every* child that
+inherits its working directory resolves the real plane. The plane check filters nothing
+there, and "undecidable" means "refused".
+
+None of this reaches you unless you run charter's own test suite. Nothing to adopt.

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -1238,7 +1238,10 @@ def _shell_launches_charter(command: str, depth: int = 0, cwd=None, env=None) ->
       up, and anything else that computes the name;
     * a wrapper that takes a command as its arguments — ``sudo``, ``eval``, ``xargs``,
       ``timeout`` — with the word anywhere after it;
-    * a string that will not lex, or nesting past the fourth level.
+    * a string that will not lex, or nesting past the fourth level — undecidable, and
+      answered "charter" whenever the WORD test finds the name in it. Not the gate: the
+      gate matches a substring, and a substring is not a reason to refuse a command
+      nothing lexed. See the comment on `named` in the body.
 
     The per-segment question is :func:`_cmd_launches_charter`'s, in full: the wrapper
     clause used to be repeated here because that function did not have one, which is how
@@ -1246,21 +1249,36 @@ def _shell_launches_charter(command: str, depth: int = 0, cwd=None, env=None) ->
     """
     if not _CHARTER_MENTION.search(command):
         return False
+    # Three exits below answer "charter" without ever having READ a command position, and
+    # each of them is reached only because the gate let the string through. The gate is
+    # deliberately loose — see :data:`_CHARTER_MENTION` — on the promise that "the word test
+    # still decides what is a COMMAND once the string is lexed". Where nothing gets lexed
+    # that promise is broken and the loose gate IS the decision, which is #830: a `bash -c
+    # printf` was refused because `tempfile` had named a directory `tmpq71ovzj50hedm9za`,
+    # three of whose random characters spell charter's pre-rename binary. `tests/_isolation`
+    # spells the same three letters on purpose, in `edm-test-`, so this is a false refusal
+    # waiting on the argv rather than on a coin.
+    #
+    # So the undecidable answers are the WORD test's, which is the one that knows a name
+    # from a path — while the gate keeps deciding nothing on its own and the lexed path
+    # keeps its full reach. What this gives up is stated where it costs something:
+    # `test_an_unlexable_string_that_names_charter_only_glued_to_a_word_is_the_price`.
+    named = bool(_CHARTER_WORD.search(command))
     if depth > 3:                         # nesting nobody writes; stop, and refuse
-        return True
+        return named
     for body in _substitution_bodies(command):
         if _shell_launches_charter(body, depth + 1, cwd, env):
             return True
     try:
         segments = _shell_segments(command)
     except ValueError:
-        return True
+        return named
     for segment in segments:
         if _cmd_launches_charter(segment, depth + 1, cwd, env):
             return True
         words, _consumed = _launcher_argv(segment)
         if words and ("$" in words[0] or "`" in words[0]):
-            return True                   # the command word is computed: undecidable
+            return named                  # the command word is computed: undecidable
     return False
 
 
@@ -1384,11 +1402,23 @@ def _charter_argv(args, opts: dict) -> list[str] | None:
     return parts if _cmd_launches_charter(parts, 0, cwd, env) else None
 
 
-def _explain_spawn(parts: list[str], plane) -> str:
+def _explain_spawn(parts: list[str], plane, source: str) -> str:
+    """The refusal, naming the plane AND where that value came from.
+
+    *source* is `_child_plane`'s second return value, and #830 is why it is printed. That
+    failure was a `bash -c printf` refused intermittently, and the log said which argv was
+    refused but not which plane it was refused against \u2014 so the two candidate stories (the
+    guard misread the argv; something moved the plane under it) could not be told apart
+    from the artifact. One line of provenance separates them: a plane that came from the
+    walk up from an untouched cwd is the guard's own steady answer, and a plane that came
+    from a handed ``$CHARTER_ROOT`` or from `find_root_or_cwd`'s fallback is not.
+    """
     return (
         f"REFUSED: spawning charter against the real control plane\n"
         f"{_current_test()} is about to run `{' '.join(parts)}`, and that child would "
-        f"resolve its plane as {plane} \u2014 the developer's REAL one. It is a separate "
+        f"resolve its plane as {plane} \u2014 the developer's REAL one.\n"
+        f"That plane came from {source}.\n"
+        f"It is a separate "
         f"process: nothing this suite patches in memory reaches it, so it would refresh "
         f"that plane's forge state, rewrite its caches, and (for `persona _gc`) collect "
         f"against it. Two ways out. (1) If the test is not about the spawn, stub it \u2014 "
@@ -1479,24 +1509,50 @@ def _child_plane(opts: dict):
     the guard — charging every test that spawns `bash` with a read it never made. A copy
     carries the same values (the ambient ones were scrubbed at install, so it is the same
     on every machine) and is exactly what the child will inherit.
+
+    Returns the plane AND the sentence saying where it came from, because the refusal has
+    to print both. #830 is the measurement: a `RealPlaneSpawn` that names a plane but not
+    its provenance leaves the reader unable to tell an inherited cwd from a handed
+    ``$CHARTER_ROOT`` from `find_root_or_cwd`'s unwalked fallback — three different bugs
+    with one message. Computed here rather than beside `_explain_spawn` because this is
+    where the three branches already are, and a second reader of them would drift.
     """
     from charter import root as _root
 
     env = opts.get("env")
     cwd = opts.get("cwd")
     try:
+        # A COPY, and `dict()` around it for the same reason the walk below takes one:
+        # ``env=os.environ`` is a legal spelling, and a targeted `.get` off the live
+        # mapping is what `_envguard` refuses.
+        pointer = dict(dict(os.environ) if env is None else env).get(_root.ENV_VAR)
+    except (TypeError, ValueError, AttributeError):
+        pointer = None                    # not a mapping at all; the walk still answers
+    try:
         start = Path(os.fsdecode(cwd)) if cwd is not None else Path.cwd()
     except (TypeError, ValueError, OSError):
-        return None
+        return None, "unreadable"
+    if pointer:
+        carrier = ("the spawn's own env=" if env is not None
+                   else "this process's environment")
+        handed = f"${_root.ENV_VAR}={pointer}, inherited from {carrier}"
+    else:
+        whose = ("the spawn's own cwd=" if cwd is not None
+                 else "this process's cwd, which the spawn did not override: ")
+        handed = f"the walk up from {whose}{start}"
     try:
-        return _root.find_root(start, env=dict(os.environ) if env is None else env)
+        return _root.find_root(start, env=dict(os.environ) if env is None else env), handed
     except _root.ControlPlaneNotFound:
         try:
-            return start.resolve()        # what `find_root_or_cwd` hands `config`
+            # What `find_root_or_cwd` hands `config`: no plane above the child at all, so
+            # its own working directory becomes one, unwalked.
+            return start.resolve(), (
+                f"{handed} — which found no plane, so `find_root_or_cwd`'s fallback makes "
+                f"that directory the plane")
         except (OSError, RuntimeError):
-            return None
+            return None, "unreadable"
     except Exception:
-        return None
+        return None, "unreadable"
 
 
 #: Whether :func:`_guard_spawns` has already wrapped ``Popen.__init__``. Separate from
@@ -1571,7 +1627,7 @@ def _guard_spawns() -> None:
         parts = _charter_argv(args, opts)
         if parts is not None:
             if _REAL_ROOT:
-                plane = _child_plane(opts)
+                plane, source = _child_plane(opts)
                 if plane is not None:
                     try:
                         here = os.path.abspath(str(plane))
@@ -1579,7 +1635,7 @@ def _guard_spawns() -> None:
                         here = None
                     if here is not None and (here in _REAL_ROOT
                                              or os.path.realpath(here) in _REAL_ROOT):
-                        raise RealPlaneSpawn(_explain_spawn(parts, plane))
+                        raise RealPlaneSpawn(_explain_spawn(parts, plane, source))
             if opts.get("start_new_session") and not _BACKGROUND_ALLOWED:
                 raise BackgroundCharterChild(_explain_background(parts))
         return original(self, args, *rest, **kw)

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -140,6 +140,41 @@ class ARefusedSpawn(_FakePlane):
         self.assertIn("maybe_spawn", msg)       # way out (1): do not spawn at all
         self.assertIn(str(self.real), msg)      # which plane it would have landed on
 
+    def test_the_message_says_where_that_plane_CAME_FROM(self):
+        """#830 put one question to a CI log and the log could not answer it.
+
+        The refusal named the argv it objected to and the plane it objected on behalf of —
+        but not where that plane came from, and `_child_plane` has three answers with three
+        different bugs behind them. A plane reached by walking up from a cwd nobody
+        overrode is the guard's own steady answer, and if it is the operator's, so is every
+        other spawn in the run. A plane that arrived as a handed ``$CHARTER_ROOT`` is a
+        fixture pointing at the wrong place. A plane that is only `find_root_or_cwd`'s
+        unwalked fallback is neither. One line separates them; without it the reader is
+        reduced to reproducing a failure that fired once in two runs of one commit.
+        """
+        stranded = {k: v for k, v in os.environ.items() if k != root.ENV_VAR}
+
+        # (1) the walk, from a cwd the spawn did not override.
+        with self.assertRaises(_planeguard.RealPlaneSpawn) as caught:
+            self.run_fake(cwd=self.real, env=stranded)
+        self.assertIn(f"the walk up from the spawn's own cwd={self.real}",
+                      str(caught.exception))
+
+        # (2) a pointer handed across the boundary — a fixture aiming at the wrong plane,
+        #     which reads nothing like (1) and used to print the same sentence.
+        with self.assertRaises(_planeguard.RealPlaneSpawn) as caught:
+            self.run_fake(cwd=self.elsewhere,
+                          env={**stranded, root.ENV_VAR: str(self.real)})
+        self.assertIn(f"${root.ENV_VAR}={self.real}, inherited from the spawn's own env=",
+                      str(caught.exception))
+
+        # (3) no plane above the child at all, so `find_root_or_cwd` makes its cwd one.
+        with self.assertRaises(_planeguard.RealPlaneSpawn) as caught:
+            self.run_fake(cwd=self.real,
+                          env={**stranded, root.ENV_VAR: str(self.elsewhere / "gone")})
+        self.assertIn("found no plane, so `find_root_or_cwd`'s fallback",
+                      str(caught.exception))
+
     def test_it_is_a_base_exception_so_charters_own_fallbacks_cannot_eat_it(self):
         """`glstate.maybe_spawn` and `update.maybe_spawn` both wrap their `Popen` in
         `except Exception: return`. A tripwire those can catch reports nothing at all."""
@@ -617,6 +652,107 @@ class SpellingsThatAreNotASpawn(_FakePlane):
         # resolved spelling — the same two-spellings problem `_REAL_ROOT` carries.
         self.assertEqual(self.allow(["/bin/sh", "-c", f'pwd > "{self.ran}"']).strip(),
                          str(self.real.resolve()))
+
+    def test_a_name_buried_in_a_longer_word_does_not_decide_an_unlexable_string(self):
+        """#830: a `bash -c printf` refused against the operator's real plane, in one of
+        two runs of the SAME commit — and the argv spawns no charter at all.
+
+        Nothing raced. `tempfile` had drawn the directory name ``tmpq71ovzj50hedm9za``, and
+        three of its eight random characters spell ``edm``, charter's pre-rename binary.
+        That is enough for the mention GATE, which asks for the name and nothing about its
+        boundaries; `shlex` cannot lex bash's ``$'…'`` ANSI-C quoting, so nothing was ever
+        segmented; and "undecidable" answered charter. The gate was the whole decision —
+        which is exactly what its own docstring says it must never be.
+
+        The second name is the same defect with the coin taken out: every throwaway plane
+        `tests._isolation` makes is ``edm-test-…``, so those three letters are in the argv
+        of anything that hands such a path to a shell.
+        """
+        for name in ("tmpq71ovzj50hedm9za", "edm-test-9f2c"):
+            with self.subTest(name=name):
+                out = self.elsewhere / name / "it-ran"
+                out.parent.mkdir()
+                # Valid bash that `shlex` will not lex: the backslash inside `$'…'` is an
+                # escape to bash and an ordinary character to shlex, which leaves shlex
+                # holding an unbalanced quote.
+                p = subprocess.Popen(["bash", "-c", f"printf %s $'a\\'b' > {out}"],
+                                     cwd=self.real, env=self.stranded)
+                self.assertEqual(p.wait(), 0)
+                self.assertEqual(out.read_text(), "a'b", "the child did not run")
+
+
+class WhatDecidesAnUndecidableShellString(unittest.TestCase):
+    """#830, at the decision function rather than through a spawn.
+
+    `_shell_launches_charter` has three exits that answer "charter" without having read a
+    command position at all: nesting past the fourth level, a string that will not lex, and
+    a command word the shell computes. Each is reached only because the mention gate let
+    the string through, so on those three the gate is not a gate — it is the verdict. And
+    the gate matches a bare SUBSTRING by design, on the promise (its own docstring) that
+    "the word test still decides what is a COMMAND once the string is lexed". Where nothing
+    is lexed, that promise has nothing behind it.
+
+    The failure that cost a run was the compound: an incidental ``edm`` in a `tempfile`
+    name AND a string `shlex` cannot lex. Pinning it as a spawn needs the guard to be
+    armed against a real plane; pinning it here needs neither, so this is the half that
+    still measures something the day the fixture above stops being reproducible.
+    """
+
+    #: Ordinary bash, and `shlex` raises on it — the premise the case below asserts rather
+    #: than assumes.
+    UNLEXABLE = "printf %s $'a\\'b'"
+
+    def test_the_premise_that_shlex_refuses_what_bash_accepts(self):
+        with self.assertRaises(ValueError):
+            _planeguard._shell_segments(self.UNLEXABLE)
+        self.assertEqual(
+            subprocess.run(["bash", "-c", self.UNLEXABLE],
+                           capture_output=True, text=True).stdout, "a'b")
+
+    def test_the_name_inside_a_longer_word_is_not_what_decides_it(self):
+        for path in ("/tmp/tmpq71ovzj50hedm9za/ran",   # the name CI actually drew
+                     "/tmp/edm-test-9f2c/ran",         # `tests._isolation`'s own prefix
+                     "/tmp/rechartering/ran"):         # and the current name, buried
+            with self.subTest(path=path):
+                command = f"{self.UNLEXABLE} > {path}"
+                self.assertTrue(_planeguard._CHARTER_MENTION.search(command),
+                                "fixture no longer reaches the gate it is about")
+                self.assertFalse(_planeguard._shell_launches_charter(command))
+
+    def test_the_name_as_a_word_still_decides_it(self):
+        """The other half, and without it the case above is satisfied by a guard that
+        answers "not charter" to everything it cannot lex."""
+        for command in (f"{self.UNLEXABLE}; charter doctor",
+                        f"{self.UNLEXABLE}; /usr/local/bin/charter doctor",
+                        f"{self.UNLEXABLE}; edm doctor",
+                        f'{self.UNLEXABLE}; CHARTER doctor'):
+            with self.subTest(command=command):
+                self.assertTrue(_planeguard._shell_launches_charter(command))
+
+    def test_a_computed_command_word_is_decided_the_same_way(self):
+        """The third exit. `ARefusedSpawn`'s spawn-level case pins the refusal; this pins
+        that an incidental substring is not what earns it."""
+        self.assertTrue(_planeguard._shell_launches_charter(
+            "# this line starts charter\n$CBIN --version"))
+        self.assertFalse(_planeguard._shell_launches_charter(
+            "cd /tmp/edm-test-9f2c && $CBIN --version"))
+
+    def test_an_unlexable_string_that_names_charter_only_glued_to_a_word_is_the_price(self):
+        """What #830's fix gives up, stated where it costs something rather than left to
+        be discovered.
+
+        ``env -Scharter`` puts a word character against the name, which is the shape the
+        mention gate exists for — so in a string that will not LEX, that spelling is no
+        longer refused. It is the intersection of two rare things (a string bash runs and
+        `shlex` cannot read, naming charter only glued to another word), and every one of
+        those spellings is still refused the moment the string lexes, which is the case
+        underneath. Narrowing this back out means finding a boundary rule that keeps
+        ``-Scharter`` and drops ``edm-test-`` — and there is none: ``edm`` there is already
+        bounded on both sides.
+        """
+        self.assertFalse(
+            _planeguard._shell_launches_charter(f"env -Scharter {self.UNLEXABLE}"))
+        self.assertTrue(_planeguard._shell_launches_charter("env -Scharter --version"))
 
 
 class TheHarnessGuardIsNotASecondCopyOfProductions(unittest.TestCase):


### PR DESCRIPTION
Closes #830.

## What it was

Not a race. `tempfile` drew the directory name `tmpq71ovzj50hedm9za`, and three of its
eight random characters spell `edm` — charter's pre-rename binary, and one of the two names
the plane guard looks for.

```
$ python3 -c "import tempfile; ns=tempfile._RandomNameSequence(); print(ns.characters, len(next(ns)))"
abcdefghijklmnopqrstuvwxyz0123456789_ 8
```

6 starting positions x 37^-3 = **one directory name in 8,442**. That is the coin the two
runs of `7e543926` flipped differently.

The chain, all of it inside `_shell_launches_charter`:

1. the cheap gate `_CHARTER_MENTION` is `charter|edm`, case-folded, **with no boundary on
   either side**. It is loose on purpose — `env -Scharter doctor` glues the name to an
   option letter, and a boundaried test would answer "charter is not named here" about a
   string whose entire content is a charter invocation. The promise under the looseness is
   its own docstring's: *"the word test still decides what is a COMMAND once the string is
   lexed."*
2. the command was `printf %s $'a\'b' && printf %s " `touch <tmpdir>/ran` "`. `$'…'` is
   bash's ANSI-C quoting; `shlex` does not know it, reads the backslash as an ordinary
   character, and is left holding an unbalanced quote. **Nothing lexed.**
3. `except ValueError: return True` — undecidable, fail closed.

So on that path the loose gate was the entire verdict, which is exactly what its own
docstring says it must never be. Two of the module's 28 cases flip verdict on nothing but
whether the temp path carries `edm`:

```
2 of 28 CASES flip verdict when the temp path contains 'edm':
   'printf %s "a \`@S@\` b"'
   'printf %s $\'a\\\'b\' && printf %s " `@S@` "'
```

**And it is not only a coin.** `tests/_isolation.py:45` names every throwaway plane
`edm-test-…`, so those three letters are already in the argv of anything that hands such a
path to a shell. Both spellings reproduce on demand, on `main`:

```
random name carrying 'edm' (the CI shape): REFUSED -> REFUSED: spawning charter against the real control plane
tests/_isolation.py's own prefix 'edm-test-': REFUSED -> REFUSED: spawning charter against the real control plane
a control name with no 'edm' in it: RAN, sentinel=True
```

## What changed

The three exits that answer "charter" without ever having read a command position —
nesting past the fourth level, a string that will not lex, a command word the shell
computes — now answer with the boundaried **word** test (`_CHARTER_WORD`) rather than with
the gate. The gate goes back to deciding nothing on its own.

`_CHARTER_WORD` is `(?<![\w.-])(?:charter|edm)(?![\w.\-/])`, and its trailing class is what
disposes of every incidental spelling at once: `…7edm9za` (word char after), `edm-test-`
(hyphen after), `…5edm/ran` (slash after). No gate boundary rule could have done it —
`edm` in `edm-test-` is already bounded on both sides.

### What this no longer catches, stated rather than buried

A shell string that **bash can run**, **`shlex` cannot lex**, *and* names charter only
glued to another word (`env -Scharter $'a\'b'`). The intersection of two rare things. Every
one of those spellings is still refused the moment the string lexes — `env -Scharter
--version` is refused exactly as before, and
`test_the_name_glued_to_an_option_letter_still_reaches_the_lexer` is untouched. The guard's
recognising power is unchanged; only "I could not read this, so I will assume the worst on
the strength of a substring" is gone.

`test_an_unlexable_string_that_names_charter_only_glued_to_a_word_is_the_price` pins both
halves so the trade is a test rather than a paragraph.

## The measurement the issue asked for

`_explain_spawn` took the plane as an argument and the log never said which one it held.
It does now — and says where the value came from, because `_child_plane` has three answers
with three different bugs behind them:

```
That plane came from the walk up from this process's cwd, which the spawn did not
override: /home/runner/work/charter/charter.
```

versus `$CHARTER_ROOT=…, inherited from the spawn's own env=` and `… — which found no
plane, so `find_root_or_cwd`'s fallback makes that directory the plane`.

**For #830 it was the first.** Which is the second finding worth writing down: the suite
runs from the checkout, so every child that inherits its working directory resolves the
real plane. The plane check filters nothing for those children — "undecidable" means
"refused", unconditionally — which is why a loose gate on the undecidable path costs a run
rather than a warning.

## Tests

Every case below reddens on `origin/main` and passes here:

| case | shape |
|---|---|
| `SpellingsThatAreNotASpawn.test_a_name_buried_in_a_longer_word_does_not_decide_an_unlexable_string` | real spawn, both names (`tmpq71ovzj50hedm9za`, `edm-test-9f2c`) |
| `WhatDecidesAnUndecidableShellString.test_the_name_inside_a_longer_word_is_not_what_decides_it` | decision function, 3 paths |
| `WhatDecidesAnUndecidableShellString.test_a_computed_command_word_is_decided_the_same_way` | the third exit |
| `WhatDecidesAnUndecidableShellString.test_an_unlexable_string_that_names_charter_only_glued_to_a_word_is_the_price` | the narrowing, held |
| `ARefusedSpawn.test_the_message_says_where_that_plane_CAME_FROM` | all three provenances |

with two controls that pass on both trees and would catch a guard that simply stopped
refusing: `test_the_premise_that_shlex_refuses_what_bash_accepts` (bash prints `a'b`;
`_shell_segments` raises) and `test_the_name_as_a_word_still_decides_it`.

Full suite, the way CI runs it (`python -m unittest discover -s tests`), from the worktree:
`Ran 10452 tests in 590.916s — OK (skipped=12)`.

**Sweep:** `charter/` and `tools/` are the swept paths and this branch changes zero lines in
either, so `nothing to sweep` is the honest verdict here rather than a gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dq9Q2fGzos3iJ46PZFdMP
